### PR TITLE
test(stella-runtime): wrapper_declared_witness runs on Windows, and its union test cannot see per-stage narrowing

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -115,3 +115,4 @@ jobs:
           --test wrapper_decided_flip
           --test wrapper_composition
           --test wrapper_late_credential
+          --test wrapper_declared_witness

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -133,6 +133,24 @@ fn main() {
         // probe used. `wrapper_late_credential.rs` reads both back: one
         // granted late, one never granted, so a mode that answered a
         // constant could not tell a delivered credential from a leaked one.
+        // Declares a witness list that narrows at `research` — the `case`
+        // the shell plugin spelled out. Kept faithful, but note the
+        // narrowing is unobservable through `wrapper_declared_witness.rs`:
+        // it asserts the *union* across stages, which is the same set
+        // either way. Checked by ablation — pinning the list leaves both
+        // its tests green.
+        "witness-by-stage" => {
+            let request = read_request();
+            let list = if request.contains("\"stage\":\"research\"") {
+                "\"tests/flip.rs\""
+            } else {
+                "\"tests/flip.rs\",\"tests/second.rs\""
+            };
+            emit(&format!(
+                "{{\"point\":\"before_turn\",\"body\":{{\"protocol_version\":1,\
+                 \"witness\":[{list}]}}}}"
+            ));
+        }
         "two-env-probe" => {
             let _ = read_request();
             let present = |name: &str| {

--- a/crates/stella-runtime/tests/wrapper_declared_witness.rs
+++ b/crates/stella-runtime/tests/wrapper_declared_witness.rs
@@ -17,9 +17,16 @@
 //! that repeats it says nothing extra.
 //!
 //! `cfg(unix)` for `wrapper_socket.rs`'s reason and tracked in the same place
-//! (#3497): the plugin is a `/bin/sh` script.
-
-#![cfg(unix)]
+//! The plugin is `wrapper-plugin-fixture` rather than a `/bin/sh` script, so
+//! this file runs on Windows too (#4697). Its `witness-by-stage` mode carries
+//! the `case` the script spelled out: the declared list narrows at `research`.
+//!
+//! That narrowing is **not** observable through the tests below, and the
+//! shell script it replaces was no better: the assertion is on the *union*
+//! across stages, which is the same set whether each stage declares its own
+//! list or every stage declares the widest one. So these tests prove the
+//! union is folded and de-duplicated, not that the declaration is per-stage.
+//! A test that reads one stage's list on its own would settle it.
 
 use std::sync::Arc;
 
@@ -50,17 +57,7 @@ name = "verify"
 /// Each stage declares one artifact, and both stages declare `tests/flip.rs` —
 /// the overlap is the point, because the union has to fold it.
 ///
-/// A plugin that writes JSON with `printf` and reads its request with `case`,
-/// which is `doc:pipeline-as-plugins` §5 commitment 2 held to: a capability
-/// only Rust can reach is a Rust API with extra steps.
-const DECLARES: &str = r#"
-request=$(cat)
-case "$request" in
-  *'"stage":"research"'*) list='"tests/flip.rs"' ;;
-  *)                      list='"tests/flip.rs","tests/second.rs"' ;;
-esac
-printf '{"point":"before_turn","body":{"protocol_version":1,"witness":[%s]}}\n' "$list"
-"#;
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
 
 fn manifest() -> PluginManifest {
     PluginManifest::from_toml_str(MANIFEST).expect("the manifest loads")
@@ -119,7 +116,7 @@ impl TurnDriver for Recording {
 #[tokio::test]
 async fn every_stage_of_a_round_declares_its_witness_into_one_union() {
     let admitted = SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), DECLARES.into()],
+        vec![FIXTURE.to_string(), "witness-by-stage".into()],
         Vec::new(),
         DEFAULT_WRAPPER_TIMEOUT,
     )
@@ -156,11 +153,9 @@ async fn every_stage_of_a_round_declares_its_witness_into_one_union() {
 async fn a_wrapper_that_declares_nothing_hands_the_host_an_empty_watch() {
     let admitted = SubprocessWrapper::declare(
         vec![
-            "/bin/sh".into(),
-            "-c".into(),
-            "cat >/dev/null; printf '{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1}}\
-             \\n'"
-                .into(),
+            FIXTURE.to_string(),
+            "drain-emit".into(),
+            "{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1}}".into(),
         ],
         Vec::new(),
         DEFAULT_WRAPPER_TIMEOUT,


### PR DESCRIPTION
Seven of twelve for #4697. `wrapper_declared_witness.rs` comes off `/bin/sh` with one new mode, `witness-by-stage`; the second plugin ("declares nothing") reuses `drain-emit`.

## The ablation found a test-coverage gap, not a port problem

Routine check, unexpected answer: pinning the witness list to a constant leaves **both tests green**.

The reason is in the assertion. Both tests read the *union* across stages, and the union is the same set whether each stage declares its own list or every stage declares the widest one — `{flip.rs}` ∪ `{flip.rs, second.rs}` and `{flip.rs, second.rs}` ∪ `{flip.rs, second.rs}` are identical. So these tests prove the union is folded and de-duplicated in first-seen order. They do **not** prove the declaration is per-stage.

The `/bin/sh` script this replaces had exactly the same branch and was equally unobservable, so this is a pre-existing property of the assertion rather than something the port introduced.

**I had asserted otherwise and corrected it.** My first pass at the module doc said the narrowing "is the per-stage behaviour these tests read back". That is false. Both the module doc and the fixture's note now say the narrowing is unobservable here, that the ablation is what showed it, and what would settle it: a test that reads one stage's list on its own.

I kept the branch — it is faithful to the plugin the file describes, and a fixture that declared the widest list at every stage would quietly make a future per-stage test impossible to write correctly. But it is documented as unexercised rather than presented as proven.

## Evidence

```
cargo test -p stella-runtime --test wrapper_declared_witness   2 passed; 0 failed
  (ablated: 2 passed — which is the finding, not a pass)
cargo clippy -p stella-runtime --all-targets -- -D warnings     exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)      exit 0
cargo fmt --all --check    exit 0
check-prose                OK — none added
```

Added to `windows-check.yml`. Not claiming a Windows pass from here; that runner reports on this PR.

Five files remain in #4697. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Port the declared-witness integration test to the cross-platform fixture and include it in Windows CI while accurately documenting its coverage boundary.

Enhancements:
- Make the declared-witness integration test run on Windows by replacing shell-based plugins with the cross-platform fixture and documenting the union assertion's per-stage coverage limitation.

CI:
- Run the declared-witness integration test in the Windows check workflow.

Documentation:
- Clarify that the existing tests verify union folding and de-duplication, but do not independently verify per-stage witness narrowing.

Tests:
- Update declared-witness scenarios to use the fixture's stage-aware and empty-output modes without changing test coverage or names.