### PR TITLE
fix(stella-cli): count embedder spawn sites in code, not in prose

### DIFF
--- a/crates/stella-cli/tests/embedder_backend_sealed_cli.rs
+++ b/crates/stella-cli/tests/embedder_backend_sealed_cli.rs
@@ -172,25 +172,207 @@ fn a_sealed_child_reaches_no_backend() {
     );
 }
 
+/// The binary-path macro, whose occurrences in code are the spawn sites.
+///
+/// Spelled as `concat!` halves so this file's own source does not carry the
+/// needle beyond the one real spawn site above. A guard that matched itself
+/// would count its own needles as evidence about the code it is judging.
+const SPAWNS: &str = concat!("CARGO_BIN_EXE", "_stella");
+
+/// What seals a spawned child. `env_clear` counts — a child with no inherited
+/// environment has no inherited key.
+const SEALS: [&str; 2] = [concat!(".without_embedder", "_backend()"), ".env_clear()"];
+
+/// `source` with its comments removed, so prose naming the binary-path macro
+/// is not counted as a spawn site (#4986).
+///
+/// String literals are copied through rather than dropped, because the needle
+/// lives inside one — `env!("CARGO_BIN_EXE_…")`. They are also *tracked*, so a
+/// `//` inside one does not open a comment and swallow the rest of the line:
+/// this directory writes `"http://{addr}/v1"`, and truncating there would drop
+/// a sealing call after it and fail a correctly sealed file.
+fn code_only(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut code = String::with_capacity(source.len());
+    let mut at = 0usize;
+    while at < bytes.len() {
+        if let Some(end) = raw_string_end(bytes, at) {
+            code.push_str(&source[at..end]);
+            at = end;
+            continue;
+        }
+        match bytes[at] {
+            b'/' if bytes.get(at + 1) == Some(&b'/') => {
+                while at < bytes.len() && bytes[at] != b'\n' {
+                    at += 1;
+                }
+            }
+            b'/' if bytes.get(at + 1) == Some(&b'*') => {
+                // Rust nests block comments, so this counts depth rather than
+                // stopping at the first `*/`.
+                let mut depth = 1usize;
+                at += 2;
+                while at < bytes.len() && depth > 0 {
+                    if bytes[at] == b'/' && bytes.get(at + 1) == Some(&b'*') {
+                        depth += 1;
+                        at += 2;
+                    } else if bytes[at] == b'*' && bytes.get(at + 1) == Some(&b'/') {
+                        depth -= 1;
+                        at += 2;
+                    } else {
+                        at += 1;
+                    }
+                }
+                // A space, so dropping a comment cannot join the tokens either
+                // side of it into a needle.
+                code.push(' ');
+            }
+            b'"' => {
+                let end = quoted_end(bytes, at);
+                code.push_str(&source[at..end]);
+                at = end;
+            }
+            b'\'' => {
+                let end = char_literal_end(bytes, at).unwrap_or(at + 1);
+                code.push_str(&source[at..end]);
+                at = end;
+            }
+            _ => {
+                let mut end = at + 1;
+                while end < bytes.len() && !source.is_char_boundary(end) {
+                    end += 1;
+                }
+                code.push_str(&source[at..end]);
+                at = end;
+            }
+        }
+    }
+    code
+}
+
+/// The byte after the raw string starting at `at`, or `None` when one does not
+/// start there. Covers `r"…"`, `r#"…"#` and the `b`-prefixed forms.
+fn raw_string_end(bytes: &[u8], at: usize) -> Option<usize> {
+    if at > 0 && (bytes[at - 1].is_ascii_alphanumeric() || bytes[at - 1] == b'_') {
+        return None;
+    }
+    let mut cursor = at;
+    if bytes.get(cursor) == Some(&b'b') {
+        cursor += 1;
+    }
+    if bytes.get(cursor) != Some(&b'r') {
+        return None;
+    }
+    cursor += 1;
+    let opened = cursor;
+    while bytes.get(cursor) == Some(&b'#') {
+        cursor += 1;
+    }
+    let hashes = cursor - opened;
+    if bytes.get(cursor) != Some(&b'"') {
+        return None;
+    }
+    cursor += 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'"' {
+            let after = cursor + 1;
+            if bytes.len() - after >= hashes
+                && bytes[after..].iter().take(hashes).all(|byte| *byte == b'#')
+            {
+                return Some(after + hashes);
+            }
+        }
+        cursor += 1;
+    }
+    Some(bytes.len())
+}
+
+/// The byte after the ordinary string literal starting at `at`.
+fn quoted_end(bytes: &[u8], at: usize) -> usize {
+    let mut cursor = at + 1;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'\\' => cursor += 2,
+            b'"' => return cursor + 1,
+            _ => cursor += 1,
+        }
+    }
+    bytes.len()
+}
+
+/// The byte after the character literal starting at `at`, or `None` when the
+/// quote opens a lifetime or a loop label instead.
+fn char_literal_end(bytes: &[u8], at: usize) -> Option<usize> {
+    let mut cursor = at + 1;
+    if bytes.get(cursor) == Some(&b'\\') {
+        cursor += 2;
+        // `'\u{1F600}'` — run on to the closing quote of a braced escape.
+        while cursor < bytes.len() && bytes[cursor] != b'\'' {
+            cursor += 1;
+        }
+    } else {
+        cursor += 1;
+        while cursor < bytes.len() && bytes[cursor] & 0b1100_0000 == 0b1000_0000 {
+            cursor += 1;
+        }
+    }
+    (bytes.get(cursor) == Some(&b'\'')).then_some(cursor + 1)
+}
+
+/// How many spawn sites `source` has, and how many seals — counted over its
+/// code, with comments excluded.
+fn spawn_and_seal_counts(source: &str) -> (usize, usize) {
+    let code = code_only(source);
+    let spawn_sites = code.matches(SPAWNS).count();
+    let sealed = SEALS.iter().map(|seal| code.matches(seal).count()).sum();
+    (spawn_sites, sealed)
+}
+
+/// Prose naming the binary-path macro is not a spawn site, and an unsealed
+/// spawn beside that prose is still caught (#4986).
+///
+/// Both fixtures are built from the needles rather than spelled, for the
+/// reason [`SPAWNS`] gives. Each carries three hazards at once: a line
+/// comment naming the macro, a nested block comment naming it, and a `//`
+/// inside a string literal on the same line as the sealing call — so a
+/// line-truncating strip fails here too, not only a strip that does nothing.
+#[test]
+fn prose_naming_the_macro_is_not_a_spawn_site() {
+    let one_sealed_spawn = format!(
+        "//! Spawned through {SPAWNS}, sealed.\n\
+         /* {SPAWNS} again, and /* nested */ */\n\
+         fn go() {{\n    \
+         Command::new(env!(\"{SPAWNS}\")).env(\"URL\", \"http://a/v1\"){}; \n\
+         }}\n",
+        SEALS[0]
+    );
+    assert_eq!(
+        spawn_and_seal_counts(&one_sealed_spawn),
+        (1, 1),
+        "a comment naming the macro was counted as a spawn site, or a `//` \
+         inside a string literal swallowed the sealing call after it"
+    );
+
+    let leaking = format!("{one_sealed_spawn}fn slip() {{ Command::new(env!(\"{SPAWNS}\")); }}\n");
+    let (spawn_sites, sealed) = spawn_and_seal_counts(&leaking);
+    assert!(
+        sealed < spawn_sites,
+        "an unsealed spawn beside the prose must still fail: \
+         {spawn_sites} spawn site(s), {sealed} sealed"
+    );
+}
+
 /// Every test in this directory that spawns the binary must seal the embedder
 /// backend, because the developer whose key is exported is not the one who
 /// wrote the seventeenth test file.
 ///
 /// # How it counts
 ///
-/// Once per occurrence of the binary-path macro, not once per file: a helper
-/// that seals one of a file's three spawn sites is the failure this is for.
-/// `env_clear` counts as a seal — a child with no inherited environment has no
-/// inherited key.
-///
-/// The two needles are spelled as `concat!` halves so this file's own source
-/// does not contain them. A guard that matched itself would count its own
-/// needles as evidence about the code it is judging.
+/// Once per occurrence of the binary-path macro in code, not once per file: a
+/// helper that seals one of a file's three spawn sites is the failure this is
+/// for. Comments do not count — see [`code_only`].
 #[test]
 fn every_spawning_test_seals_the_embedder_backend() {
-    let spawns = concat!("CARGO_BIN_EXE", "_stella");
-    let seals = [concat!(".without_embedder", "_backend()"), ".env_clear()"];
-
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
     let mut checked = 0usize;
     for entry in std::fs::read_dir(&dir).expect("read tests dir") {
@@ -199,11 +381,10 @@ fn every_spawning_test_seals_the_embedder_backend() {
             continue;
         }
         let source = std::fs::read_to_string(&path).expect("read test source");
-        let spawn_sites = source.matches(spawns).count();
+        let (spawn_sites, sealed) = spawn_and_seal_counts(&source);
         if spawn_sites == 0 {
             continue;
         }
-        let sealed: usize = seals.iter().map(|seal| source.matches(seal).count()).sum();
         assert!(
             sealed >= spawn_sites,
             "{}: {spawn_sites} spawn site(s), {sealed} sealed — a spawned child \

--- a/crates/stella-cli/tests/run_reflection_writes_cli.rs
+++ b/crates/stella-cli/tests/run_reflection_writes_cli.rs
@@ -31,17 +31,10 @@
 //!
 //! `run_turn` spawns `std::env::current_exe()`, which under `cargo test` is
 //! the test binary rather than `stella`, so a turn cannot be driven
-//! in-process at all. Cargo's binary-path macro against a `wiremock` provider
-//! is the only shape that reaches the writer through the real gate;
+//! in-process at all. `CARGO_BIN_EXE_stella` against a `wiremock` provider is
+//! the only shape that reaches the writer through the real gate;
 //! `goal_wrapped_dispatch_cli.rs` is the worked example this copies its
 //! hermeticity and its mock routing from.
-//!
-//! The macro is named once, in [`run_one_shot`], and never spelled in prose:
-//! `embedder_backend_sealed_cli.rs`'s guard counts occurrences of that literal
-//! as spawn sites and requires a seal for each, so a doc comment mentioning it
-//! reads as an unsealed spawn. That guard is right to count conservatively —
-//! an unsealed child inherits `VOYAGE_API_KEY` and bills whoever runs the
-//! suite (#4542) — so the prose moves, not the count.
 //!
 //! # Both directions, or neither is evidence
 //!


### PR DESCRIPTION
Closes #4986

## Problem

`crates/stella-cli/tests/embedder_backend_sealed_cli.rs`'s
`every_spawning_test_seals_the_embedder_backend` counted spawn sites by matching
`CARGO_BIN_EXE_stella` against the whole file. A doc comment naming the macro
therefore counted as a spawn site, and a file with one genuine, correctly sealed
spawn failed with the most alarming message in the suite — the #4542 billing
leak — whose printed remedy (`add .without_embedder_backend()`) was wrong,
because the command was already sealed.

## Fix

Direction 1 from the issue, with the string-literal hazard handled. Counting now
runs over `code_only(source)`, which drops `//` line comments and nested
`/* … */` block comments while copying string literals through. Both halves are
required:

- literals are **kept**, because the needle lives inside one —
  `env!("CARGO_BIN_EXE_…")`;
- literals are **tracked**, because a `//` inside one is not a comment. This
  directory writes `.env("STELLA_EMBED_URL", format!("http://{backend}/v1"))`,
  and a line-truncating strip would drop any sealing call after it and fail a
  correctly sealed file — trading one false positive for another.

Direction 2 (match `Command::new(env!(`) was not taken: this very file binds the
macro to a `const` and calls `Command::new(STELLA)`, so it would count zero spawn
sites here.

The failure message is unchanged. The guard still refuses to match its own
source: the needles stay `concat!` halves, now as the `SPAWNS`/`SEALS` consts,
and the new fixtures are built from those consts with `format!` rather than
spelled.

`crates/stella-cli/tests/run_reflection_writes_cli.rs`'s workaround paragraph —
which existed only to tell the next author not to spell the macro in prose — is
deleted, and its module doc now names `CARGO_BIN_EXE_stella` plainly. That file
is the live instance: it is what the ablation below flags.

## Witness

`prose_naming_the_macro_is_not_a_spawn_site` (new). One fixture carries three
hazards at once — a line comment naming the macro, a **nested** block comment
naming it, and a `//` inside a string literal on the same line as the sealing
call:

- one sealed spawn under that prose must count `(1, 1)`;
- the same fixture plus a genuinely unsealed second spawn must still count fewer
  seals than spawns.

The second arm is what stops the guard being "fixed" into missing a real
unsealed spawn.

### Ablation 1 — `code_only` returns the source unchanged (the old behaviour)

Both arms go red, including the real-file loop naming the live false positive:

```
running 4 tests
test prose_naming_the_macro_is_not_a_spawn_site ... FAILED
test every_spawning_test_seals_the_embedder_backend ... FAILED

---- prose_naming_the_macro_is_not_a_spawn_site stdout ----
assertion `left == right` failed: a comment naming the macro was counted as a
spawn site, or a `//` inside a string literal swallowed the sealing call after it
  left: (3, 1)
 right: (1, 1)

---- every_spawning_test_seals_the_embedder_backend stdout ----
crates/stella-cli/tests/run_reflection_writes_cli.rs: 2 spawn site(s), 1 sealed
— a spawned child inherits VOYAGE_API_KEY and bills whoever runs the suite
(#4542). Add `mod common; use common::SealsEmbedderBackend;` and
`.without_embedder_backend()` to the command.

test result: FAILED. 2 passed; 2 failed
```

### Ablation 2 — a naive line strip (`line.split("//").next()`), no string tracking

The block comment survives and the seal is swallowed by `http://`:

```
---- prose_naming_the_macro_is_not_a_spawn_site stdout ----
assertion `left == right` failed: a comment naming the macro was counted as a
spawn site, or a `//` inside a string literal swallowed the sealing call after it
  left: (2, 0)
 right: (1, 1)
```

### Ablation 3 — `code_only` returns `String::new()` (fixed in the wrong direction)

The guard would stop failing on a real unsealed spawn; the fixture catches it:

```
---- prose_naming_the_macro_is_not_a_spawn_site stdout ----
assertion `left == right` failed: ...
  left: (0, 0)
 right: (1, 1)
```

### Green

```
$ cargo test -p stella-cli --test embedder_backend_sealed_cli every_spawning_test_seals_the_embedder_backend
test every_spawning_test_seals_the_embedder_backend ... ok

$ cargo test -p stella-cli --test embedder_backend_sealed_cli prose_naming_the_macro_is_not_a_spawn_site
test prose_naming_the_macro_is_not_a_spawn_site ... ok

$ cargo clippy -p stella-cli --test embedder_backend_sealed_cli -- -D warnings
    Finished `dev` profile

$ make guards-fast
check-prose: OK -- 4231 grandfathered construction(s) in 1175 file(s), none added.
(all steps green)
```

## Deleted tests

None. No `#[test]` was removed or renamed; one was added.

## Not in scope

Whether `.env_clear()` remains an accepted seal — it does, unchanged.

## Summary by Sourcery

Count embedder spawn sites from code rather than prose while retaining accurate detection in literals and strengthening regression coverage.

Bug Fixes:
- Prevent embedder spawn-site checks from counting macro names in comments or documentation as real process spawns.
- Preserve spawn and seal detection inside string literals, including URLs containing `//`, while correctly handling nested block comments.
- Add regression coverage for prose false positives, nested comments, string-literal comment markers, and detection of genuinely unsealed spawns.

Enhancements:
- Centralize source scanning and spawn/seal counting for the embedder backend guard.
- Remove the workaround documentation that discouraged naming the binary-path macro in prose.

Documentation:
- Update test documentation to describe the binary-path macro directly now that comments are excluded from spawn counting.

Tests:
- Add coverage validating both correctly sealed and genuinely unsealed spawn fixtures.