### PR TITLE
The index-generation guard costs one gather, not six

### DIFF
--- a/crates/stella-tools/src/search/cache.rs
+++ b/crates/stella-tools/src/search/cache.rs
@@ -88,10 +88,14 @@
 //! embedding round trip 111-202 ms. Against those, a persisted gather cache
 //! is a rounding error.
 //!
-//! The cache's own guard is in the same range as the thing it guards:
+//! The cache's own guard is a fraction of the thing it guards:
 //! [`stella_graph::CodeGraph::index_generation`] re-hashes every indexed
-//! file's `(path, content sha)` once per render, 21.8 ms over 1 808 rows by
-//! the same Python bound.
+//! file's `(path, content sha)` once per render, **0.7-3.1 ms over 1 808
+//! rows** — measured in release against this repository's own index on
+//! 2026-08-25, four samples, the first of them disk-cold. The Python bound
+//! this paragraph used to quote said 21.8 ms and had #4785 concluding the
+//! guard cost six gathers; the Rust path costs about one, and the difference
+//! is what a bound taken outside the language is worth.
 //!
 //! A faster machine does not change the answer, because the second half of it
 //! is structural. [`GatherCache::observe_generation`] empties the whole cache


### PR DESCRIPTION
## What

`crates/stella-tools/src/search/cache.rs`'s module doc quoted **21.8 ms over 1 808 rows** for `CodeGraph::index_generation`, taken as a Python-side bound on the same SQL. #4785 read that number against a 3.7 ms gather and concluded the staleness guard "costs roughly six gathers, which inverts the point of the guard".

The Rust path does not cost that. Measured in release against this repository's own index — 1 808 files, the real 180 MB `codegraph.db` copied to a scratch path and opened there, four samples, the first disk-cold:

```
files: 1808
cold index_generation: 3.148916ms
cold index_generation: 728.959µs
cold index_generation: 1.5985ms
cold index_generation: 1.556583ms
```

So **0.7-3.1 ms**, roughly an order of magnitude under the quoted bound. Against a 3.7 ms gather the guard is about one gather, not six; against a search call that also pays 220-296 ms of chunk ranking and 111-202 ms of embedding round trip (the same paragraph's own figures) it is under one percent.

This PR corrects the number and says where the old one came from. Doc-only — no witness, and nothing else in the tree reads the figure.

## Why this does not close #4785

Two findings, both on the issue as a comment:

1. **The premise is quantitatively wrong**, per the measurement above.
2. **The memo shape the issue suggests cannot work on this call path.** `search::engine::report_with` calls `open_or_build` on *every* search and calls `graph.shutdown()` at the end of it, so each search gets a fresh `CodeGraph` with a fresh pair of connections. A memo held on `Inner` — the shape `store::image_check` uses and the one I built and measured first — hits zero times in production: one graph, one `index_generation` call, one hash either way. `PRAGMA data_version` cannot be lifted to a process-global memo either, because SQLite's own contract says the value is a local property of a connection and is not comparable across two.

   A fix that actually lands has to put the stamp **in the store**, maintained at write time, and every write to `code_graph_files` (`store.rs`'s five production sites) has to bump it or the stamp goes stale — which is #3196's staleness bug returning through the guard meant to prevent it. That is a schema-and-fence change, not the memo the issue sketches, and at ~1% of a search call it is not obviously worth making.

Refs #4785

## Summary by Sourcery

Correct the cache documentation to reflect the measured cost of the index-generation guard.

Enhancements:
- Correct the documented performance estimate for the index-generation guard and clarify that the measurement reflects the Rust path rather than the previous Python-side bound.

Documentation:
- Update the cache documentation with measured guard timings and explain the source of the previously overstated estimate.

## Tests deleted

**None.** The diff is one file, `crates/stella-tools/src/search/cache.rs`, 7 insertions and 3 deletions, all inside a `//!` module doc. Zero `#[test]` attributes removed.

## The witness

**No witness needed — documentation only.** Nothing in the tree reads the figure this PR corrects; it is prose a human reads. The measurement behind it is reproducible: release build, this repository's own `codegraph.db` (180 MB, 1 808 indexed files) copied to a scratch path and opened there, four samples, the first disk-cold — 3.148916 ms, 728.959 µs, 1.5985 ms, 1.556583 ms. The scratch harness was not committed; it opened a `CodeGraph` on the copy and timed `index_generation()`.

## Nothing left behind

The unfixed half is **#4785 itself**, which stays open with a re-scope handoff comment (https://github.com/macanderson/stella/issues/4785#issuecomment-5419858905) naming the five write sites, the connection-scoped memo that cannot work here and why, and why `MAX(indexed_at)` is not a safe substitute. Sourcery's two `❌` rows are answered in a PR comment — both are correct readings of a diff that deliberately does not implement the issue, which is why this carries `Refs` rather than `Closes`.

## The gate

`cargo fmt --all` clean; `cargo clippy -p stella-tools --all-targets -- -D warnings` exit 0; `check-prose` OK. Doc-only, so no behaviour to test.
