### PR TITLE
fix(stella-cli,stella-observatory,stella-tui): three citations that name nothing

### DIFF
--- a/crates/stella-cli/src/agent/tools.rs
+++ b/crates/stella-cli/src/agent/tools.rs
@@ -11,9 +11,10 @@ use super::*;
 use stella_plugin::{ArtifactIdentity, ArtifactKind};
 
 /// The single filesystem-isolation seam for developer script-tool discovery.
-/// The session stack goes through this report; candidate workspaces still
-/// call `discover_in_scopes` directly (see `workspace_ports`) and therefore
-/// miss the isolation gate.
+/// The session stack goes through this report, and since #3865 deleted the
+/// candidate-workspace tool chain there is no second path around it: every
+/// remaining `discover_in_scopes` caller lives inside `stella_tools::custom`
+/// itself.
 #[cfg(test)]
 pub(crate) fn custom_tool_report_for_workspace(
     root: &std::path::Path,

--- a/crates/stella-observatory/src/system_prompt.rs
+++ b/crates/stella-observatory/src/system_prompt.rs
@@ -14,7 +14,7 @@
 //! `agent/engine.rs`'s SessionStart hook append) actually emit — the same
 //! bargain `sent_context` takes for the receipt fold. Two tests pin the
 //! copy: `sections_split_a_real_shaped_prompt` here pins the exact bytes,
-//! and `the_observatory_provenance_markers_are_what_this_assembler_emits` in
+//! and `the_provenance_markers_are_what_this_assembler_emits` in
 //! `stella-cli`'s `agent/prompt/tests.rs` asserts a really-assembled prompt
 //! contains them, in this order, so a reworded heading fails on whichever
 //! side moved.

--- a/crates/stella-tui/src/views/transcript.rs
+++ b/crates/stella-tui/src/views/transcript.rs
@@ -732,7 +732,12 @@ fn kind_detail(kind: &EventKind) -> Vec<Span<'static>> {
             vec![Span::styled(format!(" · {tokens_per_sec} tok/s"), dim)]
         }
         EventKind::Run { touched } | EventKind::Other { touched, .. } => touched_detail(*touched),
-        _ => Vec::new(),
+        // Named rather than swept up by a wildcard, so adding an `EventKind`
+        // is an `E0004` here the way it already is in `head_glyph` (#4320).
+        // A kind that earns no detail column says so; it does not fall
+        // through. Both of these carry their measurement in the head's own
+        // subject, leaving nothing for a tail to add.
+        EventKind::Memory | EventKind::Compaction { .. } => Vec::new(),
     }
 }
 


### PR DESCRIPTION
Three small correctness fixes, each verified against the tree rather than taken from the issue's wording.

**#4790 — `agent/tools.rs:15` cited `workspace_ports`**, deleted by #3865. The issue asked for the name to be repointed; checking first showed the whole clause was stale. It claimed "candidate workspaces still call `discover_in_scopes` directly … and therefore miss the isolation gate", and `rg discover_in_scopes crates/` finds no such caller — every one left is inside `stella_tools::custom` itself. So the sentence promised a second path around the isolation seam that no longer exists, which is worse than a dangling name. Rewritten to state what is true now.

**#4619 — `system_prompt.rs:17` named a test that does not exist.** It cited `the_observatory_provenance_markers_are_what_this_assembler_emits`; the real test is `the_provenance_markers_are_what_this_assembler_emits` (no `observatory_` infix) at `crates/stella-cli/src/agent/prompt/tests.rs:699`. Items 1 and 3 of that issue were already done, so this citation was all that remained.

**#4727 — `views/transcript.rs`'s `kind_detail` ended in `_ => Vec::new()`** while `head_glyph` beside it is deliberately exhaustive (#4320), so a new `EventKind` would get a glyph by force and a detail column by silence. Exactly two variants were falling through — `Memory` and `Compaction` — and both are now named with the reason they earn no tail. A twelfth variant is an `E0004` in both places.

## Evidence

```
cargo test -p stella-tui --lib                       1131 passed; 0 failed
cargo test -p stella-tui --test deck_render_snapshots   24 passed; 0 failed
cargo clippy -p stella-tui -p stella-cli -p stella-observatory --all-targets -- -D warnings   exit 0
cargo doc … --no-deps                     exit 0   (plain form, run first)
cargo doc … --document-private-items      exit 0
cargo fmt --all --check                   exit 0
```

No witness test: all three are corrections to text and one exhaustiveness change whose failure mode is a future compile error, not a present assertion. The goldens are unchanged, which is the point — no rendered output moved.

Closes #4790
Closes #4619
Closes #4727

## Summary by Sourcery

Correct stale code citations and make transcript event-detail handling explicitly exhaustive.

Bug Fixes:
- Correct stale source citations in the CLI tool-isolation documentation and Observatory prompt documentation.
- Replace transcript event-kind wildcard handling with explicit coverage for kinds that intentionally have no detail text.

Enhancements:
- Keep transcript rendering exhaustive so newly added event kinds produce a compile-time review point instead of silently omitting details.