### PR TITLE
test(scripts): prove the diagnostic-code registry can still fail

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -146,6 +146,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-deck-paths.sh
 
+      - name: diagnostic-code registry failure directions
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-diagnostic-codes.sh
+
       - name: deleted-tests guard reads a live PR body over a stale one
         if: ${{ !cancelled() }}
         run: ./scripts/test-deleted-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -831,6 +831,10 @@ file-size-test: ## Test the file-size ratchet's language coverage and its change
 website-inputs-test: ## Test the website-inputs guard's three failure directions (hermetic; not part of `gate`)
 	./scripts/test-website-inputs.sh
 
+.PHONY: diagnostic-codes-test
+diagnostic-codes-test: ## Test the diagnostic-code registry's failure directions (#4948; hermetic; not part of `gate`)
+	./scripts/test-diagnostic-codes.sh
+
 .PHONY: ci-rust-scope-test
 ci-rust-scope-test: ## Test which diffs run the Rust gate, prose skips and fail-open included (hermetic; not part of `gate`)
 	./scripts/test-ci-rust-scope.sh

--- a/scripts/check-diagnostic-codes.sh
+++ b/scripts/check-diagnostic-codes.sh
@@ -23,9 +23,13 @@
 # scans source rather than running a binary — so this stays cheap and works in
 # `make guards-fast`, which compiles nothing. `make diag-reference` regenerates
 # the reference's generated parts and preserves its hand-written prose.
+#
+# An optional root is forwarded, so scripts/test-diagnostic-codes.sh can run
+# the gate's own entry point against a fixture tree rather than a paraphrase of
+# it (#4948). No caller in the tree passes one.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
-exec python3 ./scripts/diagnostic-codes.py check
+exec python3 ./scripts/diagnostic-codes.py check "$@"

--- a/scripts/diagnostic-codes.py
+++ b/scripts/diagnostic-codes.py
@@ -24,6 +24,11 @@ Three modes:
     list    print the extracted inventory as JSON (a debugging aid, not an
             interface; nothing may parse this).
 
+Every mode takes an optional root after it — `diagnostic-codes.py check /tmp/t`
+— and defaults to the repository this file lives in. That is what lets
+`scripts/test-diagnostic-codes.sh` run each of the failure directions below
+against a fixture tree; see [`Tree`].
+
 ## How codes are found, and why by reading source
 
 The generator must not need to run a binary to enumerate codes — the gate has
@@ -87,14 +92,39 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-CRATES = REPO / "crates"
-REFERENCE = REPO / "docs" / "reference" / "diagnostics.md"
-# The website's curated table. Its *rows* are hand-picked for troubleshooting
-# symptoms and its "What it means" prose is written for a reader, so neither is
-# generated; its codes and levels are facts about the tree and are checked
-# against the same scan the reference is (#3045).
-WEBSITE = REPO / "website" / "content" / "docs" / "diagnostics.mdx"
 WEBSITE_ANCHOR = "## Reading the codes"
+
+
+@dataclass(frozen=True)
+class Tree:
+    """The three places this script reads, rooted at one directory.
+
+    Rooted rather than resolved from `__file__` so `scripts/test-diagnostic-
+    codes.sh` can point the guard at a fixture tree and watch it fire. Without
+    that the guard could not be shown to fail, which is the same defect one
+    notation over from the one it exists to catch (#4948). Every caller in the
+    tree passes no root and gets this repository, as they always did.
+    """
+
+    root: Path
+
+    @property
+    def crates(self) -> Path:
+        return self.root / "crates"
+
+    @property
+    def reference(self) -> Path:
+        return self.root / "docs" / "reference" / "diagnostics.md"
+
+    @property
+    def website(self) -> Path:
+        """The website's curated table. Its *rows* are hand-picked for
+        troubleshooting symptoms and its "What it means" prose is written for a
+        reader, so neither is generated; its codes and levels are facts about
+        the tree and are checked against the same scan the reference is
+        (#3045)."""
+        return self.root / "website" / "content" / "docs" / "diagnostics.mdx"
+
 
 # The code grammar: lowercase dotted segments, at least two of them. This is
 # deliberately narrower than "any string" — it is what keeps shape 3's
@@ -330,9 +360,9 @@ def record(inventory: dict[str, Emit], code: str, crate: str, rel: str) -> Emit:
     return entry
 
 
-def scan_file(path: Path, inventory: dict[str, Emit]) -> None:
-    rel = path.relative_to(REPO).as_posix()
-    crate = path.relative_to(CRATES).parts[0]
+def scan_file(tree: Tree, path: Path, inventory: dict[str, Emit]) -> None:
+    rel = path.relative_to(tree.root).as_posix()
+    crate = path.relative_to(tree.crates).parts[0]
     src = strip_cfg_test(strip_comments(path.read_text(encoding="utf-8")))
     consts = dict(CONST_STR.findall(src))
 
@@ -395,13 +425,13 @@ def scan_file(path: Path, inventory: dict[str, Emit]) -> None:
             entry.dynamic = entry.dynamic or dynamic
 
 
-def scan_tree() -> dict[str, Emit]:
+def scan_tree(tree: Tree) -> dict[str, Emit]:
     inventory: dict[str, Emit] = {}
-    for path in sorted(CRATES.glob("*/src/**/*.rs")):
-        rel = path.relative_to(REPO).as_posix()
+    for path in sorted(tree.crates.glob("*/src/**/*.rs")):
+        rel = path.relative_to(tree.root).as_posix()
         if "/tests/" in rel or "/benches/" in rel or "/examples/" in rel:
             continue
-        scan_file(path, inventory)
+        scan_file(tree, path, inventory)
     return inventory
 
 
@@ -535,11 +565,11 @@ def parse_website_table(text: str) -> tuple[list[tuple[list[str], set[str]]], st
 # ── Modes ────────────────────────────────────────────────────────────────────
 
 
-def do_check() -> int:
+def do_check(tree: Tree) -> int:
     # The verdict is decided before anything is written, like the shell guards
     # (#1815): buffer, then emit once.
     report: list[str] = []
-    inventory = scan_tree()
+    inventory = scan_tree(tree)
 
     for entry in sorted(inventory.values(), key=lambda e: e.code):
         if len(entry.crates) > 1:
@@ -548,12 +578,13 @@ def do_check() -> int:
                 f"({', '.join(sorted(entry.crates))}); a facet vocabulary has one owner (§5.1)."
             )
 
-    if not REFERENCE.exists():
+    if not tree.reference.exists():
         report.append(
-            f"FAIL — {REFERENCE.relative_to(REPO)} does not exist. Generate it: make diag-reference"
+            f"FAIL — {tree.reference.relative_to(tree.root)} does not exist. "
+            "Generate it: make diag-reference"
         )
     else:
-        text = REFERENCE.read_text(encoding="utf-8")
+        text = tree.reference.read_text(encoding="utf-8")
         codes, prose = parse_reference(text)
         seen: set[str] = set()
         for code in codes:
@@ -582,15 +613,15 @@ def do_check() -> int:
             )
 
     surfaced = 0
-    if not WEBSITE.exists():
+    if not tree.website.exists():
         report.append(
-            f"FAIL — {WEBSITE.relative_to(REPO)} does not exist. It carries the "
-            "reader-facing code table; if the page moved, move this check with it."
+            f"FAIL — {tree.website.relative_to(tree.root)} does not exist. It carries "
+            "the reader-facing code table; if the page moved, move this check with it."
         )
     else:
-        rows, unreadable = parse_website_table(WEBSITE.read_text(encoding="utf-8"))
+        rows, unreadable = parse_website_table(tree.website.read_text(encoding="utf-8"))
         surfaced = sum(len(codes) for codes, _ in rows)
-        site = WEBSITE.relative_to(REPO)
+        site = tree.website.relative_to(tree.root)
         if unreadable:
             report.append(f"FAIL — {site}: {unreadable}.")
         for codes, levels in rows:
@@ -624,15 +655,18 @@ def do_check() -> int:
     return 0
 
 
-def do_write() -> int:
-    inventory = scan_tree()
+def do_write(tree: Tree) -> int:
+    inventory = scan_tree(tree)
     prose: dict[str, str] = {}
-    if REFERENCE.exists():
-        _, prose = parse_reference(REFERENCE.read_text(encoding="utf-8"))
-    REFERENCE.parent.mkdir(parents=True, exist_ok=True)
-    REFERENCE.write_text(render(inventory, prose), encoding="utf-8")
+    if tree.reference.exists():
+        _, prose = parse_reference(tree.reference.read_text(encoding="utf-8"))
+    tree.reference.parent.mkdir(parents=True, exist_ok=True)
+    tree.reference.write_text(render(inventory, prose), encoding="utf-8")
     missing = [c for c in sorted(inventory) if prose.get(c, "").strip() in ("", PLACEHOLDER)]
-    print(f"diagnostic-codes: wrote {REFERENCE.relative_to(REPO)} — {len(inventory)} codes.")
+    print(
+        f"diagnostic-codes: wrote {tree.reference.relative_to(tree.root)} — "
+        f"{len(inventory)} codes."
+    )
     if missing:
         print(
             f"diagnostic-codes: {len(missing)} still placeholder: {', '.join(missing)}"
@@ -640,8 +674,8 @@ def do_write() -> int:
     return 0
 
 
-def do_list() -> int:
-    inventory = scan_tree()
+def do_list(tree: Tree) -> int:
+    inventory = scan_tree(tree)
     print(
         json.dumps(
             {
@@ -660,17 +694,20 @@ def do_list() -> int:
     return 0
 
 
-def main() -> int:
-    mode = sys.argv[1] if len(sys.argv) > 1 else "check"
+def main(argv: list[str]) -> int:
+    mode = argv[1] if len(argv) > 1 else "check"
+    # An optional root, for the reason [`Tree`] gives. Absent, every mode reads
+    # the repository this script lives in.
+    tree = Tree(Path(argv[2]).resolve() if len(argv) > 2 else REPO)
     if mode == "check":
-        return do_check()
+        return do_check(tree)
     if mode == "write":
-        return do_write()
+        return do_write(tree)
     if mode == "list":
-        return do_list()
-    print(f"usage: {sys.argv[0]} check|write|list", file=sys.stderr)
+        return do_list(tree)
+    print(f"usage: {argv[0]} check|write|list [root]", file=sys.stderr)
     return 2
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv))

--- a/scripts/test-diagnostic-codes.sh
+++ b/scripts/test-diagnostic-codes.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# Tests for check-diagnostic-codes.sh — the registry that holds
+# docs/reference/diagnostics.md and website/content/docs/diagnostics.mdx to
+# the codes the tree actually emits (#2507, #3045, #4948).
+#
+#   ./scripts/test-diagnostic-codes.sh
+#
+# Not part of `make gate`: it builds throwaway fixture trees, the same posture
+# as scripts/test-website-inputs.sh.
+#
+# ── Why this suite exists ────────────────────────────────────────────────────
+#
+# The guard has six failure directions and had a self-test for none of them.
+# Every one is invisible when it stops working: a registry that has quietly
+# become incapable of failing prints the same green line as a healthy tree, and
+# the next undocumented code lands on top of it. #4947 widened what the guard
+# covers on four ablations run by hand in a pull-request body, which is a
+# session's evidence rather than a standing property.
+#
+# The green case is here for the opposite error: without it the suite would
+# prove only that the script can fail, which a `exit 1` would satisfy.
+#
+# ── The fixture ──────────────────────────────────────────────────────────────
+#
+# A tree with `crates/<name>/src/*.rs`, `docs/reference/diagnostics.md` and
+# `website/content/docs/diagnostics.mdx`, which is everything the guard reads.
+# The reference is GENERATED into the fixture by the script's own `write` mode
+# rather than pasted here: its header and facts-block format are the script's,
+# so a hand-written copy would make this suite fail on an unrelated edit to
+# either.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+GUARD="$repo_root/scripts/check-diagnostic-codes.sh"
+GENERATOR="$repo_root/scripts/diagnostic-codes.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# The prose each generated section gets, replacing the placeholder. One line,
+# so the substitution below is a line rewrite rather than a block edit.
+PROSE="Fixture prose, so the section is not the placeholder."
+
+# A fixture tree whose reference and website table both agree with its sources.
+# $1 = case name; echoes the tree root.
+#
+# Two codes, because several directions need one code left alone while another
+# is broken. `warn` and `error` differ, so a level swap is a real change.
+new_tree() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/crates/fixture-one/src" "$dir/website/content/docs"
+  cat >"$dir/crates/fixture-one/src/lib.rs" <<'EOF'
+pub fn slow(dx: &Dx) {
+    diag!(dx, warn, "fixture.thing.slow", elapsed_ms = 1);
+}
+
+pub fn broken(dx: &Dx) {
+    diag!(dx, error, "fixture.thing.broken");
+}
+EOF
+  write_website "$dir" '## Reading the codes' 'fixture.thing.slow' 'warn'
+  regenerate "$dir"
+  echo "$dir"
+}
+
+# The website page: an unrelated leading table (the real page has one, and the
+# anchor is what tells them apart), then the curated table under $2, naming
+# code $3 at level $4.
+write_website() {
+  local dir="$1" anchor="$2" code="$3" level="$4"
+  cat >"$dir/website/content/docs/diagnostics.mdx" <<EOF
+# Diagnostics
+
+| Plane | Where |
+| --- | --- |
+| records | the terminal |
+
+$anchor
+
+| Code | Level | What it means |
+| --- | --- | --- |
+| \`$code\` | $level | Something a reader arrived here about. |
+EOF
+}
+
+# Generate the reference from the fixture's sources, then write real prose into
+# every section — a section left as the placeholder is one of the directions
+# under test, so the healthy tree must not carry one.
+regenerate() {
+  local dir="$1"
+  python3 "$GENERATOR" write "$dir" >/dev/null
+  local ref="$dir/docs/reference/diagnostics.md"
+  sed "s/^_TODO: .*_\$/$PROSE/" "$ref" >"$ref.next" && mv "$ref.next" "$ref"
+}
+
+# want <name> <expect-pass|expect-fail> <tree> [substring]
+want() {
+  local name="$1" expect="$2" dir="$3" sub="${4:-}" out rc
+  out="$("$GUARD" "$dir" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ] && [ "$rc" -ne 0 ]; then
+    fail=$((fail + 1))
+    echo "FAIL $name — expected OK, got:"
+    echo "$out"
+    return
+  fi
+  if [ "$expect" = "expect-fail" ] && [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1))
+    echo "FAIL $name — the guard passed something it should have flagged:"
+    echo "$out"
+    return
+  fi
+  case "$out" in
+  *"$sub"*)
+    pass=$((pass + 1))
+    echo "ok   $name"
+    ;;
+  *)
+    fail=$((fail + 1))
+    echo "FAIL $name — verdict was right, report was not (wanted '$sub'):"
+    echo "$out"
+    ;;
+  esac
+}
+
+# ── The healthy tree ─────────────────────────────────────────────────────────
+#
+# Without this the suite would prove the script can fail and nothing else.
+t="$(new_tree clean)"
+want "D0 a tree whose reference and table both agree passes" \
+  expect-pass "$t" "check-diagnostic-codes: OK"
+
+# ── 1. A code emitted with no section in the reference ───────────────────────
+#
+# The direction the registry exists for: public surface shipping undocumented.
+t="$(new_tree undocumented)"
+cat >>"$t/crates/fixture-one/src/lib.rs" <<'EOF'
+
+pub fn fresh(dx: &Dx) {
+    diag!(dx, info, "fixture.thing.fresh");
+}
+EOF
+want "D1 a code with no section is flagged" \
+  expect-fail "$t" "\`fixture.thing.fresh\` is emitted"
+
+# ── 2. A section for a code nothing emits ────────────────────────────────────
+#
+# The other direction: a deleted emit site leaves its section behind, reading
+# as authority.
+t="$(new_tree orphan_section)"
+cat >>"$t/docs/reference/diagnostics.md" <<EOF
+
+### \`fixture.thing.retired\`
+
+$PROSE
+EOF
+want "D2 a section for a code nothing emits is flagged" \
+  expect-fail "$t" "which nothing emits any more"
+
+# ── 3. Two crates claiming one code ──────────────────────────────────────────
+#
+# A facet vocabulary has one owner (doc:diagnostics §5.1).
+t="$(new_tree two_owners)"
+mkdir -p "$t/crates/fixture-two/src"
+cat >"$t/crates/fixture-two/src/lib.rs" <<'EOF'
+pub fn also_slow(dx: &Dx) {
+    diag!(dx, warn, "fixture.thing.slow");
+}
+EOF
+want "D3 one code emitted by two crates is flagged" \
+  expect-fail "$t" "is emitted by more than one crate"
+
+# ── 4. A section whose prose is still the placeholder ────────────────────────
+#
+# A generated section with nothing written under it documents nothing; the
+# registry would otherwise count it as covered.
+t="$(new_tree placeholder)"
+sed "s/^$PROSE\$/_TODO: say what this code means and what to do about it._/" \
+  "$t/docs/reference/diagnostics.md" >"$t/ref.next" &&
+  mv "$t/ref.next" "$t/docs/reference/diagnostics.md"
+want "D4 a section still reading as the placeholder is flagged" \
+  expect-fail "$t" "is still the placeholder"
+
+# ── 5. Stale generated facts ─────────────────────────────────────────────────
+#
+# The facts block is generated from the emit site, so a hand-edit to it is a
+# claim about the tree that the tree does not make. Edited in the REFERENCE
+# rather than in the source, so this direction fires alone: moving the source's
+# level would also move the website table's answer and flag direction 6a too.
+t="$(new_tree stale_facts)"
+sed 's/^- \*\*Level:\*\* .*$/- **Level:** whatever a hand says/' \
+  "$t/docs/reference/diagnostics.md" >"$t/ref.next" &&
+  mv "$t/ref.next" "$t/docs/reference/diagnostics.md"
+want "D5 a hand-edited facts block is flagged as stale" \
+  expect-fail "$t" "generated facts are stale"
+
+# ── 6a. The website's level cell no longer matches the emit site ─────────────
+#
+# #3045's shape: the cell was transcribed by hand and read by no gate, so a
+# level change left the page confidently wrong with everything green.
+t="$(new_tree website_level)"
+write_website "$t" '## Reading the codes' 'fixture.thing.slow' 'info'
+want "D6a a website level cell the tree contradicts is flagged" \
+  expect-fail "$t" "the tree emits it at warn"
+
+# ── 6b. The website surfaces a code the tree no longer emits ─────────────────
+t="$(new_tree website_gone)"
+write_website "$t" '## Reading the codes' 'fixture.thing.gone' 'warn'
+want "D6b a website code nothing emits is flagged" \
+  expect-fail "$t" "documents \`fixture.thing.gone\`"
+
+# ── 6c. The anchor the table is located by is gone ───────────────────────────
+#
+# The arm that stops the guard going quiet when the page is restructured: a
+# guard that reports "nothing to check" is indistinguishable from one that
+# checked and found nothing.
+t="$(new_tree website_anchor)"
+write_website "$t" '## How to read a code' 'fixture.thing.slow' 'warn'
+want "D6c a renamed anchor is a failure, not a skip" \
+  expect-fail "$t" "cannot find the table"
+
+# ── 6d. The table under the anchor names no codes ────────────────────────────
+t="$(new_tree website_empty)"
+cat >"$t/website/content/docs/diagnostics.mdx" <<'EOF'
+# Diagnostics
+
+## Reading the codes
+
+A record's code is stable, versioned, public surface.
+EOF
+want "D6d an emptied table is a failure, not a skip" \
+  expect-fail "$t" "emptied or restructured"
+
+# ── The two files themselves ─────────────────────────────────────────────────
+#
+# Both fail closed. A registry whose reference has been deleted has documented
+# every code vacuously, which is the worst possible green.
+t="$(new_tree no_reference)"
+rm -f "$t/docs/reference/diagnostics.md"
+want "D7 a missing reference is a failure, not a skip" \
+  expect-fail "$t" "does not exist"
+
+t="$(new_tree no_website)"
+rm -f "$t/website/content/docs/diagnostics.mdx"
+want "D8 a missing website page is a failure, not a skip" \
+  expect-fail "$t" "if the page moved, move this check with it"
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #4948

## What was missing

`scripts/diagnostic-codes.py` is a gate step with six failure directions and a
self-test for none of them. Twenty-seven suites under `scripts/test-*.sh` exist
because a ratchet that has quietly become incapable of failing prints the same
green line as a healthy tree.

## The obstacle, and how it is removed

The script resolved everything from `__file__`:

```python
REPO = Path(__file__).resolve().parent.parent
CRATES = REPO / "crates"
REFERENCE = REPO / "docs" / "reference" / "diagnostics.md"
WEBSITE = REPO / "website" / "content" / "docs" / "diagnostics.mdx"
```

so it could only ever read its own repository. A frozen `Tree` dataclass replaces
those four globals with one root and three properties, threaded through
`scan_file`, `scan_tree`, `do_check`, `do_write` and `do_list`. Every mode takes
an optional root after it:

```
diagnostic-codes.py check /tmp/fixture
```

This is `check-tokens.py`'s recent change, for the same stated reason, as the
issue asked. `check-diagnostic-codes.sh` forwards `"$@"`, so the suite runs the
gate's own entry point rather than a paraphrase of it. No caller in the tree
passes a root; every one gets what it always got — verified below on the real
tree in all three modes.

## The suite

`scripts/test-diagnostic-codes.sh` builds a fixture tree per case: two crates,
`docs/reference/diagnostics.md`, and a `website/content/docs/diagnostics.mdx`
whose page opens with an unrelated table so the anchor is doing real work.

The reference is **generated into the fixture by the script's own `write` mode**
rather than pasted into the suite. Its header text and facts-block format belong
to the script, so a hand-written copy would make this suite fail on an unrelated
edit to either. Placeholder prose is then substituted out, because a placeholder
section is one of the directions under test.

Twelve cases — the six directions the issue names (direction 6 in its four
sub-arms), the two "the file is gone" arms, and the green case, which is there
for the opposite error: without it the suite would prove only that the script
can fail, which `exit 1` would satisfy.

```
$ make diagnostic-codes-test
ok   D0 a tree whose reference and table both agree passes
ok   D1 a code with no section is flagged
ok   D2 a section for a code nothing emits is flagged
ok   D3 one code emitted by two crates is flagged
ok   D4 a section still reading as the placeholder is flagged
ok   D5 a hand-edited facts block is flagged as stale
ok   D6a a website level cell the tree contradicts is flagged
ok   D6b a website code nothing emits is flagged
ok   D6c a renamed anchor is a failure, not a skip
ok   D6d an emptied table is a failure, not a skip
ok   D7 a missing reference is a failure, not a skip
ok   D8 a missing website page is a failure, not a skip

passed 12, failed 0
```

D5 edits the facts block in the **reference** rather than moving the level in the
source, so that direction fires alone: moving the source's level would also move
the website table's answer and flag D6a at the same time.

## Ablation 1 — the guard cannot fail

Clearing `report` just before it is read (`report = []`) in `do_check`. The green
case stays green and every failure direction goes red, so the ablation makes the
answer wrong rather than merely constant:

```
ok   D0 a tree whose reference and table both agree passes
FAIL D1 a code with no section is flagged — the guard passed something it should have flagged:
check-diagnostic-codes: OK — 3 codes emitted, all documented; 1 surfaced on the website carry the level the tree emits.
FAIL D2 a section for a code nothing emits is flagged — the guard passed something it should have flagged:
FAIL D3 one code emitted by two crates is flagged — the guard passed something it should have flagged:
FAIL D4 a section still reading as the placeholder is flagged — the guard passed something it should have flagged:
FAIL D5 a hand-edited facts block is flagged as stale — the guard passed something it should have flagged:
FAIL D6a a website level cell the tree contradicts is flagged — the guard passed something it should have flagged:
FAIL D6b a website code nothing emits is flagged — the guard passed something it should have flagged:
FAIL D6c a renamed anchor is a failure, not a skip — the guard passed something it should have flagged:
FAIL D6d an emptied table is a failure, not a skip — the guard passed something it should have flagged:
FAIL D7 a missing reference is a failure, not a skip — the guard passed something it should have flagged:
FAIL D8 a missing website page is a failure, not a skip — the guard passed something it should have flagged:

passed 1, failed 11
SUITE=1
```

Each `want` also matches the report substring, so a case cannot pass on the right
verdict reached for the wrong reason.

## Ablation 2 — the suite is unwired

Deleting the `guard-self-tests.yml` step, per the issue's constraint that
`check-gate-parity.sh` fails a suite hosted by no workflow:

```
$ make gate-parity
check-gate-parity: FAIL — no workflow runs the guard self-test 'scripts/test-diagnostic-codes.sh'.
check-gate-parity:      Add it to a workflow, or name it in UNHOSTED_SELF_TESTS in
check-gate-parity:      the Makefile with the reason it is excluded.
make: *** [gate-parity] Error 1
```

## The real tree is unchanged

```
$ python3 ./scripts/diagnostic-codes.py check
check-diagnostic-codes: OK — 46 codes emitted, all documented; 12 surfaced on the website carry the level the tree emits.

$ python3 ./scripts/diagnostic-codes.py write && git status --short docs/
diagnostic-codes: wrote docs/reference/diagnostics.md — 46 codes.
(no diff)

$ make guards-fast
EXIT=0

$ make shellcheck
EXIT=0
```

## Wiring

- `make diagnostic-codes-test` — a target beside `website-inputs-test`, excluded
  from `gate` like every other hermetic suite (it builds throwaway trees).
- `.github/workflows/guard-self-tests.yml` — one step, in the script's
  alphabetical place.
- `gate-parity` is satisfied: 48 gate steps, unchanged, and the new suite runs in
  a workflow.

Stdlib-only Python and bash 3.2 shell; no new dependency.

## Deleted tests

None. No `#[test]` was added, removed or renamed — this PR touches no Rust.

## Summary by Sourcery

Prove that the diagnostic-code registry guard detects inconsistencies by exercising it against isolated fixture trees and wiring the suite into CI.

New Features:
- Add a hermetic diagnostic-code registry self-test covering successful validation and all documented failure directions.

Bug Fixes:
- Make diagnostic-code checks fail closed when registry files, anchors, tables, or generated facts are missing or inconsistent.

Enhancements:
- Allow diagnostic-code commands and their shell wrapper to validate arbitrary fixture roots while preserving the repository-root default.

Build:
- Add a `make diagnostic-codes-test` target for the new hermetic suite.

CI:
- Run the diagnostic-code registry self-test in the guard self-tests workflow.

Tests:
- Add twelve fixture-based cases validating diagnostic-code registry consistency, failure reporting, and workflow wiring.