### PR TITLE
docs(context): the license-allowlist record says why it names no tool, without naming tools

### DIFF
--- a/.stella/rules/ctx.stella.dependency-license-allowlist.toml
+++ b/.stella/rules/ctx.stella.dependency-license-allowlist.toml
@@ -12,13 +12,19 @@
 # tracks — and the cheapest moment to catch it is the edit that would have
 # admitted it, not the release that ships it.
 #
-# The guard names no `guard_tool` on purpose. `Edit` would cover `edit_file`
-# and `apply_edits` but not `write_file`, and a guard that stops the model's
-# usual path while leaving the other one open is worse than no guard: it reads
-# as enforcement in `stella context list` and is not. With the tool field
-# omitted the guard matches on path alone, so every tool that names a path is
-# covered, and `Bash` (which carries no `path`) is not — running `cargo deny`
-# is exactly what this record wants to happen.
+# The guard names no `guard_tool` on purpose, and the reason is about shape,
+# not about which tools exist this week. A tool-scoped guard is exactly as
+# complete as the list of names it spells, and that list is open: the built-in
+# surface has been rewritten twice, an installed MCP server contributes its
+# own, and a workspace custom tool contributes another. A guard that stops the
+# names it happened to know while a sibling walks past is worse than no guard —
+# it reads as enforcement in `stella context list` and is not.
+#
+# With the tool field omitted the guard matches on path alone, so any tool
+# that names a path is covered whatever it is called and wherever it came
+# from. A shell-shaped call carries no path and falls outside for that same
+# reason, which is the right answer here: running `cargo deny` is exactly what
+# this record wants to happen.
 
 schema = "context-record/v0.1"
 set_id = "stella"


### PR DESCRIPTION
## The void reason

`.stella/rules/ctx.stella.dependency-license-allowlist.toml` explains why the
record names no `guard_tool` like this:

> `Edit` would cover `edit_file` and `apply_edits` but not `write_file` […]
> With the tool field omitted the guard matches on path alone, so every tool
> that names a path is covered, and `Bash` (which carries no `path`) is not

`apply_edits` and `write_file` are not tools any more. The conclusion still
holds; the argument for it points at a surface that no longer exists, and would
point at a different one again the next time the surface changes.

## What ships

The same conclusion, argued from shape instead of from a roster:

> The guard names no `guard_tool` on purpose, and the reason is about shape,
> not about which tools exist this week. A tool-scoped guard is exactly as
> complete as the list of names it spells, and that list is open: the built-in
> surface has been rewritten twice, an installed MCP server contributes its
> own, and a workspace custom tool contributes another. A guard that stops the
> names it happened to know while a sibling walks past is worse than no guard —
> it reads as enforcement in `stella context list` and is not.
>
> With the tool field omitted the guard matches on path alone, so any tool that
> names a path is covered whatever it is called and wherever it came from. A
> shell-shaped call carries no path and falls outside for that same reason,
> which is the right answer here: running `cargo deny` is exactly what this
> record wants to happen.

Comment lines only. `statement`, `steering`, `enforcement`, `truth` and
`provenance` are byte-identical.

## Why this is not a supersession, which is what #3269 asked for

The issue asks to supersede the record through `stella context` tooling. The
tooling refuses, and it is right to.

**1. There is nothing to supersede.** `run_keep`
(`crates/stella-cli/src/context_cmd/review.rs`) forks on content, and a
candidate whose statement matches the published one is a hard error:

```rust
Some(existing) if same_statement(&existing.statement, &record.statement) => {
    return Err(format!(
        "{} already exists — refusing to overwrite it. A published record is \
         somebody's reviewed work; this candidate says the same thing, so there is \
         nothing to supersede. Edit the file directly, or delete it first if you \
         meant to replace it.",
        path.display()
    ));
}
```

The statement here is unchanged, because a TOML comment is not record content —
it is not `statement`, it is excluded from `record_hash` by construction (the
loader never sees it), and no field on `Record`
(`crates/stella-core/src/ingest/record.rs`) holds rationale prose. The comment
is file-level text for a human reader.

**2. `replace_record` would delete the thing being fixed.**
`crates/stella-cli/src/context_records.rs`'s `replace_record` rebuilds the file
from the typed model with `toml::to_string_pretty`. Every comment in the file —
including the `[record.enforcement]` note explaining the `*deny.toml` wildcard
and the `[record.truth.probe]` note explaining why a decree gets a
`file_contains` probe — is dropped. The instrument the issue names destroys the
subject.

**3. Forcing the event by hand would turn the gate red.** `blocking_grants`
(`crates/stella-core/src/records/promotion.rs`) folds latest-event-wins and then
keeps only grants:

```rust
latest.retain(|_, event| event.action == LedgerAction::Grant && event.to == "blocking");
```

with the consequence stated in its own comment: *"a lifecycle event
(retired/superseded) on a lineage clears its blocking grant"*. This record is
`mode = "hard"` with a `guard_deny_path`, and its grant is ledger seq 1. A seq-3
`Superseded` event becomes the lineage's latest, the grant disappears, and
`regulated` governance then fails validate on an armed record with no grant —
requiring a seq-4 re-grant to undo the seq-3 nobody needed.

The #3244 precedent the issue cites is a genuine *retirement*: that record's
subject (the `verify_done` tool's shadow-worktree contract) had stopped being
true, and its `mode = "none"` meant no grant to revoke. Neither is the case
here.

## Evidence

```
$ ./target/debug/stella context validate | tail -1
Every loaded record is schema-valid and currently believed.
$ echo $?
0

$ git diff --stat origin/main
 .../ctx.stella.dependency-license-allowlist.toml | 20 +++++++++++++-------
 1 file changed, 13 insertions(+), 7 deletions(-)

$ python3 scripts/check-prose.py
check-prose: OK -- 6393 grandfathered construction(s) in 1454 file(s), none added.

$ python3 scripts/check-line-citations.py
check-line-citations: OK -- 260 grandfathered citation(s) in 36 file(s), none added.
```

## Witness

None, and none is owed: this changes a comment in a data file. No `#[test]` was
renamed or removed, and nothing the loader reads moved — which is itself the
argument above.

## Left open

#3269's definition of done says "the old revision is superseded on the ledger",
and this PR deliberately does not do that. If a maintainer wants the ledger
event regardless of the three obstacles above, that is a call to make on the
issue rather than in this diff, so the issue stays open with this reasoning on
it.

Refs #3269

## Summary by Sourcery

Refresh the dependency license allowlist rationale to describe coverage by request shape rather than by specific tool names.

Enhancements:
- Clarify that the dependency license allowlist intentionally omits tool scoping so path-bearing calls remain covered across built-in, MCP, and custom tool surfaces while shell-shaped calls remain excluded.

Documentation:
- Update the allowlist record’s rationale to explain its tool-agnostic matching strategy without relying on a changing list of tool names.