### PR TITLE
feat(scripts,ci): the warm-paper clamp reaches a shipped light surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,6 +411,15 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: python3 ./scripts/check-contrast.py
 
+      # The fourth ruler, and the one the other three could not be. All three
+      # above read the token table, and so did both enforcers of the light
+      # ground's own `warm-paper` clamp — so a hand-picked light neutral was
+      # invisible to the rule written for it, which is precisely the value that
+      # rule exists to judge. This reads the surfaces (#4941).
+      - name: every shipped light surface satisfies its declared clamp
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-light-clamp.py
+
       # A sibling question the check above cannot answer: it reasons about hex
       # literals, and an unresolvable var() is not a parse error. A token sheet
       # can name a stop deleted two releases ago, every page still renders off

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -68,11 +68,15 @@ name: docs-guards
 #     docs/brand/README.md ever invoked it. `--check` returns before it reaches
 #     rsvg-convert, so it needs no renderer and no desktop font.
 #
-# 10. the four colour rulers (scripts/check-tokens.py with gen-tokens.py
-#     --check, check-hue-separation.py, check-contrast.py, check-css-vars.py):
-#     what kind of colour a value is, whether two of them can be told apart,
-#     whether one can be read on its ground, and whether a token sheet's every
-#     var() resolves. They ran only in ci.yml, whose `check` job is skipped
+# 10. the five colour rulers (scripts/check-tokens.py with gen-tokens.py
+#     --check, check-hue-separation.py, check-contrast.py, check-css-vars.py,
+#     check-light-clamp.py): what kind of colour a value is, whether two of
+#     them can be told apart, whether one can be read on its ground, whether a
+#     token sheet's every var() resolves, and whether a shipped light SURFACE
+#     satisfies the clamp its family declares -- the fifth being the only one
+#     that reads anything but the token table, which is why the light ground's
+#     own clamp governed nothing that ships until #4941.
+#     They ran only in ci.yml, whose `check` job is skipped
 #     whole for a diff confined to `docs/**` and `website/**` -- the diff whose
 #     subject is the brand kit, the standalone HTML documents, the two
 #     hand-maintained token mirrors and the decks (#3653).
@@ -103,7 +107,9 @@ on:
       - "scripts/check-hue-separation.py"
       - "scripts/check-contrast.py"
       - "scripts/check-css-vars.py"
+      - "scripts/check-light-clamp.py"
       - "scripts/contrast-baseline.txt"
+      - "scripts/light-clamp-baseline.txt"
       - "design/tokens/**"
       - ".github/workflows/docs-guards.yml"
   push:
@@ -129,7 +135,9 @@ on:
       - "scripts/check-hue-separation.py"
       - "scripts/check-contrast.py"
       - "scripts/check-css-vars.py"
+      - "scripts/check-light-clamp.py"
       - "scripts/contrast-baseline.txt"
+      - "scripts/light-clamp-baseline.txt"
       - "design/tokens/**"
       - ".github/workflows/docs-guards.yml"
   workflow_dispatch:
@@ -205,6 +213,13 @@ jobs:
       - name: every var() in a token sheet resolves
         if: ${{ !cancelled() }}
         run: python3 scripts/check-css-vars.py
+
+      # The four above read the token table. So did both enforcers of the
+      # light ground's own `warm-paper` clamp, which is why that clamp
+      # governed nothing that ships. This one reads the surfaces (#4941).
+      - name: every shipped light surface satisfies its declared clamp
+        if: ${{ !cancelled() }}
+        run: python3 scripts/check-light-clamp.py
 
       # Both directions matter here, which is why it runs in ci.yml too. A new
       # guard is a Makefile change (ci.yml sees it); an edit that quietly drops

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -134,6 +134,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-contrast.sh
 
+      - name: light-clamp guard directions
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-light-clamp.sh
+
       - name: dead-code ratchet direction
         if: ${{ !cancelled() }}
         run: ./scripts/test-dead-code-allows.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,12 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + tokens (hue clamp + no retired hex)
                          #   + hue-separation (30° OKLCH, web tokens)
                          #   + contrast (WCAG, down-only ratchet)
+                         #   + light-clamp (a shipped light SURFACE against
+                         #     the clamp its family declares — the other
+                         #     three colour rulers all read the token table,
+                         #     and so did both enforcers of `warm-paper`,
+                         #     which is why that clamp governed nothing that
+                         #     ships; down-only ratchet)
                          #   + transcript-surfaces
                          #   + prose (no content-free constructions added)
                          #   + line-citations (prose cites code by symbol

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,7 @@ python3 ./scripts/gen-tokens.py --check
 python3 ./scripts/check-tokens.py
 python3 ./scripts/check-hue-separation.py
 python3 ./scripts/check-contrast.py
+python3 ./scripts/check-light-clamp.py
 python3 ./scripts/check-transcript-surfaces.py
 python3 ./scripts/check-line-citations.py
 python3 ./scripts/check-prose.py

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     tool-error-class \
                     dead-code-allows measured-constants diagnostic-codes consumer-sites \
                     bench-suites wire-paths \
-                    tokens hue-separation contrast transcript-surfaces prose \
+                    tokens hue-separation contrast light-clamp transcript-surfaces prose \
                     line-citations \
                     deck-fit-all-test deck-paths css-vars reserved-paths
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
@@ -404,6 +404,28 @@ contrast-update: ## Retighten the contrast ratchet (run after lightening a colou
 .PHONY: contrast-test
 contrast-test: ## Test the contrast ratchet's direction (hermetic; not part of `gate`)
 	./scripts/test-contrast.sh
+
+# The fourth colour question, and the one the other three could not ask. All
+# three above read the TOKEN TABLE; so did the two enforcers of the `warm-paper`
+# clamp (gen-tokens.py::validate and clamp.rs::satisfies). So the light ground's
+# own law applied to nothing that ships, and a hand-picked light neutral was
+# invisible to it precisely because being a non-token is what makes such a value
+# the problem. This reads SURFACES (#4941).
+.PHONY: light-clamp
+light-clamp: ## Assert every shipped light surface satisfies the clamp its family declares (#4941)
+	@python3 ./scripts/check-light-clamp.py
+
+.PHONY: light-clamp-report
+light-clamp-report: ## Name every light-scheme declaration, its family and its verdict
+	@python3 ./scripts/check-light-clamp.py --report
+
+.PHONY: light-clamp-update
+light-clamp-update: ## Retighten the light-clamp ratchet (run after warming a neutral)
+	@python3 ./scripts/check-light-clamp.py --update
+
+.PHONY: light-clamp-test
+light-clamp-test: ## Test the light-clamp guard's directions (hermetic; not part of `gate`)
+	./scripts/test-light-clamp.sh
 
 .PHONY: typed-errors
 typed-errors: ## Assert no library crate's public API returns Result<_, String> (invariant #5)

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -157,6 +157,7 @@ step_command() {
   tokens) echo 'check-tokens' ;;
   hue-separation) echo 'check-hue-separation' ;;
   contrast) echo 'check-contrast' ;;
+  light-clamp) echo 'check-light-clamp' ;;
   transcript-surfaces) echo 'check-transcript-surfaces' ;;
   prose) echo 'check-prose' ;;
   line-citations) echo 'check-line-citations' ;;

--- a/scripts/check-light-clamp.py
+++ b/scripts/check-light-clamp.py
@@ -365,6 +365,23 @@ def main(argv: list[str]) -> int:
     held = read_baseline(root)
     measured = {(file, role): hexv for file, role, hexv, _ in violations}
 
+    # Neither writing mode may run while a role is unclassifiable. Which colour
+    # family is this? is a question for a person, and a writer cannot answer it
+    # -- so without this the ratchet is written cleanly around a role nobody has
+    # judged and the run reports success. `test-light-clamp.sh`'s U2 found it in
+    # `--update`; `--bootstrap` had it too, reachable only on a tree with no
+    # ratchet yet, which is exactly the tree with nobody to notice.
+    if unclassifiable and flags & {"--bootstrap", "--update"}:
+        print(
+            f"check-light-clamp: refusing to write the ratchet while "
+            f"{len(unclassifiable)} role(s) are unclassifiable. Classify them "
+            "first — a ratchet cannot stand in for a decision:\n",
+            file=sys.stderr,
+        )
+        for line in unclassifiable:
+            print(f"  {line}", file=sys.stderr)
+        return 1
+
     if "--bootstrap" in flags:
         if (root / BASELINE_REL).exists():
             print(
@@ -378,20 +395,6 @@ def main(argv: list[str]) -> int:
         return 0
 
     if "--update" in flags:
-        # An unclassifiable role is a question for a person -- which colour
-        # family is this? -- and a writer cannot answer it. Without this the
-        # ratchet retightens cleanly around a role nobody has judged, and the
-        # run reports success. `test-light-clamp.sh`'s U2 is what found it.
-        if unclassifiable:
-            print(
-                "check-light-clamp: refusing to retighten while "
-                f"{len(unclassifiable)} role(s) are unclassifiable. Classify "
-                "them first — a ratchet cannot stand in for a decision:\n",
-                file=sys.stderr,
-            )
-            for line in unclassifiable:
-                print(f"  {line}", file=sys.stderr)
-            return 1
         added = sorted(k for k in measured if k not in held)
         if added:
             print(

--- a/scripts/check-light-clamp.py
+++ b/scripts/check-light-clamp.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Hold a shipped light surface to the clamp its colour family declares (#4941).
+
+`design/tokens/stella-tokens.json` states the light ground's law:
+
+    "warm-paper": {
+      "predicate": "r >= g >= b AND 100*g >= 97*r AND 100*b >= 93*r",
+      "why": "The light ground's clamp: warm or neutral, never blue."
+    }
+
+Until this script, that law applied to nothing that ships. It was enforced in
+exactly two places -- `gen-tokens.py::validate` and
+`crates/stella-tui-theme/src/clamp.rs::satisfies` -- and both iterate the token
+table, so the clamp only ever judged colours that were **already tokens**. A
+hand-picked light neutral that is not a token was invisible to it, and being a
+non-token is exactly the property that makes such a value the problem.
+
+So this guard reads **surfaces**. Every light-scheme declaration on the five
+web surfaces and the command deck's paper ramp is classified and judged:
+
+  1. A value that IS a kit token is held to **that token's own declared
+     clamp**. `--text: #0A0A0C` on a light page is the dark canvas token being
+     reused; whether that is the right value is #4072's question, and it is
+     not this guard's. Whether it satisfies the clamp it declares is.
+  2. A value that is NOT a token is held to the clamp of the **family its
+     surface declares** for that role, in `SURFACES` below.
+  3. A value that is neither a token nor declared is **unclassifiable**, and
+     that fails. It is the one outcome that must not be silent: a new
+     hand-picked light neutral arriving under a new name is the exact event
+     this guard exists to catch, and skipping what it cannot classify would
+     make it blind to precisely that.
+
+The predicates themselves are **not written here**. `gen-tokens.py`'s
+`check_clamp` is imported and called, so there is one Python implementation of
+`warm-paper` in the repository rather than two. A predicate written twice is
+the drift this repository keeps paying for -- `clamp.rs` is the second
+implementation and `check-tokens.py` is what holds it to the first.
+
+## The ratchet
+
+The tree does not pass this guard, and that is the finding rather than a bug in
+the guard. #4072 is deciding which values the light scheme should have --
+recolour the surfaces to the warm authority, or write a second cool clamp into
+the authority -- and that decision is a palette owner's. This guard is the half
+that is the same either way: something has to hold a shipped surface to a
+clamp, or the next hand-picked neutral lands exactly as this one did.
+
+So it ships as a **down-only ratchet** (`scripts/light-clamp-baseline.txt`), on
+`scripts/contrast-baseline.txt`'s model and for the same stated reason: the
+rule predates the guard, so the baseline records a debt that already existed
+rather than granting new permission. It records the **measured value**, not a
+count, so repainting a baselined role to a *different* off-clamp value fails --
+the licence is for the hex that shipped, not for the name.
+
+`--update` drops an entry whose value now satisfies its clamp and **refuses to
+add one**, so the only way past a red gate is to move the colour. `--bootstrap`
+writes the file once and refuses if it exists. The file is meant to reach
+empty; adding an entry by hand is the expedient CLAUDE.md forbids, and widening
+the clamp to make the gate green would delete the only law the light ground
+has.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TOKENS_REL = Path("design") / "tokens" / "stella-tokens.json"
+BASELINE_REL = Path("scripts") / "light-clamp-baseline.txt"
+
+BASELINE_HEADER = """\
+# Down-only ratchet for scripts/check-light-clamp.py.
+#
+# Each line is `<file> <role> <hex>` -- a light-scheme value that fails the
+# clamp its family declares, recorded at the value it shipped at. A repaint to
+# a *different* off-clamp value fails: the licence is for this hex, not for
+# this name.
+#
+# `make light-clamp-update` drops an entry that now satisfies its clamp and
+# refuses to add one. The only way past a red gate is to move the colour.
+#
+# This file records the debt #4941 found, which #4072 is deciding how to pay.
+# It is meant to reach empty.
+"""
+
+
+def load_generator():
+    """`gen-tokens.py`, imported so its predicates are not written twice."""
+    path = REPO / "scripts" / "gen-tokens.py"
+    spec = importlib.util.spec_from_file_location("stella_gen_tokens", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── What a surface declares ─────────────────────────────────────────────────
+#
+# `families` names the colour family for each light-scheme role whose value is
+# NOT a kit token. A role carrying a token needs no entry: rule 1 reads the
+# clamp off the token. A role carrying neither is unclassifiable and fails.
+#
+# `None` is an exemption and is reported but never failed on, the same shape
+# and for the same kind of reason as `check-contrast.py`'s exempt pairings: a
+# categorical hue identifies a *kind of thing*, and a category that changed
+# colour with the ambient theme would stop being one. It is outside the
+# ground's warm/cool law, not failing it.
+
+CSS = "css"
+RUST = "rust"
+
+# `gate` names the light block to read. Discovery belongs to
+# `crates/stella-cli/tests/design_token_parity.rs`, which finds every light
+# gate a surface declares and proves they agree with each other -- so one gate
+# read here is every gate. This guard reads six files in two syntaxes, one of
+# them Rust, where a CSS selector scan has nothing to find.
+SURFACES = (
+    {
+        "file": "crates/stella-observatory/src/assets/index.html",
+        "notation": CSS,
+        "gate": (':root[data-theme="light"]{', "\n}"),
+        "families": {
+            "--ground": "warm-paper",
+            "--surface": "warm-paper",
+            "--raised": "warm-paper",
+            "--hairline": "warm-paper",
+            "--hairline-strong": "warm-paper",
+            "--sunken": "warm-paper",
+            "--text-emph": "warm-paper",
+            "--ink": "warm-paper",
+            "--identity-ink": "warm-paper",
+            # The wordmark's darkest stop on paper. An ink like any other.
+            "--mark-bright": "warm-paper",
+        },
+    },
+    {
+        "file": "crates/stella-cli/src/export.rs",
+        "notation": CSS,
+        "gate": (':root[data-theme="light"] {{', "\n  }}"),
+        "families": {
+            "--ground": "warm-paper",
+            "--surface": "warm-paper",
+            "--raised": "warm-paper",
+            "--hairline": "warm-paper",
+            "--hairline-strong": "warm-paper",
+            "--sunken": "warm-paper",
+            "--ink": "warm-paper",
+            "--identity-ink": "warm-paper",
+        },
+    },
+    {
+        "file": "crates/stella-transcript/src/html/transcript.css",
+        "notation": CSS,
+        "gate": ("@media (prefers-color-scheme: light) {", "\n  }"),
+        "families": {
+            "--bg": "warm-paper",
+            "--panel": "warm-paper",
+            "--raised": "warm-paper",
+            "--line": "warm-paper",
+            "--line2": "warm-paper",
+            "--sunken": "warm-paper",
+            "--sunken-2": "warm-paper",
+            "--hover": "warm-paper",
+            "--hover-raised": "warm-paper",
+            "--selected": "warm-paper",
+            "--hairline-soft": "warm-paper",
+            "--code": "warm-paper",
+            "--hunk-bg": "warm-paper",
+            # The three categorical inks. A category that changed colour with
+            # the ambient theme would stop being one, which the file's own
+            # header says; they identify a diff hunk, a prompt-quote and the
+            # reader's own prose, and identity is not a ground.
+            "--hunk-ink": None,
+            "--pq-ink": None,
+            "--you-prose": None,
+        },
+    },
+    {
+        "file": "docs/benchmarks/index.html",
+        "notation": CSS,
+        "gate": (':root[data-theme="light"]{', "}"),
+        "families": {
+            "--bg": "warm-paper",
+            "--sub": "warm-paper",
+            "--panel": "warm-paper",
+            "--rule": "warm-paper",
+            "--rule-2": "warm-paper",
+        },
+    },
+    {
+        "file": "docs/benchmarks/terminal-bench-2-1-glm-5-2.html",
+        "notation": CSS,
+        "gate": (':root[data-theme="light"]{', "}"),
+        "families": {
+            "--bg": "warm-paper",
+            "--sub": "warm-paper",
+            "--panel": "warm-paper",
+            "--rule": "warm-paper",
+            "--rule-2": "warm-paper",
+            "--code": "warm-paper",
+            # The verdict washes: a green and a red at paper lightness. They
+            # are a verdict's ground, not the page's, and the kit's `verdict`
+            # clamp is what governs a verdict's hue.
+            "--pass-bg": "verdict",
+            "--fail-bg": "verdict",
+        },
+    },
+    {
+        # The command deck's own paper ramp. Rust rather than CSS, which is why it needed
+        # #4910's `Color::Rgb` notation before it could be read at all.
+        "file": "crates/stella-tui/src/palette.rs",
+        "notation": RUST,
+        "gate": ("/// Light background", "// -- Data marks"),
+        "families": {
+            "PAPER": "warm-paper",
+            "SNOW": "warm-paper",
+            "PAPER_RAISED": "warm-paper",
+            "PAPER_HAIRLINE": "warm-paper",
+            "MUTED": "warm-paper",
+            "INK_DIM": "warm-paper",
+            "INK_EMPHASIS": "warm-paper",
+        },
+    },
+)
+
+CSS_DECL = re.compile(r"(--[a-zA-Z0-9-]+)\s*:\s*(#[0-9A-Fa-f]{6})\b")
+RUST_DECL = re.compile(
+    r"pub const ([A-Z][A-Z0-9_]*)\s*:\s*Color\s*=\s*Color::Rgb\(\s*"
+    r"(0[xX][0-9A-Fa-f]{1,2})\s*,\s*(0[xX][0-9A-Fa-f]{1,2})\s*,\s*"
+    r"(0[xX][0-9A-Fa-f]{1,2})\s*\)"
+)
+
+
+def block(text: str, start: str, end: str, where: str) -> str:
+    """The slice between two markers, exclusive of them."""
+    try:
+        head = text.index(start) + len(start)
+    except ValueError:
+        raise SystemExit(f"{where}: marker {start!r} not found") from None
+    try:
+        return text[head : head + text[head:].index(end)]
+    except ValueError:
+        raise SystemExit(f"{where}: marker {end!r} not found after {start!r}") from None
+
+
+def declarations(surface: dict, root: Path) -> list[tuple[str, str]]:
+    """`(role, #RRGGBB)` for every colour the surface's light scheme declares."""
+    path = root / surface["file"]
+    body = block(path.read_text(), *surface["gate"], surface["file"])
+    if surface["notation"] == CSS:
+        return [(name, hexv.upper()) for name, hexv in CSS_DECL.findall(body)]
+    return [
+        (m.group(1), "#%02X%02X%02X" % tuple(int(m.group(i), 16) for i in (2, 3, 4)))
+        for m in RUST_DECL.finditer(body)
+    ]
+
+
+def audit(root: Path) -> tuple[list[tuple[str, str, str, str]], list[str], int]:
+    """Every light declaration judged.
+
+    Returns `(violations, unclassifiable, exempt_count)`, where a violation is
+    `(file, role, hex, why)`.
+    """
+    generator = load_generator()
+    doc = json.loads((root / TOKENS_REL).read_text())
+    clamps = doc["clamps"]
+    anchors = {t["name"]: t["hex"] for t in doc["tokens"]}
+    by_hex = {t["hex"].upper(): (t["name"], t["clamp"]) for t in doc["tokens"]}
+
+    violations: list[tuple[str, str, str, str]] = []
+    unclassifiable: list[str] = []
+    exempt = 0
+
+    for surface in SURFACES:
+        for role, hexv in declarations(surface, root):
+            token = by_hex.get(hexv)
+            if token:
+                # Rule 1: a token answers to the clamp it declares.
+                name, clamp = token
+                label = f"{role} (kit `{name}`)"
+            elif role in surface["families"]:
+                clamp = surface["families"][role]
+                if clamp is None:
+                    exempt += 1
+                    continue
+                label = role
+            else:
+                # Rule 3. The one outcome that must never be silent.
+                unclassifiable.append(
+                    f"{surface['file']}: {role} is {hexv}, which is not a kit "
+                    f"token and names no family in this guard's SURFACES table. "
+                    f"Say which colour family it belongs to, or make it a token."
+                )
+                continue
+
+            if clamp not in clamps:
+                unclassifiable.append(
+                    f"{surface['file']}: {role} declares family {clamp!r}, "
+                    f"which design/tokens/stella-tokens.json does not define"
+                )
+                continue
+            why = generator.check_clamp(label, hexv, clamp, clamps[clamp], anchors)
+            if why:
+                violations.append((surface["file"], role, hexv, why))
+
+    return violations, unclassifiable, exempt
+
+
+def read_baseline(root: Path) -> dict[tuple[str, str], str]:
+    path = root / BASELINE_REL
+    if not path.exists():
+        return {}
+    held: dict[tuple[str, str], str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        file, role, hexv = line.split()
+        held[(file, role)] = hexv.upper()
+    return held
+
+
+def write_baseline(root: Path, held: dict[tuple[str, str], str]) -> None:
+    body = "".join(f"{file} {role} {hexv}\n" for (file, role), hexv in sorted(held.items()))
+    (root / BASELINE_REL).write_text(BASELINE_HEADER + body, encoding="utf-8")
+
+
+def report(root: Path) -> int:
+    violations, unclassifiable, exempt = audit(root)
+    held = read_baseline(root)
+    print(f"{'surface':<52} {'role':<20} value      verdict")
+    for file, role, hexv, _ in violations:
+        verdict = "held" if held.get((file, role)) == hexv else "FAIL"
+        print(f"{file:<52} {role:<20} {hexv}    {verdict}")
+    for line in unclassifiable:
+        print(f"  unclassifiable: {line}")
+    print(
+        f"\n{len(violations)} violation(s), {len(held)} held by the ratchet, "
+        f"{exempt} declared exempt. Every value is judged against the clamp its "
+        "family declares in design/tokens/stella-tokens.json."
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    flags = {a for a in argv[1:] if a.startswith("--")}
+    positional = [a for a in argv[1:] if not a.startswith("--")]
+    root = Path(positional[0]).resolve() if positional else REPO
+
+    if "--report" in flags:
+        return report(root)
+
+    violations, unclassifiable, _ = audit(root)
+    held = read_baseline(root)
+    measured = {(file, role): hexv for file, role, hexv, _ in violations}
+
+    if "--bootstrap" in flags:
+        if (root / BASELINE_REL).exists():
+            print(
+                f"check-light-clamp: {BASELINE_REL} already exists — refusing to "
+                "bootstrap over a ratchet. Use --update.",
+                file=sys.stderr,
+            )
+            return 1
+        write_baseline(root, measured)
+        print(f"check-light-clamp: bootstrapped {len(measured)} entry/entries.")
+        return 0
+
+    if "--update" in flags:
+        # An unclassifiable role is a question for a person -- which colour
+        # family is this? -- and a writer cannot answer it. Without this the
+        # ratchet retightens cleanly around a role nobody has judged, and the
+        # run reports success. `test-light-clamp.sh`'s U2 is what found it.
+        if unclassifiable:
+            print(
+                "check-light-clamp: refusing to retighten while "
+                f"{len(unclassifiable)} role(s) are unclassifiable. Classify "
+                "them first — a ratchet cannot stand in for a decision:\n",
+                file=sys.stderr,
+            )
+            for line in unclassifiable:
+                print(f"  {line}", file=sys.stderr)
+            return 1
+        added = sorted(k for k in measured if k not in held)
+        if added:
+            print(
+                "check-light-clamp: refusing to grandfather "
+                f"{len(added)} new violation(s). A ratchet records debt that "
+                "predates the guard; it does not hand out permission:\n",
+                file=sys.stderr,
+            )
+            for file, role in added:
+                print(f"  {file}: {role} is {measured[(file, role)]}", file=sys.stderr)
+            return 1
+        changed = sorted(k for k in measured if held.get(k) != measured[k])
+        if changed:
+            print(
+                "check-light-clamp: refusing to move an entry to a different "
+                "off-clamp value. The licence is for the hex that shipped:\n",
+                file=sys.stderr,
+            )
+            for file, role in changed:
+                print(
+                    f"  {file}: {role} was {held[(file, role)]}, is now "
+                    f"{measured[(file, role)]}",
+                    file=sys.stderr,
+                )
+            return 1
+        write_baseline(root, measured)
+        print(f"check-light-clamp: retightened to {len(measured)} entry/entries.")
+        return 0
+
+    failures: list[str] = list(unclassifiable)
+    for file, role, hexv, why in violations:
+        recorded = held.get((file, role))
+        if recorded == hexv:
+            continue
+        if recorded is None:
+            failures.append(f"{file}: {why} — no baseline entry")
+        else:
+            failures.append(
+                f"{file}: {role} was {recorded} and is now {hexv}; the ratchet "
+                f"licenses the value that shipped, not the name. {why}"
+            )
+    stale = sorted(k for k in held if k not in measured)
+    for file, role in stale:
+        failures.append(
+            f"{file}: {role} satisfies its clamp now — run "
+            "`make light-clamp-update` so the ratchet retightens"
+        )
+
+    if failures:
+        print("check-light-clamp: FAIL\n", file=sys.stderr)
+        for line in failures:
+            print(f"  {line}", file=sys.stderr)
+        print(
+            "\nA light neutral is fixed by moving the colour, never by widening "
+            "the clamp — that would delete the only law the light ground has. "
+            "See `make light-clamp-report` for every declaration and its family.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check-light-clamp: {len(SURFACES)} shipped light surface(s) judged, "
+        f"{len(held)} held by the ratchet, none off its declared clamp."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-light-clamp.py
+++ b/scripts/check-light-clamp.py
@@ -88,9 +88,15 @@ BASELINE_HEADER = """\
 """
 
 
-def load_generator():
-    """`gen-tokens.py`, imported so its predicates are not written twice."""
-    path = REPO / "scripts" / "gen-tokens.py"
+def load_generator(root: Path):
+    """`gen-tokens.py`, imported so its predicates are not written twice.
+
+    Read from `root` rather than from this script's own repository, so a tree
+    passed on the command line is judged entirely by itself -- its clamps, its
+    surfaces and its predicates. `scripts/test-light-clamp.sh` builds such a
+    tree, and this is what makes the generator it copies in the one that runs.
+    """
+    path = root / "scripts" / "gen-tokens.py"
     spec = importlib.util.spec_from_file_location("stella_gen_tokens", path)
     if spec is None or spec.loader is None:
         raise SystemExit(f"cannot import {path}")
@@ -266,7 +272,7 @@ def audit(root: Path) -> tuple[list[tuple[str, str, str, str]], list[str], int]:
     Returns `(violations, unclassifiable, exempt_count)`, where a violation is
     `(file, role, hex, why)`.
     """
-    generator = load_generator()
+    generator = load_generator(root)
     doc = json.loads((root / TOKENS_REL).read_text())
     clamps = doc["clamps"]
     anchors = {t["name"]: t["hex"] for t in doc["tokens"]}

--- a/scripts/light-clamp-baseline.txt
+++ b/scripts/light-clamp-baseline.txt
@@ -1,0 +1,46 @@
+# Down-only ratchet for scripts/check-light-clamp.py.
+#
+# Each line is `<file> <role> <hex>` -- a light-scheme value that fails the
+# clamp its family declares, recorded at the value it shipped at. A repaint to
+# a *different* off-clamp value fails: the licence is for this hex, not for
+# this name.
+#
+# `make light-clamp-update` drops an entry that now satisfies its clamp and
+# refuses to add one. The only way past a red gate is to move the colour.
+#
+# This file records the debt #4941 found, which #4072 is deciding how to pay.
+# It is meant to reach empty.
+crates/stella-cli/src/export.rs --hairline #E9E9EE
+crates/stella-cli/src/export.rs --hairline-strong #D0D0D8
+crates/stella-cli/src/export.rs --sunken #F7F7FA
+crates/stella-cli/src/export.rs --surface #F7F7FA
+crates/stella-observatory/src/assets/index.html --hairline #E9E9EE
+crates/stella-observatory/src/assets/index.html --hairline-strong #D0D0D8
+crates/stella-observatory/src/assets/index.html --sunken #F7F7FA
+crates/stella-observatory/src/assets/index.html --surface #F7F7FA
+crates/stella-observatory/src/assets/index.html --text-emph #3C3C46
+crates/stella-transcript/src/html/transcript.css --code #2B323A
+crates/stella-transcript/src/html/transcript.css --hairline-soft #F1F4F8
+crates/stella-transcript/src/html/transcript.css --hover #F0F3F7
+crates/stella-transcript/src/html/transcript.css --hover-raised #EAEFF5
+crates/stella-transcript/src/html/transcript.css --hunk-bg #EEF3FB
+crates/stella-transcript/src/html/transcript.css --line #E9E9EE
+crates/stella-transcript/src/html/transcript.css --line2 #D0D0D8
+crates/stella-transcript/src/html/transcript.css --panel #F7F7FA
+crates/stella-transcript/src/html/transcript.css --selected #DFE6EE
+crates/stella-transcript/src/html/transcript.css --sunken #F2F5F9
+crates/stella-transcript/src/html/transcript.css --sunken-2 #EEF2F7
+crates/stella-tui/src/palette.rs INK_DIM #6C6C78
+crates/stella-tui/src/palette.rs INK_EMPHASIS #3C3C46
+crates/stella-tui/src/palette.rs MUTED #5E5E69
+crates/stella-tui/src/palette.rs PAPER #F4F4F6
+crates/stella-tui/src/palette.rs PAPER_HAIRLINE #DDDDE3
+crates/stella-tui/src/palette.rs PAPER_RAISED #E6E6EA
+crates/stella-tui/src/palette.rs SNOW #FAFAFC
+docs/benchmarks/index.html --rule #E9E9EE
+docs/benchmarks/index.html --rule-2 #D0D0D8
+docs/benchmarks/index.html --sub #F7F7FA
+docs/benchmarks/terminal-bench-2-1-glm-5-2.html --code #F7F7FA
+docs/benchmarks/terminal-bench-2-1-glm-5-2.html --rule #E9E9EE
+docs/benchmarks/terminal-bench-2-1-glm-5-2.html --rule-2 #D0D0D8
+docs/benchmarks/terminal-bench-2-1-glm-5-2.html --sub #F7F7FA

--- a/scripts/test-light-clamp.sh
+++ b/scripts/test-light-clamp.sh
@@ -171,8 +171,20 @@ with open(path, "w") as handle:
 PY
 want "U1 an off-kit value under an undeclared role is unclassifiable" \
   expect-fail "$r" "not a kit token and names no family"
-want "U2 --update refuses to retighten around it" \
-  expect-fail "$r" "refusing to retighten while" "--update"
+want "U2 --update refuses to write the ratchet around it" \
+  expect-fail "$r" "refusing to write the ratchet while" "--update"
+# `--bootstrap` needs its own case: it is reachable only on a tree with no
+# ratchet yet, which is exactly the tree with nobody to notice what it wrote.
+# Removing the ratchet is what gets past the "already exists" refusal, so this
+# case reaches the check it is about rather than stopping one door earlier.
+rm -f "$r/$BASELINE_REL"
+want "U3 --bootstrap refuses to write the ratchet around it either" \
+  expect-fail "$r" "refusing to write the ratchet while" "--bootstrap"
+if [ -f "$r/$BASELINE_REL" ]; then
+  fail=$((fail + 1)); echo "FAIL U4 the refused --bootstrap wrote a ratchet anyway"
+else
+  pass=$((pass + 1)); echo "ok   U4 the refused --bootstrap wrote no ratchet"
+fi
 
 # ── M: a baselined role repainted to a DIFFERENT off-clamp value ─────────────
 # The ratchet records a measured value, not a name. Sliding a licensed role to

--- a/scripts/test-light-clamp.sh
+++ b/scripts/test-light-clamp.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# Tests for check-light-clamp.py (#4941).
+#
+#   ./scripts/test-light-clamp.sh
+#
+# Run it after touching that script. Not part of `make gate`: it builds
+# throwaway surface trees, the same posture as `make contrast-test`.
+#
+# ── What the suite is for ────────────────────────────────────────────────────
+#
+# The guard exists because the `warm-paper` clamp was enforced over the token
+# table alone, so no shipped surface was ever judged against it. It joins the
+# gate carrying 34 pre-existing violations, which makes its ratchet the only
+# thing between "this light scheme has known debt" and "this light scheme has a
+# permission slip". Four directions have to hold and they fail independently:
+#
+#   * a cool light neutral in a shipped surface FAILS and is named;
+#   * the same surface with a warm one PASSES -- without this the suite is
+#     satisfiable by a guard that fails on everything;
+#   * a role that is neither a kit token nor a declared family is
+#     UNCLASSIFIABLE and fails, because a new hand-picked neutral arriving
+#     under a new name is the event the guard exists to catch;
+#   * `--update` refuses to grandfather a new violation AND refuses to move an
+#     entry to a different off-clamp value -- checked twice each, verdict and
+#     file, because a writer that refuses loudly and writes anyway passes a
+#     suite that only reads the verdict (#3750's shape).
+#
+# Every writing case runs against its own fixture root under $TMP. Pointing
+# `--update` at the real repository would rewrite the ratchet as a side effect
+# of running the tests; R1 is the one real-tree case and is read-only.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-light-clamp.py"
+BASELINE_REL="scripts/light-clamp-baseline.txt"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# Every file the guard reads, so a fixture root is a whole tree it can judge.
+SURFACE_FILES="crates/stella-observatory/src/assets/index.html
+crates/stella-cli/src/export.rs
+crates/stella-transcript/src/html/transcript.css
+docs/benchmarks/index.html
+docs/benchmarks/terminal-bench-2-1-glm-5-2.html
+crates/stella-tui/src/palette.rs"
+
+# A throwaway root holding this repository's real surfaces, token file, the
+# generator whose predicates the guard imports, and the ratchet.
+# $1 = case name. Echoes the root path.
+new_root() {
+  local dir="$TMP/$1" rel
+  mkdir -p "$dir/design/tokens" "$dir/scripts"
+  cp "$repo_root/design/tokens/stella-tokens.json" "$dir/design/tokens/"
+  cp "$repo_root/scripts/gen-tokens.py" "$dir/scripts/"
+  cp "$repo_root/$BASELINE_REL" "$dir/$BASELINE_REL"
+  echo "$SURFACE_FILES" | while IFS= read -r rel; do
+    mkdir -p "$dir/$(dirname "$rel")"
+    cp "$repo_root/$rel" "$dir/$rel"
+  done
+  echo "$dir"
+}
+
+# Repaint one hex inside one surface. $1 = root, $2 = file, $3 = old, $4 = new.
+repaint() {
+  python3 - "$1/$2" "$3" "$4" <<'PY'
+import sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as handle:
+    text = handle.read()
+for spelling in (old, old.lower()):
+    if spelling in text:
+        with open(path, "w") as handle:
+            handle.write(text.replace(spelling, new if spelling == old else new.lower()))
+        break
+else:
+    raise SystemExit(f"{path} does not contain {old}")
+PY
+}
+
+# want <name> <expect-pass|expect-fail> <root> [substring] [flag]
+#
+# The substring is checked on both verdicts: on expect-fail it pins which role
+# was named and in what words, and on expect-pass it pins what a passing run
+# reported, so a guard that passed by losing the surface entirely cannot
+# satisfy the case.
+want() {
+  local name="$1" expect="$2" root="$3" sub="${4:-}" flag="${5:-}" out rc
+  out="$(python3 "$SCRIPT" ${flag:+"$flag"} "$root" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -ne 0 ]; then
+      fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+      return
+    fi
+  elif [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1)); echo "FAIL $name — the guard passed what it should have flagged:"; echo "$out"
+    return
+  fi
+  case "$out" in
+    *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+    *) fail=$((fail + 1)); echo "FAIL $name — did not report '$sub':"; echo "$out" ;;
+  esac
+}
+
+# entry_is <name> <root> <file> <role> <hex|absent>
+#
+# `--update` writes and then reports, so "did it refuse" and "did it write
+# anyway" are two questions and only this one answers the second.
+entry_is() {
+  local name="$1" file="$2/$BASELINE_REL" surface="$3" role="$4" expect="$5" got
+  got="$(awk -v s="$surface" -v r="$role" '$1 == s && $2 == r { print $3; exit }' "$file")"
+  [ -n "$got" ] || got=absent
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1)); echo "ok   $name"
+  else
+    fail=$((fail + 1)); echo "FAIL $name — baseline says '$got', wanted '$expect'"
+  fi
+}
+
+BENCH="docs/benchmarks/index.html"
+
+# ── C: a cool light neutral is caught ────────────────────────────────────────
+# `--panel` on the benchmark index is #FFFFFF today — achromatic, so it clears
+# warm-paper and carries no ratchet entry. Cooling it is a first-time violation
+# rather than a regression against a recorded value.
+r="$(new_root cool_neutral)"
+repaint "$r" "$BENCH" "#FFFFFF" "#F4F6FB"
+want "C1 a cool light neutral in a shipped surface is flagged" \
+  expect-fail "$r" "no baseline entry"
+want "C2 the failure names the role and the conjunct it broke" \
+  expect-fail "$r" "needs r >= g >= b"
+want "C3 --update refuses to grandfather it" \
+  expect-fail "$r" "refusing to grandfather" "--update"
+entry_is "C4 the refused --update wrote no entry" "$r" "$BENCH" --panel absent
+
+# ── W: the same surface with a warm value passes ─────────────────────────────
+# Without this the suite is satisfiable by a guard that fails on everything.
+# `--rule` is #E9E9EE and baselined; the kit's own `paper-seam` is warm and
+# passes, so the entry must LEAVE the ratchet rather than stay as a licence.
+r="$(new_root warm_neutral)"
+repaint "$r" "$BENCH" "#E9E9EE" "#E0DDD7"
+want "W1 a warm replacement is reported as clearing, not passed silently" \
+  expect-fail "$r" "satisfies its clamp now"
+want "W2 --update drops the cleared entry" expect-pass "$r" "retightened to 33" "--update"
+entry_is "W3 the cleared entry is gone" "$r" "$BENCH" --rule absent
+
+# ── U: a role that names no family at all ────────────────────────────────────
+# The one outcome that must never be silent. A guard that skipped what it could
+# not classify would be blind to exactly the event it exists to catch.
+r="$(new_root unclassified)"
+# Anchored to the light GATE, not to the declaration text: this page declares
+# its light scheme twice -- once in the bare `:root` and once under the
+# attribute -- so an unanchored insert lands in the block the guard does not
+# read and the case passes over nothing. It did, before this comment existed.
+python3 - "$r/$BENCH" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as handle:
+    text = handle.read()
+gate = ':root[data-theme="light"]{'
+assert text.count(gate) == 1, "fixture gate moved"
+with open(path, "w") as handle:
+    handle.write(text.replace(gate, gate + "\n  --well:#EEF2F7;", 1))
+PY
+want "U1 an off-kit value under an undeclared role is unclassifiable" \
+  expect-fail "$r" "not a kit token and names no family"
+want "U2 --update refuses to retighten around it" \
+  expect-fail "$r" "refusing to retighten while" "--update"
+
+# ── M: a baselined role repainted to a DIFFERENT off-clamp value ─────────────
+# The ratchet records a measured value, not a name. Sliding a licensed role to
+# another cool hex is a new decision and gets asked about.
+r="$(new_root moved)"
+repaint "$r" "$BENCH" "#D0D0D8" "#CED4DE"
+want "M1 a repaint to another off-clamp value is flagged with both hexes" \
+  expect-fail "$r" "was #D0D0D8 and is now #CED4DE"
+want "M2 --update refuses to move the entry" \
+  expect-fail "$r" "refusing to move an entry" "--update"
+entry_is "M3 the refused --update left the old value" "$r" "$BENCH" --rule-2 "#D0D0D8"
+
+# ── B: bootstrap runs once ───────────────────────────────────────────────────
+r="$(new_root bootstrap_guard)"
+want "B1 --bootstrap refuses when the ratchet already exists" \
+  expect-fail "$r" "refusing to bootstrap" "--bootstrap"
+entry_is "B2 the refused --bootstrap left the ratchet intact" "$r" "$BENCH" --rule "#E9E9EE"
+
+# ── N: the negative direction ────────────────────────────────────────────────
+r="$(new_root unchanged)"
+want "N1 an untouched fixture tree passes" expect-pass "$r" "none off its declared clamp"
+want "N2 the report names the exemptions rather than hiding them" \
+  expect-pass "$r" "declared exempt" "--report"
+
+# ── R: the real workspace ────────────────────────────────────────────────────
+# Check mode only. Never --update here.
+want "R1 this repository matches its own ratchet" \
+  expect-pass "$repo_root" "none off its declared clamp"
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
`design/tokens/stella-tokens.json` declares `warm-paper` as the light ground's law — *"warm or neutral, never blue"* — and it governed **nothing that ships**.

Both enforcers iterate the token table: `gen-tokens.py::validate`'s `if clamp == "warm-paper"` branch walks `doc["tokens"]`, and `clamp.rs::satisfies` is driven by the generated `token::ALL`. So the clamp only ever judged colours that were *already tokens*, and a hand-picked light neutral was invisible to it — which is the one value the rule exists to judge.

## The guard

`scripts/check-light-clamp.py` reads **surfaces**. Every light-scheme declaration on the five web surfaces plus the command deck's paper ramp is classified, per the issue's rule 3:

1. **A kit token answers to its own declared clamp.** `--text: #0A0A0C` on a light page is the dark canvas token reused; whether that is the *right value* is #4072's question, not this guard's. Whether it satisfies the clamp it declares is.
2. **A non-token answers to the family its surface declares**, in `SURFACES`.
3. **A value that is neither is unclassifiable and fails.** This is the outcome that must never be silent — a new hand-picked neutral arriving under a new name is exactly the event the guard exists to catch, and skipping what it cannot classify would make it blind to precisely that.

**The predicates are not written here.** `gen-tokens.py`'s `check_clamp` is imported and called, so `warm-paper` has one Python implementation rather than two. That is the issue's point 2 taken further than "read the numbers from JSON": there is no second copy of the *logic* either.

## Measured: 34, not 12

The issue measured 12 violations. The full sweep finds 34 — the extra 22 are transcript.css's derived light surfaces (`--sunken`, `--sunken-2`, `--hover`, `--hover-raised`, `--selected`, `--hairline-soft`, `--code`, `--hunk-bg`), the two benchmark pages' `--sub`/`--rule`/`--rule-2`, and export.rs's copies.

Zero unclassifiable on a clean tree, which is what says the `SURFACES` table is total over what ships rather than quietly skipping the hard cases.

## The ratchet

Per the sequencing note: #4072 is deciding which values the light scheme should have, so this lands with a down-only ratchet on `contrast-baseline.txt`'s model and for the same stated reason — the rule predates the guard, so the baseline records debt that already existed rather than granting new permission.

It records the **measured hex**, not a count, so sliding a licensed role to a *different* cool value fails: the licence is for the value that shipped, not for the name. `--update` refuses to add an entry, refuses to move one, and refuses to retighten while anything is unclassifiable. `--bootstrap` runs once.

## Witness

Adding one hand-picked cool light neutral (`--well: #F4F6FB`) to a shipped light gate. **All four existing colour rulers stay green:**

```
tokens: 33 validated, 2 artifacts in sync
tokens: no retired hex in the tree; 3 token-only path(s) clean; 141 token citation(s) quote the palette
check-hue-separation: OK — 12 role pairs across 2 web schemes, all at or above 30° OKLCH
check-contrast: 22 licensed pairing(s), 4 held by the ratchet, none darker than it allows.
check-css-vars: OK -- 2 token sheet(s), every var() resolves.
```

The new one names it:

```
check-light-clamp: FAIL

  docs/benchmarks/index.html: --well is #F4F6FB, which is not a kit token and
  names no family in this guard's SURFACES table. Say which colour family it
  belongs to, or make it a token.
```

Four green rulers on a tree that just shipped a cool light neutral is the measurement of the hole, stated as output.

Cooling a value under an **already-classified** role reports the conjunct it broke:

```
  docs/benchmarks/index.html: --panel #F4F6FB fails warm-paper: needs
  r >= g >= b; got r=244 g=246 b=251 — no baseline entry
```

Warming the same role to the kit's `paper-raised` `#FDFAF3`:

```
check-light-clamp: 6 shipped light surface(s) judged, 34 held by the ratchet,
none off its declared clamp.
```

## Self-test

`scripts/test-light-clamp.sh`, on `test-contrast.sh`'s model — hermetic fixture roots, `--update` refusals checked twice each (verdict **and** file, #3750's shape), a real-tree read-only case, and a negative case so the suite is not satisfiable by a guard that fails on everything.

```
passed 17, failed 0
```

Two things it found while being written, both now fixed:

- **`--update` ignored the unclassifiable list** — it retightened cleanly around a role nobody had judged and reported success. U2 is that case.
- **The benchmark pages declare their light scheme twice** (a bare `:root` and the attribute gate), so the first draft's fixture edited the block the guard does not read and the case passed over nothing. The insert is now anchored to the gate, with a comment saying why.

## Wiring

`docs-guards.yml` beside the four rulers from #4929 (point 5), `ci.yml`, `guard-self-tests.yml` for the suite, `GATE_STEPS`, both prose blocks, and one row in `check-gate-parity.sh`'s alias table (its `.sh` default does not fit a Python guard).

```
check-gate-parity: OK — 48 (forty-eight) gate steps, named in AGENTS.md and
CONTRIBUTING.md, each run by a workflow.
test-gate-parity: 14 passed, 0 failed
```

## Not done here

The clamp is **not widened** anywhere and no surface is recoloured — that is #4072's call, and widening it would delete the only law the light ground has.

Closes #4941
Refs #4072, #4058, #4910, #4112

---

## Follow-up commit: the guard read the wrong generator

`load_generator` resolved `gen-tokens.py` from *this script's* repository rather than from the root it was pointed at, so a fixture tree was judged by its own clamps and surfaces but by someone else's predicates — and the copy `test-light-clamp.sh` places in every fixture was never read.

Witness: ablating the **fixture's** `check_clamp` to `return None` now makes that fixture report all 34 baselined roles as `satisfies its clamp now` and exit 1, while the real repository still reports `none off its declared clamp`. Before the fix the ablated fixture was indistinguishable from an untouched one.

It also shows a property worth having: a predicate that stops working makes this guard **fail**, not pass — the ratchet catches the false clearance, because an entry that suddenly satisfies its clamp is reported rather than dropped silently.

## Summary by Sourcery

Enforce declared colour clamps across all shipped light surfaces with a down-only ratchet and CI coverage.

New Features:
- Add a light-surface guard that evaluates shipped light-scheme colours against their declared colour-family clamps, including detection of unclassifiable values.
- Add reporting, bootstrap, and down-only ratchet update commands for tracking pre-existing light-clamp violations by measured hex value.

Bug Fixes:
- Ensure light-clamp checks load token-generation predicates from the repository root being audited, including hermetic fixture trees.

Enhancements:
- Centralize clamp predicate evaluation through the token generator and cover web, transcript, export, benchmark, and TUI light surfaces.
- Add hermetic self-tests covering violations, exemptions, unclassifiable roles, ratchet refusal and retightening behavior.

Build:
- Add the light-clamp guard and report/update/test targets to the Makefile and gate parity checks.

CI:
- Run the light-surface guard in CI and documentation guards, and run its direction tests in the guard self-test workflow.

Documentation:
- Document the light-clamp guard in contributor guidance and gate descriptions.

Tests:
- Add a 17-case shell test suite for light-clamp guard behavior and ratchet safety.

Chores:
- Add the measured light-clamp baseline for existing surface violations.