### PR TITLE
fix(stella-cli): read the provider registry docs check against the catalog module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,17 +106,25 @@ jobs:
           # gate runs. An empty diff runs nothing here — reporting that PR is
           # empty-diff.yml's job.
           #
-          # The one prose path that is not prose-only: a command reference page
-          # is asserted about by `stella-cli`'s own tests — the subcommand
-          # index, the per-command summaries, and since #3041 every flag's card
-          # — so editing one without running them is exactly the hole that
-          # sends `check-command-docs.sh` to `docs-guards.yml` a second time.
-          # A deleted card is a red test, and a test that never ran is green.
+          # The prose paths that are not prose-only, because a Rust test reads
+          # the file and a test that never ran is green:
+          #
+          #  - a command reference page is asserted about by `stella-cli`'s own
+          #    tests — the subcommand index, the per-command summaries, and
+          #    since #3041 every flag's card — so editing one without running
+          #    them is exactly the hole that sends `check-command-docs.sh` to
+          #    `docs-guards.yml` a second time. A deleted card is a red test.
+          #  - `provider-catalog.ts` is the docs' copy of the provider registry,
+          #    pinned against `PROVIDERS` by `docs_sync.rs`. #4588 moved those
+          #    records into it from `provider-cards.tsx` in a website-only diff,
+          #    which skipped the Rust gate here and merged green; `main` was
+          #    then red on that test until the next commit that touched a crate
+          #    made anyone look.
           if git diff --name-only "$BASE_SHA"...HEAD \
             | grep -Evq '^(website/|docs/|\.github/ISSUE_TEMPLATE/)|^[^/]+\.md$'; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           elif git diff --name-only "$BASE_SHA"...HEAD \
-            | grep -q '^website/content/docs/commands/'; then
+            | grep -Eq '^website/content/docs/commands/|^website/src/components/provider-catalog\.ts$'; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           else
             echo "rust=false" >> "$GITHUB_OUTPUT"

--- a/crates/stella-cli/src/config/tests/docs_sync.rs
+++ b/crates/stella-cli/src/config/tests/docs_sync.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// The docs' provider cards must not drift from [`PROVIDERS`].
 ///
-/// `website/src/components/provider-cards.tsx` holds one typed record per
+/// `website/src/components/provider-catalog.ts` holds one typed record per
 /// provider, rendered as the card grid on both the API Providers index and the
 /// getting-started walkthrough. Before it existed the same facts were typed
 /// into a markdown table on each page, and they had already drifted: Bedrock's
@@ -21,13 +21,13 @@ use super::*;
 /// docs to speak the enum's language rather than the reader's.
 #[test]
 fn provider_cards_match_the_registry() {
-    let Some(source) = read_provider_cards() else {
+    let Some(source) = read_provider_catalog() else {
         return;
     };
-    let cards = parse_provider_cards(&source);
+    let cards = parse_provider_catalog(&source);
     assert!(
         cards.len() >= PROVIDERS.len(),
-        "parsed only {} cards from provider-cards.tsx — the parser has \
+        "parsed only {} cards from provider-catalog.ts — the parser has \
          probably gone stale against the file's shape",
         cards.len()
     );
@@ -38,7 +38,7 @@ fn provider_cards_match_the_registry() {
             .find(|c| c.id == provider.id)
             .unwrap_or_else(|| {
                 panic!(
-                    "provider `{}` has no card in provider-cards.tsx — every \
+                    "provider `{}` has no card in provider-catalog.ts — every \
                      supported provider must appear in the docs grid",
                     provider.id
                 )
@@ -116,14 +116,14 @@ fn provider_cards_match_the_registry() {
     for card in &cards {
         assert!(
             PROVIDERS.iter().any(|p| p.id == card.id) || card.id == LOCAL_PROVIDER.id,
-            "provider-cards.tsx documents `{}`, which is not a provider \
+            "provider-catalog.ts documents `{}`, which is not a provider \
              Stella supports",
             card.id
         );
     }
 }
 
-/// A card's pinned fields, as written in the TSX record.
+/// A card's pinned fields, as written in the catalog record.
 struct ProviderCard {
     id: String,
     href: String,
@@ -134,9 +134,16 @@ struct ProviderCard {
 /// The docs tree, or `None` when it isn't checked out — same posture as
 /// `stella-tools/tests/docs_in_sync.rs`: a repo-hygiene gate, not a runtime
 /// invariant. Note the granularity — a missing *tree* skips, but a missing
-/// file inside a present tree panics, so renaming the component cannot
-/// silently disable this test.
-fn read_provider_cards() -> Option<String> {
+/// file inside a present tree panics, so renaming the module cannot silently
+/// disable this test.
+///
+/// The records used to live in `provider-cards.tsx` beside the rendering.
+/// #4588 split them into this plain `.ts` module so the markdown export path
+/// (`src/lib/page-markdown.ts`, exercised by `node --test`, which strips types
+/// but cannot parse JSX) could read them too. The card component now only
+/// imports the catalog, so this test kept parsing a file with no records left
+/// in it and turned `main` red on a zero-card count.
+fn read_provider_catalog() -> Option<String> {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()?
         .parent()?;
@@ -144,7 +151,7 @@ fn read_provider_cards() -> Option<String> {
     if !website.is_dir() {
         return None;
     }
-    let path = website.join("src/components/provider-cards.tsx");
+    let path = website.join("src/components/provider-catalog.ts");
     Some(
         std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("{} is missing or unreadable: {e}", path.display())),
@@ -153,10 +160,16 @@ fn read_provider_cards() -> Option<String> {
 
 /// Every `{ id: "…", …, env: "…", defaultModel: "…" }` record inside the
 /// `PROVIDER_CATALOG` array.
-fn parse_provider_cards(source: &str) -> Vec<ProviderCard> {
+///
+/// Anchored on the `export const` declaration rather than on the bare name,
+/// because the bare name also matches an `import { PROVIDER_CATALOG }` line —
+/// which is exactly what the card component became when #4588 moved the
+/// records out. Matching the import left the parser scanning a file with no
+/// records and reporting zero rather than failing on the file it was handed.
+fn parse_provider_catalog(source: &str) -> Vec<ProviderCard> {
     let start = source
-        .find("PROVIDER_CATALOG")
-        .expect("provider-cards.tsx no longer declares PROVIDER_CATALOG");
+        .find("export const PROVIDER_CATALOG")
+        .expect("provider-catalog.ts no longer declares `export const PROVIDER_CATALOG`");
     let body = &source[start..];
 
     let mut out = vec![];
@@ -168,14 +181,13 @@ fn parse_provider_cards(source: &str) -> Vec<ProviderCard> {
         let end = rest[1..].find("id: \"").map_or(rest.len(), |next| next + 1);
         let record = &rest[..end];
 
-        let Some(id) = tsx_field(record, "id") else {
+        let Some(id) = ts_field(record, "id") else {
             continue;
         };
         out.push(ProviderCard {
-            href: tsx_field(record, "href")
-                .unwrap_or_else(|| panic!("the `{id}` card has no href")),
-            env: tsx_field(record, "env").unwrap_or_else(|| panic!("the `{id}` card has no env")),
-            default_model: tsx_field(record, "defaultModel")
+            href: ts_field(record, "href").unwrap_or_else(|| panic!("the `{id}` card has no href")),
+            env: ts_field(record, "env").unwrap_or_else(|| panic!("the `{id}` card has no env")),
+            default_model: ts_field(record, "defaultModel")
                 .unwrap_or_else(|| panic!("the `{id}` card has no defaultModel")),
             id,
         });
@@ -183,8 +195,8 @@ fn parse_provider_cards(source: &str) -> Vec<ProviderCard> {
     out
 }
 
-/// The value of a `key: "value"` field in a TSX object literal.
-fn tsx_field(record: &str, key: &str) -> Option<String> {
+/// The value of a `key: "value"` field in a TypeScript object literal.
+fn ts_field(record: &str, key: &str) -> Option<String> {
     let needle = format!("{key}: \"");
     let start = record.find(&needle)? + needle.len();
     let rest = &record[start..];


### PR DESCRIPTION
`main` has been red since #4588, on one test, and every PR opened against it inherits that red — including #4593, whose merge commit (`f8cef7aa`) fails on this test alone with 2198 others passing.

## What broke

#4588 moved every provider record out of `website/src/components/provider-cards.tsx` into a new `website/src/components/provider-catalog.ts`, so the markdown export path (`src/lib/page-markdown.ts`, run under `node --test`, which strips types but cannot parse JSX) could read the same facts the card grid renders. The card component kept the rendering and an `import { PROVIDER_CATALOG }`.

`config::tests::docs_sync::provider_cards_match_the_registry` still read the `.tsx`. Its parser anchors on `source.find("PROVIDER_CATALOG")` — and the **import line matches that**. So rather than failing on a file it could no longer understand, it took the import as the array, scanned the rendering for `id: "` records, found none, and tripped its own zero-card guard:

```
parsed only 0 cards from provider-cards.tsx — the parser has probably gone stale against the file's shape
```

The guard worked exactly as designed; it just had nothing to point at.

## The fix

Two changes, both in `crates/stella-cli/src/config/tests/docs_sync.rs`:

- **Repoint the reader** at `src/components/provider-catalog.ts`, and correct every doc comment and panic message that still names the `.tsx`. `tsx_field` becomes `ts_field` — the file is a plain `.ts` module now, and the helper should say what it reads.
- **Anchor the parser on `export const PROVIDER_CATALOG`**, not the bare name. This is the half that stops the recurrence: a bare mention in an `import` can never again stand in for the declaration. Had the parser been anchored this way, #4588 would have failed loudly on `provider-catalog.ts no longer declares ...` instead of silently reporting zero.

No behaviour changes and no registry changes — this is a test reading the wrong file.

## Evidence

The assertions the test makes were never reached after #4588 (it died on the first `assert!`), so I checked the moved data against `PROVIDERS` by hand before trusting the repoint. All nine registry entries match `provider-catalog.ts` verbatim:

| id | `PROVIDERS.env_var` (+ aliases) | catalog `env` | `default_model` = catalog `defaultModel` |
|---|---|---|---|
| anthropic | `ANTHROPIC_API_KEY` | same | `claude-fable-5` |
| openai | `OPENAI_API_KEY` | same | `gpt-5.5` |
| gemini | `GEMINI_API_KEY` + `["GOOGLE_API_KEY"]` | `GEMINI_API_KEY (GOOGLE_API_KEY)` | `gemini-3-pro` |
| vertex | `VERTEX_ACCESS_TOKEN` | same | `gemini-3-pro` |
| bedrock | `AWS_ACCESS_KEY_ID` | same | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` |
| xai | `XAI_API_KEY` | same | `grok-4` |
| deepseek | `DEEPSEEK_API_KEY` | same | `deepseek-chat` |
| zai | `ZAI_API_KEY` | same | `glm-5.2` |
| openrouter | `OPENROUTER_API_KEY` | same | `moonshotai/kimi-k3` |

The gemini row is the one that exercises `split_env` — `"GEMINI_API_KEY (GOOGLE_API_KEY)"` splits to primary `GEMINI_API_KEY` and aliases `["GOOGLE_API_KEY"]`, matching `env_var_aliases`. The catalog's tenth record is `local`, which the test's reverse-direction loop already admits as the one legitimate extra (`LOCAL_PROVIDER.id`), so `10 >= PROVIDERS.len()` holds. Every `href` is `/docs/api-providers#<id>` — inside the docs, anchored, and unique per provider.

**This PR's evidence is its CI run.** I did not run the workspace suite locally (CLAUDE.md, "CI builds and tests; this laptop does not"); the one targeted `cargo test -p stella-cli --bin stella docs_sync` I attempted was killed by the OS before it produced a result, so I am not citing it. The witness is the test itself: it fails on `main` today (see `f8cef7aa`, `397a83ef`, `64b85701`) and must pass here.

## Note for review

No test was deleted or renamed — `provider_cards_match_the_registry` keeps its name. Only the two private helpers were renamed (`read_provider_cards` → `read_provider_catalog`, `parse_provider_cards` → `parse_provider_catalog`, `tsx_field` → `ts_field`).

Refs #4588

---

## Second commit: why #4588 was able to merge green

`ci.yml`'s `changes` job treats every path under `website/` as prose and skips the Rust gate for a diff confined to it. That skip is deliberate and correct in general — and because a *skipped* job still reports its required context (#1892, #1863), such a PR merges green. #4588 was a website-only diff, so the test it broke never ran on it. The push to `main` then matched the trigger's `paths-ignore: website/**` and started no Rust gate either, so the breakage stayed invisible until `7165b960` — the next commit touching a crate — went red and took the three commits after it down with it.

The `changes` job already carried one carve-out for exactly this reason: `website/content/docs/commands/` forces `rust=true` because `stella-cli`'s tests assert about those pages. `provider-catalog.ts` is the second file of that kind, so it joins the same branch, and the comment now states the shared rule — *a Rust test reads this file, and a test that never ran is green* — instead of telling each file's story separately.

Without this, the repoint in the first commit is a one-time repair: the next website-only diff that moves these records can break the test and merge green again.

### Known gap, not addressed here

This closes the **pull-request** side only. The `push:` trigger's `paths-ignore` still contains `website/**`, and GitHub path filters cannot express "ignore `website/**` except one file" — so a website-only commit that reaches `main` by some other route still starts no Rust gate. The PR path is where the merge decision is actually made, which is why it is the half worth fixing first. The trigger-side asymmetry is filed as #4606, with a repro, three candidate approaches and the guard that would stop a third file needing this by hand.
