### PR TITLE
test(stella-runtime): assert the witness declaration is per-stage, not just its union

### DIFF
--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -134,11 +134,11 @@ fn main() {
         // granted late, one never granted, so a mode that answered a
         // constant could not tell a delivered credential from a leaked one.
         // Declares a witness list that narrows at `research` — the `case`
-        // the shell plugin spelled out. Kept faithful, but note the
-        // narrowing is unobservable through `wrapper_declared_witness.rs`:
-        // it asserts the *union* across stages, which is the same set
-        // either way. Checked by ablation — pinning the list leaves both
-        // its tests green.
+        // the shell plugin spelled out. The narrowing is load-bearing:
+        // pinning the list fails
+        // `a_single_stage_round_is_handed_that_stages_own_declaration`
+        // (#4876). It is invisible to that file's union test, which is why
+        // the single-stage case had to be added to see it.
         "witness-by-stage" => {
             let request = read_request();
             let list = if request.contains("\"stage\":\"research\"") {

--- a/crates/stella-runtime/tests/wrapper_declared_witness.rs
+++ b/crates/stella-runtime/tests/wrapper_declared_witness.rs
@@ -21,12 +21,13 @@
 //! this file runs on Windows too (#4697). Its `witness-by-stage` mode carries
 //! the `case` the script spelled out: the declared list narrows at `research`.
 //!
-//! That narrowing is **not** observable through the tests below, and the
-//! shell script it replaces was no better: the assertion is on the *union*
-//! across stages, which is the same set whether each stage declares its own
-//! list or every stage declares the widest one. So these tests prove the
-//! union is folded and de-duplicated, not that the declaration is per-stage.
-//! A test that reads one stage's list on its own would settle it.
+//! The union test alone cannot see that narrowing: its assertion is the
+//! *union* across stages, which is the same set whether each stage declares
+//! its own list or every stage declares the widest one. So it proves the
+//! union is folded and de-duplicated, and
+//! `a_single_stage_round_is_handed_that_stages_own_declaration` proves the
+//! declaration is per-stage — one stage, nothing for the union to hide
+//! behind (#4876).
 
 use std::sync::Arc;
 
@@ -52,6 +53,24 @@ id = "declaring-v1"
 name = "research"
 [[wrapper.stages]]
 name = "verify"
+"#;
+
+/// The same wrapper with **one** stage, so a round asks it once and the
+/// union has nothing to fold. This is what makes the per-stage declaration
+/// observable: with two stages the union is the same set whether each stage
+/// narrows or every stage declares the widest list (#4876).
+const ONE_STAGE_MANIFEST: &str = r#"
+name = "declares-its-witness"
+description = "names the artifacts its flip is measured against"
+
+[loop]
+participation = "steering"
+points = ["before_turn"]
+
+[wrapper]
+id = "declaring-v1"
+[[wrapper.stages]]
+name = "research"
 "#;
 
 /// Each stage declares one artifact, and both stages declare `tests/flip.rs` —
@@ -141,6 +160,48 @@ async fn every_stage_of_a_round_declares_its_witness_into_one_union() {
         host.declared,
         vec!["tests/flip.rs".to_string(), "tests/second.rs".to_string()],
         "the union across stages, in first-seen order, folding the shared artifact"
+    );
+}
+
+/// **The per-stage half.** One stage, so the union cannot mask what was
+/// declared: a plugin that narrows at `research` hands the host that stage's
+/// list alone.
+///
+/// Without this, `witness-by-stage` could answer the widest list at every
+/// stage and every assertion in this file would still pass — the union of a
+/// narrowed set and a wide one is the wide one. Ablating the fixture's branch
+/// fails this test and nothing else here (#4876).
+#[tokio::test]
+async fn a_single_stage_round_is_handed_that_stages_own_declaration() {
+    let admitted = SubprocessWrapper::declare(
+        vec![FIXTURE.to_string(), "witness-by-stage".into()],
+        Vec::new(),
+        DEFAULT_WRAPPER_TIMEOUT,
+    )
+    .expect("the transport is declared with a program and a budget");
+    let manifest =
+        PluginManifest::from_toml_str(ONE_STAGE_MANIFEST).expect("the one-stage manifest loads");
+    let dispatch = WrapperDispatch::bind(manifest, Arc::new(admitted.wrapper))
+        .expect("it declares a [wrapper]");
+
+    let mut host = Recording::default();
+    dispatch
+        .run(
+            RoundInput {
+                goal: "make the flaky test deterministic".into(),
+                signals: signals(),
+                candidate: None,
+            },
+            &mut host,
+        )
+        .await
+        .expect("a validated manifest resolves");
+
+    assert_eq!(
+        host.declared,
+        vec!["tests/flip.rs".to_string()],
+        "research narrows to its own artifact; the wide list would mean the \
+         declaration is not per-stage"
     );
 }
 


### PR DESCRIPTION
Closes the gap PR #4874's ablation exposed, rather than leaving it filed.

## The gap

`wrapper_declared_witness.rs` had two tests and both asserted the **union** of witness lists across a round's stages. That union is invariant to the property the file exists to check:

```
per-stage:  {flip.rs} ∪ {flip.rs, second.rs}           = {flip.rs, second.rs}
constant:   {flip.rs, second.rs} ∪ {flip.rs, second.rs} = {flip.rs, second.rs}
```

So a plugin declaring the widest list at every stage passed every assertion. The `/bin/sh` script the fixture replaced had the same branch and was equally unobservable — the port did not introduce this, it made it checkable.

## The fix

A one-stage manifest and a test that reads that stage's declaration alone. With one stage there is no union to hide behind, so the narrowing has to show.

The ablation now flips the right way — pinning the fixture's list to the wide one:

```
test a_single_stage_round_is_handed_that_stages_own_declaration ... FAILED
test result: FAILED. 2 passed; 1 failed
```

It fails **only** the new test, which is the point: the union test is genuinely about folding and de-duplication, and it still passes because that property is still true.

## What I did not do

I did not weaken or replace the union test. Folding and first-seen ordering are worth keeping asserted; this is an added case. The issue named that constraint and it is honoured.

I also corrected the two doc comments PR #4874 left behind. They said the narrowing was unobservable and named a hypothetical test that would settle it — now they name the test that does.

## Evidence

```
cargo test -p stella-runtime --test wrapper_declared_witness   3 passed; 0 failed
  ablated fixture branch:                                      2 passed; 1 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings    exit 0
cargo fmt --all --check   exit 0
check-prose               OK — none added
```

Closes #4876

## Summary by Sourcery

Verify that wrapper witness declarations remain stage-specific instead of being observable only as a folded union.

Enhancements:
- Add coverage proving wrapper witness declarations are preserved per stage rather than only validated through their cross-stage union.

Documentation:
- Update fixture and test documentation to describe the newly observable per-stage witness assertion.

Tests:
- Add a one-stage wrapper test that verifies the host receives that stage’s narrowed witness declaration while retaining the existing union folding and de-duplication coverage.