### PR TITLE
fix(stella-cli): `plugin remove` names the MCP servers it took away

### DIFF
--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -613,6 +613,21 @@ fn configure_lines(workspace_root: &Path, plugin: &roster::InstalledPlugin) -> V
 /// collected and reported at the end, naming every directory, while the
 /// copies that did go are still removed and still reported.
 fn remove(workspace_root: &Path, name: &str) -> Result<(), String> {
+    remove_reporting(workspace_root, name, &mut |line| println!("{line}"))
+}
+
+/// [`remove`], with its stdout lines handed to `report` rather than printed.
+///
+/// The seam exists so what a removal *says* is testable — it is the whole
+/// subject of #4904 — without a test having to capture the process's stdout.
+/// A sink rather than a returned `Vec` because the lines are interleaved with
+/// the deletes and with the `eprintln!` warnings, and a report that arrives
+/// after the work is a report that cannot be ordered against it.
+fn remove_reporting(
+    workspace_root: &Path,
+    name: &str,
+    report: &mut dyn FnMut(String),
+) -> Result<(), String> {
     let name = checked_name(name)?;
     let mut removed = 0usize;
     let mut failures: Vec<String> = Vec::new();
@@ -640,6 +655,9 @@ fn remove(workspace_root: &Path, name: &str) -> Result<(), String> {
             // resolvable to a `stella.toml` yields `None`, which `revert`
             // treats as "nothing can be put back" rather than redirected.
             let expected = configure::ConfigTarget::resolve(workspace_root, scope).ok();
+            // Also before the directory goes: the `[servers]` keys are read out
+            // of the package's own `mcp.toml`, which is inside it (#4904).
+            let servers = package::Inventory::of_package(&dir).mcp;
             let reverted = installs
                 .iter()
                 .find(|plugin| plugin.dir == dir)
@@ -671,20 +689,34 @@ fn remove(workspace_root: &Path, name: &str) -> Result<(), String> {
             if let Some(entry) = dir.file_name().and_then(|entry| entry.to_str()) {
                 receipt::forget(&tier, entry);
             }
-            println!(
+            report(format!(
                 "removed `{name}` ({}) from {}",
                 scope.as_str(),
                 dir.display()
-            );
+            ));
+            // Named, unlike the other three contribution kinds, because a
+            // server is a process the host connects to and its tools were in
+            // the model's registry under `mcp__<server>__*`. A tool, skill or
+            // record is inert until something selects it, so its absence is
+            // never mistaken for a fault; a server that stops answering looks
+            // like a broken connection, and a user who is not told the removal
+            // is what took it away goes looking for one (#4904).
+            if !servers.is_empty() {
+                report(format!(
+                    "  MCP servers gone: {} — no `mcp__<server>__*` tools from {} next session",
+                    servers.join(", "),
+                    if servers.len() == 1 { "it" } else { "them" }
+                ));
+            }
             if !reverted.keys.is_empty()
                 && let Some(config) = &reverted.config
             {
-                println!(
+                report(format!(
                     "  put back {} in {}: {}",
                     reverted.keys.len(),
                     config.display(),
                     reverted.keys.join(", ")
-                );
+                ));
             }
             // The honest half. A `remove` that reported success while leaving a
             // package's configuration in force is the failure this whole

--- a/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
@@ -902,3 +902,56 @@ fn a_contributed_record_and_skill_each_name_their_plugin_as_a_field() {
     remove(&root, "vera").expect("remove must succeed");
     let _ = std::fs::remove_dir_all(&root);
 }
+
+/// **The retraction-notice witness** (#4904). `stella plugin remove` names the
+/// MCP servers it just took away.
+///
+/// A tool, skill or record a package shipped is inert until something selects
+/// it, so its absence is never read as a fault. A server is a process the host
+/// connects to, and its tools were in the model's registry as
+/// `mcp__<server>__*` — a user who is not told the removal is what took them
+/// away goes looking for a broken connection instead. The removal already
+/// names every reverted `[[configure]]` key, which is the precedent.
+#[test]
+fn removing_a_package_names_the_mcp_servers_it_took_away() {
+    let _env = crate::test_env::lock();
+    let _restore =
+        crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT", "STELLA_PROJECT_HOOKS"]);
+    let root = temp_root("package-mcp-retraction-notice");
+    let _paths = crate::paths::test_user_home(root.join("home"));
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+
+    let source = package(&root, "vera");
+    ships_a_package(&source, "vera");
+    ships_a_server(&source, "vera", "acme");
+    install(
+        &root,
+        &source,
+        PluginScope::Project,
+        true,
+        &Settings::default(),
+    )
+    .expect("install must succeed");
+
+    let mut said: Vec<String> = Vec::new();
+    super::super::remove_reporting(&root, "vera", &mut |line| said.push(line))
+        .expect("remove must succeed");
+    let said = said.join("\n");
+    assert!(
+        said.contains("removed `vera`"),
+        "anti-vacuity — the removal reported at all:\n{said}"
+    );
+    assert!(
+        said.contains("acme"),
+        "the removal names the server it took away:\n{said}"
+    );
+
+    let mut notices = Vec::new();
+    assert!(
+        package::contributed_mcp_servers(&root, &mut notices).is_empty(),
+        "and it really is gone — the notice is not the only thing that changed"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## What

`stella plugin remove <name>` now names each MCP server the package was contributing.

```
removed `vera` (project) from /repo/.stella/plugins/vera
  MCP servers gone: acme — no `mcp__<server>__*` tools from it next session
```

## Why

The removal already reported the directory it deleted and every reverted `[[configure]]` key, and said nothing about the servers.

The other three contribution kinds are inert until something selects them, so their absence is never read as a fault. An MCP server is a process the host connects to, and its tools were in the model's registry under `mcp__<server>__*`. A user who installed a package for its MCP tools got no confirmation that removing the package is what took them away, so the natural next move was to go looking for a broken connection. The `[[configure]]` lines already set the precedent that a reverted contribution is announced.

## How

- `package::Inventory::of_package(&dir).mcp` is read **before** the directory is deleted — the `[servers]` keys live in the package's own `mcp.toml`, inside it. It sits beside the `[[configure]]` journal read that already had that ordering constraint.
- `remove` is split into a thin printer and `remove_reporting`, which takes its stdout lines as a `&mut dyn FnMut(String)` sink. That is what makes *what a removal says* testable without capturing the process's stdout. A sink rather than a returned `Vec` because the lines interleave with the deletes and with the `eprintln!` warnings, and a report that arrives after the work cannot be ordered against it.

## Witness

`removing_a_package_names_the_mcp_servers_it_took_away` in `crates/stella-cli/src/plugin_cmd/tests/contributions.rs`, built on the existing `ships_a_server` fixture.

Ablated by deleting the new report line (and leaving the inventory read in place, so the ablation removes the *answer*, not the compile):

```
thread '...::removing_a_package_names_the_mcp_servers_it_took_away' panicked at
crates/stella-cli/src/plugin_cmd/tests/contributions.rs:945:5:
the removal names the server it took away:
removed `vera` (project) from /var/folders/.../.stella/plugins/vera

test result: FAILED. 0 passed; 1 failed
```

The test also asserts `removed \`vera\`` appears (anti-vacuity) and that `contributed_mcp_servers` really is empty afterwards, so it cannot pass on a notice about a retraction that did not happen.

## No deleted or renamed tests

Nothing removed or renamed; one test added.

## Verification

`cargo fmt --all --check`, `cargo clippy -p stella-cli --all-targets -- -D warnings`, `make guards-fast`, and `cargo test -p stella-cli --bins contributions::` (13 passed) locally. CI is the evidence.

Closes #4904

## Summary by Sourcery

Tell users which MCP servers are removed when uninstalling a plugin package.

New Features:
- Report the MCP servers removed with each plugin package so users know which server tools will disappear in the next session.

Enhancements:
- Separate removal reporting from console output to make notification ordering and behavior testable.

Tests:
- Add coverage verifying that removing a package reports its MCP servers and actually removes their contributions.