### PR TITLE
docs(adr,website): the durable staleness map is gone, and two pages still promised it

### DIFF
--- a/docs/adr/0013-session-artifact-boundary.md
+++ b/docs/adr/0013-session-artifact-boundary.md
@@ -7,6 +7,15 @@ status: proposed
 # ADR 0013: The session artifact boundary
 
 - Status: **Proposed** — awaiting ratification by the repository owner.
+- **Amendment, 2026-08-25 (#4653):** this ADR founds its replay fingerprint on
+  `OBSERVED_BLOB`, the session's durable staleness map. That blob was removed
+  in #3780 (landed by PR #4645) because nothing ever wrote it and nothing ever
+  read it — the no-clobber guard that shipped keys on line coverage, not on a
+  digest map. Every reference to it below therefore describes a mechanism this
+  tree does not have. The decision text is left as written, because an ADR is a
+  record of what was decided and when; what needs settling before ratification
+  is which mechanism the fingerprint rests on instead. That choice is left to
+  whoever ratifies this ADR.
 - Date: 2026-08-02
 - Deciders: repository owner (pending)
 - Scope note: ADRs 0001–0012 are the Phase 0 adaptive-context series. This one

--- a/website/content/docs/principles/session-artifacts.mdx
+++ b/website/content/docs/principles/session-artifacts.mdx
@@ -18,8 +18,10 @@ about, because it points straight at where the line belongs.
   reasoning below is settled in
   [ADR 0013](https://github.com/macanderson/stella/blob/main/docs/adr/0013-session-artifact-boundary.md);
   the export and replay APIs it describes are not built yet. Everything said
-  about *current* behaviour — the local store, the staleness map, the
-  reverse-RPC model — is shipping today.
+  about *current* behaviour — the local store, the reverse-RPC model — is
+  shipping today. The durable staleness map is **not**: it was removed in
+  #3780 as a map nothing ever wrote or read, so the fingerprint described
+  below has yet to be founded on a mechanism that exists.
 </Callout>
 
 ## Why local state is local on purpose
@@ -100,9 +102,12 @@ So the artifact carries a fingerprint of the tree it came from, and **replay
 verifies it and refuses by default**. stella is not naming your workspace. It is
 checking that this artifact belongs to this tree.
 
-The fingerprint is not a new mechanism — it is the staleness map the no-clobber
-guard already keeps: every path this session touched, and the digest of what it
-saw there. Verifying it is re-hashing those paths in the target tree. A mismatch
+The fingerprint was to be founded on the staleness map the no-clobber guard was
+thought to keep — every path this session touched, and the digest of what it saw
+there. That map was removed in #3780: nothing wrote it and nothing read it, so
+the fingerprint needs a mechanism this tree actually has before it can be built.
+What follows describes the intended shape, not a mechanism in place.
+Verifying it is re-hashing those paths in the target tree. A mismatch
 names the exact files, exactly as a refused write does, and nothing is consumed.
 Overriding it is possible, but it is a distinct argument you pass, never a
 fallback stella takes on your behalf when the check fails.


### PR DESCRIPTION
#3780 removed `OBSERVED_BLOB`, the session's durable staleness map — nothing ever wrote it and nothing ever read it, and the no-clobber guard that actually shipped keys on line coverage instead. PR #4645 corrected the four code and doc sites in its sweep. Two documents outside it still described the removed mechanism as present, and both are pages a reader goes to specifically to learn how the guarantee works.

## The website page — a false claim about today

`website/content/docs/principles/session-artifacts.mdx`'s callout listed the staleness map among the things "shipping today", beside the local store and the reverse-RPC model. That is the half of this issue that was simply wrong, and it is corrected: the map is named as removed, with the issue number, so a reader is not left to discover it from the code.

Its §"the fingerprint is not a new mechanism" paragraph then founded the replay fingerprint on that map. Reworded to say what is true — the fingerprint needs a mechanism this tree actually has before it can be built, and what follows is the intended shape rather than something in place.

## The ADR — an amendment, not a rewrite

`docs/adr/0013-session-artifact-boundary.md` is `status: proposed`, awaiting ratification, and it founds its replay fingerprint on `OBSERVED_BLOB` in three places.

I did **not** rewrite those passages. An ADR is a record of what was decided and when; editing the reasoning to match a later removal makes the record lie about its own moment, and the next reader loses the ability to see that the decision rested on something that has since gone. So it gets a dated amendment at the top instead, naming the removal, pointing at #3780 and PR #4645, and saying plainly that every reference below describes a mechanism this tree does not have.

**What the amendment deliberately does not do is pick the replacement.** Re-founding the fingerprint is a design decision — the issue says so, and it belongs to whoever ratifies the ADR, not to a docs pass.

## Verify

The issue's own check:

```
rg -n 'OBSERVED_BLOB|staleness map' docs/ website/
```

leaves no hit that describes a durable, restored map as current behaviour. The two surviving hits in the website page both now say it was removed; the ADR's hits sit under the amendment that frames them.

`check-prose` OK — and it caught a filler adverb in my own amendment, which I deleted rather than baselined. `check-doc-links` exit 0, `make guards-fast` clean.

Closes #4653

## Summary by Sourcery

Correct the session artifact documentation and ADR to reflect the removal of the durable staleness map without prematurely selecting a replacement mechanism.

Bug Fixes:
- Correct documentation that presented the removed durable staleness map as current behavior.
- Clarify that the replay fingerprint remains an intended design rather than an implemented mechanism.

Enhancements:
- Add a dated amendment to ADR 0013 documenting the removal of OBSERVED_BLOB while preserving the original decision record and deferring the replacement mechanism.

Documentation:
- Update the session artifacts documentation and ADR 0013 to accurately describe the status of the durable staleness map and replay fingerprint.