### PR TITLE
fix(scripts): resync the file-size baseline against main

### DIFF
--- a/scripts/file-size-baseline.txt
+++ b/scripts/file-size-baseline.txt
@@ -15,9 +15,9 @@
 1911 bench/terminal_bench_analysis/tb21_evidence_contract.py
 4339 bench/terminal_bench_analysis/tests/test_tb21_analysis.py
 1659 bench/terminal_bench_analysis/tests/test_tb21_evidence_contract.py
-3656 crates/stella-cli/src/command_deck.rs
+3737 crates/stella-cli/src/command_deck.rs
 1891 crates/stella-core/src/bus.rs
-1682 crates/stella-core/src/driver.rs
+1678 crates/stella-core/src/driver.rs
 2906 crates/stella-core/src/driver/tests.rs
 1781 crates/stella-model/src/anthropic/tests.rs
 1919 crates/stella-model/src/openai.rs
@@ -25,5 +25,5 @@
 1712 crates/stella-store/src/lib.rs
 2222 crates/stella-store/src/tests.rs
 1767 crates/stella-store/src/usage.rs
-3660 crates/stella-tui/src/deck_ui.rs
-1597 crates/stella-tui/src/views/engine.rs
+3675 crates/stella-tui/src/deck_ui.rs
+1598 crates/stella-tui/src/views/engine.rs


### PR DESCRIPTION
## What

`main` is red again (#4654) and the `main is not known-broken` hold is failing
on every open PR. This resyncs `scripts/file-size-baseline.txt` against
`f74d2853f`.

```
crates/stella-cli/src/command_deck.rs   3737 lines against a ceiling of 3656 (+81)
crates/stella-tui/src/deck_ui.rs        3675 lines against a ceiling of 3660 (+15)
crates/stella-tui/src/views/engine.rs   1598 lines against a ceiling of 1597  (+1)
```

#4652 resynced the same file shortly before these three landed, so its fix
did not cover them. One entry moves **down** (`driver.rs` 1682 → 1678):
`--update` retightens every ceiling to its file's current size, which is what
stops a justified raise from buying slack somewhere else.

## Worth a maintainer's eye

This is the second resync in under an hour, and the two interact. The
`command_deck.rs` overage above is `+81` against a ceiling **#4647 tightened**
an hour ago (3752 → 3656). A branch cut before that repair could grow the file
to 3737 — comfortably under the 3752 ceiling it inherited, so its own
`file-size` check passed — and then compose against the tightened one.

That is the documented trade ("splitting a god file buys structure, not slack,
since `--update` retightens every ceiling", AGENTS.md § God files), and the
retightening is doing exactly what it is meant to. But under enough concurrent
merges it converts every resync into a fresh source of red for whatever is
already in flight, which is the churn this PR is the second instance of.
Whether `--update` should retighten unconditionally, or only for files the
regenerating change actually touched, is a policy call about the ratchet rather
than something to decide inside a repair PR — flagging it here rather than
changing it.

## Evidence

- `make file-size` → `OK — 1696 watched files, 20 grandfathered over 1500 lines, and nothing went over by this change.` No inherited drift reported.
- `make guards-fast` → exit 0.
- Generated baseline only; no source file changes.

Closes #4654

## Summary by Sourcery

Resync the generated file-size baseline against main so concurrent changes no longer leave the repository checks red.

Bug Fixes:
- Resynchronize the file-size baseline with main to restore passing file-size and known-good-main checks.

Chores:
- Update the generated file-size baseline ceilings to reflect the current sizes of watched files, including tightening one previously relaxed ceiling.