### PR TITLE
feat(stella-cli,stella-parity): stella whistle reaches interactive sessions

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -110,6 +110,7 @@ mod slash_pump;
 mod steering;
 mod task_tap;
 mod theme_cmd;
+mod whistle;
 mod worker_control;
 use driver_support::{
     handle_supervisor_msg, service_registry_action, spawn_mcp_connect, spawn_notification_poller,
@@ -641,6 +642,7 @@ pub async fn run_deck_session(
         let _ = deck_tx.send(system_notice(notice));
     }
     steering::announce_withheld(cfg, &in_tx);
+    let whistle = whistle::DeckWhistle::spawn(&session_record.id);
     // An idle lead is waiting on the human, not queued behind a supervisor —
     // asserted outright, since the startup chrome above no longer folds it to
     // `Running` (see `system_notice`).
@@ -1258,6 +1260,7 @@ pub async fn run_deck_session(
                                 let _ = session_registry.upsert(&session_record);
                                 sidecar_dir = session_registry.sidecar_dir(&session_record.id);
                                 lead_holder = format!("{}/lead", session_record.id);
+                                whistle.rebind(&session_record.id);
                                 *pr_session_id.lock().unwrap_or_else(|p| p.into_inner()) =
                                     session_record.id.clone();
                                 {
@@ -1699,13 +1702,9 @@ pub async fn run_deck_session(
         let dispatch_spend_usd = budget.session_spent_usd();
 
         // Shared with the live input arms below: `>` steers, Esc soft-stops.
-        // Per-turn by construction — a stop latched here can't leak into
-        // the next turn.
-        //
-        // `Arc` because the turn runner also publishes a clone to the
-        // registry, so sub-agents this turn dispatches stop when it does
-        // (`crate::subagent`). The engine still takes it by reference.
-        let steering: Arc<subsession::SteeringTap> = Arc::default();
+        // Minted through the session's whistle relay, which is what carries a
+        // steer that arrived between turns into this one (`whistle`).
+        let steering = whistle.mint_turn_tap();
         // The lead lane's pause seam — `p` on the lead row (#1219).
         let lead_pause = lead_control::LeadPause::new();
         let mut friction = TurnFriction::default(); // #3962

--- a/crates/stella-cli/src/command_deck/whistle.rs
+++ b/crates/stella-cli/src/command_deck/whistle.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The deck's session-scoped whistle relay (#4768).
+//!
+//! Every other door `stella whistle` reaches hands the listener the very tap
+//! its engine drains, because those doors have one: a `stella run` or a
+//! `stella goal` arc builds a steering tap once and keeps it for the whole
+//! run. The deck does not. Its tap is minted per turn — a soft stop latched
+//! in one turn must not leak into the next — and between turns there is no
+//! tap at all, which is most of a deck session's life: the lead sits at
+//! `NeedsInput` waiting for a person to type.
+//!
+//! A socket bound to whichever tap happened to exist at boot would therefore
+//! steer one turn and then quietly steer nothing. So the socket is bound to
+//! [`DeckWhistle`], which outlives every turn and forwards to whichever tap is
+//! currently able to drain — buffering when none is, so a whistle at an idle
+//! deck is delivered rather than refused, and lands in front of the model the
+//! moment the next turn opens.
+//!
+//! # Why this is a sibling module
+//!
+//! `command_deck.rs` is a grandfathered god file closed to growth (AGENTS.md
+//! § "God files — plan around them, never into them"), and the deck's own
+//! `steering.rs` is the template: the driver keeps the call, the reasoning
+//! lives here. The boot spends one line, the in-deck session switch one, and
+//! the per-turn construction is the line that was already there.
+
+use std::sync::{Arc, Mutex, Weak};
+
+use crate::subsession::SteeringTap;
+use crate::whistle::tap::Whistleable;
+
+/// The publication point a deck session's whistle socket writes into.
+///
+/// Held by the driver loop for the session's lifetime. Steers reach the
+/// running turn's tap when there is one and it can still act on them, and are
+/// held for the next turn otherwise.
+#[derive(Default)]
+pub(super) struct DeckWhistle {
+    /// The turn currently able to drain a steer.
+    ///
+    /// `Weak`, not `Arc`: the driver's per-turn `steering` local is what owns
+    /// the tap, and holding a strong reference here would keep a finished
+    /// turn's tap alive past the loop iteration that made it.
+    live: Mutex<Weak<SteeringTap>>,
+    /// Steers that arrived with no turn to take them, oldest first.
+    pending: Mutex<Vec<String>>,
+    /// This session's bound socket. Replaced when the deck switches sessions;
+    /// dropping it unbinds and removes the socket file.
+    listener: Mutex<Option<crate::whistle::SessionListener>>,
+}
+
+impl DeckWhistle {
+    /// Bind `session_id`'s whistle socket and keep it for as long as the
+    /// returned relay is held.
+    pub(super) fn spawn(session_id: &str) -> Arc<Self> {
+        let relay = Arc::new(Self::default());
+        relay.rebind(session_id);
+        relay
+    }
+
+    /// Move the socket to `session_id` — the in-deck session switch, where the
+    /// driver re-keys the journal, the durability binding and the lead's claim
+    /// holder alike. Without this, a switched deck would keep answering
+    /// whistles aimed at the session it left.
+    pub(super) fn rebind(self: &Arc<Self>, session_id: &str) {
+        let handle: Arc<dyn Whistleable> = Arc::new(RelayHandle(Arc::downgrade(self)));
+        let next = crate::whistle::spawn_for_session(session_id, handle);
+        // Assigned rather than cleared first, so the new socket is bound
+        // before the old one is unbound: the ids differ, so the two paths
+        // never collide.
+        *self.listener.lock().unwrap_or_else(|p| p.into_inner()) = next;
+    }
+
+    /// The tap for a turn about to start, carrying whatever arrived while the
+    /// deck was idle.
+    ///
+    /// Per-turn by construction, which is what keeps a soft stop latched here
+    /// from leaking into the next turn. `Arc` because the turn runner also
+    /// publishes a clone to the registry, so sub-agents this turn dispatches
+    /// stop when it does (`crate::subagent`); the engine still takes it by
+    /// reference.
+    pub(super) fn mint_turn_tap(&self) -> Arc<SteeringTap> {
+        let tap: Arc<SteeringTap> = Arc::default();
+        let mut live = self.live.lock().unwrap_or_else(|p| p.into_inner());
+        let mut pending = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+        for text in pending.drain(..) {
+            tap.push(text);
+        }
+        *live = Arc::downgrade(&tap);
+        tap
+    }
+
+    /// Route one delivered steer: to the running turn when it can still drain
+    /// one, to the backlog otherwise.
+    ///
+    /// A *settling* turn counts as no turn. Its model steps are over and it is
+    /// only finishing bookkeeping ([`SteeringTap::mark_settling`]), so text
+    /// pushed into its queue would be drained by nobody — the same fact
+    /// `command_deck::steer::steer_lead` reads before deciding whether a typed
+    /// `>` steers the turn or joins the queue.
+    fn deliver(&self, text: String) {
+        let live = self.live.lock().unwrap_or_else(|p| p.into_inner());
+        match live.upgrade() {
+            Some(tap) if !tap.is_settling() => tap.push(text),
+            _ => self
+                .pending
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(text),
+        }
+    }
+}
+
+/// What the listener actually holds: a weak handle back to the relay.
+///
+/// The listener lives *inside* [`DeckWhistle`], so handing the accept loop an
+/// `Arc<DeckWhistle>` would close a cycle — the relay would never be dropped,
+/// and the `Drop` that unbinds the socket would never run. A `Weak` breaks it,
+/// and reads correctly besides: a socket whose session is gone has nothing to
+/// deliver to.
+struct RelayHandle(Weak<DeckWhistle>);
+
+impl Whistleable for RelayHandle {
+    fn push(&self, text: String) {
+        if let Some(relay) = self.0.upgrade() {
+            relay.deliver(text);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_core::ports::TurnSteering;
+
+    /// **The witness (#4768).** A whistle delivered while the deck sits idle
+    /// is in the next turn's tap the moment that turn opens.
+    ///
+    /// This is the case the deck's per-turn tap made unreachable and the
+    /// reason a session-scoped relay had to exist: on `main` there is nothing
+    /// for a listener to bind to between turns, so the message had nowhere to
+    /// go at all.
+    #[test]
+    fn a_steer_that_arrives_between_turns_opens_the_next_one() {
+        let relay = Arc::new(DeckWhistle::default());
+        RelayHandle(Arc::downgrade(&relay)).push("read the failing test".to_string());
+
+        let tap = relay.mint_turn_tap();
+        assert_eq!(tap.drain_steering(), vec!["read the failing test"]);
+    }
+
+    /// A whistle during a live turn goes to that turn, not to the backlog —
+    /// the whole point of the socket being reachable mid-turn.
+    #[test]
+    fn a_steer_during_a_turn_reaches_the_turn_that_is_running() {
+        let relay = Arc::new(DeckWhistle::default());
+        let tap = relay.mint_turn_tap();
+        RelayHandle(Arc::downgrade(&relay)).push("stop the compile".to_string());
+
+        assert_eq!(tap.drain_steering(), vec!["stop the compile"]);
+        assert!(
+            relay.mint_turn_tap().drain_steering().is_empty(),
+            "a steer the running turn took must not be replayed into the next"
+        );
+    }
+
+    /// A settling turn is past its last model step, so a steer pushed into it
+    /// would be drained by nobody. It waits for the next turn instead — the
+    /// rule `steer_lead` already applies to a typed `>`.
+    #[test]
+    fn a_steer_at_a_settling_turn_waits_for_the_next_one() {
+        let relay = Arc::new(DeckWhistle::default());
+        let settling = relay.mint_turn_tap();
+        settling.mark_settling();
+        RelayHandle(Arc::downgrade(&relay)).push("next time, run the tests".to_string());
+
+        assert!(
+            settling.drain_steering().is_empty(),
+            "a turn that is only finishing bookkeeping cannot act on a steer"
+        );
+        assert_eq!(
+            relay.mint_turn_tap().drain_steering(),
+            vec!["next time, run the tests"]
+        );
+    }
+
+    /// **The cross-process witness (#4768).** A message sent over a deck
+    /// session's real socket — by the frames `stella whistle` sends, from
+    /// outside the turn loop — reaches the next turn's tap.
+    ///
+    /// The relay tests above prove the routing; this proves there is a socket
+    /// to route from, which is the half `main` does not have: nothing binds
+    /// one for a deck session at all.
+    #[cfg(unix)]
+    #[test]
+    fn a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn() {
+        let _env = crate::test_env::lock();
+        // Under `/tmp`: a `sockaddr_un` path is capped at ~104 bytes and the
+        // platform temp dir is already half of that on macOS. The session id
+        // is short for the same reason — it is a path component.
+        let home = tempfile::Builder::new()
+            .prefix("dw")
+            .tempdir_in("/tmp")
+            .expect("home");
+        let _home = crate::test_env::home_sandbox(home.path());
+        let socket = stella_store::SessionRegistry::open_default().whistle_socket_path("dw1");
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(async {
+                let relay = DeckWhistle::spawn("dw1");
+                let mut stream = tokio::net::UnixStream::connect(&socket)
+                    .await
+                    .expect("the deck session must have bound a whistle socket");
+                crate::whistle::wire::write_frame(
+                    &mut stream,
+                    &crate::whistle::wire::WhistleRequest {
+                        text: "the deck is listening".to_string(),
+                    },
+                )
+                .await
+                .expect("write the frame");
+                let ack: crate::whistle::wire::WhistleAck =
+                    crate::whistle::wire::read_frame(&mut stream)
+                        .await
+                        .expect("ack");
+                assert!(ack.delivered);
+
+                // The push crosses the accept loop's own task, not the
+                // connection future awaited above.
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                assert_eq!(
+                    relay.mint_turn_tap().drain_steering(),
+                    vec!["the deck is listening"]
+                );
+            });
+    }
+
+    /// The turn that ended owns nothing: its tap is dropped with the loop
+    /// iteration that made it, and the relay must notice rather than push into
+    /// a queue nothing will read again.
+    #[test]
+    fn a_finished_turns_tap_stops_receiving() {
+        let relay = Arc::new(DeckWhistle::default());
+        drop(relay.mint_turn_tap());
+        RelayHandle(Arc::downgrade(&relay)).push("still worth saying".to_string());
+
+        assert_eq!(
+            relay.mint_turn_tap().drain_steering(),
+            vec!["still worth saying"]
+        );
+    }
+}

--- a/crates/stella-cli/src/command_deck/whistle.rs
+++ b/crates/stella-cli/src/command_deck/whistle.rs
@@ -247,11 +247,11 @@ mod tests {
     fn a_finished_turns_tap_stops_receiving() {
         let relay = Arc::new(DeckWhistle::default());
         drop(relay.mint_turn_tap());
-        RelayHandle(Arc::downgrade(&relay)).push("still worth saying".to_string());
+        RelayHandle(Arc::downgrade(&relay)).push("the next turn should know".to_string());
 
         assert_eq!(
             relay.mint_turn_tap().drain_steering(),
-            vec!["still worth saying"]
+            vec!["the next turn should know"]
         );
     }
 }

--- a/crates/stella-cli/src/whistle.rs
+++ b/crates/stella-cli/src/whistle.rs
@@ -18,20 +18,33 @@
 //! Windows section). `stella whistle` on a non-Unix build reports the gap
 //! rather than silently doing nothing.
 //!
-//! Not reachable yet: interactive mode. Its
-//! steering tap is minted fresh per turn inside `command_deck.rs`, a file
-//! closed to growth under the file-size ratchet (AGENTS.md "God files"), so
-//! wiring a listener into it needs either a small `file-size-update` or the
-//! per-turn tap construction moved into a sibling module first — tracked as
-//! a follow-up rather than done here under time pressure. `stella-serve`
-//! turns are also out of scope: that surface already has its own reach
-//! (`POST /v1/turns/{id}/steer`) over a different transport (HTTP).
+//! Interactive mode reaches it too, through a relay rather than a tap
+//! (`crate::command_deck::whistle`, #4768): the deck mints a fresh
+//! `SteeringTap` per turn and has none at all between turns, so its socket is
+//! bound to a session-scoped publication point that forwards to whichever tap
+//! can currently drain one.
+//!
+//! `stella-serve` turns are out of scope: that surface is a separate binary
+//! with its own reach (`POST /v1/turns/{id}/steer`) over a different
+//! transport, and a served session registers in no registry `stella whistle`
+//! can enumerate — #4770 is where reaching it is being decided.
 
 pub(crate) mod cmd;
 #[cfg(unix)]
 pub(crate) mod listener;
 pub(crate) mod tap;
 pub(crate) mod wire;
+
+/// What [`spawn_for_session`] hands back, named once so a caller storing the
+/// guard in a struct field does not have to name whichever type its build
+/// has. Dropping it unbinds and removes the socket.
+#[cfg(unix)]
+pub(crate) type SessionListener = listener::WhistleListener;
+
+/// As the `#[cfg(unix)]` twin above — there is no socket to release, so there
+/// is nothing to hold.
+#[cfg(not(unix))]
+pub(crate) type SessionListener = ();
 
 /// Start `session_id`'s whistle listener, if this platform has one, and
 /// keep it alive for as long as the returned guard is held. Best-effort and

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -239,6 +239,35 @@ pub static CAPABILITIES: &[Capability] = &[
         },
     },
     Capability {
+        id: "turn.whistle",
+        engine_home: "stella-core TurnSteering port — the same step-boundary drain `turn.steer` \
+                      uses. What this row is about is reaching that port from a SECOND process, \
+                      which the engine neither knows about nor needs to",
+        engine_entries: &[],
+        cli: SurfacePosture::Shipped {
+            mechanism: "`stella whistle <message>` — one Unix domain socket per session inside \
+                        its SessionRegistry sidecar, discovered exactly as `stella resume --list` \
+                        discovers sessions; interactive mode reaches it through a session-scoped \
+                        relay, since its own steering tap exists only during a turn",
+            witness: "a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn",
+        },
+        // Not "serve has POST /v1/turns/{id}/steer, so it is covered". It has
+        // a steer route; what it has no answer to is *discovery*. A served
+        // session is registered only in `stella-serve`'s own in-memory
+        // registry — the crate does not depend on `stella-store` and writes
+        // nothing under `~/.stella/sessions/` — so `stella whistle` cannot
+        // enumerate one, there is no route that lists live sessions, and the
+        // bind address and bearer token a client would need reach no file on
+        // disk. Closing it is a decision about whether the server may hold
+        // ambient authority (ADR 0013), not a transport to add.
+        api: SurfacePosture::Deferred {
+            waiting_on: "cross-process discovery of served sessions: serve announces into no \
+                         registry `stella whistle` can read, exposes no live-session listing, and \
+                         publishes neither its bind address nor its token — #4770 is where that \
+                         is being decided",
+        },
+    },
+    Capability {
         id: "turn.steering_requery",
         engine_home: "stella-core SteeringRequery port — the steering plane re-queried at step \
                       boundaries when TurnSignal drift says the opening prompt no longer \
@@ -678,8 +707,11 @@ mod tests {
     /// the same trade `provider_parity` documents: a witness that moves to a
     /// file outside this list fails loudly (a false alarm to fix by extending
     /// the list), never silently (the rotted proof this exists to catch).
-    fn cli_sources() -> [&'static str; 13] {
+    fn cli_sources() -> [&'static str; 14] {
         [
+            // The deck's session-scoped whistle relay (#4768) — home of the
+            // `turn.whistle` witness.
+            include_str!("../../stella-cli/src/command_deck/whistle.rs"),
             include_str!("../../stella-cli/src/agent/tests.rs"),
             // Home of `a_piped_stdin_text_run_denies_every_consumer_of_the_human_present_fact`
             // — the `turn.run` CLI witness since the staged pipeline's own

--- a/website/content/docs/commands/whistle.mdx
+++ b/website/content/docs/commands/whistle.mdx
@@ -33,13 +33,13 @@ unreachable  ses-1785956700004        stella: fix the flaky test (no listener �
 
 ## What is reachable today
 
-Foreground [`stella run`](/docs/commands/run), [`stella chat`](/docs/commands/chat)'s interactive-mode loop, and any wrapper-plugin-driven turn — daemon-supervised runs of the same are reachable too, since supervision launches the identical code path.
+Foreground [`stella run`](/docs/commands/run), any wrapper-plugin-driven turn, and both of [`stella chat`](/docs/commands/chat)'s interactive modes — the default one and `--plain`'s — are all reachable. So are daemon-supervised runs of the same, since supervision launches the identical code path.
 
-Not reachable yet, each for a distinct structural reason rather than an oversight:
+Interactive mode mints a steering tap per turn and has none between turns, so its socket is bound to a session-scoped relay instead. A whistle at a session sitting idle is delivered, held, and put in front of the model the moment the next turn opens; one during a running turn lands at that turn's next step boundary like any other.
 
-- **Interactive mode's turn driver** binds its steering tap fresh per turn inside a file closed to growth under the file-size ratchet — tracked as a follow-up.
-- **`stella-serve`-hosted turns** are a separate binary with their own HTTP steer transport; reaching them needs a second delivery path in `stella whistle`, not a copy of the socket work.
-- **[`stella goal`](/docs/commands/goal)'s multi-round arc** drives a different call path than a one-shot run.
+Not reachable yet:
+
+- **`stella-serve`-hosted turns** are a separate binary. It has a steer route of its own, but a served session registers in no registry `stella whistle` can enumerate, and neither its address nor its token reaches a file on disk — so this is a discovery problem before it is a transport one.
 
 ## Platform support
 


### PR DESCRIPTION
## What this changes

`stella whistle` now reaches interactive sessions.

Every other door hands the whistle listener the very tap its engine drains,
because those doors have one for the whole run. Interactive mode does not. Its
`SteeringTap` is minted **per turn** — which is what keeps a soft stop latched
in one turn from leaking into the next — and between turns there is none at
all, which is most of a session's life: the lead sits at `NeedsInput` waiting
for a person to type. A socket bound to whichever tap existed at boot would
steer one turn and then quietly steer nothing.

`crates/stella-cli/src/command_deck/whistle.rs` adds `DeckWhistle`, the
session-scoped publication point the socket binds to instead:

- forwards to the running turn's tap when there is one that can still act on a
  steer;
- **buffers** when there is not — an idle session, or one only finishing
  bookkeeping (`SteeringTap::is_settling`, the same fact `steer_lead` reads
  before deciding whether a typed `>` steers or queues) — so a whistle at an
  idle session is delivered rather than refused, and lands in front of the
  model the moment the next turn opens;
- **rebinds** on the in-deck session switch, beside the journal, the durability
  binding and the lead's claim holder, so a switched session stops answering
  whistles aimed at the one it left.

The listener holds a `Weak` back to the relay rather than an `Arc`. It lives
*inside* the relay, so a strong handle would close a cycle: the relay would
never drop, and the `Drop` that unbinds and removes the socket file would never
run.

### No baseline was raised

The epic offered a `file-size-update` for `command_deck.rs` as one acceptable
route. It was not needed and is not taken. **`command_deck.rs` is one line
shorter than before** (2545 → 2544): the reasoning that stood above the
per-turn tap moved into the module that now owns it, and the driver keeps three
lines — the boot, the session switch, and the tap construction that was already
there. `scripts/file-size-baseline.txt` is untouched.

### Parity

`stella-parity` gains a `turn.whistle` row. Serve is declared `Deferred` on
**discovery**, not covered by its steer route: a served session registers only
in `stella-serve`'s own in-memory registry (the crate does not depend on
`stella-store` and writes nothing under `~/.stella/sessions/`), there is no
route that lists live sessions, and neither the bind address nor the bearer
token reaches a file on disk. #4770 is where that is being decided.

## Witnesses

`crates/stella-cli/src/command_deck/whistle.rs`, five tests. The relay is a
sibling module and is tested as one — the same shape `command_deck/steering.rs`
uses for its own witness, because the driver loop it is called from is a TUI
event loop with no test harness in this tree.

- `a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn` — the
  cross-process one: `DeckWhistle::spawn` binds the real socket under a
  sandboxed stella home, a client connects and sends the same frames
  `stella whistle` sends, and the next turn's tap drains the text.
- `a_steer_that_arrives_between_turns_opens_the_next_one`
- `a_steer_during_a_turn_reaches_the_turn_that_is_running`
- `a_steer_at_a_settling_turn_waits_for_the_next_one`
- `a_finished_turns_tap_stops_receiving`

### Ablation 1 — drop the buffering arm (`_ => {}` instead of pushing to `pending`)

```
test command_deck::whistle::tests::a_steer_during_a_turn_reaches_the_turn_that_is_running ... ok
test command_deck::whistle::tests::a_steer_at_a_settling_turn_waits_for_the_next_one ... FAILED
test command_deck::whistle::tests::a_finished_turns_tap_stops_receiving ... FAILED
test command_deck::whistle::tests::a_steer_that_arrives_between_turns_opens_the_next_one ... FAILED
test command_deck::whistle::tests::a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn ... FAILED

assertion `left == right` failed
  left: []
 right: ["read the failing test"]
```

### Ablation 2 — `rebind` binds no socket (`let next = None;`)

`main`'s state exactly: nothing binds a socket for an interactive session.

```
test command_deck::whistle::tests::a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn ... FAILED

panicked at crates/stella-cli/src/command_deck/whistle.rs:219:22:
the deck session must have bound a whistle socket: Error { kind: NotFound, ... }

test result: FAILED. 0 passed; 1 failed
```

### Ablation 3 — drop the settling check (`Some(tap) => tap.push(text)`)

Isolates the third rule from the other two.

```
test command_deck::whistle::tests::a_finished_turns_tap_stops_receiving ... ok
test command_deck::whistle::tests::a_steer_that_arrives_between_turns_opens_the_next_one ... ok
test command_deck::whistle::tests::a_steer_during_a_turn_reaches_the_turn_that_is_running ... ok
test command_deck::whistle::tests::a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn ... ok
test command_deck::whistle::tests::a_steer_at_a_settling_turn_waits_for_the_next_one ... FAILED

test result: FAILED. 4 passed; 1 failed
```

Green with all three restored: `5 passed; 0 failed`. Each ablation turns an
answer wrong — a steer that arrived is reported as never having arrived — not
merely constant.

## What is not witnessed

That `command_deck.rs`'s driver loop calls `mint_turn_tap` rather than
`Arc::default()`. That is compile-level: the per-turn `Arc::default()` is gone
from the call site, and `run_lead_turn` already attaches whatever tap it is
handed (`.with_steering(steering.as_ref())`, unchanged). Proving it
behaviourally would need a harness that drives the deck's `select!` loop, which
does not exist in this tree — AGENTS.md's stated exception for TUI wiring.

## Deleted tests

None.

Closes #4768
Refs #4806, #4770

## Summary by Sourcery

Extend `stella whistle` to reliably reach interactive sessions by routing messages through a session-scoped relay that buffers them across per-turn tap lifetimes.

New Features:
- Make `stella whistle` available in interactive deck sessions, including idle, active, and session-switched states.
- Add the `turn.whistle` parity capability and witness for cross-process delivery to interactive sessions.

Bug Fixes:
- Ensure whistles received between turns or while a turn is settling are delivered to the next turn instead of being lost.
- Prevent finished turns from continuing to receive whistle messages and ensure session switches target the new session.

Enhancements:
- Update whistle command documentation to describe interactive-mode reachability and clarify that served sessions remain deferred pending discovery support.

Documentation:
- Document whistle support for both default and plain interactive chat modes, including buffering behavior between turns.

Tests:
- Add relay and cross-process socket tests covering idle, active, settling, finished-turn, and session-switch delivery behavior.