### PR TITLE
fix(stella-observatory): move the Window control into the pages it filters

### DIFF
--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -446,8 +446,8 @@ nav.bar{position:sticky;top:0;z-index:20;display:flex;align-items:center;
   letter-spacing:.005em;padding:11px 13px;margin-bottom:-1px}
 .tabs button:hover{color:var(--text);background:var(--accent-wash)}
 .tabs button[aria-selected="true"]{color:var(--text);border-bottom-color:var(--accent)}
-.tf-wrap{margin-left:auto;display:flex;align-items:center;gap:var(--sp1);padding:6px 0}
-.tf-wrap[hidden]{display:none}
+.tf-wrap{display:flex;align-items:center;justify-content:flex-end;
+  gap:var(--sp1);padding:0 0 var(--sp2)}
 .tf-label{font:var(--fs-micro)/1 var(--mono);color:var(--text-3)}
 .tf{display:flex;align-items:stretch;border:1px solid var(--control-edge);
     border-radius:var(--radius-sm);overflow:hidden}
@@ -871,18 +871,6 @@ footer b{color:var(--identity);font-weight:600}
       <button role="tab" id="tab-hub" aria-controls="panel-hub" data-tab="hub">Org / hub</button>
       <button role="tab" id="tab-config" aria-controls="panel-config" data-tab="config">Config</button>
     </div>
-    <!-- Shown only on the tabs whose surfaces the window actually filters
-         (TF_TABS in the script below). Everywhere else the control used to
-         sit in the nav and silently do nothing, which reads as broken. -->
-    <div class="tf-wrap" id="tfWrap">
-      <span class="tf-label" id="tfLabel">Window</span>
-      <div class="tf" id="tf" role="radiogroup" aria-labelledby="tfLabel">
-        <button role="radio" data-tf="24h">24h</button>
-        <button role="radio" data-tf="7d">7d</button>
-        <button role="radio" data-tf="30d">30d</button>
-        <button role="radio" data-tf="all" aria-checked="true">All</button>
-      </div>
-    </div>
   </nav>
 
   <main id="main" tabindex="-1">
@@ -1003,6 +991,15 @@ footer b{color:var(--identity);font-weight:600}
 
   <!-- ══ OVERVIEW ══════════════════════════════════════════════════════ -->
   <section data-tab="overview" id="panel-overview" role="tabpanel" aria-labelledby="tab-overview" tabindex="0" class="on">
+    <div class="tf-wrap">
+      <span class="tf-label" id="tfLabel-overview">Window</span>
+      <div class="tf" role="radiogroup" aria-labelledby="tfLabel-overview">
+        <button role="radio" data-tf="24h">24h</button>
+        <button role="radio" data-tf="7d">7d</button>
+        <button role="radio" data-tf="30d">30d</button>
+        <button role="radio" data-tf="all" aria-checked="true">All</button>
+      </div>
+    </div>
     <div class="grid kpis" id="kpis"></div>
     <div class="grid cols-2">
       <div class="card">
@@ -1051,6 +1048,15 @@ footer b{color:var(--identity);font-weight:600}
 
   <!-- ══ ACTIVITY ══════════════════════════════════════════════════════ -->
   <section data-tab="activity" id="panel-activity" role="tabpanel" aria-labelledby="tab-activity" tabindex="0">
+    <div class="tf-wrap">
+      <span class="tf-label" id="tfLabel-activity">Window</span>
+      <div class="tf" role="radiogroup" aria-labelledby="tfLabel-activity">
+        <button role="radio" data-tf="24h">24h</button>
+        <button role="radio" data-tf="7d">7d</button>
+        <button role="radio" data-tf="30d">30d</button>
+        <button role="radio" data-tf="all" aria-checked="true">All</button>
+      </div>
+    </div>
     <div id="act-undated"></div>
     <div class="grid cols-2e">
       <div class="card">
@@ -4094,19 +4100,11 @@ const TABS = [...document.querySelectorAll('#tabs button[role="tab"]')];
    must not park focus on a `hidden` button — so the arrow keys walk the
    visible tabs, which is also the set the reader can see. */
 const visibleTabs = () => TABS.filter(b => !b.hidden);
-/* The tabs whose surfaces re-render under the time window (inTf/inTfDay):
-   Overview's KPIs, timeline and executions table, and Activity's daily
-   charts. Every other tab shows all-time or configuration state, so the
-   window control hides there — a visible control that filters nothing on
-   the tab in front of the reader is indistinguishable from a broken one.
-   The selection itself survives in state.tf while hidden. */
-const TF_TABS = new Set(["overview", "activity"]);
 function switchTab(tab, arg = "") {
   // A transcript route with no execution behind it is not a route.
   if (tab === "transcript" && !arg) { location.hash = "sessions"; return; }
   const left = state.tab === "transcript" && tab !== "transcript";
   state.tab = tab;
-  $("tfWrap").hidden = !TF_TABS.has(tab);
   if (tab === "transcript") $("tab-transcript").hidden = false;
   TABS.forEach(b => {
     const on = b.dataset.tab === tab;
@@ -4186,29 +4184,38 @@ addEventListener("hashchange", () => {
 });
 
 /* ── time window: a real radiogroup, arrow-key operable ──────────────── */
-const TFS = [...$("tf").querySelectorAll('button[role="radio"]')];
-function setTf(b) {
-  state.tf = b.dataset.tf;
-  TFS.forEach(x => {
-    const on = x === b;
+/* One control inside each page it filters — Overview (KPIs, timeline,
+   executions, via inTf) and Activity (the daily charts, via inTfDay) —
+   rather than one in the nav, where it stood above ten tabs that ignore it
+   and was reported as broken for exactly that reason. The instances share
+   `state.tf`, so a window chosen on one page is the window on the other. */
+const TF_GROUPS = [...document.querySelectorAll(".tf")];
+const tfRadios = (g) => [...g.querySelectorAll('button[role="radio"]')];
+function setTf(tf) {
+  state.tf = tf;
+  TF_GROUPS.forEach(g => tfRadios(g).forEach(x => {
+    const on = x.dataset.tf === tf;
     x.setAttribute("aria-checked", on ? "true" : "false");
     x.tabIndex = on ? 0 : -1;
-  });
+  }));
   renderKpis(); renderTimeline(); renderExecutions(); renderActivity();
 }
-TFS.forEach(b => { b.tabIndex = b.getAttribute("aria-checked") === "true" ? 0 : -1; });
-$("tf").addEventListener("click", (ev) => {
-  const b = ev.target.closest('button[role="radio"]');
-  if (b) setTf(b);
-});
-$("tf").addEventListener("keydown", (ev) => {
-  const i = TFS.indexOf(document.activeElement);
-  if (i < 0) return;
-  const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 };
-  if (!(ev.key in step)) return;
-  ev.preventDefault();
-  const b = TFS[(i + step[ev.key] + TFS.length) % TFS.length];
-  b.focus(); setTf(b);
+TF_GROUPS.forEach(g => {
+  tfRadios(g).forEach(b => { b.tabIndex = b.dataset.tf === state.tf ? 0 : -1; });
+  g.addEventListener("click", (ev) => {
+    const b = ev.target.closest('button[role="radio"]');
+    if (b) setTf(b.dataset.tf);
+  });
+  g.addEventListener("keydown", (ev) => {
+    const rs = tfRadios(g);
+    const i = rs.indexOf(document.activeElement);
+    if (i < 0) return;
+    const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 };
+    if (!(ev.key in step)) return;
+    ev.preventDefault();
+    const b = rs[(i + step[ev.key] + rs.length) % rs.length];
+    b.focus(); setTf(b.dataset.tf);
+  });
 });
 
 /* ── connection state ────────────────────────────────────────────────── */

--- a/crates/stella-observatory/tests/window_scope.rs
+++ b/crates/stella-observatory/tests/window_scope.rs
@@ -1,67 +1,127 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! **The time-window control appears only where it filters something.**
+//! **The time-window control lives on the pages it filters.**
 //!
-//! The nav's Window radiogroup (`24h` / `7d` / `30d` / `All`) drives
-//! `state.tf`, and `state.tf` is consulted by exactly two tabs' surfaces:
-//! Overview (KPI tiles, the token timeline, the executions table, via
-//! `inTf`) and Activity (the daily charts, via `inTfDay`). Every other tab
-//! renders all-time aggregates or configuration state.
+//! The Window radiogroup (`24h` / `7d` / `30d` / `All`) drives `state.tf`,
+//! and `state.tf` is consulted by two tabs' surfaces: Overview (KPI tiles,
+//! the token timeline, the executions table, via `inTf`) and Activity (the
+//! daily charts, via `inTfDay`). Every other tab renders all-time aggregates
+//! or configuration state.
 //!
 //! The control nevertheless sat in the global nav on all twelve tabs, and on
 //! ten of them clicking it changed nothing — no error, no re-render, no
 //! acknowledgement beyond the highlight moving. That is indistinguishable
 //! from a broken control, and it was reported as one ("the window time
-//! filter is not working"). The fix scopes the control's visibility to the
-//! tabs it governs: `switchTab` hides `#tfWrap` unless the destination tab
-//! is in `TF_TABS`.
+//! filter is not working"). Hiding the nav control on the other ten tabs
+//! left a control that appears and disappears as the reader moves around
+//! the nav; putting one inside each page it filters leaves nothing to hide.
 //!
 //! Like the sibling asset tests, this reads the served page as text — the
-//! Rust side never executes the script — and pins the three pieces the fix
-//! is made of, each of which is absent on the code that shipped the defect:
+//! Rust side never executes the script — and pins what the fix is made of,
+//! each part of which is absent on the code that shipped the defect:
 //!
-//! 1. the wrapper is addressable (`id="tfWrap"`), so the script can hide it;
-//! 2. hiding works at all: `.tf-wrap` is `display:flex`, which overrides the
-//!    `hidden` attribute's default styling unless a `[hidden]` rule wins —
-//!    delete that rule and the attribute becomes a silent no-op;
-//! 3. `switchTab` toggles the wrapper from a `TF_TABS` set whose members are
-//!    real tabs, and that set names only tabs whose panels the window
-//!    actually re-renders.
+//! 1. the nav carries no window control at all;
+//! 2. exactly the two tabs whose renders consult `state.tf` carry one, each
+//!    a labelled radiogroup offering all four windows;
+//! 3. every instance is driven from the one `state.tf`, so a window chosen
+//!    on Overview is the window Activity renders under.
 
 /// The page exactly as the binary embeds and serves it.
 const INDEX_HTML: &str = include_str!("../src/assets/index.html");
 
+/// The tabs whose surfaces re-render under the window, in document order.
+const FILTERED_TABS: [&str; 2] = ["overview", "activity"];
+
+const PANEL_OPEN: &str = r#"<section data-tab=""#;
+
+/// `(tab, markup)` for every tab panel, each slice running from its opening
+/// tag to the next panel's or to the end of `<main>`.
+fn panels() -> Vec<(&'static str, &'static str)> {
+    let main = INDEX_HTML
+        .split_once("</main>")
+        .expect("the page wraps its tab panels in <main>")
+        .0;
+    let starts: Vec<usize> = main.match_indices(PANEL_OPEN).map(|(i, _)| i).collect();
+    assert!(!starts.is_empty(), "the page declares no tab panels");
+    starts
+        .iter()
+        .enumerate()
+        .map(|(n, &start)| {
+            let end = starts.get(n + 1).copied().unwrap_or(main.len());
+            let body = &main[start..end];
+            let tab = body[PANEL_OPEN.len()..]
+                .split('"')
+                .next()
+                .expect("a panel's data-tab attribute is quoted");
+            (tab, body)
+        })
+        .collect()
+}
+
 #[test]
-fn window_control_is_addressable_and_hideable() {
+fn the_nav_carries_no_window_control() {
+    let nav = INDEX_HTML
+        .split_once(r#"<nav class="bar""#)
+        .expect("the page has a nav bar")
+        .1
+        .split_once("</nav>")
+        .expect("the nav bar closes")
+        .0;
     assert!(
-        INDEX_HTML.contains(r#"<div class="tf-wrap" id="tfWrap">"#),
-        "the Window control's wrapper must carry id=\"tfWrap\" so switchTab can hide it"
-    );
-    assert!(
-        INDEX_HTML.contains(".tf-wrap[hidden]{display:none}"),
-        ".tf-wrap is display:flex, which beats the hidden attribute's UA styling; \
-         without this rule, hiding the control is a silent no-op"
+        !nav.contains("data-tf"),
+        "the Window control must not sit in the nav: there it stands above \
+         ten tabs whose renders ignore state.tf, which reads as broken"
     );
 }
 
 #[test]
-fn switch_tab_scopes_the_window_to_the_tabs_it_filters() {
-    assert!(
-        INDEX_HTML.contains(r#"const TF_TABS = new Set(["overview", "activity"]);"#),
-        "TF_TABS must name exactly the tabs whose surfaces consult state.tf \
-         (inTf / inTfDay); widening it without wiring the window into the new \
-         tab's renders recreates the do-nothing control this test exists for"
+fn only_the_tabs_the_window_filters_carry_it() {
+    let carrying: Vec<&str> = panels()
+        .into_iter()
+        .filter(|(_, body)| body.contains("data-tf"))
+        .map(|(tab, _)| tab)
+        .collect();
+    assert_eq!(
+        carrying, FILTERED_TABS,
+        "a Window control belongs on exactly the tabs whose surfaces consult \
+         state.tf (inTf / inTfDay); one anywhere else filters nothing, and a \
+         missing one on these two leaves their aggregates unnarrowable"
     );
-    assert!(
-        INDEX_HTML.contains(r#"$("tfWrap").hidden = !TF_TABS.has(tab);"#),
-        "switchTab must hide the Window control on tabs it does not govern"
-    );
-    // Both governed tabs are real: each has a section panel to filter.
-    for tab in ["overview", "activity"] {
+}
+
+#[test]
+fn each_control_is_a_labelled_radiogroup_over_all_four_windows() {
+    for (tab, body) in panels() {
+        if !FILTERED_TABS.contains(&tab) {
+            continue;
+        }
         assert!(
-            INDEX_HTML.contains(&format!(r#"<section data-tab="{tab}""#)),
-            "TF_TABS names {tab:?}, but no <section data-tab={tab:?}> exists"
+            body.contains(&format!(r#"aria-labelledby="tfLabel-{tab}""#)),
+            "the {tab} Window radiogroup must name its own label: the ids are \
+             per-page now, and two elements sharing one id point a reader's \
+             group label at whichever came first"
         );
+        for window in ["24h", "7d", "30d", "all"] {
+            assert!(
+                body.contains(&format!(r#"data-tf="{window}""#)),
+                "the {tab} Window control is missing the {window} option"
+            );
+        }
     }
+}
+
+#[test]
+fn one_selection_drives_every_instance() {
+    assert!(
+        INDEX_HTML.contains(r#"const TF_GROUPS = [...document.querySelectorAll(".tf")];"#),
+        "the script must bind every .tf radiogroup on the page, not one by id; \
+         a second instance nothing binds is a control that does nothing"
+    );
+    assert!(
+        INDEX_HTML.contains("state.tf = tf;"),
+        "setTf must take the window itself rather than the button clicked — \
+         that is what lets it repaint the checked state of the other page's \
+         instance from the same value"
+    );
 }

--- a/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
+++ b/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
@@ -290,6 +290,16 @@ impl crate::Store {
     /// bounded (1..=256) — an unbounded page would let one
     /// call materialize an entire backlog. A legacy row with no nonce has one
     /// minted and persisted as it is read, so callers never see an empty one.
+    ///
+    /// Decision (#4484): an enrolled org's billing export never receives a
+    /// flagged floor row for an execution whose usage never completed, even
+    /// though #4479 lets that floor stand in the *local* rollup and
+    /// `stella usage report`. SOC 2's processing-integrity criterion holds a
+    /// billing trail to complete and accurate inputs, and an admittedly
+    /// incomplete envelope fails that test regardless of the flag riding
+    /// along with it. This gate — and the one it enforces via
+    /// `usage_complete = 1` — stays as-is; do not widen it to admit flagged
+    /// floors without a fresh egress-policy decision (architecture rule 3).
     pub fn pending_enterprise_export_page(
         &self,
         sink_fingerprint: &str,

--- a/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
+++ b/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
@@ -290,16 +290,6 @@ impl crate::Store {
     /// bounded (1..=256) — an unbounded page would let one
     /// call materialize an entire backlog. A legacy row with no nonce has one
     /// minted and persisted as it is read, so callers never see an empty one.
-    ///
-    /// Decision (#4484): an enrolled org's billing export never receives a
-    /// flagged floor row for an execution whose usage never completed, even
-    /// though #4479 lets that floor stand in the *local* rollup and
-    /// `stella usage report`. SOC 2's processing-integrity criterion holds a
-    /// billing trail to complete and accurate inputs, and an admittedly
-    /// incomplete envelope fails that test regardless of the flag riding
-    /// along with it. This gate — and the one it enforces via
-    /// `usage_complete = 1` — stays as-is; do not widen it to admit flagged
-    /// floors without a fresh egress-policy decision (architecture rule 3).
     pub fn pending_enterprise_export_page(
         &self,
         sink_fingerprint: &str,


### PR DESCRIPTION
## What & why

The Observatory's Window radiogroup (24h / 7d / 30d / All) drives `state.tf`.
Two tabs' surfaces consult it: Overview (KPI tiles, the token timeline, the
executions table, via `inTf`) and Activity (the daily charts, via `inTfDay`).
Every other tab renders all-time aggregates or configuration state.

It nevertheless sat in the global nav on all twelve tabs, and on ten of them
clicking it changed nothing — reported as "the window time filter is not
working". #4589 hid it on those ten, which fixed the do-nothing control but
left one that appears and vanishes as the reader moves around the nav, and
left #4590 asking whether the remaining tabs should gain a window or be
documented as all-time history.

This takes the third option the issue's author asked for: the control moves
**inside** Overview and Activity. Nothing to hide, nothing to document, and
no global affordance implying tabs it cannot filter.

Both instances read and write the one `state.tf`, so a window chosen on
Overview is the window Activity renders under. `setTf` now takes the window
value rather than the button that was clicked — that is what lets it repaint
the sibling group's checked state. `TF_TABS` and the `#tfWrap` hide/show in
`switchTab` are gone along with the `.tf-wrap[hidden]` rule that existed only
to make that hiding work.

Closes #4590

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

### Tests removed, and why

`crates/stella-observatory/tests/window_scope.rs` is rewritten rather than
extended, so two tests from #4589 are **deliberately deleted**:

- `window_control_is_addressable_and_hideable`
- `switch_tab_scopes_the_window_to_the_tabs_it_filters`

Both pinned machinery this PR removes — the `#tfWrap` id, the
`.tf-wrap[hidden]{display:none}` rule, the `TF_TABS` set, and the
`$("tfWrap").hidden = !TF_TABS.has(tab)` line in `switchTab`. With the control
living inside the panels there is no wrapper to hide, so keeping them would
mean pinning code whose only purpose was the arrangement being replaced. The
four tests below assert the same property — the control appears only where it
filters something — against the new arrangement.

### Tests added

1. `the_nav_carries_no_window_control` — the nav slice contains no `data-tf`.
2. `only_the_tabs_the_window_filters_carry_it` — slicing `<main>` into its tab
   panels, exactly `["overview", "activity"]` carry a `data-tf` control.
3. `each_control_is_a_labelled_radiogroup_over_all_four_windows` — each names
   its own `tfLabel-<tab>` (the ids are per-page now, so a shared one would
   point both groups' labels at whichever came first) and offers all four
   windows.
4. `one_selection_drives_every_instance` — the script binds every `.tf` group
   rather than one by id, and `setTf` takes the window value.

Checked against the old asset the artisanal way — `git checkout HEAD~1 --
crates/stella-observatory/src/assets/index.html`, then re-running the test:

```
test result: FAILED. 0 passed; 4 failed
  only_the_tabs_the_window_filters_carry_it: left: [] right: ["overview", "activity"]
```

All four fail on the pre-change page; all four pass on this one.

## Driven in a real browser

The asset tests read the page as text and cannot see a render, so the built
binary was driven over CDP: `stella observe` serving this branch's page
against a real `store.db` (315 executions), headless Chrome, clicking the
controls in the panels themselves.

```
== 1. where the control lives ==
  PASS  nav carries no window control  [0 found]
  PASS  only Overview and Activity carry one  [['overview', 'activity']]

== 2. the window actually filters Overview ==
         all: execRows=315   kpis='Runs 315 234 resolved Resolve rate 74%'
         30d: execRows=315   kpis='Runs 315 234 resolved Resolve rate 74%'
          7d: execRows=186   kpis='Runs 186 154 resolved Resolve rate 83%'
         24h: execRows=82    kpis='Runs 82 66 resolved Resolve rate 80%'
  PASS  narrowing the window narrows the executions table  [all=315 > 24h=82]
  PASS  row counts are monotonic in the window width

== 3. one selection, both pages ==
  PASS  choosing 7d on Overview checks 7d on Activity
  PASS  choosing 24h on Activity checks 24h on Overview

== 4. no control where it would filter nothing ==
  PASS  no window control visible on sessions / hub / graph / config / self-driving
```

Row counts change with the window, so the relocation did not cost the control
its wiring, and the two instances stay in step in both directions.

## The gate

- [ ] `cargo fmt --check` — CI (this laptop does not build the workspace; CLAUDE.md)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI
- [x] `cargo test -p stella-observatory --test window_scope` — 4 passed, and 4
      failed on the reverted asset (above). The workspace run is CI's.
- [x] Docs: none owed. The change removes a documented behaviour rather than
      adding one, and the issue's author asked for no documentation.
- [x] `Closes #4590` appears both here and as a commit trailer.

**CI note.** The `fmt + clippy + test` job is red on
`config::tests::docs_sync::provider_cards_match_the_registry`, which parses
`website/src/components/provider-cards.tsx` and reads zero cards. That is
`main`'s existing breakage from #4588 (a website-only PR), tracked in #4632 /
#4606 with a fix already in flight; this branch touches no file under
`website/`. It will clear once that lands and this branch is updated.

## Nothing left behind

- [x] There is nothing new: everything I noticed in this area is fixed here,
      and the one unrelated red (`provider_cards_match_the_registry`) was
      already filed as #4632 / #4606 before I hit it.

The question #4590 actually asked — whether Sessions / Self-Driving / Models /
Tools / Files / Hub should gain a window — is answered by removing the premise
rather than deferred: with the control living on the pages that filter by it,
a page without one is not advertising a filter it does not have. If a window
is later wanted on one of those tabs, it is that tab's own change (a
client-side `inTf` filter for Sessions and Self-Driving, windowed SQL for the
rest), and `only_the_tabs_the_window_filters_carry_it` will require the new
control to be wired before it can be added.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**Two commits, net diff is two files.** The first commit was made in a worktree
a parallel session was also using, and `git add -A` swept in that session's
ten-line doc-comment edit to
`crates/stella-store/src/enterprise_telemetry/export_ledger.rs` (#4484 work,
not mine). The second commit reverts exactly that hunk, so
`git diff origin/main...HEAD` is the two observatory files and nothing else.

**Placement.** Each control sits at the top of its panel, right-aligned
(`.tf-wrap` is now `justify-content:flex-end` rather than the nav's
`margin-left:auto`, which does nothing for a block-level flex child).

## Summary by Sourcery

Place the Observatory window filter on the Overview and Activity pages so it is available only where it filters data.

Bug Fixes:
- Move the Observatory window filter out of the global navigation and into the Overview and Activity pages where it affects displayed data.

Enhancements:
- Keep the Overview and Activity window controls synchronized through the shared selection while preserving accessible radiogroup behavior.

Tests:
- Replace navigation visibility tests with coverage verifying control placement, per-page labelling and options, and synchronized control wiring.