### PR TITLE
test(stella-runtime): wrapper_decided_flip runs on Windows, and settles #4855's open question

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -112,3 +112,4 @@ jobs:
           --test wrapper_dispatch
           --test host_owned_tamper
           --test wrapper_claimed_evidence
+          --test wrapper_decided_flip

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -117,12 +117,12 @@ fn main() {
         // not have made. The two-substring match is the `case` the shell
         // script spelled out.
         //
-        // `wrapper_claimed_evidence.rs` currently takes only the granted
-        // side: its `report()` always passes `candidate: Some(..)`. The
-        // ungranted arm is kept because it is the plugin's honest answer,
-        // and dropping it would leave a fixture that claims `achieved`
-        // whatever it was given — which is the dishonesty that file exists
-        // to catch. A test that withholds the grant would exercise it.
+        // Both arms are load-bearing, from different files.
+        // `wrapper_claimed_evidence.rs` takes only the granted side (its
+        // `report()` always passes `candidate: Some(..)`), while
+        // `wrapper_decided_flip.rs` calls `run(None, ..)` — so neutering
+        // this branch fails `without_the_grant_or_the_snapshot_the_verdict_is_undecided`
+        // there. Checked by ablation, not assumed.
         "flip-if-granted" => {
             let request = read_request();
             let flip = if request.contains("\"root\"") && request.contains("\"program\":\"sh\"") {

--- a/crates/stella-runtime/tests/wrapper_decided_flip.rs
+++ b/crates/stella-runtime/tests/wrapper_decided_flip.rs
@@ -31,11 +31,10 @@
 //! the level every host has in common — §6 wants the same plugin decided under
 //! `stella-serve` and an embedded host too.
 //!
-//! `cfg(unix)` for `wrapper_socket.rs`'s reason and tracked in the same place:
-//! the plugin is a `/bin/sh` script, so this file proves nothing on Windows
-//! until #3497 replaces it with a portable in-tree plugin.
-
-#![cfg(unix)]
+//! The plugin is `wrapper-plugin-fixture`, the portable in-tree plugin #3497
+//! added, so this file runs on Windows too (#4697). It shares
+//! `wrapper_claimed_evidence.rs`'s `flip-if-granted` mode: the two files ask
+//! the same question of the same plugin behaviour from opposite sides.
 
 use std::sync::Arc;
 
@@ -82,14 +81,7 @@ name = "verify"
 /// It answers from the request rather than from ambient state, which is the
 /// property the grant exists to make possible: `root` and `test` are the only
 /// things it needs, and both arrived in the message.
-const OBSERVES_THE_FLIP: &str = r#"
-request=$(cat)
-case "$request" in
-  *'"root"'*'"program":"sh"'*) flip=achieved ;;
-  *) flip=unobservable ;;
-esac
-printf '%s\n' "{\"point\":\"after_turn\",\"body\":{\"protocol_version\":1,\"evidence\":{\"flip\":\"$flip\"}}}"
-"#;
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
 
 fn manifest() -> PluginManifest {
     PluginManifest::from_toml_str(MANIFEST).expect("the manifest loads")
@@ -97,7 +89,7 @@ fn manifest() -> PluginManifest {
 
 fn dispatch() -> WrapperDispatch {
     let admitted = SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), OBSERVES_THE_FLIP.into()],
+        vec![FIXTURE.to_string(), "flip-if-granted".into()],
         Vec::new(),
         DEFAULT_WRAPPER_TIMEOUT,
     )


### PR DESCRIPTION
Four of twelve for #4697. `wrapper_decided_flip.rs` carries the same `/bin/sh` script as `wrapper_claimed_evidence.rs`, so it reuses `flip-if-granted` with no new fixture mode.

## It settles the caveat #4855 shipped with

That PR was explicit that its ablation check did **not** validate the port: neutering the branch left both its tests green, because its `report()` always passes `candidate: Some(..)`. I kept the ungranted arm anyway and said a test withholding the grant would exercise it.

This file is that test. It calls `run(None, ..)`, and neutering the branch fails it:

```
test without_the_grant_or_the_snapshot_the_verdict_is_undecided ... FAILED
test result: FAILED. 2 passed; 1 failed
```

So both arms are load-bearing after all — from different files, which is why neither file alone could show it. The fixture's note said "a test that withholds the grant would exercise it"; it now says which test does, checked by ablation rather than assumed. That is the open question from #4855 closed with evidence rather than left as a standing judgement call.

## Evidence

```
cargo test -p stella-runtime --test wrapper_decided_flip        3 passed; 0 failed
cargo test -p stella-runtime --test wrapper_claimed_evidence    2 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings     exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)      exit 0
cargo fmt --all --check     exit 0
check-prose                 OK — none added
```

Added to `windows-check.yml`. Not claiming a Windows pass from here; that runner reports on this PR, and returned green for the same pattern on #4848.

Eight files remain in #4697. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Enable cross-platform wrapper decision coverage and validate the undecided outcome when no grant or snapshot is provided.

New Features:
- Run the `wrapper_decided_flip` integration test on Windows using the portable wrapper plugin fixture.
- Cover the ungranted wrapper path and verify that it produces an undecided verdict when neither a grant nor snapshot is available.

Enhancements:
- Reuse the shared portable fixture for wrapper decision tests and document that both granted and ungranted behavior are covered.

CI:
- Add `wrapper_decided_flip` to the Windows check workflow.

Tests:
- Add Windows-capable coverage confirming both sides of the wrapper decision behavior are load-bearing.