### PR TITLE
fix(stella-tui): repair the intra-doc link #4687's port left behind — main is red on `cargo doc -D warnings`

### DIFF
--- a/crates/stella-tui/src/views.rs
+++ b/crates/stella-tui/src/views.rs
@@ -6,12 +6,8 @@
 //! tab ([`settings`]) hosts as a pane of its ←/→ nav, not a tab renderer of
 //! its own — it exposes `render_panel(ui, area, buf)` plus its own key
 //! handler, modal while that panel is focused. The AGENTS pane beside it is
-//! [`crate::v2::engine_panel`]. `installed` is a second exception: it
-//! is the AGENTS tab's INSTALLED AGENTS pane, dispatched from
-//! [`agents::render`] rather than from the deck's tab match, and its
-//! `render(ui, now_ms, area, buf)` takes only the deck clock off the model rather than
-//! carry a dead one — it has no model-derived state and no key handler of
-//! its own, deck_ui.rs routes its keys directly.)
+//! [`crate::v2::engine_panel`]. The AGENTS tab's INSTALLED AGENTS pane left
+//! this module with #4687's port and is [`crate::v2::installed`] now.)
 
 /// The braille spinner's frames — the classic 10-frame dot cycle.
 const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];


### PR DESCRIPTION
## What & why

**`main` is red, and has been since #4687.** `ci.yml`'s required job runs

```
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --keep-going
```

and that step fails with `unresolved link to \`agents::render\``. #4687 ported
the AGENTS tab onto the v2 frame — deleting `crates/stella-tui/src/views/agents.rs`
and `crates/stella-tui/src/views/installed.rs` — but `crates/stella-tui/src/views.rs`'s
module doc still linked the deleted `agents::render` and still described
`installed` as a module of this file.

This fixes the link and the sentence around it: the INSTALLED AGENTS pane is
`crate::v2::installed` now, and the doc says so.

Why it is worth its own PR rather than a line inside one of the open
`tui-v2-port/*` branches: while `main` is red every open PR's checks are red
too, so red stops distinguishing "your change is broken" from "the base is" —
the exact compounding `main-red-hold.yml` exists to stop. Every one of the
fifteen open PRs is currently reporting a failure it did not cause.

Refs #4687

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: the failing
      gate step **is** the witness, and it runs on every push. A test asserting
      "rustdoc emits no warning" would be a second, weaker copy of it.

Verified both directions on this tree, same command each way:

```
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps --document-private-items
```

| tree | result |
|---|---|
| `origin/main` | `error: unresolved link to \`agents::render\`` → `error: could not document \`stella-tui\`` (exit 101) |
| this branch | `Finished \`dev\` profile` → `Generated target/doc/stella_tui/index.html` (exit 0) |

## The gate

- [x] `cargo fmt --check` — untouched: the change is a doc comment.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI.
- [ ] `cargo test --workspace` — CI. This PR's evidence is its CI run.
- [x] Docs updated where behavior/flags changed — the diff *is* the doc.
- [x] CLA signed
- [x] No `Closes #N`: the issue this repairs is a regression in a merged PR,
      not an open issue, so the trailer is a `Refs`.

## Nothing left behind

- [x] Filed: #4742 — `crates/stella-tui/README.md` carries **two**
      `src/views/*.rs` rows that contradict each other on which tabs `views/`
      owns and which module is the SETTINGS-pane exception, also left by the
      v2 ports landing one after another. Deliberately not folded in here:
      that table is the shared cell every open `tui-v2-port/*` PR is currently
      conflicting on, and AGENTS.md is explicit that a repair to one lands on
      its own from a fresh `main` rather than riding along in another diff.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No cross-boundary types changed

## Anything reviewers should know?

The doc rewrite names #4687 as where the pane went, so the next reader does
not have to `git log` the deleted file to find out.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DwYSBNu5BYbQFUR92kCW5q)_

## Summary by Sourcery

Restore warning-free stella-tui documentation by updating the stale AGENTS pane references after its v2 port.

Bug Fixes:
- Fix the stale intra-documentation link to the removed AGENTS renderer so `cargo doc -D warnings` succeeds again.

Enhancements:
- Update the views module documentation to identify the INSTALLED AGENTS pane's current v2 module and its relocation in #4687.

Documentation:
- Correct the stella-tui module documentation to reflect the current AGENTS pane structure.