### PR TITLE
A self-driving turn keeps its lessons — the drive child no longer inherits the reflection opt-out

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -78,7 +78,9 @@ pub(crate) use outcome::settled_cost_since;
 #[cfg(test)]
 pub(crate) use output::latch_for_withheld_test;
 use output::*;
-pub(crate) use output::{claim_withheld_announcement, reflection_explicitly_disabled};
+pub(crate) use output::{
+    DISABLE_REFLECTION_ENV, claim_withheld_announcement, reflection_explicitly_disabled,
+};
 pub(crate) use persistence::{
     PersistOutcome, ReasoningRun, begin_execution, close_event_stream, flush_reasoning_tail,
     persist_event, persist_owed, record_execution_end, seed_calibration, spawn_renderer,

--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -339,7 +339,11 @@ pub(super) fn emit_pre_persisted_stream_json_line_or_terminate(line: &str) {
     }
 }
 
-pub(super) const DISABLE_REFLECTION_ENV: &str = "STELLA_DISABLE_REFLECTION";
+/// `pub(crate)` because a door that *spawns* a turn owes the same switch an
+/// answer as a door that runs one: the self-driving loop names it to keep an
+/// ambient opt-out out of the child it builds
+/// (`crate::self_driving_cmd::work::turn_command`, #4362).
+pub(crate) const DISABLE_REFLECTION_ENV: &str = "STELLA_DISABLE_REFLECTION";
 
 /// Whether a one-shot run may make the post-turn reflection model call.
 ///

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -456,6 +456,33 @@ fn turn_command(exe: &Path, dir: &Path, state_root: &Path, flags: &TurnFlags) ->
         // Pointing the state root at the repository is what makes a session's
         // record of what it learned outlast the unit of work that produced it.
         .env(stella_home::WORKSPACE_STATE_ROOT_ENV, state_root)
+        // And the learning is not optional either.
+        //
+        // `Command` inherits the parent's environment wholesale, and
+        // `STELLA_DISABLE_REFLECTION` is the benchmark adapter's switch for "do
+        // not spend the extra provider call on a container that is about to be
+        // destroyed" (`bench/harbor_adapter`, `bench/evidence/run/env.sh`). A
+        // shell that had exported it for a bench run, and then started a drive,
+        // handed it to every turn — so the loop went on writing an episode per
+        // turn (`record_episode` reads no switch) while
+        // `should_reflect_after_one_shot` skipped the reflection call, and
+        // `reflections_logged` reported 0 with nothing anywhere saying why.
+        //
+        // That is the shape of #4362: on 2026-08-23 five drive turns against
+        // oxagen-platform produced five `episode` rows, 143 `role=worker`
+        // model calls and **zero** `role=reflection` calls, on a binary
+        // (0.9.143) that already carried #4130's fix for the earlier
+        // format-clause cause. Episodes fired, so `memory.is_some()` and
+        // `turn_warrants_reflection` were both true and the opt-out is the only
+        // remaining term in that gate.
+        //
+        // Removed rather than reported: a drive's whole premise is that a
+        // turn's learning outlives the turn (see `super::learning`), so an
+        // ambient switch nobody aimed at this loop must not decide it.
+        // Unconditional, which leaves no hidden branch for a report to be
+        // about. A bench trial is unaffected — the adapter sets the variable on
+        // its own `stella run` child, never by having a drive inherit it.
+        .env_remove(crate::agent::DISABLE_REFLECTION_ENV)
         .arg("run")
         .arg("--output-format")
         .arg("json");
@@ -792,17 +819,79 @@ mod tests {
     use super::*;
     use stella_protocol::issue::{IssueClass, IssueKey, IssueState};
 
-    /// The child turn's argv, as strings.
-    fn turn_args(flags: &TurnFlags) -> Vec<String> {
-        let cmd = turn_command(
+    /// The child turn as built, ready to be asked about argv or environment.
+    fn turn_cmd(flags: &TurnFlags) -> Command {
+        turn_command(
             Path::new("/usr/local/bin/stella"),
             Path::new("/tmp/worktree"),
             Path::new("/tmp/repo"),
             flags,
-        );
-        cmd.get_args()
+        )
+    }
+
+    /// The child turn's argv, as strings.
+    fn turn_args(flags: &TurnFlags) -> Vec<String> {
+        turn_cmd(flags)
+            .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect()
+    }
+
+    /// **Witness (#4362).** The turn the loop spawns does not inherit the
+    /// reflection opt-out.
+    ///
+    /// `Command` passes the parent's whole environment through, so a shell that
+    /// had exported `STELLA_DISABLE_REFLECTION` for a benchmark run silently
+    /// switched off every drive turn's reflection call — while the episode
+    /// writer, which reads no switch, kept recording. The loop then reported
+    /// `reflections_logged: 0` with nothing to distinguish "learned nothing"
+    /// from "learning was off".
+    ///
+    /// Asserted as a removal on the built command rather than by setting the
+    /// variable and reading it back: `std::env` is process-global and this test
+    /// suite runs in parallel, so mutating it here would be a race against every
+    /// other test in the binary.
+    #[test]
+    fn the_turn_does_not_inherit_the_reflection_opt_out() {
+        let removed: Vec<String> = turn_cmd(&TurnFlags::default())
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(key, _)| key.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(
+            removed.contains(&crate::agent::DISABLE_REFLECTION_ENV.to_owned()),
+            "the child must not inherit {}: {removed:?}",
+            crate::agent::DISABLE_REFLECTION_ENV
+        );
+    }
+
+    /// The state root is still *set*, not removed — the two environment edits
+    /// this command makes point in opposite directions and a fix that
+    /// confused them would take the reflection log's own home with it.
+    #[test]
+    fn the_workspace_state_root_still_reaches_the_turn() {
+        let cmd = turn_cmd(&TurnFlags::default());
+        let set: Vec<(String, String)> = cmd
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value.map(|v| {
+                    (
+                        key.to_string_lossy().into_owned(),
+                        v.to_string_lossy().into_owned(),
+                    )
+                })
+            })
+            .collect();
+
+        assert_eq!(
+            set,
+            vec![(
+                stella_home::WORKSPACE_STATE_ROOT_ENV.to_owned(),
+                "/tmp/repo".to_owned()
+            )],
+            "the state root is the one variable this command sets"
+        );
     }
 
     /// **Witness (#4352).** Every session flag the parent parsed reaches the


### PR DESCRIPTION
## What & why

`stella self-driving drive` recorded an episode per turn and never a lesson. `~/.stella/self-driving/oxagen-platform/stats.json` reads `reflections_logged: 0, memories_created: 0, proposals_made: 0` after 25 turns and 16 merged pull requests.

`crates/stella-cli/src/self_driving_cmd/work.rs`'s `turn_command` builds the child `stella run` and sets exactly one environment variable; `std::process::Command` passes the rest of the parent's environment through untouched. `STELLA_DISABLE_REFLECTION` is the benchmark adapter's switch for "do not spend the extra provider call on a container that is about to be destroyed" (`bench/harbor_adapter`, `bench/evidence/run/env.sh`, `README.md`). A shell that had exported it for a bench run and then started a drive handed it to every turn.

The two writers then diverge, which is what made the symptom so specific:

| | episode (`agent/goal.rs`, `record_episode`) | reflection (`agent/goal.rs`, `should_reflect_after_one_shot`) |
|---|---|---|
| `memory.is_some()` | yes | yes |
| `turn_warrants_reflection(&messages)` | yes | yes |
| format is `Text`/`Json`/`StreamJson` | — | yes (`json` passes) |
| **`!reflection_explicitly_disabled()`** | **—** | **yes** |

`record_episode` reads no switch, so episodes accrued while lessons did not, and `reflections_logged: 0` could not be told apart from "the loop learned nothing".

`turn_command` now removes that variable from the child it builds. A drive's premise is that a turn's learning outlives the turn (`self_driving_cmd/learning.rs`'s module doc), so an ambient switch nobody aimed at this loop must not decide it. Unconditional, so no hidden branch is left to report on. A bench trial is unaffected: the adapter sets the variable on its own `stella run` child rather than by having a drive inherit it.

## Evidence for the diagnosis

`#4130` had already fixed an earlier cause of the same symptom — a `format == OutputFormat::Text` clause at the call site — and the issue's own comment thread left the remaining hypothesis unsettled for want of the drive shell's environment. The store settles it instead.

**1. The running binary carried #4130's fix.** `~/.cargo/bin/stella` is 0.9.143, built 2026-08-22 18:59. `git merge-base --is-ancestor a1b56da6a 25c0a2b45` exits 0 — the fix commit is an ancestor of the 0.9.143 release commit, which landed 2026-08-22 17:30, ninety minutes before the binary was built.

**2. Drive turns ran on it and wrote episodes.** `oxagen-platform`'s `context.db`:

```
sqlite> select substr(recorded_at,1,10), count(*) from episode group by 1;
2026-08-20|11
2026-08-23|5
```

The last is `2026-08-23T21:03:55Z`, two seconds before the loop's own last audit line.

**3. Not one reflection model call was dispatched that day.** `store.db`, censused by `(role)` as `CLAUDE.md` requires:

```
sqlite> select json_extract(payload,'$.role'), count(*) from events
        where event_type='step_usage' and substr(ts,1,10)='2026-08-23' group by 1;
worker|143

sqlite> ... substr(ts,1,10)='2026-08-20' ...
worker|72
reflection|7
```

The seven on 2026-08-20 all fall between 08:03 and 08:16 UTC, an hour before #4130 was even authored — a pre-fix binary, reflecting from `Text`-format sessions, which is what the old clause allowed.

**4. The alternatives are excluded.** Step 2 puts `memory.is_some()` and `turn_warrants_reflection` both true (the episode writer is gated on exactly those two). Step 1 puts the format term true. Step 3 rules out every branch downstream of the call — a model error, an unparseable response, an empty lesson set — because no call was made; `execution_reflection` also carries `parse_error IS NULL` on all 22 rows across both days. The only remaining term in `should_reflect_after_one_shot` is `!reflection_explicitly_disabled()`.

Stated plainly: (4) is an elimination, not a direct reading of that shell's environment, which is gone. It is falsifiable — a single `role=reflection` row on 2026-08-23 would have ended it — and nothing found contradicts it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`the_turn_does_not_inherit_the_reflection_opt_out` in `crates/stella-cli/src/self_driving_cmd/work.rs`. It asserts on the built `Command`'s environment overrides rather than by setting the variable and reading it back: `std::env` is process-global and this suite runs in parallel, so mutating it would race every other test in the binary.

Ablated by deleting the `.env_remove(...)` line:

```
test self_driving_cmd::work::tests::the_turn_does_not_inherit_the_reflection_opt_out ... FAILED

---- self_driving_cmd::work::tests::the_turn_does_not_inherit_the_reflection_opt_out stdout ----
thread '...' panicked at crates/stella-cli/src/self_driving_cmd/work.rs:862:9:
the child must not inherit STELLA_DISABLE_REFLECTION: []

test result: FAILED. 12 passed; 1 failed; 0 ignored; 0 measured; 2300 filtered out
```

Restored:

```
test self_driving_cmd::work::tests::the_turn_does_not_inherit_the_reflection_opt_out ... ok
test self_driving_cmd::work::tests::the_workspace_state_root_still_reaches_the_turn ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 2300 filtered out
```

`the_workspace_state_root_still_reaches_the_turn` is the second half: this command makes two environment edits pointing in opposite directions, and a fix that confused them would take the reflection log's own home with it. It pins the set-variables list to exactly one entry, so a removal written as a removal of the wrong thing fails here.

## What this does not do

It does not give the loop a way to *choose* not to reflect. There is no `--no-reflect` flag and `--spend-limit` is the money control; if a reason to switch reflection off per drive appears, that is a flag, not an inherited environment variable.

## Tests deleted

None.

Closes #4362

## Summary by Sourcery

Ensure self-driving turns preserve reflection and learning even when the parent process has disabled reflections.

Bug Fixes:
- Prevent self-driving turns from inheriting the ambient reflection opt-out, ensuring each turn can record its lessons independently of benchmark settings.

Tests:
- Add regression coverage verifying the reflection opt-out is removed from spawned turns while the workspace state root remains configured.