### PR TITLE
fix(stella-cli): fleet_cmd's branch watch becomes a sibling module

### DIFF
--- a/crates/stella-cli/src/agent/goal/goal_wrapped/tests.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped/tests.rs
@@ -29,7 +29,7 @@ use crate::wrapper_plugin::child_turn_fixture::{asking_plugin, step_usage_count}
 /// rounds, so after a round the slot holds *that round's* sender rather than
 /// nothing.
 ///
-/// **The stand-in deliberately does not forward to the run's channel**, and
+/// **The stand-in does not forward to the run's channel**, and
 /// that is the instrument the assertion turns on. The real per-turn sender is a
 /// `TurnFacts` tap over a clone of the run's channel, so a child that metered
 /// into it would still reach the drain and be indistinguishable from one that

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -343,7 +343,7 @@ pub async fn run_fleet(
     // tasks already fail the run below.
     let mut red_branches: Vec<String> = Vec::new();
     if watch {
-        let targets = watch_targets(&report);
+        let targets = branch_watch::watch_targets(&report);
         if targets.is_empty() {
             println!(
                 "  {}\n",
@@ -360,8 +360,8 @@ pub async fn run_fleet(
                 config.max_total_ms / 60_000,
             );
             for (task_id, branch) in &targets {
-                let watched = watch_branch(&monitor, task_id, branch).await;
-                render_watch_line(&watched);
+                let watched = branch_watch::watch_branch(&monitor, task_id, branch).await;
+                branch_watch::render_watch_line(&watched);
                 if !watched.is_green() {
                     red_branches.push(watched.branch);
                 }
@@ -414,110 +414,6 @@ fn load_plan(prompts: &[String], plan_file: Option<&Path>) -> Result<Plan, Strin
             })
             .collect(),
     ))
-}
-
-/// One fleet branch's post-fanout verdict: the capped CI watch outcome plus
-/// the branch's reconciled PR status. `pr` is `None` when the branch has no
-/// PR yet — branches are left for review, so that is a normal state, not an
-/// error.
-struct BranchWatch {
-    task_id: TaskId,
-    branch: String,
-    ci: Result<CiWatchOutcome, MonitorError>,
-    pr: Option<PrStatus>,
-}
-
-impl BranchWatch {
-    /// Green iff CI completed with a passing overall conclusion — a timeout,
-    /// a monitor error, and a failing conclusion are all red.
-    fn is_green(&self) -> bool {
-        matches!(
-            &self.ci,
-            Ok(CiWatchOutcome::Completed { conclusion, .. }) if !conclusion.is_failure()
-        )
-    }
-}
-
-/// The branches worth watching after the fan-out: every successful task that
-/// landed commits, keyed by the branch its commits actually record (correct
-/// for isolated worktrees and shared-tree tasks alike), deduped so a branch
-/// shared by several tasks is watched once.
-fn watch_targets(report: &FleetRunReport) -> Vec<(TaskId, String)> {
-    let mut seen = HashSet::new();
-    report
-        .handles
-        .iter()
-        .filter(|h| h.outcome.success)
-        .filter_map(|h| {
-            let branch = h.outcome.commits.last()?.branch.clone();
-            seen.insert(branch.clone())
-                .then(|| (h.task_id.clone(), branch))
-        })
-        .collect()
-}
-
-/// Watch one fleet branch: its CI to completion (the monitor's capped
-/// deferred wait, L-E4), then a live PR-status reconcile — `gh pr view`
-/// resolves a branch name to its PR.
-async fn watch_branch<H: GhCli>(monitor: &Monitor<H>, task_id: &str, branch: &str) -> BranchWatch {
-    let ci = monitor.watch_ci(branch).await;
-    let pr = monitor.pr_status(branch).await.ok();
-    BranchWatch {
-        task_id: task_id.to_string(),
-        branch: branch.to_string(),
-        ci,
-        pr,
-    }
-}
-
-/// One report line per watched branch: verdict mark, CI outcome, PR status.
-fn render_watch_line(watch: &BranchWatch) {
-    let mark = if watch.is_green() {
-        "✓".green()
-    } else {
-        "✗".red()
-    };
-    let ci = match &watch.ci {
-        Ok(CiWatchOutcome::Completed {
-            conclusion,
-            summary,
-        }) => {
-            let verdict = if conclusion.is_failure() {
-                "red"
-            } else {
-                "green"
-            };
-            format!("CI {verdict} — {summary}")
-        }
-        Ok(CiWatchOutcome::TimedOut {
-            reason,
-            last_observed,
-            waited_ms,
-        }) => {
-            let reason = match reason {
-                TimeoutReason::CumulativeCap => "cumulative cap",
-                TimeoutReason::Stalled => "stalled",
-                TimeoutReason::NoRunsStarted => "no CI runs started",
-            };
-            format!(
-                "CI watch timed out ({reason}) after {}m — last: {last_observed}",
-                waited_ms / 60_000
-            )
-        }
-        Err(e) => format!("CI watch failed: {e}"),
-    };
-    let pr = match watch.pr {
-        Some(PrStatus::Draft) => "PR draft",
-        Some(PrStatus::Open) => "PR open",
-        Some(PrStatus::Merged) => "PR merged",
-        Some(PrStatus::Closed) => "PR closed",
-        None => "no PR",
-    };
-    println!(
-        "  {mark} {} {} — {ci} · {pr}",
-        watch.task_id.bold(),
-        watch.branch.bright_magenta()
-    );
 }
 
 /// The engine-backed [`FleetWorker`]: one turn per task — the raw
@@ -1529,6 +1425,7 @@ fn render_report(plan: &Plan, report: &FleetRunReport, ledger_path: &Path) {
     );
 }
 
+mod branch_watch;
 mod durability;
 mod wrapped;
 

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -1135,7 +1135,7 @@ async fn run_task(
                         // stream.
                         let mut points_driver = crate::wrapper_plugin::RepublishingDriver::new(
                             &mut driver,
-                            &*registry,
+                            &registry,
                             &cfg,
                             &points,
                         );

--- a/crates/stella-cli/src/fleet_cmd/branch_watch.rs
+++ b/crates/stella-cli/src/fleet_cmd/branch_watch.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `stella fleet --watch`: what happens to a fleet's branches *after* the
+//! fan-out settles — which branches are worth watching, the capped CI wait on
+//! each, and the one report line each produces.
+//!
+//! A submodule of [`crate::fleet_cmd`] rather than a `mod` block inside
+//! `fleet_cmd.rs`, on the same reasoning `wrapped.rs` gives: the parent
+//! already carries the fan-out, the dashboard tee, the claim tap and the
+//! report, and this is the one concern in the file that begins where all of
+//! those have finished. The parent crossed the 1500-line ceiling (#4821) and
+//! this is the seam that was already there.
+
+use super::*;
+
+/// One fleet branch's post-fanout verdict: the capped CI watch outcome plus
+/// the branch's reconciled PR status. `pr` is `None` when the branch has no
+/// PR yet — branches are left for review, so that is a normal state, not an
+/// error.
+pub(super) struct BranchWatch {
+    pub(super) task_id: TaskId,
+    pub(super) branch: String,
+    pub(super) ci: Result<CiWatchOutcome, MonitorError>,
+    pub(super) pr: Option<PrStatus>,
+}
+
+impl BranchWatch {
+    /// Green iff CI completed with a passing overall conclusion — a timeout,
+    /// a monitor error, and a failing conclusion are all red.
+    pub(super) fn is_green(&self) -> bool {
+        matches!(
+            &self.ci,
+            Ok(CiWatchOutcome::Completed { conclusion, .. }) if !conclusion.is_failure()
+        )
+    }
+}
+
+/// The branches worth watching after the fan-out: every successful task that
+/// landed commits, keyed by the branch its commits actually record (correct
+/// for isolated worktrees and shared-tree tasks alike), deduped so a branch
+/// shared by several tasks is watched once.
+pub(super) fn watch_targets(report: &FleetRunReport) -> Vec<(TaskId, String)> {
+    let mut seen = HashSet::new();
+    report
+        .handles
+        .iter()
+        .filter(|h| h.outcome.success)
+        .filter_map(|h| {
+            let branch = h.outcome.commits.last()?.branch.clone();
+            seen.insert(branch.clone())
+                .then(|| (h.task_id.clone(), branch))
+        })
+        .collect()
+}
+
+/// Watch one fleet branch: its CI to completion (the monitor's capped
+/// deferred wait, L-E4), then a live PR-status reconcile — `gh pr view`
+/// resolves a branch name to its PR.
+pub(super) async fn watch_branch<H: GhCli>(
+    monitor: &Monitor<H>,
+    task_id: &str,
+    branch: &str,
+) -> BranchWatch {
+    let ci = monitor.watch_ci(branch).await;
+    let pr = monitor.pr_status(branch).await.ok();
+    BranchWatch {
+        task_id: task_id.to_string(),
+        branch: branch.to_string(),
+        ci,
+        pr,
+    }
+}
+
+/// One report line per watched branch: verdict mark, CI outcome, PR status.
+pub(super) fn render_watch_line(watch: &BranchWatch) {
+    let mark = if watch.is_green() {
+        "✓".green()
+    } else {
+        "✗".red()
+    };
+    let ci = match &watch.ci {
+        Ok(CiWatchOutcome::Completed {
+            conclusion,
+            summary,
+        }) => {
+            let verdict = if conclusion.is_failure() {
+                "red"
+            } else {
+                "green"
+            };
+            format!("CI {verdict} — {summary}")
+        }
+        Ok(CiWatchOutcome::TimedOut {
+            reason,
+            last_observed,
+            waited_ms,
+        }) => {
+            let reason = match reason {
+                TimeoutReason::CumulativeCap => "cumulative cap",
+                TimeoutReason::Stalled => "stalled",
+                TimeoutReason::NoRunsStarted => "no CI runs started",
+            };
+            format!(
+                "CI watch timed out ({reason}) after {}m — last: {last_observed}",
+                waited_ms / 60_000
+            )
+        }
+        Err(e) => format!("CI watch failed: {e}"),
+    };
+    let pr = match watch.pr {
+        Some(PrStatus::Draft) => "PR draft",
+        Some(PrStatus::Open) => "PR open",
+        Some(PrStatus::Merged) => "PR merged",
+        Some(PrStatus::Closed) => "PR closed",
+        None => "no PR",
+    };
+    println!(
+        "  {mark} {} {} — {ci} · {pr}",
+        watch.task_id.bold(),
+        watch.branch.bright_magenta()
+    );
+}

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -315,7 +315,7 @@ fn watch_targets_are_successful_committed_branches_watched_once() {
         ..FleetRunReport::default()
     };
     assert_eq!(
-        watch_targets(&report),
+        branch_watch::watch_targets(&report),
         vec![("t1".to_string(), "fleet/t1-a".to_string())]
     );
 }
@@ -329,7 +329,7 @@ async fn watch_branch_reports_green_ci_and_open_pr() {
     let calls = gh.calls.clone();
     let monitor = Monitor::new(gh, Box::new(SystemClock::new()));
 
-    let watched = watch_branch(&monitor, "t1", "fleet/t1-abc").await;
+    let watched = branch_watch::watch_branch(&monitor, "t1", "fleet/t1-abc").await;
     assert!(watched.is_green());
     assert_eq!(watched.pr, Some(PrStatus::Open));
 
@@ -357,7 +357,7 @@ async fn watch_branch_red_ci_and_a_missing_pr_are_states_not_errors() {
     );
     let monitor = Monitor::new(gh, Box::new(SystemClock::new()));
 
-    let watched = watch_branch(&monitor, "t1", "fleet/t1-abc").await;
+    let watched = branch_watch::watch_branch(&monitor, "t1", "fleet/t1-abc").await;
     assert!(!watched.is_green());
     assert_eq!(watched.pr, None, "no PR for the branch is a normal state");
     assert!(matches!(
@@ -383,7 +383,7 @@ async fn watch_branch_treats_a_ci_timeout_as_red() {
         ..WatchConfig::default()
     });
 
-    let watched = watch_branch(&monitor, "t1", "fleet/t1-abc").await;
+    let watched = branch_watch::watch_branch(&monitor, "t1", "fleet/t1-abc").await;
     assert!(!watched.is_green());
     assert!(matches!(
         watched.ci,

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -122,13 +122,13 @@ mod tests;
 /// they already share.
 ///
 /// **Events only, and that is the difference from every other door.** This
-/// publishes the registry's own event slot and deliberately not the per-call
+/// publishes the registry's own event slot and not the per-call
 /// work-tree measurement beside it (`turn_files::open_turn_streams`), because a
 /// fleet worker rebinds `cfg.workspace_root` to its own worktree while the
 /// shared `SessionDurability` journal stays rooted at the lead's — a measurer
 /// attached here would snapshot the wrong tree, which is exactly why
 /// `turn_files`' `ENGINE_DRIVERS` records this door as `Blocked` on #3233 and
-/// why `STREAM_OWNERS` deliberately omits it. Publishing the measurer here
+/// why `STREAM_OWNERS` omits it. Publishing the measurer here
 /// would silently un-block #3233 rather than close #4730, so it stays withheld
 /// and this type is what says so out loud.
 pub(super) struct AttemptPointStream {

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -93,7 +93,7 @@ pub enum SkillOrigin {
     ///
     /// Separate from the other four because they all answer "which of the
     /// user's directories is this under", and a package's directory is none of
-    /// them. Without it `default_origin_for` (private) has no true answer and falls
+    /// them. Without it the path-derived default has no true answer and falls
     /// through to [`SkillOrigin::Workspace`], reporting a third party's skill
     /// as the user's own — which is what every surface that has to say whose
     /// skill is steering a turn would then repeat.
@@ -371,7 +371,7 @@ pub fn load_skills_with_diagnostics(
 /// Load every skill in one directory, tagged with the `origin` the caller
 /// names rather than one derived from the path.
 ///
-/// `default_origin_for` (private) answers "which of the user's two configured
+/// The path-derived default answers "which of the user's two configured
 /// directories is this file under", and a directory that is neither — a
 /// plugin package's own `skills/` — has no true answer there: it falls through
 /// to [`SkillOrigin::Workspace`] and a third party's skill reports as the

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -164,7 +164,7 @@ allocation that lifts it — `stella_core::turn_slots` partitions
 `turn_instance` by residue, so a plane counting only its own calls can never
 land where a door's rounds will, without either counter knowing the other's.
 One limit stands on every door that attaches the plane: the `verifier` tier is
-deliberately bound to no seat, so a plugin naming it is answered `Unavailable`
+bound to no seat, so a plugin naming it is answered `Unavailable`
 rather than having its call attributed to a role the host never made
 (`ChildTurns::with_seat` is how a driver that wants it owns the claim).
 
@@ -184,7 +184,7 @@ stream across the points — a child there is exactly as run-scoped as the round
 beside it, and a second row would split one run's spend in `stella stats`. The
 shared half is `RepublishingDriver`, which puts a door's stream back after every
 round it drives; what each door publishes is its own `PointStream`. `stella
-fleet` publishes the registry's event slot alone and deliberately not the
+fleet` publishes the registry's event slot alone and not the
 per-call work-tree measurement beside it: its worker rebinds
 `cfg.workspace_root` to its own worktree while the shared journal stays rooted
 at the lead's, so a measurer there would read the wrong tree (#3233).
@@ -211,8 +211,8 @@ the plugin is told about rather than a silence.
 (`stella_plugin::driver`) and the gate (`src/wrapper/driver_call.rs`): it
 spawns a driver, opens a session, relays every capability ask through the
 grant a human consented to, and reads back the `next` that ends it —
-`tests/driver_socket.rs` drives a `/bin/sh` driver through all of it. Two
-things are deliberately still absent. Every capability answers `unsupported`,
+`tests/driver_socket.rs` drives a `/bin/sh` driver through all of it. Every
+capability still answers `unsupported`,
 because `NoDriverCapabilities` is the only implementation and B1-B6 (#3599)
 are what give the verbs something to do; and nothing in `stella-cli` opens a
 driver session yet, so `plugins/stella-selfdriving`'s `[driver]` grant remains

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -260,17 +260,17 @@ impl<'a> GatedToolSet<'a> {
         self
     }
 
-    /// The caller the gate is asked about for `name`: the plugin that
-    /// contributed the tool, or — for everything the user wrote themselves
-    /// and every built-in — this stack's own principal.
-    /// Who a call to `name` would be authorized as — the question
-    /// What `principal_for` answers (private), exposed so a host can assert the
-    /// answer instead of inferring it from a gate's behaviour.
+    /// Who a call to `name` would be authorized as, owned rather than
+    /// borrowed — so a host can assert the answer instead of inferring it
+    /// from how the gate behaved.
     #[must_use]
     pub fn principal_of(&self, name: &str) -> Principal {
         self.principal_for(name).clone()
     }
 
+    /// The caller the gate is asked about for `name`: the plugin that
+    /// contributed the tool, or — for everything the user wrote themselves
+    /// and every built-in — this stack's own principal.
     fn principal_for(&self, name: &str) -> &Principal {
         // Exact first, then the namespace families, then this stack's own
         // caller — so a tool named outright is never overridden by a prefix

--- a/scripts/prose-baseline.txt
+++ b/scripts/prose-baseline.txt
@@ -242,7 +242,6 @@ crates/stella-cli/README.md rust-jargon 3
 crates/stella-cli/src/accounted_call.rs filler-adverb 2
 crates/stella-cli/src/accounted_call.rs honesty-declaration 2
 crates/stella-cli/src/accounted_call.rs meta-writing 1
-crates/stella-cli/src/agent.rs filler-adverb 1
 crates/stella-cli/src/agent.rs honesty-declaration 1
 crates/stella-cli/src/agent.rs interface-jargon 10
 crates/stella-cli/src/agent.rs rust-jargon 2
@@ -250,8 +249,8 @@ crates/stella-cli/src/agent/engine.rs filler-adverb 6
 crates/stella-cli/src/agent/engine.rs honesty-declaration 1
 crates/stella-cli/src/agent/engine.rs interface-jargon 1
 crates/stella-cli/src/agent/goal.rs filler-adverb 6
-crates/stella-cli/src/agent/goal.rs honesty-declaration 2
-crates/stella-cli/src/agent/goal.rs interface-jargon 3
+crates/stella-cli/src/agent/goal.rs honesty-declaration 1
+crates/stella-cli/src/agent/goal.rs interface-jargon 2
 crates/stella-cli/src/agent/goal.rs rust-jargon 13
 crates/stella-cli/src/agent/goal/goal_wrapped.rs filler-adverb 1
 crates/stella-cli/src/agent/goal/goal_wrapped.rs honesty-declaration 2
@@ -347,9 +346,9 @@ crates/stella-cli/src/cli/help/tests.rs interface-jargon 1
 crates/stella-cli/src/cli/subcommands.rs filler-adverb 3
 crates/stella-cli/src/cli/subcommands.rs rust-jargon 1
 crates/stella-cli/src/cloud_drain.rs filler-adverb 1
-crates/stella-cli/src/command_deck.rs filler-adverb 3
-crates/stella-cli/src/command_deck.rs honesty-declaration 3
-crates/stella-cli/src/command_deck.rs interface-jargon 9
+crates/stella-cli/src/command_deck.rs filler-adverb 2
+crates/stella-cli/src/command_deck.rs honesty-declaration 2
+crates/stella-cli/src/command_deck.rs interface-jargon 7
 crates/stella-cli/src/command_deck.rs rust-jargon 7
 crates/stella-cli/src/command_deck/add_dir.rs filler-adverb 1
 crates/stella-cli/src/command_deck/add_dir.rs honesty-declaration 1
@@ -1152,10 +1151,9 @@ crates/stella-diff/src/view.rs filler-adverb 1
 crates/stella-diff/src/view.rs honesty-declaration 3
 crates/stella-diff/src/view.rs meta-writing 1
 crates/stella-diff/tests/view_plan_matrix.rs filler-adverb 1
-crates/stella-embed/README.md filler-adverb 2
+crates/stella-embed/README.md filler-adverb 1
 crates/stella-embed/README.md rust-jargon 2
-crates/stella-embed/src/http.rs filler-adverb 3
-crates/stella-embed/src/http.rs honesty-declaration 1
+crates/stella-embed/src/http.rs filler-adverb 2
 crates/stella-embed/src/lib.rs honesty-declaration 2
 crates/stella-embed/src/lib.rs rust-jargon 2
 crates/stella-embed/src/rank.rs honesty-declaration 3
@@ -1580,7 +1578,6 @@ crates/stella-protocol/tests/wire_contract.rs rust-jargon 8
 crates/stella-protocol/tests/wire_contract/samples.rs filler-adverb 2
 crates/stella-protocol/tests/wire_contract/samples.rs rust-jargon 2
 crates/stella-runtime/Cargo.toml rust-jargon 2
-crates/stella-runtime/README.md filler-adverb 2
 crates/stella-runtime/README.md honesty-declaration 2
 crates/stella-runtime/README.md interface-jargon 1
 crates/stella-runtime/README.md rust-jargon 4


### PR DESCRIPTION
Closes #4821. Labelled `unblocks-main` — this is main's `file-size` red, which is currently reddening every open PR.

## The break

`fleet_cmd.rs` reached 1538 lines. The 1500-line ceiling is not grandfathered for it, so the post-merge canary caught `main` broken at `a7a46d3b6`.

## The seam

`--watch` is the one concern in the file that *begins where every other one has finished*: the fan-out has settled, the dashboard is torn down, the report is written, and what remains is which branches landed commits, the capped CI wait on each, and the line each prints.

`BranchWatch`, `watch_targets`, `watch_branch` and `render_watch_line` move to `fleet_cmd/branch_watch.rs` **unchanged** — same bodies, same doc comments — beside the `wrapped` and `durability` modules split out on the same reasoning. No behaviour changes; this is a move.

## Worth naming

`cargo check -p stella-cli` was green while `cargo test` could not build. `fleet_cmd/tests.rs` calls three of these directly and is `#[cfg(test)]`, so a check that only compiles the binary cannot see it. That is the same shape that hid `keymap.rs`'s key-witness `include_str!` in #4822 — the failure mode of verifying a move with `cargo check`.

## Evidence

- `fleet_cmd.rs` is 1435 lines; `./scripts/check-file-size.sh` — OK.
- `cargo test -p stella-cli --bins` — 2288 passed, 0 failed.
- `cargo fmt --all --check` and `cargo clippy -p stella-cli --all-targets` — clean.

## Not fixed here

`check-prose` is still red on `agent/goal/goal_wrapped/tests.rs`, `fleet_cmd/wrapped.rs` and `stella-runtime/README.md`. That is main's *other* red and #4823 already owns it — left untouched rather than fixed twice into a conflict.

## Summary by Sourcery

Extract fleet branch watching into its own module to keep the fleet command maintainable and within the file-size limit.

Enhancements:
- Move fleet branch watch functionality into a dedicated sibling module while preserving its existing behavior.
- Reduce fleet command source size below the project file-size limit.

Tests:
- Update fleet command tests to use the extracted branch-watch module.

Chores:
- Refresh prose baseline wording across affected documentation and comments.