### PR TITLE
docs(stella-tools): record the second dotted-key census, which is still one-sided

### DIFF
--- a/crates/stella-tools/src/search/enrich.rs
+++ b/crates/stella-tools/src/search/enrich.rs
@@ -427,6 +427,24 @@ const DEFINITION_KEYWORDS: &[&str] = &[
 /// days before it was taken (#4571), so "nobody cited one" and "nobody could"
 /// are the same measurement here. It is evidence about the cost, and the cost
 /// is what decides a widening whose benefit is still hypothetical.
+///
+/// # The second census, which settles no more than the first
+///
+/// #4739 asked for the demand half against a window that opens *after* #4571
+/// merged (2026-08-23 22:26 UTC). Re-run on 2026-08-25 across every Stella
+/// store on the measuring machine, that window holds **seven** search-shaped
+/// calls in seven executions, all of them this repository's; the two other
+/// workspaces with a store record no execution in it at all. None names a
+/// dotted table key — and zero out of seven cannot tell "no caller writes
+/// one" from "no caller has searched here since the feature landed". The
+/// whole-store totals moved from 786 calls over 314 executions to 793 over
+/// 321, and the same single execution is unreadable in both runs, so those
+/// seven calls are every search this store has taken since a dotted key
+/// became findable.
+///
+/// The refusal therefore stands where it stood, on the cost half alone and
+/// for the reason above. What would settle the other half is a store with
+/// post-#4571 search volume, not a later re-run of this one.
 fn is_bare_identifier(s: &str) -> bool {
     let mut chars = s.chars();
     matches!(chars.next(), Some(c) if c.is_alphabetic() || c == '_')


### PR DESCRIPTION
#4738 refused the dotted-table-key widening on a census, and said in the same
paragraph why that census could not settle the question it was asked: TOML
tables became indexable days before it ran (#4571), so "no query cited a dotted
table key" and "no query could have" were the same reading. #4739 asked for the
other half — demand — against a window that opens after #4571 merged.

## The measurement

`#4571` merged `2026-08-23T22:26:58Z`. Every Stella store on the measuring
machine was scanned for `tool_start` events, one `execution_id` at a time (a
single damaged page aborts a whole-table scan — execution 178 in this repo's
store is unreadable, the same one #4738 hit).

The rule under test, as #4739 states it: at least two `.`-separated segments,
every segment a bare identifier, no whitespace anywhere in the term. Terms that
`is_bare_identifier` already admits, and queries carrying the breadcrumb
separator #4738 shipped, are excluded — those are not what a dotted rule would
*newly* offer.

<details><summary>the script (<code>census.py</code>)</summary>

```python
import json, sqlite3, sys
from collections import Counter

DB = sys.argv[1]
CUTOFF = sys.argv[2] if len(sys.argv) > 2 else None
SEARCH_TOOLS = {"search", "grep"}
BREADCRUMB = "›"

def bare(s):
    return bool(s) and (s[0].isalpha() or s[0] == "_") and all(c.isalnum() or c == "_" for c in s[1:])

def dotted_run(term):
    if any(c.isspace() for c in term):
        return False
    parts = term.split(".")
    return len(parts) >= 2 and all(bare(p) for p in parts)

conn = sqlite3.connect(f"file:{DB}?mode=ro", uri=True)
conn.text_factory = bytes
execs = [(i, s.decode()) for i, s in conn.execute("SELECT id, started_at FROM executions ORDER BY id")]
execs = [(i, s) for i, s in execs if not CUTOFF or s >= CUTOFF]

calls = 0; readable = 0; unreadable = []; admitted = Counter(); by_tool = Counter()
for eid, _ in execs:
    try:
        rows = conn.execute(
            "SELECT payload FROM events WHERE execution_id = ? AND event_type = 'tool_start'", (eid,)
        ).fetchall()
    except sqlite3.DatabaseError as exc:
        unreadable.append((eid, str(exc))); continue
    readable += 1
    for (raw,) in rows:
        try:
            ev = json.loads(raw.decode("utf-8", "replace"))
        except ValueError:
            continue
        call = ev.get("call") or {}
        if call.get("name") not in SEARCH_TOOLS:
            continue
        calls += 1; by_tool[call["name"]] += 1
        inp = call.get("input") or {}
        q = inp.get("query") or inp.get("pattern")
        if not isinstance(q, str) or BREADCRUMB in q:
            continue
        for alt in q.split("|"):
            term = alt.strip()
            if not bare(term) and dotted_run(term):
                admitted[term] += 1

print(f"cutoff:      {CUTOFF or '(none)'}")
print(f"executions:  {len(execs)} in window, {readable} readable, {len(unreadable)} unreadable")
print(f"calls:       {calls}  {dict(by_tool)}")
print(f"admitted:    {sum(admitted.values())} occurrences, {len(admitted)} distinct")
for t, n in admitted.most_common():
    print(f"    {n}x {t!r}")
for eid, exc in unreadable:
    print(f"unreadable execution {eid}: {exc}")
```

</details>

### Reproducing #4738's census, to check the instrument

```
$ python3 census.py ~/Projects/stella/.stella/private/store.db
cutoff:      (none)
executions:  321 in window, 320 readable, 1 unreadable
calls:       793  {'grep': 565, 'search': 228}
admitted:    6 occurrences, 5 distinct
    2x 'verifier.verdict'
    1x 'settings.json'
    1x 'agent.error'
    1x 'hot.reload'
    1x 'driver.rs'
unreadable execution 178: database disk image is malformed
```

#4738 read 786 calls over 314 executions and named four distinct terms
(`settings.json`, `driver.rs`, `hot.reload`, `verifier.verdict` twice). All four
are here. The fifth, `agent.error`, comes from execution 64 on 2026-08-06 —
`verifier.verdict|agent.error|retryable`, the same alternation `verifier.verdict`
was counted from, so it is a per-alternative-versus-per-query difference rather
than new data. The same one execution is unreadable in both runs.

### The window that answers the demand question

```
$ python3 census.py ~/Projects/stella/.stella/private/store.db '2026-08-23 22:26:58'
cutoff:      2026-08-23 22:26:58
executions:  7 in window, 7 readable, 0 unreadable
calls:       7  {'search': 7}
admitted:    0 occurrences, 0 distinct

$ python3 census.py ~/Projects/oxagen-platform/.stella/private/store.db '2026-08-23 22:26:58'
executions:  0 in window, 0 readable, 0 unreadable
calls:       0  {}
admitted:    0 occurrences, 0 distinct

$ python3 census.py ~/Projects/agent-harness/.stella/private/store.db '2026-08-23 22:26:58'
executions:  0 in window, 0 readable, 0 unreadable
calls:       0  {}
admitted:    0 occurrences, 0 distinct
```

Those are every Stella store on the machine (`fd -HI -t f 'store.db$' ~/Projects`).
The post-#4571 corpus is **seven search-shaped calls**. 793 − 786 = 7 confirms
it from the other side: every call the first census did not see is in this
window.

## What that settles, and what it does not

Zero out of seven is not "callers do not write dotted table keys". It cannot
distinguish that from "nobody has run a Stella search in this workspace since
the feature landed", which is the more likely reading given the volume. So this
run does **not** meet #4739's "if they still do not, say so and close" arm — it
reports a sample too small to have an arm.

The refusal is unchanged, and unchanged for its original reason: the cost half
still says a dotted rule buys graph round-trips that must miss.
`a_dotted_table_key_is_still_answered_by_ranking_not_lookup` still asserts
today's behaviour and is untouched.

## What ships

The doc comment on `is_bare_identifier`
(`crates/stella-tools/src/search/enrich.rs`) — the one whose existing text is
explicit that its evidence is one-sided — now carries the second census's date,
window, sample size and result, and names what would settle the open half: a
store with real post-#4571 search volume, not a later re-run of this one.

## Witness

None, and none is owed: this is a documentation change with no behaviour
attached. No `#[test]` was renamed or removed.

Refs #4739

## Summary by Sourcery

Record the second dotted-key census while keeping the current search behavior and widening refusal unchanged.

Enhancements:
- Document the post-feature dotted-key demand census, its seven-call sample, inconclusive result, and the additional evidence needed to resolve the question.

Documentation:
- Update the bare-identifier search documentation to record the second census and preserve the existing rationale for declining dotted-key widening.