### PR TITLE
fix(workspace): every clippy suppression outside stella-cli is an expectation, and two were stale

### DIFF
--- a/crates/stella-context/src/store/edge.rs
+++ b/crates/stella-context/src/store/edge.rs
@@ -145,9 +145,10 @@ fn process_nonce() -> u64 {
 /// Insert a fact edge. `supersedes` links to the edge this one replaced (the
 /// `SUPERSEDES` relation of), or `None` for a
 /// fresh assertion. Returns the new edge's rowid.
-// The parameters are the edge row's own columns; a struct would just move
-// the same list up one level.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the parameters are the edge row's own columns; a struct would just move the same list up one level"
+)]
 pub(crate) fn insert_edge(
     conn: &Connection,
     rel: &str,

--- a/crates/stella-context/src/store/record.rs
+++ b/crates/stella-context/src/store/record.rs
@@ -9,9 +9,10 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::error::ContextError;
 
 /// Insert or update an episode (idempotent by `public_id`). Returns rowid.
-// The parameters are the episode row's own columns for a plain SQL insert;
-// a struct would just move the same list up one level.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the parameters are the episode row's own columns for a plain SQL insert; a struct would just move the same list up one level"
+)]
 pub(crate) fn insert_episode(
     conn: &Connection,
     public_id: &str,

--- a/crates/stella-core/src/context_record/lifecycle.rs
+++ b/crates/stella-core/src/context_record/lifecycle.rs
@@ -235,7 +235,10 @@ impl ProposalRecord {
     /// hand it a grade it prefers. `None` is a proposal with no supporting
     /// observations at all, which stores no grade — absent evidence, not weak
     /// evidence.
-    #[allow(clippy::too_many_arguments)] // content-addressed constructor: every field feeds the hash, so a builder would just hide the same list
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "content-addressed constructor: every field feeds the hash, so a builder would just hide the same list"
+    )]
     pub fn new(
         proposal_kind: RecordProposalKind,
         status: RecordProposalStatus,

--- a/crates/stella-core/src/driver/completion.rs
+++ b/crates/stella-core/src/driver/completion.rs
@@ -34,7 +34,10 @@ impl<'a> Engine<'a> {
     /// injects the hook's reason as a marked tail user message and returns
     /// `None`, holding the turn open for another round. `stop_consults` is
     /// the bounded consultation counter (`driver::user_hooks` module docs).
-    #[allow(clippy::too_many_arguments)] // threaded turn-state fields, same shape as its siblings
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "threaded turn-state fields, same shape as its siblings"
+    )]
     pub(super) async fn dispatch_completion(
         &self,
         committed: CommittedStep,

--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -116,7 +116,10 @@ impl<'a> Engine<'a> {
     /// rides, the same way [`Self::apply_overflow_summary`] carries the budget
     /// pair it reports. `instructions` is a PreCompact hook's `modify`
     /// steering for the summarizer, appended to its request (#2684).
-    #[allow(clippy::too_many_arguments)] // threaded turn-state fields, same shape as its siblings
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "threaded turn-state fields, same shape as its siblings"
+    )]
     pub(super) async fn summarize_overflow_span(
         &self,
         messages: &mut Vec<CompletionMessage>,
@@ -411,7 +414,10 @@ impl<'a> Engine<'a> {
     /// the restoration message appended after it reports its own size on the
     /// `agent.working_set.restored` lifecycle event instead of retroactively
     /// inflating the splice's number.
-    #[allow(clippy::too_many_arguments)] // threaded turn-state fields, same shape as its siblings
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "threaded turn-state fields, same shape as its siblings"
+    )]
     fn apply_overflow_summary(
         &self,
         messages: &mut Vec<CompletionMessage>,

--- a/crates/stella-diag/src/error.rs
+++ b/crates/stella-diag/src/error.rs
@@ -116,7 +116,10 @@ macro_rules! log_error {
             // a macro nobody uses. `vec_init_then_push` is unavoidable here —
             // the field list is assembled from two independent repetitions, so
             // it cannot be one `vec!` literal.
-            #[allow(clippy::vec_init_then_push)]
+            #[expect(
+                clippy::vec_init_then_push,
+                reason = "the field list is assembled from two independent macro repetitions, so it cannot be one `vec!` literal"
+            )]
             fn to_field(&self) -> $crate::FieldValue {
                 #[allow(unused_mut, unused_variables)]
                 match self {

--- a/crates/stella-graph/src/frames.rs
+++ b/crates/stella-graph/src/frames.rs
@@ -493,7 +493,10 @@ fn edge_frame(
     )
 }
 
-#[allow(clippy::too_many_arguments)] // the nine params are the only ContextFrame fields the two callers vary; the rest are defaulted below
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the nine params are the only ContextFrame fields the two callers vary; the rest are defaulted below"
+)]
 fn frame(
     id: String,
     kind: FrameKind,

--- a/crates/stella-observatory/src/transcript_view.rs
+++ b/crates/stella-observatory/src/transcript_view.rs
@@ -338,7 +338,10 @@ fn fmt_tok(n: u64) -> String {
     if n < 1_000 {
         n.to_string()
     } else {
-        #[allow(clippy::cast_precision_loss)] // Display only; ±1 token is invisible at 0.1k.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "display only; ±1 token is invisible at 0.1k"
+        )]
         let thousands = n as f64 / 1_000.0;
         format!("{thousands:.1}k")
     }
@@ -349,7 +352,7 @@ fn fmt_ms(ms: u64) -> String {
     if ms < 1_000 {
         format!("{ms}ms")
     } else {
-        #[allow(clippy::cast_precision_loss)] // Display only.
+        #[expect(clippy::cast_precision_loss, reason = "display only")]
         let secs = ms as f64 / 1_000.0;
         format!("{secs:.1}s")
     }
@@ -360,7 +363,7 @@ fn micros_from_usd(usd: f64) -> u64 {
     if !usd.is_finite() || usd <= 0.0 {
         return 0;
     }
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // Guarded above; saturates.
+    #[expect(clippy::cast_possible_truncation, reason = "guarded above; saturates")]
     let micros = (usd * 1_000_000.0).round() as i128;
     u64::try_from(micros.clamp(0, i128::from(u64::MAX))).unwrap_or(u64::MAX)
 }

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -729,7 +729,10 @@ fn seed_receipt(store: &Store, execution_id: i64, call: &ToolCall, output: &Tool
 /// One ledger append through the real write API, with the record's own
 /// identity, hash and timestamps — the shape every production writer uses
 /// (`crates/stella-cli/src/memory/observations.rs::append_observation` et al).
-#[allow(clippy::too_many_arguments)] // mirrors LedgerAppend's own field list
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors LedgerAppend's own field list"
+)]
 fn append_lifecycle(
     store: &ContextStore,
     kind: &str,

--- a/crates/stella-plugin/src/wire_schema.rs
+++ b/crates/stella-plugin/src/wire_schema.rs
@@ -97,7 +97,10 @@
 // serialize — a map key that is not a string, a non-finite float — are
 // unrepresentable in `Value`. The failure is excluded by the type, so plumbing
 // a `Result` no caller could match on would trade a proof for ceremony.
-#![allow(clippy::expect_used)]
+#![expect(
+    clippy::expect_used,
+    reason = "the two `expect`s below serialize a `serde_json::Value`, whose only serialization failures are unrepresentable in the type; see the paragraph above"
+)]
 
 use serde_json::{Map, Value};
 use stella_protocol::schema_export::{Discriminant, UnsupportedSchema};

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -47,7 +47,7 @@
 // clippy with `-D warnings` on that build, so a new one fails the gate instead
 // of arriving unremarked. The one exception is `schema_export.rs`, which is
 // only compiled under the `schema` feature (not part of `make lint` or CI's
-// clippy run) and carries its own justified `#[allow(clippy::expect_used)]`.
+// clippy run) and carries its own justified `#[expect(clippy::expect_used)]`.
 // `not(test)` scopes the lint exactly as the rule does: it is about runtime
 // data, and `unwrap` in a test is fine.
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/crates/stella-protocol/src/schema_export.rs
+++ b/crates/stella-protocol/src/schema_export.rs
@@ -57,7 +57,10 @@
 // a non-finite float — are unrepresentable in `Value`. The failure is excluded
 // by the type, not by convention, so plumbing a `Result` no caller could match
 // on would trade a proof for ceremony.
-#![allow(clippy::expect_used)]
+#![expect(
+    clippy::expect_used,
+    reason = "the two `expect`s below serialize a `serde_json::Value`, whose only serialization failures are unrepresentable in the type; see the paragraph above"
+)]
 
 use std::collections::BTreeSet;
 use std::fmt::Write as _;

--- a/crates/stella-serve/src/goal.rs
+++ b/crates/stella-serve/src/goal.rs
@@ -85,7 +85,10 @@ pub struct GoalRun {
 ///   work or fabricating a verdict;
 /// - the round cap is the backstop, and reaching it is `Unmet` with a named
 ///   reason, never a silent success.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the round loop's whole state, threaded from its one caller; a struct would add a second shape between the caller and the loop"
+)]
 pub(crate) async fn drive_goal(
     engine: &Engine<'_>,
     verifier: &dyn Provider,

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -1774,7 +1774,10 @@ fn stale_lock_sweep_releases_old_claims_only() {
 
 /// Test-only shorthand: a telemetry row with just the analytics-relevant
 /// fields set.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "nine columns of one telemetry row; naming them positionally is what lets a call site read as the row it is"
+)]
 fn telemetry(
     step: u64,
     provider: &str,

--- a/crates/stella-transcript/src/word.rs
+++ b/crates/stella-transcript/src/word.rs
@@ -320,7 +320,10 @@ fn saturated(spans: &[Span], line: &str) -> bool {
         .filter(|s| s.changed)
         .map(|s| s.text.chars().count())
         .sum();
-    #[allow(clippy::cast_precision_loss)] // Line lengths are far below f64's exact-integer range.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "line lengths are far below f64's exact-integer range"
+    )]
     let fraction = changed as f64 / total as f64;
     fraction > SATURATION
 }

--- a/crates/stella-tui/src/accessible/announce.rs
+++ b/crates/stella-tui/src/accessible/announce.rs
@@ -147,10 +147,10 @@ pub(crate) fn announcing_fold<T>(
 }
 
 #[cfg(test)]
-// The lint is wrong here: these fixtures build with `Type::default()` and
-// then set the few fields the test cares about, which reads better than a
-// full struct literal that lists every field.
-#[allow(clippy::field_reassign_with_default)]
+#[expect(
+    clippy::field_reassign_with_default,
+    reason = "these fixtures build with `Type::default()` and then set the few fields the test cares about, which reads better than a full struct literal listing every field"
+)]
 mod tests {
     use super::*;
     use crate::deck::DeckTab;

--- a/crates/stella-tui/src/deck_render/tests.rs
+++ b/crates/stella-tui/src/deck_render/tests.rs
@@ -1,4 +1,7 @@
-#![allow(clippy::field_reassign_with_default)]
+#![expect(
+    clippy::field_reassign_with_default,
+    reason = "these fixtures build with `Type::default()` and then set the few fields the test cares about, which reads better than a full struct literal listing every field"
+)]
 
 use super::*;
 use crate::envelope::{AgentMeta, Inbound};

--- a/crates/stella-tui/src/deck_ui/tests.rs
+++ b/crates/stella-tui/src/deck_ui/tests.rs
@@ -4,7 +4,10 @@
 //! which ~2,960 were these tests. Shared fixtures live here; each tab or
 //! overlay with its own fixtures owns a submodule below.
 
-#![allow(clippy::field_reassign_with_default)]
+#![expect(
+    clippy::field_reassign_with_default,
+    reason = "these fixtures build with `Type::default()` and then set the few fields the test cares about, which reads better than a full struct literal listing every field"
+)]
 
 use super::*;
 use crate::envelope::AgentMeta;

--- a/crates/stella-tui/src/render/entry/recall.rs
+++ b/crates/stella-tui/src/render/entry/recall.rs
@@ -118,7 +118,10 @@ const GAP_W: usize = 2;
 // for a field to be dropped, which is precisely how `latency_ms` and
 // `used_ann_index` reached no surface at all. `model/recall.rs`'s `Projected`
 // alias declines the same invitation for the same reason.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the paragraph above: these are exactly TranscriptEntry::ContextRecall's fields plus the two render inputs and the sink, and a parameter struct would be the third place a field can be dropped"
+)]
 pub(super) fn recall_lines(
     frames: &[RecalledFrameRow],
     tokens: u32,

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -235,7 +235,10 @@ pub fn provider_fallback(from: &str, to: &str, reason: &str) -> EventLine {
     }
 }
 
-#[allow(clippy::too_many_arguments)] // mirrors the event's metering fields 1:1
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors the event's metering fields 1:1"
+)]
 pub fn step_usage(
     step: usize,
     model: &str,

--- a/crates/stella-tui/src/views/files_tab.rs
+++ b/crates/stella-tui/src/views/files_tab.rs
@@ -472,10 +472,10 @@ fn find_diff<'a>(model: &'a WorkspaceModel, rec: &FileRecord) -> Option<(&'a str
 }
 
 #[cfg(test)]
-// The lint is wrong here: these fixtures build with `Type::default()` and
-// then set the few fields the test cares about, which reads better than a
-// full struct literal that lists every field.
-#[allow(clippy::field_reassign_with_default)]
+#[expect(
+    clippy::field_reassign_with_default,
+    reason = "these fixtures build with `Type::default()` and then set the few fields the test cares about, which reads better than a full struct literal listing every field"
+)]
 mod tests {
     use super::*;
     use crate::envelope::AgentMeta;

--- a/crates/stella-tui/src/views/issues_tab.rs
+++ b/crates/stella-tui/src/views/issues_tab.rs
@@ -719,10 +719,6 @@ fn footer(mode: IssuesMode) -> Line<'static> {
 }
 
 #[cfg(test)]
-// The lint wants a struct literal, and `IssuesPanel` keeps a private request
-// counter — so `Default` followed by assignment is the only way to build one
-// from outside `deck_ui`.
-#[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
 

--- a/crates/stella-tui/src/views/session/fold.rs
+++ b/crates/stella-tui/src/views/session/fold.rs
@@ -103,7 +103,10 @@ impl SessionFold {
     /// into the live tail after the last entry, so it re-wraps per frame
     /// like the tail does and vanishes without residue when the
     /// authoritative `Text` clears it — never a settled entry.
-    #[allow(clippy::too_many_arguments)] // mirrors the fold's inputs one to one; a struct would just add a second shape
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "mirrors the fold's inputs one to one; a struct would just add a second shape"
+    )]
     pub(super) fn refresh(
         &mut self,
         agent: &str,

--- a/crates/stella-tui/src/views/traces.rs
+++ b/crates/stella-tui/src/views/traces.rs
@@ -266,10 +266,10 @@ fn render_empty_hint(area: Rect, buf: &mut Buffer) {
 }
 
 #[cfg(test)]
-// The lint is wrong here: these fixtures build with `Type::default()` and
-// then set the few fields the test cares about, which reads better than a
-// full struct literal that lists every field.
-#[allow(clippy::field_reassign_with_default)]
+#[expect(
+    clippy::field_reassign_with_default,
+    reason = "these fixtures build with `Type::default()` and then set the few fields the test cares about, which reads better than a full struct literal listing every field"
+)]
 mod tests {
     use super::*;
     use crate::deck::WorkspaceModel;


### PR DESCRIPTION
## Scope, and why it is not the whole issue

#4918 has three steps. This PR is step 2 for the eleven crates that are not
`stella-cli`.

Step 3 cannot land yet, and the reason is worth stating up front: **the guard
#4918 asks to widen is not on `main`.**

```
$ git log --oneline --all -- crates/stella-cli/tests/clippy_suppressions_are_expectations.rs
7f4151cdf fix(stella-cli): every clippy suppression states why, and eight of them go away

$ git merge-base --is-ancestor 7f4151cdf origin/main && echo YES || echo NO
NO

$ git branch -r --contains 7f4151cdf
  origin/fix/3698-too-many-arguments
```

That is PR #4921, open and in flight. `main` still carries 23 bare
`#[allow(clippy::…)]` under `crates/stella-cli/src`, so a tree-wide guard would
be red on its own PR, never mind on `main`. #4921's file list is 15 files under
`crates/stella-cli/src` plus the test — disjoint from all 26 sites here, so the
two merge in either order. Full reasoning is on the issue.

## What the conversion found

`#[allow]` asserts *this lint is wrong here* and never re-checks.
`#[expect]` asserts the same thing and fails when it stops being true. Two
suppressions were already untrue:

```
$ cargo clippy -p stella-tui -p stella-observatory -p stella-serve --all-targets
warning: this lint expectation is unfulfilled
   --> crates/stella-observatory/src/transcript_view.rs:368:9
    |
368 |         clippy::cast_sign_loss,
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: guarded above; saturates
    = note: `#[warn(unfulfilled_lint_expectations)]` on by default

warning: this lint expectation is unfulfilled
   --> crates/stella-tui/src/views/issues_tab.rs:723:5
    |
723 |     clippy::field_reassign_with_default,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the lint wants a struct literal, and `IssuesPanel` keeps a private request counter — `Default` followed by assignment is the only way to build one from outside `deck_ui`
    = note: `#[warn(unfulfilled_lint_expectations)]` on by default
```

- **`micros_from_usd`** suppressed `cast_sign_loss` beside
  `cast_possible_truncation`. The cast target is `i128`, so only the second
  fires. The name is dropped.
- **`issues_tab`'s test module** suppressed `field_reassign_with_default` under
  a paragraph about `IssuesPanel`'s private request counter. The lint does not
  fire there at all any more, so the suppression and the paragraph are deleted
  rather than reworded — a comment describing a constraint the code no longer
  has is the exact thing #3698 found twice in `stella-cli`.

## Witness — the ablation

The claim under test is *`#[allow]` cannot report a suppression that has
stopped being true, and `#[expect]` can*. Ablating the fix must make the answer
**wrong**, not merely different:

```
# ablate: restore the bare #[allow] on issues_tab's test module
$ cargo clippy -p stella-tui --all-targets -- -D warnings
   (no output, exit 0)          <-- the stale suppression survives, silently

# the shipped state: the suppression removed, everything else unchanged
$ cargo clippy -p stella-tui --all-targets -- -D warnings
   (no output, exit 0)

# the intermediate state this PR passed through: #[expect] in its place
$ cargo clippy -p stella-tui --all-targets
warning: this lint expectation is unfulfilled
   --> crates/stella-tui/src/views/issues_tab.rs:723:5
```

The first and second runs are both silent, and that is the point: with
`#[allow]` the tree is silent *and wrong*, with the suppression gone it is
silent *and right*, and only `#[expect]` distinguishes the two. That
distinction is the whole content of the rule.

No test was added, because there is no assertion to add here that the compiler
does not already make — the guard that turns this into a standing property is
step 3, and it lives on #4921.

## The two sites that need a caveat

`crates/stella-protocol/src/schema_export.rs` and
`crates/stella-plugin/src/wire_schema.rs` carry `#![expect(clippy::expect_used)]`
behind the off-by-default `schema` feature, which
`cargo clippy --workspace --all-targets` never compiles. Both were checked by
hand with the feature on:

```
$ cargo clippy -p stella-protocol --features schema --lib -- -D warnings
$ cargo clippy -p stella-plugin   --features schema --lib -- -D warnings
   (both silent, exit 0)
```

And a plain rustc build with the feature on reports no unfulfilled expectation
either — rustc does not evaluate a tool lint's expectation when the tool is not
running:

```
$ touch crates/stella-plugin/src/wire_schema.rs crates/stella-protocol/src/schema_export.rs
$ cargo build -p stella-plugin -p stella-protocol \
    --features stella-plugin/schema,stella-protocol/schema 2>&1 | rg -i 'unfulfilled|warning'
   (no output)
```

Whoever writes the step-3 guard should say this in its doc rather than let the
two sites pass silently: they are correct in form and unproven by any clippy
run this repository currently does. Filed as #4949, with the fix (a clippy step
in `wire-schema.yml`, beside the `doc-warnings-schema` that closed the same
hole for rustdoc in #4584).

## The other 24

Mechanical. Where the site already carried a `//` comment the text became the
`reason` verbatim; where it carried none, the reason is written from the code:

| site | lint | reason source |
|---|---|---|
| `stella-context/src/store/{record,edge}.rs` | `too_many_arguments` | the comment above the attribute, moved inside it |
| `stella-serve/src/goal.rs` | `too_many_arguments` | written: the round loop's state, threaded from one caller |
| `stella-store/src/tests.rs` | `too_many_arguments` | written: nine columns of one telemetry row |
| `stella-tui/src/render/entry/recall.rs` | `too_many_arguments` | the paragraph above it, which already argued the case at length |
| `stella-diag/src/error.rs` | `vec_init_then_push` | the macro's own comment, which already said why |
| the rest | — | the inline comment each already carried |

Six of those had no comment at all and were floor violations on their own terms
before this PR.

## Guards

```
$ make guards-fast          # no FAIL lines; deck-fit-all self-test 13/13
$ cargo fmt --all --check
$ cargo clippy -p stella-diag -p stella-transcript -p stella-graph -p stella-context \
               -p stella-protocol -p stella-plugin -p stella-store -p stella-core \
               --all-targets -- -D warnings
$ cargo clippy -p stella-tui -p stella-observatory -p stella-serve \
               --all-targets -- -D warnings
   (all silent, exit 0)

$ rg -n '^\s*#!?\[allow\(clippy::' crates/ --glob '!crates/stella-cli/**' | wc -l
       0
```

No baseline was added or raised in either direction. No `#[test]` was renamed
or removed.

Refs #4918
