### PR TITLE
feat(stella-core): a non-Latin mined lesson gets a name, folded to ASCII

### DIFF
--- a/crates/stella-core/src/mining.rs
+++ b/crates/stella-core/src/mining.rs
@@ -6,6 +6,8 @@
 //! (These started as two byte-identical private copies; the divergence risk
 //! is why they were merged.)
 
+mod translit;
+
 use std::collections::{HashMap, HashSet};
 
 const STOPWORDS: &[&str] = &[
@@ -250,6 +252,32 @@ pub(crate) fn jaccard(a: &HashSet<String>, b: &HashSet<String>) -> f64 {
 /// Filesystem/id-safe slug: lowercase, alnum + dashes, capped short.
 /// `fallback` names the artifact kind when the text slugs to nothing
 /// (`"lesson"` for rules, `"skill"` for skills) (TS: `slugify`).
+///
+/// # Non-Latin text gets a name, and every path stays ASCII (#4913)
+///
+/// A letter outside ASCII is folded to the ASCII letters that stand for it
+/// ([`translit::ascii_fold`]) before it is dropped as a separator. Without
+/// that, a lesson mined from Russian or Czech text slugged to nothing and the
+/// whole id was `skill-<hash8>` — unique, stable, and unreadable in `ls`, in
+/// the SKILLS tab, and in a `git diff`. #3298's clustering half is what made
+/// that reachable: before it, non-Latin observations never clustered, so no
+/// such candidate was ever minted.
+///
+/// **Folding, not widening.** The output alphabet is unchanged, so this
+/// decides nothing about whether `.stella/skills/` may hold non-ASCII paths —
+/// the filesystem question the module header of [`translit`] lays out, and the
+/// reason widening is not the fix. A script with no single-codepoint
+/// romanization (Han, kana, Arabic, Hebrew) still slugs to `fallback`; #4968
+/// tracks it.
+///
+/// **No id already on disk moves.** An id is minted once and never recomputed
+/// against an existing file: the miners' [`already_captured`] guard compares
+/// *text* against the name/description/body of what is already there, so an
+/// artifact minted under the old alphabet keeps its filename and is still
+/// recognised as the duplicate it is. What moves is the id the *same text*
+/// would mint from here on — `café serveur` becomes `cafe-serveur` rather than
+/// `caf-serveur` — and an ASCII-only text mints the byte-identical id it
+/// always did, which `slugify_is_unchanged_on_ascii` holds.
 pub(crate) fn slugify(text: &str, fallback: &str) -> String {
     let mut collapsed = String::new();
     let mut prev_dash = false;
@@ -257,6 +285,11 @@ pub(crate) fn slugify(text: &str, fallback: &str) -> String {
         if ch.is_ascii_alphanumeric() {
             collapsed.push(ch);
             prev_dash = false;
+        } else if let Some(folded) = translit::ascii_fold(ch) {
+            // May be empty — a Cyrillic hard or soft sign stands for no letter
+            // of its own — and an empty folding is not a separator either.
+            collapsed.push_str(folded);
+            prev_dash = prev_dash && folded.is_empty();
         } else if !prev_dash {
             collapsed.push('-');
             prev_dash = true;
@@ -458,6 +491,87 @@ mod tests {
             ["終了時にプロセスを停止"],
             0.4
         ));
+    }
+
+    /// **Witness (#4913).** A lesson mined from non-Latin text gets a name.
+    ///
+    /// On base every one of these slugs to the bare artifact kind or to its
+    /// surviving ASCII fragments, so the whole id is `lesson-<hash8>` and a
+    /// Russian workspace's `.stella/skills/` fills with directories that are
+    /// indistinguishable from one another in `ls`.
+    #[test]
+    fn non_latin_text_slugs_to_a_readable_name() {
+        assert_eq!(
+            slugify("форматировать запросы", "lesson"),
+            "formatirovat-zaprosy"
+        );
+        assert_eq!(slugify("Ještě jednou", "lesson"), "jeste-jednou");
+        assert_eq!(slugify("straße für alle", "lesson"), "strasse-fur-alle");
+        assert_eq!(slugify("γράψε τεστ", "lesson"), "grapse-test");
+        // A hard or soft sign stands for no letter of its own, so it joins the
+        // word rather than splitting it.
+        assert_eq!(slugify("объект", "lesson"), "obekt");
+    }
+
+    /// The other half of that witness, and the reason this is a fold rather
+    /// than a widening: the slug alphabet did not move, so nothing here can
+    /// put a non-ASCII byte into a directory name.
+    #[test]
+    fn a_slug_is_still_ascii_whatever_the_text_was() {
+        for text in [
+            "форматировать запросы",
+            "café serveur",
+            "数据库查询格式化",
+            "γράψε τεστ",
+            "אבג",
+        ] {
+            let slug = slugify(text, "lesson");
+            assert!(
+                slug.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "{text:?} slugged to {slug:?}"
+            );
+        }
+        // The scripts with no single-codepoint romanization are unchanged:
+        // there is nothing to fold them to — see `translit`'s header and #4968.
+        assert_eq!(slugify("数据库查询格式化", "skill"), "skill");
+    }
+
+    proptest::proptest! {
+        /// **No id already on disk moves.** Every artifact minted before this
+        /// change came from text whose slug was decided by the ASCII rule, and
+        /// folding only ever fires on a character that rule rejected — so on
+        /// ASCII text the two are the same function. `migration_contract`'s
+        /// `candidate_identity_is_pinned_to_a_literal` pins one shipped id;
+        /// this pins the class, the same pairing #3298 used for `terms`.
+        #[test]
+        fn slugify_is_unchanged_on_ascii(text in "[ -~]{0,200}") {
+            proptest::prop_assert_eq!(slugify(&text, "lesson"), ascii_slugify(&text, "lesson"));
+        }
+    }
+
+    /// The slug rule this change replaced, verbatim, so the property above
+    /// compares against the shipped behavior rather than a description of it.
+    fn ascii_slugify(text: &str, fallback: &str) -> String {
+        let mut collapsed = String::new();
+        let mut prev_dash = false;
+        for ch in text.to_lowercase().chars() {
+            if ch.is_ascii_alphanumeric() {
+                collapsed.push(ch);
+                prev_dash = false;
+            } else if !prev_dash {
+                collapsed.push('-');
+                prev_dash = true;
+            }
+        }
+        let trimmed = collapsed.trim_matches('-');
+        let truncated: String = trimmed.chars().take(40).collect();
+        let truncated = truncated.trim_end_matches('-');
+        if truncated.is_empty() {
+            fallback.to_string()
+        } else {
+            truncated.to_string()
+        }
     }
 
     /// The two spaces still agree on *tokenization* for ASCII text — the

--- a/crates/stella-core/src/mining/translit.rs
+++ b/crates/stella-core/src/mining/translit.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One lowercase non-ASCII letter → the ASCII letters that stand for it, for
+//! [`super::slugify`] (#4913).
+//!
+//! ## Why transliterate rather than widen the alphabet
+//!
+//! A mining slug is a **directory name** — `.stella/skills/<slug>-<hash8>/` —
+//! so widening [`super::slugify`] to accept Unicode letters would decide, as a
+//! side effect, that `.stella/skills/` may hold non-ASCII paths. That is a
+//! question about filesystems, not about mining: macOS's HFS+ stores `é`
+//! decomposed while a Linux clone writes it composed, so the same logical name
+//! is two different byte strings depending on where the workspace was cloned,
+//! and a case-insensitive volume folds pairs an ext4 clone keeps apart.
+//! Folding to ASCII first keeps every path in the alphabet the repository
+//! already commits to, and the readable name is the point of the fix rather
+//! than the original codepoints.
+//!
+//! ## What is here and what is not
+//!
+//! Three scripts, chosen by one rule: a letter is here when it has an
+//! unambiguous ASCII stand-in that does not need a dictionary.
+//!
+//! - **Latin-1 Supplement and Latin Extended-A** — diacritic folding plus the
+//!   handful of digraphs (`ß` → `ss`, `æ` → `ae`, `þ` → `th`).
+//! - **Cyrillic** — BGN/PCGN romanization, the one an English reader is most
+//!   likely to have seen (`щ` → `shch`, `х` → `kh`). The hard and soft signs
+//!   romanize to nothing, which is why the table maps to a `&str` rather than
+//!   a `char`.
+//! - **Greek** — ISO 843 transcription, letter by letter. The digraph rules
+//!   (`γγ` → `ng`, `ου` → `ou`) are not applied: they need context, and a
+//!   slug is not a transcription.
+//!
+//! **CJK, Arabic, Hebrew and every other script are absent, and their text
+//! still slugs to the bare artifact kind.** Not an oversight: Han characters
+//! have no single-codepoint romanization at all — pinyin is a per-character
+//! dictionary of thousands of entries, and which reading is right depends on
+//! the word — so anything this table could return would be invented. #4968
+//! tracks that half.
+//!
+//! Uppercase is absent for the same reason it is not needed:
+//! [`super::slugify`] lowercases before it folds, and `char::to_lowercase`
+//! already knows every one of these scripts (Greek's final sigma included).
+
+/// The ASCII letters `ch` stands for, or `None` when this table has no answer
+/// and the caller should treat the character as a separator.
+///
+/// `Some("")` is a real answer, distinct from `None`: Cyrillic `ъ` and `ь`
+/// modify the letter beside them and contribute no letter of their own, so
+/// `объект` is `obekt` rather than `ob-ekt`.
+pub(super) fn ascii_fold(ch: char) -> Option<&'static str> {
+    latin(ch).or_else(|| cyrillic(ch)).or_else(|| greek(ch))
+}
+
+/// Latin-1 Supplement (U+00E0–U+00FF) and Latin Extended-A (U+0100–U+017F),
+/// lowercase.
+fn latin(ch: char) -> Option<&'static str> {
+    Some(match ch {
+        'à' | 'á' | 'â' | 'ã' | 'ä' | 'å' | 'ā' | 'ă' | 'ą' => "a",
+        'æ' => "ae",
+        'ç' | 'ć' | 'ĉ' | 'ċ' | 'č' => "c",
+        'ď' | 'đ' | 'ð' => "d",
+        'è' | 'é' | 'ê' | 'ë' | 'ē' | 'ĕ' | 'ė' | 'ę' | 'ě' => "e",
+        'ĝ' | 'ğ' | 'ġ' | 'ģ' => "g",
+        'ĥ' | 'ħ' => "h",
+        'ì' | 'í' | 'î' | 'ï' | 'ĩ' | 'ī' | 'ĭ' | 'į' | 'ı' => "i",
+        'ĳ' => "ij",
+        'ĵ' => "j",
+        'ķ' | 'ĸ' => "k",
+        'ĺ' | 'ļ' | 'ľ' | 'ŀ' | 'ł' => "l",
+        'ñ' | 'ń' | 'ņ' | 'ň' | 'ŉ' | 'ŋ' => "n",
+        'ò' | 'ó' | 'ô' | 'õ' | 'ö' | 'ø' | 'ō' | 'ŏ' | 'ő' => "o",
+        'œ' => "oe",
+        'ŕ' | 'ŗ' | 'ř' => "r",
+        'ś' | 'ŝ' | 'ş' | 'š' | 'ſ' => "s",
+        'ß' => "ss",
+        'ţ' | 'ť' | 'ŧ' => "t",
+        'þ' => "th",
+        'ù' | 'ú' | 'û' | 'ü' | 'ũ' | 'ū' | 'ŭ' | 'ů' | 'ű' | 'ų' => "u",
+        'ŵ' => "w",
+        'ý' | 'ÿ' | 'ŷ' => "y",
+        'ź' | 'ż' | 'ž' => "z",
+        _ => return None,
+    })
+}
+
+/// Cyrillic (U+0430–U+044F plus `ё`), lowercase, BGN/PCGN.
+fn cyrillic(ch: char) -> Option<&'static str> {
+    Some(match ch {
+        'а' => "a",
+        'б' => "b",
+        'в' => "v",
+        'г' => "g",
+        'д' => "d",
+        'е' | 'ё' | 'э' => "e",
+        'ж' => "zh",
+        'з' => "z",
+        'и' => "i",
+        'й' => "y",
+        'к' => "k",
+        'л' => "l",
+        'м' => "m",
+        'н' => "n",
+        'о' => "o",
+        'п' => "p",
+        'р' => "r",
+        'с' => "s",
+        'т' => "t",
+        'у' => "u",
+        'ф' => "f",
+        'х' => "kh",
+        'ц' => "ts",
+        'ч' => "ch",
+        'ш' => "sh",
+        'щ' => "shch",
+        'ы' => "y",
+        // The hard and soft signs are not letters of their own.
+        'ъ' | 'ь' => "",
+        'ю' => "yu",
+        'я' => "ya",
+        _ => return None,
+    })
+}
+
+/// Greek (U+03B1–U+03C9 plus the accented vowels), lowercase, ISO 843.
+fn greek(ch: char) -> Option<&'static str> {
+    Some(match ch {
+        'α' | 'ά' => "a",
+        'β' => "v",
+        'γ' => "g",
+        'δ' => "d",
+        'ε' | 'έ' => "e",
+        'ζ' => "z",
+        'η' | 'ή' | 'ι' | 'ί' | 'ϊ' | 'ΐ' => "i",
+        'θ' => "th",
+        'κ' => "k",
+        'λ' => "l",
+        'μ' => "m",
+        'ν' => "n",
+        'ξ' => "x",
+        'ο' | 'ό' | 'ω' | 'ώ' => "o",
+        'π' => "p",
+        'ρ' => "r",
+        // Final sigma: `char::to_lowercase` leaves it as its own codepoint.
+        'σ' | 'ς' => "s",
+        'τ' => "t",
+        'υ' | 'ύ' | 'ϋ' | 'ΰ' => "y",
+        'φ' => "f",
+        'χ' => "ch",
+        'ψ' => "ps",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every folding this table performs must land back inside the alphabet
+    /// [`super::super::slugify`] is allowed to emit — that is the whole reason
+    /// to fold rather than widen, and an entry that returned a non-ASCII
+    /// character would put a non-ASCII byte into a directory name through the
+    /// one door built to keep them out.
+    #[test]
+    fn every_folding_is_ascii_lowercase_alphanumeric() {
+        for codepoint in 0u32..0x2FFF {
+            let Some(ch) = char::from_u32(codepoint) else {
+                continue;
+            };
+            let Some(folded) = ascii_fold(ch) else {
+                continue;
+            };
+            assert!(
+                folded.chars().all(|c| c.is_ascii_lowercase()),
+                "{ch:?} (U+{codepoint:04X}) folds to {folded:?}, which slugify may not emit"
+            );
+        }
+    }
+
+    /// No ASCII character may be in the table. `slugify` handles those itself,
+    /// and an entry here would be a second answer for a character that already
+    /// has one.
+    #[test]
+    fn no_ascii_character_is_folded() {
+        for codepoint in 0u32..128 {
+            let ch = char::from_u32(codepoint).expect("ASCII is valid");
+            assert_eq!(
+                ascii_fold(ch),
+                None,
+                "{ch:?} is ASCII — slugify decides it, not this table"
+            );
+        }
+    }
+
+    /// The scripts this table leaves out, so the header paragraph saying so
+    /// cannot become false without a test going red.
+    #[test]
+    fn a_script_with_no_single_codepoint_romanization_is_absent() {
+        for ch in ['数', '据', 'あ', 'ア', 'ا', 'א', '한'] {
+            assert_eq!(
+                ascii_fold(ch),
+                None,
+                "{ch:?} has no single-codepoint ASCII stand-in — see #4968"
+            );
+        }
+    }
+}

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -628,6 +628,31 @@ fn mines_a_recurring_preference_at_the_threshold() {
     assert!(candidates[0].body.contains("prefers tables"));
 }
 
+/// **Witness (#4913), end to end.** Three Russian restatements of one lesson
+/// cluster (#3298) and mint a candidate — and on base that candidate's whole
+/// name is `skill-<hash8>`, because `slugify` kept only ASCII and the text has
+/// none. A workspace whose lessons are written in Russian filled
+/// `.stella/skills/` with directories nobody could tell apart in `ls`.
+#[test]
+fn a_non_latin_lesson_mints_a_name_a_human_can_read() {
+    let obs = vec![
+        observation("всегда форматировать запросы перед отправкой", 1),
+        observation("форматировать запросы перед отправкой, всегда", 2),
+        observation("запросы перед отправкой форматировать", 3),
+    ];
+    let candidates = mine_skill_candidates(obs, &[], &SkillMineConfig::default());
+    assert_eq!(candidates.len(), 1, "one cluster: {candidates:#?}");
+    let name = &candidates[0].name;
+    assert!(
+        name.starts_with("formatirovat-zaprosy-pered-otpravkoy"),
+        "the id carries the lesson's words, not just a hash: {name}"
+    );
+    assert!(
+        name.is_ascii(),
+        "and it is still a directory name this repository will commit: {name}"
+    );
+}
+
 #[test]
 fn does_not_mine_a_one_off_below_the_threshold() {
     let obs = vec![observation("a one-time thing nobody repeated", 1)];


### PR DESCRIPTION
## Which of the three shapes, and why

#4913 lays out three options and asks for a pick, said in the code. This is the third — **transliterate to ASCII** — implemented in-tree rather than by taking `deunicode`/`unidecode`, so the dependency decision the issue flagged does not have to be made either.

Both other options were rejected for the reason the issue names:

- **Widening the slug alphabet** decides, as a side effect, whether `.stella/skills/` may hold non-ASCII paths. macOS stores `é` decomposed where a Linux clone composes it, and a case-insensitive volume folds pairs an ext4 clone keeps apart. That is a filesystem question, it is bigger than this issue, and **this PR does not answer it** — the output alphabet is exactly where it was, so the question stays open and unforced.
- **Leaving it** loses the readability the issue is about.

The argument lives in `crates/stella-core/src/mining/translit.rs`'s module header, so the choice is reviewable rather than implied.

## What it covers, and what it does not

`translit::ascii_fold` maps one lowercase non-ASCII letter to the ASCII letters that stand for it. Three scripts, chosen by one rule — a letter is in the table when it has an unambiguous ASCII stand-in that needs no dictionary:

- **Latin-1 Supplement and Latin Extended-A** — diacritic folding plus the digraphs (`ß` → `ss`, `æ` → `ae`, `þ` → `th`).
- **Cyrillic** — BGN/PCGN (`щ` → `shch`, `х` → `kh`). The hard and soft signs romanize to nothing, which is why the table returns a `&str` and `Some("")` is a real answer distinct from `None`: `объект` is `obekt`, not `ob-ekt`.
- **Greek** — ISO 843, letter by letter. The digraph rules (`γγ` → `ng`) need context and are not applied; a slug is not a transcription.

**Han, kana, Arabic and Hebrew are absent, and their text still slugs to the artifact kind** — so the Chinese example in #4913's title is *not* fixed here. Romanizing Han needs a per-character dictionary of thousands of entries and the right reading depends on the surrounding word, so anything a small table returned would be invented. That half is filed as **#4968** with the three options and the licensing/filesystem questions each one owes, and `a_script_with_no_single_codepoint_romanization_is_absent` pins today's answer so the header cannot go quietly false.

Uppercase is not in the table: `slugify` lowercases first, and `char::to_lowercase` already knows all three scripts (Greek's final sigma included).

## No migration

An id is minted once, at mint time, and never recomputed against a file already on disk. The miners' duplicate guard — `mining::already_captured` — compares the candidate's **text** against the `name`/`description`/`body` of every existing skill, never a filename, so an artifact minted under the old rule keeps its own directory name and a re-mine of the same text is still recognised as the duplicate it is. (Verified by reading `already_captured` and `mine_skill_candidates`, not taken from the issue: the haystack is `format!("{} {} {}", s.name, s.description, s.body)`.)

What *does* move is the id the same text would mint from here on — `café serveur` becomes `cafe-serveur` rather than `caf-serveur`. Nothing is orphaned by that and no duplicate appears; it changes future names only.

ASCII text mints the byte-identical id it always did. `slugify_is_unchanged_on_ascii` holds that over generated input against a verbatim copy of the old rule, the same pairing #3298 used for `terms`, and `migration_contract::candidate_identity_is_pinned_to_a_literal` / `rendered_skill_bytes_are_pinned` are green **unchanged**.

## Witnesses

- `non_latin_text_slugs_to_a_readable_name` — Russian, Czech, German, Greek, and the hard-sign case.
- `a_slug_is_still_ascii_whatever_the_text_was` — the fold-not-widen property, including the CJK case that is still `skill`.
- `a_non_latin_lesson_mints_a_name_a_human_can_read` (`crates/stella-core/src/skills/tests.rs`) — end to end through `mine_skill_candidates`, which is #4913's own "Verify" recipe.
- `translit`'s three table tests: every folding is ASCII lowercase, no ASCII character is in the table, and the absent scripts stay absent.

Ablated by deleting the fold arm from `slugify` and leaving everything else:

```
---- mining::tests::non_latin_text_slugs_to_a_readable_name stdout ----
assertion `left == right` failed
  left: "lesson"
 right: "formatirovat-zaprosy"

---- skills::tests::a_non_latin_lesson_mints_a_name_a_human_can_read stdout ----
the id carries the lesson's words, not just a hash: skill-b10b8096

test result: FAILED. 0 passed; 2 failed
```

The answer is wrong under ablation rather than merely constant: `a_slug_is_still_ascii_whatever_the_text_was` and `slugify_is_unchanged_on_ascii` stay green either way, so the suite cannot pass by folding nothing *or* by folding everything into non-ASCII.

## No deleted or renamed tests

Nothing removed or renamed; six added.

## No new dependencies

The table is in-tree, `mining/translit.rs`, ~150 lines. That is the point of picking this shape over `deunicode`.

## Verification

`cargo fmt --all --check`, `cargo clippy -p stella-core --all-targets -- -D warnings`, `make guards-fast` (prose included), `cargo test -p stella-core` (exit 0), and `cargo test -p stella-cli --bins` (2325 passed — the id-shape assertions in `memory/tests/skill_creation.rs` and `memory/rules_mining/tests.rs` among them). CI is the evidence.

Closes #4913
Refs #3298, #4968

## Summary by Sourcery

Make mined lesson identifiers readable for supported non-Latin text without widening the repository’s ASCII path alphabet or changing existing artifact names.

New Features:
- Transliterate supported Latin, Cyrillic, and Greek lesson text into readable ASCII slug names while preserving ASCII-only paths.
- Keep scripts without unambiguous single-character romanizations on the existing artifact fallback behavior.

Bug Fixes:
- Prevent non-Latin mined lessons from losing their readable names and falling back to hash-only identifiers.

Enhancements:
- Document the ASCII-folding strategy, its filesystem rationale, and its compatibility and migration behavior.
- Add unit, property-based, and end-to-end coverage for transliteration, ASCII stability, fallback scripts, and readable mined identifiers.

Tests:
- Add coverage validating transliteration mappings, ASCII-only slug output, unchanged ASCII behavior, unsupported scripts, and end-to-end skill mining.