### PR TITLE
test(stella-runtime): host_owned_tamper runs on Windows, on the in-tree fixture

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -110,3 +110,4 @@ jobs:
           --test wrapper_socket
           --test wrapper_transport_limits
           --test wrapper_dispatch
+          --test host_owned_tamper

--- a/crates/stella-runtime/tests/host_owned_tamper.rs
+++ b/crates/stella-runtime/tests/host_owned_tamper.rs
@@ -16,12 +16,11 @@
 //! `EvidenceSet` refused as a missing field, and `EvidenceSet::from_observed`
 //! did not exist for the host to merge its own finding through.
 //!
-//! `cfg(unix)` because the plugin is a `/bin/sh` script, so this file proves
+//! The plugin is `wrapper-plugin-fixture` rather than a `/bin/sh` script
+//! (#4697), so this file runs on Windows too and proves
 //! nothing on Windows. The route out exists — `wrapper-plugin-fixture`, the
 //! portable plugin #3497 added and `wrapper_socket.rs` now drives — and this
 //! file has not taken it yet; #3497 tracks the ones that have not.
-
-#![cfg(unix)]
 
 use stella_plugin::{
     AfterTurnRequest, EvidenceProvenance, EvidenceSet, FlipObservation, ObservedEvidence,
@@ -62,18 +61,22 @@ timeout_secs = 60
 
 /// The plugin: it reports the flip it watched, and nothing about a snapshot it
 /// never took.
-const PLUGIN: &str = r#"
-cat >/dev/null
-printf '%s\n' '{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"achieved"}}}'
-"#;
+const PLUGIN: &str =
+    r#"{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"achieved"}}}"#;
 
 fn manifest() -> PluginManifest {
     PluginManifest::from_toml_str(MANIFEST).expect("the manifest loads")
 }
 
-fn plugin(script: &str) -> SubprocessWrapper {
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
+
+/// The fixture answering one canned body, after draining the request — what
+/// the `/bin/sh` scripts here did (#4697). `drain-emit` rather than `emit`
+/// because a plugin that closes stdin early is a different case, covered in
+/// `wrapper_socket.rs`, and this file is not about it.
+fn plugin(body: &str) -> SubprocessWrapper {
     SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), script.into()],
+        vec![FIXTURE.to_string(), "drain-emit".into(), body.into()],
         Vec::new(),
         DEFAULT_WRAPPER_TIMEOUT,
     )
@@ -175,10 +178,7 @@ async fn the_hosts_finding_is_what_refuses_a_tampered_flip() {
 /// as an unknown manifest key is.
 #[tokio::test]
 async fn a_plugin_claiming_the_hosts_tamper_finding_is_refused() {
-    const LIAR: &str = r#"
-cat >/dev/null
-printf '%s\n' '{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"achieved","tamper":"clean"}}}'
-"#;
+    const LIAR: &str = r#"{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"achieved","tamper":"clean"}}}"#;
     let error = plugin(LIAR)
         .after_turn(after())
         .await


### PR DESCRIPTION
Two of twelve for #4697, following the pattern PR #4848 established and its Windows job proved.

`crates/stella-runtime/tests/host_owned_tamper.rs` was `#![cfg(unix)]` because its plugin was a `/bin/sh` script. Both scripts here are canned emits — `cat >/dev/null` then `printf` one literal — so the fixture's **existing** `drain-emit` mode covers them exactly and the two constants become plain response bodies. No new fixture mode was needed, which is the cheapest shape a port in this series can take.

`drain-emit` rather than `emit` on purpose: a plugin that closes stdin early is a materially different case for the transport, it is covered in `wrapper_socket.rs`, and this file is not about it. Preserving which of the two shapes each test exercises is the part a port can silently get wrong.

## The assertions still bite

Same check as last time, because a port that quietly stops testing anything is the failure mode here. Changing the canned flip from `achieved` to `not-attempted`:

```
test a_flip_the_host_vouches_for_reaches_a_decided_verdict ... FAILED
test the_hosts_finding_is_what_refuses_a_tampered_flip ... FAILED
test result: FAILED. 1 passed; 2 failed
```

Restored: 3 passed. The evidence the tests read is genuinely coming through the fixture.

## Evidence

```
cargo test -p stella-runtime --test host_owned_tamper    3 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings   exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)    exit 0
cargo fmt --all --check    exit 0
check-prose                OK — none added
```

Added to `windows-check.yml`. As before I am **not** claiming it passes on Windows from here — that runner reports on this PR, and on #4848 it came back green for the same pattern.

Ten files remain in #4697, which stays open. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Run host-owned tamper coverage on Windows using the in-tree portable plugin fixture.

Enhancements:
- Port the host-owned tamper integration tests to the portable wrapper-plugin fixture while preserving their host-drained plugin behavior.

CI:
- Run the host_owned_tamper integration test in the Windows check workflow.

Tests:
- Enable host_owned_tamper tests on Windows by removing the Unix-only restriction and retaining coverage of verdict and tamper-finding validation.