### PR TITLE
fix(stella-tui): box the two FleetMsg::Event values its own tests build

### DIFF
--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -515,13 +515,13 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
     board.apply(
         FleetMsg::Event {
             id: "t1".into(),
-            event: AgentEvent::ScopeReview {
+            event: Box::new(AgentEvent::ScopeReview {
                 proposal: stella_protocol::ScopeProposal {
                     summary: "ship the migration".into(),
                     steps: vec!["migrate".into(), "backfill".into(), "cut over".into()],
                     ..Default::default()
                 },
-            },
+            }),
         },
         now,
     );
@@ -530,12 +530,12 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
     board.apply(
         FleetMsg::Event {
             id: "t1".into(),
-            event: AgentEvent::ToolResult {
+            event: Box::new(AgentEvent::ToolResult {
                 call_id: "c1".into(),
                 output: stella_protocol::ToolOutput::error("the plan was not approved"),
                 duration_ms: 400,
                 speculated: false,
-            },
+            }),
         },
         now,
     );


### PR DESCRIPTION
## What

`main` does not compile under `--all-targets`. `FleetMsg::Event.event` is `Box<AgentEvent>` — deliberately, per its own doc comment:

> Boxed, because every other message here is a pair of `String`s and an `AgentEvent` is several times the size of the largest of them. Inline, it would set the size of every fleet message — the register and status rows included, which the driver sends far more of than it sends events for any one task.

…but the two construction sites in `crates/stella-tui/src/fleet_dashboard/tests.rs` still pass an unboxed `AgentEvent`. This wraps both.

## Why it reached main

`cargo check --workspace` never builds a `#[cfg(test)]` body, so the pre-merge check that would notice this is `clippy --all-targets` / `cargo test` — and on the PR that introduced the boxing, those ran against a tree where the two sites did not yet collide. The post-merge canary is what caught the composition, exactly as designed (#4671).

## Evidence

```
$ cargo test -p stella-tui --lib fleet_dashboard
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 1065 filtered out
```

Before the change, the same command fails with two `E0308: expected Box<AgentEvent>, found AgentEvent` at `fleet_dashboard/tests.rs:518` and `:533` — which is the fail→pass flip; no new test is added because the existing ones are the witness (they could not compile).

## Scope

Two `Box::new(...)` wrappings, nothing else. Landed on its own from a fresh `main` rather than folded into a feature PR, per AGENTS.md — a red `main` reds every open PR, and this is blocking at least #4629.

Closes #4671

## Summary by Sourcery

Bug Fixes:
- Fix fleet dashboard tests so event messages use the required boxed agent events and compile successfully.