### PR TITLE
fix(stella-tui): box the two AgentEvent literals the #4612 witness left bare

### DIFF
--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -515,13 +515,13 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
     board.apply(
         FleetMsg::Event {
             id: "t1".into(),
-            event: AgentEvent::ScopeReview {
+            event: Box::new(AgentEvent::ScopeReview {
                 proposal: stella_protocol::ScopeProposal {
                     summary: "ship the migration".into(),
                     steps: vec!["migrate".into(), "backfill".into(), "cut over".into()],
                     ..Default::default()
                 },
-            },
+            }),
         },
         now,
     );
@@ -530,12 +530,12 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
     board.apply(
         FleetMsg::Event {
             id: "t1".into(),
-            event: AgentEvent::ToolResult {
+            event: Box::new(AgentEvent::ToolResult {
                 call_id: "c1".into(),
                 output: stella_protocol::ToolOutput::error("the plan was not approved"),
                 duration_ms: 400,
                 speculated: false,
-            },
+            }),
         },
         now,
     );


### PR DESCRIPTION
## What

`main` does not compile, and has not since `4bc0aea30`. `FleetMsg::Event` declares
`event: Box<AgentEvent>` (`crates/stella-tui/src/fleet_dashboard.rs:75`), and the two
call sites added by the #4612 witness `a_lane_stops_reading_blocked_once_its_card_is_answered`
pass a bare `AgentEvent`. `stella-tui`'s lib test target fails with two `E0308`s, so every
open PR's checks are red behind a break none of them caused.

This boxes those two literals. Nothing else changes.

## Why it happened

Neither branch was wrong on its own. One boxed the field (a `Box` on a large enum variant),
the other added the call sites, and each was green against a base that did not yet contain
the other. Git had no conflict to report, because neither side's lines overlap.

That is exactly the shared-cell composition break `main-canary.yml` exists to catch after a
merge rather than before one, and it caught this one — the canary filed #4671.

## Evidence

- The failing type is declared, not inferred: `fleet_dashboard.rs:75` is
  `Event { id: String, event: Box<AgentEvent> }`.
- Every other `FleetMsg::Event` construction in the same test file already wraps its event
  in `Box::new` — lines 67, 74, 128, 141, 148, 193, 278. Only the two from #4612 were bare.
- The exact error, file and line in #4671's canary log match `ci.yml`'s failure on unrelated
  open PRs, which is what establishes that the redness is inherited rather than per-branch.
- CI on this PR is the build evidence. I did not run a workspace build locally, per
  CLAUDE.md's "CI builds and tests; this laptop does not".

## Witness

The repaired test **is** the witness: `a_lane_stops_reading_blocked_once_its_card_is_answered`
cannot run at all on `main` today (the crate's test target does not compile), and runs here.
No behavior changes — this is a type-level repair to test-only code, so there is no new
assertion to add.

## Notes for review

Labelled `unblocks-main` so `main-red-hold.yml` does not block the repair of the condition
it is holding on.

Closes #4671

## Summary by Sourcery

Restore Stella TUI test compilation by matching the FleetMsg::Event payloads to their boxed event type.

Bug Fixes:
- Fix compilation of the Stella TUI test target by boxing the two AgentEvent values passed to FleetMsg::Event.

Tests:
- Restore compilation and execution of the lane-reading behavior witness test.