### PR TITLE
fix(guards): the main canary checks prose, so a prose-red main gets a tracker

### DIFF
--- a/scripts/main-canary.sh
+++ b/scripts/main-canary.sh
@@ -195,6 +195,28 @@ checks=(
   # trying to report. `--offline` applies only to the hermetic fixture, whose
   # workspace has no dependencies to fetch.
   "compile|cargo check --workspace --all-targets --locked${manifest_dir:+ --offline --manifest-path $manifest_dir/Cargo.toml}"
+  # A third shared cell: `scripts/prose-baseline.txt`. It earns its row the
+  # same way the two above do, and the mechanism is the one that makes a
+  # post-merge check the only possible catcher — `check-prose` judges the
+  # whole tree with no base-relative branch, so the moment drift lands on
+  # `main` it fails every open PR at once, for a reason none of their authors
+  # caused and none of them can see coming.
+  #
+  # That is worse than the file-size case rather than milder. `check-file-size`
+  # at least reports inherited drift as drift and passes the branch; the prose
+  # gate has no such arm, so the first PR to run after the drift lands simply
+  # goes red and its author starts debugging their own diff.
+  #
+  # It has happened: at a7a46d3b6 this canary ran, reported `FAIL file-size`
+  # alone and filed #4821 naming only that. Prose was red too, in three files
+  # nobody in flight had touched (#4763 had re-partitioned the baseline into
+  # per-category counts mid-session). The prose failure surfaced later on an
+  # unrelated repair PR's `gate steps` job, where it read as that PR's fault
+  # and cost a full CI cycle to attribute (#4828).
+  #
+  # No `--absolute` equivalent is needed or available: the guard is already
+  # whole-tree, which is the property that makes it belong here.
+  "prose|python3 ./scripts/check-prose.py"
 )
 
 # The remediation for ONE failing check. Per-check on purpose: this block used
@@ -221,6 +243,14 @@ SH
   compile)
     cat <<'SH'
 cargo check --workspace --all-targets --locked
+SH
+    ;;
+  prose)
+    cat <<'SH'
+# Delete the flagged constructions — never raise the baseline. Run
+#   make prose-report
+# for the file, line and what to write instead. `make prose-update` refuses to
+# raise a count or add a file, so a red gate clears only by deleting prose.
 SH
     ;;
   *)

--- a/scripts/test-main-canary.sh
+++ b/scripts/test-main-canary.sh
@@ -109,6 +109,15 @@ expect "a composing tree passes" 0 "OK — main composes green" --manifest-dir "
 refute "a green run announces nothing" "gh issue create" \
   --announce --dry-run --manifest-dir "$tmp/clean"
 
+# The prose row RUNS, rather than merely being present in the checks array
+# (#4828). It cannot be exercised the way `compile` and `lockfile-sync` are:
+# those two take `--manifest-dir` and can be pointed at a broken fixture,
+# while `check-prose` reads the live tree and has no such switch — the same
+# reason `file-size` has no red fixture case here either. So the assertion
+# available is that the row reports its verdict at all, which is exactly what
+# was missing when the canary called a prose-red `main` green.
+expect "the prose row runs and reports" 0 "ok   prose" --manifest-dir "$tmp/clean"
+
 # ── red: the 2026-08-16 incident ──────────────────────────────────────────
 # The shared-cell shape: the version moved and the lock did not. Both PRs that
 # composed into this were green on their own.


### PR DESCRIPTION
`scripts/main-canary.sh` ran `lockfile-sync`, `file-size` and `compile`, but not `check-prose`. So a `main` that was red on prose alone was reported green, no `main-red` issue was filed, and the failure surfaced later on some unrelated PR's `gate steps` job — where it reads as that PR's fault.

**Why prose belongs here, on this file's own admission rule** ("only composition-sensitive checks — the ones where two green branches can still compose red"): `check-prose` judges the whole tree and has no base-relative branch. The moment drift lands on `main` it fails *every* open PR simultaneously, for a reason none of their authors caused and none could have seen coming. That is not merely eligible for a post-merge check — a post-merge check is the only thing that can catch it.

It is worse than the `file-size` case rather than milder: `check-file-size` reports inherited drift *as drift* and passes the branch, while the prose gate simply goes red and sends its author debugging their own diff.

**It already happened.** At `a7a46d3b6` the canary ran, reported `FAIL file-size` alone and filed #4821 naming only that. Prose was red too, in three files nobody in flight had touched — #4763 had re-partitioned the baseline into per-category counts mid-session. I hit this personally: a repair PR went red on prose drift in `fleet_cmd/wrapped.rs`, `goal_wrapped/tests.rs` and `stella-runtime/README.md`, none of which it touched.

## The test, and its honest limit

`compile` and `lockfile-sync` take `--manifest-dir` and can be pointed at a broken fixture. `check-prose` reads the live tree and has no such switch — which is also why `file-size` has no red fixture case here. So the assertion available is that the row **runs and reports its verdict**, which is exactly what was missing.

Run both ways:

```
with the row:     test-main-canary: 25 passed, 0 failed
row removed:      FAIL  the prose row runs and reports — output did not contain: ok   prose
                  test-main-canary: 24 passed, 1 failed
```

Also: `bash -n` clean, `shellcheck -s bash` clean, `make guards-fast` clean, `check-prose` OK (none added by this diff).

The remedy arm tells the reader to delete the constructions and never raise the baseline — the mistake #3655 is on record for, in its prose form.

Closes #4828

## Summary by Sourcery

Ensure the main canary catches whole-tree prose baseline failures before they surface as unrelated pull request failures.

Bug Fixes:
- Add the prose baseline check to the main canary so prose-red main branches are detected and tracked immediately.
- Provide prose-specific remediation guidance that directs contributors to remove flagged constructions rather than raise the baseline.

Tests:
- Verify that the main canary executes the prose check and reports its result.