### PR TITLE
fix(brand,ci): hold every published tagline copy to the kit, and run the check

### DIFF
--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,9 +1,10 @@
 name: docs-guards
 
-# Eight guards over prose. None needs a Rust toolchain, which is why they live
-# here rather than in ci.yml -- that workflow deliberately skips its Rust jobs
-# for a diff confined to `docs/**`, `website/**` and `*.md` (a job-level prose
-# filter since #1892), and this one triggers on exactly those paths.
+# The guards over prose, listed below and enumerated by the job's own steps.
+# None needs a Rust toolchain, which is why they live here rather than in ci.yml
+# -- that workflow deliberately skips its Rust jobs for a diff confined to
+# `docs/**`, `website/**` and `*.md` (a job-level prose filter since #1892), and
+# this one triggers on exactly those paths.
 #
 #  1. doc-links (scripts/check-doc-links.py): every citation resolves to a
 #     document that has declared an identity. Documents are addressed by a
@@ -59,6 +60,14 @@ name: docs-guards
 #     diff ci.yml's Rust job is skipped for, which is why the filter above
 #     widened from `website/content/docs/**` to `website/**`.
 #
+#  9. the brand art's sources (docs/brand/social/build_social.py --check): the
+#     banner's install line against README.md, and its tagline against the kit
+#     page (#3631). Both are cross-file string claims that a render bakes into a
+#     PNG a platform then caches, so drift is unfixable after the fact. The
+#     script had never run in automation -- only a human following
+#     docs/brand/README.md ever invoked it. `--check` returns before it reaches
+#     rsvg-convert, so it needs no renderer and no desktop font.
+#
 # Rust sources are in the path filter because the first three read them: a
 # citation added to a .rs comment is exactly how one goes stale, and the
 # subcommand list the third guard checks is itself a Rust enum.
@@ -79,6 +88,7 @@ on:
       - "scripts/check-website-inputs.sh"
       - "scripts/website-rust-inputs.txt"
       - "scripts/file-size-baseline.txt"
+      - "README.md"
       - ".github/workflows/docs-guards.yml"
   push:
     branches: [main]
@@ -97,6 +107,7 @@ on:
       - "scripts/check-website-inputs.sh"
       - "scripts/website-rust-inputs.txt"
       - "scripts/file-size-baseline.txt"
+      - "README.md"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
 
@@ -174,3 +185,17 @@ jobs:
       - name: nothing outside docs/design cites docs/design
         if: ${{ !cancelled() }}
         run: bash scripts/check-design-refs.sh
+
+      # The brand kit's two cross-file strings: the install line against
+      # README.md, and now the tagline against the kit (#3631). `--check`
+      # renders nothing and needs neither rsvg-convert nor a desktop font --
+      # it returns before either is reached -- so it costs a second here.
+      #
+      # It had never run in automation at all. `check_install_line` has guarded
+      # the banner's install command since the script was written, and the only
+      # thing invoking it was a human following docs/brand/README.md. A guard
+      # nobody runs is the same as no guard, which is the gap #4089 found for
+      # five others.
+      - name: the brand art's install line and tagline match their sources
+        if: ${{ !cancelled() }}
+        run: python3 docs/brand/social/build_social.py --check

--- a/docs/brand/social/build_social.py
+++ b/docs/brand/social/build_social.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 import argparse
 import base64
+import html
+import json
 import random
 import re
 import shutil
@@ -72,6 +74,24 @@ REPO_SLUG = "macanderson/stella"
 INSTALL_CMD = "brew install macanderson/tap/stella"
 TAGLINE = "the terminal agent — faster · cheaper · more accurate"
 STAR_CTA = "star the repo"
+
+# The kit is normative for the tagline the way README.md is for the install
+# line, and `check_tagline` holds these to it. The kit's own copy is the hero
+# `<p class="tag">`; everything below is a copy of it.
+#
+# What the tagline *claims* is a separate question and an open one -- two of its
+# three legs disagree with this repository's own published run (#3631). This
+# guard takes no position on that. It makes the sentence editable in one place:
+# whichever way the claim is settled, the kit moves and every copy is named
+# until it follows.
+KIT_PAGE = REPO / "docs" / "brand" / "brand-guidelines.html"
+TAGLINE_MANIFEST = REPO / "docs" / "brand" / "pwa" / "manifest.webmanifest"
+TAGLINE_COPIES = (
+    "website/src/app/manifest.ts",
+    "website/src/app/opengraph-image.tsx",
+    "docs/brand/site/stella-site-mock.html",
+    "docs/brand/site/stella-mobile-mock.html",
+)
 
 # JetBrains Mono is monospace: one advance, every glyph, forever.
 ADVANCE = ck.ADVANCE
@@ -718,6 +738,59 @@ def check_install_line() -> None:
         raise SystemExit(f"repo slug is not org/repo: {REPO_SLUG!r}")
 
 
+def flatten(text: str) -> str:
+    """Markup out, entities in, one space between words.
+
+    The tagline is written five different ways in the tree and means the same
+    thing every time: `&middot;` for `·`, `\\u00b7` for the same, a `<b>` in the
+    middle of the sentence, and a line break wherever the source wrapped. A
+    comparison that could not see through those would report drift that is not
+    there, which is worse than not looking -- it teaches the next reader to
+    ignore it.
+    """
+    return re.sub(r"\s+", " ", html.unescape(re.sub(r"<[^>]+>", "", text))).strip()
+
+
+def check_tagline() -> None:
+    """Every published copy of the tagline must be the kit's.
+
+    The install line has been held to README.md since this script was written;
+    the tagline was held to nothing, so the kit and its copies could drift with
+    nothing to report it (#3631). They had: the two site mocks carry a longer
+    form, which is legitimate -- they extend the sentence rather than restate it
+    -- so a copy is required to *contain* the kit's tagline, and the two places
+    that are a description field rather than a sentence are held to it exactly.
+    """
+    hero = re.search(r'<p class="tag">(.*?)</p>', KIT_PAGE.read_text(encoding="utf-8"), re.S)
+    if hero is None:
+        raise SystemExit(
+            f"no <p class=\"tag\"> hero in {KIT_PAGE.relative_to(REPO)}; the kit is "
+            "where the tagline is defined, so this guard cannot read it."
+        )
+    kit = flatten(hero.group(1))
+    if kit != TAGLINE:
+        raise SystemExit(
+            f"tagline drift: the kit says {kit!r}\n"
+            f"                 TAGLINE says {TAGLINE!r}\n"
+            "The kit is normative — update TAGLINE (and re-render), or fix the kit."
+        )
+
+    described = json.loads(TAGLINE_MANIFEST.read_text(encoding="utf-8"))["description"]
+    if described != TAGLINE:
+        raise SystemExit(
+            f"tagline drift in {TAGLINE_MANIFEST.relative_to(REPO)}: "
+            f"description is {described!r}, kit says {TAGLINE!r}"
+        )
+
+    for rel in TAGLINE_COPIES:
+        path = REPO / rel
+        if TAGLINE not in flatten(path.read_text(encoding="utf-8")):
+            raise SystemExit(
+                f"tagline drift in {rel}: it does not carry the kit's tagline "
+                f"{TAGLINE!r}"
+            )
+
+
 def check_fits(lo: Layout) -> None:
     """Nothing may reach the edge, and the safe box is a hard boundary."""
     if lo.mark_only:
@@ -778,10 +851,14 @@ def main() -> int:
     args = ap.parse_args()
 
     check_install_line()
+    check_tagline()
     for lo in LAYOUTS:
         check_fits(lo)
     if args.check:
-        print(f"ok — install line and {len(LAYOUTS)} layouts fit")
+        print(
+            f"ok — install line, tagline across {len(TAGLINE_COPIES) + 2} copies, "
+            f"and {len(LAYOUTS)} layouts fit"
+        )
         return 0
 
     if not shutil.which("rsvg-convert"):


### PR DESCRIPTION
## What this does, and what it deliberately does not

#3631 has two halves. **What the tagline claims** is a brand decision, and the issue is explicit that flagging it rather than quietly changing it is the point — so this PR changes no copy. I have posted the measurement on the issue instead; the short version is that two of the three legs disagree with this repository's own published run.

**Whether the copies agree with the kit** is not a decision, and that is what this ships. It is the issue's own last line: *"ideally with `build_social.py --check` asserting that they do."*

The two are orthogonal on purpose. Whichever way the claim is settled, the tagline becomes a one-line edit in the kit that every copy is named until it follows.

## The gap

`check_install_line` has guarded the banner's install command against `README.md` since the script was written, on the reasoning its own docstring gives:

> A banner is the one place a wrong install line is unfixable after the fact: it has already been rendered, uploaded, and cached by a platform.

The tagline sits beside it in the same render, on the same PNGs, and was held to nothing. `check_fits` mentions `TAGLINE` only to measure its width.

And it had **already drifted into three shapes**:

| shape | where |
|---|---|
| `the terminal agent — faster · cheaper · more accurate` | `build_social.py`'s `TAGLINE`, `website/src/app/manifest.ts`, `website/src/app/opengraph-image.tsx`, the kit's hero `<p class="tag">` |
| `the terminal agent — faster · cheaper · more accurate` | `docs/brand/pwa/manifest.webmanifest` |
| the same sentence with `&middot;` entities, an inline `<b>`, and a `· agpl-3.0 · commercial licenses available` tail | `docs/brand/site/stella-site-mock.html`, `docs/brand/site/stella-mobile-mock.html` |

The third is legitimate — those two pages *extend* the sentence rather than restate it — so a copy is required to **contain** the kit's tagline, while the two places that are a `description` field rather than a sentence are held to it **exactly**.

`flatten` is what lets one comparison see through all three. A comparison that reported drift which is not there would be worse than not looking: it teaches the next reader to ignore the guard.

## Correction to the issue

The issue says the kit's tagline appears "in `docs/brand/brand-guidelines.html:143` and `:368` … plus the JSON-LD". **That page contains no JSON-LD** — `rg 'ld\+json' docs/brand/brand-guidelines.html` returns nothing. The second occurrence is a documented copy of the PWA manifest inside a `<pre><code>` sample. The only JSON-LD in the tree is `website/src/app/(home)/page.tsx`'s `softwareJsonLd`, whose `description` is `HOME_DESCRIPTION`, not the tagline.

The issue also missed the two site mocks, which is where the divergence actually was.

## `--check` ran nowhere

`rg build_social Makefile .github/` → **no matches**. None of the 28 workflows invoked it. So the install-line guard, which has existed for as long as the script has, was only ever exercised by a human following `docs/brand/README.md`. That is the gap #4089 found for five other guards.

It now runs in `docs-guards.yml`. `--check` returns before it reaches `shutil.which("rsvg-convert")`, so it needs neither a renderer nor a desktop font; it costs about a second. `README.md` joins the trigger paths because `check_install_line` reads it.

## Ablation — the old check gives the *wrong* answer

`website/src/app/manifest.ts` drifted (`more accurate` → `more correct`), then `origin/main`'s script run over that exact tree:

```
$ git show origin/main:docs/brand/social/build_social.py > docs/brand/social/build_social.py
$ python3 docs/brand/social/build_social.py --check
ok — install line and 5 layouts fit
OLD_EXIT=0
```

**Exit 0, and it says "ok", on a tree where the PWA install description no longer matches the kit.** Not merely constant — wrong.

New code, same drift:

```
$ python3 docs/brand/social/build_social.py --check
tagline drift in website/src/app/manifest.ts: it does not carry the kit's tagline 'the terminal agent — faster · cheaper · more accurate'
EXIT=1
```

The other direction — moving the **kit**, which is the normative one — must also fail, or the guard only pins copies to a constant rather than to a source:

```
$ # kit hero changed to "the terminal agent — BYOK · nothing proxied · verified done"
$ python3 docs/brand/social/build_social.py --check
tagline drift: the kit says 'the terminal agent — BYOK · nothing proxied · verified done'
                 TAGLINE says 'the terminal agent — faster · cheaper · more accurate'
The kit is normative — update TAGLINE (and re-render), or fix the kit.
EXIT=1
```

Clean tree:

```
$ python3 docs/brand/social/build_social.py --check
ok — install line, tagline across 6 copies, and 5 layouts fit
EXIT=0
```

## Note for the merger

This and #4929 both add a step to `.github/workflows/docs-guards.yml` — this one at the end of the job, #4929's mid-list — and both reword the header's guard count. Whichever lands second needs a trivial rebase on that file. No other overlap.

## Gate

`make guards-fast` green, `prose` included. No baseline raised. No new gate step.

## Test deletions

None.

Refs #3631

## Summary by Sourcery

Enforce brand tagline consistency in automation alongside the existing install-line guard.

Bug Fixes:
- Add tagline consistency checks that validate the brand kit, manifest, website metadata, and site mockups against the normative kit copy while allowing legitimate extended sentences.

Enhancements:
- Improve tagline comparison across HTML entities, markup, and whitespace variations.
- Make the brand kit authoritative for tagline validation and expand check output to report validated copies.

CI:
- Run the brand asset consistency check in the documentation guards workflow and trigger it when README.md changes.