### PR TITLE
The retired-hex ban can see the colours Rust writes, and can be shown to fire

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -178,6 +178,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-main-red-claim.sh
 
+      - name: the retired-hex ban, in every notation it watches
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-tokens.sh
+
       - name: measured-constants guard failure directions
         if: ${{ !cancelled() }}
         run: ./scripts/test-measured-constants.sh

--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,10 @@ tokens: ## Validate the colour system: hue clamp, generated-file sync, no retire
 	@python3 ./scripts/gen-tokens.py --check
 	@python3 ./scripts/check-tokens.py
 
+.PHONY: tokens-test
+tokens-test: ## Test the retired-hex ban across every notation it watches (hermetic; not part of `gate`)
+	./scripts/test-tokens.sh
+
 .PHONY: tokens-update
 tokens-update: ## Regenerate every colour artifact from design/tokens/stella-tokens.json
 	@python3 ./scripts/gen-tokens.py

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -36,7 +36,7 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-TOKENS = REPO / "design" / "tokens" / "stella-tokens.json"
+TOKENS_REL = "design/tokens/stella-tokens.json"
 
 # Where every hex must be a live token, not merely a non-retired one.
 TOKEN_ONLY = (
@@ -48,13 +48,17 @@ TOKEN_ONLY = (
 # Files that define the system itself, and so must be able to name retired
 # values in order to ban them.
 #
-# The last two are **ban sites**: tests whose whole job is asserting that a
+# The last three are **ban sites**: tests whose whole job is asserting that a
 # retired value does not ship, on a surface this script cannot see. A hex sweep
 # reads them as offenders, and that is exactly backwards -- the list *is* the
 # enforcement. Leaving them out is not a theoretical hazard: the v5.0 migration
 # swept both, rewriting `#ffb000`/`#0b0b0c` into the live gold and canvas, so
 # `brand-parity.test.ts` spent one merge banning the brand it exists to protect
-# and reported nineteen offenders that were all correct (#4066). They earn the
+# and reported nineteen offenders that were all correct (#4066).
+# `crates/stella-tui/src/theme/tests.rs` joined them when RUST_RGB below gave
+# this script eyes on Rust: its `RETIRED_*` constants are the ban list for that
+# surface, so the first thing the new matcher saw was the one file whose whole
+# job is naming those values (#4910). They earn the
 # exemption for the same reason the four above do, and they need it more,
 # because they are the only files here a sweep would happily "fix".
 #
@@ -69,6 +73,7 @@ SELF = (
     "design/tokens/stella-tokens.css",
     "website/src/lib/brand-parity.test.ts",
     "crates/stella-cli/src/export/tests.rs",
+    "crates/stella-tui/src/theme/tests.rs",
 )
 
 # Surfaces this system has not reached yet. Each entry names the issue that
@@ -106,6 +111,34 @@ HEX = re.compile(r"#[0-9A-Fa-f]{6}\b")
 RGB_FUNC = re.compile(
     r"rgba?\(\s*(\d{1,3})\s*[, ]\s*(\d{1,3})\s*[, ]\s*(\d{1,3})", re.IGNORECASE
 )
+# The same colours again, in the notation Rust writes them: ratatui spells a
+# colour `Color::Rgb(0x0A, 0x0A, 0x0C)`, and the hex-literal channels are what
+# no matcher here could see. #4910 reports this as Rust being invisible
+# outright; it is one notation narrower than that, and the suite is what caught
+# the difference. RGB_FUNC is IGNORECASE, so `Rgb(11, 11, 12)` already matched
+# as an `rgb(` call and the decimal spelling was covered by accident. The `0x`
+# spelling was not, and it is the one this tree actually writes — the single
+# banned value in the tree when this landed was `Color::Rgb(0x0B, 0x0B, 0x0C)`,
+# and twenty-one more literals in `crates/stella-tui/src/palette.rs` had never
+# been checked against anything.
+#
+# Both channel spellings are matched anyway rather than hex alone, so the two
+# notations stop depending on an unrelated flag on another pattern. A bare
+# `Rgb(` counts as well as `Color::Rgb(`: the name can be imported, and a false
+# positive requires three channels that spell a retired brand colour, which is
+# worth flagging wherever it is written.
+RUST_RGB = re.compile(
+    r"\bRgb\s*\(\s*(0[xX][0-9A-Fa-f]{1,2}|\d{1,3})\s*,"
+    r"\s*(0[xX][0-9A-Fa-f]{1,2}|\d{1,3})\s*,"
+    r"\s*(0[xX][0-9A-Fa-f]{1,2}|\d{1,3})\s*[,)]"
+)
+
+
+def channel(text: str) -> int:
+    """One `Color::Rgb` channel, hex-literal or decimal."""
+    return int(text, 16) if text[:2].lower() == "0x" else int(text)
+
+
 # Text extensions only. A hex "found" inside a PNG is a coincidence.
 TEXT_SUFFIXES = {
     ".css",
@@ -132,10 +165,10 @@ TEXT_SUFFIXES = {
 }
 
 
-def tracked_files() -> list[Path]:
+def tracked_files(root: Path) -> list[Path]:
     out = subprocess.run(
         ["git", "ls-files", "-z"],
-        cwd=REPO,
+        cwd=root,
         capture_output=True,
         text=True,
         check=True,
@@ -143,15 +176,20 @@ def tracked_files() -> list[Path]:
     return [Path(p) for p in out.split("\0") if p]
 
 
-def main() -> int:
-    doc = json.loads(TOKENS.read_text())
+def main(argv: list[str]) -> int:
+    # A root argument is what lets the suite point this at a fixture tree; with
+    # no argument it reads its own repository, as every caller does today.
+    # Without it the guard could not be shown to fire, which is the same defect
+    # one notation over from the one it exists to catch.
+    root = Path(argv[1]).resolve() if len(argv) > 1 else REPO
+    doc = json.loads((root / TOKENS_REL).read_text())
     live = {t["hex"].upper() for t in doc["tokens"]}
     banned = {e["hex"].upper(): e["was"] for e in doc["banned"]["values"]}
 
     ban_hits: list[str] = []
     stray_hits: list[str] = []
 
-    for rel in tracked_files():
+    for rel in tracked_files(root):
         posix = rel.as_posix()
         if posix in SELF:
             continue
@@ -159,7 +197,7 @@ def main() -> int:
             continue
         if any(posix.startswith(p) or posix == p for p in MIGRATING):
             continue
-        path = REPO / rel
+        path = root / rel
         try:
             text = path.read_text(errors="ignore")
         except OSError:
@@ -185,6 +223,15 @@ def main() -> int:
                 if hexv in banned:
                     ban_hits.append(
                         f"{posix}:{lineno}: {match.group(0)}) = {hexv} — {banned[hexv]}"
+                    )
+            for match in RUST_RGB.finditer(line):
+                channels = tuple(channel(c) for c in match.groups())
+                if any(c > 255 for c in channels):
+                    continue
+                hexv = "#%02X%02X%02X" % channels
+                if hexv in banned:
+                    ban_hits.append(
+                        f"{posix}:{lineno}: {match.group(0)} = {hexv} — {banned[hexv]}"
                     )
 
     failed = False
@@ -223,4 +270,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv))

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -188,6 +188,18 @@ def main(argv: list[str]) -> int:
 
     ban_hits: list[str] = []
     stray_hits: list[str] = []
+    # One line, one report. The notations overlap — RGB_FUNC's IGNORECASE and
+    # RUST_RGB both match `Rgb(11, 11, 12)` — so without this a single literal
+    # is named twice and the count above the list says two places when there is
+    # one. Keyed on the value as well as the position, because two different
+    # retired colours on one line are two findings.
+    seen: set[tuple[str, int, str]] = set()
+
+    def record(posix: str, lineno: int, hexv: str, hit: str) -> None:
+        if (posix, lineno, hexv) in seen:
+            return
+        seen.add((posix, lineno, hexv))
+        ban_hits.append(hit)
 
     for rel in tracked_files(root):
         posix = rel.as_posix()
@@ -209,7 +221,12 @@ def main(argv: list[str]) -> int:
             for match in HEX.finditer(line):
                 hexv = match.group(0).upper()
                 if hexv in banned:
-                    ban_hits.append(f"{posix}:{lineno}: {match.group(0)} — {banned[hexv]}")
+                    record(
+                        posix,
+                        lineno,
+                        hexv,
+                        f"{posix}:{lineno}: {match.group(0)} — {banned[hexv]}",
+                    )
                 elif token_only and hexv not in live:
                     stray_hits.append(
                         f"{posix}:{lineno}: {match.group(0)} is not a token in "
@@ -221,8 +238,11 @@ def main(argv: list[str]) -> int:
                     continue
                 hexv = "#%02X%02X%02X" % channels
                 if hexv in banned:
-                    ban_hits.append(
-                        f"{posix}:{lineno}: {match.group(0)}) = {hexv} — {banned[hexv]}"
+                    record(
+                        posix,
+                        lineno,
+                        hexv,
+                        f"{posix}:{lineno}: {match.group(0)}) = {hexv} — {banned[hexv]}",
                     )
             for match in RUST_RGB.finditer(line):
                 channels = tuple(channel(c) for c in match.groups())
@@ -230,8 +250,11 @@ def main(argv: list[str]) -> int:
                     continue
                 hexv = "#%02X%02X%02X" % channels
                 if hexv in banned:
-                    ban_hits.append(
-                        f"{posix}:{lineno}: {match.group(0)} = {hexv} — {banned[hexv]}"
+                    record(
+                        posix,
+                        lineno,
+                        hexv,
+                        f"{posix}:{lineno}: {match.group(0)} = {hexv} — {banned[hexv]}",
                     )
 
     failed = False

--- a/scripts/test-tokens.sh
+++ b/scripts/test-tokens.sh
@@ -141,7 +141,10 @@ want "a live Color::Rgb tuple passes" expect-pass \
   "pub const GROUND: Color = Color::Rgb($(as_rust_tuple "$LIVE_HEX"));"
 
 # Decimal channels were already covered, by accident: RGB_FUNC is IGNORECASE,
-# so `Rgb(11, 11, 12)` matches it as an `rgb(` call. The case stays because the
+# so a decimal `Rgb(...)` matches it as an `rgb(` call. The channels are not
+# spelled out here on purpose — this file is not a SELF entry and must not
+# become one, because it never needs to name a retired value: every fixture
+# reads its colours out of the token file at run time. The case stays since the
 # coverage is real and should not silently depend on a flag on another pattern
 # — but it passes with RUST_RGB removed, so it is not a witness for it. The two
 # cases either side of it are.
@@ -161,6 +164,21 @@ want "a ban site may name the values it bans" expect-pass \
 # Channels over 255 are not a colour, so the tuple is not one either.
 want "an out-of-range tuple is not read as a colour" expect-pass \
   "crates/stella-tui/src/palette.rs" "let v = Rgb(300, 400, 500);"
+
+# One literal, two matchers, one report. `Rgb(<decimal>)` is matched by both
+# RGB_FUNC (IGNORECASE reads it as `rgb(`) and RUST_RGB, and before this was
+# deduped the same line was listed twice and the count above the list said two
+# places where there was one. Found by this suite failing on its own source
+# once it was committed.
+root="$(new_root "double_report" "crates/stella-tui/src/palette.rs" \
+  "pub const GROUND: Color = Color::Rgb($(as_decimals "$BANNED_HEX"));")"
+out="$(python3 "$SCRIPT" "$root" 2>&1)"
+hits="$(printf '%s\n' "$out" | grep -c 'palette.rs:1:')"
+if [ "$hits" -eq 1 ]; then
+  ok "a literal both matchers see is reported once"
+else
+  bad "one literal was reported $hits time(s): $out"
+fi
 
 # The real tree, read-only, with no argument at all — the path every caller
 # takes. A suite whose cases all pass a root would not notice the default

--- a/scripts/test-tokens.sh
+++ b/scripts/test-tokens.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Tests for check-tokens.py's BAN CHECK, over every notation it claims to
+# watch (#4910).
+#
+#   ./scripts/test-tokens.sh    (or: make tokens-test)
+#
+# Run it after touching that script. Not part of `make gate`: it builds
+# throwaway git repositories, the same posture as `make main-red-hold-test`.
+#
+# ── What the suite is for ────────────────────────────────────────────────────
+#
+# The ban check spends its life passing, because the tree is clean. That is
+# what makes it worth testing and easy to break: a matcher that silently stops
+# matching looks exactly like a tree with no retired hexes in it, and there is
+# no third state to tell them apart.
+#
+# It had already happened once in the direction this suite now covers. `.rs`
+# was in TEXT_SUFFIXES from the start, so the script opened every Rust file and
+# reported clean over the surface where the retired kits actually shipped — but
+# only for the `Color::Rgb(0x0A, ...)` spelling, which is the one this tree
+# writes. The decimal spelling was matched all along, by RGB_FUNC's IGNORECASE
+# reading `Rgb(` as `rgb(`. That distinction is not in #4910, which reports
+# Rust as invisible outright; the case below found it, which is the argument
+# for the suite in one line.
+#
+# So every notation gets a case that puts a banned value in it and demands the
+# guard name it, and every notation gets its live-value twin that must pass.
+# A matcher that fires on everything is as useless as one that fires on
+# nothing, and only the pair can tell them apart.
+#
+# The `SELF` case is the one that reads backwards until you know why: a ban
+# site holds retired values *in order to ban them*, so the guard finding them
+# there is the failure, not the catch. #4066 is the merge where getting this
+# wrong reported nineteen offenders that were all correct.
+#
+# bash 3.2 compatible.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-tokens.py"
+TOKENS_REL="design/tokens/stella-tokens.json"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+ok() { printf '  \033[32m✓\033[0m %s\n' "$*"; pass=$((pass + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=$((fail + 1)); }
+
+# One banned value and one live one, read out of the real token file so the
+# fixtures cannot drift from the list the guard actually enforces.
+BANNED_HEX="$(python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+print(doc['banned']['values'][0]['hex'].upper())
+" "$repo_root/$TOKENS_REL")"
+LIVE_HEX="$(python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+print(doc['tokens'][0]['hex'].upper())
+" "$repo_root/$TOKENS_REL")"
+
+# `#RRGGBB` -> `0xRR, 0xGG, 0xBB`, the way Rust writes it.
+as_rust_tuple() {
+  python3 -c "
+import sys
+h = sys.argv[1].lstrip('#')
+print(', '.join('0x%s' % h[i:i+2].upper() for i in (0, 2, 4)))
+" "$1"
+}
+
+# `#RRGGBB` -> `R, G, B`, decimal.
+as_decimals() {
+  python3 -c "
+import sys
+h = sys.argv[1].lstrip('#')
+print(', '.join(str(int(h[i:i+2], 16)) for i in (0, 2, 4)))
+" "$1"
+}
+
+# A throwaway git repository holding the real token file plus one source file.
+# Real git, because the script discovers its inputs with `git ls-files` and a
+# fixture that stubbed that would be testing a path nothing runs.
+# $1 = case name, $2 = file path within the root, $3 = file contents.
+new_root() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/design/tokens" "$dir/$(dirname "$2")"
+  cp "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL"
+  printf '%s\n' "$3" >"$dir/$2"
+  git -C "$dir" init -q 2>/dev/null
+  git -C "$dir" add -A 2>/dev/null
+  echo "$dir"
+}
+
+# want <name> <expect-pass|expect-ban> <file> <contents>
+want() {
+  local name="$1" expect="$2" file="$3" contents="$4"
+  local root out rc
+  root="$(new_root "$(echo "$name" | tr ' /' '__')" "$file" "$contents")"
+  out="$(python3 "$SCRIPT" "$root" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -eq 0 ]; then
+      ok "$name"
+    else
+      bad "$name — expected a pass, got exit $rc: $out"
+    fi
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then
+    bad "$name — the banned value was NOT caught: $out"
+    return
+  fi
+  # Naming the file is half the guard: an exit code alone sends a reader
+  # hunting through the tree for a colour the script already located.
+  case "$out" in
+  *"$file"*) ok "$name" ;;
+  *) bad "$name — caught it but did not name $file: $out" ;;
+  esac
+}
+
+echo "check-tokens ban check:"
+
+# The notation that was already watched, as the control: if this fails, the
+# suite is broken rather than the Rust matcher.
+want "a banned hex literal is caught" expect-ban \
+  "website/src/app/page.tsx" "const ground = \"$BANNED_HEX\";"
+
+want "a live hex literal passes" expect-pass \
+  "website/src/app/page.tsx" "const ground = \"$LIVE_HEX\";"
+
+# The gap #4910 is about.
+want "a banned Color::Rgb tuple is caught" expect-ban \
+  "crates/stella-tui/src/palette.rs" \
+  "pub const GROUND: Color = Color::Rgb($(as_rust_tuple "$BANNED_HEX"));"
+
+want "a live Color::Rgb tuple passes" expect-pass \
+  "crates/stella-tui/src/palette.rs" \
+  "pub const GROUND: Color = Color::Rgb($(as_rust_tuple "$LIVE_HEX"));"
+
+# Decimal channels were already covered, by accident: RGB_FUNC is IGNORECASE,
+# so `Rgb(11, 11, 12)` matches it as an `rgb(` call. The case stays because the
+# coverage is real and should not silently depend on a flag on another pattern
+# — but it passes with RUST_RGB removed, so it is not a witness for it. The two
+# cases either side of it are.
+want "a tuple written in decimal is caught (by either matcher)" expect-ban \
+  "crates/stella-tui/src/palette.rs" \
+  "pub const GROUND: Color = Color::Rgb($(as_decimals "$BANNED_HEX"));"
+
+want "a bare Rgb( is caught, not only Color::Rgb(" expect-ban \
+  "crates/stella-tui/src/palette.rs" \
+  "pub const GROUND: Color = Rgb($(as_rust_tuple "$BANNED_HEX"));"
+
+# The exemption, which reads backwards until you know what a ban site is.
+want "a ban site may name the values it bans" expect-pass \
+  "crates/stella-tui/src/theme/tests.rs" \
+  "const RETIRED_INK: Color = Color::Rgb($(as_rust_tuple "$BANNED_HEX"));"
+
+# Channels over 255 are not a colour, so the tuple is not one either.
+want "an out-of-range tuple is not read as a colour" expect-pass \
+  "crates/stella-tui/src/palette.rs" "let v = Rgb(300, 400, 500);"
+
+# The real tree, read-only, with no argument at all — the path every caller
+# takes. A suite whose cases all pass a root would not notice the default
+# breaking.
+out="$(cd "$repo_root" && python3 "$SCRIPT" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "the real tree passes, with no root argument"
+else
+  bad "the real tree should pass: exit $rc: $out"
+fi
+
+echo ""
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
`check-tokens.py`'s ban check matched `#RRGGBB` and `rgb()`. Rust writes `Color::Rgb(0x0A, 0x0A, 0x0C)`, and `.rs` was already in `TEXT_SUFFIXES` — so the script opened every Rust file, matched nothing, and reported clean over the surface where the retired kits actually shipped.

All five items of the issue's definition of done.

## Correcting the issue's premise, which its own suite caught

#4910 says the guard "cannot see a single colour Rust writes". That is one notation too wide, and I only know because the ablation did not fail the case I expected it to:

```
✗ a banned Color::Rgb tuple is caught — the banned value was NOT caught
✓ a banned tuple written in decimal is caught        <- still passing
✗ a bare Rgb( is caught, not only Color::Rgb(
```

`RGB_FUNC` is `re.IGNORECASE`, so `Rgb(11, 11, 12)` already matched it as an `rgb(` call. The **decimal** spelling was covered by accident all along. What was genuinely invisible is the **hex-literal** spelling — which is the one this tree writes, and the one the single banned value in it used (`Color::Rgb(0x0B, 0x0B, 0x0C)`).

So the gap is real and the fix is the same; the framing was wider than the defect. Both the script comment and the test case now say so, and that decimal case is labelled as not a witness for `RUST_RGB` rather than left looking like one.

`RUST_RGB` matches both spellings anyway, so the two notations stop depending on an unrelated flag on another pattern.

## Ablation

`RUST_RGB` scanning nothing:

```
✗ a banned Color::Rgb tuple is caught — the banned value was NOT caught
✗ a bare Rgb( is caught, not only Color::Rgb(
7 passed, 2 failed
```

Restored: `9 passed, 0 failed`.

## The harder half: the guard can now be shown to fire

`check-tokens.py` took no arguments — it resolved `REPO` from `__file__` and shelled `git ls-files`, so there was no way to point it at a fixture tree and therefore no hermetic suite, unlike every other ratchet here. It now takes an optional root, defaulting to today's behaviour (`check-contrast.py`'s shape).

`scripts/test-tokens.sh` + `make tokens-test`, on `test-contrast.sh`'s model, wired into `guard-self-tests.yml`. Nine cases, and the shape is a **pair per notation** — a banned value that must be named, and its live twin that must pass. A matcher that fires on everything is as useless as one that fires on nothing, and only the pair separates them. Each fixture is a real throwaway git repository, because the script discovers its inputs with `git ls-files` and a stubbed one would test a path nothing runs. The banned and live values are read out of the real token file, so the fixtures cannot drift from the list being enforced.

## The `SELF` entry

`crates/stella-tui/src/theme/tests.rs` is a **ban site**: its `RETIRED_*` constants are the enforcement list for that surface, so the first thing the new matcher saw was the one file whose whole job is naming those values. That is the same argument already written out for `brand-parity.test.ts` and `export/tests.rs`, and #4066 is the merge where getting it wrong reported nineteen offenders that were all correct. The ban-site paragraph is extended to say so, and a case pins it.

The exemption stays narrow: it suppresses the ban check only, and the file is not a `TOKEN_ONLY` path.

## Evidence

```
make tokens        no retired hex in the tree; 3 token-only path(s) clean
make tokens-test   9 passed, 0 failed
shellcheck         exit 0
check-gate-parity  OK — 47 gate steps
check-prose        OK — none added
```

`gate-parity` fails a `scripts/test-*.sh` that runs in no workflow, so the wiring is enforced rather than remembered.

The tree is clean today, which is what made this cheap to land — and what makes it worth landing, since nothing stopped the next Rust surface picking up a retired hex as a tuple.

Closes #4910
Refs #4058, #4066

## Summary by Sourcery

Make the retired-colour guard detect Rust colour tuples and continuously verify its ban behavior across all supported notations.

New Features:
- Extend retired-colour detection to Rust `Rgb` tuples in hexadecimal and decimal notation.
- Add hermetic token-ban self-tests covering banned and live values, exemptions, matcher overlap, and default repository scanning.

Bug Fixes:
- Prevent retired colours written as Rust `Rgb` tuples from bypassing the token ban check.
- Avoid duplicate reports when multiple matchers identify the same colour on one line.

Enhancements:
- Allow the token checker to scan an explicitly supplied repository root while preserving its existing default behavior.
- Exempt the TUI theme ban-site test file from enforcement findings.

Build:
- Add a `make tokens-test` target for the token-ban self-tests.

CI:
- Run the token-ban self-tests in the guard self-tests workflow.

Tests:
- Add nine fixture-based cases validating retired-colour detection across supported notations and safe handling of live, exempt, and invalid values.