### PR TITLE
feat(stella-observatory,stella-cli): the skills view lists a plugin's skills

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
@@ -1029,3 +1029,89 @@ fn a_contributed_skills_tier_is_read_off_contributed_by_not_off_its_path() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+/// **The dashboard's trust witness** (#4917). The Observatory lists a
+/// package's skills through `storage_cmd::RosterSkills`, and an untrusted
+/// checkout's package contributes nothing there either.
+///
+/// The untrusted half is the point. A dashboard that resolved the roster
+/// itself would have to re-implement the project-tier gate (#3509), and a
+/// second implementation of a security answer is a second answer: get it wrong
+/// and the page lists skills from a cloned repository the agent would never
+/// load, which is worse than the absence it replaced. It reads the one roster
+/// the session's own skill load reads instead, so the two cannot disagree —
+/// including here.
+///
+/// The sibling one surface over is
+/// `an_untrusted_projects_contributed_tool_never_loads`.
+#[test]
+fn the_dashboards_plugin_skills_honour_the_project_trust_gate() {
+    use stella_observatory::PluginSkills as _;
+
+    /// The dashboard's `/api/skills` body, through the route the page fetches
+    /// rather than through an inner function only this test would call.
+    fn skills_json(root: &Path, source: &crate::storage_cmd::RosterSkills) -> String {
+        let response = stella_observatory::respond_with(root, "/api/skills", source);
+        String::from_utf8_lossy(&response.body).into_owned()
+    }
+
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+        "STELLA_HOME",
+    ]);
+    let root = temp_root("package-observatory-trust");
+    let _paths = crate::paths::test_user_home(root.join("home"));
+    // The dashboard's own user-scope root is `stella_home::stella_home()`,
+    // which `test_user_home` does not move — without this the assertions read
+    // the developer's real `~/.stella/skills` and a `house-style` sitting
+    // there would answer for them.
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe { std::env::set_var("STELLA_HOME", root.join("home")) };
+
+    let planted = stella_home::resolve_project_plugins_dir(&root).join("vera");
+    plant(&stella_home::resolve_project_plugins_dir(&root), "vera");
+    ships_a_package(&planted, "vera");
+
+    let source = crate::storage_cmd::RosterSkills;
+
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe {
+        std::env::remove_var("STELLA_TRUST_PROJECT");
+        std::env::remove_var("STELLA_PROJECT_HOOKS");
+    }
+    assert!(
+        source.contributed_skill_dirs(&root).is_empty(),
+        "an untrusted checkout contributes no skills to the dashboard"
+    );
+    let listed = skills_json(&root, &source);
+    assert!(
+        !listed.contains("house-style"),
+        "and nothing of the package's reaches the skills view: {listed}"
+    );
+
+    // SAFETY: as above.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+    let dirs = source.contributed_skill_dirs(&root);
+    assert_eq!(dirs.len(), 1, "the same bytes contribute once trusted");
+    assert_eq!(dirs[0].plugin, "vera");
+    assert_eq!(dirs[0].tier, stella_observatory::PluginTier::Project);
+    let listed = skills_json(&root, &source);
+    assert!(
+        listed.contains("house-style"),
+        "and the skills view lists it: {listed}"
+    );
+    assert!(
+        listed.contains("\"contributed_by\":\"vera\""),
+        "naming the package that shipped it: {listed}"
+    );
+
+    remove(&root, "vera").expect("remove must succeed");
+    assert!(
+        source.contributed_skill_dirs(&root).is_empty(),
+        "and it leaves with the package — nothing was ever copied into .stella/skills"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/stella-cli/src/storage_cmd.rs
+++ b/crates/stella-cli/src/storage_cmd.rs
@@ -98,6 +98,49 @@ pub(crate) fn preflight_observatory_stores(
     })
 }
 
+/// The dashboard's answer for "which plugin-contributed skills would a session
+/// started in this workspace load?", read off the one roster the session's own
+/// skill load reads (#4917).
+///
+/// A plugin's skills are contributed by derivation from `<plugin_dir>/skills`
+/// and are never copied into `.stella/skills`, so the observatory — which
+/// derives what it shows from the filesystem and may not link this crate —
+/// could not see them at all. It resolves them here instead of there because
+/// reaching them means answering the project-tier trust gate (#3509), the
+/// `plugins.<name> = "off"` retraction, the install receipt and the
+/// reconcile-on-every-load check, and a second implementation of those is a
+/// second answer.
+///
+/// [`package::contributed_skill_dirs`](crate::plugin_cmd::package) is that one
+/// answer, called per request rather than once at startup so a package
+/// installed while the dashboard is open appears on the next refresh — and
+/// answering an empty roster in a workspace nobody has trusted, which is the
+/// property `the_dashboards_plugin_skills_honour_the_project_trust_gate` pins.
+pub(crate) struct RosterSkills;
+
+impl stella_observatory::PluginSkills for RosterSkills {
+    fn contributed_skill_dirs(
+        &self,
+        workspace_root: &std::path::Path,
+    ) -> Vec<stella_observatory::ContributedSkills> {
+        crate::plugin_cmd::package::contributed_skill_dirs(workspace_root)
+            .into_iter()
+            .map(|contributed| stella_observatory::ContributedSkills {
+                plugin: contributed.plugin,
+                tier: match contributed.scope {
+                    crate::plugin_cmd::roster::PluginScope::Project => {
+                        stella_observatory::PluginTier::Project
+                    }
+                    crate::plugin_cmd::roster::PluginScope::User => {
+                        stella_observatory::PluginTier::User
+                    }
+                },
+                dir: contributed.dir,
+            })
+            .collect()
+    }
+}
+
 pub fn run_observe(port: u16, open: bool) -> Result<(), String> {
     let root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
@@ -109,39 +152,46 @@ pub fn run_observe(port: u16, open: bool) -> Result<(), String> {
         .enable_all()
         .build()
         .map_err(|e| format!("failed to start runtime: {e}"))?;
-    rt.block_on(stella_observatory::serve(root, port, move |addr| {
-        let url = format!("http://{addr}/");
-        println!();
-        // Comet kit v1.0: gold accent (ANSI yellow is the terminal's phosphor
-        // gold), lowercase always.
-        println!("  {} {}", "◆".yellow(), "stella observatory".bold());
-        println!("  {} {}", "→".yellow(), url);
-        // Which workspace is on screen. Unconditional, because the reader who
-        // needs it most is the one who does not yet suspect they are in the
-        // wrong directory — an advisory that only fires on an absent store
-        // would have stayed silent for the sparse-but-present case that
-        // motivated this.
-        println!("  {} {}", "·".dimmed(), workspace.dimmed());
-        println!(
-            "  {}",
-            "reads .stella (read-only) · binds 127.0.0.1 only · Ctrl+C to stop".dimmed()
-        );
-        if let Some(notice) = &notice {
-            println!("  {} {notice}", "!".yellow());
-        }
-        if open {
-            // Best-effort convenience; the printed URL is the contract.
-            let opener = if cfg!(target_os = "macos") {
-                "open"
-            } else {
-                "xdg-open"
-            };
-            let mut command = std::process::Command::new(opener);
-            command.arg(&url);
-            stella_tools::subprocess_env::scrub_sensitive_std_env(&mut command);
-            let _ = command.spawn();
-        }
-    }))
+    let plugins: std::sync::Arc<dyn stella_observatory::PluginSkills> =
+        std::sync::Arc::new(RosterSkills);
+    rt.block_on(stella_observatory::serve(
+        root,
+        port,
+        plugins,
+        move |addr| {
+            let url = format!("http://{addr}/");
+            println!();
+            // Comet kit v1.0: gold accent (ANSI yellow is the terminal's phosphor
+            // gold), lowercase always.
+            println!("  {} {}", "◆".yellow(), "stella observatory".bold());
+            println!("  {} {}", "→".yellow(), url);
+            // Which workspace is on screen. Unconditional, because the reader who
+            // needs it most is the one who does not yet suspect they are in the
+            // wrong directory — an advisory that only fires on an absent store
+            // would have stayed silent for the sparse-but-present case that
+            // motivated this.
+            println!("  {} {}", "·".dimmed(), workspace.dimmed());
+            println!(
+                "  {}",
+                "reads .stella (read-only) · binds 127.0.0.1 only · Ctrl+C to stop".dimmed()
+            );
+            if let Some(notice) = &notice {
+                println!("  {} {notice}", "!".yellow());
+            }
+            if open {
+                // Best-effort convenience; the printed URL is the contract.
+                let opener = if cfg!(target_os = "macos") {
+                    "open"
+                } else {
+                    "xdg-open"
+                };
+                let mut command = std::process::Command::new(opener);
+                command.arg(&url);
+                stella_tools::subprocess_env::scrub_sensitive_std_env(&mut command);
+                let _ = command.spawn();
+            }
+        },
+    ))
     .map_err(|e| e.to_string())
 }
 

--- a/crates/stella-observatory/examples/serve.rs
+++ b/crates/stella-observatory/examples/serve.rs
@@ -15,7 +15,11 @@ async fn main() {
         .or_else(|| std::env::current_dir().ok())
         .expect("workspace root");
     let port: u16 = args.next().and_then(|p| p.parse().ok()).unwrap_or(7787);
-    stella_observatory::serve(root, port, |addr| {
+    // No roster: resolving one means the project-tier trust gate and the rest
+    // of `stella-cli`'s plugin machinery, which is the whole reason this
+    // harness exists without it. The skills tab shows the workspace's own.
+    let plugins = std::sync::Arc::new(stella_observatory::NoPluginSkills);
+    stella_observatory::serve(root, port, plugins, |addr| {
         println!("observatory: http://{addr}");
     })
     .await

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -3165,6 +3165,7 @@ function renderSkills(rows) {
     tile("Skills", fmtInt(rows.length), "visible to this workspace") +
     tile("Project scope", fmtInt(rows.filter(r => r.scope === "project").length), ".stella/skills") +
     tile("User scope", fmtInt(rows.filter(r => r.scope === "user").length), "~/.stella/skills") +
+    tile("From plugins", fmtInt(rows.filter(r => r.contributed_by).length), "shipped by an installed package") +
     tile("Learned", fmtInt(learned.length), "auto-extracted by stella", true);
   if (!rows.length) {
     $("skills-table").innerHTML =
@@ -3173,13 +3174,17 @@ function renderSkills(rows) {
     return;
   }
   $("skills-table").innerHTML = `<table><thead><tr>
-    <th scope="col">skill</th><th scope="col">scope</th><th scope="col">description</th>
+    <th scope="col">skill</th><th scope="col">scope</th><th scope="col">via</th>
+    <th scope="col">description</th>
     <th scope="col" class="num">uses</th><th scope="col" class="num">updated</th></tr></thead><tbody>` +
     rows.map(r => {
       const u = uses.get(r.name);
       return `<tr>
       <td class="main">${r.learned ? `<span class="badge accent" title="auto-extracted from stella's own reflections">◆ learned</span> ` : ""}${esc(r.name)}</td>
       <td><span class="badge dim">${esc(r.scope)}</span></td>
+      <td>${r.contributed_by
+        ? `<span class="badge dim" title="shipped by an installed plugin — read from its package, never copied into your .stella/">${esc(r.contributed_by)}</span>`
+        : `<span style="color:var(--text-3)">—</span>`}</td>
       <td class="wrap-txt" style="max-width:520px;color:var(--text-2)">${esc(r.description || "—")}</td>
       <td class="num">${u ? fmtInt(u.uses) + "×" : "—"}</td>
       <td class="num">${agoUnix(r.modified_unix)}</td></tr>`;

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -172,6 +172,10 @@ fn skill_entry(
         "scope": scope,
         "learned": learned,
         "evidence_grade": evidence_grade,
+        // Null here and overwritten by [`skills`] for a row read out of a
+        // plugin's package, so the page never has to tell an absent field from
+        // a null one.
+        "contributed_by": Value::Null,
         "path": path.display().to_string(),
         "modified_unix": mtime_unix(path),
     }))
@@ -278,9 +282,107 @@ fn skill_evidence_grades(workspace_root: &Path) -> HashMap<String, &'static str>
         .collect()
 }
 
-/// Every skill visible to this workspace: project `.stella/skills` plus the
-/// user-scope skills dir, with learned (self-extracted) skills flagged.
-pub fn skills(workspace_root: &Path) -> Value {
+/// The tier an installed plugin sits at, which is also the tier its
+/// contributed skills are governed by (`stella_cli::skill_manager`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginTier {
+    /// `<workspace>/.stella/plugins` — the tier behind the project trust gate.
+    Project,
+    /// `~/.stella/plugins` — the operator's own machine-scope tier.
+    User,
+}
+
+impl PluginTier {
+    /// The scope label the skills view already uses for the user's own rows.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::User => "user",
+        }
+    }
+}
+
+/// One installed plugin's `skills/` directory, as the host that resolved the
+/// roster reports it.
+#[derive(Debug, Clone)]
+pub struct ContributedSkills {
+    /// The contributing plugin's manifest `name`.
+    pub plugin: String,
+    /// The tier its package is installed at.
+    pub tier: PluginTier,
+    /// `<plugin_dir>/skills`. It need not exist; an absent directory is an
+    /// empty one, the same as every other root this module scans.
+    pub dir: PathBuf,
+}
+
+/// The port a host implements to say which plugin-contributed skills a session
+/// started in this workspace would load (#4917).
+///
+/// # Why a port and not a directory scan
+///
+/// A plugin's skills live under `<plugin_dir>/skills` and are contributed *by
+/// derivation* — nothing is ever copied into the user's own `.stella/`, which
+/// is the property that makes `stella plugin remove` total
+/// (`stella_cli::plugin_cmd::roster`). So the dashboard cannot find them by
+/// widening the roots it walks: it would have to resolve the roster itself,
+/// and with it the project-tier trust gate (#3509), the `plugins.<name> =
+/// "off"` retraction, the install receipt, and the reconcile-on-every-load
+/// check. Every one of those is a security answer, and a second implementation
+/// of a security answer is a second answer — the shape this area exists to
+/// avoid.
+///
+/// So the host that already computes that answer hands it over instead —
+/// ports, not direct dependencies (AGENTS.md rule 1). `stella observe`
+/// implements this over
+/// `plugin_cmd::package::contributed_skill_dirs`, the same call the session's
+/// own skill load makes, so the dashboard and the loader cannot disagree about
+/// what is in force — including about a workspace nobody has trusted, where
+/// both answer nothing.
+///
+/// The port is asked per request rather than once at startup, so a package
+/// installed while the dashboard is open shows up on the next refresh.
+///
+/// **The observer's environment is the observer's.** `STELLA_TRUST_PROJECT`
+/// is read from the process asking, so a `stella observe` launched without it
+/// reports the project tier empty while an agent session launched with it
+/// loads those skills. That is the same authority answering in two
+/// environments rather than two authorities, and what the dashboard reports is
+/// what a session started *here* would load.
+pub trait PluginSkills: Send + Sync {
+    /// The contributed skills directories in force for `workspace_root`.
+    fn contributed_skill_dirs(&self, workspace_root: &Path) -> Vec<ContributedSkills>;
+}
+
+/// The answer for a caller with no roster to report — every unit test that
+/// drives [`crate::respond`], and any host that does not implement the port.
+pub struct NoPluginSkills;
+
+impl PluginSkills for NoPluginSkills {
+    fn contributed_skill_dirs(&self, _workspace_root: &Path) -> Vec<ContributedSkills> {
+        Vec::new()
+    }
+}
+
+/// Every skill visible to this workspace: project `.stella/skills`, the
+/// user-scope skills dir, and every installed plugin's contributed skills,
+/// with learned (self-extracted) skills flagged.
+///
+/// Contributed rows are appended last and answer three columns differently
+/// from a skill under a scope root, matching `stella_cli::skill_manager`'s
+/// `contributed_rows` one surface over:
+///
+/// - **`contributed_by` names the plugin**, and is `null` for the user's own.
+/// - **`learned` is false.** A package's `SKILL.md` may carry the miner's
+///   `origin: auto` marker, but it was mined in whatever workspace its author
+///   ran, not in this one — counted as learned it would inflate the "learned
+///   skills" tile with somebody else's loop.
+/// - **`evidence_grade` is null.** The ledger it joins against is this
+///   workspace's own, and a contributed skill was never a candidate in it.
+///
+/// A contributed skill whose name is already taken by one of the user's is
+/// omitted, matching the recall loader: it never reaches the prompt, so
+/// listing it would show a steer that is not in force.
+pub fn skills(workspace_root: &Path, plugins: &dyn PluginSkills) -> Value {
     let grades = skill_evidence_grades(workspace_root);
     let mut rows = Vec::new();
     scan_skills_dir(
@@ -291,6 +393,27 @@ pub fn skills(workspace_root: &Path) -> Value {
     );
     if let Some(user) = user_config_dir() {
         scan_skills_dir(&user.join("skills"), "user", &grades, &mut rows);
+    }
+    for contributed in plugins.contributed_skill_dirs(workspace_root) {
+        let mut found = Vec::new();
+        scan_skills_dir(
+            &contributed.dir,
+            contributed.tier.as_str(),
+            &HashMap::new(),
+            &mut found,
+        );
+        for mut row in found {
+            let name = row["name"].as_str().unwrap_or_default().to_string();
+            if rows
+                .iter()
+                .any(|seen| seen["name"].as_str() == Some(name.as_str()))
+            {
+                continue;
+            }
+            row["contributed_by"] = json!(contributed.plugin);
+            row["learned"] = json!(false);
+            rows.push(row);
+        }
     }
     rows.sort_by(|a, b| {
         let key = |v: &Value| {
@@ -451,6 +574,14 @@ const RESERVED_RULE_FILENAMES: &[&str] = &["governance.toml"];
 /// the panel under-report what actually steers the session, which for a
 /// workspace whose whole steering policy is published as TOML records meant an
 /// empty panel beside two enforced rules.
+///
+/// **A plugin's contributed records are not here**, and the same asymmetry
+/// [`skills`] closed is still open for them: a package's `rules/` steers the
+/// session (`stella context explain` prints `contributed by the \`vera\`
+/// plugin`) and this panel scans one directory. It is a second port of the
+/// [`PluginSkills`] shape, not a second design, and #4974 carries it — kept
+/// separate so the skills half ships against one test rather than two panels
+/// against none.
 pub fn rules_files(workspace_root: &Path) -> Value {
     let dir = workspace_root.join(".stella/rules");
     let mut rows = markdown_cards(&dir, 400);
@@ -1013,7 +1144,7 @@ tags       = ["testing", "pins"]
             .unwrap();
         drop(store);
 
-        let rows = skills(workspace_root);
+        let rows = skills(workspace_root, &NoPluginSkills);
         let rows = rows.as_array().expect("skills returns an array");
         let find = |name: &str| {
             rows.iter()
@@ -1120,5 +1251,143 @@ tags       = ["testing", "pins"]
         );
         assert!(!s.contains("ghp_nested"), "nested tables under env");
         assert!(s.contains("glm-5.2"), "ordinary lists are untouched");
+    }
+
+    /// A fake roster, so the skills view can be tested without this crate
+    /// linking the one that resolves rosters (which it may not).
+    struct FakeRoster(Vec<ContributedSkills>);
+
+    impl PluginSkills for FakeRoster {
+        fn contributed_skill_dirs(&self, _workspace_root: &Path) -> Vec<ContributedSkills> {
+            self.0.clone()
+        }
+    }
+
+    /// Write a `<dir>/<slug>/SKILL.md`, the layout a package ships.
+    fn plant_skill(dir: &Path, slug: &str, description: &str, body: &str) {
+        let entry = dir.join(slug);
+        std::fs::create_dir_all(&entry).unwrap();
+        std::fs::write(
+            entry.join("SKILL.md"),
+            format!("---\nname: {slug}\ndescription: {description}\n---\n\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    /// **The parity witness** (#4917). A plugin's skill is listed in the
+    /// dashboard's skills view and names the package that shipped it.
+    ///
+    /// #3567 gave a contributed skill an attribution field and put it on
+    /// screen in the SKILLS tab; this view scanned exactly two roots —
+    /// `<workspace>/.stella/skills` and `<user_config>/skills` — and a
+    /// package's skills live under `<plugin_dir>/skills` and are never copied
+    /// into either. So a user who installed a package for its skills saw them
+    /// in the deck and could not find them in the dashboard, which reads as
+    /// the complete list.
+    #[test]
+    fn a_plugins_skill_is_listed_and_names_the_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let own = root.join(".stella/skills");
+        std::fs::create_dir_all(&own).unwrap();
+        plant_skill(&own, "our-own", "the workspace's own", "OWN_BODY");
+
+        let package = root.join(".stella/plugins/vera/skills");
+        std::fs::create_dir_all(&package).unwrap();
+        plant_skill(
+            &package,
+            "house-style",
+            "how this shop writes code",
+            "PKG_BODY",
+        );
+
+        // Named rather than counted: the user-scope root this view also scans
+        // is the developer's real `~/.stella/skills`, and this crate has no
+        // env lock to move it.
+        let named = |rows: &Value, name: &str| -> Vec<Value> {
+            rows.as_array()
+                .expect("skills returns an array")
+                .iter()
+                .filter(|row| row["name"] == name)
+                .cloned()
+                .collect()
+        };
+        let empty = skills(root, &NoPluginSkills);
+        assert!(
+            named(&empty, "house-style").is_empty(),
+            "anti-vacuity — the package's skill is absent before the roster is asked"
+        );
+        assert_eq!(
+            named(&empty, "our-own").len(),
+            1,
+            "and the workspace's own is there either way"
+        );
+
+        let listed = skills(
+            root,
+            &FakeRoster(vec![ContributedSkills {
+                plugin: "vera".to_string(),
+                tier: PluginTier::Project,
+                dir: package.clone(),
+            }]),
+        );
+        let found = named(&listed, "house-style");
+        let row = found
+            .first()
+            .unwrap_or_else(|| panic!("the package's skill is listed: {listed:#?}"));
+        assert_eq!(row["contributed_by"], "vera", "and names the package");
+        assert_eq!(
+            row["scope"], "project",
+            "at the tier its package is installed at, which is the tier whose \
+             state file governs it"
+        );
+        assert_eq!(
+            row["learned"], false,
+            "a package's skill was not mined by this workspace's loop, whatever \
+             its frontmatter says — counted as learned it would inflate the tile"
+        );
+        assert!(
+            row["evidence_grade"].is_null(),
+            "no proposal here to grade it"
+        );
+        assert!(
+            named(&listed, "our-own")[0]["contributed_by"].is_null(),
+            "and the user's own row names nobody"
+        );
+    }
+
+    /// **The precedence witness.** A package may not silently take over a name
+    /// the user wrote: the recall loader drops the plugin's same-named skill
+    /// before it reaches the prompt, so listing it would show a steer that is
+    /// not in force.
+    #[test]
+    fn a_plugins_skill_never_displaces_one_the_user_wrote_in_the_listing() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let own = root.join(".stella/skills");
+        std::fs::create_dir_all(&own).unwrap();
+        plant_skill(&own, "house-style", "the user's own wording", "OWN_BODY");
+
+        let package = root.join(".stella/plugins/vera/skills");
+        std::fs::create_dir_all(&package).unwrap();
+        plant_skill(&package, "house-style", "the package's wording", "PKG_BODY");
+
+        let listed = skills(
+            root,
+            &FakeRoster(vec![ContributedSkills {
+                plugin: "vera".to_string(),
+                tier: PluginTier::Project,
+                dir: package,
+            }]),
+        );
+        let rows: Vec<&Value> = listed
+            .as_array()
+            .expect("skills returns an array")
+            .iter()
+            .filter(|row| row["name"] == "house-style")
+            .collect();
+        assert_eq!(rows.len(), 1, "one row for one name: {rows:#?}");
+        assert_eq!(rows[0]["description"], "the user's own wording");
+        assert!(rows[0]["contributed_by"].is_null());
     }
 }

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -71,6 +71,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 pub use db::{DbError, Observatory};
+/// The port a host implements to report a workspace's plugin-contributed
+/// skills, and the shapes it answers with (#4917).
+pub use fsview::{ContributedSkills, NoPluginSkills, PluginSkills, PluginTier};
 
 /// The dashboard page, embedded so the binary is self-contained.
 const INDEX_HTML: &str = include_str!("assets/index.html");
@@ -258,6 +261,18 @@ fn route_of(path: &str) -> &str {
 /// mean buffering an endless one.
 #[must_use]
 pub fn respond(workspace_root: &Path, path: &str) -> Response {
+    respond_with(workspace_root, path, &NoPluginSkills)
+}
+
+/// [`respond`], with the host's answer for which plugin-contributed skills a
+/// session started here would load ([`PluginSkills`], #4917).
+///
+/// Split from [`respond`] rather than added to it because only the one route
+/// that lists skills consults it: every other route is still a pure function
+/// of (workspace, path), and the dozens of unit tests that drive [`respond`]
+/// should not have to name a roster to ask about executions.
+#[must_use]
+pub fn respond_with(workspace_root: &Path, path: &str, plugins: &dyn PluginSkills) -> Response {
     let (route, query) = match path.split_once('?') {
         Some((r, q)) => (r, Some(q)),
         None => (path, None),
@@ -535,7 +550,7 @@ pub fn respond(workspace_root: &Path, path: &str) -> Response {
             ))
         }
         "/api/codegraph" => Ok(codegraph::snapshot(root)),
-        "/api/skills" => Ok(fsview::skills(root)),
+        "/api/skills" => Ok(fsview::skills(root, plugins)),
         "/api/mcp-servers" => Ok(fsview::mcp_servers(root)),
         "/api/config" => Ok(fsview::config(root)),
         "/api/memories" => Ok(fsview::memories(root)),
@@ -650,9 +665,15 @@ fn percent_decode(value: &str) -> String {
 /// Bind the observatory on `127.0.0.1:port` and serve until the process
 /// exits. `port` 0 picks a free port. Calls `on_ready` once with the bound
 /// address (the CLI prints the URL from it).
+///
+/// `plugins` answers which plugin-contributed skills a session started in this
+/// workspace would load — see [`PluginSkills`] for why the host is
+/// asked rather than the filesystem walked. [`NoPluginSkills`] is the
+/// answer for a host with no roster.
 pub async fn serve(
     workspace_root: PathBuf,
     port: u16,
+    plugins: Arc<dyn PluginSkills>,
     on_ready: impl FnOnce(SocketAddr),
 ) -> Result<(), ServeError> {
     let listener = TcpListener::bind(("127.0.0.1", port))
@@ -698,10 +719,11 @@ pub async fn serve(
             .await
             .expect("connection semaphore is never closed");
         let root = workspace_root.clone();
+        let plugins = Arc::clone(&plugins);
         tokio::spawn(async move {
             // Per-connection errors (bad request line, client hangup) only
             // affect that connection; the accept loop keeps serving.
-            let _ = handle(stream, &root).await;
+            let _ = handle(stream, &root, plugins).await;
             drop(permit);
         });
     }
@@ -748,7 +770,11 @@ fn host_is_local(head: &str) -> bool {
 /// because a ten-second cap on a healthy stream would sever it on a timer.
 /// What the timeout is actually for is a peer that opens a socket and says
 /// nothing; that hazard ends when the head arrives.
-async fn handle(mut stream: TcpStream, workspace_root: &Path) -> std::io::Result<()> {
+async fn handle(
+    mut stream: TcpStream,
+    workspace_root: &Path,
+    plugins: Arc<dyn PluginSkills>,
+) -> std::io::Result<()> {
     let head = match tokio::time::timeout(READ_TIMEOUT, read_head(&mut stream)).await {
         Ok(result) => result?,
         // The peer never finished its head. Dropping the connection is the whole
@@ -756,7 +782,7 @@ async fn handle(mut stream: TcpStream, workspace_root: &Path) -> std::io::Result
         // request head in ten seconds is not waiting for a status code.
         Err(_elapsed) => return Ok(()),
     };
-    respond_to_head(stream, workspace_root, head).await
+    respond_to_head(stream, workspace_root, head, plugins).await
 }
 
 /// One request head, and whether its terminator arrived inside the cap.
@@ -799,6 +825,7 @@ async fn respond_to_head(
     mut stream: TcpStream,
     workspace_root: &Path,
     head: RequestHead,
+    plugins: Arc<dyn PluginSkills>,
 ) -> std::io::Result<()> {
     let RequestHead {
         text: head,
@@ -844,7 +871,7 @@ async fn respond_to_head(
         // be on the blocking pool at once.
         let root = workspace_root.to_path_buf();
         let route = path.to_string();
-        tokio::task::spawn_blocking(move || respond(&root, &route))
+        tokio::task::spawn_blocking(move || respond_with(&root, &route, plugins.as_ref()))
             .await
             .unwrap_or_else(|_| {
                 Response::error("500 Internal Server Error", "dashboard query failed")

--- a/crates/stella-observatory/src/tests/http_surface.rs
+++ b/crates/stella-observatory/src/tests/http_surface.rs
@@ -146,9 +146,14 @@ async fn serves_over_a_real_socket() {
     let root = ws.path().to_path_buf();
     let (tx, rx) = tokio::sync::oneshot::channel();
     let server = tokio::spawn(async move {
-        let _ = serve(root, 0, move |addr| {
-            let _ = tx.send(addr);
-        })
+        let _ = serve(
+            root,
+            0,
+            std::sync::Arc::new(crate::NoPluginSkills),
+            move |addr| {
+                let _ = tx.send(addr);
+            },
+        )
         .await;
     });
     let addr = rx.await.unwrap();
@@ -238,9 +243,14 @@ async fn unterminated_request_head_is_refused_not_routed() {
     let root = ws.path().to_path_buf();
     let (tx, rx) = tokio::sync::oneshot::channel();
     let server = tokio::spawn(async move {
-        let _ = serve(root, 0, move |addr| {
-            let _ = tx.send(addr);
-        })
+        let _ = serve(
+            root,
+            0,
+            std::sync::Arc::new(crate::NoPluginSkills),
+            move |addr| {
+                let _ = tx.send(addr);
+            },
+        )
         .await;
     });
     let addr = rx.await.unwrap();

--- a/crates/stella-observatory/tests/live_stream.rs
+++ b/crates/stella-observatory/tests/live_stream.rs
@@ -27,9 +27,14 @@ fn serve(root: std::path::PathBuf) -> std::net::SocketAddr {
             .build()
             .expect("runtime");
         rt.block_on(async {
-            stella_observatory::serve(root, 0, |addr| {
-                let _ = tx.send(addr);
-            })
+            stella_observatory::serve(
+                root,
+                0,
+                std::sync::Arc::new(stella_observatory::NoPluginSkills),
+                |addr| {
+                    let _ = tx.send(addr);
+                },
+            )
             .await
         })
         .expect("serve");


### PR DESCRIPTION
## What

The Observatory's skills tab lists plugin-contributed skills, names the contributing plugin, and honours the same project-tier trust gate the loader does. Nothing is copied into the user's `.stella/`.

## Why the fix is a port and not a wider directory scan

The issue names two candidate shapes and rejects the first. I shipped neither literally, for a reason worth reviewing:

- **Option 1 — teach `fsview` to read `.stella/plugins/` itself.** The issue rejects this and it is right to: it duplicates the roster resolution *and* the trust gate, and getting that wrong lists skills from an untrusted clone the agent would never load.
- **Option 2 — move the roster's directory-resolution half into `stella-plugin`.** I looked at what that actually costs. The directory half moves cleanly, but the *gate* does not: `project_code_execution_trusted()` resolves `STELLA_TRUST_PROJECT`, `STELLA_PROJECT_HOOKS` **and** `run.auto_trust_project` out of the user/org-managed `stella.toml` via `Settings::trusted_scope_auto_trust_project()`. Moving settings-scope resolution into a near-leaf whose only workspace dependency is `stella-protocol` is a second extraction, through the code-execution boundary, and it is bigger than this issue. Without it, option 2 delivers the directories and leaves the observatory to answer the security question on its own — which is option 1 wearing a different hat.
- **What shipped:** the host that already computes the answer hands it over. `stella-observatory` declares a `PluginSkills` port; `stella-cli`'s `storage_cmd::RosterSkills` implements it over `plugin_cmd::package::contributed_skill_dirs` — literally the same call the session's own skill load makes. One authority, no extraction, and it is AGENTS.md invariant 1 rather than an exception to it.

The port is asked **per request**, not once at startup, so a package installed while the dashboard is open shows up on the next refresh — matching what `fsview` already does for everything else it walks.

Stated out loud in the port's doc comment, because it is a real limit: `STELLA_TRUST_PROJECT` is read from the process asking. A `stella observe` launched without it reports the project tier empty while an agent session launched with it loads those skills. That is the same authority answering in two environments, not two authorities, and what the dashboard reports is what a session started *there* would load.

## Row semantics

Contributed rows match `stella_cli::skill_manager::contributed_rows` one surface over:

- `contributed_by` names the plugin; `null` for the user's own (added to every row, so the page never has to tell an absent field from a null one).
- `scope` is the tier the package is installed at — the tier whose state file governs it.
- `learned` is **false**. A package's `SKILL.md` may carry the miner's `origin: auto` marker, but it was mined in its author's workspace; counted as learned it would inflate the "Learned skills" tile with somebody else's loop.
- `evidence_grade` is null — the ledger it joins against is this workspace's own.
- A contributed skill whose name the user already took is dropped, matching the recall loader: it never reaches the prompt, so listing it would show a steer that is not in force.

The page gains a `via` column and a "From plugins" tile.

## Records

Not fixed here, and said in the code: `fsview::rules_files`'s doc comment now names the gap and points at **#4974**, filed as a handoff with the port shape to copy, the fixture to build on, and the one design question the skills half did not have to answer (a rules file is a record *set*, so deduping is by lineage id and the registry's merge rule is the authority). Split rather than doubled so the skills half ships against real tests instead of two panels shipping against none.

## Does this need a `stella-parity` row?

**No.** That matrix's two axes are the community CLI (`stella-cli`) and the embeddable API (`stella-serve`), and its completeness sweeps are driven by `stella_serve::observe::Route::ALL` and the public `Engine` entry points in `stella-core`'s driver/goal modules. Listing skills in a local dashboard is neither an engine capability nor an API route, so a row would have no `engine_entries` to claim and nothing on either end to enforce it. The TUI/Observatory pair is a real parity axis, but it is not the one that crate models.

## Witnesses

Observatory side, against a fake roster (this crate may not link the one that resolves real rosters):

- `a_plugins_skill_is_listed_and_names_the_plugin` — absent before the roster is asked, listed after, naming the plugin, at the package's tier, `learned: false`, `evidence_grade: null`, and the user's own row still naming nobody.
- `a_plugins_skill_never_displaces_one_the_user_wrote_in_the_listing`.

CLI side, against the real one, through `/api/skills` (the route the page fetches, not an inner function only a test would call):

- `the_dashboards_plugin_skills_honour_the_project_trust_gate` — untrusted checkout contributes nothing and `house-style` is absent from the response body; trusted, the same bytes contribute once and the body carries `"contributed_by":"vera"`; removed, it is gone again. It sets `STELLA_HOME` under the env lock, because the dashboard's user-scope root is `stella_home::stella_home()` and `test_user_home` does not move it — without that a `house-style` in the developer's real `~/.stella/skills` would answer for the test.

### Ablation

Dropped the contributed-row loop from `fsview::skills` while keeping the port call, so the ablation removes the answer rather than the compile:

```
---- fsview::tests::a_plugins_skill_is_listed_and_names_the_plugin ----
panicked at crates/stella-observatory/src/fsview.rs:1308:32:
the package's skill is listed: Array [ … ]

test result: FAILED. 1 passed; 1 failed
```

```
---- the_dashboards_plugin_skills_honour_the_project_trust_gate ----
panicked at crates/stella-cli/src/plugin_cmd/tests/contributions.rs:965:5:
and the skills view lists it: [{"contributed_by":null,…}]

test result: FAILED. 0 passed; 1 failed
```

The answer is wrong under ablation rather than constant, and the pair is what separates the two claims: the **untrusted** half of the gate witness stays green under ablation (nothing listed is the correct answer there), while the **trusted** half fails. A change that listed everything unconditionally would fail the untrusted half instead. Neither half passes on its own.

## No deleted or renamed tests

Nothing removed or renamed; three added.

## API change

`stella_observatory::serve` takes an `Arc<dyn PluginSkills>`; `respond` is unchanged (it delegates with `NoPluginSkills`) so the ~78 unit tests that drive it do not have to name a roster to ask about executions, and `respond_with` is the new seam. Updated call sites: `stella-cli`'s `run_observe`, the dev harness `examples/serve.rs`, and two test helpers.

## Verification

`cargo fmt --all --check`, `cargo clippy -p stella-observatory -p stella-cli --all-targets -- -D warnings`, `make guards-fast` (prose included), `cargo test -p stella-observatory` (exit 0) and `cargo test -p stella-cli --bins` (2326 passed), rebased on `origin/main` before the final guard run. CI is the evidence.

Closes #4917
Refs #3567, #3509, #4974

## Summary by Sourcery

Show trusted, loader-consistent plugin-contributed skills in the Observatory without copying them into the user's skill directory.

New Features:
- List skills contributed by installed plugins in the Observatory skills view, including their plugin attribution and installation tier.
- Add a plugin-sourced skills integration port so hosts can provide loader-consistent, dynamically refreshed contributions.

Bug Fixes:
- Prevent untrusted or removed plugin skills from appearing in the dashboard, and avoid showing plugin skills that are overridden by user-owned skills.

Enhancements:
- Expose plugin contribution metadata in skills rows with appropriate learned and evidence semantics while preserving existing response helpers through a no-plugin default.
- Add Observatory UI support for plugin attribution and a dedicated From plugins summary tile.

Documentation:
- Document the plugin skills port and defer plugin-contributed rules-file support to the tracked follow-up.

Tests:
- Add Observatory coverage for plugin listing, attribution, tier metadata, and user-skill precedence.
- Add CLI route-level coverage proving plugin skills honor the project trust gate and disappear when the package is removed.