### PR TITLE
fix(stella-cli): a cancelled worker's cost is read back from the row it just closed

### DIFF
--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -23,7 +23,7 @@
 //! the deck's own running total stops under-reporting the turn the user just
 //! stopped.
 //!
-//! Not fixed here, and #2807's second half: nothing awaits the forwarder drain
+//! Not fixed here, and tracked as #4853: nothing awaits the forwarder drain
 //! before the row closes, so a `StepUsage` can still be priced after
 //! `record_execution_end` has run. The read-back heals whatever landed by the
 //! time it runs and no more. Draining first must not reintroduce the #2290

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -1127,14 +1127,14 @@ async fn run_worker(
     // private board is scaffolding for this one run, and the session's
     // `tasks` rows have exactly one writer: the driver, whose `/clear` seal
     // this thread cannot consult (#1708 — see `closeout`'s module docs).
-    closeout::close_worker_execution(
+    let settled_cost = closeout::close_worker_execution(
         execution.as_ref(),
         &registry,
         label,
         cost,
         persistence_complete,
     );
-    (execution_id, cost, end)
+    (execution_id, settled_cost, end)
 }
 
 /// Drain the driver's prompt backlog into free worker slots, oldest first.

--- a/crates/stella-cli/src/subsession/closeout.rs
+++ b/crates/stella-cli/src/subsession/closeout.rs
@@ -41,20 +41,31 @@ use crate::agent;
 /// Close out a worker's execution row: agent and MCP usage, and the outcome
 /// label ([`agent::record_execution_end`]) — best-effort, exactly as the
 /// worker's closeout always was (the inbox notification and the lane's own
-/// events are the user-facing signal).
+/// events are the user-facing signal). Returns the settled cost the caller
+/// should report — see below.
 ///
 /// The signature is the contract (#1708): no session id comes in, so the
 /// closeout **cannot** address the session-keyed `tasks` rows at all. See
 /// the module docs for why that absence is deliberate.
+///
+/// # Why this reads the row back
+///
+/// `cost_usd` is the caller's own aggregate, and on a stopped worker (#2807)
+/// that aggregate is a prefix: the turn future was dropped mid-race while
+/// other roles were still settling receipts the caller's budget guard never
+/// saw. `record_execution_end` floors the row at `MAX(cost_usd, receipts)`
+/// and never below it, so the row is always at least as tight as what was
+/// passed in — reading it back and handing that to the caller is strictly
+/// safe, not just for the stopped case.
 pub(crate) fn close_worker_execution(
     execution: Option<&(Arc<Store>, i64)>,
     registry: &ToolRegistry,
     outcome_label: &str,
     cost_usd: f64,
     persistence_complete: bool,
-) {
+) -> f64 {
     let Some((store, id)) = execution else {
-        return;
+        return cost_usd;
     };
     let _ = agent::record_execution_end(
         store,
@@ -64,6 +75,11 @@ pub(crate) fn close_worker_execution(
         cost_usd,
         persistence_complete,
     );
+    store
+        .execution_summary(*id)
+        .ok()
+        .flatten()
+        .map_or(cost_usd, |summary| summary.cost_usd)
 }
 
 #[cfg(test)]
@@ -186,6 +202,64 @@ mod tests {
             store.count("tasks").expect("count"),
             0,
             "and no session-less stray survives either"
+        );
+    }
+
+    /// **Witness (#2807).** A stopped worker's turn future is dropped
+    /// mid-cancel while other roles are still settling receipts — so the
+    /// cost `run_worker` computes locally is a prefix, the same shape #2570
+    /// found in the lead driver. The closeout must report what the receipts
+    /// actually prove, not that prefix, because this return value is what
+    /// reaches `SupervisorMsg::Ended` and the session's own spend total.
+    #[test]
+    fn a_stopped_workers_settled_cost_is_read_back_from_its_receipts() {
+        let root = tempfile::tempdir().expect("root");
+        let store = Arc::new(Store::in_memory().expect("store"));
+        let worker_exec = store
+            .begin_execution("deck-sub", "delegated work", "zai", "glm-5.2")
+            .expect("worker execution");
+        for (step, cost) in [(1u64, 0.5), (2, 4.0)] {
+            store
+                .record_telemetry(
+                    worker_exec,
+                    &stella_store::TelemetryRow {
+                        step,
+                        provider: "zai".into(),
+                        call_role: "worker".into(),
+                        model: "glm-5.2".into(),
+                        input_tokens: 1_000,
+                        estimated_input_tokens: 900,
+                        output_tokens: 100,
+                        cache_read_tokens: 0,
+                        cache_miss_tokens: 1_000,
+                        cache_write_tokens: 0,
+                        cost_usd: cost,
+                        duration_ms: 500,
+                        retries: 0,
+                        tool_calls: 1,
+                        usage_complete: true,
+                        sub_agent_id: None,
+                    },
+                )
+                .expect("receipt");
+        }
+        let registry = ToolRegistry::new(root.path().to_path_buf());
+
+        // 0.5: the prefix `run_worker`'s own budget guard held at the instant
+        // the race dropped the turn future, before the $4.00 witness receipt
+        // landed — exactly execution 99's shape in #2570, one level down.
+        let settled = close_worker_execution(
+            Some(&(store.clone(), worker_exec)),
+            &registry,
+            "cancelled",
+            0.5,
+            false,
+        );
+
+        assert!(
+            (settled - 4.5).abs() < 1e-9,
+            "must report the $4.50 the receipts prove, not the $0.50 prefix \
+             the caller's budget guard held at the moment of the drop: {settled}"
         );
     }
 }


### PR DESCRIPTION
## What & why

#4540 fixed the lead driver's cancel path (`command_deck/dropped_turn.rs`) but
left the sibling worker path in `subsession.rs` on the exact same broken
shape: a stopped lane's cost is computed from its own budget guard at the
instant the raced turn future is dropped, missing roles still settling
receipts. That number becomes `WorkerOutcome::cost_usd` and flows into
`SupervisorMsg::Ended`, which the driver adds straight into the session's
own spend total — the exact caller #2807 names as still under-reporting.

`close_worker_execution` now reads `execution_summary` back after
`record_execution_end` closes the row and returns that instead of the
caller's raw aggregate. `finish_execution_accounted` floors the row at
`MAX(cost_usd, receipts)` and never below it, so the read-back is safe for
every outcome, not just cancelled.

The forwarder-drain half of #2807 (waiting for in-flight `StepUsage` events
before the row closes) was deliberately deferred by #4540 and remains open,
filed separately as #4853.

Closes #2807

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_stopped_workers_settled_cost_is_read_back_from_its_receipts` in
`crates/stella-cli/src/subsession/closeout.rs` drives a worker execution with
two landed receipts ($0.50 + $4.00) through `close_worker_execution` with a
stale $0.50 caller aggregate and asserts the returned cost is $4.50. Verified
by hand that it fails against the pre-fix function (asserts `0.5`) and passes
against this change.

## The gate

- [x] `cargo fmt --check` (`-p stella-cli`)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally per repo policy (no workspace-wide builds on this machine); CI runs it
- [ ] `cargo test --workspace` — not run locally per repo policy; ran targeted `cargo test -p stella-cli --bin stella closeout` instead (passes)
- [x] Docs updated where behavior/flags changed (doc comment on `close_worker_execution` explains the read-back)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #4853 (the forwarder-drain half of #2807, deferred by design — see `dropped_turn.rs`'s module doc)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

`close_worker_execution`'s return type changed from `()` to `f64`; the two
existing tests in `closeout.rs` (`completed`, cost `0.0`, no receipts) still
pass unchanged since the read-back is a no-op floor there.

## Summary by Sourcery

Read back the finalized worker execution cost after closeout so cancelled work cannot under-report settled usage.

Bug Fixes:
- Report a cancelled worker's settled execution cost from the persisted execution row so receipts that arrive after the caller's local aggregate are included in session spend totals.

Enhancements:
- Document the worker closeout read-back behavior and track the separate forwarder-drain limitation.

Tests:
- Add a regression test covering a stopped worker whose persisted receipts exceed its stale caller-side cost.