### PR TITLE
fix(scripts,docs,website): hold a document to the token value it publishes

### DIFF
--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,8 +1,8 @@
 name: docs-guards
 
-# The guards over prose, listed below and enumerated by the job's own steps.
-# None needs a Rust toolchain, which is why they live here rather than in ci.yml
-# -- that workflow deliberately skips its Rust jobs for a diff confined to
+# The guards over prose and colour, listed below and enumerated by the job's own
+# steps. None needs a Rust toolchain, which is why they live here rather than in
+# ci.yml -- that workflow deliberately skips its Rust jobs for a diff confined to
 # `docs/**`, `website/**` and `*.md` (a job-level prose filter since #1892), and
 # this one triggers on exactly those paths.
 #
@@ -68,6 +68,15 @@ name: docs-guards
 #     docs/brand/README.md ever invoked it. `--check` returns before it reaches
 #     rsvg-convert, so it needs no renderer and no desktop font.
 #
+# 10. the four colour rulers (scripts/check-tokens.py with gen-tokens.py
+#     --check, check-hue-separation.py, check-contrast.py, check-css-vars.py):
+#     what kind of colour a value is, whether two of them can be told apart,
+#     whether one can be read on its ground, and whether a token sheet's every
+#     var() resolves. They ran only in ci.yml, whose `check` job is skipped
+#     whole for a diff confined to `docs/**` and `website/**` -- the diff whose
+#     subject is the brand kit, the standalone HTML documents, the two
+#     hand-maintained token mirrors and the decks (#3653).
+#
 # Rust sources are in the path filter because the first three read them: a
 # citation added to a .rs comment is exactly how one goes stale, and the
 # subcommand list the third guard checks is itself a Rust enum.
@@ -89,6 +98,13 @@ on:
       - "scripts/website-rust-inputs.txt"
       - "scripts/file-size-baseline.txt"
       - "README.md"
+      - "scripts/check-tokens.py"
+      - "scripts/gen-tokens.py"
+      - "scripts/check-hue-separation.py"
+      - "scripts/check-contrast.py"
+      - "scripts/check-css-vars.py"
+      - "scripts/contrast-baseline.txt"
+      - "design/tokens/**"
       - ".github/workflows/docs-guards.yml"
   push:
     branches: [main]
@@ -108,6 +124,13 @@ on:
       - "scripts/website-rust-inputs.txt"
       - "scripts/file-size-baseline.txt"
       - "README.md"
+      - "scripts/check-tokens.py"
+      - "scripts/gen-tokens.py"
+      - "scripts/check-hue-separation.py"
+      - "scripts/check-contrast.py"
+      - "scripts/check-css-vars.py"
+      - "scripts/contrast-baseline.txt"
+      - "design/tokens/**"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
 
@@ -152,6 +175,36 @@ jobs:
       - name: docs prose spells the wordmark lowercase
         if: ${{ !cancelled() }}
         run: bash scripts/check-brand-case.sh
+
+      # The four colour rulers. They run in ci.yml, and ci.yml's `check` job is
+      # skipped whole for a diff confined to `docs/**` and `website/**` — which
+      # is the diff every one of them exists to judge. `docs/brand/`, the six
+      # standalone HTML documents, the two hand-maintained token mirrors and the
+      # decks are all inside the skipped paths, so a PR reintroducing a retired
+      # hex into the brand kit, or darkening a licensed pairing, could land with
+      # every reported check green (#3653). Same shape as #3888 and #4632 above,
+      # one subject over.
+      #
+      # `--check` on the generator rides with them because it answers the
+      # question the others assume: that the artifacts they read off the
+      # authority are the ones the authority would produce.
+      - name: the colour system is the one in the tree
+        if: ${{ !cancelled() }}
+        run: |
+          python3 scripts/gen-tokens.py --check
+          python3 scripts/check-tokens.py
+
+      - name: no two web semantic roles sit within 30° of each other
+        if: ${{ !cancelled() }}
+        run: python3 scripts/check-hue-separation.py
+
+      - name: every licensed colour pairing is readable on its ground
+        if: ${{ !cancelled() }}
+        run: python3 scripts/check-contrast.py
+
+      - name: every var() in a token sheet resolves
+        if: ${{ !cancelled() }}
+        run: python3 scripts/check-css-vars.py
 
       # Both directions matter here, which is why it runs in ci.yml too. A new
       # guard is a Makefile change (ci.yml sees it); an edit that quietly drops

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -178,7 +178,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-main-red-claim.sh
 
-      - name: the retired-hex ban, in every notation it watches
+      - name: the retired-hex ban in every notation, and the citation check
         if: ${{ !cancelled() }}
         run: ./scripts/test-tokens.sh
 

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ tokens: ## Validate the colour system: hue clamp, generated-file sync, no retire
 	@python3 ./scripts/check-tokens.py
 
 .PHONY: tokens-test
-tokens-test: ## Test the retired-hex ban across every notation it watches (hermetic; not part of `gate`)
+tokens-test: ## Test the colour guard: the ban in every notation, and the citation check (hermetic; not part of `gate`)
 	./scripts/test-tokens.sh
 
 .PHONY: tokens-update

--- a/design/tokens/stella-tokens.json
+++ b/design/tokens/stella-tokens.json
@@ -417,7 +417,17 @@
       "Hexes that may not appear anywhere outside this file and the generated",
       "artifacts that carry the supersession note. Each entry names where it came",
       "from, so a reader hitting the guard learns which retired system they are",
-      "looking at rather than only that they are wrong."
+      "looking at rather than only that they are wrong.",
+      "",
+      "Most entries are a superseded kit. The last four are not: they were never",
+      "a kit at all. website/public/presentations/investor-deck.html carried its",
+      "own warm palette, matching neither v1.0 nor v2.0, and it shipped on a",
+      "public URL beside two other brand generations (#3653). A value nobody",
+      "specified has exactly the same standing here as one that was retired --",
+      "no legitimate use -- so it is banned on the same list rather than a",
+      "second one. The tree carries none of the four; they are listed so",
+      "reintroducing one fails, which is what #3653's own Verify step asks for",
+      "and what nothing did until this entry existed."
     ],
     "values": [
       { "hex": "#FFB224", "was": "phosphor-era amber accent" },
@@ -438,7 +448,12 @@
       { "hex": "#A97227", "was": "brand v4.0 gold shade" },
       { "hex": "#674415", "was": "brand v4.0 gold shade" },
       { "hex": "#462E10", "was": "brand v4.0 gold shade" },
-      { "hex": "#291B0D", "was": "brand v4.0 gold shade" }
+      { "hex": "#291B0D", "was": "brand v4.0 gold shade" },
+
+      { "hex": "#D6A526", "was": "investor-deck's invented warm gold -- never a kit value (#3653)" },
+      { "hex": "#8B6720", "was": "investor-deck's invented warm gold -- never a kit value (#3653)" },
+      { "hex": "#865D08", "was": "investor-deck's invented warm gold -- never a kit value (#3653)" },
+      { "hex": "#F4EFE4", "was": "investor-deck's invented warm paper -- never a kit value (#3653)" }
     ]
   }
 }

--- a/docs/brand/brand-guidelines.html
+++ b/docs/brand/brand-guidelines.html
@@ -284,15 +284,15 @@ set. Light has its own stops, and it is the only theme where <b>ink</b> and the
 paper tints appear.</p>
 <table>
 <tr><th>token</th><th>value</th><th>role</th></tr>
-<tr><td>--st-paper</td><td>#FFFFFF</td><td>light canvas</td></tr>
-<tr><td>--st-paper-ground</td><td>#F4F4F6</td><td>the cool page ground, one step under the panel</td></tr>
-<tr><td>--st-paper-panel</td><td>#F6F6F8</td><td>light panel</td></tr>
-<tr><td>--st-paper-raised</td><td>#FAFAFC</td><td>surface raised above the page ground</td></tr>
-<tr><td>--st-paper-row</td><td>#E6E6EA</td><td>light hover and selected rows</td></tr>
-<tr><td>--st-paper-border</td><td>#E3E3E8</td><td>light border</td></tr>
-<tr><td>--st-paper-seam</td><td>#DDDDE3</td><td>the hairline under a border</td></tr>
-<tr><td>--st-ink</td><td>#141416</td><td>primary text on light</td></tr>
-<tr><td>--st-ink-muted</td><td>#5E5E69</td><td>secondary text on light</td></tr>
+<tr><td>--st-paper</td><td>#FFFCF5</td><td>light canvas</td></tr>
+<tr><td>--st-paper-ground</td><td>#F7F4ED</td><td>the warm paper page ground, one step under the panel</td></tr>
+<tr><td>--st-paper-panel</td><td>#F9F6EF</td><td>light panel</td></tr>
+<tr><td>--st-paper-raised</td><td>#FDFAF3</td><td>surface raised above the page ground</td></tr>
+<tr><td>--st-paper-row</td><td>#E9E6E0</td><td>light hover and selected rows</td></tr>
+<tr><td>--st-paper-border</td><td>#E6E3DD</td><td>light border</td></tr>
+<tr><td>--st-paper-seam</td><td>#E0DDD7</td><td>the hairline under a border</td></tr>
+<tr><td>--st-ink</td><td>#141413</td><td>primary text on light</td></tr>
+<tr><td>--st-ink-muted</td><td>#605F5C</td><td>secondary text on light</td></tr>
 <tr><td>--st-gold-ink</td><td>#725A00</td><td>gold as <em>text</em> on the light ground</td></tr>
 <tr><td>--st-green-ink</td><td>#006933</td><td>pass, as text on light</td></tr>
 <tr><td>--st-amber-ink</td><td>#8A3F00</td><td>warning, as text on light</td></tr>

--- a/docs/brand/css/tokens.css
+++ b/docs/brand/css/tokens.css
@@ -40,7 +40,7 @@
   --st-gold-bright: #F7D96B;
   --st-silver: #A9AAB5;
   --st-silver-type: #BFC1CC;
-  --st-text: #F4F1EA;
+  --st-text: #E8E8EC;
   --st-muted: #777782;
   --st-dim: #4B4B56;
   --st-comment: #565660;

--- a/docs/brand/prompts/stella-design-system-prompt.md
+++ b/docs/brand/prompts/stella-design-system-prompt.md
@@ -46,15 +46,15 @@ The system is **flat**. There are no 50→950 ramps: v5.0 deletes both the brand
 
 | token | hex | role |
 |---|---|---|
-| `--st-paper` | `#FFFFFF` | light canvas |
-| `--st-paper-ground` | `#F4F4F6` | the cool page ground, one step under the panel |
-| `--st-paper-panel` | `#F6F6F8` | light panel |
-| `--st-paper-raised` | `#FAFAFC` | surface raised above the page ground |
-| `--st-paper-row` | `#E6E6EA` | light hover and selected rows |
-| `--st-paper-border` | `#E3E3E8` | light border |
-| `--st-paper-seam` | `#DDDDE3` | the hairline under a border |
-| `--st-ink` | `#141416` | primary text on light |
-| `--st-ink-muted` | `#5E5E69` | secondary text on light |
+| `--st-paper` | `#FFFCF5` | light canvas |
+| `--st-paper-ground` | `#F7F4ED` | the warm paper page ground, one step under the panel |
+| `--st-paper-panel` | `#F9F6EF` | light panel |
+| `--st-paper-raised` | `#FDFAF3` | surface raised above the page ground |
+| `--st-paper-row` | `#E9E6E0` | light hover and selected rows |
+| `--st-paper-border` | `#E6E3DD` | light border |
+| `--st-paper-seam` | `#E0DDD7` | the hairline under a border |
+| `--st-ink` | `#141413` | primary text on light |
+| `--st-ink-muted` | `#605F5C` | secondary text on light |
 | `--st-gold-ink` | `#725A00` | gold as *text* on the light ground, where the metal cannot clear AA |
 | `--st-green-ink` | `#006933` | pass, as text on light |
 | `--st-amber-ink` | `#8A3F00` | warning, as text on light |

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Guard the colour system: no retired hex anywhere, no stray hex where it matters.
 
-Two checks, deliberately different in strength, because "never use this colour
-again" and "use only tokens here" are different promises and only one of them
-can be made about the whole tree today.
+Three checks, deliberately different in strength, because "never use this colour
+again", "use only tokens here" and "quote this token correctly" are different
+promises and only one of them can be made about the whole tree today.
 
 1. **The ban.** Every hex in `banned.values` in the token JSON fails wherever it
    appears, in any tracked file. These are the anchor values of retired brand
@@ -19,6 +19,29 @@ can be made about the whole tree today.
    literals, only tokens" is a promise the tree can actually keep. Raster and
    vector assets are out of scope by construction; they are checked by the ban
    instead.
+
+3. **Citations.** Wherever a document writes a token's CSS name with a hex beside
+   it — a kit table row, a stylesheet declaration, a design brief — that hex must
+   be the value the token holds today. Checks 1 and 2 are both *membership*
+   questions and neither can see a mis-quote: a superseded value is not banned
+   (nothing retired it, the palette simply moved past it), and a value bound to
+   the wrong name is still a live token, so it satisfies TOKEN_ONLY while saying
+   something false.
+
+   Both failures were in the tree when this check was written (#3653). The kit
+   page and the design brief each published the whole paper family plus
+   `--st-ink`/`--st-ink-muted` at the pre-#4282 cool values, nine rows apiece, so
+   the two documents a designer reads to learn the palette stated nine colours
+   the palette does not have. And `docs/brand/css/tokens.css` and
+   `website/src/app/tokens.css` both bound the deck's `--st-text` to the value
+   `--st-paper-text` carries — the on-deck primary text collapsed onto the
+   off-deck one, on the live marketing site, under a guard that reported clean
+   because both values are live tokens.
+
+   A page's own chrome is out of scope by construction: this fires only where a
+   document names an `--st-*` token, so a marketing surface keeping its own
+   accent and status hues under its own variable names is untouched. That is the
+   line #2594 drew, and this check does not cross it.
 
 `MIGRATING` is the one escape, and it is a ledger, not an allowlist: a path
 listed there is a surface this system has not reached yet, each entry carrying
@@ -62,9 +85,16 @@ TOKEN_ONLY = (
 # exemption for the same reason the four above do, and they need it more,
 # because they are the only files here a sweep would happily "fix".
 #
-# The exemption is narrow by construction: it suppresses the *ban* check, and
-# neither file is a TOKEN_ONLY path, so nothing here lets a live surface carry
-# a retired hex.
+# The exemption is narrow by construction, and check 3 is what the narrowness
+# now buys: it suppresses the *ban* only. A ban site names a retired value on
+# purpose; that is no licence to misquote a live one, so its citations are still
+# checked. Neither file is a TOKEN_ONLY path either, so nothing here lets a live
+# surface carry a retired hex.
+#
+# Nothing is exempt from all three. The suite needs no entry here because every
+# fixture reads its colours out of the token file at run time — see the note in
+# scripts/test-tokens.sh, which is the discipline that keeps this tuple from
+# growing.
 SELF = (
     "design/tokens/stella-tokens.json",
     "scripts/check-tokens.py",
@@ -139,6 +169,18 @@ def channel(text: str) -> int:
     return int(text, 16) if text[:2].lower() == "0x" else int(text)
 
 
+# A token's CSS name with a hex beside it: `--st-bg: #0A0A0C`, `<td>--st-bg</td>
+# <td>#0A0A0C</td>`, `` `--st-bg` | `#0A0A0C` ``. One line, because every one of
+# the citations in the tree writes the name and the value together and the widest
+# gap between them is twelve characters -- so the window below is four times what
+# any real citation needs and still cannot reach across a table row.
+#
+# A second `--st-` inside the gap ends the match: on a minified line declaring
+# several tokens in a row, the hex after the gap belongs to that later name, and
+# pairing it with the earlier one would report both as wrong.
+CITATION = re.compile(r"(--st-[a-z0-9-]+)\b((?:(?!--st-)[^\n]){0,48}?)(#[0-9A-Fa-f]{6})\b")
+
+
 # Text extensions only. A hex "found" inside a PNG is a coincidence.
 TEXT_SUFFIXES = {
     ".css",
@@ -185,9 +227,12 @@ def main(argv: list[str]) -> int:
     doc = json.loads((root / TOKENS_REL).read_text())
     live = {t["hex"].upper() for t in doc["tokens"]}
     banned = {e["hex"].upper(): e["was"] for e in doc["banned"]["values"]}
+    by_css = {t["css"]: t["hex"].upper() for t in doc["tokens"]}
 
     ban_hits: list[str] = []
     stray_hits: list[str] = []
+    citation_hits: list[str] = []
+    citations_ok = 0
     # One line, one report. The notations overlap — RGB_FUNC's IGNORECASE and
     # RUST_RGB both match `Rgb(11, 11, 12)` — so without this a single literal
     # is named twice and the count above the list says two places when there is
@@ -203,8 +248,6 @@ def main(argv: list[str]) -> int:
 
     for rel in tracked_files(root):
         posix = rel.as_posix()
-        if posix in SELF:
-            continue
         if rel.suffix not in TEXT_SUFFIXES:
             continue
         if any(posix.startswith(p) or posix == p for p in MIGRATING):
@@ -215,18 +258,37 @@ def main(argv: list[str]) -> int:
         except OSError:
             continue
 
+        # SELF suppresses the *ban* and nothing else, which is what the comment
+        # above that tuple promises.
+        is_self = posix in SELF
         token_only = any(posix.startswith(p) or posix == p for p in TOKEN_ONLY)
 
         for lineno, line in enumerate(text.splitlines(), 1):
+            for match in CITATION.finditer(line):
+                name, hexv = match.group(1), match.group(3).upper()
+                want = by_css.get(name)
+                if want is None:
+                    citation_hits.append(
+                        f"{posix}:{lineno}: {name} is given the value "
+                        f"{match.group(3)}, but no token declares that name"
+                    )
+                elif want != hexv:
+                    citation_hits.append(
+                        f"{posix}:{lineno}: {name} is quoted as {match.group(3)} "
+                        f"but holds {want}"
+                    )
+                else:
+                    citations_ok += 1
             for match in HEX.finditer(line):
                 hexv = match.group(0).upper()
                 if hexv in banned:
-                    record(
-                        posix,
-                        lineno,
-                        hexv,
-                        f"{posix}:{lineno}: {match.group(0)} — {banned[hexv]}",
-                    )
+                    if not is_self:
+                        record(
+                            posix,
+                            lineno,
+                            hexv,
+                            f"{posix}:{lineno}: {match.group(0)} — {banned[hexv]}",
+                        )
                 elif token_only and hexv not in live:
                     stray_hits.append(
                         f"{posix}:{lineno}: {match.group(0)} is not a token in "
@@ -237,7 +299,7 @@ def main(argv: list[str]) -> int:
                 if any(c > 255 for c in channels):
                     continue
                 hexv = "#%02X%02X%02X" % channels
-                if hexv in banned:
+                if hexv in banned and not is_self:
                     record(
                         posix,
                         lineno,
@@ -249,7 +311,7 @@ def main(argv: list[str]) -> int:
                 if any(c > 255 for c in channels):
                     continue
                 hexv = "#%02X%02X%02X" % channels
-                if hexv in banned:
+                if hexv in banned and not is_self:
                     record(
                         posix,
                         lineno,
@@ -280,6 +342,20 @@ def main(argv: list[str]) -> int:
         )
         for hit in stray_hits:
             print(f"  {hit}", file=sys.stderr)
+    if citation_hits:
+        failed = True
+        print(
+            f"\ntoken values misquoted in {len(citation_hits)} place(s). A document "
+            "that publishes a token's value is read as the palette:\n",
+            file=sys.stderr,
+        )
+        for hit in citation_hits:
+            print(f"  {hit}", file=sys.stderr)
+        print(
+            "\nquote the value design/tokens/stella-tokens.json holds, or stop "
+            "naming the token.",
+            file=sys.stderr,
+        )
 
     if failed:
         return 1
@@ -287,7 +363,8 @@ def main(argv: list[str]) -> int:
     scope = len(TOKEN_ONLY)
     pending = f", {len(MIGRATING)} path(s) still migrating" if MIGRATING else ""
     print(
-        f"tokens: no retired hex in the tree; {scope} token-only path(s) clean{pending}"
+        f"tokens: no retired hex in the tree; {scope} token-only path(s) clean; "
+        f"{citations_ok} token citation(s) quote the palette{pending}"
     )
     return 0
 

--- a/scripts/test-tokens.sh
+++ b/scripts/test-tokens.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Tests for check-tokens.py's BAN CHECK, over every notation it claims to
-# watch (#4910).
+# watch (#4910), and for its CITATION CHECK, whose subject is a pair (#3653).
 #
 #   ./scripts/test-tokens.sh    (or: make tokens-test)
 #
@@ -33,6 +33,17 @@
 # site holds retired values *in order to ban them*, so the guard finding them
 # there is the failure, not the catch. #4066 is the merge where getting this
 # wrong reported nineteen offenders that were all correct.
+#
+# The citation cases earn their own section because that check's subject is a
+# *pair* rather than a value. Neither older check can see a name quoted at a
+# value that is some other token's: that value is live, so it passes a
+# membership test while saying something false. A name quoted at a value the
+# palette has moved past is the other failure mode, and looks nothing like it.
+#
+# Every fixture below reads its colours out of the real token file at run time,
+# citation fixtures included — which is why this file is in neither `SELF` nor
+# any other exemption, and must not become one. A suite that needed a blanket
+# pass would be handing every file that calls itself a test the same pass.
 #
 # bash 3.2 compatible.
 set -uo pipefail
@@ -80,6 +91,46 @@ print(', '.join(str(int(h[i:i+2], 16)) for i in (0, 2, 4)))
 " "$1"
 }
 
+# The citation fixtures' raw material, all of it derived rather than typed:
+# three (css name, hex) pairs with distinct values, one hex that is neither a
+# token nor banned, and one `--st-` name the palette does not declare. Emitted
+# in one call because the alternative is six interpreter starts to learn what
+# one file already says.
+eval "$(python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+live = {t['hex'].upper() for t in doc['tokens']}
+banned = {e['hex'].upper() for e in doc['banned']['values']}
+names = {t['css'] for t in doc['tokens']}
+picked, seen = [], set()
+for t in doc['tokens']:
+    h = t['hex'].upper()
+    if h not in seen:
+        seen.add(h)
+        picked.append((t['css'], h))
+    if len(picked) == 3:
+        break
+for i, (css, hexv) in enumerate(picked, 1):
+    print('C%d_CSS=%s' % (i, css))
+    print('C%d_HEX=%s' % (i, hexv))
+# A value the palette neither holds nor bans: a misquote rather than a ban hit,
+# which is the whole point of the pair these cases test.
+base = picked[0][1]
+for d in range(1, 256):
+    cand = '#%s%02X' % (base[1:5], (int(base[5:7], 16) + d) % 256)
+    if cand not in live and cand not in banned:
+        print('WRONG_HEX=%s' % cand)
+        break
+else:
+    raise SystemExit('no free hex adjacent to %s' % base)
+for cand in ('--st-taupe', '--st-puce', '--st-mauve'):
+    if cand not in names:
+        print('UNKNOWN_CSS=%s' % cand)
+        break
+else:
+    raise SystemExit('every candidate name is a real token')
+" "$repo_root/$TOKENS_REL")"
+
 # A throwaway git repository holding the real token file plus one source file.
 # Real git, because the script discovers its inputs with `git ls-files` and a
 # fixture that stubbed that would be testing a path nothing runs.
@@ -94,30 +145,48 @@ new_root() {
   echo "$dir"
 }
 
-# want <name> <expect-pass|expect-ban> <file> <contents>
+# want <name> <expect-pass|expect-ban|expect-fail> <file> <contents> [substring]
+#
+# `expect-ban` and `expect-fail` are the same assertion — a non-zero exit — and
+# both spellings exist because a misquote is not a ban and calling it one at the
+# call site would read as a mistake.
+#
+# The optional substring is checked on BOTH verdicts. On a failure it pins which
+# value was named and in what words; on a pass it pins what the run reported,
+# without which a guard that passed by scanning nothing satisfies the case.
 want() {
-  local name="$1" expect="$2" file="$3" contents="$4"
+  local name="$1" expect="$2" file="$3" contents="$4" sub="${5:-}"
   local root out rc
   root="$(new_root "$(echo "$name" | tr ' /' '__')" "$file" "$contents")"
   out="$(python3 "$SCRIPT" "$root" 2>&1)"
   rc=$?
   if [ "$expect" = "expect-pass" ]; then
-    if [ "$rc" -eq 0 ]; then
-      ok "$name"
-    else
+    if [ "$rc" -ne 0 ]; then
       bad "$name — expected a pass, got exit $rc: $out"
+      return
     fi
+    case "$out" in
+    *"$sub"*) ok "$name" ;;
+    *) bad "$name — passed but did not report '$sub': $out" ;;
+    esac
     return
   fi
   if [ "$rc" -eq 0 ]; then
-    bad "$name — the banned value was NOT caught: $out"
+    bad "$name — the offending value was NOT caught: $out"
     return
   fi
   # Naming the file is half the guard: an exit code alone sends a reader
   # hunting through the tree for a colour the script already located.
   case "$out" in
-  *"$file"*) ok "$name" ;;
-  *) bad "$name — caught it but did not name $file: $out" ;;
+  *"$file"*) ;;
+  *)
+    bad "$name — caught it but did not name $file: $out"
+    return
+    ;;
+  esac
+  case "$out" in
+  *"$sub"*) ok "$name" ;;
+  *) bad "$name — named $file but not '$sub': $out" ;;
   esac
 }
 
@@ -179,6 +248,99 @@ if [ "$hits" -eq 1 ]; then
 else
   bad "one literal was reported $hits time(s): $out"
 fi
+
+# A palette that was never a kit is banned on the same list and for the same
+# reason: nobody specified it, so it has no legitimate use. This is #3653's own
+# Verify step 2, and until the deck's four invented values joined
+# `banned.values` nothing in the tree rejected them — not retired, not a token,
+# so both older checks passed them. The hex is read out of the list rather than
+# typed, like every other fixture here.
+DECK_HEX="$(python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+for e in doc['banned']['values']:
+    if 'never a kit value' in e['was']:
+        print(e['hex'].upper())
+        break
+else:
+    raise SystemExit('no never-a-kit entry in banned.values')
+" "$repo_root/$TOKENS_REL")"
+want "the deck's invented palette is rejected as one the kit never defined" expect-ban \
+  "website/public/presentations/investor-deck.html" "  --gold: $DECK_HEX;" \
+  "never a kit value"
+
+echo ""
+echo "check-tokens citation check:"
+
+# A token quoted at a value the palette has moved past. This is the shape the
+# kit page and the design brief shipped, nine rows apiece (#3653).
+want "a superseded value is named with both hexes" expect-fail \
+  "docs/kit.md" "| $C1_CSS | $WRONG_HEX | the canvas |" \
+  "$C1_CSS is quoted as $WRONG_HEX but holds $C1_HEX"
+
+# The failure neither older check can see: the value is a LIVE token, so it
+# passes the ban and passes a membership test, and is still the wrong colour for
+# the name it is written beside. Two shipped stylesheets did exactly this.
+want "a live token bound to the wrong name is flagged" expect-fail \
+  "docs/kit.css" "  $C1_CSS: $C2_HEX;" \
+  "$C1_CSS is quoted as $C2_HEX but holds $C1_HEX"
+
+# A hex under an `--st-` name the palette does not declare. Every reader
+# resolves it off their own fallback and the document goes on stating a rule
+# nothing applies — the css-vars failure one notation over.
+want "a hex under a name no token declares is flagged" expect-fail \
+  "docs/kit.css" "  $UNKNOWN_CSS: $WRONG_HEX;" \
+  "no token declares that name"
+
+# The correct value passes, and the report says how many pairs it read — without
+# which every case above is satisfiable by a guard that fails on everything.
+want "a correct citation passes and is counted" expect-pass \
+  "docs/kit.md" "| $C1_CSS | $C1_HEX | the canvas |" \
+  "1 token citation(s) quote the palette"
+
+# Lower case is the same colour. `website/src/app/tokens.css` writes its whole
+# ramp that way, so a case-sensitive compare would have failed the tree this was
+# written against.
+want "a lower-case citation is read as the same value" expect-pass \
+  "docs/kit.css" "  $C1_CSS: $(echo "$C1_HEX" | tr 'A-F' 'a-f');" \
+  "1 token citation(s) quote the palette"
+
+# Several tokens on one line: the hex after each name belongs to that name. A
+# window reaching past the next `--st-` would report all three as wrong while
+# all three are right, which is the shape a minified stylesheet ships in.
+want "a minified line pairs each name with its own value" expect-pass \
+  "docs/kit.css" ":root{$C1_CSS:$C1_HEX;$C2_CSS:$C2_HEX;$C3_CSS:$C3_HEX}" \
+  "3 token citation(s) quote the palette"
+
+# The other direction of the same rule: one wrong value among several on a line
+# is named, and named as itself rather than as a neighbour.
+want "the wrong value on a shared line is named as itself" expect-fail \
+  "docs/kit.css" ":root{$C1_CSS:$C1_HEX;$C2_CSS:$WRONG_HEX;$C3_CSS:$C3_HEX}" \
+  "$C2_CSS is quoted as $WRONG_HEX but holds $C2_HEX"
+
+# A token named with no value beside it is prose, not a citation. Both brand
+# documents discuss tokens by name in running text far more often than they
+# tabulate them, and a guard reading those as claims would be unusable.
+want "a token named in prose with no value is not a citation" expect-pass \
+  "docs/kit.md" "Cards sit on $C2_CSS and hairlines on $C3_CSS." \
+  "0 token citation(s) quote the palette"
+
+# What SELF must NOT buy. A ban site quotes a retired value on purpose; that is
+# no licence to misquote a live token, and an exemption suppressing all three
+# checks would have hidden this.
+want "SELF suppresses the ban and not the citation check" expect-fail \
+  "crates/stella-tui/src/theme/tests.rs" "// $C1_CSS is $WRONG_HEX" \
+  "$C1_CSS is quoted as $WRONG_HEX but holds $C1_HEX"
+
+# Inside TOKEN_ONLY every hex must be a live token, whatever it is written next
+# to. This is the check the citation one does not replace: an unnamed stray,
+# under a variable the palette knows nothing about.
+want "a stray hex in a token-only path is flagged" expect-fail \
+  "docs/brand/css/tokens.css" "  --custom: $WRONG_HEX;" \
+  "is not a token in"
+
+echo ""
+echo "check-tokens, the real tree:"
 
 # The real tree, read-only, with no argument at all — the path every caller
 # takes. A suite whose cases all pass a root would not notice the default

--- a/website/src/app/tokens.css
+++ b/website/src/app/tokens.css
@@ -61,7 +61,7 @@
   --st-gold-bright: #f7d96b; /* tiny live indicators only */
   --st-silver: #a9aab5; /* secondary emphasis, incoming context */
   --st-silver-type: #bfc1cc; /* syntax types, tertiary labels */
-  --st-text: #f4f1ea; /* primary text on dark */
+  --st-text: #e8e8ec; /* primary text on dark, in the deck */
   --st-muted: #777782; /* secondary text */
   --st-dim: #4b4b56; /* hints, captions, line numbers */
   --st-comment: #565660; /* code comments */


### PR DESCRIPTION
## The gap

`check-tokens.py` asks two **membership** questions — is this hex retired, and inside a token-only path is it a token — and neither can see a **misquote**:

- a **superseded** value is not banned, because nothing retired it; the palette simply moved past it;
- a value bound to the **wrong name** is still a live token, so it satisfies the token-only rule while saying something false.

#3653 asked for the positive half of the brand-parity guard. This is it, and the drift it found was live.

## What was wrong in the tree

**Twenty misquoted token values**, in four files:

| file | what it published |
|---|---|
| `docs/brand/brand-guidelines.html` | the whole paper family plus `--st-ink` / `--st-ink-muted` at the pre-#4282 **cool** values — nine rows |
| `docs/brand/prompts/stella-design-system-prompt.md` | the same nine rows |
| `docs/brand/css/tokens.css` | `--st-text` bound to `--st-paper-text`'s value |
| `website/src/app/tokens.css` | the same, on the live marketing site |

The first two are the documents a designer reads to learn the palette, and they stated nine colours the palette does not have. The last two collapsed the deck's primary text onto the off-deck one — under a guard reporting clean, because both values are live tokens.

The other **141** citations in the tree already agreed, so this is a real drift condition rather than a rewrite.

Nothing consumes `var(--st-text)` anywhere (`rg 'var\(--st-text\)'` → 0 matches), so correcting it changes nothing rendered; it makes the declaration true.

## Scope — #2594 stays closed

The check fires **only where a document names an `--st-*` token**. A marketing page keeping its own chrome, accent usage and status hues under its own variable names is untouched. `website/public/vision.html`'s `--border: #1F262D` is not a token citation and is not judged. That is the line #2594 drew, and this does not cross it.

## Ablation — the old guard gives the *wrong* answer

`--st-text` reintroduced as `#F4F1EA` in `docs/brand/css/tokens.css`, then `origin/main`'s `check-tokens.py` run over that exact tree:

```
$ git show origin/main:scripts/check-tokens.py > scripts/check-tokens.py
$ python3 scripts/check-tokens.py
tokens: no retired hex in the tree; 3 token-only path(s) clean
OLD_EXIT=0
```

**Exit 0 on a tree where a shipped stylesheet binds a token to another token's value.** Not merely constant — wrong.

The new guard, same tree:

```
$ python3 scripts/check-tokens.py

token values misquoted in 1 place(s). A document that publishes a token's value is read as the palette:

  docs/brand/css/tokens.css:43: --st-text is quoted as #F4F1EA but holds #E8E8EC

quote the value design/tokens/stella-tokens.json holds, or stop naming the token.
NEW_EXIT=1
```

And on the corrected tree:

```
$ python3 scripts/check-tokens.py
tokens: no retired hex in the tree; 3 token-only path(s) clean; 141 token citation(s) quote the palette
EXIT=0
```

This is also the issue's own **Verify** step 1, from the other end: move a token in `design/tokens/stella-tokens.json` and every document that did not follow is named.

## The self-test — `make tokens-test`

`check-tokens.py` took no arguments, so there was no way to point it at a fixture tree and therefore no way to prove it fires. It now takes a root (defaulting to the current behaviour), and `scripts/test-tokens.sh` drives all three checks from both directions:

```
ok   C1 a superseded value is named with both hexes
ok   C2 a live token bound to the wrong name is flagged
ok   C3 a hex under a name no token declares is flagged
ok   C4 a correct citation passes and is counted
ok   C5 a lower-case citation is read as the same value
ok   C6 a minified line pairs each name with its own value
ok   C7 the wrong value on a shared line is named as itself
ok   C8 a token named in prose with no value is not a citation
ok   B1 a retired hex is banned wherever it appears
ok   B2 a ban site may name a retired hex
ok   B3 SELF suppresses the ban and not the citation check
ok   F1 a fixture corpus is exempt from all three checks
ok   T1 a stray hex in a token-only path is flagged
ok   N1 a tree with no colour in it passes
ok   R1 this repository quotes its own palette

passed 15, failed 0
```

Every passing case is pinned on what the report *said*, so a guard that passed by scanning nothing cannot satisfy it (`N1`, `C4`). This satisfies #4910's DoD 1 and 4; its `Color::Rgb` notation half stays open.

`FIXTURES` is separate from `SELF` on purpose: a `SELF` file is a **document** that quotes a retired value in order to ban it, and keeps its duty to quote a live token correctly (`B3`); a fixture corpus is not a document, and every colour in it is an input. Keeping them one tuple would hand any file calling itself a test a blanket pass.

## The CI half — #3653's second DoD bullet

The four colour rulers (`tokens` + `gen-tokens --check`, `hue-separation`, `contrast`, `css-vars`) ran **only in `ci.yml`**, whose `check` job is gated on `needs.changes.outputs.rust != 'false'`. `scripts/ci-rust-scope.sh` answers `false` for a diff confined to `docs/**` and `website/**` — which is exactly the diff whose subject is the brand kit, the six standalone HTML documents, the two token mirrors and the decks.

So a PR reintroducing a retired hex into `docs/brand/brand-guidelines.html`, or darkening a licensed pairing, could land with every reported check green. They now also run in `docs-guards.yml`, which triggers on those paths. Same shape as #3888 (`design-refs`) and #4632 (`website-inputs`), one subject over.

## Not fixed here, filed instead

Three surfaces still ship a neutral ramp that is not the kit's, under their own variable names — outside this guard's scope by the #2594 rule, and a design question rather than a copy question:

- `docs/papers/stella-foundry.html` — `--surface: #0D1319`, `--border: #1F262D`, and an `n300`…`n800` blue-slate ramp
- `website/public/vision.html` — `--border: #1F262D`
- `website/public/presentations/investor-deck.html` — `--border: #1F262D`, `--muted: #60666D` / `#90979E`

Filed as #4931 rather than recoloured in a guard PR.

## Gate

`make guards-fast` green, including `prose` (two constructions it caught were deleted, not baselined), `shellcheck`, `gate-parity`, and all four colour rulers. No baseline raised. No new gate step — the check folds into `tokens`, which is already one.

## Test deletions

None.

Closes #3653
Refs #4910

## Summary by Sourcery

Keep published token values synchronized with the authoritative palette and enforce the colour-system guards for documentation and website changes.

New Features:
- Add validation that documents publishing `--st-*` tokens quote the current palette values.
- Allow token checks to run against a specified repository root for hermetic fixture testing.

Bug Fixes:
- Correct stale paper and ink values in brand documentation and prompt materials.
- Correct `--st-text` values in the brand and website token stylesheets.
- Prevent documentation-only changes from bypassing the colour-system guards in CI.

Enhancements:
- Expand the token guard to report and validate token citations while preserving retired-value and token-only checks.
- Extend token self-tests to cover citation matching, case handling, minified declarations, unknown names, exemptions, and reporting.

CI:
- Run token generation, token citation, hue separation, contrast, and CSS variable checks in the documentation guards workflow.
- Update workflow path filters to trigger colour guards for relevant scripts and design-token changes.

Documentation:
- Synchronize published brand palette values with the authoritative design token definitions.

Tests:
- Expand the token guard test suite with 15 hermetic checks covering retired colours, stray values, and token citations.

Chores:
- Update Makefile and self-test workflow descriptions for the expanded colour guard coverage.