### PR TITLE
fix(stella-graph): cache Grammars::load() behind a process-wide OnceLock

### DIFF
--- a/crates/stella-graph/src/graph.rs
+++ b/crates/stella-graph/src/graph.rs
@@ -27,7 +27,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use contextgraph_types::{ContextFrame, ContextQuery};
 use notify::RecommendedWatcher;
@@ -48,7 +48,7 @@ use crate::watch;
 /// catch-up task and watcher can hold it independently of the public handle.
 pub(crate) struct Inner {
     pub(crate) root: PathBuf,
-    pub(crate) grammars: Grammars,
+    pub(crate) grammars: Arc<Grammars>,
     write_conn: Mutex<Connection>,
     read_conn: Mutex<Connection>,
     watcher: Mutex<Option<RecommendedWatcher>>,

--- a/crates/stella-graph/src/parse.rs
+++ b/crates/stella-graph/src/parse.rs
@@ -12,6 +12,7 @@
 //! regions, not the whole index batch.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, OnceLock};
 
 use tree_sitter::{Node, Parser, Query, QueryCursor, StreamingIterator};
 
@@ -20,12 +21,14 @@ use crate::import::ImportSpec;
 use crate::lang::Language;
 use crate::symbol::{CallSite, Symbol, SymbolKind};
 
-/// Compiled grammars + queries for every supported language, built once and
-/// shared by reference across the whole index (`Send + Sync`, so it lives
-/// behind the [`crate::graph::CodeGraph`] handle and is reused by the
-/// background watcher). Compiling the queries here — not per file — keeps
-/// re-indexing cheap while still sourcing them from compile-time data
-/// (L-L2).
+/// Compiled grammars + queries for every supported language. [`Grammars::load`]
+/// compiles the 11 query pairs once per process — measured at ~100ms in a
+/// release build (#4782) — and caches the result behind a process-wide
+/// `OnceLock`, so every [`crate::graph::CodeGraph::open`] and
+/// [`crate::storage::StorageExtractor::new`] after the first shares the same
+/// `Arc` rather than paying the compile again. `Send + Sync`, so the cached
+/// value is reused by the background watcher too.
+///
 /// `None` per language means "this build did not compile that grammar"
 /// (#1268), not "loading failed" — a load failure is still a hard error,
 /// because a `.scm` that does not compile is a programmer error the crate's
@@ -83,11 +86,17 @@ impl LangPack {
 }
 
 impl Grammars {
-    /// Compile every grammar's query pair. Fails loudly only if one of the
-    /// crate's own `.scm` strings does not compile — a programmer error the
-    /// crate's tests catch.
-    pub(crate) fn load() -> Result<Grammars, GraphError> {
-        Ok(Grammars {
+    /// Compile every grammar's query pair, or hand back the already-compiled
+    /// set. Fails loudly only if one of the crate's own `.scm` strings does
+    /// not compile — a programmer error the crate's tests catch; a failure
+    /// here leaves the cache unset, so a later call retries the compile
+    /// rather than latching the error in.
+    pub(crate) fn load() -> Result<Arc<Grammars>, GraphError> {
+        static CACHE: OnceLock<Arc<Grammars>> = OnceLock::new();
+        if let Some(cached) = CACHE.get() {
+            return Ok(Arc::clone(cached));
+        }
+        let grammars = Arc::new(Grammars {
             rust: LangPack::load(Language::Rust)?,
             python: LangPack::load(Language::Python)?,
             javascript: LangPack::load(Language::JavaScript)?,
@@ -99,7 +108,11 @@ impl Grammars {
             typescript: LangPack::load(Language::TypeScript)?,
             tsx: LangPack::load(Language::Tsx)?,
             sql: LangPack::load(Language::Sql)?,
-        })
+        });
+        // `OnceLock::get_or_try_init` is still unstable (rust#109737); racing
+        // in with a redundant compile and losing is the fallback, not a bug —
+        // whichever caller's `Arc` lands first is the one everyone shares.
+        Ok(Arc::clone(CACHE.get_or_init(move || grammars)))
     }
 
     /// `None` when this build carries no grammar for `lang`. Callers already
@@ -706,6 +719,16 @@ mod tests {
         // Guards the compile-time .scm strings (L-L2): a mis-edit fails here,
         // not at a host's runtime.
         Grammars::load().expect("every language query compiles");
+    }
+
+    #[test]
+    fn load_is_cached_process_wide() {
+        let first = Grammars::load().expect("grammars compile");
+        let second = Grammars::load().expect("grammars compile");
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &second),
+            "second load() must hand back the same Arc, not recompile (#4782)"
+        );
     }
 
     #[test]

--- a/crates/stella-graph/src/storage.rs
+++ b/crates/stella-graph/src/storage.rs
@@ -131,9 +131,11 @@ impl StorageExtract {
 
 /// Standalone extraction handle for callers without a [`crate::CodeGraph`]
 /// (the pre-write gate parses *proposed* content before any write lands).
-/// Compiles the grammars once; reuse across calls.
+/// [`Grammars::load`] caches the compiled queries process-wide, so
+/// constructing this after any [`crate::CodeGraph::open`] in the same
+/// process is a pointer clone, not a recompile.
 pub struct StorageExtractor {
-    grammars: Grammars,
+    grammars: std::sync::Arc<Grammars>,
 }
 
 impl StorageExtractor {

--- a/crates/stella-graph/src/storage.rs
+++ b/crates/stella-graph/src/storage.rs
@@ -131,7 +131,7 @@ impl StorageExtract {
 
 /// Standalone extraction handle for callers without a [`crate::CodeGraph`]
 /// (the pre-write gate parses *proposed* content before any write lands).
-/// [`Grammars::load`] caches the compiled queries process-wide, so
+/// `Grammars::load` caches the compiled queries process-wide, so
 /// constructing this after any [`crate::CodeGraph::open`] in the same
 /// process is a pointer clone, not a recompile.
 pub struct StorageExtractor {


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

`Grammars::load()` recompiled all 11 tree-sitter query pairs on every
`CodeGraph::open`, including the search read path, which opens per call.
Measured at ~100ms in a release build, ~410ms in debug — not small, and
the doc comment's claim that the value was "built once and shared by
reference" was false. `load()` now caches the compiled set behind a
process-wide `OnceLock<Arc<Grammars>>`; every open after the first in a
process reuses it instead of recompiling.

Closes #4782

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`parse::tests::load_is_cached_process_wide` asserts `Arc::ptr_eq` on two
`Grammars::load()` calls — fails on `main` (returns owned, uncomparable
`Grammars`) and passes here.

## The gate

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally (workspace-wide runs are CI's job here); ran `cargo check -p stella-graph` and `cargo test -p stella-graph --lib` (233 passed) instead
- [ ] `cargo test --workspace` — see above; CI runs this
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

## Nothing left behind

- [ ] Filed: #___, #___ — **or**
- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [x] New cross-boundary types round-trip through serde (test included) — n/a, `Grammars` is `pub(crate)` and never crosses a boundary

## Anything reviewers should know?

`Inner.grammars` and `StorageExtractor.grammars` became `Arc<Grammars>`;
every existing call site kept compiling via deref coercion, so the diff
is otherwise contained to `parse.rs`.

## Summary by Sourcery

Cache compiled grammars process-wide to eliminate repeated query compilation across graph and storage operations.

Bug Fixes:
- Cache compiled grammar and query sets process-wide so repeated graph openings no longer recompile them.

Enhancements:
- Share compiled grammars through reference-counted handles across graph and storage extraction paths.
- Add coverage verifying repeated grammar loads return the same cached instance.

Documentation:
- Update grammar-loading documentation to describe process-wide caching and reuse behavior.

Tests:
- Add a witness test confirming that grammar loads share the same cached allocation.