### PR TITLE
fix(stella-cli): every clippy suppression states why, and eight of them go away

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1132,7 +1132,14 @@ pub(crate) fn open_store(workspace_root: &std::path::Path) -> Option<Arc<Store>>
 /// is open. `registry` is the concrete tool registry (its ledgers close the
 /// execution's audit record); `base_tools` is the same registry as the
 /// engine's executor, possibly MCP-wrapped.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the engine's own turn entry point, and the one the other three follow; `messages`, \
+              `budget`, `session_memory` and the friction out-parameter are four `&mut` borrows \
+              of separate caller locals held for the turn, so the bundle is a struct of disjoint \
+              mutable borrows and is worth doing across all four entry points at once rather \
+              than here alone (#4916)"
+)]
 pub(crate) async fn run_turn(
     provider: &dyn Provider,
     base_tools: &dyn ToolExecutor,

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -811,7 +811,13 @@ pub(super) fn announce_withheld_steering(tx: &mpsc::UnboundedSender<AgentEvent>,
 /// worker provider itself, identical to before: no second provider is built
 /// and no extra cost is incurred. Text-mode rendering only — goal and
 /// monitor never take `--output-format`.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one of the crate's four turn entry points, which share their first eight \
+              parameters; `messages` and `budget` are `&mut` borrows of separate caller locals \
+              held for the turn, so the bundle is a struct of disjoint mutable borrows and is \
+              worth doing across all four at once rather than here alone (#4916)"
+)]
 pub(crate) async fn run_goal_turn(
     provider: &dyn Provider,
     base_tools: &dyn ToolExecutor,

--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -254,7 +254,13 @@ impl PointStream for GoalPointStream<'_> {
 /// See the module doc for what stays untouched (the goal verifier) and what
 /// is refused rather than silently mishandled (a round a plugin's own
 /// `[oracle]` holds open past one internal turn).
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one of the crate's four turn entry points, which share their first eight \
+              parameters; `messages` and `budget` are `&mut` borrows of separate caller locals \
+              held for the turn, so the bundle is a struct of disjoint mutable borrows and is \
+              worth doing across all four at once rather than here alone (#4916)"
+)]
 pub(crate) async fn run_goal_wrapped_turn(
     provider: &dyn Provider,
     base_tools: &dyn ToolExecutor,

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -953,14 +953,16 @@ pub async fn run_deck_session(
                             dispatch.held(),
                             &registry,
                             &store,
-                            &session_record.id,
-                            &workspace_name,
-                            cfg,
-                            budget_limit,
                             &mut unmetered_spend,
                             &pr_nudge,
-                            &in_tx,
-                            &sup_tx,
+                            subsession::LaneCtx {
+                                cfg,
+                                budget_limit,
+                                session_id: &session_record.id,
+                                workspace_name: &workspace_name,
+                                in_tx: &in_tx,
+                                sup_tx: &sup_tx,
+                            },
                         );
                         continue 'session;
                     }
@@ -977,12 +979,14 @@ pub async fn run_deck_session(
                             control,
                             &mut subs,
                             &mut pending_controls,
-                            cfg,
-                            budget_limit,
-                            &session_record.id,
-                            &workspace_name,
-                            &in_tx,
-                            &sup_tx,
+                            subsession::LaneCtx {
+                                cfg,
+                                budget_limit,
+                                session_id: &session_record.id,
+                                workspace_name: &workspace_name,
+                                in_tx: &in_tx,
+                                sup_tx: &sup_tx,
+                            },
                         );
                         continue 'session;
                     }
@@ -1017,12 +1021,14 @@ pub async fn run_deck_session(
                         subsession::spawn_lane_or_notice(
                             text,
                             &mut subs,
-                            cfg,
-                            budget_limit,
-                            &session_record.id,
-                            &workspace_name,
-                            &in_tx,
-                            &sup_tx,
+                            subsession::LaneCtx {
+                                cfg,
+                                budget_limit,
+                                session_id: &session_record.id,
+                                workspace_name: &workspace_name,
+                                in_tx: &in_tx,
+                                sup_tx: &sup_tx,
+                            },
                         );
                         continue 'session;
                     }
@@ -1749,14 +1755,16 @@ pub async fn run_deck_session(
                             dispatch.held(),
                             &registry,
                             &store,
-                            &session_record.id,
-                            &workspace_name,
-                            cfg,
-                            budget_limit,
                             &mut unmetered_spend,
                             &pr_nudge,
-                            &in_tx,
-                            &sup_tx,
+                            subsession::LaneCtx {
+                                cfg,
+                                budget_limit,
+                                session_id: &session_record.id,
+                                workspace_name: &workspace_name,
+                                in_tx: &in_tx,
+                                sup_tx: &sup_tx,
+                            },
                         );
                     }
                     input = sub_rx.recv() => match input {
@@ -1794,12 +1802,14 @@ pub async fn run_deck_session(
                                         &mut queue,
                                         &mut subs,
                                         dispatch.held(),
-                                        cfg,
-                                        budget_limit,
-                                        &session_record.id,
-                                        &workspace_name,
-                                        &in_tx,
-                                        &sup_tx,
+                                        subsession::LaneCtx {
+                                            cfg,
+                                            budget_limit,
+                                            session_id: &session_record.id,
+                                            workspace_name: &workspace_name,
+                                            in_tx: &in_tx,
+                                            sup_tx: &sup_tx,
+                                        },
                                     );
                                 }
                             }
@@ -1818,12 +1828,14 @@ pub async fn run_deck_session(
                             subsession::spawn_lane_or_notice(
                                 text,
                                 &mut subs,
-                                cfg,
-                                budget_limit,
-                                &session_record.id,
-                                &workspace_name,
-                                &in_tx,
-                                &sup_tx,
+                                subsession::LaneCtx {
+                                    cfg,
+                                    budget_limit,
+                                    session_id: &session_record.id,
+                                    workspace_name: &workspace_name,
+                                    in_tx: &in_tx,
+                                    sup_tx: &sup_tx,
+                                },
                             );
                         }
                         // Esc with something to say — see `steer`.
@@ -1907,12 +1919,14 @@ pub async fn run_deck_session(
                                 control,
                                 &mut subs,
                                 &mut pending_controls,
-                                cfg,
-                                budget_limit,
-                                &session_record.id,
-                                &workspace_name,
-                                &in_tx,
-                                &sup_tx,
+                                subsession::LaneCtx {
+                                    cfg,
+                                    budget_limit,
+                                    session_id: &session_record.id,
+                                    workspace_name: &workspace_name,
+                                    in_tx: &in_tx,
+                                    sup_tx: &sup_tx,
+                                },
                             );
                         }
                         // Double-Esc: cancel AND park dispatch — the

--- a/crates/stella-cli/src/command_deck/authoring.rs
+++ b/crates/stella-cli/src/command_deck/authoring.rs
@@ -77,7 +77,13 @@ pub(super) fn forward_reflection_events(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the driver loop's own end-of-turn state at its single call site, including two \
+              simultaneous `&mut` borrows (`memory`, `budget`) of separate locals — a params \
+              struct would hold those two borrows, be constructed once, and move the same eleven \
+              fields into `command_deck.rs`, which is a god file"
+)]
 pub(super) async fn record_and_reflect_turn(
     memory: &mut Option<SessionMemory>,
     prompt: &str,

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -112,10 +112,6 @@ pub(super) fn spawn_mcp_connect(
 /// Service a session-registry / inbox verb from the deck. Returns `true` if
 /// `input` was one (so the caller skips its own dispatch). All of these are
 /// cheap local file ops, serviced identically idle or mid-turn.
-// Every argument is a distinct handle the verbs need (registry, store, config,
-// budget, the two identities, the channel) — bundling them into a struct would
-// move the same list one hop away from the one call site.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn service_registry_action(
     input: &WorkspaceInput,
     scope: &sessions_view::SessionScope<'_>,
@@ -181,7 +177,15 @@ pub(super) fn notifications_inbound(store: &stella_store::NotificationStore) -> 
 /// worker succeeding completes its board task), meter the worker's spend
 /// toward the session budget, nudge the PR monitor, then drain whatever the
 /// freed slot can take — parked spawns first, then the prompt backlog.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the six lane-spawning values are already bundled as `LaneCtx`; what \
+              is left is this arm of the driver loop's own `&mut` state — the \
+              lane table, two pending queues, the durable prompt queue and the \
+              unmetered-spend accumulator — each borrowed mutably from a \
+              different local, so a second bundle would be a struct of `&mut` \
+              borrows the caller cannot form while the loop holds them"
+)]
 pub(super) fn handle_supervisor_msg(
     msg: SupervisorMsg,
     subs: &mut SubSessions,
@@ -191,15 +195,11 @@ pub(super) fn handle_supervisor_msg(
     dispatch_held: bool,
     registry: &ToolRegistry,
     store: &Option<Arc<Store>>,
-    session_id: &str,
-    workspace_name: &str,
-    cfg: &Config,
-    budget_limit: Option<f64>,
     unmetered_spend: &mut f64,
     pr_nudge: &Arc<tokio::sync::Notify>,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
+    ctx: subsession::LaneCtx<'_>,
 ) {
+    let (session_id, in_tx) = (ctx.session_id, ctx.in_tx);
     match msg {
         SupervisorMsg::SpawnTask(queued) => {
             // A task's lane is its identity: a second worker on a live lane
@@ -217,16 +217,7 @@ pub(super) fn handle_supervisor_msg(
                     },
                 });
             } else if subs.has_slot() {
-                subsession::spawn_task_worker(
-                    &queued,
-                    subs,
-                    cfg,
-                    budget_limit,
-                    session_id,
-                    workspace_name,
-                    in_tx,
-                    sup_tx,
-                );
+                subsession::spawn_task_worker(&queued, subs, ctx);
             } else {
                 pending_spawns.push_back(queued);
             }
@@ -250,16 +241,7 @@ pub(super) fn handle_supervisor_msg(
             // A Restart that arrived while this worker was live respawns it
             // now — restart takes the freed slot ahead of parked spawns.
             if freed && !deleted && pending_controls.restarts.remove(&lane) {
-                let _ = subsession::respawn(
-                    &lane,
-                    subs,
-                    cfg,
-                    budget_limit,
-                    session_id,
-                    workspace_name,
-                    in_tx,
-                    sup_tx,
-                );
+                let _ = subsession::respawn(&lane, subs, ctx);
             }
             // Worker spend reaches the session's parent budget guard (the
             // L-E9 discipline). The guard is mutably borrowed by any in-
@@ -290,28 +272,9 @@ pub(super) fn handle_supervisor_msg(
                 if subs.is_live(&subsession::task_lane(&queued.request.task_id)) {
                     continue;
                 }
-                subsession::spawn_task_worker(
-                    &queued,
-                    subs,
-                    cfg,
-                    budget_limit,
-                    session_id,
-                    workspace_name,
-                    in_tx,
-                    sup_tx,
-                );
+                subsession::spawn_task_worker(&queued, subs, ctx);
             }
-            subsession::drain_queue(
-                queue,
-                subs,
-                dispatch_held,
-                cfg,
-                budget_limit,
-                session_id,
-                workspace_name,
-                in_tx,
-                sup_tx,
-            );
+            subsession::drain_queue(queue, subs, dispatch_held, ctx);
         }
     }
 }

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -31,7 +31,14 @@ use crate::subsession::{self, SupervisorMsg};
 /// One engine turn for the lead agent: the deck-mode analogue of
 /// `agent::run_turn` — same engine, same tool stack, same persistence —
 /// with the stdout renderer replaced by [`spawn_forwarder`].
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one of the crate's four turn entry points, which share their first eight \
+              parameters; `messages`, `budget` and `friction` are three `&mut` borrows of \
+              separate driver-loop locals held for the turn, so the bundle is a struct of \
+              disjoint mutable borrows and is worth doing across all four at once rather than \
+              here alone (#4916)"
+)]
 pub(super) async fn run_lead_turn(
     provider: &dyn Provider,
     base_tools: &dyn ToolExecutor,

--- a/crates/stella-cli/src/command_deck/session_override.rs
+++ b/crates/stella-cli/src/command_deck/session_override.rs
@@ -227,8 +227,12 @@ pub(super) fn refresh_prompts(
 /// the provider handle, the prompt plane, the deck's header meta and the
 /// statline pin all move together; on refusal one chrome note says why and
 /// nothing moves.
-#[allow(clippy::too_many_arguments)] // the driver loop's owned state, threaded — a struct of nine
-// borrows would outline the same list with lifetimes on top
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the driver loop's own state, threaded: `cfg`, `provider` and `lead_meta` are three \
+              separate `&mut` borrows taken at the call site, so a struct would have to hold all \
+              three at once and could not be built there"
+)]
 pub(super) fn apply_model_override(
     id: &str,
     cfg: &mut Config,
@@ -305,7 +309,12 @@ pub(super) fn agent_scope_policy(
 /// declared) runs the same session-only switch `/model` does. A model that
 /// cannot be applied degrades softly — the persona and toolbelt still land,
 /// and the note says what did not.
-#[allow(clippy::too_many_arguments)] // same driver-loop state bundle as `apply_model_override`
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the same three simultaneous `&mut` borrows as `apply_model_override` above, plus \
+              the assumed-persona slot this verb writes and the base tool policy it restores \
+              from"
+)]
 pub(super) fn assume_agent(
     name: &str,
     scope: AgentScope,

--- a/crates/stella-cli/src/command_deck/slash_commands.rs
+++ b/crates/stella-cli/src/command_deck/slash_commands.rs
@@ -137,7 +137,13 @@ pub(super) fn handle_agents_input(
 /// not a silent reindex that discards the rest. Custom commands/skills (⚡)
 /// DO take arguments: `/fix-bug issue-42` expands the `fix-bug` template
 /// with `issue-42`.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the deck's slash dispatcher reaches most of the session: `cfg` arrives as `&mut` \
+              because `/model` rewrites it while `provider` and `registry` are borrowed \
+              immutably beside it, so the three cannot share a struct the driver loop is able to \
+              construct"
+)]
 pub(super) async fn run_deck_command(
     prompt: &str,
     in_tx: &UnboundedSender<Inbound>,

--- a/crates/stella-cli/src/command_deck/worker_control.rs
+++ b/crates/stella-cli/src/command_deck/worker_control.rs
@@ -12,8 +12,7 @@
 
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::config::Config;
-use crate::subsession::{self, SubSessions, SupervisorMsg};
+use crate::subsession::{self, SubSessions};
 use stella_tui::{AgentStatus, Inbound};
 
 /// Verbs accepted while a lane's worker was live, finished when its `Ended`
@@ -33,19 +32,14 @@ pub(super) struct Pending {
 /// retained spec, stopping the live worker first when necessary; Delete
 /// takes the lane's row off the deck for good — stopping a live worker
 /// first, spec dropped either way so a later Restart cannot revive it.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn service(
     lane: &str,
     control: stella_tui::AgentControl,
     subs: &mut SubSessions,
     pending: &mut Pending,
-    cfg: &Config,
-    budget_limit: Option<f64>,
-    session_id: &str,
-    workspace_name: &str,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
+    ctx: subsession::LaneCtx<'_>,
 ) {
+    let in_tx = ctx.in_tx;
     match control {
         stella_tui::AgentControl::Stop => {
             subs.stop(lane);
@@ -71,16 +65,7 @@ pub(super) fn service(
                 pending.restarts.insert(lane.to_string());
                 subs.stop(lane);
             } else {
-                let _ = subsession::respawn(
-                    lane,
-                    subs,
-                    cfg,
-                    budget_limit,
-                    session_id,
-                    workspace_name,
-                    in_tx,
-                    sup_tx,
-                );
+                let _ = subsession::respawn(lane, subs, ctx);
             }
         }
         stella_tui::AgentControl::Delete => delete(lane, subs, pending, in_tx),

--- a/crates/stella-cli/src/config.rs
+++ b/crates/stella-cli/src/config.rs
@@ -914,7 +914,13 @@ impl Config {
         Err(no_api_key_error())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "credential resolution's inputs are four independent overrides plus the two \
+                  files it may write and the terminal it may prompt on; every one is read on \
+                  some path and none travels with another, so a bundle would carry seven fields \
+                  that no caller fills together"
+    )]
     fn resolve(
         provider: &ProviderConfig,
         model_id: String,

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -87,7 +87,12 @@ const SUMMARY_CHARS: usize = 96;
 
 /// Run a fleet: build/load the plan, dispatch it wave by wave, report —
 /// then, with `watch`, hold the fleet PR/CI monitor on the branches.
-#[allow(clippy::too_many_arguments)] // composition-root wiring; one caller
+#[expect(
+    clippy::too_many_arguments,
+    reason = "every parameter is one `stella fleet` flag, taken from clap and passed straight \
+              through by the single caller in `main`; a struct here would be a second copy of \
+              the subcommand's own field list, free to drift from it one flag at a time"
+)]
 pub async fn run_fleet(
     cfg: &Config,
     prompts: &[String],
@@ -836,7 +841,13 @@ fn same_tree(attempt_root: &Path, invocation_root: &Path) -> bool {
 /// (`--pipeline classic`); that driver has been removed from this build
 /// (#3865), so the raw loop is what a wrapper wraps and what an unwrapped
 /// attempt runs.
-#[allow(clippy::too_many_arguments)] // one caller (EngineWorker::run); composition wiring
+#[expect(
+    clippy::too_many_arguments,
+    reason = "`controls` and `spend` are already the bundles; what is left is one attempt's own \
+              values plus a `oneshot::Receiver` that must be moved in, and `EngineWorker::run` \
+              is the only caller — a further struct would be built and destructured in the same \
+              two functions"
+)]
 async fn run_task(
     cfg: &Config,
     budget_limit: Option<f64>,

--- a/crates/stella-cli/src/proposals_cmd.rs
+++ b/crates/stella-cli/src/proposals_cmd.rs
@@ -369,7 +369,6 @@ fn decide(
 /// auto-activation below the confidence bar precisely so a person decides, and
 /// a "keep" that recorded an event without writing the rule would be a decision
 /// with no effect.
-#[allow(clippy::too_many_arguments)]
 fn decide_in(
     store: &ContextStore,
     workspace_root: Option<&std::path::Path>,

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -707,7 +707,13 @@ where
 // A worker genuinely needs every one of these (identity, budget, session
 // link, both channels, stop signal) — bundling them into a struct would just
 // move the field list one hop away from the one call shape.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the worker task's owned half of a lane: `LaneCtx`'s borrows cannot cross the \
+              `tokio::spawn` boundary, so this takes the owned session id, workspace name and \
+              cloned senders, plus the receiving ends of the stop and pause channels whose \
+              senders `SubSessions` keeps"
+)]
 pub(crate) fn spawn(
     cfg: &Config,
     spec: SubSessionSpec,
@@ -900,7 +906,12 @@ fn initial_messages(
 /// the driver's stop signal (the same clean drop-at-await cancel the lead
 /// uses) and steered through `tap` at each step boundary. Returns
 /// `(execution_id, cost_usd, end)`.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "`spawn`'s body, one `async move` away: it receives the same owned lane values plus \
+              the two channel receivers, and folding them into a struct would only rename the \
+              capture list `spawn` already assembles"
+)]
 async fn run_worker(
     cfg: &Config,
     spec: &SubSessionSpec,
@@ -1137,22 +1148,36 @@ async fn run_worker(
     (execution_id, settled_cost, end)
 }
 
+/// What every lane entry point needs and none of them owns: which session
+/// this deck is, the workspace it sits in, the spend ceiling a worker
+/// inherits, and the two channels a worker reports on.
+///
+/// The five functions below took these as six positional parameters each,
+/// which is the whole reason their argument counts were what they were —
+/// `respawn` carried nine to do one thing with three. `Copy`, because they
+/// nest (`drain_queue` → `spawn_prompt_lane` → `spawn`) and a bundle that has
+/// to be re-borrowed at every hop is a worse trade than the six parameters it
+/// replaces.
+#[derive(Clone, Copy)]
+pub(crate) struct LaneCtx<'a> {
+    pub(crate) cfg: &'a Config,
+    pub(crate) budget_limit: Option<f64>,
+    pub(crate) session_id: &'a str,
+    pub(crate) workspace_name: &'a str,
+    pub(crate) in_tx: &'a UnboundedSender<Inbound>,
+    pub(crate) sup_tx: &'a UnboundedSender<SupervisorMsg>,
+}
+
 /// Drain the driver's prompt backlog into free worker slots, oldest first.
 /// Stops at a slash command (those belong to the lead's dispatcher — letting
 /// a later prompt jump it would also desync the deck's FIFO queue view) and
 /// while dispatch is held. Sends the `PromptStarted` front-pop for every
 /// prompt it takes, exactly like lead dispatch does.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn drain_queue(
     queue: &mut crate::session_persist::DurableQueue,
     subs: &mut SubSessions,
     dispatch_held: bool,
-    cfg: &Config,
-    budget_limit: Option<f64>,
-    session_id: &str,
-    workspace_name: &str,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
+    ctx: LaneCtx<'_>,
 ) {
     while !dispatch_held
         && subs.has_slot()
@@ -1163,16 +1188,7 @@ pub(crate) fn drain_queue(
         let Some(text) = queue.pop_front() else {
             break;
         };
-        spawn_prompt_lane(
-            text,
-            subs,
-            cfg,
-            budget_limit,
-            session_id,
-            workspace_name,
-            in_tx,
-            sup_tx,
-        );
+        spawn_prompt_lane(text, subs, ctx);
     }
 }
 
@@ -1180,19 +1196,9 @@ pub(crate) fn drain_queue(
 /// agents page's "describe a task for a new session"
 /// (`WorkspaceInput::SpawnLane`). The caller has already checked
 /// [`SubSessions::has_slot`]. Returns the lane id it started.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn spawn_prompt_lane(
-    text: String,
-    subs: &mut SubSessions,
-    cfg: &Config,
-    budget_limit: Option<f64>,
-    session_id: &str,
-    workspace_name: &str,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
-) -> String {
+pub(crate) fn spawn_prompt_lane(text: String, subs: &mut SubSessions, ctx: LaneCtx<'_>) -> String {
     let lane = subs.next_req_lane();
-    let _ = in_tx.send(Inbound::PromptStarted {
+    let _ = ctx.in_tx.send(Inbound::PromptStarted {
         agent: lane.clone(),
         text: text.clone(),
     });
@@ -1203,14 +1209,12 @@ pub(crate) fn spawn_prompt_lane(
     // reach it. `ShellEvent` is the transcript-only channel (no status
     // flip, no counters, no second trace row), which is exactly right for
     // a notice about a lane other than the one it prints on.
-    let _ = in_tx.send(Inbound::ShellEvent {
+    let _ = ctx.in_tx.send(Inbound::ShellEvent {
         agent: LEAD.to_string(),
         event: AgentEvent::Text {
             text: spawn_notice(&lane, &text),
         },
     });
-    let (stop_tx, stop_rx) = oneshot::channel();
-    let (pause_tx, pause_rx) = watch::channel(false);
     let spec = SubSessionSpec {
         lane: lane.clone(),
         title: prompt_line(&text, 48),
@@ -1224,21 +1228,33 @@ pub(crate) fn spawn_prompt_lane(
         // `SpawnLane` are each a person's own words, never a delegation.
         dispatched_by: None,
     };
-    let (generation, tap) = subs.started(&lane, stop_tx, pause_tx, spec.clone());
+    launch(subs, &lane, spec, ctx);
+    lane
+}
+
+/// Register a lane with [`SubSessions`] and start its worker task.
+///
+/// The three spawning entry points differ only in the spec they build; this is
+/// the rest of it, stated once — including the stop and pause channels, whose
+/// sending halves [`SubSessions::started`] keeps and whose receiving halves
+/// [`spawn`] takes, so neither end outlives the lane.
+fn launch(subs: &mut SubSessions, lane: &str, spec: SubSessionSpec, ctx: LaneCtx<'_>) {
+    let (stop_tx, stop_rx) = oneshot::channel();
+    let (pause_tx, pause_rx) = watch::channel(false);
+    let (generation, tap) = subs.started(lane, stop_tx, pause_tx, spec.clone());
     spawn(
-        cfg,
+        ctx.cfg,
         spec,
         generation,
-        budget_limit,
-        session_id.to_string(),
-        workspace_name.to_string(),
-        in_tx.clone(),
-        sup_tx.clone(),
+        ctx.budget_limit,
+        ctx.session_id.to_string(),
+        ctx.workspace_name.to_string(),
+        ctx.in_tx.clone(),
+        ctx.sup_tx.clone(),
         stop_rx,
         pause_rx,
         tap,
     );
-    lane
 }
 
 /// The lead-transcript notice a spawn prints: that the prompt started, which
@@ -1263,31 +1279,12 @@ pub(crate) fn spawn_notice(lane: &str, prompt: &str) -> String {
 /// new session": start a lane on `text` when a worker slot is free, and say
 /// so on the lead transcript when none is, quoting the task so the words
 /// survive the refusal (the page's composer already cleared on submit).
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn spawn_lane_or_notice(
-    text: String,
-    subs: &mut SubSessions,
-    cfg: &Config,
-    budget_limit: Option<f64>,
-    session_id: &str,
-    workspace_name: &str,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
-) {
+pub(crate) fn spawn_lane_or_notice(text: String, subs: &mut SubSessions, ctx: LaneCtx<'_>) {
     if subs.has_slot() {
-        spawn_prompt_lane(
-            text,
-            subs,
-            cfg,
-            budget_limit,
-            session_id,
-            workspace_name,
-            in_tx,
-            sup_tx,
-        );
+        spawn_prompt_lane(text, subs, ctx);
         return;
     }
-    let _ = in_tx.send(Inbound::ShellEvent {
+    let _ = ctx.in_tx.send(Inbound::ShellEvent {
         agent: LEAD.to_string(),
         event: AgentEvent::Text {
             text: format!(
@@ -1300,39 +1297,14 @@ pub(crate) fn spawn_lane_or_notice(
 
 /// Respawn an ended lane from its retained spec — the Restart verb. `false`
 /// when the lane has no retained spec or is still live (stop it first).
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn respawn(
-    lane: &str,
-    subs: &mut SubSessions,
-    cfg: &Config,
-    budget_limit: Option<f64>,
-    session_id: &str,
-    workspace_name: &str,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
-) -> bool {
+pub(crate) fn respawn(lane: &str, subs: &mut SubSessions, ctx: LaneCtx<'_>) -> bool {
     if subs.is_live(lane) {
         return false;
     }
     let Some(spec) = subs.spec(lane) else {
         return false;
     };
-    let (stop_tx, stop_rx) = oneshot::channel();
-    let (pause_tx, pause_rx) = watch::channel(false);
-    let (generation, tap) = subs.started(lane, stop_tx, pause_tx, spec.clone());
-    spawn(
-        cfg,
-        spec,
-        generation,
-        budget_limit,
-        session_id.to_string(),
-        workspace_name.to_string(),
-        in_tx.clone(),
-        sup_tx.clone(),
-        stop_rx,
-        pause_rx,
-        tap,
-    );
+    launch(subs, lane, spec, ctx);
     true
 }
 
@@ -1344,21 +1316,9 @@ pub(crate) fn task_lane(task_id: &str) -> String {
 
 /// Dispatch one `task_assign` spawn request (or park it if no slot is free —
 /// the caller owns the pending queue).
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn spawn_task_worker(
-    queued: &QueuedSpawn,
-    subs: &mut SubSessions,
-    cfg: &Config,
-    budget_limit: Option<f64>,
-    session_id: &str,
-    workspace_name: &str,
-    in_tx: &UnboundedSender<Inbound>,
-    sup_tx: &UnboundedSender<SupervisorMsg>,
-) {
+pub(crate) fn spawn_task_worker(queued: &QueuedSpawn, subs: &mut SubSessions, ctx: LaneCtx<'_>) {
     let req = &queued.request;
     let lane = task_lane(&req.task_id);
-    let (stop_tx, stop_rx) = oneshot::channel();
-    let (pause_tx, pause_rx) = watch::channel(false);
     let spec = SubSessionSpec {
         lane: lane.clone(),
         title: format!("task #{}: {}", req.task_id, prompt_line(&req.subject, 40)),
@@ -1371,20 +1331,7 @@ pub(crate) fn spawn_task_worker(
         ),
         dispatched_by: queued.dispatched_by,
     };
-    let (generation, tap) = subs.started(&lane, stop_tx, pause_tx, spec.clone());
-    spawn(
-        cfg,
-        spec,
-        generation,
-        budget_limit,
-        session_id.to_string(),
-        workspace_name.to_string(),
-        in_tx.clone(),
-        sup_tx.clone(),
-        stop_rx,
-        pause_rx,
-        tap,
-    );
+    launch(subs, &lane, spec, ctx);
 }
 
 /// How long Quit waits for stopped workers to settle before abandoning

--- a/crates/stella-cli/src/tune_cmd.rs
+++ b/crates/stella-cli/src/tune_cmd.rs
@@ -108,7 +108,13 @@ pub fn run_tune(cmd: &TuneCmd) -> Result<(), String> {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the two arms being compared, stated symmetrically: a path and an effort label \
+              each, plus where a promotion would be written and how many samples make the \
+              comparison. Pairing them into a struct would let a caller pass the baseline's path \
+              with the candidate's effort, which the flat list cannot express"
+)]
 fn run_effort(
     workspace_root: &Path,
     baseline_path: &Path,

--- a/crates/stella-cli/tests/clippy_suppressions_are_expectations.rs
+++ b/crates/stella-cli/tests/clippy_suppressions_are_expectations.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Every clippy suppression in this crate is an `#[expect(…, reason = "…")]`.
+//!
+//! AGENTS.md's "Code style and conventions" asks that no `#[allow]` on a
+//! clippy lint land without a comment saying why the lint is wrong *here*.
+//! The crate had 23 `#[allow(clippy::too_many_arguments)]`, four of which
+//! carried a reason and nineteen of which carried nothing (#3698).
+//!
+//! The remedy is `#[expect]` rather than a commented `#[allow]`, for a reason
+//! `#[allow]` cannot offer: an expectation that stops being true is a compile
+//! error under `-D warnings`. That is not theoretical here — converting the
+//! nineteen made clippy report `proposals_cmd::decide_in`'s suppression
+//! unfulfilled, and `driver_support::service_registry_action` was carrying one
+//! under a comment listing seven handles for a function that takes three. An
+//! `#[allow]` would have hidden both for as long as they lasted.
+//!
+//! `reason` is required by the attribute's own grammar in the form used here,
+//! so this test asserts only the form; whether a reason is *true* is a review
+//! question, exactly as AGENTS.md states it.
+//!
+//! Scoped to this crate because it is the one #3698 audited and the one that
+//! now has zero. Widening it to the workspace is #4918.
+
+use std::path::{Path, PathBuf};
+
+fn crate_src() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+/// Every `.rs` file under `src/`, recursively.
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
+        .filter_map(Result::ok);
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn no_clippy_lint_is_silenced_with_a_bare_allow() {
+    let mut sources = Vec::new();
+    rust_sources(&crate_src(), &mut sources);
+    assert!(!sources.is_empty(), "no Rust sources found under src/");
+
+    let mut offenders: Vec<String> = Vec::new();
+    for path in &sources {
+        let source = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+        for (i, line) in source.lines().enumerate() {
+            if line.trim_start().starts_with("#[allow(clippy::")
+                || line.trim_start().starts_with("#![allow(clippy::")
+            {
+                offenders.push(format!("{}:{}: {}", path.display(), i + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "clippy suppressions in this crate are `#[expect(<lint>, reason = \"…\")]`, \
+         so a suppression that stops being true fails the build instead of \
+         outliving its argument (#3698). Found {}:\n  {}",
+        offenders.len(),
+        offenders.join("\n  "),
+    );
+}


### PR DESCRIPTION
## What & why

`crates/stella-cli` carried 23 `#[allow(clippy::too_many_arguments)]`. Four had a reason
in a trailing comment; nineteen had nothing at all, which AGENTS.md's "Code style and
conventions" already forbids ("do not `#[allow]` your way past a lint without a comment
saying why the lint is wrong *here*"). The crate now has **zero** `#[allow(clippy::…)]`
of any lint.

**Eight are deleted rather than explained**, because those argument lists really were
reducible — the issue's step 2 asks for exactly this judgement, per site.

Five functions in `subsession.rs` (`drain_queue`, `spawn_prompt_lane`,
`spawn_lane_or_notice`, `respawn`, `spawn_task_worker`) each took the same six positional
values — `cfg`, `budget_limit`, `session_id`, `workspace_name`, `in_tx`, `sup_tx` — and so
did `worker_control::service` and `driver_support::handle_supervisor_msg`.
`subsession::LaneCtx<'_>` is those six. It is `Copy`, so it threads through the nesting
(`drain_queue` → `spawn_prompt_lane` → `launch`) without a re-borrow at every hop.

| function | before | after |
|---|---|---|
| `respawn` | 9 | 3 |
| `spawn_prompt_lane` | 8 | 3 |
| `spawn_lane_or_notice` | 8 | 3 |
| `spawn_task_worker` | 8 | 3 |
| `drain_queue` | 9 | 4 |
| `worker_control::service` | 10 | 5 |
| `handle_supervisor_msg` | 16 | 11 (still suppressed, with a reason) |

`subsession::launch` then states the rest of a spawn once instead of three times: the two
channels, `SubSessions::started`, and the `spawn` call whose eleven arguments the three
entry points were each spelling out.

Two more suppressions were already stale and are simply gone:
`proposals_cmd::decide_in` (clippy reported the expectation unfulfilled the moment it
became one) and `driver_support::service_registry_action`, which sat under a comment
listing seven handles — "registry, store, config, budget, the two identities, the
channel" — for a function that takes three.

**The other fifteen become `#[expect(clippy::too_many_arguments, reason = "…")]`**,
matching the form already used at `self_driving_cmd.rs`'s ledger writer. `#[expect]`
rather than a commented `#[allow]` for the reason the two stale ones demonstrate: an
expectation that stops being true is a build error under `-D warnings`, while a comment
outlives its argument silently. Each reason is about that call site — the flags of
`stella fleet`, the two arms `tune_cmd::run_effort` compares symmetrically, the three
simultaneous `&mut` borrows `session_override` takes from the driver loop — not
boilerplate.

**Where I disagree with the issue's recommendation.** The owner's comment recommends a
params struct for `command_deck/authoring.rs`'s `record_and_reflect_turn`. I judged it
irreducible and wrote the reason instead: it has one caller, in `command_deck.rs` (a god
file); two of its eleven parameters are `&mut` borrows of separate locals held for the
call; and the struct would be constructed at exactly one site out of the same eleven
fields — the case the issue's own step 2 names as "bundling would just move the same
fields one file over". `config.rs`'s `resolve` I judged the same way after reading its
callers: four independent overrides plus the two files it may write and the terminal it
may prompt on, no two of which travel together. Both calls are reversible in review.

Closes #3698

## The witness

`crates/stella-cli/tests/clippy_suppressions_are_expectations.rs` walks every `.rs` file
under `crates/stella-cli/src` and fails on any `#[allow(clippy::…)]` / `#![allow(clippy::…)]`.

Ablation — the source reverted, the test kept:

```
$ git stash push -- crates/stella-cli/src
$ cargo test -p stella-cli --test clippy_suppressions_are_expectations

test no_clippy_lint_is_silenced_with_a_bare_allow ... FAILED

clippy suppressions in this crate are `#[expect(<lint>, reason = "…")]`, so a suppression
that stops being true fails the build instead of outliving its argument (#3698). Found 23:
  …/src/proposals_cmd.rs:372: #[allow(clippy::too_many_arguments)]
  …/src/tune_cmd.rs:111: #[allow(clippy::too_many_arguments)]
  …/src/config.rs:917: #[allow(clippy::too_many_arguments)]
  …/src/fleet_cmd.rs:90: #[allow(clippy::too_many_arguments)] // composition-root wiring; one caller
  …/src/subsession.rs:1303: #[allow(clippy::too_many_arguments)]
  … (23 in total)

test result: FAILED. 0 passed; 1 failed
```

With the change:

```
test no_clippy_lint_is_silenced_with_a_bare_allow ... ok
test result: ok. 1 passed; 0 failed
```

## The gate

- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean, no unfulfilled expectations
- [x] `cargo test -p stella-cli` — 2311 + all integration binaries green
- [x] `cargo fmt --all`
- [x] `./scripts/check-file-size.sh` — OK (`command_deck.rs` 2545 → 2559, ceiling 3737)
- [x] `python3 scripts/check-prose.py` — OK, none added (checked against `origin/main`'s copy of the guard and baseline, which this branch matches byte for byte)
- [x] `./scripts/check-left-behind.sh` — OK
- [x] `Closes #3698` above and as a commit trailer

The workspace build and test suite are CI's, per CLAUDE.md.

## Deleted tests

None.

## Nothing left behind

- **#4916** — the four turn entry points (`agent::run_turn`, `run_goal_turn`,
  `run_goal_wrapped_turn`, `run_lead_turn`) share their first eight parameters verbatim
  and each still carries an expectation. Bundling them is a real refactor across every
  caller, with two to four disjoint `&mut` borrows per call site; each of those four
  reasons names the issue rather than claiming the shape is fine.
- **#4918** — widen this guard from `stella-cli` to the workspace, converting whatever
  other crates hold.

## Anything reviewers should know?

The issue cites `self_driving_cmd.rs:569` as the `#[expect]` exemplar; that function has
moved (the attribute is at `self_driving_cmd.rs:869` today) but the form is unchanged and
is what the fifteen follow.

`LaneCtx` is constructed inline at each of its call sites rather than once per driver-loop
iteration. A single long-lived binding would hold `&Config` across arms that re-borrow
`cfg` mutably, which the borrow checker refuses; the inline literals cost `command_deck.rs`
fourteen net lines against 1,178 of headroom.

## Summary by Sourcery

Make Stella CLI Clippy suppressions explicit and self-invalidating while simplifying repeated lane-spawning interfaces.

Enhancements:
- Replace Stella CLI's bare Clippy argument-count suppressions with justified, warning-checked expectations and remove stale suppressions.
- Reduce repeated lane-spawning parameters by introducing a shared lane context and centralizing worker launch setup.

Tests:
- Add an integration test that rejects bare Clippy allowances throughout the Stella CLI source tree.