### PR TITLE
test(stella-runtime): wrapper_composition runs on Windows, on the in-tree fixture

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -113,3 +113,4 @@ jobs:
           --test host_owned_tamper
           --test wrapper_claimed_evidence
           --test wrapper_decided_flip
+          --test wrapper_composition

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -123,6 +123,25 @@ fn main() {
         // `wrapper_decided_flip.rs` calls `run(None, ..)` — so neutering
         // this branch fails `without_the_grant_or_the_snapshot_the_verdict_is_undecided`
         // there. Checked by ablation, not assumed.
+        // Echoes back the stage it was asked at, labelled — what
+        // `wrapper_composition.rs` used `sed` for. Composition tests read
+        // those labels to prove each member saw its own declared stages and
+        // no others, so echoing a fixed string here would let a composition
+        // that dispatched the wrong stage pass.
+        "echo-stage" => {
+            let request = read_request();
+            let label = arg(&args, 1);
+            if request.contains("\"point\":\"before_turn\"") {
+                let stage = string_field(&request, "stage").unwrap_or_default();
+                emit(&format!(
+                    "{{\"point\":\"before_turn\",\"body\":{{\"protocol_version\":1,\
+                     \"context\":[{{\"label\":\"{label}\",\
+                     \"text\":\"{label} contributed at {stage}\"}}]}}}}"
+                ));
+            } else {
+                emit(&measurements(&[]));
+            }
+        }
         "flip-if-granted" => {
             let request = read_request();
             let flip = if request.contains("\"root\"") && request.contains("\"program\":\"sh\"") {

--- a/crates/stella-runtime/tests/wrapper_composition.rs
+++ b/crates/stella-runtime/tests/wrapper_composition.rs
@@ -20,8 +20,6 @@
 //!
 //! `cfg(unix)` for `wrapper_socket.rs`'s reason (#3497).
 
-#![cfg(unix)]
-
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -144,36 +142,20 @@ name = "execute"
 
 /// Echoes which plugin and which stage it was asked about, so the fold is
 /// readable off the messages the turn receives rather than inferred.
-fn echoing(label: &str) -> String {
-    format!(
-        r#"
-input=$(cat)
-case "$input" in
-  *'"point":"before_turn"'*)
-    stage=$(printf '%s' "$input" | sed 's/.*"stage":"\([a-z_]*\)".*/\1/')
-    printf '{{"point":"before_turn","body":{{"protocol_version":1,"context":[{{"label":"{label}","text":"{label} contributed at STAGE"}}]}}}}\n' | sed "s/STAGE/$stage/"
-    ;;
-  *)
-    printf '%s\n' '{{"point":"after_turn","body":{{"protocol_version":1,"evidence":{{"flip":"not-attempted","measurements":{{}}}}}}}}'
-    ;;
-esac
-"#
-    )
-}
-
 fn manifest(text: &str) -> PluginManifest {
     PluginManifest::from_toml_str(text).expect("the fixture manifest loads")
 }
 
-fn plugin(script: &str) -> Arc<SubprocessWrapper> {
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
+
+/// One member of a composition, driving the portable fixture (#4697).
+fn plugin(mode: &[&str]) -> Arc<SubprocessWrapper> {
+    let mut argv = vec![FIXTURE.to_string()];
+    argv.extend(mode.iter().map(|part| (*part).to_string()));
     Arc::new(
-        SubprocessWrapper::declare(
-            vec!["/bin/sh".into(), "-c".into(), script.into()],
-            Vec::new(),
-            DEFAULT_WRAPPER_TIMEOUT,
-        )
-        .expect("the transport is declared with a program and a budget")
-        .wrapper,
+        SubprocessWrapper::declare(argv, Vec::new(), DEFAULT_WRAPPER_TIMEOUT)
+            .expect("the transport is declared with a program and a budget")
+            .wrapper,
     )
 }
 
@@ -248,8 +230,8 @@ impl Recorder {
 #[tokio::test]
 async fn two_plugins_compose_into_one_selection_and_both_reach_the_turn() {
     let dispatch = WrapperDispatch::bind_composed(vec![
-        (manifest(RECALLER), plugin(&echoing("recaller"))),
-        (manifest(PLANNER), plugin(&echoing("planner"))),
+        (manifest(RECALLER), plugin(&["echo-stage", "recaller"])),
+        (manifest(PLANNER), plugin(&["echo-stage", "planner"])),
     ])
     .expect("two agreeing manifests compose");
 
@@ -308,8 +290,8 @@ async fn two_plugins_compose_into_one_selection_and_both_reach_the_turn() {
 async fn composition_unions_contributions_and_not_permissions() {
     // The arbiter declares `points = ["after_turn"]` only.
     let dispatch = WrapperDispatch::bind_composed(vec![
-        (manifest(RECALLER), plugin(&echoing("recaller"))),
-        (manifest(ARBITER), plugin(&echoing("arbiter"))),
+        (manifest(RECALLER), plugin(&["echo-stage", "recaller"])),
+        (manifest(ARBITER), plugin(&["echo-stage", "arbiter"])),
     ])
     .expect("a steering member and an arbiter member compose");
 
@@ -339,8 +321,8 @@ async fn composition_unions_contributions_and_not_permissions() {
 #[test]
 fn a_stage_order_conflict_is_refused_at_bind_time() {
     let error = WrapperDispatch::bind_composed(vec![
-        (manifest(RECALLER), plugin("exit 0")),
-        (manifest(CONTRARIAN), plugin("exit 0")),
+        (manifest(RECALLER), plugin(&["exit", "0", ""])),
+        (manifest(CONTRARIAN), plugin(&["exit", "0", ""])),
     ])
     .expect_err("`recall` before `execute` and `execute` before `recall` have no one order");
 
@@ -371,8 +353,8 @@ fn a_stage_order_conflict_is_refused_at_bind_time() {
 #[test]
 fn two_arbiters_are_refused_at_bind_time() {
     let error = WrapperDispatch::bind_composed(vec![
-        (manifest(ARBITER), plugin("exit 0")),
-        (manifest(OTHER_ARBITER), plugin("exit 0")),
+        (manifest(ARBITER), plugin(&["exit", "0", ""])),
+        (manifest(OTHER_ARBITER), plugin(&["exit", "0", ""])),
     ])
     .expect_err("at most one member may hold a turn open");
     match error {
@@ -425,8 +407,8 @@ name = "execute"
     // refusal, arrived at one layer up.
     assert!(matches!(
         WrapperDispatch::bind_composed(vec![
-            (manifest(ARBITER), plugin("exit 0")),
-            (manifest(ARBITER), plugin("exit 0")),
+            (manifest(ARBITER), plugin(&["exit", "0", ""])),
+            (manifest(ARBITER), plugin(&["exit", "0", ""])),
         ])
         .expect_err("two oracles are two arbiters"),
         WrapperError::TwoArbiters { .. }
@@ -459,8 +441,8 @@ fn only_an_arbiter_may_declare_requirements_which_is_why_they_cannot_collide() {
     // And the arbiter that *may* declare them composes with a member that has
     // none, which is the ordinary case the fold exists to serve.
     WrapperDispatch::bind_composed(vec![
-        (manifest(ARBITER), plugin("exit 0")),
-        (manifest(RECALLER), plugin("exit 0")),
+        (manifest(ARBITER), plugin(&["exit", "0", ""])),
+        (manifest(RECALLER), plugin(&["exit", "0", ""])),
     ])
     .expect("one member's requirements and another's none is a union of one");
 }


### PR DESCRIPTION
Five of twelve for #4697. `wrapper_composition.rs` comes off `/bin/sh`, with one new fixture mode `echo-stage <label>` replacing the `sed` its script used to pull the stage out of the request; the two `exit 0` members reuse the existing `exit` mode.

## The extraction is load-bearing

Composition tests read those echoed labels to prove each member saw *its own* declared stages and no others. A mode that echoed a fixed string would let a composition that dispatched the wrong stage pass — the exact failure this file exists to catch.

Pinning the stage to a constant:

```
test two_plugins_compose_into_one_selection_and_both_reach_the_turn ... FAILED
test result: FAILED. 7 passed; 1 failed
```

Restored: 8 passed.

## One thing left behind on purpose

The `ARBITER` manifest still declares `[runtime] argv = ["/bin/sh", "-c", "cat >/dev/null"]`, and `host_owned_tamper.rs` has the same shape. That argv is **never spawned** — these tests drive the wrapper through `plugin()` directly, and the `[runtime]` block exists to satisfy `OracleCommandRequired` during manifest validation, which is string parsing and platform-independent. So it does not block Windows today.

It is still a latent trap: if anything later makes that runtime real, it breaks on Windows silently. I left it rather than churn several manifests toward a portable program that would imply the block is executed when it is not, and I have noted it on #4697 so the last port in the series can decide once, with all the sites in view.

## Evidence

```
cargo test -p stella-runtime --test wrapper_composition   8 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings   exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)    exit 0
cargo fmt --all --check   exit 0
check-prose               OK — none added
```

Added to `windows-check.yml`. Not claiming a Windows pass from here; that runner reports on this PR, and returned green for this pattern on #4848.

Seven files remain in #4697. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Port wrapper composition tests to the cross-platform fixture and include them in Windows CI.

Bug Fixes:
- Make the wrapper composition integration tests runnable on Windows by replacing shell-based plugin scripts with the portable in-tree fixture.

Enhancements:
- Add stage-aware fixture output so composition tests verify that each member receives its declared stages and no others.
- Reuse the fixture's exit mode for composition validation cases instead of invoking shell commands.

CI:
- Run the wrapper_composition integration test in the Windows check workflow.

Tests:
- Preserve coverage for composition ordering, contribution, and arbiter validation without deleting or renaming tests.