### PR TITLE
On Windows a hook, custom tool or bash call that backgrounds work has no group-kill test

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -47,6 +47,13 @@ name: windows-check
 # running it would report a green that means "nothing ran". A target list makes
 # what is covered on Windows a thing a reader can count.
 #
+# The third step is the same shape for the three spawn sites `wrapper-plugin-
+# fixture` does not cover — `bash`, a custom script tool, a hook — each armed
+# with the same guard and each backing onto the compile blocker two
+# paragraphs up: `--test group_kill_witnesses` links only the compiled
+# `stella-tools` library, not its `--lib` test binary, so it runs here without
+# waiting on that binary's Windows compile (#4698).
+#
 # Its own file rather than a job in ci.yml for the reason wire-schema.yml has
 # one: ci.yml's required job is what every PR waits on, and a Windows runner is
 # minutes of wall clock that a diff touching neither crate has no use for.
@@ -110,3 +117,7 @@ jobs:
           --test wrapper_socket
           --test wrapper_transport_limits
           --test wrapper_dispatch
+
+      - name: the group-kill guard at the bash/custom-tool/hook spawn sites, on Windows (#4698)
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: cargo test -p stella-tools --test group_kill_witnesses

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -52,7 +52,11 @@ name: windows-check
 # with the same guard and each backing onto the compile blocker two
 # paragraphs up: `--test group_kill_witnesses` links only the compiled
 # `stella-tools` library, not its `--lib` test binary, so it runs here without
-# waiting on that binary's Windows compile (#4698).
+# waiting on that binary's Windows compile (#4698). Only the custom-tool
+# witness runs unconditionally here today — the other two are `ignore`d on
+# Windows, where plain `bash` resolves to Windows' own WSL launcher stub
+# rather than a shell (#4861), a separate defect this step's green does not
+# claim is fixed.
 #
 # Its own file rather than a job in ci.yml for the reason wire-schema.yml has
 # one: ci.yml's required job is what every PR waits on, and a Windows runner is

--- a/crates/stella-tools/Cargo.toml
+++ b/crates/stella-tools/Cargo.toml
@@ -77,3 +77,19 @@ windows-sys = { version = "0.61", features = [
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "fs", "io-util"] }
 # Property tests for foundry authorship and the approval precedence ladder.
 proptest.workspace = true
+
+# The custom-tool group-kill witness's own child (#4698), the same pattern
+# `stella-runtime`'s `wrapper-plugin-fixture` established (#3497): a portable
+# binary rather than a `/bin/sh` script, so `tests/group_kill_witnesses.rs`
+# locates it with `env!("CARGO_BIN_EXE_group-kill-fixture")` and needs no
+# shell to prove `run_custom`'s spawn (`command[0]` directly, no shell in
+# between) reaches a backgrounded grandchild. Under `tests/fixtures/`, not
+# `src/bin/`, for the same reason as its sibling: it is a process apart from
+# the library, not a second thing the library ships.
+[[bin]]
+name = "group-kill-fixture"
+path = "tests/fixtures/group-kill-fixture.rs"
+
+# A test fixture, never a shipped surface — keep it out of dist.
+[package.metadata.dist]
+dist = false

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -908,52 +908,9 @@ mod tests {
         );
     }
 
-    /// Dropping the future mid-wait (a cancelled turn) must kill the whole
-    /// process group — the `crate::exec::GroupKillGuard` backstop. Without
-    /// it, Esc during a long `bash` call left the command running and
-    /// mutating the tree, `setsid`'d beyond the reach of anything else.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn a_dropped_bash_call_kills_the_process_group() {
-        let dir = tempfile::tempdir().unwrap();
-        let pidfile = dir.path().join("pid");
-        // Record the *grandchild*'s pid: when the group dies, the orphaned
-        // sleep is reaped by init, so a surviving pid means a real leak.
-        // `kill_on_drop` alone would not reach it — only the group kill does.
-        let command = format!("sleep 30 & echo $! > {} && wait", pidfile.display());
-        let root = dir.path().to_path_buf();
-        let handle = tokio::spawn(async move {
-            Bash::new(None)
-                .execute(
-                    &serde_json::json!({"command": command, "timeout_secs": 60}),
-                    &cx(&root),
-                )
-                .await
-        });
-        let mut pid = None;
-        for _ in 0..250 {
-            if let Some(p) = std::fs::read_to_string(&pidfile)
-                .ok()
-                .and_then(|s| s.trim().parse::<i32>().ok())
-            {
-                pid = Some(p);
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-        let pid = pid.expect("the child never started");
-        handle.abort();
-        let _ = handle.await;
-        let mut dead = false;
-        for _ in 0..250 {
-            if unsafe { libc::kill(pid, 0) } == -1 {
-                dead = true;
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-        assert!(dead, "cancelled bash call left subprocess {pid} running");
-    }
+    // `GroupKillGuard`'s own witness for this spawn site lives in
+    // `stella-tools/tests/group_kill_witnesses.rs`, not here: it needs to run
+    // on Windows too, and this file's `#[cfg(test)] mod` does not (#4698).
 
     #[tokio::test]
     async fn truncates_multibyte_output_without_panicking() {

--- a/crates/stella-tools/src/custom/tests/execution.rs
+++ b/crates/stella-tools/src/custom/tests/execution.rs
@@ -259,53 +259,9 @@ async fn a_script_outliving_the_old_fixed_budget_still_succeeds() {
     }
 }
 
-/// Dropping the future mid-wait (a cancelled turn) must kill the whole
-/// process group — the `crate::exec::GroupKillGuard` backstop, the same
-/// leak the `bash` tool had. Without it, a cancelled turn left the
-/// script's own children running, `setsid`'d beyond anyone's reach.
-#[cfg(unix)]
-#[tokio::test]
-async fn a_dropped_custom_tool_kills_the_process_group() {
-    let dir = tempfile::tempdir().unwrap();
-    let pidfile = dir.path().join("pid");
-    // Record the *grandchild*'s pid: when the group dies, the orphaned
-    // sleep is reaped by init, so a surviving pid means a real leak.
-    // `kill_on_drop` alone would not reach it — only the group kill does.
-    let tool = script_tool(
-        dir.path(),
-        "bg.sh",
-        &format!(
-            "#!/bin/sh\nsleep 30 &\necho $! > {}\nwait\n",
-            pidfile.display()
-        ),
-    );
-    let root = dir.path().to_path_buf();
-    let handle =
-        tokio::spawn(async move { run_custom(&tool, &serde_json::json!({}), &root).await });
-    let mut pid = None;
-    for _ in 0..250 {
-        if let Some(p) = std::fs::read_to_string(&pidfile)
-            .ok()
-            .and_then(|s| s.trim().parse::<i32>().ok())
-        {
-            pid = Some(p);
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    let pid = pid.expect("the child never started");
-    handle.abort();
-    let _ = handle.await;
-    let mut dead = false;
-    for _ in 0..250 {
-        if unsafe { libc::kill(pid, 0) } == -1 {
-            dead = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-    assert!(dead, "cancelled custom tool left subprocess {pid} running");
-}
+// `GroupKillGuard`'s own witness for this spawn site lives in
+// `stella-tools/tests/group_kill_witnesses.rs`, not here: it needs to run on
+// Windows too, and this file's `#[cfg(test)] mod` does not (#4698).
 
 #[tokio::test]
 async fn missing_script_names_the_path_tried() {

--- a/crates/stella-tools/tests/fixtures/group-kill-fixture.rs
+++ b/crates/stella-tools/tests/fixtures/group-kill-fixture.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The custom-tool group-kill witness's own child (#4698), the same shape as
+//! `stella-runtime`'s `wrapper-plugin-fixture` (#3497): a portable binary
+//! instead of a `/bin/sh` script, so the witness needs no shell at all —
+//! `run_custom` spawns `command[0]` directly with no shell in between, and a
+//! shebang script would not run on Windows regardless of anything a shell
+//! could fix.
+//!
+//! # Modes
+//!
+//! - `background <path>` — start a grandchild `heartbeat <path>` process and
+//!   hang, so the dropped-future witness has a tree to fail to kill, not
+//!   just a direct child `kill_on_drop` already reaches on its own.
+//! - `heartbeat <path>` — the grandchild: append a byte to `<path>` forever.
+
+use std::io::Write;
+use std::time::Duration;
+
+/// How often a heartbeat appends. Short enough that the witness's
+/// observation window separates a live process from a killed one by tens of
+/// bytes.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(20);
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("background") => background(arg(&args, 1)),
+        Some("heartbeat") => heartbeat(arg(&args, 1)),
+        other => {
+            eprintln!("group-kill-fixture: no such mode `{other:?}`");
+            std::process::exit(64);
+        }
+    }
+}
+
+fn arg(args: &[String], index: usize) -> &str {
+    args.get(index).map_or("", String::as_str)
+}
+
+fn heartbeat(path: &str) -> ! {
+    loop {
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = file.write_all(b".");
+            let _ = file.flush();
+        }
+        std::thread::sleep(HEARTBEAT_INTERVAL);
+    }
+}
+
+fn background(path: &str) -> ! {
+    let started = std::env::current_exe().and_then(|exe| {
+        std::process::Command::new(exe)
+            .args(["heartbeat", path])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+    });
+    if let Err(error) = started {
+        // The witness's whole subject is a grandchild that outlives the
+        // caller, so one that never started must not be mistaken for one
+        // that was killed.
+        eprintln!("group-kill-fixture: no grandchild started: {error}");
+        std::process::exit(70);
+    }
+    loop {
+        std::thread::sleep(Duration::from_secs(60));
+    }
+}

--- a/crates/stella-tools/tests/group_kill_witnesses.rs
+++ b/crates/stella-tools/tests/group_kill_witnesses.rs
@@ -12,12 +12,21 @@
 //! `#[cfg(unix)]` tests — read a pid with `libc::kill`, which has no Windows
 //! answer, so nothing here ever exercised the guard's Windows arm. `hook_runner.rs`
 //! had no such test at all. This file replaces the two and adds the third,
-//! all three heartbeating to a file from a background shell job that touches
-//! no pipe, exactly as the plugin witness does: `ps -o state=` on a recorded
-//! pid cannot be ported (a killed orphan lingers as a zombie until reaped,
-//! which Windows has no state column for), but a file that stops growing
-//! reports the same fact — that the process is still *doing* something — on
-//! both platforms.
+//! all three heartbeating to a file instead of polling a pid, exactly as the
+//! plugin witness does: `ps -o state=` on a recorded pid cannot be ported (a
+//! killed orphan lingers as a zombie until reaped, which Windows has no
+//! state column for), but a file that stops growing reports the same fact —
+//! that the process is still *doing* something — on both platforms.
+//!
+//! The custom-tool witness's heartbeat writer is `group-kill-fixture`, a
+//! portable binary (`tests/fixtures/`, the same pattern
+//! `wrapper-plugin-fixture` established for the plugin transport): the tool
+//! runs `command[0]` with no shell, so it needs none. The `bash` and hook
+//! witnesses have no such escape — both call sites hardcode
+//! `Command::new("bash")` — so they instead defend against a real
+//! environment hazard `ensure_bash_resolves_to_a_real_shell` documents: on
+//! `windows-latest`, plain `bash` can resolve to Windows' own WSL launcher
+//! stub ahead of Git for Windows' real shell.
 //!
 //! An integration test on purpose, not a `#[cfg(test)] mod` beside the
 //! production code: `custom/tests.rs` and several other `stella-tools`
@@ -107,11 +116,53 @@ fn backgrounding_command(pulse: &Path) -> String {
     )
 }
 
+/// Make `Command::new("bash")` — what `Bash::execute` and the hook runner's
+/// operator path both hardcode — resolve to a real shell on this runner.
+///
+/// On a stock `windows-latest` GitHub Actions image, `%SystemRoot%\System32`
+/// precedes Git for Windows in `PATH`, and Windows ships its own
+/// `bash.exe` there: the WSL launcher stub, which — with no distribution
+/// installed — prints an install prompt and exits nonzero instead of running
+/// anything. `Bash::execute`/`HostHookRunner::run` inherit this process's
+/// `PATH` (neither clears the operator's environment), so prepending Git's
+/// documented, stable install location — the same one GitHub's own
+/// `shell: bash` step type resolves — makes these two witnesses exercise a
+/// real shell here instead of failing on an environment quirk unrelated to
+/// `GroupKillGuard`. This is a Windows CI fixture concern, not a claim about
+/// what `stella-tools` does in production; #4861 tracks the underlying
+/// PATH-order hazard for a real fix.
+#[cfg(windows)]
+fn ensure_bash_resolves_to_a_real_shell() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let git_bin = std::path::PathBuf::from(
+            std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".into()),
+        )
+        .join("Git")
+        .join("bin");
+        if !git_bin.join("bash.exe").is_file() {
+            return;
+        }
+        let mut path = std::ffi::OsString::from(&git_bin);
+        path.push(";");
+        path.push(std::env::var_os("PATH").unwrap_or_default());
+        // SAFETY: the `Once` above makes this run exactly once, and it runs
+        // before any of this binary's three tests spawn a child that reads
+        // `PATH` — `still_beating`/`beats` only ever touch the filesystem, so
+        // there is no concurrent reader of the environment block to race.
+        unsafe { std::env::set_var("PATH", path) };
+    });
+}
+
+#[cfg(not(windows))]
+fn ensure_bash_resolves_to_a_real_shell() {}
+
 /// **Witness 1** (ported from `bash.rs`'s `#[cfg(unix)]` test). Dropping the
 /// future driving a `bash` call — Esc during a long call — must kill the
 /// whole group, not just the shell that fronts it.
 #[tokio::test]
 async fn a_dropped_bash_call_kills_the_process_group() {
+    ensure_bash_resolves_to_a_real_shell();
     let dir = tempfile::tempdir().expect("tempdir");
     let pulse = dir.path().join("bash.pulse");
     let root = dir.path().to_path_buf();
@@ -142,9 +193,11 @@ async fn a_dropped_bash_call_kills_the_process_group() {
 /// test). Dropping the future driving a custom tool must kill its whole
 /// group the same way — the same guard, a different spawn site.
 ///
-/// The tool's `command` runs `bash` directly (no shebang): `run_custom` spawns
-/// `command[0]` as the program with no shell, so a `#!/bin/sh` script — the
-/// shape the file's other fixtures use — never executes on Windows at all.
+/// The tool's `command` runs `group-kill-fixture` directly, not `bash`:
+/// `run_custom` spawns `command[0]` as the program with no shell in between
+/// (a `#!/bin/sh` script — the shape the file's other fixtures use — never
+/// executes on Windows at all), and a portable binary sidesteps needing a
+/// shell to exist on the runner in the first place, unlike Witnesses 1 and 3.
 #[tokio::test]
 async fn a_dropped_custom_tool_kills_the_process_group() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -153,7 +206,11 @@ async fn a_dropped_custom_tool_kills_the_process_group() {
     let tool = CustomTool {
         name: "bg".into(),
         description: "backgrounds a heartbeat writer".into(),
-        command: vec!["bash".into(), "-c".into(), backgrounding_command(&pulse)],
+        command: vec![
+            env!("CARGO_BIN_EXE_group-kill-fixture").to_string(),
+            "background".to_string(),
+            pulse.display().to_string(),
+        ],
         timeout_ms: MAX_TIMEOUT_MS,
         input_schema: serde_json::json!({ "type": "object" }),
         env: HashMap::new(),
@@ -190,6 +247,7 @@ async fn a_dropped_custom_tool_kills_the_process_group() {
 /// only the hook process that fronted it.
 #[tokio::test]
 async fn a_timed_out_hook_leaves_no_surviving_grandchild() {
+    ensure_bash_resolves_to_a_real_shell();
     let dir = tempfile::tempdir().expect("tempdir");
     let pulse = dir.path().join("hook.pulse");
     let mut hung = HookAction::new(backgrounding_command(&pulse));

--- a/crates/stella-tools/tests/group_kill_witnesses.rs
+++ b/crates/stella-tools/tests/group_kill_witnesses.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Portable witnesses for `crate::exec::GroupKillGuard` at the three spawn
+//! planes that are not the plugin transport: `bash`, a custom script tool,
+//! and a hook (#4698).
+//!
+//! #4456 gave the guard a Windows Job Object arm and #4675 proved it for the
+//! plugin transport (`stella-runtime`'s `wrapper_transport_limits.rs`, which
+//! this file's shape is copied from). The equivalents that lived beside these
+//! three call sites — `bash.rs`'s and `custom/tests/execution.rs`'s
+//! `#[cfg(unix)]` tests — read a pid with `libc::kill`, which has no Windows
+//! answer, so nothing here ever exercised the guard's Windows arm. `hook_runner.rs`
+//! had no such test at all. This file replaces the two and adds the third,
+//! all three heartbeating to a file from a background shell job that touches
+//! no pipe, exactly as the plugin witness does: `ps -o state=` on a recorded
+//! pid cannot be ported (a killed orphan lingers as a zombie until reaped,
+//! which Windows has no state column for), but a file that stops growing
+//! reports the same fact — that the process is still *doing* something — on
+//! both platforms.
+//!
+//! An integration test on purpose, not a `#[cfg(test)] mod` beside the
+//! production code: `custom/tests.rs` and several other `stella-tools`
+//! modules import `std::os::unix::fs::PermissionsExt` unconditionally inside
+//! `#[cfg(test)]`, so the crate's `--lib` test binary does not compile on
+//! Windows today (`windows-check.yml`'s own comment names this). A file
+//! under `tests/` links only the compiled library, sidestepping that
+//! altogether, and it is why `windows-check.yml` runs it by name rather than
+//! folding it into `--lib`.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use stella_core::hooks::{HookAction, HookExecError, HookRunner};
+use stella_core::ports::ToolExecutor;
+use stella_tools::ToolRegistry;
+use stella_tools::bash::Bash;
+use stella_tools::ctx::ToolCtx;
+use stella_tools::custom::{CustomTool, CustomToolSet, MAX_TIMEOUT_MS};
+use stella_tools::hook_runner::HostHookRunner;
+use stella_tools::registry::Tool;
+
+/// How long one observation of a heartbeat file lasts. The script below
+/// appends every 20ms, so a running writer grows the file by roughly ten
+/// bytes here and a killed one by none.
+const OBSERVATION: Duration = Duration::from_millis(200);
+
+/// Bytes written to a heartbeat file so far; `0` for one that does not exist
+/// yet.
+fn beats(path: &Path) -> u64 {
+    std::fs::metadata(path).map(|meta| meta.len()).unwrap_or(0)
+}
+
+/// Whether whatever is writing `path` is still writing it.
+///
+/// An `async fn` sleeping on the Tokio clock rather than blocking the OS
+/// thread — the two dropped-future witnesses below poll this while a
+/// `tokio::spawn`ed task is still in flight on the same single-threaded test
+/// runtime, and a `std::thread::sleep` here would starve that task of the
+/// chance to ever call `spawn` at all.
+async fn still_beating(path: &Path) -> bool {
+    let before = beats(path);
+    tokio::time::sleep(OBSERVATION).await;
+    beats(path) != before
+}
+
+/// Poll [`still_beating`] until it answers `false`, up to `budget`.
+///
+/// The kill is delivered asynchronously and the writer's last append may
+/// already be in flight, so a single immediate check would be a race against
+/// the kernel rather than a check on the guard. Answering `true` after the
+/// whole budget is a real leak: nothing is coming to stop it.
+async fn outlived(path: &Path, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if !still_beating(path).await {
+            return false;
+        }
+    }
+    still_beating(path).await
+}
+
+/// Wait until `path` has been written at all, so a test cannot pass because
+/// the grandchild it watches never started — the premise every witness below
+/// asserts before trusting a still file.
+async fn started_beating(path: &Path, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if beats(path) > 0 {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    false
+}
+
+/// A shell fragment that backgrounds a heartbeat writer and then hangs, so
+/// the group the caller kills has a real grandchild to fail to reach.
+/// Single-quoted so a Windows temp path's backslashes reach `printf`
+/// literally rather than as shell escapes.
+fn backgrounding_command(pulse: &Path) -> String {
+    format!(
+        "( while true; do printf '.' >> '{}'; sleep 0.02; done ) & sleep 30",
+        pulse.display()
+    )
+}
+
+/// **Witness 1** (ported from `bash.rs`'s `#[cfg(unix)]` test). Dropping the
+/// future driving a `bash` call — Esc during a long call — must kill the
+/// whole group, not just the shell that fronts it.
+#[tokio::test]
+async fn a_dropped_bash_call_kills_the_process_group() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pulse = dir.path().join("bash.pulse");
+    let root = dir.path().to_path_buf();
+    let command = backgrounding_command(&pulse);
+
+    let handle = tokio::spawn(async move {
+        Bash::new(None)
+            .execute(
+                &serde_json::json!({"command": command, "timeout_secs": 60}),
+                &ToolCtx::bare(root),
+            )
+            .await
+    });
+    assert!(
+        started_beating(&pulse, Duration::from_secs(5)).await,
+        "the backgrounded heartbeat never started, so this test would prove nothing"
+    );
+    handle.abort();
+    let _ = handle.await;
+
+    assert!(
+        !outlived(&pulse, Duration::from_secs(5)).await,
+        "a dropped bash call left its backgrounded child running"
+    );
+}
+
+/// **Witness 2** (ported from `custom/tests/execution.rs`'s `#[cfg(unix)]`
+/// test). Dropping the future driving a custom tool must kill its whole
+/// group the same way — the same guard, a different spawn site.
+///
+/// The tool's `command` runs `bash` directly (no shebang): `run_custom` spawns
+/// `command[0]` as the program with no shell, so a `#!/bin/sh` script — the
+/// shape the file's other fixtures use — never executes on Windows at all.
+#[tokio::test]
+async fn a_dropped_custom_tool_kills_the_process_group() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pulse = dir.path().join("custom.pulse");
+    let root = dir.path().to_path_buf();
+    let tool = CustomTool {
+        name: "bg".into(),
+        description: "backgrounds a heartbeat writer".into(),
+        command: vec!["bash".into(), "-c".into(), backgrounding_command(&pulse)],
+        timeout_ms: MAX_TIMEOUT_MS,
+        input_schema: serde_json::json!({ "type": "object" }),
+        env: HashMap::new(),
+        source: dir.path().join("bg.toml"),
+        foundry: None,
+        claimed_read_only: false,
+        claimed_risk: None,
+        claimed_idempotent: false,
+        output_schema: None,
+        contributed_by: None,
+    };
+    let registry: Arc<dyn ToolExecutor> = Arc::new(ToolRegistry::new(root.clone()));
+    let set = CustomToolSet::new_owned(registry, vec![tool], root);
+
+    let handle = tokio::spawn(async move { set.execute("bg", &serde_json::json!({})).await });
+    assert!(
+        started_beating(&pulse, Duration::from_secs(5)).await,
+        "the backgrounded heartbeat never started, so this test would prove nothing"
+    );
+    handle.abort();
+    let _ = handle.await;
+
+    assert!(
+        !outlived(&pulse, Duration::from_secs(5)).await,
+        "a dropped custom tool call left its backgrounded child running"
+    );
+}
+
+/// **Witness 3** (new — `hook_runner.rs` had no group-kill test at all). A
+/// hook that backgrounds work and then runs out of budget leaves nothing
+/// behind, the same property `wrapper_transport_limits.rs`'s
+/// `a_timed_out_plugin_leaves_no_surviving_grandchild` proves for the plugin
+/// transport: `kill_now` on the timeout path reaches the grandchild, not
+/// only the hook process that fronted it.
+#[tokio::test]
+async fn a_timed_out_hook_leaves_no_surviving_grandchild() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pulse = dir.path().join("hook.pulse");
+    let mut hung = HookAction::new(backgrounding_command(&pulse));
+    hung.timeout_ms = Some(300);
+
+    let err = HostHookRunner
+        .run(&hung, "{}", &dir.path().display().to_string())
+        .await
+        .expect_err("the hook never answers inside its budget");
+    assert!(
+        matches!(err, HookExecError::TimedOut { .. }),
+        "the budget is what ended it: {err}"
+    );
+    assert!(
+        started_beating(&pulse, Duration::from_secs(5)).await,
+        "no grandchild ever ran, so this test would prove nothing about killing one"
+    );
+    assert!(
+        !outlived(&pulse, Duration::from_secs(5)).await,
+        "the backgrounded grandchild outlived the hook's own timeout"
+    );
+}

--- a/crates/stella-tools/tests/group_kill_witnesses.rs
+++ b/crates/stella-tools/tests/group_kill_witnesses.rs
@@ -21,12 +21,14 @@
 //! The custom-tool witness's heartbeat writer is `group-kill-fixture`, a
 //! portable binary (`tests/fixtures/`, the same pattern
 //! `wrapper-plugin-fixture` established for the plugin transport): the tool
-//! runs `command[0]` with no shell, so it needs none. The `bash` and hook
+//! runs `command[0]` with no shell, so it needs none, and it is the one
+//! witness here that runs unconditionally on Windows. The `bash` and hook
 //! witnesses have no such escape — both call sites hardcode
-//! `Command::new("bash")` — so they instead defend against a real
-//! environment hazard `ensure_bash_resolves_to_a_real_shell` documents: on
-//! `windows-latest`, plain `bash` can resolve to Windows' own WSL launcher
-//! stub ahead of Git for Windows' real shell.
+//! `Command::new("bash")` — and on `windows-latest` that resolves to
+//! Windows' own WSL launcher stub, not a real shell, regardless of `PATH`
+//! (`CreateProcessW` checks `System32` before `PATH` at all). They are
+//! `#[cfg_attr(windows, ignore)]` until #4861 fixes that, rather than forced
+//! green against an environment neither call site can see through.
 //!
 //! An integration test on purpose, not a `#[cfg(test)] mod` beside the
 //! production code: `custom/tests.rs` and several other `stella-tools`
@@ -116,53 +118,24 @@ fn backgrounding_command(pulse: &Path) -> String {
     )
 }
 
-/// Make `Command::new("bash")` — what `Bash::execute` and the hook runner's
-/// operator path both hardcode — resolve to a real shell on this runner.
-///
-/// On a stock `windows-latest` GitHub Actions image, `%SystemRoot%\System32`
-/// precedes Git for Windows in `PATH`, and Windows ships its own
-/// `bash.exe` there: the WSL launcher stub, which — with no distribution
-/// installed — prints an install prompt and exits nonzero instead of running
-/// anything. `Bash::execute`/`HostHookRunner::run` inherit this process's
-/// `PATH` (neither clears the operator's environment), so prepending Git's
-/// documented, stable install location — the same one GitHub's own
-/// `shell: bash` step type resolves — makes these two witnesses exercise a
-/// real shell here instead of failing on an environment quirk unrelated to
-/// `GroupKillGuard`. This is a Windows CI fixture concern, not a claim about
-/// what `stella-tools` does in production; #4861 tracks the underlying
-/// PATH-order hazard for a real fix.
-#[cfg(windows)]
-fn ensure_bash_resolves_to_a_real_shell() {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        let git_bin = std::path::PathBuf::from(
-            std::env::var("ProgramFiles").unwrap_or_else(|_| r"C:\Program Files".into()),
-        )
-        .join("Git")
-        .join("bin");
-        if !git_bin.join("bash.exe").is_file() {
-            return;
-        }
-        let mut path = std::ffi::OsString::from(&git_bin);
-        path.push(";");
-        path.push(std::env::var_os("PATH").unwrap_or_default());
-        // SAFETY: the `Once` above makes this run exactly once, and it runs
-        // before any of this binary's three tests spawn a child that reads
-        // `PATH` — `still_beating`/`beats` only ever touch the filesystem, so
-        // there is no concurrent reader of the environment block to race.
-        unsafe { std::env::set_var("PATH", path) };
-    });
-}
-
-#[cfg(not(windows))]
-fn ensure_bash_resolves_to_a_real_shell() {}
-
 /// **Witness 1** (ported from `bash.rs`'s `#[cfg(unix)]` test). Dropping the
 /// future driving a `bash` call — Esc during a long call — must kill the
 /// whole group, not just the shell that fronts it.
+///
+/// Ignored on Windows, not skipped silently: `Bash::execute` hardcodes
+/// `Command::new("bash")`, and on `windows-latest` that resolves to Windows'
+/// own WSL launcher stub — with no distribution installed it prints an
+/// install prompt and exits nonzero instead of running anything, ahead of
+/// Git for Windows' real shell regardless of `PATH` order (`CreateProcessW`
+/// checks `System32` before consulting `PATH` at all). #4861 tracks fixing
+/// that; until then this witness cannot prove `GroupKillGuard` reaches a
+/// backgrounded child here.
+#[cfg_attr(
+    windows,
+    ignore = "blocked on #4861: bash resolves to the WSL launcher stub here, not a real shell"
+)]
 #[tokio::test]
 async fn a_dropped_bash_call_kills_the_process_group() {
-    ensure_bash_resolves_to_a_real_shell();
     let dir = tempfile::tempdir().expect("tempdir");
     let pulse = dir.path().join("bash.pulse");
     let root = dir.path().to_path_buf();
@@ -245,9 +218,16 @@ async fn a_dropped_custom_tool_kills_the_process_group() {
 /// `a_timed_out_plugin_leaves_no_surviving_grandchild` proves for the plugin
 /// transport: `kill_now` on the timeout path reaches the grandchild, not
 /// only the hook process that fronted it.
+///
+/// Ignored on Windows for the same reason as Witness 1, tracked by the same
+/// #4861: the hook runner's operator path (an action with no `[plugin]`
+/// origin) also hardcodes `Command::new("bash")`.
+#[cfg_attr(
+    windows,
+    ignore = "blocked on #4861: bash resolves to the WSL launcher stub here, not a real shell"
+)]
 #[tokio::test]
 async fn a_timed_out_hook_leaves_no_surviving_grandchild() {
-    ensure_bash_resolves_to_a_real_shell();
     let dir = tempfile::tempdir().expect("tempdir");
     let pulse = dir.path().join("hook.pulse");
     let mut hung = HookAction::new(backgrounding_command(&pulse));


### PR DESCRIPTION
## What & why

`GroupKillGuard` got a Windows Job Object arm in #4456, proved for the plugin transport by #4675. The other three spawn sites that arm it — `bash`, a custom script tool, a hook — had no Windows witness: `bash.rs`'s and `custom/tests/execution.rs`'s tests were `#[cfg(unix)]` and polled a pid with `libc::kill` (no Windows equivalent), and `hook_runner.rs` had no group-kill test at all.

Adds `crates/stella-tools/tests/group_kill_witnesses.rs`, the same three assertions ported to heartbeat a file instead of polling a pid — the shape `wrapper_transport_limits.rs` already uses for the plugin transport. It's a new integration test rather than a `#[cfg(test)] mod` beside the production code: several other modules in this crate import `std::os::unix::fs::PermissionsExt` unconditionally, so the crate's `--lib` test binary doesn't compile on Windows yet (tracked by #4697). An integration test links only the compiled library, so it sidesteps that. Wired into `windows-check.yml` as a named step.

**Only the custom-tool witness runs unconditionally on Windows.** It spawns a new portable fixture binary (`group-kill-fixture`, same pattern as `wrapper-plugin-fixture`) directly, with no shell. The `bash`-tool and hook witnesses cannot avoid a real defect discovered while proving them on `windows-latest`: both `bash.rs` and `hook_runner.rs`'s operator path hardcode `Command::new("bash")`, and on that runner plain `bash` resolves to Windows' own WSL launcher stub rather than a shell — confirmed against two different fixes (a PATH-order tweak doesn't work either, since `CreateProcessW` checks `System32` before `PATH` at all). Filed #4861 for that; the two witnesses are `#[cfg_attr(windows, ignore = "blocked on #4861: ...")]` rather than forced green, and they run and pass normally on unix.

Refs #4698 — not closing it: two of the three assertions it asks for don't run on Windows yet, blocked on #4861.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here) — the custom-tool one, unconditionally on both platforms; the other two are real, passing witnesses on unix and honestly `ignore`d on Windows pending #4861.

## The gate

- [x] `cargo fmt --check` (targeted: `-p stella-tools`)
- [x] `cargo clippy -p stella-tools --tests -- -D warnings` (targeted, not `--workspace --all-targets` — see CONTRIBUTING.md on local workspace builds)
- [x] `cargo test -p stella-tools --test group_kill_witnesses` (targeted; full verification is CI's `windows-check.yml` run)
- [ ] Docs updated — n/a, no behavior/flag change
- [ ] CLA signed
- [x] `Refs #4698` appears above and as a commit trailer

## Nothing left behind

- [x] Filed: #4861 (bash resolves to the WSL launcher stub on Windows) — the production fix that unblocks the last two witnesses. #4697 (the wider `--lib`-on-Windows compile gap) was already tracked before this PR.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary types

## Anything reviewers should know?

This PR is a partial close of #4698 by design: it proves `GroupKillGuard` on Windows for the custom-tool spawn site now, and gets the other two to a state (real tests, honestly marked blocked, not silently skipped or falsely green) where landing #4861 is the only remaining step — flip two `#[cfg_attr]`s off.

## Summary by Sourcery

Add cross-platform group-kill witnesses for non-plugin tool and hook execution paths, with Windows CI coverage for the currently runnable cases.

New Features:
- Add portable group-kill witness coverage for bash, custom-tool, and hook spawn sites, including a Windows-compatible custom-tool fixture.

Enhancements:
- Replace Unix-only PID polling tests with cross-platform heartbeat-based integration tests and explicitly mark bash and hook witnesses as Windows-blocked until shell resolution is fixed.

CI:
- Run the new group-kill witness integration test as a named step in the Windows check workflow.

Tests:
- Cover cancellation and timeout cleanup of backgrounded grandchildren across the custom-tool, bash, and hook execution paths.