### PR TITLE
test(stella-runtime): driver_socket runs on Windows, on eight driver-socket modes

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -130,6 +130,7 @@ jobs:
           --test wrapper_run_test
           --test wrapper_host_call
           --test wrapper_child_turn
+          --test driver_socket
 
       - name: the group-kill guard at the bash/custom-tool/hook spawn sites, on Windows (#4698)
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}

--- a/crates/stella-runtime/tests/driver_socket.rs
+++ b/crates/stella-runtime/tests/driver_socket.rs
@@ -8,18 +8,18 @@
 //! be told, and no code path connected the two — `DriveRequest` was never
 //! written to a process and `DriverMessage` was never read from one.
 //!
-//! The drivers below are `sh` scripts, for the reason
-//! `tests/wrapper_host_call.rs` runs its plugins as `sh`: a channel that needs
-//! an SDK is a Rust API with extra steps (`doc:pipeline-as-plugins` §5). None of
-//! them uses a JSON library. The self-driving loop this channel exists for is
-//! eight markdown files and a shell script today (#3599), so "a shell program
-//! can drive" is the requirement rather than a demonstration.
+//! The drivers below are modes of `wrapper-plugin-fixture`, which links `std`
+//! and nothing else: it matches substrings in and writes string literals out,
+//! with no JSON library on either side. That constraint is the point. A channel
+//! that needs an SDK is a Rust API with extra steps
+//! (`doc:pipeline-as-plugins` §5), and the self-driving loop this channel
+//! exists for is eight markdown files and a shell script today (#3599) — so
+//! "a program that is not Rust can drive" is the requirement, not a
+//! demonstration.
 //!
-//! `cfg(unix)` is the same declared gap the rest of this suite carries, tracked
-//! in #3497. The fixture binary that closes it exists —
-//! `wrapper-plugin-fixture`, which `wrapper_socket.rs` and
-//! `wrapper_transport_limits.rs` now drive — and this file has not moved onto
-//! it yet.
+//! Moving off `/bin/sh` is what lets this file run on Windows (#3497, #4697),
+//! where `windows-check.yml` compiles the platform arms nothing else here
+//! parses.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/stella-runtime/tests/driver_socket.rs
+++ b/crates/stella-runtime/tests/driver_socket.rs
@@ -21,8 +21,6 @@
 //! `wrapper_transport_limits.rs` now drive — and this file has not moved onto
 //! it yet.
 
-#![cfg(unix)]
-
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -81,27 +79,35 @@ fn gate(
     Arc::new(DriverCallGate::declare(grant, ceiling, capabilities))
 }
 
-fn driver(script: &str, gate: Arc<DriverCallGate>, timeout: Duration) -> SubprocessDriver {
-    SubprocessDriver::declare(
-        vec!["/bin/sh".into(), "-c".into(), script.into()],
-        Vec::new(),
-        timeout,
-    )
-    .expect("the transport is declared with a program and a budget")
-    .driver
-    .serving(gate)
+/// The ask `an_abandoned_session_is_not_a_decision` makes before walking away:
+/// `call-once` emits it and exits without reading the answer.
+const BACKLOG_ASK: &[&str] = &["call-once", "{\"call\":\"backlog_next\",\"id\":1}"];
+
+/// A driver that reads its request, complains on stderr and dies deciding
+/// nothing — the existing `exit` mode, exit code 0.
+const CRASHES: &[&str] = &["exit", "0", "the driver crashed before deciding"];
+
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
+
+fn argv(mode: &[&str]) -> Vec<String> {
+    let mut argv = vec![FIXTURE.to_string()];
+    argv.extend(mode.iter().map(|part| (*part).to_string()));
+    argv
+}
+
+fn driver(mode: &[&str], gate: Arc<DriverCallGate>, timeout: Duration) -> SubprocessDriver {
+    SubprocessDriver::declare(argv(mode), Vec::new(), timeout)
+        .expect("the transport is declared with a program and a budget")
+        .driver
+        .serving(gate)
 }
 
 /// A driver with no gate at all — the host that attached none. Stdin closes
 /// after the request, exactly as it does for a manifest declaring no calls.
-fn ungated(script: &str, timeout: Duration) -> SubprocessDriver {
-    SubprocessDriver::declare(
-        vec!["/bin/sh".into(), "-c".into(), script.into()],
-        Vec::new(),
-        timeout,
-    )
-    .expect("the transport is declared with a program and a budget")
-    .driver
+fn ungated(mode: &[&str], timeout: Duration) -> SubprocessDriver {
+    SubprocessDriver::declare(argv(mode), Vec::new(), timeout)
+        .expect("the transport is declared with a program and a budget")
+        .driver
 }
 
 /// **The witness.** A driver is opened, asks the host for a capability it
@@ -120,22 +126,7 @@ async fn a_driver_holds_a_session_asks_for_a_capability_and_says_what_comes_next
 
     // The session identity is read back out of the request, so the answer is
     // genuinely a function of what the host opened rather than a fixed string.
-    let script = r#"
-read -r request
-case "$request" in
-  *'"session":"cycle-17"'*) ;;
-  *) printf 'the driver was not told which session it is in\n' >&2 ; exit 1 ;;
-esac
-printf '%s\n' '{"call":"backlog_next","id":1}'
-read -r answer
-case "$answer" in
-  *'"result":1'*'"ok"'*) secs=900 ;;
-  *) printf 'the host did not perform the declared capability: %s\n' "$answer" >&2 ; exit 1 ;;
-esac
-printf '{"point":"drive","body":{"next":{"sleep":{"secs":%s}}}}\n' "$secs"
-"#;
-
-    let response = driver(script, Arc::clone(&gate), Duration::from_secs(10))
+    let response = driver(&["drive-sleep"], Arc::clone(&gate), Duration::from_secs(10))
         .drive(DriveRequest::new("cycle-17"))
         .await
         .expect("the driver was opened, served, and ended its own session");
@@ -169,27 +160,14 @@ async fn an_undeclared_capability_is_refused_to_the_driver_and_the_session_conti
     );
     let gate = gate(grant, DEFAULT_DRIVER_MAX_CALLS, Box::new(Serves));
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"deliver_merge","id":1}'
-read -r refused
-case "$refused" in
-  *'"refusal":"undeclared"'*) ;;
-  *) printf 'a capability this driver never declared was performed: %s\n' "$refused" >&2 ; exit 1 ;;
-esac
-printf '%s\n' '{"call":"backlog_file","id":2}'
-read -r served
-case "$served" in
-  *'"result":2'*'"ok"'*) reason="merge was not granted; filed the finding and stopped" ;;
-  *) reason="the session died on a refusal" ;;
-esac
-printf '{"point":"drive","body":{"next":{"halt":{"reason":"%s"}}}}\n' "$reason"
-"#;
-
-    let response = driver(script, Arc::clone(&gate), Duration::from_secs(10))
-        .drive(DriveRequest::new("cycle-18"))
-        .await
-        .expect("a refused capability is a value the driver reads, never a death");
+    let response = driver(
+        &["drive-degrade"],
+        Arc::clone(&gate),
+        Duration::from_secs(10),
+    )
+    .drive(DriveRequest::new("cycle-18"))
+    .await
+    .expect("a refused capability is a value the driver reads, never a death");
 
     assert_eq!(
         response.next,
@@ -219,21 +197,14 @@ async fn the_shipping_host_performs_no_capability_yet_and_the_driver_is_told() {
         Box::new(NoDriverCapabilities),
     );
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"backlog_next","id":1}'
-read -r answer
-case "$answer" in
-  *'"refusal":"unsupported"'*) reason="the host has no backlog yet" ;;
-  *) reason="unexpected: $answer" ;;
-esac
-printf '{"point":"drive","body":{"next":{"halt":{"reason":"%s"}}}}\n' "$reason"
-"#;
-
-    let response = driver(script, Arc::clone(&gate), Duration::from_secs(10))
-        .drive(DriveRequest::new("cycle-19"))
-        .await
-        .expect("an unsupported capability is answered, not fatal");
+    let response = driver(
+        &["drive-unsupported"],
+        Arc::clone(&gate),
+        Duration::from_secs(10),
+    )
+    .drive(DriveRequest::new("cycle-19"))
+    .await
+    .expect("an unsupported capability is answered, not fatal");
     assert_eq!(
         response.next,
         DriveNext::Halt {
@@ -251,23 +222,14 @@ async fn the_session_allowance_is_the_hosts_and_a_spent_one_is_answered() {
     let gate = gate(grant_of(DRIVING_MANIFEST), 1, Box::new(Serves));
     assert_eq!(gate.max_calls(), 1, "the manifest's ask of 4 is clamped");
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"backlog_next","id":1}'
-read -r first
-printf '%s\n' '{"call":"backlog_next","id":2}'
-read -r second
-case "$second" in
-  *'"refusal":"allowance-spent"'*) reason="one ask per session here" ;;
-  *) reason="the ceiling did not hold" ;;
-esac
-printf '{"point":"drive","body":{"next":{"halt":{"reason":"%s"}}}}\n' "$reason"
-"#;
-
-    let response = driver(script, Arc::clone(&gate), Duration::from_secs(10))
-        .drive(DriveRequest::new("cycle-20"))
-        .await
-        .expect("a spent allowance is answered, not fatal");
+    let response = driver(
+        &["drive-allowance"],
+        Arc::clone(&gate),
+        Duration::from_secs(10),
+    )
+    .drive(DriveRequest::new("cycle-20"))
+    .await
+    .expect("a spent allowance is answered, not fatal");
     assert_eq!(
         response.next,
         DriveNext::Halt {
@@ -302,21 +264,12 @@ async fn a_driver_that_declares_no_capability_gets_its_eof_and_is_not_left_hangi
         "an empty [driver] calls list can never be served"
     );
 
-    let script = r#"
-request=$(cat)
-case "$request" in
-  *'"point":"drive"'*) reason="read the whole session request to EOF" ;;
-  *) reason="unexpected request" ;;
-esac
-printf '{"point":"drive","body":{"next":{"halt":{"reason":"%s"}}}}\n' "$reason"
-"#;
-
     // Served by the gate, not by `ungated`: the transport's own
     // `offers_calls()` consultation is the thing under test, and a driver with
     // no gate at all would reach the same EOF for a different reason.
     let budget = Duration::from_secs(10);
     let started = Instant::now();
-    let response = driver(script, Arc::clone(&gate), budget)
+    let response = driver(&["drive-eof"], Arc::clone(&gate), budget)
         .drive(DriveRequest::new("cycle-21"))
         .await
         .expect("a driver that asks for nothing still ends its session");
@@ -338,16 +291,9 @@ printf '{"point":"drive","body":{"next":{"halt":{"reason":"%s"}}}}\n' "$reason"
 /// manifest declares no `[driver] calls`, or this host attached no gate.
 #[tokio::test]
 async fn an_ask_with_no_channel_open_is_reported_rather_than_waited_out() {
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"backlog_next","id":1}'
-read -r answer
-printf '{"point":"drive","body":{"next":{"halt":{"reason":"unreachable"}}}}\n'
-"#;
-
     let budget = Duration::from_secs(10);
     let started = Instant::now();
-    let failed = ungated(script, budget)
+    let failed = ungated(&["drive-unannounced"], budget)
         .drive(DriveRequest::new("cycle-22"))
         .await
         .expect_err("an unanswerable ask is a failure, not a silence");
@@ -390,12 +336,7 @@ async fn a_driver_that_asks_and_then_ends_without_a_next_names_what_it_abandoned
 
     // Asks, and exits without ever reading the answer. Its stdout closes with
     // the ask as the last thing it said.
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"backlog_next","id":1}'
-"#;
-
-    let failed = driver(script, Arc::clone(&gate), Duration::from_secs(10))
+    let failed = driver(BACKLOG_ASK, Arc::clone(&gate), Duration::from_secs(10))
         .drive(DriveRequest::new("cycle-79"))
         .await
         .expect_err("an abandoned session is not a decision");
@@ -420,12 +361,7 @@ printf '%s\n' '{"call":"backlog_next","id":1}'
 /// restart a broken driver forever.
 #[tokio::test]
 async fn a_driver_that_ends_without_a_next_is_a_failure_rather_than_a_halt() {
-    let script = r#"
-cat >/dev/null
-printf 'the driver crashed before deciding\n' >&2
-"#;
-
-    let failed = ungated(script, Duration::from_secs(10))
+    let failed = ungated(CRASHES, Duration::from_secs(10))
         .drive(DriveRequest::new("cycle-23"))
         .await
         .expect_err("silence is not a decision");
@@ -445,16 +381,13 @@ printf 'the driver crashed before deciding\n' >&2
 /// not a decode failure about the answer it never wrote.
 #[tokio::test]
 async fn a_driver_that_dies_loudly_is_reported_with_its_status_and_stderr() {
-    let script = r#"
-cat >/dev/null
-printf 'no issue provider configured\n' >&2
-exit 3
-"#;
-
-    let failed = ungated(script, Duration::from_secs(10))
-        .drive(DriveRequest::new("cycle-24"))
-        .await
-        .expect_err("a non-zero exit is a failure");
+    let failed = ungated(
+        &["exit", "3", "no issue provider configured"],
+        Duration::from_secs(10),
+    )
+    .drive(DriveRequest::new("cycle-24"))
+    .await
+    .expect_err("a non-zero exit is a failure");
 
     assert!(
         matches!(&failed, DriverError::Exit { status, stderr, .. }
@@ -477,16 +410,8 @@ async fn the_session_cannot_outlive_its_budget_by_asking() {
     let budget = Duration::from_millis(700);
 
     // Never writes a `next`. Every iteration is a legitimate, declared ask.
-    let script = r#"
-read -r request
-while :; do
-  printf '%s\n' '{"call":"backlog_next","id":1}'
-  read -r answer || exit 0
-done
-"#;
-
     let started = Instant::now();
-    let failed = driver(script, Arc::clone(&gate), budget)
+    let failed = driver(&["drive-ask-forever"], Arc::clone(&gate), budget)
         .drive(DriveRequest::new("cycle-25"))
         .await
         .expect_err("a session that never ends is killed at its budget");
@@ -560,14 +485,13 @@ async fn a_driver_is_denied_the_model_credential_and_inherits_none_from_the_host
     // cannot — the same probe `tests/wrapper_env_refusal.rs` uses, and it
     // reports the *absence* of a variable without ever putting its value on
     // the wire.
-    let probe = r#"
-read -r request
-printf '{"point":"drive","body":{"next":{"halt":{"reason":"key=%s inherited=%s ordinary=%s"}}}}\n' \
-  "${ANTHROPIC_API_KEY:+1}0" "${STELLA_DRIVER_INHERITANCE_PROBE:+1}0" "${STELLA_DRIVER_ROLE:+1}0"
-"#;
-
     let admitted = SubprocessDriver::declare(
-        vec!["/bin/sh".into(), "-c".into(), probe.into()],
+        argv(&[
+            "drive-env-probe",
+            "ANTHROPIC_API_KEY",
+            "STELLA_DRIVER_INHERITANCE_PROBE",
+            "STELLA_DRIVER_ROLE",
+        ]),
         vec![
             // Declared by the manifest, and refused: a credential.
             ("ANTHROPIC_API_KEY".into(), "sk-must-not-arrive".into()),
@@ -618,19 +542,14 @@ printf '{"point":"drive","body":{"next":{"halt":{"reason":"key=%s inherited=%s o
 async fn a_driver_that_talks_after_deciding_does_not_wedge_the_session() {
     let budget = Duration::from_secs(8);
     let trailing_past_one_pipe_buffer = 3 * 64 * 1024;
-    let script = format!(
-        "read -r request\n\
-         printf '%s\\n' '{{\"point\":\"drive\",\"body\":{{\"next\":{{\"sleep\":{{\"secs\":60}}}}}}}}'\n\
-         yes stella | tr -d '\\n' | head -c {trailing_past_one_pipe_buffer}\n",
-    );
-
     let started = Instant::now();
-    let response = ungated(&script, budget)
-        .drive(DriveRequest::new("cycle-28"))
-        .await
-        .expect(
-            "a driver that decided correctly and then kept talking is not lost to a pipe deadlock",
-        );
+    let response = ungated(
+        &["drive-trailing", &trailing_past_one_pipe_buffer.to_string()],
+        budget,
+    )
+    .drive(DriveRequest::new("cycle-28"))
+    .await
+    .expect("a driver that decided correctly and then kept talking is not lost to a pipe deadlock");
     let elapsed = started.elapsed();
 
     assert_eq!(

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -222,6 +222,96 @@ fn main() {
                  \"text\":\"granted {granted} refused {refused}\"}}]}}}}"
             ));
         }
+        // ── driver-socket conversations (`driver_socket.rs`, #4697) ──
+        //
+        // These answer at the `drive` point rather than `before_turn`, and
+        // each exits 1 on an answer it did not expect. That is the scripts'
+        // own discipline and it is kept: a driver that reads an unexpected
+        // answer and carries on would turn a host fault into a plausible
+        // decision, which is the thing this file exists to catch.
+
+        // Confirms the request named its session, asks a declared capability,
+        // and sleeps on a served answer.
+        "drive-sleep" => {
+            let request = read_line();
+            if !request.contains("\"session\":\"cycle-17\"") {
+                eprintln!("the driver was not told which session it is in");
+                std::process::exit(1);
+            }
+            emit("{\"call\":\"backlog_next\",\"id\":1}");
+            let answer = read_line();
+            if !(answer.contains("\"result\":1") && answer.contains("ok")) {
+                eprintln!("the host did not perform the declared capability: {answer}");
+                std::process::exit(1);
+            }
+            emit("{\"point\":\"drive\",\"body\":{\"next\":{\"sleep\":{\"secs\":900}}}}");
+        }
+        // Asks something it never declared, reads the refusal, then degrades
+        // to what it may do — a refusal is a value, never a death.
+        "drive-degrade" => {
+            let _request = read_line();
+            emit("{\"call\":\"deliver_merge\",\"id\":1}");
+            let refused = read_line();
+            if !refused.contains("\"refusal\":\"undeclared\"") {
+                eprintln!("a capability this driver never declared was performed: {refused}");
+                std::process::exit(1);
+            }
+            emit("{\"call\":\"backlog_file\",\"id\":2}");
+            let served = read_line();
+            let reason = if served.contains("\"result\":2") && served.contains("ok") {
+                "merge was not granted; filed the finding and stopped"
+            } else {
+                "the session died on a refusal"
+            };
+            emit(&drive_halt(reason));
+        }
+        // Reads a refusal the host gives for a capability it cannot serve at
+        // all, and halts with what it was told.
+        "drive-unsupported" => {
+            let _request = read_line();
+            emit("{\"call\":\"backlog_next\",\"id\":1}");
+            let answer = read_line();
+            let reason = if answer.contains("\"refusal\":\"unsupported\"") {
+                "the host has no backlog yet".to_string()
+            } else {
+                format!("unexpected: {}", answer.trim())
+            };
+            emit(&drive_halt(&reason));
+        }
+        // Asks twice so the second meets a ceiling the first spent.
+        "drive-allowance" => {
+            let _request = read_line();
+            emit("{\"call\":\"backlog_next\",\"id\":1}");
+            let _first = read_line();
+            emit("{\"call\":\"backlog_next\",\"id\":2}");
+            let second = read_line();
+            let reason = if second.contains("\"refusal\":\"allowance-spent\"") {
+                "one ask per session here"
+            } else {
+                "the ceiling did not hold"
+            };
+            emit(&drive_halt(reason));
+        }
+        // Reads the request to EOF rather than by line — a driver that asks
+        // nothing, so the host closes and this must still decide.
+        "drive-eof" => {
+            let request = read_request();
+            let reason = if request.contains("\"point\":\"drive\"") {
+                "read the whole session request to EOF"
+            } else {
+                "unexpected request"
+            };
+            emit(&drive_halt(reason));
+        }
+        // Asks a capability the host never announced, reads whatever comes
+        // back, and decides anyway. The host is expected to fail the session
+        // before this decision is ever read.
+        "drive-unannounced" => {
+            let _request = read_line();
+            emit("{\"call\":\"backlog_next\",\"id\":1}");
+            let _answer = read_line();
+            emit(&drive_halt("unreachable"));
+        }
         "call-once" => {
             let _request = read_line();
             emit(arg(&args, 1));
@@ -394,6 +484,50 @@ fn main() {
         "candidate-probe" => candidate_probe(&read_request()),
         "flood" => flood(arg(&args, 1).parse().unwrap_or(0), arg(&args, 2)),
         "trailing" => trailing(arg(&args, 1).parse().unwrap_or(0)),
+        // A driver that decides, then keeps writing past its answer. Reads
+        // the request first so the host has asked before the flood starts.
+        // The driver-socket twin of `ask-forever`. Separate rather than
+        // shared because the two sockets have different vocabularies:
+        // `recall` is a wrapper capability and the driver's decoder refuses
+        // it by name, so reusing that mode here fails on a decode error
+        // instead of on the budget the test is about.
+        // Reports which of three named variables reached the driver, as
+        // `10` present / `0` absent — the `${NAME:+1}0` idiom, which states
+        // a variable's *absence* without ever putting its value on the wire.
+        // A credential must read `0` here, so the mode can never be allowed
+        // to echo what it found.
+        "drive-env-probe" => {
+            let _request = read_line();
+            let present = |name: &str| {
+                if std::env::var_os(name).is_some() {
+                    "10"
+                } else {
+                    "0"
+                }
+            };
+            emit(&drive_halt(&format!(
+                "key={} inherited={} ordinary={}",
+                present(arg(&args, 1)),
+                present(arg(&args, 2)),
+                present(arg(&args, 3)),
+            )));
+        }
+        "drive-ask-forever" => {
+            let _request = read_line();
+            loop {
+                emit("{\"call\":\"backlog_next\",\"id\":1}");
+                if read_line().is_empty() {
+                    return;
+                }
+            }
+        }
+        "drive-trailing" => {
+            let _request = read_line();
+            trailing_after(
+                "{\"point\":\"drive\",\"body\":{\"next\":{\"sleep\":{\"secs\":60}}}}",
+                arg(&args, 1).parse().unwrap_or(0),
+            );
+        }
         "background" => background(arg(&args, 1)),
         "heartbeat" => heartbeat(arg(&args, 1)),
         other => {
@@ -440,6 +574,13 @@ fn emit(message: &str) {
     let mut stdout = std::io::stdout();
     let _ = writeln!(stdout, "{message}");
     let _ = stdout.flush();
+}
+
+/// A `drive` response that halts with this reason.
+fn drive_halt(reason: &str) -> String {
+    format!(
+        "{{\"point\":\"drive\",\"body\":{{\"next\":{{\"halt\":{{\"reason\":\"{reason}\"}}}}}}}}"
+    )
 }
 
 /// A `before_turn` response carrying one `note`-labelled context line.
@@ -628,7 +769,17 @@ fn flood(bytes: usize, heartbeat_path: &str) -> ! {
 /// Answer the point correctly, then keep writing to stdout past the pipe
 /// buffer the host has stopped draining.
 fn trailing(bytes: usize) {
-    emit("{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1,\"context\":[]}}");
+    trailing_after(
+        "{\"point\":\"before_turn\",\"body\":{\"protocol_version\":1,\"context\":[]}}",
+        bytes,
+    );
+}
+
+/// [`trailing`] over an answer the caller chooses — `driver_socket.rs` needs
+/// the same deadlock reproduced after a `drive` answer, which is a different
+/// point and so a different literal.
+fn trailing_after(answer: &str, bytes: usize) {
+    emit(answer);
     let mut stdout = std::io::stdout();
     let chunk = vec![b'a'; 8 * 1024];
     let mut written = 0;


### PR DESCRIPTION
Eleven of twelve for #4697, and the largest file in the series: eight scripted conversations, an environment probe, and two loops.

## What reused, what is new

Two sites reuse existing modes — `call-once` for the driver that asks and walks away, `exit` for the one that dies loudly. Six are new `drive`-point conversations, and every one keeps the scripts' **exit-1-on-unexpected**. That discipline is the file's subject: a driver that reads an answer it did not expect and carries on turns a host fault into a plausible decision.

## The mistake worth reporting

I first reused `ask-forever` for the endless-ask case. The test refused it:

```
Decode { answer: "{\"call\":\"recall\",...}",
         source: unknown variant `recall`, expected one of `backlog_next`, `backlog_claim`, … }
```

`recall` is a **wrapper** capability; the driver socket has its own vocabulary and its decoder rejects the foreign name. So the session died on a decode error rather than on the budget the test is about — a green would have been meaningless, and the test caught it instead. `drive-ask-forever` is now a separate mode, with the reason written at both.

That is the sharing risk I flagged on #4887 landing for real: two sockets that look alike are not interchangeable, and the fixture now says which is which.

## Ablation

The environment probe pinned to all-absent:

```
test a_driver_is_denied_the_model_credential_and_inherits_none_from_the_host ... FAILED
test result: FAILED. 12 passed; 1 failed
```

That test asserts a credential does **not** reach the child, so a probe that always reports absence would pass it while proving nothing. It fails, which is what makes the port evidence.

## Evidence

```
cargo test -p stella-runtime --test driver_socket   13 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings   exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)    exit 0
cargo fmt --all --check   exit 0
check-prose               OK — none added
```

Zero `/bin/sh` references remain in the file. Added to `windows-check.yml`.

One file left in #4697: `wrapper_candidate_fanout`. No test deleted or renamed.

Refs #4697, #3497

## Summary by Sourcery

Port the driver socket integration suite to Windows and broaden its coverage with cross-platform scripted driver conversations.

New Features:
- Run the driver socket integration tests on Windows using the cross-platform plugin fixture.
- Add scripted driver conversations covering capability refusals, unsupported calls, call limits, EOF handling, endless requests, environment isolation, and trailing output.

Bug Fixes:
- Remove the Unix-only shell dependency from the driver socket test suite.

Enhancements:
- Strengthen driver conversation fixtures so unexpected responses fail explicitly instead of producing misleading decisions.

CI:
- Include the driver_socket test target in the Windows check workflow.

Tests:
- Expand driver socket coverage across eight driver modes, including session timeout and environment credential isolation.