### PR TITLE
refactor(stella-store): telemetry.step is a seq, and now says so

### DIFF
--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -762,6 +762,9 @@ pub(crate) fn persist_event_detailed(
     let mut recovered = None;
     let mut died = None;
     if let AgentEvent::StepUsage {
+        step,
+        turn_instance,
+        call_seq,
         role,
         provider,
         model,
@@ -789,8 +792,22 @@ pub(crate) fn persist_event_detailed(
                 execution_id,
                 &TelemetryRow {
                     // Event-stream seq is the execution-global call identity;
-                    // engine-local `step` restarts on each pipeline turn.
-                    step: seq,
+                    // engine-local `step` restarts on each pipeline turn. The
+                    // column is named for what it holds since #4924 — it was
+                    // called `step` and held this, and the comment saying so
+                    // was the only place a reader could learn it.
+                    stream_seq: seq,
+                    // The engine-side identity, so this cost can be joined to
+                    // the receipt of the call that produced it without going
+                    // back to `stella-events.jsonl`: with `execution_id` these
+                    // three are `step_receipt`'s primary key. Carried through
+                    // rather than derived — `turn_instance` and `call_seq`
+                    // ride the event itself since #4793, and re-deriving them
+                    // here would be this process guessing at what the emitter
+                    // already knew.
+                    turn_instance: *turn_instance,
+                    engine_step: Some(*step as u64),
+                    call_seq: *call_seq,
                     provider: actual_provider.to_string(),
                     call_role: serde_json::to_value(role)
                         .ok()
@@ -866,7 +883,16 @@ pub(crate) fn persist_event_detailed(
             .record_telemetry(
                 execution_id,
                 &TelemetryRow {
-                    step: seq,
+                    stream_seq: seq,
+                    // All three NULL, because `UsageIncomplete` carries none
+                    // of them: the call died before the engine named a turn
+                    // for it, so there is no receipt to join to and nothing
+                    // here to record. NULL says "this row cannot say", which
+                    // is the truth; 0 would say "the worker call of turn 0",
+                    // which is a claim (#4924).
+                    turn_instance: None,
+                    engine_step: None,
+                    call_seq: None,
                     provider: actual_provider.to_string(),
                     call_role: enum_tag(role),
                     model: model.clone(),

--- a/crates/stella-cli/src/agent/persistence/usage_recovery_tests.rs
+++ b/crates/stella-cli/src/agent/persistence/usage_recovery_tests.rs
@@ -174,7 +174,13 @@ fn an_abandoned_attempt_with_nothing_to_salvage_still_lands_a_flagged_row() {
         "an abandoned call must be visible, not a hole in the count"
     );
     let row = &rows[0].telemetry;
-    assert_eq!(row.step, 7, "the row names the call that died");
+    assert_eq!(row.stream_seq, 7, "the row names the call that died");
+    // …and cannot name the receipt it belongs to, because `UsageIncomplete`
+    // carries no turn identity: the call died before the engine named one.
+    // NULL says that; 0 would claim it was the worker call of turn 0 (#4924).
+    assert_eq!(row.turn_instance, None);
+    assert_eq!(row.engine_step, None);
+    assert_eq!(row.call_seq, None);
     assert_eq!(row.model, "claude-opus-5");
     assert_eq!(row.input_tokens, 0);
     assert_eq!(row.output_tokens, 0);

--- a/crates/stella-cli/src/cloud_drain.rs
+++ b/crates/stella-cli/src/cloud_drain.rs
@@ -278,7 +278,10 @@ mod tests {
             execution_id: 1,
             recorded_at: "2026-07-28T06:00:00Z".into(),
             telemetry: stella_store::TelemetryRow {
-                step: 1,
+                stream_seq: 1,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 provider: "zai".into(),
                 call_role: "engine".into(),
                 model: "glm-5.2".into(),

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -153,7 +153,10 @@ mod tests {
                 .record_telemetry(
                     id,
                     &stella_store::TelemetryRow {
-                        step,
+                        stream_seq: step,
+                        turn_instance: None,
+                        engine_step: None,
+                        call_seq: None,
                         provider: "zai".into(),
                         call_role: "worker".into(),
                         model: "glm-5.2".into(),

--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -30,7 +30,10 @@ fn seed_session(root: &Path, session: &str, provider: &str, touched: &str) {
         .record_telemetry(
             id,
             &TelemetryRow {
-                step: 0,
+                stream_seq: 0,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 call_role: "worker".into(),
                 provider: provider.into(),
                 model: "claude-test".into(),
@@ -402,7 +405,10 @@ fn export_round_trips_through_a_real_store() {
         .record_telemetry(
             1,
             &TelemetryRow {
-                step: 0,
+                stream_seq: 0,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 call_role: "worker".into(),
                 provider: "test".into(),
                 model: "test-model".into(),

--- a/crates/stella-cli/src/fleet_spend.rs
+++ b/crates/stella-cli/src/fleet_spend.rs
@@ -93,7 +93,10 @@ mod tests {
     /// One landed model call's durable receipt, priced at `cost_usd`.
     fn receipt(step: u64, cost_usd: f64) -> TelemetryRow {
         TelemetryRow {
-            step,
+            stream_seq: step,
+            turn_instance: None,
+            engine_step: None,
+            call_seq: None,
             provider: "anthropic".into(),
             call_role: "worker".into(),
             model: "test-model".into(),

--- a/crates/stella-cli/src/subsession/closeout.rs
+++ b/crates/stella-cli/src/subsession/closeout.rs
@@ -223,7 +223,10 @@ mod tests {
                 .record_telemetry(
                     worker_exec,
                     &stella_store::TelemetryRow {
-                        step,
+                        stream_seq: step,
+                        turn_instance: None,
+                        engine_step: None,
+                        call_seq: None,
                         provider: "zai".into(),
                         call_role: "worker".into(),
                         model: "glm-5.2".into(),

--- a/crates/stella-cli/tests/stats_prune_cli.rs
+++ b/crates/stella-cli/tests/stats_prune_cli.rs
@@ -22,7 +22,10 @@ use common::SealsEmbedderBackend;
 
 fn telemetry(step: u64) -> TelemetryRow {
     TelemetryRow {
-        step,
+        stream_seq: step,
+        turn_instance: None,
+        engine_step: None,
+        call_seq: None,
         provider: "anthropic".into(),
         call_role: "worker".into(),
         model: "opus".into(),

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -2579,11 +2579,17 @@ function downloadTranscriptJson(execution, journal, calls, steps, tools, files, 
 }
 /* One metering row. `sub_agent_id` (telemetry, v33) badges the rows a
    delegate spent rather than the lead — without it a turn's fan-out is
-   indistinguishable from the lead making every call itself. */
+   indistinguishable from the lead making every call itself.
+
+   The leading number is `stream_seq`: the event-stream seq, which is the
+   execution-global call identity. It is NOT the engine's step, which restarts
+   on every turn and which several calls can share — the column was called
+   `step` and held this until #4924. The context dialog's `c.step` a few
+   functions down is the engine's, and they are different numbers. */
 function stepRowHtml(s, maxTok) {
   const t = num(s.input_tokens) + num(s.output_tokens);
   const inW = t ? 100 * num(s.input_tokens) / t : 0;
-  return `<div class="step-row"><span>${fmtInt(s.step)}</span>
+  return `<div class="step-row"><span>${fmtInt(s.stream_seq)}</span>
     <span class="tokbar" style="width:${(100 * t / maxTok).toFixed(1)}%">
       <i style="background:var(--c1);width:${inW.toFixed(1)}%"></i>
       <i style="background:var(--c2);flex:1"></i></span>

--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -312,20 +312,31 @@ impl Observatory {
         // call (`telemetry`, v33) and which ran it (`tool_calls`, v35) — so a
         // page can separate a turn's lead from its fan-out on either axis
         // without a second round trip. NULL is the lead's own, in both tables.
+        //
+        // The seq column is named per store, not hardcoded: an observer opens
+        // read-only and never migrates, so a workspace that has not run a turn
+        // since #4924 still spells it `step`. Probing keeps both readable; the
+        // JSON key is the new name either way, because the page's job is to
+        // say what the number is rather than what its column was called.
+        let seq_column = crate::store_shape::telemetry_seq_column(&conn);
         let steps = collect_rows_degrading(
             &conn,
             id,
-            "SELECT step, provider, model, input_tokens, output_tokens,
+            &format!(
+                "SELECT {seq_column}, provider, model, input_tokens, output_tokens,
                     cache_read_tokens, cache_miss_tokens, cache_write_tokens,
                     cost_usd, duration_ms, retries, tool_calls, sub_agent_id
-             FROM telemetry WHERE execution_id = ?1 ORDER BY step ASC",
-            "SELECT step, provider, model, input_tokens, output_tokens,
+             FROM telemetry WHERE execution_id = ?1 ORDER BY {seq_column} ASC"
+            ),
+            &format!(
+                "SELECT {seq_column}, provider, model, input_tokens, output_tokens,
                     cache_read_tokens, cache_miss_tokens, cache_write_tokens,
                     cost_usd, duration_ms, retries, tool_calls, NULL
-             FROM telemetry WHERE execution_id = ?1 ORDER BY step ASC",
+             FROM telemetry WHERE execution_id = ?1 ORDER BY {seq_column} ASC"
+            ),
             |r| {
                 Ok(json!({
-                    "step": r.get::<_, i64>(0)?,
+                    "stream_seq": r.get::<_, i64>(0)?,
                     "provider": r.get::<_, String>(1)?,
                     "model": r.get::<_, String>(2)?,
                     "input_tokens": r.get::<_, i64>(3)?,

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -56,6 +56,7 @@ mod self_driving;
 mod self_driving_sessions;
 mod sent_context;
 mod sessions;
+mod store_shape;
 mod system_prompt;
 mod transcript_view;
 mod turn_agents;

--- a/crates/stella-observatory/src/store_shape.rs
+++ b/crates/stella-observatory/src/store_shape.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Which spelling of a store column this file uses.
+//!
+//! An observer opens every store `SQLITE_OPEN_READ_ONLY` and migrates none of
+//! them, so a workspace that has not run a turn since an upgrade is still on
+//! the old shape. `db.rs`'s [`collect_rows_degrading`] handles a column that
+//! is simply *missing*; this module handles the other case — a column that is
+//! present under a different name — which degrading to `NULL` would answer
+//! wrongly.
+//!
+//! Its own file rather than more lines in `db.rs`, which sits within fifty
+//! lines of the 1500-line ceiling (AGENTS.md § "God files — plan around them,
+//! never into them").
+//!
+//! [`collect_rows_degrading`]: crate::db
+
+use rusqlite::Connection;
+
+/// What this store calls `telemetry`'s event-stream seq column.
+///
+/// `stream_seq` since store schema v37; `step` before it, where the name said
+/// "the engine's step" and the column held a seq the whole time (#4924).
+/// Both spellings are live at once for as long as un-migrated stores exist,
+/// and blanking a turn's whole Steps table over a column name would be the
+/// worst answer available.
+///
+/// Answers with the current name when the table cannot be read at all, so a
+/// missing `telemetry` degrades through the caller rather than here.
+pub(crate) fn telemetry_seq_column(conn: &Connection) -> &'static str {
+    let legacy = conn
+        .query_row(
+            "SELECT count(*) FROM pragma_table_info('telemetry') WHERE name = 'step'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0);
+    if legacy > 0 { "step" } else { "stream_seq" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_with(column: &str) -> Connection {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(&format!(
+            "CREATE TABLE telemetry (execution_id INTEGER NOT NULL, {column} INTEGER NOT NULL);"
+        ))
+        .expect("seed");
+        conn
+    }
+
+    #[test]
+    fn a_migrated_store_reads_the_current_name() {
+        assert_eq!(
+            telemetry_seq_column(&store_with("stream_seq")),
+            "stream_seq"
+        );
+    }
+
+    /// The case this module exists for: a store nobody has run a turn against
+    /// since the rename still answers, rather than losing its Steps table.
+    #[test]
+    fn a_store_older_than_the_rename_reads_the_old_name() {
+        assert_eq!(telemetry_seq_column(&store_with("step")), "step");
+    }
+
+    /// No `telemetry` table at all is the caller's problem, not this one's —
+    /// it answers with the current name and lets the read degrade there.
+    #[test]
+    fn a_store_with_no_telemetry_table_answers_the_current_name() {
+        let conn = Connection::open_in_memory().expect("db");
+        assert_eq!(telemetry_seq_column(&conn), "stream_seq");
+    }
+}

--- a/crates/stella-observatory/src/turn_agents.rs
+++ b/crates/stella-observatory/src/turn_agents.rs
@@ -272,7 +272,7 @@ mod tests {
              );
              CREATE TABLE telemetry (
                execution_id INTEGER NOT NULL,
-               step INTEGER NOT NULL,
+               stream_seq INTEGER NOT NULL,
                ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                provider TEXT NOT NULL,
                call_role TEXT NOT NULL DEFAULT 'unknown',
@@ -286,7 +286,7 @@ mod tests {
                retries INTEGER NOT NULL,
                tool_calls INTEGER NOT NULL,
                sub_agent_id TEXT,
-               UNIQUE (execution_id, step)
+               UNIQUE (execution_id, stream_seq)
              );",
         )
         .expect("schema");
@@ -354,7 +354,7 @@ mod tests {
             (3, "audit-2", 70),
         ] {
             conn.execute(
-                "INSERT INTO telemetry (execution_id, step, provider, model, input_tokens,
+                "INSERT INTO telemetry (execution_id, stream_seq, provider, model, input_tokens,
                    output_tokens, cache_read_tokens, cache_miss_tokens, cost_usd,
                    duration_ms, retries, tool_calls, sub_agent_id)
                  VALUES (7, ?1, 'zai', 'glm-5.2', ?2, 50, 0, 0, 0.002, 1200, 0, 1, ?3)",
@@ -410,7 +410,7 @@ mod tests {
 
         conn.execute_batch(
             "ALTER TABLE telemetry RENAME TO telemetry_v33;
-             CREATE TABLE telemetry AS SELECT execution_id, step, provider, model
+             CREATE TABLE telemetry AS SELECT execution_id, stream_seq, provider, model
              FROM telemetry_v33;",
         )
         .expect("drop the column");

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -93,7 +93,10 @@ const ROUTES: &[(&str, Option<&str>)] = &[
     ("/api/v1/snapshot", Some("/executions/0/id")),
     ("/api/overview", Some("/runs")),
     ("/api/executions", Some("/0/id")),
-    ("/api/execution?id=1", Some("/steps/0/step")),
+    // `stream_seq`, not `step`: the telemetry column was renamed in store
+    // schema v37 and the JSON key followed it (#4924). This probe caught the
+    // rename, which is exactly its job.
+    ("/api/execution?id=1", Some("/steps/0/stream_seq")),
     ("/api/execution-journal?id=1", Some("/0/type")),
     ("/api/execution-context?id=1", Some("/calls/0/step")),
     (
@@ -340,7 +343,10 @@ fn real_store_workspace() -> tempfile::TempDir {
         .record_telemetry(
             completed,
             &TelemetryRow {
-                step: 1,
+                stream_seq: 1,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 provider: "zai".into(),
                 call_role: "worker".into(),
                 model: "glm-5.2".into(),
@@ -363,7 +369,10 @@ fn real_store_workspace() -> tempfile::TempDir {
         .record_telemetry(
             completed,
             &TelemetryRow {
-                step: 2,
+                stream_seq: 2,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 provider: "zai".into(),
                 call_role: "worker".into(),
                 model: "glm-5.2".into(),

--- a/crates/stella-store/src/cache_gaps.rs
+++ b/crates/stella-store/src/cache_gaps.rs
@@ -51,13 +51,13 @@ impl Store {
                t.cache_write_tokens,
                CAST(
                  (julianday(t.ts) - julianday(
-                   LAG(t.ts) OVER (PARTITION BY e.session_id ORDER BY e.id, t.step)
+                   LAG(t.ts) OVER (PARTITION BY e.session_id ORDER BY e.id, t.stream_seq)
                  )) * 86400 AS INTEGER
                ) AS gap_secs
              FROM telemetry t
              JOIN executions e ON e.id = t.execution_id
              WHERE e.session_id IS NOT NULL
-             ORDER BY e.session_id, e.id, t.step",
+             ORDER BY e.session_id, e.id, t.stream_seq",
         )?;
         let rows = stmt.query_map([], |row| {
             Ok(CacheCallGap {
@@ -146,7 +146,10 @@ mod tests {
         cache_write: u64,
     ) -> crate::TelemetryRow {
         crate::TelemetryRow {
-            step: 0,
+            stream_seq: 0,
+            turn_instance: None,
+            engine_step: None,
+            call_seq: None,
             provider: provider.into(),
             call_role: "worker".into(),
             model: model.into(),

--- a/crates/stella-store/src/cache_trend.rs
+++ b/crates/stella-store/src/cache_trend.rs
@@ -122,7 +122,10 @@ mod tests {
 
     fn telemetry(cache_read: u64, cache_write: u64) -> crate::TelemetryRow {
         crate::TelemetryRow {
-            step: 0,
+            stream_seq: 0,
+            turn_instance: None,
+            engine_step: None,
+            call_seq: None,
             provider: "anthropic".into(),
             call_role: "worker".into(),
             model: "claude".into(),
@@ -157,12 +160,12 @@ mod tests {
         // Three ordinary small calls: input 1_000 each (the helper's shape).
         for step in 0..3 {
             let mut call = telemetry(0, 0);
-            call.step = step;
+            call.stream_seq = step;
             store.record_telemetry(e1, &call).unwrap();
         }
         // One call whose prompt lives almost entirely in the write column.
         let mut mostly_written = telemetry(0, 4_541);
-        mostly_written.step = 3;
+        mostly_written.stream_seq = 3;
         mostly_written.input_tokens = 2;
         store.record_telemetry(e1, &mostly_written).unwrap();
 

--- a/crates/stella-store/src/content_free.rs
+++ b/crates/stella-store/src/content_free.rs
@@ -162,7 +162,10 @@ pub const HUB_TELEMETRY_COLUMNS: &[&str] = &[
     // --- addressing ---
     "source_rowid",
     "execution_id",
-    "step",
+    // The event-stream `seq`, called `step` here until #4924 renamed it on
+    // both sides. A rename, reviewed as one: the same integer, already
+    // admitted, under the name that says what it is.
+    "stream_seq",
     "recorded_at",
     // --- content-free telemetry ---
     "provider",
@@ -464,7 +467,10 @@ pub fn poisoned_cloud_event() -> CloudTelemetryEvent {
         source_rowid: 99,
         recorded_at: "2026-07-24T00:00:00Z".into(),
         telemetry: TelemetryRow {
-            step: 3,
+            stream_seq: 3,
+            turn_instance: None,
+            engine_step: None,
+            call_seq: None,
             provider: "zai".into(),
             // Excluded from the drain contract by design — poisoned so any
             // encoder that blanket-serializes the hub row is caught.
@@ -925,9 +931,12 @@ mod tests {
             .collect();
         assert_eq!(
             excluded,
+            // `stream_seq` is `step` renamed (#4924), not a new exclusion:
+            // the same column, still not shipped, under the name that says
+            // what it holds. Nothing was added to or removed from this set.
             vec![
                 &"execution_id",
-                &"step",
+                &"stream_seq",
                 &"call_role",
                 &"estimated_input_tokens"
             ],

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -185,10 +185,36 @@ pub(crate) fn files_touched_ddl(table: &str) -> String {
 /// `telemetry` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION) — see [`events_ddl`] for why it is
 /// name-parameterized.
 ///
-/// UNIQUE (execution_id, step): one row per committed model call —
-/// `StepUsage` is emitted exactly once per step that lands. `drift_samples`
-/// treats `(execution_id, step)` as insertion order and `usage_stats` sums
-/// tokens/cost per execution, so a duplicate step double-counts money.
+/// UNIQUE (execution_id, stream_seq): one row per committed model call.
+///
+/// `stream_seq` is the **event-stream `seq`**, not the engine's step — it was
+/// called `step` until v37 and held a seq for as long as it existed (#4924).
+/// The value is right and the old name was not: the seq is the
+/// execution-global call identity, while the engine's `step` restarts on
+/// every `run_turn` and several calls can share one, so keying on it would
+/// collide and double-count money. `drift_samples` treats
+/// `(execution_id, stream_seq)` as insertion order and `usage_stats` sums
+/// tokens/cost per execution, so a duplicate is a real accounting error.
+/// AGENTS.md § Glossary is the authority on how far apart `step`,
+/// `turn_instance` and `call_seq` are; this column was that hazard sitting in
+/// the schema.
+///
+/// `turn_instance`, `engine_step` and `call_seq` (v37) carry the engine-side
+/// identity the `step_usage` event has carried since #4793, so a receipt can
+/// be found for a cost without going back to `stella-events.jsonl`: together
+/// with `execution_id` they are `step_receipt`'s primary key
+/// `(execution_id, turn_instance, step, call_seq)` — `engine_step` is that
+/// `step`, spelled apart from it here because this table's `step` meant
+/// something else for thirty-six versions.
+///
+/// All three are nullable, and NULL means **this row cannot say**, never
+/// zero. A row written before v37 genuinely does not know; so does a
+/// `usage_incomplete` receipt for a call that died before the engine could
+/// name the turn. Turn instances and call seqs are both 0-based, so
+/// defaulting either to 0 would state that every legacy auxiliary call was
+/// the worker call of turn 0 — the same reason the event's own fields are
+/// `Option` (`AgentEvent::StepUsage::call_seq`'s doc). A consumer joining on
+/// them treats NULL as unjoinable.
 ///
 /// `sub_agent_id` (v33) names which delegate spent the call, or NULL for the
 /// lead's own (#4383). Nullable with no default because NULL is the lead — a
@@ -201,7 +227,10 @@ pub(crate) fn telemetry_ddl(table: &str) -> String {
     format!(
         "CREATE TABLE {table} (
            execution_id INTEGER NOT NULL,
-           step INTEGER NOT NULL,
+           stream_seq INTEGER NOT NULL,
+           turn_instance INTEGER,
+           engine_step INTEGER,
+           call_seq INTEGER,
            ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
            provider TEXT NOT NULL,
            call_role TEXT NOT NULL DEFAULT 'unknown',
@@ -218,7 +247,7 @@ pub(crate) fn telemetry_ddl(table: &str) -> String {
            tool_calls INTEGER NOT NULL,
            usage_complete INTEGER NOT NULL DEFAULT 0 CHECK(usage_complete IN (0, 1)),
            sub_agent_id TEXT,
-           UNIQUE (execution_id, step)
+           UNIQUE (execution_id, stream_seq)
          );"
     )
 }
@@ -240,12 +269,12 @@ pub(crate) const RULES_TABLE: &str = "CREATE TABLE IF NOT EXISTS rules (
      );";
 
 /// `drift_samples` filters (provider, model) and sorts (execution_id DESC,
-/// step DESC) at EVERY session start, over a table that grows one row per
-/// model call forever — without this index it full-scans. Non-unique on
-/// purpose: uniqueness lives on the (execution_id, step) key; this is the
-/// query's covering access path.
+/// stream_seq DESC) at EVERY session start, over a table that grows one row
+/// per model call forever — without this index it full-scans. Non-unique on
+/// purpose: uniqueness lives on the (execution_id, stream_seq) key; this is
+/// the query's covering access path.
 pub(crate) const TELEMETRY_INDEX: &str = "CREATE INDEX IF NOT EXISTS telemetry_by_model
-       ON telemetry(provider, model, execution_id, step);";
+       ON telemetry(provider, model, execution_id, stream_seq);";
 
 /// `memory_citations` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION).
 ///

--- a/crates/stella-store/src/drain.rs
+++ b/crates/stella-store/src/drain.rs
@@ -524,7 +524,10 @@ mod tests {
             source_rowid: 99,
             recorded_at: "2026-07-23T00:00:00Z".into(),
             telemetry: TelemetryRow {
-                step: 3,
+                stream_seq: 3,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 provider: "zai".into(),
                 call_role: "lead".into(),
                 model: "glm-5.2".into(),
@@ -752,7 +755,10 @@ mod tests {
                     execution_id: 1,
                     recorded_at: "2026-07-23T10:00:00Z".into(),
                     telemetry: TelemetryRow {
-                        step: *id as u64,
+                        stream_seq: *id as u64,
+                        turn_instance: None,
+                        engine_step: None,
+                        call_seq: None,
                         provider: "zai".into(),
                         call_role: "engine".into(),
                         model: "glm-5.2".into(),

--- a/crates/stella-store/src/export.rs
+++ b/crates/stella-store/src/export.rs
@@ -132,11 +132,11 @@ impl ExportExclusions {
 const CHILD_TABLES: [(&str, &str, &str); 8] = [
     (
         "telemetry",
-        "SELECT execution_id, step, ts, provider, call_role, model, input_tokens, \
+        "SELECT execution_id, stream_seq, ts, provider, call_role, model, input_tokens, \
          estimated_input_tokens, output_tokens, cache_read_tokens, cache_miss_tokens, \
          cache_write_tokens, cost_usd, duration_ms, retries, tool_calls, usage_complete, \
          sub_agent_id FROM telemetry",
-        "ORDER BY execution_id ASC, step ASC",
+        "ORDER BY execution_id ASC, stream_seq ASC",
     ),
     (
         "tool_calls",
@@ -525,7 +525,10 @@ mod tests {
                 .record_telemetry(
                     id,
                     &TelemetryRow {
-                        step: 0,
+                        stream_seq: 0,
+                        turn_instance: None,
+                        engine_step: None,
+                        call_seq: None,
                         call_role: "worker".into(),
                         provider: provider.into(),
                         model: "m".into(),
@@ -708,7 +711,10 @@ mod tests {
                 .record_telemetry(
                     id,
                     &TelemetryRow {
-                        step: 0,
+                        stream_seq: 0,
+                        turn_instance: None,
+                        engine_step: None,
+                        call_seq: None,
                         call_role: "worker".into(),
                         provider: "anthropic".into(),
                         model: "m".into(),

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -65,6 +65,7 @@ mod schema_removal;
 mod sub_agent_calls;
 mod sub_agent_tool_calls;
 mod task_contract;
+mod telemetry_call_identity;
 mod token_unit;
 
 // `Durability` is NOT re-exported alongside the runner: its only
@@ -103,7 +104,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 36] = [
+pub(crate) const MIGRATIONS: [Migration; 37] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -297,6 +298,13 @@ pub(crate) const MIGRATIONS: [Migration; 36] = [
     // from the composer, and nothing recorded the fact for the rest. See the
     // module's own doc.
     dispatched_executions::migrate_v35_to_v36,
+    // v36 → v37: `telemetry.step` is renamed `stream_seq` — it always held
+    // the event-stream seq, never the engine's step — and the table grows
+    // nullable `turn_instance`/`engine_step`/`call_seq`, which together with
+    // `execution_id` are `step_receipt`'s primary key, so a cost can be
+    // joined to the receipt of the call that produced it (#4924). NULL is
+    // "this row cannot say", never 0. See the module's own doc.
+    telemetry_call_identity::migrate_v36_to_v37,
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `SCHEMA_VERSION` is its length, so
     // a slot is claimed by position, not by name. Two branches that each
@@ -347,7 +355,9 @@ pub(crate) const MIGRATIONS: [Migration; 36] = [
     //   v33 → v34: CLAIMED above by `step_receipt.upstream_provider` (#3054).
     //   v34 → v35: CLAIMED above by `tool_calls.sub_agent_id` (#4624).
     //   v35 → v36: CLAIMED above by `executions.parent_execution_id` (#4628).
-    // Nothing is reserved now: take v36 → v37 and add your own line here.
+    //   v36 → v37: CLAIMED above by `telemetry.stream_seq` + the receipt join
+    //              columns (#4924).
+    // Nothing is reserved now: take v37 → v38 and add your own line here.
     // If a reserved phase ships without needing its slot, delete its line
     // rather than leaving a hole — index order is the contract.
 ];

--- a/crates/stella-store/src/migrations/legacy_rebuild.rs
+++ b/crates/stella-store/src/migrations/legacy_rebuild.rs
@@ -138,9 +138,16 @@ pub(super) fn migrate_v0_to_v1(tx: &rusqlite::Transaction<'_>) -> Result<()> {
         } else {
             "0"
         };
+        // `telemetry_ddl` is the CURRENT shape, so the rebuilt table already
+        // carries #4924's names: the target column is `stream_seq` while the
+        // v0 file being read still spells the same value `step`. Both sides
+        // of this statement are correct and they disagree on purpose — the
+        // whole point of the rename is that the value was never a step.
+        // Later rungs of the ladder are column-guarded and no-op over a table
+        // that arrived here already renamed.
         tx.execute_batch(&telemetry_ddl("telemetry_v1"))?;
         tx.execute_batch(&format!(
-            "INSERT INTO telemetry_v1 (execution_id, step, ts, provider, model, input_tokens,
+            "INSERT INTO telemetry_v1 (execution_id, stream_seq, ts, provider, model, input_tokens,
                estimated_input_tokens, output_tokens, cache_read_tokens, cache_miss_tokens,
                cache_write_tokens, cost_usd, duration_ms, retries, tool_calls)
              SELECT execution_id, step, ts, provider, model, input_tokens,

--- a/crates/stella-store/src/migrations/telemetry_call_identity.rs
+++ b/crates/stella-store/src/migrations/telemetry_call_identity.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! v36 → v37: `telemetry.step` becomes `stream_seq`, and the table grows the
+//! engine-side call identity it never recorded (#4924).
+//!
+//! # The rename
+//!
+//! The column was called `step` and held the event-stream `seq`. That value
+//! is the right one — the seq is the execution-global call identity, while
+//! the engine's `step` restarts on every `run_turn` and several calls can
+//! share one, so `UNIQUE (execution_id, step)` under the engine's meaning
+//! would collide and a collision here double-counts money. Only the name was
+//! wrong, and it was wrong in the most expensive way a name can be: AGENTS.md
+//! § Glossary exists because `step`, `turn_instance` and `call_seq` look
+//! alike and are not, and this column was that hazard written into the
+//! schema. `stella-cli`'s writer had a comment saying so at the assignment
+//! and no reader ever saw it.
+//!
+//! `stream_seq` rather than `call_seq_global`, which the issue also floated:
+//! `call_seq` is a real and *different* identifier, added to this same table
+//! below, and two columns a prefix apart would be the same trap one turn of
+//! the screw tighter.
+//!
+//! # The three new columns
+//!
+//! `step_receipt`'s primary key is `(execution_id, turn_instance, step,
+//! call_seq)`. A telemetry row carried only the first of those, so a cost
+//! could not be joined to the receipt of the call that produced it — the
+//! reader had to go back to `stella-events.jsonl` and re-derive it. Since
+//! #4793 the `step_usage` event carries `turn_instance` and `call_seq`
+//! alongside its `step`, so the durable row can simply record what the event
+//! already said.
+//!
+//! `engine_step` is `step_receipt.step` under a different spelling, because
+//! this table's `step` meant a seq for thirty-six versions and reusing the
+//! word immediately would be the same collision the rename exists to end.
+//!
+//! # Nullable, no default, no backfill
+//!
+//! NULL means **this row cannot say**. Every row written before v37 is in
+//! that state, and so is a `usage_incomplete` receipt whose call died before
+//! the engine could name a turn. Zero is not available as the absent value:
+//! turn instances and call seqs are both 0-based, so a default of 0 would
+//! assert that every legacy row was the worker call of turn 0. That is the
+//! same argument `AgentEvent::StepUsage::call_seq`'s own doc makes for the
+//! field being `Option` rather than a bare `u64`, and it has to hold on both
+//! sides of the wire or the durable row claims more than the event did.
+//!
+//! There is no backfill, because nothing in the store recorded the fact. The
+//! seq orders calls within an execution and says nothing about which turn
+//! they rode; pairing a telemetry row with whichever receipt sorts alongside
+//! it would be a guess dressed as a record — and the one case it would get
+//! wrong is the auxiliary call sharing a step with the worker, which is
+//! exactly the case `call_seq` was added to disambiguate.
+
+use crate::Result;
+use crate::migrations::{column_exists, table_exists};
+
+/// Rename `telemetry.step` to `stream_seq` and add the three join columns,
+/// each guarded so a file that already carries it is untouched.
+///
+/// `ALTER TABLE … RENAME COLUMN` also rewrites the `telemetry_by_model` index
+/// and the `UNIQUE (execution_id, step)` constraint that name the column, so
+/// the ladder does not have to rebuild the table to keep either.
+pub(super) fn migrate_v36_to_v37(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if !table_exists(tx, "telemetry")? {
+        return Ok(());
+    }
+    if column_exists(tx, "telemetry", "step")? && !column_exists(tx, "telemetry", "stream_seq")? {
+        tx.execute_batch("ALTER TABLE telemetry RENAME COLUMN step TO stream_seq;")?;
+    }
+    for column in ["turn_instance", "engine_step", "call_seq"] {
+        if !column_exists(tx, "telemetry", column)? {
+            tx.execute_batch(&format!(
+                "ALTER TABLE telemetry ADD COLUMN {column} INTEGER;"
+            ))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::apply_migration;
+    use rusqlite::Connection;
+
+    /// A v36 file: the column still called `step`, the unique key and the
+    /// covering index both naming it, and one row of real telemetry in it.
+    fn v36_file() -> Connection {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE telemetry (
+               execution_id INTEGER NOT NULL,
+               step INTEGER NOT NULL,
+               provider TEXT NOT NULL,
+               model TEXT NOT NULL,
+               cost_usd REAL NOT NULL,
+               UNIQUE (execution_id, step)
+             );
+             CREATE INDEX telemetry_by_model
+               ON telemetry(provider, model, execution_id, step);
+             INSERT INTO telemetry (execution_id, step, provider, model, cost_usd)
+               VALUES (7, 42, 'zai', 'glm-5.2', 0.25);",
+        )
+        .expect("seed a v36 file");
+        conn
+    }
+
+    /// The seq survives the rename with its value intact. It was never the
+    /// data that was wrong.
+    #[test]
+    fn the_seq_keeps_its_value_under_its_real_name() {
+        let mut conn = v36_file();
+        apply_migration(&mut conn, migrate_v36_to_v37, 37).expect("migrate");
+        let seq: i64 = conn
+            .query_row(
+                "SELECT stream_seq FROM telemetry WHERE execution_id = 7",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read back");
+        assert_eq!(seq, 42);
+    }
+
+    /// `usage_stats` sums per execution, so a duplicate row double-counts
+    /// real money — which makes `UNIQUE (execution_id, step)` the thing that
+    /// stops it. The rename must carry the key over rather than drop it.
+    #[test]
+    fn the_uniqueness_that_stops_double_counting_survives_the_rename() {
+        let mut conn = v36_file();
+        apply_migration(&mut conn, migrate_v36_to_v37, 37).expect("migrate");
+        let duplicate = conn.execute(
+            "INSERT INTO telemetry (execution_id, stream_seq, provider, model, cost_usd) \
+             VALUES (7, 42, 'zai', 'glm-5.2', 0.25)",
+            [],
+        );
+        assert!(
+            duplicate.is_err(),
+            "a second row on the same (execution_id, stream_seq) must still be refused"
+        );
+    }
+
+    /// And so does `drift_samples`'/`usage_stats`' covering access path,
+    /// which named the old column in its own definition.
+    #[test]
+    fn the_covering_index_follows_the_column() {
+        let mut conn = v36_file();
+        apply_migration(&mut conn, migrate_v36_to_v37, 37).expect("migrate");
+        let sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'telemetry_by_model'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("the index still exists");
+        assert!(
+            sql.contains("stream_seq"),
+            "the index must name the renamed column, got: {sql}"
+        );
+    }
+
+    /// Every pre-v37 row reads as unjoinable, which is the only reading the
+    /// store can make: nothing recorded which turn the call rode.
+    #[test]
+    fn an_existing_row_cannot_say_which_receipt_it_belongs_to() {
+        let mut conn = v36_file();
+        apply_migration(&mut conn, migrate_v36_to_v37, 37).expect("migrate");
+        let identity: (Option<i64>, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "SELECT turn_instance, engine_step, call_seq FROM telemetry WHERE execution_id = 7",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("read back");
+        assert_eq!(
+            identity,
+            (None, None, None),
+            "absence must be NULL, never 0 — turn 0 and call_seq 0 are real values"
+        );
+    }
+
+    /// Running it twice is a no-op — the column guards, not the error
+    /// handler, are what make that true.
+    #[test]
+    fn the_migration_is_idempotent() {
+        let mut conn = v36_file();
+        apply_migration(&mut conn, migrate_v36_to_v37, 37).expect("first");
+        apply_migration(&mut conn, migrate_v36_to_v37, 37).expect("second");
+    }
+
+    /// A file with no `telemetry` table at all still climbs the ladder — the
+    /// rebuild path can present exactly that shape.
+    #[test]
+    fn a_file_with_no_telemetry_table_still_migrates() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        apply_migration(&mut conn, migrate_v36_to_v37, 37).expect("migrate");
+    }
+}

--- a/crates/stella-store/src/prune.rs
+++ b/crates/stella-store/src/prune.rs
@@ -328,7 +328,7 @@ impl Store {
             if policy.telemetry_cursor > 0 && report.telemetry_pruned > 0 {
                 watermark_key = tx
                     .query_row(
-                        "SELECT execution_id, step FROM telemetry \
+                        "SELECT execution_id, stream_seq FROM telemetry \
                          WHERE rowid <= ?1 ORDER BY rowid DESC LIMIT 1",
                         params![policy.telemetry_cursor],
                         |r| Ok((r.get(0)?, r.get(1)?)),
@@ -356,11 +356,11 @@ impl Store {
         //    answer reflects whatever the reclaim did to the rowid space. A
         //    watermark row that did not survive resolves to 0, which re-ships
         //    the retained backlog instead of skipping anything.
-        if let Some((execution_id, step)) = watermark_key {
+        if let Some((execution_id, stream_seq)) = watermark_key {
             report.telemetry_cursor_after = Some(
                 conn.query_row(
-                    "SELECT rowid FROM telemetry WHERE execution_id = ?1 AND step = ?2",
-                    params![execution_id, step],
+                    "SELECT rowid FROM telemetry WHERE execution_id = ?1 AND stream_seq = ?2",
+                    params![execution_id, stream_seq],
                     |r| r.get(0),
                 )
                 .optional()?
@@ -487,7 +487,10 @@ mod tests {
 
     fn telemetry_row(step: u64) -> TelemetryRow {
         TelemetryRow {
-            step,
+            stream_seq: step,
+            turn_instance: None,
+            engine_step: None,
+            call_seq: None,
             provider: "zai".into(),
             call_role: "worker".into(),
             model: "glm-5.2".into(),

--- a/crates/stella-store/src/telemetry.rs
+++ b/crates/stella-store/src/telemetry.rs
@@ -5,11 +5,47 @@ use rusqlite::params;
 
 use crate::{Result, Store, sqlite_i64};
 
+#[cfg(test)]
+pub(crate) mod fixtures;
+
 /// One StepUsage-shaped telemetry record (mirrors the event, plus the
 /// derived cache-miss column so analytics never re-derive it).
 #[derive(Debug, Clone, PartialEq)]
 pub struct TelemetryRow {
-    pub step: u64,
+    /// The event-stream `seq` — the execution-global call identity, and this
+    /// row's half of `UNIQUE (execution_id, stream_seq)`.
+    ///
+    /// Called `step` until #4924, which is what it was never holding: the
+    /// engine's step restarts on every `run_turn` and several calls can share
+    /// one, so keying on it would collide, and a collision here double-counts
+    /// money. AGENTS.md § Glossary is the authority on how far apart `step`,
+    /// `turn_instance` and `call_seq` are. For the engine's own step, see
+    /// [`TelemetryRow::engine_step`].
+    pub stream_seq: u64,
+    /// The `run_turn` this call rode — `step_receipt.turn_instance`.
+    ///
+    /// `None` is "this row cannot say", never turn 0: a row written before
+    /// #4924, or a dead call the engine never got to name. Turn instances are
+    /// 0-based, so collapsing the two would claim every legacy row rode the
+    /// first turn. Same contract as the event's own field
+    /// (`AgentEvent::StepUsage::turn_instance`).
+    pub turn_instance: Option<u32>,
+    /// The engine's step within that turn — `step_receipt.step`.
+    ///
+    /// Spelled apart from `step` because this table's column of that name
+    /// held a seq for thirty-six schema versions, and reusing the word here
+    /// would rebuild the confusion the rename removed. `None` is "cannot
+    /// say".
+    pub engine_step: Option<u64>,
+    /// Which of the calls sharing `(turn_instance, engine_step)` this one was
+    /// — `step_receipt.call_seq`. The engine's worker call is 0; the
+    /// auxiliary calls riding the same step (the overflow summarizer, a
+    /// plugin's management roles) take 1, 2, …
+    ///
+    /// `None` is "cannot say" and must not be read as the worker, for the
+    /// reason `AgentEvent::StepUsage::call_seq` gives: a row written before
+    /// the field existed may equally have been an auxiliary call's.
+    pub call_seq: Option<u64>,
     pub provider: String,
     pub call_role: String,
     pub model: String,
@@ -83,7 +119,15 @@ impl Store {
     /// *after* close-out (the forwarder drain outruns the closeout on the
     /// cancel path) still repairs it.
     pub fn record_telemetry(&self, execution_id: i64, row: &TelemetryRow) -> Result<()> {
-        let step = sqlite_i64("telemetry step", row.step)?;
+        let stream_seq = sqlite_i64("telemetry stream seq", row.stream_seq)?;
+        let engine_step = row
+            .engine_step
+            .map(|step| sqlite_i64("telemetry engine step", step))
+            .transpose()?;
+        let call_seq = row
+            .call_seq
+            .map(|seq| sqlite_i64("telemetry call seq", seq))
+            .transpose()?;
         let input_tokens = sqlite_i64("telemetry input tokens", row.input_tokens)?;
         let estimated_input_tokens = sqlite_i64(
             "telemetry estimated input tokens",
@@ -102,14 +146,18 @@ impl Store {
         // now implies.
         let tx = conn.transaction()?;
         tx.execute(
-            "INSERT INTO telemetry (execution_id, step, provider, call_role, model, input_tokens, \
+            "INSERT INTO telemetry (execution_id, stream_seq, turn_instance, engine_step, \
+             call_seq, provider, call_role, model, input_tokens, \
              estimated_input_tokens, output_tokens, cache_read_tokens, cache_miss_tokens, \
              cache_write_tokens, cost_usd, duration_ms, retries, tool_calls, usage_complete, \
              sub_agent_id) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 execution_id,
-                step,
+                stream_seq,
+                row.turn_instance,
+                engine_step,
+                call_seq,
                 row.provider,
                 row.call_role,
                 row.model,
@@ -147,7 +195,8 @@ impl Store {
     ) -> Result<Vec<SourceTelemetryRow>> {
         let conn = self.lock();
         let mut stmt = conn.prepare(
-            "SELECT t.rowid, t.execution_id, COALESCE(e.started_at, ''), t.step, t.provider, \
+            "SELECT t.rowid, t.execution_id, COALESCE(e.started_at, ''), t.stream_seq, \
+                    t.turn_instance, t.engine_step, t.call_seq, t.provider, \
                     t.call_role, t.model, t.input_tokens, t.estimated_input_tokens, \
                     t.output_tokens, t.cache_read_tokens, t.cache_miss_tokens, \
                     t.cache_write_tokens, t.cost_usd, t.duration_ms, t.retries, t.tool_calls, \
@@ -161,22 +210,25 @@ impl Store {
                 execution_id: r.get(1)?,
                 recorded_at: r.get(2)?,
                 telemetry: TelemetryRow {
-                    step: r.get::<_, i64>(3)? as u64,
-                    provider: r.get(4)?,
-                    call_role: r.get(5)?,
-                    model: r.get(6)?,
-                    input_tokens: r.get::<_, i64>(7)? as u64,
-                    estimated_input_tokens: r.get::<_, i64>(8)? as u64,
-                    output_tokens: r.get::<_, i64>(9)? as u64,
-                    cache_read_tokens: r.get::<_, i64>(10)? as u64,
-                    cache_miss_tokens: r.get::<_, i64>(11)? as u64,
-                    cache_write_tokens: r.get::<_, i64>(12)? as u64,
-                    cost_usd: r.get(13)?,
-                    duration_ms: r.get::<_, i64>(14)? as u64,
-                    retries: r.get(15)?,
-                    tool_calls: r.get::<_, i64>(16)? as u64,
-                    usage_complete: r.get(17)?,
-                    sub_agent_id: r.get(18)?,
+                    stream_seq: r.get::<_, i64>(3)? as u64,
+                    turn_instance: r.get::<_, Option<i64>>(4)?.map(|v| v as u32),
+                    engine_step: r.get::<_, Option<i64>>(5)?.map(|v| v as u64),
+                    call_seq: r.get::<_, Option<i64>>(6)?.map(|v| v as u64),
+                    provider: r.get(7)?,
+                    call_role: r.get(8)?,
+                    model: r.get(9)?,
+                    input_tokens: r.get::<_, i64>(10)? as u64,
+                    estimated_input_tokens: r.get::<_, i64>(11)? as u64,
+                    output_tokens: r.get::<_, i64>(12)? as u64,
+                    cache_read_tokens: r.get::<_, i64>(13)? as u64,
+                    cache_miss_tokens: r.get::<_, i64>(14)? as u64,
+                    cache_write_tokens: r.get::<_, i64>(15)? as u64,
+                    cost_usd: r.get(16)?,
+                    duration_ms: r.get::<_, i64>(17)? as u64,
+                    retries: r.get(18)?,
+                    tool_calls: r.get::<_, i64>(19)? as u64,
+                    usage_complete: r.get(20)?,
+                    sub_agent_id: r.get(21)?,
                 },
             })
         })?;
@@ -209,13 +261,13 @@ impl Store {
         let mut stmt = conn.prepare(
             "SELECT estimated_input_tokens, input_tokens + cache_write_tokens FROM (
                SELECT estimated_input_tokens, input_tokens, cache_write_tokens,
-                      execution_id, step
+                      execution_id, stream_seq
                FROM telemetry
                WHERE provider = ? AND model = ? AND usage_complete = 1
                  AND estimated_input_tokens > 0 AND input_tokens + cache_write_tokens > 0
-               ORDER BY execution_id DESC, step DESC
+               ORDER BY execution_id DESC, stream_seq DESC
                LIMIT ?
-             ) ORDER BY execution_id ASC, step ASC",
+             ) ORDER BY execution_id ASC, stream_seq ASC",
         )?;
         let rows = stmt.query_map(params![provider, model, limit as i64], |row| {
             let estimated: i64 = row.get(0)?;
@@ -408,10 +460,14 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StepManifestRow as ManifestRow;
 
-    fn row(step: u64, cost_usd: f64) -> TelemetryRow {
+    fn row(stream_seq: u64, cost_usd: f64) -> TelemetryRow {
         TelemetryRow {
-            step,
+            stream_seq,
+            turn_instance: None,
+            engine_step: None,
+            call_seq: None,
             provider: "zai".into(),
             call_role: "worker".into(),
             model: "glm-5.2".into(),
@@ -474,10 +530,10 @@ mod tests {
     }
 
     /// One receipt per role, priced and labelled as the run's stages settle.
-    fn role_receipt(step: u64, call_role: &str, cost_usd: f64) -> TelemetryRow {
+    fn role_receipt(stream_seq: u64, call_role: &str, cost_usd: f64) -> TelemetryRow {
         TelemetryRow {
             call_role: call_role.into(),
-            ..row(step, cost_usd)
+            ..row(stream_seq, cost_usd)
         }
     }
 
@@ -635,5 +691,162 @@ mod tests {
                 "execution {id} reports ${reported} against ${receipts} of receipts"
             );
         }
+    }
+
+    /// One receipt for a call at `(turn, step, call_seq)`, priced so the two
+    /// in the witness below cannot be confused for each other.
+    fn receipt_at(turn_instance: u32, step: u64, call_seq: u64, call_role: &str) -> ManifestRow {
+        ManifestRow {
+            turn_instance,
+            step,
+            call_seq,
+            provider: "zai".into(),
+            upstream_provider: None,
+            model: "glm-5.2".into(),
+            call_role: call_role.into(),
+            effective_budget_tokens: 100_000,
+            calibration_factor: 1.0,
+            estimated_input_tokens: 900,
+            stall_seconds_requested: None,
+            compiled_frame_id: None,
+            frame_hash: None,
+            blocks: Vec::new(),
+        }
+    }
+
+    /// The metering row for that same call, addressed by the stream seq and
+    /// carrying the engine-side identity beside it.
+    fn cost_of(stream_seq: u64, turn: u32, step: u64, call_seq: u64, usd: f64) -> TelemetryRow {
+        TelemetryRow {
+            turn_instance: Some(turn),
+            engine_step: Some(step),
+            call_seq: Some(call_seq),
+            ..row(stream_seq, usd)
+        }
+    }
+
+    /// **Witness (#4924).** A cost can be joined to the receipt of the call
+    /// that produced it, on `step_receipt`'s own primary key.
+    ///
+    /// The case that earns it is the one `call_seq` exists for: two calls
+    /// share one `(turn_instance, step)` — the engine's worker and the
+    /// overflow summarizer riding the same step — and they cost different
+    /// money. Before this change a telemetry row carried only
+    /// `execution_id` and the stream seq, so nothing in the store could say
+    /// which of the two receipts a given cost belonged to; a reader had to go
+    /// back to `stella-events.jsonl` and re-derive it from the event stream.
+    ///
+    /// Fails on the old schema for the plainest possible reason: the three
+    /// columns the join names do not exist, so the statement does not prepare.
+    #[test]
+    fn a_cost_joins_to_the_receipt_of_the_call_that_produced_it() {
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+
+        // Two calls on step 4 of turn 2, and one on step 5, so the join has
+        // something to get wrong.
+        for receipt in [
+            receipt_at(2, 4, 0, "worker"),
+            receipt_at(2, 4, 1, "summarizer"),
+            receipt_at(2, 5, 0, "worker"),
+        ] {
+            store.record_step_manifest(id, &receipt).unwrap();
+        }
+        store
+            .record_telemetry(id, &cost_of(7, 2, 4, 0, 3.00))
+            .unwrap();
+        store
+            .record_telemetry(id, &cost_of(8, 2, 4, 1, 0.05))
+            .unwrap();
+        store
+            .record_telemetry(id, &cost_of(9, 2, 5, 0, 1.50))
+            .unwrap();
+
+        let conn = store.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT sr.call_role, t.cost_usd
+                 FROM telemetry t
+                 JOIN step_receipt sr
+                   ON sr.execution_id = t.execution_id
+                  AND sr.turn_instance = t.turn_instance
+                  AND sr.step = t.engine_step
+                  AND sr.call_seq = t.call_seq
+                 WHERE t.execution_id = ?1 AND t.turn_instance = 2 AND t.engine_step = 4
+                 ORDER BY sr.call_seq ASC",
+            )
+            .expect("the join key exists");
+        let paired: Vec<(String, f64)> = stmt
+            .query_map(params![id], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(
+            paired.len(),
+            2,
+            "both calls on this step must find their own receipt, got {paired:?}"
+        );
+        assert_eq!(paired[0].0, "worker");
+        assert!(
+            (paired[0].1 - 3.00).abs() < 1e-9,
+            "the expensive call is the worker's, got {paired:?}"
+        );
+        assert_eq!(paired[1].0, "summarizer");
+        assert!(
+            (paired[1].1 - 0.05).abs() < 1e-9,
+            "and the cheap one is the summarizer's, got {paired:?}"
+        );
+    }
+
+    /// The other direction: a row that cannot say which call it was stays
+    /// unjoined rather than being attributed to turn 0's worker.
+    ///
+    /// This is what makes NULL the right absent value. `usage_incomplete`
+    /// writes exactly this shape — the call died before the engine named a
+    /// turn — and so does every row written before v37. Defaulting the three
+    /// columns to 0 would have silently joined all of them to
+    /// `(turn 0, step 0, call_seq 0)`, which is a real receipt on almost
+    /// every execution.
+    #[test]
+    fn a_row_that_cannot_say_is_not_attributed_to_turn_zero() {
+        let store = Store::in_memory().unwrap();
+        let id = store.begin_execution("run", "p", "zai", "glm-5.2").unwrap();
+        store
+            .record_step_manifest(id, &receipt_at(0, 0, 0, "worker"))
+            .unwrap();
+        // The dead call: recorded, priced, and unjoinable.
+        store.record_telemetry(id, &row(3, 0.0)).unwrap();
+
+        let conn = store.lock();
+        let joined: i64 = conn
+            .query_row(
+                "SELECT count(*)
+                 FROM telemetry t
+                 JOIN step_receipt sr
+                   ON sr.execution_id = t.execution_id
+                  AND sr.turn_instance = t.turn_instance
+                  AND sr.step = t.engine_step
+                  AND sr.call_seq = t.call_seq
+                 WHERE t.execution_id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            joined, 0,
+            "a NULL identity must not match a receipt — `turn 0, step 0, call 0` is a real call"
+        );
+        let recorded: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM telemetry WHERE execution_id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            recorded, 1,
+            "and the row is still there — unjoinable, not absent"
+        );
     }
 }

--- a/crates/stella-store/src/telemetry/fixtures.rs
+++ b/crates/stella-store/src/telemetry/fixtures.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One metering row for tests to vary, instead of four copies of the same
+//! twenty-line literal.
+//!
+//! [`TelemetryRow`] is exhaustive by design — a new column has to be answered
+//! for at every construction site — and four crate tests had each written the
+//! whole literal out. Adding #4924's three join columns meant editing all four,
+//! two of which live in files closed to growth (`src/tests.rs` and
+//! `src/usage.rs` are grandfathered god files; AGENTS.md § "God files"). One
+//! builder plus `..` update syntax is both the smaller diff and the better
+//! shape: a test that varies `cost_usd` now says only that.
+//!
+//! `#[cfg(test)]` rather than an `#[allow(dead_code)]` builder on the public
+//! type: nothing ships a call to this, and the compiler should keep it that
+//! way (AGENTS.md § "Code style", on why `cfg(test)` beats a suppression).
+
+use super::TelemetryRow;
+
+/// A complete, plausible metering row: one worker call that read some cache,
+/// settled, and named no delegate and no receipt.
+///
+/// Vary what a test is about and leave the rest:
+///
+/// ```ignore
+/// TelemetryRow { cost_usd: 3.0, ..metering_row(7, "zai", "glm-5.2") }
+/// ```
+///
+/// The receipt identity is `None` — "this row cannot say" — because that is
+/// the shape a fixture that has not opted into the join should have. A test
+/// about the join sets all three.
+pub(crate) fn metering_row(stream_seq: u64, provider: &str, model: &str) -> TelemetryRow {
+    TelemetryRow {
+        stream_seq,
+        turn_instance: None,
+        engine_step: None,
+        call_seq: None,
+        provider: provider.into(),
+        call_role: "worker".into(),
+        model: model.into(),
+        input_tokens: 1_000,
+        estimated_input_tokens: 900,
+        output_tokens: 100,
+        cache_read_tokens: 600,
+        cache_miss_tokens: 400,
+        cache_write_tokens: 0,
+        cost_usd: 0.001,
+        duration_ms: 800,
+        retries: 0,
+        tool_calls: 1,
+        usage_complete: true,
+        sub_agent_id: None,
+    }
+}

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -3,6 +3,7 @@ mod quarantine;
 mod usage_completeness;
 
 use super::*;
+use crate::telemetry::fixtures::metering_row;
 
 #[test]
 fn execution_lifecycle_events_and_telemetry_roundtrip() {
@@ -36,22 +37,16 @@ fn execution_lifecycle_events_and_telemetry_roundtrip() {
         .record_telemetry(
             id,
             &TelemetryRow {
-                step: 0,
-                provider: "zai".into(),
-                call_role: "worker".into(),
-                model: "glm-5.2".into(),
                 input_tokens: 12_000,
                 estimated_input_tokens: 11_000,
                 output_tokens: 400,
                 cache_read_tokens: 9_000,
                 cache_miss_tokens: 3_000,
-                cache_write_tokens: 0,
                 cost_usd: 0.0042,
                 duration_ms: 1_830,
                 retries: 1,
                 tool_calls: 3,
-                usage_complete: true,
-                sub_agent_id: None,
+                ..metering_row(0, "zai", "glm-5.2")
             },
         )
         .unwrap();
@@ -1055,8 +1050,10 @@ fn skill_usage_records_per_execution_version_rows() {
     //       `tool_calls.sub_agent_id` (#4624) — which delegate RAN one; the
     //       pair is what lets a turn page say both what a child cost and what
     //       it did. v36 `executions.parent_execution_id` (#4628) — which turn
-    //       dispatched a deck lane, NULL when nobody's turn did.
-    assert_eq!(SCHEMA_VERSION, 36);
+    //       dispatched a deck lane, NULL when nobody's turn did. v37
+    //       `telemetry.step` becomes `stream_seq` and gains the receipt join
+    //       key (#4924) — the column never held the engine's step.
+    assert_eq!(SCHEMA_VERSION, 37);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")
@@ -1128,22 +1125,12 @@ fn v4_migration_adds_agent_uses_to_a_pre_v4_file() {
 /// fields vary.
 fn drift_row(step: u64, provider: &str, model: &str, estimated: u64, actual: u64) -> TelemetryRow {
     TelemetryRow {
-        step,
-        provider: provider.into(),
-        call_role: "worker".into(),
-        model: model.into(),
         input_tokens: actual,
         estimated_input_tokens: estimated,
-        output_tokens: 100,
         cache_read_tokens: 0,
         cache_miss_tokens: actual,
-        cache_write_tokens: 0,
-        cost_usd: 0.001,
         duration_ms: 500,
-        retries: 0,
-        tool_calls: 1,
-        usage_complete: true,
-        sub_agent_id: None,
+        ..metering_row(step, provider, model)
     }
 }
 
@@ -1499,7 +1486,7 @@ fn v1_migration_dedupes_a_v0_database_and_retrofits_the_unique_keys() {
         );
         let input: i64 = conn
             .query_row(
-                "SELECT input_tokens FROM telemetry WHERE execution_id = 1 AND step = 0",
+                "SELECT input_tokens FROM telemetry WHERE execution_id = 1 AND stream_seq = 0",
                 [],
                 |row| row.get(0),
             )
@@ -1545,8 +1532,8 @@ fn v1_migration_dedupes_a_v0_database_and_retrofits_the_unique_keys() {
         let conn = store.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT step, usage_complete FROM telemetry \
-                 WHERE execution_id = 1 ORDER BY step",
+                "SELECT stream_seq, usage_complete FROM telemetry \
+                 WHERE execution_id = 1 ORDER BY stream_seq",
             )
             .unwrap();
         stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
@@ -1790,10 +1777,6 @@ fn telemetry(
     duration_ms: u64,
 ) -> TelemetryRow {
     TelemetryRow {
-        step,
-        provider: provider.into(),
-        call_role: "worker".into(),
-        model: model.into(),
         input_tokens: input,
         // This fixture predates drift correction and exercises
         // usage_stats, which ignores the estimate; 0 = "no estimate
@@ -1805,10 +1788,8 @@ fn telemetry(
         cache_write_tokens: cache_write,
         cost_usd: cost,
         duration_ms,
-        retries: 0,
         tool_calls: 0,
-        usage_complete: true,
-        sub_agent_id: None,
+        ..metering_row(step, provider, model)
     }
 }
 
@@ -2047,26 +2028,7 @@ fn open_hardens_a_fresh_dot_stella_dir() {
 
 #[test]
 fn telemetry_replicates_to_the_hub_and_heals_missed_turns() {
-    fn call(step: u64) -> TelemetryRow {
-        TelemetryRow {
-            step,
-            provider: "zai".into(),
-            call_role: "worker".into(),
-            model: "glm-5.2".into(),
-            input_tokens: 1_000,
-            estimated_input_tokens: 900,
-            output_tokens: 100,
-            cache_read_tokens: 600,
-            cache_miss_tokens: 400,
-            cache_write_tokens: 0,
-            cost_usd: 0.001,
-            duration_ms: 800,
-            retries: 0,
-            tool_calls: 1,
-            usage_complete: true,
-            sub_agent_id: None,
-        }
-    }
+    let call = |step: u64| metering_row(step, "zai", "glm-5.2");
 
     let tmp = tempfile::tempdir().unwrap();
     let store = Store::open(tmp.path()).unwrap();

--- a/crates/stella-store/src/tests/usage_completeness.rs
+++ b/crates/stella-store/src/tests/usage_completeness.rs
@@ -277,7 +277,10 @@ fn a_pruned_rollup_row_reports_as_unknown_never_as_complete() {
 /// One paid call at `cost_usd`, with everything else the shape a row needs.
 fn telemetry_row(step: u64, cost_usd: f64) -> TelemetryRow {
     TelemetryRow {
-        step,
+        stream_seq: step,
+        turn_instance: None,
+        engine_step: None,
+        call_seq: None,
         provider: "openrouter".into(),
         call_role: "worker".into(),
         model: "kimi".into(),

--- a/crates/stella-store/src/usage.rs
+++ b/crates/stella-store/src/usage.rs
@@ -313,7 +313,8 @@ impl UsageStore {
             let t = &row.telemetry;
             tx.execute(
                 "INSERT OR REPLACE INTO telemetry \
-                 (project_id, source_rowid, org_id, workspace_id, repo_id, execution_id, step, \
+                 (project_id, source_rowid, org_id, workspace_id, repo_id, execution_id, \
+                  stream_seq, \
                   recorded_at, provider, call_role, model, input_tokens, estimated_input_tokens, \
                   output_tokens, cache_read_tokens, cache_miss_tokens, cache_write_tokens, \
                   cost_usd, duration_ms, retries, tool_calls, usage_complete) \
@@ -325,7 +326,7 @@ impl UsageStore {
                     scope.workspace_id,
                     scope.repo_id,
                     row.execution_id,
-                    t.step as i64,
+                    t.stream_seq as i64,
                     row.recorded_at,
                     t.provider,
                     t.call_role,
@@ -362,7 +363,7 @@ impl UsageStore {
         let conn = self.lock();
         let mut stmt = conn.prepare(
             "SELECT t.rowid, t.org_id, t.workspace_id, t.repo_id, t.project_id, t.execution_id, \
-                    t.step, t.recorded_at, t.provider, t.call_role, t.model, t.input_tokens, \
+                    t.stream_seq, t.recorded_at, t.provider, t.call_role, t.model, t.input_tokens, \
                     t.estimated_input_tokens, t.output_tokens, t.cache_read_tokens, \
                     t.cache_miss_tokens, t.cache_write_tokens, t.cost_usd, t.duration_ms, \
                     t.retries, t.tool_calls, t.usage_complete, t.source_rowid \
@@ -383,7 +384,12 @@ impl UsageStore {
                 source_rowid: r.get(22)?,
                 recorded_at: r.get(7)?,
                 telemetry: crate::TelemetryRow {
-                    step: r.get::<_, i64>(6)? as u64,
+                    stream_seq: r.get::<_, i64>(6)? as u64,
+                    // No receipt identity crosses into the hub: #4924 renamed
+                    // a column on `content_free`'s allowlist, never added one.
+                    turn_instance: None,
+                    engine_step: None,
+                    call_seq: None,
                     provider: r.get(8)?,
                     call_role: r.get(9)?,
                     model: r.get(10)?,
@@ -995,6 +1001,7 @@ mod rekey;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::telemetry::fixtures;
 
     pub(super) fn rollup(execution_id: i64, tools: Vec<ToolBucket>) -> ExecutionRollupRow {
         ExecutionRollupRow {
@@ -1118,22 +1125,14 @@ mod tests {
             execution_id: 1,
             recorded_at: "2026-07-23T10:00:00Z".into(),
             telemetry: crate::TelemetryRow {
-                step: source_rowid as u64,
-                provider: "zai".into(),
                 call_role: "engine".into(),
-                model: "glm-5.2".into(),
-                input_tokens: 1000,
-                estimated_input_tokens: 900,
-                output_tokens: 100,
                 cache_read_tokens: 500,
                 cache_miss_tokens: 500,
                 cache_write_tokens: 40,
                 cost_usd: cost,
                 duration_ms: 1200,
-                retries: 0,
                 tool_calls: 2,
-                usage_complete: true,
-                sub_agent_id: None,
+                ..fixtures::metering_row(source_rowid as u64, "zai", "glm-5.2")
             },
         }
     }

--- a/crates/stella-store/src/usage/backfill.rs
+++ b/crates/stella-store/src/usage/backfill.rs
@@ -79,7 +79,10 @@ mod tests {
             execution_id: 1,
             recorded_at: "2026-07-23T10:00:00Z".into(),
             telemetry: crate::TelemetryRow {
-                step: source_rowid as u64,
+                stream_seq: source_rowid as u64,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 provider: "zai".into(),
                 call_role: "engine".into(),
                 model: "glm-5.2".into(),

--- a/crates/stella-store/src/usage/drain_state.rs
+++ b/crates/stella-store/src/usage/drain_state.rs
@@ -145,7 +145,10 @@ mod tests {
             execution_id: 1,
             recorded_at: "2026-07-28T06:00:00Z".into(),
             telemetry: crate::TelemetryRow {
-                step: 1,
+                stream_seq: 1,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 provider: "zai".into(),
                 call_role: "engine".into(),
                 model: "glm-5.2".into(),

--- a/crates/stella-store/src/usage/rekey.rs
+++ b/crates/stella-store/src/usage/rekey.rs
@@ -130,7 +130,10 @@ mod tests {
             execution_id: 1,
             recorded_at: "2026-07-28T06:00:00Z".into(),
             telemetry: crate::TelemetryRow {
-                step: 1,
+                stream_seq: 1,
+                turn_instance: None,
+                engine_step: None,
+                call_seq: None,
                 provider: "zai".into(),
                 call_role: "engine".into(),
                 model: "glm-5.2".into(),

--- a/crates/stella-store/src/usage/schema.rs
+++ b/crates/stella-store/src/usage/schema.rs
@@ -132,7 +132,11 @@ CREATE TABLE IF NOT EXISTS telemetry (
     workspace_id   TEXT,
     repo_id        TEXT NOT NULL DEFAULT '',
     execution_id   INTEGER NOT NULL,
-    step           INTEGER NOT NULL,
+    -- The event-stream `seq` the project store replicated, under the name it
+    -- has held there since #4924. It was called `step` on both sides and was
+    -- never the engine's step; the hub keeps the source column's spelling so
+    -- a reader joining the two surfaces meets one word for one thing.
+    stream_seq     INTEGER NOT NULL,
     recorded_at    TEXT NOT NULL DEFAULT '',
     provider       TEXT NOT NULL,
     call_role      TEXT NOT NULL,
@@ -213,7 +217,7 @@ struct HubMigrationStep {
 ///
 /// Append only -- see the module doc for why position is the contract -- and
 /// **never renumber**: a slot is claimed by position, not by name.
-const HUB_MIGRATIONS: [HubMigrationStep; 3] = [
+const HUB_MIGRATIONS: [HubMigrationStep; 4] = [
     // v0 -> v1: back-propagate #3388's door-only `kind` vocabulary, and give
     // the hub the `role` column #3395 gave the project store.
     HubMigrationStep {
@@ -232,6 +236,13 @@ const HUB_MIGRATIONS: [HubMigrationStep; 3] = [
         target_version: 3,
         apply: migrate_hub_v2_to_v3,
     },
+    // v3 -> v4: `telemetry.step` becomes `stream_seq`, following the project
+    // store's rename (#4924). A rename only -- no new column crosses into the
+    // hub, which is a `content_free` decision of its own.
+    HubMigrationStep {
+        target_version: 4,
+        apply: migrate_hub_v3_to_v4,
+    },
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `HUB_SCHEMA_VERSION` is its length,
     // so a slot is claimed by position, not by name. Two branches that each
@@ -245,7 +256,7 @@ const HUB_MIGRATIONS: [HubMigrationStep; 3] = [
     // fails loudly if a parallel merge left two entries claiming the same
     // slot.
     //
-    // Nothing is reserved now: take v3 -> v4 and add your own line here. If a
+    // Nothing is reserved now: take v4 -> v5 and add your own line here. If a
     // reserved phase ships without needing its slot, delete its line rather
     // than leaving a hole -- index order is the contract.
 ];
@@ -399,6 +410,30 @@ fn migrate_hub_v2_to_v3(tx: &rusqlite::Transaction<'_>) -> Result<()> {
             "ALTER TABLE execution_rollup \
              ADD COLUMN usage_complete INTEGER NOT NULL DEFAULT 1;",
         )?;
+    }
+    Ok(())
+}
+
+/// v3 -> v4: the hub's `telemetry.step` follows the project store's, and
+/// becomes `stream_seq` (#4924).
+///
+/// The column replicates the source store's, and the source column was never
+/// the engine's step: it holds the event-stream `seq`, the execution-global
+/// call identity. The hub inherited both the value and the wrong name, which
+/// makes it the surface where the confusion costs most — a cross-project
+/// reader has no `stella-events.jsonl` to check the meaning against.
+///
+/// A rename and nothing else. The engine-side identity the store gained in
+/// the same change (`turn_instance`, `engine_step`, `call_seq`) does **not**
+/// follow: what may cross into the hub is governed by
+/// [`crate::content_free`]'s reviewed allowlist and AGENTS.md's rule 3, and
+/// adding a column there is a decision a human takes on its own rather than a
+/// side effect of repairing a name. `stream_seq` was already on that
+/// allowlist under its old spelling, so this changes what the column is
+/// called and nothing about what leaves the machine.
+fn migrate_hub_v3_to_v4(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if column_exists(tx, "telemetry", "step")? && !column_exists(tx, "telemetry", "stream_seq")? {
+        tx.execute_batch("ALTER TABLE telemetry RENAME COLUMN step TO stream_seq;")?;
     }
     Ok(())
 }

--- a/crates/stella-store/tests/enterprise_telemetry/spool.rs
+++ b/crates/stella-store/tests/enterprise_telemetry/spool.rs
@@ -19,7 +19,10 @@ fn sqlite_integer_writes_reject_u64_overflow() {
             .is_err()
     );
     let telemetry = TelemetryRow {
-        step: 0,
+        stream_seq: 0,
+        turn_instance: None,
+        engine_step: None,
+        call_seq: None,
         call_role: "worker".into(),
         provider: "zai".into(),
         model: "glm".into(),


### PR DESCRIPTION
## What

Scope 2 from the issue — the rename, plus the columns that make the rename buy something.

`telemetry.step` held the event-stream `seq`. The value was right and the name was not: the seq is the execution-global call identity, while the engine's `step` restarts on every `run_turn` and several calls can share one, so `UNIQUE (execution_id, step)` under the engine's meaning would collide — and a collision here double-counts real money. AGENTS.md § Glossary exists because `step`, `turn_instance` and `call_seq` look alike and are not; this column was that hazard written into the schema, and the only thing that said so was a comment at the write site in `stella-cli` that no reader of the DDL ever saw.

**Store schema v37** (`migrations/telemetry_call_identity.rs`):

- `step` → **`stream_seq`**. Not `call_seq_global`, which the issue also floated: `call_seq` is a real and *different* identifier arriving in the same table, and two columns a prefix apart would be the same trap one turn tighter.
- Three new nullable columns: **`turn_instance`, `engine_step`, `call_seq`**. With `execution_id` those are `step_receipt`'s primary key `(execution_id, turn_instance, step, call_seq)`, so a cost joins to the receipt of the call that produced it. `engine_step` is that `step`, spelled apart from it because this table's `step` meant something else for thirty-six versions.
- Fed from the `step_usage` event, which has carried `turn_instance` and `call_seq` since #4793 and has always carried `step`.

**Three columns, not the issue's two.** The issue says "nullable `turn_instance` and `call_seq`", but the join key has four parts and `execution_id` is only the first. Without the engine's `step` the join is ambiguous across steps in the same turn, so the third column is what actually makes the stated definition of done reachable.

**NULL means "this row cannot say", never zero.** Turn instances and call seqs are both 0-based, so a default of 0 would assert that every legacy row was the worker call of turn 0 — which is a real receipt on almost every execution. `usage_incomplete` writes exactly that shape (its event carries no turn identity; the call died before the engine named one), and so does every row written before v37. Same argument `AgentEvent::StepUsage::call_seq`'s own doc makes for the field being `Option`.

**No backfill.** The seq orders calls within an execution and says nothing about which turn they rode. Pairing a telemetry row with whichever receipt sorts alongside it would be a guess dressed as a record, and the case it would get wrong is the auxiliary call sharing a step with the worker — the exact case `call_seq` exists to disambiguate.

### The issue's constraints

- **`UNIQUE (execution_id, step)` is load-bearing.** Kept: `ALTER TABLE … RENAME COLUMN` carries the unique constraint and the `telemetry_by_model` covering index over, and there is a test for each (`the_uniqueness_that_stops_double_counting_survives_the_rename`, `the_covering_index_follows_the_column`).
- **`Store::prune`'s cascade is unaffected — but check it.** Checked. This adds no table, and `prune`'s watermark key is `(execution_id, step)`, which is now `(execution_id, stream_seq)` — same key, renamed on both the read and the re-read after VACUUM. `stats_prune_cli` passes.
- **The hub is a separate decision.** The hub column follows the **rename only** (hub schema v4). No new column crosses into `~/.stella/usage.db`: what may is `content_free.rs`'s reviewed allowlist under invariant 3, and `stream_seq` was already on it under the old spelling — so this changes what a column is called and nothing about what leaves the machine. `native_drain_exclusions_are_deliberate` still names the same four exclusions.

### Observatory

It opens every store `SQLITE_OPEN_READ_ONLY` and migrates none of them, so both spellings are live at once until a workspace runs a turn. `store_shape::telemetry_seq_column` probes `pragma_table_info` and picks; an un-migrated workspace keeps its Steps table instead of blanking it. The JSON key and the page's own renderer follow the new name, because a surface a human reads is where the wrong name costs most. `schema_conformance`'s `/steps/0/step` probe caught the rename, which is its job.

### File-size ratchet: split, not raised

`scripts/file-size-baseline.txt` is **unchanged**. Three files would have grown past a ceiling:

- `stella-store/src/tests.rs` and `src/usage.rs` (both grandfathered god files) each wrote the whole twenty-line `TelemetryRow` literal out, four copies between them. They now share one `telemetry::fixtures::metering_row` builder and `..` update syntax — `tests.rs` 2237 → 2182 against a 2222 ceiling, `usage.rs` 1774 → 1765 against 1767.
- `stella-observatory/src/db.rs` would have made a **first-time** crossing at 1504, which gets no baseline entry ever. The probe moved to its own `store_shape.rs`; db.rs is 1481.

## Witness

**1. The join, on the case that earns it.** `a_cost_joins_to_the_receipt_of_the_call_that_produced_it` seeds two calls sharing `(turn 2, step 4)` — a worker at $3.00 and a summarizer at $0.05 — plus a third on step 5, and joins on all four key parts. Ablated by having the fixture record no identity (the pre-change state):

```
$ cargo test -p stella-store --lib telemetry::tests::a_cost_joins
test telemetry::tests::a_cost_joins_to_the_receipt_of_the_call_that_produced_it ... FAILED

assertion `left == right` failed: both calls on this step must find their own receipt, got []
  left: 0
 right: 2

test result: FAILED. 0 passed; 1 failed; ...
```

Not merely constant — the join returns the empty set where it must return two attributed rows.

**2. NULL is not zero.** `a_row_that_cannot_say_is_not_attributed_to_turn_zero` is the other direction, so the first test is not satisfied by a build that stamps 0 everywhere. Ablated by writing `unwrap_or(0)` instead of the `Option` in `record_telemetry`:

```
$ cargo test -p stella-store --lib telemetry::tests
test telemetry::tests::a_cost_joins_to_the_receipt_of_the_call_that_produced_it ... ok
test telemetry::tests::a_row_that_cannot_say_is_not_attributed_to_turn_zero ... FAILED

assertion `left == right` failed: a NULL identity must not match a receipt — `turn 0, step 0, call 0` is a real call
  left: 1
 right: 0

test result: FAILED. 7 passed; 1 failed; ...
```

The dead call is silently attributed to a receipt that is not its own — which is the bug the nullability exists to prevent, made visible.

**3. The migration**, five cases in `telemetry_call_identity.rs`: the seq keeps its value, the unique key survives, the index follows the column, an existing row reads as unjoinable (all three NULL, not 0), and the step is idempotent over a file with no `telemetry` table.

Both ablations restored. Green:

```
$ cargo test -p stella-store -p stella-observatory --no-fail-fast
test result: ok. 428 passed; 0 failed; ...   (stella-store lib)
test result: ok. 31 passed; 0 failed; ...    (stella-store integration)
test result: ok. 138 passed; 0 failed; ...   (stella-observatory lib)
test result: ok. 20 passed; 0 failed; ...    (schema_conformance)

$ cargo test -p stella-cli --bins
test result: ok. 2325 passed; 0 failed; ...

$ cargo clippy -p stella-store -p stella-observatory -p stella-cli --all-targets -- -D warnings
(clean)

$ make guards-fast
(clean — file-size OK with no baseline diff, prose OK)
```

## Deleted tests

None. `stella-store/src/tests.rs`'s `telemetry_replicates_to_the_hub_and_heals_missed_turns` keeps its name and assertions; its inner `fn call(step)` fixture became a closure over the shared builder. No `#[test]` was renamed or removed.

## Filed alongside

- `AgentEvent::UsageIncomplete` carries no `turn_instance`/`step`/`call_seq`, so a dead call's cost row is permanently unjoinable. Recorded honestly as NULL here; adding the identity to that event is the follow-up.
- The join is now possible but nothing in `stella inspect` uses it yet — the issue names that as the payoff and it is deliberately not wired here rather than shipped unwired.

Closes #4924

## Summary by Sourcery

Disambiguate telemetry call identity by renaming the event-stream sequence field and storing nullable engine receipt keys for accurate cost attribution.

New Features:
- Record engine turn, step, and call identity alongside telemetry so costs can be joined directly to their originating step receipts.
- Expose telemetry's event-stream sequence as `stream_seq` in the store, hub, and observatory surfaces.

Bug Fixes:
- Prevent ambiguous or incorrect cost attribution when multiple calls share an engine step, while preserving NULL for telemetry rows without reliable receipt identity.

Enhancements:
- Add store schema v37 and hub schema v4 migrations that rename the telemetry sequence column while preserving uniqueness and supporting indexes.
- Keep the observatory compatible with both migrated and unmigrated workspaces.

Tests:
- Add migration, receipt-join, NULL identity, schema compatibility, and constraint-preservation coverage.

Chores:
- Consolidate telemetry test fixtures to accommodate the expanded telemetry row identity.