### PR TITLE
fix(stella-tui): retire the brand gradient, which had no consumer left

### DIFF
--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -232,9 +232,10 @@ pub const SUBAGENT: Color = TEAL;
 // keeps ~700 `theme::TOKEN` call sites untouched: a theme is a substitution
 // table, not a parameter threaded through the render tree.
 //
-// The one thing a value remap can't recolour is the progress bar's *gradient*,
-// whose interpolated cells are never equal to a token; so its source
-// ([`brand_gradient`] via [`primary_stops`]) is theme-aware directly.
+// It works because every colour the deck paints IS a token. Rule 5 of the v5
+// colour alignment retires gradients on every surface, and SPEC 2 (`cell-grid
+// honest`) allows only per-cell colour steps, so there are no interpolated
+// cells for the remap to miss (#4058).
 
 /// The shipped themes. `stella-dark` (gold on the cool near-black ramp) is
 /// the default; `stella-light` (the deep gold ramp on cool paper) is its
@@ -299,39 +300,6 @@ pub fn set_active_theme(theme: ThemeName) {
         ThemeName::StellaLight => 1,
     };
     ACTIVE_THEME.store(v, std::sync::atomic::Ordering::Relaxed);
-}
-
-/// The active theme's brand gradient stops, resting → live: `brand` →
-/// `brand-live` on `stella-dark`, `brand-ink-deep` → `brand-ink` on
-/// `stella-light`. Feeds [`brand_gradient`] so the progress fill and wordmark
-/// sweep recolour with the theme.
-///
-/// The palette allows exactly two golds, so the sweep IS those two: the fill
-/// rests on [`ACCENT`] and lights up to [`ACCENT_LIVE`] at its head, which is
-/// precisely the job the live stop is reserved for. This also removes the
-/// downgrade-path hazard the previous three-gold ramp had to reason around —
-/// `crate::progress` paints a solid [`ACCENT`] when [`ColorMode::is_truecolor`]
-/// is false, and that is now the gradient's own resting stop rather than a
-/// third value.
-///
-/// There is deliberately no second, wider "identity" sweep any more. It
-/// existed to let chrome run quieter than the progress fill across four gold
-/// stops; with two, a second gradient over the same pair would be a
-/// distinction that renders identically — and `gold_stops`/`gold_gradient`,
-/// which had no caller outside this module, are gone with it.
-pub fn primary_stops() -> [Color; 2] {
-    stops_for(active_theme())
-}
-
-/// The pure half of [`primary_stops`]: which pair a *named* theme sweeps
-/// between, reading none of the process-global active theme. Split out so the
-/// table can be asserted for every theme at once without a test flipping
-/// global state the rest of the binary shares.
-fn stops_for(theme: ThemeName) -> [Color; 2] {
-    match theme {
-        ThemeName::StellaDark => [palette::BRAND, palette::BRAND_LIVE],
-        ThemeName::StellaLight => [palette::BRAND_INK_DEEP, palette::BRAND_INK],
-    }
 }
 
 // ── Diff panel ──────────────────────────────────────────────────────────────
@@ -406,58 +374,6 @@ pub const SYNTAX_FUNCTION: Color = MAGENTA;
 /// and an alarm hue on every backticked word was the single loudest thing on
 /// the deck. Not a palette value — it is TUI-only.
 pub const CODE: Color = Color::Rgb(0x6F, 0xBF, 0x92);
-
-// ── Brand gradient (the wordmark sweep and the progress-bar fill) ───────────
-//
-// Two stops, and there are only two golds to make them from: the sweep runs
-// resting → live, left to right. An earlier generation ran two separate
-// gradients — one for brand chrome and a second for the progress bar — which
-// is precisely the split this palette collapses. Progress *is* activity,
-// activity is the brand hue, so one gradient serves both. The stops track the
-// ACTIVE theme via [`primary_stops`]: the progress fill interpolates non-token
-// cells the per-frame [`apply_theme`] remap can't see, so its source has to be
-// theme-aware directly.
-
-/// The brand gradient's stops for the *default* (dark) theme, resting → live.
-/// [`primary_stops`] returns these for `stella-dark` and the paper pair for
-/// `stella-light`; prefer that accessor. The determinate progress fill
-/// interpolates across the active stops per cell (truecolor only; lesser
-/// terminals collapse to a solid [`ACCENT`] fill).
-pub const BRAND_STOPS: [Color; 2] = [ACCENT, ACCENT_LIVE];
-
-/// Linear-interpolate two RGB colors at `t ∈ [0, 1]`. Non-RGB inputs return
-/// `a` unchanged (the gradient only ever feeds it `Color::Rgb` stops).
-pub fn lerp_rgb(a: Color, b: Color, t: f64) -> Color {
-    let (Color::Rgb(ar, ag, ab), Color::Rgb(br, bg, bb)) = (a, b) else {
-        return a;
-    };
-    let t = t.clamp(0.0, 1.0);
-    let mix = |x: u8, y: u8| (f64::from(x) + (f64::from(y) - f64::from(x)) * t).round() as u8;
-    Color::Rgb(mix(ar, br), mix(ag, bg), mix(ab, bb))
-}
-
-/// The brand gradient sampled at `t ∈ [0, 1]`: deep at 0, bright at 1, linearly
-/// interpolated across the ACTIVE theme's [`primary_stops`]. This is the run
-/// progress bar's fill and the wordmark sweep — recolours with the theme.
-pub fn brand_gradient(t: f64) -> Color {
-    gradient_at(&primary_stops(), t)
-}
-
-/// Sample an n-stop gradient at `t ∈ [0, 1]`. Panics on fewer than two stops,
-/// which is a programming error rather than a runtime condition.
-fn gradient_at(stops: &[Color], t: f64) -> Color {
-    let t = t.clamp(0.0, 1.0);
-    let span = (stops.len() - 1) as f64;
-    let scaled = t * span;
-    let i = (scaled.floor() as usize).min(stops.len() - 2);
-    lerp_rgb(stops[i], stops[i + 1], scaled - i as f64)
-}
-
-/// Lighten `color` toward white by `amount ∈ [0, 1]` — the shimmer band and the
-/// pulsing head ride a lifted copy of the underlying gradient cell.
-pub fn lighten(color: Color, amount: f64) -> Color {
-    lerp_rgb(color, Color::Rgb(255, 255, 255), amount)
-}
 
 // ── Color-depth degradation (truecolor → 256 → 16 → none) ───────────────────
 //

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -531,7 +531,6 @@ fn palette_law_gold_is_the_brand() {
         CITRON,
         ORCHID,
     ]);
-    all.extend(BRAND_STOPS);
     all.extend(LIGHT_REMAP.iter().map(|(_, to)| *to));
     for token in &all {
         for (retired, name) in [
@@ -942,9 +941,15 @@ fn apply_theme_is_identity_for_dark_and_remaps_for_light() {
             "{token:?} has no LIGHT_REMAP entry"
         );
     }
-    // An unmapped colour (an interpolated gradient cell) passes through.
-    let mid = lerp_rgb(palette::BRAND, palette::BRAND_LIVE, 0.5);
-    assert_eq!(remap_theme(mid, LIGHT_REMAP), mid);
+    // A colour that is not a token passes through untouched. Nothing paints
+    // one any more (#4058 retired the gradient that used to), so this pins
+    // the remap's total behavior rather than a live path.
+    let unmapped = Color::Rgb(0x7B, 0x9A, 0x35);
+    assert!(
+        !ALL_RGB_TOKENS.contains(&unmapped),
+        "pick a value no token holds, or this asserts nothing"
+    );
+    assert_eq!(remap_theme(unmapped, LIGHT_REMAP), unmapped);
     // Every LIGHT_REMAP key is a distinct value (aliases share one entry).
     for (i, (from, _)) in LIGHT_REMAP.iter().enumerate() {
         assert!(
@@ -986,62 +991,41 @@ fn degrade_buffer_strips_color_under_no_color() {
     assert_eq!(buf.content[0].bg, Color::Reset);
 }
 
-/// Which two golds a theme sweeps between is the whole contract of the brand
-/// gradient, and it used to be readable a second way — through the
-/// `primary`/`primary_deep` wrappers, which projected one end each. Those had
-/// no caller and are gone (#3741), so this is where the pairing is pinned:
-/// per theme, in full, on the accessor that survived.
+/// **Witness (#4058, rule 5).** No gradient may come back to this crate.
 ///
-/// It asserts against `stops_for` rather than `primary_stops` because the
-/// latter reads process-global state every other test in this binary shares —
-/// a test that flipped the active theme to see the light row would race
-/// `theme_remap_and_apply`'s "stella-dark is the identity" assertion.
+/// The brand gradient (`BRAND_STOPS`, `primary_stops`, `brand_gradient`,
+/// `gradient_at`, `lerp_rgb`, `lighten`) was `pub`, so nothing in the gate
+/// could see that its last consumer had gone: `crate::progress`, the module
+/// its own doc comments named as the fill it painted, does not exist. Rule 5
+/// of the v5 colour alignment retires gradients on every surface and SPEC 2
+/// (`cell-grid honest`) allows only per-cell colour steps, so a re-added
+/// interpolator is a spec violation rather than an unused item — and a `pub`
+/// one leaves no other trace.
+///
+/// This asserts against the crate's own source rather than against a symbol,
+/// because a deleted symbol cannot be named in a test that must compile.
 #[test]
-fn primary_stops_are_the_two_golds_per_theme() {
-    assert_eq!(
-        stops_for(ThemeName::StellaDark),
-        [palette::BRAND, palette::BRAND_LIVE],
-        "stella-dark sweeps resting gold → live gold"
-    );
-    assert_eq!(
-        stops_for(ThemeName::StellaLight),
-        [palette::BRAND_INK_DEEP, palette::BRAND_INK],
-        "stella-light sweeps the deep paper gold → the paper gold"
-    );
-    // No theme may collapse the sweep to one colour: a gradient between a
-    // value and itself is a flat fill wearing a gradient's cost.
-    for theme in ThemeName::ALL {
-        let [resting, live] = stops_for(theme);
-        assert_ne!(resting, live, "{} has a one-colour sweep", theme.slug());
+fn no_colour_interpolator_lives_in_this_crate() {
+    for (file, source) in [
+        ("theme.rs", include_str!("../theme.rs")),
+        ("palette.rs", include_str!("../palette.rs")),
+    ] {
+        for banned in [
+            "fn lerp_rgb",
+            "fn brand_gradient",
+            "fn gradient_at",
+            "fn lighten",
+            "fn primary_stops",
+            "BRAND_STOPS",
+        ] {
+            assert!(
+                !source.contains(banned),
+                "{file} declares `{banned}` — rule 5 retires gradients on \
+                 every surface, and `apply_theme`'s value remap cannot see an \
+                 interpolated cell"
+            );
+        }
     }
-    // And the live accessor is that table read at the active theme, not a
-    // second copy of it.
-    assert_eq!(primary_stops(), stops_for(active_theme()));
-}
-
-#[test]
-fn brand_gradient_spans_resting_to_live_accent() {
-    // The default theme is `stella-dark`, so the stops are the two golds;
-    // `primary_stops` swaps them for the deep paper pair under
-    // `stella-light`.
-    assert_eq!(brand_gradient(0.0), ACCENT);
-    assert_eq!(brand_gradient(1.0), ACCENT_LIVE);
-    // Monotonic, clamped, never panics across the range.
-    for i in 0..=20 {
-        let _ = brand_gradient(f64::from(i) / 20.0);
-    }
-    assert_eq!(brand_gradient(-1.0), ACCENT);
-    assert_eq!(brand_gradient(2.0), ACCENT_LIVE);
-    // The *resting* end is exactly what `crate::progress` falls back to when
-    // the terminal cannot render the gradient, so a degraded fill is the
-    // gradient's own tail rather than a value that appears nowhere in it.
-    assert_eq!(brand_gradient(0.0), ACCENT);
-}
-
-#[test]
-fn lighten_moves_toward_white() {
-    assert_eq!(lighten(ACCENT, 0.0), ACCENT);
-    assert_eq!(lighten(ACCENT, 1.0), Color::Rgb(255, 255, 255));
 }
 
 /// The transcript's tool-class hues are a *set*, and a set only works if


### PR DESCRIPTION
## What

`crates/stella-tui/src/theme.rs` still carried the brand gradient — `BRAND_STOPS`, `primary_stops`, `stops_for`, `brand_gradient`, `gradient_at`, `lerp_rgb`, `lighten` — which rule 5 of the v5 colour alignment retires on every surface, and which SPEC 2 (`cell-grid honest`) forbids by allowing only per-cell colour steps.

It had no consumer. Three of those doc comments name `crate::progress` as the fill they paint; there is no `progress` module in this crate. The wordmark they name as the other consumer comes from `stella_tui_theme::wordmark::spans()` and is two flat spans. Every symbol was `pub`, so `dead_code` never fired and nothing in the gate could see the last caller had gone — the only thing still calling them was the test asserting they worked.

Also corrected: the `apply_theme` module comment claimed the value remap "can't recolour the progress bar's gradient", which was the standing justification for the gradient being theme-aware directly. There are no interpolated cells left for the remap to miss.

## Witness test

`no_colour_interpolator_lives_in_this_crate` (`crates/stella-tui/src/theme/tests.rs`) scans `theme.rs` and `palette.rs` for the interpolators by name. A source scan rather than a symbol reference, because a deleted symbol cannot be named in a test that has to compile — the same shape as the `RETIRED_*` ban list a few hundred lines above it in the same file.

## Ablation

`lerp_rgb` and `BRAND_STOPS` pasted back into `theme.rs`, test untouched:

```
thread 'theme::tests::no_colour_interpolator_lives_in_this_crate' panicked at
crates/stella-tui/src/theme/tests.rs:1021:13:
theme.rs declares `fn lerp_rgb` — rule 5 retires gradients on every surface,
and `apply_theme`'s value remap cannot see an interpolated cell

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1134 filtered out
```

Restored:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1134 filtered out
```

## That this is a deletion and not a recolour

`cargo test -p stella-tui` — 1134 + 71 across the integration binaries, 0 failed, **every deck golden passing unblessed**. Nothing under `tests/snapshots/deck/` was re-blessed in this PR; a single changed cell would have failed one of them.

The one test that had to change for a reason other than deletion is `theme_remap_and_apply`'s pass-through case, which built "a colour no token holds" by calling `lerp_rgb` on the two golds. It now uses a literal and asserts the literal really is absent from `ALL_RGB_TOKENS`, so the case cannot pass by accidentally picking a token.

`cargo clippy -p stella-tui --all-targets -- -D warnings` clean. `python3 scripts/check-tokens.py`, `check-prose.py`, `check-line-citations.py`, `./scripts/check-file-size.sh` all green.

## Why this is `Refs` and not `Closes`

#4058's DoD item 3 is "the wordmark renders `stella*` and the brand gradient is gone". The wordmark half landed in #4135; this is the other half.

Items 2, 4 and 5 are already done on `main` (`token.rs` *is* the generated table, no `generated.rs` and no second copy; 33 of 35 deck snapshots carry `stella*` and `✧` appears nowhere in the crate; `MIGRATING` is `{}` and `make tokens` exits 0).

**Item 1 is what keeps the issue open**, and it is the part this PR deliberately does not touch, because the remaining twenty-one literals in `palette.rs` are the three decisions the issue's own 2026-08-20 comment names — the light/paper theme, the `WARNING` amber that fails the gold clamp without being a verdict, and the derived ramp steps — plus five `DATA_*` chart hues the comment does not cover. Each needs a token-system answer, not a remap. Detail on the issue.

Refs #4058

## Tests deleted in this PR

Three, all dropped with the feature they covered — they tested the gradient this PR retires, so there is nothing left for them to assert:

- **`brand_gradient_spans_resting_to_live_accent`** — asserted `brand_gradient(0.0) == ACCENT` and `(1.0) == ACCENT_LIVE`. Its own comment justified the endpoint check by naming `crate::progress` as the consumer that falls back to the resting stop; that module does not exist.
- **`primary_stops_are_the_two_golds_per_theme`** — pinned which pair each theme sweeps between. No sweep, no pair.
- **`lighten_moves_toward_white`** — pinned `lighten`, one of the interpolators removed.

`no_colour_interpolator_lives_in_this_crate` replaces all three: instead of asserting the gradient behaves correctly, it asserts the gradient is absent, which is what rule 5 actually requires. Nothing else was dropped — `theme_remap_and_apply` survives and is edited in place (its pass-through case stopped building its sample colour out of `lerp_rgb`).
