### PR TITLE
fix(stella-tui): close the Box::new the ToolResult site lost in a three-way repair

### DIFF
--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -537,7 +537,7 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
                 duration_ms: 400,
                 speculated: false,
                 sub_agent_id: None,
-            },
+            }),
         },
         now,
     );


### PR DESCRIPTION
## What

`main` does not parse. `crates/stella-tui/src/fleet_dashboard/tests.rs:534` opens
`Box::new(AgentEvent::ToolResult {` and closes it `},` instead of `}),`, so `stella-tui`'s
lib test target fails with `mismatched closing delimiter` before type checking begins.

One character. The sibling `ScopeReview` site twenty lines above already reads `}),`; this
one now matches it.

## Why it happened — worth reading, because it is the second break in this file today

The missing paren is the residue of a collision, not a typo:

1. #4671 (`main` red, `FleetMsg::Event` carries `Box<AgentEvent>` but two call sites passed a
   bare one) was fixed **three times in parallel** — #4672, #4673 and #4674, all merged inside
   about a minute, all editing these same two call sites.
2. #4670 then added `sub_agent_id: None` inside this same block.

One of those merges kept the added field **and** the opening `Box::new(` while dropping the
closing paren. Git reported no conflict, because each side's lines were individually reachable —
the same shape that produced the original #4671 break, one layer deeper.

The duplication that set this up is filed as #4680: `main-canary.yml` files one `main-red` issue
and nothing lets a session claim it, so every session that notices red `main` writes the same
patch. I claimed #4678 before starting this one.

## Evidence

- `cargo fmt --check` on the file **passes** here and could not have before: a mismatched
  delimiter is a parse error, and rustfmt fails on parse errors. That is what makes the check
  able to tell fixed from broken rather than merely being consistent with both.
- The canary's log on #4678 names the exact file, line and column (`tests.rs:534:28`), and points
  at `Box::new(` as the unclosed delimiter and line 541's `},` as the mismatched close.
- **What I have not shown:** that `stella-tui` fully *compiles*. A parse error halts the
  compiler before type checking, so any type error behind it — for instance another site #4670's
  new field did not reach — is still unproven either way. CI on this PR settles that, and I have
  said so rather than implying a green build I did not run (this laptop does not build the
  workspace, per CLAUDE.md).

## Witness

The repaired test **is** the witness: `a_lane_stops_reading_blocked_once_its_card_is_answered`
cannot run on `main` today because its crate does not parse, and runs here. No behavior changes —
this is a syntax repair to test-only code.

## Notes for review

Labelled `unblocks-main` so `main-red-hold.yml` does not block the repair of the condition it is
holding on.

Closes #4678
Refs #4680

## Summary by Sourcery

Bug Fixes:
- Fix the malformed `Box::new` expression in the fleet dashboard test so the `stella-tui` test target parses successfully.