### PR TITLE
A blunt-fallback diff renders with no 'replace everything' banner once the patch path carries it

### DIFF
--- a/crates/stella-cli/src/agent/summary.rs
+++ b/crates/stella-cli/src/agent/summary.rs
@@ -168,6 +168,7 @@ mod tests {
             added,
             removed,
             diff: None,
+            minimal: true,
         }
     }
 

--- a/crates/stella-cli/src/arena.rs
+++ b/crates/stella-cli/src/arena.rs
@@ -627,6 +627,7 @@ mod tests {
             added: 1,
             removed: 0,
             diff: Some("+hello".into()),
+            minimal: true,
         });
         recorder.observe(&AgentEvent::ToolResult {
             call_id: "call_1".into(),
@@ -683,6 +684,7 @@ mod tests {
                 added: 1,
                 removed: 0,
                 diff: Some("+hello".into()),
+                minimal: true,
             });
         }
         {
@@ -708,6 +710,7 @@ mod tests {
                 added: 1,
                 removed: 0,
                 diff: Some("+hello world".into()),
+                minimal: true,
             });
             recorder.observe(&AgentEvent::ToolResult {
                 call_id: "call_2".into(),

--- a/crates/stella-cli/src/dataset_cmd.rs
+++ b/crates/stella-cli/src/dataset_cmd.rs
@@ -935,6 +935,7 @@ fn fold_journal(events: &[stella_store::SessionEventRecord]) -> JournalFold {
                 added,
                 removed,
                 diff,
+                ..
             } if kind.is_mutation() => {
                 fold.changes.push(DatasetChange {
                     path: path.clone(),

--- a/crates/stella-cli/src/dataset_cmd/tests.rs
+++ b/crates/stella-cli/src/dataset_cmd/tests.rs
@@ -67,6 +67,7 @@ fn edit_events() -> Vec<AgentEvent> {
             added: 1,
             removed: 1,
             diff: Some("@@ -1 +1 @@\n-old\n+new\n".into()),
+            minimal: true,
         },
     ]
 }
@@ -84,6 +85,7 @@ fn one_pass_over_the_journal_recovers_the_whole_trajectory() {
         added: 0,
         removed: 0,
         diff: None,
+        minimal: true,
     });
     events.push(AgentEvent::Verdict {
         passed: true,
@@ -151,6 +153,7 @@ fn acceptance_needs_a_success_outcome_and_a_real_change() {
         added: 0,
         removed: 0,
         diff: None,
+        minimal: true,
     }]));
 
     assert!(is_accepted("completed", &with_change, false));

--- a/crates/stella-cli/src/diag_bridge.rs
+++ b/crates/stella-cli/src/diag_bridge.rs
@@ -1302,6 +1302,7 @@ mod tests {
             added: 12,
             removed: 3,
             diff: Some("- old secret\n+ new secret".into()),
+            minimal: true,
         });
 
         let json = serde_json::to_string(&records.records()[0]).expect("serialize");

--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -331,6 +331,7 @@ impl<'a> Fold<'a> {
                 added,
                 removed,
                 diff,
+                ..
             } => {
                 let kind = wire_token(kind);
                 let path = self.clean(path);

--- a/crates/stella-cli/src/export/transcript/tests.rs
+++ b/crates/stella-cli/src/export/transcript/tests.rs
@@ -537,6 +537,7 @@ fn a_rewrite(adds: usize) -> AgentEvent {
         diff: Some(format!(
             "--- a/src/big.rs\n+++ b/src/big.rs\n@@ -0,0 +1,{adds} @@\n{body}"
         )),
+        minimal: true,
     }
 }
 
@@ -583,6 +584,7 @@ fn a_modified_line_pair_highlights_only_the_changed_token() {
              +\\setlength{\\parindent}{12pt}\n"
                 .to_string(),
         ),
+        minimal: true,
     };
     let out = render(&at(vec![event]), &no_prompts());
     assert!(
@@ -665,6 +667,7 @@ fn a_diff_that_parses_to_no_hunks_still_renders_as_readable_text() {
             added: 1,
             removed: 0,
             diff: Some("+just a bare line".into()),
+            minimal: true,
         }]),
         &no_prompts(),
     );

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -524,6 +524,7 @@ pub fn render_event(event: &AgentEvent) {
             added,
             removed,
             diff,
+            ..
         } => file_change_card(path, *kind, *added, *removed, diff.as_deref()),
         AgentEvent::Reasoning { delta } => reasoning_delta(delta),
         AgentEvent::BudgetTick {

--- a/crates/stella-cli/src/turn_facts.rs
+++ b/crates/stella-cli/src/turn_facts.rs
@@ -167,6 +167,7 @@ mod tests {
             added: 2,
             removed: 1,
             diff: None,
+            minimal: true,
         }
     }
 

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -553,6 +553,9 @@ fn file_change(change: JournalChange) -> AgentEvent {
         added: change.added,
         removed: change.removed,
         diff: change.diff,
+        // `git diff-tree -p` computed this, not `stella_diff::unified_diff` —
+        // there is no area cap to trip.
+        minimal: true,
     }
 }
 
@@ -1026,6 +1029,7 @@ mod tests {
             added,
             removed,
             diff,
+            minimal,
         }) = rx.try_recv()
         else {
             panic!("the call's own reading must be published when nothing was measured");
@@ -1037,6 +1041,7 @@ mod tests {
             diff.as_deref().is_some_and(|d| d.contains("+- one")),
             "the diff rides the event: {diff:?}"
         );
+        assert!(minimal, "two lines never trips the area cap");
         assert!(rx.try_recv().is_err(), "one change, one event");
     }
 

--- a/crates/stella-cli/tests/dataset_export_cli.rs
+++ b/crates/stella-cli/tests/dataset_export_cli.rs
@@ -256,6 +256,7 @@ fn seeded_workspace() -> Seeded {
             added: 1,
             removed: 1,
             diff: Some("@@ -1 +1 @@\n-old\n+new\n".into()),
+            minimal: true,
         },
         AgentEvent::Verdict {
             passed: true,
@@ -314,6 +315,7 @@ fn seeded_workspace() -> Seeded {
                 added: 3,
                 removed: 0,
                 diff: None,
+                minimal: true,
             },
         )
         .expect("event");
@@ -334,6 +336,7 @@ fn seeded_workspace() -> Seeded {
             added: 2,
             removed: 0,
             diff: None,
+            minimal: true,
         },
         AgentEvent::Verdict {
             passed: false,
@@ -388,6 +391,7 @@ fn seeded_workspace() -> Seeded {
                 added: 1,
                 removed: 0,
                 diff: None,
+                minimal: true,
             },
         )
         .expect("event");
@@ -431,6 +435,7 @@ fn seeded_workspace() -> Seeded {
             added: 4,
             removed: 1,
             diff: None,
+            minimal: true,
         },
         AgentEvent::Verdict {
             passed: true,
@@ -521,6 +526,7 @@ fn seed_mismatching_execution(store: &Store, prompt: &str) -> i64 {
             added: 1,
             removed: 0,
             diff: None,
+            minimal: true,
         },
     ];
     for (seq, event) in events.iter().enumerate() {

--- a/crates/stella-observatory/src/transcript_view.rs
+++ b/crates/stella-observatory/src/transcript_view.rs
@@ -459,6 +459,10 @@ fn measured_patch(row: &Value) -> Option<(String, Patch)> {
             text: text.to_string(),
             added: usize::try_from(row["added"].as_u64().unwrap_or(0)).unwrap_or(usize::MAX),
             removed: usize::try_from(row["removed"].as_u64().unwrap_or(0)).unwrap_or(usize::MAX),
+            // Absent on a row recorded before #4696 — the flag's own wire
+            // default, matching what every consumer already assumed of a
+            // patch back then.
+            minimal: row["minimal"].as_bool().unwrap_or(true),
         },
     ))
 }
@@ -658,6 +662,33 @@ mod tests {
         let run = build_run(&execution(), &edit_journal(Some("paper/main.tex")));
         let call = run.turns[0].steps[0].call.as_ref().unwrap();
         assert!(call.files[0].patch.is_some());
+    }
+
+    /// **The witness for #4696.** A `file_change` row whose producer tripped
+    /// `LCS_AREA_CAP` carries `"minimal": false`; the rendered diff must say
+    /// so rather than default to a precise one.
+    #[test]
+    fn a_blunt_fallback_row_renders_a_non_minimal_diff() {
+        let mut journal = vec![json!({
+            "type": "tool_start", "ts": 0, "call_id": "c1", "name": "edit_file",
+            "body": "{\"path\":\"main.tex\",\"old_string\":\"{15pt}\",\"new_string\":\"{12pt}\"}",
+        })];
+        journal.push(json!({
+            "type": "file_change", "ts": 20, "path": "main.tex", "kind": "modified",
+            "added": 1, "removed": 1, "minimal": false,
+            "diff": "--- a/main.tex\n+++ b/main.tex\n@@ -1,1 +1,1 @@\n-{15pt}\n+{12pt}\n",
+        }));
+        journal.push(json!({
+            "type": "tool_result", "ts": 30, "call_id": "c1",
+            "ok": true, "duration_ms": 30, "body": "edited main.tex",
+        }));
+        let run = build_run(&execution(), &journal);
+        let call = run.turns[0].steps[0].call.as_ref().unwrap();
+        let diff = stella_transcript::file_diff::FileDiff::build(&call.files[0]);
+        assert!(
+            !diff.minimal,
+            "the producer's cap trip must survive onto the rendered diff"
+        );
     }
 
     /// One `edit_file` call, optionally measured. `measured` is the path the

--- a/crates/stella-protocol/src/event.rs
+++ b/crates/stella-protocol/src/event.rs
@@ -180,6 +180,15 @@ fn retries_exhausted_retryable_default() -> bool {
     true
 }
 
+/// `serde(default)` value for [`AgentEvent::FileChange::minimal`]: streams
+/// recorded before the field existed (#4696) replay as a precise diff, which
+/// is what every consumer already assumed of a patch-carrying event back then
+/// — the flag narrows that assumption for new streams, it does not retract it
+/// for old ones.
+fn file_change_minimal_default() -> bool {
+    true
+}
+
 mod kind;
 pub use kind::AgentEvent;
 

--- a/crates/stella-protocol/src/event/kind.rs
+++ b/crates/stella-protocol/src/event/kind.rs
@@ -776,6 +776,14 @@ pub enum AgentEvent {
         #[serde(default)]
         removed: u32,
         diff: Option<String>,
+        /// Whether `diff` is the minimal edit script, or the producer's diff
+        /// tripped its area cap and fell back to a blunt replace-everything
+        /// rendering (`stella_diff::LCS_AREA_CAP`). A transcript surface
+        /// renders a banner over `false` so a degraded diff is never mistaken
+        /// for a precise one (#4696). `true` for a work-tree measurement:
+        /// git's own diff never takes this fallback.
+        #[serde(default = "file_change_minimal_default")]
+        minimal: bool,
     },
     /// Context recall completed: which frames reached the prompt, from which
     /// providers, at what token cost. Every frame carries a human

--- a/crates/stella-protocol/src/event/tests.rs
+++ b/crates/stella-protocol/src/event/tests.rs
@@ -273,6 +273,7 @@ fn file_change_carries_the_delta_and_the_diff_on_the_single_event_path() {
         added: 12,
         removed: 3,
         diff: Some("@@ -1 +1 @@\n-old\n+new".into()),
+        minimal: false,
     };
     let json = serde_json::to_string(&event).unwrap();
     assert!(json.contains("\"type\":\"file_change\""), "{json}");
@@ -283,6 +284,7 @@ fn file_change_carries_the_delta_and_the_diff_on_the_single_event_path() {
             added,
             removed,
             diff,
+            minimal,
             ..
         } => {
             assert_eq!(kind, FileChangeKind::Modified);
@@ -293,6 +295,7 @@ fn file_change_carries_the_delta_and_the_diff_on_the_single_event_path() {
                  not have to recount the diff text"
             );
             assert!(diff.is_some());
+            assert!(!minimal, "the blunt-fallback flag survives the wire");
         }
         other => panic!("unexpected variant: {other:?}"),
     }
@@ -300,7 +303,9 @@ fn file_change_carries_the_delta_and_the_diff_on_the_single_event_path() {
 
 /// Journals written before the counts existed must still replay. They
 /// recorded no delta, so they come back as `0/0` — the honest answer for a
-/// stream that never measured one.
+/// stream that never measured one. `minimal` predates neither field and is
+/// absent too; it comes back `true` — #4696's own wire default, matching
+/// what a consumer already assumed of a patch-carrying event back then.
 #[test]
 fn a_file_change_without_counts_still_parses() {
     let old = r#"{"type":"file_change","path":"a.rs","kind":"modified","diff":null}"#;
@@ -309,10 +314,12 @@ fn a_file_change_without_counts_still_parses() {
             path,
             added,
             removed,
+            minimal,
             ..
         } => {
             assert_eq!(path, "a.rs");
             assert_eq!((added, removed), (0, 0));
+            assert!(minimal);
         }
         other => panic!("unexpected variant: {other:?}"),
     }

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -1076,6 +1076,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                 added: 4,
                 removed: 1,
                 diff: Some("+ a\n- b".into()),
+                minimal: true,
             },
             AgentEvent::FileChange {
                 path: "src/main.rs".into(),
@@ -1083,6 +1084,7 @@ pub(crate) fn sample_events() -> Vec<AgentEvent> {
                 added: 0,
                 removed: 0,
                 diff: None,
+                minimal: false,
             },
         ]
     }));

--- a/crates/stella-tools/src/own_change.rs
+++ b/crates/stella-tools/src/own_change.rs
@@ -73,6 +73,9 @@ pub struct OwnChange {
     pub removed: u32,
     /// The unified diff, in the shape described in the module docs.
     pub diff: String,
+    /// Whether `diff` is the minimal edit script, or `stella_diff` tripped
+    /// `LCS_AREA_CAP` and fell back to replace-everything.
+    pub minimal: bool,
 }
 
 /// Whether the call created the path, changed one that was there, or removed
@@ -105,6 +108,7 @@ pub fn own_change(path: &str, before: Option<&str>, after: &str) -> OwnChange {
         // more than four billion lines is not a file this tool writes.
         added: u32::try_from(diff.added).unwrap_or(u32::MAX),
         removed: u32::try_from(diff.removed).unwrap_or(u32::MAX),
+        minimal: diff.minimal,
         diff: patch_text(path, kind, &diff),
     }
 }
@@ -125,6 +129,7 @@ pub fn own_delete(path: &str, before: &str) -> OwnChange {
         kind,
         added: u32::try_from(diff.added).unwrap_or(u32::MAX),
         removed: u32::try_from(diff.removed).unwrap_or(u32::MAX),
+        minimal: diff.minimal,
         diff: patch_text(path, kind, &diff),
     }
 }
@@ -205,6 +210,7 @@ pub fn file_change(change: OwnChange) -> stella_protocol::AgentEvent {
         added: change.added,
         removed: change.removed,
         diff: Some(change.diff),
+        minimal: change.minimal,
     }
 }
 
@@ -254,6 +260,7 @@ pub fn from_output(output: &ToolOutput) -> Vec<OwnChange> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use stella_protocol::AgentEvent;
 
     /// A created file is all-green, counted, and headed `/dev/null` on the old
     /// side — the git spelling every consumer keys "new file" on.
@@ -290,6 +297,28 @@ mod tests {
                 .starts_with("--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,7 +1,7 @@\n")
         );
         assert!(change.diff.contains("\n-d\n+D\n"), "{}", change.diff);
+        assert!(change.minimal, "seven lines never trips the area cap");
+    }
+
+    /// **The witness for #4696.** An edit large enough to trip
+    /// `stella_diff::LCS_AREA_CAP` reports `minimal: false` on the call's own
+    /// reading — the flag [`file_change`] must carry onto the wire event so a
+    /// transcript surface can tell a real rewrite from a degraded diff.
+    #[test]
+    fn a_blunt_fallback_edit_reports_itself_as_non_minimal() {
+        // 2001 * 2001 = 4,004,001, just over LCS_AREA_CAP (4,000,000) —
+        // mirrors `stella_diff`'s own witness for the fallback threshold.
+        let before: String = (0..2001).map(|i| format!("old-{i}\n")).collect();
+        let after: String = (0..2001).map(|i| format!("new-{i}\n")).collect();
+
+        let change = own_change("big.rs", Some(&before), &after);
+        assert!(!change.minimal, "the area cap must have tripped");
+
+        let event = file_change(change);
+        let AgentEvent::FileChange { minimal, .. } = event else {
+            panic!("file_change must produce a FileChange event");
+        };
+        assert!(!minimal, "the wire event must carry the same reading");
     }
 
     /// A deletion is all-red and headed `/dev/null` on the NEW side — the

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -167,6 +167,7 @@ async fn a_file_tool_s_own_reading_is_published_without_a_measurer() {
         added,
         removed,
         diff,
+        minimal,
     }) = rx.try_recv()
     else {
         panic!("the write's own reading must reach the stream");
@@ -175,6 +176,7 @@ async fn a_file_tool_s_own_reading_is_published_without_a_measurer() {
     assert_eq!(kind, FileChangeKind::Created);
     assert_eq!((added, removed), (2, 0));
     assert!(diff.as_deref().is_some_and(|d| d.contains("+two")));
+    assert!(minimal, "two lines never trips the area cap");
 
     // An edit on the file the session just authored reads as a modification
     // of it, with both sides of the change on the wire.
@@ -226,10 +228,12 @@ async fn a_deletion_publishes_its_own_reading_as_an_all_red_diff() {
         added,
         removed,
         diff,
+        minimal,
     }) = rx.try_recv()
     else {
         panic!("the deletion's own reading must reach the stream");
     };
+    assert!(minimal, "three lines never trips the area cap");
     assert_eq!(path, "doomed.txt");
     assert_eq!(kind, FileChangeKind::Deleted);
     assert_eq!(

--- a/crates/stella-transcript/src/file_diff.rs
+++ b/crates/stella-transcript/src/file_diff.rs
@@ -105,14 +105,13 @@ pub struct FileDiff {
     /// The hunks.
     pub hunks: Vec<RenderHunk>,
     /// Whether the underlying edit script is the minimal one. `false` means
-    /// this build compared the two sides, tripped [`stella_diff::LCS_AREA_CAP`]
-    /// and fell back to replace-everything; surfaces say so rather than
-    /// presenting a blunt diff as a precise answer.
+    /// the differ tripped [`stella_diff::LCS_AREA_CAP`] and fell back to
+    /// replace-everything; surfaces say so rather than presenting a blunt
+    /// diff as a precise answer.
     ///
-    /// A build from [`FileChange::patch`] compares nothing, so it can never
-    /// have fallen back and is always `true`. Whether the *producer's* differ
-    /// fell back is not on the wire — a declared gap, tracked in #3577's
-    /// follow-up rather than guessed at here.
+    /// A build from [`FileChange::patch`] carries the producer's own reading
+    /// ([`crate::model::Patch::minimal`], #4696); a build that compares the
+    /// two sides in-process reads it straight off [`stella_diff::Diff`].
     pub minimal: bool,
 }
 
@@ -135,7 +134,7 @@ impl FileDiff {
                     .iter()
                     .map(render_hunk)
                     .collect(),
-                minimal: true,
+                minimal: patch.minimal,
             };
         }
         let diff = stella_diff::unified_diff(&change.before, &change.after, CONTEXT);

--- a/crates/stella-transcript/src/model.rs
+++ b/crates/stella-transcript/src/model.rs
@@ -379,6 +379,17 @@ pub struct Patch {
     pub added: usize,
     /// Lines removed, as the producer counted them.
     pub removed: usize,
+    /// Whether `text` is the minimal edit script, or the producer's differ
+    /// tripped its area cap and fell back to a blunt replace-everything
+    /// rendering. `true` for a patch built before the producer carried this
+    /// (`AgentEvent::FileChange::minimal`'s own wire default) — the reading
+    /// every consumer already assumed of a patch back then.
+    #[serde(default = "default_minimal")]
+    pub minimal: bool,
+}
+
+fn default_minimal() -> bool {
+    true
 }
 
 /// The status dot on a file header bar.

--- a/crates/stella-transcript/src/tests/file_kinds.rs
+++ b/crates/stella-transcript/src/tests/file_kinds.rs
@@ -29,6 +29,7 @@ fn a_producers_patch_is_drawn_at_the_files_own_line_numbers() {
                 .to_string(),
             added: 1,
             removed: 1,
+            minimal: true,
         }),
         ..fragment
     };
@@ -43,13 +44,33 @@ fn a_producers_patch_is_drawn_at_the_files_own_line_numbers() {
         vec![(Some(212), None), (None, Some(212))]
     );
     assert_eq!((diff.added, diff.removed), (1, 1));
-    assert!(
-        diff.minimal,
-        "nothing was compared, so nothing can have fallen back"
-    );
+    assert!(diff.minimal, "the producer reported an exact diff");
     // The pairing that gives a modified line its word spans survives the patch
     // path — it is the same row builder, reached with parsed hunks.
     assert!(diff.hunks[0].rows[0].spans.iter().any(|s| s.changed));
+}
+
+/// **The witness for #4696.** A producer's patch that tripped
+/// `LCS_AREA_CAP` carries `minimal: false` on the wire; the build must read
+/// that flag rather than assume every patch is exact.
+#[test]
+fn a_producers_blunt_fallback_patch_stays_marked_non_minimal() {
+    let change = FileChange {
+        path: "big.txt".to_string(),
+        before: String::new(),
+        after: String::new(),
+        status: FileStatus::Modified,
+        patch: Some(Patch {
+            text: "--- a/big.txt\n+++ b/big.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n".to_string(),
+            added: 1,
+            removed: 1,
+            minimal: false,
+        }),
+    };
+    assert!(
+        !FileDiff::build(&change).minimal,
+        "the producer's own cap trip must survive onto the rendered diff"
+    );
 }
 
 #[test]

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -463,6 +463,7 @@ async fn mini_run(tx: &mpsc::UnboundedSender<Inbound>, id: &str) {
             added: 2,
             removed: 1,
             diff: Some("@@ -1 +1,2 @@\n-old\n+new\n+line\n".into()),
+            minimal: true,
         }),
         ev(AgentEvent::StepUsage {
             upstream_provider: None,

--- a/crates/stella-tui/src/accessible/tests.rs
+++ b/crates/stella-tui/src/accessible/tests.rs
@@ -95,6 +95,7 @@ fn measured(agent: &str, path: &str, added: u32, removed: u32) -> Inbound {
             added,
             removed,
             diff: None,
+            minimal: true,
         },
     }
 }

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -353,6 +353,7 @@ fn step_usage_accumulates_tokens_and_file_change_fills_ledger() {
             added: 2,
             removed: 1,
             diff: Some("+one\n+two\n-gone\n".into()),
+            minimal: true,
         },
     ));
     let lead = &w.agents[0];
@@ -466,6 +467,7 @@ fn ledger_counts_reads_without_regressing_the_mutation_badge() {
                 added: 0,
                 removed: 0,
                 diff: None,
+                minimal: true,
             },
         )
     };
@@ -486,6 +488,7 @@ fn ledger_counts_reads_without_regressing_the_mutation_badge() {
             added: 1,
             removed: 0,
             diff: Some("+one\n".into()),
+            minimal: true,
         },
     ));
     w.apply_inbound(&read("src/a.rs"));

--- a/crates/stella-tui/src/deck_ui/tests/files.rs
+++ b/crates/stella-tui/src/deck_ui/tests/files.rs
@@ -18,6 +18,7 @@ fn model_with_one_change() -> WorkspaceModel {
             added: 2,
             removed: 1,
             diff: Some("@@ -1,2 +1,3 @@\n context\n-old\n+new\n".into()),
+            minimal: true,
         },
     });
     m

--- a/crates/stella-tui/src/fleet_dashboard.rs
+++ b/crates/stella-tui/src/fleet_dashboard.rs
@@ -437,6 +437,7 @@ impl FleetBoard {
                 added,
                 removed,
                 diff,
+                ..
             } if kind.is_mutation() => {
                 // Enrich the last action with the +A-B the recorder measured,
                 // and keep the diff for the focused task's detail pane.

--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -78,6 +78,7 @@ fn grid_shows_tasks_statuses_last_action_and_header_clocks() {
                 added: 2,
                 removed: 1,
                 diff: Some("@@\n+a\n+b\n-c\n".into()),
+                minimal: true,
             }),
         },
         Instant::now(),

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -751,6 +751,7 @@ impl SessionModel {
                 added,
                 removed,
                 diff,
+                ..
             } => {
                 self.turn_counters.touch(path);
                 self.touch_file(path, *kind, *added, *removed, diff);

--- a/crates/stella-tui/src/model/file_state.rs
+++ b/crates/stella-tui/src/model/file_state.rs
@@ -295,6 +295,7 @@ mod tests {
             added,
             removed: 0,
             diff,
+            minimal: true,
         };
 
         model.apply(&mutate(Some("@@\n+first".into()), 1));
@@ -341,6 +342,7 @@ mod tests {
                 added: 1,
                 removed: 0,
                 diff: Some(format!("@@\n+edit_{i}")),
+                minimal: true,
             });
         }
         let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
@@ -371,6 +373,7 @@ mod tests {
             added: 1,
             removed: 0,
             diff: Some("@@\n+x".into()),
+            minimal: true,
         };
         model.apply(&change("src/first.rs".into()));
         for i in 0..300 {
@@ -404,6 +407,7 @@ mod tests {
                 added: 2,
                 removed: 1,
                 diff: Some("x".repeat(chunk)),
+                minimal: true,
             });
         }
         let file = model.files.iter().find(|f| f.path == "src/a.rs").unwrap();
@@ -442,6 +446,7 @@ mod tests {
             added: 1,
             removed: 0,
             diff: Some("@@\n+x".into()),
+            minimal: true,
         };
         for i in 0..MAX_TRACKED_FILES {
             model.apply(&change(format!("src/f{i}.rs")));
@@ -478,6 +483,7 @@ mod tests {
             added: 1,
             removed: 0,
             diff: Some("@@\n+x".into()),
+            minimal: true,
         };
         for i in 0..MAX_TRACKED_FILES {
             model.apply(&change(format!("src/f{i}.rs")));

--- a/crates/stella-tui/src/model/tests.rs
+++ b/crates/stella-tui/src/model/tests.rs
@@ -556,6 +556,7 @@ fn file_change_keeps_latest_diff_and_counts_touches() {
         added: 1,
         removed: 0,
         diff: Some("+first".into()),
+        minimal: true,
     });
     model.apply(&AgentEvent::FileChange {
         path: "src/a.rs".into(),
@@ -563,6 +564,7 @@ fn file_change_keeps_latest_diff_and_counts_touches() {
         added: 1,
         removed: 0,
         diff: Some("+second".into()),
+        minimal: true,
     });
     assert_eq!(model.files.len(), 1);
     let f = &model.files[0];
@@ -581,6 +583,7 @@ fn reads_count_without_clobbering_mutation_state() {
         added: 0,
         removed: 0,
         diff: None,
+        minimal: true,
     });
     assert_eq!(model.files.len(), 1, "reads appear in the files panel");
     let f = &model.files[0];
@@ -596,6 +599,7 @@ fn reads_count_without_clobbering_mutation_state() {
         added: 1,
         removed: 0,
         diff: Some("+x".into()),
+        minimal: true,
     });
     model.apply(&AgentEvent::FileChange {
         path: "src/a.rs".into(),
@@ -603,6 +607,7 @@ fn reads_count_without_clobbering_mutation_state() {
         added: 0,
         removed: 0,
         diff: None,
+        minimal: true,
     });
     let f = &model.files[0];
     assert_eq!(
@@ -624,6 +629,7 @@ fn files_are_kept_in_first_touched_order() {
             added: 0,
             removed: 0,
             diff: None,
+            minimal: true,
         });
     }
     let order: Vec<&str> = model.files.iter().map(|f| f.path.as_str()).collect();
@@ -1215,6 +1221,7 @@ fn turn_boundary(model: &mut SessionModel, path: &str, diff: Option<&str>, adds:
         added: adds,
         removed: dels,
         diff: diff.map(Into::into),
+        minimal: true,
     });
 }
 

--- a/crates/stella-tui/src/model/tests/producer_seq.rs
+++ b/crates/stella-tui/src/model/tests/producer_seq.rs
@@ -62,6 +62,7 @@ fn fold_edit(model: &mut SessionModel, call_id: &str, path: &str, diff: &str, ad
         added,
         removed: 0,
         diff: Some(diff.into()),
+        minimal: true,
     });
     model.apply(&AgentEvent::ToolResult {
         call_id: call_id.into(),
@@ -268,6 +269,7 @@ fn a_bash_call_renders_the_change_it_measured() {
         added: 3,
         removed: 1,
         diff: Some("@@ sed did this @@\n".into()),
+        minimal: true,
     });
     model.apply(&AgentEvent::ToolResult {
         call_id: "c1".into(),

--- a/crates/stella-tui/src/model/tests/retention.rs
+++ b/crates/stella-tui/src/model/tests/retention.rs
@@ -132,6 +132,7 @@ fn replay_of_the_same_log_yields_identical_models() {
             added: 1,
             removed: 1,
             diff: Some("@@\n-a\n+b".into()),
+            minimal: true,
         },
         AgentEvent::RunComplete {
             model: "glm".into(),

--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -406,6 +406,7 @@ fn the_receipt_reports_what_the_turn_measured() {
             added: 1,
             removed: 0,
             diff: None,
+            minimal: true,
         });
     }
     // memories ← ContextWrite's upserts

--- a/crates/stella-tui/src/render/tests/mutation_diff_e2e.rs
+++ b/crates/stella-tui/src/render/tests/mutation_diff_e2e.rs
@@ -81,6 +81,7 @@ fn fold_one_call(model: &mut SessionModel, name: &str, path: &str) {
         added: 1,
         removed: 1,
         diff: Some(REAL_PATCH.into()),
+        minimal: true,
     });
     model.apply(&AgentEvent::ToolResult {
         call_id: "c1".into(),
@@ -118,6 +119,7 @@ fn fold_batch(model: &mut SessionModel, paths: &[(&str, &str)]) {
             added: 1,
             removed: 1,
             diff: Some(patch_for("alpha", marker)),
+            minimal: true,
         });
     }
     model.apply(&AgentEvent::ToolResult {
@@ -154,6 +156,7 @@ fn fold_shell(model: &mut SessionModel, command: &str, paths: &[(&str, &str)]) {
             added: 1,
             removed: 1,
             diff: Some(patch_for("alpha", marker)),
+            minimal: true,
         });
     }
     model.apply(&AgentEvent::ToolResult {

--- a/crates/stella-tui/src/scenario.rs
+++ b/crates/stella-tui/src/scenario.rs
@@ -354,6 +354,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 added: crate::diff::count_diff_lines(PAGE_DIFF).0,
                 removed: crate::diff::count_diff_lines(PAGE_DIFF).1,
                 diff: Some(PAGE_DIFF.into()),
+                minimal: true,
             },
         ),
         ev(
@@ -480,6 +481,7 @@ pub fn demo_inbound(started_ms: u64, self_pid: u32) -> Vec<Inbound> {
                 added: crate::diff::count_diff_lines(TRIGGERS_DIFF).0,
                 removed: crate::diff::count_diff_lines(TRIGGERS_DIFF).1,
                 diff: Some(TRIGGERS_DIFF.into()),
+                minimal: true,
             },
         ),
         ev(

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -1232,6 +1232,7 @@ mod tests {
                 added: 0,
                 removed: 0,
                 diff: None,
+                minimal: true,
             },
             AgentEvent::ContextRecall {
                 frames: vec![ContextFrameRef {

--- a/crates/stella-tui/src/transcript_build.rs
+++ b/crates/stella-tui/src/transcript_build.rs
@@ -143,8 +143,9 @@ impl RunBuilder {
                 added,
                 removed,
                 diff,
+                minimal,
                 ..
-            } => self.attach_file(path, *added, *removed, diff.as_deref()),
+            } => self.attach_file(path, *added, *removed, diff.as_deref(), *minimal),
             AgentEvent::TurnComplete { .. } => self.finish_turn(Status::Ok),
             AgentEvent::Error { .. } => {
                 self.note(event);
@@ -348,7 +349,14 @@ impl RunBuilder {
     }
 
     /// Hang a file change on the step that produced it.
-    fn attach_file(&mut self, path: &str, added: u32, removed: u32, diff: Option<&str>) {
+    fn attach_file(
+        &mut self,
+        path: &str,
+        added: u32,
+        removed: u32,
+        diff: Option<&str>,
+        minimal: bool,
+    ) {
         let status = if removed > 0 && added == 0 {
             FileStatus::Deleted
         } else if removed == 0 && added > 0 {
@@ -371,6 +379,7 @@ impl RunBuilder {
                 text: text.to_string(),
                 added: added as usize,
                 removed: removed as usize,
+                minimal,
             }),
         };
         if let Some(turn) = self.turn.as_mut()

--- a/crates/stella-tui/src/transcript_build/tests.rs
+++ b/crates/stella-tui/src/transcript_build/tests.rs
@@ -215,6 +215,7 @@ fn a_file_change_renders_at_the_files_own_line_numbers() {
         added: 2,
         removed: 1,
         diff: Some("@@ -3,2 +3,3 @@\n context\n-old line\n+new line\n+added line\n".to_string()),
+        minimal: true,
     });
     b.finish_turn(Status::Ok);
 
@@ -254,6 +255,7 @@ fn a_diffless_file_change_still_records_the_file() {
         added: 1,
         removed: 1,
         diff: None,
+        minimal: true,
     });
     b.finish_turn(Status::Ok);
 

--- a/crates/stella-tui/src/views/files_tab.rs
+++ b/crates/stella-tui/src/views/files_tab.rs
@@ -510,6 +510,7 @@ mod tests {
                 added: 2,
                 removed: 0,
                 diff: Some("+one\n+two\n".into()),
+                minimal: true,
             },
         });
         m.apply_inbound(&Inbound::Event {
@@ -520,6 +521,7 @@ mod tests {
                 added: 2,
                 removed: 1,
                 diff: Some("@@ -1,2 +1,3 @@\n context\n-old\n+new\n+another\n".into()),
+                minimal: true,
             },
         });
         m
@@ -722,6 +724,7 @@ mod tests {
                 added: 5,
                 removed: 2,
                 diff: None,
+                minimal: true,
             },
         });
 
@@ -815,6 +818,7 @@ mod tests {
                 added: 1,
                 removed: 0,
                 diff: Some("@@ -1,0 +1,1 @@\n+kept\n".into()),
+                minimal: true,
             },
         });
         model.apply_inbound(&Inbound::SessionReset {
@@ -847,6 +851,7 @@ mod tests {
                 added: 0,
                 removed: 0,
                 diff: None,
+                minimal: true,
             },
         });
         let mut ui = DeckUi::default();
@@ -875,6 +880,7 @@ mod tests {
                     added: 0,
                     removed: 0,
                     diff: None,
+                    minimal: true,
                 },
             });
         }

--- a/crates/stella-tui/src/views/session.rs
+++ b/crates/stella-tui/src/views/session.rs
@@ -748,6 +748,7 @@ mod tests {
             added: 1,
             removed: 0,
             diff: Some("@@ -1,1 +1,1 @@\n+first_diff_line".into()),
+            minimal: true,
         });
         let expanded = HashSet::new();
         let mut fold = SessionFold::default();
@@ -783,6 +784,7 @@ mod tests {
             added: 1,
             removed: 0,
             diff: Some("@@ -1,1 +1,1 @@\n+second_diff_line".into()),
+            minimal: true,
         });
         assert_eq!(model.transcript.len(), len_before, "no transcript append");
         fold.refresh(
@@ -824,6 +826,7 @@ mod tests {
                 added: 0,
                 removed: 0,
                 diff: Some(format!("@@ -1,1 +1,1 @@\n+evicting_edit_{i}")),
+                minimal: true,
             });
         }
         assert_eq!(model.transcript.len(), len_before, "still no append");

--- a/crates/stella-tui/src/views/session/fold_backfill.rs
+++ b/crates/stella-tui/src/views/session/fold_backfill.rs
@@ -108,6 +108,7 @@ fn a_settled_head_states_its_size_once_the_turn_boundary_measures_it() {
         added: 1,
         removed: 0,
         diff: Some("@@ -1,1 +1,1 @@\n+measured".into()),
+        minimal: true,
     });
     refresh(&mut fold, &model);
     let after = text(&fold);

--- a/crates/stella-tui/src/views/traces.rs
+++ b/crates/stella-tui/src/views/traces.rs
@@ -339,6 +339,7 @@ mod tests {
                 added: 1,
                 removed: 1,
                 diff: Some("+one\n-two\n".into()),
+                minimal: true,
             },
         ));
         model

--- a/crates/stella-tui/src/views/transcript_source.rs
+++ b/crates/stella-tui/src/views/transcript_source.rs
@@ -557,6 +557,7 @@ mod tests {
                 added: *added,
                 removed: *removed,
                 diff: Some(format!("@@ -1,1 +1,1 @@\n+{path}")),
+                minimal: true,
             });
         }
         model

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1953,6 +1953,15 @@ export type AgentEvent = {
   added?: number;
   diff?: string | null;
   kind: FileChangeKind;
+  /**
+   * Whether `diff` is the minimal edit script, or the producer's diff
+   * tripped its area cap and fell back to a blunt replace-everything
+   * rendering (`stella_diff::LCS_AREA_CAP`). A transcript surface
+   * renders a banner over `false` so a degraded diff is never mistaken
+   * for a precise one (#4696). `true` for a work-tree measurement:
+   * git's own diff never takes this fallback.
+   */
+  minimal?: boolean;
   path: string;
   removed?: number;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -3294,6 +3294,11 @@
         "kind": {
           "$ref": "#/$defs/FileChangeKind"
         },
+        "minimal": {
+          "default": true,
+          "description": "Whether `diff` is the minimal edit script, or the producer's diff\ntripped its area cap and fell back to a blunt replace-everything\nrendering (`stella_diff::LCS_AREA_CAP`). A transcript surface\nrenders a banner over `false` so a degraded diff is never mistaken\nfor a precise one (#4696). `true` for a work-tree measurement:\ngit's own diff never takes this fallback.",
+          "type": "boolean"
+        },
         "path": {
           "type": "string"
         },

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -466,6 +466,15 @@ export type AgentEvent = {
   added?: number;
   diff?: string | null;
   kind: FileChangeKind;
+  /**
+   * Whether `diff` is the minimal edit script, or the producer's diff
+   * tripped its area cap and fell back to a blunt replace-everything
+   * rendering (`stella_diff::LCS_AREA_CAP`). A transcript surface
+   * renders a banner over `false` so a degraded diff is never mistaken
+   * for a precise one (#4696). `true` for a work-tree measurement:
+   * git's own diff never takes this fallback.
+   */
+  minimal?: boolean;
   path: string;
   removed?: number;
   type: "file_change";

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -893,6 +893,11 @@
             "kind": {
               "$ref": "#/$defs/FileChangeKind"
             },
+            "minimal": {
+              "default": true,
+              "description": "Whether `diff` is the minimal edit script, or the producer's diff\ntripped its area cap and fell back to a blunt replace-everything\nrendering (`stella_diff::LCS_AREA_CAP`). A transcript surface\nrenders a banner over `false` so a degraded diff is never mistaken\nfor a precise one (#4696). `true` for a work-tree measurement:\ngit's own diff never takes this fallback.",
+              "type": "boolean"
+            },
             "path": {
               "type": "string"
             },


### PR DESCRIPTION
## What & why

`FileDiff::minimal` always read `true` on the patch path: `AgentEvent::FileChange` had no field to carry `stella_diff::Diff::minimal`, and `own_change::file_change` dropped it computing the patch text. A producer's blunt replace-everything fallback rendered with no banner once #4683 put producers on the patch path.

Adds `minimal` to `AgentEvent::FileChange` (additive, `#[serde(default = ...)]` true for streams recorded before the field existed) and to `Patch`. Both producers set it — `own_change`'s differ reads it straight off `stella_diff::Diff`, and `turn_files.rs`'s git measurement is always `true` (`git diff-tree -p` never trips the area cap). `transcript_view::measured_patch` and `FileDiff::build` read it through to the render. Wire schema regenerated via `scripts/export-agentevent-schema.sh`; `docs/wire/` diffs are additive only, `PROTOCOL_VERSION` untouched.

Closes #4696

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

Four, at each layer the flag crosses:
- `own_change.rs`: `a_blunt_fallback_edit_reports_itself_as_non_minimal` — an edit past `LCS_AREA_CAP` reports `minimal: false` on both the call's own reading and the wire event it produces.
- `stella-protocol`: `file_change_carries_the_delta_and_the_diff_on_the_single_event_path` extended to round-trip `minimal: false`; `a_file_change_without_counts_still_parses` extended to assert the pre-#4696 default (`true`).
- `stella-observatory`: `a_blunt_fallback_row_renders_a_non_minimal_diff` — a `file_change` row carrying `"minimal": false` renders a non-minimal `FileDiff`.
- `stella-transcript`: `a_producers_blunt_fallback_patch_stays_marked_non_minimal` — a `Patch` with `minimal: false` builds a non-minimal `FileDiff` (the file that renders `html.rs`'s banner).

## The gate

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally per this repo's CLAUDE.md (no workspace-wide builds on the maintainer's machine); CI runs it
- [ ] `cargo test --workspace` — same; ran targeted instead: `cargo test -p stella-protocol -p stella-tools -p stella-transcript -p stella-observatory -p stella-tui -p stella-cli`, all green, plus `make guards-fast`
- [ ] Docs updated where behavior/flags changed — no user-facing flag; the wire doc is `docs/wire/`, regenerated
- [ ] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing new: everything I noticed is fixed in this PR, or already tracked by an open issue (see below)

Three other render surfaces build their own diff independently of `stella_transcript::file_diff`/`html.rs` and so still show no blunt-fallback banner — `stella-cli/src/export/transcript.rs` (`stella export`'s HTML), `stella-cli/src/plain.rs` (`file_change_card`), and `stella-tui/src/diff.rs` (interactive mode's own painter). Each is the exact "second renderer" drift already tracked by open issues #4270, #3578 and #4289 respectively (confirmed via `make guards-fast`'s `transcript-surfaces` ledger, which lists all three as declared gaps) — folding them onto the shared renderer is the fix for the banner there too, so no new issue.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] New cross-boundary type (`AgentEvent::FileChange::minimal`) round-trips through serde — tested in `stella-protocol/src/event/tests.rs` and covered by the wire-contract corpus (`every_sample_event_validates_against_the_committed_schema`)

## Anything reviewers should know?

`Patch::minimal` also defaults `true` via `#[serde(default = "default_minimal")]`, mirroring the wire field's own default — a `Patch` built from a pre-#4696 stream reads as minimal, which is what every consumer already assumed of a patch back then.

## Summary by Sourcery

Preserve diff minimality metadata across file-change producers, protocol events, and transcript rendering so blunt fallbacks are clearly identified.

New Features:
- Propagate whether a file diff is minimal through file-change events and transcript patches so renderers can identify blunt replace-everything fallbacks.

Bug Fixes:
- Restore the non-minimal diff banner for producer-generated fallbacks when changes travel through the patch path.

Enhancements:
- Preserve backward compatibility by defaulting the new wire and patch metadata to minimal for older streams.
- Carry producer diff metadata into transcript rendering and regenerate the additive wire schemas.

Documentation:
- Regenerate the AgentEvent wire documentation and schemas with the new optional minimal field.

Tests:
- Add coverage for non-minimal fallback propagation across producers, protocol serialization, observatory rendering, and transcript diff construction.