### PR TITLE
fix(guards): stop reporting a superseded document as an uncited orphan

### DIFF
--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -730,6 +730,14 @@ def report_orphans(docs, cited_ids):
     for doc in docs:
         if doc.status == "archived":
             continue
+        # A superseded document cannot be cited without failing this same
+        # guard -- `check` errors on `doc:<id>` naming one and tells the
+        # reader to cite the successor. So it can never legitimately appear
+        # in `cited_ids`, and listing it under "retire or adopt" asks for the
+        # one thing the guard forbids. `superseded_by` already records where
+        # it went; being uncited is the correct end state, not a finding.
+        if doc.status == "superseded":
+            continue
         if doc.id and cited_ids.get(doc.id):
             continue
         # A bare document is uncitable by construction, so "uncited" is not news


### PR DESCRIPTION
`report_orphans` skips `archived` but not `superseded`. That is inconsistent with the rest of the guard: `check` **errors** on a `doc:<id>` citation naming a superseded document and tells the reader to cite the successor instead.

So a superseded document can never legitimately appear in `cited_ids`, is therefore reported as an orphan on every run forever, and the report's advice — "retire or adopt" — asks for the one thing the guard itself forbids. Its `superseded_by` frontmatter already records where it went; being uncited is the correct end state for it, not a finding.

## Scope, stated plainly

```
rg -l '^status: superseded' docs/ --glob '*.md' | wc -l   →  1
```

Exactly one document carries that status today (`docs/spec/adaptive-context/context-prs-spec.md`), so this is a rule correction with a single current subject rather than a sweep. I would rather say that than let the diff imply broader reach.

## Effect

```
before this PR:  nothing cites these 7 document(s)
after:           nothing cites these 6 document(s)
```

(The 14 → 7 step was #4757, merged as PR #4837.)

The six that remain each need a real adopt / mark-uncitable / retire decision, which is #4773's work — I have not guessed at any of them. Two look mechanical from the outside and are not: `docs/wire/README.md` is reported *deliberately*, under the rule that a bare document over 100 lines is one somebody clearly meant to matter, so giving it an id would not remove it — only a citation would.

`ruff check` clean, `make guards-fast` clean, `check-prose` OK.

Refs #4773

## Summary by Sourcery

Bug Fixes:
- Stop reporting superseded documents as uncited orphans, since the guard correctly rejects citations to them and directs readers to their successors.