### PR TITLE
docs(stella-tui): send a new deck tab's key handler to a submodule, not the god file

### DIFF
--- a/crates/stella-tui/README.md
+++ b/crates/stella-tui/README.md
@@ -335,11 +335,23 @@ Adding a deck tab:
    UPPERCASE by convention.
 2. Write `src/views/<tab>.rs` exposing
    `render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer)`,
-   pulling every color from `theme` and recording viewport metrics onto
+   pulling every colour from `stella_tui_theme::token` and every state glyph
+   from `stella_tui_theme::glyph`, and recording viewport metrics onto
    `ui.metrics`. Register it in [`src/views.rs`](src/views.rs).
+   [`src/views/mcp_tab.rs`](src/views/mcp_tab.rs) is the worked example.
+   `area` is the content band `render_deck` has already carved between the tab
+   row and the pulse row, and the chrome around it is
+   [`src/views/frame.rs`](src/views/frame.rs)'s — so a tab fills the band and
+   draws no box of its own.
 3. Add the match arm in `render_deck` ([`src/deck_render.rs`](src/deck_render.rs)).
-4. Add a `handle_<tab>_key` in [`src/deck_ui.rs`](src/deck_ui.rs) and wire it
-   into the per-tab dispatch, taking `composer_empty` and honoring the
+4. Write `handle_<tab>_key` in a `src/deck_ui/<tab>_keys.rs` submodule the way
+   [`src/deck_ui/mcp_keys.rs`](src/deck_ui/mcp_keys.rs),
+   [`src/deck_ui/issues_keys.rs`](src/deck_ui/issues_keys.rs) and
+   [`src/deck_ui/skills_keys.rs`](src/deck_ui/skills_keys.rs) do, then add its
+   `mod`/`use` pair and the `match ui.tab` arm in
+   [`src/deck_ui.rs`](src/deck_ui.rs). That file is the god file named above and
+   is closed to growth, so the handler body goes in the submodule and only the
+   three wiring lines land here. Take `composer_empty` and honour the
    empty-composer rule for bare-letter hotkeys.
 5. `deck_renders_every_tab_with_real_content` in
    [`tests/deck_snapshot.rs`](tests/deck_snapshot.rs) iterates the tabs — extend


### PR DESCRIPTION
## What & why

`crates/stella-tui/README.md` § "Extending it" → "Adding a deck tab" sent a contributor
into a file the same README closes to growth 200 lines earlier.

**Step 4 (the live half of #4755).** It said to add `handle_<tab>_key` in
`src/deck_ui.rs`. That file is 3,591 lines against the 3,675-line ceiling at
`scripts/file-size-baseline.txt:28`, and the README's own "God files — do not add lines"
section says to plan changes so no new line lands in it and to put new modal key handling
in a `src/deck_ui/` submodule. Step 4 now names `src/deck_ui/<tab>_keys.rs` and the three
tabs already built that way — `mcp_keys.rs`, `issues_keys.rs`, `skills_keys.rs` — so
following the recipe leaves only the `mod`/`use` pair and the `match ui.tab` arm in
`deck_ui.rs`.

**Step 2's premise has since changed, and the issue's suggested fix would now be wrong.**
#4755 was written on `c88af1e19`, when 7 of 9 tabs dispatched into `crate::v2::*` and
`src/views/` was being emptied; its definition of done asks step 2 to name
`src/v2/<tab>.rs` and register it in `src/v2.rs`. On today's `main` **`src/v2/` does not
exist** — `fd -t d . crates/stella-tui/src --max-depth 1` lists no `v2`, `rg -c 'crate::v2'
crates/stella-tui/src` matches nothing, and all nine arms of `render_deck` read
`crate::views::*`. The port landed by folding v2 back into `views/`, so step 2's
`src/views/<tab>.rs` is correct as it stands.

What step 2 was actually missing is the frame contract the issue names: `render_deck`
carves the content band between the tab row and the pulse row, and `views::frame` draws
the chrome, so a tab fills that band and draws no box of its own. Added, along with
`views/mcp_tab.rs` as the worked example and the token/glyph modules the colours really
come from (`stella_tui_theme::{token, glyph}`, not a `theme` the crate no longer exposes
to views).

**Steps 1, 3 and 5 re-checked** against `deck.rs` (`pub const ALL: [DeckTab; 9]`, the
exhaustive `title()` match), `deck_render.rs` (`render_deck`'s nine-arm dispatch) and
`tests/deck_snapshot.rs` (`deck_renders_every_tab_with_real_content`, line 65). All three
are accurate as written and are unchanged.

Closes #4755

## The witness

- [x] No witness needed — documentation only. No code changes, so nothing can fail on
      `main` and pass here.

Verified instead by running the issue's own two checks on this tree and confirming every
path the recipe names resolves:

```
$ rg -n 'DeckTab::' crates/stella-tui/src/deck_render.rs | rg -c 'crate::v2::'
(no matches — v2 is gone; the recipe's `src/views/` is where the tabs are)

$ rg -n 'deck_ui.rs' scripts/file-size-baseline.txt
28:3675 crates/stella-tui/src/deck_ui.rs      (file is 3,591 lines — 84 of headroom)

$ ls src/deck.rs src/views.rs src/views/mcp_tab.rs src/views/frame.rs src/deck_render.rs \
     src/deck_ui.rs src/deck_ui/mcp_keys.rs src/deck_ui/issues_keys.rs \
     src/deck_ui/skills_keys.rs tests/deck_snapshot.rs
(all ten exist)
```

## The gate

- [x] `make doc-links` — OK, 1098 citations resolve
- [x] `python3 scripts/check-prose.py` — OK, none added
- [x] `./scripts/check-brand-case.sh` — OK
- [x] `Closes #4755` above and as a commit trailer

## Deleted tests

None.

## Nothing left behind

- Nothing new. The `src/v2/` half of #4755 was resolved by the port itself, which is
  reported above rather than silently dropped, and a comment on the issue says the same.

## Anything reviewers should know?

Landed from a fresh `main` on its own, per the issue's constraint about the open
`tui-v2-port/*` PRs. It touches only the recipe, well away from the Layout table those
PRs collide on.

## Summary by Sourcery

Align the deck-tab extension documentation with the current rendering and key-handling architecture.

Enhancements:
- Update the deck-tab extension guide to use the current view architecture, including theme tokens, state glyphs, content-area and frame responsibilities, and a worked example.
- Keep new tab key handling in dedicated deck UI submodules while limiting the main UI file to wiring changes.

Documentation:
- Correct and clarify the deck-tab implementation recipe to reflect the current source layout and prevent contributors from expanding the deck UI god file.