### PR TITLE
fix(stella-tui-theme,design): retire the comment token and state the syntax palette that ships

### DIFF
--- a/crates/stella-tui-theme/src/fallback.rs
+++ b/crates/stella-tui-theme/src/fallback.rs
@@ -63,7 +63,7 @@ pub fn ansi16(color: Color) -> Color {
         token::GOLD | token::GOLD_BRIGHT => Color::Yellow,
         token::SILVER | token::SILVER_TYPE => Color::Gray,
         token::TEXT => Color::White,
-        token::MUTED | token::DIM | token::COMMENT => Color::DarkGray,
+        token::MUTED | token::DIM => Color::DarkGray,
         token::GREEN => Color::Green,
         token::RED => Color::Red,
         // The light-theme stops. They reach the terminal only when a paper

--- a/crates/stella-tui-theme/src/token.rs
+++ b/crates/stella-tui-theme/src/token.rs
@@ -122,9 +122,6 @@ pub const MUTED: Color = Color::Rgb(0x77, 0x77, 0x82);
 /// Hints, captions, line numbers. `#4B4B56`
 pub const DIM: Color = Color::Rgb(0x4B, 0x4B, 0x56);
 
-/// Code comments. `#565660`
-pub const COMMENT: Color = Color::Rgb(0x56, 0x56, 0x60);
-
 /// Pass, additive diff sign. `#74C991`
 pub const GREEN: Color = Color::Rgb(0x74, 0xC9, 0x91);
 
@@ -190,7 +187,6 @@ pub const ALL: &[(&str, Color, Clamp)] = &[
     ("text", TEXT, Clamp::NeutralGray),
     ("muted", MUTED, Clamp::NeutralGray),
     ("dim", DIM, Clamp::NeutralGray),
-    ("comment", COMMENT, Clamp::NeutralGray),
     ("green", GREEN, Clamp::Verdict),
     ("red", RED, Clamp::Verdict),
     ("diff-add-bg", DIFF_ADD_BG, Clamp::Surface),

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -192,6 +192,19 @@ pub const GOLD_LIVE: Color = palette::GOLD_LIVE;
 /// Primary text.
 pub const INK: Color = TEXT_PRIMARY;
 /// Dimmed secondary text.
+///
+/// **This is `silver`, not the `muted` tier.** It resolves to
+/// [`palette::TEXT_SECONDARY`], which is `stella_tui_theme::token::SILVER`
+/// `#A9AAB5` — a different colour from `token::MUTED` `#777782`, one tier
+/// brighter, and two tiers from `token::DIM`. The word is shared and the value
+/// is not, so a call site reaching for "the muted tier" and writing
+/// [`muted()`] gets silver.
+///
+/// That is not hypothetical. `crate::diff`'s `gutter` paints [`muted()`], and
+/// `design/tui-v2/SPEC.md` §6.4 recorded the result as *"Line number gutter in
+/// `dim`"* — wrong by two tiers, for as long as both existed. #4946 corrected
+/// the spec against the code; #4966 is where renaming this constant is being
+/// decided, and until it is, the name is checked against nothing.
 pub const MUTED: Color = TEXT_SECONDARY;
 /// Panel border / rule.
 pub const RULE: Color = HAIRLINE;

--- a/crates/stella-tui/tests/spec_syntax_palette.rs
+++ b/crates/stella-tui/tests/spec_syntax_palette.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! **`design/tui-v2/SPEC.md` §6.4 describes the highlighter that ships.**
+//!
+//! §6.4 named the syntax palette in one sentence — *"keywords gold, types
+//! silver_type, identifiers text, comments comment, strings silver, primitives
+//! silver_type"* — and every clause of it was false. Keywords ride the bright
+//! neutral, strings are a green at the scheme's own chroma, numbers are violet,
+//! and the grammar-backed lexer (#4283) added a type and a function position
+//! the sentence predates entirely. Comments were the clause that got noticed
+//! (#4946): the `comment` token the sentence named was painted by nothing
+//! anywhere in the tree, and the highlighter has always used the caption tier.
+//!
+//! A specification that disagrees with the code in six of six roles is worse
+//! than none, because it is read as the answer. So the sentence is now a table
+//! between two markers, and this test is what makes the table true: it reads
+//! §6.4 and holds every row to the constant it names.
+//!
+//! It reads the file as text rather than generating it. Generation would make
+//! the spec a projection of the code, and the point of a spec is that it can
+//! disagree — a row that no longer matches is a decision someone has to make,
+//! which is the conversation this file exists to force rather than to
+//! foreclose.
+
+use std::path::{Path, PathBuf};
+
+use ratatui::style::Color;
+use stella_tui::theme;
+
+const BEGIN: &str = "<!-- BEGIN syntax palette -->";
+const END: &str = "<!-- END syntax palette -->";
+
+fn spec() -> String {
+    let path: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../design/tui-v2/SPEC.md")
+        .canonicalize()
+        .expect("design/tui-v2/SPEC.md resolves from CARGO_MANIFEST_DIR");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// The constants §6.4 is allowed to name, and their shipped values.
+///
+/// Spelled here rather than looked up, because Rust has no reflection over
+/// module constants — and spelling them is what makes the table's *coverage*
+/// checkable: a `SYNTAX_*` constant that grows without a row is caught by
+/// `every_syntax_constant_has_a_row` below, which is the half a value
+/// comparison alone would miss.
+fn shipped() -> Vec<(&'static str, Color)> {
+    vec![
+        ("SYNTAX_KEYWORD", theme::SYNTAX_KEYWORD),
+        ("SYNTAX_STRING", theme::SYNTAX_STRING),
+        ("SYNTAX_NUMBER", theme::SYNTAX_NUMBER),
+        ("SYNTAX_COMMENT", theme::SYNTAX_COMMENT),
+        ("SYNTAX_TYPE", theme::SYNTAX_TYPE),
+        ("SYNTAX_FUNCTION", theme::SYNTAX_FUNCTION),
+    ]
+}
+
+fn hex(color: Color) -> String {
+    match color {
+        Color::Rgb(r, g, b) => format!("#{r:02X}{g:02X}{b:02X}"),
+        other => panic!("a syntax role must be a truecolor value, not {other:?}"),
+    }
+}
+
+/// `(constant, stated hex)` for every row of §6.4's table.
+fn rows(markdown: &str) -> Vec<(String, String)> {
+    let from = markdown
+        .find(BEGIN)
+        .unwrap_or_else(|| panic!("design/tui-v2/SPEC.md carries no `{BEGIN}`"))
+        + BEGIN.len();
+    let len = markdown[from..]
+        .find(END)
+        .unwrap_or_else(|| panic!("no `{END}` after `{BEGIN}`"));
+    markdown[from..from + len]
+        .lines()
+        .filter_map(|line| {
+            let cells: Vec<&str> = line.trim().trim_matches('|').split('|').collect();
+            if cells.len() != 3 {
+                return None;
+            }
+            let constant = cells[1].trim().trim_matches('`');
+            let value = cells[2].trim().trim_matches('`');
+            if !constant.starts_with("SYNTAX_") || !value.starts_with('#') {
+                return None;
+            }
+            Some((constant.to_string(), value.to_ascii_uppercase()))
+        })
+        .collect()
+}
+
+/// Every value §6.4 states is the value that constant carries.
+#[test]
+fn the_spec_states_the_syntax_palette_that_ships() {
+    let table = rows(&spec());
+    assert!(
+        !table.is_empty(),
+        "§6.4's syntax table parsed to no rows. An empty table passes every \
+         comparison below, which is the one way this test can be green and \
+         mean nothing."
+    );
+
+    let mut drift = Vec::new();
+    for (constant, stated) in &table {
+        match shipped().iter().find(|(name, _)| name == constant) {
+            None => drift.push(format!(
+                "§6.4 names `theme::{constant}`, which does not exist"
+            )),
+            Some((_, color)) => {
+                let real = hex(*color);
+                if &real != stated {
+                    drift.push(format!(
+                        "§6.4 says `theme::{constant}` is {stated}; it is {real}"
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        drift.is_empty(),
+        "design/tui-v2/SPEC.md §6.4 disagrees with the highlighter in {} \
+         role(s):\n  {}\n\nMove the code or move the spec — but a reader has \
+         to be able to trust one of them.",
+        drift.len(),
+        drift.join("\n  ")
+    );
+}
+
+/// Every syntax role the highlighter paints has a row.
+///
+/// The value check above cannot see an *absence*, and absence is how §6.4 went
+/// stale in the first place: `SYNTAX_TYPE` and `SYNTAX_FUNCTION` arrived with
+/// #4283 and the spec's sentence was never widened to admit they existed.
+#[test]
+fn every_syntax_constant_has_a_row() {
+    let table = rows(&spec());
+    let missing: Vec<&str> = shipped()
+        .iter()
+        .map(|(name, _)| *name)
+        .filter(|name| !table.iter().any(|(stated, _)| stated == name))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "the highlighter paints {} role(s) design/tui-v2/SPEC.md §6.4 does not \
+         mention: {}",
+        missing.len(),
+        missing.join(", ")
+    );
+}

--- a/crates/stella-tui/tests/status_bar_goldens.rs
+++ b/crates/stella-tui/tests/status_bar_goldens.rs
@@ -114,7 +114,6 @@ fn metal(color: Color) -> char {
         token::TEXT => 'w',
         token::MUTED => 'm',
         token::DIM => 'd',
-        token::COMMENT => 'c',
         token::GREEN => 'n',
         token::RED => 'R',
         token::BORDER => 'b',

--- a/design/tokens/stella-tokens.css
+++ b/design/tokens/stella-tokens.css
@@ -24,7 +24,6 @@
   --st-paper-text: #F4F1EA; /* primary text on dark, off the deck */
   --st-muted: #777782; /* secondary text */
   --st-dim: #4B4B56; /* hints, captions, line numbers */
-  --st-comment: #565660; /* code comments */
   --st-green: #74C991; /* pass, additive diff sign */
   --st-red: #E0687A; /* fail, destructive, removal diff sign */
   --st-diff-add: #10201A; /* added diff row background */

--- a/design/tokens/stella-tokens.json
+++ b/design/tokens/stella-tokens.json
@@ -225,15 +225,6 @@
       "surfaces": ["tui", "web-dark"]
     },
     {
-      "name": "comment",
-      "hex": "#565660",
-      "clamp": "neutral-gray",
-      "css": "--st-comment",
-      "rust": "COMMENT",
-      "role": "code comments",
-      "surfaces": ["tui", "web-dark"]
-    },
-    {
       "name": "green",
       "hex": "#74C991",
       "clamp": "verdict",
@@ -419,15 +410,22 @@
       "from, so a reader hitting the guard learns which retired system they are",
       "looking at rather than only that they are wrong.",
       "",
-      "Most entries are a superseded kit. The last four are not: they were never",
-      "a kit at all. website/public/presentations/investor-deck.html carried its",
-      "own warm palette, matching neither v1.0 nor v2.0, and it shipped on a",
-      "public URL beside two other brand generations (#3653). A value nobody",
+      "Most entries are the anchors of a superseded kit. Five are not, and they",
+      "arrived by two different routes.",
+      "",
+      "Four were never a kit at all. website/public/presentations/investor-deck.html",
+      "carried its own warm palette, matching neither v1.0 nor v2.0, and it shipped",
+      "on a public URL beside two other brand generations (#3653). A value nobody",
       "specified has exactly the same standing here as one that was retired --",
       "no legitimate use -- so it is banned on the same list rather than a",
       "second one. The tree carries none of the four; they are listed so",
       "reintroducing one fails, which is what #3653's own Verify step asks for",
-      "and what nothing did until this entry existed."
+      "and what nothing did until this entry existed.",
+      "",
+      "The fifth is `comment`, a v5.1 token of THIS kit that nothing ever painted",
+      "(#4946). It is banned rather than merely deleted because deleting it leaves",
+      "the value sitting in three design renderings and two brand tables, where the",
+      "next reader reads it as live."
     ],
     "values": [
       { "hex": "#FFB224", "was": "phosphor-era amber accent" },
@@ -453,7 +451,8 @@
       { "hex": "#D6A526", "was": "investor-deck's invented warm gold -- never a kit value (#3653)" },
       { "hex": "#8B6720", "was": "investor-deck's invented warm gold -- never a kit value (#3653)" },
       { "hex": "#865D08", "was": "investor-deck's invented warm gold -- never a kit value (#3653)" },
-      { "hex": "#F4EFE4", "was": "investor-deck's invented warm paper -- never a kit value (#3653)" }
+      { "hex": "#F4EFE4", "was": "investor-deck's invented warm paper -- never a kit value (#3653)" },
+      { "hex": "#565660", "was": "v5.1 `comment` -- retired unpainted; code comments ship in `muted` (#4946)" }
     ]
   }
 }

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -48,7 +48,6 @@ All values are `Color::Rgb`. Grays are neutral or one to two points blue above r
 | `text` | `#E8E8EC` | primary text |
 | `muted` | `#777782` | secondary text |
 | `dim` | `#4B4B56` | hints, keybinding rows, line numbers |
-| `comment` | `#565660` | code comments |
 | `green` | `#74C991` | pass, `+` diff sign |
 | `red` | `#E0687A` | fail, `-` diff sign, delete events, destructive |
 | `diff_add_bg` | `#10201A` | added diff row background |
@@ -239,12 +238,31 @@ Rail metals: read silver-dim, edit gold, write gold, delete red, run gold, skill
 
 ### 6.4 Syntax highlighting and diffs
 
-- Engine: `syntect` with a custom theme built from section 3.1 (keywords gold, types silver_type, identifiers text, comments comment, strings silver, primitives silver_type). Two metals plus white is the full syntax palette on purpose.
+- Engine: `syntect` with a custom theme. The roles and the constants that carry them:
+
+  <!-- BEGIN syntax palette -->
+
+  | role | `stella_tui::theme` | value |
+  |---|---|---|
+  | keyword, and a JSON object key | `SYNTAX_KEYWORD` | `#BFC1CC` |
+  | string / char literal | `SYNTAX_STRING` | `#93D896` |
+  | numeric literal | `SYNTAX_NUMBER` | `#8F70E8` |
+  | comment | `SYNTAX_COMMENT` | `#777782` |
+  | type position | `SYNTAX_TYPE` | `#2FD3C6` |
+  | function or method name | `SYNTAX_FUNCTION` | `#E4408F` |
+
+  <!-- END syntax palette -->
+
+  `crates/stella-tui/tests/spec_syntax_palette.rs` holds this table to those constants. It is a table rather than the sentence it replaces because that sentence described a *different* palette in all six roles — keywords gold, strings silver, types silver_type, comments in the `comment` token — and had said so, unchallenged, since before the grammar-backed lexer (#4283) gave the highlighter a type and a function position at all. The `comment` token it named was painted by nothing anywhere in the tree, and is retired (#4946).
+
+  Keywords ride the bright neutral rather than a hue: the amber they used to take measured 5.5° from the resting gold, which puts a keyword within confusion range of the running mark in the one place gold chrome never reaches to disambiguate it. Literals keep a hue so a value stands out from the shape of the code around it.
 - Highlight once when the event arrives, cache `Vec<Line<'static>>`. Never highlight per frame.
 - Diff rows are two-layer: a background tint (`diff_add_bg` or `diff_del_bg`) under foreground spans that keep their syntax colors. The tint covers the **code column, out to the pane edge** — reaching the edge is what makes the ground read as a band rather than tracing the ragged right end of the code — and it covers **nothing to the left of it**. A rail, a line-number gutter, or any other chrome the surface draws in the margin is not part of the diff and never takes the tint.
 
   Stated as a constraint because the obvious mechanism violates it. `Line.style` is the one-call way to tint a row and is correct only where the row is *nothing but* diff; on any row carrying a margin it paints the whole row's area, so a green band swallows the rail whose metal says which event the diff belongs to (SPEC 6.2) — the two layers then disagree about what the row is. In the transcript every diff row carries that rail, so the tint rides a per-span `bg` on the code plus one trailing padded span to the pane edge. A surface with no margin may use `Line.style`; a surface with one must not. The reference implementation is `push_diff_line` in `crates/stella-tui/src/render/row.rs`, and `a_rust_diff_renders_add_and_remove_rows_per_spec_64` asserts both halves — the band reaches the pane edge, and the rail span's `bg` stays `None`.
-- Line number gutter in `dim`. Sign column (`+`/`-`) is mandatory and colored; color is never the only diff signal.
+- Line number gutter in `silver`. Sign column (`+`/`-`) is mandatory and colored; color is never the only diff signal.
+
+  This line read `dim`, and the gutter has never been dim: `crates/stella-tui/src/diff.rs`'s `gutter` paints `theme::muted()`, and `theme::MUTED` aliases `palette::TEXT_SECONDARY`, which is `token::SILVER` `#A9AAB5` — not `token::MUTED` `#777782` and not `dim` `#4B4B56` (#4946). The line is corrected to what ships rather than the gutter recoloured to what it said, because two tiers of difference in a margin is a design call. #4966 is where the alias that makes this easy to fall into is being decided.
 
 ## 7. Plan and task contracts
 

--- a/design/tui-v2/renderings/svg/01-session-turn-lifecycle.svg
+++ b/design/tui-v2/renderings/svg/01-session-turn-lifecycle.svg
@@ -32,7 +32,7 @@
 <text x="72" y="180" font-size="11" fill="#BFC1CC">Seen</text>
 <text x="112" y="180" font-size="11" fill="#E8E8EC">{</text>
 <text x="40" y="198" font-size="11" fill="#4B4B56">121</text>
-<text x="72" y="198" font-size="11" fill="#565660">/// Digest a finding into its dedup key.</text>
+<text x="72" y="198" font-size="11" fill="#777782">/// Digest a finding into its dedup key.</text>
 <rect x="32" y="204" width="632" height="18" fill="#241019"/>
 <text x="40" y="217" font-size="11" fill="#E0687A">122 -</text>
 <text x="88" y="217" font-size="11" fill="#E8E8EC">digest:</text>

--- a/design/tui-v2/renderings/svg/02-event-vocabulary.svg
+++ b/design/tui-v2/renderings/svg/02-event-vocabulary.svg
@@ -12,7 +12,7 @@
 <text x="238" y="58" font-size="11" fill="#BFC1CC">BTreeSet</text>
 <text x="302" y="58" font-size="11" fill="#E8E8EC">;</text>
 <text x="40" y="76" font-size="11" fill="#4B4B56">2</text>
-<text x="64" y="76" font-size="11" fill="#565660">/// Stable dedup key for findings.</text>
+<text x="64" y="76" font-size="11" fill="#777782">/// Stable dedup key for findings.</text>
 <text x="40" y="94" font-size="11" fill="#4B4B56">3</text>
 <text x="64" y="94" font-size="11" fill="#EFC53F">pub struct</text>
 <text x="150" y="94" font-size="11" fill="#BFC1CC">DigestKey</text>

--- a/design/tui-v2/renderings/svg/09-gate-failure.svg
+++ b/design/tui-v2/renderings/svg/09-gate-failure.svg
@@ -33,8 +33,8 @@
 <line x1="20" y1="204" x2="20" y2="278" stroke="#E0687A" stroke-width="2"/>
 <rect x="32" y="208" width="632" height="72" fill="#0F0F12" stroke="#E0687A" stroke-width="1"/>
 <text x="44" y="228" font-size="11" fill="#E0687A">✗ case auth_refresh_parallel</text>
-<text x="44" y="248" font-size="11" fill="#565660">assertion failed: findings.len() == 1</text>
-<text x="44" y="264" font-size="11" fill="#565660">expected 1 finding, got 2 (duplicate digest)</text>
+<text x="44" y="248" font-size="11" fill="#777782">assertion failed: findings.len() == 1</text>
+<text x="44" y="264" font-size="11" fill="#777782">expected 1 finding, got 2 (duplicate digest)</text>
 <text x="380" y="228" font-size="11" fill="#4B4B56">^N jump · l full log · r rerun gate</text>
 <line x1="20" y1="292" x2="20" y2="384" stroke="#F7D96B" stroke-width="2"/>
 <rect x="32" y="296" width="632" height="92" fill="#0F0F12" stroke="#EFC53F" stroke-width="1"/>

--- a/docs/brand/brand-guidelines.html
+++ b/docs/brand/brand-guidelines.html
@@ -270,7 +270,6 @@ retired or is not a live token.</p>
 <tr><td>--st-text</td><td>#E8E8EC</td><td>primary text on dark</td></tr>
 <tr><td>--st-muted</td><td>#777782</td><td>secondary text</td></tr>
 <tr><td>--st-dim</td><td>#4B4B56</td><td>hints, captions, line numbers</td></tr>
-<tr><td>--st-comment</td><td>#565660</td><td>code comments</td></tr>
 <tr><td>--st-green</td><td>#74C991</td><td>pass, additive diff sign</td></tr>
 <tr><td>--st-red</td><td>#E0687A</td><td>fail, destructive, removal diff sign</td></tr>
 <tr><td>--st-amber</td><td>#E78D54</td><td>warning</td></tr>

--- a/docs/brand/css/tokens.css
+++ b/docs/brand/css/tokens.css
@@ -43,7 +43,6 @@
   --st-text: #E8E8EC;
   --st-muted: #777782;
   --st-dim: #4B4B56;
-  --st-comment: #565660;
   --st-green: #74C991;
   --st-red: #E0687A;
   --st-diff-add: #10201A;

--- a/docs/brand/prompts/stella-design-system-prompt.md
+++ b/docs/brand/prompts/stella-design-system-prompt.md
@@ -36,7 +36,6 @@ The system is **flat**. There are no 50→950 ramps: v5.0 deletes both the brand
 | `--st-text` | `#E8E8EC` | primary text on dark |
 | `--st-muted` | `#777782` | secondary text |
 | `--st-dim` | `#4B4B56` | hints, captions, line numbers |
-| `--st-comment` | `#565660` | code comments |
 | `--st-green` | `#74C991` | pass, additive diff sign |
 | `--st-red` | `#E0687A` | fail, destructive, removal diff sign |
 | `--st-amber` | `#E78D54` | warning — the one status the core palette does not otherwise name |

--- a/scripts/check-contrast.py
+++ b/scripts/check-contrast.py
@@ -20,11 +20,11 @@ The logotype exemption is what lets rule 6 say "gold for the mark and for icons
 at 24px and larger, never gold body text on light" without contradicting
 itself.
 
-Four pairings sit under their threshold today, and they are palette values
+Three pairings sit under their threshold today, and they are palette values
 rather than an oversight: `muted` is 4.47:1 on the canvas against a 4.5 floor,
-and `dim`/`comment` are decorative tiers the terminal already documents as
-below every text floor. Moving them is a recolour and belongs to whoever owns
-the palette (#4063), so this guard records them in a **down-only ratchet**
+and `dim` is a decorative tier the terminal already documents as below every
+text floor. Moving them is a recolour and belongs to whoever owns the palette
+(#4063), so this guard records them in a **down-only ratchet**
 (`scripts/contrast-baseline.txt`) rather than waiting to become a gate step
 until they are fixed -- which is what it did for two releases, in no gate at
 all, while the tree carried figures that disagreed with it (#4423).
@@ -102,7 +102,12 @@ PAIRINGS = [
     ("green", "bg", "pass verdict", 4.5),
     ("red", "bg", "fail verdict", 4.5),
     ("dim", "bg", "hints and line numbers (large/decorative floor)", 3.0),
-    ("comment", "panel", "code comments (large/decorative floor)", 3.0),
+    # `comment on panel` sat here at 2.64:1 and measured a value nothing
+    # painted: `comment` was a token with no consumer on any surface, and code
+    # comments ship in `muted` — already on this list, at 4.32:1 on the same
+    # ground. It was one of the four sub-threshold rows #4063 is deciding about,
+    # so a quarter of that decision was about a colour no reader had seen.
+    # #4946 retired the token; this row and its floor went with it.
     ("border", "bg", "hairlines — a divider, not information", None),
     ("rule", "bg", "section rules — a divider, not information", None),
     ("gold-bright", "bg", "single-cell live indicators", 3.0),

--- a/scripts/contrast-baseline.txt
+++ b/scripts/contrast-baseline.txt
@@ -11,7 +11,6 @@
 # for every pairing and the ground it is measured on.
 #
 # This file records the debt #4423 found; it is meant to reach empty.
-comment panel 2.64
 dim bg 2.30
 muted bg 4.47
 muted panel 4.32

--- a/scripts/test-contrast.sh
+++ b/scripts/test-contrast.sh
@@ -137,19 +137,28 @@ entry_is "U6 the refused --update left the floor where it was" "$r" muted bg 4.4
 # ── D: a pairing that got better ─────────────────────────────────────────────
 # Lighter but still under its 3.0 floor, so it stays on the ledger at a higher
 # number rather than dropping off it.
+#
+# `dim` rather than `comment`, which carried this case until #4946 retired that
+# token — it was a colour with no paint site on any surface, so its ratchet row
+# guarded nothing. `dim` is the other pairing held to the 3.0 decorative floor,
+# and it is a live tier: hints, keybinding rows and the terminal's line numbers.
+# It appears in a second pairing (`dim on paper`, at 4.5), and #5A5A66 leaves
+# that one at 6.63:1 — well clear, so this case moves the pairing it is about
+# and nothing else.
 r="$(new_root lightened)"
-repaint "$r" comment "#5E5E68"
+repaint "$r" dim "#5A5A66"
 want "D1 a pairing that improved but still fails passes the check" expect-pass "$r" "held by the ratchet"
-want "D2 --update raises its floor" expect-pass "$r" "retightened to 4 pairing(s)" "--update"
-entry_is "D3 the floor is what was really measured" "$r" comment panel 2.99
+want "D2 --update raises its floor" expect-pass "$r" "retightened to 3 pairing(s)" "--update"
+entry_is "D3 the floor is what was really measured" "$r" dim bg 2.91
 
 # Over the threshold: the entry must go, and the check must say so rather than
 # pass — a baselined pairing nobody needs is a standing permission slip.
+# `muted` is on the ledger twice and this clears both, so the count drops by two.
 r="$(new_root cleared)"
 repaint "$r" muted "#7A7A85"
 want "D4 a pairing that cleared its threshold is reported, not passed" \
   expect-fail "$r" "clears its threshold now"
-want "D5 --update drops it" expect-pass "$r" "retightened to 2 pairing(s)" "--update"
+want "D5 --update drops it" expect-pass "$r" "retightened to 1 pairing(s)" "--update"
 entry_is "D6 the cleared pairing is gone" "$r" muted bg absent
 
 # ── B: bootstrap runs once ───────────────────────────────────────────────────

--- a/website/src/app/tokens.css
+++ b/website/src/app/tokens.css
@@ -64,7 +64,6 @@
   --st-text: #e8e8ec; /* primary text on dark, in the deck */
   --st-muted: #777782; /* secondary text */
   --st-dim: #4b4b56; /* hints, captions, line numbers */
-  --st-comment: #565660; /* code comments */
   --st-green: #74c991; /* pass, additive diff sign */
   --st-red: #e0687a; /* fail, destructive, removal diff sign */
   --st-diff-add: #10201a; /* added diff row background */

--- a/website/src/lib/brand-parity.test.ts
+++ b/website/src/lib/brand-parity.test.ts
@@ -266,8 +266,32 @@ test("the site's brand tokens are the kit's, value for value", () => {
 
   // The generated ramp, taken from the kit rather than restated here.
   const ramp = [...kit.keys()].filter((name) => name.startsWith("--st-"));
+  // Every name the kit sheet declares is a token that exists. This is the half
+  // the floor below cannot do: a count says nothing about a `--st-` name that
+  // the palette has no entry for, and the loop underneath would then compare a
+  // role against itself and pass.
+  const authority: { tokens: { css: string }[] } = JSON.parse(
+    read(join(REPO, "design", "tokens", "stella-tokens.json")),
+  );
+  const live = new Set(authority.tokens.map((t) => t.css));
+  const unknown = ramp.filter((name) => !live.has(name));
+  assert.deepEqual(
+    unknown,
+    [],
+    `docs/brand/css/tokens.css declares --st-* name(s) that design/tokens/` +
+      `stella-tokens.json does not define: ${unknown.join(", ")}`,
+  );
+
+  // And the sheet has not quietly lost rows, which would make the loop below
+  // pass over less than it thinks. The number moved 21 -> 20 when #4946
+  // retired `comment`, a token nothing painted; it is a floor on the mirror's
+  // size, so it moves only when the palette itself shrinks and the reason goes
+  // here beside it.
+  //
+  // The sheet is a subset by design: it carries 20 of the palette's 32, and
+  // the twelve it has never mirrored are #4978.
   assert.ok(
-    ramp.length >= 21,
+    ramp.length >= 20,
     `docs/brand/css/tokens.css defines the generated --st-* ramp ` +
       `(found ${ramp.length})`,
   );


### PR DESCRIPTION
Three findings, all the same shape: the name says one tier and the value is another.

## 1. `comment` is retired, not wired

`token::COMMENT` `#565660` had zero paint sites. The issue measured the Rust half; the CSS half is the same — `--st-comment` is declared on four surfaces and `var(--st-comment)` appears nowhere in the tree.

The definition of done offers wire-it or retire-it. Wiring it is what `SPEC.md` §6.4 specified, and it would drop code comments from **4.32:1 to 2.64:1** on panel — a visible regression, to ship a colour nothing had asked for. Retirement it is.

It is **banned** rather than merely deleted. Deleting the token alone leaves `#565660` sitting in three design renderings and two brand tables, where the next reader reads it as live; the ban is what forces those clean. The renderings now paint code comments in `#777782`, which is what the TUI actually draws.

### The ratchet retightens

`scripts/contrast-baseline.txt` held `comment panel 2.64` — a floor on a value no reader has ever seen, and one of the **four** sub-AA rows #4063 is deciding about. A quarter of that decision was about nothing.

The guard named the remedy itself:

```
check-contrast: FAIL
  comment on panel: baselined, but it clears its threshold now —
  run `make contrast-update` so the ratchet retightens
```

```diff
 # This file records the debt #4423 found; it is meant to reach empty.
-comment panel 2.64
 dim bg 2.30
 muted bg 4.47
 muted panel 4.32
```

Four pairings to three, **no floor lowered**. `check-contrast: 21 licensed pairing(s), 3 held by the ratchet, none darker than it allows.`

## 2. §6.4's syntax sentence was false in six of six roles

The issue found one clause wrong. Reading `theme.rs` against it, all of them are:

| §6.4 said | ships |
|---|---|
| keywords gold | `SYNTAX_KEYWORD` = the bright neutral `#BFC1CC` |
| strings silver | `SYNTAX_STRING` = `#93D896` |
| primitives silver_type | `SYNTAX_NUMBER` = violet `#8F70E8` |
| comments `comment` | `SYNTAX_COMMENT` = `#777782` |
| types silver_type | `SYNTAX_TYPE` = teal `#2FD3C6` |
| — | `SYNTAX_FUNCTION` = magenta `#E4408F` |

The last two arrived with the grammar-backed lexer (#4283), which the sentence predates entirely — it never admitted a type or a function position exists.

So the sentence is now a **table between markers**, and `crates/stella-tui/tests/spec_syntax_palette.rs` holds every row to its constant. It reads `SPEC.md` as text rather than generating it: a spec that is a projection of the code cannot disagree with the code, and disagreeing is the whole job of one.

## 3. §6.4's gutter line was wrong by two tiers

*"Line number gutter in `dim`"* — `diff.rs`'s `gutter` paints `theme::muted()`, and `theme::MUTED` aliases `palette::TEXT_SECONDARY` = `token::SILVER` `#A9AAB5`. Not `dim` `#4B4B56`, and not `token::MUTED` `#777782` either.

The line is corrected to what ships rather than the gutter recoloured to what it said: two tiers of difference in a margin is a design call, not a typo, and it is not mine to make.

Finding 3 — the alias that makes this trap easy to fall into — takes the definition of done's second option here (*"document the divergence at the definition"*) and is filed as **#4966** for the rename, because the issue's own wording leaves that to a maintainer and it is 81 production references through two god files. `theme::MUTED`'s doc comment now states which tier it is, which it is not, and what it has already cost.

## Witness

The comment role, with §6.4's table restored to the retired token's value:

```
---- the_spec_states_the_syntax_palette_that_ships stdout ----
design/tui-v2/SPEC.md §6.4 disagrees with the highlighter in 1 role(s):
  §6.4 says `theme::SYNTAX_COMMENT` is #565660; it is #777782

Move the code or move the spec — but a reader has to be able to trust one of them.

test result: FAILED. 1 passed; 1 failed
```

The absence half, with the `SYNTAX_TYPE` row deleted — #4283's own shape:

```
---- every_syntax_constant_has_a_row stdout ----
the highlighter paints 1 role(s) design/tui-v2/SPEC.md §6.4 does not
mention: SYNTAX_TYPE

test result: FAILED. 1 passed; 1 failed
```

Clean tree: `2 passed; 0 failed`.

## Guards

```
check-contrast: 21 licensed pairing(s), 3 held by the ratchet, none darker than it allows.
tokens: no retired hex in the tree; 3 token-only path(s) clean
tokens: 32 validated, 2 artifacts in sync
check-hue-separation: OK — 12 role pairs across 2 web schemes, all at or above 30° OKLCH
check-css-vars: OK -- 2 token sheet(s), every var() resolves.
scripts/test-tokens.sh: 10 passed, 0 failed
check-prose: OK -- none added.   check-line-citations: OK -- none added.
cargo test -p stella-tui-theme: ok
cargo test -p stella-tui --test status_bar_goldens: 15 passed
```

`crates/stella-tui-theme/src/token.rs` and `design/tokens/stella-tokens.css` are `make tokens-update` output, not hand edits.

## Deleted tests

None. `token::COMMENT => 'c'` is removed from `status_bar_goldens.rs`'s colour map (no golden used `c`) and `token::COMMENT` from `fallback.rs`'s `ansi16` arm; both are lines inside tests, not tests.

Closes #4946
Refs #4063, #4966, #4112

## Summary by Sourcery

Retire the unused comment token and align the documented design palette with the colors and syntax roles implemented by the TUI.

Bug Fixes:
- Retire the unused `comment` color token and remove its generated palette, CSS, documentation, rendering, and fallback references.
- Correct the TUI specification to document the syntax palette and line-number gutter colors that actually ship.
- Tighten contrast and token consistency checks after removing the unused color.

Enhancements:
- Add tests that verify every documented syntax role matches its shipped color and that all syntax constants are represented in the specification.
- Document the `theme::MUTED` alias’s divergence from the muted palette tier until it can be renamed.

Documentation:
- Update the TUI syntax-highlighting and gutter documentation to reflect the implemented palette.
- Remove the retired comment token from brand and design token references.

Tests:
- Add specification coverage for syntax palette values and role completeness.
- Update contrast-ratchet tests and brand parity checks for the reduced token set.