### PR TITLE
test(stella-runtime): wrapper_run_test runs on Windows, on a two-exchange fixture mode

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -127,6 +127,7 @@ jobs:
           --test wrapper_composition
           --test wrapper_late_credential
           --test wrapper_declared_witness
+          --test wrapper_run_test
 
       - name: the group-kill guard at the bash/custom-tool/hook spawn sites, on Windows (#4698)
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -111,28 +111,38 @@ fn main() {
         }
         "dispatch-reference" => dispatch_reference(&read_request()),
         "dispatch-contributed" => dispatch_contributed(&read_request()),
-        // Claims a flip only when a candidate grant naming `sh` arrived, and
-        // says `unobservable` otherwise — so a host that withholds the grant
-        // gets an honest refusal rather than an assertion the plugin could
-        // not have made. The two-substring match is the `case` the shell
-        // script spelled out.
+        // Asks the host to run the test plan for a candidate, then builds its
+        // evidence from the answer it reads back — the two-exchange shape a
+        // host call has. `flip=achieved` only when the host reported the
+        // assertions passed, so a plugin cannot fabricate a flip it did not
+        // observe, which is what `wrapper_run_test.rs` is about.
         //
-        // Both arms are load-bearing, from different files.
-        // `wrapper_claimed_evidence.rs` takes only the granted side (its
-        // `report()` always passes `candidate: Some(..)`), while
-        // `wrapper_decided_flip.rs` calls `run(None, ..)` — so neutering
-        // this branch fails `without_the_grant_or_the_snapshot_the_verdict_is_undecided`
-        // there. Checked by ablation, not assumed.
-        // Echoes back the stage it was asked at, labelled — what
-        // `wrapper_composition.rs` used `sed` for. Composition tests read
-        // those labels to prove each member saw its own declared stages and
-        // no others, so echoing a fixed string here would let a composition
-        // that dispatched the wrong stage pass.
-        // Reports which of two named variables reached the child, as `10`
-        // for present and `0` for absent — the `${VAR:+1}0` idiom the shell
-        // probe used. `wrapper_late_credential.rs` reads both back: one
-        // granted late, one never granted, so a mode that answered a
-        // constant could not tell a delivered credential from a leaked one.
+        // The id check is the shell script's and is kept: an answer carrying
+        // someone else's id means the transport crossed two calls, and
+        // failing loudly there beats reporting a flip against the wrong one.
+        "run-test-probe" => {
+            let _request = read_line();
+            let handle = arg(&args, 1);
+            emit(&format!(
+                "{{\"call\":\"run_test\",\"id\":7,\"args\":{{\"candidate\":\"{handle}\"}}}}"
+            ));
+            let answer = read_line();
+            if !answer.contains("\"result\":7") {
+                eprintln!("the answer did not carry the id this plugin chose");
+                std::process::exit(1);
+            }
+            let flip = if answer.contains("\"assertions\":\"passed\"") {
+                "achieved"
+            } else if answer.contains("\"err\"") {
+                "unobservable"
+            } else {
+                "not-achieved"
+            };
+            emit(&format!(
+                "{{\"point\":\"after_turn\",\"body\":{{\"protocol_version\":1,\
+                 \"evidence\":{{\"flip\":\"{flip}\"}}}}}}"
+            ));
+        }
         // Declares a witness list that narrows at `research` — the `case`
         // the shell plugin spelled out. The narrowing is load-bearing:
         // pinning the list fails
@@ -151,6 +161,11 @@ fn main() {
                  \"witness\":[{list}]}}}}"
             ));
         }
+        // Reports which of two named variables reached the child, as `10`
+        // for present and `0` for absent — the `${VAR:+1}0` idiom the shell
+        // probe used. `wrapper_late_credential.rs` reads both back: one
+        // granted late, one never granted, so a mode that answered a
+        // constant could not tell a delivered credential from a leaked one.
         "two-env-probe" => {
             let _ = read_request();
             let present = |name: &str| {
@@ -165,6 +180,11 @@ fn main() {
                 ("mode", present(arg(&args, 2))),
             ]));
         }
+        // Echoes back the stage it was asked at, labelled — what
+        // `wrapper_composition.rs` used `sed` for. Composition tests read
+        // those labels to prove each member saw its own declared stages and
+        // no others, so echoing a fixed string here would let a composition
+        // that dispatched the wrong stage pass.
         "echo-stage" => {
             let request = read_request();
             let label = arg(&args, 1);
@@ -179,6 +199,18 @@ fn main() {
                 emit(&measurements(&[]));
             }
         }
+        // Claims a flip only when a candidate grant naming `sh` arrived, and
+        // says `unobservable` otherwise — so a host that withholds the grant
+        // gets an honest refusal rather than an assertion the plugin could
+        // not have made. The two-substring match is the `case` the shell
+        // script spelled out.
+        //
+        // Both arms are load-bearing, from different files.
+        // `wrapper_claimed_evidence.rs` takes only the granted side (its
+        // `report()` always passes `candidate: Some(..)`), while
+        // `wrapper_decided_flip.rs` calls `run(None, ..)` — so neutering
+        // this branch fails `without_the_grant_or_the_snapshot_the_verdict_is_undecided`
+        // there. Checked by ablation, not assumed.
         "flip-if-granted" => {
             let request = read_request();
             let flip = if request.contains("\"root\"") && request.contains("\"program\":\"sh\"") {
@@ -217,6 +249,20 @@ fn read_request() -> String {
     let mut buf = Vec::new();
     let _ = std::io::stdin().read_to_end(&mut buf);
     String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// One line, for the modes that hold a conversation rather than answering
+/// once — the shell's `read -r`.
+///
+/// A host call is two exchanges: the plugin reads its request, writes a call,
+/// and reads the answer. `read_request` cannot serve that, because reading to
+/// EOF consumes the answer that has not been written yet and then blocks
+/// until the host gives up. Returns an empty string at EOF, which the callers
+/// treat as a host that said nothing.
+fn read_line() -> String {
+    let mut line = String::new();
+    let _ = std::io::stdin().read_line(&mut line);
+    line
 }
 
 /// Write one message and flush it. Nothing here buffers past the process, so a

--- a/crates/stella-runtime/tests/wrapper_run_test.rs
+++ b/crates/stella-runtime/tests/wrapper_run_test.rs
@@ -20,8 +20,6 @@
 //! `cfg(unix)` is the same declared gap the rest of this suite carries, tracked
 //! in #3497.
 
-#![cfg(unix)]
-
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -139,9 +137,14 @@ fn host_without_a_plane(manifest: &PluginManifest) -> Arc<HostCallGate> {
     ))
 }
 
-fn plugin(script: &str, gate: Arc<HostCallGate>) -> SubprocessWrapper {
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
+
+/// The plugin asks about the handle it was given and reports the flip from
+/// the answer it reads (#4697). `flip=achieved` only if the host said the
+/// assertions passed, so a fabricated report cannot produce it.
+fn plugin(handle: &str, gate: Arc<HostCallGate>) -> SubprocessWrapper {
     SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), script.into()],
+        vec![FIXTURE.to_string(), "run-test-probe".into(), handle.into()],
         Vec::new(),
         Duration::from_secs(10),
     )
@@ -167,29 +170,6 @@ fn after() -> AfterTurnRequest {
     }
 }
 
-/// The plugin asks about the handle it was given and reports the flip from the
-/// answer it reads. `flip=achieved` only if the host said the assertions
-/// passed, so a fabricated report cannot produce it.
-const ASKS_ABOUT: &str = r#"
-read -r request
-printf '%s\n' '{"call":"run_test","id":7,"args":{"candidate":"CANDIDATE"}}'
-read -r answer
-case "$answer" in
-  *'"result":7'*) ;;
-  *) printf 'the answer did not carry the id this plugin chose\n' >&2 ; exit 1 ;;
-esac
-case "$answer" in
-  *'"assertions":"passed"'*) flip=achieved ;;
-  *'"err"'*)                 flip=unobservable ;;
-  *)                         flip=not-achieved ;;
-esac
-printf '{"point":"after_turn","body":{"protocol_version":1,"evidence":{"flip":"%s"}}}\n' "$flip"
-"#;
-
-fn asks_about(handle: &str) -> String {
-    ASKS_ABOUT.replace("CANDIDATE", handle)
-}
-
 /// **The witness.** The plugin asks, the host runs, and the plugin's evidence
 /// is built from the answer it read.
 ///
@@ -206,7 +186,7 @@ async fn a_plugin_asks_the_host_to_re_run_the_candidates_tests_and_the_host_does
     let workspaces = Workspaces::green();
     let gate = host(&manifest, Arc::clone(&workspaces));
 
-    let evidence = plugin(&asks_about("candidate-1"), gate)
+    let evidence = plugin("candidate-1", gate)
         .after_turn(after())
         .await
         .expect("the plugin answers the point")
@@ -237,7 +217,7 @@ async fn a_handle_from_another_run_is_refused_unavailable_not_unsupported() {
     let workspaces = Workspaces::green();
     let gate = host(&manifest, Arc::clone(&workspaces));
 
-    let evidence = plugin(&asks_about("candidate-from-another-run"), Arc::clone(&gate))
+    let evidence = plugin("candidate-from-another-run", Arc::clone(&gate))
         .after_turn(after())
         .await
         .expect("a refused call is a value, not a death")
@@ -267,7 +247,7 @@ async fn a_host_with_no_plane_is_unavailable_and_the_plugin_degrades() {
     let manifest = manifest();
     let gate = host_without_a_plane(&manifest);
 
-    let evidence = plugin(&asks_about("candidate-1"), Arc::clone(&gate))
+    let evidence = plugin("candidate-1", Arc::clone(&gate))
         .after_turn(after())
         .await
         .expect("a refused call is a value")
@@ -298,7 +278,7 @@ async fn a_plugin_that_did_not_declare_the_call_never_reaches_the_plane() {
     let workspaces = Workspaces::green();
     let gate = host(&undeclared, Arc::clone(&workspaces));
 
-    let evidence = plugin(&asks_about("candidate-1"), Arc::clone(&gate))
+    let evidence = plugin("candidate-1", Arc::clone(&gate))
         .after_turn(after())
         .await
         .expect("a refused call is a value")


### PR DESCRIPTION
Eight of twelve for #4697, and the first **host-call** port — the shape the four remaining files all take.

## What a host call needs that the fixture did not have

A host call is two exchanges: the plugin reads its request, writes a call, then reads the host's answer. `read_request()` reads to EOF, which consumes an answer that has not been written yet and then blocks until the host gives up — so it cannot serve this at all.

Added `read_line()` (the shell's `read -r`) and a `run-test-probe <handle>` mode that asks, reads the answer, and builds its evidence from it. The script's id check is kept rather than simplified away: an answer carrying someone else's id means the transport crossed two calls, and failing loudly beats reporting a flip against the wrong one.

This unblocks `driver_socket`, `wrapper_host_call`, `wrapper_child_turn` and `wrapper_candidate_fanout`, which are all host-call shaped.

## The answer branch is load-bearing

This file's whole point is that a plugin cannot fabricate a flip it did not observe. Pinning the flip to `achieved`:

```
test a_handle_from_another_run_is_refused_unavailable_not_unsupported ... FAILED
test a_plugin_that_did_not_declare_the_call_never_reaches_the_plane ... FAILED
test a_host_with_no_plane_is_unavailable_and_the_plugin_degrades ... FAILED
test result: FAILED. 1 passed; 3 failed
```

Restored: 4 passed. Three of four tests rest on the plugin actually reading what the host said.

## Also in this diff: comment drift I caused

Successive mode insertions had left four comment blocks stacked above `"dispatch-contributed"`, detached from the arms they document — each new arm went in above the previous one and pushed its comment up. Every comment is now back above its own arm. No behaviour change, and the four suites involved were re-run to confirm it (`wrapper_dispatch` 8, `wrapper_composition` 8, `wrapper_declared_witness` 3, `wrapper_late_credential` 1).

Worth naming rather than folding in silently: a fixture whose comments describe the wrong arm is exactly the stale-comment defect this repo treats as a bug.

## Evidence

```
cargo test -p stella-runtime --test wrapper_run_test    4 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings   exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)    exit 0
cargo fmt --all --check   exit 0
check-prose               OK — none added
```

Added to `windows-check.yml`, which is green on `main` again after PR #4880.

Four files remain in #4697. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Make the runtime wrapper host-call test cross-platform by using a two-exchange fixture protocol and running it in Windows CI.

New Features:
- Add a Windows-compatible runtime wrapper test covering two-exchange host calls and host responses.

Bug Fixes:
- Ensure wrapper test evidence reflects the host's response and rejects responses for the wrong call.

Enhancements:
- Reorganize fixture comments so they document the correct dispatch modes.
- Replace the Unix shell probe with the cross-platform Rust fixture executable.

CI:
- Run the wrapper runtime test in the Windows check workflow.

Tests:
- Enable the wrapper runtime test on Windows while preserving coverage of successful, unavailable, and undeclared host-call scenarios.