### PR TITLE
Drop a stray character from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,6 @@
 
 @AGENTS.md
 
-b
 ## Hard rules for every session
 
 - **The bar is reference-grade Rust, and there is no second bar.** This


### PR DESCRIPTION
A bare `b` sat on its own line between the `@AGENTS.md` import and the first rule heading, committed on `main`.

Prose-only, no witness: nothing reads that line, and there is no behaviour to fail on the old code. `check-prose` stays OK.

Noticed while editing CLAUDE.md for #4680.

Refs #4600

## Summary by Sourcery

Documentation:
- Remove the stray standalone character from CLAUDE.md.