### PR TITLE
test(stella-runtime): wrapper_candidate_fanout runs on Windows, closing the #4697 port series

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -131,6 +131,7 @@ jobs:
           --test wrapper_host_call
           --test wrapper_child_turn
           --test driver_socket
+          --test wrapper_candidate_fanout
 
       - name: the group-kill guard at the bash/custom-tool/hook spawn sites, on Windows (#4698)
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}

--- a/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
+++ b/crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs
@@ -222,6 +222,57 @@ fn main() {
                  \"text\":\"granted {granted} refused {refused}\"}}]}}}}"
             ));
         }
+        // ── candidate fan-out (`wrapper_candidate_fanout.rs`, #4697) ──
+
+        // Best-of-N on the socket: ask for three attempts, score them from the
+        // evidence the answer carries, adopt the winner by handle. The scoring
+        // is deliberately crude — the claim under test is that a plugin can
+        // reach a winner from the wire alone, never that it picks well.
+        "fanout-adopt" => {
+            let _request = read_line();
+            emit(concat!(
+                r#"{"call":"candidate_fanout","id":7,"args":{"role":"attempt","#,
+                r#""instruction":"make tests/test_flip.py pass","width":3}}"#
+            ));
+            let answer = read_line();
+            let green = answer.contains(concat!(
+                r#""candidate":"candidate-2","root":"/tmp/stella-candidates/candidate-2","#,
+                r#""report":"green"#
+            ));
+            if !green {
+                emit(&labelled_context("candidates", "no green candidate"));
+                return;
+            }
+            emit(r#"{"call":"adopt_candidate","id":8,"args":{"candidate":"candidate-2"}}"#);
+            let applied = read_line();
+            let note = if applied.contains(r#""adopted":"candidate-2""#) {
+                "landed candidate-2 of 3"
+            } else {
+                "the adoption did not land"
+            };
+            emit(&labelled_context("candidates", note));
+        }
+        // Asks for a width over the host's ceiling and reports both numbers:
+        // what it asked for, read back from the answer, and how many candidates
+        // the answer actually named.
+        "fanout-clamp" => {
+            let _request = read_line();
+            emit(concat!(
+                r#"{"call":"candidate_fanout","id":1,"args":{"role":"attempt","#,
+                r#""instruction":"try it","width":8}}"#
+            ));
+            let answer = read_line();
+            let asked = if answer.contains(r#""requested":8"#) {
+                "8"
+            } else {
+                "?"
+            };
+            let ran = answer.matches(r#""candidate":"candidate-"#).count();
+            emit(&labelled_context(
+                "candidates",
+                &format!("asked {asked}, ran {ran}"),
+            ));
+        }
         // ── driver-socket conversations (`driver_socket.rs`, #4697) ──
         //
         // These answer at the `drive` point rather than `before_turn`, and
@@ -583,12 +634,17 @@ fn drive_halt(reason: &str) -> String {
     )
 }
 
-/// A `before_turn` response carrying one `note`-labelled context line.
-fn note_context(note: &str) -> String {
+/// A `before_turn` response carrying one context line under this label.
+fn labelled_context(label: &str, text: &str) -> String {
     format!(
         "{{\"point\":\"before_turn\",\"body\":{{\"protocol_version\":1,\
-         \"context\":[{{\"label\":\"note\",\"text\":\"{note}\"}}]}}}}"
+         \"context\":[{{\"label\":\"{label}\",\"text\":\"{text}\"}}]}}}}"
     )
+}
+
+/// A `before_turn` response carrying one `note`-labelled context line.
+fn note_context(note: &str) -> String {
+    labelled_context("note", note)
 }
 
 /// An `after_turn` response carrying exactly these measurements.

--- a/crates/stella-runtime/tests/host_owned_tamper.rs
+++ b/crates/stella-runtime/tests/host_owned_tamper.rs
@@ -54,6 +54,9 @@ proven = "a witness test failed before the change and passes after it"
 [oracle]
 flip = "required"
 
+# The manifest requires an argv; nothing here spawns it. These tests drive
+# the wrapper through a transport they construct themselves, so the string
+# is parsed and never reached — which is why it stays portable on Windows.
 [runtime]
 argv = ["/bin/sh", "-c", "true"]
 timeout_secs = 60

--- a/crates/stella-runtime/tests/wrapper_candidate_fanout.rs
+++ b/crates/stella-runtime/tests/wrapper_candidate_fanout.rs
@@ -24,10 +24,6 @@
 //! three things the plugin contributed are the three fields
 //! `CandidateFanoutArgs` has.
 //!
-//! `cfg(unix)` is the same declared gap the rest of this suite carries, tracked
-//! in #3497.
-
-#![cfg(unix)]
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -215,9 +211,11 @@ fn host(
     (gate, plane)
 }
 
-fn plugin(script: &str, gate: Arc<HostCallGate>) -> SubprocessWrapper {
+const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
+
+fn plugin(mode: &str, gate: Arc<HostCallGate>) -> SubprocessWrapper {
     SubprocessWrapper::declare(
-        vec!["/bin/sh".into(), "-c".into(), script.into()],
+        vec![FIXTURE.to_string(), mode.to_string()],
         Vec::new(),
         Duration::from_secs(10),
     )
@@ -258,30 +256,7 @@ async fn a_plugin_asks_for_three_attempts_scores_them_and_the_host_lands_the_win
     let substrate = Substrate::default();
     let (gate, plane) = host(&manifest, substrate.clone(), Some(0.30));
 
-    // The plugin picks the candidate whose report is green and whose diff is
-    // smallest — a real (if crude) selection, made from the wire's evidence.
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"candidate_fanout","id":7,"args":{"role":"attempt","instruction":"make tests/test_flip.py pass","width":3}}'
-read -r answer
-winner=""
-case "$answer" in
-  *'"candidate":"candidate-2","root":"/tmp/stella-candidates/candidate-2","report":"green'*) winner="candidate-2" ;;
-esac
-if [ -z "$winner" ]; then
-  printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"candidates","text":"no green candidate"}]}}\n'
-  exit 0
-fi
-printf '{"call":"adopt_candidate","id":8,"args":{"candidate":"%s"}}\n' "$winner"
-read -r applied
-case "$applied" in
-  *'"adopted":"candidate-2"'*) note="landed candidate-2 of 3" ;;
-  *) note="the adoption did not land" ;;
-esac
-printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"candidates","text":"%s"}]}}\n' "$note"
-"#;
-
-    let response = plugin(script, Arc::clone(&gate))
+    let response = plugin("fanout-adopt", Arc::clone(&gate))
         .before_turn(before())
         .await
         .expect("the plugin asked twice, was answered twice, and answered the point");
@@ -440,19 +415,7 @@ async fn a_width_over_the_ceiling_is_clamped_and_the_clamp_is_reported_back() {
     let substrate = Substrate::default();
     let (gate, plane) = host(&manifest, substrate.clone(), None);
 
-    let script = r#"
-read -r request
-printf '%s\n' '{"call":"candidate_fanout","id":1,"args":{"role":"attempt","instruction":"try it","width":8}}'
-read -r answer
-case "$answer" in
-  *'"requested":8'*) asked="8" ;;
-  *) asked="?" ;;
-esac
-ran=$(printf '%s' "$answer" | tr ',' '\n' | grep -c '"candidate":"candidate-')
-printf '{"point":"before_turn","body":{"protocol_version":1,"context":[{"label":"candidates","text":"asked %s, ran %s"}]}}\n' "$asked" "$ran"
-"#;
-
-    let response = plugin(script, Arc::clone(&gate))
+    let response = plugin("fanout-clamp", Arc::clone(&gate))
         .before_turn(before())
         .await
         .expect("the plugin asked and was answered");

--- a/crates/stella-runtime/tests/wrapper_claimed_evidence.rs
+++ b/crates/stella-runtime/tests/wrapper_claimed_evidence.rs
@@ -60,6 +60,9 @@ proven = "a witness test failed before the change and passes after it"
 [oracle]
 flip = "required"
 
+# The manifest requires an argv; nothing here spawns it. These tests drive
+# the wrapper through a transport they construct themselves, so the string
+# is parsed and never reached — which is why it stays portable on Windows.
 [runtime]
 argv = ["/bin/sh", "-c", "true"]
 timeout_secs = 60

--- a/crates/stella-runtime/tests/wrapper_decided_flip.rs
+++ b/crates/stella-runtime/tests/wrapper_decided_flip.rs
@@ -66,6 +66,9 @@ proven = "a witness test failed before the change and passes after it"
 [oracle]
 flip = "required"
 
+# The manifest requires an argv; nothing here spawns it. These tests drive
+# the wrapper through a transport they construct themselves, so the string
+# is parsed and never reached — which is why it stays portable on Windows.
 [runtime]
 argv = ["/bin/sh", "-c", "true"]
 timeout_secs = 60


### PR DESCRIPTION
The last of twelve for #4697. Every `/bin/sh` wrapper test in `crates/stella-runtime/tests/` now runs on Windows.

Stacked on #4889 (eleventh) — both touch the fixture, and unstacked they would collide on adjacent insertions.

## The port

Two scripted conversations, both multi-exchange host calls:

- **`fanout-adopt`** — best-of-N: ask for three attempts, score them from the evidence the answer carries, adopt the winner by handle. The scoring is deliberately crude; the claim under test is that a plugin can reach a winner from the wire alone, never that it picks well.
- **`fanout-clamp`** — ask for a width over the host's ceiling and report both numbers: what it asked for, read back from the answer, and how many candidates the answer actually named.

`note_context` gained a general `labelled_context(label, text)` rather than a second near-copy of the same format string — these two label their line `candidates`, and two copies of one format string is how they drift apart.

## Ablation, including one that did not bite

I first ablated the adoption **echo** — made the plugin report `landed candidate-2 of 3` without reading the host's answer. It passed. That is not a weak port: the adoption is proven host-side by `Op::Adopted("candidate-2")`, the exactly-one assertion, the losers' `Op::Removed`, and `plane.live()` being empty. The plugin's echo was never the evidence, in the shell script either. Reporting it because "the ablation passed" is the kind of result that gets quietly dropped.

The ablation aimed at the load-bearing point does bite — adopting the loser:

```
test a_plugin_asks_for_three_attempts_scores_them_and_the_host_lands_the_winner ... FAILED
test result: FAILED. 7 passed; 1 failed
```

and pinning the clamp's count instead of counting:

```
test a_width_over_the_ceiling_is_clamped_and_the_clamp_is_reported_back ... FAILED
test result: FAILED. 7 passed; 1 failed
```

## The deferred question, settled

#4697 carried a question I held until every port was in view: several manifests declare `[runtime] argv = ["/bin/sh", "-c", "true"]` that nothing ever spawns.

Settled as **not a portability defect**: the manifest requires an argv, these tests construct their own transport, and the string is parsed and never reached — so it is inert on Windows. It still *reads* like a spawn, which is the trap. Three sites now carry the line that says so (`wrapper_claimed_evidence`, `wrapper_decided_flip`, `host_owned_tamper`); `wrapper_composition` already explained its own.

## Evidence

```
cargo test -p stella-runtime --test wrapper_candidate_fanout   8 passed; 0 failed
cargo test -p stella-runtime --test driver_socket             13 passed; 0 failed
cargo clippy -p stella-runtime --all-targets -- -D warnings    exit 0
cargo doc -p stella-runtime --no-deps (plain, after clean)     exit 0
cargo fmt --all --check    exit 0
check-prose                OK — none added
```

Added to `windows-check.yml`. No test deleted or renamed.

Closes #4697
Refs #3497

## Summary by Sourcery

Complete the Windows port of the candidate fan-out runtime wrapper tests.

Enhancements:
- Port the candidate fan-out wrapper integration tests to Windows by replacing shell-script plugins with a cross-platform Rust fixture.
- Generalize fixture context-message generation for reusable labelled output.
- Document that test manifests’ shell argv values are parsed but never spawned, preserving portability.

CI:
- Run the wrapper_candidate_fanout integration test in the Windows check workflow.

Tests:
- Enable the candidate fan-out test suite on Windows without deleting or renaming tests.