### PR TITLE
fix(stella-cli): route a contributed skill by contributed_by, not by its path

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
@@ -955,3 +955,77 @@ fn removing_a_package_names_the_mcp_servers_it_took_away() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+/// **The tier-lookup witness** (#4905). A contributed skill is routed to its
+/// package's install tier by [`stella_core::skills::Skill::contributed_by`],
+/// the field the loader stamps — not by matching its `source_path` against the
+/// package directory.
+///
+/// The two agree for a skill loaded straight out of `<plugin_dir>/skills`,
+/// which is why the path match survived. They stop agreeing the moment the
+/// directory is resolved rather than joined — a symlinked tier, a
+/// canonicalised package root — and the skill then matches neither tier's
+/// disable list, so a skill the user switched off in the SKILLS tab silently
+/// comes back on. The `source_path` here is that case: outside the package
+/// directory and outside both scope roots.
+#[test]
+fn a_contributed_skills_tier_is_read_off_contributed_by_not_off_its_path() {
+    let _env = crate::test_env::lock();
+    let _restore =
+        crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT", "STELLA_PROJECT_HOOKS"]);
+    let root = temp_root("package-skill-tier-lookup");
+    let _paths = crate::paths::test_user_home(root.join("home"));
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+
+    let source = package(&root, "vera");
+    ships_a_package(&source, "vera");
+    install(
+        &root,
+        &source,
+        PluginScope::Project,
+        true,
+        &Settings::default(),
+    )
+    .expect("install must succeed");
+
+    // The package is installed at the project tier, so that is the tier whose
+    // state file governs its skills — and the tab writes into it by name.
+    crate::skill_manager::set_enabled(stella_tui::SkillScope::Project, "house-style", false, &root)
+        .expect("disable must succeed");
+
+    let elsewhere = |name: &str| stella_core::skills::Skill {
+        name: name.to_string(),
+        description: "how this shop writes code".to_string(),
+        domains: Vec::new(),
+        body: "PACKAGE_SKILL_MARKER".to_string(),
+        // Neither under a scope root nor under the package directory: the
+        // case a path prefix cannot see.
+        source_path: root
+            .join("somewhere-else")
+            .join("SKILL.md")
+            .display()
+            .to_string(),
+        origin: stella_core::skills::SkillOrigin::Contributed,
+        contributed_by: Some("vera".to_string()),
+    };
+
+    let mut skills = vec![elsewhere("house-style")];
+    crate::skill_manager::retain_enabled(&mut skills, &root);
+    assert!(
+        skills.is_empty(),
+        "a disabled contributed skill is dropped however its path reads: {skills:?}"
+    );
+
+    // The other direction, so the assertion above cannot pass by dropping
+    // everything: the same skill under the same package, not switched off.
+    let mut still_on = vec![elsewhere("other-style")];
+    crate::skill_manager::retain_enabled(&mut still_on, &root);
+    assert_eq!(
+        still_on.len(),
+        1,
+        "and one that was never disabled still loads"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/stella-cli/src/skill_manager.rs
+++ b/crates/stella-cli/src/skill_manager.rs
@@ -312,13 +312,22 @@ pub fn disabled_names(scope_root: &Path) -> HashSet<String> {
 
 /// Drop disabled skills from a merged skill list (used by the recall/selection
 /// path so a disabled skill is never injected — its file stays on disk). A
-/// skill is matched to its scope by `source_path` containment.
+/// skill the user wrote is matched to its scope by `source_path` containment.
 ///
 /// A contributed skill lives under its package's directory rather than either
-/// scope root, so containment alone never reaches it and it could not be
-/// turned off at all. It is matched instead to the tier its package is
-/// installed at — the same tier [`enumerate`] gives its row, so unchecking it
-/// in the tab is what turns it off here.
+/// scope root, so containment never reaches it and it could not be turned off
+/// at all. It is matched instead to the tier its package is installed at — the
+/// same tier [`enumerate`] gives its row, so unchecking it in the tab is what
+/// turns it off here.
+///
+/// **Which package** is read off [`Skill::contributed_by`], the field the
+/// loader stamps when it chooses the directory (#3567), and never off the
+/// path. A path prefix is a second authority over an answer the loader already
+/// gave: it agrees only while a contributed skill's `source_path` literally
+/// begins with the directory it was found in, and a skills directory that is
+/// resolved rather than joined — a symlinked tier, a package root behind a
+/// canonicalised path — silently routes the skill to neither list, so a
+/// disabled skill quietly comes back on (#4905).
 pub fn retain_enabled(skills: &mut Vec<Skill>, workspace_root: &Path) {
     let project = scope_root(SkillScope::Project, workspace_root);
     let user = scope_root(SkillScope::User, workspace_root);
@@ -328,17 +337,22 @@ pub fn retain_enabled(skills: &mut Vec<Skill>, workspace_root: &Path) {
     skills.retain(|s| {
         let source = Path::new(&s.source_path);
         let under = |root: &Option<PathBuf>| root.as_ref().is_some_and(|r| source.starts_with(r));
-        if under(&project) {
-            !project_disabled.contains(&s.name)
-        } else if under(&user) {
-            !user_disabled.contains(&s.name)
-        } else if let Some(dir) = contributed.iter().find(|dir| source.starts_with(&dir.dir)) {
-            match scope_of(dir.scope) {
-                SkillScope::Project => !project_disabled.contains(&s.name),
-                SkillScope::User => !user_disabled.contains(&s.name),
-            }
-        } else {
-            true
+        let tier = match s.contributed_by.as_deref() {
+            Some(plugin) => contributed
+                .iter()
+                .find(|dir| dir.plugin == plugin)
+                .map(|dir| scope_of(dir.scope)),
+            None if under(&project) => Some(SkillScope::Project),
+            None if under(&user) => Some(SkillScope::User),
+            None => None,
+        };
+        match tier {
+            Some(SkillScope::Project) => !project_disabled.contains(&s.name),
+            Some(SkillScope::User) => !user_disabled.contains(&s.name),
+            // Neither tier governs it: a skill from somewhere else entirely, or
+            // one naming a package that is no longer installed. Nothing can have
+            // been switched off for it, so it stays.
+            None => true,
         }
     });
 }


### PR DESCRIPTION
## What

`skill_manager::retain_enabled` reaches a contributed skill's install tier through `Skill::contributed_by` and a roster lookup, instead of matching `source_path` against every contributed directory. No `source_path.starts_with(<package dir>)` remains in `skill_manager.rs` — the containment that stays is against the user's own scope roots, where it is the only answer there is.

## Why

#3567 gave a contributed skill a field so nothing has to parse `source_path` to answer "which plugin gave me this?". `retain_enabled` was the caller still doing it — a second authority over an answer the loader already stamped one line away.

The two agree today, which is why it survived. They stop agreeing the moment a package's skills directory is resolved rather than joined — a symlinked tier, a canonicalised package root. The skill then matches neither the project root, nor the user root, nor any `dir.dir`, falls to the `else { true }` arm, and a skill the user switched off in the SKILLS tab silently comes back on in the prompt.

`retain_enabled` does not want the plugin's *name*, it wants its *install scope*, so the lookup keys `contributed_by` against `contributed_skill_dirs`, which already yields both `plugin` and `scope`.

The `else` arm is now an explicit `None` with a comment: a skill from somewhere else entirely, or one naming a package no longer installed. Nothing can have been switched off for it, so it stays.

## Witness

`a_contributed_skills_tier_is_read_off_contributed_by_not_off_its_path` in `crates/stella-cli/src/plugin_cmd/tests/contributions.rs`: install `vera` at the project tier, disable `house-style` there, then hand `retain_enabled` a `Skill` carrying `contributed_by: Some("vera")` and a `source_path` under neither scope root nor the package directory — the case a path prefix cannot see.

Ablated back to the path match:

```
thread '...::a_contributed_skills_tier_is_read_off_contributed_by_not_off_its_path'
panicked at crates/stella-cli/src/plugin_cmd/tests/contributions.rs:1015:5:
a disabled contributed skill is dropped however its path reads: [Skill { name: "house-style",
description: "how this shop writes code", domains: [], body: "PACKAGE_SKILL_MARKER",
source_path: "/var/folders/.../somewhere-else/SKILL.md", origin: Contributed,
contributed_by: Some("vera") }]

test result: FAILED. 0 passed; 1 failed
```

The ablation makes the answer wrong rather than constant: the test asserts both directions, so a `retain_enabled` that dropped everything would fail the second half (`other-style`, never disabled, still loads).

## No deleted or renamed tests

Nothing removed or renamed; one test added.

## Verification

`cargo fmt --all --check`, `cargo clippy -p stella-cli --all-targets -- -D warnings`, `make guards-fast`, and `cargo test -p stella-cli --bins contributions::` (12 passed) locally. CI is the evidence.

Closes #4905

## Summary by Sourcery

Fix contributed skill filtering so package identity, rather than source-path matching, determines which install-tier disable state applies.

Bug Fixes:
- Route contributed skills to their package's installed scope using the loader-provided package identity, ensuring disabled skills remain disabled even when their paths do not match package directories.

Enhancements:
- Preserve path-based scope detection for user-owned skills while explicitly retaining skills with no applicable installed scope.

Tests:
- Add coverage for contributed skill tier resolution when the skill source path is outside both scope roots and its package directory.