### PR TITLE
The file-size guard names the files nearing their ceiling, before one of them fails a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -825,6 +825,14 @@ inputs, not review afterthoughts:
   a PR of its own — safe precisely when nothing is blocked on it. Both modes
   still retire an entry whose file dropped under the limit or is gone, because
   the check hard-fails on those and names the update as the only remedy.
+- **A passing run names the files nearing the line** (#4897). `check-file-size`
+  used to say nothing about a file until the moment it failed, so a file eight
+  lines under its ceiling and a file at four hundred produced the same green
+  line — and the author who then met the ceiling was the one whose change was
+  about something else and who had no room to design a seam. The run now lists
+  the crowded files, tightest first, and exits 0 either way: it reports, it does
+  not judge. Grandfathered files are left out, because a baseline entry sits at
+  its ceiling by construction and is already named here and in its crate README.
 
 **The ratchet judges your change, not the tree** (#2004). A file over the line
 fails only when `current > max(its own limit, size in the base tree)` — where

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -144,6 +144,27 @@ set -euo pipefail
 
 LIMIT=1500
 
+# How little headroom a file may have before the guard names it, and how many
+# of the tightest it names before falling back to a count.
+#
+# Advisory, never a verdict: every file this reports is still UNDER its ceiling,
+# the check passes, and the exit code is 0. Failing a change because some other
+# file is crowded is the bug #2004 rewrote this guard to stop.
+#
+# It exists because the guard was otherwise silent about a file until the moment
+# it failed, so a file at 1492 lines and a file at 400 produced the same green
+# line. The author who then meets the ceiling is the one whose PR is about
+# something else, who has no room to design a module seam, and for whom the
+# cheapest-looking fix is the baseline entry CLAUDE.md calls a defect against
+# the PR that introduces it. #3923 named that trap; this is what puts it in view
+# beforehand (#4897).
+#
+# The cap is here because an advisory nobody reads is worse than none: 44 files
+# were within this margin when it was written, and a 44-line block on every
+# `make guards-fast` run trains people to scroll past the whole guard.
+CROWDING_MARGIN=50
+CROWDING_SHOW=10
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
@@ -438,10 +459,25 @@ raw_report="$(
   {
     grep -v '^#' "$baseline" | sed 's/^/B /'
     current_sizes | sed 's/^/C /'
-  } | awk -v limit="$LIMIT" '
+  } | awk -v limit="$LIMIT" -v margin="$CROWDING_MARGIN" '
     $1 == "B" { ceiling[$3] = $2; next }
     $1 == "C" {
       path = $3; n = $2; seen[path] = 1
+      # The crowding advisory, and only for a file with NO baseline entry.
+      # (No apostrophes in this block: it sits inside a single-quoted awk
+      # program, where one closes the quote and bash reports a syntax error
+      # forty lines away.)
+      #
+      # A grandfathered file sits at its recorded ceiling by construction, so
+      # including them puts every one of them at zero headroom and they fill
+      # the list — measured on this tree, all ten of the tightest were
+      # grandfathered and not one of the files the advisory exists for got
+      # printed. They also need it least: a baseline entry is already named in
+      # the per-crate table in AGENTS.md and in the crate README, so three
+      # places say "closed to growth" before this one. The trap #3923
+      # describes is the file with no entry available and none coming.
+      if (!(path in ceiling) && n <= limit && limit - n <= margin)
+        crowded = crowded sprintf("CROWDED %d %s %d %d\n", limit - n, path, n, limit)
       if (path in ceiling) {
         if (n <= limit)
           obsolete = obsolete sprintf("  %s is now %d lines (<= %d) — drop its baseline entry\n", path, n, limit)
@@ -455,6 +491,8 @@ raw_report="$(
       for (p in ceiling)
         if (!(p in seen))
           stale = stale sprintf("  %s (baseline entry, file no longer tracked)\n", p)
+      # First, so the report sections below keep the order they had.
+      if (crowded) printf "%s", crowded
       if (newover) printf "%s", newover
       if (grew) printf "%s", grew
       if (obsolete) printf "OBSOLETE\n%s", obsolete
@@ -484,10 +522,18 @@ effective_limit() {
 # the GREW section still lands between NEWOVER and OBSOLETE.
 report=""
 drift=""
+crowded=""
 newover_header_emitted=0
 grew_header_emitted=0
 while IFS= read -r line; do
   case "$line" in
+  "CROWDED "*)
+    # Sortable form: headroom first, so the tightest files lead the advisory.
+    # Handled explicitly rather than falling through to the `*)` arm below,
+    # which appends to `report` — and a non-empty `report` is a failed gate.
+    crowded="$crowded${line#CROWDED }
+"
+    ;;
   "NEWCAND "*)
     # Deliberate word split, as for GREWCAND below.
     # shellcheck disable=SC2086
@@ -602,3 +648,22 @@ else
 fi
 trap '' PIPE
 echo "check-file-size: OK — $tracked watched files, $grandfathered grandfathered over $LIMIT lines, and nothing went over by this change.${mode_note}${drift_note}" || true
+
+# The advisory (#4897). Printed after the verdict because it is not one: every
+# file named here is UNDER its ceiling and the exit code stays 0. See
+# CROWDING_MARGIN's comment at the top for why it exists at all.
+if [ -n "$crowded" ]; then
+  crowded_total="$(printf '%s' "$crowded" | grep -c '^')"
+  shown="$(printf '%s' "$crowded" | LC_ALL=C sort -n -k1,1 | head -n "$CROWDING_SHOW")"
+  if [ "$crowded_total" -gt "$CROWDING_SHOW" ]; then
+    lead="$crowded_total file(s) sit within $CROWDING_MARGIN lines of their ceiling. The $CROWDING_SHOW tightest:"
+  else
+    lead="$crowded_total file(s) sit within $CROWDING_MARGIN lines of their ceiling:"
+  fi
+  {
+    echo "check-file-size: $lead"
+    printf '%s\n' "$shown" | awk '{ printf "  %-64s %5d / %-5d %d line(s) left\n", $2, $3, $4, $1 }'
+    echo "Plan around these rather than into them: a file that crosses gets no baseline"
+    echo "entry, only a split (AGENTS.md, \"God files\")."
+  } || true
+fi

--- a/scripts/test-file-size.sh
+++ b/scripts/test-file-size.sh
@@ -437,6 +437,64 @@ entry_is "U7 --update still refuses to add an entry for a first-time crossing" "
 "$r/scripts/check-file-size.sh" --update --retighten >/dev/null 2>&1
 entry_is "U8 --retighten refuses it too" "$r" src/new.rs absent
 
+# ── The crowding advisory (#4897) ────────────────────────────────────────────
+#
+# The guard used to say nothing about a file until the moment it failed, so a
+# file at 1492 lines and a file at 400 produced the same green line. The author
+# who then meets the ceiling is the one whose change is about something else,
+# who has no room to design a module seam, and for whom the cheapest-looking
+# fix is the baseline entry the guard refuses to write (#3923).
+#
+# Every case here is expect-pass, which is the property that matters most: the
+# advisory reports, it does not judge.
+
+# want_absent <name> <repo> <substring> — the guard passes and does NOT say it.
+# The positive cases below are all satisfiable by an advisory that names every
+# watched file, and that advisory would be noise rather than a signal.
+want_absent() {
+  local name="$1" dir="$2" sub="$3" out
+  if ! out="$("$dir/scripts/check-file-size.sh" 2>&1)"; then
+    fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+    return
+  fi
+  case "$out" in
+    *"$sub"*) fail=$((fail + 1)); echo "FAIL $name — named '$sub' when it should not:"; echo "$out" ;;
+    *) pass=$((pass + 1)); echo "ok   $name" ;;
+  esac
+}
+
+r="$(new_repo "crowding")"
+plant "$r" "src/crowded.rs" 1492
+plant "$r" "src/roomy.rs" 900
+want "W1 a file 8 lines under the limit is named while there is room" \
+  expect-pass "$r" "src/crowded.rs"
+want "W2 ...with its size, its ceiling and its headroom" \
+  expect-pass "$r" "1492 / 1500  8 line(s) left"
+want_absent "W3 a file with room to spare is not named" "$r" "src/roomy.rs"
+
+# The narrowing this advisory makes, and the measurement behind it: a
+# grandfathered file sits AT its recorded ceiling by construction, so counting
+# them puts every one at zero headroom and they fill the list. Measured on the
+# tree that introduced this, all ten of the tightest were grandfathered and not
+# one of the files the advisory exists for was printed. They also need it least
+# — the per-crate table in AGENTS.md and the crate README already say "closed
+# to growth".
+r="$(new_repo "crowding_skips_grandfathered")"
+plant "$r" "src/godfile.rs" 2400
+plant "$r" "src/crowded.rs" 1490
+set_baseline "$r" "2400 src/godfile.rs"
+want "W4 a file with no entry is still named beside a god file" \
+  expect-pass "$r" "src/crowded.rs"
+want_absent "W5 a grandfathered file at its own ceiling is not named" \
+  "$r" "src/godfile.rs"
+
+# Nothing crowded means nothing printed. Without this the advisory could emit
+# its "0 file(s)" header forever and read as a finding on a clean tree.
+r="$(new_repo "crowding_quiet")"
+plant "$r" "src/small.rs" 200
+want_absent "W6 a tree with nothing near the line says nothing" \
+  "$r" "of their ceiling"
+
 echo
 echo "passed ${pass}, failed ${fail}"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

`scripts/check-file-size.sh` was silent about a file until the moment it failed. Its success line —

```
check-file-size: OK — 1758 watched files, 19 grandfathered over 1500 lines, and nothing went over by this change.
```

— reads the same whether the tightest file in the tree has eight lines of headroom or eleven hundred. So the trap #3923 exists to describe sprang without warning: the author who meets the ceiling is the one whose change is about something else, who has no room to stop and design a module seam, and for whom the cheapest-looking fix is the baseline entry `CLAUDE.md` calls a defect against the PR that introduces it.

A passing run now lists the crowded files, tightest first:

```
check-file-size: OK — 1758 watched files, 19 grandfathered over 1500 lines, and nothing went over by this change. Judged against 118b8721e.
check-file-size: 6 file(s) sit within 50 lines of their ceiling:
  crates/stella-tui/src/model.rs                                    1492 / 1500  8 line(s) left
  crates/stella-plugin/src/consent.rs                               1486 / 1500  14 line(s) left
  crates/stella-tui/src/model/tests.rs                              1476 / 1500  24 line(s) left
  crates/stella-observatory/src/db.rs                               1470 / 1500  30 line(s) left
  crates/stella-plugin/src/wire.rs                                  1459 / 1500  41 line(s) left
  crates/stella-tui/src/diff.rs                                     1452 / 1500  48 line(s) left
Plan around these rather than into them: a file that crosses gets no baseline
entry, only a split (AGENTS.md, "God files").
```

## Three decisions worth reviewing

**It reports, it does not judge.** Every file named is under its ceiling and the exit code stays 0. A warning about a file nobody touched must never become a second way for an unrelated PR to go red — that is the bug #2004 rewrote this guard to stop, and `W1`–`W6` are all `expect-pass` cases for that reason.

**Grandfathered files are excluded, and the measurement is why.** The first draft counted them, since a baseline entry sits at its recorded ceiling by construction and has zero headroom. Run on this tree, all ten of the tightest were grandfathered and not one of the files the advisory exists for was printed:

```
check-file-size: 23 file(s) sit within 50 lines of their ceiling. The 10 tightest:
  bench/harbor_adapter/stella_harbor/__init__.py                    1862 / 1862  0 line(s) left
  bench/harbor_adapter/stella_harbor/secure_launcher.py             4383 / 4383  0 line(s) left
  ...
```

They also need it least: the per-crate table in `AGENTS.md` and each crate's own README already say "closed to growth". The trap is the file with no entry available and none coming.

**The list is capped.** An advisory nobody reads is worse than none, and 23 lines on every `make guards-fast` run trains people to scroll past the whole guard. `CROWDING_SHOW=10`, with a count for the remainder; both it and `CROWDING_MARGIN=50` live in one variable each beside `LIMIT`, never repeated in prose.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Six cases in `scripts/test-file-size.sh` (`make file-size-test`), covering both directions. Ablated by deleting the two lines that emit a `CROWDED` record:

```
FAIL W1 a file 8 lines under the limit is named while there is room — passed, but did not report 'src/crowded.rs':
check-file-size: OK — 3 watched files, 0 grandfathered over 1500 lines, and nothing went over by this change. No base resolved — strict whole-tree check.
FAIL W2 ...with its size, its ceiling and its headroom — passed, but did not report '1492 / 1500  8 line(s) left':
check-file-size: OK — 3 watched files, 0 grandfathered over 1500 lines, and nothing went over by this change. No base resolved — strict whole-tree check.
ok   W3 a file with room to spare is not named
FAIL W4 a file with no entry is still named beside a god file — passed, but did not report 'src/crowded.rs':
check-file-size: OK — 3 watched files, 1 grandfathered over 1500 lines, and nothing went over by this change. No base resolved — strict whole-tree check.
ok   W5 a grandfathered file at its own ceiling is not named
ok   W6 a tree with nothing near the line says nothing

passed 37, failed 3
```

Restored:

```
ok   W1 a file 8 lines under the limit is named while there is room
ok   W2 ...with its size, its ceiling and its headroom
ok   W3 a file with room to spare is not named
ok   W4 a file with no entry is still named beside a god file
ok   W5 a grandfathered file at its own ceiling is not named
ok   W6 a tree with nothing near the line says nothing

passed 40, failed 0
```

The three that survive ablation are the point of including them: `W3`/`W5`/`W6` are what stops an advisory that names every watched file from satisfying `W1`/`W2`/`W4`.

`want_absent` is new in that harness — the existing `want` only asserts a substring is present, and the negative direction needs the opposite.

## Also

- `shellcheck` clean on both scripts.
- `make guards-fast` green, `make prose` and `make line-citations` unchanged.
- One paragraph added to `AGENTS.md` § "God files", with no counts in it.
- A note in the awk block warning that an apostrophe inside that single-quoted program closes the quote and makes bash report a syntax error forty lines away. It cost me a debugging round; the next person gets it free.

## Tests deleted

None.

Closes #4897
Refs #3776, #3923

## Summary by Sourcery

Warn about files approaching the size ceiling before they block future changes without turning the advisory into a failing check.

New Features:
- Add a passing file-size advisory that identifies non-grandfathered files nearing the line limit, ordered by remaining headroom and capped to keep output readable.

Enhancements:
- Keep crowding reports informational so unrelated pull requests continue to pass.
- Exclude grandfathered files from the crowding advisory and document the guidance in AGENTS.md.

Documentation:
- Document the proactive file-size crowding advisory in the God files guidance.

Tests:
- Add witness coverage for reporting crowded files, formatting headroom, excluding roomy and grandfathered files, and remaining silent when no files are near the limit.