### PR TITLE
fix(stella-tui): port the shared floating-card chrome to the v2 SPEC 5 border

### DIFF
--- a/crates/stella-tui/src/views/cards.rs
+++ b/crates/stella-tui/src/views/cards.rs
@@ -86,8 +86,11 @@ pub(crate) fn card_frame(
         .title(Line::from(title));
     if !hints.is_empty() {
         block = block.title_bottom(
-            Line::from(Span::styled(format!(" {hints} "), Style::new().fg(token::DIM)))
-                .alignment(Alignment::Right),
+            Line::from(Span::styled(
+                format!(" {hints} "),
+                Style::new().fg(token::DIM),
+            ))
+            .alignment(Alignment::Right),
         );
     }
     let inner = block.inner(area);
@@ -204,26 +207,24 @@ mod tests {
 
     /// `card_frame` draws the same chrome family as every hand-rolled v2
     /// overlay: a rounded border, and hints on the bottom rule rather than
-    /// the top title. Both halves fail against the old `Plain` border with
-    /// top-title hints this pins the port against regressing to.
+    /// the top title. This pins the port against regressing to the old
+    /// `Plain` border with top-title hints.
     #[test]
     fn card_frame_draws_the_shared_v2_chrome() {
         let area = Rect::new(0, 0, 30, 6);
         let mut buf = Buffer::empty(area);
-        card_frame(
-            area,
-            "plan",
-            Vec::new(),
-            "esc close",
-            &mut buf,
-        );
+        card_frame(area, "plan", Vec::new(), "esc close", &mut buf);
         assert_eq!(
             buf.cell((0, 0)).map(|c| c.symbol()),
             Some("╭"),
             "top-left corner is rounded"
         );
         let bottom_row: String = (0..area.width)
-            .map(|x| buf.cell((x, area.height - 1)).map(|c| c.symbol()).unwrap_or(" "))
+            .map(|x| {
+                buf.cell((x, area.height - 1))
+                    .map(|c| c.symbol())
+                    .unwrap_or(" ")
+            })
             .collect();
         assert!(
             bottom_row.contains("esc close"),

--- a/crates/stella-tui/src/views/cards.rs
+++ b/crates/stella-tui/src/views/cards.rs
@@ -1,19 +1,20 @@
 //! Shared chrome for the floating cards (`/plan` · `/models` · `/budget`):
-//! one bordered block floated above the composer,
-//! max-width ~56 cells, title row = accent-colored name + dimmed context +
-//! right-aligned dim key hints; body rows below. Implemented once so the three
-//! cards read as one system, and so the selection convention — a `▸` marker
-//! glyph **plus** the background tint — is structural: the golden suite
-//! strips style, so a style-only selection would be invisible to it (the
-//! exact gap the FILES list has today).
+//! one `BorderType::Rounded` block in `token::BORDER`, floated above the
+//! composer, max-width ~56 cells — the same border every other v2 overlay
+//! draws (`crate::v2::approval`, `v2::picker`, `v2::queue`, …), so these
+//! three cards are not a second chrome family. Title row = gold name +
+//! dimmed context; the key hints ride the BOTTOM border, right-aligned, the
+//! way every hand-rolled v2 overlay already places them. Implemented once so
+//! the three cards read as one system, and so the selection convention — a
+//! `▸` marker glyph **plus** the background tint — is structural: the golden
+//! suite strips style, so a style-only selection would be invisible to it.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Rect};
-use ratatui::style::Style;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
-
-use crate::theme;
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget};
+use stella_tui_theme::token;
 
 /// Widest card, in columns (matches the panic boundary's error card).
 pub(crate) const CARD_MAX_W: u16 = 56;
@@ -54,8 +55,13 @@ pub(crate) fn card_area(frame: Rect, body_rows: u16, max_w: u16, full_width: boo
 ///
 /// The title row rides the top border: `name` in the accent, the `context`
 /// spans (dim by convention; the task card's fraction bar keeps its own
-/// success color) beside it, `hints` dim and right-aligned. Everything
-/// meaningful in it is a glyph/word (style-blind goldens can pin it).
+/// success color) beside it. `hints` rides the BOTTOM border, right-aligned —
+/// `crate::v2::approval`, `v2::picker`, `v2::queue` and every other
+/// hand-rolled v2 overlay already draw hints there rather than on the top
+/// title; this shared helper used to be the one holdout, so `/plan`,
+/// `/models` and `/budget` (its only callers) read as a different chrome
+/// family from the rest of the deck's floating cards. Everything meaningful
+/// in it is still a glyph/word (style-blind goldens can pin it).
 pub(crate) fn card_frame(
     area: Rect,
     name: &str,
@@ -64,7 +70,10 @@ pub(crate) fn card_frame(
     buf: &mut Buffer,
 ) -> Rect {
     Clear.render(area, buf);
-    let mut title = vec![Span::styled(format!(" {name} "), theme::accent())];
+    let mut title = vec![Span::styled(
+        format!(" {name} "),
+        Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD),
+    )];
     if !context.is_empty() {
         title.push(Span::raw(" "));
         title.extend(context);
@@ -72,15 +81,13 @@ pub(crate) fn card_frame(
     }
     let mut block = Block::default()
         .borders(Borders::ALL)
-        .border_style(theme::panel_rule())
+        .border_type(BorderType::Rounded)
+        .border_style(Style::new().fg(token::BORDER))
         .title(Line::from(title));
     if !hints.is_empty() {
-        block = block.title(
-            Line::from(Span::styled(
-                format!(" {hints} "),
-                Style::new().fg(theme::TEXT_TERTIARY),
-            ))
-            .alignment(Alignment::Right),
+        block = block.title_bottom(
+            Line::from(Span::styled(format!(" {hints} "), Style::new().fg(token::DIM)))
+                .alignment(Alignment::Right),
         );
     }
     let inner = block.inner(area);
@@ -90,11 +97,11 @@ pub(crate) fn card_frame(
 
 /// The selection affordance every card row uses: the mandatory `▸ ` marker
 /// (unselected rows get two spaces so columns hold), and the row tint via
-/// `SELECT_BG` layered by the caller. Returned as a span so the caller
+/// [`token::HL`] layered by the caller. Returned as a span so the caller
 /// controls the rest of the row.
 pub(crate) fn marker(selected: bool) -> Span<'static> {
     if selected {
-        Span::styled("▸ ", theme::accent())
+        Span::styled("▸ ", Style::new().fg(token::GOLD))
     } else {
         Span::raw("  ")
     }
@@ -112,7 +119,7 @@ pub(crate) fn render_body(
     if let Some(sel) = selected_row
         && let Some(line) = lines.get_mut(sel)
     {
-        line.style = line.style.bg(theme::SELECT_BG);
+        line.style = line.style.bg(token::HL);
     }
     Paragraph::new(lines).render(inner, buf);
 }
@@ -133,10 +140,7 @@ pub(crate) fn mini_fraction_bar(
     let filled = (done * width).div_ceil(total).min(width);
     vec![
         Span::styled("▰".repeat(filled), Style::new().fg(color)),
-        Span::styled(
-            "▱".repeat(width - filled),
-            Style::new().fg(theme::TEXT_TERTIARY),
-        ),
+        Span::styled("▱".repeat(width - filled), Style::new().fg(token::MUTED)),
     ]
 }
 
@@ -197,6 +201,42 @@ pub(crate) fn truncate_cols(text: &str, max_cols: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `card_frame` draws the same chrome family as every hand-rolled v2
+    /// overlay: a rounded border, and hints on the bottom rule rather than
+    /// the top title. Both halves fail against the old `Plain` border with
+    /// top-title hints this pins the port against regressing to.
+    #[test]
+    fn card_frame_draws_the_shared_v2_chrome() {
+        let area = Rect::new(0, 0, 30, 6);
+        let mut buf = Buffer::empty(area);
+        card_frame(
+            area,
+            "plan",
+            Vec::new(),
+            "esc close",
+            &mut buf,
+        );
+        assert_eq!(
+            buf.cell((0, 0)).map(|c| c.symbol()),
+            Some("╭"),
+            "top-left corner is rounded"
+        );
+        let bottom_row: String = (0..area.width)
+            .map(|x| buf.cell((x, area.height - 1)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect();
+        assert!(
+            bottom_row.contains("esc close"),
+            "hints ride the bottom border: {bottom_row:?}"
+        );
+        let top_row: String = (0..area.width)
+            .map(|x| buf.cell((x, 0)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect();
+        assert!(
+            !top_row.contains("esc close"),
+            "hints no longer ride the top title: {top_row:?}"
+        );
+    }
 
     #[test]
     fn card_area_fits_inside_any_frame() {

--- a/crates/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -32,11 +32,11 @@
 
 ☰  plan  5/7  ·  Workflows canvas
 
-⏸ plan  Refactor the automations store into a shared┌ budget  session spend cap ⏎ set · ⌫ edit · esc close ┐
+⏸ plan  Refactor the automations store into a shared╭ budget  session spend cap ───────────────────────────╮
                                                     │run     $0.05 of $7.50 ▰▱▱▱▱▱▱▱▱                      │
                                                     │new cap $                                             │
                                                     │the cap applies when the driver's budget stream folds │
-                                                    └──────────────────────────────────────────────────────┘
+                                                    ╰────────────────────────── ⏎ set · ⌫ edit · esc close ╯
 
 
 

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -19,7 +19,7 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx          ┌ models  resolved routing ───────────────────────────────── esc close ┐
+ │ ⊙ apps/app/automations/page.tsx          ╭ models  resolved routing ────────────────────────────────────────────╮
  │ ⎿ 312 lines                              │session   glm-5.2                                                     │                         42ms
                                             │auto      model off · effort on · thinking off                        │
  │ ● edit apps/app/automations/page.tsx +4 -│                                                                      │
@@ -36,7 +36,7 @@
                                             │verify    anthropic/claude-opus-5                         unassigned  │
                                             │          high  (effort_auto replaced "max") · thinking on            │
                                             │          from pipeline_verifier_model                                │
-                                            └──────────────────────────────────────────────────────────────────────┘
+                                            ╰─────────────────────────────────────────────────────────── esc close ╯
 
 
 

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -23,7 +23,7 @@
  │ ⎿ 312 lines                                                                                                                               42ms
 
  │ ● edit apps/app/automations/page.tsx +4 -1
- │ ⎿                                                ┌ plan  pending approval · 3 steps  x skip · esc close ┐                         +4 −1 · 18ms
+ │ ⎿                                                ╭ plan  pending approval · 3 steps ────────────────────╮                         +4 −1 · 18ms
  │     10 -  const items = []                       │Refactor the automations store into a shared worksp…  │
  │     10 +  const items = useAutomations()         │                                                      │
  │     11 +  const [q, setQ] = useState("")         │▸ ○ 1. extract types                                  │
@@ -36,7 +36,7 @@
                                                     │budget    $0.04 of $2.50 ▰▱▱▱▱▱▱                      │
                                                     │models    think — · work glm-5.2-air · verify —       │
                                                     │shell     allowlisted                                 │
-                                                    └──────────────────────────────────────────────────────┘
+                                                    ╰────────────────────────────────── x skip · esc close ╯
 
 
 

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
@@ -28,7 +28,7 @@
  │     10 +  const items = useAutomations()
  │     11 +  const [q, setQ] = useState("")
  │     12 +  const filtered = filter(items, q)
-┌ question ──────────────────────────────────────────────────────────────────────────────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ┐
+╭ question ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │from the `research-child` sub-agent                                                                                                                           │
 │                                                                                                                                                              │
 │Which auth should the new endpoint use?                                                                                                                       │
@@ -36,7 +36,7 @@
 │▸ [ ] Session cookie — Matches the rest of the app                                                                                                            │
 │  [ ] Bearer token                                                                                                                                            │
 │  [ ] Type your own answer                                                                                                                                    │
-└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+╰────────────────────────────────────────────────────────────────────────────────────────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
 
 
 

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
@@ -26,7 +26,7 @@
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()
- │     11 +  const [q, setQ] = useState(""┌ question ───────────────────────────────────── ⏎ save note · esc discard ┐
+ │     11 +  const [q, setQ] = useState(""╭ question ────────────────────────────────────────────────────────────────╮
  │     12 +  const filtered = filter(items│from the `research-child` sub-agent                                       │
  │     13 +  const onNew = () => open()   │                                                                          │
                                           │Which auth should the new endpoint use?                                   │
@@ -36,7 +36,7 @@
                                           │  [ ] Type your own answer                                                │
                                           │                                                                          │
                                           │  note: only for the admin routes▏                                        │
-                                          └──────────────────────────────────────────────────────────────────────────┘
+                                          ╰─────────────────────────────────────────────── ⏎ save note · esc discard ╯
 
 
 

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
@@ -21,7 +21,7 @@
 
  │ ⊙ apps/app/automations/page.tsx
  │ ⎿ 312 lines                                                                                                                               42ms
-                                          ┌ question ────────────────────── ↑↓ move · ⏎ choose · ⇥ back · esc cancel ┐
+                                          ╭ question ────────────────────────────────────────────────────────────────╮
  │ ● edit apps/app/automations/page.tsx +4│from the `research-child` sub-agent                                       │
  │ ⎿                                      │                                                                          │               +4 −1 · 18ms
  │     10 -  const items = []             │Review your answers                                                       │
@@ -36,7 +36,7 @@
                                           │▸ Submit answers                                                          │
                                           │  Chat about this instead                                                 │
                                           │  Cancel — no answer                                                      │
-                                          └──────────────────────────────────────────────────────────────────────────┘
+                                          ╰──────────────────────────────── ↑↓ move · ⏎ choose · ⇥ back · esc cancel ╯
 
 
 

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
@@ -28,7 +28,7 @@
  │     10 +  const items = useAutomations()
  │     11 +  const [q, setQ] = useState("")
  │     12 +  const filtered = filter(items, q)
- │     13 +  const onNew = () => open()   ┌ question ──── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ┐
+ │     13 +  const onNew = () => open()   ╭ question ────────────────────────────────────────────────────────────────╮
                                           │from the `research-child` sub-agent                                       │
 ☰  plan  5/7  ·  Workflows canvas         │                                                                          │
                                           │Which auth should the new endpoint use?                                   │
@@ -36,7 +36,7 @@
                                           │▸ [ ] Session cookie — Matches the rest of the app                        │
                                           │  [ ] Bearer token                                                        │
                                           │  [ ] Type your own answer                                                │
-                                          └──────────────────────────────────────────────────────────────────────────┘
+                                          ╰────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
 
 
 

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
@@ -25,7 +25,7 @@
  │ ● edit apps/app/automations/page.tsx +4 -1
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
- │     10 +  const items = useAutomations(┌ question ──── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ┐
+ │     10 +  const items = useAutomations(╭ question ────────────────────────────────────────────────────────────────╮
  │     11 +  const [q, setQ] = useState(""│from the `research-child` sub-agent                                       │
  │     12 +  const filtered = filter(items│                                                                          │
  │     13 +  const onNew = () => open()   │● Auth method  ○ Rollout                                                  │
@@ -36,7 +36,7 @@
                                           │▸ [ ] staging — the usual soak                                            │
                                           │  [ ] canary                                                              │
                                           │  [ ] Type your own answer                                                │
-                                          └──────────────────────────────────────────────────────────────────────────┘
+                                          ╰────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
 
 
 


### PR DESCRIPTION
Reconciling epic #4676's v2 TUI port — the last of the cross-PR chrome inconsistencies an independent multi-agent review found after all 15 original v1→v2 view-port PRs had merged.

`views::cards::card_frame` is the one shared helper `/plan`, `/models`, `/budget`, and the question overlay all draw their chrome through. It was the last holdout of the v1-era look — Plain border, `theme::panel_rule()`, hints on a second TOP-border title. Seven other card-drawing PRs in the batch independently converged on a different shape (`BorderType::Rounded`, `token::BORDER`, hints via `title_bottom()`); these two consumers only looked different because they went through this one unported helper. Porting it here means both inherit the majority convention for free — no changes needed to their own files.

Also migrated `marker()`/`render_body()` (the selection glyph/tint pair) and `mini_fraction_bar()`'s groove color from `crate::theme` to `stella_tui_theme::token`, value-identical mappings already established elsewhere in v2. No remaining non-test `crate::theme` reference in this file.

New witness: `card_frame_draws_the_shared_v2_chrome`.

The 8 affected golden frames (card_budget/models/plan, overlay_question_*) are re-blessed — I read every line of the diff; each change is exactly a corner glyph (┌┐└┘→╭╮╰╯) or the hint text moving from the top rule to the bottom one, nothing else.

Evidence: `cargo test -p stella-tui --lib views::cards` (5/5), `cargo clippy -p stella-tui --all-targets -- -D warnings` clean, `cargo test -p stella-tui --test deck_render_snapshots` (21/21).

Refs #4676

## Summary by Sourcery

Standardize shared floating cards on the v2 overlay visual style.

Enhancements:
- Align shared floating-card chrome with the v2 overlay convention by using rounded borders, shared border tokens, and bottom-aligned hints.
- Migrate card selection and progress-bar styling to the shared v2 theme tokens.

Tests:
- Add coverage ensuring shared card chrome uses rounded corners and places hints on the bottom border.
- Update affected card and question-overlay golden snapshots for the v2 chrome changes.