### PR TITLE
test(bench): check the exit-code parser against Harbor's own message

### DIFF
--- a/bench/harbor_adapter/tests/test_code_graph.py
+++ b/bench/harbor_adapter/tests/test_code_graph.py
@@ -8,13 +8,35 @@ incomplete, because the parser structurally could not emit any of the three.
 Before #3670 a failed exec's exit code and stderr were only ever reachable by
 re-parsing the exception's ``str()`` by eye.
 
+``TestUnavailable`` covers ``_NONZERO_EXIT_PATTERN`` against a message the
+test wrote. ``TestUnavailableAgainstHarbor`` covers it against the message
+**Harbor** writes, which is the only one that ships (#4899): the parser is
+pinned to Harbor's behaviour by a regex and to Harbor's version by nothing,
+so a reordered line or a renamed ``stderr:`` prefix on an upgrade would drop
+``exit_code`` and ``stderr`` from every trial's metadata with the whole suite
+still green.
+
 In its own file rather than ``test_adapter.py``, which is grandfathered at
 its file-size ceiling and closed to growth.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
 from stella_harbor import code_graph
+
+pytest.importorskip("harbor", reason="Harbor is required to produce its own message")
+
+from harbor.agents.installed.base import (  # noqa: E402 - after importorskip by design
+    NonZeroAgentExitCodeError,
+)
+
+from stella_harbor import StellaAgent  # noqa: E402 - after importorskip by design
 
 
 class TestFromStdoutCodeGraphLine:
@@ -142,3 +164,124 @@ class TestUnavailable:
         assert result["exit_code"] == "1"
         assert result["stderr"] == "tree-sitter: unsupported grammar for *.mojo"
         assert result["detail"] == message
+
+
+_STDERR = "tree-sitter: unsupported grammar for *.mojo"
+_STDOUT = "indexing /app"
+
+
+class _FailingEnvironment:
+    """Harbor's ``BaseEnvironment.exec`` contract, answering non-zero.
+
+    Only ``exec`` — the adapter's own ``_stella_secure_exec_with_stdin`` hook
+    is absent, so a test that reached the credential branch by mistake would
+    raise rather than pass on the wrong path.
+    """
+
+    def __init__(self, *, return_code: int, stderr: str) -> None:
+        self.task_env_config = SimpleNamespace(workdir="/app")
+        self.commands: list[str] = []
+        self._return_code = return_code
+        self._stderr = stderr
+
+    async def exec(
+        self,
+        *,
+        command: str,
+        user: str | int | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout_sec: int | None = None,
+    ) -> SimpleNamespace:
+        self.commands.append(command)
+        return SimpleNamespace(
+            return_code=self._return_code, stdout=_STDOUT, stderr=self._stderr
+        )
+
+
+def _agent_over_harbors_exec() -> StellaAgent:
+    """An agent whose ``exec_as_agent`` is Harbor's real, unpatched ``_exec``.
+
+    Constructed through ``__new__`` like ``test_exit_cause``'s agents, because
+    ``BaseInstalledAgent.__init__`` wants a logs dir and a resolved descriptor
+    set that none of this needs. Nothing here overrides ``_exec``, which is
+    the point: the exception under test has to be the one Harbor raises.
+    """
+    agent = StellaAgent.__new__(StellaAgent)
+    agent._extra_env = {}
+    agent.logger = logging.getLogger("stella_harbor.tests.code_graph")
+    agent._configured_value = lambda name, default=None: None
+    return agent
+
+
+class TestUnavailableAgainstHarbor:
+    """The parser against the string Harbor writes, not the string we wrote.
+
+    ``TestUnavailable`` above builds the message by hand and raises a locally
+    defined subclass, so it proves the regex matches the test's own literal
+    and says nothing about Harbor. These drive Harbor's
+    ``BaseInstalledAgent._exec`` against a fake environment and feed the
+    ``NonZeroAgentExitCodeError`` *it* raises to :func:`code_graph.unavailable`
+    — so a Harbor upgrade that reorders the message's lines, renames the
+    ``stderr:`` prefix, or drops the ``(exit N)`` clause fails here instead of
+    silently emptying every trial's metadata (#4899).
+    """
+
+    def test_harbors_own_exception_yields_the_exit_code_and_stderr(self) -> None:
+        environment = _FailingEnvironment(return_code=3, stderr=_STDERR)
+        agent = _agent_over_harbors_exec()
+
+        with pytest.raises(NonZeroAgentExitCodeError) as raised:
+            asyncio.run(
+                StellaAgent.exec_as_agent(
+                    agent, environment, command="/usr/local/bin/stella init"
+                )
+            )
+
+        result = code_graph.unavailable(raised.value)
+        assert result["kind"] == "NonZeroAgentExitCodeError"
+        assert result["exit_code"] == "3"
+        # Exact equality, not a substring: if Harbor moves `stdout:` below
+        # `stderr:`, the greedy trailing group swallows it and this fails.
+        assert result["stderr"] == _STDERR
+
+    def test_build_code_graph_records_what_harbor_raised(self) -> None:
+        """The whole chain, through the production call site.
+
+        Harbor's ``_exec`` raises, ``_build_code_graph``'s ``except`` arm
+        catches, and the parsed fields land in the summary a trial discloses.
+        """
+        environment = _FailingEnvironment(return_code=101, stderr=_STDERR)
+        agent = _agent_over_harbors_exec()
+
+        asyncio.run(StellaAgent._build_code_graph(agent, environment))
+
+        summary = agent._code_graph_summary
+        assert summary["state"] == "unavailable"
+        assert summary["kind"] == "NonZeroAgentExitCodeError"
+        assert summary["exit_code"] == "101"
+        assert summary["stderr"] == _STDERR
+        assert environment.commands, "init never reached the environment"
+
+    def test_harbors_truncation_survives_the_parse(self) -> None:
+        """``code_graph``'s comment claims Harbor truncates and we do not.
+
+        ``_truncate_output`` cuts at 1000 characters and appends a marker.
+        The parser must hand that string back whole, so the recovered
+        ``stderr`` is exactly what Harbor decided to disclose — a second
+        truncation of ours would show up here as a shorter string.
+        """
+        long_stderr = "x" * 1500
+        environment = _FailingEnvironment(return_code=1, stderr=long_stderr)
+        agent = _agent_over_harbors_exec()
+
+        with pytest.raises(NonZeroAgentExitCodeError) as raised:
+            asyncio.run(
+                StellaAgent.exec_as_agent(
+                    agent, environment, command="/usr/local/bin/stella init"
+                )
+            )
+
+        recovered = code_graph.unavailable(raised.value)["stderr"]
+        assert recovered == "x" * 1000 + " ... [truncated]"
+        assert recovered != long_stderr


### PR DESCRIPTION
## What

`bench/harbor_adapter/stella_harbor/code_graph.py`'s `unavailable()` recovers a failed `stella init`'s exit code and stderr by re-parsing the exception's `str()` with `_NONZERO_EXIT_PATTERN`. The only test over that regex built Harbor's message **by hand as a string literal** and raised a locally defined `RuntimeError` subclass — so it proved the regex matches the string the test wrote, and said nothing about the string Harbor writes.

This adds `TestUnavailableAgainstHarbor`, which never authors the message. It drives Harbor's real, unpatched `BaseInstalledAgent._exec` against a fake environment whose `ExecResult` carries a non-zero return code, catches the `NonZeroAgentExitCodeError` **Harbor** raises, and feeds that to `unavailable()`. That is shape 1 from the issue's "Done means", the one it calls strongest.

Three cases:

1. `test_harbors_own_exception_yields_the_exit_code_and_stderr` — the exception straight off `exec_as_agent`, asserting `kind` is Harbor's real class name (the existing tests only ever saw `RuntimeError` and a local subclass), plus `exit_code` and `stderr`.
2. `test_build_code_graph_records_what_harbor_raised` — the whole production chain: Harbor's `_exec` raises, `_build_code_graph`'s `except` arm catches, and the parsed fields land in `_code_graph_summary`, which is the thing a trial actually discloses.
3. `test_harbors_truncation_survives_the_parse` — `code_graph.py`'s own comment claims Harbor truncates at 1000 characters and that we parse rather than re-truncate "so a change to Harbor's truncation length cannot silently disagree with a second one of ours". Nothing checked that claim; now a 1500-character stderr must come back as Harbor's 1000 characters plus its `... [truncated]` marker.

`stderr` is asserted by **exact equality**, not substring. The regex's trailing group is greedy under `re.DOTALL`, so a Harbor release that moves `stdout:` below `stderr:` would have the group swallow the stdout line — exact equality catches that; a substring assertion would not.

No production code changed. `_NONZERO_EXIT_PATTERN` is correct against Harbor 0.6.1 (the version `pyproject.toml` pins) — what was missing was anything that would notice if it stopped being.

## Witness

The issue asks for the parser's expected shape to be broken so the new tests fail. I ran the ablation as the *realistic* version of that failure — the parser and its hand-written test updated together to a shape someone believed Harbor used (here, `stderr:` above `stdout:`), which is exactly how this drifts in practice:

```
--- a/bench/harbor_adapter/stella_harbor/code_graph.py
-    r"^Command failed \(exit (?P<exit_code>-?\d+)\):.*?\nstderr: (?P<stderr>.*)$",
+    r"^Command failed \(exit (?P<exit_code>-?\d+)\):.*?\nstderr: (?P<stderr>.*?)\nstdout: .*$",
--- a/bench/harbor_adapter/tests/test_code_graph.py
-            "stdout: some stdout\n"
-            "stderr: tree-sitter: unsupported grammar for *.mojo"
+            "stderr: tree-sitter: unsupported grammar for *.mojo\n"
+            "stdout: some stdout"
```

```
$ python3 -m pytest tests/test_code_graph.py -q --no-header -p no:warnings -rA | rg 'PASSED|FAILED'
PASSED tests/test_code_graph.py::TestFromStdoutCodeGraphLine::test_reports_the_code_graph_summary_line
PASSED tests/test_code_graph.py::TestFromStdoutCodeGraphLine::test_no_summary_line_when_init_says_nothing_about_it
PASSED tests/test_code_graph.py::TestFromStdoutCodeGraphLine::test_no_summary_line_on_empty_stdout
PASSED tests/test_code_graph.py::TestFromStdoutSemanticIndex::test_skipped_no_backend
PASSED tests/test_code_graph.py::TestFromStdoutSemanticIndex::test_built_with_backend_and_file_count
PASSED tests/test_code_graph.py::TestFromStdoutSemanticIndex::test_progress_ticks_do_not_shadow_the_terminal_line
PASSED tests/test_code_graph.py::TestFromStdoutSemanticIndex::test_attempted_failed_when_not_built
PASSED tests/test_code_graph.py::TestFromStdoutSemanticIndex::test_attempted_failed_when_partially_embedded
PASSED tests/test_code_graph.py::TestFromStdoutSemanticIndex::test_no_summary_line_when_init_says_nothing_about_semantic_index
PASSED tests/test_code_graph.py::TestFromStdoutSemanticIndex::test_the_states_are_pairwise_distinguishable
PASSED tests/test_code_graph.py::TestUnavailable::test_kind_names_the_exception_class
PASSED tests/test_code_graph.py::TestUnavailable::test_extracts_exit_code_and_stderr_from_a_nonzero_exit_message
FAILED tests/test_code_graph.py::TestUnavailableAgainstHarbor::test_harbors_own_exception_yields_the_exit_code_and_stderr
FAILED tests/test_code_graph.py::TestUnavailableAgainstHarbor::test_build_code_graph_records_what_harbor_raised
FAILED tests/test_code_graph.py::TestUnavailableAgainstHarbor::test_harbors_truncation_survives_the_parse
```

That is the whole point in one run: the hand-written test **passes** on a parser that no longer matches Harbor, and all three new tests fail. The failures are the right ones, not a constant — `KeyError: 'stderr'`, i.e. the `if match:` arm not firing, which is precisely the silent-drop the issue describes:

```
>       recovered = code_graph.unavailable(raised.value)["stderr"]
E       KeyError: 'stderr'
tests/test_code_graph.py:285: KeyError
```

Restored, and green:

```
$ python3 -m pytest tests/ -q -p no:warnings
763 passed, 2 skipped in 14.22s

$ python3 -m ruff check tests/test_code_graph.py
All checks passed!
$ python3 -m ruff format --check tests/test_code_graph.py
1 file already formatted
```

Run from `bench/harbor_adapter/` against the Harbor the adapter pins (`harbor 0.6.1`), as `.github/workflows/bench.yml` runs it — not through `make gate`.

## Deleted tests

None. `TestUnavailable`'s two existing tests are untouched and still pass; the issue explicitly keeps the hand-written one as a unit test of the regex, the point being that it is no longer the only one.

Closes #4899

## Summary by Sourcery

Verify that code-graph failure metadata remains compatible with Harbor’s actual exception messages.

Enhancements:
- Add integration tests that validate code-graph error parsing against exceptions produced by Harbor itself, including the production metadata path and Harbor’s stderr truncation behavior.

Tests:
- Exercise Harbor’s real non-zero-exit exception generation with exact exit-code and stderr assertions to detect message-format drift.