### PR TITLE
feat(stella-cli,stella-tui): section the system prompt by provenance in both inspectors

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -50,7 +50,7 @@ pub(crate) mod outcome;
 mod output;
 pub(crate) mod persistence;
 mod presence;
-mod prompt;
+pub(crate) mod prompt;
 mod reflect;
 pub(crate) mod resume;
 pub(crate) mod seats;

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -331,11 +331,18 @@ pub(crate) fn clamp_hook_context(context: &str) -> String {
 /// bounds the cost of that mistake; it cannot remove it.
 pub(crate) async fn with_session_hook_context(mut system_prompt: String, cfg: &Config) -> String {
     if let Some(context) = session_start_hook_context(cfg).await {
-        system_prompt.push_str("\n\nSession context (from SessionStart hooks):\n");
+        system_prompt.push_str(SESSION_HOOK_CONTEXT_HEADER);
         system_prompt.push_str(&clamp_hook_context(&context));
     }
     system_prompt
 }
+
+/// The hook-context section's opening bytes, named for the reason
+/// [`crate::agent::prompt::SESSION_ENVIRONMENT_HEADER`] is: it is the last
+/// marker `crate::agent::prompt::provenance` splits a reconstructed prompt on,
+/// and a reworded heading here would relabel a span in every inspector.
+pub(crate) const SESSION_HOOK_CONTEXT_HEADER: &str =
+    "\n\nSession context (from SessionStart hooks):\n";
 
 // Pipeline port adapters
 

--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -414,6 +414,27 @@ Rules:
 /// the prompt cache on every call, so they must stay dense.
 const MEMORY_PROMPT_BUDGET_CHARS: usize = 16_000;
 
+/// The session-environment block's opening bytes.
+///
+/// Named, rather than written inline at the one `push_str` that emits it,
+/// because [`provenance`] labels the reconstructed prompt by finding these
+/// exact bytes: a heading reworded here would silently relabel a span in
+/// `stella inspect --system-prompt` and the deck's INSPECT overlay. Sharing
+/// the constant is what makes that impossible.
+pub(crate) const SESSION_ENVIRONMENT_HEADER: &str = "\n\n## Session environment\n";
+
+/// The workspace-memories block's opening bytes — a [`provenance`] marker on
+/// the same terms as [`SESSION_ENVIRONMENT_HEADER`].
+pub(crate) const MEMORIES_HEADER: &str =
+    "\n\nWorkspace memories (lessons from previous sessions — apply them):\n";
+
+/// The fail-closed memories notice's opening bytes — a [`provenance`] marker
+/// on the same terms as [`SESSION_ENVIRONMENT_HEADER`]. Distinct from
+/// [`MEMORIES_HEADER`] because the two mean opposite things: one says the
+/// memories are here, the other says they were withheld.
+pub(crate) const MEMORIES_OMITTED_PREFIX: &str =
+    "\n\nWorkspace memories were omitted from this prompt: ";
+
 // The A/B recall measurement rate lived here as a `pub(crate)` constant every
 // driver had to pass by hand, and exactly one of them did. It is now
 // `context.retrieval.ab_recall_rate` (`crate::settings`), read once at session
@@ -549,7 +570,7 @@ fn append_session_environment(
         " — not a git repository"
     };
     prompt.push_str(&format!(
-        "\n\n## Session environment\nWorkspace root: {}{repo_note}\nPlatform: {} {}",
+        "{SESSION_ENVIRONMENT_HEADER}Workspace root: {}{repo_note}\nPlatform: {} {}",
         workspace_root.display(),
         std::env::consts::OS,
         std::env::consts::ARCH,
@@ -657,9 +678,8 @@ fn append_workspace_memories(prompt: &mut String, workspace_root: &std::path::Pa
         Ok(suppression) => suppression,
         Err(error) => {
             prompt.push_str(&format!(
-                "
-
-Workspace memories were omitted from this prompt: {error}. They are still on disk in .stella/memories/ and will return once the suppression state is readable."
+                "{MEMORIES_OMITTED_PREFIX}{error}. They are still on disk in .stella/memories/ \
+                 and will return once the suppression state is readable."
             ));
             return;
         }
@@ -704,12 +724,7 @@ Workspace memories were omitted from this prompt: {error}. They are still on dis
     if memories.is_empty() {
         return;
     }
-    prompt.push_str(&format!(
-        "
-
-Workspace memories (lessons from previous sessions — apply them):
-{memories}"
-    ));
+    prompt.push_str(&format!("{MEMORIES_HEADER}{memories}"));
     if dropped > 0 {
         prompt.push_str(&format!(
             "
@@ -791,6 +806,11 @@ pub(crate) fn expected_isolated_pipeline_prompt(workspace_root: &std::path::Path
     append_session_environment(&mut expected, workspace_root, None);
     expected
 }
+
+/// The read side of the assembly above: which setting produced each span of an
+/// already-assembled prompt. A submodule of this one so its marker table can
+/// name the constants the appenders push, instead of copying their bytes.
+pub(crate) mod provenance;
 
 /// The structural half of the shared-contract discipline: the tests above are
 /// written one per contract, so they cover the contracts that exist and say

--- a/crates/stella-cli/src/agent/prompt/provenance.rs
+++ b/crates/stella-cli/src/agent/prompt/provenance.rs
@@ -1,0 +1,260 @@
+//! Which setting put each span in the system prompt.
+//!
+//! A reconstructed call carries the exact `system_prefix` bytes it was sent
+//! ([`stella_store::Reconstruction`]), and a reader who opens them wants one
+//! thing the bytes do not say: *which knob produced this paragraph?* This
+//! module answers it by splitting those bytes on the assembler's own section
+//! openers and labelling each span with the configuration surface behind it.
+//!
+//! # The markers are the emitting constants, not copies
+//!
+//! Every prefix in `MARKERS` is the same `&'static str` the emitting site
+//! pushes — [`super::SESSION_ENVIRONMENT_HEADER`], [`super::MEMORIES_HEADER`],
+//! [`super::MEMORIES_OMITTED_PREFIX`],
+//! [`crate::agent::engine::SESSION_HOOK_CONTEXT_HEADER`] — so a reworded
+//! heading moves both sides at once and cannot silently relabel a span. The
+//! rules heading is the one that cannot be shared outright:
+//! [`stella_core::records::CACHED_HEADING`] opens with a single newline and
+//! [`super::assemble_system_prompt`] pushes the second, so the marker is that
+//! constant with a newline in front of it. `RULES_HEADER` spells the joined
+//! bytes out, and `the_rules_marker_is_the_heading_the_record_channel_renders`
+//! below pins it against the real constant.
+//!
+//! `the_provenance_markers_are_what_this_assembler_emits` in `super::tests`
+//! holds the other direction: a really-assembled prompt carries these bytes,
+//! so a reworded heading fails even if this table were changed to match it.
+//! That test is also what a second splitter would be pinned against — the
+//! Observatory renders the same view on its own page and links no crate that
+//! defines these constants, so its table can only ever be an acknowledged
+//! copy (#4602).
+//!
+//! # A view over exact bytes, not a parse
+//!
+//! Splitting is by earliest next marker, so a memory file that quotes a
+//! heading can shift a boundary. What can never be wrong is the whole:
+//! concatenating the section bodies in order reproduces the input
+//! byte-for-byte (`sections_concatenate_to_the_input` below is the property),
+//! so a reader who distrusts a boundary still has every byte the call was sent
+//! in front of them, in order.
+
+use crate::agent::engine::SESSION_HOOK_CONTEXT_HEADER;
+
+use super::{MEMORIES_HEADER, MEMORIES_OMITTED_PREFIX, SESSION_ENVIRONMENT_HEADER};
+
+/// The workspace-rules heading as it lands in the prompt: the record
+/// channel's own [`stella_core::records::CACHED_HEADING`] with the newline
+/// [`super::assemble_system_prompt`] pushes before it. Written out because
+/// `const` concatenation of a non-literal is not a thing Rust does; pinned by
+/// a test rather than by a comment asking the next reader to check.
+const RULES_HEADER: &str = "\n\n## Workspace rules (cite the ^handle of any you apply)";
+
+/// One provenance marker: the bytes that open a section, the label a reader
+/// sees, and the setting surface that produces it.
+struct Marker {
+    prefix: &'static str,
+    label: &'static str,
+    source: &'static str,
+}
+
+/// The section openers an assembled prompt can carry, in the order
+/// [`super::assemble_system_prompt`] appends them. Everything before the first
+/// hit is the base instruction set.
+const MARKERS: &[Marker] = &[
+    Marker {
+        prefix: SESSION_ENVIRONMENT_HEADER,
+        label: "Session environment",
+        source: "computed from the live process and workspace at session open — not configurable",
+    },
+    Marker {
+        prefix: MEMORIES_HEADER,
+        label: "Workspace memories",
+        source: ".stella/memories/*.md (loaded when authority permits project prompts)",
+    },
+    Marker {
+        prefix: MEMORIES_OMITTED_PREFIX,
+        label: "Workspace memories (omitted)",
+        source: ".stella/memories/*.md — withheld because the suppression state was unreadable",
+    },
+    Marker {
+        prefix: RULES_HEADER,
+        label: "Workspace rules",
+        source: ".stella/rules/*.toml context records (edit via `stella context`)",
+    },
+    Marker {
+        prefix: SESSION_HOOK_CONTEXT_HEADER,
+        label: "SessionStart hook context",
+        source: "hooks.SessionStart (settings.json / stella.toml [hooks])",
+    },
+];
+
+/// The label on the span before the first marker.
+const BASE_LABEL: &str = "Base instructions";
+
+/// Where that span comes from — named so a reader who wants it different
+/// knows which field to set.
+const BASE_SOURCE: &str =
+    "the built-in persona, replaced whole by agents.default.prompt (model settings)";
+
+/// One labelled span of a system prompt: where it came from, and its exact
+/// bytes.
+pub(crate) struct Section<'a> {
+    /// What this span is, in a reader's words.
+    pub(crate) label: &'static str,
+    /// The configuration surface that produced it.
+    pub(crate) source: &'static str,
+    /// The span itself, including the marker bytes that opened it.
+    pub(crate) body: &'a str,
+}
+
+/// Split one call's exact `system_prefix` bytes into provenance-labelled
+/// sections.
+///
+/// A marker's own bytes belong to the section it opens, and the leading span
+/// is the base instruction set. The sections concatenate back to `prompt`
+/// byte-for-byte — including for the empty prompt, which is one empty base
+/// section rather than none, so a caller never has to distinguish "no
+/// sections" from "nothing to show".
+pub(crate) fn sections(prompt: &str) -> Vec<Section<'_>> {
+    let mut sections = Vec::new();
+    // The open section's provenance, where its body starts, and where the
+    // search for the next marker resumes — past the open marker's own bytes,
+    // so a marker can never re-find itself.
+    let mut open = (BASE_LABEL, BASE_SOURCE);
+    let mut start = 0usize;
+    let mut search_from = 0usize;
+    loop {
+        let next = MARKERS
+            .iter()
+            .filter_map(|marker| {
+                prompt[search_from..]
+                    .find(marker.prefix)
+                    .map(|at| (search_from + at, marker))
+            })
+            .min_by_key(|(at, _)| *at);
+        match next {
+            Some((at, marker)) => {
+                if at > start {
+                    sections.push(section(open, &prompt[start..at]));
+                }
+                open = (marker.label, marker.source);
+                start = at;
+                search_from = at + marker.prefix.len();
+            }
+            None => {
+                if prompt.len() > start || sections.is_empty() {
+                    sections.push(section(open, &prompt[start..]));
+                }
+                return sections;
+            }
+        }
+    }
+}
+
+/// One section from its provenance pair and its bytes.
+///
+/// `'static` and the body's borrow are two different lifetimes in parameter
+/// position, so there is no single one for an elided `'_` to mean.
+fn section<'a>((label, source): (&'static str, &'static str), body: &'a str) -> Section<'a> {
+    Section {
+        label,
+        source,
+        body,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A prompt shaped the way `assemble_system_prompt` plus the SessionStart
+    /// hook append shape one: base, environment, memories, rules, hook
+    /// context. Built from the marker constants themselves, so it cannot
+    /// describe a prompt the assembler would not emit.
+    fn shaped_prompt() -> String {
+        format!(
+            "You are Stella, a terminal coding agent.\
+             {SESSION_ENVIRONMENT_HEADER}Workspace root: /w — a git repository\
+             {MEMORIES_HEADER}\n### one\nlesson\n\
+             {RULES_HEADER}\n\n### Must\n- rule ^r1\
+             {SESSION_HOOK_CONTEXT_HEADER}hook output"
+        )
+    }
+
+    fn labels(sections: &[Section<'_>]) -> Vec<&'static str> {
+        sections.iter().map(|s| s.label).collect()
+    }
+
+    #[test]
+    fn sections_split_a_real_shaped_prompt() {
+        let prompt = shaped_prompt();
+        let sections = sections(&prompt);
+        assert_eq!(
+            labels(&sections),
+            [
+                BASE_LABEL,
+                "Session environment",
+                "Workspace memories",
+                "Workspace rules",
+                "SessionStart hook context",
+            ]
+        );
+        assert_eq!(
+            sections[0].body, "You are Stella, a terminal coding agent.",
+            "the base span is everything before the first marker"
+        );
+        assert!(sections[1].body.contains("Workspace root: /w"));
+        assert!(sections[4].body.ends_with("hook output"));
+        // A section that cannot name the setting behind it teaches nothing,
+        // which is the whole reason this view exists over the raw bytes.
+        for section in &sections {
+            assert!(
+                !section.source.is_empty(),
+                "{} names no setting surface",
+                section.label
+            );
+        }
+    }
+
+    /// The property the module docs promise: whatever a boundary heuristic
+    /// does, the whole is exact.
+    #[test]
+    fn sections_concatenate_to_the_input() {
+        for prompt in [
+            shaped_prompt(),
+            "a bare custom prompt with no markers at all".to_string(),
+            // A memory whose body quotes a later heading: the boundary is
+            // allowed to shift, the concatenation is not.
+            format!(
+                "base{SESSION_ENVIRONMENT_HEADER}x{MEMORIES_HEADER}\n### sneaky\nquotes {RULES_HEADER} in prose"
+            ),
+            // The fail-closed branch, which replaces the memories section
+            // rather than joining it.
+            format!("base{SESSION_ENVIRONMENT_HEADER}x{MEMORIES_OMITTED_PREFIX}permission denied."),
+            String::new(),
+        ] {
+            let rebuilt: String = sections(&prompt).iter().map(|s| s.body).collect();
+            assert_eq!(rebuilt, prompt, "sections must concatenate to the input");
+        }
+    }
+
+    /// A markerless prompt — a custom base with nothing appended — is one base
+    /// section, never zero and never an error.
+    #[test]
+    fn a_markerless_prompt_is_one_base_section() {
+        assert_eq!(labels(&sections("just a custom persona")), [BASE_LABEL]);
+        assert_eq!(labels(&sections("")), [BASE_LABEL]);
+    }
+
+    /// `RULES_HEADER` is the only marker that spells its bytes out instead
+    /// of naming the constant that emits them, because the assembler pushes a
+    /// newline before the record channel's heading. This is what keeps the
+    /// spelled-out copy equal to the real thing.
+    #[test]
+    fn the_rules_marker_is_the_heading_the_record_channel_renders() {
+        assert_eq!(
+            RULES_HEADER,
+            format!("\n{}", stella_core::records::CACHED_HEADING),
+            "the assembler pushes '\\n' then the rendered channel, which opens with CACHED_HEADING"
+        );
+    }
+}

--- a/crates/stella-cli/src/agent/prompt/tests.rs
+++ b/crates/stella-cli/src/agent/prompt/tests.rs
@@ -641,3 +641,60 @@ fn forgetting_one_authored_memory_does_not_suppress_a_similar_one() {
         "the forgotten one does not: {prompt}"
     );
 }
+
+/// The provenance markers are the bytes a really-assembled prompt carries, in
+/// the order the splitter expects — asserted from the *producing* side, so a
+/// reworded heading fails here even if the marker table were changed to match
+/// it (#4602).
+///
+/// Both inspectors share the marker table — `stella inspect --system-prompt`
+/// and the deck's INSPECT overlay — and the Observatory keeps an acknowledged
+/// copy of it that this test is the producing half of.
+#[test]
+fn the_provenance_markers_are_what_this_assembler_emits() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    // Memories are what an authority-permitting session appends, and the rules
+    // channel renders its heading only for a non-empty record set, so the
+    // marker coverage here is deliberately split: the two headings that ship
+    // unconditionally are asserted on a real assembly, and the other three are
+    // asserted to be exactly the constants the emitting sites push.
+    let assembled = super::assemble_system_prompt(
+        super::SYSTEM_PROMPT,
+        root,
+        &crate::settings::AuthorityPolicy::default(),
+        &crate::rules::ResolvedRules::default(),
+        None,
+    );
+    assert!(
+        assembled.contains(super::SESSION_ENVIRONMENT_HEADER),
+        "the environment marker must be the bytes the assembler pushes: {assembled}"
+    );
+    assert!(
+        assembled.starts_with(super::SYSTEM_PROMPT),
+        "everything before the first marker is the base instruction set, which is \
+         what lets the splitter label the leading span without a marker of its own"
+    );
+
+    // The rules heading arrives through the record channel, which owns it —
+    // the splitter's copy is joined from that constant plus the newline
+    // `assemble_system_prompt` pushes before the rendered channel.
+    assert!(
+        stella_core::records::CACHED_HEADING.starts_with("\n## Workspace rules"),
+        "the rules marker is derived from this constant"
+    );
+
+    // A workspace with a memory in it appends the memories marker, so the
+    // section the splitter labels `.stella/memories/*.md` is one a real
+    // assembly produces rather than one only the table believes in.
+    let memories = root.join(".stella/memories");
+    std::fs::create_dir_all(&memories).expect("memories dir");
+    std::fs::write(memories.join("one.md"), "A_REAL_LESSON").expect("memory file");
+    let mut appended = String::new();
+    append_workspace_memories(&mut appended, root);
+    assert!(
+        appended.starts_with(super::MEMORIES_HEADER),
+        "the memories marker must be the bytes the appender pushes: {appended}"
+    );
+    assert!(appended.contains("A_REAL_LESSON"), "{appended}");
+}

--- a/crates/stella-cli/src/cli/command.rs
+++ b/crates/stella-cli/src/cli/command.rs
@@ -596,6 +596,14 @@ pub(crate) enum Command {
         /// that would otherwise bury the prompt's own delta
         #[arg(long, value_enum, default_value = "all")]
         only: inspect::RoleFilter,
+
+        /// Show only this call's system prompt, split into provenance-labelled
+        /// sections: which setting put each span there — the built-in persona,
+        /// the session environment, workspace memories, workspace rules, the
+        /// SessionStart hook context. The sections concatenate back to the
+        /// exact bytes the model was sent
+        #[arg(long = "system-prompt")]
+        system_prompt: bool,
     },
 
     /// Pass calibration: false-positive rate vs CI and reverts

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -94,6 +94,7 @@ mod authoring;
 mod dropped_turn;
 pub(crate) mod forwarder;
 mod init_cmd;
+mod inspect_service;
 mod lead_control;
 mod model_cmd;
 mod pr_observe;
@@ -1371,7 +1372,12 @@ pub async fn run_deck_session(
                                 },
                                 &in_tx,
                             )
-                            && !service_inspect_action(&other, &store, last_execution_id, &in_tx)
+                            && !inspect_service::service_inspect_action(
+                                &other,
+                                &store,
+                                last_execution_id,
+                                &in_tx,
+                            )
                             && !handle_agents_input(&other, cfg, &in_tx)
                             && !issues::handle_issues_input(&other, cfg, &in_tx)
                             && !handle_engine_config_input(&other, cfg, &mut settings_stale, &in_tx)
@@ -1975,7 +1981,7 @@ pub async fn run_deck_session(
                             input @ (WorkspaceInput::InspectRefresh
                             | WorkspaceInput::InspectCall { .. }),
                         ) => {
-                            service_inspect_action(&input, &store, last_execution_id, &in_tx);
+                            inspect_service::service_inspect_action(&input, &store, last_execution_id, &in_tx);
                         }
                         // Navigation waits for the road to clear: switching
                         // sessions mid-turn would tear down live work, so the
@@ -2521,112 +2527,6 @@ fn service_registry_action(
         _ => return false,
     }
     true
-}
-
-/// The INSPECT overlay's driver half: answer the recorded-call index and the
-/// reconstruction of one call. Returns `false` for anything else so the caller
-/// can keep trying the other service handlers.
-///
-/// Both arms are blocking SQLite reads — `reconstruct_call` replays the block
-/// registry and the event journal — so they run on `spawn_blocking` and answer
-/// out of band, the same shape as [`WorkspaceInput::FocusGraphFile`]. Stalling
-/// the event pump to rebuild a prompt would stutter a live turn.
-fn service_inspect_action(
-    input: &WorkspaceInput,
-    store: &Option<Arc<Store>>,
-    execution_id: Option<i64>,
-    in_tx: &mpsc::UnboundedSender<Inbound>,
-) -> bool {
-    if !matches!(
-        input,
-        WorkspaceInput::InspectRefresh | WorkspaceInput::InspectCall { .. }
-    ) {
-        return false;
-    }
-    // No store (claim mode, or it failed to open) or no turn yet: answer with
-    // an empty index rather than silence, so the overlay renders its "nothing
-    // recorded yet" line instead of looking hung.
-    let (Some(store), Some(execution_id)) = (store.clone(), execution_id) else {
-        let _ = in_tx.send(Inbound::RecordedCalls(Vec::new()));
-        return true;
-    };
-    let in_tx = in_tx.clone();
-    match input {
-        WorkspaceInput::InspectRefresh => {
-            tokio::task::spawn_blocking(move || {
-                let calls = store.recorded_calls(execution_id).unwrap_or_default();
-                let _ = in_tx.send(Inbound::RecordedCalls(
-                    calls.iter().map(recorded_call_info).collect(),
-                ));
-            });
-        }
-        WorkspaceInput::InspectCall {
-            turn_instance,
-            step,
-            call_seq,
-        } => {
-            let (turn_instance, step, call_seq) = (*turn_instance, *step, *call_seq);
-            tokio::task::spawn_blocking(move || {
-                let Ok(recon) = store.reconstruct_call(execution_id, turn_instance, step, call_seq)
-                else {
-                    let _ = in_tx.send(Inbound::RecordedCalls(Vec::new()));
-                    return;
-                };
-                // Re-read the header so the detail can name the model/role that
-                // served this call; the reconstruction itself carries only the
-                // messages.
-                let call = store
-                    .recorded_calls(execution_id)
-                    .unwrap_or_default()
-                    .iter()
-                    .find(|c| {
-                        (c.turn_instance, c.step, c.call_seq) == (turn_instance, step, call_seq)
-                    })
-                    .map(recorded_call_info)
-                    .unwrap_or_else(|| stella_tui::RecordedCallInfo {
-                        turn_instance,
-                        step,
-                        call_seq,
-                        call_role: "unknown".into(),
-                        provider: "unknown".into(),
-                        model: "unknown".into(),
-                        estimated_input_tokens: 0,
-                    });
-                let _ = in_tx.send(Inbound::InspectedCall(Box::new(stella_tui::InspectView {
-                    call,
-                    messages: recon
-                        .messages
-                        .iter()
-                        // The CLI's `stella inspect` renderer, reused verbatim:
-                        // the overlay shows wire shape, and the two surfaces
-                        // must not disagree about what a message looked like.
-                        .map(|m| stella_tui::InspectMessage {
-                            role: crate::inspect::role_tag(m.role).to_string(),
-                            content: crate::inspect::message_body(m),
-                        })
-                        .collect(),
-                    verified: recon.is_verified(),
-                    unresolved: recon.unresolved.len(),
-                    digest_mismatches: recon.digest_mismatches.len(),
-                    journal_era: crate::inspect::deck_journal_era(recon.journal_era),
-                })));
-            });
-        }
-        _ => unreachable!("guarded by the matches! above"),
-    }
-    true
-}
-
-fn recorded_call_info(call: &stella_store::RecordedCall) -> stella_tui::RecordedCallInfo {
-    stella_tui::RecordedCallInfo {
-        turn_instance: call.turn_instance,
-        step: call.step,
-        call_seq: call.call_seq,
-        call_role: call.call_role.clone(),
-        provider: call.provider.clone(),
-        model: call.model.clone(),
-        estimated_input_tokens: call.estimated_input_tokens,
-    }
 }
 
 /// The inbox snapshot for the deck (badge + overlay), newest first.

--- a/crates/stella-cli/src/command_deck/inspect_service.rs
+++ b/crates/stella-cli/src/command_deck/inspect_service.rs
@@ -1,0 +1,219 @@
+//! The INSPECT overlay's driver half (`⌃g`, `/inspect`): answer the deck's
+//! recorded-call index, and the reconstruction of the one call it selects.
+//!
+//! Split out of `command_deck.rs`, which is a grandfathered god file closed to
+//! growth (AGENTS.md § "God files — plan around them, never into them"), when
+//! the reconstruction gained the provenance breakdown below.
+//!
+//! # Why the split of the system prompt happens here
+//!
+//! `stella-tui` links no store crate and knows no prompt headings — every type
+//! on its envelope is a shape this driver maps into. The provenance markers
+//! are the prompt assembler's own section-opener constants
+//! ([`crate::agent::prompt::provenance`]), and the assembler lives in this
+//! binary, so this is the only place that can both read a reconstruction and
+//! name the setting behind each span of it. The overlay renders labels it is
+//! handed and derives nothing.
+//!
+//! This is the same bargain the message bodies already take: they are rendered
+//! by `crate::inspect`'s own functions so the overlay and `stella inspect`
+//! cannot disagree about what a call looked like. The sections are that rule
+//! applied to the prompt's provenance — `stella inspect --system-prompt` and
+//! this overlay split the same bytes with the same table.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use stella_store::Store;
+use stella_tui::{Inbound, WorkspaceInput};
+
+/// The INSPECT overlay's driver half: answer the recorded-call index and the
+/// reconstruction of one call. Returns `false` for anything else so the caller
+/// can keep trying the other service handlers.
+///
+/// Both arms are blocking SQLite reads — `reconstruct_call` replays the block
+/// registry and the event journal — so they run on `spawn_blocking` and answer
+/// out of band, the same shape as [`WorkspaceInput::FocusGraphFile`]. Stalling
+/// the event pump to rebuild a prompt would stutter a live turn.
+pub(super) fn service_inspect_action(
+    input: &WorkspaceInput,
+    store: &Option<Arc<Store>>,
+    execution_id: Option<i64>,
+    in_tx: &mpsc::UnboundedSender<Inbound>,
+) -> bool {
+    if !matches!(
+        input,
+        WorkspaceInput::InspectRefresh | WorkspaceInput::InspectCall { .. }
+    ) {
+        return false;
+    }
+    // No store (claim mode, or it failed to open) or no turn yet: answer with
+    // an empty index rather than silence, so the overlay renders its "nothing
+    // recorded yet" line instead of looking hung.
+    let (Some(store), Some(execution_id)) = (store.clone(), execution_id) else {
+        let _ = in_tx.send(Inbound::RecordedCalls(Vec::new()));
+        return true;
+    };
+    let in_tx = in_tx.clone();
+    match input {
+        WorkspaceInput::InspectRefresh => {
+            tokio::task::spawn_blocking(move || {
+                let calls = store.recorded_calls(execution_id).unwrap_or_default();
+                let _ = in_tx.send(Inbound::RecordedCalls(
+                    calls.iter().map(recorded_call_info).collect(),
+                ));
+            });
+        }
+        WorkspaceInput::InspectCall {
+            turn_instance,
+            step,
+            call_seq,
+        } => {
+            let (turn_instance, step, call_seq) = (*turn_instance, *step, *call_seq);
+            tokio::task::spawn_blocking(move || {
+                let Ok(recon) = store.reconstruct_call(execution_id, turn_instance, step, call_seq)
+                else {
+                    let _ = in_tx.send(Inbound::RecordedCalls(Vec::new()));
+                    return;
+                };
+                // Re-read the header so the detail can name the model/role that
+                // served this call; the reconstruction itself carries only the
+                // messages.
+                let call = store
+                    .recorded_calls(execution_id)
+                    .unwrap_or_default()
+                    .iter()
+                    .find(|c| {
+                        (c.turn_instance, c.step, c.call_seq) == (turn_instance, step, call_seq)
+                    })
+                    .map(recorded_call_info)
+                    .unwrap_or_else(|| stella_tui::RecordedCallInfo {
+                        turn_instance,
+                        step,
+                        call_seq,
+                        call_role: "unknown".into(),
+                        provider: "unknown".into(),
+                        model: "unknown".into(),
+                        estimated_input_tokens: 0,
+                    });
+                let _ = in_tx.send(Inbound::InspectedCall(Box::new(stella_tui::InspectView {
+                    call,
+                    messages: recon.messages.iter().map(inspect_message).collect(),
+                    verified: recon.is_verified(),
+                    unresolved: recon.unresolved.len(),
+                    digest_mismatches: recon.digest_mismatches.len(),
+                    journal_era: crate::inspect::deck_journal_era(recon.journal_era),
+                })));
+            });
+        }
+        _ => unreachable!("guarded by the matches! above"),
+    }
+    true
+}
+
+/// One reconstructed message, flattened for the overlay.
+///
+/// The body comes from `crate::inspect`'s renderer verbatim: the overlay shows
+/// wire shape, and the two surfaces must not disagree about what a message
+/// looked like. The system message additionally carries its provenance
+/// breakdown — see the module docs for why the split belongs here.
+fn inspect_message(message: &stella_protocol::CompletionMessage) -> stella_tui::InspectMessage {
+    stella_tui::InspectMessage {
+        role: crate::inspect::role_tag(message.role).to_string(),
+        content: crate::inspect::message_body(message),
+        sections: system_sections(message),
+    }
+}
+
+/// The provenance breakdown of a system message, or an empty list for every
+/// other role.
+///
+/// Empty is also the answer for a system message that resolved to no bytes:
+/// the overlay's fallback then renders `content`, which is what the receipt
+/// actually holds. A single section wrapping an empty body would claim
+/// the model was sent an empty base persona, which the receipt does not say.
+fn system_sections(
+    message: &stella_protocol::CompletionMessage,
+) -> Vec<stella_tui::InspectSection> {
+    if message.role != stella_protocol::MessageRole::System || message.content.is_empty() {
+        return Vec::new();
+    }
+    crate::agent::prompt::provenance::sections(&message.content)
+        .into_iter()
+        .map(|section| stella_tui::InspectSection {
+            label: section.label.to_string(),
+            source: section.source.to_string(),
+            body: section.body.to_string(),
+        })
+        .collect()
+}
+
+fn recorded_call_info(call: &stella_store::RecordedCall) -> stella_tui::RecordedCallInfo {
+    stella_tui::RecordedCallInfo {
+        turn_instance: call.turn_instance,
+        step: call.step,
+        call_seq: call.call_seq,
+        call_role: call.call_role.clone(),
+        provider: call.provider.clone(),
+        model: call.model.clone(),
+        estimated_input_tokens: call.estimated_input_tokens,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::prompt::{MEMORIES_HEADER, SESSION_ENVIRONMENT_HEADER};
+    use stella_protocol::CompletionMessage;
+
+    /// The overlay must be handed the same split `stella inspect
+    /// --system-prompt` prints, and only for the system message — a user
+    /// message that happens to quote a heading is not a prompt with
+    /// provenance.
+    #[test]
+    fn only_the_system_message_carries_a_provenance_breakdown() {
+        let system = inspect_message(&CompletionMessage::system(format!(
+            "You are Stella.{SESSION_ENVIRONMENT_HEADER}Workspace root: /w"
+        )));
+        assert_eq!(
+            system
+                .sections
+                .iter()
+                .map(|s| s.label.as_str())
+                .collect::<Vec<_>>(),
+            ["Base instructions", "Session environment"]
+        );
+        let user = inspect_message(&CompletionMessage::user(format!(
+            "quoting {SESSION_ENVIRONMENT_HEADER} in a goal"
+        )));
+        assert!(
+            user.sections.is_empty(),
+            "provenance is a property of the assembled prompt, not of any text quoting it"
+        );
+    }
+
+    /// The property the CLI renderer promises, asserted on the shape the deck
+    /// actually receives: nothing is hidden by rendering sections instead of
+    /// the flat body.
+    #[test]
+    fn the_sections_handed_to_the_deck_concatenate_to_the_message() {
+        let content =
+            format!("base{SESSION_ENVIRONMENT_HEADER}env{MEMORIES_HEADER}\n### m\nlesson");
+        let mapped = inspect_message(&CompletionMessage::system(content.clone()));
+        let rebuilt: String = mapped.sections.iter().map(|s| s.body.as_str()).collect();
+        assert_eq!(rebuilt, content);
+    }
+
+    /// A system message the receipt could not resolve gets no breakdown, so
+    /// the overlay falls back to the body rather than drawing one empty
+    /// section labelled as a base persona.
+    #[test]
+    fn an_empty_system_message_gets_no_sections() {
+        assert!(
+            inspect_message(&CompletionMessage::system(""))
+                .sections
+                .is_empty()
+        );
+    }
+}

--- a/crates/stella-cli/src/inspect.rs
+++ b/crates/stella-cli/src/inspect.rs
@@ -155,6 +155,7 @@ pub(crate) struct InspectArgs {
     pub(crate) diff: Option<DiffBase>,
     pub(crate) context: usize,
     pub(crate) only: RoleFilter,
+    pub(crate) system_prompt: bool,
 }
 
 /// `stella inspect [id] [--turn T] [--step N] [--call-seq S] [--diff [BASE]]`.
@@ -166,7 +167,25 @@ pub(crate) fn run_inspect(args: &InspectArgs) -> Result<(), String> {
             "--diff compares one call against an earlier one, so it needs to know which: \
              add --step <STEP> (`stella inspect {id}` lists them)"
         )),
+        // Same shape as `--diff` above, and the same remedy: both name one
+        // call, so neither can answer without being told which.
+        (Some(id), None) if args.system_prompt => Err(format!(
+            "--system-prompt sections the prompt one call was sent, so it needs to know which: \
+             add --step <STEP> (`stella inspect {id}` lists them)"
+        )),
         (Some(id), None) => list_calls(&store, id, args.format),
+        // Two views of one call, and each renders the whole output: silently
+        // letting one win would answer a question the caller did not ask.
+        // `--diff --only system` is the intersection they are reaching for.
+        (Some(_), Some(_)) if args.system_prompt && args.diff.is_some() => Err(
+            "--system-prompt and --diff are two different views of one call: --system-prompt \
+             sections what was sent, --diff shows what moved. For the prompt's delta alone, \
+             use --diff --only system"
+                .to_string(),
+        ),
+        (Some(id), Some(step)) if args.system_prompt => {
+            show_system_prompt(&store, id, args.turn, step, args.call_seq, args)
+        }
         (Some(id), Some(step)) => match args.diff {
             Some(base) => show_diff(&store, id, step, base, args),
             None => show_call(
@@ -509,6 +528,115 @@ fn print_reconstruction(
         "\nstella inspect {execution_id} --step {step} --diff \
          to see only what changed since the previous call of this role."
     );
+}
+
+/// The system prefix one call was sent, split into provenance-labelled
+/// sections — `stella inspect <id> --step N --system-prompt`.
+///
+/// The whole context answers "what did the model see"; this answers the
+/// question a reader actually arrives with when the answer is hundreds of
+/// stable lines: *which setting put this paragraph here?* The split itself is
+/// [`crate::agent::prompt::provenance`], which reads the assembler's own
+/// section-opener constants rather than a copy of their bytes.
+fn show_system_prompt(
+    store: &Store,
+    execution_id: i64,
+    turn: u32,
+    step: u64,
+    call_seq: u64,
+    args: &InspectArgs,
+) -> Result<(), String> {
+    let recon = store
+        .reconstruct_call(execution_id, turn, step, call_seq)
+        .map_err(|e| format!("cannot reconstruct: {e}"))?;
+    // A system message that resolved to no bytes is the same answer as no
+    // system message at all, and both must say so out loud: printing an empty
+    // prompt would read as "the model was sent nothing", which is a claim the
+    // receipt does not make.
+    let prefix = recon
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::System)
+        .map(|m| m.content.as_str())
+        .filter(|content| !content.is_empty());
+    let Some(prefix) = prefix else {
+        return no_system_prefix(execution_id, turn, step, call_seq, args.format);
+    };
+    let sections = crate::agent::prompt::provenance::sections(prefix);
+    match args.format {
+        QueryFormat::Json => print_json(&Versioned::new(SystemPromptJson {
+            found: true,
+            bytes: prefix.len(),
+            sections: sections
+                .iter()
+                .map(|s| SectionJson {
+                    label: s.label,
+                    source: s.source,
+                    body: s.body.to_string(),
+                })
+                .collect(),
+        })),
+        QueryFormat::Text => {
+            println!("execution {execution_id} · turn {turn} · step {step} · call-seq {call_seq}");
+            println!(
+                "system prompt · {} section(s) · {} bytes{}",
+                sections.len(),
+                prefix.len(),
+                if args.full { ", full bodies" } else { "" }
+            );
+            for section in &sections {
+                println!("\n─── {} ───", section.label.bold());
+                println!("{}", format!("from: {}", section.source).dimmed());
+                let body = section.body;
+                if args.full || body.len() <= DEFAULT_BODY_LIMIT {
+                    println!("{body}");
+                } else {
+                    let cut = floor_char_boundary(body, DEFAULT_BODY_LIMIT);
+                    println!(
+                        "{}\n… {} more bytes (--full to print, --format json for the exact bytes)",
+                        &body[..cut],
+                        body.len() - cut
+                    );
+                }
+            }
+            // The boundaries are found by scanning for the assembler's
+            // headings, so a memory that quotes one can move a boundary. The
+            // whole is exact either way, and saying so is what lets a reader
+            // trust the view without having to trust the heuristic.
+            println!(
+                "\nthe sections above concatenate to the exact bytes this call was sent; \
+                 section boundaries are found by the assembler's own headings."
+            );
+            Ok(())
+        }
+    }
+}
+
+/// What every surface says when the addressed call resolved no `system_prefix`
+/// bytes. Never an empty prompt: "nothing was recorded" and "the model was
+/// sent nothing" are different claims, and only the first one is true.
+fn no_system_prefix(
+    execution_id: i64,
+    turn: u32,
+    step: u64,
+    call_seq: u64,
+    format: QueryFormat,
+) -> Result<(), String> {
+    match format {
+        QueryFormat::Json => print_json(&Versioned::new(SystemPromptJson {
+            found: false,
+            bytes: 0,
+            sections: Vec::new(),
+        })),
+        QueryFormat::Text => {
+            println!("execution {execution_id} · turn {turn} · step {step} · call-seq {call_seq}");
+            println!(
+                "no system_prefix block resolved for this call — `stella inspect \
+                 {execution_id} --step {step}` shows what the receipt does hold"
+            );
+            Ok(())
+        }
+    }
 }
 
 /// The digest-mismatch line, or `None` when nothing mismatched.
@@ -879,7 +1007,8 @@ fn diff_json(
 /// tool calls/results it carried (they are separate blocks in the receipt but
 /// belong to one message on the wire).
 ///
-/// Shared with the deck's INSPECT overlay (`command_deck::service_inspect_action`):
+/// Shared with the deck's INSPECT overlay
+/// (`command_deck::inspect_service::service_inspect_action`):
 /// the CLI and the deck must never disagree about what a message looked like,
 /// so there is one renderer, not a copy per surface.
 pub(crate) fn message_body(message: &CompletionMessage) -> String {
@@ -957,6 +1086,28 @@ struct CallJson {
 struct MessageJson {
     role: &'static str,
     content: String,
+}
+
+/// One provenance-labelled span of a system prompt.
+#[derive(Serialize)]
+struct SectionJson {
+    /// What this span is — `Base instructions`, `Workspace rules`, …
+    label: &'static str,
+    /// The configuration surface that produced it.
+    source: &'static str,
+    /// The exact bytes, marker heading included. Never elided in JSON: the
+    /// concatenation property is the reason a script would read this at all.
+    body: String,
+}
+
+#[derive(Serialize)]
+struct SystemPromptJson {
+    /// Whether the addressed call resolved any `system_prefix` bytes. A script
+    /// must be able to tell "nothing recorded" from "an empty prompt" without
+    /// inferring it from an empty array.
+    found: bool,
+    bytes: usize,
+    sections: Vec<SectionJson>,
 }
 
 #[derive(Serialize)]

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -740,6 +740,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             diff,
             context,
             only,
+            system_prompt,
         }) => {
             // Reads the local receipt tables only — no provider, no API key.
             return inspect::run_inspect(&inspect::InspectArgs {
@@ -752,6 +753,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 diff: *diff,
                 context: *context,
                 only: *only,
+                system_prompt: *system_prompt,
             })
             .map_err(failure::CliFailure::from);
         }

--- a/crates/stella-cli/tests/inspect_cli.rs
+++ b/crates/stella-cli/tests/inspect_cli.rs
@@ -529,3 +529,206 @@ fn inspect_names_a_missing_receipt_instead_of_printing_an_empty_transcript() {
         "says what was missing: {stderr}"
     );
 }
+
+/// A prompt shaped the way `assemble_system_prompt` shapes one: the base
+/// persona, the session-environment block, workspace memories, workspace
+/// rules, and the SessionStart hook context.
+///
+/// The headings here are a copy of the bytes the assembler emits, and
+/// deliberately so: `stella-cli` ships no library, so an integration test
+/// cannot reach the constants. The copy is safe because it is not the source
+/// of truth for anything — `agent/prompt/provenance.rs`'s own tests pin the
+/// marker table against the emitting constants, and the concatenation
+/// assertion below holds whatever the split does. What this fixture has to be
+/// is a *realistic* prompt, which it is.
+const SYSTEM_SECTIONED: &str = "You are Stella.\
+\n\n## Session environment\nWorkspace root: /w — a git repository\
+\n\nWorkspace memories (lessons from previous sessions — apply them):\n\n### one\nlesson\n\
+\n\n## Workspace rules (cite the ^handle of any you apply)\n\n### Must\n- rule ^r1\
+\n\nSession context (from SessionStart hooks):\nhook output";
+
+/// One execution with two worker calls: step 0 was sent a sectioned system
+/// prompt, and step 1 was sent no `system_prefix` block at all — the receipt
+/// shape that must say so rather than print an empty prompt.
+fn seeded_provenance_workspace() -> (tempfile::TempDir, i64) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(dir.path()).expect("store");
+    let id = store
+        .begin_execution("run", "explain the prompt", "anthropic", "opus")
+        .expect("execution");
+
+    store
+        .record_context_block(id, &block("blk_prov", "system_prefix", SYSTEM_SECTIONED))
+        .expect("sectioned system block");
+    store
+        .record_context_block(id, &block("blk_goal", "user_goal", "explain the prompt"))
+        .expect("goal block");
+
+    for (step, blocks) in [
+        (0, vec![entry("blk_prov", 0), entry("blk_goal", 1)]),
+        // No system block: the goal is the whole call.
+        (1, vec![entry("blk_goal", 0)]),
+    ] {
+        store
+            .record_step_manifest(
+                id,
+                &StepManifestRow {
+                    turn_instance: 0,
+                    step,
+                    call_seq: 0,
+                    provider: "anthropic".into(),
+                    model: "opus".into(),
+                    call_role: "worker".into(),
+                    effective_budget_tokens: 136_363,
+                    calibration_factor: 1.1,
+                    estimated_input_tokens: 20,
+                    stall_seconds_requested: None,
+                    compiled_frame_id: None,
+                    frame_hash: None,
+                    blocks,
+                },
+            )
+            .expect("manifest");
+    }
+    (dir, id)
+}
+
+/// The feature #4602 asks for: the terminal reader gets the same sectioned
+/// provenance view the Observatory has — every span headed by what it is and
+/// by the setting surface that produced it.
+#[test]
+fn system_prompt_sections_name_the_setting_behind_each_span() {
+    let (dir, id) = seeded_provenance_workspace();
+    let out = inspect(
+        &dir,
+        &[&id.to_string(), "--step", "0", "--system-prompt", "--full"],
+    );
+
+    for label in [
+        "Base instructions",
+        "Session environment",
+        "Workspace memories",
+        "Workspace rules",
+        "SessionStart hook context",
+    ] {
+        assert!(
+            out.contains(label),
+            "section {label} is missing from: {out}"
+        );
+    }
+    // A label alone would only rename the bytes. The setting surface is what
+    // turns "this paragraph exists" into "this is the knob that put it here".
+    for source in [
+        ".stella/memories/*.md",
+        ".stella/rules/*.toml",
+        "hooks.SessionStart",
+    ] {
+        assert!(out.contains(source), "no attribution for {source}: {out}");
+    }
+    assert!(
+        out.contains("Workspace root: /w"),
+        "sections carry their bodies, not just their headings: {out}"
+    );
+}
+
+/// The property the whole view rests on: however the boundaries fall, the
+/// sections are the exact bytes the call was sent, in order. A reader who
+/// distrusts a boundary has lost nothing by reading the sections.
+#[test]
+fn the_sections_concatenate_to_the_bytes_the_call_was_sent() {
+    let (dir, id) = seeded_provenance_workspace();
+    let out = inspect(
+        &dir,
+        &[
+            &id.to_string(),
+            "--step",
+            "0",
+            "--system-prompt",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+    assert_eq!(parsed["found"], true, "{out}");
+    let sections = parsed["sections"].as_array().expect("sections array");
+    assert_eq!(
+        sections
+            .iter()
+            .map(|s| s["label"].as_str().expect("label"))
+            .collect::<Vec<_>>(),
+        [
+            "Base instructions",
+            "Session environment",
+            "Workspace memories",
+            "Workspace rules",
+            "SessionStart hook context",
+        ],
+        "{out}"
+    );
+    let rebuilt: String = sections
+        .iter()
+        .map(|s| s["body"].as_str().expect("body"))
+        .collect();
+    assert_eq!(
+        rebuilt, SYSTEM_SECTIONED,
+        "the sections must reproduce the prompt byte-for-byte"
+    );
+    assert_eq!(parsed["bytes"], SYSTEM_SECTIONED.len());
+}
+
+/// A call whose receipt holds no `system_prefix` block says so. Printing an
+/// empty prompt would read as "the model was sent nothing", which is a claim
+/// the receipt does not make.
+#[test]
+fn a_call_with_no_system_prefix_says_so_instead_of_printing_an_empty_prompt() {
+    let (dir, id) = seeded_provenance_workspace();
+    let out = inspect(&dir, &[&id.to_string(), "--step", "1", "--system-prompt"]);
+    assert!(
+        out.contains("no system_prefix block resolved"),
+        "names the gap: {out}"
+    );
+
+    let json = inspect(
+        &dir,
+        &[
+            &id.to_string(),
+            "--step",
+            "1",
+            "--system-prompt",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    assert_eq!(
+        parsed["found"], false,
+        "a script must tell an absent prompt from an empty one: {json}"
+    );
+    assert!(parsed["sections"].as_array().expect("array").is_empty());
+}
+
+/// `--system-prompt` and `--diff` are two whole-output views of one call.
+/// Letting either win silently would answer a question the caller did not ask.
+#[test]
+fn system_prompt_and_diff_together_are_refused_rather_than_one_winning() {
+    let (dir, id) = seeded_provenance_workspace();
+    let output = Command::new(env!("CARGO_BIN_EXE_stella"))
+        .without_embedder_backend()
+        .args([
+            "inspect",
+            &id.to_string(),
+            "--step",
+            "0",
+            "--system-prompt",
+            "--diff",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("run");
+    assert!(!output.status.success(), "the combination is refused");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--diff --only system"),
+        "names the flag that answers the question they were reaching for: {stderr}"
+    );
+}

--- a/crates/stella-core/src/records.rs
+++ b/crates/stella-core/src/records.rs
@@ -61,7 +61,8 @@ pub use decision::{Decision, DecisionEvent, should_repropose};
 pub use handle::assign_handles;
 pub use registry::{Entry, Facts, Registry};
 pub use render::{
-    CACHED_RECORD_BUDGET_CHARS, Channel, RenderInput, RenderedChannel, render_channel,
+    CACHED_HEADING, CACHED_RECORD_BUDGET_CHARS, Channel, RenderInput, RenderedChannel,
+    render_channel,
 };
 pub use select::{TurnFacts, applies_this_turn};
 pub use sweep::{Disposition, ExpiryAction, SweepInput, disposition, honored_probe, probe_is_due};

--- a/crates/stella-core/src/records/render.rs
+++ b/crates/stella-core/src/records/render.rs
@@ -67,7 +67,12 @@ use super::sweep::Disposition;
 /// the heading is amortised across every record in the block, so the instruction
 /// costs a handful of tokens once instead of a clause per bullet — the same argument
 /// that made grouping by force worth doing.
-const CACHED_HEADING: &str = "\n## Workspace rules (cite the ^handle of any you apply)";
+/// Public because it is also a **provenance marker**: `stella inspect
+/// --system-prompt` and the deck's INSPECT overlay label the span of a
+/// reconstructed prompt that this channel produced, and they find it by these
+/// exact bytes. Sharing the constant is what stops the label drifting from the
+/// heading — see `stella-cli`'s `agent/prompt/provenance.rs`.
+pub const CACHED_HEADING: &str = "\n## Workspace rules (cite the ^handle of any you apply)";
 
 /// The default budget for the cached record channel, in characters (#2709).
 ///

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -640,21 +640,35 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
                 Style::default().fg(theme::SUCCESS),
             )));
         }
+        let body_width = (w as usize).saturating_sub(6);
         for (index, message) in view.messages.iter().enumerate() {
             lines.push(Line::default());
             lines.push(Line::from(Span::styled(
                 format!("  ─── [{index}] {} ───", message.role),
                 theme::accent().add_modifier(Modifier::BOLD),
             )));
-            // Wrap by hand: Paragraph's own wrap would fight the scroll offset
-            // (rows would no longer equal lines, so the clamp below would lie).
-            for raw in message.content.lines() {
-                for chunk in wrap_chars(raw, (w as usize).saturating_sub(6)) {
+            // A message the driver could break down by provenance — the system
+            // prefix — renders as its sections instead of one wall, each headed
+            // by the setting that produced it. The bodies concatenate to
+            // `content`, so nothing is hidden by taking this branch; a message
+            // with no breakdown takes the flat path it always did.
+            if message.sections.is_empty() {
+                push_wrapped(&mut lines, &message.content, body_width);
+                continue;
+            }
+            for section in &message.sections {
+                lines.push(Line::from(Span::styled(
+                    format!("    ┌ {}", section.label),
+                    theme::accent(),
+                )));
+                let attribution = format!("from: {}", section.source);
+                for chunk in wrap_chars(&attribution, body_width.saturating_sub(2)) {
                     lines.push(Line::from(Span::styled(
-                        format!("    {chunk}"),
-                        Style::default().fg(theme::INK),
+                        format!("    │ {chunk}"),
+                        theme::muted(),
                     )));
                 }
+                push_wrapped(&mut lines, &section.body, body_width);
             }
         }
         lines.push(Line::default());
@@ -732,6 +746,23 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
         .block(block)
         .scroll((scroll_row, 0))
         .render(popup, buf);
+}
+
+/// Push a multi-line body into the INSPECT overlay's line buffer, hard-wrapped
+/// and indented.
+///
+/// Wrapped by hand rather than by `Paragraph`: the overlay scrolls by row
+/// offset, so its own wrap would make rows stop equalling lines and the scroll
+/// clamp would lie about how far there is left to go.
+fn push_wrapped(lines: &mut Vec<Line<'static>>, body: &str, width: usize) {
+    for raw in body.lines() {
+        for chunk in wrap_chars(raw, width) {
+            lines.push(Line::from(Span::styled(
+                format!("    {chunk}"),
+                Style::default().fg(theme::INK),
+            )));
+        }
+    }
 }
 
 /// Hard-wrap one logical line to `width` characters, char-safe. Returns at

--- a/crates/stella-tui/src/deck_render/tests.rs
+++ b/crates/stella-tui/src/deck_render/tests.rs
@@ -492,6 +492,7 @@ fn inspect_overlay_scroll_saturates_past_u16_instead_of_wrapping() {
         messages: vec![crate::envelope::InspectMessage {
             role: "user".into(),
             content,
+            sections: Vec::new(),
         }],
         verified: false,
         unresolved: 0,
@@ -511,6 +512,104 @@ fn inspect_overlay_scroll_saturates_past_u16_instead_of_wrapping() {
     assert!(
         !text.contains("ctx-004"),
         "66_000 as u16 would have wrapped to ~464:\n{text}"
+    );
+}
+
+/// The deck half of #4602: a system message the driver could break down by
+/// provenance renders as labelled sections, each naming the setting that put
+/// it in the prompt — the same view `stella inspect --system-prompt` prints.
+///
+/// The overlay derives no headings of its own; it renders the labels it is
+/// handed, which is why this test hands it labels rather than a prompt.
+#[test]
+fn inspect_overlay_renders_the_system_prompt_by_provenance() {
+    let mut ui = DeckUi::default();
+    ui.inspect_open = true;
+    ui.inspect_view = Some(Box::new(crate::envelope::InspectView {
+        call: crate::envelope::RecordedCallInfo {
+            turn_instance: 0,
+            step: 0,
+            call_seq: 0,
+            call_role: "worker".into(),
+            provider: "openrouter".into(),
+            model: "m".into(),
+            estimated_input_tokens: 0,
+        },
+        messages: vec![crate::envelope::InspectMessage {
+            role: "system".into(),
+            content: "You are Stella.\nWorkspace root: /w".into(),
+            sections: vec![
+                crate::envelope::InspectSection {
+                    label: "Base instructions".into(),
+                    source: "the built-in persona".into(),
+                    body: "You are Stella.".into(),
+                },
+                crate::envelope::InspectSection {
+                    label: "Workspace rules".into(),
+                    source: ".stella/rules/*.toml context records".into(),
+                    body: "RULE_BODY_MARKER".into(),
+                },
+            ],
+        }],
+        verified: true,
+        unresolved: 0,
+        digest_mismatches: 0,
+        journal_era: crate::envelope::JournalEra::CompactionJournaled,
+    }));
+
+    let area = Rect::new(0, 0, 100, 40);
+    let mut buf = Buffer::empty(area);
+    render_inspect_overlay(&mut ui, area, &mut buf);
+    let text = buffer_text(&buf);
+    assert!(text.contains("Base instructions"), "{text}");
+    assert!(text.contains("Workspace rules"), "{text}");
+    assert!(
+        text.contains(".stella/rules/*.toml"),
+        "each section names the setting behind it, not just what it is:\n{text}"
+    );
+    assert!(
+        text.contains("RULE_BODY_MARKER"),
+        "the bodies still render — sectioning labels the bytes, it does not \
+         replace them:\n{text}"
+    );
+}
+
+/// A message with no provenance breakdown renders exactly as it always did:
+/// one flat body, no section furniture. Every role but the system prefix takes
+/// this path.
+#[test]
+fn inspect_overlay_falls_back_to_the_flat_body_without_sections() {
+    let mut ui = DeckUi::default();
+    ui.inspect_open = true;
+    ui.inspect_view = Some(Box::new(crate::envelope::InspectView {
+        call: crate::envelope::RecordedCallInfo {
+            turn_instance: 0,
+            step: 0,
+            call_seq: 0,
+            call_role: "worker".into(),
+            provider: "openrouter".into(),
+            model: "m".into(),
+            estimated_input_tokens: 0,
+        },
+        messages: vec![crate::envelope::InspectMessage {
+            role: "user".into(),
+            content: "FLAT_BODY_MARKER".into(),
+            sections: Vec::new(),
+        }],
+        verified: true,
+        unresolved: 0,
+        digest_mismatches: 0,
+        journal_era: crate::envelope::JournalEra::CompactionJournaled,
+    }));
+
+    let area = Rect::new(0, 0, 100, 40);
+    let mut buf = Buffer::empty(area);
+    render_inspect_overlay(&mut ui, area, &mut buf);
+    let text = buffer_text(&buf);
+    assert!(text.contains("FLAT_BODY_MARKER"), "{text}");
+    assert!(
+        !text.contains("from:"),
+        "no breakdown means no attribution furniture:\n{text}"
     );
 }
 

--- a/crates/stella-tui/src/deck_ui/tests/help.rs
+++ b/crates/stella-tui/src/deck_ui/tests/help.rs
@@ -144,6 +144,7 @@ fn esc_steps_back_from_the_detail_to_the_list_before_closing() {
             messages: vec![crate::envelope::InspectMessage {
                 role: "system".into(),
                 content: "You are Stella.".into(),
+                sections: Vec::new(),
             }],
             verified: true,
             unresolved: 0,

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -16,7 +16,7 @@ use stella_protocol::AgentEvent;
 
 mod inspect;
 
-pub use inspect::{InspectMessage, InspectView, JournalEra, RecordedCallInfo};
+pub use inspect::{InspectMessage, InspectSection, InspectView, JournalEra, RecordedCallInfo};
 
 use stella_tools::search::readiness::IndexReadiness;
 

--- a/crates/stella-tui/src/envelope/inspect.rs
+++ b/crates/stella-tui/src/envelope/inspect.rs
@@ -32,6 +32,27 @@ impl RecordedCallInfo {
     }
 }
 
+/// One provenance-labelled span of a system prompt: which setting put these
+/// bytes in the prompt this call was sent.
+///
+/// The split is the driver's, not this crate's — the markers are the prompt
+/// assembler's own section-opener constants, which live in `stella-cli` where
+/// the assembler does (`agent/prompt/provenance.rs`). The overlay renders what
+/// it is handed and knows no headings, exactly as it knows no protocol types.
+///
+/// The bodies concatenate, in order, to the exact bytes the call was sent, so
+/// a reader who distrusts a boundary has lost nothing by reading the sections
+/// instead of the raw message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InspectSection {
+    /// What this span is, in a reader's words — `Workspace rules`, …
+    pub label: String,
+    /// The configuration surface that produced it.
+    pub source: String,
+    /// The exact bytes, marker heading included.
+    pub body: String,
+}
+
 /// One message of a reconstructed call, flattened for display: tool calls and
 /// results are already rendered into `content` by the driver, so the overlay
 /// never needs the protocol types.
@@ -39,6 +60,11 @@ impl RecordedCallInfo {
 pub struct InspectMessage {
     pub role: String,
     pub content: String,
+    /// The provenance breakdown of `content`, when the driver could compute
+    /// one — the system prefix, and nothing else. Empty everywhere else, and
+    /// the overlay falls back to `content` when it is: a message with no
+    /// breakdown renders exactly as it always did.
+    pub sections: Vec<InspectSection>,
 }
 
 /// Which compaction-journaling era wrote the journal a reconstruction came

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -116,12 +116,12 @@ pub use deck_ui::{
 };
 pub use envelope::{
     AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, EngineAgentState,
-    EngineConfigState, EngineRole, EntityField, EntityHit, Inbound, InspectMessage, InspectView,
-    InstalledAgentEntry, IssueAction, IssueRow, JournalEra, McpLiveIdentity, McpLookupState,
-    McpSearchItem, McpSearchOutcome, McpServerDetail, McpServerInfo, McpToolRow, NotificationInfo,
-    RecordedCallInfo, SeatRow, Secret, SessionInfo, SessionPhase, SkillOp, SkillRow, SkillScope,
-    SkillSearchHit, SkillsView, SplashCue, ToolDenial, ToolPolicyState, ToolRow, ToolScope,
-    WorkspaceInput,
+    EngineConfigState, EngineRole, EntityField, EntityHit, Inbound, InspectMessage, InspectSection,
+    InspectView, InstalledAgentEntry, IssueAction, IssueRow, JournalEra, McpLiveIdentity,
+    McpLookupState, McpSearchItem, McpSearchOutcome, McpServerDetail, McpServerInfo, McpToolRow,
+    NotificationInfo, RecordedCallInfo, SeatRow, Secret, SessionInfo, SessionPhase, SkillOp,
+    SkillRow, SkillScope, SkillSearchHit, SkillsView, SplashCue, ToolDenial, ToolPolicyState,
+    ToolRow, ToolScope, WorkspaceInput,
 };
 pub use fleet_dashboard::{
     FleetControl, FleetDashResult, FleetMsg, FleetStatus, TaskSummary, run as run_fleet_dashboard,

--- a/crates/stella-tui/tests/deck_snapshot.rs
+++ b/crates/stella-tui/tests/deck_snapshot.rs
@@ -374,10 +374,12 @@ fn inspect_overlay_renders_the_call_list_then_the_context_sent() {
             InspectMessage {
                 role: "system".into(),
                 content: "Condense this span faithfully.".into(),
+                sections: Vec::new(),
             },
             InspectMessage {
                 role: "user".into(),
                 content: "t0 t1 t2".into(),
+                sections: Vec::new(),
             },
         ],
         verified: true,

--- a/website/content/docs/commands/inspect.mdx
+++ b/website/content/docs/commands/inspect.mdx
@@ -7,6 +7,8 @@ Answer "what did the model actually see?" for any past call. `stella inspect` re
 
 Add [`--diff`](#--diff--what-changed-not-what-was-sent) to ask the other question: what did *this* call see that the last one didn't — rendered as a unified diff, including against the prompt you actually typed.
 
+Add [`--system-prompt`](#--system-prompt--which-setting-put-each-span-there) to ask a third: of the hundreds of stable lines in that prompt, which setting put each one there.
+
 ## Synopsis
 
 ```bash
@@ -14,6 +16,7 @@ stella inspect                                   # executions that have receipts
 stella inspect <EXEC>                            # that execution's model calls
 stella inspect <EXEC> --step <N> [--turn <T>] [--call-seq <S>]
 stella inspect <EXEC> --step <N> --diff [prev|first|prompt] [--only system]
+stella inspect <EXEC> --step <N> --system-prompt   # the prompt, by provenance
 ```
 
 ## What it does
@@ -51,6 +54,10 @@ It reads `<workspace>/.stella/private/store.db` only. Like `stella stats`, it re
   </OptionCard>
   <OptionCard name="--context <N>" defaultValue="3">
     Unchanged lines printed around each change.
+  </OptionCard>
+  <OptionCard name="--system-prompt">
+    Show only this call's system prompt, split into provenance-labelled
+    sections — see below.
   </OptionCard>
 </CardGrid>
 
@@ -143,6 +150,69 @@ call, not just the first.
 byte-identical to the previous turn is a direct check that the prompt-cache
 stability invariant is holding.
 </Callout>
+
+## `--system-prompt` — which setting put each span there
+
+A system prompt is assembled, not written. The base persona comes from one
+place, the session-environment block from another, workspace memories from
+`.stella/memories/`, workspace rules from `.stella/rules/`, and a SessionStart
+hook can append to the end of it. By the time a call is made, all of that is one
+undifferentiated wall of text — and "which of my settings produced this
+paragraph?" is not a question you can answer by reading it.
+
+`--system-prompt` splits the exact bytes the call was sent on the assembler's
+own section headings and labels each span with the surface behind it:
+
+```bash
+stella inspect 42 --step 0 --system-prompt --full
+```
+
+```text
+execution 42 · turn 0 · step 0 · call-seq 0
+system prompt · 4 section(s) · 9,214 bytes, full bodies
+
+─── Base instructions ───
+from: the built-in persona, replaced whole by agents.default.prompt (model settings)
+You are Stella, a terminal coding agent.
+…
+
+─── Session environment ───
+from: computed from the live process and workspace at session open — not configurable
+
+## Session environment
+Workspace root: /repo — a git repository
+…
+
+─── Workspace memories ───
+from: .stella/memories/*.md (loaded when authority permits project prompts)
+…
+
+─── Workspace rules ───
+from: .stella/rules/*.toml context records (edit via `stella context`)
+…
+```
+
+The boundaries are found by scanning for the assembler's headings, so a memory
+that quotes one can move a boundary. The whole is exact either way: **the
+sections concatenate, in order, to the bytes the call was sent**, which is what
+lets you trust the view without having to trust the heuristic. `--format json`
+gives the same split with unelided bodies, plus a `found` flag so a script can
+tell an absent prompt from an empty one.
+
+A call whose receipt holds no system prefix says `no system_prefix block
+resolved` rather than printing an empty prompt — "nothing was recorded" and
+"the model was sent nothing" are different claims, and only the first is true.
+
+<Callout type="info">
+The same view is in interactive mode: `⌃g` (or `/inspect`) opens the recorded
+calls, and the system message of the one you select renders as these sections
+rather than one wall. The two surfaces split with the same table, so they
+cannot disagree.
+</Callout>
+
+`--system-prompt` and `--diff` are two whole-output views of one call, so asking
+for both is refused rather than letting one win. For the prompt's *delta* alone,
+`--diff --only system` is the flag pair you want.
 
 ## Why `--call-seq` exists
 


### PR DESCRIPTION
Closes #4602

## The gap

`stella inspect <id> --step N` reconstructs the exact `system_prefix` bytes a
call was sent and prints them as one undifferentiated wall. A system prompt is
*assembled* — base persona, session environment, `.stella/memories/`,
`.stella/rules/`, a SessionStart hook append — and "which of my settings put
this paragraph here?" is not a question you can answer by reading the result.
The deck's INSPECT overlay (`⌃g` / `/inspect`) had the same gap, which is what
the issue comment asks for.

## What this ships

Both inspectors now split those exact bytes on the assembler's own section
openers and head each span with its label and the setting surface that produces
it.

```
─── Workspace rules ───
from: .stella/rules/*.toml context records (edit via `stella context`)
…
```

- **CLI**: `stella inspect <id> --step N --system-prompt` (`--full` and
  `--format json` both honored; JSON carries a `found` flag so a script can tell
  an absent prompt from an empty one).
- **Deck**: the system message of a selected call renders as those sections.
  No new key, no new state — `/inspect` and `⌃g` already open the overlay.

## Design

The issue's constraint was that the Observatory's splitter is an acknowledged
copy, and that the CLI "can share the real thing instead". It does:
`crates/stella-cli/src/agent/prompt/provenance.rs` is a **submodule of the
assembler**, so its marker table names the constants the appenders push rather
than copying their bytes.

Four literals gained names at their emit sites to make that possible —
`SESSION_ENVIRONMENT_HEADER`, `MEMORIES_HEADER`, `MEMORIES_OMITTED_PREFIX`
(`agent/prompt.rs`) and `SESSION_HOOK_CONTEXT_HEADER` (`agent/engine.rs`).
**Every rewrite is byte-identical**, so the cached prefix is untouched (L-E8);
the diff is reviewable as such.

The rules heading is the one marker that cannot be shared outright:
`stella_core::records::CACHED_HEADING` opens with a single newline and
`assemble_system_prompt` pushes the second. It is now `pub`, and the joined
constant is pinned to it by `the_rules_marker_is_the_heading_the_record_channel_renders`
rather than by a comment asking the next reader to check.

`stella-tui` learns no headings. It gains an `InspectSection` on its envelope
and renders labels it is handed — the same bargain the message bodies already
take (rendered by `crate::inspect`'s own functions so the two surfaces cannot
disagree). The driver that maps a `Reconstruction` into that shape moved out of
`command_deck.rs`, a grandfathered god file closed to growth, into
`command_deck/inspect_service.rs` (AGENTS.md § "God files"); that file is 105
lines smaller than before.

Two behaviours worth calling out, both chosen so a surface never overstates what
the receipt says:

- A call that resolved no `system_prefix` prints `no system_prefix block
  resolved`, never an empty prompt. "Nothing was recorded" and "the model was
  sent nothing" are different claims and only the first is true.
- `--system-prompt` with `--diff` is **refused** rather than letting one view
  win silently, and the error names `--diff --only system` as the delta the
  caller was reaching for.

## Witnesses

`crates/stella-cli/tests/inspect_cli.rs` (drives the shipped binary against a
real store):

- `system_prompt_sections_name_the_setting_behind_each_span` — every label and
  every attribution reaches stdout.
- `the_sections_concatenate_to_the_bytes_the_call_was_sent` — the property the
  whole view rests on, asserted over the JSON: joining the bodies reproduces the
  stored prefix byte-for-byte.
- `a_call_with_no_system_prefix_says_so_instead_of_printing_an_empty_prompt` —
  both formats.
- `system_prompt_and_diff_together_are_refused_rather_than_one_winning`.

Plus: the same concatenation property at the splitter
(`sections_concatenate_to_the_input`, including a memory that quotes a later
heading and the empty prompt) and at the driver
(`the_sections_handed_to_the_deck_concatenate_to_the_message`);
`only_the_system_message_carries_a_provenance_breakdown`; two deck render tests
(`inspect_overlay_renders_the_system_prompt_by_provenance` and the no-sections
fallback, so an unsectioned message renders exactly as it always did); and
`the_provenance_markers_are_what_this_assembler_emits`, which holds the table
from the **producing** side on a really-assembled prompt — a reworded heading
fails there even if the table were edited to match it.

None of these pass on `main`.

Every deleted test: none. `deck_snapshot.rs`'s golden frames are unchanged —
its fixtures pass `sections: Vec::new()`, which takes the flat path.

## Relationship to #4601

#4601 is open and introduces the Observatory's `system_prompt.rs` splitter plus
two of the same constants (`MEMORIES_OMITTED_PREFIX`,
`SESSION_HOOK_CONTEXT_HEADER`) at the same emit sites. This branch is cut from
`main` rather than stacked on it, so **expect a small textual conflict in those
two spots** — both sides define the same name with the same value, so resolution
is "keep one". Whichever lands second should also repoint the surviving
Observatory copy's pin at
`the_provenance_markers_are_what_this_assembler_emits`, which is the
producing-side guard #4601's own test was going to be.

That hand-off, and the `BASE_SOURCE` wording minimal-prompt mode will need, are
filed as #4619 so neither depends on this description being re-read.

## Evidence

**CI is green on every check** for head `3ba1292b2`, rebased onto current `main`
— `cargo check --workspace` (MSRV), `cargo fmt --check`,
`cargo clippy -D warnings`, `cargo doc -D warnings`, `cargo test --workspace`,
the release smoke build, and every guard including `prose` and `file-size`.

All fourteen new tests are confirmed run and passing by name in that job's log:
the four `inspect_cli.rs` integration witnesses, the four splitter tests, the
three driver-mapping tests, the two deck-render tests, and the producing-side
marker guard.

Worth stating because an earlier run on this PR was red for two reasons that
were **not** this diff: it briefly carried a concurrent session's commit (see
the force-push note below), and its base predated #4605's repair of
`provider_cards_match_the_registry` — which failed identically on `main` at the
old base commit `64b85701d`. The one genuine failure of my own was two
`rustdoc::broken_intra_doc_links` on unqualified private consts in a module's
`//!` docs; those are now plain code spans, and `cargo doc -D warnings` passes.

## Docs

`website/content/docs/commands/inspect.mdx` gains the flag card, the synopsis
line, and a `--system-prompt` section covering the boundary heuristic, the
concatenation guarantee, and the deck equivalent.
