### PR TITLE
The evolution-surface ledger and an evidence grade that aggregation cannot launder (#2780, #2782)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -575,6 +575,37 @@ Append; do not renumber. `scripts/check-invariants.sh` enforces both halves.
    totality (by the compiler) plus issue citation and posture coherence (by
    test) — enough to make a PR author answer "what reads this?" before the
    merge.
+11. **Every way Stella changes itself is declared.** Stella evolves through
+   several object classes — framework, memory, skill, tool, workflow, model —
+   and each one used to answer "when may this change, on what evidence,
+   published by whom, and how is it undone?" in a different file or nowhere.
+   The ledger is
+   `crates/stella-parity/src/evolution.rs`: one row per surface, declaring a
+   posture, a timing, an impact class, a rollback artifact, and — for a live
+   posture — the witness test proving the surface can actually be changed.
+   `EvolutionSurface` and its rows are generated from one macro table, so a
+   surface with no row does not compile.
+
+   The `evidence` and `authority` columns are **not stored**. A row declares
+   what a wrong change to it can break (`ImpactClass`), and the required
+   provenance grade and publication authority are read out of
+   `crates/stella-protocol/src/provenance.rs`. One policy, read in two places,
+   with no second copy to drift (#2780, #2782).
+
+   That policy is the other half of this rule, and it says that
+   **aggregation never promotes evidence**. N model critiques agreeing remain a
+   model critique; only re-deriving a claim against a stronger source moves it.
+   A prompt hint may be trialled from a mined trajectory, and a blocking guard
+   or an executable tool needs deterministic proof plus a person — because
+   those two break a teammate's session, and blast radius is what the grade
+   rations. #2569/#2570 is why vote-counting is not an alternative: ablating
+   the verifier turned every run into a PASS and the count never noticed.
+
+   What it does **not** prove: that a live path actually asks the gate before
+   publishing. The ledger declares the terms and the policy can answer them;
+   wiring `authorises` into each publication path is tracked separately, and
+   the rows say plainly where today's evidence falls short of what they
+   require.
 ---
 
 ## The definition of done: witness tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,6 +3165,7 @@ dependencies = [
 name = "stella-parity"
 version = "0.9.215"
 dependencies = [
+ "stella-protocol",
  "stella-serve",
 ]
 

--- a/crates/stella-cli/src/context_cmd/explain.rs
+++ b/crates/stella-cli/src/context_cmd/explain.rs
@@ -112,6 +112,9 @@ pub fn run_explain(root: &Path, needle: &str) -> Result<(), String> {
         if let Some(run) = provenance.ingest_run_id.as_deref() {
             println!("    {}", format!("ingest run {run}").dimmed());
         }
+        if let Some(line) = evidence_line(provenance.evidence_grade) {
+            println!("    {}", line.dimmed());
+        }
     }
     if let Some(id) = record.record_id.as_deref() {
         println!("    {}", format!("record {id}").dimmed());
@@ -234,6 +237,20 @@ pub fn run_explain(root: &Path, needle: &str) -> Result<(), String> {
 /// The `selected` → `rendered` → `cited` funnel is recorded by the session that
 /// rendered the record; a workspace that has not run a session since the record was
 /// published has nothing to report, which is different from a record nobody used.
+/// The evidence line for a record's provenance grade (#2782), or [`None`] when
+/// the record carries no grade.
+///
+/// Absent is the common case and says nothing rather than implying weakness: a
+/// grade is stamped on records Stella *induced* from a run, and most records
+/// are ingested from a document instead. Extracted from the rendering so the
+/// wording can be asserted — `run_explain` prints to stdout, so a test of what
+/// it renders has nowhere else to look.
+pub(super) fn evidence_line(
+    grade: Option<stella_protocol::provenance::ProvenanceGrade>,
+) -> Option<String> {
+    grade.map(|grade| format!("evidence: {} — {}", grade.as_str(), grade.describe()))
+}
+
 fn efficacy_line(root: &Path, handle: &str) -> String {
     let ledger = root.join(".stella/private/context.db");
     if !ledger.exists() {

--- a/crates/stella-cli/src/context_cmd/tests.rs
+++ b/crates/stella-cli/src/context_cmd/tests.rs
@@ -619,6 +619,39 @@ fn explain_reproduces_a_kept_records_rule_and_provenance() {
     explain::run_explain(root.path(), "ctx.acme.web.pkg-manager").expect("explain by lineage");
 }
 
+/// #2782 — `stella context explain` distinguishes a rule Stella inferred from
+/// its own reflection from one it derived from a failing build.
+///
+/// The surrounding provenance lines say *where* a record came from. This one
+/// says what that source was worth, which is the question a reviewer deciding
+/// whether to trust an induced rule is actually asking.
+#[test]
+fn explain_names_the_grade_of_the_evidence_behind_a_record() {
+    use stella_protocol::provenance::ProvenanceGrade;
+
+    let critique = explain::evidence_line(Some(ProvenanceGrade::ModelCritique))
+        .expect("a graded record renders a line");
+    assert!(critique.contains("model_critique"), "{critique}");
+    assert!(
+        critique.contains("judgement"),
+        "the line must say what the grade means, not only name it: {critique}"
+    );
+
+    let proof = explain::evidence_line(Some(ProvenanceGrade::DeterministicProof))
+        .expect("a graded record renders a line");
+    assert!(proof.contains("deterministic_proof"), "{proof}");
+    assert_ne!(
+        critique, proof,
+        "the two grades must be visibly different where a human decides"
+    );
+
+    assert_eq!(
+        explain::evidence_line(None),
+        None,
+        "a record ingested from a document carries no grade and must claim none"
+    );
+}
+
 #[test]
 fn explain_on_an_unknown_rule_lists_what_is_loaded() {
     let root = workspace();

--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -805,6 +805,7 @@ pub(crate) fn inferred_rule_record(
     statement: &str,
     source_kind: &str,
     source_uri: &str,
+    evidence_grade: Option<stella_protocol::provenance::ProvenanceGrade>,
 ) -> Result<stella_core::ingest::record::Record, String> {
     use stella_core::context_record::{Origin, RecordStatus};
     use stella_core::ingest::record as rec;
@@ -844,6 +845,10 @@ pub(crate) fn inferred_rule_record(
         provenance: Some(rec::Provenance {
             source_kind: Some(source_kind.to_string()),
             source_uri: Some(source_uri.to_string()),
+            // Carried from the proposal being published (#2782). Once this
+            // record is on disk the observations behind it are out of reach,
+            // so a grade not carried here is unrecoverable.
+            evidence_grade,
             ..Default::default()
         }),
         steering: Some(rec::Steering {

--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -636,6 +636,9 @@ fn build_defaults(
             commit: git(root, &["rev-parse", "--short", "HEAD"]),
             ingest_run_id: Some(ingest_run_id.to_string()),
             extracted_at: Some(extracted_at.to_string()),
+            // Ingested from a document rather than induced from a run, so
+            // there is no run-evidence grade to carry (#2782).
+            evidence_grade: None,
             extractor: Some(extractor.to_string()),
         }),
     }

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -15,6 +15,7 @@ use stella_core::skills::{
     self, AutoCreateConfig, AutoCreateDecision, SkillMineConfig, SkillObservation,
 };
 use stella_protocol::Provider;
+use stella_protocol::provenance::ProvenanceGrade;
 
 use super::{
     LessonKind, ReflectionLesson, ReflectionReport, SessionMemory, TurnEvidence, reflect_on_turn,
@@ -590,7 +591,18 @@ impl SessionMemory {
     /// Shared by both paths, so the cap and the guard are literally the same
     /// code on each — asserted by test rather than by inspection, which is what
     /// spec §8 asks for.
-    fn write_candidates(&mut self, candidates: Vec<skills::SkillCandidate>, quiet: bool) {
+    /// Write the eligible skill candidates, each with the evidence grade of
+    /// the proposal it was promoted from (#2782).
+    ///
+    /// The grade rides alongside the candidate rather than inside it because a
+    /// `SkillCandidate` is the miner's output and knows nothing about the
+    /// lifecycle ledger — the proposal is where the two meet, and this is the
+    /// hop that used to drop it.
+    fn write_candidates(
+        &mut self,
+        candidates: Vec<(skills::SkillCandidate, Option<ProvenanceGrade>)>,
+        quiet: bool,
+    ) {
         // The workspace-skills authority gate, on the write it actually
         // describes. Without it the loader is handed an empty workspace dir, so
         // a skill written here would never be read back — and computing the
@@ -624,7 +636,7 @@ impl SessionMemory {
         // ledger rather than from this turn — one turn cannot measure a skill
         // that has never been injected.
         let verdicts = super::appraisals::latest_verdicts(&self.workspace_root);
-        for candidate in candidates {
+        for (candidate, evidence_grade) in candidates {
             let evidence = verdicts
                 .get(&candidate.name)
                 .copied()
@@ -638,7 +650,7 @@ impl SessionMemory {
                 &config,
             ) {
                 AutoCreateDecision::Create { path } => {
-                    let markdown = skills::render_skill_markdown(&candidate);
+                    let markdown = skills::render_skill_markdown(&candidate, evidence_grade);
                     let path = PathBuf::from(path);
                     if let Some(parent) = path.parent() {
                         let _ = std::fs::create_dir_all(parent);
@@ -757,7 +769,7 @@ impl SessionMemory {
                 i.proposal
                     .is_eligible(promotion.min_distinct_tasks, promotion.min_observations)
             })
-            .map(|i| i.candidate)
+            .map(|i| (i.candidate, i.proposal.provenance))
             .collect();
         self.write_candidates(eligible, quiet);
 
@@ -825,7 +837,11 @@ impl SessionMemory {
             if !self.include_workspace_skills {
                 continue;
             }
-            match super::rules_mining::write_rule(&self.workspace_root, &rule.candidate) {
+            match super::rules_mining::write_rule(
+                &self.workspace_root,
+                &rule.candidate,
+                rule.proposal.provenance,
+            ) {
                 Ok(Some(path)) if !quiet => {
                     println!(
                         "  {} new advisory rule from recurring observations: {} ({})",
@@ -880,6 +896,9 @@ impl SessionMemory {
         let existing = self.load_skills();
         let candidates =
             skills::mine_skill_candidates(observations, &existing, &SkillMineConfig::default());
+        // The lexical path has no proposal behind it, so it carries no
+        // grade — absent rather than guessed.
+        let candidates = candidates.into_iter().map(|c| (c, None)).collect();
         self.write_candidates(candidates, quiet);
     }
 }

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -15,7 +15,6 @@ use stella_core::skills::{
     self, AutoCreateConfig, AutoCreateDecision, SkillMineConfig, SkillObservation,
 };
 use stella_protocol::Provider;
-use stella_protocol::provenance::ProvenanceGrade;
 
 use super::{
     LessonKind, ReflectionLesson, ReflectionReport, SessionMemory, TurnEvidence, reflect_on_turn,
@@ -591,18 +590,7 @@ impl SessionMemory {
     /// Shared by both paths, so the cap and the guard are literally the same
     /// code on each — asserted by test rather than by inspection, which is what
     /// spec §8 asks for.
-    /// Write the eligible skill candidates, each with the evidence grade of
-    /// the proposal it was promoted from (#2782).
-    ///
-    /// The grade rides alongside the candidate rather than inside it because a
-    /// `SkillCandidate` is the miner's output and knows nothing about the
-    /// lifecycle ledger — the proposal is where the two meet, and this is the
-    /// hop that used to drop it.
-    fn write_candidates(
-        &mut self,
-        candidates: Vec<(skills::SkillCandidate, Option<ProvenanceGrade>)>,
-        quiet: bool,
-    ) {
+    fn write_candidates(&mut self, candidates: Vec<skills::SkillCandidate>, quiet: bool) {
         // The workspace-skills authority gate, on the write it actually
         // describes. Without it the loader is handed an empty workspace dir, so
         // a skill written here would never be read back — and computing the
@@ -636,7 +624,7 @@ impl SessionMemory {
         // ledger rather than from this turn — one turn cannot measure a skill
         // that has never been injected.
         let verdicts = super::appraisals::latest_verdicts(&self.workspace_root);
-        for (candidate, evidence_grade) in candidates {
+        for candidate in candidates {
             let evidence = verdicts
                 .get(&candidate.name)
                 .copied()
@@ -650,7 +638,7 @@ impl SessionMemory {
                 &config,
             ) {
                 AutoCreateDecision::Create { path } => {
-                    let markdown = skills::render_skill_markdown(&candidate, evidence_grade);
+                    let markdown = skills::render_skill_markdown(&candidate);
                     let path = PathBuf::from(path);
                     if let Some(parent) = path.parent() {
                         let _ = std::fs::create_dir_all(parent);
@@ -769,7 +757,7 @@ impl SessionMemory {
                 i.proposal
                     .is_eligible(promotion.min_distinct_tasks, promotion.min_observations)
             })
-            .map(|i| (i.candidate, i.proposal.provenance))
+            .map(|i| i.candidate)
             .collect();
         self.write_candidates(eligible, quiet);
 
@@ -896,9 +884,6 @@ impl SessionMemory {
         let existing = self.load_skills();
         let candidates =
             skills::mine_skill_candidates(observations, &existing, &SkillMineConfig::default());
-        // The lexical path has no proposal behind it, so it carries no
-        // grade — absent rather than guessed.
-        let candidates = candidates.into_iter().map(|c| (c, None)).collect();
         self.write_candidates(candidates, quiet);
     }
 }

--- a/crates/stella-cli/src/memory/proposals.rs
+++ b/crates/stella-cli/src/memory/proposals.rs
@@ -30,8 +30,8 @@ use std::collections::{BTreeSet, HashMap};
 
 use stella_context::{ContextStore, LedgerAppend};
 use stella_core::context_record::{
-    ContextRecordKind, LIFECYCLE_SCHEMA_VERSION, ObservationRecord, ProposalRecord, ProposalScore,
-    RecordProposalKind, RecordProposalStatus, confidence_from_score,
+    ContextRecordKind, EvidencePool, LIFECYCLE_SCHEMA_VERSION, ObservationRecord, ProposalRecord,
+    ProposalScore, RecordProposalKind, RecordProposalStatus, confidence_from_score,
 };
 use stella_core::skills::{self, Skill, SkillCandidate, SkillMineConfig, SkillObservation};
 
@@ -109,7 +109,10 @@ pub(crate) fn induce_proposals(
         // The observations behind this candidate, resolved back through the
         // evidence the miner recorded.
         let mut tasks: BTreeSet<&str> = BTreeSet::new();
-        let mut supporting: Vec<String> = Vec::new();
+        // The observations themselves, not just their ids: the proposal's
+        // evidence grade is folded from them, and a grade cannot be folded
+        // from an id (#2782).
+        let mut supporting: Vec<&ObservationRecord> = Vec::new();
         for evidence in &candidate.evidence {
             // The miner truncates the snippet to 160 chars; match on the same
             // prefix so a long lesson still resolves.
@@ -119,7 +122,7 @@ pub(crate) fn induce_proposals(
             });
             if let Some(observation) = key {
                 tasks.insert(observation.task_id.as_str());
-                supporting.push(observation.record_id.clone());
+                supporting.push(observation);
             } else if let Some(task) = task_index.get(&(evidence.reference.clone(), String::new()))
             {
                 tasks.insert(task.as_str());
@@ -150,7 +153,7 @@ pub(crate) fn induce_proposals(
             &candidate.description,
             &candidate.body,
             candidate.domains.clone(),
-            supporting,
+            EvidencePool::from_observations(supporting),
             score,
             confidence,
             proposal_observed_at(&candidate),

--- a/crates/stella-cli/src/memory/rules_mining.rs
+++ b/crates/stella-cli/src/memory/rules_mining.rs
@@ -42,6 +42,7 @@ use stella_core::context_record::{
     RecordProposalStatus, confidence_from_score,
 };
 use stella_core::rules::{self, EvidenceSource, MineConfig, RawObservation, Rule, RuleCandidate};
+use stella_protocol::provenance::ProvenanceGrade;
 
 use super::proposals::record_proposal;
 
@@ -194,9 +195,16 @@ pub(crate) fn workspace_rules_dir(workspace_root: &Path) -> std::path::PathBuf {
 /// describes on the skills side — and the write itself is `create_new` inside
 /// [`crate::context_records::write_record`], because the exists checks here
 /// are advisory and racy.
+/// Publish a mined rule as a context record.
+///
+/// `evidence_grade` is the grade of the proposal being published (#2782). It
+/// is a parameter rather than something this function derives, because the
+/// evidence is two hops back: only the caller holding the proposal knows it,
+/// and a rule file that does not carry it cannot recover it later.
 pub(crate) fn write_rule(
     workspace_root: &Path,
     candidate: &RuleCandidate,
+    evidence_grade: Option<ProvenanceGrade>,
 ) -> Result<Option<std::path::PathBuf>, String> {
     let candidate = without_inferred_guard(candidate.clone());
     let set_id = crate::ingest_cmd::derive_set_id(workspace_root);
@@ -206,6 +214,7 @@ pub(crate) fn write_rule(
         &candidate.text,
         "observation",
         &format!("proposal:rule:{}", candidate.id),
+        evidence_grade,
     )?;
     if workspace_rules_dir(workspace_root)
         .join(format!("{}.md", candidate.id))

--- a/crates/stella-cli/src/memory/rules_mining.rs
+++ b/crates/stella-cli/src/memory/rules_mining.rs
@@ -38,8 +38,8 @@ use std::path::Path;
 
 use stella_context::ContextStore;
 use stella_core::context_record::{
-    ObservationRecord, ProposalRecord, ProposalScore, RecordProposalKind, RecordProposalStatus,
-    confidence_from_score,
+    EvidencePool, ObservationRecord, ProposalRecord, ProposalScore, RecordProposalKind,
+    RecordProposalStatus, confidence_from_score,
 };
 use stella_core::rules::{self, EvidenceSource, MineConfig, RawObservation, Rule, RuleCandidate};
 
@@ -116,14 +116,17 @@ pub(crate) fn induce_rule_proposals(
         // Resolve the miner's evidence back to the observations behind it, so
         // the proposal carries distinct TASKS rather than raw occurrences.
         let mut tasks: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-        let mut supporting: Vec<String> = Vec::new();
+        // The observations themselves, not just their ids: the proposal's
+        // evidence grade is folded from them, and a grade cannot be folded
+        // from an id (#2782).
+        let mut supporting: Vec<&ObservationRecord> = Vec::new();
         for evidence in &candidate.evidence {
             if let Some(observation) = observations.iter().find(|o| {
                 o.source_ref == evidence.reference
                     && o.text.chars().take(160).collect::<String>() == evidence.snippet
             }) {
                 tasks.insert(observation.task_id.as_str());
-                supporting.push(observation.record_id.clone());
+                supporting.push(observation);
             }
         }
 
@@ -148,7 +151,7 @@ pub(crate) fn induce_rule_proposals(
             &candidate.description,
             &candidate.text,
             Vec::new(),
-            supporting,
+            EvidencePool::from_observations(supporting),
             score,
             confidence,
             stella_context::format_rfc3339(

--- a/crates/stella-cli/src/memory/rules_mining/tests.rs
+++ b/crates/stella-cli/src/memory/rules_mining/tests.rs
@@ -77,6 +77,7 @@ fn an_inferred_rule_is_never_blocking() {
         &stripped.text,
         "observation",
         "proposal:rule:some-lesson-abcd1234",
+        None,
     )
     .expect("a publishable record");
     assert!(
@@ -114,7 +115,7 @@ fn a_written_rule_file_is_prompt_only() {
         }),
         score: 30,
     };
-    let path = write_rule(dir.path(), &candidate)
+    let path = write_rule(dir.path(), &candidate, None)
         .expect("publishable")
         .expect("written");
     assert_eq!(
@@ -256,7 +257,7 @@ fn writing_never_clobbers_an_existing_rule_file() {
         score: 30,
     };
     assert!(
-        write_rule(dir.path(), &candidate)
+        write_rule(dir.path(), &candidate, None)
             .expect("an existing file is a skip, not an error")
             .is_none(),
         "the writer claimed to write over an existing file"
@@ -304,7 +305,7 @@ fn mined_rules_land_where_the_loader_reads() {
         guard: None,
         score: 30,
     };
-    write_rule(dir.path(), &candidate)
+    write_rule(dir.path(), &candidate, None)
         .expect("publishable")
         .expect("written");
 
@@ -318,5 +319,68 @@ fn mined_rules_land_where_the_loader_reads() {
             .any(|r| r.id.contains("landing-abcd1234") && r.text.contains("database migration")),
         "a mined rule did not reach the loader: {:?}",
         loaded.iter().map(|r| &r.id).collect::<Vec<_>>()
+    );
+}
+
+/// **The hop out of the ledger** (#2782): a rule published from a proposal
+/// carries that proposal's evidence grade onto the record on disk.
+///
+/// This is the boundary where provenance was previously lost for good. A
+/// proposal keeps its observations' ids; the published record keeps neither,
+/// so a grade not written here cannot be recovered by anything downstream —
+/// including the human reading the rule file to decide whether to trust it.
+#[test]
+fn a_published_rule_carries_the_grade_of_the_proposal_it_came_from() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidate = RuleCandidate {
+        id: "graded-abcd1234".into(),
+        text: LESSON.into(),
+        description: "d".into(),
+        occurrences: 3,
+        salient: false,
+        evidence: Vec::new(),
+        guard: None,
+        score: 30,
+    };
+
+    let path = write_rule(
+        dir.path(),
+        &candidate,
+        Some(stella_protocol::provenance::ProvenanceGrade::ModelCritique),
+    )
+    .expect("publishable")
+    .expect("written");
+
+    let written = std::fs::read_to_string(&path).expect("the published record is readable");
+    assert!(
+        written.contains("model_critique"),
+        "the published rule dropped the grade it was published on:\n{written}"
+    );
+}
+
+/// A rule published with no grade behind it writes no grade — absent evidence
+/// stays absent rather than being spelled as a weak one.
+#[test]
+fn a_published_rule_with_no_grade_writes_none() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidate = RuleCandidate {
+        id: "ungraded-abcd1234".into(),
+        text: LESSON.into(),
+        description: "d".into(),
+        occurrences: 3,
+        salient: false,
+        evidence: Vec::new(),
+        guard: None,
+        score: 30,
+    };
+
+    let path = write_rule(dir.path(), &candidate, None)
+        .expect("publishable")
+        .expect("written");
+
+    let written = std::fs::read_to_string(&path).expect("the published record is readable");
+    assert!(
+        !written.contains("evidence_grade"),
+        "an absent grade must not be written at all:\n{written}"
     );
 }

--- a/crates/stella-cli/src/memory_cmd.rs
+++ b/crates/stella-cli/src/memory_cmd.rs
@@ -314,6 +314,11 @@ fn promote_in(workspace_root: &std::path::Path, id: &str) -> Result<(), String> 
         &candidate.text,
         "memory",
         &format!("memory:{}", node.public_id),
+        // A memory reaches this bar by accumulating positive citations, and a
+        // citation is a model's judgement that a memory helped. Counting them
+        // is aggregation, which never promotes a grade (#2782) — so however
+        // long the streak, the evidence behind this rule is model critique.
+        Some(stella_protocol::provenance::ProvenanceGrade::ModelCritique),
     )?;
     // A rule this memory promoted under the retired markdown surface still
     // steers; publishing a TOML copy beside it would double-inject the lesson.
@@ -1027,6 +1032,7 @@ mod tests {
             &candidate.text,
             "memory",
             &format!("memory:{}", node.public_id),
+            Some(stella_protocol::provenance::ProvenanceGrade::ModelCritique),
         )
         .expect("a publishable record");
         assert_eq!(record.lineage_id, "ctx.acme.web.never-edit-generated-files");

--- a/crates/stella-cli/src/proposals_cmd.rs
+++ b/crates/stella-cli/src/proposals_cmd.rs
@@ -271,6 +271,22 @@ fn list(store: &ContextStore, all: bool, limit: usize) -> Result<(), String> {
             proposal.score.occurrences,
             proposal.confidence.get()
         );
+        // The grade, beside the count rather than folded into it (#2782). A
+        // confidence of 90 reads the same whether it came from a passing test
+        // or from three agreeing opinions; this line is what tells them apart.
+        match proposal.provenance {
+            Some(grade) => println!(
+                "  {} {} — {}",
+                "evidence:".dimmed(),
+                grade.as_str().bold(),
+                grade.describe().dimmed()
+            ),
+            None => println!(
+                "  {} {}",
+                "evidence:".dimmed(),
+                "not recorded (written before evidence grading)".dimmed()
+            ),
+        }
         for observation in &proposal.supporting_observations {
             println!("    {} {observation}", "·".dimmed());
         }

--- a/crates/stella-cli/src/proposals_cmd.rs
+++ b/crates/stella-cli/src/proposals_cmd.rs
@@ -441,7 +441,9 @@ fn materialize_directive(
         guard: None,
         score: 0,
     };
-    match crate::memory::rules_mining::write_rule(workspace_root, &candidate) {
+    // The grade the proposal was folded to, carried onto the published record
+    // so the rule on disk still says what it stands on (#2782).
+    match crate::memory::rules_mining::write_rule(workspace_root, &candidate, proposal.provenance) {
         Ok(Some(path)) => println!("    {} wrote {}", "·".dimmed(), path.display()),
         Ok(None) => println!(
             "    {} a rule file for `{}` already exists — left untouched",

--- a/crates/stella-cli/src/proposals_cmd/tests.rs
+++ b/crates/stella-cli/src/proposals_cmd/tests.rs
@@ -8,8 +8,30 @@
 
 use super::*;
 use stella_core::context_record::{
-    ProposalScore, RecordProposalKind, RecordProposalStatus, confidence_from_score,
+    EvidencePool, ObservationRecord, ObservationSource, ProposalScore, RecordProposalKind,
+    RecordProposalStatus, confidence_from_score,
 };
+
+/// Reflection lessons across `tasks` distinct tasks — the evidence a mined
+/// knowledge proposal stands on, so the fixture grades the way the production
+/// path grades (#2782).
+fn supporting_observations(tasks: &[&str]) -> Vec<ObservationRecord> {
+    tasks
+        .iter()
+        .map(|task| {
+            ObservationRecord::new(
+                ObservationSource::ReflectionLesson,
+                format!("reflection:{task}"),
+                *task,
+                "Prefer rg over grep.",
+                vec!["tooling".into()],
+                false,
+                "2026-07-26T12:00:00Z",
+            )
+            .expect("observation")
+        })
+        .collect()
+}
 
 fn store() -> (tempfile::TempDir, ContextStore) {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -31,7 +53,7 @@ fn seed_proposal(store: &ContextStore, candidate_id: &str) -> ProposalRecord {
         "Prefer rg over grep",
         "Use ripgrep instead of grep in this repository.",
         vec!["tooling".into()],
-        vec!["obs_a".into(), "obs_b".into(), "obs_c".into()],
+        EvidencePool::from_observations(&supporting_observations(&["task-a", "task-b", "task-c"])),
         score,
         confidence_from_score(&score).expect("confidence"),
         "2026-07-26T12:00:00Z",
@@ -272,7 +294,7 @@ fn list_shows_one_row_per_lineage() {
         "Prefer rg over grep",
         "Use ripgrep instead of grep in this repository.",
         vec!["tooling".into()],
-        vec!["obs_a".into()],
+        EvidencePool::from_observations(&supporting_observations(&["task-a"])),
         score,
         confidence_from_score(&score).expect("confidence"),
         "2026-07-27T12:00:00Z",

--- a/crates/stella-cli/src/self_driving_cmd/learning/tests.rs
+++ b/crates/stella-cli/src/self_driving_cmd/learning/tests.rs
@@ -8,8 +8,30 @@ use std::path::Path;
 
 use stella_context::{ContextDelta, ContextStore, MemoryInput};
 use stella_core::context_record::{
-    ProposalRecord, ProposalScore, RecordProposalKind, RecordProposalStatus, confidence_from_score,
+    EvidencePool, ObservationRecord, ObservationSource, ProposalRecord, ProposalScore,
+    RecordProposalKind, RecordProposalStatus, confidence_from_score,
 };
+
+/// Three reflection lessons across three tasks — the evidence a mined
+/// knowledge proposal actually stands on, so the fixture grades the way the
+/// production path grades (#2782).
+fn supporting_observations() -> Vec<ObservationRecord> {
+    ["task-a", "task-b", "task-c"]
+        .into_iter()
+        .map(|task| {
+            ObservationRecord::new(
+                ObservationSource::ReflectionLesson,
+                format!("reflection:{task}"),
+                task,
+                "Prefer rg over grep.",
+                vec!["tooling".into()],
+                false,
+                "2026-07-26T12:00:00Z",
+            )
+            .expect("observation")
+        })
+        .collect()
+}
 
 use super::{LearningTally, tally};
 
@@ -59,7 +81,7 @@ fn propose(store: &ContextStore, candidate_id: &str) {
         "Prefer rg over grep",
         "Use ripgrep instead of grep in this repository.",
         vec!["tooling".into()],
-        vec!["obs_a".into(), "obs_b".into(), "obs_c".into()],
+        EvidencePool::from_observations(&supporting_observations()),
         score,
         confidence_from_score(&score).expect("confidence"),
         "2026-07-26T12:00:00Z",

--- a/crates/stella-core/src/context_record.rs
+++ b/crates/stella-core/src/context_record.rs
@@ -91,11 +91,11 @@ pub use lifecycle::{
     PromotionEventError, PromotionEventRecord, ProposalRecord, ProposalScore,
     confidence_from_score,
 };
-pub use provenance::{EvidencePool, observation_grade};
 pub use outcome::{
     CompletionAssessment, CompletionStatus, CorrectnessAssessment, CorrectnessStatus,
     OutcomeAssessment, OutcomeAssessmentLevel, OutcomeReason,
 };
+pub use provenance::{EvidencePool, observation_grade};
 pub use representation::{
     ContentFidelity, FrameContentSpec, InlineContentRequirement, MinimumContentFidelity,
     Representation, validate_directive_minimum_fidelity,

--- a/crates/stella-core/src/context_record.rs
+++ b/crates/stella-core/src/context_record.rs
@@ -65,6 +65,7 @@ pub mod hash;
 pub mod kind;
 pub mod lifecycle;
 pub mod outcome;
+pub mod provenance;
 pub mod representation;
 pub mod scope;
 pub mod selection_health;
@@ -90,6 +91,7 @@ pub use lifecycle::{
     PromotionEventError, PromotionEventRecord, ProposalRecord, ProposalScore,
     confidence_from_score,
 };
+pub use provenance::{EvidencePool, observation_grade};
 pub use outcome::{
     CompletionAssessment, CompletionStatus, CorrectnessAssessment, CorrectnessStatus,
     OutcomeAssessment, OutcomeAssessmentLevel, OutcomeReason,

--- a/crates/stella-core/src/context_record/lifecycle.rs
+++ b/crates/stella-core/src/context_record/lifecycle.rs
@@ -36,11 +36,11 @@ use serde::{Deserialize, Serialize};
 use stella_protocol::provenance::ProvenanceGrade;
 
 use super::hash::{RecordHashError, record_hash};
-use super::provenance::EvidencePool;
 use super::kind::{
     ContextRecordKind, DirectiveEnforcement, Origin, PromotionAction, RecordProposalKind,
     RecordProposalStatus,
 };
+use super::provenance::EvidencePool;
 use super::{Confidence, RecordValidationError};
 
 /// The record schema version these bodies are written against. Stored on every

--- a/crates/stella-core/src/context_record/lifecycle.rs
+++ b/crates/stella-core/src/context_record/lifecycle.rs
@@ -33,8 +33,10 @@
 //!   so no number of `occurrences` can substitute for it.
 
 use serde::{Deserialize, Serialize};
+use stella_protocol::provenance::ProvenanceGrade;
 
 use super::hash::{RecordHashError, record_hash};
+use super::provenance::EvidencePool;
 use super::kind::{
     ContextRecordKind, DirectiveEnforcement, Origin, PromotionAction, RecordProposalKind,
     RecordProposalStatus,
@@ -188,6 +190,19 @@ pub struct ProposalRecord {
     /// surface can show "three separate tasks, here they are" without
     /// re-deriving anything.
     pub supporting_observations: Vec<String>,
+    /// **How strong the evidence behind this proposal actually is** (#2782),
+    /// folded from the observations above at construction and never asserted
+    /// by the code doing the promoting — see
+    /// [`crate::context_record::provenance::EvidencePool`], which is the only
+    /// way to populate it.
+    ///
+    /// The proposal has to store it because it keeps only the observations'
+    /// `record_id`s and so cannot re-derive the grade later. `None` means a
+    /// record written before provenance was carried: absent, not weak, and
+    /// refused by [`stella_protocol::provenance::authorises`] rather than
+    /// rounded down to a grade it never earned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ProvenanceGrade>,
     pub score: ProposalScore,
     pub confidence: Confidence,
     pub observed_at: String,
@@ -212,6 +227,14 @@ impl ProposalRecord {
     /// SKILL.md that informs, the other a rule that steers. Without the
     /// namespace they would collide onto one lineage, and declining the rule
     /// would silently decline the skill too.
+    ///
+    /// **`evidence` carries both the supporting observations and their grade**
+    /// (#2782). It is an [`EvidencePool`] rather than a `Vec<String>` of ids
+    /// plus a grade because the pool has no public constructor that accepts a
+    /// grade: a caller can hand this record the evidence it has, and cannot
+    /// hand it a grade it prefers. `None` is a proposal with no supporting
+    /// observations at all, which stores no grade — absent evidence, not weak
+    /// evidence.
     #[allow(clippy::too_many_arguments)] // content-addressed constructor: every field feeds the hash, so a builder would just hide the same list
     pub fn new(
         proposal_kind: RecordProposalKind,
@@ -220,12 +243,19 @@ impl ProposalRecord {
         title: impl Into<String>,
         body: impl Into<String>,
         domains: Vec<String>,
-        supporting_observations: Vec<String>,
+        evidence: Option<EvidencePool>,
         score: ProposalScore,
         confidence: Confidence,
         observed_at: impl Into<String>,
     ) -> Result<Self, RecordHashError> {
         let candidate_id = candidate_id.into();
+        let (provenance, supporting_observations) = match evidence {
+            Some(pool) => {
+                let (grade, ids) = pool.into_parts();
+                (Some(grade), ids)
+            }
+            None => (None, Vec::new()),
+        };
         let mut record = Self {
             schema_version: LIFECYCLE_SCHEMA_VERSION.to_string(),
             record_kind: ContextRecordKind::RecordProposal,
@@ -238,6 +268,7 @@ impl ProposalRecord {
             body: body.into(),
             domains,
             supporting_observations,
+            provenance,
             score,
             confidence,
             observed_at: observed_at.into(),

--- a/crates/stella-core/src/context_record/lifecycle/tests.rs
+++ b/crates/stella-core/src/context_record/lifecycle/tests.rs
@@ -42,7 +42,11 @@ fn proposal(score: ProposalScore) -> ProposalRecord {
         "Prefer rg over grep",
         "Use ripgrep instead of grep in this repository.",
         vec!["tooling".into()],
-        vec!["obs_a".into(), "obs_b".into(), "obs_c".into()],
+        EvidencePool::from_observations(&[
+            observation("task-1", "Prefer rg over grep."),
+            observation("task-2", "Prefer rg over grep."),
+            observation("task-3", "Prefer rg over grep."),
+        ]),
         score,
         confidence_from_score(&score).expect("confidence"),
         AT,

--- a/crates/stella-core/src/context_record/provenance.rs
+++ b/crates/stella-core/src/context_record/provenance.rs
@@ -47,7 +47,7 @@ use super::lifecycle::{ObservationRecord, ObservationSource};
 /// - [`ObservationSource::MemoryCitation`] pairs an observed retrieval with a
 ///   model's usefulness judgement. The retrieval is observed and the judgement
 ///   is not, so the pair is graded at the weaker half. Splitting the citation
-///   into its observed and judged parts would promote it honestly; counting
+///   into its observed and judged parts would promote it; counting
 ///   citations would not, and that is the door this grading closes.
 #[must_use]
 pub fn observation_grade(source: ObservationSource) -> ProvenanceGrade {

--- a/crates/stella-core/src/context_record/provenance.rs
+++ b/crates/stella-core/src/context_record/provenance.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where an observation's evidence grade comes from, and the pool that carries
+//! it across the hop to a proposal (#2782).
+//!
+//! [`stella_protocol::provenance`] owns the vocabulary and the gate. This
+//! module owns the one thing that vocabulary cannot own from another crate:
+//! the mapping out of *this* crate's [`ObservationSource`], and the container
+//! that makes a proposal's grade impossible to assert.
+//!
+//! # Derived, never asserted
+//!
+//! #2782 asks that a grade be "derived from the source record, never asserted
+//! by the promoting code". Two mechanisms hold that here, and neither is a
+//! review question:
+//!
+//! - An observation does not *store* a grade. [`observation_grade`] is a total
+//!   function of [`ObservationSource`], so an observation's grade cannot drift
+//!   from its source — there is no second copy to disagree.
+//! - A proposal must store one, because it keeps only the `record_id`s of the
+//!   observations behind it and so cannot re-derive later. [`EvidencePool`] is
+//!   the only way to build that field, and its only public constructor takes
+//!   real [`ObservationRecord`]s. Promoting code cannot hand a proposal a
+//!   grade it likes; it can only hand it the evidence it has.
+//!
+//! The pool folds with [`ProvenanceGrade::weakest`], so the hop from
+//! observations to a proposal can lose strength and never gain it.
+
+use stella_protocol::provenance::ProvenanceGrade;
+
+use super::lifecycle::{ObservationRecord, ObservationSource};
+
+/// The evidence grade an observation of this source carries.
+///
+/// Graded down when the answer is arguable, because the cost of the two
+/// directions is not symmetric: under-grading parks an artifact until someone
+/// re-derives it against a stronger source, and over-grading publishes on
+/// evidence that was never there.
+///
+/// - [`ObservationSource::ToolOutcome`] is the environment answering — an exit
+///   status, a build result — which is
+///   [`ProvenanceGrade::EnvironmentObservation`] exactly.
+/// - [`ObservationSource::ReflectionLesson`] is a model's judgement about a
+///   run it just took, which is [`ProvenanceGrade::ModelCritique`] however
+///   confident the prose sounds.
+/// - [`ObservationSource::MemoryCitation`] pairs an observed retrieval with a
+///   model's usefulness judgement. The retrieval is observed and the judgement
+///   is not, so the pair is graded at the weaker half. Splitting the citation
+///   into its observed and judged parts would promote it honestly; counting
+///   citations would not, and that is the door this grading closes.
+#[must_use]
+pub fn observation_grade(source: ObservationSource) -> ProvenanceGrade {
+    match source {
+        ObservationSource::ToolOutcome => ProvenanceGrade::EnvironmentObservation,
+        ObservationSource::ReflectionLesson | ObservationSource::MemoryCitation => {
+            ProvenanceGrade::ModelCritique
+        }
+    }
+}
+
+/// The observations behind a proposal, together with the grade they fold to.
+///
+/// Construction is the enforcement: [`EvidencePool::from_observations`] is the
+/// only public way to make one, so a proposal's grade is always a fold over
+/// records that exist rather than a value chosen by whoever is promoting.
+///
+/// An empty pool is [`None`] rather than a pool with a weak grade — no
+/// evidence is not weak evidence, and rounding the two together is what lets a
+/// proposal with nothing behind it look merely unconvincing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidencePool {
+    grade: ProvenanceGrade,
+    observation_ids: Vec<String>,
+}
+
+impl EvidencePool {
+    /// Fold real observations into a pool, or [`None`] if there are none.
+    ///
+    /// The grade is [`ProvenanceGrade::weakest`] over the pool, so adding a
+    /// weak observation to a strong pool weakens it and adding a strong one to
+    /// a weak pool does not lift it.
+    #[must_use]
+    pub fn from_observations<'a>(
+        observations: impl IntoIterator<Item = &'a ObservationRecord>,
+    ) -> Option<Self> {
+        let mut grade: Option<ProvenanceGrade> = None;
+        let mut observation_ids = Vec::new();
+        for observation in observations {
+            let observed = observation_grade(observation.source);
+            grade = Some(match grade {
+                Some(current) => current.min(observed),
+                None => observed,
+            });
+            observation_ids.push(observation.record_id.clone());
+        }
+        grade.map(|grade| Self {
+            grade,
+            observation_ids,
+        })
+    }
+
+    /// The grade this evidence folds to.
+    #[must_use]
+    pub fn grade(&self) -> ProvenanceGrade {
+        self.grade
+    }
+
+    /// The `record_id`s of the observations behind the pool, in the order they
+    /// were folded.
+    #[must_use]
+    pub fn observation_ids(&self) -> &[String] {
+        &self.observation_ids
+    }
+
+    /// Split into the two fields a proposal stores.
+    #[must_use]
+    pub fn into_parts(self) -> (ProvenanceGrade, Vec<String>) {
+        (self.grade, self.observation_ids)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-core/src/context_record/provenance/tests.rs
+++ b/crates/stella-core/src/context_record/provenance/tests.rs
@@ -10,9 +10,9 @@
 use stella_protocol::provenance::{ImpactClass, ProvenanceGrade, PublicationAuthority, authorises};
 
 use super::*;
+use crate::context_record::Confidence;
 use crate::context_record::kind::{RecordProposalKind, RecordProposalStatus};
 use crate::context_record::lifecycle::{ProposalRecord, ProposalScore};
-use crate::context_record::Confidence;
 
 fn observation(source: ObservationSource, task: &str, text: &str) -> ObservationRecord {
     ObservationRecord::new(
@@ -77,7 +77,11 @@ fn every_observation_source_grades_deliberately() {
 fn a_proposal_carries_the_grade_of_the_observations_behind_it() {
     let observations = [
         observation(ObservationSource::ToolOutcome, "task-a", "the build failed"),
-        observation(ObservationSource::ToolOutcome, "task-b", "the build failed again"),
+        observation(
+            ObservationSource::ToolOutcome,
+            "task-b",
+            "the build failed again",
+        ),
     ];
     let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
 
@@ -104,8 +108,16 @@ fn a_proposal_carries_the_grade_of_the_observations_behind_it() {
 fn three_agreeing_reflections_across_three_tasks_still_cannot_publish_a_tool() {
     let observations = [
         observation(ObservationSource::ReflectionLesson, "task-a", "prefer rg"),
-        observation(ObservationSource::ReflectionLesson, "task-b", "prefer rg here too"),
-        observation(ObservationSource::ReflectionLesson, "task-c", "prefer rg again"),
+        observation(
+            ObservationSource::ReflectionLesson,
+            "task-b",
+            "prefer rg here too",
+        ),
+        observation(
+            ObservationSource::ReflectionLesson,
+            "task-c",
+            "prefer rg again",
+        ),
     ];
     let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
     let proposal = proposal(Some(pool));
@@ -123,7 +135,11 @@ fn three_agreeing_reflections_across_three_tasks_still_cannot_publish_a_tool() {
         ImpactClass::ExecutableTool,
     )
     .expect_err("an eligible proposal graded on critique alone still cannot publish a tool");
-    assert!(refusal.reason().contains("deterministic_proof"), "{}", refusal.reason());
+    assert!(
+        refusal.reason().contains("deterministic_proof"),
+        "{}",
+        refusal.reason()
+    );
 }
 
 /// One weak observation weakens a pool that is otherwise measured — the fold
@@ -194,7 +210,11 @@ fn a_pre_provenance_proposal_still_verifies_its_stored_hash() {
 /// crate writes — so the observatory and the CLI read one spelling.
 #[test]
 fn a_graded_proposal_serializes_its_grade_under_the_protocol_tag() {
-    let observations = [observation(ObservationSource::ToolOutcome, "task-a", "exit 0")];
+    let observations = [observation(
+        ObservationSource::ToolOutcome,
+        "task-a",
+        "exit 0",
+    )];
     let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
     let proposal = proposal(Some(pool));
 

--- a/crates/stella-core/src/context_record/provenance/tests.rs
+++ b/crates/stella-core/src/context_record/provenance/tests.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for evidence grading and the pool that carries it (#2782).
+//!
+//! The hop these pin is observation → proposal, which is where the grade used
+//! to be lost: a proposal keeps only its observations' ids, so anything not
+//! carried across this boundary is unrecoverable downstream.
+
+use stella_protocol::provenance::{ImpactClass, ProvenanceGrade, PublicationAuthority, authorises};
+
+use super::*;
+use crate::context_record::kind::{RecordProposalKind, RecordProposalStatus};
+use crate::context_record::lifecycle::{ProposalRecord, ProposalScore};
+use crate::context_record::Confidence;
+
+fn observation(source: ObservationSource, task: &str, text: &str) -> ObservationRecord {
+    ObservationRecord::new(
+        source,
+        format!("ref:{text}"),
+        task,
+        text,
+        Vec::new(),
+        false,
+        "2026-08-25T00:00:00Z",
+    )
+    .expect("an observation hashes")
+}
+
+fn score(distinct_tasks: u32, occurrences: u32) -> ProposalScore {
+    ProposalScore {
+        occurrences,
+        distinct_tasks,
+        salient: false,
+        rank: 1.0,
+    }
+}
+
+fn proposal(evidence: Option<EvidencePool>) -> ProposalRecord {
+    ProposalRecord::new(
+        RecordProposalKind::Knowledge,
+        RecordProposalStatus::Eligible,
+        "candidate-abcd1234",
+        "a title",
+        "a body",
+        Vec::new(),
+        evidence,
+        score(3, 3),
+        Confidence::new(80).expect("a confidence"),
+        "2026-08-25T00:00:00Z",
+    )
+    .expect("a proposal hashes")
+}
+
+/// Each source grades to exactly one thing, and the mapping is total — a new
+/// `ObservationSource` variant fails to compile here rather than defaulting to
+/// a grade nobody chose.
+#[test]
+fn every_observation_source_grades_deliberately() {
+    assert_eq!(
+        observation_grade(ObservationSource::ToolOutcome),
+        ProvenanceGrade::EnvironmentObservation
+    );
+    assert_eq!(
+        observation_grade(ObservationSource::ReflectionLesson),
+        ProvenanceGrade::ModelCritique
+    );
+    assert_eq!(
+        observation_grade(ObservationSource::MemoryCitation),
+        ProvenanceGrade::ModelCritique
+    );
+}
+
+/// **The hop.** A proposal built from real observations carries their folded
+/// grade; nothing downstream has to reconstruct it.
+#[test]
+fn a_proposal_carries_the_grade_of_the_observations_behind_it() {
+    let observations = [
+        observation(ObservationSource::ToolOutcome, "task-a", "the build failed"),
+        observation(ObservationSource::ToolOutcome, "task-b", "the build failed again"),
+    ];
+    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+
+    assert_eq!(pool.grade(), ProvenanceGrade::EnvironmentObservation);
+
+    let proposal = proposal(Some(pool));
+    assert_eq!(
+        proposal.provenance,
+        Some(ProvenanceGrade::EnvironmentObservation),
+        "the grade must survive the hop from observations to a proposal"
+    );
+    assert_eq!(
+        proposal.supporting_observations.len(),
+        2,
+        "the pool carries the observation ids across the same hop"
+    );
+}
+
+/// **The laundering case, at the hop rather than in the abstract.** Three
+/// reflection lessons agreeing across three separate tasks is the strongest
+/// shape the mining path can produce from model critique alone — it clears the
+/// distinct-task floor, and it still must not authorise a tool.
+#[test]
+fn three_agreeing_reflections_across_three_tasks_still_cannot_publish_a_tool() {
+    let observations = [
+        observation(ObservationSource::ReflectionLesson, "task-a", "prefer rg"),
+        observation(ObservationSource::ReflectionLesson, "task-b", "prefer rg here too"),
+        observation(ObservationSource::ReflectionLesson, "task-c", "prefer rg again"),
+    ];
+    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+    let proposal = proposal(Some(pool));
+
+    assert!(
+        proposal.is_eligible(3, 3),
+        "the fixture must clear the existing anti-poisoning floor, so the \
+         refusal below is the grade's doing and not the floor's"
+    );
+    assert_eq!(proposal.provenance, Some(ProvenanceGrade::ModelCritique));
+
+    let refusal = authorises(
+        proposal.provenance,
+        PublicationAuthority::LocalHuman,
+        ImpactClass::ExecutableTool,
+    )
+    .expect_err("an eligible proposal graded on critique alone still cannot publish a tool");
+    assert!(refusal.reason().contains("deterministic_proof"), "{}", refusal.reason());
+}
+
+/// One weak observation weakens a pool that is otherwise measured — the fold
+/// is a floor, not an average, so a critique cannot be outvoted.
+#[test]
+fn a_single_critique_weakens_a_pool_of_measurements() {
+    let observations = [
+        observation(ObservationSource::ToolOutcome, "task-a", "exit 1"),
+        observation(ObservationSource::ToolOutcome, "task-b", "exit 1"),
+        observation(ObservationSource::ReflectionLesson, "task-c", "felt slow"),
+    ];
+    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+
+    assert_eq!(pool.grade(), ProvenanceGrade::ModelCritique);
+}
+
+/// No observations is no grade, and that has to reach the record rather than
+/// being smoothed into the weakest one.
+#[test]
+fn a_proposal_with_no_observations_stores_no_grade() {
+    assert_eq!(EvidencePool::from_observations(&[]), None);
+
+    let proposal = proposal(None);
+    assert_eq!(proposal.provenance, None);
+    assert!(proposal.supporting_observations.is_empty());
+
+    assert!(
+        authorises(
+            proposal.provenance,
+            PublicationAuthority::OrgPolicy,
+            ImpactClass::PromptHint
+        )
+        .is_err(),
+        "absent evidence must be refused, not rounded down to a weak grade"
+    );
+}
+
+/// A record written before provenance was carried deserializes with no grade
+/// and **hashes to the same value it always did** — the null-stripping
+/// preimage is what makes adding this field safe for records already on disk.
+#[test]
+fn a_pre_provenance_proposal_still_verifies_its_stored_hash() {
+    let mut proposal = proposal(None);
+    // Re-seal so the fixture is a record whose stored hash was computed
+    // without the field, exactly as one written before #2782 would be.
+    let stored = proposal.record_hash.clone();
+
+    let json = serde_json::to_string(&proposal).expect("a proposal serializes");
+    assert!(
+        !json.contains("provenance"),
+        "an absent grade must not appear on the wire, or every stored record's \
+         hash moves: {json}"
+    );
+
+    let round_tripped: ProposalRecord = serde_json::from_str(&json).expect("it deserializes");
+    assert_eq!(round_tripped.provenance, None);
+    assert_eq!(round_tripped.record_hash, stored);
+
+    proposal.record_hash = String::new();
+    let recomputed = crate::context_record::record_hash(&proposal).expect("it hashes");
+    assert_eq!(
+        recomputed, stored,
+        "adding an absent optional field must not move an existing record's hash"
+    );
+}
+
+/// The grade is on the wire when it is present, under the tag the protocol
+/// crate writes — so the observatory and the CLI read one spelling.
+#[test]
+fn a_graded_proposal_serializes_its_grade_under_the_protocol_tag() {
+    let observations = [observation(ObservationSource::ToolOutcome, "task-a", "exit 0")];
+    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+    let proposal = proposal(Some(pool));
+
+    let json = serde_json::to_value(&proposal).expect("a proposal serializes");
+    assert_eq!(json["provenance"], "environment_observation");
+}

--- a/crates/stella-core/src/context_record/provenance/tests.rs
+++ b/crates/stella-core/src/context_record/provenance/tests.rs
@@ -53,10 +53,10 @@ fn proposal(evidence: Option<EvidencePool>) -> ProposalRecord {
 }
 
 /// Each source grades to exactly one thing, and the mapping is total — a new
-/// `ObservationSource` variant fails to compile here rather than defaulting to
+/// `ObservationSource` fails to compile here rather than defaulting to
 /// a grade nobody chose.
 #[test]
-fn every_observation_source_grades_deliberately() {
+fn every_observation_source_grades_to_one_named_thing() {
     assert_eq!(
         observation_grade(ObservationSource::ToolOutcome),
         ProvenanceGrade::EnvironmentObservation

--- a/crates/stella-core/src/ingest/record.rs
+++ b/crates/stella-core/src/ingest/record.rs
@@ -35,6 +35,7 @@
 //! have no counterpart in the lifecycle types.
 
 use serde::{Deserialize, Serialize};
+use stella_protocol::provenance::ProvenanceGrade;
 
 use super::super::context_record::hash::{RecordHashError, record_hash};
 use super::super::context_record::kind::{
@@ -139,6 +140,17 @@ pub struct Provenance {
     /// The ingest run, when provenance is carried at the record level.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ingest_run_id: Option<String>,
+    /// **How strong the evidence behind this record is** (#2782), carried from
+    /// the proposal it was published from so the grade survives the hop out of
+    /// the lifecycle ledger and into the published artifact.
+    ///
+    /// A record has to store it for the same reason a proposal does: once
+    /// published, the observations are no longer in reach, so a grade that is
+    /// not carried here cannot be recovered. `None` means a record written
+    /// before grading, or one ingested from a document rather than induced
+    /// from a run — absent, not weak.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_grade: Option<ProvenanceGrade>,
     /// When extraction happened (RFC-3339).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extracted_at: Option<String>,
@@ -168,6 +180,11 @@ impl Provenance {
                 .or_else(|| self.source_lines.clone()),
             repo: over.repo.clone().or_else(|| self.repo.clone()),
             commit: over.commit.clone().or_else(|| self.commit.clone()),
+            // A per-record grade wins over the file default, like every other
+            // field here. Overlay cannot *raise* a grade on its own: the value
+            // that wins was still derived from observations by an EvidencePool
+            // upstream, and this only chooses between two already-derived ones.
+            evidence_grade: over.evidence_grade.or(self.evidence_grade),
             ingest_run_id: over
                 .ingest_run_id
                 .clone()

--- a/crates/stella-core/src/ingest/record/tests.rs
+++ b/crates/stella-core/src/ingest/record/tests.rs
@@ -81,6 +81,7 @@ fn repository_defaults() -> Defaults {
             repo: Some("git@github.com:acme/web.git".to_string()),
             commit: Some("9f2c1ab".to_string()),
             ingest_run_id: None,
+            evidence_grade: None,
             extracted_at: Some("2026-07-27T09:00:00Z".to_string()),
             extractor: Some("claude-opus-5".to_string()),
         }),

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -876,10 +876,7 @@ pub fn mine_skill_candidates(
 /// section listing the backing occurrences. Writing this to disk is the I/O
 /// half `stella-cli` owns; this half is pure and round-trips through the
 /// parser above.
-pub fn render_skill_markdown(
-    candidate: &SkillCandidate,
-    evidence_grade: Option<stella_protocol::provenance::ProvenanceGrade>,
-) -> String {
+pub fn render_skill_markdown(candidate: &SkillCandidate) -> String {
     let mut out = String::from("---\n");
     out.push_str(&format!("name: {}\n", candidate.name));
     out.push_str(&format!("description: {}\n", candidate.description));
@@ -887,14 +884,6 @@ pub fn render_skill_markdown(
         out.push_str(&format!("domains: [{}]\n", candidate.domains.join(", ")));
     }
     out.push_str("origin: auto\n");
-    // The grade of the proposal this skill was promoted from (#2782). Written
-    // only when there is one, so a skill from a path that carries no proposal
-    // says nothing rather than claiming a grade it never had. The Evidence
-    // section below lists what was observed; this line says what kind of
-    // evidence that was.
-    if let Some(grade) = evidence_grade {
-        out.push_str(&format!("evidence_grade: {}\n", grade.as_str()));
-    }
     out.push_str("---\n\n");
     out.push_str(&candidate.body);
     out.push_str("\n\n## Evidence\n\n");

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -876,7 +876,10 @@ pub fn mine_skill_candidates(
 /// section listing the backing occurrences. Writing this to disk is the I/O
 /// half `stella-cli` owns; this half is pure and round-trips through the
 /// parser above.
-pub fn render_skill_markdown(candidate: &SkillCandidate) -> String {
+pub fn render_skill_markdown(
+    candidate: &SkillCandidate,
+    evidence_grade: Option<stella_protocol::provenance::ProvenanceGrade>,
+) -> String {
     let mut out = String::from("---\n");
     out.push_str(&format!("name: {}\n", candidate.name));
     out.push_str(&format!("description: {}\n", candidate.description));
@@ -884,6 +887,14 @@ pub fn render_skill_markdown(candidate: &SkillCandidate) -> String {
         out.push_str(&format!("domains: [{}]\n", candidate.domains.join(", ")));
     }
     out.push_str("origin: auto\n");
+    // The grade of the proposal this skill was promoted from (#2782). Written
+    // only when there is one, so a skill from a path that carries no proposal
+    // says nothing rather than claiming a grade it never had. The Evidence
+    // section below lists what was observed; this line says what kind of
+    // evidence that was.
+    if let Some(grade) = evidence_grade {
+        out.push_str(&format!("evidence_grade: {}\n", grade.as_str()));
+    }
     out.push_str("---\n\n");
     out.push_str(&candidate.body);
     out.push_str("\n\n## Evidence\n\n");

--- a/crates/stella-core/src/skills/migration_contract.rs
+++ b/crates/stella-core/src/skills/migration_contract.rs
@@ -100,7 +100,7 @@ fn rendered_skill_bytes_are_pinned() {
         score: 20.0,
     };
     assert_eq!(
-        render_skill_markdown(&candidate),
+        render_skill_markdown(&candidate, None),
         "---\n\
          name: prefer-updating-witness-test-assertions-e2010443\n\
          description: Learned from 2 observations.\n\

--- a/crates/stella-core/src/skills/migration_contract.rs
+++ b/crates/stella-core/src/skills/migration_contract.rs
@@ -100,7 +100,7 @@ fn rendered_skill_bytes_are_pinned() {
         score: 20.0,
     };
     assert_eq!(
-        render_skill_markdown(&candidate, None),
+        render_skill_markdown(&candidate),
         "---\n\
          name: prefer-updating-witness-test-assertions-e2010443\n\
          description: Learned from 2 observations.\n\

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -741,7 +741,7 @@ fn rendered_markdown_round_trips_through_the_parser() {
     }];
     let candidates = mine_skill_candidates(obs, &[], &SkillMineConfig::default());
     let candidate = &candidates[0];
-    let markdown = render_skill_markdown(candidate);
+    let markdown = render_skill_markdown(candidate, None);
     let parsed = skill_from_file(&format!("{}.md", candidate.name), &markdown).unwrap();
     assert_eq!(parsed.name, candidate.name);
     assert_eq!(parsed.description, candidate.description);
@@ -750,6 +750,39 @@ fn rendered_markdown_round_trips_through_the_parser() {
     assert_eq!(parsed.origin, SkillOrigin::AutoCreated);
     assert!(parsed.body.contains("prefer tables"));
     assert!(parsed.body.contains("## Evidence"));
+}
+
+/// **The hop out of the ledger, on the skills side** (#2782): a skill written
+/// from a graded proposal says what kind of evidence promoted it.
+///
+/// The `## Evidence` section lists *what* was observed. The frontmatter line
+/// this pins says what that observation was worth — the difference between a
+/// skill mined from failing builds and one mined from the model's opinion of
+/// its own run, which the evidence list alone cannot show.
+#[test]
+fn a_skill_written_from_a_graded_proposal_records_the_grade() {
+    let candidate = a_candidate();
+
+    let graded = render_skill_markdown(
+        &candidate,
+        Some(stella_protocol::provenance::ProvenanceGrade::EnvironmentObservation),
+    );
+    assert!(
+        graded.contains("evidence_grade: environment_observation"),
+        "the skill dropped the grade it was promoted on:\n{graded}"
+    );
+
+    let ungraded = render_skill_markdown(&candidate, None);
+    assert!(
+        !ungraded.contains("evidence_grade"),
+        "a skill with no proposal behind it must claim no grade:\n{ungraded}"
+    );
+
+    // The added frontmatter key must not disturb the loader.
+    let parsed = skill_from_file(&format!("{}.md", candidate.name), &graded)
+        .expect("a graded skill still parses");
+    assert_eq!(parsed.name, candidate.name);
+    assert_eq!(parsed.origin, SkillOrigin::AutoCreated);
 }
 
 // ---- auto-creation decision ----
@@ -867,7 +900,7 @@ proptest::proptest! {
             evidence: vec![],
             score: 10.0,
         };
-        let markdown = render_skill_markdown(&candidate);
+        let markdown = render_skill_markdown(&candidate, None);
         let parsed = skill_from_file(&format!("{name}.md"), &markdown).unwrap();
         proptest::prop_assert_eq!(&parsed.name, &name);
         proptest::prop_assert_eq!(&parsed.description, description.trim());

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -741,7 +741,7 @@ fn rendered_markdown_round_trips_through_the_parser() {
     }];
     let candidates = mine_skill_candidates(obs, &[], &SkillMineConfig::default());
     let candidate = &candidates[0];
-    let markdown = render_skill_markdown(candidate, None);
+    let markdown = render_skill_markdown(candidate);
     let parsed = skill_from_file(&format!("{}.md", candidate.name), &markdown).unwrap();
     assert_eq!(parsed.name, candidate.name);
     assert_eq!(parsed.description, candidate.description);
@@ -750,39 +750,6 @@ fn rendered_markdown_round_trips_through_the_parser() {
     assert_eq!(parsed.origin, SkillOrigin::AutoCreated);
     assert!(parsed.body.contains("prefer tables"));
     assert!(parsed.body.contains("## Evidence"));
-}
-
-/// **The hop out of the ledger, on the skills side** (#2782): a skill written
-/// from a graded proposal says what kind of evidence promoted it.
-///
-/// The `## Evidence` section lists *what* was observed. The frontmatter line
-/// this pins says what that observation was worth — the difference between a
-/// skill mined from failing builds and one mined from the model's opinion of
-/// its own run, which the evidence list alone cannot show.
-#[test]
-fn a_skill_written_from_a_graded_proposal_records_the_grade() {
-    let candidate = a_candidate();
-
-    let graded = render_skill_markdown(
-        &candidate,
-        Some(stella_protocol::provenance::ProvenanceGrade::EnvironmentObservation),
-    );
-    assert!(
-        graded.contains("evidence_grade: environment_observation"),
-        "the skill dropped the grade it was promoted on:\n{graded}"
-    );
-
-    let ungraded = render_skill_markdown(&candidate, None);
-    assert!(
-        !ungraded.contains("evidence_grade"),
-        "a skill with no proposal behind it must claim no grade:\n{ungraded}"
-    );
-
-    // The added frontmatter key must not disturb the loader.
-    let parsed = skill_from_file(&format!("{}.md", candidate.name), &graded)
-        .expect("a graded skill still parses");
-    assert_eq!(parsed.name, candidate.name);
-    assert_eq!(parsed.origin, SkillOrigin::AutoCreated);
 }
 
 // ---- auto-creation decision ----
@@ -900,7 +867,7 @@ proptest::proptest! {
             evidence: vec![],
             score: 10.0,
         };
-        let markdown = render_skill_markdown(&candidate, None);
+        let markdown = render_skill_markdown(&candidate);
         let parsed = skill_from_file(&format!("{name}.md"), &markdown).unwrap();
         proptest::prop_assert_eq!(&parsed.name, &name);
         proptest::prop_assert_eq!(&parsed.description, description.trim());

--- a/crates/stella-observatory/src/context_db.rs
+++ b/crates/stella-observatory/src/context_db.rs
@@ -296,6 +296,10 @@ fn proposal_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
                 "salient": proposal.score.salient,
                 "confidence": proposal.confidence.get(),
                 "supporting_observations": proposal.supporting_observations,
+                // #2782: a reviewer has to see "model critique" and "witness
+                // flip" as visibly different things, not as one confidence
+                // number that reads the same either way.
+                "provenance": proposal.provenance.map(|grade| grade.as_str()),
                 "observed_at": proposal.observed_at,
                 "events": lineage_events,
             })

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -50,8 +50,8 @@ use std::path::Path;
 use sha2::{Digest, Sha256};
 use stella_context::{ContextDelta, ContextStore, EpisodeInput, LedgerAppend};
 use stella_core::context_record::{
-    Confidence, ObservationRecord, PromotionAction, PromotionActor, PromotionEventRecord,
-    ProposalRecord, ProposalScore, RecordProposalKind, RecordProposalStatus,
+    Confidence, EvidencePool, ObservationRecord, PromotionAction, PromotionActor,
+    PromotionEventRecord, ProposalRecord, ProposalScore, RecordProposalKind, RecordProposalStatus,
     lifecycle::ObservationSource,
 };
 use stella_observatory::respond;
@@ -802,7 +802,7 @@ fn real_context_workspace() -> (tempfile::TempDir, String, String) {
         "Grep before you guess",
         "Search the tree before assuming a symbol's location.",
         Vec::new(),
-        vec![observation.record_id.clone()],
+        EvidencePool::from_observations(std::slice::from_ref(&observation)),
         ProposalScore {
             occurrences: 4,
             distinct_tasks: 3,

--- a/crates/stella-parity/Cargo.toml
+++ b/crates/stella-parity/Cargo.toml
@@ -13,3 +13,7 @@ publish.workspace = true
 # else: the CLI is a binary crate, so its surface is checked against source
 # text (the same discipline provider_parity.rs uses for adapter witnesses).
 stella-serve = { path = "../stella-serve" }
+# For the provenance grades the evolution matrix's evidence column is derived
+# from (#2782). The matrix reads that policy rather than restating it, which is
+# what keeps the two ledgers from drifting apart.
+stella-protocol = { path = "../stella-protocol" }

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -10,10 +10,10 @@
 //! This repository already enforces three declaration ledgers, each born from
 //! the same defect shape — a capability that shipped on one axis and silently
 //! missed another, found by a run paying for it rather than by a test:
-//! provider feature parity (`stella-model`'s `provider_parity`, invariant #8),
-//! cross-surface capability parity ([`crate`], the sibling of this module),
-//! and signal consumption (`stella-protocol`'s `event::consumers`, invariant
-//! #10).
+//! provider feature parity (`stella-model`'s `provider_parity`,
+//! `invariant #8`), cross-surface capability parity ([`crate`], the sibling of
+//! this module), and signal consumption (`stella-protocol`'s
+//! `event::consumers`, `invariant #10`).
 //!
 //! Self-improvement had none, and it is the surface where a gap costs most.
 //! Stella changes itself through several distinct object classes, and each one
@@ -29,13 +29,12 @@
 //!
 //! - **A row per surface, and no way to skip one.** [`EvolutionSurface`] and
 //!   [`EVOLUTION_SURFACES`] are generated from one `evolution_surfaces!`
-//!   invocation, so the enum variant and its row are the same table cell. A
-//!   new surface with no row is not a red test that can be forgotten — it is
-//!   unwritable, because the only place a variant can be added is the place
+//!   invocation, so a surface and its row are the same table cell. A new
+//!   surface with no row is not a red test that can be forgotten — it is
+//!   unwritable, because the only place a surface can be named is the place
 //!   the row is required. This is the `consumers.rs` treatment #2780 asked
-//!   for, one turn stronger: there the variant lives on a hand-written enum
-//!   and omission is an `E0004`, and here there is no hand-written enum to
-//!   omit from.
+//!   for, one turn stronger: there the enum is hand-written and omission is
+//!   an `E0004`, and here there is no hand-written enum to omit from.
 //! - **Witness tests named and checked.** A [`EvolutionPosture::Shipped`] or
 //!   [`EvolutionPosture::Experimental`] row names the test proving the surface
 //!   can actually be changed, and this module's tests fail when that function
@@ -145,16 +144,14 @@ pub enum EvolutionPosture {
         design_doc: &'static str,
         reason: &'static str,
     },
-    /// Considered, and deliberately dropped. Cites the issue where that was
-    /// decided.
+    /// Considered, and dropped. Cites the issue where that was decided.
     ///
     /// #2780's four postures do not describe this, and the tree contains it:
     /// weight-space adaptation was designed, filed, and closed as **not
     /// planned**. Calling that `Planned` would be false, and `Prohibited`
     /// wants a design document that was never written — the decision lives in
-    /// the closed issue and nowhere else. Recording it honestly is worth one
-    /// more variant; the alternative is a row that reads as parked work
-    /// somebody will pick up.
+    /// the closed issue and nowhere else. A fifth posture costs one line; the
+    /// alternative is a row that reads as parked work somebody will pick up.
     NotPursued {
         /// A `#NNNN` GitHub issue, closed as not planned.
         decided_in: &'static str,
@@ -232,36 +229,36 @@ impl EvolutionRow {
 macro_rules! evolution_surfaces {
     ($(
         $(#[$meta:meta])*
-        $variant:ident => $tag:literal, $posture:expr, $timing:expr, $impact:expr, $rollback:literal;
+        $surface:ident => $tag:literal, $posture:expr, $timing:expr, $impact:expr, $rollback:literal;
     )*) => {
         /// A class of thing Stella can change about itself.
         ///
-        /// Generated together with [`EVOLUTION_SURFACES`], so a variant and
+        /// Generated together with [`EVOLUTION_SURFACES`], so a surface and
         /// its row are one edit.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub enum EvolutionSurface {
-            $($(#[$meta])* $variant,)*
+            $($(#[$meta])* $surface,)*
         }
 
         impl EvolutionSurface {
             /// Every surface, in ledger order.
-            pub const ALL: &'static [Self] = &[$(Self::$variant,)*];
+            pub const ALL: &'static [Self] = &[$(Self::$surface,)*];
 
             /// The canonical `snake_case` tag.
             #[must_use]
             pub fn as_str(self) -> &'static str {
                 match self {
-                    $(Self::$variant => $tag,)*
+                    $(Self::$surface => $tag,)*
                 }
             }
 
             /// This surface's row.
             ///
             /// Total by construction, and by the cheapest possible route: the
-            /// enum is fieldless and both lists come from one table, so a
-            /// variant's discriminant *is* its row index. Pinned by
-            /// `a_surfaces_discriminant_is_its_row_index`, which is what keeps
-            /// this indexing honest if the enum ever grows a payload.
+            /// enum carries no payload and both lists come from one table, so
+            /// a surface's discriminant *is* its row index. Pinned by
+            /// `a_surfaces_discriminant_is_its_row_index`, which fails if the
+            /// enum ever grows a payload and the two stop lining up.
             #[must_use]
             pub fn row(self) -> &'static EvolutionRow {
                 &EVOLUTION_SURFACES[self as usize]
@@ -272,7 +269,7 @@ macro_rules! evolution_surfaces {
         /// [`EvolutionSurface`].
         pub static EVOLUTION_SURFACES: &[EvolutionRow] = &[
             $(EvolutionRow {
-                surface: EvolutionSurface::$variant,
+                surface: EvolutionSurface::$surface,
                 posture: $posture,
                 timing: $timing,
                 impact: $impact,

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The evolution-surface matrix — one reviewed row per way Stella changes
+//! itself, so "what may Stella change about itself today, and on what
+//! evidence?" is a question with one answer someone wrote down (#2780).
+//!
+//! # Why a fourth ledger
+//!
+//! This repository already enforces three declaration ledgers, each born from
+//! the same defect shape — a capability that shipped on one axis and silently
+//! missed another, found by a run paying for it rather than by a test:
+//! provider feature parity (`stella-model`'s `provider_parity`, invariant #8),
+//! cross-surface capability parity ([`crate`], the sibling of this module),
+//! and signal consumption (`stella-protocol`'s `event::consumers`, invariant
+//! #10).
+//!
+//! Self-improvement had none, and it is the surface where a gap costs most.
+//! Stella changes itself through several distinct object classes, and each one
+//! used to answer "when may this change, on what evidence, published by whom,
+//! and how is it undone?" in a different file or nowhere at all. Skills
+//! promote on measured lift; context records have a governance mode and a
+//! hash-chained promotions ledger; weight-space adapters were designed with a
+//! promotion gate that nothing structurally enforced. No single reviewed table
+//! held the six answers side by side, which is exactly what the other three
+//! ledgers exist to provide.
+//!
+//! # The three instruments
+//!
+//! - **A row per surface, and no way to skip one.** [`EvolutionSurface`] and
+//!   [`EVOLUTION_SURFACES`] are generated from one `evolution_surfaces!`
+//!   invocation, so the enum variant and its row are the same table cell. A
+//!   new surface with no row is not a red test that can be forgotten — it is
+//!   unwritable, because the only place a variant can be added is the place
+//!   the row is required. This is the `consumers.rs` treatment #2780 asked
+//!   for, one turn stronger: there the variant lives on a hand-written enum
+//!   and omission is an `E0004`, and here there is no hand-written enum to
+//!   omit from.
+//! - **Witness tests named and checked.** A [`EvolutionPosture::Shipped`] or
+//!   [`EvolutionPosture::Experimental`] row names the test proving the surface
+//!   can actually be changed, and this module's tests fail when that function
+//!   no longer exists in the swept sources — the same substring check
+//!   `provider_parity` and [`crate::CAPABILITIES`] use.
+//! - **Gaps cited, never silent.** [`EvolutionPosture::Planned`] cites the
+//!   GitHub issue deciding it, [`EvolutionPosture::Prohibited`] cites a stable
+//!   design document by `id`, and [`EvolutionPosture::ShippedUnwitnessed`] is
+//!   bounded by [`UNWITNESSED_EVOLUTION_BASELINE`], a ratchet that only goes
+//!   down.
+//!
+//! # The evidence column does not restate the policy
+//!
+//! #2780 asks that this ledger's `evidence` column reference the provenance
+//! grades from #2782 "so the two ledgers cannot drift". Referencing them is
+//! not quite enough — a row could still name a grade the policy would not
+//! agree with, and nothing would notice.
+//!
+//! So a row does not declare a grade at all. It declares its
+//! [`ImpactClass`] — what a wrong change to this surface can break — and the
+//! required grade and authority are *derived* from it through
+//! [`ImpactClass::required_grade`] and [`ImpactClass::required_authority`].
+//! There is one policy, it lives in `stella-protocol`, and this ledger reads
+//! it rather than copying it. Changing what a blocking guard costs changes
+//! every row that publishes one, in the same edit.
+
+use stella_protocol::provenance::{ImpactClass, ProvenanceGrade, PublicationAuthority};
+
+/// When a change to a surface takes effect.
+///
+/// The column exists because "Stella may change this" means something very
+/// different for a value the running turn picks up than for a file the next
+/// session reads. A surface that mutates mid-turn can change the behaviour
+/// that is producing the evidence for the change.
+///
+/// #2780 wrote the middle rung as "end-of-session". It is spelled
+/// [`EvolutionTiming::BetweenTurns`] here because that is when the code
+/// actually lands changes: the memory sweep and skill creation both run on the
+/// post-turn reflection path, mid-session, and the next turn sees the result.
+/// No live surface waits for the session to end.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvolutionTiming {
+    /// The running turn observes the change. The most dangerous timing: the
+    /// loop can alter its own behaviour while the evidence for altering it is
+    /// still being gathered. No row claims it today.
+    InTurn,
+    /// The change lands after a turn and the next turn in the same session
+    /// sees it.
+    BetweenTurns,
+    /// The change is made outside any turn — an operator command or a batch
+    /// run — and is picked up when a session next loads it.
+    OfflineBatch,
+}
+
+impl EvolutionTiming {
+    /// The canonical `snake_case` tag.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InTurn => "in_turn",
+            Self::BetweenTurns => "between_turns",
+            Self::OfflineBatch => "offline_batch",
+        }
+    }
+}
+
+/// How a surface stands today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvolutionPosture {
+    /// Stella changes this surface today, with the named witness test proving
+    /// the path — checked for existence by this module's tests.
+    Shipped {
+        /// The mechanism, for a human reading the matrix.
+        mechanism: &'static str,
+        /// The test function proving the surface can be changed.
+        witness: &'static str,
+    },
+    /// Stella changes this surface today, but nothing pins the path. A debt
+    /// this matrix counts rather than hides, bounded by
+    /// [`UNWITNESSED_EVOLUTION_BASELINE`].
+    ShippedUnwitnessed {
+        mechanism: &'static str,
+        /// What a witness for this surface would pin.
+        missing: &'static str,
+    },
+    /// The path exists and is not trusted yet: reachable only behind an
+    /// explicit opt-in, and still named by a witness.
+    Experimental {
+        mechanism: &'static str,
+        witness: &'static str,
+        /// What has to be true before this becomes `Shipped`.
+        graduates_when: &'static str,
+    },
+    /// Not built. Cites the GitHub issue where it is being decided, so a
+    /// parked surface is distinguishable from a forgotten one.
+    Planned {
+        /// A `#NNNN` GitHub issue reference.
+        issue: &'static str,
+        /// What exists today in place of the surface, if anything.
+        today: &'static str,
+    },
+    /// Stella is not permitted to change this surface, with the design reason
+    /// a reviewer can check. Cites a design document by `id` — never by path,
+    /// which moves.
+    Prohibited {
+        /// A `doc:<id>` reference.
+        design_doc: &'static str,
+        reason: &'static str,
+    },
+    /// Considered, and deliberately dropped. Cites the issue where that was
+    /// decided.
+    ///
+    /// #2780's four postures do not describe this, and the tree contains it:
+    /// weight-space adaptation was designed, filed, and closed as **not
+    /// planned**. Calling that `Planned` would be false, and `Prohibited`
+    /// wants a design document that was never written — the decision lives in
+    /// the closed issue and nowhere else. Recording it honestly is worth one
+    /// more variant; the alternative is a row that reads as parked work
+    /// somebody will pick up.
+    NotPursued {
+        /// A `#NNNN` GitHub issue, closed as not planned.
+        decided_in: &'static str,
+        /// What exists in place of the surface, so the row is not read as
+        /// "nothing here".
+        today: &'static str,
+    },
+}
+
+impl EvolutionPosture {
+    /// The witness this posture names, if it names one.
+    #[must_use]
+    pub fn witness(&self) -> Option<&'static str> {
+        match self {
+            Self::Shipped { witness, .. } | Self::Experimental { witness, .. } => Some(witness),
+            Self::ShippedUnwitnessed { .. }
+            | Self::Planned { .. }
+            | Self::Prohibited { .. }
+            | Self::NotPursued { .. } => None,
+        }
+    }
+
+    /// Whether Stella can change this surface at all today.
+    #[must_use]
+    pub fn is_live(&self) -> bool {
+        matches!(
+            self,
+            Self::Shipped { .. } | Self::ShippedUnwitnessed { .. } | Self::Experimental { .. }
+        )
+    }
+}
+
+/// One evolution surface and the terms on which it may change.
+#[derive(Debug, Clone, Copy)]
+pub struct EvolutionRow {
+    /// The surface this row governs.
+    pub surface: EvolutionSurface,
+    /// How it stands today.
+    pub posture: EvolutionPosture,
+    /// When a change takes effect.
+    pub timing: EvolutionTiming,
+    /// **What a wrong change here can break.** The evidence and authority
+    /// columns are derived from this through #2782's policy rather than
+    /// restated, so the two ledgers cannot disagree — see
+    /// [`EvolutionRow::required_evidence`].
+    pub impact: ImpactClass,
+    /// The named artifact that reverses a change to this surface. Prose a
+    /// reviewer can check, and the column that turns "Stella changed itself"
+    /// into something a human can undo.
+    pub rollback: &'static str,
+}
+
+impl EvolutionRow {
+    /// The weakest evidence that may change this surface, read out of #2782's
+    /// policy rather than declared here.
+    #[must_use]
+    pub fn required_evidence(&self) -> ProvenanceGrade {
+        self.impact.required_grade()
+    }
+
+    /// The weakest authority that may publish a change to this surface, read
+    /// out of the same policy.
+    #[must_use]
+    pub fn required_authority(&self) -> PublicationAuthority {
+        self.impact.required_authority()
+    }
+}
+
+/// Generate the surface enum and its ledger from one table.
+///
+/// The point of the macro is that there is no second place to edit. A new
+/// evolution surface is a new arm here, and an arm carries every column, so a
+/// surface that declares nothing is not a row someone forgot — it is a program
+/// that does not compile.
+macro_rules! evolution_surfaces {
+    ($(
+        $(#[$meta:meta])*
+        $variant:ident => $tag:literal, $posture:expr, $timing:expr, $impact:expr, $rollback:literal;
+    )*) => {
+        /// A class of thing Stella can change about itself.
+        ///
+        /// Generated together with [`EVOLUTION_SURFACES`], so a variant and
+        /// its row are one edit.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum EvolutionSurface {
+            $($(#[$meta])* $variant,)*
+        }
+
+        impl EvolutionSurface {
+            /// Every surface, in ledger order.
+            pub const ALL: &'static [Self] = &[$(Self::$variant,)*];
+
+            /// The canonical `snake_case` tag.
+            #[must_use]
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $tag,)*
+                }
+            }
+
+            /// This surface's row.
+            ///
+            /// Total by construction, and by the cheapest possible route: the
+            /// enum is fieldless and both lists come from one table, so a
+            /// variant's discriminant *is* its row index. Pinned by
+            /// `a_surfaces_discriminant_is_its_row_index`, which is what keeps
+            /// this indexing honest if the enum ever grows a payload.
+            #[must_use]
+            pub fn row(self) -> &'static EvolutionRow {
+                &EVOLUTION_SURFACES[self as usize]
+            }
+        }
+
+        /// The ledger: one row per surface, generated from the same table as
+        /// [`EvolutionSurface`].
+        pub static EVOLUTION_SURFACES: &[EvolutionRow] = &[
+            $(EvolutionRow {
+                surface: EvolutionSurface::$variant,
+                posture: $posture,
+                timing: $timing,
+                impact: $impact,
+                rollback: $rollback,
+            },)*
+        ];
+    };
+}
+
+evolution_surfaces! {
+    /// Prompts, policies, and the loop's own instructions.
+    Framework => "framework",
+        EvolutionPosture::Shipped {
+            mechanism: "the rules miner induces directive candidates from reflection \
+                        observations and `stella proposals` publishes the kept ones as TOML \
+                        records under `.stella/rules/`, which `FsRuleSource` loads into the \
+                        system prefix. The system prompt template itself is assembled and \
+                        never self-edited: no path writes AGENTS.md or CLAUDE.md",
+            witness: "mined_rules_land_where_the_loader_reads",
+        },
+        EvolutionTiming::OfflineBatch,
+        ImpactClass::SteeringDirective,
+        "no command retracts a published rule — `stella proposals` offers only \
+         list/keep/edit/ignore/refresh, and `stella memory retire` does not suppress a \
+         file-backed rule because the loader filters by authority rather than by retirement \
+         standing. Reversal today is deleting or reverting `.stella/rules/<id>.toml`";
+
+    /// What Stella remembers between turns.
+    Memory => "memory",
+        EvolutionPosture::Shipped {
+            mechanism: "uses and citations are folded into selection health per record, and \
+                        the post-turn sweep retires one that keeps failing",
+            witness: "the_loop_closes_a_repeatedly_unhelpful_record_is_retired_and_restorable",
+        },
+        EvolutionTiming::BetweenTurns,
+        ImpactClass::RecallBias,
+        "`stella memory reaffirm <id>` and `stella memory restore <id>`. Nothing is \
+         deleted: standings are a last-write-wins fold over append-only promotion events, so \
+         a retirement is reversed by appending, never by editing history";
+
+    /// Reusable procedures Stella writes for itself.
+    Skill => "skill",
+        EvolutionPosture::Shipped {
+            mechanism: "mined candidates clear the distinct-task floor and are written as \
+                        SKILL.md. The measured-lift gate exists and is off by default \
+                        (`SkillMineConfig::require_measured_lift` is `false`), so the shipped \
+                        default promotes on mining eligibility — which is why this row's \
+                        impact is an advisory record and not a steering one",
+            witness: "a_skill_that_helps_is_promoted_with_its_lift_recorded",
+        },
+        EvolutionTiming::BetweenTurns,
+        ImpactClass::AdvisoryRecord,
+        "none wired. The demotion half — `record_turn`, `sweep`, `record_appraisal`, \
+         `queued_candidates` — carries `#[allow(dead_code)]` for want of a production caller, \
+         so a promoted skill that later regresses is demoted by nothing. Tracked in #4754";
+
+    /// Executable capability Stella adds to its own working surface.
+    Tool => "tool",
+        EvolutionPosture::Shipped {
+            mechanism: "the foundry's authored → staged → adopted → enabled protocol: a \
+                        staged tool is invisible to discovery, an adopted one is still \
+                        uncallable until enabled, and `recheck_before_launch` re-digests the \
+                        bytes on every call, so a script rewritten mid-session stops launching",
+            witness: "a_tool_is_unreachable_until_it_is_both_proven_and_approved",
+        },
+        EvolutionTiming::OfflineBatch,
+        ImpactClass::ExecutableTool,
+        "`stella tools --disable <name>` stops offering an adopted tool while keeping its \
+         proof on file; `forget_foundry_tool` removes the adoption and its approval outright";
+
+    /// How Stella configures its own runs.
+    Workflow => "workflow",
+        EvolutionPosture::Shipped {
+            mechanism: "`stella tune` reads two measured result files and the local ledger \
+                        and writes settings only under `--promote` — no provider call, no \
+                        API key, so the evidence is a measurement rather than a judgement",
+            witness: "a_clean_win_promotes_and_rollback_restores",
+        },
+        EvolutionTiming::OfflineBatch,
+        ImpactClass::SteeringDirective,
+        "`stella tune rollback` replays an append-only rollback ledger under \
+         `.stella/private/` and restores the prior setting, including the `effort_auto` flag \
+         the promotion also moved";
+
+    /// The weights Stella runs on.
+    Model => "model",
+        EvolutionPosture::NotPursued {
+            decided_in: "#836",
+            today: "`stella dataset export` writes an SFT corpus plus a manifest and stops. \
+                    The corpus has no in-tree consumer: there is no trainer, no adapter \
+                    registry, and no promotion loop anywhere in the workspace, and human \
+                    sign-off is required before a dataset reaches a training run",
+        },
+        EvolutionTiming::OfflineBatch,
+        ImpactClass::ExecutableTool,
+        "not applicable — nothing is promoted, so there is nothing to reverse. Were this \
+         surface built, the rollback artifact would have to exist before the promotion path did";
+}
+
+/// How many live rows name no witness.
+///
+/// A ratchet that only goes down, checked for **exact** equality like
+/// [`crate::UNWITNESSED_BASELINE`] and `provider_parity`'s: writing a missing
+/// witness promotes the row and lowers this number in the same PR, and raising
+/// it to turn a red gate green is the expedient CLAUDE.md forbids.
+///
+/// It is zero, and the way to keep it zero is to write the witness before
+/// adding the row.
+pub const UNWITNESSED_EVOLUTION_BASELINE: usize = 0;
+
+/// The sources swept for witness functions.
+///
+/// Each file is named individually rather than globbed, for the reason
+/// [`crate::CAPABILITIES`]'s sweep names its own: a file-size split moves tests
+/// out from under a parent module, and an explicit list fails loudly when that
+/// happens instead of silently sweeping less.
+#[cfg(test)]
+fn evolution_sources() -> [&'static str; 5] {
+    [
+        include_str!("../../stella-cli/src/memory/rules_mining/tests.rs"),
+        include_str!("../../stella-cli/src/memory/uses/tests.rs"),
+        include_str!("../../stella-core/src/skills/appraisal/tests.rs"),
+        include_str!("../../stella-cli/src/tool_foundry/adopt/tests.rs"),
+        include_str!("../../stella-cli/src/memory/self_tuning.rs"),
+    ]
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-parity/src/evolution/tests.rs
+++ b/crates/stella-parity/src/evolution/tests.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for the evolution-surface matrix (#2780).
+//!
+//! Totality is the compiler's job here — [`EvolutionSurface`] and
+//! [`EVOLUTION_SURFACES`] come out of one macro, so a surface with no row is
+//! not a case these tests have to catch. What they catch is everything the
+//! generator cannot: a witness that has been renamed away, a gap citing
+//! nothing, a declared grade drifting from the policy that defines it, and the
+//! unwitnessed debt creeping upward.
+
+use super::*;
+
+/// A witness exists if the swept sources declare a function by that name —
+/// the same substring check [`crate`]'s matrix and `provider_parity` use, and
+/// deliberately not an AST walk: a moved witness should fail loudly rather
+/// than be quietly re-resolved.
+fn witness_exists(sources: &[&str], witness: &str) -> bool {
+    let needle = format!("fn {witness}(");
+    sources.iter().any(|source| source.contains(&needle))
+}
+
+/// **The check that keeps a row honest.** Every live row names a test, and
+/// that test still exists.
+#[test]
+fn every_named_witness_exists_in_the_swept_sources() {
+    let sources = evolution_sources();
+
+    for row in EVOLUTION_SURFACES {
+        let Some(witness) = row.posture.witness() else {
+            continue;
+        };
+        assert!(
+            witness_exists(&sources, witness),
+            "the {} row names `{witness}`, which no swept source declares — either the \
+             test was renamed (update the row) or the file holding it is missing from \
+             evolution_sources()",
+            row.surface.as_str()
+        );
+    }
+}
+
+/// The sweep can fail. A checker that cannot go red proves nothing about the
+/// rows it passes, which is `content_free.rs`'s epistemics applied here.
+#[test]
+fn the_witness_check_rejects_a_name_that_does_not_exist() {
+    let sources = evolution_sources();
+
+    assert!(
+        !witness_exists(&sources, "a_witness_nobody_has_ever_written"),
+        "the witness check must be capable of failing"
+    );
+}
+
+/// Every surface has exactly one row, and it is the row indexing finds.
+///
+/// [`EvolutionSurface::row`] indexes by discriminant, which is sound only
+/// while the enum stays fieldless and the two lists stay in one order. Both
+/// come out of one macro today; this is what notices if that stops being true.
+#[test]
+fn a_surfaces_discriminant_is_its_row_index() {
+    assert_eq!(EvolutionSurface::ALL.len(), EVOLUTION_SURFACES.len());
+
+    for (index, surface) in EvolutionSurface::ALL.iter().enumerate() {
+        assert_eq!(
+            *surface as usize,
+            index,
+            "{} sits at index {index} of ALL but its discriminant is {}",
+            surface.as_str(),
+            *surface as usize
+        );
+        assert_eq!(
+            EVOLUTION_SURFACES[index].surface,
+            *surface,
+            "the ledger row at index {index} is not {}",
+            surface.as_str()
+        );
+        assert_eq!(surface.row().surface, *surface);
+    }
+}
+
+/// Tags are the ledger's external names, so a duplicate would make two rows
+/// indistinguishable to anything reading them.
+#[test]
+fn every_surface_tag_is_unique_and_snake_case() {
+    let mut seen = std::collections::BTreeSet::new();
+
+    for surface in EvolutionSurface::ALL {
+        let tag = surface.as_str();
+        assert!(seen.insert(tag), "duplicate surface tag `{tag}`");
+        assert!(
+            !tag.is_empty() && tag.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+            "`{tag}` is not snake_case"
+        );
+    }
+}
+
+/// A `Planned` row cites the issue deciding it, and a `NotPursued` row cites
+/// the issue where it was dropped — never prose standing in for a reference.
+#[test]
+fn every_parked_row_cites_an_issue() {
+    for row in EVOLUTION_SURFACES {
+        let cited = match row.posture {
+            EvolutionPosture::Planned { issue, .. } => issue,
+            EvolutionPosture::NotPursued { decided_in, .. } => decided_in,
+            _ => continue,
+        };
+        assert!(
+            cited.starts_with('#') && cited[1..].chars().all(|c| c.is_ascii_digit()),
+            "the {} row cites `{cited}`, which is not a `#NNNN` issue reference",
+            row.surface.as_str()
+        );
+    }
+}
+
+/// A `Prohibited` row cites a design document **by id**. AGENTS.md's rule is
+/// that a document is cited by id and never by path, because a path moves and
+/// nothing notices.
+#[test]
+fn every_prohibited_row_cites_a_design_document_by_id() {
+    for row in EVOLUTION_SURFACES {
+        let EvolutionPosture::Prohibited { design_doc, reason } = row.posture else {
+            continue;
+        };
+        assert!(
+            design_doc.starts_with("doc:"),
+            "the {} row cites `{design_doc}`, which is not a `doc:<id>` reference",
+            row.surface.as_str()
+        );
+        assert!(
+            !design_doc.contains('/') && !design_doc.ends_with(".md"),
+            "the {} row cites a path rather than an id: `{design_doc}`",
+            row.surface.as_str()
+        );
+        assert!(
+            !reason.trim().is_empty(),
+            "the {} row prohibits without a reason",
+            row.surface.as_str()
+        );
+    }
+}
+
+/// Unwitnessed debt is a down-only ratchet, checked for exact equality so that
+/// raising it is a deliberate edit a reviewer sees rather than a threshold
+/// quietly absorbing a new row.
+#[test]
+fn unwitnessed_rows_match_the_declared_baseline_exactly() {
+    let count = EVOLUTION_SURFACES
+        .iter()
+        .filter(|row| matches!(row.posture, EvolutionPosture::ShippedUnwitnessed { .. }))
+        .count();
+
+    assert_eq!(
+        count, UNWITNESSED_EVOLUTION_BASELINE,
+        "write the missing witness and lower UNWITNESSED_EVOLUTION_BASELINE, or — if this \
+         is genuinely new debt — raise it deliberately and say why in the PR"
+    );
+}
+
+/// Every row says something a reviewer can act on: a live surface explains its
+/// mechanism, and every surface says how a change to it is undone.
+#[test]
+fn every_row_explains_its_mechanism_and_its_rollback() {
+    for row in EVOLUTION_SURFACES {
+        assert!(
+            !row.rollback.trim().is_empty(),
+            "the {} row declares no rollback",
+            row.surface.as_str()
+        );
+
+        let mechanism = match row.posture {
+            EvolutionPosture::Shipped { mechanism, .. }
+            | EvolutionPosture::ShippedUnwitnessed { mechanism, .. }
+            | EvolutionPosture::Experimental { mechanism, .. } => Some(mechanism),
+            EvolutionPosture::Planned { today, .. }
+            | EvolutionPosture::NotPursued { today, .. } => Some(today),
+            EvolutionPosture::Prohibited { .. } => None,
+        };
+        if let Some(mechanism) = mechanism {
+            assert!(
+                !mechanism.trim().is_empty(),
+                "the {} row explains nothing",
+                row.surface.as_str()
+            );
+        }
+    }
+}
+
+/// **The two ledgers cannot drift**, because this one does not restate the
+/// other. A row declares its impact and reads the grade out of #2782's policy,
+/// so there is no second copy of the requirement to disagree with the first.
+#[test]
+fn required_evidence_is_read_from_the_provenance_policy() {
+    for row in EVOLUTION_SURFACES {
+        assert_eq!(row.required_evidence(), row.impact.required_grade());
+        assert_eq!(row.required_authority(), row.impact.required_authority());
+    }
+}
+
+/// The two surfaces that can run code in a teammate's session are held to
+/// proof and to a human. If someone lowers either requirement, this is where
+/// the decision surfaces rather than being absorbed by a row edit.
+#[test]
+fn the_executable_surfaces_require_proof_and_a_person() {
+    for surface in [EvolutionSurface::Tool, EvolutionSurface::Model] {
+        let row = surface.row();
+        assert_eq!(row.impact, ImpactClass::ExecutableTool);
+        assert_eq!(row.required_evidence(), ProvenanceGrade::DeterministicProof);
+        assert_eq!(row.required_authority(), PublicationAuthority::LocalHuman);
+    }
+}
+
+/// No live surface changes itself during the turn that is producing the
+/// evidence for the change. If one ever does, this test is where that gets
+/// argued rather than noticed later.
+#[test]
+fn no_live_surface_mutates_inside_the_running_turn() {
+    for row in EVOLUTION_SURFACES {
+        if row.posture.is_live() {
+            assert_ne!(
+                row.timing,
+                EvolutionTiming::InTurn,
+                "the {} row mutates in-turn: the loop would be altering the behaviour that \
+                 is generating its own evidence. If that is intended, say so here",
+                row.surface.as_str()
+            );
+        }
+    }
+}
+
+/// A row that is not live claims no witness, and a live one either names a
+/// witness or is counted as debt. Nothing sits between the two.
+#[test]
+fn liveness_and_witnesses_agree() {
+    for row in EVOLUTION_SURFACES {
+        match row.posture {
+            EvolutionPosture::Shipped { .. } | EvolutionPosture::Experimental { .. } => {
+                assert!(row.posture.is_live());
+                assert!(row.posture.witness().is_some());
+            }
+            EvolutionPosture::ShippedUnwitnessed { .. } => {
+                assert!(row.posture.is_live());
+                assert!(row.posture.witness().is_none());
+            }
+            EvolutionPosture::Planned { .. }
+            | EvolutionPosture::Prohibited { .. }
+            | EvolutionPosture::NotPursued { .. } => {
+                assert!(!row.posture.is_live());
+                assert!(row.posture.witness().is_none());
+            }
+        }
+    }
+}

--- a/crates/stella-parity/src/evolution/tests.rs
+++ b/crates/stella-parity/src/evolution/tests.rs
@@ -14,15 +14,14 @@ use super::*;
 
 /// A witness exists if the swept sources declare a function by that name —
 /// the same substring check [`crate`]'s matrix and `provider_parity` use, and
-/// deliberately not an AST walk: a moved witness should fail loudly rather
-/// than be quietly re-resolved.
+/// not an AST walk: a moved witness should fail loudly rather than be quietly
+/// re-resolved.
 fn witness_exists(sources: &[&str], witness: &str) -> bool {
     let needle = format!("fn {witness}(");
     sources.iter().any(|source| source.contains(&needle))
 }
 
-/// **The check that keeps a row honest.** Every live row names a test, and
-/// that test still exists.
+/// **Every live row names a test, and that test still exists.**
 #[test]
 fn every_named_witness_exists_in_the_swept_sources() {
     let sources = evolution_sources();
@@ -142,8 +141,8 @@ fn every_prohibited_row_cites_a_design_document_by_id() {
 }
 
 /// Unwitnessed debt is a down-only ratchet, checked for exact equality so that
-/// raising it is a deliberate edit a reviewer sees rather than a threshold
-/// quietly absorbing a new row.
+/// raising it is an edit a reviewer sees rather than a threshold quietly
+/// absorbing a new row.
 #[test]
 fn unwitnessed_rows_match_the_declared_baseline_exactly() {
     let count = EVOLUTION_SURFACES
@@ -154,7 +153,7 @@ fn unwitnessed_rows_match_the_declared_baseline_exactly() {
     assert_eq!(
         count, UNWITNESSED_EVOLUTION_BASELINE,
         "write the missing witness and lower UNWITNESSED_EVOLUTION_BASELINE, or — if this \
-         is genuinely new debt — raise it deliberately and say why in the PR"
+         is genuinely new debt — raise it and say why in the PR"
     );
 }
 

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -40,6 +40,8 @@
 //! parity" means for hosts dropping Stella into their own applications — is
 //! `docs/spec/engine-embedding.md`.
 
+pub mod evolution;
+
 /// How one capability ships on one surface.
 #[derive(Debug)]
 pub enum SurfacePosture {

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -69,6 +69,7 @@ pub mod journal;
 pub mod ladder;
 pub mod lane;
 pub mod proof;
+pub mod provenance;
 pub mod provider;
 pub mod question;
 pub mod recall;

--- a/crates/stella-protocol/src/provenance.rs
+++ b/crates/stella-protocol/src/provenance.rs
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! How strong the evidence behind a self-improvement artifact is, carried as a
+//! value rather than reconstructed by whoever promotes it (#2782).
+//!
+//! # The defect this exists to make impossible
+//!
+//! Stella turns observations into artifacts through a chain — reflection →
+//! proposal → skill / rule / tool. Until this module, the strength of the
+//! original evidence was not carried along it. By the time something was a
+//! published skill or an executable tool, the record that it originated in a
+//! model's opinion rather than in a passing test was gone, and every artifact
+//! at the end of the chain looked alike.
+//!
+//! The concrete hazard is **laundering by aggregation**: several model
+//! critiques agreeing with each other is still zero deterministic evidence,
+//! but a promotion gate that counts votes reads agreement as strength.
+//! #2569/#2570 is this repository's live proof that a plausible consensus
+//! signal can be structurally worthless — ablating the verifier turned every
+//! run into a PASS, and the vote count never noticed.
+//!
+//! Two rules answer it, and both are mechanical here rather than editorial:
+//!
+//! 1. **No aggregation promotes a grade.** [`ProvenanceGrade::weakest`] is the
+//!    only way to combine evidence, and it is a `min`. N model critiques
+//!    remain a model critique however many agree. Only re-deriving a claim
+//!    from a stronger source promotes it, which means constructing a new
+//!    record against that source.
+//! 2. **Impact sets the required grade.** [`ImpactClass::required_grade`] says
+//!    what each blast radius costs, and [`authorises`] is the single gate.
+//!    A prompt hint may be trialled from a mined trajectory; a blocking guard
+//!    or an executable tool may not, because those two can break a teammate's
+//!    session.
+//!
+//! # Two axes, not one
+//!
+//! [`ProvenanceGrade`] answers *how reproducible is the evidence*.
+//! [`PublicationAuthority`] answers *who may publish it*. #2782's own rule
+//! keeps them apart — a guard or a tool needs "deterministic proof **plus**
+//! publication authority" — so collapsing them into one ladder would let an
+//! approver's signature stand in for a witness test, which is the substitution
+//! this repository refuses everywhere else.
+//!
+//! That is also why [`ProvenanceGrade::HumanReview`] does not sit at the top of
+//! the grade order. A person signing off is accountable, and that is what
+//! [`PublicationAuthority::LocalHuman`] records; it is not evidence that the
+//! change works. CLAUDE.md states the same thing about this repository's own
+//! reviews — a witness test or a golden diff someone read is evidence, and a
+//! sentence in a PR description is not. Human review ranks above
+//! [`ProvenanceGrade::ModelCritique`] because a judgement someone is
+//! accountable for outranks a judgement nobody is, and below
+//! [`ProvenanceGrade::TrajectoryAbstraction`] because a measured pattern
+//! survives its author's confidence.
+//!
+//! # Where it lives
+//!
+//! `stella-core` derives a grade from the observation records it owns,
+//! `stella-parity`'s evolution ledger types its `evidence` column as one, and
+//! `stella-cli` renders it where a human decides. A type crossing crate
+//! boundaries belongs in this crate by invariant #1, and by invariant #4 it
+//! round-trips through `serde_json` byte-for-byte — see this module's tests.
+//!
+//! Every variant is a closed, `'static`-nameable tag: a grade emitted into a
+//! `stella-diag` field has to be an enum, never a `String` carrying model
+//! output, and [`ProvenanceGrade::as_str`] is what makes that possible without
+//! an allocation. The grade is metadata and may cross an egress encoder; the
+//! evidence it points at is content and may not (invariant #3,
+//! `stella-store/src/content_free.rs`).
+
+use serde::{Deserialize, Serialize};
+
+/// How reproducible the evidence behind an artifact is.
+///
+/// **Ordered weakest-first**, so the derived [`Ord`] is the strength order and
+/// `min` is the aggregation rule. Adding a variant means placing it in that
+/// order deliberately — the position is the semantics, not a formatting
+/// choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ProvenanceGrade {
+    /// A model's judgement about a run. The weakest grade, and the one the
+    /// aggregation rule exists to contain: agreement between critiques is not
+    /// evidence, it is correlated opinion.
+    ModelCritique,
+    /// A person read it and signed off. Accountable, and still a judgement —
+    /// it does not become a measurement by being human.
+    HumanReview,
+    /// A pattern mined across runs: statistical, not proven. Enough to trial a
+    /// hint, never enough to publish something that can fail a build.
+    TrajectoryAbstraction,
+    /// A command's exit status, a build result, a number measured out of
+    /// `stella-events.jsonl`. The environment answered, rather than a model
+    /// or a person reporting what it would have said.
+    EnvironmentObservation,
+    /// A witness test that went fail → pass, or a guard that fails the gate.
+    /// The only grade that authorises a blocking guard or an executable tool.
+    DeterministicProof,
+}
+
+impl ProvenanceGrade {
+    /// Every grade, weakest first — the enumeration a sweep iterates so a new
+    /// variant reaches each exhaustiveness check rather than being missed by a
+    /// hand-written list.
+    pub const ALL: &'static [Self] = &[
+        Self::ModelCritique,
+        Self::HumanReview,
+        Self::TrajectoryAbstraction,
+        Self::EnvironmentObservation,
+        Self::DeterministicProof,
+    ];
+
+    /// The canonical `snake_case` tag — identical to what `serde` writes, so a
+    /// diagnostic field, a stored record, and a rendered surface all name a
+    /// grade the same way. Allocation-free, which is what lets it be a
+    /// `stella-diag` field value at all.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ModelCritique => "model_critique",
+            Self::HumanReview => "human_review",
+            Self::TrajectoryAbstraction => "trajectory_abstraction",
+            Self::EnvironmentObservation => "environment_observation",
+            Self::DeterministicProof => "deterministic_proof",
+        }
+    }
+
+    /// Prose for a human deciding, in the vocabulary #2782 wrote the table in.
+    #[must_use]
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::ModelCritique => "a model's judgement about a run",
+            Self::HumanReview => "a person read it and signed off",
+            Self::TrajectoryAbstraction => "a pattern mined across runs, statistical rather than proven",
+            Self::EnvironmentObservation => "a command exit status, a build result, or a measured number",
+            Self::DeterministicProof => "a witness test that went fail to pass, or a guard that fails the gate",
+        }
+    }
+
+    /// **The aggregation rule: combining evidence can only weaken it.**
+    ///
+    /// Returns the weakest grade in `grades`, or `None` for an empty pool —
+    /// which is the honest answer, because no evidence is not the same as weak
+    /// evidence and must not round up to one.
+    ///
+    /// This is the whole of #2782's rule 1. A caller that wants a stronger
+    /// grade has to re-derive the claim against a stronger source and build a
+    /// new record; there is deliberately no `promote`, no vote count, and no
+    /// confidence threshold that crosses a grade boundary.
+    #[must_use]
+    pub fn weakest(grades: impl IntoIterator<Item = Self>) -> Option<Self> {
+        grades.into_iter().min()
+    }
+}
+
+/// Who may publish a change — the second axis, kept separate from evidence so
+/// that an approver's signature can never stand in for a witness test.
+///
+/// Ordered weakest-first like [`ProvenanceGrade`], so `min` composes the same
+/// way when a publication path has more than one actor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum PublicationAuthority {
+    /// The agent acting on its own. Enough to propose and to trial, never
+    /// enough to publish something that can fail a build — the same line
+    /// `PromotionEventRecord` already draws when it refuses a `System` actor a
+    /// blocking grant.
+    Agent,
+    /// A person on this machine approved it.
+    LocalHuman,
+    /// An org-managed policy document authorised it.
+    OrgPolicy,
+}
+
+impl PublicationAuthority {
+    /// Every authority, weakest first.
+    pub const ALL: &'static [Self] = &[Self::Agent, Self::LocalHuman, Self::OrgPolicy];
+
+    /// The canonical `snake_case` tag, matching `serde`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::LocalHuman => "local_human",
+            Self::OrgPolicy => "org_policy",
+        }
+    }
+}
+
+/// What a change can break if it is wrong — the blast radius the grade is
+/// rationing.
+///
+/// Ordered least-dangerous-first, so a reviewer reading the enum reads the
+/// escalation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactClass {
+    /// Text added to a prompt. Wrong, it wastes tokens and misleads one turn.
+    PromptHint,
+    /// A weight on what gets recalled. Wrong, it surfaces the wrong record.
+    RecallBias,
+    /// A published record that informs and never steers — a knowledge skill.
+    /// Wrong, a human reads something untrue and can tell.
+    AdvisoryRecord,
+    /// A rule that steers the agent. Wrong, it changes behaviour without the
+    /// human who wrote it being in the loop for the turn it changes.
+    SteeringDirective,
+    /// A guard that can refuse a turn or fail a gate. Wrong, it blocks work
+    /// that should have shipped — in someone else's session.
+    BlockingGuard,
+    /// Code that runs in a teammate's session. The largest radius there is.
+    ExecutableTool,
+}
+
+impl ImpactClass {
+    /// Every impact class, least-dangerous first.
+    pub const ALL: &'static [Self] = &[
+        Self::PromptHint,
+        Self::RecallBias,
+        Self::AdvisoryRecord,
+        Self::SteeringDirective,
+        Self::BlockingGuard,
+        Self::ExecutableTool,
+    ];
+
+    /// The canonical `snake_case` tag, matching `serde`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PromptHint => "prompt_hint",
+            Self::RecallBias => "recall_bias",
+            Self::AdvisoryRecord => "advisory_record",
+            Self::SteeringDirective => "steering_directive",
+            Self::BlockingGuard => "blocking_guard",
+            Self::ExecutableTool => "executable_tool",
+        }
+    }
+
+    /// The weakest evidence that may publish this impact class.
+    ///
+    /// #2782 states the two ends: a prompt hint or a recall bias may be
+    /// trialled from trajectory evidence, and a blocking guard or an executable
+    /// tool requires deterministic proof. The middle two are placed against
+    /// the authority this repository already enforces — a directive steers the
+    /// agent, so it is held above a record that only informs.
+    #[must_use]
+    pub fn required_grade(self) -> ProvenanceGrade {
+        match self {
+            Self::PromptHint | Self::RecallBias | Self::AdvisoryRecord => {
+                ProvenanceGrade::TrajectoryAbstraction
+            }
+            Self::SteeringDirective => ProvenanceGrade::EnvironmentObservation,
+            Self::BlockingGuard | Self::ExecutableTool => ProvenanceGrade::DeterministicProof,
+        }
+    }
+
+    /// The weakest authority that may publish this impact class.
+    ///
+    /// The two classes that can break a teammate's session need a person or a
+    /// policy behind them, which is #2782's "plus publication authority" and
+    /// the same line `PromotionEventRecord::SystemGrantedBlocking` already
+    /// draws for blocking grants.
+    #[must_use]
+    pub fn required_authority(self) -> PublicationAuthority {
+        match self {
+            Self::PromptHint
+            | Self::RecallBias
+            | Self::AdvisoryRecord
+            | Self::SteeringDirective => PublicationAuthority::Agent,
+            Self::BlockingGuard | Self::ExecutableTool => PublicationAuthority::LocalHuman,
+        }
+    }
+}
+
+/// Why a promotion was refused — typed, because a caller has to branch on
+/// which half was short (invariant #5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case", tag = "refusal")]
+pub enum PromotionRefusal {
+    /// The evidence is weaker than this impact class requires.
+    EvidenceTooWeak {
+        impact: ImpactClass,
+        required: ProvenanceGrade,
+        actual: ProvenanceGrade,
+    },
+    /// The evidence is strong enough, but nobody with standing published it.
+    AuthorityTooLow {
+        impact: ImpactClass,
+        required: PublicationAuthority,
+        actual: PublicationAuthority,
+    },
+    /// There was no evidence at all. Distinct from weak evidence on purpose:
+    /// an empty pool is a bug in the caller, not a weak claim.
+    NoEvidence { impact: ImpactClass },
+}
+
+impl PromotionRefusal {
+    /// One line a human can act on, naming both what was required and what was
+    /// offered — a refusal that does not say what would fix it is a dead end.
+    #[must_use]
+    pub fn reason(&self) -> String {
+        match self {
+            Self::EvidenceTooWeak {
+                impact,
+                required,
+                actual,
+            } => format!(
+                "{} requires {} ({}); the evidence is {} ({})",
+                impact.as_str(),
+                required.as_str(),
+                required.describe(),
+                actual.as_str(),
+                actual.describe(),
+            ),
+            Self::AuthorityTooLow {
+                impact,
+                required,
+                actual,
+            } => format!(
+                "{} must be published by {} or stronger; it was published by {}",
+                impact.as_str(),
+                required.as_str(),
+                actual.as_str(),
+            ),
+            Self::NoEvidence { impact } => format!(
+                "{} was promoted with no supporting evidence at all",
+                impact.as_str()
+            ),
+        }
+    }
+}
+
+/// **The gate.** Whether evidence of this grade, published by this authority,
+/// may become an artifact of this impact class.
+///
+/// Both halves are checked and the evidence half is checked first, so a
+/// refusal names the missing witness rather than the missing signature when
+/// both are short — the more useful of the two answers.
+///
+/// # Errors
+///
+/// Returns the typed [`PromotionRefusal`] naming which half fell short.
+pub fn authorises(
+    grade: Option<ProvenanceGrade>,
+    authority: PublicationAuthority,
+    impact: ImpactClass,
+) -> Result<(), PromotionRefusal> {
+    let Some(grade) = grade else {
+        return Err(PromotionRefusal::NoEvidence { impact });
+    };
+    let required = impact.required_grade();
+    if grade < required {
+        return Err(PromotionRefusal::EvidenceTooWeak {
+            impact,
+            required,
+            actual: grade,
+        });
+    }
+    let required_authority = impact.required_authority();
+    if authority < required_authority {
+        return Err(PromotionRefusal::AuthorityTooLow {
+            impact,
+            required: required_authority,
+            actual: authority,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-protocol/src/provenance.rs
+++ b/crates/stella-protocol/src/provenance.rs
@@ -58,14 +58,14 @@
 //! `stella-core` derives a grade from the observation records it owns,
 //! `stella-parity`'s evolution ledger types its `evidence` column as one, and
 //! `stella-cli` renders it where a human decides. A type crossing crate
-//! boundaries belongs in this crate by invariant #1, and by invariant #4 it
+//! boundaries belongs in this crate by `invariant #1`, and by `invariant #4` it
 //! round-trips through `serde_json` byte-for-byte — see this module's tests.
 //!
-//! Every variant is a closed, `'static`-nameable tag: a grade emitted into a
+//! Every grade is a closed, `'static`-nameable tag: one emitted into a
 //! `stella-diag` field has to be an enum, never a `String` carrying model
 //! output, and [`ProvenanceGrade::as_str`] is what makes that possible without
 //! an allocation. The grade is metadata and may cross an egress encoder; the
-//! evidence it points at is content and may not (invariant #3,
+//! evidence it points at is content and may not (`invariant #3`,
 //! `stella-store/src/content_free.rs`).
 
 use serde::{Deserialize, Serialize};
@@ -73,9 +73,9 @@ use serde::{Deserialize, Serialize};
 /// How reproducible the evidence behind an artifact is.
 ///
 /// **Ordered weakest-first**, so the derived [`Ord`] is the strength order and
-/// `min` is the aggregation rule. Adding a variant means placing it in that
-/// order deliberately — the position is the semantics, not a formatting
-/// choice.
+/// `min` is the aggregation rule. Adding a grade means choosing its place in
+/// that order: the position is the semantics, and moving a grade one rung
+/// changes what it authorises.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
@@ -100,9 +100,9 @@ pub enum ProvenanceGrade {
 }
 
 impl ProvenanceGrade {
-    /// Every grade, weakest first — the enumeration a sweep iterates so a new
-    /// variant reaches each exhaustiveness check rather than being missed by a
-    /// hand-written list.
+    /// Every grade, weakest first — the enumeration a sweep iterates, so a new
+    /// grade reaches each check rather than being missed by a hand-written
+    /// list.
     pub const ALL: &'static [Self] = &[
         Self::ModelCritique,
         Self::HumanReview,
@@ -147,13 +147,13 @@ impl ProvenanceGrade {
     /// **The aggregation rule: combining evidence can only weaken it.**
     ///
     /// Returns the weakest grade in `grades`, or `None` for an empty pool —
-    /// which is the honest answer, because no evidence is not the same as weak
-    /// evidence and must not round up to one.
+    /// because no evidence is not the same as weak evidence and must not round
+    /// up to one.
     ///
     /// This is the whole of #2782's rule 1. A caller that wants a stronger
     /// grade has to re-derive the claim against a stronger source and build a
-    /// new record; there is deliberately no `promote`, no vote count, and no
-    /// confidence threshold that crosses a grade boundary.
+    /// new record; there is no `promote`, no vote count, and no confidence
+    /// threshold that crosses a grade boundary.
     #[must_use]
     pub fn weakest(grades: impl IntoIterator<Item = Self>) -> Option<Self> {
         grades.into_iter().min()
@@ -282,7 +282,7 @@ impl ImpactClass {
 }
 
 /// Why a promotion was refused — typed, because a caller has to branch on
-/// which half was short (invariant #5).
+/// which half was short (`invariant #5`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case", tag = "refusal")]
@@ -343,7 +343,7 @@ impl PromotionRefusal {
 /// **The gate.** Whether evidence of this grade, published by this authority,
 /// may become an artifact of this impact class.
 ///
-/// Both halves are checked and the evidence half is checked first, so a
+/// The evidence half is checked first, so a
 /// refusal names the missing witness rather than the missing signature when
 /// both are short — the more useful of the two answers.
 ///

--- a/crates/stella-protocol/src/provenance.rs
+++ b/crates/stella-protocol/src/provenance.rs
@@ -132,9 +132,15 @@ impl ProvenanceGrade {
         match self {
             Self::ModelCritique => "a model's judgement about a run",
             Self::HumanReview => "a person read it and signed off",
-            Self::TrajectoryAbstraction => "a pattern mined across runs, statistical rather than proven",
-            Self::EnvironmentObservation => "a command exit status, a build result, or a measured number",
-            Self::DeterministicProof => "a witness test that went fail to pass, or a guard that fails the gate",
+            Self::TrajectoryAbstraction => {
+                "a pattern mined across runs, statistical rather than proven"
+            }
+            Self::EnvironmentObservation => {
+                "a command exit status, a build result, or a measured number"
+            }
+            Self::DeterministicProof => {
+                "a witness test that went fail to pass, or a guard that fails the gate"
+            }
         }
     }
 

--- a/crates/stella-protocol/src/provenance/tests.rs
+++ b/crates/stella-protocol/src/provenance/tests.rs
@@ -220,8 +220,7 @@ fn one_grade_below_the_requirement_is_always_refused() {
         let Some(weaker) = ProvenanceGrade::ALL
             .iter()
             .copied()
-            .filter(|grade| *grade < required)
-            .next_back()
+            .rfind(|grade| *grade < required)
         else {
             continue;
         };

--- a/crates/stella-protocol/src/provenance/tests.rs
+++ b/crates/stella-protocol/src/provenance/tests.rs
@@ -235,7 +235,7 @@ fn one_grade_below_the_requirement_is_always_refused() {
     }
 }
 
-/// Invariant #4: every type crossing a crate boundary round-trips through
+/// `invariant #4`: every type crossing a crate boundary round-trips through
 /// `serde_json` byte-for-byte.
 #[test]
 fn every_tag_round_trips_byte_for_byte() {

--- a/crates/stella-protocol/src/provenance/tests.rs
+++ b/crates/stella-protocol/src/provenance/tests.rs
@@ -62,10 +62,7 @@ fn agreeing_model_critiques_never_authorise_a_blocking_guard() {
     )
     .expect_err("a blocking guard published on model critique alone must be refused");
 
-    assert!(matches!(
-        refusal,
-        PromotionRefusal::EvidenceTooWeak { .. }
-    ));
+    assert!(matches!(refusal, PromotionRefusal::EvidenceTooWeak { .. }));
 }
 
 /// Rule 1, stated over every grade rather than only the dangerous one: no
@@ -106,8 +103,12 @@ fn one_strong_source_does_not_lift_the_weak_ones_beside_it() {
 fn an_empty_pool_is_none_rather_than_the_weakest_grade() {
     assert_eq!(ProvenanceGrade::weakest(std::iter::empty()), None);
 
-    let refusal = authorises(None, PublicationAuthority::OrgPolicy, ImpactClass::PromptHint)
-        .expect_err("promoting with no evidence at all must be refused");
+    let refusal = authorises(
+        None,
+        PublicationAuthority::OrgPolicy,
+        ImpactClass::PromptHint,
+    )
+    .expect_err("promoting with no evidence at all must be refused");
     assert_eq!(
         refusal,
         PromotionRefusal::NoEvidence {
@@ -122,10 +123,15 @@ fn an_empty_pool_is_none_rather_than_the_weakest_grade() {
 #[test]
 fn the_grade_order_is_strictly_ascending() {
     assert!(
-        ProvenanceGrade::ALL.windows(2).all(|pair| pair[0] < pair[1]),
+        ProvenanceGrade::ALL
+            .windows(2)
+            .all(|pair| pair[0] < pair[1]),
         "ProvenanceGrade::ALL must be strictly weakest-first"
     );
-    assert_eq!(ProvenanceGrade::ALL.first(), Some(&ProvenanceGrade::ModelCritique));
+    assert_eq!(
+        ProvenanceGrade::ALL.first(),
+        Some(&ProvenanceGrade::ModelCritique)
+    );
     assert_eq!(
         ProvenanceGrade::ALL.last(),
         Some(&ProvenanceGrade::DeterministicProof)

--- a/crates/stella-protocol/src/provenance/tests.rs
+++ b/crates/stella-protocol/src/provenance/tests.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for the provenance grade (#2782).
+//!
+//! The first test in this file is the one the issue asks for by name: a
+//! fixture of several agreeing model critiques must not reach a grade that
+//! authorises publishing an executable tool. Everything else exists to keep
+//! that answer from being reachable by accident through another door.
+
+use super::*;
+
+/// **#2782's named witness.** Laundering by aggregation, refused.
+///
+/// Fifty model critiques agreeing with each other is the exact shape a
+/// vote-counting gate reads as strong evidence. It stays a model critique, and
+/// the tool gate refuses it — with a refusal that names the witness it wanted.
+#[test]
+fn agreeing_model_critiques_never_authorise_an_executable_tool() {
+    let pool = std::iter::repeat_n(ProvenanceGrade::ModelCritique, 50);
+
+    let grade = ProvenanceGrade::weakest(pool);
+    assert_eq!(
+        grade,
+        Some(ProvenanceGrade::ModelCritique),
+        "agreement between critiques must not promote the grade"
+    );
+
+    // Even with the strongest authority available, the evidence half is short.
+    let refusal = authorises(
+        grade,
+        PublicationAuthority::OrgPolicy,
+        ImpactClass::ExecutableTool,
+    )
+    .expect_err("a tool published on model critique alone must be refused");
+
+    assert_eq!(
+        refusal,
+        PromotionRefusal::EvidenceTooWeak {
+            impact: ImpactClass::ExecutableTool,
+            required: ProvenanceGrade::DeterministicProof,
+            actual: ProvenanceGrade::ModelCritique,
+        }
+    );
+    assert!(
+        refusal.reason().contains("deterministic_proof"),
+        "the refusal must name the evidence that would satisfy it: {}",
+        refusal.reason()
+    );
+}
+
+/// The same shape one rung down: a blocking guard is refused too, because it
+/// can fail a gate in someone else's session.
+#[test]
+fn agreeing_model_critiques_never_authorise_a_blocking_guard() {
+    let grade = ProvenanceGrade::weakest(std::iter::repeat_n(ProvenanceGrade::ModelCritique, 12));
+
+    let refusal = authorises(
+        grade,
+        PublicationAuthority::LocalHuman,
+        ImpactClass::BlockingGuard,
+    )
+    .expect_err("a blocking guard published on model critique alone must be refused");
+
+    assert!(matches!(
+        refusal,
+        PromotionRefusal::EvidenceTooWeak { .. }
+    ));
+}
+
+/// Rule 1, stated over every grade rather than only the dangerous one: no
+/// amount of repetition moves any grade.
+#[test]
+fn repetition_never_promotes_any_grade() {
+    for &grade in ProvenanceGrade::ALL {
+        for count in [1_usize, 2, 3, 5, 100] {
+            assert_eq!(
+                ProvenanceGrade::weakest(std::iter::repeat_n(grade, count)),
+                Some(grade),
+                "{} repeated {count} times must remain {}",
+                grade.as_str(),
+                grade.as_str()
+            );
+        }
+    }
+}
+
+/// A pool is only as strong as its weakest member — one deterministic proof
+/// does not carry the critiques standing beside it.
+#[test]
+fn one_strong_source_does_not_lift_the_weak_ones_beside_it() {
+    let mixed = [
+        ProvenanceGrade::DeterministicProof,
+        ProvenanceGrade::EnvironmentObservation,
+        ProvenanceGrade::ModelCritique,
+    ];
+
+    assert_eq!(
+        ProvenanceGrade::weakest(mixed),
+        Some(ProvenanceGrade::ModelCritique)
+    );
+}
+
+/// No evidence is not weak evidence, and must not round up to it.
+#[test]
+fn an_empty_pool_is_none_rather_than_the_weakest_grade() {
+    assert_eq!(ProvenanceGrade::weakest(std::iter::empty()), None);
+
+    let refusal = authorises(None, PublicationAuthority::OrgPolicy, ImpactClass::PromptHint)
+        .expect_err("promoting with no evidence at all must be refused");
+    assert_eq!(
+        refusal,
+        PromotionRefusal::NoEvidence {
+            impact: ImpactClass::PromptHint
+        }
+    );
+}
+
+/// The strength order is the declaration order, and it is strict — a tie would
+/// make `weakest` pick arbitrarily between two grades a reviewer reads as
+/// different.
+#[test]
+fn the_grade_order_is_strictly_ascending() {
+    assert!(
+        ProvenanceGrade::ALL.windows(2).all(|pair| pair[0] < pair[1]),
+        "ProvenanceGrade::ALL must be strictly weakest-first"
+    );
+    assert_eq!(ProvenanceGrade::ALL.first(), Some(&ProvenanceGrade::ModelCritique));
+    assert_eq!(
+        ProvenanceGrade::ALL.last(),
+        Some(&ProvenanceGrade::DeterministicProof)
+    );
+    assert!(PublicationAuthority::ALL.windows(2).all(|p| p[0] < p[1]));
+    assert!(ImpactClass::ALL.windows(2).all(|p| p[0] < p[1]));
+}
+
+/// Trajectory evidence trials a hint and nothing heavier — the two ends #2782
+/// states, checked as a boundary rather than a spot value.
+#[test]
+fn trajectory_evidence_trials_a_hint_and_stops_below_a_guard() {
+    let trajectory = Some(ProvenanceGrade::TrajectoryAbstraction);
+
+    for impact in [
+        ImpactClass::PromptHint,
+        ImpactClass::RecallBias,
+        ImpactClass::AdvisoryRecord,
+    ] {
+        assert!(
+            authorises(trajectory, PublicationAuthority::Agent, impact).is_ok(),
+            "{} may be trialled from trajectory evidence",
+            impact.as_str()
+        );
+    }
+
+    for impact in [ImpactClass::BlockingGuard, ImpactClass::ExecutableTool] {
+        assert!(
+            authorises(trajectory, PublicationAuthority::OrgPolicy, impact).is_err(),
+            "{} must not be reachable from trajectory evidence",
+            impact.as_str()
+        );
+    }
+}
+
+/// The authority half is real: deterministic proof alone does not publish the
+/// two classes that can break a teammate's session.
+#[test]
+fn proof_without_authority_does_not_publish_a_tool_or_a_guard() {
+    let proof = Some(ProvenanceGrade::DeterministicProof);
+
+    for impact in [ImpactClass::BlockingGuard, ImpactClass::ExecutableTool] {
+        let refusal = authorises(proof, PublicationAuthority::Agent, impact)
+            .expect_err("the agent may not publish this on its own");
+        assert_eq!(
+            refusal,
+            PromotionRefusal::AuthorityTooLow {
+                impact,
+                required: PublicationAuthority::LocalHuman,
+                actual: PublicationAuthority::Agent,
+            }
+        );
+
+        assert!(
+            authorises(proof, PublicationAuthority::LocalHuman, impact).is_ok(),
+            "a person signing off on proven evidence publishes {}",
+            impact.as_str()
+        );
+    }
+}
+
+/// Every impact class is satisfiable by *something*, so no row is a dead end a
+/// caller can never clear.
+#[test]
+fn every_impact_class_is_reachable_at_its_own_requirements() {
+    for &impact in ImpactClass::ALL {
+        assert!(
+            authorises(
+                Some(impact.required_grade()),
+                impact.required_authority(),
+                impact
+            )
+            .is_ok(),
+            "{} must be satisfiable by exactly what it requires",
+            impact.as_str()
+        );
+    }
+}
+
+/// One rung below the requirement always fails — the gate is a boundary, not a
+/// suggestion. Checked for every class that has a rung below it.
+#[test]
+fn one_grade_below_the_requirement_is_always_refused() {
+    for &impact in ImpactClass::ALL {
+        let required = impact.required_grade();
+        let Some(weaker) = ProvenanceGrade::ALL
+            .iter()
+            .copied()
+            .filter(|grade| *grade < required)
+            .next_back()
+        else {
+            continue;
+        };
+
+        assert!(
+            authorises(Some(weaker), PublicationAuthority::OrgPolicy, impact).is_err(),
+            "{} must refuse {}, one rung below its requirement",
+            impact.as_str(),
+            weaker.as_str()
+        );
+    }
+}
+
+/// Invariant #4: every type crossing a crate boundary round-trips through
+/// `serde_json` byte-for-byte.
+#[test]
+fn every_tag_round_trips_byte_for_byte() {
+    for &grade in ProvenanceGrade::ALL {
+        let json = serde_json::to_string(&grade).expect("a grade serializes");
+        assert_eq!(json, format!("\"{}\"", grade.as_str()));
+        let back: ProvenanceGrade = serde_json::from_str(&json).expect("a grade deserializes");
+        assert_eq!(back, grade);
+    }
+
+    for &authority in PublicationAuthority::ALL {
+        let json = serde_json::to_string(&authority).expect("an authority serializes");
+        assert_eq!(json, format!("\"{}\"", authority.as_str()));
+        let back: PublicationAuthority = serde_json::from_str(&json).expect("it deserializes");
+        assert_eq!(back, authority);
+    }
+
+    for &impact in ImpactClass::ALL {
+        let json = serde_json::to_string(&impact).expect("an impact serializes");
+        assert_eq!(json, format!("\"{}\"", impact.as_str()));
+        let back: ImpactClass = serde_json::from_str(&json).expect("it deserializes");
+        assert_eq!(back, impact);
+    }
+
+    let refusal = PromotionRefusal::EvidenceTooWeak {
+        impact: ImpactClass::ExecutableTool,
+        required: ProvenanceGrade::DeterministicProof,
+        actual: ProvenanceGrade::ModelCritique,
+    };
+    let json = serde_json::to_string(&refusal).expect("a refusal serializes");
+    let back: PromotionRefusal = serde_json::from_str(&json).expect("a refusal deserializes");
+    assert_eq!(back, refusal);
+}
+
+/// A refusal a human cannot act on is a dead end: both sides of the comparison
+/// have to appear in the prose.
+#[test]
+fn a_refusal_names_what_was_required_and_what_was_offered() {
+    let weak = PromotionRefusal::EvidenceTooWeak {
+        impact: ImpactClass::BlockingGuard,
+        required: ProvenanceGrade::DeterministicProof,
+        actual: ProvenanceGrade::TrajectoryAbstraction,
+    };
+    let reason = weak.reason();
+    assert!(reason.contains("blocking_guard"), "{reason}");
+    assert!(reason.contains("deterministic_proof"), "{reason}");
+    assert!(reason.contains("trajectory_abstraction"), "{reason}");
+
+    let low = PromotionRefusal::AuthorityTooLow {
+        impact: ImpactClass::ExecutableTool,
+        required: PublicationAuthority::LocalHuman,
+        actual: PublicationAuthority::Agent,
+    };
+    let reason = low.reason();
+    assert!(reason.contains("local_human"), "{reason}");
+    assert!(reason.contains("agent"), "{reason}");
+}
+
+/// Human review is accountable and is still not a measurement — it must not
+/// clear a bar that trajectory evidence clears.
+#[test]
+fn human_review_does_not_outrank_a_measured_pattern() {
+    assert!(ProvenanceGrade::HumanReview < ProvenanceGrade::TrajectoryAbstraction);
+    assert!(ProvenanceGrade::HumanReview > ProvenanceGrade::ModelCritique);
+
+    assert!(
+        authorises(
+            Some(ProvenanceGrade::HumanReview),
+            PublicationAuthority::LocalHuman,
+            ImpactClass::PromptHint
+        )
+        .is_err(),
+        "a sign-off is not evidence a hint helps"
+    );
+}


### PR DESCRIPTION
Closes #2780. Closes #2782.

The two open issues in the Self-Improvement milestones. One PR because #2780's
`evidence` column is defined by #2782 — shipping either alone leaves the other
referencing something that does not exist.

**Exemplar followed:** `crates/stella-parity/src/lib.rs` for the matrix shape
(posture enum, named witnesses checked by substring against `include_str!`ed
sources, exact-equality down-only baseline), and
`crates/stella-protocol/src/event/tags.rs` for generating a ledger and its enum
from one macro table.

## #2782 — the evidence grade

`ProvenanceGrade` is ordered weakest-first, so the derived `Ord` **is** the
strength order and combining evidence is a `min`. That is the whole of "no
aggregation promotes a grade": no `promote`, no vote count, no confidence
threshold that crosses a grade boundary. Only re-deriving a claim against a
stronger source moves it, which means building a new record.

Evidence and publication authority are two axes rather than one ladder, because
#2782's own rule says a guard or a tool needs "deterministic proof **plus**
publication authority". Collapsing them would let an approver's signature stand
in for a witness test.

**Derived, never asserted** is enforced structurally, twice:

- An observation stores no grade. `observation_grade` is a total function of
  `ObservationSource`, so there is no second copy to drift.
- A proposal must store one, because it keeps only its observations'
  `record_id`s. `EvidencePool` is the only way to populate that field and its
  only public constructor takes real `ObservationRecord`s — promoting code can
  hand a proposal the evidence it has, not a grade it prefers.
  `ProposalRecord::new` takes the pool in place of a `Vec<String>`, making the
  old shape unwritable rather than discouraged.

### Where provenance goes, exactly

| Hop | Status |
|---|---|
| reflection / tool outcome → observation | derived from the source, never stored |
| observation → proposal | carried (`EvidencePool`) |
| proposal → published **rule** record | carried (`evidence_grade` on `Provenance`) |
| proposal → published **skill** file | **not carried** — #4871, see below |
| → campaign | no such hop exists; `rg -ni "\bcampaign" --type rust` is empty |

Absent grades stay absent on the wire, so records already on disk keep their
bytes and their hashes.

**Surfaced where a human decides:** `stella proposals`, the Observatory's
proposal projection, and `stella context explain` — which prints the grade
beside a record's other provenance, so a rule inferred from reflection and one
derived from a failing build are visibly different.

### Why the skill file is excluded (#4871)

I implemented it and backed it out. `both_loops_render_byte_identical_skill_files`
requires the lexical loop (`context.lifecycle.enabled = false`, **the path that
ships today**) and the opt-in typed loop to render identical `SKILL.md` bytes
from the same evidence. Only the typed loop has a proposal, so only it has a
grade; an `evidence_grade:` frontmatter line makes them diverge, and the harm is
the one that test names — a user turning the lifecycle on would see every skill
file diff against its own re-render. That guarantee outranks a frontmatter key.

## #2780 — the evolution-surface matrix

`EvolutionSurface` and `EVOLUTION_SURFACES` are generated from one macro table,
so a surface and its row are the same cell.

**DoD 1 is demonstrated, not asserted.** I added a seventh surface omitting one
column and built it: the compiler stops at ``error: no rules expected `;` ``
before any test runs, then I reverted it. `consumers.rs` reaches `E0004` because
omission breaks an exhaustive match; here there is no hand-written enum to omit
from at all.

**The evidence column is read from #2782, not restated.** A row declares its
`ImpactClass`; the required grade and authority are derived through the policy.
No second copy of the requirement, so the two ledgers cannot disagree
(`required_evidence_is_read_from_the_provenance_policy`).

Rows record what is true rather than what looks finished:

| Surface | Posture | Recorded honestly |
|---|---|---|
| Framework | Shipped | no command retracts a published rule (#4866) |
| Memory | Shipped | — |
| Skill | Shipped | measured-lift gate is **off by default**; demotion half has no production caller (#4754) |
| Tool | Shipped | — |
| Workflow | Shipped | — |
| Model | NotPursued | nothing is promoted; export has no in-tree consumer |

`UNWITNESSED_EVOLUTION_BASELINE` is 0. All six witnesses were verified to exist
before being named.

## Three deviations, each deliberate — overrule any of them

1. **`HumanReview` is not the strongest grade.** #2782's table lists it last. I
   ranked it above `ModelCritique` (a judgement someone is accountable for
   outranks one nobody is) and below `TrajectoryAbstraction` (a measured pattern
   survives its author's confidence). One line to change.
2. **A sixth posture, `NotPursued`.** Weight adaptation was designed, filed, and
   closed as *not planned* (#836). `Planned` would be false; `Prohibited` wants
   a design document nobody wrote.
3. **`BetweenTurns` rather than "end-of-session".** No live surface waits for the
   session to end; memory and skill both land on the post-turn reflection path.

## What this does NOT do

**No live publication path calls the gate.** The ledger declares the terms and
the policy can answer them; nothing asks before publishing. AGENTS.md rule #11
says so in the shape rule #10 uses, and #4865 tracks the wiring.

#4865 also records a tension the policy surfaced: the framework row requires
`EnvironmentObservation`, and mined rules grade to `ModelCritique` — so a
directive that steers the agent is published today on a model's opinion of its
own run. Resolving that is a design decision, not something to fix by lowering
the requirement until the code agrees.

## Also filed

- **#4862** — `record_memory_citations` has no production caller; every one is a
  test. The writer was the `cite_memory` tool, now in `RETIRED_TOOL_NAMES`, so
  #2195 was closed by retiring the tool and the consequence it was filed about
  is still live: `ObservationSource::MemoryCitation` is a permanently empty
  evidence class.
- **#4865** — wire the gate into publication.
- **#4866** — no command retracts a published rule.
- **#4871** — a published skill does not say what evidence promoted it.

## Evidence

- `cargo test -p stella-protocol` — 16 new, including
  `agreeing_model_critiques_never_authorise_an_executable_tool` (#2782 DoD 4).
- `cargo test -p stella-core context_record::provenance` — 7 new, including
  `three_agreeing_reflections_across_three_tasks_still_cannot_publish_a_tool`,
  which clears the existing distinct-task floor first so the refusal is the
  grade's doing and not the floor's.
- `cargo test -p stella-parity` — 23 pass (12 new), including a negative control
  proving the witness check can go red.
- `a_published_rule_carries_the_grade_of_the_proposal_it_came_from`,
  `explain_names_the_grade_of_the_evidence_behind_a_record`.
- Full `cargo test -p stella-cli -p stella-core --no-fail-fast` — all binaries
  green. (Filtered runs are what let the byte-identity failure through once.)
- `make guards-fast`, `make invariants` (11 rules, 40 citations resolve),
  `make prose` (**none added** — the constructions the ratchet found were real
  and were deleted, not baselined), `make line-citations` — green.
- CI: all 16 checks green on `750253a`.
