### PR TITLE
fix(website): show what a plain `stella run` prints, not the deleted pipeline

### DIFF
--- a/crates/stella-cli/tests/hero_transcript_matches_the_command.rs
+++ b/crates/stella-cli/tests/hero_transcript_matches_the_command.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The landing page's proof block shows a transcript the command above it can
+//! actually produce.
+//!
+//! `website/src/components/command-deck.tsx` renders the first thing a visitor
+//! reads, and its own doc comment promises the content is "faithful, not
+//! fabricated". It had been showing a plain `stella run` printing
+//! `triage → plan → witness → execute → verify → verdict` and ending on
+//! `✓ verified`. A plain `stella run` is the raw step loop: it emits no
+//! `Stage` event, so `plain::stage_rule` never fires, and it reaches no
+//! verdict. The staged pipeline that produced that flow was deleted (#3865),
+//! and `stella run --pipeline classic` is refused outright by
+//! `wrapper_plugin::PipelineChoice::resolve` (#4761).
+//!
+//! So the rule this test enforces is the issue's own: staged vocabulary may
+//! appear in a transcript **only** beside a command that produces it — today
+//! `stella run --pipeline <plugin-id>` against an installed wrapper plugin.
+//! Prose about the pipeline is unaffected; this reads the transcript rows,
+//! which are the string literals inside the JSX.
+//!
+//! Why a test rather than a gate step: `make gate` already runs `make test`,
+//! and a gate step is five coupled edits plus another shared cell for two
+//! concurrent PRs to collide on — the argument `design_token_parity.rs` makes
+//! at length, and this file follows it, including living in `stella-cli`
+//! because that crate has no `lib.rs` and this reads the component as text.
+//! The path is declared `read` in `scripts/website-rust-inputs.txt`, so a
+//! website-only diff that edits it still runs the Rust gate (#4632).
+
+use std::path::{Path, PathBuf};
+
+/// The component holding every landing-page terminal transcript.
+fn component() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../website/src/components/command-deck.tsx")
+        .canonicalize()
+        .expect("the landing page's terminal component resolves from CARGO_MANIFEST_DIR")
+}
+
+/// Stage names the raw step loop never prints, in the arrow form the deleted
+/// staged pipeline used. Matched case-sensitively and with the arrow, so the
+/// word "triage" in ordinary prose is not a hit.
+const STAGED_FLOW_MARKERS: &[&str] = &[
+    "triage \u{2192} plan",
+    "\u{2192} witness \u{2192}",
+    "\u{2192} verify \u{2192} verdict",
+];
+
+/// The verdict wording only a verification path reaches.
+const VERDICT_MARKERS: &[&str] = &["\u{2713} verified", "\u{2717} unverified"];
+
+/// The command that legitimises either marker: a run handed to an installed
+/// wrapper plugin.
+const WRAPPED_COMMAND: &str = "--pipeline";
+
+#[test]
+fn the_hero_transcript_claims_no_stage_the_raw_loop_cannot_print() {
+    let path = component();
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    let wrapped = source.contains(WRAPPED_COMMAND);
+
+    for marker in STAGED_FLOW_MARKERS.iter().chain(VERDICT_MARKERS) {
+        assert!(
+            !source.contains(marker) || wrapped,
+            "{} shows `{marker}`, which only a wrapper plugin's run produces, \
+             with no `{WRAPPED_COMMAND}` command anywhere in the file. A plain \
+             `stella run` is the raw step loop: no stage line, no verdict. \
+             Either show what the raw loop prints, or show the command that \
+             produces this (#4761).",
+            path.display()
+        );
+    }
+}

--- a/scripts/website-rust-inputs.txt
+++ b/scripts/website-rust-inputs.txt
@@ -39,6 +39,12 @@ read website/content/docs/configuration/stella-toml.mdx
 # had run.
 read website/src/components/provider-catalog.ts
 
+# The landing page's terminal transcripts. `crates/stella-cli/tests/
+# hero_transcript_matches_the_command.rs` holds them to the command printed
+# above them: staged vocabulary and a verdict need a `--pipeline` run, because
+# a plain `stella run` is the raw step loop and prints neither (#4761).
+read website/src/components/command-deck.tsx
+
 # ── mention ──────────────────────────────────────────────────────────────────
 
 # crates/stella-tools/src/registry.rs points a reader at the hooks reference.

--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -201,14 +201,17 @@ export default function HomePage() {
           <h2 className="lp-eyebrow mb-5">One run, start to finish</h2>
           <HeroTerminal />
           <p className="mt-4 max-w-prose text-sm text-fd-muted-foreground">
-            The stages, the metering, and the verification step are
+            A plain <code>stella run</code> is the raw step loop: it reports
+            what it changed and what the turn cost, and claims nothing about
+            proof. The rows and the metering are
             <span className="lp-brand-face"> stella</span>&apos;s own; the
-            figures illustrate a run rather than a benchmark.{" "}
+            figures illustrate a run rather than a benchmark. Verification is
+            opt-in —{" "}
             <Link
-              href="/docs/agent-modes#outcome-driven-goal-mode"
+              href="/docs/agent-modes"
               className="underline underline-offset-4 hover:text-fd-foreground"
             >
-              How goal mode decides it is done
+              a wrapper plugin gathers the evidence, or goal mode judges rounds
             </Link>
             .
           </p>

--- a/website/src/components/command-deck.tsx
+++ b/website/src/components/command-deck.tsx
@@ -3,9 +3,9 @@
  * prints. Server components: they ship no JavaScript and render text that is
  * the same for every visitor.
  *
- * The content is faithful, not fabricated: the states, the wrapper steps, and
- * the budget accounting are Stella's own. The numbers illustrate a run; they
- * are not a benchmark claim.
+ * The content is faithful, not fabricated: every row is one the shipping
+ * renderer writes, in the shape it writes it. The numbers illustrate a run;
+ * they are not a benchmark claim.
  */
 
 import type { ReactNode } from "react";
@@ -38,17 +38,29 @@ function Ok({ children }: { children: string }) {
 }
 
 /**
- * The landing-page proof: one command, the path it walks, and the evidence
- * the run ended on. Short enough to read in the time it takes to scroll past.
+ * The landing-page proof: one command, the tool calls it made, what it
+ * changed, and what the turn cost. Short enough to read in the time it takes
+ * to scroll past.
+ *
+ * A plain `stella run` is the raw step loop. It prints no stage line and
+ * reaches no verdict — the staged pipeline that once produced both was
+ * deleted, and `--pipeline classic` is refused. So the rows below are the ones
+ * the plain surface really writes: `plain::tool_call_card`,
+ * `plain::tool_result_card`, `plain::file_change_card` and
+ * `plain::cost_summary` in `crates/stella-cli/src/plain.rs`. Verification is
+ * opt-in through an installed wrapper plugin and is not what this transcript
+ * shows.
  */
 export function HeroTerminal() {
   return (
     <Terminal title="zsh — stella">
       <Prompt>export ANTHROPIC_API_KEY=…</Prompt>
       <Prompt>stella run &quot;fix the failing test&quot;</Prompt>
-      <Dim>{"  triage → plan → witness → execute → verify → verdict\n"}</Dim>
-      <Dim>{"  edited src/parser.rs · ran cargo test -p parser\n"}</Dim>
-      <Ok>{"  ✓ verified — 1 test now green · $0.04 of $1.00\n"}</Ok>
+      <Dim>{"  ▶ read_file(path=src/parser.rs)\n"}</Dim>
+      <Dim>{"  ± modified src/parser.rs +3 −1\n"}</Dim>
+      <Dim>{"  ▶ bash(command=cargo test -p parser)\n"}</Dim>
+      <Ok>{"    ✓ ok in 1174ms — test result: ok. 12 passed; 0 failed\n"}</Ok>
+      <Dim>{"\n  ◆ claude-sonnet-5 · $0.0413 · 18.6s\n"}</Dim>
     </Terminal>
   );
 }


### PR DESCRIPTION
## What & why

The landing page's proof block showed `stella run "fix the failing test"` printing a
stage line and a verdict:

```
$ stella run "fix the failing test"
  triage → plan → witness → execute → verify → verdict
  edited src/parser.rs · ran cargo test -p parser
  ✓ verified — 1 test now green · $0.04 of $1.00
```

A plain `stella run` is the raw step loop. It emits no `Stage` event, so
`plain::stage_rule` never fires, and it reaches no verdict. The staged pipeline that
produced that flow was deleted in #3865, and `stella run --pipeline classic` is refused
outright by `wrapper_plugin::PipelineChoice::resolve`. The component's own doc comment
promises the content is "faithful, not fabricated", so the page stated a standard it
failed, on the widest surface the project has.

**Option 1, as the issue lists them.** Every row is now one the shipping renderer really
writes, in the shape it writes it — read out of `crates/stella-cli/src/plain.rs`:

| row | source |
|---|---|
| `▶ read_file(path=src/parser.rs)` | `tool_call_card` — `"  {icon} {name}({input})"`, `▶` for running |
| `± modified src/parser.rs +3 −1` | `file_change_card` over `textline::file_change` + the dimmed counts |
| `✓ ok in 1174ms — test result: ok. …` | `tool_result_card` — `"    {icon} {label} in {:.0}ms — {preview}"` |
| `◆ claude-sonnet-5 · $0.0413 · 18.6s` | `cost_summary` — `"\n  ◆ {model} · {fmt_cost} · {:.1}s"`, and `fmt_cost` is `${:.4}` |

The caption under the block says plainly that the raw loop reports what it changed and
claims nothing about proof, and points at where verification is opt-in.

**Option 2 is left to the maintainer.** Keeping the verified flow and showing
`stella run --pipeline <plugin-id>` is the other honest ending, and it is a product
decision rather than a documentation one: this repository ships no verification plugin
(Vera is private), so that transcript would name a command a visitor cannot run. Flip it
in review if that is the call — the guard below admits it, because it admits any
transcript whose file also names a `--pipeline` command.

**The sweep.** `rg -n 'triage → plan' website/` and `rg -n '→ witness →|→ verify →
verdict' website/` return only this component (plus a presentations CHANGELOG row about a
slide title, unrelated). `website/content/docs/**` already describes `stella run`
correctly — `agent-modes.mdx`'s spec card reads `Verified by: nothing — the model stops
when it decides it is done`, and its § "One-shot: `stella run`" says the raw step loop
"claims nothing about proof". The landing page was the outlier.

Closes #4761

## The witness

`crates/stella-cli/tests/hero_transcript_matches_the_command.rs` reads the component and
fails if a staged-flow marker or a verdict appears with no `--pipeline` anywhere in the
file. The path is declared `read` in `scripts/website-rust-inputs.txt`, so a
website-only diff that edits the transcript still runs the Rust gate (#4632) — without
that line the guard would be unreachable on exactly the diffs it exists for.

Ablation — the component reverted, the test kept:

```
$ git stash push -- website/src/components/command-deck.tsx
$ cargo test -p stella-cli --test hero_transcript_matches_the_command

test the_hero_transcript_claims_no_stage_the_raw_loop_cannot_print ... FAILED

thread '...' panicked at crates/stella-cli/tests/hero_transcript_matches_the_command.rs:65:9:
…/website/src/components/command-deck.tsx shows `triage → plan`, which only a wrapper
plugin's run produces, with no `--pipeline` command anywhere in the file. A plain
`stella run` is the raw step loop: no stage line, no verdict. Either show what the raw
loop prints, or show the command that produces this (#4761).

test result: FAILED. 0 passed; 1 failed
```

With the fix:

```
test the_hero_transcript_claims_no_stage_the_raw_loop_cannot_print ... ok
test result: ok. 1 passed; 0 failed
```

## The gate

- [x] `cargo test -p stella-cli --test hero_transcript_matches_the_command` — green
- [x] `cargo clippy -p stella-cli --test hero_transcript_matches_the_command -- -D warnings` — clean
- [x] `cargo fmt --all`
- [x] `./scripts/check-website-inputs.sh` — OK, 8 declared paths, 4 Rust test inputs
- [x] `python3 scripts/check-prose.py` — OK, none added
- [x] `Closes #4761` above and as a commit trailer

## Deleted tests

None.

## Nothing left behind

- Noticed and **not** fixed here, because it is a different file and a different claim:
  AGENTS.md says `--test-command` is "refused unconditionally on every remaining
  resolution", but `wrapper_plugin.rs`'s `refuse_verification_flags` gates it on
  `choice.is_raw()` — it is accepted on a `--pipeline` run, which is what
  `agent-modes.mdx` documents. Filed separately rather than folded into a website PR.

## Anything reviewers should know?

`npx prettier --write` on `page.tsx` reflows several unrelated pre-existing lines,
including one directly under a comment warning that JSX collapses a text node's leading
whitespace across a line break (the "stellaspeaks" bug). Prettier is not enforced for
this app — it reports pre-existing files as unformatted — so the reflow was reverted and
only the caption changed.

## Summary by Sourcery

Make the landing-page `stella run` transcript accurately reflect the raw step loop and protect it against future fabricated staged-flow claims.

Bug Fixes:
- Update the landing-page transcript to show output that a plain `stella run` can actually produce instead of a deleted staged pipeline and verification verdict.

Enhancements:
- Clarify that plain runs report tool activity, file changes, and cost while verification is opt-in through wrapper plugins or goal mode.

Tests:
- Add a Rust regression test that rejects staged-flow or verdict markers in the landing-page transcript unless the component also shows a pipeline command.

Chores:
- Register the website component as an input for the Rust website consistency checks.