### PR TITLE
test(stella-runtime): wrapper_late_credential runs on Windows, on the in-tree fixture

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -114,3 +114,4 @@ jobs:
           --test wrapper_claimed_evidence
           --test wrapper_decided_flip
           --test wrapper_composition
+          --test wrapper_late_credential

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -128,6 +128,25 @@ fn main() {
         // those labels to prove each member saw its own declared stages and
         // no others, so echoing a fixed string here would let a composition
         // that dispatched the wrong stage pass.
+        // Reports which of two named variables reached the child, as `10`
+        // for present and `0` for absent — the `${VAR:+1}0` idiom the shell
+        // probe used. `wrapper_late_credential.rs` reads both back: one
+        // granted late, one never granted, so a mode that answered a
+        // constant could not tell a delivered credential from a leaked one.
+        "two-env-probe" => {
+            let _ = read_request();
+            let present = |name: &str| {
+                if std::env::var_os(name).is_some() {
+                    "10"
+                } else {
+                    "0"
+                }
+            };
+            emit(&measurements(&[
+                ("late", present(arg(&args, 1))),
+                ("mode", present(arg(&args, 2))),
+            ]));
+        }
         "echo-stage" => {
             let request = read_request();
             let label = arg(&args, 1);

--- a/crates/stella-runtime/tests/wrapper_late_credential.rs
+++ b/crates/stella-runtime/tests/wrapper_late_credential.rs
@@ -37,10 +37,10 @@
 //! argument from call order rather than a property — which is the exact thing
 //! #3512 existed to stop relying on.
 //!
-//! `cfg(unix)` for `wrapper_socket.rs`'s reason and tracked in the same place
-//! (#3497): the child that answers is a `/bin/sh` script.
-
-#![cfg(unix)]
+//! The child that answers is `wrapper-plugin-fixture` rather than a
+//! `/bin/sh` script, so this file runs on Windows too (#4697). Its
+//! `two-env-probe` mode reports which named variables reached the child,
+//! which is the question these tests ask.
 
 use stella_plugin::{AfterTurnRequest, DriveRequest, PROTOCOL_VERSION, TurnOutcome};
 use stella_runtime::wrapper::{
@@ -66,11 +66,7 @@ fn declared_env() -> Vec<(String, String)> {
 /// The child is the oracle for `wrapper_env_refusal.rs`'s reason: inspecting
 /// the transport's own field would only prove the constructor agrees with
 /// itself.
-const PROBE: &str = r#"
-cat >/dev/null
-printf '{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"not-attempted","measurements":{"late":%s,"mode":%s}}}}\n' \
-  "${STELLA_TEST_CORP_AUTH:+1}0" "${PLUGIN_MODE:+1}0"
-"#;
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
 
 fn after() -> AfterTurnRequest {
     AfterTurnRequest {
@@ -91,7 +87,12 @@ fn after() -> AfterTurnRequest {
 
 fn wrapper() -> SubprocessWrapper {
     SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), PROBE.into()],
+        vec![
+            FIXTURE.to_string(),
+            "two-env-probe".into(),
+            "STELLA_TEST_CORP_AUTH".into(),
+            "PLUGIN_MODE".into(),
+        ],
         declared_env(),
         DEFAULT_WRAPPER_TIMEOUT,
     )
@@ -133,7 +134,7 @@ async fn a_credential_registered_after_declare_never_reaches_the_child() {
     // is filtered at declare time and would prove nothing about this.
     let held = wrapper();
     let held_driver = SubprocessDriver::declare(
-        vec!["/bin/sh".into(), "-c".into(), "true".into()],
+        vec![FIXTURE.to_string(), "drain-emit".into(), String::new()],
         declared_env(),
         DEFAULT_WRAPPER_TIMEOUT,
     )
@@ -179,7 +180,12 @@ async fn a_credential_registered_after_declare_never_reaches_the_child() {
     // as it always was, and its report says so — the two mechanisms answer the
     // same question at different moments and must not disagree.
     let admitted = SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), PROBE.into()],
+        vec![
+            FIXTURE.to_string(),
+            "two-env-probe".into(),
+            "STELLA_TEST_CORP_AUTH".into(),
+            "PLUGIN_MODE".into(),
+        ],
         declared_env(),
         DEFAULT_WRAPPER_TIMEOUT,
     )


### PR DESCRIPTION
Six of twelve for #4697. `wrapper_late_credential.rs` comes off `/bin/sh` with one new fixture mode, `two-env-probe <a> <b>`, reporting which of two named variables reached the child as `10` for present and `0` for absent — the `${VAR:+1}0` idiom the shell probe used.

The second plugin in the file (`sh -c true`, a child that answers nothing) becomes `drain-emit` with an empty body.

## The check is load-bearing, and it guards a credential property

This file asks whether a credential registered *after* `declare` reaches the child — the leak #3512 exists to prevent. A fixture that answered a constant could not tell a delivered credential from a leaked one, so the test would pass whatever the transport did.

Replacing the env lookup with a constant:

```
test a_credential_registered_after_declare_never_reaches_the_child ... FAILED
test result: FAILED. 0 passed; 1 failed
```

Restored: 1 passed. The distinction the test rests on is genuinely coming from the environment the child received.

Worth noting the fixture is allowed to read env precisely because it lives under `tests/` — `no_ambient_reads.rs` governs `src/`, and moving this fixture out of `src/bin/` for that reason was #4690's fix. A mode that reports its own environment is exactly why that placement matters.

## Evidence

```
cargo test -p stella-runtime --test wrapper_late_credential   1 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings    exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)     exit 0
cargo fmt --all --check   exit 0
check-prose               OK — none added
```

Added to `windows-check.yml`. Not claiming a Windows pass from here; that runner reports on this PR, and returned green for this pattern on #4848.

Six files remain in #4697. No test deleted or renamed.

Refs #4697, #3497, #3512

## Summary by Sourcery

Make the late-credential wrapper test cross-platform without weakening its verification of credential isolation.

Enhancements:
- Replace the Unix shell-based late-credential wrapper test with the cross-platform in-tree fixture, including environment-sensitive probing and a draining child mode.

CI:
- Run the late-credential wrapper integration test in the Windows check workflow.

Tests:
- Preserve coverage that credentials declared after wrapper initialization are not leaked to children while allowing the test to run on Windows.