### PR TITLE
fix(stella-tui): stop budget_card linking a pub(crate) item, which reds the doc gate

### DIFF
--- a/crates/stella-tui/src/v2/budget_card.rs
+++ b/crates/stella-tui/src/v2/budget_card.rs
@@ -7,8 +7,11 @@
 //! is only ever the folded one, so an ignored or clamped request can never
 //! render as a cap in force.
 //!
-//! A floating card draws its own frame ([`cards::card_frame`]) because it is
-//! an overlay rather than a tab body — the frame [`crate::v2::frame`] carves
+//! A floating card draws its own frame (`views::cards::card_frame`, named
+//! rather than linked: it is `pub(crate)`, and an intra-doc link to it
+//! resolves only under `--document-private-items`, which the doc gate does not
+//! pass) because it is an overlay rather than a tab body — the frame
+//! [`crate::v2::frame`] carves
 //! out is what it floats *above*, and a card with no border of its own would
 //! read as content the deck had appended to whatever is underneath it.
 


### PR DESCRIPTION
## What

**`main` fails `cargo doc -D warnings`.** One line, from #4686:

```
error: public documentation for `budget_card` links to private item `cards::card_frame`
  --> crates/stella-tui/src/v2/budget_card.rs:10:44
   = note: this link resolves only because you passed `--document-private-items`, but will break without
   = note: `-D rustdoc::private-intra-doc-links` implied by `-D warnings`
error: could not document `stella-tui`
```

`views::cards::card_frame` is `pub(crate)`. The gate deliberately does not pass `--document-private-items` — the published docs are what it checks — so the link cannot resolve there.

The blast radius is bigger than one crate's docs: **`cargo doc` runs before `cargo test` in the same CI job**, so the workspace suite is not failing, it is not being *reached*. Every PR waiting on this tree is red for a reason that has nothing to do with its own diff.

The fix names the function in backticks instead of linking it, with the reason on the line so the next person does not re-add the brackets. The sibling link to `crate::v2::frame` is untouched — that one is public and resolves.

## Evidence

Reproduced on a fresh `main` (`22961967c`) before the change:

```
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps      → exit 101
```

After:

```
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps                            → exit 0
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps --document-private-items    → exit 0
make prose                                                                              → OK, none added
```

Both forms, because a link to a `pub(crate)` item passes under the private-items flag and fails without it — checking only the flagged form is how this class of break reaches `main`.

No witness test: rustdoc's own `-D warnings` is the check, and it is already a gate step.

## Context — this is one of three independent breaks on the same red `main`

The canary files one issue per red tree, so #4691's title names only the first:

| Cause | Where | Repair |
|---|---|---|
| `file-size` | `crates/stella-transcript/src/tests.rs` is 1523 lines | unowned as far as I can see |
| `cargo doc` | `crates/stella-tui/src/v2/budget_card.rs:10` (#4686) | **this PR** |
| `cargo test` → `no_ambient_reads` | `crates/stella-runtime/src/bin/wrapper-plugin-fixture.rs` (#4675) | #4690 |

I am the author of the third and went looking for why its repair could not go green. Landed on its own from a fresh `main` rather than folded into #4690, per AGENTS.md.

**If the in-flight v2 SPEC 5 series (#4695, #4701–#4708) already carries this fix, close this as a duplicate** — I searched open PRs for it and found none, but that series is from another session and is touching these files.

Refs #4691

## Summary by Sourcery

Restore warning-free published documentation by removing the invalid private-item link from the budget card documentation.

Bug Fixes:
- Fix the Stella TUI documentation warning caused by linking public documentation to the private `card_frame` item.

Documentation:
- Clarify why `card_frame` is named without an intra-documentation link while retaining the link to the public frame API.