### PR TITLE
ci(wire-schema): run clippy over the schema-gated wire-contract modules

### DIFF
--- a/.github/workflows/wire-schema.yml
+++ b/.github/workflows/wire-schema.yml
@@ -102,3 +102,22 @@ jobs:
       - name: rustdoc over the schema-gated wire-contract modules
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: make doc-warnings-schema
+
+      # The clippy half of the same hole, which #4584 left open. ci.yml's lint
+      # step is `cargo clippy --workspace --all-targets` with DEFAULT features,
+      # so no job anywhere linted these modules -- and
+      # `stella-protocol::schema_export` and `stella-plugin::wire_schema` carry
+      # the tree's only two `#![expect(clippy::expect_used)]` that nothing could
+      # police. An `#[expect]` that stops being true is an error only where
+      # clippy runs; rustc does not evaluate a tool lint's expectation when the
+      # tool is absent, so a `cargo build --features schema` reports nothing
+      # (#4949).
+      #
+      # Here for the step above's reasons -- the toolchain is installed, these
+      # three crates are already built under the feature, and this workflow's
+      # trigger paths are exactly the crates that own the modules. The crate
+      # list and the feature spellings are the Makefile recipe's, read through
+      # the target rather than restated.
+      - name: clippy over the schema-gated wire-contract modules
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: make lint-schema

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #     `schema`-gated wire-contract modules the
                          #     default-feature run never compiles)
                          #   + lint (clippy -D warnings)
+                         #   + lint-schema (the same, for those modules —
+                         #     an `#[expect]` there is policed by nothing
+                         #     else, because rustc does not evaluate a tool
+                         #     lint's expectation with the tool absent)
                          #   + test (test --workspace)
                          #   + tool-docs (docs/tools/ vs the declarations)
                          #   + self-driving-test (the shell harness)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ cargo fmt --check
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --keep-going
 make doc-warnings-schema
 cargo clippy --workspace --all-targets -- -D warnings
+make lint-schema
 cargo test --workspace
 ./scripts/check-tool-docs.sh
 cargo build -p stella-cli --bin stella && \

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ GATE_NO_BUILD := lockfile-sync format-check
 # had already re-rotted twice, in the same direction each time: a guard was
 # added here and the prose kept the old count (#1437).
 GATE_STEPS := $(GATE_GUARDS) $(GATE_NO_BUILD) doc-warnings doc-warnings-schema \
-               lint test tool-docs self-driving-test
+               lint lint-schema test tool-docs self-driving-test
 
 # The hermetic guard self-tests — `scripts/test-*.sh` — that deliberately run
 # in NO workflow, and why each one does not. Every other suite runs server-side
@@ -565,10 +565,10 @@ doc-warnings: ## Assert rustdoc is clean workspace-wide, private items included 
 
 # The crates that describe the wire format behind an off-by-default `schema`
 # feature, and the feature spellings that turn it on for each. Named once here
-# because two recipe lines and one workflow read the list; a second copy is the
-# drift `shellcheck` above already paid for (#3375).
-SCHEMA_DOC_CRATES := -p stella-protocol -p stella-plugin -p stella-serve
-SCHEMA_DOC_FEATURES := stella-protocol/schema,stella-plugin/schema,stella-serve/schema
+# because three recipe lines and one workflow read the list; a second copy is
+# the drift `shellcheck` above already paid for (#3375).
+SCHEMA_CRATES := -p stella-protocol -p stella-plugin -p stella-serve
+SCHEMA_FEATURES := stella-protocol/schema,stella-plugin/schema,stella-serve/schema
 
 # The modules `doc-warnings` cannot see. It runs with default features, and
 # describing the wire format is deliberately off by default in all three crates
@@ -590,10 +590,27 @@ SCHEMA_DOC_FEATURES := stella-protocol/schema,stella-plugin/schema,stella-serve/
 # one failing crate must not mask the ones behind it.
 .PHONY: doc-warnings-schema
 doc-warnings-schema: ## Assert rustdoc is clean for the `schema`-gated wire-contract modules (#4584)
-	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_DOC_CRATES) \
-	  --features $(SCHEMA_DOC_FEATURES) --no-deps --keep-going
-	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_DOC_CRATES) \
-	  --features $(SCHEMA_DOC_FEATURES) --no-deps --document-private-items --keep-going
+	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \
+	  --features $(SCHEMA_FEATURES) --no-deps --keep-going
+	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \
+	  --features $(SCHEMA_FEATURES) --no-deps --document-private-items --keep-going
+
+# The same hole, one instrument over. `lint` runs `cargo clippy --workspace`
+# with DEFAULT features, so clippy never reached `stella-protocol::schema_export`,
+# `stella-plugin::{wire_corpus,wire_schema}` or `stella-serve::schema_export`
+# either — and those two modules carry the tree's only
+# `#![expect(clippy::expect_used)]` that nothing could police. `#[expect]` turns
+# a suppression that stops being true into an error, but only where clippy
+# runs; rustc does not evaluate a tool lint's expectation when the tool is not
+# running, so a plain `cargo build --features schema` reports nothing (#4949).
+#
+# `--all-targets`, unlike `doc-warnings-schema`'s `--lib`: the `#[cfg(test)]`
+# bodies in these three crates do compile under the feature, so there is no
+# reason to lint less than the workspace run does.
+.PHONY: lint-schema
+lint-schema: ## Run clippy over the `schema`-gated wire-contract modules (#4949)
+	cargo clippy $(SCHEMA_CRATES) --features $(SCHEMA_FEATURES) \
+	  --all-targets -- -D warnings
 
 # The presence guard exists because the failure it replaces was
 # indistinguishable from a real finding: on a machine without the binary this

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -46,8 +46,11 @@
 // default build has zero production `unwrap`/`expect`, and `make lint` runs
 // clippy with `-D warnings` on that build, so a new one fails the gate instead
 // of arriving unremarked. The one exception is `schema_export.rs`, which is
-// only compiled under the `schema` feature (not part of `make lint` or CI's
-// clippy run) and carries its own justified `#[expect(clippy::expect_used)]`.
+// compiled only under the `schema` feature and carries its own justified
+// `#[expect(clippy::expect_used)]`. `make lint` runs with default features and
+// never reaches it; `make lint-schema` does, in the gate and in
+// wire-schema.yml, which is what makes that `#[expect]` fail when it stops
+// being true (#4949).
 // `not(test)` scopes the lint exactly as the rule does: it is about runtime
 // data, and `unwrap` in a test is fine.
 #![cfg_attr(not(test), warn(clippy::unwrap_used, clippy::expect_used))]

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -148,6 +148,9 @@ step_command() {
   # It must not be 'cargo doc' either — that is `doc-warnings`' alias, and two
   # steps sharing one needle makes both checks vacuous.
   doc-warnings-schema) echo 'make doc-warnings-schema' ;;
+  # Same reasoning one instrument over: the crate list is the Makefile's, and
+  # it must not be 'cargo clippy' — that is `lint`'s alias (#4949).
+  lint-schema) echo 'make lint-schema' ;;
   # The Python guards, whose scripts the `.sh` default below does not fit.
   doc-links) echo 'check-doc-links' ;;
   module-reachability) echo 'check-module-reachability' ;;


### PR DESCRIPTION
Closes #4949

## What ran nowhere

`make lint` and `ci.yml`'s lint step are both `cargo clippy --workspace
--all-targets -- -D warnings` with **default** features, and `schema` is off by
default, so clippy never reached `stella-protocol::schema_export`,
`stella-plugin::{wire_corpus,wire_schema}` or `stella-serve::schema_export`.
Those modules carry the tree's only two `#![expect(clippy::expect_used)]`, and
an `#[expect]` becomes an error only where clippy runs.

## The fix

`make lint-schema` — clippy over the three crates with the feature on:

```make
lint-schema:
	cargo clippy $(SCHEMA_CRATES) --features $(SCHEMA_FEATURES) \
	  --all-targets -- -D warnings
```

`--all-targets` rather than `doc-warnings-schema`'s `--lib`: the issue asked to
check this first, and the `#[cfg(test)]` bodies in these three crates do compile
under the feature (green run below), so there is no reason to lint less than the
workspace run does.

The crate list and the feature spellings are read from the
`SCHEMA_DOC_CRATES`/`SCHEMA_DOC_FEATURES` pair `doc-warnings-schema` already
owns — renamed to `SCHEMA_CRATES`/`SCHEMA_FEATURES` now that a non-doc recipe
reads them. No second copy; that is the drift #3375 paid for.

### One correction to the issue's plan

The issue said to add this as a workflow step only, because "`doc-warnings-schema`
did — it is a `wire-schema.yml` step, not a `GATE_STEPS` member". That premise is
false: `doc-warnings-schema` **is** a `GATE_STEPS` member (`Makefile`'s
`GATE_STEPS`, and it is named in AGENTS.md's and CONTRIBUTING.md's fences), and
`wire-schema.yml` is where `gate-parity` finds it running server-side.

So this follows the precedent it actually set rather than the one the issue
described: `lint-schema` joins `GATE_STEPS` beside `doc-warnings-schema`, and
`wire-schema.yml` gains the step that runs it. `check-gate-parity.sh` gets the
alias entry (`make lint-schema`, not `cargo clippy` — that needle is `lint`'s,
and two steps sharing one makes both checks vacuous), and both fences gain the
line. That keeps `make gate` and CI answering the same question, which is what
`gate-parity` exists for.

Cost is a warm-cache clippy on three crates in a workflow that already builds
exactly those three under exactly that feature.

## The prose correction the issue required

`crates/stella-protocol/src/lib.rs` said, and had said for as long as it
existed:

> The one exception is `schema_export.rs`, which is only compiled under the
> `schema` feature (not part of `make lint` or CI's clippy run) …

That is no longer true and now names what does police it.

## Evidence

### Green, as landed

```
$ make lint-schema
cargo clippy -p stella-protocol -p stella-plugin -p stella-serve --features stella-protocol/schema,stella-plugin/schema,stella-serve/schema \
	  --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.86s
EXIT=0

$ make gate-parity
check-gate-parity: OK — 49 (forty-nine) gate steps, named in AGENTS.md and CONTRIBUTING.md, each run by a workflow.

$ make guards-fast
EXIT=0
```

### Ablation 1 — delete `schema_export.rs`'s `#![expect(clippy::expect_used)]`

Proves the step reaches the module at all:

```
error: used `expect()` on a `Result` value
   --> crates/stella-protocol/src/schema_export.rs:178:20
    |
178 |       let mut json = serde_json::to_string_pretty(&agent_event_schema())
179 | |         .expect("a JSON Schema is always serializable");
    |
    = note: `-D clippy::expect-used` implied by `-D warnings`

error: used `expect()` on a `Result` value
   --> crates/stella-protocol/src/schema_export.rs:194:9

error: could not compile `stella-protocol` (lib) due to 2 previous errors
make: *** [lint-schema] Error 101
```

### Ablation 2 — keep the attribute, remove the two `expect`s it justifies

This is the mechanism the issue is about: a suppression that has stopped being
true.

```
error: this lint expectation is unfulfilled
  --> crates/stella-protocol/src/schema_export.rs:61:5
   |
61 |     clippy::expect_used,
   |     ^^^^^^^^^^^^^^^^^^^
   |
   = note: the two `expect`s below serialize a `serde_json::Value`, whose only
     serialization failures are unrepresentable in the type; see the paragraph above
   = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`

error: could not compile `stella-protocol` (lib) due to 1 previous error
make: *** [lint-schema] Error 101
```

**On that same tree**, the thing that used to be the only compiler to see these
modules says nothing:

```
$ cargo build -p stella-protocol --features schema
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.15s
BUILD_EXIT=0
```

Green build, red `lint-schema`, same source — which is what makes the new step
the only thing that can catch this, rather than a second opinion on something
already covered.

## Deleted tests

None. No `#[test]` was added, removed or renamed — this is a CI/lint-coverage
change, so it ships no witness test; the two ablations above are its evidence.

## Not done

The `schema` feature is not turned on by default, per the issue's constraint and
`docs/wire/README.md` §2.

## Summary by Sourcery

Add schema-aware Clippy coverage to ensure schema-gated wire-contract modules and their lint expectations are enforced in both local gates and CI.

New Features:
- Add a schema-specific Clippy gate covering the schema-enabled wire-contract modules.

Enhancements:
- Include schema-specific linting in the project gate and keep its crate and feature configuration shared with schema documentation checks.
- Update gate-parity validation and contributor guidance to require the new lint step.
- Clarify protocol lint documentation to reflect that schema modules are now explicitly checked.

CI:
- Run the schema-specific Clippy check in the wire-schema workflow.