### PR TITLE
test(stella-runtime): wrapper_claimed_evidence runs on Windows, on the in-tree fixture

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -111,3 +111,4 @@ jobs:
           --test wrapper_transport_limits
           --test wrapper_dispatch
           --test host_owned_tamper
+          --test wrapper_claimed_evidence

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -111,6 +111,30 @@ fn main() {
         }
         "dispatch-reference" => dispatch_reference(&read_request()),
         "dispatch-contributed" => dispatch_contributed(&read_request()),
+        // Claims a flip only when a candidate grant naming `sh` arrived, and
+        // says `unobservable` otherwise — so a host that withholds the grant
+        // gets an honest refusal rather than an assertion the plugin could
+        // not have made. The two-substring match is the `case` the shell
+        // script spelled out.
+        //
+        // `wrapper_claimed_evidence.rs` currently takes only the granted
+        // side: its `report()` always passes `candidate: Some(..)`. The
+        // ungranted arm is kept because it is the plugin's honest answer,
+        // and dropping it would leave a fixture that claims `achieved`
+        // whatever it was given — which is the dishonesty that file exists
+        // to catch. A test that withholds the grant would exercise it.
+        "flip-if-granted" => {
+            let request = read_request();
+            let flip = if request.contains("\"root\"") && request.contains("\"program\":\"sh\"") {
+                "achieved"
+            } else {
+                "unobservable"
+            };
+            emit(&format!(
+                "{{\"point\":\"after_turn\",\"body\":{{\"protocol_version\":1,\
+                 \"evidence\":{{\"flip\":\"{flip}\"}}}}}}"
+            ));
+        }
         "candidate-probe" => candidate_probe(&read_request()),
         "flood" => flood(arg(&args, 1).parse().unwrap_or(0), arg(&args, 2)),
         "trailing" => trailing(arg(&args, 1).parse().unwrap_or(0)),

--- a/crates/stella-runtime/tests/wrapper_claimed_evidence.rs
+++ b/crates/stella-runtime/tests/wrapper_claimed_evidence.rs
@@ -24,12 +24,10 @@
 //! this tree can — the one host call that would run a check answers
 //! `Unsupported` (#3580).
 //!
-//! `cfg(unix)` for `wrapper_decided_flip.rs`'s reason: the plugin is a
-//! `/bin/sh` script, so this file proves nothing on Windows. The route out is
-//! `wrapper-plugin-fixture`, the portable plugin #3497 added; this file has not
-//! taken it yet.
-
-#![cfg(unix)]
+//! The plugin is `wrapper-plugin-fixture`, the portable plugin #3497 added,
+//! so this file runs on Windows too (#4697). Its `flip-if-granted` mode is the
+//! `case` the `/bin/sh` script spelled out: a flip is claimed only when a
+//! candidate grant naming `sh` arrived, which is the branch these tests read.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -74,22 +72,11 @@ name = "verify"
 
 /// A plugin that runs **no test at all**: it string-matches the request and
 /// prints the flip it wants to be believed about.
-const ASSERTS_A_FLIP_IT_NEVER_RAN: &str = r#"
-request=$(cat)
-case "$request" in
-  *'"root"'*'"program":"sh"'*) flip=achieved ;;
-  *) flip=unobservable ;;
-esac
-printf '%s\n' "{\"point\":\"after_turn\",\"body\":{\"protocol_version\":1,\"evidence\":{\"flip\":\"$flip\"}}}"
-"#;
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
 
 fn dispatch() -> WrapperDispatch {
     let admitted = SubprocessWrapper::declare(
-        vec![
-            "/bin/sh".into(),
-            "-c".into(),
-            ASSERTS_A_FLIP_IT_NEVER_RAN.into(),
-        ],
+        vec![FIXTURE.to_string(), "flip-if-granted".into()],
         Vec::new(),
         DEFAULT_WRAPPER_TIMEOUT,
     )


### PR DESCRIPTION
Three of twelve for #4697. `crates/stella-runtime/tests/wrapper_claimed_evidence.rs` comes off `/bin/sh` onto `wrapper-plugin-fixture`, with a new `flip-if-granted` mode carrying the `case` the script spelled out: claim a flip only when a candidate grant naming `sh` arrived, say `unobservable` otherwise.

## The ablation check does not validate this port, and I am not pretending it does

The previous two PRs in this series leaned on a specific proof: neuter the fixture's branch, watch the tests fail, restore. That is what makes a port evidence rather than a rewrite.

Here it does not hold. Replacing the branch with a constant `achieved` leaves **both tests green**, because `report()` always passes `candidate: Some(granted(..))` — this file only ever takes the granted side. So the honest statement is narrower than last time: the tests pass through the fixture, and nothing here proves the ungranted arm.

**I kept the arm anyway**, and the reason is not symmetry. Without it the fixture would answer `achieved` whatever it was handed — which is precisely the dishonesty this file exists to catch, sitting inside the tool used to catch it. That is a worse object than an unexercised branch. The fixture says so at the site, and names what would exercise it: a test that withholds the grant.

If a reviewer would rather have the branch deleted until something tests it, that is a defensible call and I will take it — but it should be made deliberately rather than by my quietly shipping the simpler mode.

## Evidence

```
cargo test -p stella-runtime --test wrapper_claimed_evidence   2 passed; 0 failed
  (and the two already ported: host_owned_tamper 3, wrapper_dispatch 8)
cargo clippy -p stella-runtime --all-targets -- -D warnings    exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)     exit 0
cargo fmt --all --check    exit 0
check-prose                OK — none added
```

Added to `windows-check.yml`. Not claiming a Windows pass from here; that runner reports on this PR, as it did green for #4848.

Nine files remain in #4697. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Make the wrapper claimed-evidence test portable and run it as part of Windows validation.

Enhancements:
- Port the claimed-evidence wrapper test from a Unix shell script to the portable in-tree plugin fixture, enabling it to run on Windows.
- Add fixture support for reporting an achieved flip only when the expected grant is present, while preserving an honest unobservable response otherwise.

CI:
- Include wrapper_claimed_evidence in the Windows runtime test workflow.

Documentation:
- Update the test documentation to reflect its cross-platform fixture-based execution.

Tests:
- Run the claimed-evidence test through the shared wrapper fixture without deleting or renaming existing tests.