### PR TITLE
fix(stella-diff,stella-transcript): point the golden matrices at the arenabench repo

### DIFF
--- a/crates/stella-diff/tests/fixtures/view-plan-matrix.txt
+++ b/crates/stella-diff/tests/fixtures/view-plan-matrix.txt
@@ -1,8 +1,10 @@
 # stella_diff::view::plan over a fixed matrix.
 # Generated — re-bless with:
 #   BLESS=1 cargo test -p stella-diff --test view_plan_matrix
-# The TypeScript port must reproduce this byte for byte:
-#   node arenabench/ui/scripts/check-diff-view-parity.mjs
+# The TypeScript port must reproduce this byte for byte. It lives in
+# github.com/macanderson/arenabench, which vendors this file as
+# `ui/golden/view-plan-matrix.txt`; from that repo's `ui/`:
+#   node scripts/check-diff-view-parity.mjs
 # `fold` is the index the elision marker precedes, or `-` for none.
 total=15 step=3 cap=0 shown=[] hidden=15 fold=0
 total=15 step=3 cap=1 shown=[0-1] hidden=14 fold=1

--- a/crates/stella-diff/tests/view_plan_matrix.rs
+++ b/crates/stella-diff/tests/view_plan_matrix.rs
@@ -6,9 +6,10 @@
 //!
 //! [`stella_diff::view::plan`] decides how much of a diff every Stella surface
 //! draws and which part. Four surfaces consume it in Rust; a fifth, the arena
-//! transcript, reimplements it in TypeScript
-//! (`arenabench/ui/lib/diff-view.ts::selectDiffLines`) because that page is a
-//! Next.js client with no way to call into the workspace. Two implementations
+//! transcript, reimplements it in TypeScript (`ui/lib/diff-view.ts::selectDiffLines`
+//! in github.com/macanderson/arenabench, where that page went with the
+//! ejection) because it is a Next.js client with no way to call into the
+//! workspace. Two implementations
 //! of one policy, and an arena transcript is read *beside* the deck and the
 //! Observatory when someone is arguing about a run — so drift there means one
 //! edit looking like two.
@@ -18,9 +19,10 @@
 //! - this test regenerates the matrix and asserts it still matches
 //!   `tests/fixtures/view-plan-matrix.txt`, so a Rust change to the policy
 //!   cannot land without consciously re-blessing the golden;
-//! - `arenabench/ui/scripts/check-diff-view-parity.mjs` runs the TypeScript
-//!   over the same matrix and asserts it reproduces that same file, so a
-//!   re-blessed golden fails the TypeScript until it is ported.
+//! - the arenabench repo vendors it as `ui/golden/view-plan-matrix.txt`, and
+//!   its `ui/scripts/check-diff-view-parity.mjs` runs the TypeScript over the
+//!   same matrix and asserts it reproduces that same file, so a re-blessed
+//!   golden here fails the TypeScript there until it is synced and ported.
 //!
 //! Re-bless with `BLESS=1 cargo test -p stella-diff --test view_plan_matrix`,
 //! and then **read the diff**: a golden blessed without looking is a
@@ -65,8 +67,10 @@ fn render_matrix() -> String {
         "# stella_diff::view::plan over a fixed matrix.\n\
          # Generated — re-bless with:\n\
          #   BLESS=1 cargo test -p stella-diff --test view_plan_matrix\n\
-         # The TypeScript port must reproduce this byte for byte:\n\
-         #   node arenabench/ui/scripts/check-diff-view-parity.mjs\n\
+         # The TypeScript port must reproduce this byte for byte. It lives in\n\
+         # github.com/macanderson/arenabench, which vendors this file as\n\
+         # `ui/golden/view-plan-matrix.txt`; from that repo's `ui/`:\n\
+         #   node scripts/check-diff-view-parity.mjs\n\
          # `fold` is the index the elision marker precedes, or `-` for none.\n",
     );
     for &(total, step) in MATRIX {

--- a/crates/stella-transcript/tests/fixtures/word-highlight-matrix.txt
+++ b/crates/stella-transcript/tests/fixtures/word-highlight-matrix.txt
@@ -1,8 +1,10 @@
 # stella_transcript::word::highlight over a fixed matrix.
 # Generated — re-bless with:
 #   BLESS=1 cargo test -p stella-transcript --test word_highlight_matrix
-# The TypeScript port must reproduce this byte for byte:
-#   node arenabench/ui/scripts/check-word-highlight-parity.mjs
+# The TypeScript port must reproduce this byte for byte. It lives in
+# github.com/macanderson/arenabench, which vendors this file as
+# `ui/golden/word-highlight-matrix.txt`; from that repo's `ui/`:
+#   node scripts/check-word-highlight-parity.mjs
 # Inputs are not echoed; `cases()`/`blocks()` are mirrored in the port.
 pair=identical old=plain("let x = 1;")
 pair=identical new=plain("let x = 1;")

--- a/crates/stella-transcript/tests/word_highlight_matrix.rs
+++ b/crates/stella-transcript/tests/word_highlight_matrix.rs
@@ -9,9 +9,11 @@
 //! [`stella_transcript::file_diff`]'s change-block pairing decides which
 //! removal is compared with which addition. Every Rust surface consumes those
 //! two directly. A sixth surface, the arena transcript, reimplements them in
-//! TypeScript (`arenabench/ui/lib/word-highlight.ts`) because that page is a
-//! Next.js client with no way to call into the workspace — the same situation,
-//! and the same remedy, as `stella-diff`'s `view-plan-matrix` (#3558).
+//! TypeScript (`ui/lib/word-highlight.ts` in
+//! github.com/macanderson/arenabench, where that page went with the ejection)
+//! because it is a Next.js client with no way to call into the workspace — the
+//! same situation, and the same remedy, as `stella-diff`'s `view-plan-matrix`
+//! (#3558).
 //!
 //! Before this existed the TypeScript port had **no** word highlighting at all
 //! and no mechanism to notice: `transcript-page.tsx` was whole-line tint only,
@@ -24,9 +26,11 @@
 //! - this test regenerates the matrix and asserts it still matches
 //!   `tests/fixtures/word-highlight-matrix.txt`, so a Rust change to the rules
 //!   cannot land without consciously re-blessing the golden;
-//! - `arenabench/ui/scripts/check-word-highlight-parity.mjs` runs the
-//!   TypeScript over the same matrix and asserts it reproduces that same file,
-//!   so a re-blessed golden fails the TypeScript until it is ported.
+//! - the arenabench repo vendors it as `ui/golden/word-highlight-matrix.txt`,
+//!   and its `ui/scripts/check-word-highlight-parity.mjs` runs the TypeScript
+//!   over the same matrix and asserts it reproduces that same file, so a
+//!   re-blessed golden here fails the TypeScript there until it is synced and
+//!   ported.
 //!
 //! Re-bless with
 //! `BLESS=1 cargo test -p stella-transcript --test word_highlight_matrix`,
@@ -201,8 +205,10 @@ fn render_matrix() -> String {
         "# stella_transcript::word::highlight over a fixed matrix.\n\
          # Generated — re-bless with:\n\
          #   BLESS=1 cargo test -p stella-transcript --test word_highlight_matrix\n\
-         # The TypeScript port must reproduce this byte for byte:\n\
-         #   node arenabench/ui/scripts/check-word-highlight-parity.mjs\n\
+         # The TypeScript port must reproduce this byte for byte. It lives in\n\
+         # github.com/macanderson/arenabench, which vendors this file as\n\
+         # `ui/golden/word-highlight-matrix.txt`; from that repo's `ui/`:\n\
+         #   node scripts/check-word-highlight-parity.mjs\n\
          # Inputs are not echoed; `cases()`/`blocks()` are mirrored in the port.\n",
     );
     for (label, old, new) in cases() {


### PR DESCRIPTION
## What & why

`crates/stella-diff/tests/fixtures/view-plan-matrix.txt` and
`crates/stella-transcript/tests/fixtures/word-highlight-matrix.txt` each carried a
header naming `arenabench/ui/scripts/*.mjs`, a path that left this tree with the
ArenaBench ejection (#2380). Those header bytes are written by the Rust test's own
literal (`view_plan_matrix.rs`'s `render_matrix`, `word_highlight_matrix.rs`'s
`render_matrix`), not stored only in the fixture, so re-blessing alone would have
reproduced them. The literal and the module doc are edited first; the bless follows.

Each header now names github.com/macanderson/arenabench, the vendored `ui/golden/`
copy its checker compares against, and the command as run from that repo's `ui/`.

Closes #4707

## The witness

The matrix tests are their own witness: the golden is compared byte for byte, so the
edited literal fails against the committed fixture and passes once blessed.

Before blessing (old fixture, new literal):

```
$ cargo test -p stella-diff --test view_plan_matrix
test the_view_policy_still_matches_its_committed_matrix ... FAILED

thread '...' panicked at crates/stella-diff/tests/view_plan_matrix.rs:136:5:
the view policy no longer matches .../fixtures/view-plan-matrix.txt.
  golden: # The TypeScript port must reproduce this byte for byte:
  now:    # The TypeScript port must reproduce this byte for byte. It lives in
test result: FAILED. 1 passed; 1 failed
```

```
$ cargo test -p stella-transcript --test word_highlight_matrix
test the_word_rules_still_match_their_committed_matrix ... FAILED

thread '...' panicked at crates/stella-transcript/tests/word_highlight_matrix.rs:291:5:
word highlighting no longer matches .../fixtures/word-highlight-matrix.txt.
  golden: # The TypeScript port must reproduce this byte for byte:
  now:    # The TypeScript port must reproduce this byte for byte. It lives in
test result: FAILED. 1 passed; 1 failed
```

After `BLESS=1`, both are green:

```
test the_view_policy_still_matches_its_committed_matrix ... ok
test result: ok. 2 passed; 0 failed
test the_word_rules_still_match_their_committed_matrix ... ok
test result: ok. 2 passed; 0 failed
```

The blessed diff moves the header lines and nothing else — six lines in each
fixture, all inside the comment block.

## The gate

- [x] `cargo fmt --all`
- [x] `cargo test -p stella-diff --test view_plan_matrix`, `cargo test -p stella-transcript --test word_highlight_matrix`
- [x] `python3 scripts/check-prose.py` — OK, none added
- [x] `Closes #4707` appears above and as a commit trailer

Clippy and the workspace test suite are CI's, per CLAUDE.md's "CI builds and tests;
this laptop does not".

## Deleted tests

None.

## Nothing left behind

- The other half of #4707 is cross-repo: macanderson/arenabench holds its own copies
  of both headers (in `ui/scripts/check-diff-view-parity.mjs` and
  `ui/scripts/check-word-highlight-parity.mjs`) and the vendored goldens under
  `ui/golden/`. A companion PR there carries the same four lines. That repo's check
  compares its own render against its own vendored golden, so it stays self-consistent
  either way — nothing here waits on it.

## Anything reviewers should know?

The fixtures are golden files; read the diff rather than the stat. Only the comment
header moved.

## Summary by Sourcery

Point the Stella parity matrices and their documentation at the relocated ArenaBench implementation and vendored goldens.

Bug Fixes:
- Update the view-plan and word-highlight golden matrix headers to reference the arenabench repository and its vendored golden files after the ArenaBench ejection.

Enhancements:
- Clarify the cross-repository parity workflow and commands in the associated test documentation and generated matrix headers.

Tests:
- Re-bless both golden fixtures so they match the updated matrix headers.