### PR TITLE
test(stella-runtime): wrapper_child_turn runs on Windows, on three fixture modes

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -129,6 +129,7 @@ jobs:
           --test wrapper_declared_witness
           --test wrapper_run_test
           --test wrapper_host_call
+          --test wrapper_child_turn
 
       - name: the group-kill guard at the bash/custom-tool/hook spawn sites, on Windows (#4698)
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -142,6 +142,86 @@ fn main() {
                 }
             }
         }
+        // Asks for a child turn and reports what came back, seat included.
+        // Two independent greps as the script had: the seat and the finding
+        // are separate facts, and `wrapper_child_turn.rs` reads the composed
+        // sentence, so collapsing them would prove less while looking right.
+        "child-review" => {
+            let _request = read_line();
+            emit(
+                "{\"call\":\"child_turn\",\"id\":11,\"args\":\
+                 {\"role\":\"reviewer\",\"instruction\":\"does the diff drop the retry?\"}}",
+            );
+            let answer = read_line();
+            if !answer.contains("\"result\":11") {
+                eprintln!("the answer did not carry the id this plugin chose");
+                std::process::exit(1);
+            }
+            let seat = if answer.contains("\"seat\":\"research\"") {
+                "research"
+            } else {
+                "unknown"
+            };
+            let finding = if answer.contains("drops the retry on 429") {
+                format!("the reviewer ({seat}) says the diff drops the retry on 429")
+            } else {
+                "no assessment was available".to_string()
+            };
+            emit(&format!(
+                "{{\"point\":\"before_turn\",\"body\":{{\"protocol_version\":1,\
+                 \"context\":[{{\"label\":\"reviewer\",\"text\":\"{finding}\"}}]}}}}"
+            ));
+        }
+        // Asks for a child turn the host will refuse, and reports the refusal
+        // it was actually given. Parameterised because two tests differ only
+        // in which refusal they expect — `undeclared` for a role the manifest
+        // never named, `forbidden` for the worker's own seat — and an
+        // unrecognised answer must say so rather than pass as either.
+        "child-refusal" => {
+            let _request = read_line();
+            let role = arg(&args, 1);
+            let expected = arg(&args, 2);
+            let note = arg(&args, 3);
+            emit(&format!(
+                "{{\"call\":\"child_turn\",\"id\":1,\"args\":\
+                 {{\"role\":\"{role}\",\"instruction\":\"grade it\"}}}}"
+            ));
+            let answer = read_line();
+            let text = if answer.contains(&format!("\"refusal\":\"{expected}\"")) {
+                note
+            } else {
+                "unexpected answer"
+            };
+            emit(&note_context(text));
+        }
+        // Asks three times against an allowance that admits fewer, counting
+        // what was granted and what was refused. An answer that is neither
+        // is a fault rather than a third category — the script exited on it
+        // and so does this.
+        "child-allowance" => {
+            let _request = read_line();
+            let (mut granted, mut refused) = (0u32, 0u32);
+            for id in 1..=3 {
+                emit(&format!(
+                    "{{\"call\":\"child_turn\",\"id\":{id},\"args\":\
+                     {{\"role\":\"reviewer\",\"instruction\":\"ask {id}\"}}}}"
+                ));
+                let answer = read_line();
+                if answer.contains("\"refusal\":\"allowance-spent\"") {
+                    refused += 1;
+                } else if answer.contains("\"seat\":\"research\"") {
+                    granted += 1;
+                } else {
+                    eprintln!("unexpected answer: {answer}");
+                    std::process::exit(1);
+                }
+            }
+            emit(&format!(
+                "{{\"point\":\"before_turn\",\"body\":{{\"protocol_version\":1,\
+                 \"context\":[{{\"label\":\"asks\",\
+                 \"text\":\"granted {granted} refused {refused}\"}}]}}}}"
+            ));
+        }
         "call-once" => {
             let _request = read_line();
             emit(arg(&args, 1));

--- a/crates/stella-runtime/tests/wrapper_child_turn.rs
+++ b/crates/stella-runtime/tests/wrapper_child_turn.rs
@@ -24,8 +24,6 @@
 //! `cfg(unix)` is the same declared gap the rest of this suite carries, tracked
 //! in #3497.
 
-#![cfg(unix)]
-
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -139,15 +137,15 @@ fn host(
     (gate, plane, dispatcher)
 }
 
-fn plugin(script: &str, gate: Arc<HostCallGate>) -> SubprocessWrapper {
-    SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), script.into()],
-        Vec::new(),
-        Duration::from_secs(10),
-    )
-    .expect("the transport is declared with a program and a budget")
-    .wrapper
-    .serving(gate)
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
+
+fn plugin(mode: &[&str], gate: Arc<HostCallGate>) -> SubprocessWrapper {
+    let mut argv = vec![FIXTURE.to_string()];
+    argv.extend(mode.iter().map(|part| (*part).to_string()));
+    SubprocessWrapper::declare(argv, Vec::new(), Duration::from_secs(10))
+        .expect("the transport is declared with a program and a budget")
+        .wrapper
+        .serving(gate)
 }
 
 fn before() -> BeforeTurnRequest {
@@ -178,26 +176,7 @@ async fn a_plugin_asks_for_a_model_call_at_a_declared_role_and_the_host_makes_it
     let manifest = manifest();
     let (gate, plane, dispatcher) = host(&manifest, 2);
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"child_turn","id":11,"args":{"role":"reviewer","instruction":"does the diff drop the retry?"}}'
-read -r answer
-case "$answer" in
-  *'"result":11'*) ;;
-  *) printf 'the answer did not carry the id this plugin chose\n' >&2 ; exit 1 ;;
-esac
-case "$answer" in
-  *'"seat":"research"'*) seat="research" ;;
-  *) seat="unknown" ;;
-esac
-case "$answer" in
-  *'drops the retry on 429'*) finding="the reviewer ($seat) says the diff drops the retry on 429" ;;
-  *) finding="no assessment was available" ;;
-esac
-printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"reviewer","text":"%s"}]}}\n' "$finding"
-"#;
-
-    let response = plugin(script, Arc::clone(&gate))
+    let response = plugin(&["child-review"], Arc::clone(&gate))
         .before_turn(before())
         .await
         .expect("the plugin asked, was answered, and answered the point");
@@ -249,21 +228,18 @@ async fn an_undeclared_role_intent_is_refused_to_the_plugin_and_reported_to_the_
     let manifest = manifest();
     let (gate, plane, dispatcher) = host(&manifest, 2);
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"child_turn","id":1,"args":{"role":"auditor","instruction":"grade it"}}'
-read -r answer
-case "$answer" in
-  *'"refusal":"undeclared"'*) note="the host refused an undeclared role intent; degrading" ;;
-  *) note="unexpected answer" ;;
-esac
-printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"note","text":"%s"}]}}\n' "$note"
-"#;
-
-    let response = plugin(script, Arc::clone(&gate))
-        .before_turn(before())
-        .await
-        .expect("a refused call is a value the plugin reads, never a death");
+    let response = plugin(
+        &[
+            "child-refusal",
+            "auditor",
+            "undeclared",
+            "the host refused an undeclared role intent; degrading",
+        ],
+        Arc::clone(&gate),
+    )
+    .before_turn(before())
+    .await
+    .expect("a refused call is a value the plugin reads, never a death");
     let messages = admissible(&manifest, response)
         .expect("the contribution is admissible")
         .into_messages();
@@ -305,21 +281,18 @@ async fn a_plugin_cannot_name_a_role_intent_that_resolves_to_the_worker() {
     );
     let (gate, plane, dispatcher) = host(&manifest, 2);
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"child_turn","id":2,"args":{"role":"grader","instruction":"grade your own work"}}'
-read -r answer
-case "$answer" in
-  *'"refusal":"forbidden"'*) note="the worker's seat is not for sale" ;;
-  *) note="unexpected answer" ;;
-esac
-printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"note","text":"%s"}]}}\n' "$note"
-"#;
-
-    let response = plugin(script, Arc::clone(&gate))
-        .before_turn(before())
-        .await
-        .expect("the point still completes");
+    let response = plugin(
+        &[
+            "child-refusal",
+            "grader",
+            "forbidden",
+            "the worker's seat is not for sale",
+        ],
+        Arc::clone(&gate),
+    )
+    .before_turn(before())
+    .await
+    .expect("the point still completes");
     let messages = admissible(&manifest, response)
         .expect("the contribution is admissible")
         .into_messages();
@@ -344,23 +317,7 @@ async fn a_plugin_asking_for_more_child_turns_than_the_ceiling_is_clamped_not_ob
     let (gate, plane, dispatcher) = host(&manifest, 1);
     assert_eq!(plane.max_turns(), 1);
 
-    let script = r#"
-read -r request
-granted=0
-refused=0
-for id in 1 2 3; do
-  printf '{"call":"child_turn","id":%s,"args":{"role":"reviewer","instruction":"ask %s"}}\n' "$id" "$id"
-  read -r answer
-  case "$answer" in
-    *'"refusal":"allowance-spent"'*) refused=$((refused + 1)) ;;
-    *'"seat":"research"'*) granted=$((granted + 1)) ;;
-    *) printf 'unexpected answer: %s\n' "$answer" >&2 ; exit 1 ;;
-  esac
-done
-printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"asks","text":"granted %s refused %s"}]}}\n' "$granted" "$refused"
-"#;
-
-    let response = plugin(script, Arc::clone(&gate))
+    let response = plugin(&["child-allowance"], Arc::clone(&gate))
         .before_turn(before())
         .await
         .expect("a spent allowance is answered, never fatal");
@@ -400,21 +357,18 @@ async fn a_host_with_no_child_turn_plane_says_so_rather_than_pretending() {
         Box::new(HostPlanes::none()),
     ));
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"child_turn","id":1,"args":{"role":"reviewer","instruction":"grade it"}}'
-read -r answer
-case "$answer" in
-  *'"refusal":"unavailable"'*) note="this host runs no child turns" ;;
-  *) note="unexpected answer" ;;
-esac
-printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"note","text":"%s"}]}}\n' "$note"
-"#;
-
-    let response = plugin(script, Arc::clone(&gate))
-        .before_turn(before())
-        .await
-        .expect("the point completes");
+    let response = plugin(
+        &[
+            "child-refusal",
+            "reviewer",
+            "unavailable",
+            "this host runs no child turns",
+        ],
+        Arc::clone(&gate),
+    )
+    .before_turn(before())
+    .await
+    .expect("the point completes");
     let messages = admissible(&manifest, response)
         .expect("the contribution is admissible")
         .into_messages();


### PR DESCRIPTION
Ten of twelve for #4697. Three new fixture modes carry this file's five shell plugins.

## Where the modes split, and why

- **`child-review`** keeps the script's *two independent* greps. The seat and the finding are separate facts that the test reads back as one composed sentence, so collapsing them into a single match would still look right while proving less.
- **`child-allowance`** counts granted against refused across three asks, and treats an answer that is neither as a **fault** — `exit 1`, as the script did — rather than as a quiet third category.
- **`child-refusal`** is parameterised, because three tests differ only in which refusal they expect: `undeclared` for a role the manifest never named, `forbidden` for the worker's own seat, `unavailable` for a host running no child turns. One mode, three arguments, and an unrecognised answer reports "unexpected answer" rather than passing as any of them.

Parameterising is a risk worth naming: a shared mode can make three tests pass on one accident. The ablation below is what rules that out.

## Ablation, aimed correctly

Pointing the refusal match at a value that never occurs — so the note becomes *wrong*, not merely constant (the correction from #4885):

```
test a_host_with_no_child_turn_plane_says_so_rather_than_pretending ... FAILED
test a_plugin_cannot_name_a_role_intent_that_resolves_to_the_worker ... FAILED
test an_undeclared_role_intent_is_refused_to_the_plugin_and_reported_to_the_host ... FAILED
test result: FAILED. 2 passed; 3 failed
```

All three dependents fail together, which is exactly what a shared mode has to demonstrate: each test is reading a real refusal, not inheriting a default.

## Evidence

```
cargo test -p stella-runtime --test wrapper_child_turn   5 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings   exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)    exit 0
cargo fmt --all --check   exit 0
check-prose               OK — none added
```

Added to `windows-check.yml`. Two files remain in #4697: `driver_socket` and `wrapper_candidate_fanout`. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Enable the wrapper child-turn test suite to run portably on Windows while retaining its existing behavioral coverage.

Enhancements:
- Run the wrapper child-turn integration tests on Windows by replacing embedded shell scripts with portable Rust fixture modes for review responses, refusal handling, and allowance accounting.

CI:
- Add `wrapper_child_turn` to the Windows runtime test workflow.

Tests:
- Preserve coverage for declared-role responses, distinct refusal reasons, and child-turn allowance limits through shared parameterized fixture modes.