### PR TITLE
fix(stella-tui): stop budget_card's public doc linking a crate-private helper

### DIFF
--- a/crates/stella-tui/src/v2/budget_card.rs
+++ b/crates/stella-tui/src/v2/budget_card.rs
@@ -7,7 +7,7 @@
 //! is only ever the folded one, so an ignored or clamped request can never
 //! render as a cap in force.
 //!
-//! A floating card draws its own frame ([`cards::card_frame`]) because it is
+//! A floating card draws its own frame (`views::cards::card_frame`) because it is
 //! an overlay rather than a tab body — the frame [`crate::v2::frame`] carves
 //! out is what it floats *above*, and a card with no border of its own would
 //! read as content the deck had appended to whatever is underneath it.


### PR DESCRIPTION
## What

`main` fails `cargo doc -D warnings`, which is a step of the required
`fmt + clippy + test` job — so every open PR fails on it regardless of its own
diff. Reproduced on `22961967c`, current `main`:

```
error: public documentation for `budget_card` links to private item `cards::card_frame`
  --> crates/stella-tui/src/v2/budget_card.rs:10:44
   |
10 | //! A floating card draws its own frame ([`cards::card_frame`]) because it is
   |                                            ^^^^^^^^^^^^^^^^^ this item is private
   |
   = note: this link will resolve properly if you pass `--document-private-items`
   = note: `-D rustdoc::private-intra-doc-links` implied by `-D warnings`
```

#4686 gave `v2::budget_card` a module doc that links `[`cards::card_frame`]`,
and `views::cards::card_frame` is `pub(crate)` (`views/cards.rs:59`). Note the
first `note:` line — the link resolves under `--document-private-items` and
only there, so a local `cargo doc` run with that flag looks clean while CI's
plain run does not. That is the shape that let this land.

The helper is named rather than linked. It has no public page to point at, and
making it `pub` to satisfy a doc comment would widen an internal frame helper's
surface for the sake of a hyperlink. The sibling `[`crate::v2::frame`]` link on
the next line is public and is untouched. This is the only such link in the
crate — `rg 'card_frame' crates/stella-tui/src` finds eight call sites and one
doc reference, and this was the doc reference.

## Evidence

```
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps
    before: exit 101, the error above
    after:  exit 0
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps --document-private-items
    after:  exit 0
cargo fmt --all --check    clean
python3 scripts/check-prose.py   OK — none added
```

No witness test: the guard that failed is the witness, and it is `cargo doc`
itself.

Refs #4686

## Summary by Sourcery

Bug Fixes:
- Fix the `stella-tui` documentation so public module docs no longer link to the crate-private `card_frame` helper, allowing rustdoc warnings to pass.