### PR TITLE
test(stella-runtime): wrapper_dispatch runs on Windows, on the in-tree fixture

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -109,3 +109,4 @@ jobs:
           cargo test -p stella-runtime
           --test wrapper_socket
           --test wrapper_transport_limits
+          --test wrapper_dispatch

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -164,7 +164,7 @@ fn measurements(pairs: &[(&str, &str)]) -> String {
 /// The reference wrapper: a budget rather than a flip, so its verdict is
 /// decided by a number it reports against a threshold a human read at install.
 /// `wrapper_dispatch.rs`'s own reference plugin, which its `/bin/sh` script
-/// used to spell out (#4697). Distinct from [`reference`] above in two ways
+/// used to spell out (#4697). Distinct from [`fn@reference`] above in two ways
 /// the tests assert on: the `after_turn` p50 keys on "unrolled the loop"
 /// rather than "slower", and the `before_turn` declares a `scope`.
 ///

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -42,6 +42,13 @@
 //! - `hang` — never read, never answer (the timeout case).
 //! - `env-probe` — report whether the parent's environment leaked in, and what
 //!   was granted.
+//! - `tally <path>` — append a byte per start, so a caller counting bytes
+//!   counts process starts.
+//! - `dispatch-reference` — `wrapper_dispatch.rs`'s reference wrapper: a
+//!   `scope`-declaring `before_turn`, and an `after_turn` p50 that keys on
+//!   whether the turn mentioned the correction.
+//! - `dispatch-contributed` — the same, with a third branch for a contributed
+//!   stage name, which is what proves it reaches the plugin as itself.
 //! - `candidate-probe` — report facts about the candidate grant that arrived in
 //!   the request: whether its root really holds the test file, whether the test
 //!   program is the one named, whether the baseline was red.
@@ -88,6 +95,22 @@ fn main() {
                 ("granted", &granted),
             ]));
         }
+        // Appends one byte per start, so a caller counting bytes counts
+        // process starts — how `wrapper_dispatch.rs` proves a composition
+        // reuses one process rather than spawning per point.
+        "tally" => {
+            let _ = read_request();
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(arg(&args, 1))
+            {
+                let _ = f.write_all(b"x\n");
+            }
+            emit("{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1}}");
+        }
+        "dispatch-reference" => dispatch_reference(&read_request()),
+        "dispatch-contributed" => dispatch_contributed(&read_request()),
         "candidate-probe" => candidate_probe(&read_request()),
         "flood" => flood(arg(&args, 1).parse().unwrap_or(0), arg(&args, 2)),
         "trailing" => trailing(arg(&args, 1).parse().unwrap_or(0)),
@@ -140,6 +163,52 @@ fn measurements(pairs: &[(&str, &str)]) -> String {
 
 /// The reference wrapper: a budget rather than a flip, so its verdict is
 /// decided by a number it reports against a threshold a human read at install.
+/// `wrapper_dispatch.rs`'s own reference plugin, which its `/bin/sh` script
+/// used to spell out (#4697). Distinct from [`reference`] above in two ways
+/// the tests assert on: the `after_turn` p50 keys on "unrolled the loop"
+/// rather than "slower", and the `before_turn` declares a `scope`.
+///
+/// The branch is the whole point. A mode that answered one canned body
+/// whatever it was asked would pass nothing here — the dispatch tests read
+/// both p50 values back and compare them, so a fixture that stopped
+/// branching fails them rather than passing vacuously.
+fn dispatch_reference(request: &str) {
+    if request.contains("\"point\":\"after_turn\"") {
+        let p50 = if request.contains("unrolled the loop") {
+            101
+        } else {
+            118
+        };
+        emit(&measurements(&[("p50", &p50.to_string())]));
+    } else {
+        emit(
+            "{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1,\"context\":\
+             [{\"label\":\"budget\",\"text\":\"the recorded p50 budget is 105\"}],\
+             \"role\":\"triage\",\"scope\":[\"crates/stella-core\"],\
+             \"publish\":[{\"signal\":\"questions\",\"value\":{\"count\":2}}]}}",
+        );
+    }
+}
+
+/// The contributed-stage plugin, whose three-way branch is what proves a
+/// contributed stage name reaches the plugin as itself rather than as the
+/// host stage it runs under.
+fn dispatch_contributed(request: &str) {
+    if request.contains("\"point\":\"after_turn\"") {
+        emit(&measurements(&[("answers", "1")]));
+    } else if request.contains("\"stage\":\"triage-lite\"") {
+        emit(
+            "{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1,\"context\":\
+             [{\"label\":\"triage-lite\",\"text\":\"this task is small; skip the plan\"}]}}",
+        );
+    } else {
+        emit(
+            "{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1,\"context\":\
+             [{\"label\":\"other\",\"text\":\"a host stage\"}]}}",
+        );
+    }
+}
+
 fn reference(request: &str) {
     if request.contains("\"point\":\"after_turn\"") {
         let p50 = if request.contains("slower") { 118 } else { 103 };

--- a/crates/stella-runtime/tests/wrapper_dispatch.rs
+++ b/crates/stella-runtime/tests/wrapper_dispatch.rs
@@ -10,15 +10,16 @@
 //! handle and no dispatch.
 //!
 //! These tests drive `stella_runtime::WrapperDispatch` — the production
-//! sequence — with a plugin written in `sh` on one side and a recording
+//! sequence — with a plugin binary on one side and a recording
 //! [`TurnDriver`] on the other. They fail before the change for the plainest
 //! possible reason: `WrapperDispatch` did not exist, so no code path anywhere
 //! carried a contribution from a plugin into a turn.
 //!
-//! `cfg(unix)` for the reason `wrapper_socket.rs` states: the plugins here are
-//! `/bin/sh` scripts, so on Windows this file compiles to nothing (#3497).
-
-#![cfg(unix)]
+//! The plugins here drive `wrapper-plugin-fixture`, the in-tree binary
+//! `wrapper_socket.rs` introduced, so this file runs on Windows too (#4697).
+//! Its branching modes are what the `/bin/sh` scripts used to spell out; the
+//! branch is asserted by the tests below rather than assumed, so a fixture
+//! that stopped branching fails them.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -79,38 +80,19 @@ if = "questions > 0"
 name = "execute"
 "#;
 
-/// The plugin. It contributes a budget note at every stage, and reports a p50
-/// that is **outside** the budget until the turn it is told about mentions the
-/// correction — so a second round is the only thing that can make it green.
-const PLUGIN: &str = r#"
-input=$(cat)
-case "$input" in
-  *'"point":"after_turn"'*)
-    case "$input" in
-      *"unrolled the loop"*) p50=101 ;;
-      *) p50=118 ;;
-    esac
-    printf '{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"not-attempted","measurements":{"p50":%s}}}}\n' "$p50"
-    ;;
-  *)
-    printf '%s\n' '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"budget","text":"the recorded p50 budget is 105"}],"role":"triage","scope":["crates/stella-core"],"publish":[{"signal":"questions","value":{"count":2}}]}}'
-    ;;
-esac
-"#;
-
 fn manifest() -> PluginManifest {
     PluginManifest::from_toml_str(MANIFEST).expect("the reference manifest loads")
 }
 
-fn plugin(script: &str) -> Arc<SubprocessWrapper> {
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
+
+fn plugin(mode: &[&str]) -> Arc<SubprocessWrapper> {
+    let mut argv = vec![FIXTURE.to_string()];
+    argv.extend(mode.iter().map(|part| (*part).to_string()));
     Arc::new(
-        SubprocessWrapper::declare(
-            vec!["/bin/sh".into(), "-c".into(), script.into()],
-            Vec::new(),
-            DEFAULT_WRAPPER_TIMEOUT,
-        )
-        .expect("the transport is declared with a program and a budget")
-        .wrapper,
+        SubprocessWrapper::declare(argv, Vec::new(), DEFAULT_WRAPPER_TIMEOUT)
+            .expect("the transport is declared with a program and a budget")
+            .wrapper,
     )
 }
 
@@ -213,7 +195,8 @@ impl TurnDriver for Recorder {
 /// for another one.
 #[tokio::test]
 async fn a_wrapper_plugins_verdict_decides_whether_another_turn_runs() {
-    let dispatch = WrapperDispatch::bind(manifest(), plugin(PLUGIN)).expect("[wrapper] declared");
+    let dispatch = WrapperDispatch::bind(manifest(), plugin(&["dispatch-reference"]))
+        .expect("[wrapper] declared");
     assert_eq!(dispatch.variant(), "reference-v1");
 
     // The first turn does not mention the correction, so the plugin measures
@@ -341,21 +324,6 @@ name = "execute"
 /// A plugin that answers **differently per stage**, so what reaches it is
 /// observable rather than assumed: only the request naming `triage-lite`
 /// produces the lite-triage note.
-const CONTRIBUTED_PLUGIN: &str = r#"
-input=$(cat)
-case "$input" in
-  *'"point":"after_turn"'*)
-    printf '%s\n' '{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"not-attempted","measurements":{"answers":1}}}}'
-    ;;
-  *'"stage":"triage-lite"'*)
-    printf '%s\n' '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"triage-lite","text":"this task is small; skip the plan"}]}}'
-    ;;
-  *)
-    printf '%s\n' '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"other","text":"a host stage"}]}}'
-    ;;
-esac
-"#;
-
 /// **The witness for #3963.** A stage that exists only because a manifest said
 /// so is dispatched under its own word: the plugin is asked `before_turn` for
 /// `triage-lite`, and what it contributes for that stage reaches the turn.
@@ -367,7 +335,7 @@ esac
 async fn a_contributed_stage_is_dispatched_under_its_own_word() {
     let manifest = PluginManifest::from_toml_str(CONTRIBUTED_MANIFEST)
         .expect("a manifest may contribute a stage");
-    let dispatch = WrapperDispatch::bind(manifest, plugin(CONTRIBUTED_PLUGIN))
+    let dispatch = WrapperDispatch::bind(manifest, plugin(&["dispatch-contributed"]))
         .expect("[wrapper] declared")
         .with_host_max_holds(0);
 
@@ -407,7 +375,7 @@ async fn a_contributed_stage_is_dispatched_under_its_own_word() {
 /// running forever — and the unmet clause is reported, never dropped.
 #[tokio::test]
 async fn a_spent_allowance_stops_the_loop_and_still_reports_what_is_unmet() {
-    let dispatch = WrapperDispatch::bind(manifest(), plugin(PLUGIN))
+    let dispatch = WrapperDispatch::bind(manifest(), plugin(&["dispatch-reference"]))
         .expect("[wrapper] declared")
         .with_host_max_holds(1);
     let mut host = Recorder::new(vec!["rewrote the parser"]);
@@ -451,8 +419,8 @@ async fn a_spent_allowance_stops_the_loop_and_still_reports_what_is_unmet() {
 /// collected. Both failures are reported.
 #[tokio::test]
 async fn a_wrapper_that_fails_abstains_and_the_turn_still_runs() {
-    let dispatch = WrapperDispatch::bind(manifest(), plugin("cat >/dev/null; exit 7"))
-        .expect("[wrapper] declared");
+    let dispatch =
+        WrapperDispatch::bind(manifest(), plugin(&["exit", "7", ""])).expect("[wrapper] declared");
     let mut host = Recorder::new(vec!["did the work anyway"]);
     let report = dispatch
         .run(input("make the parser faster"), &mut host)
@@ -501,8 +469,8 @@ async fn an_undeclared_point_is_never_dispatched() {
     // a fault and an undispatched one is silence. Three stages resolve, and if
     // `before_turn` were asked anyway there would be four faults rather than
     // the one `after_turn` earns.
-    let dispatch = WrapperDispatch::bind(manifest, plugin("cat >/dev/null; exit 7"))
-        .expect("[wrapper] declared");
+    let dispatch =
+        WrapperDispatch::bind(manifest, plugin(&["exit", "7", ""])).expect("[wrapper] declared");
     let mut host = Recorder::new(vec!["work"]);
     let report = dispatch
         .run(input("make the parser faster"), &mut host)
@@ -581,19 +549,12 @@ points = ["before_turn"]
 /// One `before_turn` answer, and one line appended to `path` per process start
 /// — counted by the child itself, because that is the only place the cost is
 /// real.
-fn counting_plugin(path: &str) -> String {
-    format!(
-        "cat >/dev/null\nprintf 'x\\n' >>{path}\n\
-         printf '%s\\n' '{{\"point\":\"before_turn\",\"body\":{{\"protocol_version\":1}}}}'\n"
-    )
-}
-
 /// Run one round against the counting plugin and answer with how many times it
 /// was started.
 async fn process_starts(manifest: &str, path: &str) -> usize {
     let dispatch = WrapperDispatch::bind(
         PluginManifest::from_toml_str(manifest).expect("the counting manifest loads"),
-        plugin(&counting_plugin(path)),
+        plugin(&["tally", path]),
     )
     .expect("[wrapper] declared");
     let mut host = Recorder::new(vec!["done"]);


### PR DESCRIPTION
`crates/stella-runtime/tests/wrapper_dispatch.rs` was `#![cfg(unix)]` because its plugins were `/bin/sh` scripts, so on Windows it compiled to nothing. It is the first of the twelve files #4697 names as portable onto `wrapper-plugin-fixture`, and the one whose pattern the rest can copy.

## What moved

Two shell scripts became two fixture modes, and the process-counting helper became a third:

| was | now |
|---|---|
| `PLUGIN` — `case` on `after_turn` / "unrolled the loop" | `dispatch-reference` |
| `CONTRIBUTED_PLUGIN` — three-way `case` including `"stage":"triage-lite"` | `dispatch-contributed` |
| `counting_plugin(path)` — `printf 'x' >>path` | `tally <path>` |
| `cat >/dev/null; exit 7` | the existing `exit` mode |

`wrapper_dispatch` is added to `windows-check.yml`'s test list, which is the point of the exercise.

## The branch is load-bearing, and I checked rather than assumed

These scripts do not answer one canned body — they read the request and branch on it. A fixture mode that ignored the request would still return well-formed JSON, and the risk is a port that passes for the wrong reason.

It does not. The existing tests already assert the branch *outcomes*, so ablating the branch breaks them. Replacing the p50 selection with a constant:

```
test a_wrapper_plugins_verdict_decides_whether_another_turn_runs ... FAILED
test result: FAILED. 7 passed; 1 failed
```

Restored: 8 passed. That is the anti-vacuity guarantee — the second round only runs because the plugin measured a *different* p50 once the turn mentioned the correction, so a non-branching fixture cannot fake it.

## The fixture stays what it is

Still `std` and nothing else — no `serde`, no `stella-plugin`, no JSON parser. Substring match in, literal out: the same tooling a `printf`-and-`case` script had, which is the acceptance criterion `doc:pipeline-as-plugins` §5 commitment 2 sets. The new modes are matched with `str::contains` and emit string literals, exactly like the ones already there.

## Evidence

```
cargo test -p stella-runtime --test wrapper_dispatch     8 passed; 0 failed
cargo test -p stella-runtime --test wrapper_socket      11 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings   exit 0
cargo fmt --all --check    exit 0
make guards-fast           clean
check-prose                OK — none added
```

**Not claimed:** that it passes on Windows. I cannot run that runner; `windows-check.yml` will say on this PR. What is established here is that the file no longer depends on `/bin/sh` and that its assertions still bite.

Eleven files remain in #4697, which stays open. No test was deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Port wrapper dispatch integration coverage to the cross-platform fixture and include it in Windows checks.

Bug Fixes:
- Make the wrapper dispatch integration tests run on Windows by replacing Unix-only shell plugins with cross-platform in-tree fixture modes.

Enhancements:
- Preserve and verify request-dependent plugin branching for dispatch, contributed-stage routing, process counting, and failure cases through the shared fixture.

CI:
- Add wrapper_dispatch to the Windows runtime test workflow.

Documentation:
- Document the new wrapper-plugin-fixture modes used by wrapper dispatch tests.

Tests:
- Port wrapper_dispatch tests from /bin/sh scripts to the wrapper-plugin-fixture without deleting or renaming test coverage.