### PR TITLE
test(stella-cli): prove a non-interactive run writes a lesson to disk

### DIFF
--- a/crates/stella-cli/tests/run_exits_cli.rs
+++ b/crates/stella-cli/tests/run_exits_cli.rs
@@ -35,8 +35,24 @@ const EXIT_BUDGET: Duration = Duration::from_secs(120);
 /// How often to check. Cheap: `try_wait` does not block.
 const POLL: Duration = Duration::from_millis(100);
 
+/// clap's exit code for a usage error. The one status that must never satisfy
+/// these tests: a process that died in the argument parser reached no
+/// shutdown path at all, and "it exited" is then a fact about clap.
+const USAGE_ERROR: i32 = 2;
+
 /// Run `stella run` to completion, or give up at [`EXIT_BUDGET`]. Returns how
-/// long it took; panics (after killing the child) if it never exited.
+/// long it took; panics (after killing the child) if it never exited, or if
+/// it exited without ever starting.
+///
+/// The exit *code* is checked as well as the fact of exiting, because these
+/// tests were vacuous for as long as the argument order was wrong.
+/// `--output-format` used to be a root-position flag and became a `run` flag
+/// (`crates/stella-cli/src/tests.rs`'s `run_and_fleet_declare_output_format`,
+/// and its sibling asserting the root spelling is now a parse error); this
+/// file kept the old order and was never updated. Every run therefore exited
+/// in milliseconds with `error: unexpected argument '--output-format' found`,
+/// which satisfies "it exited" perfectly and says nothing whatever about
+/// #960's shutdown path.
 fn time_to_exit(workspace: &Path, data: &Path, format: &str) -> Duration {
     let started = Instant::now();
     let mut child = Command::new(env!("CARGO_BIN_EXE_stella"))
@@ -51,9 +67,9 @@ fn time_to_exit(workspace: &Path, data: &Path, format: &str) -> Duration {
             "http://127.0.0.1:1",
             "--spend-limit",
             "0.05",
+            "run",
             "--output-format",
             format,
-            "run",
             "say hi and stop",
         ])
         .current_dir(workspace)
@@ -68,13 +84,25 @@ fn time_to_exit(workspace: &Path, data: &Path, format: &str) -> Duration {
         // held open; closed is the one a CI step actually has.
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        // Piped rather than discarded so a usage error can be quoted back
+        // when the assertion below fires.
+        .stderr(Stdio::piped())
         .spawn()
         .expect("spawn stella");
 
     loop {
         match child.try_wait().expect("wait on stella") {
-            Some(_) => return started.elapsed(),
+            Some(status) => {
+                assert_ne!(
+                    status.code(),
+                    Some(USAGE_ERROR),
+                    "`stella run --output-format {format}` died in the argument \
+                     parser, so it never reached the shutdown path this test is \
+                     about — stderr: {}",
+                    read_stderr(&mut child),
+                );
+                return started.elapsed();
+            }
             None if started.elapsed() >= EXIT_BUDGET => {
                 let _ = child.kill();
                 let _ = child.wait();
@@ -86,6 +114,16 @@ fn time_to_exit(workspace: &Path, data: &Path, format: &str) -> Duration {
             None => std::thread::sleep(POLL),
         }
     }
+}
+
+/// Drain the child's piped stderr, for the failure message above.
+fn read_stderr(child: &mut std::process::Child) -> String {
+    use std::io::Read;
+    let mut buffer = String::new();
+    if let Some(stderr) = child.stderr.as_mut() {
+        let _ = stderr.read_to_string(&mut buffer);
+    }
+    buffer
 }
 
 fn assert_exits(format: &str) {

--- a/crates/stella-cli/tests/run_reflection_writes_cli.rs
+++ b/crates/stella-cli/tests/run_reflection_writes_cli.rs
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! **Witness (#4936).** A non-interactive `stella run --output-format json`
+//! writes a lesson to `.stella/private/reflections.jsonl`.
+//!
+//! Nothing proved that before this file. The chain was covered in three
+//! disconnected pieces — the gate admits a machine format
+//! (`agent::tests::a_machine_format_turn_reflects_like_a_text_one`), the
+//! spawned child does not inherit the opt-out
+//! (`self_driving_cmd::work`'s `the_turn_does_not_inherit_the_reflection_opt_out`,
+//! #4914), and the writer appends a line when called directly
+//! (`memory::tests::reflection_mining`'s
+//! `reflect_and_record_writes_lessons_to_log_and_store`) — and none of them
+//! joined. The third is invoked directly and bypasses the gate entirely, so no
+//! test reached the writer *through* `run_raw_one_shot`.
+//!
+//! That gap cost two bugs with the same symptom, neither caught by CI:
+//!
+//! - **#4130** — a `format == OutputFormat::Text` clause at the call site made
+//!   the three conditions after it unreachable for every machine format. The
+//!   gate's own test asserted the opposite and passed throughout, because the
+//!   fourth condition lived where that test could not see it. 22 turns, 16
+//!   merged pull requests, no reflections.
+//! - **#4362** — the drive child inherited `STELLA_DISABLE_REFLECTION` from an
+//!   unrelated shell. 143 `role=worker` model calls, zero `role=reflection`
+//!   ones, and `reflections_logged: 0` with nothing distinguishing it from
+//!   "learned nothing".
+//!
+//! # Why this is a spawned binary and not an in-process test
+//!
+//! `run_turn` spawns `std::env::current_exe()`, which under `cargo test` is
+//! the test binary rather than `stella`, so a turn cannot be driven
+//! in-process at all. Cargo's binary-path macro against a `wiremock` provider
+//! is the only shape that reaches the writer through the real gate;
+//! `goal_wrapped_dispatch_cli.rs` is the worked example this copies its
+//! hermeticity and its mock routing from.
+//!
+//! The macro is named once, in [`run_one_shot`], and never spelled in prose:
+//! `embedder_backend_sealed_cli.rs`'s guard counts occurrences of that literal
+//! as spawn sites and requires a seal for each, so a doc comment mentioning it
+//! reads as an unsealed spawn. That guard is right to count conservatively —
+//! an unsealed child inherits `VOYAGE_API_KEY` and bills whoever runs the
+//! suite (#4542) — so the prose moves, not the count.
+//!
+//! # Both directions, or neither is evidence
+//!
+//! The positive case alone is satisfied by a build that always reflects, so
+//! [`the_opt_out_stops_the_lesson_being_written`] is the other half: the same
+//! run with `STELLA_DISABLE_REFLECTION=1` **set on the child's `Command`**
+//! must write nothing. On the child rather than in this process, for the
+//! reason #4914 gives — `std::env` is process-global and this suite runs in
+//! parallel, so a test that set the variable would decide other tests'
+//! answers — and because the child's environment is the thing #4362 was
+//! about.
+//!
+//! # Routing by body, never by call order
+//!
+//! The three calls a passing run makes (worker tool call, worker answer,
+//! reflection) are told apart by what is *in* the request, not by how many
+//! came before it: the reflection call is the only one carrying
+//! [`REFLECTION_SYSTEM_PROMPT`], which `memory::reflection::reflect_on_turn`
+//! puts at the head of its request and which reaches no worker prompt. A
+//! change in dispatch order therefore cannot silently turn a two-call
+//! assertion into a one-call one.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+mod common;
+use common::SealsEmbedderBackend;
+
+/// The opening words of the system message
+/// `memory::reflection::reflect_on_turn` sends, and the only string that
+/// separates the reflection call from a worker call on the wire.
+const REFLECTION_SYSTEM_PROMPT: &str = "You are a self-reflection module";
+
+/// The lesson the mocked reflection call returns. Asserted verbatim out of
+/// the log, so the line under test is provably the one this mock produced and
+/// not something else that happened to write the file.
+const LESSON: &str = "the fixture provider answers on /chat/completions only";
+
+/// A [`Match`] wiremock has no built-in for: "the body does NOT contain this
+/// substring". Needed to route the worker's calls away from the reflection
+/// mock without matching on the (large, prompt-engineering-internal, and
+/// therefore fragile) worker system prompt instead. Same shape as
+/// `goal_wrapped_dispatch_cli.rs`'s.
+struct NotContains(&'static str);
+
+impl Match for NotContains {
+    fn matches(&self, request: &Request) -> bool {
+        !String::from_utf8_lossy(&request.body).contains(self.0)
+    }
+}
+
+/// One SSE completion, in the shape `stella-model`'s shared chat-completions
+/// adapter parses: one content delta carrying the whole answer, a trailing
+/// usage frame, then `[DONE]`.
+fn sse_completion(text: &str) -> String {
+    let content = serde_json::to_string(text).expect("text encodes");
+    format!(
+        "data: {{\"choices\":[{{\"delta\":{{\"content\":{content}}}}}]}}\n\n\
+         data: {{\"choices\":[{{\"delta\":{{}}}}],\"usage\":{{\"prompt_tokens\":8,\"completion_tokens\":3}}}}\n\n\
+         data: [DONE]\n\n"
+    )
+}
+
+/// One SSE completion carrying a single tool call and no text, in the
+/// index-keyed fragment dialect the shared chat-completions adapter parses.
+///
+/// The turn has to dispatch a tool for this test to mean anything:
+/// `memory::turn_warrants_reflection` is `true` only when some message in the
+/// turn carries a tool call, so a text-only turn would take the gate's
+/// "nothing to mine" arm and write no line — and the test would then be
+/// asserting the absence of a lesson in both directions.
+///
+/// `get_environment` is chosen for what it is *not*: it takes no arguments,
+/// changes nothing, and its `Always` authority means no approval gate stands
+/// between this fixture and a dispatched call — a run in non-interactive mode
+/// has no human to answer one.
+fn sse_tool_call() -> String {
+    concat!(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_env\",\
+         \"function\":{\"name\":\"get_environment\",\"arguments\":\"{}\"}}]}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{}}],\"usage\":{\"prompt_tokens\":8,\
+         \"completion_tokens\":3}}\n\n",
+        "data: [DONE]\n\n",
+    )
+    .to_string()
+}
+
+/// The reflection response, in the object shape
+/// `memory::reflection::parse_lessons_checked` reads: one lesson with no
+/// domain tags (a fresh workspace has no `domains.toml`, so every tag would
+/// be dropped as invented), plus the self-review that rides in the same call.
+fn sse_reflection() -> String {
+    let body = serde_json::json!({
+        "lessons": [{
+            "lesson": LESSON,
+            "trigger": "any turn in this fixture workspace",
+            "saves": "the wrong base URL, which costs a whole failed turn",
+            "kind": "domain",
+            "domains": [],
+        }],
+        "self_review": {
+            "delivered": true,
+            "rating": 7,
+            "went_well": "the tool call dispatched",
+            "to_improve": "nothing",
+            "critique": "a fixture turn",
+        },
+    });
+    sse_completion(&body.to_string())
+}
+
+/// The mocked provider a reflecting run talks to: a tool call, then an
+/// answer, then the reflection — each selected by request body.
+async fn mock_reflecting_provider() -> MockServer {
+    let server = MockServer::start().await;
+
+    // Higher priority (a lower number) than the general worker mock below,
+    // and capped at one use, so the *second* worker call falls through to the
+    // text answer and the turn ends.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(NotContains(REFLECTION_SYSTEM_PROMPT))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_tool_call(), "text/event-stream"))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(NotContains(REFLECTION_SYSTEM_PROMPT))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            sse_completion("did the requested work"),
+            "text/event-stream",
+        ))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains(REFLECTION_SYSTEM_PROMPT))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(sse_reflection(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    server
+}
+
+/// `<workspace>/.stella/private/reflections.jsonl` — the mining log
+/// `self_driving_cmd::learning::reflection_lines` counts, and the file whose
+/// emptiness was #4130's and #4362's whole visible symptom.
+fn reflection_log(workspace: &Path) -> std::path::PathBuf {
+    workspace
+        .join(".stella")
+        .join("private")
+        .join("reflections.jsonl")
+}
+
+/// Every non-empty line of the mining log, or none if it was never written.
+fn logged_lessons(workspace: &Path) -> Vec<String> {
+    std::fs::read_to_string(reflection_log(workspace))
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Run one hermetic `stella run --output-format json` against `server_uri`.
+///
+/// `opt_out` sets `STELLA_DISABLE_REFLECTION=1` **on this child**, which is
+/// both the safe way to pin it (`std::env` is process-global and this suite
+/// runs in parallel) and the thing #4362 was actually about.
+///
+/// `STELLA_HOME` as well as `STELLA_DATA_DIR`: the narrower variable moves
+/// only the data tier, so a test that set it alone would still read the real
+/// `~/.stella` — including `credentials.toml`, which is the second way a
+/// provider key reaches this process and would make the run billable.
+fn run_one_shot(
+    workspace: &Path,
+    data: &Path,
+    server_uri: &str,
+    opt_out: bool,
+) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_stella"));
+    command
+        .without_embedder_backend()
+        .args([
+            "--model",
+            "zai/glm-5.2",
+            "--api-key",
+            "sk-test-zai",
+            "--base-url",
+            server_uri,
+            "--spend-limit",
+            "5.0",
+            "run",
+            "--output-format",
+            "json",
+            "read the environment, then stop",
+        ])
+        .current_dir(workspace)
+        .env("STELLA_HOME", data)
+        .env("STELLA_DATA_DIR", data)
+        .env("STELLA_NO_ENV_FILE", "1")
+        .env_remove("STELLA_DISABLE_REFLECTION")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("ZAI_API_KEY")
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("XAI_API_KEY")
+        .env_remove("DEEPSEEK_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("GOOGLE_API_KEY")
+        .env_remove("GOOGLE_APPLICATION_CREDENTIALS")
+        .env_remove("VERTEX_ACCESS_TOKEN")
+        .env_remove("AWS_ACCESS_KEY_ID")
+        .env_remove("AWS_SECRET_ACCESS_KEY")
+        .env_remove("AWS_SESSION_TOKEN")
+        .env_remove("AWS_REGION")
+        .env_remove("AWS_DEFAULT_REGION")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if opt_out {
+        command.env("STELLA_DISABLE_REFLECTION", "1");
+    }
+    command.output().expect("spawn stella run")
+}
+
+/// A workspace with one source file, so the session code-graph build has
+/// something real to index — the same seed `run_exits_cli.rs` uses.
+fn seed_workspace(workspace: &Path) {
+    std::fs::write(workspace.join("lib.rs"), "pub fn hello() {}\n").expect("source file");
+}
+
+/// How many requests the mock actually served carrying the reflection
+/// prompt. Zero here and a written log would mean the line came from
+/// somewhere other than this turn's reflection call.
+async fn reflection_calls(server: &MockServer) -> usize {
+    server
+        .received_requests()
+        .await
+        .unwrap_or_default()
+        .iter()
+        .filter(|request| String::from_utf8_lossy(&request.body).contains(REFLECTION_SYSTEM_PROMPT))
+        .count()
+}
+
+#[tokio::test]
+async fn a_non_interactive_json_run_writes_its_lesson_to_the_mining_log() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let data = tempfile::tempdir().expect("data dir");
+    seed_workspace(workspace.path());
+    let server = mock_reflecting_provider().await;
+
+    let output = tokio::task::spawn_blocking({
+        let workspace = workspace.path().to_path_buf();
+        let data = data.path().to_path_buf();
+        let uri = server.uri();
+        move || run_one_shot(&workspace, &data, &uri, false)
+    })
+    .await
+    .expect("join");
+    assert!(
+        output.status.success(),
+        "`stella run --output-format json` did not exit 0 — stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert_eq!(
+        reflection_calls(&server).await,
+        1,
+        "the turn must make exactly one reflection model call — stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let lines = logged_lessons(workspace.path());
+    assert_eq!(
+        lines.len(),
+        1,
+        "`{}` must have gained exactly one line — stderr: {}",
+        reflection_log(workspace.path()).display(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // The line is this reflection's, not an artifact of some other writer.
+    let logged: serde_json::Value = serde_json::from_str(&lines[0]).expect("the line is JSON");
+    assert_eq!(
+        logged["lesson"].as_str(),
+        Some(LESSON),
+        "the logged lesson must be the one the reflection call returned: {}",
+        lines[0]
+    );
+}
+
+/// The negative direction. Without it the case above is satisfied by a build
+/// that reflects unconditionally, which is a different bug from the one it is
+/// meant to catch.
+#[tokio::test]
+async fn the_opt_out_stops_the_lesson_being_written() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let data = tempfile::tempdir().expect("data dir");
+    seed_workspace(workspace.path());
+    let server = mock_reflecting_provider().await;
+
+    let output = tokio::task::spawn_blocking({
+        let workspace = workspace.path().to_path_buf();
+        let data = data.path().to_path_buf();
+        let uri = server.uri();
+        move || run_one_shot(&workspace, &data, &uri, true)
+    })
+    .await
+    .expect("join");
+    assert!(
+        output.status.success(),
+        "the opted-out run did not exit 0 — stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert_eq!(
+        reflection_calls(&server).await,
+        0,
+        "`STELLA_DISABLE_REFLECTION=1` must buy no reflection model call"
+    );
+    assert!(
+        logged_lessons(workspace.path()).is_empty(),
+        "the opted-out run wrote to the mining log: {:?}",
+        logged_lessons(workspace.path())
+    );
+}


### PR DESCRIPTION
## What

Nothing in this repository proved that a non-interactive `stella run` writes a line to `.stella/private/reflections.jsonl`. The chain was covered in three disconnected pieces and none of the joins were: the gate admits a machine format, the drive child does not inherit the opt-out, the writer appends when called directly. The third is invoked directly and bypasses the gate entirely, so no test reached the writer *through* `run_raw_one_shot` — which is how #4130 and #4362 both shipped, each found by reading a store months later rather than by CI.

`crates/stella-cli/tests/run_reflection_writes_cli.rs` closes it, as the issue's "Verify / done" specifies:

- **`a_non_interactive_json_run_writes_its_lesson_to_the_mining_log`** spawns `CARGO_BIN_EXE_stella` with `run --output-format json` in a temp workspace against a `wiremock` provider, and asserts the log gained **exactly one** line carrying the lesson the mocked reflection call returned. It also asserts the mock served exactly one reflection request, so a written file cannot be credited to some other writer.
- **`the_opt_out_stops_the_lesson_being_written`** is the negative direction, with `STELLA_DISABLE_REFLECTION=1` set on the **child's `Command`** — the constraint the issue names, and the thing #4362 was actually about. Without this case the first is satisfied by a build that always reflects.

Constraints from the issue, all honoured:

- **`STELLA_HOME` as well as `STELLA_DATA_DIR`.** The narrower variable moves only the data tier, so a test setting it alone still reads the real `~/.stella` — including `credentials.toml`, the second way a key reaches the process — and could make a real, billed call. Both are set; every `*_API_KEY` and `STELLA_DISABLE_REFLECTION` are removed; `common::SealsEmbedderBackend` clears the embedder surface.
- **`std::env` is never touched in-process.** The opt-out goes on the spawned child, so this test cannot decide another test's answer in a parallel suite.
- **The mock routes on request body, never on call order.** The reflection call is the only one carrying `reflect_on_turn`'s "You are a self-reflection module" system message; the worker mocks are selected by its *absence* (a `NotContains` matcher, the same one `goal_wrapped_dispatch_cli.rs` uses). A change in dispatch order therefore cannot silently turn a two-call assertion into a one-call one.
- The worker's first response is a `get_environment` tool call, because `turn_warrants_reflection` is true only if some message in the turn carries one. A text-only turn would take the gate's "nothing to mine" arm and the test would be asserting absence in both directions.

## Witness

The ablation the issue asks for — restore #4130's `format == OutputFormat::Text` clause at `agent/goal.rs`'s reflection gate:

```
--- a/crates/stella-cli/src/agent/goal.rs
-    if should_reflect_after_one_shot(
-        format,
-        turn_warrants_reflection(&messages),
-        memory.is_some(),
-    ) && let Some(m) = &mut memory
+    if format == OutputFormat::Text
+        && should_reflect_after_one_shot(
+            format,
+            turn_warrants_reflection(&messages),
+            memory.is_some(),
+        )
+        && let Some(m) = &mut memory
```

```
$ cargo test -p stella-cli --test run_reflection_writes_cli
running 2 tests
test the_opt_out_stops_the_lesson_being_written ... ok
test a_headless_json_run_writes_its_lesson_to_the_mining_log ... FAILED

---- a_headless_json_run_writes_its_lesson_to_the_mining_log stdout ----
assertion `left == right` failed: the turn must make exactly one reflection model call — stderr:   ◈ indexing code graph…
  ✓ code graph: 1 symbols, 0 imports across 1 file (1 re-parsed, 0 unchanged this pass)
  · start here: lib.rs — nothing in the index imports it

  left: 0
 right: 1

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

(The test was renamed to `a_non_interactive_json_run_…` after this run, for `make prose`'s `interface-jargon` rule. Same test.)

**Second ablation, so the negative case is not vacuous either.** The first ablation leaves `the_opt_out_stops_the_lesson_being_written` passing, as it must — #4130 makes everything absent, which is what that case asserts. So it needs its own: make `reflection_explicitly_disabled()` return `false` unconditionally, i.e. stop reading `STELLA_DISABLE_REFLECTION` at all.

```
$ cargo test -p stella-cli --test run_reflection_writes_cli
running 2 tests
test the_opt_out_stops_the_lesson_being_written ... FAILED
test a_headless_json_run_writes_its_lesson_to_the_mining_log ... ok

---- the_opt_out_stops_the_lesson_being_written stdout ----
assertion `left == right` failed: `STELLA_DISABLE_REFLECTION=1` must buy no reflection model call
  left: 1
 right: 0

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

Each direction is independently falsifiable, and neither ablation merely makes the answer constant — each makes it **wrong**, in opposite directions.

Both restored, green:

```
$ cargo test -p stella-cli --test run_reflection_writes_cli --test run_exits_cli
running 3 tests
test run_exits_on_its_own_with_stream_json ... ok
test run_exits_on_its_own_with_json ... ok
test run_exits_on_its_own_with_text ... ok
test result: ok. 3 passed; 0 failed; ... finished in 13.36s

running 2 tests
test a_non_interactive_json_run_writes_its_lesson_to_the_mining_log ... ok
test the_opt_out_stops_the_lesson_being_written ... ok
test result: ok. 2 passed; 0 failed; ...
```

`cargo clippy -p stella-cli --tests -- -D warnings` clean; `cargo fmt --check` clean; `make guards-fast` green.

## Also in this diff: `run_exits_cli.rs` had stopped asserting anything

Found while writing the test above, and fixed here because it is the same defect in the same directory — a green test over a run that never happened.

`--output-format` moved off the root position onto `run` (`crates/stella-cli/src/tests.rs` now asserts the root spelling is a **parse error**, and `run_and_fleet_declare_output_format` pins the new one). `run_exits_cli.rs` kept the old order and was never updated, so all three of its cases had been spawning:

```
$ ./target/debug/stella --model … --output-format json run "say hi and stop"
error: unexpected argument '--output-format' found
  tip: 'run --output-format' exists
EXIT=2
```

The file asserts only that the process *exited* within 120s. A clap usage error satisfies that perfectly, so the three tests protecting #960's shutdown path had been passing on a process that died in the argument parser — the whole binary finishing in 2.47s where a real run takes ~16s.

Fixed: the argument order, plus an assertion that the exit code is not clap's usage status (stderr piped so a future recurrence quotes itself back). Ablating it back to the old order:

```
---- run_exits_on_its_own_with_json stdout ----
assertion `left != right` failed: `stella run --output-format json` died in the argument parser, so it never reached the shutdown path this test is about — stderr: error: unexpected argument '--output-format' found
  left: Some(2)
 right: Some(2)

test result: FAILED. 0 passed; 3 failed; ... finished in 2.69s
```

Repaired, the suite runs in 16.38s instead of 2.47s — which is the three runs actually happening.

## Deleted tests

None. `run_exits_cli.rs`'s three `#[test]` functions keep their names and their assertions; only the argument order and an added exit-code check changed.

Closes #4936

## Summary by Sourcery

Verify that non-interactive runs persist reflections correctly while strengthening shutdown tests against argument-parsing false positives.

Bug Fixes:
- Add end-to-end coverage proving non-interactive JSON runs write exactly one reflection lesson and honor STELLA_DISABLE_REFLECTION.

Enhancements:
- Restore the run-exit tests' intended coverage by using the current argument order and rejecting clap usage errors as false-positive exits.

Tests:
- Add hermetic wiremock-backed CLI tests covering both reflection persistence and the child-process opt-out path.