### PR TITLE
fix(stella-tui): close the Box::new the third boxing fix left open

### DIFF
--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -537,7 +537,7 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
                 duration_ms: 400,
                 speculated: false,
                 sub_agent_id: None,
-            },
+            }),
         },
         now,
     );


### PR DESCRIPTION
## What

`main` has not compiled since `c7dd083bf`. One character fixes it.

Three PRs boxed `FleetMsg::Event`'s payload in sequence — #4672, #4673, #4674 — as
`FleetMsg::Event { event: Box<AgentEvent> }` propagated to its construction sites. The last
of them wrapped the `AgentEvent::ToolResult` literal at
`crates/stella-tui/src/fleet_dashboard/tests.rs:534` in `Box::new(` and closed it with `},`
instead of `}),`, so the file stopped parsing:

```
error: mismatched closing delimiter: `}`
   --> crates/stella-tui/src/fleet_dashboard/tests.rs:534:28
    |
532 |         FleetMsg::Event {
    |                         - closing delimiter possibly meant for this
533 |             id: "t1".into(),
534 |             event: Box::new(AgentEvent::ToolResult {
    |                            ^ unclosed delimiter
...
541 |         },
    |         ^ mismatched closing delimiter
error: could not compile `stella-tui` (lib test) due to 1 previous error
```

A parse error, so it takes the whole `stella-tui` lib-test target down and nothing after it
in the workspace runs — which is why every open PR is red right now.

## The fix

`},` → `}),` on line 540. Nothing else.

Every other `FleetMsg::Event` construction site in the tree is already balanced: the eight
others in this file (lines 68, 75, 129, 142, 149, 194, 279, 519) and
`crates/stella-cli/src/fleet_cmd.rs:1109`. Checked by enumerating every `FleetMsg::Event`
in `crates/` and reading each site's `event:` line, so this is the only one.

## Evidence

**The witness is the compile itself.** `cargo check -p stella-tui --tests` fails to *parse*
on the old code and succeeds on the new — a syntax error cannot be witnessed by a test,
because no test in the file can be built to run.

I could not produce that locally and am not claiming I did: this machine SIGKILLs `rustc`
under its current load, and the run died building the `zerocopy` dependency
(`signal: 9, SIGKILL`) before reaching `stella-tui` at all. That is a fact about the
laptop, not about the diff. **CI's `fmt + clippy + test` job on this PR is the evidence** —
per CLAUDE.md, "CI builds and tests; this laptop does not."

## Why this is not caught pre-merge

It is the shared-cell shape AGENTS.md describes and `main-canary.yml` exists for: #4673 and
#4674 each boxed the sites their own base could see, and each was green against a base
lacking the other's. The canary caught it post-merge and filed #4678.

Labelled `unblocks-main` so the `main-red-hold` check does not block its own repair.

Closes #4678

## Summary by Sourcery

Bug Fixes:
- Fix the unbalanced `Box::new` delimiter in a Stella TUI fleet dashboard test so the workspace parses and builds again.