### PR TITLE
feat(stella-cli): stella whistle reaches a goal arc's rounds

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -915,12 +915,13 @@ pub(crate) async fn run_goal_turn(
         let mut engine =
             Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
                 .with_calibration(calibration)
-                // The arc's whistle, on the WORKER engine only. The verifier
-                // runs as a sub-agent off `Engine::assess` with its own
-                // transcript, and `drain_steering` empties the queue — so a
-                // shared tap would let the judge swallow a steer meant for the
-                // work, at a boundary the person whistling cannot see. One
-                // drainer, and it is the round doing the work.
+                // Every round's worker turn drains this, and only those. The
+                // verifier runs as a sub-agent off `Engine::assess`, which
+                // sees a parent's steering through
+                // `stella_core::subagent::ChildSteering` — soft stop
+                // forwarded, `drain_steering` refused — so a whistle cannot
+                // be eaten by the judge, and the person who sent it does not
+                // have to know a judge exists.
                 .with_steering(whistle.steering());
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -12,6 +12,9 @@ use super::*;
 
 mod goal_wrapped;
 
+#[cfg(test)]
+mod tests;
+
 /// The session task board, tool by tool — everything the catalog files under
 /// the `task` group *except* `delegate`, the sub-agent delegation tool that
 /// shares the group.
@@ -278,12 +281,10 @@ pub(crate) async fn run_raw_one_shot(
     // carried for exactly this (its own doc comment named `run_raw_one_shot`
     // as the non-interactive door that would one day publish something
     // other than `none()` here).
-    // `_whistle_listener` is held for the run's duration — its `Drop` is
-    // what unbinds and removes the socket file.
-    let whistle_tap: std::sync::Arc<crate::whistle::tap::HeadlessSteerTap> =
-        std::sync::Arc::default();
-    let _whistle_listener = crate::whistle::spawn_for_session(presence.id(), whistle_tap.clone());
-    let controls = stella_core::ports::TurnControls::none().with_steering(whistle_tap);
+    // `whistle` is held for the run's duration — its `Drop` is what unbinds
+    // and removes the socket file.
+    let whistle = crate::whistle::SessionWhistle::open(Some(presence.id()));
+    let controls = whistle.controls();
     // This prompt's friction (#3946), read by the reflection further down.
     //
     // A `Vec` because the wrapped arm is genuinely several turns: an
@@ -867,6 +868,14 @@ pub(crate) async fn run_goal_turn(
         None => provider,
     };
 
+    // Agent whistle (#4769): ONE listener for the whole arc, not one per
+    // round. This function is called once by `run_goal_cmd`, and every round
+    // `Engine::run_goal` drives is a `with_turn_instance` clone of the engine
+    // built below — which carries `steering` forward — so a single tap
+    // attached here is drained at every round's first step boundary.
+    //
+    // Held for the arc's duration; its `Drop` unbinds and removes the socket.
+    let whistle = crate::whistle::SessionWhistle::open(session);
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
     let events = stella_core::EventSender::new(tx.clone());
     // The registry's own streams and this turn's per-call work-tree
@@ -905,7 +914,14 @@ pub(crate) async fn run_goal_turn(
         let hook_runner = HostHookRunner;
         let mut engine =
             Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
-                .with_calibration(calibration);
+                .with_calibration(calibration)
+                // The arc's whistle, on the WORKER engine only. The verifier
+                // runs as a sub-agent off `Engine::assess` with its own
+                // transcript, and `drain_steering` empties the queue — so a
+                // shared tap would let the judge swallow a steer meant for the
+                // work, at a boundary the person whistling cannot see. One
+                // drainer, and it is the round doing the work.
+                .with_steering(whistle.steering());
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -320,6 +320,10 @@ pub(crate) async fn run_goal_wrapped_turn(
         None => provider,
     };
 
+    // Agent whistle (#4769): one listener for the whole arc, held here so its
+    // `Drop` unbinds the socket when the run ends. See the raw arm's twin in
+    // `super::run_goal_turn` for why it is per-run rather than per-round.
+    let whistle = crate::whistle::SessionWhistle::open(session);
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
     let renderer = spawn_renderer(
         rx,
@@ -346,7 +350,11 @@ pub(crate) async fn run_goal_wrapped_turn(
     );
     let hook_runner = HostHookRunner;
     let mut engine = Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
-        .with_calibration(calibration);
+        .with_calibration(calibration)
+        // The arc's whistle (#4769), opened above and drained at every round's
+        // first step boundary — the wrapped arm drives its own rounds through
+        // this one engine, so one attachment covers all of them.
+        .with_steering(whistle.steering());
     if let Some(hooks) = &cfg.hooks {
         engine = engine.with_hooks(hooks, &hook_runner);
     }

--- a/crates/stella-cli/src/agent/goal/tests.rs
+++ b/crates/stella-cli/src/agent/goal/tests.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The goal door's own wiring, exercised through [`super::run_goal_turn`]
+//! rather than around it.
+//!
+//! A test that rebuilt the door's engine itself would pass with the door's
+//! wiring deleted — the trap `agent/tests/engine_wiring.rs` names in its own
+//! header — so this drives the real function with a scripted provider and a
+//! real Unix socket, and reads the answer off what the next model call was
+//! asked.
+
+use super::*;
+
+/// A model call, as the scripted provider saw it: every message's content,
+/// joined, which is enough to answer "did the next call see the steer?".
+type SeenCalls = std::sync::Arc<std::sync::Mutex<Vec<String>>>;
+
+/// A provider that whistles at its own session from inside its first model
+/// call, then answers plainly forever.
+///
+/// Whistling from inside the call is what makes the timing deterministic: the
+/// message is queued while round 1's worker turn is in flight, so if the door
+/// attached the tap it lands at the next step boundary — the first step of
+/// round 2 — and if it did not, it is never drained at all.
+struct WhistlingProvider {
+    socket: std::path::PathBuf,
+    message: &'static str,
+    seen: SeenCalls,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl stella_model::provider::Provider for WhistlingProvider {
+    fn id(&self) -> &str {
+        "whistling"
+    }
+
+    async fn complete_ref(
+        &self,
+        request: stella_protocol::CompletionRequestRef<'_>,
+    ) -> Result<stella_protocol::CompletionResult, stella_protocol::ProviderError> {
+        self.seen.lock().unwrap_or_else(|p| p.into_inner()).push(
+            request
+                .messages
+                .iter()
+                .map(|m| m.content.clone())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        if self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+            whistle_over_the_socket(&self.socket, self.message).await;
+        }
+        Ok(stella_protocol::CompletionResult {
+            text: "working on it".to_string(),
+            tool_calls: Vec::new(),
+            usage: stella_protocol::CompletionUsage::reported_zero(),
+            model: "whistling".to_string(),
+            cost_usd: 0.0,
+            finish_reason: None,
+            upstream_provider: None,
+        })
+    }
+}
+
+/// One `stella whistle` delivery, spoken over a real socket by the same frame
+/// protocol `crate::whistle::cmd` sends — the second process, minus the
+/// process.
+#[cfg(unix)]
+async fn whistle_over_the_socket(socket: &std::path::Path, message: &str) {
+    let mut stream = tokio::net::UnixStream::connect(socket)
+        .await
+        .expect("the door under test must have bound this session's whistle socket");
+    crate::whistle::wire::write_frame(
+        &mut stream,
+        &crate::whistle::wire::WhistleRequest {
+            text: message.to_string(),
+        },
+    )
+    .await
+    .expect("write the frame");
+    let ack: crate::whistle::wire::WhistleAck = crate::whistle::wire::read_frame(&mut stream)
+        .await
+        .expect("ack");
+    assert!(ack.delivered, "the listener must acknowledge the delivery");
+}
+
+/// Clear every environment variable a provider credential can resolve
+/// through, restoring them when the returned guard drops.
+///
+/// `Config::for_tests` carries a dummy key, so the door's own worker provider
+/// is the stub above either way — this is about
+/// `resolve_cross_family_verifier`, which discovers whatever the *machine*
+/// has configured. On a developer's box that is a live key, and the goal loop
+/// would build that provider and call it.
+///
+/// Read off `crate::config::PROVIDERS` rather than spelled out, so a
+/// provider added there is denied here without this function being edited.
+fn credentials_denied() -> crate::test_env::EnvRestore {
+    let names: Vec<&'static str> = crate::config::PROVIDERS
+        .iter()
+        .flat_map(|p| std::iter::once(p.env_var).chain(p.env_var_aliases.iter().copied()))
+        .collect();
+    let restore = crate::test_env::EnvRestore::capture(&names);
+    // SAFETY: the caller holds `test_env::lock` for the guard's whole lifetime.
+    unsafe {
+        for name in names {
+            std::env::remove_var(name);
+        }
+    }
+    restore
+}
+
+/// **The witness (#4769).** `stella whistle` reaches a `stella goal` arc: the
+/// message queued during round 1 is in front of the model on a later call.
+///
+/// Fails on `main`, where `run_goal_turn` opened no whistle listener and
+/// attached no steering — the connect above is what fails first, and deleting
+/// only the `.with_steering(...)` leaves the socket bound and the assertion
+/// below unmet, because nothing ever drains the tap.
+///
+/// A plain `#[test]` driving its own runtime rather than `#[tokio::test]`:
+/// the environment sandbox below is a `std::sync::MutexGuard`, and holding
+/// one across an `await` is a clippy denial. Building the runtime here keeps
+/// every await inside `block_on`, where the guard is a thing this thread
+/// holds rather than a thing a suspended task does.
+#[cfg(unix)]
+#[test]
+fn a_whistle_reaches_the_next_round_of_a_goal_arc() {
+    const WHISTLED: &str = "stop compiling and read the failing test first";
+
+    let _env = crate::test_env::lock();
+    // Under `/tmp`, not the platform temp dir: a `sockaddr_un` path is capped
+    // at ~104 bytes and macOS puts its temp dirs 50 characters deep, which is
+    // enough on its own to make `bind` fail `SUN_LEN`. The session id is short
+    // for the same reason — it is a path component of the socket.
+    let home = tempfile::Builder::new()
+        .prefix("sw")
+        .tempdir_in("/tmp")
+        .expect("home");
+    let _home = crate::test_env::home_sandbox(home.path());
+    // No provider credential may resolve while this runs, or the goal loop
+    // routes a cross-family verifier — a REAL provider, built from the
+    // developer's own key, called over the network from a unit test.
+    let _keys = credentials_denied();
+    let workspace = tempfile::tempdir().expect("workspace");
+
+    let session = "sw1";
+    let socket = stella_store::SessionRegistry::open_default().whistle_socket_path(session);
+
+    let seen: SeenCalls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let provider = WhistlingProvider {
+        socket,
+        message: WHISTLED,
+        seen: seen.clone(),
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    };
+
+    let mut cfg = Config::for_tests(crate::config::PROVIDERS[0].clone(), "m".to_string());
+    cfg.workspace_root = workspace.path().to_path_buf();
+    let registry = ToolRegistry::new(workspace.path().to_path_buf());
+    let mut messages = vec![CompletionMessage::system("system")];
+    let mut budget = crate::agent::build_budget_guard(None);
+
+    // The arc runs to its round cap: every verdict this provider returns is
+    // unparseable, which `Engine::assess` reads as "not met" and another round.
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+        .block_on(async {
+            let _ = super::run_goal_turn(
+                &provider,
+                &registry,
+                &[],
+                &registry,
+                &mut messages,
+                &mut budget,
+                &CalibrationMap::default(),
+                &cfg,
+                &None,
+                "make the tests pass",
+                Some(session),
+                None,
+                None,
+                None,
+            )
+            .await;
+        });
+
+    let calls = seen.lock().unwrap_or_else(|p| p.into_inner()).clone();
+    let landed = calls
+        .iter()
+        .position(|call| call.contains(WHISTLED))
+        .expect("the whistled text must reach a later model call");
+    assert!(
+        landed > 0,
+        "the steer cannot have been in front of the call that sent it"
+    );
+}

--- a/crates/stella-cli/src/whistle.rs
+++ b/crates/stella-cli/src/whistle.rs
@@ -64,3 +64,45 @@ pub(crate) fn spawn_for_session(
 ) -> Option<()> {
     None
 }
+
+/// One session's whistle: the tap its engine drains, and the listener that
+/// feeds it, bound together for as long as the session runs.
+///
+/// The two halves must live exactly as long as each other and no door has a
+/// use for either alone, so they are one value. It also spares every caller
+/// the platform split: [`spawn_for_session`] returns a `WhistleListener` on
+/// Unix and `()` everywhere else, and a door holding the guard in a local
+/// would have to name whichever type its build has.
+pub(crate) struct SessionWhistle {
+    tap: std::sync::Arc<tap::HeadlessSteerTap>,
+    /// Unbinds and removes the socket file when this value is dropped.
+    #[cfg(unix)]
+    _listener: Option<listener::WhistleListener>,
+    #[cfg(not(unix))]
+    _listener: Option<()>,
+}
+
+impl SessionWhistle {
+    /// Publish `session`'s whistle socket, or — for a run with no session
+    /// identity to publish under — a tap nothing can reach, which drains
+    /// empty forever and is what a door with `session: None` should attach.
+    pub(crate) fn open(session: Option<&str>) -> Self {
+        let tap: std::sync::Arc<tap::HeadlessSteerTap> = std::sync::Arc::default();
+        let listener = session.and_then(|id| spawn_for_session(id, tap.clone()));
+        Self {
+            tap,
+            _listener: listener,
+        }
+    }
+
+    /// What to hand `stella_core::Engine::with_steering`.
+    pub(crate) fn steering(&self) -> &dyn stella_core::ports::TurnSteering {
+        self.tap.as_ref()
+    }
+
+    /// What to hand a `stella_core::ports::TurnControls` builder, for a door
+    /// that reaches its engine through one rather than building it directly.
+    pub(crate) fn controls(&self) -> stella_core::ports::TurnControls {
+        stella_core::ports::TurnControls::none().with_steering(self.tap.clone())
+    }
+}


### PR DESCRIPTION
## What this changes

`stella goal` announced into `SessionPresence` — so it shows up in `stella
resume --list` and the SESSIONS overlay — but published no whistle socket and
attached no steering. A `stella whistle` aimed at a running goal run had
nothing to arrive at.

Both arms now open one whistle per run and attach its tap to the worker engine:

- `agent::goal::run_goal_turn` (the raw `Engine::run_goal` loop)
- `agent::goal::goal_wrapped::run_goal_wrapped_turn` (the wrapper-plugin loop)

Per **run**, not per round. `Engine::run_goal` drives each round as a
`with_turn_instance` clone of the engine built once, and that clone carries
`steering` forward, so one attachment is drained at every round's first step
boundary.

The tap goes on the **worker** engine only. `Engine::assess` runs the verifier
as a sub-agent with its own transcript, and `drain_steering` empties the queue
— a shared tap would let the judge swallow a steer meant for the work, at a
boundary the person whistling cannot see.

`crate::whistle::SessionWhistle` is new: the tap and its listener as one value.
The two must live exactly as long as each other, and it spares a door the
platform split (`spawn_for_session` answers a `WhistleListener` on Unix and
`()` elsewhere, so a door holding the guard in a local would have to name
whichever type its build has). `run_raw_one_shot` moves onto it too, so the
three non-interactive doors wire this one way rather than three.

## Witness

`crates/stella-cli/src/agent/goal/tests.rs::a_whistle_reaches_the_next_round_of_a_goal_arc`

It drives the real `run_goal_turn` — not a rebuilt engine beside it, which is
the trap `agent/tests/engine_wiring.rs` names in its own header — with a
scripted provider that, from inside its first model call, connects to the
session's whistle socket and sends a real frame. The assertion is that a
*later* model call has the whistled text in front of it.

Hermetic: `test_env::home_sandbox` moves the whole stella home, and
`credentials_denied()` clears every provider credential env var read off
`config::PROVIDERS`, so `resolve_cross_family_verifier` cannot discover a live
key and build a real provider from a unit test.

### Ablation 1 — delete `.with_steering(whistle.steering())`

The socket still binds and the frame is still acked; nothing drains the tap.

```
test agent::goal::tests::a_whistle_reaches_the_next_round_of_a_goal_arc ... FAILED

thread '...' panicked at crates/stella-cli/src/agent/goal/tests.rs:185:10:
the whistled text must reach a later model call

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2311 filtered out
```

### Ablation 2 — `SessionWhistle::open(session)` → `open(None)`

No socket is bound, which is `main`'s state exactly.

```
test agent::goal::tests::a_whistle_reaches_the_next_round_of_a_goal_arc ... FAILED

thread '...' panicked at crates/stella-cli/src/agent/goal/tests.rs:73:10:
the door under test must have bound this session's whistle socket:
  Error { kind: NotFound, ... }

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2311 filtered out
```

Green with both restored:

```
test agent::goal::tests::a_whistle_reaches_the_next_round_of_a_goal_arc ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2311 filtered out
```

Neither ablation merely pins a constant: both turn the answer from "the steer
landed" into "it never arrived".

## Deleted tests

None.

## Scope

`stella-serve`-hosted turns (#4770) are untouched and stay unreachable — see
the comment on that issue for why it is a larger piece of work than its body
assumes.

Closes #4769
Refs #4806

## Summary by Sourcery

Wire session whistles into goal runs so steering messages reach the worker on later rounds.

New Features:
- Deliver `stella whistle` messages to active `stella goal` runs across subsequent rounds in both raw and wrapped goal execution paths.

Bug Fixes:
- Ensure goal-run whistle input is attached to the worker engine so verifier sub-agents cannot consume steering intended for the worker.

Enhancements:
- Introduce a shared session whistle abstraction that manages the socket listener and steering tap for the lifetime of a run.

Tests:
- Add an end-to-end Unix socket test verifying that a whistle sent during one goal round reaches a later model call.