### PR TITLE
Separate the three verification flags: two refused everywhere, one passed to a plugin's oracle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -636,10 +636,15 @@ stage, a flip oracle, a terminal verify ladder — is exactly what
 verification plugin, rather than reinventing.** Host-run verification is no
 longer something Stella ships in-tree: `stella run --pipeline classic` is
 refused outright (`crates/stella-cli/src/wrapper_plugin.rs`'s
-`PipelineChoice::resolve`), and `--test-command`/`--keep-witness`/
-`--require-verified` are refused unconditionally on every remaining
-resolution, naming `stella plugin install` — an installed verification
-plugin — as the remedy rather than a flag this repository ships. When such a
+`PipelineChoice::resolve`), and the three verification flags split two ways
+in the same file's `reject_verification_flags_without_pipeline`:
+`--keep-witness` and `--require-verified` are refused on every resolution,
+because what they asked for was host-run machinery that no longer exists
+here; `--test-command` is refused on the raw default and **passed through**
+under `--pipeline <variant>`, where it hands the bound plugin's own
+`[oracle]` a command to check against. Each refusal names `stella plugin
+install` — an installed verification plugin — as the remedy rather than a
+flag this repository ships. When such a
 plugin is installed, `stella run --pipeline <plugin-id>` hands it the turn;
 the plugin's own `[oracle]` runs the check and reports its evidence, which
 Stella evaluates against the plugin's declared verdict rule and does not

--- a/crates/stella-cli/src/wrapper_plugin/tests.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests.rs
@@ -275,6 +275,43 @@ fn each_verification_flag_alone_is_refused_against_the_raw_loop() {
     assert!(err.contains("--require-verified"), "{err}");
 }
 
+/// A refusal names the flags it refused, and **only** those: passing
+/// `--test-command` alongside `--keep-witness` under an installed plugin
+/// must produce a message about `--keep-witness` with no mention of the flag
+/// that was accepted.
+///
+/// `plugin_variant_accepts_test_command_but_still_refuses_witness_flags`
+/// above covers each flag on its own and is where the acceptance is pinned;
+/// this covers them together, which is the combination a message could get
+/// wrong without failing that one, because it passes `None` for
+/// `test_command` in its refusing half.
+///
+/// Worth its own case because the confusion is the expensive part. AGENTS.md
+/// described all three flags as refused unconditionally and was wrong about
+/// this one (#4907); a refusal message that lists an accepted flag teaches a
+/// reader the same wrong thing, from the terminal, where it is likelier to be
+/// believed.
+#[test]
+fn a_refusal_never_names_the_flag_it_accepted() {
+    for (keep_witness, require_verified, flag) in [
+        (true, false, "--keep-witness"),
+        (false, true, "--require-verified"),
+    ] {
+        let err = reject_verification_flags_without_pipeline(
+            PipelineChoice::Plugin("budget-v1"),
+            Some("pytest"),
+            keep_witness,
+            require_verified,
+        )
+        .expect_err("the host-run flags are refused on every resolution");
+        assert!(err.contains(flag), "{err}");
+        assert!(
+            !err.contains("--test-command"),
+            "--test-command rode along on another flag's refusal: {err}"
+        );
+    }
+}
+
 /// **Witness (#3867).** The gate no longer has a bypass arm: `--keep-witness`
 /// is refused against **every** [`PipelineChoice`] that exists, with no
 /// variant left that accepts it.


### PR DESCRIPTION
AGENTS.md said `--test-command`/`--keep-witness`/`--require-verified` are "refused unconditionally on every remaining resolution". True of two of them.

Verified against the authority rather than the issue's account of it — `reject_verification_flags_without_pipeline`:

```rust
if choice.is_raw() && test_command.is_some() {   // raw only
    offending.push("--test-command");
}
if keep_witness      { offending.push("--keep-witness"); }      // every resolution
if require_verified  { offending.push("--require-verified"); }  // every resolution
```

The sentence now splits the three, says why the split exists (the two refused everywhere asked for host-run machinery that no longer exists here; `--test-command` arms a bound plugin's own `[oracle]`), and names the function rather than only `PipelineChoice::resolve`.

The issue also asks to check the sentence's other claims against `PipelineChoice::resolve`. Its `classic` claim is right: `Some(variant) if variant == PIPELINE_VARIANT_CLASSIC => Err(classic_removed_message())`.

## A premise of mine that was wrong

I set out to add the missing witness, on the reasoning that the doc had drifted precisely where no test pinned the behaviour — every test name I had seen ended in `without_pipeline`.

The ablation said otherwise. Refusing `--test-command` everywhere (what AGENTS.md described) failed **two** tests, and one was already there:

```
test plugin_variant_accepts_test_command_but_still_refuses_witness_flags ... FAILED
```

So the accepted arm was pinned all along, and my tidy explanation for the drift was wrong: the doc drifted next to a test that contradicted it. I had inferred coverage from the integration-test file's names and a partial read of the unit tests, which is not the same as looking.

That made my new test redundant, so I cut it down to the one property it actually owned.

## What survives, and why it is worth a case

`a_refusal_never_names_the_flag_it_accepted`: passing `--test-command` **alongside** `--keep-witness` under an installed plugin must produce a message about `--keep-witness` and not mention the accepted flag. The existing test covers each flag alone and passes `None` for `test_command` in its refusing half, so a message that listed every flag the caller passed would slip by it.

Worth a case because the confusion is the expensive part. A refusal that lists an accepted flag teaches a reader exactly what AGENTS.md taught, from the terminal, where it is likelier to be believed.

Ablation, at the property this test owns:

```
test a_refusal_never_names_the_flag_it_accepted ... FAILED
test plugin_variant_accepts_test_command_but_still_refuses_witness_flags ... FAILED
test result: FAILED. 48 passed; 2 failed
```

Restored: `50 passed; 0 failed`.

## Evidence

```
cargo test -p stella-cli --bin stella wrapper_plugin   50 passed; 0 failed
cargo test -p stella-cli --test verification_flags_require_pipeline_cli   6 passed; 0 failed
cargo clippy -p stella-cli --all-targets -- -D warnings   exit 0
check-prose         OK — none added
check-doc-links     OK — 1098 citations resolve
check-line-citations OK — none added
```

No test deleted or renamed.

Closes #4907

## Summary by Sourcery

Align verification-flag documentation and tests with the distinct handling of plugin-bound test commands and host-run witness options.

Bug Fixes:
- Correct the verification-flag documentation to reflect that `--test-command` is passed through for plugin pipelines while witness-related flags remain rejected.
- Ensure refusal messages identify only flags that are actually rejected.

Documentation:
- Clarify the behavior and rationale of the three verification flags and identify the relevant validation logic.

Tests:
- Add coverage for combined verification flags so accepted flags are omitted from refusal messages.