### PR TITLE
All four doors read the reflection opt-out, not two

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -730,7 +730,11 @@ pub async fn run_goal_cmd(
     // `succeeded=false`). Only a user-chosen soft stop is excluded
     // (issue #373, item 7).
     if crate::memory::should_reflect_on(&outcome)
-        && turn_warrants_reflection(&messages)
+        && crate::agent::output::should_reflect_on_turn(
+            turn_warrants_reflection(&messages),
+            memory.is_some(),
+            crate::agent::reflection_explicitly_disabled(),
+        )
         && let Some(m) = &mut memory
     {
         // One ledger per round (#3962): this reflection covers an arc of

--- a/crates/stella-cli/src/agent/output.rs
+++ b/crates/stella-cli/src/agent/output.rs
@@ -383,6 +383,29 @@ pub(crate) fn should_reflect_after_one_shot(
     one_shot_reflection_enabled(format) && warrants_reflection && has_memory
 }
 
+/// Whether a door that has no [`OutputFormat`] reflects on this turn — the
+/// whole rule, in one place a test can reach.
+///
+/// The sibling of [`should_reflect_after_one_shot`], which cannot serve the
+/// goal arc or interactive mode because it asks a format question neither of
+/// them has an answer to. Everything else is the same, including the reason it is a
+/// function at all: a condition at a call site is a condition no test can see,
+/// which is how #4130's `format == OutputFormat::Text` clause survived a test
+/// asserting the opposite.
+///
+/// `opted_out` is passed rather than read here, so a test pins it without
+/// touching `std::env`. That is process-global and this suite runs in
+/// parallel, so a test that set the variable would decide other tests' answers
+/// — `self_driving_cmd::work`'s `the_turn_does_not_inherit_the_reflection_opt_out`
+/// took the arguments-not-environment route for the same reason (#4914).
+pub(crate) fn should_reflect_on_turn(
+    warrants_reflection: bool,
+    has_memory: bool,
+    opted_out: bool,
+) -> bool {
+    warrants_reflection && has_memory && !opted_out
+}
+
 /// The reflection opt-out itself, separated from the one-shot format question
 /// above because it is neither about one-shots nor about formats: it is the
 /// workspace-wide "do not spend the extra provider call" switch, and every door
@@ -390,6 +413,14 @@ pub(crate) fn should_reflect_after_one_shot(
 /// of attempts is the largest batch of reflection calls Stella can make, so an
 /// automation that opted out would otherwise have opted out of the cheapest
 /// door and kept the dearest.
+///
+/// All four doors read it now. Two did not until #4915: the goal arc and
+/// interactive mode each carried their own gate at the call site, so
+/// `STELLA_DISABLE_REFLECTION` suppressed the call on the one-shot and fleet
+/// doors and not on those two — while this comment said every door owed it.
+/// `stella goal` was the one that mattered: it is scriptable and runs several
+/// rounds, so a goal invoked from a shell that had opted out spent a call per
+/// round the operator had asked it not to spend.
 pub(crate) fn reflection_explicitly_disabled() -> bool {
     std::env::var(DISABLE_REFLECTION_ENV).is_ok_and(|value| is_truthy_env_value(&value))
 }

--- a/crates/stella-cli/src/agent/reflect.rs
+++ b/crates/stella-cli/src/agent/reflect.rs
@@ -97,7 +97,11 @@ pub(super) async fn reflect_on_interactive_turn<T, E: std::fmt::Display>(
     budget: &mut BudgetGuard,
 ) {
     if should_reflect_on(result)
-        && turn_warrants_reflection(turn.turn_slice())
+        && crate::agent::output::should_reflect_on_turn(
+            turn_warrants_reflection(turn.turn_slice()),
+            memory.is_some(),
+            crate::agent::reflection_explicitly_disabled(),
+        )
         && let Some(m) = memory
     {
         let mut report = reflect_routed(

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -3,6 +3,88 @@ use crate::config::{ConfiguredProvider, PROVIDERS, ProviderConfig};
 use stella_model::credential::ApiKey;
 use stella_protocol::event::BudgetMode; // no longer re-exported via `super::*` (#971)
 
+/// The opt-out reaches the two doors that have no [`OutputFormat`] to ask
+/// about — the goal arc and interactive mode.
+///
+/// Neither read it until #4915: each carried its own gate at its own call
+/// site, so `STELLA_DISABLE_REFLECTION` suppressed the call on the one-shot
+/// and fleet doors and not on those two, while `reflection_explicitly_disabled`'s
+/// own doc comment said every door that spends the call owes it. `stella goal`
+/// was the expensive half — scriptable, several rounds, so one opted-out
+/// invocation spent a call per round.
+#[test]
+fn the_opt_out_stops_a_turn_that_would_otherwise_reflect() {
+    assert!(
+        should_reflect_on_turn(true, true, false),
+        "a turn worth reflecting on, with memory open and no opt-out, reflects"
+    );
+    assert!(
+        !should_reflect_on_turn(true, true, true),
+        "the opt-out wins over a turn that would otherwise have reflected"
+    );
+}
+
+/// The other two facts still gate, so the opt-out is not the only thing
+/// standing between a trivial turn and a paid round trip.
+#[test]
+fn a_turn_with_no_lesson_or_nowhere_to_put_it_still_reflects_on_nothing() {
+    assert!(
+        !should_reflect_on_turn(false, true, false),
+        "a turn that did nothing has no lesson in it"
+    );
+    assert!(
+        !should_reflect_on_turn(true, false, false),
+        "with no memory open there is nowhere for the lesson to go"
+    );
+}
+
+/// Every door that spends a reflection call routes through the shared gate.
+///
+/// The truth table above proves the rule; it cannot prove a door *asks*. That
+/// gap is this file's own history: `one_shot_reflection_defaults_on_for_every_output_format`
+/// asserted `Json` was enabled and passed for the whole period no JSON turn
+/// ever reflected, because the call site carried a condition the test could
+/// not see (#4130). A door that stops calling the gate fails here instead of
+/// silently keeping its own copy of the rule.
+///
+/// Source-level on purpose. The alternative is a live turn per door, which
+/// needs a provider — and the thing under test is which function the call site
+/// names, which the source answers directly.
+#[test]
+fn every_reflecting_door_consults_the_shared_gate() {
+    let crate_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    for (door, file, gate) in [
+        (
+            "the goal arc",
+            "src/agent/goal.rs",
+            "should_reflect_on_turn",
+        ),
+        (
+            "interactive mode",
+            "src/agent/reflect.rs",
+            "should_reflect_on_turn",
+        ),
+        (
+            "the fleet wave",
+            "src/fleet_cmd.rs",
+            "reflection_explicitly_disabled",
+        ),
+        (
+            "the one-shot run",
+            "src/agent/output.rs",
+            "should_reflect_after_one_shot",
+        ),
+    ] {
+        let text = std::fs::read_to_string(crate_root.join(file))
+            .unwrap_or_else(|why| panic!("{door}'s source must be readable: {why}"));
+        assert!(
+            text.contains(gate),
+            "{door} ({file}) no longer names `{gate}`, so its reflection rule \
+             is back at the call site where no test can see it (#4915, #4130)"
+        );
+    }
+}
+
 #[test]
 fn one_shot_reflection_defaults_on_for_every_output_format() {
     let _env = crate::test_env::lock();


### PR DESCRIPTION
`STELLA_DISABLE_REFLECTION` suppressed the reflection call on the one-shot and fleet doors and not on the goal arc or interactive mode — while `reflection_explicitly_disabled`'s own doc comment said "every door that spends one owes it".

## Which way the disagreement was resolved

Option 1 from the issue: **every door reads it**. The doc comment already in the tree states the intent, so the code was the half that was wrong. Making the code match a declaration that predates it is the conservative direction; rewriting the declaration to match two call sites that had quietly diverged is not.

`stella goal` is the one that mattered. It is scriptable and runs several rounds, so one invocation from a shell that had opted out spent a call *per round* the operator asked it not to spend.

Interactive mode was arguably a deliberate exception ("a person is sitting there"), but the switch says "do not spend the extra provider call" and a person who exported it meant it. If a future maintainer wants interactive mode exempt, that is now a change to one function with a test on it rather than an omission indistinguishable from an oversight.

## Shape

The rule lives in `should_reflect_on_turn(warrants_reflection, has_memory, opted_out)`, beside `should_reflect_after_one_shot`, which cannot serve these two doors because it asks a format question neither of them has an answer to.

`opted_out` is a **parameter, not a read**, so a test pins it without touching `std::env` — process-global state this suite runs in parallel against. #4914's `the_turn_does_not_inherit_the_reflection_opt_out` took the same route for the same reason.

## Two tests, because one of them cannot do the other's job

The truth table proves the rule. It cannot prove a door *asks* — and that gap is this file's own history: `one_shot_reflection_defaults_on_for_every_output_format` asserted `Json` was enabled and passed for the entire period no JSON turn ever reflected, because the call site carried a `format == OutputFormat::Text` clause the test could not see (#4130).

So `every_reflecting_door_consults_the_shared_gate` reads the four door sources and asserts each names its gate. Source-level on purpose: the alternative is a live turn per door, which needs a provider, and the thing under test is which function the call site names.

## Ablation, one per test

The goal arc keeping its own gate (main's state):

```
test every_reflecting_door_consults_the_shared_gate ... FAILED
the goal arc (src/agent/goal.rs) no longer names `should_reflect_on_turn`, so its
reflection rule is back at the call site where no test can see it (#4915, #4130)
test result: FAILED. 104 passed; 1 failed
```

The gate ignoring the opt-out:

```
test the_opt_out_stops_a_turn_that_would_otherwise_reflect ... FAILED
test result: FAILED. 104 passed; 1 failed
```

Each fails alone, so neither test is carrying the other.

## Evidence

```
cargo test -p stella-cli --bin stella agent::tests    105 passed; 0 failed
cargo clippy -p stella-cli --all-targets -- -D warnings   exit 0
check-prose      OK — 6386, none added (7 fewer than before: "REPL" retired from the comments I touched)
check-file-size  OK — nothing went over by this change
```

`README.md` documents the variable as workspace-wide, which is now true of all four doors rather than two.

No test deleted or renamed.

Closes #4915
Refs #4130, #4362, #4914, #3956

## Summary by Sourcery

Ensure every reflection door honors the workspace-wide reflection opt-out.

Bug Fixes:
- Apply the reflection opt-out consistently to goal arcs and interactive turns, preventing unwanted reflection calls across all four reflection doors.

Enhancements:
- Centralize turn-level reflection eligibility in a shared, testable gate for doors without an output format.

Documentation:
- Update reflection opt-out documentation to reflect that all four reflection doors honor the workspace-wide setting.

Tests:
- Add truth-table coverage for turn reflection eligibility and source-level checks ensuring every reflection door uses the shared gate.