### PR TITLE
docs(stella-tui,stella-cli): drop the two present-tense PLAN rail claims

### DIFF
--- a/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
+++ b/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
@@ -8,7 +8,7 @@
 //!
 //! `ScopeReview` had a complete consumer chain and no producer at all after
 //! the staged pipeline left the workspace (#3865): the deck's plan card, the
-//! plan rail, the fleet dashboard's `Blocked` row, the transcript fold and
+//! fleet dashboard's `Blocked` row, the transcript fold and
 //! the forwarder's board seeding all branch on it, and every `ScopeProposal`
 //! in the tree was a fixture. The pipeline's own emitter had asked a planner
 //! model to write a plan and then gated on it — but the raw step loop that

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -131,8 +131,8 @@ fn a_turn_that_ends_mid_park_closes_the_span_anyway() {
 }
 
 /// A *retryable* error is a warning mid-flight, not the end of the turn, so it
-/// must leave an open park alone — the same reading the plan rail and the
-/// plan take of the identical event.
+/// must leave an open park alone — the same reading the plan takes of the
+/// identical event.
 #[test]
 fn a_retryable_error_does_not_close_an_open_park() {
     let mut model = SessionModel::new();


### PR DESCRIPTION
SPEC 5 folded the always-on PLAN rail into the tab row's breadcrumb and `crates/stella-tui/src/views/plan_rail.rs` was deleted, so a comment telling a reader that some surface renders it *now* points at nothing.

## What the count actually was

#4685 estimated "about thirty doc comments and code comments". Measured on current `main`, five references remain and **two** are wrong:

| site | tense | verdict |
|---|---|---|
| `stella-tui/src/model/tests.rs:134` | "the same reading the plan rail **and the plan take**" | stale — fixed |
| `stella-cli/.../task_tap/plan_gate.rs:11` | "the plan card, the plan rail, … all **branch** on it" | stale — fixed |
| `stella-tui/src/views/session.rs:185` | "the PLAN rail … **are gone**" | accurate history — left |
| `stella-cli/.../task_tap.rs:312` | consumers "**branched** on it" before #3865 | accurate history — left |
| `stella-tui/README.md:167` | "SPEC 5 **folded** the always-on PLAN rail into the breadcrumb" | describes the fold itself — left |

The gap between thirty and two is because the floating-cards port and the SPEC 5 work already cleaned most of them; the issue was filed against an older tree.

**Why the other three stay.** They are past-tense statements about what was removed and why, which is exactly the record a reader needs to understand the current shape. Rewriting them to avoid the words "plan rail" would make accurate history read as though the rail never existed — a different kind of wrong comment, and the more expensive kind, because the next reader re-derives the removal.

## Evidence

```
cargo test -p stella-tui --lib                     1131 passed; 0 failed
cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings   exit 0
cargo fmt --all --check                            exit 0
check-prose                                        OK — none added
```

No witness test: the change is three lines of comment text, and its failure mode is a reader misled rather than an assertion that can flip.

Closes #4685

## Summary by Sourcery

Enhancements:
- Remove two stale present-tense references to the retired PLAN rail from Stella TUI and CLI comments while preserving accurate historical references.