### PR TITLE
fix(stella-cli): a redirected user home is the one every crate resolves

### DIFF
--- a/crates/stella-cli/src/command_deck/model_cmd.rs
+++ b/crates/stella-cli/src/command_deck/model_cmd.rs
@@ -241,7 +241,7 @@ mod tests {
     /// unrestored `HOME`. The redirect is per-thread now (#1139): nothing to
     /// serialize, nothing to restore, and the returned guard only has to
     /// outlive the caller's test.
-    fn scratch() -> (tempfile::TempDir, crate::paths::TestPathsGuard) {
+    fn scratch() -> (tempfile::TempDir, crate::paths::TestHomeGuard) {
         let td = tempfile::tempdir().unwrap();
         let home = td.path().join("home");
         std::fs::create_dir_all(&home).unwrap();

--- a/crates/stella-cli/src/command_deck/session_override.rs
+++ b/crates/stella-cli/src/command_deck/session_override.rs
@@ -379,7 +379,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn scratch() -> (tempfile::TempDir, crate::paths::TestPathsGuard) {
+    fn scratch() -> (tempfile::TempDir, crate::paths::TestHomeGuard) {
         let td = tempfile::tempdir().unwrap();
         let home = td.path().join("home");
         std::fs::create_dir_all(&home).unwrap();

--- a/crates/stella-cli/src/config/tests/resolution.rs
+++ b/crates/stella-cli/src/config/tests/resolution.rs
@@ -80,7 +80,7 @@ fn resolved_config_carries_the_authority_computed_during_settings_load() {
 /// real home mid-test.
 pub(in crate::config) fn reload_fixture(
     tag: &str,
-) -> (std::path::PathBuf, crate::paths::TestPathsGuard, Config) {
+) -> (std::path::PathBuf, crate::paths::TestHomeGuard, Config) {
     let home = std::env::temp_dir().join(format!("stella-test-{tag}-{}", std::process::id()));
     let workspace = home.join("ws");
     std::fs::create_dir_all(home.join(".stella")).unwrap();

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -472,7 +472,7 @@ fn an_unfinished_worker_turn_claims_no_closing_boundary() {
 /// `~/.stella/skills` as well as from the workspace, so without it whoever runs
 /// this suite would have their own real skills join the block and the
 /// assertions would be reading someone's disk instead of this fixture.
-fn steered_workspace() -> (tempfile::TempDir, crate::paths::TestPathsGuard, PathBuf) {
+fn steered_workspace() -> (tempfile::TempDir, crate::paths::TestHomeGuard, PathBuf) {
     let td = tempfile::tempdir().unwrap();
     let home = td.path().join("home");
     std::fs::create_dir_all(&home).unwrap();

--- a/crates/stella-cli/src/paths.rs
+++ b/crates/stella-cli/src/paths.rs
@@ -29,18 +29,26 @@
 //!
 //! # Redirecting without touching the process environment
 //!
-//! Tests install a **per-thread** override — `test_paths` and its two
-//! narrower spellings, all `#[cfg(test)]`, which is why nothing here links to
-//! them. No `unsafe`, no process mutation, no lock, nothing another test
-//! running in parallel can observe — so a test that redirects home or
-//! data-dir resolution needs neither `test_env::lock` nor `EnvRestore`. Those
-//! remain for genuinely env-shaped fixtures, such as provider credential
-//! variables.
+//! Tests install a **per-thread** override — `test_paths` and its narrower
+//! spellings, all `#[cfg(test)]`, which is why nothing here links to them. No
+//! `unsafe`, no process mutation, no lock, nothing another test running in
+//! parallel can observe — so a test that redirects home or data-dir
+//! resolution needs neither `test_env::lock` nor `EnvRestore`. Those remain
+//! for genuinely env-shaped fixtures, such as provider credential variables.
 //!
 //! The redirect is what needs no lock. A test that *also reads the ambient
 //! environment and asserts on what it read* still does, because two reads
 //! either side of a window are not thread-safe just because neither of them
 //! writes — see `a_redirect_needs_no_process_environment_mutation` (#4516).
+//!
+//! # The one spelling that does mutate the environment
+//!
+//! A thread-local reaches `stella-cli` and stops there, and the user tier is
+//! resolved by more crates than this one. `test_user_home` is therefore the
+//! exception: it moves the thread-local *and* `HOME`, so a test calling into
+//! `stella-observatory` or `stella-store` gets the redirect it asked for
+//! rather than the developer's real `~/.stella` (#4980). It takes the env lock
+//! itself; its own doc comment carries the argument.
 
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -276,15 +284,64 @@ pub(crate) fn test_paths(paths: UserPaths) -> TestPathsGuard {
     amend(|current| *current = paths)
 }
 
-/// Redirect the home directory alone — user scope, extensions included.
+/// Redirect the home directory — user scope, extensions included — for every
+/// crate this test calls into, not just `stella-cli`.
+///
+/// # Why this one spelling leaves the thread
+///
+/// Two resolvers answer "where is the user's stella home", and only one of
+/// them is the thread-local above. `stella-cli` reads it; `stella-observatory`,
+/// `stella-store` and everything else read [`stella_home::stella_home`], which
+/// resolves `STELLA_HOME` — or `$HOME/.stella` — out of the process
+/// environment and cannot see another crate's thread-local. So the moment a
+/// test redirecting the user tier calls out of this crate, a thread-local-only
+/// redirect stops isolating: `stella_observatory::respond_with` served ~45 rows
+/// out of the developer's real `~/.stella/skills` in a test whose whole subject
+/// was a temp directory, and passed, because nothing in that directory happened
+/// to collide (#4980). A test that *writes* through the other resolver writes
+/// into the real home, which is the same hole pointed the other way.
+///
+/// Moving both is what makes the call site's promise true, and it is why this
+/// takes the process-wide env lock itself rather than asking the caller to:
+/// `setenv` racing a concurrent `getenv` is UB on POSIX, and roughly half the
+/// call sites hold the lock already for their own mutations. [`crate::test_env::lock`]
+/// nests for exactly this reason. [`test_paths`] and the other narrow spellings
+/// stay thread-local and lock-free — they redirect only what `stella-cli`
+/// resolves and claim nothing more.
 #[cfg(test)]
-pub(crate) fn test_user_home(home: PathBuf) -> TestPathsGuard {
-    amend(move |current| {
+pub(crate) fn test_user_home(home: PathBuf) -> TestHomeGuard {
+    let lock = crate::test_env::lock();
+    // SAFETY: `lock` is held for the whole lifetime of the returned guard, and
+    // `restore` puts the process environment back even on an unwinding panic.
+    let restore = crate::test_env::home_sandbox(&home);
+    let paths = amend(move |current| {
         current.state_home = Some(home.join(".local/state"));
         current.stella_root = Some(home.join(".stella"));
         current.home = Some(home);
         current.extensions_visible = true;
-    })
+    });
+    TestHomeGuard {
+        _paths: paths,
+        _restore: restore,
+        _lock: lock,
+    }
+}
+
+/// What [`test_user_home`] hands back: both redirects and the lock that makes
+/// the process-global half sound.
+///
+/// The fields drop in declaration order, which is the order the restore has to
+/// happen in — the thread-local first, then the environment, and the lock last
+/// so that no other thread observes a half-restored environment.
+#[cfg(test)]
+#[must_use]
+pub(crate) struct TestHomeGuard {
+    /// Restores `stella-cli`'s own thread-local redirect.
+    _paths: TestPathsGuard,
+    /// Restores `HOME` and every [`stella_home::OVERRIDE_ENV_VARS`] entry.
+    _restore: crate::test_env::EnvRestore,
+    /// Held for the whole mutate-read-restore window.
+    _lock: crate::test_env::EnvLock,
 }
 
 /// Close (or reopen) the filesystem-isolation boundary alone.
@@ -418,6 +475,50 @@ mod tests {
             Some(PathBuf::from("/tmp/stella-paths-extensions/.stella")),
             "installing a home is the opt-in"
         );
+    }
+
+    /// Witness for #4980: the home a test installs is the home **every other
+    /// crate** resolves, not only `stella-cli`'s thread-local.
+    ///
+    /// The two assertions are the same question asked of the two resolvers,
+    /// and only the second one used to be able to fail: `stella-observatory`,
+    /// `stella-store` and every other crate reach the user tier through
+    /// `stella_home::stella_home`, which reads the process environment. A test
+    /// that redirected the thread-local alone read the developer's real
+    /// `~/.stella` from that side and said nothing about it.
+    ///
+    /// The ambient `STELLA_HOME` set first is what makes the case real rather
+    /// than accidental: a developer with the variable exported is the machine
+    /// this was found on, and clearing `HOME` alone would leave it answering.
+    #[test]
+    fn an_installed_home_is_the_one_every_other_crate_resolves() {
+        let _env = crate::test_env::lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outer = crate::test_env::EnvRestore::capture(&stella_home::OVERRIDE_ENV_VARS);
+        // SAFETY: serialized behind the env lock, and `outer` outlives the body.
+        unsafe { std::env::set_var(stella_home::STELLA_HOME_ENV, dir.path().join("elsewhere")) };
+
+        let home = dir.path().join("home");
+        let guard = test_user_home(home.clone());
+
+        assert_eq!(
+            stella_root(),
+            Some(home.join(".stella")),
+            "stella-cli's own resolver"
+        );
+        assert_eq!(
+            stella_home::stella_home(),
+            Some(home.join(".stella")),
+            "and the one every crate outside stella-cli reads"
+        );
+
+        drop(guard);
+        assert_eq!(
+            std::env::var_os(stella_home::STELLA_HOME_ENV),
+            Some(dir.path().join("elsewhere").into_os_string()),
+            "the guard puts the ambient override back"
+        );
+        drop(outer);
     }
 
     /// Witness for #2178: `STELLA_HOME` moves the **whole** home, not just the

--- a/crates/stella-cli/src/settings_check.rs
+++ b/crates/stella-cli/src/settings_check.rs
@@ -811,7 +811,7 @@ mod tests {
     /// every assertion here quietly depended on the developer's own user-scope
     /// settings, and passed in CI only because the runner has none (#1139).
     /// One seam now, and the redirect is real.
-    fn workspace(settings: &str) -> (tempfile::TempDir, crate::paths::TestPathsGuard) {
+    fn workspace(settings: &str) -> (tempfile::TempDir, crate::paths::TestHomeGuard) {
         let dir = tempfile::tempdir().expect("workspace");
         std::fs::create_dir_all(dir.path().join(".stella")).expect("dot dir");
         std::fs::write(dir.path().join(".stella/settings.json"), settings).expect("settings");

--- a/crates/stella-cli/src/skill_manager.rs
+++ b/crates/stella-cli/src/skill_manager.rs
@@ -682,7 +682,7 @@ mod tests {
     /// races are UB and the harness runs these on parallel threads. The
     /// redirect is per-thread now (#1139), so there is nothing to serialize
     /// and no window in which another test could see an unrestored `HOME`.
-    fn scratch() -> (tempfile::TempDir, PathBuf, crate::paths::TestPathsGuard) {
+    fn scratch() -> (tempfile::TempDir, PathBuf, crate::paths::TestHomeGuard) {
         let td = tempfile::tempdir().unwrap();
         let home = td.path().join("home");
         std::fs::create_dir_all(&home).unwrap();

--- a/crates/stella-cli/src/test_env.rs
+++ b/crates/stella-cli/src/test_env.rs
@@ -14,11 +14,58 @@
 //! is exactly the kind of thing AGENTS.md says lands in a sibling rather than
 //! in the file that is running out of room.
 
+/// A held env lock. Releases on drop, including on an unwinding panic.
+///
+/// Neither `Send` nor `Sync`, which is what the `PhantomData` is for: the
+/// nesting depth below is per-thread, so a handle that reached another thread
+/// would decrement a count it never incremented.
+#[must_use]
+pub(crate) struct EnvLock(std::marker::PhantomData<*const ()>);
+
+std::thread_local! {
+    /// How many [`EnvLock`]s this thread holds. The mutex itself is taken on
+    /// the way from 0 to 1 and released on the way back.
+    static DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    /// The guard, parked here rather than inside the outermost [`EnvLock`], so
+    /// that releasing depends on the count reaching zero and not on which
+    /// handle happens to drop first.
+    static HELD: std::cell::RefCell<Option<std::sync::MutexGuard<'static, ()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
 /// Acquire the env lock, recovering from a poisoned mutex (a prior
 /// env-mutating test that panicked mid-hold must not cascade).
-pub(crate) fn lock() -> std::sync::MutexGuard<'static, ()> {
+///
+/// # Re-entrant, on purpose
+///
+/// A nested acquisition on a thread that already holds the lock returns a
+/// handle that releases nothing, so a helper needing the lock can take it
+/// without knowing whether its caller already did. That is what lets
+/// [`crate::paths::test_user_home`] acquire the lock itself (#4980): it
+/// mutates the process environment, so it needs one, and half its call sites
+/// already hold one for their own `set_var`. The alternative — a token
+/// threaded through every call site and every fixture helper that returns a
+/// guard — puts the requirement in ~90 signatures and still lets a caller
+/// hand the token to something that outlives it.
+pub(crate) fn lock() -> EnvLock {
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    let depth = DEPTH.with(std::cell::Cell::get);
+    if depth == 0 {
+        let guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        HELD.with(|held| *held.borrow_mut() = Some(guard));
+    }
+    DEPTH.with(|d| d.set(depth + 1));
+    EnvLock(std::marker::PhantomData)
+}
+
+impl Drop for EnvLock {
+    fn drop(&mut self) {
+        let depth = DEPTH.with(std::cell::Cell::get);
+        DEPTH.with(|d| d.set(depth - 1));
+        if depth == 1 {
+            HELD.with(|held| held.borrow_mut().take());
+        }
+    }
 }
 
 /// Captures the current value of each named env var and restores it on
@@ -150,6 +197,40 @@ fn a_home_sandbox_moves_the_stella_home_not_just_the_unix_home() {
         "the guard must put the outer STELLA_HOME back"
     );
     drop(outer);
+}
+
+/// Witness for #4980: the lock nests. A second acquisition on a thread that
+/// already holds it must return rather than block, and the mutex must still be
+/// released once the outermost handle is gone — otherwise
+/// [`crate::paths::test_user_home`] could not take the lock itself, which is
+/// what stops a call site forgetting it.
+///
+/// A regression here shows up as a hang rather than a failure, which is the
+/// price of witnessing a deadlock; the depth and guard assertions below fail
+/// fast on the accounting bugs that do not deadlock.
+#[test]
+fn a_nested_acquisition_does_not_deadlock_and_still_releases() {
+    let outer = lock();
+    assert_eq!(DEPTH.with(std::cell::Cell::get), 1);
+    let inner = lock();
+    assert_eq!(DEPTH.with(std::cell::Cell::get), 2);
+    assert!(
+        HELD.with(|held| held.borrow().is_some()),
+        "the mutex is held for the whole nest, taken once"
+    );
+
+    drop(inner);
+    assert!(
+        HELD.with(|held| held.borrow().is_some()),
+        "a nested handle releases nothing"
+    );
+
+    drop(outer);
+    assert_eq!(DEPTH.with(std::cell::Cell::get), 0);
+    assert!(
+        HELD.with(|held| held.borrow().is_none()),
+        "the outermost handle releases the mutex, or every later test blocks"
+    );
 }
 
 /// Witness for #911: the hand-rolled "capture previous, mutate, restore


### PR DESCRIPTION
## What

`paths::test_user_home(tmp)` reads at the call site like full isolation and was partial. It amended a `stella-cli` thread-local and set no environment variable; every other crate resolves the user tier through `stella_home::stella_home()`, which reads `STELLA_HOME` — or `$HOME/.stella` — out of the process environment and cannot see another crate's thread-local.

It now moves both, and the call site's promise is true again.

## Which option, and why

The issue gives three. This is **option 1** — `test_user_home` sets the environment too — and the issue names the thing that made it a decision rather than an obvious yes: "an env var is process-global while `TestPathsGuard` is thread-local, so this only holds under `crate::test_env::lock()` — which most of these tests already take, but not all. Whether that coupling is acceptable is the decision."

The coupling is acceptable **because the function can take the lock itself**, which is the shape shipped here. That needed one change to `test_env::lock`: it is now re-entrant per thread. A nested acquisition returns a handle that releases nothing, so a helper needing the lock can take it without knowing whether its caller already did.

I costed the alternative before choosing. A lock **token** in the signature (`test_user_home(&env, home)`) is compile-enforced, and I built it far enough to see what it costs: 48 call sites, plus six fixture helpers (`skill_manager::scratch`, `settings_check::workspace`, `fleet_cmd::steered_workspace`, both `command_deck` `scratch`es, `config::tests::resolution`) that **return** the guard to their callers and would each have to take and propagate the token — about 33 more sites, ~90 signatures in all. It is also not stronger where it matters: a helper handed a `&EnvLock` can still return a guard that outlives the borrow unless the guard itself borrows the lock, and a guard that borrows the lock cannot be returned from a helper at all. Acquiring the lock inside the function makes it impossible to call without one, which is the property the token was for.

Option 2 (a second explicit seam) is the one the issue itself says "gets forgotten exactly when it matters", and option 3 (a guard over the real `$HOME`) needs a resolver both crates route through, which does not exist.

## What changed

- `test_env::lock` returns `EnvLock`, a `!Send`/`!Sync` handle. The mutex is taken on the way from depth 0 to 1 and released on the way back to 0. The guard is parked in a thread-local rather than inside the outermost handle, so releasing depends on the count reaching zero and not on which handle drops first.
- `paths::test_user_home` composes `test_env::home_sandbox` (which sets `HOME` and clears every `stella_home::OVERRIDE_ENV_VARS` entry) with the thread-local amend, and returns `TestHomeGuard`. Its fields drop in the order the restore has to happen: thread-local, then environment, then the lock — so no other thread observes a half-restored environment.
- Six fixture helpers change their declared return type from `TestPathsGuard` to `TestHomeGuard`. Nothing else at any of the 48 call sites changes; that is the point of the re-entrant lock.
- `paths.rs`'s module header said a redirect needs "no `unsafe`, no process mutation, no lock". That is still true of `test_paths` and the other narrow spellings and is now false of `test_user_home`, so the header names the exception.

## The survey the issue asked for

`rg -l test_user_home crates/stella-cli/src` is 19 files, 48 call sites. 28 of them held no env lock at all before this change — including all seven in `tool_foundry/adopt/tests.rs`, all five in `self_driving_cmd/state.rs`, and both in `settings/tests/private_state.rs`. Those are the tests that were reading, and in some cases writing, through a resolver the redirect never reached. They are all covered now without an edit, because the seam takes the lock.

## Witness

`paths::tests::an_installed_home_is_the_one_every_other_crate_resolves` — sets an ambient `STELLA_HOME` first, because a developer with that variable exported is the machine this was found on and clearing `HOME` alone would leave it answering. Then it installs a home and asks both resolvers the same question.

### Ablation

Replaced the `home_sandbox` call in `test_user_home` with an `EnvRestore` over no names, leaving the thread-local half intact — so the ablation removes the answer rather than the compile:

```
---- paths::tests::an_installed_home_is_the_one_every_other_crate_resolves stdout ----
thread '...' panicked at crates/stella-cli/src/paths.rs:509:9:
assertion `left == right` failed: and the one every crate outside stella-cli reads
  left: Some("/var/folders/.../T/.tmpPXTkCB/elsewhere")
 right: Some("/var/folders/.../T/.tmpPXTkCB/home/.stella")

test result: FAILED. 0 passed; 1 failed
```

It fails at exactly the assertion under test, with the wrong answer rather than a constant one, and the assertion above it — `stella-cli`'s own resolver, which the ablation does not touch — stays green. Those two are the pair: a change that moved only the environment would fail the first instead.

`test_env::a_nested_acquisition_does_not_deadlock_and_still_releases` covers the re-entrancy the fix rests on, including that a nested handle releases nothing and the outermost one does. Its doc says out loud that a deadlock regression there shows as a hang rather than a failure, which is the price of witnessing a deadlock; the depth and guard assertions fail fast on the accounting bugs that do not deadlock.

## The workaround this was supposed to remove

`the_dashboards_plugin_skills_honour_the_project_trust_gate` and its `STELLA_HOME` line are on #4977's branch and not on `main`, so there is nothing here to delete. #4974 is stacked on #4977 and drops it there, citing this PR.

## No deleted or renamed tests

Nothing removed or renamed; two added.

## Verification

`cargo fmt --all --check`, `cargo clippy -p stella-cli --all-targets -- -D warnings`, `make guards-fast`, and `cargo test -p stella-cli` (2328 unit + every integration binary, exit 0), rebased on `origin/main` before the final guard run. CI is the evidence.

Closes #4980
Refs #4917, #3864, #4974

## Summary by Sourcery

Make test user-home redirects apply consistently across the process while preserving safe isolation for parallel tests.

Bug Fixes:
- Ensure test home redirects are observed consistently by both stella-cli and other crates resolving the user home.
- Prevent environment restoration and concurrent test access from racing when tests install temporary homes.

Enhancements:
- Make environment locking re-entrant so helpers can safely acquire the lock regardless of whether their callers already hold it.
- Add coverage validating cross-crate home resolution and nested lock acquisition.

Documentation:
- Document the distinction between thread-local path redirects and the environment-backed test home redirect.

Tests:
- Add regression tests for cross-crate home resolution and re-entrant environment locking.