### PR TITLE
A red-main repair can be claimed, so two sessions do not write it twice

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -174,6 +174,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-main-red-hold.sh
 
+      - name: the red-main claim pre-flight, standing-down branch included
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-main-red-claim.sh
+
       - name: measured-constants guard failure directions
         if: ${{ !cancelled() }}
         run: ./scripts/test-measured-constants.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,30 @@ hand; `make main-red-hold-test` covers it, blocking branch included. Reporting
 becomes holding only when a maintainer adds it to main's required checks —
 a repository setting, not a file in this tree.
 
-A seventh, `windows-check.yml`, is the only compiler in this project that
+The chain has a third link, and it is not a workflow: **before you repair a
+red `main`, check whether somebody already is.** On 2026-08-24 three sessions
+each wrote the same two-line fix for the same break and merged them 95 seconds
+apart (#4672, #4673, #4674). None was wrong — the hold means every session
+with an open PR notices the red at once, and they all reach the same correct
+conclusion. The canary's signal says `main` is broken; nothing said it was
+being fixed. `scripts/main-red-claim.sh` is that second signal, the
+`dispatch_claims` mechanic (#4300) with the tracker as the table:
+
+```bash
+./scripts/main-red-claim.sh check   # exit 0 proceed, 1 stand down
+./scripts/main-red-claim.sh claim   # check, then post the claim
+```
+
+A claim is a comment, so it carries an author and a timestamp, and it lapses
+after twenty minutes — an assignee would never lapse, and a crashed session
+would then hold the repair of a red `main` shut. Every unknown proceeds
+loudly: no `gh`, an unreachable tracker, an unreadable identity, two open
+`main-red` issues at once. That direction is the whole safety argument, since
+a claim check that can block a repair is worse than the duplication it
+prevents. `make main-red-claim` asks by hand; `make main-red-claim-test`
+covers it, standing-down branch included.
+
+An eighth, `windows-check.yml`, is the only compiler in this project that
 looks at a `#[cfg(windows)]` arm: `ci.yml` runs on `ubuntu-latest` and
 `release.yml`'s matrix is two Apple targets and two Linux ones, so every
 non-unix body in the tree — `rootfd.rs`'s and `durable_write.rs`'s string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,3 +215,14 @@
   toolchain-free guards (`make guards-fast`) compile nothing and are always
   fine. A PR's evidence is its CI run, so cite the run — a green workspace
   build on this laptop is not evidence, it is a cost.
+- **Before you repair a red `main`, ask whether somebody already is.** Run
+  `./scripts/main-red-claim.sh check`; if it stands you down, wait. If it
+  clears you, `./scripts/main-red-claim.sh claim` before you start writing,
+  so the next session reads your claim rather than colliding with it. Three
+  sessions each wrote the same two-line fix on 2026-08-24 and merged them 95
+  seconds apart (#4680); they composed by luck, because identical edits
+  resolve cleanly. Every session that notices red `main` reaches the same
+  correct conclusion at the same moment, which is why the check is a step
+  rather than a judgement. It fails open at every unknown, so it can never
+  be what stops a repair — see AGENTS.md § the canary for why a claim lapses
+  after twenty minutes instead of being an assignee.

--- a/Makefile
+++ b/Makefile
@@ -754,6 +754,18 @@ main-red-hold: ## Ask whether an open `main-red` issue should hold a PR (reads t
 main-red-hold-test: ## Test the red-main hold, blocking branch included (hermetic; not part of `gate`)
 	./scripts/test-main-red-hold.sh
 
+# The third signal in the red-main chain: the canary detects, the hold stops
+# a merge, and this stops a second session writing the same patch (#4680).
+# Not a gate step for the same reason as the other two — it reads the tracker,
+# and it informs a decision made before CI has anything to look at.
+.PHONY: main-red-claim
+main-red-claim: ## Ask whether somebody is already repairing a red `main` (reads the tracker)
+	@./scripts/main-red-claim.sh check
+
+.PHONY: main-red-claim-test
+main-red-claim-test: ## Test the red-main claim pre-flight, standing-down branch included (hermetic; not part of `gate`)
+	./scripts/test-main-red-claim.sh
+
 .PHONY: check
 check: $(GATE_GUARDS) $(GATE_NO_BUILD) lint ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy, no rustdoc and no tests
 	@./scripts/check-hooks-installed.sh

--- a/scripts/main-red-claim.sh
+++ b/scripts/main-red-claim.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# The pre-flight a session runs before it repairs a red `main`: is someone
+# already fixing this? See #4680, filed from the incident.
+#
+# On 2026-08-24 `main` was red from a single two-line composition break, and
+# three separate PRs fixed it independently, all merging inside 95 seconds:
+#
+#   18:13:22  #4672 — box the two AgentEvent literals the #4612 witness left bare
+#   18:13:—   #4673 — box the two FleetMsg::Event payloads #4663 added
+#   18:13:48  #4674 — box the two FleetMsg::Event values its own tests build
+#
+# All three changed the same two call sites in
+# `crates/stella-tui/src/fleet_dashboard/tests.rs` in the same way. The merges
+# happened to compose, because identical edits resolve cleanly, so it cost
+# duplicated work rather than correctness. It could as easily not have.
+#
+# Nobody was wrong. `main-canary.yml` files one `main-red` issue and
+# `main-red-hold.yml` consumes it to hold merges — and with the hold in place
+# every session holding an open PR notices the red at once, reaches the same
+# correct conclusion, and writes the same patch. The signal said "main is
+# broken"; no signal said "and it is being fixed". This file is that second
+# signal. It is the `dispatch_claims` mechanic (#4300) with the tracker as
+# the table, which is the one store every session already shares.
+#
+# ## Why a lapsing comment, and not an assignee or a linked PR
+#
+# Both alternatives were live in #4680 and both fail on this incident:
+#
+#   - An **assignee** never lapses. A session that crashes mid-repair holds
+#     the claim until a human clears it, and the thing it is holding shut is
+#     the repair of a red `main` — a deadlock the constraint below forbids.
+#   - A **linked PR** cannot be seen until a branch is pushed, and all three
+#     patches above were written before any of them opened. The window this
+#     is meant to close is the window where there is nothing to link to yet.
+#
+# A comment carries an author and a timestamp, which are exactly the two facts
+# the decision needs, and the window makes a crashed claim expire on its own.
+# Twenty minutes is long enough to write a two-line fix and short enough that
+# a dead session is not in the way for a second incident.
+#
+# ## Fail-open, deliberately, at every unknown
+#
+# Anything this cannot answer means PROCEED, loudly. An unreachable tracker, a
+# `gh` that is not installed, an identity it cannot read, two open `main-red`
+# issues at once: each prints a note and exits 0. That is not caution about
+# GitHub's uptime, it is the ordering of costs — duplicated work is what this
+# prevents, and a blocked repair is worse than what it prevents. Standing a
+# session down is reserved for the one case it can actually establish: a
+# claim, by somebody else, inside the window.
+#
+# ## What this is NOT
+#
+# It does not open, merge or label anything, it compiles nothing, and it is
+# not a gate step — no CI job runs it, because the decision it informs is made
+# by whoever is about to write the patch, before CI has anything to look at.
+#
+# Usage:
+#   scripts/main-red-claim.sh check            # exit 0 proceed, 1 stand down
+#   scripts/main-red-claim.sh claim            # check, then claim it
+#   scripts/main-red-claim.sh check --window-minutes 20
+#   scripts/main-red-claim.sh check --fixture-open-issues "4671" \
+#                                   --fixture-login "ada" \
+#                                   --fixture-claims "grace 300"
+#
+# Uses portable POSIX tools plus `gh` so it runs anywhere a clone does. The
+# staleness arithmetic is done by `gh --jq`, not by `date`, because `date -d`
+# and `date -j` disagree across the platforms this repository is cloned on.
+set -uo pipefail
+
+label="main-red"
+marker="main-red-claim:"
+mode=""
+window_minutes=20
+fixture_open_issues=""
+fixture_login=""
+fixture_claims=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  check | claim)
+    mode="$1"
+    shift
+    ;;
+  --window-minutes)
+    [ $# -ge 2 ] || {
+      echo "main-red-claim: --window-minutes needs a number" >&2
+      exit 2
+    }
+    window_minutes="$2"
+    shift 2
+    ;;
+  # Test-only seams. Supplying any one of them stubs the tracker entirely: a
+  # test that stubbed the issue list but let the comment lookup reach the
+  # network would pass or fail for a reason the test did not choose — the
+  # same trap check-main-red-hold.sh's paired fixtures avoid.
+  --fixture-open-issues)
+    [ $# -ge 2 ] || {
+      echo "main-red-claim: --fixture-open-issues needs a value" >&2
+      exit 2
+    }
+    fixture_open_issues="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-login)
+    [ $# -ge 2 ] || {
+      echo "main-red-claim: --fixture-login needs a value" >&2
+      exit 2
+    }
+    fixture_login="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  # Zero or more `<login> <age-seconds>` pairs, newline-separated, in any
+  # order: the freshest is picked by age, not by position.
+  --fixture-claims)
+    [ $# -ge 2 ] || {
+      echo "main-red-claim: --fixture-claims needs a value" >&2
+      exit 2
+    }
+    fixture_claims="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  -h | --help)
+    # The whole comment block after the shebang, bounded by its first
+    # non-comment line — hardcoded line numbers truncate silently the first
+    # time the header grows. Same reader as check-main-red-hold.sh's --help.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    echo "main-red-claim: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+[ -n "$mode" ] || mode="check"
+
+case "$window_minutes" in
+'' | *[!0-9]*)
+  echo "main-red-claim: --window-minutes takes a whole number of minutes" >&2
+  exit 2
+  ;;
+esac
+window_seconds=$((window_minutes * 60))
+
+# `proceed` is the only exit this script takes when it is unsure, so it is
+# one function rather than a repeated pair of lines that could drift apart.
+proceed() {
+  # SIGPIPE ignored and the write discarded, so a reader that closed the pipe
+  # cannot turn a proceed into a failure (the #1815 shape).
+  trap '' PIPE
+  echo "$1" || true
+  exit 0
+}
+
+if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  echo "note: gh is not installed, so this run could not ask whether the" >&2
+  echo "      repair is already claimed. Proceeding: a claim check that can" >&2
+  echo "      block a repair is worse than the duplication it prevents." >&2
+  proceed "ok  proceed (could not ask)"
+fi
+
+if [ "$use_fixture" -eq 1 ]; then
+  open_issues="$fixture_open_issues"
+elif ! open_issues="$(gh issue list --label "$label" --state open \
+  --limit 20 --json number --jq '.[].number' 2>/dev/null)"; then
+  echo "note: could not reach the issue tracker. Proceeding (fail-open); see" >&2
+  echo "      this script's header for why an unknown always means proceed." >&2
+  proceed "ok  proceed (tracker unreachable)"
+fi
+
+# Newlines to spaces, then squeezed — deliberately NOT `tr -d ' '`, which
+# check-main-red-hold.sh can afford because it only ever prints this list.
+# This one splits it, and deleting the separator turns "4671 4672" into the
+# single issue 46714672: two open issues would read as one unambiguous one,
+# and the ambiguity branch below could never fire. Caught by its own case.
+open_issues="$(printf '%s' "$open_issues" | tr '\n' ' ' | tr -s ' ')"
+open_issues="${open_issues# }"
+open_issues="${open_issues% }"
+
+if [ -z "$open_issues" ]; then
+  proceed "ok  no open \`$label\` issue — main is not known-broken."
+fi
+
+# More than one open `main-red` issue means the canary filed twice, or a human
+# filed alongside it. Which one a claim belongs on is then a judgement, and
+# guessing it would put the claim where the next session does not look.
+case "$open_issues" in
+*' '*)
+  echo "note: several open \`$label\` issues ($open_issues), so this run cannot" >&2
+  echo "      tell which one a repair claims. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (ambiguous: $open_issues)"
+  ;;
+esac
+issue="$open_issues"
+
+if [ "$use_fixture" -eq 1 ]; then
+  me="$fixture_login"
+elif ! me="$(gh api user --jq .login 2>/dev/null)"; then
+  me=""
+fi
+if [ -z "$me" ]; then
+  echo "note: could not read this session's login, so a claim on #$issue cannot" >&2
+  echo "      be told from one of its own. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (identity unknown)"
+fi
+
+# Every claim comment, as `<login> <age-in-seconds>`. The arithmetic is jq's:
+# `date` spells the same conversion two incompatible ways across macOS and
+# Linux, and this script is run from a clone on both.
+if [ "$use_fixture" -eq 1 ]; then
+  claims="$fixture_claims"
+elif ! claims="$(gh issue view "$issue" --json comments --jq "
+    .comments[]
+    | select(.body | startswith(\"$marker\"))
+    | \"\(.author.login) \((now - (.createdAt | fromdateiso8601)) | floor)\"
+  " 2>/dev/null)"; then
+  echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (comments unreadable)"
+fi
+
+# The freshest claim by anybody else. A claim of this session's own is not a
+# reason to stand it down: re-running the pre-flight is what a session does
+# when it comes back to the repair it already started.
+held_by=""
+held_age=""
+while read -r who age; do
+  [ -n "$who" ] || continue
+  [ "$who" = "$me" ] && continue
+  case "$age" in
+  '' | *[!0-9]*) continue ;;
+  esac
+  [ "$age" -lt "$window_seconds" ] || continue
+  if [ -z "$held_age" ] || [ "$age" -lt "$held_age" ]; then
+    held_by="$who"
+    held_age="$age"
+  fi
+done <<EOF
+$claims
+EOF
+
+if [ -n "$held_by" ]; then
+  minutes=$((held_age / 60))
+  echo "STAND DOWN  #$issue is already being repaired." >&2
+  echo "" >&2
+  echo "     claimed by @$held_by, ${minutes}m ago (window: ${window_minutes}m)" >&2
+  echo "" >&2
+  echo "     On 2026-08-24 three sessions each wrote the same two-line fix for" >&2
+  echo "     the same break and merged them 95 seconds apart (#4680). Every" >&2
+  echo "     one of them was reasoning correctly in isolation; what none of" >&2
+  echo "     them could see was the other two." >&2
+  echo "" >&2
+  echo "     What to do:" >&2
+  echo "       - Wait. The claim lapses by itself after ${window_minutes}m, so a" >&2
+  echo "         session that died mid-repair cannot hold this shut." >&2
+  echo "       - Repairing it anyway (the claim looks stale, or you are" >&2
+  echo "         fixing a second, separate break)? Say so on #$issue, so the" >&2
+  echo "         next session reads a reason rather than a collision." >&2
+  exit 1
+fi
+
+if [ "$mode" = "check" ]; then
+  proceed "ok  #$issue is unclaimed — the repair is yours to take."
+fi
+
+body="$marker $me
+Repairing this. The claim lapses after ${window_minutes} minutes, so it cannot
+hold the repair shut if this session dies (\`scripts/main-red-claim.sh\`, #4680)."
+
+if [ "$use_fixture" -eq 1 ]; then
+  proceed "ok  claimed #$issue as @$me (fixture: nothing was posted)"
+fi
+
+if ! gh issue comment "$issue" --body "$body" >/dev/null 2>&1; then
+  echo "note: could not post the claim on #$issue. Proceeding anyway: the" >&2
+  echo "      claim is an optimisation, and the repair is not." >&2
+  proceed "ok  proceed (claim not posted)"
+fi
+
+trap '' PIPE
+echo "ok  claimed #$issue as @$me" || true

--- a/scripts/main-red-claim.sh
+++ b/scripts/main-red-claim.sh
@@ -39,7 +39,7 @@
 # Twenty minutes is long enough to write a two-line fix and short enough that
 # a dead session is not in the way for a second incident.
 #
-# ## Fail-open, deliberately, at every unknown
+# ## Fail-open at every unknown
 #
 # Anything this cannot answer means PROCEED, loudly. An unreachable tracker, a
 # `gh` that is not installed, an identity it cannot read, two open `main-red`
@@ -174,7 +174,7 @@ elif ! open_issues="$(gh issue list --label "$label" --state open \
   proceed "ok  proceed (tracker unreachable)"
 fi
 
-# Newlines to spaces, then squeezed — deliberately NOT `tr -d ' '`, which
+# Newlines to spaces, then squeezed, and not `tr -d ' '` — which
 # check-main-red-hold.sh can afford because it only ever prints this list.
 # This one splits it, and deleting the separator turns "4671 4672" into the
 # single issue 46714672: two open issues would read as one unambiguous one,

--- a/scripts/test-main-red-claim.sh
+++ b/scripts/test-main-red-claim.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Hermetic tests for scripts/main-red-claim.sh.
+#
+#   ./scripts/test-main-red-claim.sh    (or: make main-red-claim-test)
+#
+# No network and no `gh`: every case drives the fixture seams, so the suite is
+# the same on a bare runner as on a dev box with a live tracker.
+#
+# The cases that matter most are the two controls, one on each side:
+#
+#   - the **positive** control — a fresh claim by somebody else must actually
+#     stand a session down. A pre-flight that cannot be shown to block is a
+#     comment, not a guard, and this one spends its life proceeding, because
+#     main is usually green.
+#   - the **negative** controls — every unknown must proceed. That is the
+#     whole safety argument (a claim check that can block a repair is worse
+#     than the duplication it prevents), and it is one branch per unknown, so
+#     it is one case per branch.
+#
+# Deliberately not a `make gate` step, matching `main-red-hold-test`: the
+# subject asks the issue tracker a question, and the gate is hermetic and
+# offline by contract.
+#
+# bash 3.2 compatible.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/main-red-claim.sh"
+
+pass=0
+fail=0
+
+ok() { printf '  \033[32m✓\033[0m %s\n' "$*"; pass=$((pass + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=$((fail + 1)); }
+
+# One assertion shape: run with every seam pinned and compare the exit code.
+# An expected block must also name its reason, because "exit 1" is satisfied
+# by a typo in the script just as well as by the case's own subject — the
+# discipline test-main-red-hold.sh applies to its blocking branch.
+want() { # want <name> <expect-proceed|expect-block> <want-substring> <mode> <issues> <login> <claims>
+  local name="$1" expect="$2" want_text="$3" mode="$4" issues="$5" login="$6" claims="$7"
+  local out rc
+  out="$("$SCRIPT" "$mode" \
+    --fixture-open-issues "$issues" \
+    --fixture-login "$login" \
+    --fixture-claims "$claims" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-proceed" ] && [ "$rc" -ne 0 ]; then
+    bad "$name — expected proceed, got exit $rc: $out"
+    return
+  fi
+  if [ "$expect" = "expect-block" ] && [ "$rc" -eq 0 ]; then
+    bad "$name — expected STAND DOWN, but it proceeded: $out"
+    return
+  fi
+  case "$out" in
+  *"$want_text"*) ok "$name" ;;
+  *) bad "$name — exit code was right but the reason was not; wanted '$want_text', got: $out" ;;
+  esac
+}
+
+echo "main-red-claim:"
+
+# The incident. Three sessions, one break: the second and third must stand down.
+want "a fresh claim by somebody else stands this session down" \
+  expect-block "claimed by @grace" check "4671" "ada" "grace 300"
+
+want "and it names the window it judged against" \
+  expect-block "window: 20m" check "4671" "ada" "grace 300"
+
+# The lapse. A session that died mid-repair must not hold the repair shut.
+want "a claim past the window has lapsed" \
+  expect-proceed "unclaimed" check "4671" "ada" "grace 1500"
+
+# The window is a knob, so a case has to move it: 5m old is claimed at the
+# default and lapsed at a one-minute window.
+out="$("$SCRIPT" check --window-minutes 1 \
+  --fixture-open-issues 4671 --fixture-login ada --fixture-claims "grace 300" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a shorter window lapses a claim the default still honours"
+else
+  bad "--window-minutes did not shorten the window: exit $rc: $out"
+fi
+
+# A session's own claim is not a reason to stand it down: re-running the
+# pre-flight is what a session does when it returns to a repair it started.
+want "this session's own claim does not block it" \
+  expect-proceed "unclaimed" check "4671" "ada" "ada 60"
+
+want "the freshest OTHER claim decides, not the freshest claim" \
+  expect-block "claimed by @grace" check "4671" "ada" "ada 10
+grace 300"
+
+# Every unknown proceeds. One case per branch, because each is a separate
+# early return and a regression in one is invisible from the others.
+want "no open main-red issue proceeds" \
+  expect-proceed "not known-broken" check "" "ada" ""
+
+want "two open main-red issues are ambiguous, so it proceeds" \
+  expect-proceed "ambiguous" check "4671 4672" "ada" "grace 60"
+
+want "an unreadable identity proceeds" \
+  expect-proceed "identity unknown" check "4671" "" "grace 60"
+
+want "an unparseable claim age is ignored rather than trusted" \
+  expect-proceed "unclaimed" check "4671" "ada" "grace soon"
+
+want "no claims at all proceeds" \
+  expect-proceed "unclaimed" check "4671" "ada" ""
+
+# `claim` is `check` plus a post, so it must inherit the block.
+want "claim stands down on somebody else's fresh claim" \
+  expect-block "claimed by @grace" claim "4671" "ada" "grace 300"
+
+want "claim takes an unclaimed issue" \
+  expect-proceed "claimed #4671 as @ada" claim "4671" "ada" ""
+
+# A `gh` that is not installed is the one unknown the fixtures cannot pin,
+# because supplying a fixture is what bypasses the lookup. A PATH of nothing
+# is not the way to drive it — that breaks the shebang and exits 127, which
+# is a broken test rather than a missing `gh`. Instead: a PATH holding every
+# program this script does use, and not `gh`.
+gh_less="$(mktemp -d)"
+trap 'rm -rf "$gh_less"' EXIT
+for tool in bash awk tr mktemp; do
+  tool_path="$(command -v "$tool")"
+  if [ -z "$tool_path" ]; then
+    bad "the suite needs $tool on PATH to build its gh-less fixture"
+    continue
+  fi
+  ln -s "$tool_path" "$gh_less/$tool"
+done
+out="$(PATH="$gh_less" "$SCRIPT" check 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  case "$out" in
+  *"could not ask"*) ok "a missing gh proceeds" ;;
+  *) bad "a missing gh proceeded for the wrong reason: $out" ;;
+  esac
+else
+  bad "a missing gh must proceed, got exit $rc: $out"
+fi
+
+# Bad input is a caller error, distinct from both verdicts: exit 2.
+if "$SCRIPT" check --window-minutes soon >/dev/null 2>&1; then
+  bad "a non-numeric window should exit 2, not proceed"
+else
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    ok "a non-numeric window is a usage error, not a verdict"
+  else
+    bad "a non-numeric window should exit 2, got $rc"
+  fi
+fi
+
+if "$SCRIPT" --nonsense >/dev/null 2>&1; then
+  bad "an unknown argument should exit 2, not proceed"
+else
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    ok "an unknown argument is a usage error"
+  else
+    bad "an unknown argument should exit 2, got $rc"
+  fi
+fi
+
+# --help prints the whole header, however long it grows.
+out="$("$SCRIPT" --help 2>&1)"
+case "$out" in
+*"Fail-open, deliberately, at every unknown"*) ok "--help reaches the end of the header" ;;
+*) bad "--help truncated the header" ;;
+esac
+
+echo ""
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/test-main-red-claim.sh
+++ b/scripts/test-main-red-claim.sh
@@ -18,7 +18,7 @@
 #     than the duplication it prevents), and it is one branch per unknown, so
 #     it is one case per branch.
 #
-# Deliberately not a `make gate` step, matching `main-red-hold-test`: the
+# Not a `make gate` step, matching `main-red-hold-test`: the
 # subject asks the issue tracker a question, and the gate is hermetic and
 # offline by contract.
 #
@@ -169,7 +169,7 @@ fi
 # --help prints the whole header, however long it grows.
 out="$("$SCRIPT" --help 2>&1)"
 case "$out" in
-*"Fail-open, deliberately, at every unknown"*) ok "--help reaches the end of the header" ;;
+*"Fail-open at every unknown"*) ok "--help reaches the end of the header" ;;
 *) bad "--help truncated the header" ;;
 esac
 


### PR DESCRIPTION
The red-main chain had a detector (`main-canary.yml`) and a hold (`main-red-hold.yml`), and no way for one session to see that another was already writing the fix. On 2026-08-24 three did, 95 seconds apart, all editing the same two call sites the same way.

## The design, and the two alternatives it rejects

`scripts/main-red-claim.sh check` — exit 0 proceed, exit 1 stand down. `claim` checks, then posts.

A claim is a **comment with a twenty-minute lapse**, which is #4680's option 3. Both other options in the issue fail on this incident:

- **An assignee never lapses.** A session that crashes mid-repair holds the claim until a human clears it, and what it holds shut is the repair of a red `main`. That is the deadlock the issue's own constraint forbids.
- **A linked PR cannot be seen until a branch is pushed**, and all three patches were written before any of them opened. The window this closes is precisely the window with nothing to link to yet.

A comment carries an author and a timestamp — the two facts the decision needs — and the window makes a crashed claim expire by itself.

## Fail-open at every unknown

No `gh`, unreachable tracker, unreadable identity, two open `main-red` issues at once: each prints a note and exits 0. Standing a session down is reserved for the one thing it can establish — a claim, by somebody else, inside the window. That ordering is the issue's first constraint, and it is one case per branch in the suite because each is a separate early return.

The staleness arithmetic is `gh --jq`'s, not `date`'s: `date -d` and `date -j` disagree across the platforms this repo is cloned on, and `stat-portability` exists because that class of thing has bitten here before.

## Witness

The suite's positive control is the witness. Ablating the freshness test so no claim is ever considered current — the guard can then never stand anybody down, the one thing it exists for:

```
13 passed, 4 failed
```

Restored: `17 passed, 0 failed`.

## Two bugs its own cases caught

- **The ambiguity branch could never fire.** I copied `tr -d ' '` from `check-main-red-hold.sh`, which can afford it because it only ever *prints* the issue list. This one splits it, so `4671 4672` became the single issue `46714672` — two open issues read as one unambiguous one. Caught by the two-issue case.
- **`PATH=/nonexistent` is not a missing `gh`**, it is a broken shebang: exit 127. That case was asserting nothing. It now builds a temp dir holding every program the script does use, and not `gh`.

## Also fixed here

`AGENTS.md` had two workflows both calling themselves "A seventh" — `main-red-hold.yml` (which is) and `windows-check.yml` (the eighth).

## Wiring

`make main-red-claim` / `make main-red-claim-test`, and a step in `guard-self-tests.yml` — `gate-parity` fails a `scripts/test-*.sh` that runs in no workflow, so an omission cannot pass for a decision. The rule is written in AGENTS.md § the canary and CLAUDE.md's red-main guidance, which is where #4680 says it has to be, because the failure mode is each session reasoning correctly in isolation.

```
make main-red-claim-test   17 passed, 0 failed
shellcheck                 exit 0
check-gate-parity          OK — 47 gate steps
check-prose                OK — none added
check-doc-links            OK
```

Not a gate step and no CI job runs it: it compiles nothing, and it informs a decision made before CI has anything to look at.

Closes #4680

## Summary by Sourcery

Prevent duplicate red-main repairs by introducing a fail-open, twenty-minute claim pre-flight for repair sessions.

New Features:
- Add a lapsing red-main repair claim workflow that lets sessions detect an active repair and claim unclaimed repairs.

Bug Fixes:
- Prevent concurrent sessions from independently writing duplicate fixes to red main.
- Correct red-main issue-list parsing so multiple open issues are treated as ambiguous.
- Fix the missing-`gh` test to exercise a genuinely unavailable CLI without breaking the script interpreter.

Enhancements:
- Make claim checks fail open for unknown tracker, identity, comment, or issue state while standing down only for a fresh claim by another session.
- Provide configurable claim windows, hermetic fixtures, and explicit check and claim commands.

Build:
- Add Makefile targets for running the red-main claim command and its tests.

CI:
- Run the red-main claim test suite in the guard self-tests workflow.

Documentation:
- Document the red-main repair pre-flight and its twenty-minute lapsing claim policy in AGENTS.md and CLAUDE.md.
- Correct the workflow numbering in AGENTS.md.

Tests:
- Add comprehensive hermetic coverage for fresh and stale claims, ambiguity, fail-open behavior, input validation, and help output.