### PR TITLE
A published skill names the evidence grade that promoted it

### DIFF
--- a/crates/stella-cli/src/memory/proposals.rs
+++ b/crates/stella-cli/src/memory/proposals.rs
@@ -27,6 +27,7 @@
 //! produce a proposal that is recorded and visible but never eligible — spec §7.
 
 use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
 
 use stella_context::{ContextStore, LedgerAppend};
 use stella_core::context_record::{
@@ -34,6 +35,7 @@ use stella_core::context_record::{
     ProposalScore, RecordProposalKind, RecordProposalStatus, confidence_from_score,
 };
 use stella_core::skills::{self, Skill, SkillCandidate, SkillMineConfig, SkillObservation};
+use stella_protocol::provenance::ProvenanceGrade;
 
 /// A mined candidate together with the durable proposal recorded for it.
 pub(crate) struct InducedProposal {
@@ -213,6 +215,73 @@ pub(crate) fn all_proposals(store: &ContextStore, limit: usize) -> Vec<ProposalR
         .into_iter()
         .filter_map(|row| serde_json::from_str::<ProposalRecord>(&row.body).ok())
         .collect()
+}
+
+/// Ledger revisions read for a grade lookup — generous, because a candidate
+/// stops being re-proposed once its skill file exists (`already_captured`
+/// takes over), so the real count per workspace is small.
+const GRADE_PEEK_READ_LIMIT: usize = 5_000;
+
+/// `.stella/private/context.db`, if it already exists — pure enough to be the
+/// whole guard: it stats one path and creates nothing, mirroring
+/// `stella_store::rules_peek::existing_store_db`'s reasoning for `store.db`.
+/// No legacy fallback: `context.db`'s records are "born canonical"
+/// (`stella_core::context_record::lifecycle`'s module doc) with no
+/// pre-`private/` layout to have moved from.
+fn existing_context_db(workspace_root: &Path) -> Option<std::path::PathBuf> {
+    let path = workspace_root
+        .join(".stella")
+        .join("private")
+        .join("context.db");
+    path.is_file().then_some(path)
+}
+
+/// The evidence grade recorded against each skill candidate id, read straight
+/// off `.stella/private/context.db` without opening it as a store.
+///
+/// [`ContextStore::open`] runs migrations and registers an embedder
+/// fingerprint on every call — a write, correct for a session and wrong for
+/// the SKILLS tab, which calls this on every refresh. [`stella_context::peek_records_of_kind`]
+/// is the ledger crate's own answer to that problem (mirrors
+/// `stella_store::rules_peek`'s identical reasoning for `store.db`), so this
+/// resolves the path and parses the bodies — the typed half `stella-context`
+/// does not own — and nothing more. A workspace with no ledger
+/// at all — the common case, since the shipped lexical loop never writes one
+/// — answers an empty map.
+///
+/// Folds every `Knowledge` proposal ever recorded for a candidate with
+/// [`ProvenanceGrade::weakest`] — #2782's rule 1, that combining evidence can
+/// only weaken it, applied across ledger revisions the same way `EvidencePool`
+/// applies it across observations within one revision. A candidate with no
+/// recorded proposal — every skill the lexical loop wrote, and any typed-loop
+/// skill from before this existed — is simply absent from the map: absent,
+/// not a weak grade this invented.
+pub(crate) fn peek_grade_by_candidate(workspace_root: &Path) -> HashMap<String, ProvenanceGrade> {
+    let mut grades: HashMap<String, ProvenanceGrade> = HashMap::new();
+    let Some(db_path) = existing_context_db(workspace_root) else {
+        return grades;
+    };
+    let records = stella_context::peek_records_of_kind(
+        &db_path,
+        ContextRecordKind::RecordProposal.as_str(),
+        GRADE_PEEK_READ_LIMIT,
+    );
+    for record in records {
+        let Ok(proposal) = serde_json::from_str::<ProposalRecord>(&record.body) else {
+            continue;
+        };
+        if proposal.proposal_kind != RecordProposalKind::Knowledge {
+            continue;
+        }
+        let Some(grade) = proposal.provenance else {
+            continue;
+        };
+        grades
+            .entry(proposal.candidate_id)
+            .and_modify(|g| *g = ProvenanceGrade::weakest([*g, grade]).unwrap_or(*g))
+            .or_insert(grade);
+    }
+    grades
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/memory/proposals/tests.rs
+++ b/crates/stella-cli/src/memory/proposals/tests.rs
@@ -224,3 +224,95 @@ fn new_evidence_appends_a_revision_rather_than_replacing() {
     let tasks: Vec<u32> = stored.iter().map(|p| p.score.distinct_tasks).collect();
     assert!(tasks.contains(&3) && tasks.contains(&4));
 }
+
+// ---- #4871: a published skill's evidence grade is distinguishable ----
+
+/// A skill mined from a tool's exit status is not the same kind of evidence
+/// as one mined from the model's own reflection, and the SKILLS tab must be
+/// able to tell them apart (#4871). This is the witness: before
+/// `peek_grade_by_candidate` existed, nothing downstream of a written
+/// `SKILL.md` could answer "was this observed or opined" at all — the
+/// byte-identity guarantee holds the file's own bytes silent on it. Here two
+/// candidates are mined from evidence of each kind, and the
+/// grades read back out of the ledger must differ exactly as the sources did.
+#[test]
+fn peek_grade_by_candidate_distinguishes_environment_observation_from_model_critique() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workspace_root = dir.path();
+    let private = workspace_root.join(".stella").join("private");
+    std::fs::create_dir_all(&private).expect("private dir");
+    let store = ContextStore::open(private.join("context.db")).expect("open");
+
+    const BUILD_LESSON: &str = "The build fails when the config schema omits a required migration.";
+    const OPINION_LESSON: &str =
+        "Prefer updating witness-test assertions to match the live renderer output.";
+
+    let mut observations: Vec<ObservationRecord> = [100, 200, 300]
+        .into_iter()
+        .map(|t| {
+            ObservationRecord::new(
+                ObservationSource::ToolOutcome,
+                format!("tool:cargo_test#{t}"),
+                format!("turn:{t}"),
+                BUILD_LESSON,
+                vec!["testing".into()],
+                false,
+                stella_context::format_rfc3339(t as i64),
+            )
+            .expect("observation")
+        })
+        .collect();
+    observations.extend(
+        [400, 500, 600]
+            .into_iter()
+            .map(|t| observation(OPINION_LESSON, t)),
+    );
+
+    let induced = induce_proposals(&store, &observations, &[], &SkillMineConfig::default());
+    assert_eq!(induced.len(), 2, "one proposal per distinct lesson cluster");
+    let candidate_named = |body: &str| {
+        induced
+            .iter()
+            .find(|i| i.candidate.body == body)
+            .unwrap_or_else(|| panic!("no candidate for {body:?}"))
+            .candidate
+            .name
+            .clone()
+    };
+    let build_candidate = candidate_named(BUILD_LESSON);
+    let opinion_candidate = candidate_named(OPINION_LESSON);
+    drop(store);
+
+    let grades = peek_grade_by_candidate(workspace_root);
+    assert_eq!(
+        grades.get(&build_candidate).map(|g| g.as_str()),
+        Some("environment_observation")
+    );
+    assert_eq!(
+        grades.get(&opinion_candidate).map(|g| g.as_str()),
+        Some("model_critique")
+    );
+    assert_ne!(
+        grades.get(&build_candidate),
+        grades.get(&opinion_candidate),
+        "a skill promoted from a passing/failing build must read differently \
+         from one promoted from the model's own opinion about a run"
+    );
+}
+
+/// A workspace that has never run the typed loop (the shipped default) has no
+/// `context.db` at all — this must answer empty rather than create one, the
+/// same "no creation" bargain `stella_store::rules_peek` documents.
+#[test]
+fn peek_grade_by_candidate_creates_nothing_for_a_workspace_with_no_ledger() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workspace_root = dir.path();
+    std::fs::create_dir_all(workspace_root.join(".stella")).expect("bare .stella");
+
+    let grades = peek_grade_by_candidate(workspace_root);
+    assert!(grades.is_empty());
+    assert!(
+        !workspace_root.join(".stella").join("private").exists(),
+        "a grade lookup must not create the private state directory"
+    );
+}

--- a/crates/stella-cli/src/skill_manager.rs
+++ b/crates/stella-cli/src/skill_manager.rs
@@ -188,6 +188,10 @@ fn latest_version(entry_path: &Path) -> u32 {
 /// is steering me?", and one that loads, is selectable, and is absent from the
 /// list makes that answer wrong (#4734).
 pub fn enumerate(workspace_root: &Path) -> Vec<SkillRow> {
+    // Read once for the whole enumeration, not per row: the peek opens
+    // `context.db` read-only itself (#4871), and a workspace's ledger does not
+    // change between one row and the next in the same call.
+    let grades = crate::memory::proposals::peek_grade_by_candidate(workspace_root);
     let mut rows = Vec::new();
     for scope in [SkillScope::Project, SkillScope::User] {
         let Some(root) = scope_root(scope, workspace_root) else {
@@ -199,6 +203,7 @@ pub fn enumerate(workspace_root: &Path) -> Vec<SkillRow> {
             let name = entry.skill.name.clone();
             let latest = latest_version(&entry.entry_path).max(1);
             let version = state.pins.get(&name).copied().unwrap_or(latest).min(latest);
+            let evidence_grade = grades.get(&name).map(|g| g.as_str().to_string());
             rows.push(SkillRow {
                 scope,
                 enabled: !disabled.contains(&name),
@@ -206,6 +211,7 @@ pub fn enumerate(workspace_root: &Path) -> Vec<SkillRow> {
                 description: entry.skill.description,
                 body: entry.skill.body,
                 origin: origin_label(entry.skill.origin).to_string(),
+                evidence_grade,
                 version,
                 latest,
                 // Everything under a managed scope dir is deletable — uninstall
@@ -261,6 +267,10 @@ fn contributed_rows(workspace_root: &Path, own: &[SkillRow]) -> Vec<SkillRow> {
                 description: skill.description,
                 body: skill.body,
                 origin: origin_label(skill.origin).to_string(),
+                // A contributed skill was never mined in this workspace's own
+                // loop, so there is no proposal here for it to be graded
+                // against.
+                evidence_grade: None,
                 version: 1,
                 latest: 1,
                 removable: false,
@@ -696,6 +706,95 @@ mod tests {
                 && r.origin == "user")
         );
         assert!(rows.iter().all(|r| r.enabled), "all enabled by default");
+    }
+
+    /// A learned (`origin: auto`) row names the grade of the evidence that
+    /// promoted it, joined out of `context.db`'s proposal ledger by candidate
+    /// id (#4871) — the SKILLS tab's own half of what `stella proposals`
+    /// already shows before a skill exists. A hand-authored skill was never a
+    /// candidate and carries none.
+    #[test]
+    fn enumerate_names_the_evidence_grade_of_a_learned_skill() {
+        use stella_context::{ContextStore, LedgerAppend};
+        use stella_core::context_record::{
+            ContextRecordKind, EvidencePool, LIFECYCLE_SCHEMA_VERSION, ObservationRecord,
+            ObservationSource, ProposalRecord, ProposalScore, RecordProposalKind,
+            RecordProposalStatus, confidence_from_score,
+        };
+
+        let (td, _home, _lock) = scratch();
+        let ws = td.path().join("ws");
+        let skills_dir = ws.join(".stella/skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(
+            skills_dir.join("money-is-minor-units-a1b2c3d4.md"),
+            "---\nname: money-is-minor-units-a1b2c3d4\ndescription: d\norigin: auto\n---\nbody",
+        )
+        .unwrap();
+        write_skill(&skills_dir, "hand-written", "not mined");
+
+        let private = ws.join(".stella/private");
+        std::fs::create_dir_all(&private).unwrap();
+        let store = ContextStore::open(private.join("context.db")).unwrap();
+        let observation = ObservationRecord::new(
+            ObservationSource::ToolOutcome,
+            "tool:cargo_test#1",
+            "turn:1",
+            "money amounts must be stored as minor units",
+            Vec::new(),
+            false,
+            "2026-01-01T00:00:00Z",
+        )
+        .unwrap();
+        let score = ProposalScore {
+            occurrences: 3,
+            distinct_tasks: 3,
+            salient: false,
+            rank: 30.0,
+        };
+        let confidence = confidence_from_score(&score).unwrap();
+        let proposal = ProposalRecord::new(
+            RecordProposalKind::Knowledge,
+            RecordProposalStatus::Eligible,
+            "money-is-minor-units-a1b2c3d4",
+            "money is minor units",
+            "money amounts must be stored as minor units",
+            Vec::new(),
+            EvidencePool::from_observations([&observation]),
+            score,
+            confidence,
+            "2026-01-01T00:00:00Z",
+        )
+        .unwrap();
+        let body = serde_json::to_string(&proposal).unwrap();
+        store
+            .append_record(LedgerAppend {
+                record_id: &proposal.record_id,
+                lineage_id: &proposal.lineage_id,
+                record_kind: ContextRecordKind::RecordProposal.as_str(),
+                record_hash: &proposal.record_hash,
+                schema_version: LIFECYCLE_SCHEMA_VERSION,
+                body: &body,
+                observed_at: &proposal.observed_at,
+                supersedes: None,
+            })
+            .unwrap();
+        drop(store);
+
+        let rows = enumerate(&ws);
+        let learned = rows
+            .iter()
+            .find(|r| r.name == "money-is-minor-units-a1b2c3d4")
+            .expect("learned row present");
+        assert_eq!(
+            learned.evidence_grade.as_deref(),
+            Some("environment_observation")
+        );
+        let authored = rows
+            .iter()
+            .find(|r| r.name == "hand-written")
+            .expect("hand-written row present");
+        assert_eq!(authored.evidence_grade, None);
     }
 
     #[test]

--- a/crates/stella-context/src/lib.rs
+++ b/crates/stella-context/src/lib.rs
@@ -83,7 +83,7 @@ pub use retrieval::{
     DropReason, DroppedFrame, RECALL_TIER_PROVENANCE_KIND, RecallResult, RecallScope, RecallTier,
     RecallTuning, SELECTION_PROVENANCE_KIND, SelectionReason, is_lexical_fallback,
 };
-pub use store::ledger::{AppendOutcome, LedgerAppend, LedgerRecord};
+pub use store::ledger::{AppendOutcome, LedgerAppend, LedgerRecord, peek_records_of_kind};
 pub use store::{
     CompactionWatermark, ContextCompactPolicy, ContextCompactReport, ContextStore,
     MemoryLineageStats, MemoryRevision, NodeInput, NodeKind, NodeRow,

--- a/crates/stella-context/src/store/ledger.rs
+++ b/crates/stella-context/src/store/ledger.rs
@@ -268,6 +268,33 @@ pub(crate) fn records_of_kind_newest_in_append_order(
     Ok(out)
 }
 
+/// Read-only, no-migration peek at the newest `limit` records of one kind, in
+/// append order — [`crate::ContextStore::open`] without the write.
+///
+/// `ContextStore::open` creates the file if absent, replays every migration,
+/// and registers an embedder fingerprint, on every call: right for a session,
+/// wrong for a passive listing that reruns this on every refresh (the SKILLS
+/// tab reading proposal grades back onto their skills, #4871 — mirrors
+/// `stella_store::rules_peek`'s identical reasoning for `store.db`). This
+/// opens its own `SQLITE_OPEN_READ_ONLY` connection and answers an empty list
+/// for any failure — a missing file, a schema that predates this table, a
+/// lock held by a writer — because the only sensible fallback for "cannot
+/// peek" is "nothing to show", never an error the caller has to route around.
+pub fn peek_records_of_kind(
+    db_path: &std::path::Path,
+    record_kind: &str,
+    limit: usize,
+) -> Vec<LedgerRecord> {
+    let Ok(conn) = Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) else {
+        return Vec::new();
+    };
+    let _ = conn.busy_timeout(std::time::Duration::from_millis(2_000));
+    records_of_kind_newest_in_append_order(&conn, record_kind, limit).unwrap_or_default()
+}
+
 /// Every revision in one lineage, oldest first — the audit trail for a single
 /// logical record.
 pub(crate) fn records_for_lineage(
@@ -372,6 +399,34 @@ mod tests {
         assert_eq!(read.lineage_id, "obs_1");
         assert!(read.supersedes.is_none());
         assert!(!read.recorded_at.is_empty(), "recorded_at is stamped");
+    }
+
+    /// The read-only peek sees exactly what a real session wrote through
+    /// `ContextStore::open` — it is a second door onto the same table, not a
+    /// different one (#4871).
+    #[test]
+    fn peek_reads_back_what_a_real_store_appended() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("context.db");
+        {
+            let store = ContextStore::open(&db_path).expect("open");
+            store
+                .append_record(append("obs_1", r#"{"a":1}"#, "sha256:aa"))
+                .expect("append");
+        }
+        let peeked = peek_records_of_kind(&db_path, "observation", 10);
+        assert_eq!(peeked.len(), 1);
+        assert_eq!(peeked[0].body, r#"{"a":1}"#);
+    }
+
+    /// The whole point: a passive listing (the SKILLS tab, #4871) must not
+    /// create the ledger `ContextStore::open` would create for it.
+    #[test]
+    fn peek_creates_no_file_for_a_workspace_with_no_ledger() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("context.db");
+        assert!(peek_records_of_kind(&db_path, "observation", 10).is_empty());
+        assert!(!db_path.exists(), "peeking must not create the ledger file");
     }
 
     #[test]

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -3,15 +3,18 @@
 //! the `settings.json` scope chain.
 //!
 //! Everything here is plain reads of files stella (or the user) already
-//! wrote. Two invariants:
+//! wrote — [`skills`] additionally joins in a read-only peek at
+//! `context.db`'s ledger to name the evidence grade behind a learned skill
+//! (#4871), never opening it as a store. Two invariants:
 //!
-//! 1. **Nothing is created or modified** — absent files and directories are
-//!    states, rendered as empty sections.
+//! 1. **Nothing is created or modified** — absent files, directories, and
+//!    ledger rows are states, rendered as empty sections.
 //! 2. **Secrets never reach the browser.** `settings.json` and `mcp.toml`
 //!    may carry credentials; [`redact`] scrubs any value under a
 //!    sensitive-looking key (and every value under `env`/`headers` maps)
 //!    before the JSON is serialized into a response.
 
+use std::collections::HashMap;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -133,7 +136,12 @@ fn frontmatter_fields(text: &str) -> (Option<String>, Option<String>, Option<Str
 /// promoted. `origin: auto` is the marker the writer itself stamps into the
 /// frontmatter (`render_skill_markdown`), so it is the authority here — and it
 /// keeps traveling with the file if the user moves or renames it.
-fn skill_entry(path: &Path, scope: &str, in_learned_dir: bool) -> Option<Value> {
+fn skill_entry(
+    path: &Path,
+    scope: &str,
+    in_learned_dir: bool,
+    grades: &HashMap<String, &'static str>,
+) -> Option<Value> {
     // Only the frontmatter block is read out of this, so a bounded head read is
     // equivalent for any file whose frontmatter is not itself 64 KiB.
     let text = read_head(path)?;
@@ -152,11 +160,18 @@ fn skill_entry(path: &Path, scope: &str, in_learned_dir: bool) -> Option<Value> 
     } else {
         stem
     };
+    let name = name.unwrap_or(fallback);
+    // The candidate id the miner named the file for is the skill's own `name`
+    // (`stella_core::skills::decide_auto_creation` builds `{name}.md`), so
+    // that is the join key back to the proposal that promoted it (#4871). A
+    // hand-authored skill was never a candidate and has no entry to find.
+    let evidence_grade = grades.get(&name).copied();
     Some(json!({
-        "name": name.unwrap_or(fallback),
+        "name": name,
         "description": description.unwrap_or_default(),
         "scope": scope,
         "learned": learned,
+        "evidence_grade": evidence_grade,
         "path": path.display().to_string(),
         "modified_unix": mtime_unix(path),
     }))
@@ -167,7 +182,12 @@ fn skill_entry(path: &Path, scope: &str, in_learned_dir: bool) -> Option<Value> 
 /// recognized by its `origin: auto` frontmatter rather than by landing in
 /// `learned/` — see [`skill_entry`] — so the flat-file branch below yields
 /// learned skills too, which is where the miner actually writes them.
-fn scan_skills_dir(dir: &Path, scope: &str, out: &mut Vec<Value>) {
+fn scan_skills_dir(
+    dir: &Path,
+    scope: &str,
+    grades: &HashMap<String, &'static str>,
+    out: &mut Vec<Value>,
+) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -180,32 +200,97 @@ fn scan_skills_dir(dir: &Path, scope: &str, out: &mut Vec<Value>) {
                     for file in learned.flatten().take(MAX_DIR_ENTRIES) {
                         let p = file.path();
                         if p.extension().is_some_and(|e| e == "md") {
-                            out.extend(skill_entry(&p, scope, true));
+                            out.extend(skill_entry(&p, scope, true, grades));
                         }
                     }
                 }
             } else {
                 let manifest = path.join("SKILL.md");
                 if manifest.is_file() {
-                    out.extend(skill_entry(&manifest, scope, false));
+                    out.extend(skill_entry(&manifest, scope, false, grades));
                 }
             }
         } else if path.extension().is_some_and(|e| e == "md") {
             // `extend`, not `push(…unwrap_or_default())`: an unreadable file is
             // a skipped row, never a JSON `null` the dashboard would try to
             // render as a skill.
-            out.extend(skill_entry(&path, scope, false));
+            out.extend(skill_entry(&path, scope, false, grades));
         }
     }
+}
+
+/// The evidence grade recorded against each skill candidate id, read straight
+/// off `.stella/private/context.db`'s `record_proposal` rows (#4871).
+///
+/// Read-only and best-effort, the same posture as everything else in this
+/// module (module doc point 1): a missing or unreadable ledger — the common
+/// case, since the shipped lexical loop never writes one — answers an empty
+/// map rather than failing the dashboard. Folds every `Knowledge` proposal
+/// recorded for a candidate with the weakest grade recorded
+/// (`stella_protocol::provenance::ProvenanceGrade::weakest`) — #2782's rule
+/// that combining evidence can only weaken it, applied across ledger
+/// revisions the same way `EvidencePool` applies it across observations
+/// within one. Named only through `ProposalRecord`'s own field and method,
+/// never by importing `stella_protocol` itself: this crate's isolation note
+/// (see the dev-dependency comments in `Cargo.toml`) keeps every write-path
+/// crate a dev-only dependency, `ProvenanceGrade` included.
+fn skill_evidence_grades(workspace_root: &Path) -> HashMap<String, &'static str> {
+    use stella_core::context_record::{ProposalRecord, RecordProposalKind};
+
+    let db = workspace_root
+        .join(".stella")
+        .join("private")
+        .join("context.db");
+    let Some(conn) = crate::db::open_read_only(&db) else {
+        return HashMap::new();
+    };
+    let Ok(mut stmt) =
+        conn.prepare("SELECT body FROM context_records WHERE record_kind = 'record_proposal'")
+    else {
+        return HashMap::new();
+    };
+    let Ok(rows) = stmt.query_map([], |r| r.get::<_, String>(0)) else {
+        return HashMap::new();
+    };
+
+    let mut grades = HashMap::new();
+    for body in rows.flatten() {
+        let Ok(proposal) = serde_json::from_str::<ProposalRecord>(&body) else {
+            continue;
+        };
+        if proposal.proposal_kind != RecordProposalKind::Knowledge {
+            continue;
+        }
+        let Some(grade) = proposal.provenance else {
+            continue;
+        };
+        let weaker = match grades.get(&proposal.candidate_id) {
+            Some(&existing) => grade < existing,
+            None => true,
+        };
+        if weaker {
+            grades.insert(proposal.candidate_id, grade);
+        }
+    }
+    grades
+        .into_iter()
+        .map(|(id, grade)| (id, grade.as_str()))
+        .collect()
 }
 
 /// Every skill visible to this workspace: project `.stella/skills` plus the
 /// user-scope skills dir, with learned (self-extracted) skills flagged.
 pub fn skills(workspace_root: &Path) -> Value {
+    let grades = skill_evidence_grades(workspace_root);
     let mut rows = Vec::new();
-    scan_skills_dir(&workspace_root.join(".stella/skills"), "project", &mut rows);
+    scan_skills_dir(
+        &workspace_root.join(".stella/skills"),
+        "project",
+        &grades,
+        &mut rows,
+    );
     if let Some(user) = user_config_dir() {
-        scan_skills_dir(&user.join("skills"), "user", &mut rows);
+        scan_skills_dir(&user.join("skills"), "user", &grades, &mut rows);
     }
     rows.sort_by(|a, b| {
         let key = |v: &Value| {
@@ -838,7 +923,7 @@ tags       = ["testing", "pins"]
         )
         .unwrap();
         let mut rows = Vec::new();
-        scan_skills_dir(dir.path(), "project", &mut rows);
+        scan_skills_dir(dir.path(), "project", &HashMap::new(), &mut rows);
         let find = |name: &str| {
             rows.iter()
                 .find(|r| r["name"] == name)
@@ -847,6 +932,103 @@ tags       = ["testing", "pins"]
         };
         assert_eq!(find("money-is-minor-units")["learned"], true);
         assert_eq!(find("hand-written")["learned"], false);
+    }
+
+    /// A learned skill's dashboard row names the grade of the evidence that
+    /// promoted it (#4871), joined out of `context.db`'s ledger by candidate
+    /// id — never by touching the `SKILL.md` bytes, which the byte-identity
+    /// guarantee (`stella-cli`'s `learning::guarantees`) requires stay
+    /// silent on it. A hand-authored skill was never a candidate and carries
+    /// no grade at all.
+    #[test]
+    fn skills_names_the_evidence_grade_behind_a_learned_skill() {
+        use stella_context::{ContextStore, LedgerAppend};
+        use stella_core::context_record::{
+            ContextRecordKind, EvidencePool, LIFECYCLE_SCHEMA_VERSION, ObservationRecord,
+            ObservationSource, ProposalRecord, ProposalScore, RecordProposalKind,
+            RecordProposalStatus, confidence_from_score,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace_root = dir.path();
+        let skills_dir = workspace_root.join(".stella").join("skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(
+            skills_dir.join("money-is-minor-units-a1b2c3d4.md"),
+            "---\nname: money-is-minor-units-a1b2c3d4\ndescription: d\norigin: auto\n---\nbody",
+        )
+        .unwrap();
+        std::fs::write(
+            skills_dir.join("hand-written.md"),
+            "---\nname: hand-written\ndescription: d\n---\nbody",
+        )
+        .unwrap();
+
+        let private = workspace_root.join(".stella").join("private");
+        std::fs::create_dir_all(&private).unwrap();
+        let store = ContextStore::open(private.join("context.db")).unwrap();
+
+        let observation = ObservationRecord::new(
+            ObservationSource::ToolOutcome,
+            "tool:cargo_test#1",
+            "turn:1",
+            "money amounts must be stored as minor units",
+            Vec::new(),
+            false,
+            "2026-01-01T00:00:00Z",
+        )
+        .unwrap();
+        let score = ProposalScore {
+            occurrences: 3,
+            distinct_tasks: 3,
+            salient: false,
+            rank: 30.0,
+        };
+        let confidence = confidence_from_score(&score).unwrap();
+        let proposal = ProposalRecord::new(
+            RecordProposalKind::Knowledge,
+            RecordProposalStatus::Eligible,
+            "money-is-minor-units-a1b2c3d4",
+            "money is minor units",
+            "money amounts must be stored as minor units",
+            Vec::new(),
+            EvidencePool::from_observations([&observation]),
+            score,
+            confidence,
+            "2026-01-01T00:00:00Z",
+        )
+        .unwrap();
+        let body = serde_json::to_string(&proposal).unwrap();
+        store
+            .append_record(LedgerAppend {
+                record_id: &proposal.record_id,
+                lineage_id: &proposal.lineage_id,
+                record_kind: ContextRecordKind::RecordProposal.as_str(),
+                record_hash: &proposal.record_hash,
+                schema_version: LIFECYCLE_SCHEMA_VERSION,
+                body: &body,
+                observed_at: &proposal.observed_at,
+                supersedes: None,
+            })
+            .unwrap();
+        drop(store);
+
+        let rows = skills(workspace_root);
+        let rows = rows.as_array().expect("skills returns an array");
+        let find = |name: &str| {
+            rows.iter()
+                .find(|r| r["name"] == name)
+                .unwrap_or_else(|| panic!("{name} listed"))
+                .clone()
+        };
+        assert_eq!(
+            find("money-is-minor-units-a1b2c3d4")["evidence_grade"],
+            "environment_observation"
+        );
+        assert_eq!(
+            find("hand-written")["evidence_grade"],
+            serde_json::Value::Null
+        );
     }
 
     #[test]

--- a/crates/stella-tui/examples/deck_film.rs
+++ b/crates/stella-tui/examples/deck_film.rs
@@ -523,6 +523,7 @@ fn fixture_skills() -> SkillsView {
             description: description.to_string(),
             body: format!("# {name}\n\n{description}\n"),
             origin: origin.to_string(),
+            evidence_grade: None,
             enabled,
             version,
             latest,

--- a/crates/stella-tui/src/deck_ui/tests/skills.rs
+++ b/crates/stella-tui/src/deck_ui/tests/skills.rs
@@ -21,6 +21,7 @@ fn a_row(name: &str, scope: SkillScope, enabled: bool) -> SkillRow {
         description: "d".to_string(),
         body: "b".to_string(),
         origin: "workspace".to_string(),
+        evidence_grade: None,
         enabled,
         version: 1,
         latest: 1,

--- a/crates/stella-tui/src/envelope/skills.rs
+++ b/crates/stella-tui/src/envelope/skills.rs
@@ -40,6 +40,16 @@ pub struct SkillRow {
     /// Provenance label — `"workspace"`, `"user"`, `"installed"`, `"auto"`,
     /// `"plugin"`.
     pub origin: String,
+    /// How strong the evidence behind an `"auto"` skill actually is —
+    /// `stella_protocol::provenance::ProvenanceGrade::as_str()`, e.g.
+    /// `"model_critique"` or `"environment_observation"` — looked up from the
+    /// proposal ledger by candidate id (#4871). `None` for a hand-authored,
+    /// installed, or contributed skill, and for an auto-created one whose
+    /// promoting proposal predates the ledger or has aged out of it: absent,
+    /// not a weak grade the tab invented. Kept a plain label rather than the
+    /// typed enum so this crate stays independent of `stella-protocol`, the
+    /// same reason [`Self::origin`] is a `String`.
+    pub evidence_grade: Option<String>,
     /// The plugin package that ships this skill, by its manifest `name`, when
     /// it is a contributed one; `None` for a skill the user wrote, installed,
     /// or had written for them.

--- a/crates/stella-tui/src/views/skills.rs
+++ b/crates/stella-tui/src/views/skills.rs
@@ -209,9 +209,19 @@ fn render_installed(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
         // A contributed skill names its package instead of a version and a
         // scope: neither is a thing it has (`skill_manager::contributed_rows`),
         // and whose it is is the column a reader of this row actually needs.
+        //
+        // A learned row names the grade of the evidence that promoted it
+        // (#4871) when the ledger still has one — the same `snake_case` token
+        // `stella proposals` prints, so a reader learns one vocabulary rather
+        // than two. Absent for a skill mined before the ledger existed, or
+        // under the shipped lexical loop, which records no proposal at all —
+        // there is no grade to name, not a missing feature.
         let meta = match (&row.contributed_by, row.origin.as_str()) {
             (Some(plugin), _) => format!(" via {plugin} "),
-            (None, "auto") => " learned ".to_string(),
+            (None, "auto") => match &row.evidence_grade {
+                Some(grade) => format!(" learned · {grade} "),
+                None => " learned ".to_string(),
+            },
             (None, _) => format!(" {ver} · {} ", row.scope.label()),
         };
         let name = format!("{:<24}", row.name);
@@ -530,9 +540,28 @@ mod tests {
             description: format!("{name} does a thing"),
             body: format!("body of {name}"),
             origin: "workspace".to_string(),
+            evidence_grade: None,
             enabled,
             version,
             latest,
+            removable: true,
+            contributed_by: None,
+        }
+    }
+
+    /// A learned (`origin: auto`) row, optionally carrying the evidence grade
+    /// the SKILLS tab looked up for it (#4871).
+    fn learned_row(name: &str, evidence_grade: Option<&str>) -> SkillRow {
+        SkillRow {
+            scope: SkillScope::Project,
+            name: name.to_string(),
+            description: format!("{name} does a thing"),
+            body: format!("body of {name}"),
+            origin: "auto".to_string(),
+            evidence_grade: evidence_grade.map(str::to_string),
+            enabled: true,
+            version: 1,
+            latest: 1,
             removable: true,
             contributed_by: None,
         }
@@ -562,6 +591,34 @@ mod tests {
         assert!(text.contains("[ ]"), "disabled box:\n{text}");
         assert!(text.contains("v2/3"), "pinned-older version shown:\n{text}");
         assert!(text.contains("pdf-extract"), "{text}");
+    }
+
+    /// A learned skill's row names the grade of the evidence that promoted it
+    /// (#4871), and two skills promoted from different-strength evidence read
+    /// as different rows rather than both saying only "learned". A learned
+    /// row with no grade at all (mined before the ledger existed, or under
+    /// the shipped lexical loop) still reads plainly as "learned".
+    #[test]
+    fn learned_rows_name_their_evidence_grade_and_differ_by_it() {
+        let mut ui = DeckUi {
+            tab: crate::deck::DeckTab::Skills,
+            ..Default::default()
+        };
+        ui.skills.view = SkillsView {
+            rows: vec![
+                learned_row("from-build-failures", Some("environment_observation")),
+                learned_row("from-model-opinion", Some("model_critique")),
+            ],
+            status: None,
+            busy: false,
+            created: None,
+        };
+        let area = Rect::new(0, 0, 120, 20);
+        let mut buf = Buffer::empty(area);
+        render(&WorkspaceModel::new(), &mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("learned · environment_observation"), "{text}");
+        assert!(text.contains("learned · model_critique"), "{text}");
     }
 
     #[test]

--- a/crates/stella-tui/tests/accessible_layout.rs
+++ b/crates/stella-tui/tests/accessible_layout.rs
@@ -139,6 +139,7 @@ fn skills_ui(accessible: bool) -> DeckUi {
             description: "read and write PDFs".into(),
             body: String::new(),
             origin: "workspace".into(),
+            evidence_grade: None,
             enabled: true,
             version: 1,
             latest: 1,

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -327,6 +327,7 @@ fn fixture_skills() -> SkillsView {
             description: description.to_string(),
             body: format!("# {name}\n\n{description}\n"),
             origin: origin.to_string(),
+            evidence_grade: None,
             enabled,
             version,
             latest,


### PR DESCRIPTION
## Summary

Closes #4871.

The proposal ledger has carried an evidence grade per skill candidate since
#2782 (`ProposalRecord.provenance`), but nothing downstream ever read it back:
a promoted `SKILL.md` looked the same whether it came from a passing/failing
build (`environment_observation`) or from the model's own opinion of a run
(`model_critique`). Writing the grade into the rendered file was tried and
reverted (#2782's revert commit) because it breaks
`memory::learning::guarantees::both_loops_render_byte_identical_skill_files`
while the lexical loop still ships as the default — only the typed loop has a
proposal, so the two loops would render different bytes for the same skill.

This implements #4871's second option instead: carry the grade out of band,
leaving the `SKILL.md` bytes untouched.

- `stella_context::peek_records_of_kind` — a new read-only, no-migration peek
  at one ledger record kind, mirroring `stella_store::rules_peek`'s bargain for
  `store.db`: `ContextStore::open` is a write (it creates the file, replays
  every migration, and registers an embedder fingerprint) on every call, which
  is wrong for a passive listing that reruns on every SKILLS-tab refresh.
- `stella-cli`'s `skill_manager::enumerate` (the SKILLS tab's data source) and
  `stella-observatory`'s `fsview::skills` (the dashboard's skills panel) each
  join a skill's name back to its proposal's `candidate_id` and surface the
  weakest grade recorded for it (`ProvenanceGrade::weakest`, #2782's rule that
  combining evidence can only weaken it, applied across ledger revisions).
- The SKILLS tab renders it beside the existing "learned" label, e.g.
  `learned · environment_observation`.
- A skill with no matching proposal (every skill the shipped lexical loop
  wrote, and any typed-loop skill from before this existed) shows no grade —
  absent, not a weak grade invented for it.

## Test plan

- [x] `cargo test -p stella-context --lib store::ledger` — the new peek
      function reads back what a real store wrote, and creates nothing for a
      workspace with no ledger.
- [x] `cargo test -p stella-cli --bin stella -- memory::proposals
      skill_manager:: memory::learning::guarantees` — including the witness
      test that a `ToolOutcome`-sourced candidate reads as
      `environment_observation` and a `ReflectionLesson`-sourced one as
      `model_critique`, and that `both_loops_render_byte_identical_skill_files`
      still passes (the byte-identity guarantee is untouched).
- [x] `cargo test -p stella-observatory --lib fsview::` — the dashboard's
      skills panel names the same grade.
- [x] `cargo test -p stella-tui --lib skills::` — the SKILLS tab renders two
      differently-graded learned rows as distinguishable text.
- [x] `cargo clippy --no-deps --all-targets` and `cargo fmt --check` clean on
      all four touched crates.
- [x] `make guards-fast` clean, including `check-prose`.

## Summary by Sourcery

Expose the evidence grade that promoted each learned skill without changing rendered skill files.

New Features:
- Surface the evidence provenance grade associated with learned skills in the CLI skills listing, dashboard, and TUI.

Enhancements:
- Add a read-only ledger peek to retrieve proposal records without creating or migrating the context database.
- Aggregate proposal evidence by candidate using the weakest recorded provenance grade while leaving published SKILL.md contents unchanged.
- Keep provenance absent for authored, contributed, legacy, or otherwise unmatched skills.

Tests:
- Add coverage for read-only ledger peeking, provenance-grade aggregation, dashboard and CLI exposure, and TUI rendering differences.