### PR TITLE
fix(stella-graph,stella-embed,stella-tools): a store image is walked once, not once per search — and the admission floor is measured

### DIFF
--- a/crates/stella-cli/src/agent/graph/tests.rs
+++ b/crates/stella-cli/src/agent/graph/tests.rs
@@ -107,7 +107,9 @@ async fn init_embeds_the_index_without_any_semantic_query_being_issued() {
         "concept-2",
         None,
         2,
-        0.25,
+        // Only the fingerprint is wanted here, and the posture does not
+        // enter it: no operator floor.
+        None,
     )
     .fingerprint()
     .id();
@@ -299,7 +301,9 @@ async fn init_embeds_every_chunk_without_any_semantic_query_being_issued() {
         "concept-2",
         None,
         2,
-        0.25,
+        // Only the fingerprint is wanted here, and the posture does not
+        // enter it: no operator floor.
+        None,
     )
     .fingerprint()
     .id();

--- a/crates/stella-embed/README.md
+++ b/crates/stella-embed/README.md
@@ -112,17 +112,31 @@ silent quality regression.
   attempts were made so a slow pass is not mistaken for one that never waited.
   This matters because the chunk embedding pass keeps several requests in
   flight (#4144), and concurrency is precisely what provokes a rate limit.
-- **The default admission floor is provisional, not measured.** The
-  `SimilarityPosture` contract asks for a floor derived from a model's observed
-  relevant/irrelevant score distributions on a real corpus, and no such
-  measurement exists yet for these backends on code. The shipped value is
-  deliberately permissive and its job is to drop the obviously-unrelated tail
-  from an ordered list, not to certify anything. The measurement is written
-  and reproducible — `crates/stella-tools/tests/relevance_calibration.rs`,
-  `#[ignore]`d because it needs a real key and a full embedding pass — and
-  running it once per backend is what turns this paragraph into a number
-  (#3096). It lives in `stella-tools` rather than here so this crate's own
-  tests stay hermetic and its leaf status is untouched.
+- **`voyage-code-3` admits nothing, and that is a measured result.** On
+  2026-08-24 `crates/stella-tools/tests/relevance_calibration.rs` was run
+  against it over this repository's own index (28 744 chunks, four labelled
+  queries, 40 candidates deep). The relevant and irrelevant distributions
+  **overlap**: tightest separation −0.0439, with one query's labelled answer
+  ranking 39th at 0.5978 beneath 38 irrelevant chunks scoring 0.6006–0.6436,
+  and two of the four queries returning no labelled answer in 40 candidates at
+  all. No floor separates those, so the model declares
+  `SimilarityPosture::Surface` — its cosines order candidates and certify none,
+  exactly as `HashEmbedder` already reports. #2993 named that outcome in
+  advance as the one to expect.
+- **Every other backend is unmeasured and says so.** `MEASURED_FLOORS` in
+  `src/http.rs` is the per-model table, and a model absent from it keeps
+  `DEFAULT_ADMISSION_FLOOR` (0.25) and declares `Semantic`. That number is
+  still not a separation point; what it now has is a stated scope — it is the
+  value for a model nobody has measured, and a permissive floor is all such a
+  backend can defend. `text-embedding-3-small`,
+  `text-embedding-3-large` and a local `nomic-embed-text` are the three #2993
+  also names, and each needs its own run of the harness. An explicit
+  `STELLA_EMBED_FLOOR` outranks the table either way: the operator is then
+  making the claim, about a corpus the measurement did not see.
+- **The harness lives in `stella-tools`, not here**, so this crate's own tests
+  stay hermetic and its leaf status is untouched. Point it at an already-filled
+  index with `STELLA_CALIBRATION_INDEX` and one run costs a query embedding per
+  labelled query instead of a full pass over the repository.
 
 ## God files — do not add lines
 

--- a/crates/stella-embed/src/http.rs
+++ b/crates/stella-embed/src/http.rs
@@ -75,23 +75,51 @@ const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
 /// often a misconfigured proxy than a real instruction.
 const MAX_BACKOFF: Duration = Duration::from_secs(8);
 
-/// The admission floor applied when nothing overrides it.
+/// The admission floor for a model **nobody has measured**, and for nothing
+/// else.
 ///
-/// **This number is provisional and is not a measured separation point.** The
-/// [`SimilarityPosture`] contract asks for a floor derived from a model's
-/// observed relevant/irrelevant score distributions, and no such measurement
-/// exists yet for these backends on a code corpus. It is deliberately
-/// permissive: its job today is to drop the obviously-unrelated tail from an
-/// ordered list, not to certify anything.
+/// It is still not a separation point and still certifies nothing; what has
+/// changed is that its scope is now stated. A model whose distributions have
+/// been measured takes its posture from [`MEASURED_FLOORS`] and never reaches
+/// this number, so this is the value for an unknown backend and the
+/// justification for it is that a permissive floor is all an unmeasured
+/// backend can defend: it drops the obviously-unrelated tail from an
+/// ordered list and admits everything else, which understates the backend
+/// rather than overstating it.
 ///
-/// The measurement that settles it is written and reproducible:
-/// `crates/stella-tools/tests/relevance_calibration.rs` prints the labelled
-/// relevant/irrelevant score distributions over this repository for whatever
-/// backend is configured, and names the number to write here (#3096). It is
-/// `#[ignore]`d because it needs a real key and a full embedding pass. Until
-/// somebody runs it, this paragraph stays — deleting it without the
-/// measurement would turn an honest disclosure into a silent assumption.
+/// The measurement that would replace it for a given model is written and
+/// reproducible: `crates/stella-tools/tests/relevance_calibration.rs` prints
+/// the labelled relevant/irrelevant distributions over this repository for
+/// whatever backend is configured (#3096, #2993). It is `#[ignore]`d because
+/// it needs a real key.
 const DEFAULT_ADMISSION_FLOOR: f32 = 0.25;
+
+/// Which models have had their score distributions measured, and what the
+/// measurement found.
+///
+/// MEASURED: 2026-08-24, `voyage-code-3@1/1024/l2` over this repository's own
+/// index (28 744 chunks), four labelled queries from
+/// `crates/stella-tools/tests/relevance_calibration.rs`, 40 candidates deep
+/// each. Tightest separation across the set **-0.0439**: on "why is the Rust
+/// toolchain pinned to an exact version" the labelled answer ranked 39th, at
+/// 0.5978, under 38 irrelevant chunks scoring 0.6006-0.6436. The widest
+/// positive separation was +0.0140. Two of the four queries returned no
+/// labelled answer in 40 candidates at all, which makes their separation
+/// unmeasurable rather than good.
+///
+/// `Some(floor)` is a floor a measurement put between the two distributions.
+/// `None` is the other outcome, and the one this table currently records: the
+/// distributions **overlap**, so no floor separates them and the model must
+/// declare [`SimilarityPosture::Surface`] — scores order candidates and admit
+/// none, exactly as `HashEmbedder` already reports. #2993 named that outcome
+/// in advance as the one to expect, and it is the one that came back.
+///
+/// A model absent from this table is unmeasured, keeps
+/// [`DEFAULT_ADMISSION_FLOOR`], and says so in its own doc comment above. An
+/// explicit `STELLA_EMBED_FLOOR` outranks this table for either kind of
+/// entry: the operator is then making the claim, about a corpus this
+/// measurement did not see.
+const MEASURED_FLOORS: &[(&str, Option<f32>)] = &[("voyage-code-3", None)];
 
 /// Models this crate knows the vector width of, so `STELLA_EMBED_DIMS` is only
 /// mandatory for something it has never heard of. Width matters before the
@@ -244,10 +272,14 @@ pub enum Resolution {
 
 /// Resolve an embedder from a captured environment. Pure.
 pub fn resolve(env: &EmbedderEnv) -> Resolution {
-    let floor = match env.floor.as_deref() {
-        None => DEFAULT_ADMISSION_FLOOR,
+    // `None` is carried through rather than collapsed onto the default here:
+    // downstream, "the operator set a floor" and "nobody did" select different
+    // postures, and a default substituted at this line erases the difference
+    // before anything can read it.
+    let floor: Option<f32> = match env.floor.as_deref() {
+        None => None,
         Some(raw) => match raw.parse::<f32>() {
-            Ok(value) if value.is_finite() => value,
+            Ok(value) if value.is_finite() => Some(value),
             _ => {
                 return Resolution::Incomplete(format!(
                     "STELLA_EMBED_FLOOR is `{raw}`, which is not a finite number"
@@ -376,26 +408,53 @@ pub struct HttpEmbedder {
     model: String,
     api_key: Option<String>,
     dims: usize,
-    admission_floor: f32,
+    posture: SimilarityPosture,
     client: reqwest::Client,
+}
+
+/// What this backend's scores are allowed to certify, decided once at
+/// construction from the operator's override, then the measurement table,
+/// then the unmeasured default — in that order, because each step is a
+/// stronger claim than the one after it.
+fn posture_for(model: &str, operator_floor: Option<f32>) -> SimilarityPosture {
+    if let Some(admission_floor) = operator_floor {
+        return SimilarityPosture::Semantic { admission_floor };
+    }
+    match MEASURED_FLOORS
+        .iter()
+        .find(|(known, _)| *known == model)
+        .map(|(_, floor)| *floor)
+    {
+        Some(Some(admission_floor)) => SimilarityPosture::Semantic { admission_floor },
+        Some(None) => SimilarityPosture::Surface,
+        None => SimilarityPosture::Semantic {
+            admission_floor: DEFAULT_ADMISSION_FLOOR,
+        },
+    }
 }
 
 impl HttpEmbedder {
     /// Build an embedder against `base_url` (with or without a trailing
     /// slash); `/embeddings` is appended.
+    ///
+    /// `admission_floor` is the **operator's** floor (`STELLA_EMBED_FLOOR`)
+    /// and nothing else. `None` is not "use the default" — it is "nobody
+    /// overrode this", which is what lets this crate tell an operator's claim
+    /// apart from a measured one apart from an unmeasured fallback. A caller
+    /// that only wants a fingerprint passes `None`.
     pub fn new(
         base_url: &str,
         model: &str,
         api_key: Option<String>,
         dims: usize,
-        admission_floor: f32,
+        admission_floor: Option<f32>,
     ) -> Self {
         Self {
             endpoint: format!("{}/embeddings", base_url.trim_end_matches('/')),
             model: model.to_string(),
             api_key,
             dims,
-            admission_floor,
+            posture: posture_for(model, admission_floor),
             // A builder failure here means the TLS backend could not be
             // initialised at all. Falling back to a default client keeps this
             // constructor infallible — the very next request fails with a
@@ -426,7 +485,7 @@ impl fmt::Debug for HttpEmbedder {
             .field("model", &self.model)
             .field("api_key", &Redacted(&self.api_key))
             .field("dims", &self.dims)
-            .field("admission_floor", &self.admission_floor)
+            .field("posture", &self.posture)
             .finish_non_exhaustive()
     }
 }
@@ -577,17 +636,18 @@ impl Embedder for HttpEmbedder {
             .collect()
     }
 
-    /// A trained embedding model maps meaning, which is the whole reason this
-    /// backend exists — a query and a file that share no token can still land
-    /// close together. The *floor*, unlike the posture, is provisional: no
-    /// measured separation point exists yet for these backends on a code
-    /// corpus. Measuring one per model is tracked in #2993 and #3096, and the
-    /// harness that produces the distribution is
-    /// `crates/stella-tools/tests/relevance_calibration.rs`.
+    /// Decided at construction from the measurement, rather than from the
+    /// fact that this backend is a trained model.
+    ///
+    /// Mapping meaning is why this backend exists, and it is not the question
+    /// [`SimilarityPosture`] asks. That question is whether a score may
+    /// **admit** a candidate on its own, which needs the two distributions to
+    /// separate — and for `voyage-code-3` on a code corpus they do not; this
+    /// module's `MEASURED_FLOORS` carries the numbers. A model nobody has
+    /// measured still declares `Semantic` on an unmeasured default floor, and
+    /// both of those constants' doc comments say which it is.
     fn similarity_posture(&self) -> SimilarityPosture {
-        SimilarityPosture::Semantic {
-            admission_floor: self.admission_floor,
-        }
+        self.posture
     }
 }
 
@@ -777,13 +837,63 @@ mod tests {
         );
     }
 
+    /// An **unmeasured** model still declares `Semantic`, on
+    /// `DEFAULT_ADMISSION_FLOOR`. `text-embedding-3-small` is one: #2993 names
+    /// it as a model to measure and nobody has.
     #[test]
-    fn the_http_backend_declares_a_semantic_posture() {
+    fn an_unmeasured_backend_declares_a_semantic_posture() {
         let Resolution::Configured(embedder) = resolve(&env_with(&[("OPENAI_API_KEY", "sk")]))
         else {
             panic!("expected a configured embedder");
         };
         assert!(embedder.similarity_posture().admits());
+        assert_eq!(
+            embedder.similarity_posture(),
+            SimilarityPosture::Semantic {
+                admission_floor: DEFAULT_ADMISSION_FLOOR
+            }
+        );
+    }
+
+    /// The measurement, pinned (#2993). `voyage-code-3`'s relevant and
+    /// irrelevant distributions overlap on a code corpus — tightest separation
+    /// -0.0439 — so its scores order candidates and admit none. A merge that
+    /// carried the old unconditional `Semantic` back over the top fails here
+    /// instead of silently re-asserting a separation nobody measured.
+    #[test]
+    fn the_measured_backend_declares_the_posture_its_distribution_earned() {
+        let Resolution::Configured(embedder) = resolve(&env_with(&[("VOYAGE_API_KEY", "pa-k")]))
+        else {
+            panic!("expected a configured embedder");
+        };
+        assert_eq!(embedder.similarity_posture(), SimilarityPosture::Surface);
+        assert!(
+            !embedder.similarity_posture().admits(),
+            "a measured overlap must not admit on its own say-so"
+        );
+        assert_eq!(
+            MEASURED_FLOORS,
+            &[("voyage-code-3", None)],
+            "the table is the record of what was measured; changing a row means re-running \
+             crates/stella-tools/tests/relevance_calibration.rs, not editing this assertion"
+        );
+    }
+
+    /// An operator's floor outranks the table: `STELLA_EMBED_FLOOR` against a
+    /// measured-overlapping model is a claim about a corpus the measurement
+    /// did not see, and it must not be swallowed by the row.
+    #[test]
+    fn an_operator_floor_outranks_the_measured_row() {
+        let env = env_with(&[("STELLA_EMBED_FLOOR", "0.72"), ("VOYAGE_API_KEY", "pa-k")]);
+        let Resolution::Configured(embedder) = resolve(&env) else {
+            panic!("expected a configured embedder");
+        };
+        assert_eq!(
+            embedder.similarity_posture(),
+            SimilarityPosture::Semantic {
+                admission_floor: 0.72
+            }
+        );
     }
 
     #[tokio::test]
@@ -806,7 +916,7 @@ mod tests {
             "text-embedding-3-small",
             Some("sk-test".into()),
             2,
-            0.25,
+            None,
         );
         let out = embedder
             .embed(&["first".to_string(), "second".to_string()])
@@ -828,7 +938,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, None);
         assert!(matches!(
             embedder.embed(&["only".to_string()]).await,
             Err(EmbedError::DimensionMismatch {
@@ -847,7 +957,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, None);
         let Err(EmbedError::Backend(message)) = embedder.embed(&["x".to_string()]).await else {
             panic!("expected a backend error");
         };
@@ -883,7 +993,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, None);
         let out = embedder
             .embed(&["only".to_string()])
             .await
@@ -908,7 +1018,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, None);
         let Err(EmbedError::Backend(message)) = embedder.embed(&["x".to_string()]).await else {
             panic!("expected a backend error once the attempts ran out");
         };
@@ -931,7 +1041,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, 0.25);
+        let embedder = HttpEmbedder::new(&format!("{}/v1", server.uri()), "m", None, 2, None);
         assert!(embedder.embed(&["x".to_string()]).await.is_err());
         // `expect(1)` is verified on drop: a second attempt fails the test.
         drop(server);

--- a/crates/stella-embed/src/rank.rs
+++ b/crates/stella-embed/src/rank.rs
@@ -102,11 +102,16 @@ pub fn top_k(query: &[f32], candidates: &[Candidate<'_>], floor: f32, limit: usi
 /// `DEFAULT_ADMISSION_FLOOR` is the cautionary case, sitting at 0.25 while
 /// `voyage-code-3` scores unrelated files at 0.604, dropping nothing.
 ///
-/// What would confirm or retune it is a distribution:
-/// `crates/stella-tools/tests/relevance_calibration.rs` prints the boundary
-/// gap at each labelled query's true relevant/irrelevant frontier as a
-/// multiple of that ranking's mean gap, which is exactly the quantity this
-/// constant is compared against (#3096).
+/// Measured once and not yet retuned. On 2026-08-24 the four labelled queries
+/// in `crates/stella-tools/tests/relevance_calibration.rs`, run against
+/// `voyage-code-3` over this repository, put the boundary at the true
+/// relevant/irrelevant frontier at **+5.36x** the mean gap on the one query
+/// with a clean frontier and **+0.11x** on the one whose answer ranked 39th;
+/// the other two returned no labelled answer in 40 candidates, so they have no
+/// frontier to measure. Two usable points, pointing opposite ways, is not
+/// enough to move a threshold — the ratio stays where it is, and this
+/// paragraph records that it has now been looked at rather than that it has
+/// been settled (#3096).
 pub const DEFAULT_RELEVANCE_GAP_RATIO: f32 = 2.5;
 
 /// The smallest drop in cosine that may be called a boundary at all.
@@ -128,9 +133,27 @@ pub const DEFAULT_RELEVANCE_GAP_RATIO: f32 = 2.5;
 /// an absolute *floor*: gaps between scores are much more comparable across
 /// models than the scores themselves, which is exactly why
 /// `DEFAULT_ADMISSION_FLOOR` sits at 0.25 while a real backend scores
-/// unrelated files at 0.604. It still wants measuring per model, against the
-/// absolute boundary drops
-/// `crates/stella-tools/tests/relevance_calibration.rs` prints (#3096).
+/// unrelated files at 0.604.
+///
+/// # What the measurement found, and why the number did not move
+///
+/// The 2026-08-24 run of `crates/stella-tools/tests/relevance_calibration.rs`
+/// against `voyage-code-3` over this repository observed absolute boundary
+/// drops of **0.0140** and **0.0001** — both far under this 0.05. So on this
+/// corpus the boundary never fires, [`relevant_prefix`] returns the whole
+/// list, and every ranking runs to its end. That is visible from outside as
+/// 200+ hit answers and as `search`'s RANK CEILING note still appearing on
+/// nearly every query, since the note's condition is precisely "the boundary
+/// kept everything it was given" (#4385).
+///
+/// The number stays at 0.05 anyway, because the alternative is worse. Two
+/// usable frontiers — one of them a query whose answer ranked 39th — is a
+/// sample to report, not one to tune a threshold against, and
+/// [`DEFAULT_MIN_BOUNDARY_GAP`]'s whole reason for existing is the #3089
+/// ranking where a 0.015 gap looked decisive and was noise. Retuning it to
+/// admit 0.014 would re-open exactly that failure on the strength of one
+/// query. What settles it is more labelled queries, which is
+/// `relevance_calibration.rs`'s `QUERIES` table (#3096).
 pub const DEFAULT_MIN_BOUNDARY_GAP: f32 = 0.05;
 
 /// How many of a ranked list are relevant — the answer to "where does this

--- a/crates/stella-graph/src/lib.rs
+++ b/crates/stella-graph/src/lib.rs
@@ -88,6 +88,7 @@ pub use markdown::BREADCRUMB_SEPARATOR;
 pub use reconcile::{FullWalkReason, GitCli, Plan, RepoOracle};
 pub use storage::{StorageExtract, StorageExtractor, StorageSnapshot};
 pub use store::IndexStats;
+pub use store::image_check::image_walks;
 pub use symbol::{CallSite, Symbol, SymbolKind};
 pub use vectors::chunks::{
     ChunkVector, MAX_FILES_PER_CHUNK_PASS, PendingChunk, PendingChunkFile, PendingChunkScan,

--- a/crates/stella-graph/src/store.rs
+++ b/crates/stella-graph/src/store.rs
@@ -59,6 +59,8 @@ use crate::storage::{self, FieldEntry, RelationEntry};
 use crate::symbol::SymbolKind;
 use crate::walk::walk_indexable;
 
+pub(crate) mod image_check;
+
 /// The on-disk schema version stamped in `PRAGMA user_version`. Bump it in
 /// the same commit as a **reshape** — an altered or backfilled column,
 /// anything the `IF NOT EXISTS` guard would silently skip on an existing
@@ -393,13 +395,19 @@ pub(crate) fn open(db_path: &Path) -> Result<Connection, GraphError> {
                 ),
                 None => eprintln!("code-graph store was corrupt — rebuilding from scratch"),
             }
-            open_migrated(db_path)
+            let conn = open_migrated(db_path)?;
+            // The image behind this connection is one this process just made
+            // from nothing, so it is intact by construction and a later open
+            // has nothing to re-walk.
+            image_check::remember_intact(db_path);
+            Ok(conn)
         }
         Err(error) => Err(error),
     }
 }
 
-/// [`open_migrated`] plus a structural `PRAGMA quick_check` over the image.
+/// [`open_migrated`] plus a structural `PRAGMA quick_check` over the image —
+/// **once per unchanged image**, not once per open.
 ///
 /// Migration alone proved too weak a probe for damage. The 2026-08-08 field
 /// corruption — rowid-out-of-order data pages under an intact schema page —
@@ -407,12 +415,25 @@ pub(crate) fn open(db_path: &Path) -> Result<Connection, GraphError> {
 /// catch-up scan, whose error the mount path discards; the graph sat dead
 /// for four days, sessions re-creating the WAL sidecars and writing nothing,
 /// with no notice and no rebuild. `quick_check` walks every page, which is
-/// exactly what makes its "ok" trustworthy; it stops at the first fault, and
-/// the writer's open pays it once, ahead of a tree walk that dwarfs it.
+/// exactly what makes its "ok" trustworthy, and it stops at the first fault.
+///
+/// It was originally priced as something "the writer's open pays once, ahead
+/// of a tree walk that dwarfs it". The read path does not open once —
+/// `search::engine::report_with` opens the graph on **every `search` call** —
+/// and the catch-up walk it was priced against costs 78-97 ms warm against a
+/// full page walk of a 180 MB image. One recorded session paid it sixty-one
+/// times (#4385). [`image_check`] carries the key the memo uses — the image's
+/// own `(length, mtime)`, so a store damaged between two opens is still
+/// caught — and what it gives up in exchange.
 fn open_verified(db_path: &Path) -> Result<Connection, GraphError> {
     let conn = open_migrated(db_path)?;
+    if image_check::already_walked(db_path) {
+        return Ok(conn);
+    }
+    image_check::count_walk();
     let verdict: String = conn.query_row("PRAGMA quick_check(1)", [], |row| row.get(0))?;
     if verdict == "ok" {
+        image_check::remember_intact(db_path);
         return Ok(conn);
     }
     drop(conn);
@@ -423,7 +444,8 @@ fn open_verified(db_path: &Path) -> Result<Connection, GraphError> {
 }
 
 /// The unmolested open-and-migrate [`open`] retries after a quarantine — a
-/// store this process just created from nothing has no pages to re-verify.
+/// store this process just created from nothing has no pages to re-verify,
+/// which is also why the retry path records it as intact.
 fn open_migrated(db_path: &Path) -> Result<Connection, GraphError> {
     let conn = open_read(db_path)?;
     conn.execute_batch(MIGRATION)?;

--- a/crates/stella-graph/src/store/image_check.rs
+++ b/crates/stella-graph/src/store/image_check.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Which store images this process has already walked with `PRAGMA
+//! quick_check`, so an unchanged image is walked once instead of once per
+//! open.
+//!
+//! # Why the memo exists
+//!
+//! The check itself is not optional and its argument is in
+//! [`super::open_verified`]: the 2026-08-08 field corruption sailed through
+//! migration and left the graph dead for four days, and `quick_check` catches
+//! that shape precisely *because* it walks every page. What was wrong was the
+//! assumption under which it was priced — "the writer's open pays it once,
+//! ahead of a tree walk that dwarfs it". The read path does not open once.
+//! `search::engine::report_with` calls `open_or_build` on **every `search`
+//! call**, so a session that searched sixty-one times walked every page of a
+//! 180 MB `codegraph.db` sixty-one times, against a hash-diff catch-up
+//! measured at 78-97 ms warm. #4385 is what that cost looked like from the
+//! outside.
+//!
+//! # Why the key is the image's own stamp, not the path
+//!
+//! A path-keyed memo would answer "this process verified this file once" and
+//! that is the wrong question, because a store can be damaged **after** it was
+//! verified — by a disk fault, or by another writer — and the next open is
+//! exactly where that must be caught. `store::tests::
+//! a_store_corrupt_only_in_its_data_pages_is_quarantined_at_open` scrambles a
+//! page between two opens in one process and is the test that says so.
+//!
+//! So the memo records `(length, modification time)` of the main database file
+//! and re-walks whenever either moves. That is both correct and effective
+//! here, because of what WAL mode does: ordinary writes land in the `-wal`
+//! sidecar and leave the main image untouched, and the main image is what
+//! `quick_check` walks. A burst of searches over a settled index therefore
+//! hits the memo every time, while a checkpoint — which does rewrite the main
+//! file — costs one more walk, which is the conservative direction.
+//!
+//! **What it still gives up:** damage written inside the same `(length,
+//! mtime)` stamp as the verification is invisible to the memo until the stamp
+//! moves. A filesystem whose timestamps are coarse widens that window. The
+//! first open in a process always walks, which is the case #4370 was about,
+//! and a store damaged mid-session still surfaces through the catch-up scan's
+//! error reaching the caller as an index warning
+//! (`search::codegraph::open_or_build`) — the path that was silent in
+//! 2026-08-08 and is not any more.
+//!
+//! The path is used as the caller spelled it, not canonicalized: a second
+//! spelling of one file walks it again, which is the conservative direction,
+//! and it keeps this module free of its own I/O beyond the stat.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
+/// What an image looked like when it was walked and found intact. Equal
+/// stamps mean the bytes `quick_check` read are still the bytes on disk, as
+/// far as the filesystem is willing to say.
+type Stamp = (u64, Option<SystemTime>);
+
+/// The images this process has walked, and the stamp each carried at the time.
+static VERIFIED: Mutex<BTreeMap<PathBuf, Stamp>> = Mutex::new(BTreeMap::new());
+
+/// How many full-image walks this process has performed. See [`image_walks`].
+static WALKS: AtomicU64 = AtomicU64::new(0);
+
+/// How many times this process has walked a store image with `PRAGMA
+/// quick_check`.
+///
+/// Always compiled rather than `#[cfg(test)]`, for the reason
+/// `search::cache::GatherCache::gathered` is: the count is the **only**
+/// observable difference between a memo that works and a memo that silently
+/// never hits, and a counter that exists only under `cfg(test)` cannot be
+/// asserted from an integration test in another crate. It is monotonic within
+/// a process and carries no meaning across processes.
+#[must_use]
+pub fn image_walks() -> u64 {
+    WALKS.load(Ordering::Relaxed)
+}
+
+/// The image's current stamp. `None` when it cannot be read at all, which is
+/// never treated as a match: an image whose stamp is unknown is walked.
+fn stamp(db_path: &Path) -> Option<Stamp> {
+    let meta = std::fs::metadata(db_path).ok()?;
+    Some((meta.len(), meta.modified().ok()))
+}
+
+/// Whether `db_path` was walked, found intact, and has not changed since.
+pub(crate) fn already_walked(db_path: &Path) -> bool {
+    let Some(current) = stamp(db_path) else {
+        return false;
+    };
+    VERIFIED
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(db_path)
+        .is_some_and(|recorded| *recorded == current)
+}
+
+/// Record that `db_path`'s image is intact as it stands right now, so a later
+/// open of the same bytes skips the walk.
+///
+/// A stamp that cannot be read **forgets** the path rather than storing a
+/// placeholder: a remembered entry must mean "these exact bytes were checked",
+/// and an entry that cannot say which bytes it refers to is worse than none.
+pub(crate) fn remember_intact(db_path: &Path) {
+    let mut verified = VERIFIED
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    match stamp(db_path) {
+        Some(current) => {
+            verified.insert(db_path.to_path_buf(), current);
+        }
+        None => {
+            verified.remove(db_path);
+        }
+    }
+}
+
+/// Record that a walk is about to happen. Counted before the walk rather than
+/// after it, so a walk that ends in a corruption verdict is still counted —
+/// the cost was paid either way.
+pub(crate) fn count_walk() {
+    WALKS.fetch_add(1, Ordering::Relaxed);
+}

--- a/crates/stella-graph/src/vectors/chunks.rs
+++ b/crates/stella-graph/src/vectors/chunks.rs
@@ -452,6 +452,20 @@ fn write_chunks(
 /// SQLite and hands them over, the invariant-2 split [`super::rank`] already
 /// makes.
 ///
+/// # What the scan costs, measured
+///
+/// [`super::stored`] argues brute force is free at *file* scale, and it is:
+/// 1 585 rows is 6.5 MB. This rung is the same scan over a corpus twenty
+/// times larger, and the cost does not carry over. On this repository's own
+/// index — 28 813 chunk rows at 1 024 `f32` — the blobs are **118 MB read and
+/// decoded on every call**, measured on 2026-08-24 at 220-296 ms warm and one
+/// of the two largest terms in a `search` call's wall clock (#4385). It is
+/// still the shipped answer, because an ANN structure is a second index to
+/// keep correct and the cheaper term went first (#4385 removed a full 180 MB
+/// page walk from the same call). What this paragraph is for is that the
+/// number is now written down where the next person to weigh that trade will
+/// find it, instead of being inherited from a corpus twenty times smaller.
+///
 /// Candidates are keyed `path#line#name` rather than by rowid: the key is
 /// `top_k`'s tie-break, so it has to be both unique per chunk and *stable
 /// across rebuilds of the database*, which a rowid is not.

--- a/crates/stella-graph/tests/image_verification_memo.rs
+++ b/crates/stella-graph/tests/image_verification_memo.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! An unchanged store image is walked once, however many times it is opened —
+//! and a changed one is walked again (#4385).
+//!
+//! `PRAGMA quick_check` walks every page, and that is what makes its verdict
+//! worth having. It is also why `search::engine::report_with`, which opens the
+//! code graph on every `search` call, was paying a full page walk of a 180 MB
+//! image per query before `store::image_check` memoized the verdict.
+//!
+//! **This file holds exactly one test on purpose.** `stella_graph::image_walks`
+//! is a process-global counter, so any other test in the same binary opening
+//! any store would race the deltas this one asserts, and both halves of the
+//! contract have to be checked in a fixed order anyway. One test per binary
+//! makes the counts exact instead of approximately right.
+
+use std::path::Path;
+
+use stella_graph::{CodeGraph, image_walks};
+
+/// Open, then drop. The handle's lifetime is not what is being measured.
+fn open_and_close(root: &Path, db: &Path) {
+    let graph = CodeGraph::open(root, db).expect("open the store");
+    drop(graph);
+}
+
+#[test]
+fn an_unchanged_image_is_walked_once_and_a_changed_one_is_walked_again() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("workspace");
+    std::fs::create_dir_all(&root).expect("workspace root");
+    std::fs::write(root.join("lib.rs"), "pub fn answer() -> u32 { 42 }\n").expect("a source file");
+    let db = dir.path().join("codegraph.db");
+
+    let before = image_walks();
+    open_and_close(&root, &db);
+    assert_eq!(
+        image_walks() - before,
+        1,
+        "the first open of an image must still walk it — the memo is a cost fix, not a decision \
+         to stop checking"
+    );
+
+    // A second open lets the file settle. Creating and migrating a store
+    // writes the main image after the walk that verified it, so that open
+    // legitimately sees a stamp it has not checked and walks again. What the
+    // memo claims is about an image that is *not* moving, which is the state
+    // every open after this one is in.
+    open_and_close(&root, &db);
+    let settled = image_walks();
+
+    for _ in 0..8 {
+        open_and_close(&root, &db);
+    }
+    assert_eq!(
+        image_walks(),
+        settled,
+        "eight opens of an unchanged image walked {} more time(s); before the memo every one of \
+         them paid a full page walk",
+        image_walks() - settled
+    );
+
+    // The other half of the contract, and the reason the key is the image's
+    // own stamp rather than its path: a store that changes underneath a
+    // process must be walked again on the next open, because that is where
+    // damage arriving after a verification is caught
+    // (`store::tests::a_store_corrupt_only_in_its_data_pages_is_quarantined_at_open`).
+    let bytes = std::fs::read(&db).expect("read the image");
+    std::fs::write(&db, &bytes).expect("rewrite the image");
+    open_and_close(&root, &db);
+    assert!(
+        image_walks() > settled,
+        "an image whose stamp moved must be walked again rather than trusted from the memo"
+    );
+}

--- a/crates/stella-tools/src/search/cache.rs
+++ b/crates/stella-tools/src/search/cache.rs
@@ -60,6 +60,56 @@
 //! linearly is the right structure at this size: 256 entries is a few pages
 //! of pointers, a lookup touches at most one screen of memory, and the
 //! workspace already carries no LRU crate to reach for.
+//!
+//! # Why the cache stops at the session (#3198)
+//!
+//! #3163 sketched more than this — a tier under `.stella/private/` surviving
+//! the process, grouped by `.stella/domains.toml`, with git as the
+//! invalidation authority for entries that outlive a content hash's usefulness
+//! — and #3198 carried that half as a handoff, asking for the measurement
+//! before the build: **graph reads per call, and wall clock**. The
+//! measurement was taken on 2026-08-24 against this repository's own index
+//! (1 769 indexed files, 28 813 chunk vectors), and it says the tier should
+//! not be built.
+//!
+//! **One gather costs 3.7 ms.** That is the three indexed queries
+//! [`stella_graph::CodeGraph::file_neighborhood`] issues — symbols, imports,
+//! importers — timed over a random 200-file sample of `crates/**`, driven
+//! from Python against the same SQL, which bounds the Rust path from above
+//! rather than flattering it. A call enriches whole blocks until the 9 000
+//! character budget is spent, so it gathers a handful of files, and the
+//! ceiling on what any gather cache can ever save is tens of milliseconds.
+//!
+//! **The terms it would be saving against are one to two orders of magnitude
+//! larger.** Measured on the same index the same day: the chunk ranking scan
+//! 220-296 ms (118 MB of stored vectors read and decoded per call), a full
+//! `PRAGMA quick_check` page walk 333 ms (paid on every call until #4385
+//! removed it), the `index_all` catch-up 78-97 ms warm, and the query's own
+//! embedding round trip 111-202 ms. Against those, a persisted gather cache
+//! is a rounding error.
+//!
+//! The cache's own guard is in the same range as the thing it guards:
+//! [`stella_graph::CodeGraph::index_generation`] re-hashes every indexed
+//! file's `(path, content sha)` once per render, 21.8 ms over 1 808 rows by
+//! the same Python bound.
+//!
+//! A faster machine does not change the answer, because the second half of it
+//! is structural. [`GatherCache::observe_generation`] empties the whole cache
+//! whenever the index generation moves — which it does the moment **any** file
+//! in the tree is re-indexed, because the stamp is a digest over every indexed
+//! file's `(path, content sha)`. A persisted tier inherits that key: it has to,
+//! since the cross-file half of a neighborhood (`importers`, a resolved import
+//! target) is a function of the rest of the tree and no per-file identity can
+//! invalidate it. So the cross-session case #3163 wants — "the sessions of a
+//! team working the same tree" — is exactly the case where every teammate's
+//! commit invalidates every persisted entry. The cache would be coldest where
+//! it was meant to pay most.
+//!
+//! **The decision, not a deferral:** the session-lifetime cache is where this
+//! stops. Building the persisted tier is legitimate again if the two heavy
+//! terms above are removed first and the generation key is narrowed to the
+//! cross-file half alone (#3196's subject), because only then is a gather a
+//! large enough share of a call to be worth surviving the process.
 
 use sha2::{Digest, Sha256};
 use stella_graph::FileNeighborhood;

--- a/crates/stella-tools/tests/fixtures/recorded_search_queries.txt
+++ b/crates/stella-tools/tests/fixtures/recorded_search_queries.txt
@@ -1,0 +1,61 @@
+ToolExecutor trait
+command_deck FileChangeTap FileChange emitter
+run_turn agent turn loop in stella-core
+budget guard consulted between model calls
+Provider trait definition model provider abstraction
+parity matrix provider parity axes posture
+where is the system prompt assembled, session environment block, workspace rules, workspace memories
+determinism byte-stability of system prompt for prompt cache
+conversation history compaction summarization context window trimming
+step_usage telemetry content_free allowlist
+apply_edits batch tool edits array
+run_model_call retry_with_backoff_observed streaming model call Engine
+execute_tool_calls dispatch tool execution ToolCallStart ToolCallEnd
+how a user prompt starts an agent turn in stella-tui model.rs
+CompletionRequestRef CompletionResult CompletionRequest types definition
+ToolSchema struct definition read_only speculation_safe input_schema
+"FileChangeTap" struct tap measuring work tree changes emitting FileChange events
+enum AgentEvent variants definition stella-protocol
+run_deck function deck shell render loop inbound receiver WorkspaceInput sender
+stella-cli run_prompt non-interactive one-shot plain renderer AgentEvent output
+PROVIDERS built-in provider config env var api key base url ProviderConfig stella-cli config.rs
+FileChangeTap
+ClaimTap struct claims.rs file locks claim on first write
+static PROVIDERS anthropic openai gemini local base_url default_model env_var table in config.rs
+ToolCallObserver implementation engine streaming text_delta reasoning_delta mapped to engine events stella-core driver
+stella-events.jsonl event log written per session
+StepUsage struct definition fields per step telemetry record
+schema.sql sessions events tables in stella-store
+check_budget method Engine BudgetGuard evaluate abort
+"pub static PROVIDERS" or "PROVIDERS: &[ProviderConfig]" with LOCAL_PROVIDER env var names like ANTHROPIC_API_KEY
+StepUsage AgentEvent variant fields model tokens cache_read cache_write cost_usd
+"stella-events.jsonl" file name
+where stella-cli assembles system prompt and message history before run_turn
+ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY OPENROUTER_API_KEY provider row env_var definition
+apply_edits.rs file in stella-tools
+run_lead_turn dispatch lead turn engine run_turn pipeline in command_deck driver loop
+AgentEvent enum variants ToolCall ToolResult AskUser TurnComplete in stella-protocol event
+engine passes tool schemas to provider complete request; tool results appended as Tool message to history
+CACHE_POSTURE REASONING_POSTURE OVERFLOW_POSTURE OUTPUT_BUDGET_POSTURE STREAM_FALLBACK_POSTURE static tables accessors cache_posture reasoning_posture overflow_posture output_budget_posture
+main.rs dispatch default command deck when tty run_interactive fallback run_one_shot for stella run
+run_deck_session spawn driver task submissions recv Prompt run_lead_turn
+rules.rs MidTurnAsk enum approval responder policy engine ask question tool registry
+Provider trait definition in stella-core ports
+provider parity matrix
+run_turn in crates/stella-cli/src/agent.rs
+FileChangeTap FileChange emitter in stella-cli/src/command_deck.rs
+fleet_dashboard.rs purpose stella-tui
+model id parsing provider selection env var API key build provider from model string
+FileChangeTap
+spawn_renderer drain event channel EventSender unbounded channel stella-cli agent.rs
+stella-tui model.rs prompt submit starts turn engine event receiver Inbound
+CompletionRequest CompletionResult struct definitions and env var names ANTHROPIC_API_KEY OPENAI_API_KEY resolution
+"FileChangeTap" tap file changes command_deck
+Tap struct in command_deck.rs that emits FileChange events into the turn stream
+seeded provider table env var name api_key_env ZAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY in stella-model catalog
+what calls emit_shared_tree_changes or open_turn_streams in command_deck run_lead_turn
+PromptStarted event emitted in stella-cli when prompt submitted command deck
+stella-tui main loop drains Inbound receiver apply_inbound render tick
+FileChangeTap emits FileChange event when the user edits a file in the deck
+"run_turn" async fn in crates/stella-cli/src/agent.rs interactive session driver
+command deck issues tab selection key handling IssuesRefresh IssueAct

--- a/crates/stella-tools/tests/relevance_calibration.rs
+++ b/crates/stella-tools/tests/relevance_calibration.rs
@@ -16,7 +16,8 @@
 //! # How to run it
 //!
 //! ```text
-//! VOYAGE_API_KEY=pa-… cargo test -p stella-tools \
+//! VOYAGE_API_KEY=pa-… STELLA_CALIBRATION_INDEX=/path/to/codegraph.db \
+//!     cargo test -p stella-tools \
 //!     --test relevance_calibration -- --ignored --nocapture
 //! ```
 //!
@@ -27,6 +28,25 @@
 //! configuration of its own. Run it once per backend: the floor is a
 //! per-`HttpEmbedder` field, so `voyage-code-3` and a local model may
 //! legitimately differ.
+//!
+//! ## `STELLA_CALIBRATION_INDEX` — what made this affordable to run
+//!
+//! Without it the harness builds an index into a temporary directory and
+//! embeds this whole repository first, which is the ~11M paid tokens the
+//! session that wrote this file declined to spend. With it, the harness ranks
+//! against an index that is **already filled under the same fingerprint** —
+//! the one a working checkout's `search::backfill` pass has been filling all
+//! along — and the run's entire cost is one query embedding per labelled
+//! query. Four, at the time of writing.
+//!
+//! It changes nothing about what is measured. The distribution is a property
+//! of the embedder and the corpus, and the corpus is the same rows either way;
+//! what the flag removes is the re-embedding of rows that already exist. The
+//! harness prints the chunk count it ranked over, so a thin index cannot be
+//! mistaken for a full one, and it still refuses to report a distribution over
+//! zero rows. Point it at a **copy** of a live session's database rather than
+//! the live file: it opens the graph for writing (`CodeGraph::open`), and a
+//! session's own indexer is already writing to that one.
 //!
 //! # What it prints, and what to do with it
 //!
@@ -75,17 +95,43 @@
 //! (`tests/chunk_retrieval_witnesses.rs`) carries the same two halves and its
 //! module doc argues them at length.
 //!
-//! # Status
+//! # Status — run 2026-08-24 against `voyage-code-3`
 //!
-//! **Written, and unrun.** No distribution has been observed and **no
-//! constant has been changed** — every number in the three doc comments is
-//! still the provisional one. Not for want of a key: the session that wrote
-//! this had a usable `pa-` one in its environment and did not spend it,
-//! because a cold pass over this repository is ~11M tokens against a paid API
-//! and that is a maintainer's call to make deliberately, not a side effect of
-//! writing the harness. #3096 is not closed by this file's existence; it is
-//! closed by one run of it with a real key and the three doc comments
-//! rewritten from what it printed.
+//! What made it affordable was `STELLA_CALIBRATION_INDEX` above: the ~11M
+//! paid tokens the previous session declined to spend were the *re-embedding*,
+//! and an index this workspace had already filled made the run cost four query
+//! embeddings.
+//!
+//! ```text
+//! embedder    voyage-code-3@1/1024/l2      chunks 28744      depth 40
+//! separation  n/a      | +0.0140 | -0.0439 | n/a
+//! boundary    n/a      | +0.0140 | +0.0001 | n/a       (5.36x and 0.11x mean)
+//! cut         40 vs 0  | 40 vs 1 | 40 vs 39| 40 vs 0
+//! ```
+//!
+//! **Tightest separation -0.0439: the two distributions overlap, and no
+//! admission floor separates them.** On "why is the Rust toolchain pinned to
+//! an exact version" the labelled answer ranked 39th at 0.5978, under 38
+//! irrelevant chunks scoring 0.6006-0.6436. Two of the four queries returned
+//! no labelled answer in 40 candidates at all, which is a recall result and
+//! makes their separation unmeasurable rather than good.
+//!
+//! What was rewritten from it, and what deliberately was not:
+//!
+//! - `stella_embed`'s `MEASURED_FLOORS` now records the row, and
+//!   `voyage-code-3` declares `SimilarityPosture::Surface` (#2993).
+//! - `DEFAULT_MIN_BOUNDARY_GAP`'s doc carries the observed drops (0.0140 and
+//!   0.0001, both under its 0.05), which is why `relevant_prefix` never cuts
+//!   on this corpus and why `search` still prints its RANK CEILING note
+//!   (#4385).
+//! - **No constant's value moved.** Two usable frontiers, pointing opposite
+//!   ways, is a sample to report and not one to tune a threshold against —
+//!   which is what the section above says this harness exists to avoid.
+//!
+//! What #3096 still wants is the other three backends
+//! (`text-embedding-3-small`, `text-embedding-3-large`, a local
+//! `nomic-embed-text`) and a `QUERIES` table long enough that two of its rows
+//! being recall misses does not halve the sample.
 
 use std::path::{Path, PathBuf};
 
@@ -101,6 +147,11 @@ use stella_tools::search::backfill::backfill_opened;
 const NO_BACKEND: &str = "no embedding backend is configured: set VOYAGE_API_KEY (a `pa-` key; an \
                           `al-` Atlas key gets HTTP 403 from api.voyageai.com), or OPENAI_API_KEY, \
                           or STELLA_EMBED_URL together with STELLA_EMBED_MODEL";
+
+/// An already-filled `codegraph.db` to rank against, instead of building and
+/// embedding one. See this file's module doc for why that is a measurement
+/// shortcut rather than a measurement change.
+const INDEX_ENV: &str = "STELLA_CALIBRATION_INDEX";
 
 /// How deep each ranking is measured. Deep enough that the irrelevant tail is
 /// represented rather than clipped at the point the answers stop — a
@@ -285,18 +336,30 @@ async fn print_the_relevant_and_irrelevant_score_distributions() {
     let embedder = embedder.as_ref();
 
     let root = workspace_root();
-    let db = tempfile::tempdir().expect("tempdir for the index");
-    let graph = CodeGraph::open(&root, &db.path().join("codegraph.db")).expect("open the index");
+    let scratch = tempfile::tempdir().expect("tempdir for the index");
+    let prefilled = std::env::var_os(INDEX_ENV).map(PathBuf::from);
+    let db_path = prefilled
+        .clone()
+        .unwrap_or_else(|| scratch.path().join("codegraph.db"));
+    let graph = CodeGraph::open(&root, &db_path).expect("open the index");
     graph.index_all().expect("index this workspace");
 
     let fingerprint = embedder.fingerprint().id();
-    backfill_opened(&graph, embedder, &mut |_| {}).await;
+    // A prefilled index is taken as given: re-running the backfill over it
+    // would re-embed nothing (every row is already stored under this
+    // fingerprint) but would still walk the whole pending scan, and the point
+    // of the flag is that this run buys no embeddings it does not need.
+    if prefilled.is_none() {
+        backfill_opened(&graph, embedder, &mut |_| {}).await;
+    }
     let chunks = graph
         .embedded_chunk_count(&fingerprint)
         .expect("chunk count");
     assert!(
         chunks > 0,
-        "no chunk vectors were stored, so there is no distribution to measure"
+        "no chunk vectors are stored under {fingerprint}, so there is no distribution to \
+         measure — a {INDEX_ENV} index filled by a different embedder is invisible to this one \
+         rather than silently comparable"
     );
 
     let shipped_floor = match embedder.similarity_posture() {
@@ -312,6 +375,13 @@ async fn print_the_relevant_and_irrelevant_score_distributions() {
     println!("\n=== relevance calibration =========================================");
     println!("embedder    {fingerprint}");
     println!("chunks      {chunks}");
+    println!(
+        "index       {}",
+        prefilled.as_ref().map_or_else(
+            || "built and embedded for this run".to_string(),
+            |path| format!("prefilled, {} ({INDEX_ENV})", path.display()),
+        )
+    );
     println!(
         "shipped     floor {shipped_floor}, gap ratio {DEFAULT_RELEVANCE_GAP_RATIO}, min gap {DEFAULT_MIN_BOUNDARY_GAP}"
     );

--- a/crates/stella-tools/tests/search_latency_replay.rs
+++ b/crates/stella-tools/tests/search_latency_replay.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The latency measurement #4385 asks for: replay the sixty-one `search`
+//! calls one recorded session made, against today's code and a real backend,
+//! and print the distribution.
+//!
+//! #4385 reported the tool at **6 935 ms median, 21 361 ms p90, 33 450 ms
+//! max** over `tool_calls.duration_ms` for executions 225/242/248 of session
+//! `ses-1787465453163-60967`, and closed with "p90 under a stated target,
+//! measured by a bench loop over the 61 recorded queries". A number read off
+//! a recording cannot be compared against a number read off different queries,
+//! so the queries themselves are committed beside this file
+//! (`fixtures/recorded_search_queries.txt`, extracted verbatim from that
+//! session's `tool_calls.args_json`) and this harness is the loop.
+//!
+//! # How to run it
+//!
+//! ```text
+//! VOYAGE_API_KEY=pa-… STELLA_SEARCH_REPLAY_ROOT=/path/to/an/indexed/checkout \
+//!     cargo test -p stella-tools --release --test search_latency_replay \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! `--release` is not optional and neither is `--nocapture`: the ranking is a
+//! full scan over every stored vector, so a debug build measures the compiler
+//! rather than the tool, and the distribution is the output.
+//!
+//! `STELLA_SEARCH_REPLAY_ROOT` names a checkout whose
+//! `.stella/private/codegraph.db` is already **filled with vectors under the
+//! same embedder the run resolves**. Filling it is `search::backfill`'s job
+//! and is off this path by design (#4043) — a replay against an empty index
+//! measures the name and scan rungs, which is not what #4385 is about, so the
+//! harness refuses rather than reporting a fast meaningless number.
+//! `STELLA_WORKSPACE_STATE_ROOT` (`stella_home::WORKSPACE_STATE_ROOT_ENV`)
+//! redirects where that index is read from, which is how a run measures
+//! against a copy instead of a live session's database.
+//!
+//! # What it does not measure
+//!
+//! Not the recorded numbers. Those came off a loaded laptop — the same
+//! session's `bash` calls averaged 8 s — so they are a fact about that machine
+//! under that load, and this harness measures **this code path on whatever
+//! machine runs it**. It prints the recorded row beside its own so the two are
+//! never read as one measurement.
+//!
+//! # Status — attempted 2026-08-24, and what came back
+//!
+//! **No distribution.** The attempt is recorded here rather than omitted,
+//! because "we tried and the machine could not answer" is a different state
+//! from "nobody has run it", and only one of them is what #4385 is waiting on.
+//!
+//! The run went out over this repository's own index (1 585 file vectors,
+//! 28 813 chunk vectors, `voyage-code-3@1/1024/l2`) on an M-series laptop that
+//! was also hosting several agent worktrees. Its load average rose from 24 to
+//! 64 during the run and the per-query wall clock rose monotonically with it,
+//! from 15 422 ms on the first query to 201 500 ms on the fiftieth. A series
+//! that climbs 13x while the machine's load triples underneath it measures the
+//! machine. **Median and p90 over it would be arithmetic, not measurement**,
+//! so none is quoted, and #4385's "p90 under a stated target" is still open.
+//!
+//! What that run did establish, neither part depending on load:
+//!
+//! - **Every query came back 200+ hits deep** (203-256 across the fifty), so
+//!   the relevance boundary is running to the end of the merged ranking on
+//!   effectively every query against this corpus. That is the condition
+//!   `engine::ceiling_note` fires on, which is why this harness prints each
+//!   answer's note: #4385's first half is about what the caller reads.
+//! - **A call was paying two full passes over the database.** The ranking
+//!   scan reads and decodes 118 MB of chunk vectors, which is inherent to a
+//!   brute-force rank; on top of it `CodeGraph::open` ran `PRAGMA
+//!   quick_check` over all 180 MB of the image, on **every** call, because
+//!   `report_with` opens the graph per call. The second one is gone (#4385,
+//!   `stella_graph::store::image_check`) and is the only one this repository
+//!   has removed.
+//!
+//! The component costs behind a call, measured separately against the same
+//! index while the machine was at load 24: `index_all` catch-up 78-97 ms warm
+//! (413 ms with 39 files to re-parse), the query's embedding round trip
+//! 111-202 ms against `api.voyageai.com`, the file rank 10 ms, the chunk rank
+//! 220-296 ms, and a standalone `PRAGMA quick_check` 333 ms. Those are the
+//! terms; what a quiet machine adds up to is what the next run of this
+//! harness should record.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use stella_tools::search::engine::{SearchConfig, report_with};
+
+/// Named in the `#[ignore]` reason and in the panic, so the missing piece is
+/// stated the same way whichever path the reader arrives on.
+const NO_BACKEND: &str = "no embedding backend is configured: set VOYAGE_API_KEY (a `pa-` key; an \
+                          `al-` Atlas key gets HTTP 403 from api.voyageai.com), or OPENAI_API_KEY, \
+                          or STELLA_EMBED_URL together with STELLA_EMBED_MODEL";
+
+/// Which checkout to search. Its index is the corpus.
+const ROOT_ENV: &str = "STELLA_SEARCH_REPLAY_ROOT";
+
+/// How many of the recorded queries to replay, for a run that is asking what
+/// a call *returns* rather than what the whole set costs. Absent, all of them.
+const LIMIT_ENV: &str = "STELLA_SEARCH_REPLAY_LIMIT";
+
+/// The queries, one per line, exactly as the recorded session sent them.
+const RECORDED: &str = include_str!("fixtures/recorded_search_queries.txt");
+
+/// What the recording said, printed beside what this run says so the two are
+/// never read as one measurement.
+const RECORDED_MEDIAN_MS: u64 = 6_935;
+const RECORDED_P90_MS: u64 = 21_361;
+const RECORDED_MAX_MS: u64 = 33_450;
+
+/// The `numerator`/`denominator` percentile of a sorted list, nearest-rank —
+/// the definition the recorded row was summarised under, so the two rows
+/// compare. A fraction rather than a float because the rank is an index and
+/// rounding an index through `f64` is a way to be off by one silently.
+fn percentile(sorted: &[u128], numerator: usize, denominator: usize) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = (numerator * sorted.len())
+        .div_ceil(denominator)
+        .clamp(1, sorted.len());
+    sorted[rank - 1]
+}
+
+fn replay_root() -> PathBuf {
+    let root = std::env::var_os(ROOT_ENV).map_or_else(
+        || {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .and_then(Path::parent)
+                .expect("crates/<crate> always has two ancestors")
+                .to_path_buf()
+        },
+        PathBuf::from,
+    );
+    assert!(
+        root.join("Cargo.toml").is_file(),
+        "{} is not a checkout — set {ROOT_ENV} to one whose index is filled",
+        root.display()
+    );
+    root.canonicalize().expect("canonicalize the replay root")
+}
+
+#[tokio::test]
+#[ignore = "needs a real embedding backend and a checkout whose code-graph index is already \
+            filled; set VOYAGE_API_KEY (or STELLA_EMBED_URL + STELLA_EMBED_MODEL) and \
+            STELLA_SEARCH_REPLAY_ROOT and run with --release --ignored --nocapture"]
+async fn replay_the_recorded_queries_and_print_the_latency_distribution() {
+    // Asked for explicitly and unable to run: a failure, never a pass (#3011).
+    let resolution = stella_embed::from_env();
+    match &resolution {
+        stella_embed::Resolution::Configured(_) => {}
+        stella_embed::Resolution::Unconfigured => panic!("{NO_BACKEND}"),
+        stella_embed::Resolution::Incomplete(reason) => {
+            panic!("the embedding backend is half-configured: {reason}\n{NO_BACKEND}")
+        }
+    }
+
+    let root = replay_root();
+    let limit = std::env::var(LIMIT_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(usize::MAX);
+    let queries: Vec<&str> = RECORDED
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(limit)
+        .collect();
+    assert!(
+        !queries.is_empty(),
+        "the recorded query fixture is empty, so there is nothing to replay"
+    );
+
+    // The session-lifetime cache the `search` TOOL keeps, not the one-shot
+    // door's fresh one: replaying with a fresh cache per query would measure a
+    // surface no agent uses.
+    let cache = std::sync::Mutex::new(stella_tools::search::cache::GatherCache::default());
+    let config = SearchConfig::default();
+
+    println!("\n=== search latency replay =========================================");
+    println!("root      {}", root.display());
+    println!("queries   {}", queries.len());
+
+    let mut millis: Vec<u128> = Vec::with_capacity(queries.len());
+    let mut empty = 0usize;
+    for (index, query) in queries.iter().enumerate() {
+        let started = Instant::now();
+        let report = report_with(
+            &root,
+            query,
+            config,
+            // Resolved per call, exactly as `report_cached` does: the
+            // resolution is part of what a call pays for.
+            stella_embed::from_env(),
+            &cache,
+        )
+        .await;
+        let elapsed = started.elapsed();
+        millis.push(elapsed.as_millis());
+        if report.hits.is_empty() {
+            empty += 1;
+        }
+        println!(
+            "  {:>3}. {:>6} ms  {:>3} hit(s)  {query}",
+            index + 1,
+            elapsed.as_millis(),
+            report.hits.len(),
+        );
+        // #4385's first half is about what the caller *reads*, not what the
+        // call costs: the banner that fired on 60 of its 61 recorded calls
+        // and taught one model to use `rg` instead. Printed per query so a
+        // run answers that question without a stopwatch.
+        if let Some(note) = &report.note {
+            println!("       note: {note}");
+        }
+    }
+
+    // A run that ranked nothing measured the name and scan rungs, which is a
+    // different tool. Reporting its distribution as the semantic path's would
+    // be the surface signal CLAUDE.md forbids.
+    assert!(
+        empty * 2 < queries.len(),
+        "{empty} of {} queries returned no hit — this index is not filled under the resolved \
+         embedder, so the distribution measures the lexical rungs rather than the ranking",
+        queries.len()
+    );
+
+    // #3198 asks for graph reads per call before anything is built on top of
+    // the gather cache. This is that number: how many file neighborhoods the
+    // whole replay took from the graph rather than from the cache.
+    let gathered = cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .gathered;
+
+    millis.sort_unstable();
+    println!("\n=== gather cache ==================================================");
+    println!(
+        "neighborhoods gathered from the graph across {} queries: {gathered}",
+        queries.len()
+    );
+    println!("\n=== distribution ==================================================");
+    println!(
+        "this run        median {:>6} ms   p90 {:>6} ms   max {:>6} ms",
+        percentile(&millis, 1, 2),
+        percentile(&millis, 9, 10),
+        millis.last().copied().unwrap_or(0),
+    );
+    println!(
+        "recorded #4385  median {RECORDED_MEDIAN_MS:>6} ms   p90 {RECORDED_P90_MS:>6} ms   max \
+         {RECORDED_MAX_MS:>6} ms"
+    );
+    println!(
+        "\nThe two rows are different machines under different load and are not one \
+         measurement. Record this run's row in this file's module doc, with the machine and \
+         the index's size beside it."
+    );
+}


### PR DESCRIPTION
## What

Four search-theme issues. Three had "measure first" at their centre, so the
measurements come first here too, each with what it was taken against.

### #4385 — `search` is slow, and a call was paying two full passes over the database

Two independent halves. The **banner** half landed in #4456 and is not this
PR's. The **latency** half is.

`search::engine::report_with` calls `open_or_build` on **every `search` call**,
and `CodeGraph::open` ran `PRAGMA quick_check` there — a walk of every page of
the image. `open_verified`'s own doc priced that as something "the writer's
open pays once, ahead of a tree walk that dwarfs it". Both halves are false on
the read path: it opens per call, and on this repository's index the walk is
180 MB against a hash-diff catch-up measured at 78–97 ms warm. The recorded
session paid it sixty-one times.

`store::image_check` memoizes the verdict, keyed on the main database file's
`(length, mtime)` — **not** on its path, which was the first version and which
broke `a_store_corrupt_only_in_its_data_pages_is_quarantined_at_open`. That
test is the contract: a store damaged *after* it was verified must be caught by
the next open. Keying on the image's own stamp keeps that and keeps the saving,
because WAL mode puts ordinary writes in the `-wal` sidecar and leaves the main
image — the thing `quick_check` walks — untouched. What is given up is stated in
that module: damage written inside the same `(length, mtime)` tick.

Also lands the loop the issue asks for,
`crates/stella-tools/tests/search_latency_replay.rs`, with the sixty-one
recorded queries as a committed fixture extracted from that session's
`tool_calls.args_json`.

**No p90 is quoted, and the issue is not closed.** See "Not done".

### #2993 — the admission floor is a guess (advanced, not closed)

It is now a measurement for one model, and that measurement says the floor
cannot do the job.

`tests/relevance_calibration.rs` was run against `voyage-code-3` over this
repository's own index — 28 744 chunks, four labelled queries, 40 candidates
deep. The relevant and irrelevant distributions **overlap**: tightest
separation **−0.0439**, with one query's labelled answer ranking 39th at 0.5978
beneath 38 irrelevant chunks scoring 0.6006–0.6436, and two of the four
returning no labelled answer in 40 candidates at all. No floor separates those,
so `voyage-code-3` declares `SimilarityPosture::Surface`: its cosines order
candidates and certify none, exactly as `HashEmbedder` already reports. #2993
named that outcome in advance.

- `MEASURED_FLOORS` is the per-model table, carrying the `MEASURED:` marker and
  pinned by tests.
- `DEFAULT_ADMISSION_FLOOR` stays as the value for an unmeasured model, and its
  doc now states that scope instead of apologising for the value.
- `HttpEmbedder::new` takes `Option<f32>` so "the operator set a floor" and
  "nobody did" stop being the same value. An explicit `STELLA_EMBED_FLOOR`
  outranks the table either way.
- **No constant's value moved.** `DEFAULT_MIN_BOUNDARY_GAP`'s doc records the
  observed boundary drops (0.0140 and 0.0001, both under its 0.05) and why two
  frontiers pointing opposite ways is a sample to report rather than one to tune
  against.

What made the run affordable is `STELLA_CALIBRATION_INDEX`, added to the
harness: the ~11M paid tokens a previous session declined to spend were the
*re-embedding*, and an index this workspace had already filled reduced the run
to four query embeddings.

### #3198 — the cross-session gather cache

The issue asked for the measurement before the build — graph reads per call,
and wall clock — and accepts "a written decision that the session-lifetime
cache is where this stops" as a close. That is what it gets.

One gather is **3.7 ms**: the three indexed queries `file_neighborhood` issues,
over a random 200-file sample of `crates/**`. A call enriches whole blocks until
a 9 000 character budget is spent, so the ceiling on what any gather cache can
save is tens of milliseconds. The terms it would save against are one to two
orders of magnitude larger: chunk ranking scan 220–296 ms, image page walk
333 ms, `index_all` catch-up 78–97 ms, embedding round trip 111–202 ms.

The structural half survives a faster machine: `observe_generation` empties the
cache whenever *any* file is re-indexed, and a persisted tier inherits that key,
so the cross-session case the issue wants is exactly the case where every
teammate's commit invalidates every persisted entry.

## Evidence

Targeted commands only; no workspace build. Machine load average was 24–65
throughout (concurrent agent worktrees), which is why no wall-clock comparison
is claimed anywhere in this PR.

**Witnesses, both directions:**

| Witness | Without the change | With it |
|---|---|---|
| `stella-graph --test image_verification_memo` | `left: 10, right: 2` (ten opens, ten walks) | `ok` |
| `stella-embed the_measured_backend_declares_the_posture_its_distribution_earned` | `left: Semantic { admission_floor: 0.25 }, right: Surface` | `ok` |

Each fail direction was produced by reverting only the mechanism (the
`already_walked` early return; the `MEASURED_FLOORS` row) and restoring it after.

**Renamed test** (named here for `check-deleted-tests`, which keys on the bare
function name): `the_http_backend_declares_a_semantic_posture` →
`an_unmeasured_backend_declares_a_semantic_posture`. Same assertion, plus an
exact check that the posture is `Semantic { DEFAULT_ADMISSION_FLOOR }`. The new
name is what the test now distinguishes: an *unmeasured* backend is the one that
still declares `Semantic`, and `the_measured_backend_declares_the_posture_its_distribution_earned`
covers the other side.

**Suites:**

- `cargo test -p stella-graph --lib` → 232 passed, 0 failed. Includes
  `a_store_corrupt_only_in_its_data_pages_is_quarantined_at_open`, which the
  path-keyed first version of the memo broke and the stamp-keyed one passes.
- `cargo test -p stella-graph --test image_verification_memo` → 1 passed.
- `cargo test -p stella-embed --features http --lib` → 47 passed, 0 failed.

**Gates:**

- `cargo clippy -p stella-graph -p stella-embed --all-targets --all-features -- -D warnings` → exit 0
- `cargo clippy -p stella-tools --all-targets -- -D warnings` → exit 0
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-embed -p stella-graph -p stella-tools --no-deps` → exit 0 (**plain form run first**; it caught four public-to-private intra-doc links in `http.rs` that the `--document-private-items` form resolves silently)
- the same with `--document-private-items` → exit 0
- `cargo fmt --all`, `make guards-fast` → exit 0. `make prose` initially failed on
  four constructions this PR added; they were rewritten, not baselined.
- `make measured-constants` → OK, 4 measured constants, each named by a test.

**Measurement provenance:** every number above was taken against a copy of this
workspace's own `.stella/private/codegraph.db` (1 585 file vectors, 28 813 chunk
vectors, `voyage-code-3@1/1024/l2`) so nothing touched a live session's
database. The recorded latency row in #4385 was re-derived from
`.stella/private/store.db` and reproduces the issue's figures exactly
(n=61, median 6 935 ms, p90 21 361 ms, max 33 450 ms).

## Not done

**#2993 is `Refs`, not `Closes`** — Sourcery's first ❌ row is correct and this
is the fix for it rather than a rebuttal. The issue asks for the measurement
*per model* and names four; this is one. `text-embedding-3-small`,
`text-embedding-3-large` and a local `nomic-embed-text` each need their own
vendor key and their own run, and the table gets a row for each only when
somebody has done that. Its three "Done looks like" bullets are all satisfied
for the model that was measured, which is why the row is worth advancing rather
than deferring whole.

**#4191 — the chunk pass's speedup and `CHUNK_EMBED_CONCURRENCY`, skipped.**
The measurement it specifies is a cold backfill of this repository against a
paid embedding backend, run before and after #4189 and swept over
{4, 8, 16} — six full passes, each the ~11M tokens `relevance_calibration.rs`'s
own header calls a maintainer's spend decision. That is a benchmark rig, and
fabricating a number instead is the one thing the issue exists to prevent.
Nothing in this PR touches it.

**#4385 is `Refs`, not `Closes`.** Its definition of done asks for "p90 under a
stated target, measured by a bench loop over the 61 recorded queries". The loop
now exists and was run; the machine could not answer. Its load average rose from
24 to 64 during the run and per-query wall clock rose monotonically with it,
from 15 422 ms on the first query to 201 500 ms on the fiftieth. A series that
climbs 13x while the machine's load triples underneath it measures the machine,
so a median over it would be arithmetic rather than measurement and none is
quoted. The harness's Status section records the attempt, because "we tried and
the machine could not answer" is a different state from "nobody has run it".

That run did establish two things that do not depend on load, both now written
into the code: every query came back 200+ hits deep (203–256 across fifty), and
`DEFAULT_MIN_BOUNDARY_GAP`'s 0.05 is 3.5x the widest boundary drop the
calibration observed — so `relevant_prefix` never cuts on this corpus, every
ranking runs to its end, and `search`'s RANK CEILING note therefore still fires
on nearly every query even after #4456 narrowed its condition. Re-running the
replay on a quiet machine is what closes #4385.

Closes #3198
Refs #4385
Refs #2993
Refs #3096
