### PR TITLE
fix(ci,scripts): one prose filter for both events, a declared website-input inventory, raise-only file-size updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,24 @@ on:
   # and `**/*.md` to run the prose guards. It is deliberately isolated from
   # this workflow.
   pull_request:
-  # A push to `main` is not gated by required contexts, so the trigger-level
-  # filter is still safe here — a docs-only merge does not start the Rust
-  # gate at all. Keep this list and the `changes` job's regex in agreement.
+  # Deliberately NO `paths-ignore` here either, and for a second reason on top
+  # of the one above (#4606). This trigger carried the prose list, with a
+  # comment asking a human to keep it in agreement with the `changes` job's
+  # regex — which is what a repository writes when it cannot enforce
+  # something, and they were not in agreement. `paths-ignore` has no negation,
+  # so "ignore website/** except the files a Rust test reads" is not
+  # expressible; the job's carve-out could exist and the trigger's could not.
+  #
+  # A merge whose diff was confined to `website/` therefore started no Rust
+  # gate at all — not skipped-and-reported, never started. That is how #4588
+  # left `main` red on `config::tests::docs_sync` with nothing saying so, until
+  # the next commit that touched a crate went red and took three more with it.
+  #
+  # The `changes` job now answers for pushes too, from the same script the
+  # pull_request side uses. A prose-only merge pays one checkout and one diff
+  # instead of an hour of Rust — the same saving, decided in one place.
   push:
     branches: [main]
-    paths-ignore:
-      - "website/**"
-      - "docs/**"
-      - "*.md"
-      - ".github/ISSUE_TEMPLATE/**"
   # Merge queue: GitHub tests each queued PR against the current queue tip
   # before it lands, so two individually-green PRs can't combine into a red
   # `main` (see #306). The queue evaluates the required checks on the
@@ -74,12 +82,12 @@ jobs:
     outputs:
       rust: ${{ steps.scope.outputs.rust }}
     steps:
-      # Full history, pull requests only: the scope check diffs against the PR
-      # base, and a shallow clone may not contain the merge base. Every other
-      # event runs the full gate without looking at the diff, so it needs no
-      # checkout at all.
+      # Full history, for the two events that have a diff to look at: the scope
+      # check needs both endpoints, and a shallow clone may not contain the
+      # base. The merge queue and a manual dispatch run the full gate without
+      # looking at anything, so they need no checkout at all.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
         with:
           fetch-depth: 0
 
@@ -88,46 +96,31 @@ jobs:
         env:
           # Via env rather than inlined into the shell, so a ref name can
           # never be read as script (same shape as empty-diff.yml).
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          #
+          # `base.sha` for a pull request, `event.before` for a push — the
+          # previous tip of `main`, which is exactly what that merge changed.
+          # Only one of the two is ever set, so the `||` picks it.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          # Anything that is not a PR — a push to main, the merge queue, a
-          # manual dispatch — always runs the full gate: main and the queued
-          # merge result are what the green claim is about.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "rust=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # The prose paths, mirroring the push trigger's paths-ignore above:
-          # website/, docs/, .github/ISSUE_TEMPLATE/, and root-level *.md
-          # only (`[^/]+\.md$` stops at the first `/`, like the glob `*.md` —
-          # a crate's own README still pays the gate, which is what we want).
-          # `grep -v` inverts: any changed file OUTSIDE those paths means the
-          # gate runs. An empty diff runs nothing here — reporting that PR is
-          # empty-diff.yml's job.
-          #
-          # The prose paths that are not prose-only, because a Rust test reads
-          # the file and a test that never ran is green:
-          #
-          #  - a command reference page is asserted about by `stella-cli`'s own
-          #    tests — the subcommand index, the per-command summaries, and
-          #    since #3041 every flag's card — so editing one without running
-          #    them is exactly the hole that sends `check-command-docs.sh` to
-          #    `docs-guards.yml` a second time. A deleted card is a red test.
-          #  - `provider-catalog.ts` is the docs' copy of the provider registry,
-          #    pinned against `PROVIDERS` by `docs_sync.rs`. #4588 moved those
-          #    records into it from `provider-cards.tsx` in a website-only diff,
-          #    which skipped the Rust gate here and merged green; `main` was
-          #    then red on that test until the next commit that touched a crate
-          #    made anyone look.
-          if git diff --name-only "$BASE_SHA"...HEAD \
-            | grep -Evq '^(website/|docs/|\.github/ISSUE_TEMPLATE/)|^[^/]+\.md$'; then
-            echo "rust=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$BASE_SHA"...HEAD \
-            | grep -Eq '^website/content/docs/commands/|^website/src/components/provider-catalog\.ts$'; then
-            echo "rust=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "rust=false" >> "$GITHUB_OUTPUT"
+          # The merge queue and a manual dispatch always run the full gate:
+          # the queued merge result is what the green claim is about, and a
+          # dispatch is someone asking for the gate by hand.
+          case "$EVENT_NAME" in
+            pull_request | push) ;;
+            *)
+              echo "rust=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          # The rule itself lives in one script, called from one place, for
+          # both events (#4606). It used to be written twice — here, and as
+          # `paths-ignore` on the push trigger — with a comment asking a human
+          # to keep the copies in agreement, which they were not.
+          rust="$(./scripts/ci-rust-scope.sh "$BASE_SHA" HEAD)"
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          if [ "$rust" = "false" ]; then
             echo "Prose-only diff — the Rust gate is skipped." >> "$GITHUB_STEP_SUMMARY"
             echo "Both required contexts still report (as skipped), so the PR can merge." >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -261,6 +254,16 @@ jobs:
       - name: every subcommand has a reference page
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-command-docs.sh
+
+      # Also toolchain-free. The `website/` paths a Rust test reads are the
+      # ones the `changes` job above must NOT treat as prose, and that list was
+      # kept by hand in the workflow with no relation to the tests — it was
+      # already missing `stella-toml.mdx` when this landed (#4632). It runs
+      # here so a Rust diff that starts reading a new website file is declared,
+      # and in docs-guards.yml so a website-only diff that moves one is caught.
+      - name: every website path a Rust source reads is declared
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-website-inputs.sh
 
       # Also toolchain-free. The brand's lowercase rule was documented in two
       # places and enforced in none — 389 capitalised uses accumulated in the

--- a/.github/workflows/docker-serve.yml
+++ b/.github/workflows/docker-serve.yml
@@ -10,9 +10,10 @@ name: docker-serve
 #   - ci.yml's `check` job is a required context. A multi-minute image build
 #     hanging off it would slow every Rust PR to prove something only the
 #     packaging files can break.
-#   - ci.yml uses `paths-ignore` (run unless it's prose); this needs `paths`
-#     (run only when the packaging surface moves). The two cannot be mixed in
-#     one workflow, and combining them by hand is how a filter goes wrong.
+#   - ci.yml runs unless the diff is prose, decided in a job rather than a
+#     trigger; this needs `paths` (run only when the packaging surface moves).
+#     The two shapes cannot be mixed in one workflow, and combining them by
+#     hand is how a filter goes wrong.
 #
 # No `merge_group` trigger for the same reason: `paths` filters are ignored on
 # that event, so queuing any PR at all would build the image.

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,6 +1,6 @@
 name: docs-guards
 
-# Seven guards over prose. None needs a Rust toolchain, which is why they live
+# Eight guards over prose. None needs a Rust toolchain, which is why they live
 # here rather than in ci.yml -- that workflow deliberately skips its Rust jobs
 # for a diff confined to `docs/**`, `website/**` and `*.md` (a job-level prose
 # filter since #1892), and this one triggers on exactly those paths.
@@ -51,6 +51,14 @@ name: docs-guards
 #     workflows: its subject is Rust comments, so a Rust-only PR must run it
 #     too.
 #
+#  8. website-inputs (scripts/check-website-inputs.sh): every `website/` path a
+#     Rust source names is declared in scripts/website-rust-inputs.txt, and
+#     every declared path still exists (#4632). ci.yml builds its prose
+#     carve-out from the `read` entries, so the filter and the tests cannot
+#     drift; this is the half that catches the move. A website-only PR is the
+#     diff ci.yml's Rust job is skipped for, which is why the filter above
+#     widened from `website/content/docs/**` to `website/**`.
+#
 # Rust sources are in the path filter because the first three read them: a
 # citation added to a .rs comment is exactly how one goes stale, and the
 # subcommand list the third guard checks is itself a Rust enum.
@@ -62,12 +70,14 @@ on:
       - "**/*.rs"
       - "scripts/check-doc-links.py"
       - "scripts/check-invariants.sh"
-      - "website/content/docs/**"
+      - "website/**"
       - "scripts/check-command-docs.sh"
       - "scripts/check-brand-case.sh"
       - "scripts/check-gate-parity.sh"
       - "scripts/check-god-files.sh"
       - "scripts/check-design-refs.sh"
+      - "scripts/check-website-inputs.sh"
+      - "scripts/website-rust-inputs.txt"
       - "scripts/file-size-baseline.txt"
       - ".github/workflows/docs-guards.yml"
   push:
@@ -78,12 +88,14 @@ on:
       - "**/*.rs"
       - "scripts/check-doc-links.py"
       - "scripts/check-invariants.sh"
-      - "website/content/docs/**"
+      - "website/**"
       - "scripts/check-command-docs.sh"
       - "scripts/check-brand-case.sh"
       - "scripts/check-gate-parity.sh"
       - "scripts/check-god-files.sh"
       - "scripts/check-design-refs.sh"
+      - "scripts/check-website-inputs.sh"
+      - "scripts/website-rust-inputs.txt"
       - "scripts/file-size-baseline.txt"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
@@ -137,6 +149,17 @@ jobs:
       - name: the documented gate is the real gate
         if: ${{ !cancelled() }}
         run: bash scripts/check-gate-parity.sh
+
+      # This is the copy that matters, and the reason the path filter above
+      # widened from `website/content/docs/**` to `website/**` (#4632). A
+      # website-only PR that renames, moves or deletes a file a Rust test reads
+      # is precisely the diff ci.yml's Rust job is skipped for, so ci.yml
+      # cannot report it — #4588 moved PROVIDER_CATALOG out of the file
+      # `docs_sync` read and merged green, and `main` was red on a test nobody
+      # had run until someone else's PR went red with it.
+      - name: every website path a Rust source reads is declared, and present
+        if: ${{ !cancelled() }}
+        run: bash scripts/check-website-inputs.sh
 
       # Same two directions. The baseline moving is a non-md change ci.yml
       # catches; a README dropping a god file from its list, or a crate quietly

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,8 @@ name: docs
 
 # The docs site's CI: lint, typecheck, and a production build of
 # website/. Scoped to the paths that can affect the site, the mirror
-# image of ci.yml's paths-ignore — every PR runs exactly one of the two
-# (or both, when it genuinely touches both worlds).
+# image of ci.yml's prose list (scripts/ci-rust-scope.sh) — every PR runs
+# exactly one of the two (or both, when it genuinely touches both worlds).
 on:
   pull_request:
     paths:

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -114,6 +114,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-changelog-roll.sh
 
+      - name: which diffs run the Rust gate
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-ci-rust-scope.sh
+
       - name: consumer-sites guard failure directions
         if: ${{ !cancelled() }}
         run: ./scripts/test-consumer-sites.sh
@@ -205,6 +209,10 @@ jobs:
       - name: tool-error-class ratchet direction
         if: ${{ !cancelled() }}
         run: ./scripts/test-tool-error-class.sh
+
+      - name: website-inputs guard failure directions
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-website-inputs.sh
 
       - name: wire-path guard failure directions
         if: ${{ !cancelled() }}

--- a/.github/workflows/main-red-hold.yml
+++ b/.github/workflows/main-red-hold.yml
@@ -18,7 +18,7 @@ name: main-red-hold
 # their own files. The canary runs on `push` to main and must judge the merged
 # tree; this runs on `pull_request` and must reach a human while there is
 # still a decision to make. Folding it into ci.yml would also hide it behind
-# that workflow's `paths-ignore`, and "main does not compile" is not a fact
+# that workflow's prose filter, and "main does not compile" is not a fact
 # about which paths a PR touched.
 #
 # Deliberately NOT wired into `merge_group`: a queue builds the merged result,

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -8,8 +8,10 @@ name: msrv
 # and never urgent. In practice that meant a PR using a 1.91+ API merged
 # green and the break was discovered up to 7 days and an unknown number of
 # commits later, at which point bisecting it is someone's afternoon instead
-# of a review comment (#917). Now also runs on `pull_request`, mirroring
-# ci.yml's `paths-ignore` so a docs-only PR doesn't pay for it. It is not
+# of a review comment (#917). Now also runs on `pull_request`, over the same
+# prose paths ci.yml skips (scripts/ci-rust-scope.sh) so a docs-only PR
+# doesn't pay for it. This one can stay a trigger filter: it reports no
+# required context, so a suppressed run blocks nothing. It is not
 # marked as a required status check in branch protection — that's a repo
 # Settings change outside this file — so until it is, treat a red run here
 # the same as any other non-required check: fix before merging, don't ignore.

--- a/.gitignore
+++ b/.gitignore
@@ -132,8 +132,17 @@ dist/
 build/
 out/
 
-# Package manager
-node_modules/
+# Package manager.
+#
+# No trailing slash, and that is the whole point (#4608). `node_modules/`
+# matches a directory only; a *symlink* named node_modules is a file to git, so
+# the trailing-slash form let one be committed — #4595 tracked
+# `arenabench/ui/node_modules` as mode 120000 pointing at an absolute path on
+# the author's machine, dangling in every other clone and in CI. `no-scratch`
+# could not see it either: that guard asserts no tracked file matches a
+# .gitignore rule, and this rule did not match. The bare form matches both
+# shapes, so the guard now fails on a recurrence.
+node_modules
 
 # Python (for bench/harbor_adapter)
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,9 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + license-allowlist-parity + repro-wiring
                          #   + shellcheck + invariants + doc-links
                          #   + command-docs + brand-case + file-size
+                         #   + website-inputs (a Rust test's website/ inputs
+                         #     are declared, and ci.yml's filter is built
+                         #     from that declaration)
                          #   + god-files
                          #   + gate-parity + left-behind + role-names
                          #   + stat-portability + module-reachability
@@ -134,11 +137,13 @@ CI enforces the same steps split across four workflows:
 validate`, a release smoke build (thin LTO), and the deleted-test guard
 (`scripts/check-deleted-tests.sh`);
 `docs-guards.yml` runs those two plus a second run of `command-docs`,
-`brand-case`, `gate-parity`, `god-files` and `design-refs`, because all of them
-trigger on the `docs/**` and `*.md` paths `ci.yml` ignores — `design-refs` was
-the last to join, after a docs-only PR was found able to move a document into
-the `docs/design` scratchpad, invalidate every Rust comment citing it, and land
-green (#3888); and
+`website-inputs`, `brand-case`, `gate-parity`, `god-files` and `design-refs`,
+because all of them trigger on the `docs/**`, `website/**` and `*.md` paths
+`ci.yml` skips — `website-inputs` was the last to join, after a website-only PR
+was found able to move a file a Rust test reads and land green, leaving `main`
+red on a test nobody had run (#4632, and #3888 is the same shape one boundary
+over: a docs-only PR moving a document into the `docs/design` scratchpad and
+invalidating every Rust comment citing it); and
 `wire-schema.yml` runs `wire-schema` on `docs/wire/**` and the protocol crates,
 because a PR that hand-edits a generated schema and nothing else starts neither
 of the other two (#1439) — and `doc-warnings-schema` beside it, because

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -754,6 +754,19 @@ inputs, not review afterthoughts:
   crossing is genuinely irreducible, say so out loud with
   `./scripts/check-file-size.sh --update --grandfather <path>` and justify it
   in review.
+- **`make file-size-update` raises; `make file-size-retighten` lowers** (#4657).
+  The update moves the ceilings that must move for your tree to pass and leaves
+  every other entry at the number it had, so a PR repairing a red `main` edits
+  exactly the lines it needs. It used to lower them all to their size on the
+  branch it ran on, which made the repair PR the carrier of the next break: it
+  is the one PR guaranteed to be racing every other merge, because main is red
+  and everyone is waiting on it. #4652 repaired `driver.rs` and `usage.rs` and
+  in the same run lowered `command_deck.rs` from 3752 to 3656 against a main
+  whose copy was 3737; that is #4654, and it held every open PR for half an
+  hour. Reclaiming the slack a split earned is `file-size-retighten`, and it is
+  a PR of its own — safe precisely when nothing is blocked on it. Both modes
+  still retire an entry whose file dropped under the limit or is gone, because
+  the check hard-fails on those and names the update as the only remedy.
 
 **The ratchet judges your change, not the tree** (#2004). A file over the line
 fails only when `current > max(its own limit, size in the base tree)` — where
@@ -771,8 +784,8 @@ every growing PR must write, and three times running two PRs that each wrote it
 correctly composed into a red `main` that then failed everyone downstream. Two
 consequences for planning: **do not "fix" a red ratchet you did not cause** by
 folding a baseline regeneration into an unrelated PR — land it on its own from
-a fresh `main`; and note that splitting a god file buys structure, not slack,
-since `--update` retightens every ceiling to its file's current size.
+a fresh `main`; and note that splitting a god file buys structure, not slack
+until someone runs `make file-size-retighten`, which is a separate PR.
 
 The workspace's Rust god files, by crate (the bench harness's Python offenders
 sit in the same baseline). Each file's ceiling lives in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ make shellcheck
 ./scripts/check-invariants.sh
 python3 ./scripts/check-doc-links.py check
 ./scripts/check-command-docs.sh
+./scripts/check-website-inputs.sh
 ./scripts/check-brand-case.sh
 ./scripts/check-file-size.sh
 ./scripts/check-god-files.sh
@@ -124,9 +125,9 @@ touched (#1437).
 
 CI enforces the same steps, split across `ci.yml` (plus a release smoke build);
 `docs-guards.yml`, which runs the prose guards — `invariants`, `doc-links`,
-`command-docs`, `brand-case`, `gate-parity`, `god-files` and `design-refs` — on
-their own because they trigger on the `docs/**` and `*.md` paths that `ci.yml`
-deliberately ignores; `wire-schema.yml`, for the
+`command-docs`, `website-inputs`, `brand-case`, `gate-parity`, `god-files` and
+`design-refs` — on their own because they trigger on the `docs/**`, `website/**`
+and `*.md` paths that `ci.yml` deliberately skips; `wire-schema.yml`, for the
 same reason in the other direction — a PR that only hand-edits a generated
 schema under `docs/wire/` starts neither of the others (#1439); and
 `guard-self-tests.yml`, which runs `prose`, `hue-separation` and

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CARGO_SCOPE ?= --workspace
 # saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
-                    command-docs brand-case file-size god-files gate-parity left-behind \
+                    command-docs website-inputs brand-case file-size god-files gate-parity left-behind \
                     role-names stat-portability module-reachability typed-errors \
                     tool-error-class \
                     dead-code-allows measured-constants diagnostic-codes consumer-sites \
@@ -299,6 +299,10 @@ doc-adopt: ## Scaffold frontmatter onto a document so it can be cited: make doc-
 .PHONY: command-docs
 command-docs: ## Assert every stella subcommand has a listed reference page (#993)
 	@./scripts/check-command-docs.sh
+
+.PHONY: website-inputs
+website-inputs: ## Assert every website/ path a Rust source reads is declared and present (#4632)
+	@./scripts/check-website-inputs.sh
 
 .PHONY: brand-case
 brand-case: ## Assert docs prose spells the wordmark lowercase (#1500)
@@ -758,6 +762,14 @@ automerge-nudge-test: ## Test which PR the auto-merge nudge picks (hermetic; not
 .PHONY: file-size-test
 file-size-test: ## Test the file-size ratchet's language coverage and its change-relative judgement (hermetic; not part of `gate`)
 	./scripts/test-file-size.sh
+
+.PHONY: website-inputs-test
+website-inputs-test: ## Test the website-inputs guard's three failure directions (hermetic; not part of `gate`)
+	./scripts/test-website-inputs.sh
+
+.PHONY: ci-rust-scope-test
+ci-rust-scope-test: ## Test which diffs run the Rust gate, prose skips and fail-open included (hermetic; not part of `gate`)
+	./scripts/test-ci-rust-scope.sh
 
 .PHONY: no-scratch-test
 no-scratch-test: ## Test the session-scratch boundary: the ignore rules and the guard together (#2888; hermetic; not part of `gate`)

--- a/Makefile
+++ b/Makefile
@@ -342,9 +342,19 @@ wire-paths-test: ## Test the wire-path guard's failure directions (hermetic; not
 file-size: ## Assert no new source file exceeds the 1500-line ratchet (#629, #825, #1563, #3811)
 	@./scripts/check-file-size.sh
 
+# Raise-only: it moves the ceilings that must move for this tree to pass and
+# leaves every other entry at the number it had. A repair PR then edits exactly
+# the lines it needs, instead of lowering twenty ceilings measured on a branch
+# that main is about to overtake (#4657).
 .PHONY: file-size-update
-file-size-update: ## Retighten the 1500-line ratchet baseline (run after splitting a file)
+file-size-update: ## Raise the 1500-line ratchet ceilings this tree needs, lowering none (#4657)
 	@./scripts/check-file-size.sh --update
+
+# The other direction, and a PR of its own: reclaiming the slack a split earned
+# is safe exactly when nothing is blocked on it.
+.PHONY: file-size-retighten
+file-size-retighten: ## Lower every ceiling to its file's current size (a deliberate, separate pass)
+	@./scripts/check-file-size.sh --update --retighten
 
 .PHONY: tokens
 tokens: ## Validate the colour system: hue clamp, generated-file sync, no retired hex

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -39,7 +39,38 @@
 # from 2,400 to 2,100 lines does NOT fail the gate. Demanding a baseline edit for
 # every incremental improvement would tax exactly the refactoring work this
 # guard exists to encourage (see #458, which decomposes the two worst files).
-# Run --update after such work to tighten the ceilings.
+# Run --update --retighten after such work to tighten the ceilings; see the
+# next section for why the tightening is a separate, deliberate pass.
+#
+# ── --update raises; --retighten lowers, and only when asked (#4657) ──────────
+#
+# `--update` used to rewrite every ceiling to its file's current size on the
+# branch it ran on. Correct for that branch, and it turned the PR *repairing* a
+# red `main` into the next break, because a repair PR is the one PR guaranteed
+# to be racing every other merge — main is red and everyone is waiting on it.
+#
+# On 2026-08-24 that happened twice in a row, the second time caused by the
+# first one's fix. #4646 was `main` red on driver.rs and usage.rs. PR #4652
+# repaired those two, and the same run also lowered command_deck.rs from 3752
+# to 3656 — measured on #4652's branch, while main's copy was 3737 lines. The
+# moment #4652 merged, `main` was red again on command_deck.rs (+81),
+# deck_ui.rs (+15) and views/engine.rs (+1), which is #4654, and every open PR
+# was blocked by `main-red-hold` for half an hour. The author could not decline
+# those other twenty edits, and nothing in the diff said which of them were
+# newly risky.
+#
+# So the two directions are split. `--update` is RAISE-ONLY: a ceiling that
+# must go up to admit the tree goes up, every other live entry keeps the number
+# it had, and a repair PR edits exactly the lines it needs. `--retighten` adds
+# the lowering, for the deliberate pass that reclaims the slack — which is safe
+# precisely when nothing is blocked on it.
+#
+# Neither mode ADDS an entry (see the refusal below), and both still RETIRE
+# one: an entry whose file dropped to <= LIMIT, or whose file is gone, is a
+# hard failure of the check with `--update` named as the only remedy, so
+# raise-only that kept them would leave the gate red with no way out. Retiring
+# an exemption whose subject no longer exists is not a tightening of a live
+# ceiling, which is the thing that raced.
 #
 # What this guard does NOT do is forbid a grandfathered file from ever growing.
 # Adding any subcommand to stella-cli, or any module to stella-store, costs a
@@ -193,8 +224,13 @@ if [ "${1:-}" = "--update" ]; then
   shift
   grandfathered_arg="$(mktemp)"
   trap 'rm -f "$grandfathered_arg"' EXIT
+  retighten=""
   while [ "$#" -gt 0 ]; do
     case "$1" in
+    --retighten)
+      retighten=1
+      shift
+      ;;
     --grandfather)
       if [ "$#" -lt 2 ]; then
         echo "check-file-size: --grandfather needs a path." >&2
@@ -265,6 +301,28 @@ if [ "${1:-}" = "--update" ]; then
     fi
   fi
 
+  # Raise-only unless --retighten was asked for (#4657). Every path here is
+  # already over the limit and already carries a prior decision or an explicit
+  # --grandfather, so the only question left is which number it gets: the size
+  # measured on this branch, or the larger of that and the ceiling the baseline
+  # already records. Taking the max is what stops a repair PR quietly lowering
+  # twenty ceilings it never looked at.
+  #
+  # A path with no recorded ceiling — the --grandfather case — takes its
+  # current size under both modes; `max(current, absent)` is `current`.
+  written="$over"
+  if [ -z "$retighten" ] && [ -f "$baseline" ]; then
+    written="$(printf '%s\n' "$over" | awk 'NF' | awk -v baseline="$baseline" '
+      BEGIN {
+        while ((getline line < baseline) > 0) {
+          if (line ~ /^#/) continue
+          if (split(line, f, " ") >= 2) ceiling[f[2]] = f[1] + 0
+        }
+      }
+      { n = $1 + 0; p = $2; if (p in ceiling && ceiling[p] > n) n = ceiling[p]; printf "%d %s\n", n, p }
+    ' | LC_ALL=C sort -k2)"
+  fi
+
   {
     echo "# Grandfathered files over the ${LIMIT}-line ratchet. See #629 and"
     echo "# scripts/check-file-size.sh. Format: <ceiling> <path>."
@@ -279,12 +337,17 @@ if [ "${1:-}" = "--update" ]; then
     # on every machine. A UTF-8 locale sorts punctuation differently (macOS
     # orders agent/tests.rs before agent.rs), which reshuffles untouched lines
     # and buries the one ceiling that actually moved.
-    # Already computed above, and deliberately not recomputed: the set written
-    # must be the exact set the refusal check judged.
-    if [ -n "$over" ]; then printf '%s\n' "$over"; fi
+    # Derived from `$over` above and deliberately not recomputed: the set of
+    # PATHS written must be the exact set the refusal check judged.
+    if [ -n "$written" ]; then printf '%s\n' "$written"; fi
   } >"$baseline.tmp"
   mv "$baseline.tmp" "$baseline"
-  echo "check-file-size: baseline updated — $(grep -cv '^#' "$baseline") grandfathered file(s) over $LIMIT lines."
+  if [ -n "$retighten" ]; then
+    mode="retightened to current sizes"
+  else
+    mode="raised where needed, no ceiling lowered"
+  fi
+  echo "check-file-size: baseline updated ($mode) — $(grep -cv '^#' "$baseline") grandfathered file(s) over $LIMIT lines."
   exit 0
 fi
 

--- a/scripts/check-website-inputs.sh
+++ b/scripts/check-website-inputs.sh
@@ -120,8 +120,15 @@ $entries
 EOF
 
 # Every website path any Rust source under crates/ names, as one literal.
+#
+# `|| true` on the grep: it exits 1 when nothing matches, and `pipefail` would
+# turn that into the whole script dying here — before any verdict, with no
+# message — for a tree where no Rust source names a website path at all. That
+# tree is the goal state, not an error, and it is exactly when the stale-entry
+# check below has something to say. Same trap #1800 documents in
+# scripts/check-file-size.sh.
 literals="$(
-  git grep -ohE 'website/[A-Za-z0-9._/-]*' -- 'crates/**/*.rs' |
+  { git grep -ohE 'website/[A-Za-z0-9._/-]*' -- 'crates/**/*.rs' || true; } |
     sed -e 's/\/$//' | LC_ALL=C sort -u
 )"
 

--- a/scripts/check-website-inputs.sh
+++ b/scripts/check-website-inputs.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# Guard: every path under website/ that a Rust source names is declared in
+# scripts/website-rust-inputs.txt, and every declared path still exists. See
+# #4632.
+#
+# ── Why ──────────────────────────────────────────────────────────────────────
+#
+# `website/` is on ci.yml's prose list: a diff confined to it skips the Rust
+# gate. That is safe only while nothing under website/ can break a Rust test,
+# and three files there are test inputs today. #4588 moved PROVIDER_CATALOG out
+# of the file `config::tests::docs_sync` read, in a website-only diff. Nothing
+# ran that test before the merge, and nothing ran it on the push either, so
+# `main` was red until the next commit that touched a crate went red with it
+# and took three more down.
+#
+# The instance was repaired by carving the two known paths out of the prose
+# filter. The class is that the carve-out is a hand-kept list in a YAML file,
+# with no relation to what the tests actually read — and it was already
+# incomplete when this guard was written: `settings/completeness.rs` reads
+# `website/content/docs/configuration/stella-toml.mdx`, which the carve-out did
+# not name.
+#
+# So the inventory moves into one file that both sides read. ci.yml builds its
+# carve-out from the `read` entries (scripts/ci-rust-scope.sh), and this guard
+# holds the entries to the tree. Neither is a copy of the other.
+#
+# ── What it checks ───────────────────────────────────────────────────────────
+#
+#   1. Every declared path exists. A website-only PR that renames, moves or
+#      deletes a file a Rust test reads goes red here, before the merge — which
+#      is the pre-merge report #4632 asks for, and the one ci.yml cannot give
+#      because its Rust job is skipped for exactly that diff. This guard runs in
+#      docs-guards.yml, which triggers on website/**.
+#
+#   2. Every `website/...` path a Rust source under crates/ names is covered by
+#      an entry. Adding a test that reads a new website file, or a doc comment
+#      pointing at one, is a red gate until the path is declared — and a `read`
+#      declaration lands in ci.yml's carve-out by construction, so the gate will
+#      run for a diff that touches it. Had this existed, #4588's diff would have
+#      run the Rust gate and gone red on its own PR.
+#
+#   3. No stale entry: every declared path is still named by some Rust source.
+#      An entry nobody reads widens the carve-out for nothing, and reads as a
+#      cross-boundary coupling that no longer exists.
+#
+# ── What it does NOT check ───────────────────────────────────────────────────
+#
+# Whether a `read` was declared as a `mention`. Nothing mechanical can tell a
+# doc comment that names a path from a test that opens it, and pretending a
+# grep could would be worse than saying so: a reviewer decides, and the two
+# kinds are spelled differently in the inventory so there is something to
+# decide about.
+#
+# It also sees a path only where it appears as one literal. A test that builds
+# `root.join("website").join("src/…")` names no `website/…` string, so nothing
+# here can find it — declare it, and say the path once in the doc comment above
+# the helper, which is what `docs_sync.rs` does.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+inventory="${WEBSITE_INPUTS_FILE:-scripts/website-rust-inputs.txt}"
+
+fail=0
+report=""
+note() { report="${report}check-website-inputs: $1"$'\n'; }
+
+# The verdict is decided before anything is written, and the write is
+# best-effort: a reader that closed the pipe (`| head -1`) must be able to
+# change neither the report nor the exit code (#1815).
+emit() {
+  trap '' PIPE
+  printf '%s' "$report" >&2 || true
+}
+
+if [ ! -f "$inventory" ]; then
+  note "FAIL — $inventory does not exist."
+  note "     It is the single list ci.yml's prose carve-out is built from;"
+  note "     without it the Rust gate cannot know which website paths are"
+  note "     test inputs."
+  emit
+  exit 1
+fi
+
+# `<kind> <path>`, comments and blanks dropped. A trailing slash is stripped
+# here so the whole script compares normalized paths and the inventory can
+# spell a directory either way.
+entries="$(sed -e 's/#.*//' "$inventory" | awk 'NF >= 2 { sub(/\/$/, "", $2); print $1, $2 }')"
+
+if [ -z "$entries" ]; then
+  note "FAIL — $inventory declares nothing."
+  emit
+  exit 1
+fi
+
+while read -r kind path; do
+  [ -n "${kind:-}" ] || continue
+  case "$kind" in
+  read | mention) ;;
+  *)
+    note "FAIL — unknown kind '$kind' for '$path' in $inventory."
+    note "     Use 'read' (a Rust test opens it) or 'mention' (prose names it)."
+    fail=1
+    continue
+    ;;
+  esac
+  if [ ! -e "$path" ]; then
+    note "FAIL — $inventory declares '$path', which does not exist."
+    note "     A Rust source names it, so moving or deleting it breaks that"
+    note "     source. Repoint the Rust side and this entry together, in one"
+    note "     change — that is the whole point of declaring it here."
+    fail=1
+  fi
+done <<EOF
+$entries
+EOF
+
+# Every website path any Rust source under crates/ names, as one literal.
+literals="$(
+  git grep -ohE 'website/[A-Za-z0-9._/-]*' -- 'crates/**/*.rs' |
+    sed -e 's/\/$//' | LC_ALL=C sort -u
+)"
+
+# A `read` entry covers its subtree, because the tests walk one. A `mention`
+# covers itself and nothing below it: one line must never silence a directory.
+covered() {
+  local needle="$1" kind path
+  while read -r kind path; do
+    [ -n "${kind:-}" ] || continue
+    [ "$needle" = "$path" ] && return 0
+    if [ "$kind" = read ]; then
+      case "$needle" in
+      "$path"/*) return 0 ;;
+      esac
+    fi
+  done <<EOF
+$entries
+EOF
+  return 1
+}
+
+undeclared=""
+for literal in $literals; do
+  covered "$literal" || undeclared="${undeclared}  ${literal}"$'\n'
+done
+
+if [ -n "$undeclared" ]; then
+  note "FAIL — a Rust source names these website paths, and $inventory does not:"
+  report="${report}${undeclared}"
+  note ""
+  note "     Declare each one. 'read <path>' if a test opens it — that also"
+  note "     puts it in ci.yml's carve-out, so a diff touching it runs the"
+  note "     Rust gate instead of skipping it as prose. 'mention <path>' if"
+  note "     it is only prose pointing a reader somewhere."
+  fail=1
+fi
+
+# The other direction: an entry nothing names any more.
+while read -r kind path; do
+  [ -n "${kind:-}" ] || continue
+  found=0
+  for literal in $literals; do
+    if [ "$literal" = "$path" ]; then
+      found=1
+      break
+    fi
+    if [ "$kind" = read ]; then
+      case "$literal" in
+      "$path"/*)
+        found=1
+        break
+        ;;
+      esac
+    fi
+  done
+  if [ "$found" -eq 0 ]; then
+    note "FAIL — $inventory declares '$path', which no Rust source names."
+    note "     Drop the entry. A stale 'read' widens the Rust gate's trigger"
+    note "     for a coupling that no longer exists, and reads as one that does."
+    fail=1
+  fi
+done <<EOF
+$entries
+EOF
+
+if [ "$fail" -ne 0 ]; then
+  emit
+  exit 1
+fi
+
+emit
+declared="$(printf '%s\n' "$entries" | awk 'NF' | wc -l | tr -d ' ')"
+reads="$(printf '%s\n' "$entries" | awk '$1 == "read"' | wc -l | tr -d ' ')"
+trap '' PIPE
+printf 'check-website-inputs: OK — %s declared website path(s), %s of them Rust test inputs, all present.\n' \
+  "$declared" "$reads" || true

--- a/scripts/ci-rust-scope.sh
+++ b/scripts/ci-rust-scope.sh
@@ -80,12 +80,21 @@ if [ -z "$changed" ]; then
   exit 0
 fi
 
+# The file list goes to a file, and every grep below reads that file rather
+# than a pipe. `grep -q` exits on its first match and closes the pipe under it,
+# so the writer takes a SIGPIPE — and `pipefail` then reports 141 for a
+# pipeline that MATCHED. It is a race, so it answers wrongly on some runs and
+# not others, and the wrong answer here is `false`: a skipped Rust gate. Same
+# shape as #1815, which scripts/check-gate-parity.sh carries a note about.
+files="$(mktemp "${TMPDIR:-/tmp}/stella-ci-rust-scope.XXXXXX")"
+trap 'rm -f "$files"' EXIT INT TERM
+printf '%s\n' "$changed" >"$files"
+
 # The prose paths: website/, docs/, .github/ISSUE_TEMPLATE/, and root-level
 # *.md only — `[^/]+\.md$` stops at the first `/`, like the glob `*.md`, so a
 # crate's own README still pays the gate. Anything outside them means the gate
 # runs.
-if printf '%s\n' "$changed" |
-  grep -Evq '^(website/|docs/|\.github/ISSUE_TEMPLATE/)|^[^/]+\.md$'; then
+if grep -Evq '^(website/|docs/|\.github/ISSUE_TEMPLATE/)|^[^/]+\.md$' "$files"; then
   echo "true"
   exit 0
 fi
@@ -95,15 +104,21 @@ fi
 # is not restated here: scripts/check-website-inputs.sh holds those entries to
 # what the Rust sources actually name, so the filter and the tests cannot drift
 # apart the way the filter and the trigger did.
-if [ -f "$inventory" ]; then
-  carve="$(sed -e 's/#.*//' "$inventory" |
-    awk '$1 == "read" { p = $2; sub(/\/$/, "", p); gsub(/\./, "\\.", p); print "^" p "(/|$)" }')"
-  if [ -n "$carve" ] && printf '%s\n' "$changed" | grep -Eq "$(printf '%s' "$carve" | paste -sd '|' -)"; then
-    echo "true"
-    exit 0
-  fi
-else
+if [ ! -f "$inventory" ]; then
   open "$inventory is missing, so the carve-out cannot be built"
+fi
+
+carve="$(sed -e 's/#.*//' "$inventory" |
+  awk '$1 == "read" { p = $2; sub(/\/$/, "", p); gsub(/\./, "\\.", p); print "^" p "(/|$)" }' |
+  paste -sd '|' -)"
+
+if [ -z "$carve" ]; then
+  open "$inventory declares no read paths, so the carve-out would be empty"
+fi
+
+if grep -Eq "$carve" "$files"; then
+  echo "true"
+  exit 0
 fi
 
 echo "false"

--- a/scripts/ci-rust-scope.sh
+++ b/scripts/ci-rust-scope.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Does this diff reach past the prose paths? Prints `true` or `false`.
+#
+#   ./scripts/ci-rust-scope.sh <base> <head>
+#
+# `.github/workflows/ci.yml`'s `changes` job is the only caller. See #1892 for
+# why that job exists at all, #4632 for the carve-out, and #4606 for why the
+# push side asks the same question the pull_request side does.
+#
+# ── One rule, one place (#4606) ──────────────────────────────────────────────
+#
+# The rule used to be written twice: once as `paths-ignore` on ci.yml's `push:`
+# trigger, and once as a regex inside the `changes` job for pull requests. The
+# trigger carried a comment asking a human to keep the two in agreement, which
+# is what a repository writes when it cannot enforce something — and they were
+# not in agreement. The job had a carve-out for the website files a Rust test
+# reads; the trigger could not have one, because `paths-ignore` has no negation
+# and "ignore website/** except this one file" is not expressible. So a merge
+# whose diff was confined to website/ started no Rust gate at all.
+#
+# That is how `main` went red on 2026-08-23 with nothing reporting it: #4588's
+# pull_request run answered `rust=false` (before the carve-out existed) and its
+# push run never started. Four consecutive commits were red, one root cause,
+# none of them the change that caused it.
+#
+# Now the trigger has no path filter and this script answers for both events. A
+# website-only merge pays one checkout and one diff instead of an hour of Rust
+# — the same saving, decided once.
+#
+# ── Failing open ─────────────────────────────────────────────────────────────
+#
+# A base this clone cannot resolve — a force-push whose predecessor is gone, a
+# branch's first push, a fetch too shallow to reach it — answers `true`. The
+# expensive answer is the safe one: the cost of running the gate when it was
+# not needed is minutes, and the cost of skipping it when it was is a red
+# `main` nobody is watching.
+#
+# Uses portable POSIX tools so it runs on a bare CI runner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+base="${1:-}"
+head="${2:-HEAD}"
+
+inventory="${WEBSITE_INPUTS_FILE:-scripts/website-rust-inputs.txt}"
+
+open() {
+  echo "ci-rust-scope: $1 — running the full gate." >&2
+  echo "true"
+  exit 0
+}
+
+# The all-zero SHA is what GitHub sends as `github.event.before` for a branch's
+# first push. There is no predecessor to diff against.
+case "$base" in
+"") open "no base commit given" ;;
+0000000000000000000000000000000000000000) open "the base is the null commit" ;;
+esac
+
+if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+  open "the base commit $base is not in this clone"
+fi
+
+# Three-dot: what HEAD changed since it and the base diverged. For a push where
+# the base is an ancestor that is the push's own diff; for a pull request it is
+# the PR's diff, unpolluted by whatever landed on the base branch meanwhile.
+# With no merge base at all it errors, and the trap above turns that into the
+# expensive answer.
+if ! changed="$(git diff --name-only "$base...$head" 2>/dev/null)"; then
+  open "no merge base between $base and $head"
+fi
+
+# An empty diff runs nothing here. Reporting that a PR is empty is
+# .github/workflows/empty-diff.yml's job, not this script's.
+if [ -z "$changed" ]; then
+  echo "false"
+  exit 0
+fi
+
+# The prose paths: website/, docs/, .github/ISSUE_TEMPLATE/, and root-level
+# *.md only — `[^/]+\.md$` stops at the first `/`, like the glob `*.md`, so a
+# crate's own README still pays the gate. Anything outside them means the gate
+# runs.
+if printf '%s\n' "$changed" |
+  grep -Evq '^(website/|docs/|\.github/ISSUE_TEMPLATE/)|^[^/]+\.md$'; then
+  echo "true"
+  exit 0
+fi
+
+# The prose paths that are not prose, because a Rust test reads the file and a
+# test that never ran is green. The list is scripts/website-rust-inputs.txt and
+# is not restated here: scripts/check-website-inputs.sh holds those entries to
+# what the Rust sources actually name, so the filter and the tests cannot drift
+# apart the way the filter and the trigger did.
+if [ -f "$inventory" ]; then
+  carve="$(sed -e 's/#.*//' "$inventory" |
+    awk '$1 == "read" { p = $2; sub(/\/$/, "", p); gsub(/\./, "\\.", p); print "^" p "(/|$)" }')"
+  if [ -n "$carve" ] && printf '%s\n' "$changed" | grep -Eq "$(printf '%s' "$carve" | paste -sd '|' -)"; then
+    echo "true"
+    exit 0
+  fi
+else
+  open "$inventory is missing, so the carve-out cannot be built"
+fi
+
+echo "false"

--- a/scripts/test-ci-rust-scope.sh
+++ b/scripts/test-ci-rust-scope.sh
@@ -18,7 +18,7 @@
 #
 # The decision used to live in a YAML `run:` block, where nothing could
 # exercise it, beside a `paths-ignore` list a comment asked a human to keep in
-# agreement with it. Both halves are here now, so both are testable.
+# agreement with it. It is one script now, and this suite is what exercises it.
 #
 # bash 3.2 compatible.
 

--- a/scripts/test-ci-rust-scope.sh
+++ b/scripts/test-ci-rust-scope.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Tests for ci-rust-scope.sh — the one place that decides whether a diff runs
+# the Rust gate (#4606, #4632).
+#
+#   ./scripts/test-ci-rust-scope.sh
+#
+# Not part of `make gate`: it builds throwaway git repositories, the same
+# posture as scripts/test-file-size.sh.
+#
+# ── Why this suite exists ────────────────────────────────────────────────────
+#
+# The rule this script implements decides whether the required Rust context
+# runs at all. When it answers wrongly in the cheap direction nothing reports:
+# the job is skipped, the PR is green, and the failure surfaces on somebody
+# else's branch hours later. #4588 is that shape, and it cost four consecutive
+# red commits on `main`.
+#
+# The decision used to live in a YAML `run:` block, where nothing could
+# exercise it, beside a `paths-ignore` list a comment asked a human to keep in
+# agreement with it. Both halves are here now, so both are testable.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/ci-rust-scope.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# A throwaway repository with the script installed at the path it expects (it
+# derives the repo root from its own location) and an inventory declaring one
+# read path and one mention. $1 = case name. Echoes the repo path.
+new_repo() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/scripts"
+  cp "$SCRIPT" "$dir/scripts/ci-rust-scope.sh"
+  cat >"$dir/scripts/website-rust-inputs.txt" <<'EOF'
+# test inventory
+read website/content/docs/commands/
+read website/src/components/provider-catalog.ts
+mention website/content/docs/scripting.mdx
+EOF
+  git -C "$dir" init -q
+  git -C "$dir" config user.email t@t.invalid
+  git -C "$dir" config user.name t
+  printf 'seed\n' >"$dir/seed.txt"
+  git -C "$dir" add -A
+  git -C "$dir" commit -q -m base
+  echo "$dir"
+}
+
+# $1 = repo, then paths to create and commit as one change.
+change() {
+  local dir="$1"
+  shift
+  local p
+  for p in "$@"; do
+    mkdir -p "$(dirname "$dir/$p")"
+    printf 'x\n' >>"$dir/$p"
+  done
+  git -C "$dir" add -A
+  git -C "$dir" commit -q -m change
+}
+
+# want <name> <true|false> <repo> [base]
+#
+# `${4-...}` and not `${4:-...}`: O3 passes an EMPTY base on purpose, and the
+# colon form would substitute the default for it and test HEAD^ instead.
+want() {
+  local name="$1" expect="$2" dir="$3" base="${4-HEAD^}" got
+  got="$("$dir/scripts/ci-rust-scope.sh" "$base" HEAD 2>/dev/null)"
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1))
+    echo "ok   $name"
+  else
+    fail=$((fail + 1))
+    echo "FAIL $name — wanted '$expect', got '$got'"
+  fi
+}
+
+# ── The prose paths skip ─────────────────────────────────────────────────────
+r="$(new_repo prose_docs)"
+change "$r" "docs/spec/thing.md"
+want "P1 a docs-only diff is prose" false "$r"
+
+r="$(new_repo prose_root_md)"
+change "$r" "README.md"
+want "P2 a root-level *.md is prose" false "$r"
+
+r="$(new_repo prose_website)"
+change "$r" "website/src/app/page.tsx"
+want "P3 an ordinary website file is prose" false "$r"
+
+r="$(new_repo prose_issue_template)"
+change "$r" ".github/ISSUE_TEMPLATE/bug.yml"
+want "P4 an issue template is prose" false "$r"
+
+# ── ...and what is not prose ─────────────────────────────────────────────────
+r="$(new_repo rust)"
+change "$r" "crates/stella-core/src/lib.rs"
+want "R1 a crate diff runs the gate" true "$r"
+
+# A crate's own README is not a root-level *.md, which is the distinction the
+# `[^/]+\.md$` anchor exists to make.
+r="$(new_repo crate_readme)"
+change "$r" "crates/stella-core/README.md"
+want "R2 a crate README runs the gate" true "$r"
+
+r="$(new_repo mixed)"
+change "$r" "docs/spec/thing.md" "crates/stella-core/src/lib.rs"
+want "R3 prose mixed with code runs the gate" true "$r"
+
+# ── The carve-out: website paths a Rust test reads (#4632) ───────────────────
+#
+# C1 is the witness for #4588's shape: a diff confined to website/, touching
+# nothing but the file `docs_sync` reads. It skipped the gate, and `main` was
+# red on a test nobody had run.
+r="$(new_repo carve_file)"
+change "$r" "website/src/components/provider-catalog.ts"
+want "C1 a website file a Rust test reads runs the gate" true "$r"
+
+r="$(new_repo carve_dir)"
+change "$r" "website/content/docs/commands/run.mdx"
+want "C2 a file under a read directory runs the gate" true "$r"
+
+# The carve-out must stay exactly as wide as the inventory. A `mention` is
+# prose: nothing reads it, so it must not drag the gate in.
+r="$(new_repo mention_is_prose)"
+change "$r" "website/content/docs/scripting.mdx"
+want "C3 a mentioned-but-unread page is still prose" false "$r"
+
+# The dot in a filename is a regex metacharacter, and an unescaped one makes
+# the carve-out match paths it was never given.
+r="$(new_repo dot_is_literal)"
+change "$r" "website/src/components/provider-catalogXts"
+want "C4 the carve-out's dots are literal" false "$r"
+
+# ── Failing open ─────────────────────────────────────────────────────────────
+#
+# Every one of these answers the expensive way. A base this clone cannot
+# resolve must never read as "nothing changed": the cost of a needless gate run
+# is minutes, and the cost of a skipped one is a red main nobody is watching.
+r="$(new_repo open_null)"
+change "$r" "docs/spec/thing.md"
+want "O1 the null commit (a branch's first push) runs the gate" true "$r" \
+  0000000000000000000000000000000000000000
+
+r="$(new_repo open_missing)"
+change "$r" "docs/spec/thing.md"
+want "O2 a base commit this clone does not have runs the gate" true "$r" \
+  deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+
+r="$(new_repo open_empty)"
+change "$r" "docs/spec/thing.md"
+want "O3 an empty base runs the gate" true "$r" ""
+
+# An inventory that has gone missing cannot build a carve-out, so the filter
+# would silently narrow back to what it was before #4605 — the exact hole.
+r="$(new_repo open_no_inventory)"
+change "$r" "website/src/components/provider-catalog.ts"
+rm -f "$r/scripts/website-rust-inputs.txt"
+want "O4 a missing inventory runs the gate rather than narrowing the filter" true "$r"
+
+# ── The negative direction ───────────────────────────────────────────────────
+# Without this the suite is satisfiable by a script that always answers true.
+r="$(new_repo empty_diff)"
+want "N1 an empty diff runs nothing" false "$r" HEAD
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]

--- a/scripts/test-ci-rust-scope.sh
+++ b/scripts/test-ci-rust-scope.sh
@@ -159,12 +159,25 @@ r="$(new_repo open_empty)"
 change "$r" "docs/spec/thing.md"
 want "O3 an empty base runs the gate" true "$r" ""
 
+# Two histories with no common ancestor. `git diff A...B` exits 128 with "no
+# merge base" rather than printing an empty diff, and an empty diff is exactly
+# what `false` means — so without this branch the guard would read a
+# force-pushed rewrite as "nothing changed".
+r="$(new_repo open_no_merge_base)"
+change "$r" "docs/spec/thing.md"
+orphan_base="$(git -C "$r" rev-parse HEAD)"
+git -C "$r" checkout -q --orphan unrelated
+git -C "$r" rm -rq --cached .
+rm -f "$r/seed.txt" "$r/docs/spec/thing.md"
+change "$r" "docs/spec/other.md"
+want "O4 two histories with no common ancestor run the gate" true "$r" "$orphan_base"
+
 # An inventory that has gone missing cannot build a carve-out, so the filter
 # would silently narrow back to what it was before #4605 — the exact hole.
 r="$(new_repo open_no_inventory)"
 change "$r" "website/src/components/provider-catalog.ts"
 rm -f "$r/scripts/website-rust-inputs.txt"
-want "O4 a missing inventory runs the gate rather than narrowing the filter" true "$r"
+want "O5 a missing inventory runs the gate rather than narrowing the filter" true "$r"
 
 # ── The negative direction ───────────────────────────────────────────────────
 # Without this the suite is satisfiable by a script that always answers true.

--- a/scripts/test-file-size.sh
+++ b/scripts/test-file-size.sh
@@ -375,6 +375,68 @@ commit "$r" "a tree well inside the limit"
 want "C3 --absolute passes a tree within its ceilings" \
   expect-pass "$r" "check-file-size: OK" "--absolute"
 
+# ── --update raises; --retighten lowers, and only when asked (#4657) ──────────
+#
+# The retighten was unconditional, so the PR repairing a red `main` also lowered
+# every ceiling it never looked at, measured on a branch main was about to
+# overtake. #4652 lowered command_deck.rs from 3752 to 3656 while main's copy
+# was 3737, and #4654 — main red again, every open PR held — was the result.
+#
+# U1 is the witness: the same run that raises the ceiling it was called for must
+# leave the untouched entry alone. U2 is what stops that becoming a freeze, and
+# U3/U4 pin the two edits raise-only must still make, because the check hard-
+# fails on both and names `--update` as the only remedy.
+
+# $1 = name, $2 = repo, $3 = path, $4 = expected ceiling or "absent".
+entry_is() {
+  local name="$1" dir="$2" path="$3" want_val="$4" got
+  got="$(awk -v p="$path" '$2 == p { print $1 }' "$dir/scripts/file-size-baseline.txt")"
+  [ -n "$got" ] || got="absent"
+  if [ "$got" = "$want_val" ]; then
+    pass=$((pass + 1)); echo "ok   $name"
+  else
+    fail=$((fail + 1)); echo "FAIL $name — baseline says '$got' for $path, wanted '$want_val'"
+  fi
+}
+
+# The repair shape: one file grew past its ceiling and must be admitted; a
+# sibling god file happens to be smaller on this branch than the number main
+# recorded for it. Only the first may move.
+r="$(new_repo "update_raise_only")"
+plant "$r" "src/grew.rs" 1700
+plant "$r" "src/sibling.rs" 1600
+set_baseline "$r" "1650 src/grew.rs" "1690 src/sibling.rs"
+"$r/scripts/check-file-size.sh" --update >/dev/null 2>&1
+entry_is "U1 --update raises the ceiling that had to move" "$r" src/grew.rs 1700
+entry_is "U2 --update leaves an unrelated ceiling where it was" "$r" src/sibling.rs 1690
+
+# The deliberate pass, which is the whole point of keeping the old behaviour
+# available: asked for by name, it reclaims the slack.
+"$r/scripts/check-file-size.sh" --update --retighten >/dev/null 2>&1
+entry_is "U3 --retighten lowers the unrelated ceiling when asked" "$r" src/sibling.rs 1600
+
+# Raise-only must still RETIRE. Both of these are hard failures of the check
+# with `--update` named as the only remedy, so a mode that kept them would
+# leave the gate red with no way out.
+r="$(new_repo "update_retires")"
+plant "$r" "src/split.rs" 900
+plant "$r" "src/still_big.rs" 1600
+set_baseline "$r" "2400 src/split.rs" "1600 src/still_big.rs" "1800 src/deleted.rs"
+"$r/scripts/check-file-size.sh" --update >/dev/null 2>&1
+entry_is "U4 --update retires an entry whose file dropped under the limit" "$r" src/split.rs absent
+entry_is "U5 --update retires an entry whose file is gone" "$r" src/deleted.rs absent
+entry_is "U6 --update leaves the entry that is still earning its place" "$r" src/still_big.rs 1600
+
+# And the refusal is unchanged by the split: neither mode may grandfather a
+# first-time crossing.
+r="$(new_repo "update_still_refuses")"
+plant "$r" "src/new.rs" 1600
+set_baseline "$r"
+"$r/scripts/check-file-size.sh" --update >/dev/null 2>&1
+entry_is "U7 --update still refuses to add an entry for a first-time crossing" "$r" src/new.rs absent
+"$r/scripts/check-file-size.sh" --update --retighten >/dev/null 2>&1
+entry_is "U8 --retighten refuses it too" "$r" src/new.rs absent
+
 echo
 echo "passed ${pass}, failed ${fail}"
 [ "$fail" -eq 0 ]

--- a/scripts/test-website-inputs.sh
+++ b/scripts/test-website-inputs.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Tests for check-website-inputs.sh — the inventory that ties ci.yml's prose
+# carve-out to what the Rust sources actually read (#4632).
+#
+#   ./scripts/test-website-inputs.sh
+#
+# Not part of `make gate`: it builds throwaway git repositories, the same
+# posture as scripts/test-file-size.sh.
+#
+# ── Why this suite exists ────────────────────────────────────────────────────
+#
+# The guard's whole value is its failure directions, and each of the three is
+# invisible when it stops working: an inventory that has quietly become
+# incapable of failing reports the same green line as a healthy tree, and the
+# next website-only rename lands on top of it.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-website-inputs.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# A throwaway repository with the guard installed at the path it expects, one
+# Rust source naming a website path, and that path present. $1 = case name.
+new_repo() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/scripts" "$dir/crates/stella-cli/src" "$dir/website/content/docs/commands"
+  cp "$SCRIPT" "$dir/scripts/check-website-inputs.sh"
+  cat >"$dir/crates/stella-cli/src/tests.rs" <<'EOF'
+const COMMANDS_DOCS_DIR: &str = "website/content/docs/commands";
+EOF
+  printf 'run\n' >"$dir/website/content/docs/commands/run.mdx"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email t@t.invalid
+  git -C "$dir" config user.name t
+  echo "$dir"
+}
+
+# Overwrite the inventory. $1 = repo, then one "<kind> <path>" per entry.
+set_inventory() {
+  local dir="$1"
+  shift
+  {
+    printf '# test inventory\n'
+    local entry
+    for entry in "$@"; do printf '%s\n' "$entry"; done
+  } >"$dir/scripts/website-rust-inputs.txt"
+}
+
+# want <name> <expect-pass|expect-fail> <repo> [substring]
+want() {
+  local name="$1" expect="$2" dir="$3" sub="${4:-}" out rc
+  git -C "$dir" add -A >/dev/null 2>&1
+  out="$("$dir/scripts/check-website-inputs.sh" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ] && [ "$rc" -ne 0 ]; then
+    fail=$((fail + 1))
+    echo "FAIL $name — expected OK, got:"
+    echo "$out"
+    return
+  fi
+  if [ "$expect" = "expect-fail" ] && [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1))
+    echo "FAIL $name — the guard passed something it should have flagged:"
+    echo "$out"
+    return
+  fi
+  case "$out" in
+  *"$sub"*)
+    pass=$((pass + 1))
+    echo "ok   $name"
+    ;;
+  *)
+    fail=$((fail + 1))
+    echo "FAIL $name — verdict was right, report was not (wanted '$sub'):"
+    echo "$out"
+    ;;
+  esac
+}
+
+# ── The healthy tree ─────────────────────────────────────────────────────────
+r="$(new_repo clean)"
+set_inventory "$r" "read website/content/docs/commands/"
+want "W1 a declared, present, still-named path passes" \
+  expect-pass "$r" "check-website-inputs: OK"
+
+# ── 1. A declared path that vanished (#4632's own shape) ─────────────────────
+#
+# The website-only rename this guard exists to catch, and the direction ci.yml
+# cannot report: its Rust job is skipped for exactly this diff.
+r="$(new_repo moved)"
+set_inventory "$r" "read website/content/docs/commands/"
+rm -rf "$r/website/content/docs/commands"
+want "W2 a declared path that no longer exists is flagged" \
+  expect-fail "$r" "which does not exist"
+
+# ── 2. A Rust source naming a path nobody declared ───────────────────────────
+#
+# The forward direction: a new test that reads a website file must land in the
+# inventory, because that is what puts it in ci.yml's carve-out.
+r="$(new_repo undeclared)"
+mkdir -p "$r/website/src/components"
+printf 'x\n' >"$r/website/src/components/provider-catalog.ts"
+cat >>"$r/crates/stella-cli/src/tests.rs" <<'EOF'
+const CATALOG: &str = "website/src/components/provider-catalog.ts";
+EOF
+set_inventory "$r" "read website/content/docs/commands/"
+want "W3 an undeclared website path a Rust source names is flagged" \
+  expect-fail "$r" "provider-catalog.ts"
+
+# ── 3. A stale entry ─────────────────────────────────────────────────────────
+r="$(new_repo stale)"
+mkdir -p "$r/website/content/docs/configuration"
+printf 'x\n' >"$r/website/content/docs/configuration/stella-toml.mdx"
+set_inventory "$r" \
+  "read website/content/docs/commands/" \
+  "read website/content/docs/configuration/stella-toml.mdx"
+want "W4 an entry no Rust source names any more is flagged" \
+  expect-fail "$r" "which no Rust source names"
+
+# ── A mention covers itself and nothing under it ─────────────────────────────
+#
+# One line must never silence a directory: declaring the docs root as prose
+# cannot be what lets an unread page pass for a page a test opens.
+r="$(new_repo mention_is_narrow)"
+mkdir -p "$r/website/content/docs/configuration"
+printf 'x\n' >"$r/website/content/docs/configuration/stella-toml.mdx"
+cat >>"$r/crates/stella-cli/src/tests.rs" <<'EOF'
+/// See `website/content/docs/`.
+const PAGE: &str = "website/content/docs/configuration/stella-toml.mdx";
+EOF
+set_inventory "$r" \
+  "read website/content/docs/commands/" \
+  "mention website/content/docs/"
+want "W5 a mentioned directory does not cover the files under it" \
+  expect-fail "$r" "stella-toml.mdx"
+
+# ...and the same tree passes once the page is declared for what it is.
+set_inventory "$r" \
+  "read website/content/docs/commands/" \
+  "mention website/content/docs/" \
+  "read website/content/docs/configuration/stella-toml.mdx"
+want "W6 declaring it clears W5" expect-pass "$r" "check-website-inputs: OK"
+
+# ── The inventory itself ─────────────────────────────────────────────────────
+r="$(new_repo unknown_kind)"
+set_inventory "$r" "reads website/content/docs/commands/"
+want "W7 an unknown kind is flagged rather than ignored" \
+  expect-fail "$r" "unknown kind"
+
+r="$(new_repo no_inventory)"
+rm -f "$r/scripts/website-rust-inputs.txt"
+want "W8 a missing inventory is a failure, not a skip" \
+  expect-fail "$r" "does not exist"
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]

--- a/scripts/website-rust-inputs.txt
+++ b/scripts/website-rust-inputs.txt
@@ -1,0 +1,56 @@
+# Every path under website/ that a Rust source in crates/ names, and what kind
+# of naming it is. See scripts/check-website-inputs.sh and #4632.
+#
+# Format: <kind> <path>
+#
+#   read     a Rust test reads this file (or this directory) as an input, so a
+#            diff touching it MUST run the Rust gate. `.github/workflows/ci.yml`
+#            builds its carve-out from these lines, so the filter cannot drift
+#            from the inventory — there is only one list.
+#
+#            A `read` path names a directory when the tests walk one; coverage
+#            then extends to everything under it.
+#
+#   mention  prose names it — a doc comment, a module header, an assertion
+#            message. Nothing reads it, so a diff touching it is prose and the
+#            gate stays skipped. Exact match only: a mention of a directory
+#            does not cover the files inside it, or one line here would silence
+#            the guard for a whole subtree.
+#
+# Moving an entry from `mention` to `read` is what a reviewer checks when a
+# test starts reading a file the tree only used to talk about. Nothing can
+# decide that automatically; declaring it is what makes it reviewable.
+
+# ── read ─────────────────────────────────────────────────────────────────────
+
+# The command reference pages: the subcommand index, the per-command summaries,
+# and every flag's card since #3041. Asserted about by crates/stella-cli's
+# src/tests.rs, src/tests/flag_docs.rs and src/cli/help/tests.rs.
+read website/content/docs/commands/
+
+# The stella.toml reference page. Every root section the parser accepts must
+# carry a heading here — crates/stella-cli/src/settings/completeness.rs, #4425.
+read website/content/docs/configuration/stella-toml.mdx
+
+# The docs' copy of the provider registry, pinned field-by-field against
+# PROVIDERS by crates/stella-cli/src/config/tests/docs_sync.rs. #4588 moved the
+# records into this file in a website-only diff, which skipped the Rust gate on
+# both the pull_request and the push side and left `main` red on a test nobody
+# had run.
+read website/src/components/provider-catalog.ts
+
+# ── mention ──────────────────────────────────────────────────────────────────
+
+# crates/stella-tools/src/registry.rs points a reader at the hooks reference.
+mention website/content/docs/agent-tools/hooks.mdx
+
+# crates/stella-cli/src/main.rs points at where the scripting contract is
+# stated for consumers.
+mention website/content/docs/scripting.mdx
+
+# crates/stella-cli/src/tests/flag_docs.rs's module doc names the docs root.
+mention website/content/docs/
+
+# crates/stella-tui/src/palette.rs's module doc corrects a claim about which
+# sheet the v1 palette is mirrored in.
+mention website/src/app/tokens.css


### PR DESCRIPTION
Four CI-correctness issues, all four fixed. Nothing skipped.

## What

### #4606 — a website-only merge started no Rust gate at all

`.github/workflows/ci.yml`'s `push:` trigger carried `paths-ignore: website/**`,
so a commit reaching `main` whose diff was confined to `website/` started no
Rust gate — not skipped and reported, never started. `paths-ignore` has no
negation, so the trigger could not express "ignore `website/**` except the files
a Rust test reads" even in principle. It carried a comment asking a human to
keep it in agreement with the `changes` job's regex, and they were not in
agreement: the job had a carve-out and the trigger could not have one.

The trigger's path filter is gone. `changes` now answers for pushes too,
diffing `github.event.before`, through **one script** —
`scripts/ci-rust-scope.sh` — which the pull_request side calls as well. The rule
lives in one place, and it is testable, which a YAML `run:` block is not.

A prose-only merge pays one checkout and one diff instead of an hour of Rust.
An unresolvable base (a branch's first push, a force-push whose predecessor is
gone, a fetch too shallow) answers `true`: the cost of a needless gate run is
minutes, and the cost of a skipped one is a red `main` nobody is watching.

### #4632 — the class: a Rust test that reads `website/**` is unenforceable

The carve-out named two paths, kept by hand in YAML with no relation to the
tests — and it was **already incomplete**:
`crates/stella-cli/src/settings/completeness.rs` reads
`website/content/docs/configuration/stella-toml.mdx`, and the filter did not
name it. So a website-only PR deleting a `[section]` heading from that page
broke `every_root_section_is_documented_on_the_reference_page` and merged green.

The inventory moves into `scripts/website-rust-inputs.txt`: every `website/`
path a Rust source names, declared `read` (a test opens it) or `mention` (prose
points at it).

- `ci-rust-scope.sh` builds the carve-out from the `read` entries, so the
  filter cannot drift from the list — there is only one list.
- `check-website-inputs.sh` (gate step `website-inputs`) holds the list to the
  tree in three directions: every declared path **exists**, every `website/`
  path a Rust source **names** is declared, and no entry is **stale**.

It runs in `ci.yml` so a diff that starts reading a new website file must
declare it — which puts it in the carve-out by construction — and in
`docs-guards.yml`, whose filter widens from `website/content/docs/**` to
`website/**`, so a website-only PR that renames or moves a file a Rust test
reads goes red **before** the merge. That is the report `ci.yml` structurally
cannot give, because its Rust job is skipped for exactly that diff.

Had this existed, #4588's diff would have run the Rust gate on its own PR: the
file its test read would have been a declared `read` entry.

**What it deliberately does not decide:** whether a `read` was declared as a
`mention`. Nothing mechanical separates a doc comment naming a path from a test
opening it, and the guard's header says so rather than implying a grep could.
It also sees a path only where it appears as one literal; a helper that builds
`root.join("website").join("src/…")` names no `website/…` string, which is why
`docs_sync.rs` says the path once in the doc comment above it.

### #4608 — `node_modules` could be committed as a symlink

`.gitignore`'s `node_modules/` matches a directory only. A symlink named
`node_modules` is a *file* to git, so the trailing-slash form let #4595 commit
`arenabench/ui/node_modules` as mode 120000 pointing at an absolute path on the
author's machine. `no-scratch` — the guard that asserts no tracked file matches
a `.gitignore` rule — could not see it, because the rule did not match.

Dropping the trailing slash matches both shapes. The symlink itself is already
gone (#4642 ejected arenabench into its own repository), so this is the half
that stops it coming back.

### #4657 — `make file-size-update` retightened unrelated ceilings

`--update` rewrote every ceiling to its file's size on the branch it ran on.
Correct for that branch, and it made the PR *repairing* a red `main` the carrier
of the next break — a repair PR is the one PR guaranteed to be racing every
other merge, because main is red and everyone is waiting on it.

`--update` is now **raise-only**: a ceiling that must go up to admit the tree
goes up, every other live entry keeps the number it had. `--retighten`
(`make file-size-retighten`) adds the lowering, for the deliberate pass that
reclaims the slack a split earned — safe precisely when nothing is blocked on
it.

Neither mode adds an entry (#3441's refusal is untouched, and U7/U8 pin it for
both). Both still **retire** an entry whose file dropped under the limit or is
no longer tracked, because the check hard-fails on those and names `--update`
as the only remedy; a raise-only mode that kept them would leave the gate red
with no way out.

`scripts/file-size-baseline.txt` is **not** touched by this PR.

## Evidence

**Witness — #4657**, `scripts/test-file-size.sh`. Ran the suite with the guard
from `origin/main` in place and with this branch's:

```
origin/main:  passed 33, failed 1
              FAIL U2 --update leaves an unrelated ceiling where it was
                   — wanted '1690', got '1600'
this branch:  passed 34, failed 0
```

U2 is the witness. The other seven `U` cases pass both ways and are what stop
the change becoming a freeze (U3 `--retighten` still lowers; U4/U5 still retire;
U7/U8 still refuse to add).

**Witness — #4632**, the carve-out gap, on a one-line diff touching
`website/content/docs/configuration/stella-toml.mdx`:

```
== main's inline filter (ci.yml as of origin/main) ==
rust=false
== the inventory-driven carve-out (this branch) ==
rust=true
```

`rust=false` is a skipped Rust gate for a diff that breaks
`settings::completeness::every_root_section_is_documented_on_the_reference_page`.

**Witness — #4608**, the ignore rule, against a planted symlink:

```
$ ln -s /abs/path probe/ui/node_modules
$ git check-ignore -v probe/ui/node_modules
.gitignore:145:node_modules	probe/ui/node_modules      # matches (this branch)
                                                       # no match on main
```

`no-scratch` fails on a tracked file that matches a rule, so a recurrence is
now a red gate. `./scripts/check-no-scratch.sh` is green on this tree.

**No witness — #4606's trigger change.** A workflow trigger is not testable off
the forge; CI is the evidence. The *rule* it delegates to is covered by
`scripts/test-ci-rust-scope.sh` (17 cases: the four prose paths, three
gate-running shapes including a crate README, the carve-out and its literal dot,
five fail-open directions, and the empty diff). Both new suites are new files —
on main the decision lived in a YAML `run:` block where nothing could exercise
it, which is half the reason #4588 landed.

**Targeted commands, all green on this branch:**

```
./scripts/test-file-size.sh          passed 34, failed 0
./scripts/test-ci-rust-scope.sh      passed 17, failed 0
./scripts/test-website-inputs.sh     passed  8, failed 0
./scripts/test-gate-parity.sh        14 passed, 0 failed
./scripts/check-website-inputs.sh    OK — 7 declared paths, 3 Rust test inputs, all present
./scripts/check-no-scratch.sh        OK
./scripts/check-gate-parity.sh       OK — 46 gate steps, named in both documents, each run by a workflow
make guards-fast                     exit 0
make shellcheck                      exit 0
python3 -c "yaml.safe_load"          all 28 workflows parse
```

No cargo build or workspace test was run locally (CLAUDE.md, "CI builds and
tests; this laptop does not"). No Rust source is touched by this PR.

**Wiring, the full way `gate-parity` demands:** `website-inputs` is in
`GATE_STEPS`, has a `Makefile` target, is named in AGENTS.md's gate block and
CONTRIBUTING.md's fence, and runs in two workflows. The two new
`scripts/test-*.sh` suites run in `guard-self-tests.yml`, so neither needed an
`UNHOSTED_SELF_TESTS` exclusion. `check-gate-parity.sh` confirms all of it.

### Two hazards found and fixed on this branch (commit 3)

The first CI run went red on `prose` (a content-free line in the new suite's
header), and reading the scripts again turned up two shapes this repository has
been bitten by before:

- `ci-rust-scope.sh` piped the changed-file list into `grep -Eq`. That grep
  exits on its first match and closes the pipe under it, so the writer takes a
  SIGPIPE and `pipefail` reports **141 for a pipeline that matched**. It is a
  race, and the wrong answer is `false` — a skipped Rust gate, which is the
  exact failure the script exists to end (#1815's shape). The list now goes to
  a temp file and every grep reads the file.
- `check-website-inputs.sh` let `git grep`'s exit 1 — no match, which is the
  goal state — kill the script under `pipefail` before any verdict, with no
  message (#1800's shape). It would have hit exactly when the stale-entry check
  had something to say.

Commit 4 adds the one fail-open direction nothing covered: `git diff A...B`
across two histories with no common ancestor exits 128 rather than printing an
empty diff, and an empty diff is what `false` means.

## Not done

Nothing skipped.

Two things noticed and deliberately left, both filed rather than folded in:

- **`docs_sync.rs` builds its path from two `join`s**, so the literal
  `website/src/components/provider-catalog.ts` appears in that file only in a
  doc comment. The inventory guard therefore sees the declaration but not the
  read. Harmless today — the doc comment is the declaration site the guard
  reads, and the path is declared — but a future helper written the same way
  with no doc comment would be invisible. Fixing it means editing a Rust file
  and recompiling `stella-cli`, which this PR otherwise does not need.
- **`docs-guards.yml` now runs on every `website/**` diff**, which includes
  deck edits under `website/public/presentations/`. Eight toolchain-free guards,
  about a minute; the alternative is a second path list to keep in agreement,
  which is the defect this PR is about.

Closes #4606
Closes #4608
Closes #4632
Closes #4657
