### PR TITLE
fix(guards): count a resolved relative href as a citation in the orphan report

### DIFF
--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -636,6 +636,23 @@ def check(docs, manifest_on_disk, fix=False):
                     f"     `doc:<id>` so it cannot break again. `make doc-links-fix`\n"
                     f"     repoints one across a move it can prove."
                 )
+            else:
+                # A resolved relative href is a citation, and the orphan report
+                # has to count it as one (#4757). `docs/README.md` calls this
+                # the prevailing style inside `docs/`, so without this a
+                # document every neighbour links to is still reported as cited
+                # by nothing -- and a report whose entries are mostly wrong is
+                # one people stop reading, which costs the real orphan its
+                # only surface.
+                #
+                # Recorded here rather than by widening `cited_ids` at the
+                # bottom of the loop, because the branch above returns before
+                # reaching it: the two rooted forms resolve to a `Doc`, and
+                # this one resolves to a path that may belong to no document
+                # at all.
+                target_doc = by_path.get(resolved)
+                if target_doc is not None:
+                    cited_ids[target_doc.id].append(f"{path}:{line}")
             continue
         if kind == "id":
             doc = by_id.get(target)


### PR DESCRIPTION
`report_orphans` consulted `cited_ids`, which was populated from the two rooted citation forms only — `doc:<id>` and a repo-rooted `docs/….md` path. A **relative** markdown href was validated (#3886 added that, and `heal_relative_hrefs` repoints one across a move) but never recorded as a citation.

So a document that every neighbour links to was still reported as cited by nothing — and `docs/README.md` itself calls relative links "the prevailing style" inside `docs/`. The cost is not the wrong number: it is that a report whose entries are mostly false is one people stop reading, which leaves the real orphan with no surface.

## Measured on the live tree

```
before:  nothing cites these 14 document(s) -- retire or adopt:
after:   nothing cites these  7 document(s) -- retire or adopt:
```

Half the list was documents their own neighbours cite. The seven that remain are genuine, and they are what #4773 triages:

```
docs/spec/oxagen-trace-drain.md              (proposed)
docs/spec/adaptive-context/context-prs-spec.md (superseded)
docs/reference/diagnostics.md                (living)
docs/spec/step-grading-and-productive-ratio.md (living)
docs/wire/README.md                          (no status)
docs/playbooks/tool-removal.md               (living)
docs/brand/prompts/stella-design-system-prompt.md (no status)
```

## Where the recording goes, and why not the obvious place

At the bottom of the citation loop there is already a `cited_ids[doc.id].append(...)`, and widening that would have been the smaller diff. It cannot work: the `relhref` branch `continue`s before reaching it, because the two rooted forms resolve to a `Doc` while this one resolves to a *path* that may belong to no document at all (a plain markdown file under `docs/` with no frontmatter is deliberately not citable). So the append happens in the branch, guarded on the path actually being a known document.

## Evidence

There is no self-test harness for this guard, so the witness is the reproducible before/after above rather than a failing test — stating that plainly rather than implying a test exists. Also: `ruff check` clean, `make guards-fast` clean, `check-prose` OK (none added).

This is #4757's half. #4773 is the other — triaging the residue — and it now has an accurate list to work from; I have noted the corrected count there.

Closes #4757

## Summary by Sourcery

Bug Fixes:
- Count resolved relative Markdown links as citations in orphan reports when they target known documents.