### PR TITLE
fix(guards): the canary reports the commit it tested, not one it blames

### DIFF
--- a/scripts/main-canary.sh
+++ b/scripts/main-canary.sh
@@ -334,7 +334,12 @@ Checked: $(printf '%s ' "${checks[@]%%|*}")"
       printf 'main-canary: main recovered — closed #%s\n' "$open_issue" || true
     fi
   else
-    body="The post-merge canary found \`main\` broken at \`${short_sha}\`.
+    body="The post-merge canary tested \`main\` at \`${short_sha}\` and it is red.
+
+**This names the commit that was tested, not the commit that broke the tree.**
+This run did not check \`${short_sha}\`'s parent, so the break may be older —
+possibly by many merges. Confirm before reverting anything: re-run the failing
+check on \`${short_sha}^\` and walk back while it still fails.
 
 Failing: **${failed_names}**
 

--- a/scripts/test-main-canary.sh
+++ b/scripts/test-main-canary.sh
@@ -185,6 +185,19 @@ expect "the issue explains the pre-merge blind spot" 1 "shared cell" \
 expect "the issue is labelled so only one stays open" 1 "main-red" \
   --announce --dry-run --manifest-dir "$tmp/red"
 
+# The body must not assert that the break STARTED at the commit it tested
+# (#4815). It cannot know that without checking the parent, which this run
+# does not do. #4810 made exactly that claim about `ce6b1cf3c` — an innocent
+# merge whose whole diff to the broken file was three of its own lines — and
+# the first instinct of everyone reading it was to revert that commit. The
+# real cause was many merges older.
+expect "the issue says what it tested, not what broke" 1 "tested \`main\` at" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+expect "and warns the cause may be older" 1 "not the commit that broke the tree" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+refute "and never claims the break started there" "canary found \`main\` broken at" \
+  --announce --dry-run --manifest-dir "$tmp/red"
+
 # The label does not exist in this repository yet, and `gh issue create
 # --label` fails outright on an unknown label — the canary would have broken at
 # the exact moment it first had something to say. Creating it is idempotent.


### PR DESCRIPTION
The canary's issue body said *"found `main` broken at `<sha>`"*. That asserts causation the run cannot establish — it tests one commit and never looks at the parent.

**It misdirected a real investigation.** #4810 made that claim about `ce6b1cf3c`, which is #4799's merge commit and was not the cause: that PR's entire diff to the broken file was three of its own lines, and the commit immediately before it already carried the duplicate definition. The tree had not compiled for many merges. The first instinct of everyone who reads "broken at X" is to revert X, and here that would have reverted an innocent PR while leaving the break in place.

## The wording now

```
The post-merge canary tested `main` at `<sha>` and it is red.

**This names the commit that was tested, not the commit that broke the tree.**
This run did not check `<sha>`'s parent, so the break may be older — possibly
by many merges. Confirm before reverting anything: re-run the failing check on
`<sha>^` and walk back while it still fails.
```

This is **option 2** of the two the issue offers, and the issue says so itself: *"Option 2 alone would have been enough here."* Bisecting (option 1) would mean checking out and re-running per commit inside the canary, and the issue's own constraint is that an unbounded walk on a long-broken tree is worse than the hedge. A hedge that is true beats a precise claim that is wrong — the same rule the repository applies everywhere else about evidence distinguishing a claim from its opposite.

## Evidence, run both ways

Three cases, including a `refute` so the old sentence cannot come back:

```
with the fix:      test-main-canary: 28 passed, 0 failed
old wording:       FAIL  the issue says what it tested, not what broke
                   FAIL  and warns the cause may be older
                   FAIL  and never claims the break started there
                   test-main-canary: 25 passed, 3 failed
```

`shellcheck -s bash` clean on both scripts, `bash -n` clean, `check-prose` OK.

Closes #4815

## Summary by Sourcery

Clarify canary failure reports to prevent misleading commit attribution and unsafe revert decisions.

Bug Fixes:
- Correct the post-merge canary issue wording so it identifies the tested commit without incorrectly attributing the tree breakage to it.

Enhancements:
- Warn that the failure may predate the tested commit and guide investigators to verify the parent before reverting changes.

Tests:
- Add regression coverage ensuring canary reports distinguish the tested commit from the possible cause and avoid the previous wording.