### PR TITLE
fix(stella-cli): mirror a non-deck turn's task board into tasks

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -21,7 +21,9 @@ use stella_core::{
 use stella_mcp::{McpConfig, McpServerConfig, McpToolSet};
 use stella_model::credential::ApiKey;
 use stella_model::provider::Provider;
-use stella_protocol::{AgentEvent, CompletionMessage, ModelRef, Role, ToolOutput, UNKNOWN_MODEL};
+use stella_protocol::{
+    AgentEvent, CompletionMessage, ModelRef, Role, TaskItem, ToolOutput, UNKNOWN_MODEL,
+};
 use stella_store::{ContextBlockRow, ManifestBlockRow, StepManifestRow, Store, TelemetryRow};
 use stella_tools::ToolRegistry;
 use stella_tools::custom::{self, CustomTool};
@@ -1281,6 +1283,7 @@ pub(crate) async fn run_turn(
     // tree is measured rather than inferred from tool inputs, and for the deck
     // defect that made the two one call.
     crate::turn_files::close_turn_boundary(cfg, registry, &tx, execution.as_ref(), &outcome);
+    mirror_task_board(execution.as_ref(), session, registry);
     // The re-query adapter holds an `EventSender` clone of this run's channel
     // (#3366 telemetry), so it must be released here too — otherwise it keeps
     // the channel open and the renderer's `recv()` loop never ends (#2290).
@@ -1338,6 +1341,37 @@ pub(crate) async fn run_turn(
         TurnOutcome::Aborted { reason, kind, .. } => Err(CliFailure::from_abort(reason, kind)),
         completed => Ok(completed),
     }
+}
+
+/// Mirror this turn's final task board into the store's `tasks` table — the
+/// same write the deck's lead turn makes at its own turn end
+/// (`command_deck`) and `/clear` makes at its own boundary
+/// (`command_deck::session_clear`). #4613 put `TaskUpdate` on the turn stream
+/// and in `events` for every door; this raw one-shot / non-interactive door
+/// (`run_turn`) was the one left with no write site of its own, so a
+/// non-interactive `stella run` that used the task board was replayable
+/// from the journal but invisible to a `tasks` query (#4700).
+///
+/// Silent and best-effort like every sibling call site: no open store, or a
+/// board nobody touched, leaves nothing to mirror.
+fn mirror_task_board(
+    execution: Option<&(Arc<Store>, i64)>,
+    session: Option<&str>,
+    registry: &ToolRegistry,
+) {
+    let Some((store, id)) = execution else {
+        return;
+    };
+    let items: Vec<TaskItem> = registry
+        .task_board()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .items()
+        .to_vec();
+    if items.is_empty() {
+        return;
+    }
+    let _ = store.record_task_board(*id, session, &items, crate::command_deck::now_ms());
 }
 
 fn print_help() {

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -1286,3 +1286,64 @@ fn session_hook_context_is_clamped_with_a_visible_marker() {
         "the clamp bounds the section, not the hook's appetite"
     );
 }
+
+/// **Witness for #4700.** A non-deck door (`stella run`, the plain
+/// non-interactive door) ends its turn through `run_turn`, and until now
+/// nothing on that path ever called `Store::record_task_board` — the
+/// mirror the deck's lead turn and `/clear` both make at their own turn
+/// ends. A non-interactive run that used the task board was replayable
+/// from the journal but invisible to a `tasks` query.
+#[test]
+fn a_non_deck_turn_mirrors_its_board_into_the_tasks_table() {
+    let root = tempfile::tempdir().expect("root");
+    let store = std::sync::Arc::new(Store::in_memory().expect("store"));
+    let execution_id = store
+        .begin_execution("run", "ship the parser", "anthropic", "claude")
+        .expect("execution");
+    let registry = ToolRegistry::new(root.path().to_path_buf());
+    registry
+        .task_board()
+        .lock()
+        .unwrap()
+        .create("ship the parser", None, None);
+
+    mirror_task_board(
+        Some(&(store.clone(), execution_id)),
+        Some("ses-nondeck"),
+        &registry,
+    );
+
+    let mirrored = store.list_session_tasks("ses-nondeck").expect("read back");
+    assert_eq!(
+        mirrored.len(),
+        1,
+        "the board's one task must land in `tasks`"
+    );
+    assert_eq!(mirrored[0].subject, "ship the parser");
+}
+
+/// An untouched board (no `task_*` call this turn) writes nothing — matching
+/// every sibling call site, which all guard on `!items.is_empty()` so a
+/// session that never used the board does not grow a phantom row.
+#[test]
+fn an_empty_board_writes_no_row() {
+    let root = tempfile::tempdir().expect("root");
+    let store = std::sync::Arc::new(Store::in_memory().expect("store"));
+    let execution_id = store
+        .begin_execution("run", "no board work", "anthropic", "claude")
+        .expect("execution");
+    let registry = ToolRegistry::new(root.path().to_path_buf());
+
+    mirror_task_board(
+        Some(&(store.clone(), execution_id)),
+        Some("ses-empty"),
+        &registry,
+    );
+
+    assert!(
+        store
+            .list_session_tasks("ses-empty")
+            .expect("read back")
+            .is_empty()
+    );
+}


### PR DESCRIPTION
## What & why

`run_turn` (the plain chat loop and `stella run`) closed its turn boundary
without ever calling `Store::record_task_board`. The deck's lead turn and
`/clear` both mirror the live board into `tasks` at their own turn ends
(#4613 got `TaskUpdate` onto the stream and into `events` for every door,
but left this write site out); a non-deck run that used the task board
stayed replayable from the journal but was invisible to a `tasks` query.

Adds the same mirror at `run_turn`'s own turn end, in a small extracted
`mirror_task_board` so it's guarded like the other three call sites and
directly testable.

Closes #4700

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`agent::tests::a_non_deck_turn_mirrors_its_board_into_the_tasks_table`
drives `mirror_task_board` against a real in-memory store and asserts the
board lands in `list_session_tasks`; `an_empty_board_writes_no_row` covers
the untouched-board guard.

## The gate

- [x] `cargo fmt --check` (scoped: `-p stella-cli`)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally per repo policy (no workspace builds on this machine); CI runs it
- [ ] `cargo test --workspace` — not run locally per repo policy; ran `cargo test -p stella-cli --bin stella agent::tests::` (102 passed) instead; CI runs the full suite
- [ ] Docs updated where behavior/flags changed — no flag/behavior surface changed, only what a headless run persists
- [ ] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- N/A New cross-boundary types round-trip through serde — no new wire type

## Anything reviewers should know?

`subsession/closeout.rs:95`'s `record_task_board` call the issue named is
test-fixture code, not a production call site (#1708 already removed the
worker-closeout mirror in production, deliberately — see that file's module
docs). The production callers were `command_deck.rs` and `session_clear.rs`
only; this PR adds the third, at `run_turn`.

## Summary by Sourcery

Persist task-board updates when non-deck turns complete so task state remains queryable after headless runs.

Bug Fixes:
- Mirror task-board state from non-deck turns into the session tasks table so headless runs are visible to task queries.

Enhancements:
- Extract the task-board mirroring logic into a reusable, guarded helper consistent with existing turn-boundary behavior.

Tests:
- Add coverage for persisting a non-deck turn's task board and skipping writes for untouched boards.