### PR TITLE
fix(bench): delete the launcher posture vocabulary nothing read

### DIFF
--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -447,23 +447,17 @@ _MANIFEST_CALIBRATION_FIELDS = frozenset(
     }
 )
 _MANIFEST_CONFIRMATORY_FIELDS = frozenset({"job_name", "n_concurrent_trials"})
+# The `engine_posture` record wrapping one posture — the only posture shape this
+# module states. The posture *inside* it is not described here by a field set:
+# `_validate_confirmatory_manifest_contract` rebuilds it with the adapter's own
+# `_benchmark_engine_posture` and compares the whole dict, roles and all, so a
+# key-name vocabulary beside that equality could only ever be weaker than the
+# check already running. The root keys the trusted launcher will accept at all
+# are `settings::ENGINE_ROOT_FIELDS` in `unknown.rs`, read from the Rust rather
+# than copied (`tests/test_posture.py::_engine_root_fields`); the required and
+# optional halves of the recorded posture are
+# `terminal_bench_analysis/tb21_posture_schema.py` (#4668).
 _ENGINE_POSTURE_RECORD_FIELDS = frozenset({"version", "posture", "sha256"})
-_ENGINE_POSTURE_FIELDS = frozenset(
-    {
-        "default_model",
-        "allowed_models",
-        "auto_mode",
-        "effort_auto",
-        "reasoning_auto",
-        "minimal_prompt",
-        "headless_scope_bypass",
-        "agents",
-    }
-)
-_ENGINE_POSTURE_AGENT_ROLES = frozenset({"default", "worker", "verifier", "triage"})
-# Every role is the same shape: #2411 took the output cap out of the posture, so
-# nothing is left for a `params` key to hold. `posture.py` is the normative home.
-_ENGINE_POSTURE_AGENT_FIELDS = frozenset({"effort", "reasoning"})
 RUNTIME_IDENTITY_FIELDS = frozenset(
     {
         "binary_sha256",

--- a/bench/harbor_adapter/tests/test_posture.py
+++ b/bench/harbor_adapter/tests/test_posture.py
@@ -15,6 +15,7 @@ metadata.
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import json
 import re
@@ -1000,6 +1001,63 @@ class TestWitnessArmEndToEnd:
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _BENCH_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "bench.yml"
 _UNKNOWN_RS = _REPO_ROOT / "crates" / "stella-cli" / "src" / "settings" / "unknown.rs"
+_SECURE_LAUNCHER_PY = (
+    _REPO_ROOT / "bench" / "harbor_adapter" / "stella_harbor" / "secure_launcher.py"
+)
+
+
+def _unread_private_module_constants(path: Path) -> list[str]:
+    """Module-level ``_NAME = ...`` bindings the module never loads again.
+
+    A private name has no importer outside the file by construction, so one
+    that is never loaded inside it is read by nothing at all — which is how a
+    schema the launcher looks like it enforces can sit beside the check that
+    actually runs and describe a different shape.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bound: list[str] = []
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id.startswith("_"):
+                bound.append(target.id)
+    loaded = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+    return sorted(name for name in bound if name not in loaded)
+
+
+class TestLauncherDeclaresNoVocabularyNothingReads:
+    """#4668: the launcher states a posture shape or it does not state one.
+
+    `_ENGINE_POSTURE_FIELDS` listed eight root keys and was referenced nowhere.
+    It read as the fail-closed schema and was not one, and it had drifted from
+    both authorities that are: `settings::ENGINE_ROOT_FIELDS` decides what the
+    trusted launcher accepts, and `tb21_posture_schema.py` splits the recorded
+    posture into required and optional halves — a split this set did not have,
+    so wiring it as written would have refused every posture omitting an
+    optional arm key. The check that does run is stronger than either: the
+    confirmatory manifest's posture is rebuilt with `_benchmark_engine_posture`
+    and compared whole.
+    """
+
+    def test_no_private_constant_in_the_launcher_is_read_by_nothing(self) -> None:
+        assert _unread_private_module_constants(_SECURE_LAUNCHER_PY) == []
+
+    def test_the_reader_finds_a_planted_dead_constant(self, tmp_path: Path) -> None:
+        """The guard's own witness: without this, an `ast` walk that silently
+        matched nothing would report a clean module forever."""
+        probe = tmp_path / "probe.py"
+        probe.write_text(
+            "_LIVE = 1\n_DEAD = 2\nPUBLIC = 3\nprint(_LIVE)\n", encoding="utf-8"
+        )
+        assert _unread_private_module_constants(probe) == ["_DEAD"]
 
 
 def _parse_rust_str_slice(source: str, const_name: str) -> frozenset[str]:


### PR DESCRIPTION
## What & why

`bench/harbor_adapter/stella_harbor/secure_launcher.py` declared three posture field
sets that nothing referenced: `_ENGINE_POSTURE_FIELDS`, `_ENGINE_POSTURE_AGENT_ROLES`,
`_ENGINE_POSTURE_AGENT_FIELDS`. #4668 gives two acceptable endings — wire them with a
required/optional split, or delete them and document the check that actually runs. This
takes the second, because wiring them would have been **weaker than what already runs**:

- `_validate_confirmatory_manifest_contract` builds the expected posture with the
  adapter's own `_benchmark_engine_posture` and compares the whole dict — once for the
  SUT record (`expected_sut["engine_posture"] = primary_posture[0]`, compared by
  `sut != expected_sut`) and once per calibration config
  (`expected_calibration_fixed["engine_postures_by_config"]`, compared by the
  `calibration.get(key) != value` sweep). Exact dict equality over the root keys, the
  `agents` map and every role row. A key-name vocabulary beside that can only agree
  with it.
- What the *trusted launcher* will accept is `settings::ENGINE_ROOT_FIELDS` in
  `unknown.rs`, read from the Rust rather than copied
  (`tests/test_posture.py::_engine_root_fields`).
- What a *recorded* posture must look like is `tb21_posture_schema.py`, which splits
  required from optional — the split the deleted set did not have. Its `minimal_prompt`
  entry, added by #4665, is **optional** there; requiring it (as a wired
  `_require_exact_object` would) would have refused every posture recorded before that
  arm existed.

`_ENGINE_POSTURE_RECORD_FIELDS` stays: it is wired, at the calibration-record check.

The launcher shrinks 4383 → 4377 lines, so nothing is spent against its ceiling.

Closes #4668

## The witness

`bench/harbor_adapter/tests/test_posture.py::TestLauncherDeclaresNoVocabularyNothingReads`
walks `secure_launcher.py` with `ast` and fails on any module-level private binding the
module never loads. It lives in `test_posture.py` because both `secure_launcher.py` and
`test_secure_launcher.py` are on their size ceilings.

Ablation — the fix reverted, the test kept:

```
$ git stash push -- bench/harbor_adapter/stella_harbor/secure_launcher.py
$ uv run --frozen pytest tests/test_posture.py -k VocabularyNothingReads -q

def test_no_private_constant_in_the_launcher_is_read_by_nothing(self) -> None:
>   assert _unread_private_module_constants(_SECURE_LAUNCHER_PY) == []
E   AssertionError: assert ['_ENGINE_POS...STURE_FIELDS'] == []
E     Left contains 3 more items, first extra item: '_ENGINE_POSTURE_AGENT_FIELDS'

1 failed, 1 passed, 45 deselected
```

With the fix:

```
$ uv run --frozen pytest tests/test_posture.py -q
47 passed
```

The second test in the class is the guard's own witness: it plants `_LIVE`, `_DEAD` and
`PUBLIC` in a `tmp_path` module and asserts the reader returns exactly `['_DEAD']`, so an
`ast` walk that silently matched nothing could not report a clean module forever.

## The gate

- [x] `bench/harbor_adapter`: `pytest tests/test_posture.py tests/test_manifest_parity.py` — green
- [x] `./scripts/check-file-size.sh` — OK, nothing went over
- [x] `python3 scripts/check-prose.py` — OK, none added
- [x] `Closes #4668` above and as a commit trailer

## Deleted tests

None.

## Nothing left behind

- Filed **#4894**: `PRIOR_STAGE_OUTCOME_FIELDS` and `PROVIDER_KEY_LIVE_SNAPSHOT_FIELDS`
  in the same file are unread too, and have been since #301. They are public names, so
  deleting one is an API change the private posture sets could not have been, and either
  may want wiring to a parse site rather than deletion — which is why the guard here is
  scoped to private names (a scope that needs no allow-list) and why they are a separate
  issue rather than more of this diff.

## Anything reviewers should know?

`tests/test_secure_launcher.py::test_missing_prior_readiness_job_never_reserves_or_execs`
and `…::test_forged_prior_readiness_artifacts_never_reserve_or_exec` fail on my machine
**on unmodified `origin/main` as well** — the raised message is `prior-stage replay
analyzer could not be loaded` where the test expects `prior Harbor job is missing`. I
have not established whether that is a real defect or a local environment artifact, so I
am reporting it rather than claiming it; the bench workflow's run on this PR is the
evidence that settles it, and I will file it if it reproduces there.

## Summary by Sourcery

Remove unused launcher posture vocabularies and add a regression guard against unread private constants.

Bug Fixes:
- Remove three unused private posture vocabulary constants from the secure launcher to prevent stale schema declarations from implying validation that does not occur.

Enhancements:
- Document the existing whole-dictionary posture validation and its authoritative schema sources.
- Add an AST-based regression guard that detects unread private module constants and verifies the guard itself works.

Tests:
- Add posture tests covering unused private constants in the launcher and the dead-constant detection helper.