### PR TITLE
fix(stella-cli,stella-runtime): fleet_cmd splits its report half; main is green

### DIFF
--- a/crates/stella-cli/src/agent/goal/goal_wrapped/tests.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped/tests.rs
@@ -29,7 +29,7 @@ use crate::wrapper_plugin::child_turn_fixture::{asking_plugin, step_usage_count}
 /// rounds, so after a round the slot holds *that round's* sender rather than
 /// nothing.
 ///
-/// **The stand-in deliberately does not forward to the run's channel**, and
+/// **The stand-in does not forward to the run's channel**, and
 /// that is the instrument the assertion turns on. The real per-turn sender is a
 /// `TurnFacts` tap over a clone of the run's channel, so a child that metered
 /// into it would still reach the drain and be indistinguishable from one that

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -60,7 +60,6 @@ use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Duration;
 
 use colored::Colorize;
 use stella_core::{Engine, TurnOutcome};
@@ -81,9 +80,6 @@ use crate::runtime::{SystemClock, TokioSleeper, WallClock};
 // attempt publishes its own channel across the dispatch's points (#4730).
 use crate::wrapper_plugin::PointStream;
 use crate::{agent, plain, rules};
-
-/// Cap on the per-task summary line so the report table stays a table.
-const SUMMARY_CHARS: usize = 96;
 
 /// Run a fleet: build/load the plan, dispatch it wave by wave, report —
 /// then, with `watch`, hold the fleet PR/CI monitor on the branches.
@@ -468,56 +464,6 @@ async fn watch_branch<H: GhCli>(monitor: &Monitor<H>, task_id: &str, branch: &st
         ci,
         pr,
     }
-}
-
-/// One report line per watched branch: verdict mark, CI outcome, PR status.
-fn render_watch_line(watch: &BranchWatch) {
-    let mark = if watch.is_green() {
-        "✓".green()
-    } else {
-        "✗".red()
-    };
-    let ci = match &watch.ci {
-        Ok(CiWatchOutcome::Completed {
-            conclusion,
-            summary,
-        }) => {
-            let verdict = if conclusion.is_failure() {
-                "red"
-            } else {
-                "green"
-            };
-            format!("CI {verdict} — {summary}")
-        }
-        Ok(CiWatchOutcome::TimedOut {
-            reason,
-            last_observed,
-            waited_ms,
-        }) => {
-            let reason = match reason {
-                TimeoutReason::CumulativeCap => "cumulative cap",
-                TimeoutReason::Stalled => "stalled",
-                TimeoutReason::NoRunsStarted => "no CI runs started",
-            };
-            format!(
-                "CI watch timed out ({reason}) after {}m — last: {last_observed}",
-                waited_ms / 60_000
-            )
-        }
-        Err(e) => format!("CI watch failed: {e}"),
-    };
-    let pr = match watch.pr {
-        Some(PrStatus::Draft) => "PR draft",
-        Some(PrStatus::Open) => "PR open",
-        Some(PrStatus::Merged) => "PR merged",
-        Some(PrStatus::Closed) => "PR closed",
-        None => "no PR",
-    };
-    println!(
-        "  {mark} {} {} — {ci} · {pr}",
-        watch.task_id.bold(),
-        watch.branch.bright_magenta()
-    );
 }
 
 /// The engine-backed [`FleetWorker`]: one turn per task — the raw
@@ -1239,7 +1185,7 @@ async fn run_task(
                         // stream.
                         let mut points_driver = crate::wrapper_plugin::RepublishingDriver::new(
                             &mut driver,
-                            &*registry,
+                            &registry,
                             &cfg,
                             &points,
                         );
@@ -1414,123 +1360,12 @@ async fn git_stdout(root: &Path, args: &[&str]) -> Result<String, String> {
     Ok(output.stdout.trim().to_string())
 }
 
-fn truncate(s: &str) -> String {
-    let one_line = s.replace('\n', " ");
-    let mut out: String = one_line.chars().take(SUMMARY_CHARS).collect();
-    if one_line.chars().count() > SUMMARY_CHARS {
-        out.push('…');
-    }
-    out
-}
-
-/// The live grid's one-screen recap, printed on the normal screen after the
-/// dashboard restores it: each task's final status, wall-clock ELAPSED, and
-/// tool-call count, then the total SESSION time. The `render_report` below
-/// follows with the durable details (spend, commits, worktrees).
-fn print_dash_summary(res: &FleetDashResult) {
-    let fmt_elapsed = |d: Duration| {
-        let s = d.as_secs();
-        format!("{:02}:{:02}", s / 60, s % 60)
-    };
-    let fmt_session = |d: Duration| {
-        let s = d.as_secs();
-        format!("{:02}:{:02}:{:02}", s / 3600, (s % 3600) / 60, s % 60)
-    };
-    println!();
-    for t in &res.tasks {
-        let glyph = match t.status {
-            FleetStatus::Done => t.status.glyph().green(),
-            FleetStatus::Failed | FleetStatus::Killed => t.status.glyph().red(),
-            FleetStatus::Blocked => t.status.glyph().yellow(),
-            _ => t.status.glyph().normal(),
-        };
-        println!(
-            "  {glyph} {} — {} ({}, {} tool call{})",
-            t.id.bold(),
-            t.title,
-            fmt_elapsed(t.elapsed),
-            t.tool_calls,
-            if t.tool_calls == 1 { "" } else { "s" },
-        );
-    }
-    let tail = if res.detached {
-        " (detached — run continued to completion)"
-    } else {
-        ""
-    };
-    println!(
-        "  {} session {}{tail}",
-        "·".dimmed(),
-        fmt_session(res.session_elapsed).bold()
-    );
-}
-
-/// The end-of-run report: per task its outcome, spend, commits, and (when
-/// isolated) the worktree that holds the work, then the totals and where the
-/// receipts live.
-fn render_report(plan: &Plan, report: &FleetRunReport, ledger_path: &Path) {
-    println!();
-    for handle in &report.handles {
-        let ok = handle.outcome.success;
-        let mark = if ok { "✓".green() } else { "✗".red() };
-        let title = plan
-            .task(&handle.task_id)
-            .map(|t| t.title.as_str())
-            .unwrap_or("");
-        println!(
-            "  {mark} {} — {} (${:.4}, {} commit{})",
-            handle.task_id.bold(),
-            title,
-            handle.outcome.cost_usd,
-            handle.outcome.commits.len(),
-            if handle.outcome.commits.len() == 1 {
-                ""
-            } else {
-                "s"
-            },
-        );
-        if let Some(worktree) = &handle.worktree {
-            println!(
-                "      {} {} @ {}",
-                "↳".dimmed(),
-                worktree.branch.bright_magenta(),
-                worktree.path.display().to_string().dimmed()
-            );
-        }
-        if !handle.outcome.summary.is_empty() {
-            println!("      {}", handle.outcome.summary.dimmed());
-        }
-        // Durable-failure notices (a ledger close that failed after the
-        // worker settled, a dispatch lease lost mid-run) are composed in
-        // stella-fleet — this file is at its size ceiling (#1677).
-        for notice in stella_fleet::handle_notices(handle) {
-            println!("      {} {notice}", "!".yellow());
-        }
-    }
-    for (task_id, reason) in &report.dispatch_failures {
-        println!(
-            "  {} {} — dispatch failed: {}",
-            "✗".red(),
-            task_id.bold(),
-            reason.dimmed()
-        );
-    }
-    if !report.skipped.is_empty() {
-        println!(
-            "  {} skipped (dependency failed or budget stop): {}",
-            "○".yellow(),
-            report.skipped.join(", ").dimmed()
-        );
-    }
-    println!(
-        "\n  total ${:.4} · ledger {} · worktrees kept for review (`git worktree list`)\n",
-        report.total_cost_usd(),
-        ledger_path.display(),
-    );
-}
-
 mod durability;
+/// The report the run prints when it is over — see the module's own header
+/// for why these four moved together.
+mod render;
 mod wrapped;
+use render::{print_dash_summary, render_report, render_watch_line, truncate};
 
 /// Where the fleet command's plan-shape belongs in docs/tests: a plan file is
 /// the serde form of [`stella_fleet::Plan`].

--- a/crates/stella-cli/src/fleet_cmd/render.rs
+++ b/crates/stella-cli/src/fleet_cmd/render.rs
@@ -1,0 +1,177 @@
+//! Turning a finished fleet run into terminal output.
+//!
+//! Split out of `fleet_cmd.rs` when it crossed the 1500-line ceiling. These
+//! four are the group with no callers inside the parent beyond the two print
+//! points and no dependency on the run machinery — they read a finished report
+//! and write to stdout, which is why they move together and why nothing else
+//! had to move with them.
+
+use std::time::Duration;
+
+use colored::Colorize;
+
+use super::*;
+
+/// Cap on the per-task summary line so the report table stays a table.
+pub(super) const SUMMARY_CHARS: usize = 96;
+/// One report line per watched branch: verdict mark, CI outcome, PR status.
+pub(super) fn render_watch_line(watch: &BranchWatch) {
+    let mark = if watch.is_green() {
+        "✓".green()
+    } else {
+        "✗".red()
+    };
+    let ci = match &watch.ci {
+        Ok(CiWatchOutcome::Completed {
+            conclusion,
+            summary,
+        }) => {
+            let verdict = if conclusion.is_failure() {
+                "red"
+            } else {
+                "green"
+            };
+            format!("CI {verdict} — {summary}")
+        }
+        Ok(CiWatchOutcome::TimedOut {
+            reason,
+            last_observed,
+            waited_ms,
+        }) => {
+            let reason = match reason {
+                TimeoutReason::CumulativeCap => "cumulative cap",
+                TimeoutReason::Stalled => "stalled",
+                TimeoutReason::NoRunsStarted => "no CI runs started",
+            };
+            format!(
+                "CI watch timed out ({reason}) after {}m — last: {last_observed}",
+                waited_ms / 60_000
+            )
+        }
+        Err(e) => format!("CI watch failed: {e}"),
+    };
+    let pr = match watch.pr {
+        Some(PrStatus::Draft) => "PR draft",
+        Some(PrStatus::Open) => "PR open",
+        Some(PrStatus::Merged) => "PR merged",
+        Some(PrStatus::Closed) => "PR closed",
+        None => "no PR",
+    };
+    println!(
+        "  {mark} {} {} — {ci} · {pr}",
+        watch.task_id.bold(),
+        watch.branch.bright_magenta()
+    );
+}
+pub(super) fn truncate(s: &str) -> String {
+    let one_line = s.replace('\n', " ");
+    let mut out: String = one_line.chars().take(SUMMARY_CHARS).collect();
+    if one_line.chars().count() > SUMMARY_CHARS {
+        out.push('…');
+    }
+    out
+}
+/// The live grid's one-screen recap, printed on the normal screen after the
+/// dashboard restores it: each task's final status, wall-clock ELAPSED, and
+/// tool-call count, then the total SESSION time. The `render_report` below
+/// follows with the durable details (spend, commits, worktrees).
+pub(super) fn print_dash_summary(res: &FleetDashResult) {
+    let fmt_elapsed = |d: Duration| {
+        let s = d.as_secs();
+        format!("{:02}:{:02}", s / 60, s % 60)
+    };
+    let fmt_session = |d: Duration| {
+        let s = d.as_secs();
+        format!("{:02}:{:02}:{:02}", s / 3600, (s % 3600) / 60, s % 60)
+    };
+    println!();
+    for t in &res.tasks {
+        let glyph = match t.status {
+            FleetStatus::Done => t.status.glyph().green(),
+            FleetStatus::Failed | FleetStatus::Killed => t.status.glyph().red(),
+            FleetStatus::Blocked => t.status.glyph().yellow(),
+            _ => t.status.glyph().normal(),
+        };
+        println!(
+            "  {glyph} {} — {} ({}, {} tool call{})",
+            t.id.bold(),
+            t.title,
+            fmt_elapsed(t.elapsed),
+            t.tool_calls,
+            if t.tool_calls == 1 { "" } else { "s" },
+        );
+    }
+    let tail = if res.detached {
+        " (detached — run continued to completion)"
+    } else {
+        ""
+    };
+    println!(
+        "  {} session {}{tail}",
+        "·".dimmed(),
+        fmt_session(res.session_elapsed).bold()
+    );
+}
+/// The end-of-run report: per task its outcome, spend, commits, and (when
+/// isolated) the worktree that holds the work, then the totals and where the
+/// receipts live.
+pub(super) fn render_report(plan: &Plan, report: &FleetRunReport, ledger_path: &Path) {
+    println!();
+    for handle in &report.handles {
+        let ok = handle.outcome.success;
+        let mark = if ok { "✓".green() } else { "✗".red() };
+        let title = plan
+            .task(&handle.task_id)
+            .map(|t| t.title.as_str())
+            .unwrap_or("");
+        println!(
+            "  {mark} {} — {} (${:.4}, {} commit{})",
+            handle.task_id.bold(),
+            title,
+            handle.outcome.cost_usd,
+            handle.outcome.commits.len(),
+            if handle.outcome.commits.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
+        );
+        if let Some(worktree) = &handle.worktree {
+            println!(
+                "      {} {} @ {}",
+                "↳".dimmed(),
+                worktree.branch.bright_magenta(),
+                worktree.path.display().to_string().dimmed()
+            );
+        }
+        if !handle.outcome.summary.is_empty() {
+            println!("      {}", handle.outcome.summary.dimmed());
+        }
+        // Durable-failure notices (a ledger close that failed after the
+        // worker settled, a dispatch lease lost mid-run) are composed in
+        // stella-fleet — this file is at its size ceiling (#1677).
+        for notice in stella_fleet::handle_notices(handle) {
+            println!("      {} {notice}", "!".yellow());
+        }
+    }
+    for (task_id, reason) in &report.dispatch_failures {
+        println!(
+            "  {} {} — dispatch failed: {}",
+            "✗".red(),
+            task_id.bold(),
+            reason.dimmed()
+        );
+    }
+    if !report.skipped.is_empty() {
+        println!(
+            "  {} skipped (dependency failed or budget stop): {}",
+            "○".yellow(),
+            report.skipped.join(", ").dimmed()
+        );
+    }
+    println!(
+        "\n  total ${:.4} · ledger {} · worktrees kept for review (`git worktree list`)\n",
+        report.total_cost_usd(),
+        ledger_path.display(),
+    );
+}

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -10,6 +10,8 @@ use stella_fleet::CommitRecord;
 use stella_protocol::CompletionMessage;
 
 use super::*;
+// The width the truncation test asserts against, from the module that owns it.
+use super::render::SUMMARY_CHARS;
 
 /// The #803 cancellation seam, pinned from both directions: dropping the
 /// dispatch's abandon sender IS a stop (the claims are being released;

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -122,13 +122,13 @@ mod tests;
 /// they already share.
 ///
 /// **Events only, and that is the difference from every other door.** This
-/// publishes the registry's own event slot and deliberately not the per-call
+/// publishes the registry's own event slot and not the per-call
 /// work-tree measurement beside it (`turn_files::open_turn_streams`), because a
 /// fleet worker rebinds `cfg.workspace_root` to its own worktree while the
 /// shared `SessionDurability` journal stays rooted at the lead's — a measurer
 /// attached here would snapshot the wrong tree, which is exactly why
 /// `turn_files`' `ENGINE_DRIVERS` records this door as `Blocked` on #3233 and
-/// why `STREAM_OWNERS` deliberately omits it. Publishing the measurer here
+/// why `STREAM_OWNERS` omits it. Publishing the measurer here
 /// would silently un-block #3233 rather than close #4730, so it stays withheld
 /// and this type is what says so out loud.
 pub(super) struct AttemptPointStream {

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -184,7 +184,7 @@ stream across the points — a child there is exactly as run-scoped as the round
 beside it, and a second row would split one run's spend in `stella stats`. The
 shared half is `RepublishingDriver`, which puts a door's stream back after every
 round it drives; what each door publishes is its own `PointStream`. `stella
-fleet` publishes the registry's event slot alone and deliberately not the
+fleet` publishes the registry's event slot alone and not the
 per-call work-tree measurement beside it: its worker rebinds
 `cfg.workspace_root` to its own worktree while the shared journal stays rooted
 at the lead's, so a measurer there would read the wrong tree (#3233).


### PR DESCRIPTION
`main` at `a7a46d3b6` fails `check-file-size` (#4821):
`crates/stella-cli/src/fleet_cmd.rs` is 1538 lines and is **not** grandfathered,
so the guard's own remedy is a split — "Do not add a baseline entry: the
baseline only covers files that predate the guard, and this is the rule that
stops the tree getting worse."

## The split

`fleet_cmd::render` takes the four functions that turn a finished run into
terminal output — `render_watch_line`, `truncate`, `print_dash_summary`,
`render_report` — plus the `SUMMARY_CHARS` width they share. They are the group
with no callers beyond the two print points and no dependency on the run
machinery: they read a finished report and write to stdout, which is why they
move together and why nothing else had to move with them.

`fleet_cmd.rs` 1538 → **1375**. `render.rs` is 177.

`SUMMARY_CHARS` is imported by the test module from `render` directly rather
than re-exported through the parent — the parent does not use it, and carrying
it only to satisfy a test is how an unused-import warning gets created.

## Two more reds on the same tree

Composed here rather than raced on separate branches, because separate repairs
for one red main deadlock each other behind this very check:

- **prose** — four `deliberately` filler-adverbs over the per-pattern
  allowance (`goal_wrapped/tests.rs`, `fleet_cmd/wrapped.rs` ×2,
  `crates/stella-runtime/README.md`). Each sentence already states its reason;
  the adverb sat in front of it.
- **clippy** — `explicit_auto_deref` on `RepublishingDriver::new`'s registry
  argument. `&Arc<T>` coerces to `&T` without the explicit reborrow.

## Evidence

| check | result |
|---|---|
| `make guards-fast` | exit 0 — `check-file-size` OK, `check-prose` OK |
| `make lint CARGO_SCOPE="-p stella-cli"` | exit 0 |
| `make doc-warnings` (stella-cli + stella-runtime) | exit 0 |
| `cargo test -p stella-cli --bin stella` | 2288 passed, 0 failed |
| `cargo fmt --check` | clean |

Labelled `unblocks-main` per the hold check's instruction, which is otherwise
red on #4821 and would block its own repair.

Closes #4821.

## Summary by Sourcery

Split fleet report rendering into its own module and clean up guard and lint violations to unblock the main branch.

Bug Fixes:
- Fix the clippy warning in fleet task setup by relying on implicit dereferencing for registry arguments.
- Remove unnecessary filler wording from prose checked by repository guards.

Enhancements:
- Split fleet terminal rendering into a dedicated module, reducing fleet_cmd.rs below the file-size limit while preserving report output behavior.