### PR TITLE
test(stella-cli): export.rs's two light gates are compared to each other

### DIFF
--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -594,7 +594,12 @@ fn render_dashboard(
      Two gates, the same pattern as docs/brand/css/tokens.css: the OS
      preference unless the page was told "dark" explicitly, and an explicit
      `data-theme` the reader can stamp. No colour is defined only inside the
-     media query, so the attribute wins in both directions. */
+     media query, so the attribute wins in both directions —
+     `crates/stella-cli/tests/design_token_parity.rs`'s
+     `each_surface_declares_one_scheme_per_gate` is what makes that true. It
+     was a sentence here and nothing else until #4942, and the Observatory is
+     what a sentence buys: its two gates drifted seventeen roles apart, and an
+     OS-light reader read #BFC1CC on paper at 1.68:1 (#4296). */
   @media (prefers-color-scheme: light) {{
     :root:not([data-theme="dark"]) {{
       color-scheme: light;

--- a/crates/stella-cli/tests/design_token_parity.rs
+++ b/crates/stella-cli/tests/design_token_parity.rs
@@ -308,10 +308,10 @@ fn scheme_gates(css: &str, scheme: &str) -> Vec<(String, BTreeMap<String, String
 /// What [`scheme_gates`] must find, so a scanner that quietly stops matching
 /// fails instead of passing over nothing.
 ///
-/// This half is not decoration. The bug being fixed is an *unread* gate, so
-/// "the gates agree" and "the scanner found one gate" produce the identical
-/// green — and the second is the state this test exists to end. Each row was
-/// counted by hand against the file it names.
+/// The bug being fixed is an *unread* gate. "The scanner found one gate" is
+/// the state this test exists to end, and it produces the same green as "the
+/// gates agree", so without a census the two are indistinguishable. Each row
+/// was counted by hand against the file it names.
 const GATE_CENSUS: [(&str, &str, usize); 6] = [
     // The two-gate surfaces: an OS-preference query and a toggle attribute.
     (

--- a/crates/stella-cli/tests/design_token_parity.rs
+++ b/crates/stella-cli/tests/design_token_parity.rs
@@ -125,8 +125,10 @@ const ROLES: [&str; 9] = [
 fn canonical() -> Vec<(&'static str, String, String)> {
     let observatory = read("crates/stella-observatory/src/assets/index.html");
     let dark = declarations(between(&observatory, "BEGIN palette", "END palette"));
-    // The explicit gate, not the media query: identical values, and it is the
-    // one a reader's own toggle reaches.
+    // The explicit gate, not the media query. It is the one a reader's own
+    // toggle reaches, and the two carry the same values — which is now a fact
+    // `each_surface_declares_one_scheme_per_gate` checks rather than a claim
+    // this comment makes.
     let light = declarations(between(&observatory, r#":root[data-theme="light"]"#, "\n}"));
 
     let role = |name: &str| -> (String, String) {
@@ -148,6 +150,249 @@ fn canonical() -> Vec<(&'static str, String, String)> {
             (r, dark, light)
         })
         .collect()
+}
+
+/// `css` with every `/* … */` comment removed.
+///
+/// The gate scanner below matches on selector text, and these files carry more
+/// prose than declarations — `export.rs`'s own light-mode header spells
+/// `data-theme` in a sentence, and the Observatory's toggle script quotes
+/// `@media (prefers-color-scheme: light)` inside a `String.replace`. A scanner
+/// that reads those as gates extracts whatever braces follow a sentence.
+fn strip_comments(css: &str) -> String {
+    let mut out = String::with_capacity(css.len());
+    let mut rest = css;
+    while let Some(open) = rest.find("/*") {
+        out.push_str(&rest[..open]);
+        match rest[open..].find("*/") {
+            Some(close) => rest = &rest[open + close + 2..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Every `--token: value` declaration in a block, custom properties only, with
+/// the value taken verbatim rather than parsed.
+///
+/// [`declarations`] keeps only `#rrggbb`, because the parity matrix compares
+/// colours across three vocabularies. Two gates of *one* surface are the same
+/// author writing the same block twice, so everything they say is comparable —
+/// `rgba(10,10,12,.06)` and `color-scheme` included, and those are precisely
+/// the declarations a copy-paste edit forgets.
+fn gate_declarations(block: &str) -> BTreeMap<String, String> {
+    let mut found = BTreeMap::new();
+    // Braces end a declaration as surely as a semicolon does, and a media
+    // query's block opens with a nested `:root{` — so without this the first
+    // declaration inside it reads as part of that selector and vanishes, which
+    // is a *silent* loss: the token then looks absent from the gate rather
+    // than mismatched.
+    let block = block.replace(['{', '}'], ";");
+    for decl in block.split(';') {
+        let Some((name, value)) = decl.split_once(':') else {
+            continue;
+        };
+        let name = name.trim();
+        if !name.starts_with("--")
+            || !name[2..]
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        {
+            continue;
+        }
+        let value = value.trim().to_ascii_lowercase();
+        if !value.is_empty() {
+            found.insert(name.to_string(), value);
+        }
+    }
+    found
+}
+
+/// The block opened by the first `{` at or after `from`, brace-balanced.
+///
+/// `export.rs` is a Rust `format!` string, so its CSS braces are doubled. That
+/// is invisible to a balanced count — `{{` is +2 and `}}` is -2 — and so are
+/// the file's `{placeholder}` interpolations, which are +1 then -1.
+fn balanced_block(css: &str, from: usize) -> Option<&str> {
+    let open = from + css[from..].find('{')?;
+    let mut depth = 0usize;
+    for (offset, byte) in css[open..].bytes().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&css[open + 1..open + offset]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Where a `:root` selector's block starts, if the selector is bare — i.e. the
+/// text after it is whitespace and then `{`.
+///
+/// The Observatory declares `:root[data-theme="light"] .bword-dark{…}` for its
+/// wordmark swap and `:root[data-theme="light"] .theme-toggle .i-sun{…}` for
+/// its icon swap. Those are the same gate qualifying one element, not a second
+/// declaration of the scheme, and they carry no custom property at all.
+fn bare_root_block(css: &str, after: usize) -> Option<&str> {
+    let tail = &css[after..];
+    let gap = tail.len() - tail.trim_start().len();
+    if !tail[gap..].starts_with('{') {
+        return None;
+    }
+    balanced_block(css, after + gap)
+}
+
+/// Every block in `css` that declares the named scheme, as
+/// `(selector, its declarations)`.
+///
+/// Discovery is by selector rather than by a per-surface marker list, which is
+/// the point: a surface that *grows* a second gate is covered the moment it
+/// does. That is how `export.rs`'s unchecked half arrived — the matrix named
+/// one gate, the file grew two.
+///
+/// A gate declaring no custom property is dropped rather than compared: it is
+/// styling an element under the scheme, not declaring the scheme.
+fn scheme_gates(css: &str, scheme: &str) -> Vec<(String, BTreeMap<String, String>)> {
+    let css = strip_comments(css);
+    let mut gates = Vec::new();
+
+    let attribute = format!(r#":root[data-theme="{scheme}"]"#);
+    for (index, _) in css.match_indices(attribute.as_str()) {
+        if let Some(block) = bare_root_block(&css, index + attribute.len()) {
+            gates.push((attribute.clone(), gate_declarations(block)));
+        }
+    }
+
+    // Both CSS spellings of the query, and `not(…)` cannot appear in either:
+    // `:root:not([data-theme="dark"])` is the light gate's *inner* selector and
+    // is reached as part of the query's block, never as a gate of its own.
+    for spacing in [" ", ""] {
+        let query = format!("@media (prefers-color-scheme:{spacing}{scheme})");
+        for (index, _) in css.match_indices(query.as_str()) {
+            if let Some(block) = balanced_block(&css, index + query.len()) {
+                gates.push((query.clone(), gate_declarations(block)));
+            }
+        }
+    }
+
+    gates.retain(|(_, declarations)| !declarations.is_empty());
+    gates
+}
+
+/// **A surface's gates for one scheme declare one scheme, not several.**
+///
+/// The OS-preference gate and the explicit `data-theme` gate paint the same
+/// page for different readers — one who left their desktop on light, one who
+/// clicked the toggle — so a role that differs between them is one design
+/// shipping in two casts, and the matrix above reads only one of them.
+///
+/// The Observatory had drifted exactly that way: its media query kept the
+/// pre-v5.0 cool-graphite neutrals while its attribute gate moved to the
+/// product ramp, seventeen roles apart, and the worst was an absence — nothing
+/// re-pointed `--text-emph`, so an OS-light reader got `#BFC1CC` on paper at
+/// 1.68:1. #4296 fixed that surface and
+/// `crates/stella-observatory/tests/light_mode.rs` holds it there.
+///
+/// `crates/stella-cli/src/export.rs` has the same two gates and had no such
+/// test. What stood in for one was a sentence in the file — *"No colour is
+/// defined only inside the media query, so the attribute wins in both
+/// directions"* — and `canonical()`'s own comment, *"identical values"*. Both
+/// were true and neither was checked, which is the same position the
+/// Observatory was in the day before it drifted.
+/// What [`scheme_gates`] must find, so a scanner that quietly stops matching
+/// fails instead of passing over nothing.
+///
+/// This half is not decoration. The bug being fixed is an *unread* gate, so
+/// "the gates agree" and "the scanner found one gate" produce the identical
+/// green — and the second is the state this test exists to end. Each row was
+/// counted by hand against the file it names.
+const GATE_CENSUS: [(&str, &str, usize); 6] = [
+    // The two-gate surfaces: an OS-preference query and a toggle attribute.
+    (
+        "crates/stella-observatory/src/assets/index.html",
+        "light",
+        2,
+    ),
+    ("crates/stella-cli/src/export.rs", "light", 2),
+    // No `data-theme` gate by design — neither page has a toggle to hang one
+    // on, so the media query is the whole light scheme.
+    (
+        "crates/stella-transcript/src/html/transcript.css",
+        "light",
+        1,
+    ),
+    // The benchmark pages declare light in a bare `:root` and repeat it under
+    // the attribute; the base block is not a gate and is not counted here.
+    ("docs/benchmarks/index.html", "dark", 2),
+    ("docs/benchmarks/terminal-bench-2-1-glm-5-2.html", "dark", 2),
+    ("docs/benchmarks/index.html", "light", 1),
+];
+
+#[test]
+fn each_surface_declares_one_scheme_per_gate() {
+    let mut files: Vec<&'static str> = vec!["crates/stella-observatory/src/assets/index.html"];
+    files.extend(surfaces().iter().map(|s| s.file));
+
+    for (file, scheme, want) in GATE_CENSUS {
+        let found = scheme_gates(&read(file), scheme).len();
+        assert_eq!(
+            found, want,
+            "{file}: the scanner found {found} {scheme} gate(s), not {want}. \
+             Either the file changed or the scanner stopped seeing a gate — \
+             and an unseen gate is the exact defect this test exists to catch, \
+             so it must not pass silently."
+        );
+    }
+
+    let mut drift = Vec::new();
+    for file in files {
+        let text = read(file);
+        for scheme in ["light", "dark"] {
+            let gates = scheme_gates(&text, scheme);
+            let Some(((first_selector, first), rest)) = gates.split_first() else {
+                continue;
+            };
+            for (selector, other) in rest {
+                for (token, want) in first {
+                    match other.get(token) {
+                        Some(got) if got == want => {}
+                        Some(got) => drift.push(format!(
+                            "{file}: {scheme} `{token}` is {got} under `{selector}` \
+                             and {want} under `{first_selector}`"
+                        )),
+                        None => drift.push(format!(
+                            "{file}: {scheme} `{token}` is declared under \
+                             `{first_selector}` and absent from `{selector}`, \
+                             which therefore inherits whatever the page's \
+                             default scheme says"
+                        )),
+                    }
+                }
+                for token in other.keys() {
+                    if !first.contains_key(token) {
+                        drift.push(format!(
+                            "{file}: {scheme} `{token}` is declared under \
+                             `{selector}` and absent from `{first_selector}`"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        drift.is_empty(),
+        "{} gate disagreement(s); a reader who uses their OS preference and a \
+         reader who clicked a toggle see different casts of the same page:\n  {}",
+        drift.len(),
+        drift.join("\n  ")
+    );
 }
 
 /// A derived surface: where it lives, and how it spells each canonical role.


### PR DESCRIPTION
`crates/stella-cli/src/export.rs` declares its light scheme twice and only one gate was ever checked.

## What was unchecked

`design_token_parity.rs::canonical()` reads `:root[data-theme="light"]`, and said so in a comment: *"The explicit gate, not the media query: identical values"*. `export.rs` made the same promise in its own prose: *"No colour is defined only inside the media query, so the attribute wins in both directions."* Both were true. Neither was a check.

That is the exact position the Observatory was in the day before it drifted — its media query kept the pre-v5.0 cool-graphite neutrals while the attribute gate moved to the product ramp, seventeen roles apart, and the worst was an *absence*: nothing re-pointed `--text-emph`, so an OS-light reader read `#BFC1CC` on paper at **1.68:1** (#4296).

## The approach

The issue offers two shapes and prefers the generalised one, which is what this ships. `scheme_gates()` discovers a surface's gates **by selector** rather than from a per-surface marker list, so a surface that *grows* a second gate is covered the moment it does — which is how this hole arrived in the first place.

Three details that are load-bearing rather than incidental:

- **It compares every custom property, not only `#rrggbb`.** Two gates of one surface are the same author writing the same block twice, so `--accent-wash: rgba(10,10,12,.06)` and `color-scheme` are comparable too — and those are precisely what a copy-paste edit forgets. The parity matrix's own `declarations()` stays hex-only, because it compares across three vocabularies.
- **A gate declaring no custom property is dropped.** The Observatory has `:root[data-theme="light"] .bword-dark{display:none}` and a matching icon swap: those style an element *under* a scheme, they do not declare one.
- **`GATE_CENSUS` pins what the scanner must find.** Without it, "the gates agree" and "the scanner stopped seeing a gate" produce the identical green — and the second is the state this test exists to end.

## Scope

The issue's table is correct: `export.rs` was the one remaining hole of this shape. The **dark** gates on the two benchmark pages — one of the "two smaller unchecked regions" it flags for the same pass — are covered by the same helper at no extra cost: each page declares dark twice, both agree today, and neither was read.

The other region, each benchmark page's base `:root{` block (which *is* that page's light scheme, repeated under the attribute gate), is filed as a follow-up rather than folded in: reading a bare `:root` as a scheme needs a per-surface fact about which scheme a page defaults to, and that is config, not discovery.

## Witness

Reverting `--text-2` to the pre-v5.0 `#4D535A` in **export.rs's media query alone**:

```
running 12 tests
test every_web_surface_agrees_with_the_observatory_palette ... ok
test the_transcript_ramp_steps_agree_with_the_observatory ... ok
test every_wash_is_a_channel_copy_of_a_declared_colour ... ok
test each_surface_declares_one_scheme_per_gate ... FAILED
[... every other test ok ...]

---- each_surface_declares_one_scheme_per_gate stdout ----
1 gate disagreement(s); a reader who uses their OS preference and a reader
who clicked a toggle see different casts of the same page:
  crates/stella-cli/src/export.rs: light `--text-2` is #4d535a under
  `@media (prefers-color-scheme: light)` and #4b4b56 under
  `:root[data-theme="light"]`

test result: FAILED. 11 passed; 1 failed
```

**11 passed** is the measurement: the parity matrix and every other test in the file are green on a tree whose light scheme now ships in two casts. That is the hole, stated as a number.

The absence case — `--control-edge` deleted from the media query, which is #4296's real failure mode:

```
  crates/stella-cli/src/export.rs: light `--control-edge` is declared under
  `:root[data-theme="light"]` and absent from
  `@media (prefers-color-scheme: light)`, which therefore inherits whatever
  the page's default scheme says
```

Clean tree: `12 passed; 0 failed`.

## Also

Both comments that stood in for the check now name the test that performs it.

Closes #4942
Refs #4072, #4296

## Summary by Sourcery

Ensure every discovered color-scheme gate declares an identical custom-property scheme and remains covered by the parity tests.

Bug Fixes:
- Add coverage that detects mismatched or missing custom-property declarations between light and dark scheme gates across web surfaces.

Enhancements:
- Generalize scheme-gate discovery by selector and validate all custom properties, including non-hex values.
- Add gate-count census checks so scanner regressions and newly added gates cannot pass unnoticed.
- Update palette comments to reference the automated parity check instead of serving as unchecked assertions.

Tests:
- Add tests covering light and dark gate parity for the Observatory, CLI export, transcript, and benchmark surfaces.