### PR TITLE
The guards see a file you have not staged yet

### DIFF
--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -212,7 +212,13 @@ def run(*args):
 
 
 def tracked(*globs):
-    return [p for p in run("git", "ls-files", *globs).splitlines() if p]
+    return [
+        p
+        for p in run(
+            "git", "ls-files", "--cached", "--others", "--exclude-standard", *globs
+        ).splitlines()
+        if p
+    ]
 
 
 def read(path):

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -222,7 +222,8 @@ RATCHET_PATHSPECS=('*.rs' '*.py' '*.sh' '.githooks/*' '*.ts' '*.tsx' '*.mjs' '*.
 # while the guard watched only *.rs. Shell counts (#1563) and TypeScript and
 # JavaScript count (#3811) for the same reason, each after the same incident.
 current_sizes() {
-  git ls-files -z "${RATCHET_PATHSPECS[@]}" | while IFS= read -r -d '' f; do
+  git ls-files -z --cached --others --exclude-standard "${RATCHET_PATHSPECS[@]}" |
+    while IFS= read -r -d '' f; do
     # A tracked file deleted from the working tree but not yet staged is a
     # legitimate transient state on a working branch (#3268); judge the files
     # that exist rather than erroring on the ones that do not. Once the
@@ -617,7 +618,7 @@ if [ -n "$report" ]; then
   exit 1
 fi
 
-tracked=$(git ls-files "${RATCHET_PATHSPECS[@]}" | wc -l | tr -d ' ')
+tracked=$(git ls-files --cached --others --exclude-standard "${RATCHET_PATHSPECS[@]}" | wc -l | tr -d ' ')
 # The verdict is already decided; the write is best-effort. SIGPIPE is ignored
 # and the write's failure discarded, so a reader that closed the pipe
 # (`| head -1`, `| true`) cannot turn a green verdict into a failure (#1815).

--- a/scripts/check-left-behind.sh
+++ b/scripts/check-left-behind.sh
@@ -95,7 +95,7 @@ current_counts() {
   # The existence filter skips tracked files deleted from the working tree but
   # not yet staged (#3268) — awk would otherwise die on the missing path
   # instead of judging the files that exist.
-  git ls-files -z '*.rs' '*.py' '*.sh' '.githooks/*' |
+  git ls-files -z --cached --others --exclude-standard '*.rs' '*.py' '*.sh' '.githooks/*' |
     while IFS= read -r -d '' f; do [ -f "$f" ] && printf '%s\0' "$f"; done |
     xargs -0 awk '
       FILENAME == "scripts/check-left-behind.sh"      { next }
@@ -178,7 +178,7 @@ if [ -n "$report" ]; then
   exit 1
 fi
 
-scanned=$(git ls-files '*.rs' '*.py' '*.sh' '.githooks/*' | wc -l | tr -d ' ')
+scanned=$(git ls-files --cached --others --exclude-standard '*.rs' '*.py' '*.sh' '.githooks/*' | wc -l | tr -d ' ')
 carried=$(grep -cv '^#' "$baseline" || true)
 # The verdict is already decided; the write is best-effort. SIGPIPE is ignored
 # and the write's failure discarded, so a reader that closed the pipe

--- a/scripts/check-line-citations.py
+++ b/scripts/check-line-citations.py
@@ -80,7 +80,11 @@ HEADER = """\
 
 def tracked_files(root: Path) -> list[str]:
     out = subprocess.run(
-        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.split("\n")
     keep = []
     for path in out:

--- a/scripts/check-module-reachability.py
+++ b/scripts/check-module-reachability.py
@@ -235,7 +235,16 @@ def reachable_from(roots: list[Path]) -> tuple[set[Path], list[str]]:
 def tracked_sources(root: Path, crate: Path) -> list[Path]:
     rel = crate.relative_to(root)
     out = subprocess.run(
-        ["git", "ls-files", "-z", f"{rel}/src/**/*.rs", f"{rel}/src/*.rs"],
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            f"{rel}/src/**/*.rs",
+            f"{rel}/src/*.rs",
+        ],
         cwd=root,
         capture_output=True,
         text=True,

--- a/scripts/check-no-scratch.sh
+++ b/scripts/check-no-scratch.sh
@@ -18,6 +18,13 @@
 # file as "not ignored" — which is exactly the state this guard exists to
 # find — so the check uses `git ls-files --cached --ignored` instead.
 #
+# This is the one guard #4952 did NOT widen, and the reason is here so the
+# next reader does not take it for an oversight. Every other scanner
+# there gained `--others --exclude-standard` so a brand-new file stops being
+# invisible; here `--cached` is the subject. An untracked scratch file is the
+# correct outcome, not a miss, and adding `--others` would fail the gate on
+# every session's own working directory. Do not "fix" it to match the others.
+#
 # Uses portable POSIX tools so it runs on a bare CI runner.
 set -euo pipefail
 

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -188,7 +188,11 @@ HEADER = """\
 
 def tracked_files(root: Path) -> list[str]:
     out = subprocess.run(
-        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.split("\n")
     keep = []
     for path in out:

--- a/scripts/check-reserved-paths.sh
+++ b/scripts/check-reserved-paths.sh
@@ -38,7 +38,7 @@ reserved='con|prn|aux|nul|com[1-9]|lpt[1-9]'
 # first dot) — `aux.rs`, `aux.tar.gz` and a bare `aux` directory are all
 # refused, which is what Windows does.
 offenders=$(
-  git ls-files -z \
+  git ls-files -z --cached --others --exclude-standard \
     | tr '\0' '\n' \
     | awk -v re="^($reserved)$" '
         {

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -167,7 +167,7 @@ TEXT_SUFFIXES = {
 
 def tracked_files(root: Path) -> list[Path]:
     out = subprocess.run(
-        ["git", "ls-files", "-z"],
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
         cwd=root,
         capture_output=True,
         text=True,

--- a/scripts/check-transcript-surfaces.py
+++ b/scripts/check-transcript-surfaces.py
@@ -173,7 +173,7 @@ FOREIGN: list[tuple[str, str, int, str]] = []
 def production_sources(repo: Path = REPO) -> list[Path]:
     """Every tracked Rust file that ships, excluding tests and examples."""
     out = subprocess.run(
-        ["git", "ls-files", "*.rs"],
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "*.rs"],
         cwd=repo,
         capture_output=True,
         text=True,
@@ -213,7 +213,7 @@ def references(path: Path, entry: str, repo: Path = REPO) -> bool:
 def dependent_crates(repo: Path = REPO) -> set[str]:
     """Crate directories whose manifest depends on `stella-transcript`."""
     out = subprocess.run(
-        ["git", "ls-files", "*/Cargo.toml"],
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "*/Cargo.toml"],
         cwd=repo,
         capture_output=True,
         text=True,

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -64,6 +64,13 @@ doc() {
   (cd "$1" && git add -A) >/dev/null 2>&1
 }
 
+# The same, but deliberately NOT `git add`ed — the #4952 direction.
+# $1 = root, $2 = relative path, body on stdin.
+doc_untracked() {
+  mkdir -p "$(dirname "$1/$2")"
+  cat >"$1/$2"
+}
+
 # $1 = root, then `path pattern count` triples.
 baseline() {
   root="$1"
@@ -266,6 +273,43 @@ if python3 "$SCRIPT" --adopt=no-such-pattern "$r" >/dev/null 2>&1; then
   no "P13 --adopt rejects an unknown pattern" "--adopt exited 0"
 else
   ok "P13 --adopt rejects an unknown pattern"
+fi
+
+# A brand-new file the author has not staged yet is the file most likely to
+# carry new prose, and it was invisible: `git ls-files` lists tracked files
+# only, so the guard reported OK — which reads exactly like "I read it and
+# found nothing". CI never agreed, because on a PR branch the file is
+# committed (#4952).
+r="$(new_root P14)"
+doc "$r" docs/tracked.md <<'EOF'
+The store keys every child table off `executions.id`.
+EOF
+doc_untracked "$r" docs/untracked.md <<'EOF'
+Two things stated rather than hidden: the guard cannot see this file.
+EOF
+baseline "$r"
+if python3 "$SCRIPT" "$r" >/dev/null 2>&1; then
+  no "P14 an unstaged file is scanned" "the guard passed a file it never read"
+else
+  ok "P14 an unstaged file is scanned"
+fi
+
+# The other direction, so P14 cannot pass by scanning everything: a file
+# `.gitignore` covers stays out. `--exclude-standard` is what keeps a build
+# directory or a session scratch file from failing the gate.
+r="$(new_root P15)"
+printf 'ignored/\n' >"$r/.gitignore"
+doc "$r" docs/tracked.md <<'EOF'
+The store keys every child table off `executions.id`.
+EOF
+doc_untracked "$r" ignored/scratch.md <<'EOF'
+Two things stated rather than hidden: this one is ignored and must stay out.
+EOF
+baseline "$r"
+if python3 "$SCRIPT" "$r" >/dev/null 2>&1; then
+  ok "P15 a gitignored file stays out of the scan"
+else
+  no "P15 a gitignored file stays out of the scan" "the guard read an ignored file"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"


### PR DESCRIPTION
Several gate guards enumerate with `git ls-files`, which lists **tracked** files only. A brand-new file that has not been `git add`ed is invisible to them, and they answer `OK` — which reads exactly like "I read your file and found nothing".

CI never agreed: on a PR branch the file is committed, so the same guard reads it and fails. Green locally, red in CI, on a diff the author already checked.

## Scope: eleven scanners, each checked rather than assumed

The issue names four confirmed and lists seven more as "likely to share the gap — each needs checking rather than assuming". I checked all eleven and widened them: `check-prose.py`, `check-line-citations.py`, `check-tokens.py`, `check-transcript-surfaces.py` (both call sites), `check-module-reachability.py`, `check-doc-links.py`, `check-file-size.sh` (the ratchet loop and the count), `check-left-behind.sh` (the scan and the count), `check-reserved-paths.sh`.

`check-invariants.sh` and `check-no-secrets.sh` are listed in the issue but read `git ls-files '*.md'` / a name filter for key material; both are left as they are because widening them changes what they are about, not how much they see.

`git ls-files --cached --others --exclude-standard` is the one-flag form: tracked plus new, minus anything `.gitignore` covers — which is what every one of these wants.

## The one guard left alone, and why

`check-no-scratch.sh` asks whether a **tracked** file matches a `.gitignore` rule. Untracked is the correct answer there, and `--others` would fail the gate on every session's own working directory. Its header now says so, so the next reader does not "fix" it into agreement with the others.

## Witness

Two cases in `scripts/test-prose-guard.sh`, and they are a pair on purpose:

- **P14** — an unstaged file carrying a banned construction must fail.
- **P15** — a `.gitignore`d file must still be skipped.

Without P15, P14 could pass by scanning everything, which would fail the gate on every `target/` directory in the repo. The ablation shows they separate:

```
# reverting check-prose.py to bare `git ls-files`
FAIL P14 an unstaged file is scanned -- the guard passed a file it never read
ok   P15 a gitignored file stays out of the scan
19 passed, 1 failed
```

Restored: `20 passed, 0 failed`.

And the issue's own repro, run against the change — an untracked file with a meta-writing line and an issue-less `TODO`:

```
untracked, never `git add`ed:
  check-prose.py           FAIL <- sees it
  check-left-behind.sh     FAIL <- sees it
```

Both reported `OK` before.

## No baseline moved

The DoD asks that turning the enumeration on be reported rather than absorbed if it surfaces pre-existing hits. It surfaced none: every guard is green on this tree with the wider scan, `check-prose` included at 6386 with none added. `scripts/prose-baseline.txt`, `file-size-baseline.txt` and the rest are untouched.

## Evidence

```
check-prose.py · check-line-citations.py · check-tokens.py
check-transcript-surfaces.py · check-module-reachability.py · check-doc-links.py
check-file-size.sh · check-left-behind.sh · check-reserved-paths.sh
check-invariants.sh · check-no-secrets.sh · check-no-scratch.sh      all exit 0

test-prose-guard.sh       20 passed, 0 failed
test-line-citations.sh    10 passed, 0 failed
test-no-scratch.sh        passed 5, failed 0
shellcheck                exit 0
check-gate-parity         OK — 47 gate steps
```

Nothing compiles here, so `make guards-fast` stays free.

This is the defect that produced #4922's own red CI: `scripts/test-tokens.sh` passed locally while untracked, then failed on its own source the moment it was committed. It was also confirmed independently on `check-tokens.py` with a full transcript on the issue.

No test deleted or renamed.

Closes #4952
Refs #4768, #4806

## Summary by Sourcery

Make repository scanners inspect all relevant working-tree files, including unstaged files, while continuing to exclude gitignored paths.

Bug Fixes:
- Ensure repository guards scan unstaged, non-ignored files so local checks match CI behavior.

Enhancements:
- Keep scratch-file detection limited to tracked files because untracked files are its intended subject.
- Document the intentional exception for the scratch-file guard.

Tests:
- Add prose-guard coverage confirming unstaged files are scanned while gitignored files remain excluded.