### PR TITLE
docs: main is red on the new prose pattern, and #4775's split left two public docs pointing at private items

### DIFF
--- a/crates/stella-cli/src/agent/goal/goal_wrapped/tests.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped/tests.rs
@@ -29,7 +29,7 @@ use crate::wrapper_plugin::child_turn_fixture::{asking_plugin, step_usage_count}
 /// rounds, so after a round the slot holds *that round's* sender rather than
 /// nothing.
 ///
-/// **The stand-in deliberately does not forward to the run's channel**, and
+/// **The stand-in does not forward to the run's channel**, and
 /// that is the instrument the assertion turns on. The real per-turn sender is a
 /// `TurnFacts` tap over a clone of the run's channel, so a child that metered
 /// into it would still reach the drain and be indistinguishable from one that

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -122,13 +122,13 @@ mod tests;
 /// they already share.
 ///
 /// **Events only, and that is the difference from every other door.** This
-/// publishes the registry's own event slot and deliberately not the per-call
+/// publishes the registry's own event slot and not the per-call
 /// work-tree measurement beside it (`turn_files::open_turn_streams`), because a
 /// fleet worker rebinds `cfg.workspace_root` to its own worktree while the
 /// shared `SessionDurability` journal stays rooted at the lead's — a measurer
 /// attached here would snapshot the wrong tree, which is exactly why
 /// `turn_files`' `ENGINE_DRIVERS` records this door as `Blocked` on #3233 and
-/// why `STREAM_OWNERS` deliberately omits it. Publishing the measurer here
+/// why `STREAM_OWNERS` omits it. Publishing the measurer here
 /// would silently un-block #3233 rather than close #4730, so it stays withheld
 /// and this type is what says so out loud.
 pub(super) struct AttemptPointStream {

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -93,7 +93,7 @@ pub enum SkillOrigin {
     ///
     /// Separate from the other four because they all answer "which of the
     /// user's directories is this under", and a package's directory is none of
-    /// them. Without it `default_origin_for` (private) has no true answer and falls
+    /// them. Without it the path-derived default has no true answer and falls
     /// through to [`SkillOrigin::Workspace`], reporting a third party's skill
     /// as the user's own — which is what every surface that has to say whose
     /// skill is steering a turn would then repeat.
@@ -371,7 +371,7 @@ pub fn load_skills_with_diagnostics(
 /// Load every skill in one directory, tagged with the `origin` the caller
 /// names rather than one derived from the path.
 ///
-/// `default_origin_for` (private) answers "which of the user's two configured
+/// The path-derived default answers "which of the user's two configured
 /// directories is this file under", and a directory that is neither — a
 /// plugin package's own `skills/` — has no true answer there: it falls through
 /// to [`SkillOrigin::Workspace`] and a third party's skill reports as the

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -164,7 +164,7 @@ allocation that lifts it — `stella_core::turn_slots` partitions
 `turn_instance` by residue, so a plane counting only its own calls can never
 land where a door's rounds will, without either counter knowing the other's.
 One limit stands on every door that attaches the plane: the `verifier` tier is
-deliberately bound to no seat, so a plugin naming it is answered `Unavailable`
+bound to no seat, so a plugin naming it is answered `Unavailable`
 rather than having its call attributed to a role the host never made
 (`ChildTurns::with_seat` is how a driver that wants it owns the claim).
 
@@ -184,7 +184,7 @@ stream across the points — a child there is exactly as run-scoped as the round
 beside it, and a second row would split one run's spend in `stella stats`. The
 shared half is `RepublishingDriver`, which puts a door's stream back after every
 round it drives; what each door publishes is its own `PointStream`. `stella
-fleet` publishes the registry's event slot alone and deliberately not the
+fleet` publishes the registry's event slot alone and not the
 per-call work-tree measurement beside it: its worker rebinds
 `cfg.workspace_root` to its own worktree while the shared journal stays rooted
 at the lead's, so a measurer there would read the wrong tree (#3233).
@@ -211,8 +211,8 @@ the plugin is told about rather than a silence.
 (`stella_plugin::driver`) and the gate (`src/wrapper/driver_call.rs`): it
 spawns a driver, opens a session, relays every capability ask through the
 grant a human consented to, and reads back the `next` that ends it —
-`tests/driver_socket.rs` drives a `/bin/sh` driver through all of it. Two
-things are deliberately still absent. Every capability answers `unsupported`,
+`tests/driver_socket.rs` drives a `/bin/sh` driver through all of it. Every
+capability still answers `unsupported`,
 because `NoDriverCapabilities` is the only implementation and B1-B6 (#3599)
 are what give the verbs something to do; and nothing in `stella-cli` opens a
 driver session yet, so `plugins/stella-selfdriving`'s `[driver]` grant remains

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -260,17 +260,17 @@ impl<'a> GatedToolSet<'a> {
         self
     }
 
-    /// The caller the gate is asked about for `name`: the plugin that
-    /// contributed the tool, or — for everything the user wrote themselves
-    /// and every built-in — this stack's own principal.
-    /// Who a call to `name` would be authorized as — the question
-    /// What `principal_for` answers (private), exposed so a host can assert the
-    /// answer instead of inferring it from a gate's behaviour.
+    /// Who a call to `name` would be authorized as, owned rather than
+    /// borrowed — so a host can assert the answer instead of inferring it
+    /// from how the gate behaved.
     #[must_use]
     pub fn principal_of(&self, name: &str) -> Principal {
         self.principal_for(name).clone()
     }
 
+    /// The caller the gate is asked about for `name`: the plugin that
+    /// contributed the tool, or — for everything the user wrote themselves
+    /// and every built-in — this stack's own principal.
     fn principal_for(&self, name: &str) -> &Principal {
         // Exact first, then the namespace families, then this stack's own
         // caller — so a tool named outright is never overridden by a prefix

--- a/scripts/prose-baseline.txt
+++ b/scripts/prose-baseline.txt
@@ -242,7 +242,6 @@ crates/stella-cli/README.md rust-jargon 3
 crates/stella-cli/src/accounted_call.rs filler-adverb 2
 crates/stella-cli/src/accounted_call.rs honesty-declaration 2
 crates/stella-cli/src/accounted_call.rs meta-writing 1
-crates/stella-cli/src/agent.rs filler-adverb 1
 crates/stella-cli/src/agent.rs honesty-declaration 1
 crates/stella-cli/src/agent.rs interface-jargon 10
 crates/stella-cli/src/agent.rs rust-jargon 2
@@ -250,8 +249,8 @@ crates/stella-cli/src/agent/engine.rs filler-adverb 6
 crates/stella-cli/src/agent/engine.rs honesty-declaration 1
 crates/stella-cli/src/agent/engine.rs interface-jargon 1
 crates/stella-cli/src/agent/goal.rs filler-adverb 6
-crates/stella-cli/src/agent/goal.rs honesty-declaration 2
-crates/stella-cli/src/agent/goal.rs interface-jargon 3
+crates/stella-cli/src/agent/goal.rs honesty-declaration 1
+crates/stella-cli/src/agent/goal.rs interface-jargon 2
 crates/stella-cli/src/agent/goal.rs rust-jargon 13
 crates/stella-cli/src/agent/goal/goal_wrapped.rs filler-adverb 1
 crates/stella-cli/src/agent/goal/goal_wrapped.rs honesty-declaration 2
@@ -347,9 +346,9 @@ crates/stella-cli/src/cli/help/tests.rs interface-jargon 1
 crates/stella-cli/src/cli/subcommands.rs filler-adverb 3
 crates/stella-cli/src/cli/subcommands.rs rust-jargon 1
 crates/stella-cli/src/cloud_drain.rs filler-adverb 1
-crates/stella-cli/src/command_deck.rs filler-adverb 3
-crates/stella-cli/src/command_deck.rs honesty-declaration 3
-crates/stella-cli/src/command_deck.rs interface-jargon 9
+crates/stella-cli/src/command_deck.rs filler-adverb 2
+crates/stella-cli/src/command_deck.rs honesty-declaration 2
+crates/stella-cli/src/command_deck.rs interface-jargon 7
 crates/stella-cli/src/command_deck.rs rust-jargon 7
 crates/stella-cli/src/command_deck/add_dir.rs filler-adverb 1
 crates/stella-cli/src/command_deck/add_dir.rs honesty-declaration 1
@@ -1152,10 +1151,9 @@ crates/stella-diff/src/view.rs filler-adverb 1
 crates/stella-diff/src/view.rs honesty-declaration 3
 crates/stella-diff/src/view.rs meta-writing 1
 crates/stella-diff/tests/view_plan_matrix.rs filler-adverb 1
-crates/stella-embed/README.md filler-adverb 2
+crates/stella-embed/README.md filler-adverb 1
 crates/stella-embed/README.md rust-jargon 2
-crates/stella-embed/src/http.rs filler-adverb 3
-crates/stella-embed/src/http.rs honesty-declaration 1
+crates/stella-embed/src/http.rs filler-adverb 2
 crates/stella-embed/src/lib.rs honesty-declaration 2
 crates/stella-embed/src/lib.rs rust-jargon 2
 crates/stella-embed/src/rank.rs honesty-declaration 3
@@ -1580,7 +1578,6 @@ crates/stella-protocol/tests/wire_contract.rs rust-jargon 8
 crates/stella-protocol/tests/wire_contract/samples.rs filler-adverb 2
 crates/stella-protocol/tests/wire_contract/samples.rs rust-jargon 2
 crates/stella-runtime/Cargo.toml rust-jargon 2
-crates/stella-runtime/README.md filler-adverb 2
 crates/stella-runtime/README.md honesty-declaration 2
 crates/stella-runtime/README.md interface-jargon 1
 crates/stella-runtime/README.md rust-jargon 4


### PR DESCRIPTION
Two reds on `main`, both in prose the compiler does not read.

## 1. `check-prose.py` fails on main

`check-prose.py` gained a `filler-adverb` pattern and `main` went red on six hits it had never been checked for — `guard self-tests` runs the script directly, so this reds every PR too:

```
crates/stella-cli/src/agent/goal/goal_wrapped/tests.rs [filler-adverb]: 0 allowed, 1 found
crates/stella-cli/src/fleet_cmd/wrapped.rs            [filler-adverb]: 0 allowed, 2 found
crates/stella-runtime/README.md                       [filler-adverb]: 2 allowed, 3 found
```

The guard's own message is "Fix the prose. Do not add a baseline entry." In every case the adverb sat in front of a clause that already gave the reason — "and that is the instrument the assertion turns on", "because a fleet worker rebinds `cfg.workspace_root`" — so it announced that a choice was made and the next clause said why. The README's "Two things are deliberately still absent." also announced a list instead of writing it; both items read the same without it.

`scripts/prose-baseline.txt` is retightened via `make prose-update`, which cannot raise a count.

## 2. Two public docs name a private item

#4775's split landed through #4814. The doc repairs that had ridden with it in #4812 did not — #4812 was closed unmerged, so these were dropped on the floor:

- **`gated.rs`**: `principal_of` carried two fused doc comments, the second starting mid-clause ("Who a call to `name` would be authorized as — the question / What `principal_for` answers"). The first sentence describes `principal_for` and is moved onto it; `principal_of` now says the one thing a caller needs — it hands back an owned `Principal`, so a host can assert the answer instead of inferring it from how the gate behaved.
- **`skills.rs`**: two public doc comments named `default_origin_for`, a private fn, pointing a reader of the public API somewhere they cannot follow. Both now say "the path-derived default", which is what the sentences were about anyway.

This is the same class \#4814's CI caught as `cargo doc -D warnings` errors on `stella-tools` and `stella-core`.

## Evidence

- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p stella-tools -p stella-core` — clean.
- `python3 ./scripts/check-prose.py` — `OK -- 6438 grandfathered construction(s) in 1473 file(s), none added.` (was FAIL).
- `cargo fmt --check` — clean.

## Summary by Sourcery

Clean up prose violations and repair public documentation references left behind by the gated-tool and skill-origin split.

Bug Fixes:
- Fix prose validation failures by removing unnecessary filler adverbs and list-announcing language from CLI tests, fleet documentation, and the runtime README.
- Restore public documentation that no longer references private implementation items and clarify the ownership semantics of `principal_of`.

Documentation:
- Correct public API documentation in `gated.rs` and `skills.rs` so it describes accessible concepts and methods without exposing private names.

Chores:
- Retighten the prose baseline without increasing allowed construction counts.