### PR TITLE
feat(stella-store,stella-cli,stella-observatory,bench): carry ErrorClass into the rollups and the envelope detector

### DIFF
--- a/bench/trace_triage/README.md
+++ b/bench/trace_triage/README.md
@@ -95,7 +95,7 @@ next comparison is against the truth.
 | `agent-timeout` | harbor's own `AgentTimeoutError` classification |
 | `witness-unavailable` | `proof` `step.kind == "witness_unavailable"`, split per reason |
 | `oracle-flip-ungraded` | an oracle flip (baseline fail, candidate pass) on a trial graded 0 |
-| `tool-error-envelope` | an error envelope wrapping substantial output before `[exit code: N]` |
+| `tool-error-envelope` | an error envelope wrapping substantial output before `[exit code: N]`, unless its `class` names a refusal |
 | `repeated-identical-tool-call` | adjacent identical `(tool, args)` with byte-identical output |
 | `role-model-census-mismatch` | `(role, model)` off `step_usage` against the run's declared seat |
 | `no-post-verdict-file-change` | no `verdict` at all, or a verdict with no `file_change` after it |

--- a/bench/trace_triage/detectors.py
+++ b/bench/trace_triage/detectors.py
@@ -60,6 +60,16 @@ from run_trace import Run, Trial
 _SUBSTANTIAL_OUTPUT_CHARS = 200
 _SUBSTANTIAL_OUTPUT_LINES = 3
 
+# The `ErrorClass` tokens (`crates/stella-protocol/src/tool.rs`) that name a
+# refusal rather than a command envelope: the executor declined or could not
+# address the request, so the message wraps a denial, never output the model
+# needed. `environment`, `timeout`, `internal`, and `other` stay eligible —
+# a command that ran can still hand back a page of real output under any of
+# them — and an absent class (old traces, unclassified errors) claims nothing.
+_REFUSAL_ERROR_CLASSES = frozenset(
+    {"invalid_input", "not_found", "permission_denied", "refused_by_policy"}
+)
+
 
 @dataclass(frozen=True)
 class Occurrence:
@@ -495,15 +505,27 @@ def _tool_error_envelope(run: Run) -> list[Finding]:
     at. So the predicate *is* the identity: everything it matches is the same
     defect, and the discriminator is spent on nothing.
 
+    The executor's own `ErrorClass` is the primary discriminator. An error it
+    classified `invalid_input`, `not_found`, `permission_denied`, or
+    `refused_by_policy` wraps a denial, never command output, and is skipped
+    before any string matching — whatever its message happens to contain. An
+    `environment` or `timeout` error, and any unclassified one (old traces and
+    unclassified errors are both classless on the wire), falls through to the
+    heuristics below, so a classless trace behaves exactly as it did before
+    the class existed.
+
     The `[exit code:` trailer is required rather than optional for the same
     reason. A guard refusal (`refused before running: … graded tree …`) is also
     an error envelope, and it is a different defect with its own issue — it
     carries no useful output, only a refusal, so demanding the trailer keeps the
-    two apart without asking the normalizer to tell them apart by prose.
+    two apart on a classless trace without asking the normalizer to tell them
+    apart by prose.
     """
     matches: list[tuple[Trial, Any]] = []
     for trial in run.trials:
         for call in trial.tool_calls:
+            if call.error_class in _REFUSAL_ERROR_CLASSES:
+                continue
             message = call.error_message
             if not message or "[exit code:" not in message:
                 continue
@@ -530,6 +552,7 @@ def _tool_error_envelope(run: Run) -> list[Finding]:
                 location=(
                     f"tool `{call.name}`, call_id `{call.call_id}`, "
                     f"stella-events.jsonl:{call.result_index}"
+                    + (f", error class `{call.error_class}`" if call.error_class else "")
                 ),
                 excerpt=(
                     "call.input:\n"
@@ -565,9 +588,11 @@ def _tool_error_envelope(run: Run) -> list[Finding]:
                 f"{len(seen_trials)} trial(s) — one occurrence shown per trial."
             ),
             caveats=[
-                "Requires the `[exit code: N]` trailer, so a guard refusal is not counted "
-                "here: it is an error envelope too, but it wraps a refusal rather than "
-                "output, and it is a different defect."
+                "An error the executor classified as a refusal (`invalid_input`, "
+                "`not_found`, `permission_denied`, `refused_by_policy`) is never counted "
+                "here: it wraps a denial rather than output, and it is a different "
+                "defect. On a classless trace the `[exit code: N]` trailer requirement "
+                "keeps the same two apart."
             ],
         )
     ]

--- a/bench/trace_triage/run_trace.py
+++ b/bench/trace_triage/run_trace.py
@@ -104,6 +104,21 @@ class ToolCall:
         return message if isinstance(message, str) else ""
 
     @property
+    def error_class(self) -> str | None:
+        """The executor's `ErrorClass` token, or `None` when the wire has none.
+
+        Serialized by `crates/stella-protocol/src/tool.rs` only when the error
+        was classified, so an old trace and an unclassified error look the
+        same here: both `None`. A detector reading this must treat `None` as
+        "no claim", never as a class of its own.
+        """
+        err = self.error
+        if not err:
+            return None
+        cls = err.get("class")
+        return cls if isinstance(cls, str) else None
+
+    @property
     def ok_content(self) -> str:
         if not self.result:
             return ""

--- a/bench/trace_triage/tests/fixtures.py
+++ b/bench/trace_triage/tests/fixtures.py
@@ -39,8 +39,17 @@ def ok(content: str) -> dict[str, Any]:
     return {"ok": {"content": content}}
 
 
-def err(message: str) -> dict[str, Any]:
-    return {"error": {"message": message}}
+def err(message: str, *, cls: str | None = None) -> dict[str, Any]:
+    """An error envelope; `cls` adds the wire's optional `class` token.
+
+    The default omits the key entirely, matching what an old trace or an
+    unclassified error puts on the wire (`skip_serializing_if` in
+    `crates/stella-protocol/src/tool.rs`).
+    """
+    envelope: dict[str, Any] = {"message": message}
+    if cls is not None:
+        envelope["class"] = cls
+    return {"error": envelope}
 
 
 def write_run(

--- a/bench/trace_triage/tests/test_detectors.py
+++ b/bench/trace_triage/tests/test_detectors.py
@@ -219,6 +219,61 @@ def test_error_envelope_around_substantial_output_fires(tmp_path):
     assert CHAIN_OUTPUT in finding.occurrences[0].excerpt
 
 
+def test_an_environment_classed_envelope_still_fires(tmp_path):
+    """A classified `environment` error proceeds to the envelope heuristics."""
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": tool_pair(
+                    "c1",
+                    "bash",
+                    {"command": "ls -la docs/; file docs/*"},
+                    err(
+                        CHAIN_OUTPUT
+                        + "\nbash: line 1: file: command not found\n\n[exit code: 127]",
+                        cls="environment",
+                    ),
+                ),
+            }
+        ],
+    )
+    (finding,) = _findings(tmp_path, "tool-error-envelope")
+    assert CHAIN_OUTPUT in finding.occurrences[0].excerpt
+    assert "error class `environment`" in finding.occurrences[0].location
+
+
+def test_a_refusal_class_beats_an_envelope_shaped_message(tmp_path):
+    """The class is the discriminator, not the prose.
+
+    This payload passes every string heuristic — `[exit code:` trailer,
+    substantial body — and the executor classified it `refused_by_policy`, so
+    it must not fire. A detector that only reads the message fires here.
+    """
+    write_run(
+        tmp_path,
+        [
+            {
+                "task": "alpha__AAA",
+                "reward": 0,
+                "events": tool_pair(
+                    "c1",
+                    "bash",
+                    {"command": "ls -la docs/; file docs/*"},
+                    err(
+                        CHAIN_OUTPUT
+                        + "\nbash: line 1: file: command not found\n\n[exit code: 127]",
+                        cls="refused_by_policy",
+                    ),
+                ),
+            }
+        ],
+    )
+    assert _findings(tmp_path, "tool-error-envelope") == []
+
+
 def test_a_guard_refusal_is_not_this_defect(tmp_path):
     """A refusal wraps a refusal, not output, and is a different ticket."""
     refusal = (

--- a/crates/stella-cli/src/enterprise_telemetry/tests.rs
+++ b/crates/stella-cli/src/enterprise_telemetry/tests.rs
@@ -190,6 +190,7 @@ fn rollup(id: i64) -> ExecutionRollupRow {
         started_at: "2026-07-21 12:00:00".into(),
         day: "2026-07-21".into(),
         tool_histogram: Vec::new(),
+        error_class_histogram: Vec::new(),
     }
 }
 

--- a/crates/stella-cli/src/usage_cmd.rs
+++ b/crates/stella-cli/src/usage_cmd.rs
@@ -347,6 +347,19 @@ fn tool_report(format: StatsFormat) -> Result<(), String> {
     let rows = hub
         .tool_report()
         .map_err(|e| format!("cannot read the usage hub: {e}"))?;
+    // The per-class split of the errors column (#4550), read beside the rows
+    // it splits. Executions folded before the split existed have no class
+    // rows, so a class sum may undercount `errors` — never the reverse.
+    let classes = hub
+        .tool_error_class_report()
+        .map_err(|e| format!("cannot read the usage hub: {e}"))?;
+    let split_of = |tool: &str, surface: &str| -> Vec<(String, i64)> {
+        classes
+            .iter()
+            .filter(|c| c.tool == tool && c.surface == surface)
+            .map(|c| (class_label(&c.class).to_string(), c.errors))
+            .collect()
+    };
     let rate = |calls: i64, errors: i64| {
         if calls > 0 {
             errors as f64 / calls as f64
@@ -359,12 +372,18 @@ fn tool_report(format: StatsFormat) -> Result<(), String> {
             let objects: Vec<serde_json::Value> = rows
                 .iter()
                 .map(|r| {
+                    let by_class: serde_json::Map<String, serde_json::Value> =
+                        split_of(&r.tool, &r.surface)
+                            .into_iter()
+                            .map(|(class, errors)| (class, errors.into()))
+                            .collect();
                     serde_json::json!({
                         "tool": r.tool,
                         "surface": r.surface,
                         "calls": r.calls,
                         "errors": r.errors,
                         "error_rate": rate(r.calls, r.errors),
+                        "errors_by_class": by_class,
                     })
                 })
                 .collect();
@@ -374,17 +393,19 @@ fn tool_report(format: StatsFormat) -> Result<(), String> {
             );
         }
         StatsFormat::Csv => {
-            println!("tool,surface,calls,errors,error_rate");
+            println!("tool,surface,calls,errors,error_rate,errors_by_class");
             for r in &rows {
                 // Tool names are model- and MCP-supplied text: same RFC-4180
-                // escape as every other text column on this surface.
+                // escape as every other text column on this surface. The
+                // class column is closed-vocabulary tokens and counts.
                 println!(
-                    "{},{},{},{},{:.4}",
+                    "{},{},{},{},{:.4},{}",
                     crate::stats::csv_escape(&r.tool),
                     crate::stats::csv_escape(&r.surface),
                     r.calls,
                     r.errors,
                     rate(r.calls, r.errors),
+                    class_summary(&split_of(&r.tool, &r.surface), ";"),
                 );
             }
         }
@@ -397,18 +418,19 @@ fn tool_report(format: StatsFormat) -> Result<(), String> {
                 return Ok(());
             }
             println!(
-                "{:<28} {:<8} {:>8} {:>8} {:>8}",
+                "{:<28} {:<8} {:>8} {:>8} {:>8}  CLASSES",
                 "TOOL", "SURFACE", "CALLS", "ERRORS", "ERR-RATE"
             );
             let mut totals = (0i64, 0i64);
             for r in &rows {
                 println!(
-                    "{:<28} {:<8} {:>8} {:>8} {:>7.2}%",
+                    "{:<28} {:<8} {:>8} {:>8} {:>7.2}%  {}",
                     r.tool,
                     r.surface,
                     r.calls,
                     r.errors,
                     100.0 * rate(r.calls, r.errors),
+                    class_summary(&split_of(&r.tool, &r.surface), " "),
                 );
                 totals.0 += r.calls;
                 totals.1 += r.errors;
@@ -424,6 +446,28 @@ fn tool_report(format: StatsFormat) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+/// The display spelling of a stored class token: the hub stores `''` for a
+/// site not yet audited into a class, which no report cell can show.
+/// `"unclassified"` cannot collide — `ErrorClass`'s closed vocabulary never
+/// contains it.
+fn class_label(class: &str) -> &str {
+    if class.is_empty() {
+        "unclassified"
+    } else {
+        class
+    }
+}
+
+/// `class:count` pairs joined by `sep`, largest first (the hub report's own
+/// order) — the compact spelling the CSV and text surfaces share.
+fn class_summary(split: &[(String, i64)], sep: &str) -> String {
+    split
+        .iter()
+        .map(|(class, errors)| format!("{class}:{errors}"))
+        .collect::<Vec<_>>()
+        .join(sep)
 }
 
 fn sync(all: bool) -> Result<(), String> {

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -1829,7 +1829,9 @@ function renderTools(rows) {
   $("tools").querySelectorAll(".hbar").forEach((el, i) => {
     const r = top[i];
     el.addEventListener("mousemove", ev => showTip(ev,
-      `<b>${esc(r.name)}</b>${fmtInt(r.calls)} calls · ${fmtInt(r.errors)} errors<br>` +
+      `<b>${esc(r.name)}</b>${fmtInt(r.calls)} calls · ${fmtInt(r.errors)} errors` +
+      Object.entries(r.errors_by_class || {})
+        .map(([cls, n]) => ` · ${esc(cls)} ${fmtInt(n)}`).join("") + `<br>` +
       `p50 ${fmtMs(r.p50_ms)} · p90 ${fmtMs(r.p90_ms)} · p99 ${fmtMs(r.p99_ms)} · ` +
       `max ${fmtMs(r.max_ms)} · ${fmtTok(r.bytes_out)}B returned`));
     el.addEventListener("mouseleave", hideTip);

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -651,11 +651,12 @@ impl Observatory {
     }
 
     /// Tool leaderboard over the newest `TOOL_CALL_SCAN_WINDOW` calls:
-    /// calls, failures, latency, bytes returned. The p50 is computed here
-    /// (SQLite has no percentile function).
+    /// calls, failures (with a per-`error_class` split), latency, bytes
+    /// returned. The p50 is computed here (SQLite has no percentile
+    /// function).
     ///
     /// Accumulates into `ToolAgg` rather than a bare tuple so the fold and
-    /// the row-building loop name the same four quantities.
+    /// the row-building loop name the same quantities.
     pub fn tools(&self) -> Result<Value, DbError> {
         let Some(conn) = self.store() else {
             return Ok(json!([]));
@@ -667,12 +668,25 @@ impl Observatory {
         // the whole history was unbounded, and calls old enough to age out of
         // the window no longer describe how the tools behave today anyway.
         let sql = format!(
-            "SELECT name, state, duration_ms, bytes_out FROM tool_calls
+            "SELECT name, state, duration_ms, bytes_out, error_class FROM tool_calls
+             ORDER BY rowid DESC LIMIT {TOOL_CALL_SCAN_WINDOW}"
+        );
+        // `error_class` arrived in store schema v25, and this reader never
+        // migrates the files it opens (see `is_missing_schema`). An older
+        // store re-prepares with a literal '' in the column's place, so it
+        // keeps its full leaderboard — every error unclassified — instead of
+        // losing the panel to one missing column.
+        let fallback = format!(
+            "SELECT name, state, duration_ms, bytes_out, '' FROM tool_calls
              ORDER BY rowid DESC LIMIT {TOOL_CALL_SCAN_WINDOW}"
         );
         let mut stmt = match conn.prepare(&sql) {
             Ok(stmt) => stmt,
-            Err(e) if is_missing_schema(&e) => return Ok(json!([])),
+            Err(e) if is_missing_schema(&e) => match conn.prepare(&fallback) {
+                Ok(stmt) => stmt,
+                Err(e) if is_missing_schema(&e) => return Ok(json!([])),
+                Err(e) => return Err(e.into()),
+            },
             Err(e) => return Err(e.into()),
         };
         let scanned = stmt.query_map([], |r| {
@@ -681,12 +695,13 @@ impl Observatory {
                 r.get::<_, String>(1)?,
                 r.get::<_, i64>(2)?,
                 r.get::<_, i64>(3)?,
+                r.get::<_, String>(4)?,
             ))
         })?;
         let mut by_name: std::collections::BTreeMap<String, ToolAgg> =
             std::collections::BTreeMap::new();
         for call in scanned {
-            let (name, state, duration_ms, bytes_out) = call?;
+            let (name, state, duration_ms, bytes_out, error_class) = call?;
             let entry = by_name.entry(name).or_default();
             entry.calls += 1;
             // An abandoned call is a fact about its turn, not the tool: it
@@ -694,7 +709,20 @@ impl Observatory {
             // not yet migrated to v24 still spells abandonment 'error'; its
             // rates stay conservatively inflated until its next CLI open.
             match state.as_str() {
-                "error" => entry.errors += 1,
+                "error" => {
+                    entry.errors += 1;
+                    // '' is the store's spelling for "not audited into a
+                    // class yet" (the v25 default). It counts under
+                    // "unclassified" — a key deliberately outside the wire
+                    // vocabulary of `stella-protocol`'s `ErrorClass`, so it
+                    // can never collide with a real class token.
+                    let class = if error_class.is_empty() {
+                        "unclassified".to_owned()
+                    } else {
+                        error_class
+                    };
+                    *entry.errors_by_class.entry(class).or_insert(0) += 1;
+                }
                 "abandoned" => entry.abandoned += 1,
                 _ => {}
             }
@@ -729,6 +757,7 @@ impl Observatory {
                     "name": name,
                     "calls": agg.calls,
                     "errors": agg.errors,
+                    "errors_by_class": agg.errors_by_class,
                     "abandoned": agg.abandoned,
                     "p50_ms": p50,
                     "p90_ms": p90,
@@ -1247,6 +1276,10 @@ fn rules_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
 struct ToolAgg {
     calls: i64,
     errors: i64,
+    /// `errors` partitioned by the store's `error_class` token, with `''`
+    /// counted as `"unclassified"`. The values sum to `errors`; abandoned
+    /// calls land in no bucket.
+    errors_by_class: std::collections::BTreeMap<String, i64>,
     /// Calls whose turn ended before they returned — counted apart from
     /// `errors` because abandonment is a fact about the turn, not the tool
     /// (#3146).

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -392,6 +392,13 @@ fn tool_leaderboard_counts_errors() {
         .unwrap();
     assert_eq!(bash["calls"], 1);
     assert_eq!(bash["errors"], 1);
+    // This fixture's `tool_calls` predates the v25 `error_class` column, so
+    // this doubles as the old-store witness: the fallback scan keeps the
+    // totals and reports every error unclassified.
+    assert_eq!(
+        bash["errors_by_class"],
+        serde_json::json!({ "unclassified": 1 })
+    );
 }
 
 #[test]

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -56,7 +56,8 @@ use stella_core::context_record::{
 };
 use stella_observatory::respond;
 use stella_protocol::{
-    AgentEvent, ContextFrameRef, ProviderShare, TaskItem, TaskStatus, ToolCall, ToolOutput,
+    AgentEvent, ContextFrameRef, ErrorClass, ProviderShare, TaskItem, TaskStatus, ToolCall,
+    ToolOutput,
 };
 use stella_store::{
     AgentUseRow, ContextBlockRow, ExecutionReflectionRow, FileTouchRow, ManifestBlockRow,

--- a/crates/stella-observatory/tests/schema_conformance/ratings_and_calls.rs
+++ b/crates/stella-observatory/tests/schema_conformance/ratings_and_calls.rs
@@ -258,4 +258,85 @@ fn an_abandoned_call_is_not_a_tool_error_on_the_leaderboard() {
         bash["abandoned"], 1,
         "the abandonment is visible, apart from the error count: {bash}"
     );
+    assert_eq!(
+        bash["errors_by_class"],
+        serde_json::json!({ "unclassified": 1 }),
+        "the class split carries only the real failure — an abandoned call \
+         lands in no bucket: {bash}"
+    );
+}
+
+/// Classified errors split by class on the leaderboard (#4550).
+///
+/// `errors` stays the total it always was; `errors_by_class` partitions it by
+/// the `ErrorClass` wire token, with the store's `''` default counted as
+/// `"unclassified"` — a key outside that vocabulary, so no future class can
+/// shadow it. The payoff asserted at the end: "errors for bash excluding
+/// invalid_input" is a subtraction over the payload, with no error prose
+/// consulted.
+#[test]
+fn tool_errors_split_by_error_class_on_the_leaderboard() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let store = Store::open(dir.path()).expect("store");
+    let id = store
+        .begin_execution("run", "three flavors of failure", "anthropic", "opus")
+        .expect("begin");
+    let outputs = [
+        ToolOutput::classified_error(ErrorClass::InvalidInput, "not the tool's schema"),
+        ToolOutput::classified_error(ErrorClass::Environment, "network unreachable"),
+        ToolOutput::error("not audited into a class yet"),
+    ];
+    for (i, output) in outputs.into_iter().enumerate() {
+        let call_id = format!("c{i}");
+        store
+            .record_event(
+                id,
+                (2 * i) as u64,
+                &AgentEvent::ToolStart {
+                    call: ToolCall {
+                        call_id: call_id.clone(),
+                        name: "bash".into(),
+                        input: serde_json::json!({ "command": "false" }),
+                    },
+                },
+            )
+            .expect("start");
+        store
+            .record_event(
+                id,
+                (2 * i + 1) as u64,
+                &AgentEvent::ToolResult {
+                    call_id,
+                    output,
+                    duration_ms: 1,
+                    speculated: false,
+                },
+            )
+            .expect("result");
+    }
+
+    let tools: serde_json::Value =
+        serde_json::from_slice(&respond(dir.path(), "/api/tools").body).expect("json");
+    let bash = tools
+        .as_array()
+        .expect("array")
+        .iter()
+        .find(|t| t["name"] == "bash")
+        .cloned()
+        .expect("bash row");
+    assert_eq!(bash["errors"], 3, "the total is unchanged: {bash}");
+    assert_eq!(
+        bash["errors_by_class"],
+        serde_json::json!({ "environment": 1, "invalid_input": 1, "unclassified": 1 }),
+        "and the split partitions it by class: {bash}"
+    );
+    let excluding_invalid_input = bash["errors"].as_i64().expect("errors")
+        - bash["errors_by_class"]["invalid_input"]
+            .as_i64()
+            .expect("invalid_input");
+    assert_eq!(
+        excluding_invalid_input, 2,
+        "errors that are not the model's own mistake, derived without \
+         touching a message string: {bash}"
+    );
 }

--- a/crates/stella-store/src/content_free.rs
+++ b/crates/stella-store/src/content_free.rs
@@ -66,7 +66,7 @@ use serde_json::Value;
 use crate::enterprise_telemetry::{
     ManagedModelDimension, OperationalEventContext, OperationalIdentity, StellaOperationalEventV1,
 };
-use crate::usage::{CloudTelemetryEvent, ExecutionRollupRow, ToolBucket};
+use crate::usage::{CloudTelemetryEvent, ErrorClassBucket, ExecutionRollupRow, ToolBucket};
 use crate::{DrainBatch, Result, StoreError, TelemetryRow};
 
 // ---------------------------------------------------------------------------
@@ -520,6 +520,16 @@ pub fn poisoned_execution_rollup() -> ExecutionRollupRow {
             tool: content_sentinel("tool_histogram.tool"),
             surface: content_sentinel("tool_histogram.surface"),
             calls: 3,
+            errors: 1,
+        }],
+        error_class_histogram: vec![ErrorClassBucket {
+            tool: content_sentinel("error_class_histogram.tool"),
+            surface: content_sentinel("error_class_histogram.surface"),
+            // The reviewed decision #4550 asks for: an `ErrorClass` wire
+            // token is a closed vocabulary — `ErrorClass::parse` coerces any
+            // unknown token to `other`, so free text cannot ride it — and,
+            // like `outcome` above, it needs no sentinel.
+            class: "environment".into(),
             errors: 1,
         }],
     }

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -1229,26 +1229,8 @@ impl Store {
             )
             .optional()?
             .flatten();
-        let tool_histogram = {
-            let mut stmt = conn.prepare(
-                "SELECT name, surface, COUNT(*), \
-                        SUM(CASE WHEN state = 'error' THEN 1 ELSE 0 END) \
-                 FROM tool_calls WHERE execution_id = ?1 GROUP BY name, surface",
-            )?;
-            let rows = stmt.query_map(params![execution_id], |r| {
-                Ok(usage::ToolBucket {
-                    tool: r.get(0)?,
-                    surface: r.get(1)?,
-                    calls: r.get(2)?,
-                    errors: r.get(3)?,
-                })
-            })?;
-            let mut v = Vec::new();
-            for row in rows {
-                v.push(row?);
-            }
-            v
-        };
+        let tool_histogram = tool_calls::tool_histogram(&conn, execution_id)?;
+        let error_class_histogram = tool_calls::error_class_histogram(&conn, execution_id)?;
         drop(conn);
 
         let day = started_at.get(0..10).unwrap_or("").to_string();
@@ -1280,6 +1262,7 @@ impl Store {
             started_at,
             day,
             tool_histogram,
+            error_class_histogram,
         }))
     }
 

--- a/crates/stella-store/src/tool_calls.rs
+++ b/crates/stella-store/src/tool_calls.rs
@@ -778,6 +778,62 @@ impl Store {
     }
 }
 
+/// One execution's per-tool call/error buckets for the usage hub —
+/// [`Store::execution_rollup`]'s histogram, computed here because this table
+/// is where the counted facts live.
+pub(crate) fn tool_histogram(
+    conn: &Connection,
+    execution_id: i64,
+) -> Result<Vec<crate::usage::ToolBucket>> {
+    let mut stmt = conn.prepare(
+        "SELECT name, surface, COUNT(*), \
+                SUM(CASE WHEN state = 'error' THEN 1 ELSE 0 END) \
+         FROM tool_calls WHERE execution_id = ?1 GROUP BY name, surface",
+    )?;
+    let rows = stmt.query_map(params![execution_id], |r| {
+        Ok(crate::usage::ToolBucket {
+            tool: r.get(0)?,
+            surface: r.get(1)?,
+            calls: r.get(2)?,
+            errors: r.get(3)?,
+        })
+    })?;
+    let mut v = Vec::new();
+    for row in rows {
+        v.push(row?);
+    }
+    Ok(v)
+}
+
+/// The classified split of [`tool_histogram`]'s `errors` (#4550): the same
+/// `state = 'error'` rows, grouped also by `error_class` (`''` for a site not
+/// yet audited into a class). Abandonment is not an error here for the same
+/// reason it is not one there (#3146).
+pub(crate) fn error_class_histogram(
+    conn: &Connection,
+    execution_id: i64,
+) -> Result<Vec<crate::usage::ErrorClassBucket>> {
+    let mut stmt = conn.prepare(
+        "SELECT name, surface, error_class, COUNT(*) \
+         FROM tool_calls WHERE execution_id = ?1 AND state = 'error' \
+         GROUP BY name, surface, error_class \
+         ORDER BY name, surface, error_class",
+    )?;
+    let rows = stmt.query_map(params![execution_id], |r| {
+        Ok(crate::usage::ErrorClassBucket {
+            tool: r.get(0)?,
+            surface: r.get(1)?,
+            class: r.get(2)?,
+            errors: r.get(3)?,
+        })
+    })?;
+    let mut v = Vec::new();
+    for row in rows {
+        v.push(row?);
+    }
+    Ok(v)
+}
+
 mod orphan_sweep;
 
 #[cfg(test)]

--- a/crates/stella-store/src/tool_calls/tests.rs
+++ b/crates/stella-store/src/tool_calls/tests.rs
@@ -566,6 +566,62 @@ fn rollup_bucket_counts_errors_but_not_abandonment() {
     );
 }
 
+/// #4550's project-side half: the rollup carries the classified split of the
+/// errors it counts, so the hub can key an error rate by class with no string
+/// ever matched. Abandonment stays out of the split for the same reason it
+/// stays out of `errors` (#3146), and an unaudited site rides as `''` — not
+/// as any class.
+#[test]
+fn rollup_splits_errors_by_class_and_still_ignores_abandonment() {
+    use stella_protocol::ErrorClass;
+    let (store, id) = fixture();
+    store.record_event(id, 0, &start("c1", "bash")).unwrap();
+    store
+        .record_event(
+            id,
+            1,
+            &AgentEvent::ToolResult {
+                call_id: "c1".into(),
+                output: ToolOutput::classified_error(ErrorClass::Environment, "exit 1"),
+                duration_ms: 1,
+                speculated: false,
+            },
+        )
+        .unwrap();
+    store.record_event(id, 2, &start("c2", "bash")).unwrap();
+    store
+        .record_event(id, 3, &err_result("c2", "boom"))
+        .unwrap();
+    // Announced, never returned: settles to abandoned at the turn-end fold.
+    store.record_event(id, 4, &start("c3", "bash")).unwrap();
+    store.materialize_tool_calls(id).unwrap();
+    store.finish_execution(id, "completed", 0.0).unwrap();
+
+    let rollup = store
+        .execution_rollup(id, std::path::Path::new("/tmp/workspace"))
+        .unwrap()
+        .expect("a finished, accounted execution rolls up");
+    let split: Vec<(&str, i64)> = rollup
+        .error_class_histogram
+        .iter()
+        .map(|b| (b.class.as_str(), b.errors))
+        .collect();
+    assert_eq!(
+        split,
+        vec![("", 1), ("environment", 1)],
+        "classified and unaudited errors split apart; the abandoned call is neither"
+    );
+    assert_eq!(
+        rollup
+            .error_class_histogram
+            .iter()
+            .map(|b| b.errors)
+            .sum::<i64>(),
+        rollup.tool_histogram.iter().map(|b| b.errors).sum::<i64>(),
+        "the split's total is exactly the errors column it splits"
+    );
+}
+
 /// The repair fold keeps them apart too, or a turn-end re-materialization
 /// would silently re-collapse what the live fold recorded correctly. Moved
 /// here from `store::tests` with #4033: it is a projection test, and it

--- a/crates/stella-store/src/usage.rs
+++ b/crates/stella-store/src/usage.rs
@@ -109,8 +109,13 @@ pub struct ExecutionRollupRow {
     pub day: String,
     /// Per-tool buckets for this turn, folded into `tool_usage_rollup`.
     pub tool_histogram: Vec<ToolBucket>,
+    /// Per-class error buckets for this turn, folded into
+    /// `tool_error_class_rollup` (#4550). See [`ErrorClassBucket`].
+    pub error_class_histogram: Vec<ErrorClassBucket>,
 }
 
+mod class_rollup;
+pub use class_rollup::{ErrorClassBucket, ToolErrorClassRow};
 mod schema;
 mod tool_fold;
 
@@ -221,6 +226,7 @@ impl UsageStore {
                     params![r.project_id, b.tool, b.surface, r.day, b.calls, b.errors],
                 )?;
             }
+            class_rollup::fold(&tx, &r.project_id, &r.day, &r.error_class_histogram)?;
         }
         tx.commit()?;
         Ok(())
@@ -635,6 +641,7 @@ impl UsageStore {
                     "DELETE FROM tool_usage_rollup WHERE project_id = ?1",
                     params![pid],
                 )?;
+                class_rollup::gc_project(&tx, pid)?;
                 tool_fold::forget_project(&tx, pid)?;
                 tx.execute(
                     "DELETE FROM telemetry_sync_cursors WHERE project_id = ?1",
@@ -677,6 +684,7 @@ impl UsageStore {
                     "DELETE FROM tool_usage_rollup WHERE day < date('now', ?1)",
                     params![modifier],
                 )? as u64;
+                report.rollups_aged_out += class_rollup::age_out(&tx, modifier)?;
                 // Not counted as a rollup: it is the ledger over them, and it
                 // ages out on exactly their predicate so the two never part.
                 tool_fold::age_out(&tx, modifier)?;
@@ -1012,6 +1020,7 @@ mod tests {
             started_at: "2026-07-17T13:00:00Z".into(),
             day: "2026-07-17".into(),
             tool_histogram: tools,
+            error_class_histogram: Vec::new(),
         }
     }
 

--- a/crates/stella-store/src/usage/class_rollup.rs
+++ b/crates/stella-store/src/usage/class_rollup.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The per-class error split beside `tool_usage_rollup` (#4550).
+//!
+//! `tool_usage_rollup.errors` counts every `state = 'error'` call as the same
+//! failure, which is exactly the number #3145 says cannot mean anything: a
+//! tool defect, a model mistake, and a policy refusal all land in it. This
+//! module keys the same additive fold by [`stella_protocol::ErrorClass`]'s
+//! wire token, so "error rate for `bash`, excluding `invalid_input`" is a SUM
+//! over rows rather than a string match over messages.
+//!
+//! A sibling table rather than a column on `tool_usage_rollup`, because the
+//! class is part of the key: splitting `errors` inside the existing
+//! `(project, tool, surface, day)` primary key would rebuild that table for a
+//! count that is additive anyway. Being a new table, schema convergence
+//! creates it on existing hubs with no migration rung.
+//!
+//! The fold rides [`super::tool_fold`]'s claim — one claim covers both
+//! tables, so they can only be counted together or not at all. Buckets folded
+//! before this table existed have no class rows here; like `tool_report`'s
+//! pre-v24 caveat, the split converges on the truth going forward rather than
+//! pretending to know the past.
+
+use rusqlite::{Transaction, params};
+
+use super::{Result, UsageStore};
+
+/// One per-class error bucket for one execution: how many of a tool's failed
+/// calls fell in one [`stella_protocol::ErrorClass`].
+///
+/// `class` is the class's `snake_case` wire token, or the empty string for a
+/// call whose error site has not been audited into a class — the same
+/// spelling `tool_calls.error_class` stores, kept distinct from every real
+/// class because "not audited" is not a class.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorClassBucket {
+    pub tool: String,
+    pub surface: String,
+    pub class: String,
+    pub errors: i64,
+}
+
+/// One tool's cross-project error total for one class, straight off
+/// `tool_error_class_rollup` — the classified counterpart of
+/// [`super::ToolReportRow`]'s `errors`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolErrorClassRow {
+    pub tool: String,
+    pub surface: String,
+    /// The [`stella_protocol::ErrorClass`] wire token, `""` for unclassified.
+    pub class: String,
+    pub errors: i64,
+}
+
+/// Fold one execution's class buckets into the per-day counts, inside the
+/// caller's transaction and under the claim it already holds.
+pub(super) fn fold(
+    tx: &Transaction<'_>,
+    project_id: &str,
+    day: &str,
+    buckets: &[ErrorClassBucket],
+) -> Result<()> {
+    for b in buckets {
+        tx.execute(
+            "INSERT INTO tool_error_class_rollup (project_id, tool, surface, day, class, errors) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(project_id, tool, surface, day, class) DO UPDATE SET \
+               errors = errors + excluded.errors",
+            params![project_id, b.tool, b.surface, day, b.class, b.errors],
+        )?;
+    }
+    Ok(())
+}
+
+/// Drop a garbage-collected project's class rows, beside the bucket and
+/// ledger deletes in [`super::UsageStore::prune`].
+pub(super) fn gc_project(tx: &Transaction<'_>, project_id: &str) -> Result<()> {
+    tx.execute(
+        "DELETE FROM tool_error_class_rollup WHERE project_id = ?1",
+        params![project_id],
+    )?;
+    Ok(())
+}
+
+/// Age out class rows on exactly the predicate that ages out
+/// `tool_usage_rollup` and the fold ledger, returning how many went — the
+/// three tables share one claim, so they must share one cutoff.
+pub(super) fn age_out(tx: &Transaction<'_>, modifier: &str) -> Result<u64> {
+    Ok(tx.execute(
+        "DELETE FROM tool_error_class_rollup WHERE day < date('now', ?1)",
+        params![modifier],
+    )? as u64)
+}
+
+impl UsageStore {
+    /// Cross-project per-tool error totals split by class, largest first.
+    ///
+    /// The classified half of [`UsageStore::tool_report`]: same table family,
+    /// same additive fold, with the class in the key. Unclassified errors
+    /// appear under `class == ""` rather than vanishing, so the two reports'
+    /// totals reconcile for every execution folded since the split existed.
+    pub fn tool_error_class_report(&self) -> Result<Vec<ToolErrorClassRow>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT tool, surface, class, SUM(errors) AS e \
+             FROM tool_error_class_rollup \
+             GROUP BY tool, surface, class \
+             ORDER BY e DESC, tool ASC, surface ASC, class ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ToolErrorClassRow {
+                tool: row.get(0)?,
+                surface: row.get(1)?,
+                class: row.get(2)?,
+                errors: row.get(3)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::rollup;
+    use super::super::{ErrorClassBucket, PrunePolicy, ToolBucket, UsageStore};
+
+    /// Two bash failures in one turn: one the model's fault, one the world's,
+    /// plus one from a site not yet audited.
+    fn classified_bash(execution_id: i64) -> super::super::ExecutionRollupRow {
+        let mut row = rollup(
+            execution_id,
+            vec![ToolBucket {
+                tool: "bash".into(),
+                surface: "native".into(),
+                calls: 5,
+                errors: 3,
+            }],
+        );
+        row.error_class_histogram = vec![
+            ErrorClassBucket {
+                tool: "bash".into(),
+                surface: "native".into(),
+                class: "invalid_input".into(),
+                errors: 1,
+            },
+            ErrorClassBucket {
+                tool: "bash".into(),
+                surface: "native".into(),
+                class: "environment".into(),
+                errors: 1,
+            },
+            ErrorClassBucket {
+                tool: "bash".into(),
+                surface: "native".into(),
+                class: String::new(),
+                errors: 1,
+            },
+        ];
+        row
+    }
+
+    /// The witness for #4550's definition of done, carried from #3145: "error
+    /// rate for `bash`, excluding `invalid_input`" is arithmetic over
+    /// classified rows — no string ever inspected.
+    #[test]
+    fn bash_errors_excluding_invalid_input_need_no_string_matching() {
+        let usage = UsageStore::in_memory().unwrap();
+        usage.sync_execution(&classified_bash(1)).unwrap();
+
+        let split = usage.tool_error_class_report().unwrap();
+        let bash_excluding_model_mistakes: i64 = split
+            .iter()
+            .filter(|r| r.tool == "bash" && r.class != "invalid_input")
+            .map(|r| r.errors)
+            .sum();
+        assert_eq!(bash_excluding_model_mistakes, 2);
+
+        let total: i64 = split.iter().map(|r| r.errors).sum();
+        let report = usage.tool_report().unwrap();
+        assert_eq!(
+            total, report[0].errors,
+            "the split's total reconciles with the unsplit errors column"
+        );
+    }
+
+    /// The split rides the same fold claim as the calls/errors buckets: a
+    /// re-sync adds nothing to either.
+    #[test]
+    fn a_re_sync_does_not_double_the_class_counts() {
+        let usage = UsageStore::in_memory().unwrap();
+        let row = classified_bash(7);
+        usage.sync_execution(&row).unwrap();
+        usage.sync_execution(&row).unwrap();
+
+        let split = usage.tool_error_class_report().unwrap();
+        assert_eq!(split.iter().map(|r| r.errors).sum::<i64>(), 3);
+    }
+
+    /// Prune's project GC and age cutoff take the class rows with the buckets
+    /// and the claim, on the same predicates, so a later re-sync folds from
+    /// zero instead of adding onto survivors.
+    #[test]
+    fn prune_takes_the_class_rows_with_their_buckets() {
+        let usage = UsageStore::in_memory().unwrap();
+        let row = classified_bash(7);
+
+        usage.sync_execution(&row).unwrap();
+        usage
+            .prune(&PrunePolicy {
+                gc_project_ids: vec![row.project_id.clone()],
+                ..PrunePolicy::default()
+            })
+            .unwrap();
+        assert!(usage.tool_error_class_report().unwrap().is_empty());
+        usage.sync_execution(&row).unwrap();
+        assert_eq!(
+            usage
+                .tool_error_class_report()
+                .unwrap()
+                .iter()
+                .map(|r| r.errors)
+                .sum::<i64>(),
+            3,
+            "a returning project counts from zero, never from residue"
+        );
+
+        usage
+            .prune(&PrunePolicy {
+                older_than: Some("-1 days".into()),
+                ..PrunePolicy::default()
+            })
+            .unwrap();
+        assert!(
+            usage.tool_error_class_report().unwrap().is_empty(),
+            "the age cutoff reaches the class rows on the buckets' predicate"
+        );
+    }
+}

--- a/crates/stella-store/src/usage/rekey.rs
+++ b/crates/stella-store/src/usage/rekey.rs
@@ -77,6 +77,21 @@ impl UsageStore {
             "DELETE FROM tool_usage_rollup WHERE project_id = ?1",
             params![old_project_id],
         )?;
+        // The per-class split merges on the same rule as the buckets it
+        // splits, or the merged project's classified and unsplit error counts
+        // would stop reconciling.
+        moved += tx.execute(
+            "INSERT INTO tool_error_class_rollup (project_id, tool, surface, day, class, errors) \
+             SELECT ?1, tool, surface, day, class, errors \
+               FROM tool_error_class_rollup WHERE project_id = ?2 \
+             ON CONFLICT(project_id, tool, surface, day, class) DO UPDATE SET \
+               errors = errors + excluded.errors",
+            params![new_project_id, old_project_id],
+        )? as u64;
+        tx.execute(
+            "DELETE FROM tool_error_class_rollup WHERE project_id = ?1",
+            params![old_project_id],
+        )?;
         // The cursor merges by MAX so replication continues from wherever
         // either identity had reached — never a rewind, never a re-replication.
         moved += tx.execute(

--- a/crates/stella-store/src/usage/schema.rs
+++ b/crates/stella-store/src/usage/schema.rs
@@ -99,6 +99,21 @@ CREATE TABLE IF NOT EXISTS tool_usage_rollup (
     errors     INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (project_id, tool, surface, day)
 );
+-- The per-class error split beside `tool_usage_rollup` (#4550): the same
+-- additive fold keyed also by the `ErrorClass` wire token ('' means the error
+-- site was not yet audited into a class). A sibling rather than a column
+-- because the class is part of the key, and a new table converges onto
+-- existing hubs with no migration rung. Folded under the same
+-- `tool_fold_ledger` claim as the buckets above — see `super::class_rollup`.
+CREATE TABLE IF NOT EXISTS tool_error_class_rollup (
+    project_id TEXT NOT NULL,
+    tool       TEXT NOT NULL,
+    surface    TEXT NOT NULL,
+    day        TEXT NOT NULL,
+    class      TEXT NOT NULL,
+    errors     INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (project_id, tool, surface, day, class)
+);
 -- Which executions have already been folded into `tool_usage_rollup` (#3411).
 -- That fold is additive, so it must happen once per execution; asking
 -- `execution_rollup` instead was wrong because `prune` deletes from it on

--- a/crates/stella-store/tests/enterprise_telemetry/main.rs
+++ b/crates/stella-store/tests/enterprise_telemetry/main.rs
@@ -66,6 +66,7 @@ fn rollup(execution_id: i64) -> ExecutionRollupRow {
         started_at: "2026-07-21 12:00:00".into(),
         day: "2026-07-21".into(),
         tool_histogram: Vec::new(),
+        error_class_histogram: Vec::new(),
     }
 }
 

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -64,7 +64,11 @@ Group every hub row by org, provider, and model, and total it. Rows are ordered 
   </OptionCard>
   <OptionCard name="--by-tool">
     Per-tool reliability instead of per-model spend: cross-project calls, errors, and the
-    derived error rate per `(tool, surface)`, read from the hub's tool rollup. This is the
+    derived error rate per `(tool, surface)`, read from the hub's tool rollup. Each row also
+    splits its errors by `ErrorClass` token
+    (`errors_by_class` in JSON/CSV, `CLASSES` in the table; `unclassified` for calls recorded
+    before their error site was audited), so "bash's error rate excluding `invalid_input`"
+    is arithmetic, not string matching. This is the
     scriptable surface for a tool-reliability ceiling — the same numbers the Observatory
     leaderboard draws, unwindowed and pipeable. Cannot combine with `--org` (the rollup is
     project-keyed, and a silently unhonored filter would misreport). Named `--by-tool`


### PR DESCRIPTION
## What

#4550 — the slice PR #4549 deliberately deferred, and the last of #3167's
definition-of-done clauses: carry `ErrorClass` into the rollups and their
consumers, so a class-aware error-rate query is arithmetic over tokens rather
than string matching over messages.

- **The content-free decision, on the record** (invariant #3): an
  `ErrorClass` wire token is a **closed vocabulary** — `ErrorClass::parse`
  coerces any unknown token to `other`, so free text cannot ride it — and is
  therefore not content, the same reasoning `poisoned_execution_rollup`
  already records for `outcome`. The decision lives where the guard enforces
  it: the exhaustive fixture in `crates/stella-store/src/content_free.rs`
  gains the new field with that comment, and the sentinel harness proves no
  encoder leaks it. The hub `telemetry` allowlist is untouched — the class
  rides the local-only rollup family, which never drains.
- **Hub**: `tool_error_class_rollup`, a sibling of `tool_usage_rollup` keyed
  `(project, tool, surface, day, class)` — a sibling because the class is
  part of the key, and a new table converges onto existing hubs with no
  migration rung. It folds under the **same** `tool_fold_ledger` claim
  (counted together or not at all), ages out and GCs on the buckets' own
  predicates, and re-keys additively in `adopt_project_identity`.
  `''` = unclassified, exactly the store's spelling. New module
  `crates/stella-store/src/usage/class_rollup.rs`; `usage.rs` (a god file)
  gains only call sites.
- **Producer**: `Store::execution_rollup`'s histogram queries move from
  `lib.rs` (a god file, now net smaller) into `tool_calls.rs`, and gain the
  classified split (`GROUP BY name, surface, error_class` over
  `state = 'error'` — abandonment stays excluded, #3146).
- **CLI**: `stella usage report --by-tool` shows `errors_by_class` in all
  three formats (JSON object; `class:count` pairs in CSV/text), spelled
  `unclassified` for `''` — a token the closed vocabulary can never mint.
- **Observatory**: `/api/tools` rows gain `errors_by_class`; a pre-v25 store
  degrades to everything-`unclassified` instead of a blank leaderboard; the
  tooltip row renders the split. Loopback-only, read-only — a read-side
  change, no new egress.
- **Bench**: `trace_triage`'s `tool-error-envelope` detector reads
  `output.error.class` and skips refusal classes (`invalid_input`,
  `not_found`, `permission_denied`, `refused_by_policy`) before any string
  matching — the `[exit code:` heuristic stays as the classless-trace
  fallback, so recorded traces behave byte-for-byte as before, and the
  fingerprint is unchanged.

The rollup shape follows the existing `tool_usage_rollup` family
(`tool_fold`/`tool_report` are the exemplars); no new dependencies.

## Evidence

Targeted, per-crate (never a workspace build — CI is the full gate):

- `cargo test -p stella-store` — 442 passed, 0 failed (the content-free
  harness, the new fold/prune/rekey witnesses, and the projection split
  included).
- `cargo test -p stella-observatory --all-targets` — 11 suites, 0 failed
  (120 unit + 16 schema-conformance among them; 1 pre-existing ignored).
- `uv run --with pytest --no-project pytest -q bench/trace_triage/tests` —
  92 passed (the `bench.yml` workflow's own invocation).
- `cargo clippy -p stella-store --all-targets -- -D warnings` and
  `-p stella-observatory` — clean; `-p stella-cli` — clean before the rebase
  onto current `main` (a 17-minute build this shared box kept reaping on
  re-runs; the rebase touched no CLI file, and this PR's CI run is the
  claim's evidence).
- `cargo fmt --all -- --check` — clean.
- `scripts/check-file-size.sh`, `scripts/check-prose.py` — exit 0 (prose
  re-run green after #4599 tightened the gate).
- `cargo test -p stella-cli --bin stella` — **not run locally**: three
  attempts were reaped by cargo-lock contention mid-compile. The CLI change
  is one report function; it is type-checked as a test target by the clean
  pre-rebase `clippy --all-targets`, and the suite's execution evidence is
  this PR's CI run.

**Witnesses — class-aware queries with no string matching** (#3145's own
definition-of-done clause, carried through #3167 and #4550):

- Project store: `tool_calls::tests::rollup_splits_errors_by_class_and_still_ignores_abandonment`
  — classified + unclassified + abandoned on one tool: the split keeps them
  apart and its total is exactly the `errors` it splits. Fails on `main`
  (`ExecutionRollupRow` has no `error_class_histogram` — the feature is
  absent at compile time).
- Hub: `class_rollup::tests::bash_errors_excluding_invalid_input_need_no_string_matching`
  — the exclusion is a filtered SUM over tokens; plus idempotence
  (`a_re_sync_does_not_double_the_class_counts`) and prune/GC symmetry
  (`prune_takes_the_class_rows_with_their_buckets`).
- Observatory: `tool_errors_split_by_error_class_on_the_leaderboard` — the
  "bash minus `invalid_input`" arithmetic asserted on `/api/tools`, and
  `an_abandoned_call_is_not_a_tool_error_on_the_leaderboard` extended to
  prove abandonment lands in no class bucket. On `main` these read
  `errors_by_class` as JSON `null` and fail.
- Bench: `test_a_refusal_class_beats_an_envelope_shaped_message` — **fails on
  the pre-change detector** (verified by restoring the original
  `detectors.py` from a byte copy and re-running: 1 failed), passes on the
  new one; `test_an_environment_classed_envelope_still_fires` covers the
  other direction.

Closes #4550

## Summary by Sourcery

Carry closed-vocabulary error classes through usage rollups and their CLI, Observatory, and trace-analysis consumers.

New Features:
- Carry `ErrorClass` data through execution rollups and expose per-class tool error totals in the CLI and Observatory leaderboard.
- Update the trace triage envelope detector to use refusal error classes while preserving classless-trace behavior.

Bug Fixes:
- Prevent refusal-classified tool errors from being misidentified as output-bearing error envelopes based solely on message text.

Enhancements:
- Add a class-keyed usage rollup with synchronized folding, project rekeying, pruning, garbage collection, and unclassified-error handling.
- Preserve Observatory tool metrics for pre-v25 stores by treating missing error classes as unclassified.
- Move execution histogram queries into the tool-call projection and include classified error splits while excluding abandoned calls.

Documentation:
- Document per-class error reporting for `stella usage --by-tool` and clarify refusal handling in the trace triage detector.

Tests:
- Add store, Observatory, and trace triage coverage for class-aware error splits, refusal filtering, legacy-store fallback, idempotent folding, and lifecycle operations.

Chores:
- Record the closed-vocabulary `ErrorClass` field in content-free telemetry safeguards without adding it to the hub telemetry allowlist.