### PR TITLE
fix(stella-cli): the GRAPH q box answers through the CGP host, not CodeGraph directly

### DIFF
--- a/crates/stella-cli/src/agent/graph_view.rs
+++ b/crates/stella-cli/src/agent/graph_view.rs
@@ -13,7 +13,26 @@
 //! ([`graph_snapshot_focus`]) or a free-form query ([`graph_query_snapshot`])
 //! — and both report the wall clock they spent, because the deck cannot
 //! measure a query it did not run (#4335).
+//!
+//! The two reach the index by different routes, on purpose. The picker names
+//! a **file** and wants that file's stored neighborhood verbatim, so it reads
+//! [`stella_graph::CodeGraph`] directly. The `q` box asks a **question**, and
+//! a question is what the Context Graph Protocol exists to route: it goes out
+//! as a [`ContextQuery`] through a [`contextgraph_host::Host`] and comes back
+//! as [`ContextFrame`]s, so the tab names no `stella-graph` type and a
+//! graph-capable provider registered on that host later answers the `q` box
+//! with no change here (#4335).
+//!
+//! Going through frames costs fidelity the direct path keeps, and the cost is
+//! paid where [`node_kind`] and [`frame_location`] are written: a frame
+//! carries the citation keyword (`fn`), not the index's stored tag
+//! (`function` / `method`), and carries a symbol's line inside
+//! `provenance.range` as the string `"L12-40"` rather than as a number.
+//! Both are recoverable, neither is free, and a reader deciding whether to
+//! move the picker onto this path should read those two functions first.
 
+use contextgraph_host::Host;
+use contextgraph_types::{ContextFrame, ContextQuery, FrameKind, Relation};
 use stella_tui::{GraphEdge, GraphNode, GraphSnapshot};
 
 /// Query the code graph (if `stella init` has built it) for the
@@ -68,71 +87,146 @@ pub(crate) fn graph_snapshot_focus(
     })
 }
 
-/// Answer a free-form query from the Graph tab's `q` box.
+/// How many frames the tab asks the host for.
 ///
-/// `text` is resolved as a **symbol name** against the index's definitions.
-/// That is narrower than the CGP host's `ContextQuery`: the
-/// host assembles prose frames with snippets and provenance for a *model* to
-/// read, while this tab needs structure — a label, a kind, a file and a line
-/// per node — and rendering prose as a graph would be a worse answer than
-/// the one the index can give directly.
+/// The tab draws every node it is given, so this is a guard against a
+/// pathological query (a one-letter needle matching thousands of symbols)
+/// rather than a context budget. The host drops frames past this count, so it
+/// is set well above any neighborhood a human can read.
+const QUERY_MAX_FRAMES: u32 = 256;
+
+/// The token budget the tab declares to the host.
 ///
-/// The neighborhood is rooted on the file holding the first definition, so a
-/// query lands the reader somewhere real rather than on a bare node. Every
-/// other definition of the same name rides as its own node, because a name
-/// defined in several places is ambiguous and the tab should show that
-/// rather than silently pick one.
+/// The tab renders no content, so every token a frame declares is spent on
+/// something it discards — but the host drops a provider's whole leg when its
+/// frames sum above `max_tokens`
+/// (`ProviderResult::BudgetLie`), and a code-graph frame quotes up to sixty
+/// lines of source. Set high enough that a full neighborhood of quoted
+/// definitions never trips that audit, because a dropped leg would reach the
+/// user as "your query found nothing".
+const QUERY_MAX_TOKENS: u32 = 1_000_000;
+
+/// Answer a free-form query from the Graph tab's `q` box, through the CGP host.
 ///
-/// `None` when there is no index or a read fails. A query that simply matches
-/// nothing is NOT `None`: it comes back as a snapshot carrying the query and
-/// no nodes, so the tab can say the query found nothing instead of leaving
-/// the previous neighborhood on screen as if it were the answer.
-pub(crate) fn graph_query_snapshot(
+/// The query goes out as a [`ContextQuery`] and the answer comes back as
+/// [`ContextFrame`]s: this function names no `stella-graph` type, so whichever
+/// graph-capable providers are registered on `host` are the ones that answer
+/// (#4335). Two round trips, because a rooted neighborhood needs to know its
+/// root first:
+///
+/// 1. `query_text` = the needle, `kinds = [Symbol]`. The best-scoring frame's
+///    file is the root — a query lands the reader somewhere real rather than
+///    on a bare node.
+/// 2. `anchors = [that file]`, `kinds = [Symbol, Graph]`. Anchors are what the
+///    protocol offers for "the neighborhood around here", and the `Graph`
+///    frames are the ones carrying [`Relation`]s, which become the edges.
+///
+/// Every definition of the needle rides as its own node, because a name
+/// defined in several places is ambiguous and the tab should show that rather
+/// than silently pick one.
+///
+/// `None` when the workspace has no index at all — the tab then shows its "run
+/// `stella init`" hint. A query that simply matches nothing is NOT `None`: it
+/// comes back as a snapshot carrying the query and no nodes, so the tab can
+/// say the query found nothing instead of leaving the previous neighborhood on
+/// screen as if it were the answer.
+pub(crate) async fn graph_query_snapshot(
+    host: &Host,
     workspace_root: &std::path::Path,
     text: &str,
 ) -> Option<GraphSnapshot> {
-    let db_path = open_path(workspace_root)?;
+    // An unindexed workspace is the one case the tab must tell apart from an
+    // empty answer, and the host cannot report it: a provider with no index
+    // answers "no frames", exactly as it does for a needle that matches
+    // nothing. So the index's existence is still checked on disk.
+    open_path(workspace_root)?;
     let started = std::time::Instant::now();
-    let graph = stella_graph::CodeGraph::open(workspace_root, &db_path).ok()?;
     let needle = text.trim();
-    let spans = graph.definition_spans(needle).unwrap_or_default();
-    let hood = spans.first().and_then(|span| {
-        graph
-            .file_neighborhood(std::path::Path::new(&span.path))
-            .ok()
-    });
-    let files = graph.all_files().unwrap_or_default();
-    graph.shutdown();
+    // Frame URIs are minted against the index's own root, and
+    // `CodeGraph::open` canonicalizes it — so on any workspace reached through
+    // a symlink (every macOS `/tmp` and `/var` path, among others) the deck's
+    // spelling of the root is not the one the frames carry, and stripping the
+    // wrong prefix costs every node its file and line.
+    let index_root = canonical_root(workspace_root);
 
-    let (mut nodes, mut edges) = match &hood {
-        Some(hood) => neighborhood_graph(hood),
-        None => (Vec::new(), Vec::new()),
-    };
-    // The further definitions, hung off the root so the ambiguity is an edge
-    // rather than a footnote. Skipping the first: it is inside the
-    // neighborhood already.
-    for span in spans.iter().skip(1) {
-        if !nodes.is_empty() {
-            edges.push(GraphEdge {
-                from: 0,
-                to: nodes.len(),
-                kind: "defines".to_string(),
-            });
+    // A fan-out nobody answered is not an empty answer: returning `None` here
+    // leaves the neighborhood the reader was already looking at on screen,
+    // rather than replacing it with "no matches" for a query that never
+    // reached a provider.
+    let hits = crate::contextgraph::query_frames_via_host(
+        host,
+        &tab_query(needle, Vec::new(), vec![FrameKind::Symbol]),
+    )
+    .await?;
+    let root = hits
+        .first()
+        .and_then(|frame| frame_rel_path(frame, &index_root));
+
+    let frames = match &root {
+        Some(rel) => {
+            crate::contextgraph::query_frames_via_host(
+                host,
+                &tab_query(
+                    needle,
+                    vec![file_uri(&index_root, rel)],
+                    vec![FrameKind::Symbol, FrameKind::Graph],
+                ),
+            )
+            .await?
         }
-        nodes.push(GraphNode {
-            label: span.name.clone(),
-            kind: span.kind.clone(),
-            location: Some(format!("{}:{}", span.path, span.start_line)),
-        });
-    }
+        // Nothing matched, so there is no neighborhood to ask for. The
+        // first-pass frames are the whole answer (an empty one).
+        None => hits,
+    };
+
+    let (nodes, edges) = frames_graph(&frames, root.as_deref(), &index_root);
     Some(GraphSnapshot {
         focus: needle.to_string(),
         nodes,
         edges,
-        files,
+        // The picker's inventory, not the query's answer: it lists every
+        // indexed file so any of them can be re-rooted onto, which is a
+        // question about the index rather than about `needle`. No CGP query
+        // asks "what do you hold" — the protocol answers questions about
+        // content — so this stays a direct read.
+        files: all_files(workspace_root),
         query_ms: Some(elapsed_ms(started)),
         query: Some(needle.to_string()),
     })
+}
+
+/// The tab's [`ContextQuery`] shape, varying only in what it anchors on and
+/// which frame kinds it will accept.
+fn tab_query(needle: &str, anchors: Vec<String>, kinds: Vec<FrameKind>) -> ContextQuery {
+    ContextQuery {
+        // `goal` is the protocol's required field and providers fall back to
+        // it when `query_text` is absent; the tab sets both to the needle so a
+        // provider reading either one asks the same question.
+        goal: needle.to_string(),
+        query_text: Some(needle.to_string()),
+        embedding: None,
+        kinds,
+        anchors,
+        max_frames: QUERY_MAX_FRAMES,
+        max_tokens: QUERY_MAX_TOKENS,
+        as_of: None,
+        representation_preferences: Vec::new(),
+    }
+}
+
+/// Every indexed file, for the picker. Empty when the index cannot be read:
+/// the picker lists nothing rather than the tab refusing to answer a query it
+/// did answer.
+fn all_files(workspace_root: &std::path::Path) -> Vec<String> {
+    let Some(db_path) = open_path(workspace_root) else {
+        return Vec::new();
+    };
+    let Ok(graph) = stella_graph::CodeGraph::open(workspace_root, &db_path) else {
+        return Vec::new();
+    };
+    let files = graph.all_files().unwrap_or_default();
+    graph.shutdown();
+    files
 }
 
 /// The index path, or `None` when `stella init` has never run here.
@@ -147,6 +241,244 @@ fn open_path(workspace_root: &std::path::Path) -> Option<std::path::PathBuf> {
 /// number the query bar prints must never be a wrapped one.
 fn elapsed_ms(started: std::time::Instant) -> u64 {
     u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+/// The workspace root in the spelling the index uses.
+///
+/// [`stella_graph::CodeGraph::open`] canonicalizes the root it is given and
+/// mints every frame URI against that, so comparing URIs to the deck's own
+/// path only works once both sides are canonical. Falls back to the path as
+/// given when it cannot be resolved — a workspace that does not exist yields
+/// no frames either way, so the fallback costs nothing.
+fn canonical_root(workspace_root: &std::path::Path) -> std::path::PathBuf {
+    workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf())
+}
+
+/// `file://` URI for a root-relative path, matching what the code-graph
+/// provider mints so an anchor round-trips back to the same file.
+fn file_uri(root: &std::path::Path, rel: &str) -> String {
+    format!("file://{}", root.join(rel).display())
+}
+
+/// A `file://` URI (or bare path) as a root-relative slash path, or `None`
+/// when it points outside the workspace — the inverse of [`file_uri`].
+fn uri_to_rel(uri: &str, root: &std::path::Path) -> Option<String> {
+    let raw = uri.strip_prefix("file://").unwrap_or(uri);
+    let rel = std::path::Path::new(raw).strip_prefix(root).ok()?;
+    let mut out = String::new();
+    for part in rel.components() {
+        if !out.is_empty() {
+            out.push('/');
+        }
+        out.push_str(&part.as_os_str().to_string_lossy());
+    }
+    (!out.is_empty()).then_some(out)
+}
+
+/// The root-relative file a frame is about, from its `uri`.
+fn frame_rel_path(frame: &ContextFrame, root: &std::path::Path) -> Option<String> {
+    uri_to_rel(frame.uri.as_deref()?, root)
+}
+
+/// A frame's title split into the citation keyword and the symbol name —
+/// `"fn run_turn"` → `("fn", "run_turn")`. A title with no space is all name,
+/// which is what an edge frame's title (`"imports of src/x.rs"`) would
+/// degrade to; those never reach here as nodes.
+fn split_title(title: &str) -> (&str, &str) {
+    match title.split_once(' ') {
+        Some((keyword, name)) => (keyword, name),
+        None => ("", title),
+    }
+}
+
+/// The citation keyword as the node kind the deck's `kind_glyph` understands.
+///
+/// This is where the frame route loses fidelity the direct read keeps. The
+/// index stores `function` and `method` as distinct tags and
+/// `SymbolKind::keyword` projects **both** onto `fn`, so a method arrives here
+/// indistinguishable from a free function and is drawn as one. That is a
+/// one-glyph difference in a browsing view, which is why it is accepted rather
+/// than worked around: recovering the tag would mean either re-reading the
+/// index the query just went through, or widening a frame `id` that the
+/// protocol calls stable for dedup. Every other keyword already *is* the
+/// deck's vocabulary and passes through unchanged.
+fn node_kind(keyword: &str) -> String {
+    match keyword {
+        "fn" => "function".to_string(),
+        "" => "symbol".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// `path:line` for a symbol frame's detail panel.
+///
+/// The line lives in `provenance.range` as the string `"L12-40"` — the
+/// protocol has no numeric span — so it is parsed back out here. A frame whose
+/// provenance carries no range still gets its file, because a node that can be
+/// opened at line 1 beats a node with no location at all.
+fn frame_location(frame: &ContextFrame, root: &std::path::Path) -> Option<String> {
+    let rel = frame_rel_path(frame, root)?;
+    let line = frame
+        .provenance
+        .iter()
+        .find_map(|p| p.range.as_deref())
+        .and_then(range_start_line);
+    Some(match line {
+        Some(line) => format!("{rel}:{line}"),
+        None => rel,
+    })
+}
+
+/// The first line number in a provenance range string (`"L12-40"` → `12`).
+fn range_start_line(range: &str) -> Option<u32> {
+    let digits = range.trim_start_matches('L');
+    let end = digits.find('-').unwrap_or(digits.len());
+    digits[..end].parse().ok()
+}
+
+/// The deck's edge kind for a relation's protocol verb. Unknown verbs are
+/// lowercased rather than dropped: the protocol says a host MUST NOT reject an
+/// unknown `rel`, and an edge drawn with an unfamiliar label still tells the
+/// reader the edge is there.
+fn edge_kind(rel: &str) -> String {
+    match rel {
+        "IMPORTS" | "IMPORTED_BY" => "imports".to_string(),
+        "CALLS" => "calls".to_string(),
+        other => other.to_lowercase(),
+    }
+}
+
+/// Host frames as the deck's node/edge pair.
+///
+/// `Symbol` frames are nodes; `Graph` frames are edge listings whose
+/// [`Relation`]s are the edges, and are never drawn as nodes themselves — a
+/// node captioned "imports of src/x.rs" is a frame's title leaking into a
+/// graph. The root file, when the query found one, is node 0 so the tab opens
+/// on something real.
+///
+/// Node order follows frame order, which
+/// [`query_frames_via_host`](crate::contextgraph::query_frames_via_host) has
+/// already made a total order — the lookup map is only ever read, never
+/// iterated, so the result is byte-stable across runs and the deck's goldens
+/// can pin it.
+fn frames_graph(
+    frames: &[ContextFrame],
+    root_rel: Option<&str>,
+    workspace_root: &std::path::Path,
+) -> (Vec<GraphNode>, Vec<GraphEdge>) {
+    let mut nodes: Vec<GraphNode> = Vec::new();
+    let mut edges: Vec<GraphEdge> = Vec::new();
+    let mut by_key: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    if let Some(rel) = root_rel {
+        by_key.insert(rel.to_string(), 0);
+        nodes.push(GraphNode {
+            label: rel.to_string(),
+            kind: "file".to_string(),
+            location: Some(rel.to_string()),
+        });
+    }
+
+    for frame in frames {
+        if frame.kind != FrameKind::Symbol {
+            continue;
+        }
+        // Keyed by frame id: the provider mints one per `path:line:name`, so
+        // two same-named symbols in different files stay two nodes, and the
+        // same symbol reached twice (once as a definition, once as the root
+        // file's neighbor) stays one.
+        let at = match by_key.get(&frame.id) {
+            Some(at) => *at,
+            None => {
+                let (keyword, name) = split_title(&frame.title);
+                let at = nodes.len();
+                by_key.insert(frame.id.clone(), at);
+                nodes.push(GraphNode {
+                    label: name.to_string(),
+                    kind: node_kind(keyword),
+                    location: frame_location(frame, workspace_root),
+                });
+                at
+            }
+        };
+        if root_rel.is_some() && at != 0 {
+            edges.push(GraphEdge {
+                from: 0,
+                to: at,
+                kind: "defines".to_string(),
+            });
+        }
+    }
+
+    for frame in frames {
+        if frame.kind != FrameKind::Graph {
+            continue;
+        }
+        // An edge needs a node to leave from, and node 0 is the fallback.
+        if nodes.is_empty() {
+            continue;
+        }
+        // The frame's own `uri` names the file the listing is about; it is the
+        // root for the neighborhood query that produced it, but a provider
+        // free to answer differently gets its edges hung off the right node.
+        let source = frame
+            .uri
+            .as_deref()
+            .and_then(|uri| uri_to_rel(uri, workspace_root))
+            .and_then(|rel| by_key.get(&rel).copied())
+            .unwrap_or(0);
+        for relation in &frame.relations {
+            let to = relation_node(relation, workspace_root, &mut nodes, &mut by_key);
+            let (from, to) = if relation.rel == "IMPORTED_BY" {
+                (to, source)
+            } else {
+                (source, to)
+            };
+            edges.push(GraphEdge {
+                from,
+                to,
+                kind: edge_kind(&relation.rel),
+            });
+        }
+    }
+
+    (nodes, edges)
+}
+
+/// The node index a relation points at, appending one when it is new.
+///
+/// A resolved `file://` target is keyed by its workspace path so it collapses
+/// onto the file node that is already there; an unresolved import
+/// (`unresolved:serde`) or a name-only call target (`symbol:run_turn`) is
+/// keyed by the raw URI and drawn as a module, because it names something the
+/// index did not resolve to a file in this workspace.
+fn relation_node(
+    relation: &Relation,
+    workspace_root: &std::path::Path,
+    nodes: &mut Vec<GraphNode>,
+    by_key: &mut std::collections::HashMap<String, usize>,
+) -> usize {
+    let rel_path = uri_to_rel(&relation.target_uri, workspace_root)
+        .filter(|_| relation.target_uri.starts_with("file://"));
+    let key = rel_path
+        .clone()
+        .unwrap_or_else(|| relation.target_uri.clone());
+    if let Some(at) = by_key.get(&key) {
+        return *at;
+    }
+    let at = nodes.len();
+    by_key.insert(key, at);
+    nodes.push(GraphNode {
+        label: relation
+            .display_name
+            .clone()
+            .unwrap_or_else(|| relation.target_uri.clone()),
+        kind: if rel_path.is_some() { "file" } else { "module" }.to_string(),
+        location: rel_path,
+    });
+    at
 }
 
 /// One file neighborhood as the deck's node/edge pair: the file at index 0,
@@ -197,3 +529,6 @@ fn neighborhood_graph(hood: &stella_graph::FileNeighborhood) -> (Vec<GraphNode>,
     }
     (nodes, edges)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/agent/graph_view/tests.rs
+++ b/crates/stella-cli/src/agent/graph_view/tests.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The `q` box's route from a typed query to a drawn neighborhood.
+//!
+//! Two layers, because they fail differently. The mapping tests pin what a
+//! frame *becomes* and need no index — they are where a protocol field
+//! quietly changing shape (a `provenance.range` that stops saying `L12-40`)
+//! shows up as a failure rather than as a node with no line. The end-to-end
+//! tests run a real index behind a real [`Host`] and pin that the tab's answer
+//! survives the whole round trip (#4335).
+
+use contextgraph_types::{ContextFrame, FrameKind, Provenance, Relation};
+
+use super::*;
+
+/// A symbol frame shaped the way `stella-graph`'s `symbol_frame` mints one:
+/// `"{keyword} {name}"` title, a `file://` uri, and the line span living in
+/// provenance as a string.
+fn symbol_frame(
+    root: &std::path::Path,
+    rel: &str,
+    keyword: &str,
+    name: &str,
+    line: u32,
+) -> ContextFrame {
+    let uri = file_uri(root, rel);
+    let mut frame = ContextFrame::full(
+        format!("code-graph:sym:{rel}:{line}:{name}"),
+        FrameKind::Symbol,
+        format!("{keyword} {name}"),
+        "body",
+        0.9,
+        4,
+    );
+    frame.provenance = vec![Provenance {
+        kind: "file".to_string(),
+        uri: Some(uri.clone()),
+        range: Some(format!("L{line}-{}", line + 2)),
+        digest: None,
+        method: None,
+        by: None,
+    }];
+    frame.uri = Some(uri);
+    frame
+}
+
+/// `"L12-40"` is the only place the protocol puts a line number, so every
+/// node's `path:line` depends on parsing it back out.
+#[test]
+fn a_provenance_range_yields_its_first_line() {
+    assert_eq!(range_start_line("L12-40"), Some(12));
+    assert_eq!(range_start_line("L7"), Some(7));
+    assert_eq!(range_start_line("12-40"), Some(12));
+    assert_eq!(range_start_line(""), None);
+    assert_eq!(range_start_line("Lnope"), None);
+}
+
+/// A `file://` uri round-trips back to the workspace-relative path the deck
+/// draws; anything outside the workspace is not a node location.
+#[test]
+fn a_file_uri_round_trips_to_a_relative_path() {
+    let root = std::path::Path::new("/w");
+    assert_eq!(
+        uri_to_rel(&file_uri(root, "src/x.rs"), root).as_deref(),
+        Some("src/x.rs")
+    );
+    assert_eq!(uri_to_rel("file:///elsewhere/y.rs", root), None);
+    assert_eq!(uri_to_rel("symbol:run_turn", root), None);
+}
+
+/// The citation keyword becomes the deck's node kind. `fn` is the lossy one:
+/// the index's `function` and `method` both arrive as `fn`, so both draw as a
+/// function — the documented cost of answering through frames.
+#[test]
+fn a_citation_keyword_becomes_the_decks_node_kind() {
+    assert_eq!(node_kind("fn"), "function");
+    assert_eq!(node_kind("struct"), "struct");
+    assert_eq!(node_kind("trait"), "trait");
+    assert_eq!(node_kind(""), "symbol");
+}
+
+/// Symbol frames become nodes hung off the root file; a `Graph` frame is an
+/// edge listing and never becomes a node of its own.
+#[test]
+fn symbol_frames_become_nodes_and_graph_frames_become_edges() {
+    let root = std::path::Path::new("/w");
+    let frames = vec![
+        symbol_frame(root, "hub.rs", "fn", "a", 1),
+        symbol_frame(root, "hub.rs", "struct", "C", 3),
+    ];
+    let (nodes, edges) = frames_graph(&frames, Some("hub.rs"), root);
+
+    assert_eq!(nodes[0].label, "hub.rs", "the root file is node 0");
+    assert_eq!(nodes[0].kind, "file");
+    assert_eq!(
+        nodes.iter().map(|n| n.label.as_str()).collect::<Vec<_>>(),
+        vec!["hub.rs", "a", "C"],
+        "node order follows frame order, so the deck's goldens can pin it"
+    );
+    assert_eq!(
+        nodes[1].kind, "function",
+        "`fn` maps to the deck's vocabulary"
+    );
+    assert_eq!(
+        nodes[1].location.as_deref(),
+        Some("hub.rs:1"),
+        "the line comes out of provenance, not out of the citation prose"
+    );
+    assert!(
+        edges.iter().all(|e| e.from == 0 && e.kind == "defines"),
+        "every symbol is defined by the root file"
+    );
+}
+
+/// `IMPORTED_BY` points *at* the root, not away from it — the one relation
+/// whose direction the deck must reverse, and the one a mapping that just
+/// copied `rel` would draw backwards.
+#[test]
+fn an_imported_by_relation_points_at_the_root() {
+    let root = std::path::Path::new("/w");
+    let mut edge_frame = ContextFrame::full(
+        "code-graph:importers:hub.rs",
+        FrameKind::Graph,
+        "importers of hub.rs",
+        "leaf.rs",
+        0.5,
+        2,
+    );
+    edge_frame.uri = Some(file_uri(root, "hub.rs"));
+    edge_frame.relations = vec![Relation {
+        rel: "IMPORTED_BY".to_string(),
+        target_uri: file_uri(root, "leaf.rs"),
+        display_name: Some("leaf.rs".to_string()),
+    }];
+    let frames = vec![edge_frame];
+    let (nodes, edges) = frames_graph(&frames, Some("hub.rs"), root);
+
+    assert_eq!(
+        nodes.iter().map(|n| n.label.as_str()).collect::<Vec<_>>(),
+        vec!["hub.rs", "leaf.rs"],
+        "the edge listing itself is not a node — only its target is"
+    );
+    assert_eq!(edges.len(), 1);
+    assert_eq!(
+        edges[0].from, 1,
+        "leaf.rs imports hub.rs, so the edge leaves leaf.rs"
+    );
+    assert_eq!(edges[0].to, 0);
+    assert_eq!(edges[0].kind, "imports");
+}
+
+/// An import the index could not resolve still draws, as a module rather than
+/// a file — it names something real that simply is not in this workspace.
+#[test]
+fn an_unresolved_import_draws_as_a_module_with_no_location() {
+    let root = std::path::Path::new("/w");
+    let mut edge_frame = ContextFrame::full(
+        "code-graph:imports:hub.rs",
+        FrameKind::Graph,
+        "imports of hub.rs",
+        "serde",
+        0.5,
+        2,
+    );
+    edge_frame.uri = Some(file_uri(root, "hub.rs"));
+    edge_frame.relations = vec![Relation {
+        rel: "IMPORTS".to_string(),
+        target_uri: "unresolved:serde".to_string(),
+        display_name: Some("serde".to_string()),
+    }];
+    let (nodes, edges) = frames_graph(&[edge_frame], Some("hub.rs"), root);
+
+    assert_eq!(nodes[1].label, "serde");
+    assert_eq!(nodes[1].kind, "module");
+    assert_eq!(
+        nodes[1].location, None,
+        "a module outside the workspace opens nowhere"
+    );
+    assert_eq!(edges[0].from, 0, "hub.rs imports serde");
+    assert_eq!(edges[0].to, 1);
+}
+
+/// Build a real code-graph index: `hub.rs` holds three symbols, `leaf.rs` one.
+fn fixture() -> tempfile::TempDir {
+    let root = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        root.path().join("hub.rs"),
+        "pub fn alpha() {}\npub fn beta() {}\npub struct Gamma;\n",
+    )
+    .unwrap();
+    std::fs::write(root.path().join("leaf.rs"), "pub fn delta() {}\n").unwrap();
+    let db = stella_store::workspace_private_sqlite_path(root.path(), "codegraph.db").unwrap();
+    let graph = stella_graph::CodeGraph::open(root.path(), &db).expect("open graph");
+    graph.index_all().expect("index");
+    graph.shutdown();
+    root
+}
+
+/// The whole round trip: a typed needle goes out as a `ContextQuery` through a
+/// real `Host`, and the neighborhood the tab draws is assembled from the
+/// frames that came back. This is the test that fails if the tab ever goes
+/// back to reading `CodeGraph` behind the host's back (#4335).
+#[tokio::test]
+async fn a_query_is_answered_through_the_host() {
+    let root = fixture();
+    let host = crate::contextgraph::graph_tab_host(root.path().to_path_buf());
+    let snap = graph_query_snapshot(&host, root.path(), "alpha")
+        .await
+        .expect("an indexed workspace answers");
+
+    assert_eq!(
+        snap.query.as_deref(),
+        Some("alpha"),
+        "the bar echoes the query"
+    );
+    assert_eq!(snap.focus, "alpha");
+    assert!(snap.query_ms.is_some(), "the driver times what it spent");
+    assert!(
+        snap.nodes
+            .iter()
+            .any(|n| n.label == "hub.rs" && n.kind == "file"),
+        "the answer is rooted on the file holding the definition, got {:?}",
+        snap.nodes
+    );
+    assert!(
+        snap.nodes
+            .iter()
+            .any(|n| n.label == "alpha" && n.kind == "function"),
+        "the queried symbol is a node, typed, got {:?}",
+        snap.nodes
+    );
+    assert!(
+        snap.nodes
+            .iter()
+            .find(|n| n.label == "alpha")
+            .and_then(|n| n.location.as_deref())
+            .is_some_and(|loc| loc.starts_with("hub.rs:")),
+        "a node the reader can open"
+    );
+    assert_eq!(
+        snap.files,
+        vec!["hub.rs".to_string(), "leaf.rs".to_string()],
+        "the picker's inventory still lists every indexed file"
+    );
+}
+
+/// The neighborhood, not just the hit: querying a symbol also brings back the
+/// other symbols its file defines, which is what makes the answer a graph
+/// rather than a single node.
+#[tokio::test]
+async fn a_query_brings_back_the_neighborhood_around_its_hit() {
+    let root = fixture();
+    let host = crate::contextgraph::graph_tab_host(root.path().to_path_buf());
+    let snap = graph_query_snapshot(&host, root.path(), "alpha")
+        .await
+        .expect("snapshot");
+
+    for sibling in ["beta", "Gamma"] {
+        assert!(
+            snap.nodes.iter().any(|n| n.label == sibling),
+            "{sibling} shares hub.rs with alpha and belongs in its neighborhood, got {:?}",
+            snap.nodes
+        );
+    }
+    assert!(
+        !snap.edges.is_empty(),
+        "a neighborhood with no edges is a list, not a graph"
+    );
+}
+
+/// A needle that matches nothing is an *answer* — an empty one — not a
+/// missing snapshot. The tab must be able to say "no matches" instead of
+/// leaving the previous neighborhood up as if it were the result.
+#[tokio::test]
+async fn a_query_matching_nothing_is_an_empty_answer_not_a_missing_one() {
+    let root = fixture();
+    let host = crate::contextgraph::graph_tab_host(root.path().to_path_buf());
+    let snap = graph_query_snapshot(&host, root.path(), "nosuchsymbol")
+        .await
+        .expect("an indexed workspace still answers");
+
+    assert!(
+        snap.nodes.is_empty(),
+        "nothing matched, so nothing is drawn"
+    );
+    assert!(snap.edges.is_empty());
+    assert_eq!(
+        snap.query.as_deref(),
+        Some("nosuchsymbol"),
+        "the bar still shows what was asked"
+    );
+}
+
+/// A host with no provider registered answers nothing at all, which must not
+/// read as "your query found nothing" — the tab keeps what it had. This is the
+/// shape a timed-out or crashed provider leg takes, and the reason the fan-out
+/// helper distinguishes "nobody answered" from "answered, empty".
+#[tokio::test]
+async fn a_fanout_nobody_answered_is_not_an_empty_answer() {
+    let root = fixture();
+    let empty_host = contextgraph_host::Host::new();
+    assert!(
+        graph_query_snapshot(&empty_host, root.path(), "alpha")
+            .await
+            .is_none(),
+        "no provider answered, so the tab is told nothing rather than told 'no matches'"
+    );
+}
+
+/// No index at all is the one case that is *not* an empty answer: the tab
+/// shows its "run `stella init`" hint instead, and only `None` gets it there.
+#[tokio::test]
+async fn a_workspace_with_no_index_gets_no_snapshot() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let host = crate::contextgraph::graph_tab_host(root.path().to_path_buf());
+    assert!(
+        graph_query_snapshot(&host, root.path(), "alpha")
+            .await
+            .is_none()
+    );
+}

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -411,6 +411,13 @@ pub async fn run_deck_session(
     // screen; a memory-less session degrades silently here.
     let mut memory =
         SessionMemory::open_for_session(&cfg.workspace_root, false, &cfg.authority, &active_rules);
+    // The GRAPH tab's `q` box answers through the CGP host rather than by
+    // reaching into the code index itself (#4335). Built once and shared by
+    // `Arc` because both recv sites answer the tab and the mid-turn one hands
+    // the work to a spawned task, which needs an owned handle.
+    let graph_host = std::sync::Arc::new(crate::contextgraph::graph_tab_host(
+        cfg.workspace_root.clone(),
+    ));
     // Custom extensions: ⚡ commands/skills in the slash menu, custom agents
     // behind `/agents`. Reloaded after `/init`, which may adopt new ones.
     let mut custom = crate::extensions::CustomExtensions::load_with_authority(
@@ -1080,7 +1087,7 @@ pub async fn run_deck_session(
                         input @ (WorkspaceInput::FocusGraphFile { .. }
                         | WorkspaceInput::GraphQuery { .. }),
                     ) => {
-                        graph_input::answer(input, &cfg.workspace_root, &in_tx);
+                        graph_input::answer(input, &graph_host, &cfg.workspace_root, &in_tx).await;
                         continue 'session;
                     }
                     // SKILLS-tab ops work whether or not a turn is running — handled
@@ -1951,18 +1958,20 @@ pub async fn run_deck_session(
                             }));
                         }
                         // The Graph tab can re-root mid-turn (a user browsing
-                        // the graph while an agent works). The requery opens
-                        // SQLite + loads grammars, so run it on the blocking
-                        // pool rather than stalling this event pump; it sends
-                        // the fresh snapshot back when done.
+                        // the graph while an agent works). The requery reads
+                        // SQLite and loads grammars, so it runs as its own
+                        // task rather than stalling this event pump; it sends
+                        // the fresh snapshot back when done. `answer` decides
+                        // which half of that work needs the blocking pool.
                         Some(
                             input @ (WorkspaceInput::FocusGraphFile { .. }
                             | WorkspaceInput::GraphQuery { .. }),
                         ) => {
                             let tx = in_tx.clone();
                             let root = cfg.workspace_root.clone();
-                            tokio::task::spawn_blocking(move || {
-                                graph_input::answer(input, &root, &tx);
+                            let host = graph_host.clone();
+                            tokio::spawn(async move {
+                                graph_input::answer(input, &host, &root, &tx).await;
                             });
                         }
                         // The INSTALLED AGENTS pane stays live while a turn

--- a/crates/stella-cli/src/command_deck/graph_input.rs
+++ b/crates/stella-cli/src/command_deck/graph_input.rs
@@ -9,28 +9,42 @@
 //! the `q` box's query as a second verb is what made one home for the
 //! answering worth having (#4335).
 
+use contextgraph_host::Host;
 use stella_tui::envelope::{Inbound, WorkspaceInput};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::agent;
 
-/// Answer a re-root request by requerying the index and pushing a fresh
-/// snapshot back, the same out-of-band refresh path `/init` uses.
+/// Answer a re-root request by requerying and pushing a fresh snapshot back,
+/// the same out-of-band refresh path `/init` uses.
 ///
-/// Blocking: it opens SQLite and loads grammars. Silent on anything that is
-/// not a re-root, and silent when the index cannot answer — the deck then
-/// keeps the neighborhood it has, which is what a reader should still be
-/// looking at when nothing was learned.
-pub(super) fn answer(
+/// Silent on anything that is not a re-root, and silent when nothing can
+/// answer — the deck then keeps the neighborhood it has, which is what a
+/// reader should still be looking at when nothing was learned.
+///
+/// The two verbs take different routes and so are offloaded differently. The
+/// picker's file re-root is a synchronous SQLite read plus a grammar load, so
+/// it goes to the blocking pool. The `q` box's query goes through the CGP
+/// host, which is already async and already puts its provider's SQLite work on
+/// the blocking pool itself ([`crate::contextgraph`]), so it is awaited here
+/// rather than wrapped again.
+pub(super) async fn answer(
     input: WorkspaceInput,
+    host: &Host,
     workspace_root: &std::path::Path,
     in_tx: &UnboundedSender<Inbound>,
 ) {
     let snapshot = match input {
         WorkspaceInput::FocusGraphFile { file } => {
-            agent::graph_snapshot_focus(workspace_root, Some(&file))
+            let root = workspace_root.to_path_buf();
+            tokio::task::spawn_blocking(move || agent::graph_snapshot_focus(&root, Some(&file)))
+                .await
+                .ok()
+                .flatten()
         }
-        WorkspaceInput::GraphQuery { text } => agent::graph_query_snapshot(workspace_root, &text),
+        WorkspaceInput::GraphQuery { text } => {
+            agent::graph_query_snapshot(host, workspace_root, &text).await
+        }
         _ => None,
     };
     if let Some(snapshot) = snapshot {

--- a/crates/stella-cli/src/contextgraph.rs
+++ b/crates/stella-cli/src/contextgraph.rs
@@ -70,6 +70,17 @@ use suppression::no_suppression;
 /// providers' frames still arrive.
 const RECALL_TIMEOUT_MS: u64 = 2_000;
 
+/// Per-provider timeout for the deck's GRAPH tab.
+///
+/// The same bound recall uses, and not a shorter one. A tab
+/// answering a keystroke invites a tighter budget, but the code-graph
+/// provider's first query in a session pays for opening SQLite *and* loading
+/// every tree-sitter grammar, and on a loaded machine that alone can outrun a
+/// sub-second budget. A timeout there is indistinguishable from an empty
+/// index at the frame layer, so being impatient does not cost a slow answer —
+/// it costs a wrong one.
+const GRAPH_TAB_TIMEOUT_MS: u64 = RECALL_TIMEOUT_MS;
+
 fn local_info(name: &str) -> ProviderInfo {
     ProviderInfo {
         name: name.to_string(),
@@ -336,6 +347,73 @@ pub fn session_host(
         caps: graph_capabilities(),
     }));
     host
+}
+
+/// A host carrying only the `code-graph` provider, for the deck's GRAPH tab.
+///
+/// The tab asks a structural question — "what is `run_turn` and what sits
+/// around it" — so it wants the code index and nothing else. The session host
+/// would also fan the query out to `workspace-memory`, which advertises
+/// `symbol` among its kinds ([`memory_capabilities`]) and would answer a
+/// symbol query with reflections and episodes: prose the tab has no node to
+/// draw for. Registering one provider is how the tab states which source it
+/// is asking, rather than filtering the fan-out afterwards by provider id.
+///
+/// The point of routing through a [`Host`] at all is that the tab stops
+/// naming `stella_graph` types: it sends a [`ContextQuery`] and reads
+/// [`ContextFrame`]s, so a graph-capable provider registered here later
+/// answers the `q` box with no change to the tab (#4335).
+///
+/// Separate from [`session_host`] rather than sharing it because the two have
+/// different lifetimes and different mutability: the session host is admitted
+/// once (`register_external_providers` needs `&mut`) and then borrowed by the
+/// running turn, while the tab answers keystrokes from two call sites, one of
+/// them off-thread. Built once per deck session and shared by `Arc`.
+pub fn graph_tab_host(workspace_root: PathBuf) -> Host {
+    let mut host = Host::with_timeout(std::time::Duration::from_millis(GRAPH_TAB_TIMEOUT_MS));
+    host.register(Box::new(GraphProvider {
+        workspace_root,
+        info: local_info("code-graph"),
+        caps: graph_capabilities(),
+    }));
+    host
+}
+
+/// Every frame a fan-out accepted, best-scoring first.
+///
+/// [`recall_via_host`] is the wrong entry point for the GRAPH tab: it packs
+/// the fan-out a second time against a prompt's token budget and reports
+/// what it dropped, because its caller is assembling a model's context. The
+/// tab has no prompt and no token budget — it draws every node the providers
+/// returned — so it takes the accepted frames and orders them itself.
+///
+/// The tie-break on `id` matters: the code-graph provider fuses its frames
+/// through a `HashMap`, so score alone leaves the node order of two equally
+/// scored symbols to hash iteration, and the deck's goldens would flake.
+///
+/// `None` when **no** provider answered at all — every leg timed out, was
+/// refused, or crashed. That is a different fact from an empty `Some`, and the
+/// protocol flattens the two: a provider that times out contributes no frames,
+/// exactly as one with nothing to say does. A caller that cannot tell them
+/// apart reports "nothing matched" for a query that was never actually asked,
+/// so the distinction is drawn here rather than left to each caller.
+pub async fn query_frames_via_host(host: &Host, query: &ContextQuery) -> Option<Vec<ContextFrame>> {
+    let fanout = host.query_all(query).await;
+    let answered = fanout
+        .outcomes
+        .iter()
+        .any(|outcome| matches!(outcome.result, ProviderResult::Frames(_)));
+    if !answered {
+        return None;
+    }
+    let mut frames: Vec<ContextFrame> = fanout.accepted_frames().cloned().collect();
+    frames.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    Some(frames)
 }
 
 /// What happened when the host was asked to admit an external provider.


### PR DESCRIPTION
Closes the one ❌ Sourcery raised against #4799's linked issue #4335:

> Implement a graph free-form query mode opened with `q` … The PR implements the query input and `WorkspaceInput::GraphQuery`, but resolves queries directly through `CodeGraph::definition_spans` rather than answering them through the CGP host as required by the issue.

#4799 has since merged (`ce6b1cf3c`) and #4335 auto-closed as completed, so the objective was never delivered. This is the follow-up.

## Correcting the record on #4799

A comment on #4799 answered that row rather than fixing it, arguing the host could not carry a graph. Three of its claims do not survive reading the pinned `contextgraph-types 0.1.2`:

| Claim on #4799 | What the code says |
| --- | --- |
| "no node kind … on a frame" | `FrameKind::Symbol` and `FrameKind::Graph`, `frame.rs:25-33` |
| "no edge list on a frame" | `ContextFrame.relations: Vec<Relation>`, `frame.rs:319`; `Relation { rel, target_uri, display_name }`, `frame.rs:190` |
| "needs a structured node/edge frame kind in the protocol first" | `stella-graph/src/frames.rs:485` already emits `FrameKind::Graph` frames carrying those relations, and SPEC §G1/§G2 are written for graph-capable providers |

One claim does hold, and this PR pays it rather than denying it: the frame route loses fidelity the direct read kept. That cost is documented at `node_kind` and `frame_location` and pinned by tests.

## What changed

`graph_query_snapshot` sends a `ContextQuery` through a `contextgraph_host::Host` and assembles the neighborhood from the returned `ContextFrame`s, naming no `stella-graph` type. Two round trips: `kinds = [Symbol]` locates the root file, then `anchors = [that file]` with `kinds = [Symbol, Graph]` returns the neighborhood, because `Graph` frames carry the `Relation`s that become edges.

`graph_tab_host` registers only `code-graph` — the session host also advertises `symbol` from `workspace-memory`, which would answer a structural query with reflections the tab has no node to draw.

### Fidelity accepted, and stated

- `SymbolKind::keyword` projects both `function` and `method` onto `fn`, so a method draws as a function. One glyph in a browsing view; recovering the tag would mean re-reading the index the query just went through, or widening a frame `id` the protocol calls stable for dedup.
- A symbol's line rides `provenance.range` as `"L12-40"` rather than as a number, so it is parsed back out.

## Two defects the witness caught

Neither pre-existed this PR; both were introduced by routing through the host and found by the tests, not by inspection.

1. **Symlinked workspaces lost every node's file and line.** Frame URIs are minted against the index's root and `CodeGraph::open` canonicalizes it, so the deck's `/var/...` spelling never matched the frames' `/private/var/...`. That is every macOS `/tmp` and `/var` workspace. `canonical_root` resolves both sides once.
2. **A wedged provider read as "your query found nothing".** A fan-out where every leg timed out, was refused, or crashed is indistinguishable from "no matches" at the frame layer. `query_frames_via_host` now returns `None` for that case and the tab keeps the neighborhood it had. The 750ms tab timeout that surfaced this is gone — the code-graph provider's first query pays for a grammar load — so the tab uses the same bound recall does.

## Evidence

- 11 new tests in `crates/stella-cli/src/agent/graph_view/tests.rs`: mapping units plus a round trip against a real index behind a real `Host`, covering the `IMPORTED_BY` edge reversal, unresolved imports, and the nobody-answered case.
- `cargo test -p stella-cli --bin stella --no-fail-fast` — **2297 passed, 0 failed**. Both defects above reproduced only under full-suite parallel load; they are fixed, not filtered.
- `make guards-fast` exit 0; `make prose` clean; `cargo clippy -p stella-cli --bin stella --all-targets` silent; `cargo fmt --check` clean.

## Stacked on #4812

`main` has not compiled since #4775 (`E0255`, 45 errors on a clean checkout — issues #4807, #4810). #4812 fixes it. This PR is based on that branch so its diff is only the five files it touches and CI runs on a tree that compiles. Retarget to `main` once #4812 merges.

## Not in scope

The picker's file re-root still reads `CodeGraph` directly: it names a file and wants that file's stored neighborhood, and `GraphSnapshot.files` is the picker's inventory rather than a query answer. Moving it onto frames would need the protocol to carry a node's kind and span, which is a `context-graph-protocol` change — filed separately.

## Summary by Sourcery

Route GRAPH tab free-form queries through the Context Graph Protocol host while preserving graph rendering, workspace navigation, and reliable empty-answer behavior.

New Features:
- Route GRAPH tab free-form queries through a dedicated Context Graph Protocol host and render returned symbol and graph frames as a navigable neighborhood.
- Preserve indexed-file inventory for graph file selection while using host-backed query results for the `q` box.

Bug Fixes:
- Preserve node file locations for symlinked workspaces by normalizing workspace roots.
- Keep the existing graph neighborhood when no provider answers instead of reporting a false empty query result.
- Correct imported-by edge direction and retain unresolved relation targets in rendered graphs.

Enhancements:
- Translate protocol frames into graph nodes and edges with supported kinds, locations, relation labels, and accepted documented fidelity tradeoffs.
- Use the host's standard recall timeout and asynchronous query path for GRAPH interactions.

Tests:
- Add mapping and end-to-end coverage for frame conversion, provenance locations, relation direction, unresolved imports, host-backed queries, empty answers, unavailable providers, and unindexed workspaces.