### PR TITLE
fix(ci): the ported wrapper tests belong to stella-runtime, not stella-tools

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -122,13 +122,13 @@ jobs:
           --test wrapper_transport_limits
           --test wrapper_dispatch
           --test host_owned_tamper
-
-      - name: the group-kill guard at the bash/custom-tool/hook spawn sites, on Windows (#4698)
-        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
-        run: >-
-          cargo test -p stella-tools --test group_kill_witnesses
           --test wrapper_claimed_evidence
           --test wrapper_decided_flip
           --test wrapper_composition
           --test wrapper_late_credential
           --test wrapper_declared_witness
+
+      - name: the group-kill guard at the bash/custom-tool/hook spawn sites, on Windows (#4698)
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: >-
+          cargo test -p stella-tools --test group_kill_witnesses


### PR DESCRIPTION
`windows-check.yml` has been failing on `main` — and on every open PR — since #4698's step landed. This fixes it, and the cause is mine.

## What the log says

```
cargo test -p stella-tools --test group_kill_witnesses
  --test wrapper_claimed_evidence --test wrapper_decided_flip
  --test wrapper_composition --test wrapper_late_credential
  --test wrapper_declared_witness

error: no test target named `wrapper_claimed_evidence` in `stella-tools` package
help: available test in `stella-runtime` package:
        wrapper_claimed_evidence
```

Five `stella-runtime` test names were being passed to a `-p stella-tools` command.

## How it happened, and why neither diff was wrong

Each of my #4697 port PRs appended one `--test <name>` line after the previous one. #4698 then inserted a **new** `-p stella-tools` step immediately below that block. My later additions anchored to what was by then the last `--test` line in the file — which now belonged to the new step.

Both sides were correct in isolation and green on their own bases. The composition is what broke: this is the shared-cell shape, arriving through a workflow file instead of a baseline.

I own it — the misplaced lines are mine, and I should have re-read the step boundary after the base moved rather than trusting an append.

## The cost, which is larger than one red job

That job runs **nine** suites. While it dies at the first command, none of them report on Windows — including all eight files ported in #4848, #4850, #4855, #4864, #4869, #4872, #4874 and #4878. So the Windows evidence those PRs were built to produce has been absent since the break, and #4698's own group-kill assertion has never run either. A red job hides every result inside it.

## Fix and verification

The five names move back to the `-p stella-runtime` step. Both commands were run exactly as the workflow now spells them:

```
cargo test -p stella-runtime --test wrapper_socket --test wrapper_transport_limits \
  --test wrapper_dispatch --test host_owned_tamper --test wrapper_claimed_evidence \
  --test wrapper_decided_flip --test wrapper_composition --test wrapper_late_credential \
  --test wrapper_declared_witness
  → 9 suites, 42 tests, 0 failed

cargo test -p stella-tools --test group_kill_witnesses
  → 3 passed; 0 failed
```

YAML parses (`yaml.safe_load`). Reported on #4698 before the cause was known; that comment's guess — that the binary had not run — was right for the wrong reason, and this PR names the real one.

Refs #4698, #4697

## Summary by Sourcery

Fix the Windows CI test package assignments to restore execution of the runtime wrapper suites and tools group-kill tests.

Bug Fixes:
- Correct the Windows CI workflow so wrapper integration tests run under the stella-runtime package and the group-kill tests run under stella-tools.

CI:
- Restore the intended separation of Windows test suites so all runtime and tools test results are executed and reported.