### PR TITLE
fix(stella-tui): close the Box::new that three concurrent red-main repairs left open

### DIFF
--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -537,7 +537,7 @@ fn a_lane_stops_reading_blocked_once_its_card_is_answered() {
                 duration_ms: 400,
                 speculated: false,
                 sub_agent_id: None,
-            },
+            }),
         },
         now,
     );


### PR DESCRIPTION
`main`'s `stella-tui` lib test target does not parse:

```
error: mismatched closing delimiter: `}`
  --> crates/stella-tui/src/fleet_dashboard/tests.rs:534:28
534 |             event: Box::new(AgentEvent::ToolResult {
    |                            ^ unclosed delimiter
541 |         },
    |         ^ mismatched closing delimiter
```

One call site has an opened `Box::new(` and no closing paren. This PR adds the `)`.

**How it got there, because the shape matters more than the character.** #4665 boxed `FleetMsg::Event`'s payload; #4671 recorded that two literals in `fleet_dashboard/tests.rs` were left bare. Three PRs to fix it — #4672, #4673, #4674 — were opened within **sixty seconds** of each other by parallel sessions, each green against its own base, and all three merged. Their edits overlap on the same two call sites, and the composition is what lost the paren: no author was wrong, and no pre-merge check could see it. That is the same shared-cell composition failure `main-canary` exists for, arriving through a source file rather than a baseline.

Evidence: `cargo test -p stella-tui --lib fleet_dashboard` fails to compile on `origin/main` at the line above, and this is a one-character syntactic repair — the surrounding assertions are untouched. My local verification build was killed twice by memory pressure from concurrent work on this machine, so I am **not** claiming a local green: the CI run on this PR is the evidence, and it is the honest one to cite.

Closes #4671

## Summary by Sourcery

Bug Fixes:
- Restore the missing closing parenthesis so the stella-tui fleet dashboard library tests compile again.