### PR TITLE
fix(stella-tui): box the two FleetMsg::Event payloads #4663 added

### DIFF
--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -515,13 +515,13 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
     board.apply(
         FleetMsg::Event {
             id: "t1".into(),
-            event: AgentEvent::ScopeReview {
+            event: Box::new(AgentEvent::ScopeReview {
                 proposal: stella_protocol::ScopeProposal {
                     summary: "ship the migration".into(),
                     steps: vec!["migrate".into(), "backfill".into(), "cut over".into()],
                     ..Default::default()
                 },
-            },
+            }),
         },
         now,
     );
@@ -530,12 +530,12 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
     board.apply(
         FleetMsg::Event {
             id: "t1".into(),
-            event: AgentEvent::ToolResult {
+            event: Box::new(AgentEvent::ToolResult {
                 call_id: "c1".into(),
                 output: stella_protocol::ToolOutput::error("the plan was not approved"),
                 duration_ms: 400,
                 speculated: false,
-            },
+            }),
         },
         now,
     );


### PR DESCRIPTION
`main` does not compile (#4671). #4665 boxed `FleetMsg::Event`'s `AgentEvent` to settle `large_enum_variant` and updated every construction site it could see; #4663 had added two more to the same test file hours earlier. Both PRs were green and the merge was textually clean, because neither tree contains the other's lines — the shared-cell composition break AGENTS.md describes. `main-canary` caught it at `4bc0aea30`.

## What

Two `Box::new(...)` wrappers in `crates/stella-tui/src/fleet_dashboard/tests.rs`. No behaviour change, no other file touched; the seven sibling sites in that file already read this way.

## Evidence

Reproduced by merging `origin/main` into an unrelated feature branch: `cargo check -p stella-tui --all-targets` failed with the canary's two `error[E0308]: mismatched types` at lines 519 and 534, and passes (exit 0) with these two wrappers applied. That is the same tree state `main` is in.

No witness test: this is a compile repair to a test file. The tests it fixes are #4663's own witnesses, which cannot run at all while the crate does not build.

Closes #4671

## Summary by Sourcery

Bug Fixes:
- Fix test compilation by boxing the two remaining `FleetMsg::Event` payloads in the fleet dashboard tests.