### PR TITLE
Say why a cancelled plan's verdict outlives the board

### DIFF
--- a/crates/stella-tui/src/model/tests/scope_review.rs
+++ b/crates/stella-tui/src/model/tests/scope_review.rs
@@ -202,6 +202,68 @@ fn a_refused_plan_stops_claiming_a_decision_is_pending() {
     assert_eq!(model.plan.state, crate::plan::PlanState::PendingApproval);
 }
 
+/// The window between a refusal and the re-proposal, driven through the event
+/// path (#4667).
+///
+/// `Plan::cancel` freezes the state word, and the worry was that it froze the
+/// rail with it. It does not: `TaskUpdate` folds into the board through
+/// `apply_board`, and the fraction and the active step read the board rather
+/// than the state — so the deck names what is running while the model revises,
+/// under a word that still says the user sent this plan back.
+#[test]
+fn the_board_reaches_the_rail_while_a_refused_plan_is_being_revised() {
+    let mut model = SessionModel::new();
+    start_a_plan(&mut model, "1", &["migrate", "backfill", "cut over"]);
+    model.apply(&AgentEvent::ToolResult {
+        call_id: "1".into(),
+        output: ToolOutput::error("the plan was not approved — they said: smaller"),
+        duration_ms: 400,
+        speculated: false,
+        sub_agent_id: None,
+    });
+    assert_eq!(model.plan.state, crate::plan::PlanState::Cancelled);
+
+    model.apply(&AgentEvent::TaskUpdate {
+        tasks: vec![
+            task("1", "migrate", TaskStatus::Completed),
+            task("2", "backfill", TaskStatus::InProgress),
+            task("3", "cut over", TaskStatus::Pending),
+        ],
+    });
+    assert_eq!(
+        model.plan.state,
+        crate::plan::PlanState::Cancelled,
+        "a board snapshot is not a decision and may not overturn one"
+    );
+    assert_eq!(
+        model.plan.progress(),
+        (1, 3),
+        "the rail counts what the board says, refusal or not"
+    );
+    assert_eq!(
+        model.plan.active().map(|s| s.title).as_deref(),
+        Some("backfill"),
+        "the running step is named while the model revises"
+    );
+
+    // The revised plan is what clears the verdict, and it clears the board with
+    // it — the new proposal's steps are the ones being decided on.
+    start_a_plan(&mut model, "2", &["cut over"]);
+    assert_eq!(model.plan.state, crate::plan::PlanState::PendingApproval);
+    assert_eq!(model.plan.progress(), (0, 1));
+}
+
+fn task(id: &str, subject: &str, status: TaskStatus) -> stella_protocol::TaskItem {
+    stella_protocol::TaskItem {
+        id: id.into(),
+        subject: subject.into(),
+        description: None,
+        status,
+        owner: None,
+        contract: None,
+    }
+}
+
 /// A `task_start` that fails for its own reasons — after the driver approved,
 /// so no gate is open — is an ordinary tool error and must not be read as a
 /// refusal of a plan nobody re-proposed.

--- a/crates/stella-tui/src/plan.rs
+++ b/crates/stella-tui/src/plan.rs
@@ -206,6 +206,20 @@ impl Plan {
     /// The plan-level state is *derived*, not stored, for the reason the proof
     /// rail's invariant exists: a state that has to be remembered at every exit
     /// is one refactor away from being wrong, and wrong invisibly.
+    ///
+    /// `Cancelled` is the exception, and it is terminal until [`Self::propose`]
+    /// replaces the plan. It is the only state here that records a *person's*
+    /// decision rather than a fold of the board, and the board cannot answer
+    /// for it: with every step still `Planned` and `decided` set, the
+    /// derivation below lands on `Approved`, which is the refusal read back as
+    /// its opposite. So the verdict outlives the snapshot, and the revised
+    /// proposal — not a `TaskUpdate` — is what clears it (#4667).
+    ///
+    /// This costs the rail nothing, because the state word is not how the rail
+    /// shows movement. [`Self::steps`] and [`Self::progress`] read `board`
+    /// directly, so a board arriving after a refusal moves the glyphs, the
+    /// active step and the fraction while the word stays `cancelled` —
+    /// `a_declined_plan_still_shows_the_board_moving` pins exactly that.
     fn resettle(&mut self) {
         if matches!(self.state, PlanState::Cancelled) {
             return;
@@ -406,6 +420,8 @@ mod tests {
         assert_eq!(plan.steps().len(), 1);
     }
 
+    /// The verdict is the user's, so nothing on the board may overwrite it —
+    /// see [`Plan::resettle`] for why a derivation would land on `Approved`.
     #[test]
     fn a_declined_plan_stays_cancelled_whatever_arrives_next() {
         let mut plan = Plan::default();
@@ -413,6 +429,50 @@ mod tests {
         plan.cancel();
         plan.apply_board(&[item("1", "one", TaskStatus::Completed)]);
         assert_eq!(plan.state, PlanState::Cancelled);
+    }
+
+    /// The other half of the same rule, and the half nothing pinned (#4667): a
+    /// terminal verdict freezes the *word*, never the board under it. A
+    /// `TaskUpdate` landing between a refusal and the re-proposal moves the
+    /// glyphs, the active step and the fraction, because [`Plan::steps`] and
+    /// [`Plan::progress`] read the snapshot rather than the state.
+    ///
+    /// Without this, an early return in [`Plan::apply_board`] for a cancelled
+    /// plan — the obvious reading of "cancelled is terminal" — would blank the
+    /// rail for the whole window the model spends revising, and no test would
+    /// have said so.
+    #[test]
+    fn a_declined_plan_still_shows_the_board_moving() {
+        let mut plan = Plan::default();
+        plan.propose(&proposal(&["one", "two", "three"]));
+        plan.cancel();
+        assert_eq!(plan.progress(), (0, 3));
+        assert!(plan.active().is_none());
+
+        plan.apply_board(&[
+            item("1", "one", TaskStatus::Completed),
+            item("2", "two", TaskStatus::InProgress),
+            item("3", "three", TaskStatus::Pending),
+        ]);
+        assert_eq!(
+            plan.state,
+            PlanState::Cancelled,
+            "the verdict is the user's"
+        );
+        assert_eq!(plan.progress(), (1, 3), "the fraction follows the board");
+        assert_eq!(
+            plan.active().map(|s| s.title).as_deref(),
+            Some("two"),
+            "the running step is named while the model revises"
+        );
+        assert_eq!(
+            plan.steps().iter().map(|s| s.state).collect::<Vec<_>>(),
+            vec![
+                PlanStepState::Complete,
+                PlanStepState::Started,
+                PlanStepState::Planned
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The premise, checked first

#4667 says a cancelled plan "hides the task board's movement while the model re-plans" and "the deck shows none of it". **That half is not true**, and I checked before writing anything:

```
after cancel: state=Cancelled progress=(0, 3)
after board:  state=Cancelled progress=(1, 3) active=Some("two")
  step 1 Complete one
  step 2 Started  two
  step 3 Planned  three
```

`apply_board` stores the snapshot *before* `resettle` bails, and `steps()` / `progress()` read `board` directly rather than `state`. So the glyphs, the active step and the fraction all move while the model revises. What freezes is the state **word**: the rail says `plan cancelled · task 2 two · 1/3`.

So this PR takes the issue's second arm — "`resettle` carries a comment saying why `Cancelled` is terminal until re-proposed — with a test pinning whichever is chosen".

## Why `Cancelled` is terminal

`Cancelled` is the only state here that records a *person's* decision rather than a fold of the board. Deriving it away is not neutral: with every step still `Planned` and `decided` set, the derivation below the early return lands on `Approved` — the refusal read back as its exact opposite. #4612's point was that the rail must stop saying `pending approval` for a plan that was sent back; flipping it to `approved` or `working` on the next snapshot is the same lie in a new costume. The revised proposal clears the verdict, and it clears the board with it (`propose` already does).

That reasoning is now in `Plan::resettle`'s doc comment, and `a_declined_plan_stays_cancelled_whatever_arrives_next` — which already pinned terminality with no stated reason — points at it.

## The test that was missing

Nothing pinned the *other* half: that the board still reaches the rail. The obvious reading of "cancelled is terminal" is an early return in `apply_board`, which would blank the rail for the whole window the model spends revising — and every test in the tree would have stayed green.

- `plan::tests::a_declined_plan_still_shows_the_board_moving` — the fold, directly.
- `model::tests::scope_review::the_board_reaches_the_rail_while_a_refused_plan_is_being_revised` — the issue's own repro, through the event path: `a_refused_plan_stops_claiming_a_decision_is_pending`'s sequence with an `AgentEvent::TaskUpdate` inserted before the second `start_a_plan`.

## Ablation

Adding the early return to `apply_board`:

```rust
pub fn apply_board(&mut self, board: &[TaskItem]) {
    if matches!(self.state, PlanState::Cancelled) {
        return;
    }
    self.board = board.to_vec();
```

```
test model::tests::scope_review::the_board_reaches_the_rail_while_a_refused_plan_is_being_revised ... FAILED
test plan::tests::a_declined_plan_still_shows_the_board_moving ... FAILED

---- model::tests::scope_review::the_board_reaches_the_rail_while_a_refused_plan_is_being_revised stdout ----
panicked at crates/stella-tui/src/model/tests/scope_review.rs:238:5:
assertion `left == right` failed: the rail counts what the board says, refusal or not

---- plan::tests::a_declined_plan_still_shows_the_board_moving stdout ----
panicked at crates/stella-tui/src/plan.rs:461:9:
assertion `left == right` failed: the fraction follows the board

test result: FAILED. 1136 passed; 2 failed; 1 ignored; 0 measured; 0 filtered out
```

Restored: `test result: ok. 1138 passed; 0 failed; 1 ignored`.

No behaviour changed, so there is no fail-on-old witness to show — the tests are pins, ablated above to prove they can fail. No test was deleted or renamed.

Closes #4667

## Summary by Sourcery

Clarify and pin the separation between a cancelled plan’s persistent verdict and the board movement shown while it is being revised.

Enhancements:
- Document that cancelled plan verdicts remain terminal until a revised plan is proposed while incoming board updates continue to drive displayed progress and active-step information.

Tests:
- Add unit and event-path coverage confirming refused plans retain their cancelled state while task updates continue reaching the rail and revised proposals reset the board.