### PR TITLE
feat(design,scripts): every colour token declares what paints it (#4975)

### DIFF
--- a/design/tokens/stella-tokens.json
+++ b/design/tokens/stella-tokens.json
@@ -13,7 +13,38 @@
     "kind of colour it is -- and the warm-drift predicates reject the choice that",
     "kills a gold-on-black scheme. The predicates are defined once in",
     "crates/stella-tui-theme/src/clamp.rs and mirrored by scripts/check-tokens.py;",
-    "both are held to this file's `clamps` block below."
+    "both are held to this file's `clamps` block below.",
+    "",
+    "Every token also declares a `paint` posture, for the same reason and against a",
+    "different failure. `clamp` asks what KIND of colour this is; `paint` asks",
+    "WHETHER ANYTHING RENDERS IT. Nothing asked that until #4975, and `comment`",
+    "is what got through: a published token with a role sentence, a --st-comment",
+    "declaration on four surfaces, a COMMENT constant in the generated token.rs,",
+    "a row in the SPEC's palette table, three design renderings using its hex, a",
+    "row in the contrast ratchet -- and no call site anywhere. One of the sub-AA",
+    "pairings #4063 was deciding about was a colour no reader had ever seen. This",
+    "is AGENTS.md invariant #10 (`every emitted signal names its consumer`) pointed",
+    "at the palette, and crates/stella-protocol/src/event/consumers.rs is the shape",
+    "it copies: a declared posture per row, enforced from both sides.",
+    "",
+    "Two postures, and the guard checks each against the tree rather than trusting",
+    "it -- a declaration nothing verifies is what `comment`'s `role` field already",
+    "was:",
+    "",
+    "  \"paint\": \"painted\"          some hand-written surface names this token,",
+    "                              as var(--st-<css>) or as token::<rust>. The",
+    "                              sweep fails if it finds none.",
+    "  \"paint\": { \"gap\": \"#N\" }   nothing names it, and #N is where that is being",
+    "                              decided. The sweep fails if it finds a site --",
+    "                              a gap that has been closed must be redeclared,",
+    "                              not left standing.",
+    "",
+    "What the sweep can and cannot see is stated at check 4 in",
+    "scripts/check-tokens.py. The short version: it is a NAME sweep, not a render",
+    "trace. It cannot follow a value copied under another name, which is why the",
+    "eleven web stops below sit at `gap` while the site ships every one of their",
+    "values -- as literals under --stella-* rather than through var(--st-*). That",
+    "is #4978's subject and completing those sheets is what would paint them."
   ],
   "version": "5.1.0",
   "name": "stella black and gold",
@@ -115,7 +146,8 @@
       "css": "--st-bg",
       "rust": "BG",
       "role": "canvas",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "panel",
@@ -124,7 +156,8 @@
       "css": "--st-panel",
       "rust": "PANEL",
       "role": "panels, cards, code blocks",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "hl",
@@ -133,7 +166,8 @@
       "css": "--st-hl",
       "rust": "HL",
       "role": "selected and hover rows",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "border",
@@ -142,7 +176,8 @@
       "css": "--st-border",
       "rust": "BORDER",
       "role": "hairlines, dividers, unfilled meter track",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "rule",
@@ -151,7 +186,8 @@
       "css": "--st-rule",
       "rust": "RULE",
       "role": "section rules, turn boundaries",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "gold",
@@ -160,7 +196,8 @@
       "css": "--st-gold",
       "rust": "GOLD",
       "role": "the brand metal: actions, active states, money, the mark",
-      "surfaces": ["tui", "web-dark", "web-light", "asset"]
+      "surfaces": ["tui", "web-dark", "web-light", "asset"],
+      "paint": "painted"
     },
     {
       "name": "gold-bright",
@@ -169,7 +206,8 @@
       "css": "--st-gold-bright",
       "rust": "GOLD_BRIGHT",
       "role": "tiny live indicators only: spinner, hot marker, drift glyph",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "silver",
@@ -178,7 +216,8 @@
       "css": "--st-silver",
       "rust": "SILVER",
       "role": "secondary emphasis, incoming context, syntax strings",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "silver-type",
@@ -187,7 +226,8 @@
       "css": "--st-silver-type",
       "rust": "SILVER_TYPE",
       "role": "syntax types, tertiary labels",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "text",
@@ -196,7 +236,8 @@
       "css": "--st-text",
       "rust": "TEXT",
       "role": "primary text on dark, in the deck",
-      "surfaces": ["tui"]
+      "surfaces": ["tui"],
+      "paint": "painted"
     },
     {
       "name": "paper-text",
@@ -204,7 +245,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-text",
       "role": "primary text on dark, off the deck",
-      "surfaces": ["web-dark", "asset"]
+      "surfaces": ["web-dark", "asset"],
+      "paint": "painted"
     },
     {
       "name": "muted",
@@ -213,7 +255,8 @@
       "css": "--st-muted",
       "rust": "MUTED",
       "role": "secondary text",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "dim",
@@ -222,7 +265,8 @@
       "css": "--st-dim",
       "rust": "DIM",
       "role": "hints, captions, line numbers",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "green",
@@ -231,7 +275,8 @@
       "css": "--st-green",
       "rust": "GREEN",
       "role": "pass, additive diff sign",
-      "surfaces": ["tui", "web-dark", "web-light"]
+      "surfaces": ["tui", "web-dark", "web-light"],
+      "paint": "painted"
     },
     {
       "name": "red",
@@ -240,7 +285,8 @@
       "css": "--st-red",
       "rust": "RED",
       "role": "fail, destructive, removal diff sign",
-      "surfaces": ["tui", "web-dark", "web-light"]
+      "surfaces": ["tui", "web-dark", "web-light"],
+      "paint": "painted"
     },
     {
       "name": "diff-add-bg",
@@ -249,7 +295,8 @@
       "css": "--st-diff-add",
       "rust": "DIFF_ADD_BG",
       "role": "added diff row background",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": { "gap": "#4058" }
     },
     {
       "name": "diff-del-bg",
@@ -258,7 +305,8 @@
       "css": "--st-diff-del",
       "rust": "DIFF_DEL_BG",
       "role": "removed diff row background",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": { "gap": "#4058" }
     },
     {
       "name": "ink",
@@ -267,7 +315,8 @@
       "css": "--st-ink",
       "rust": "INK",
       "role": "primary text on light surfaces (web light mode only)",
-      "surfaces": ["web-light", "asset"]
+      "surfaces": ["web-light", "asset"],
+      "paint": "painted"
     },
     {
       "name": "paper",
@@ -276,7 +325,8 @@
       "css": "--st-paper",
       "rust": "PAPER",
       "role": "the warm light canvas",
-      "surfaces": ["web-light", "asset"]
+      "surfaces": ["web-light", "asset"],
+      "paint": "painted"
     },
     {
       "name": "paper-panel",
@@ -285,7 +335,8 @@
       "css": "--st-paper-panel",
       "rust": "PAPER_PANEL",
       "role": "light panel",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4058" }
     },
     {
       "name": "paper-border",
@@ -294,7 +345,8 @@
       "css": "--st-paper-border",
       "rust": "PAPER_BORDER",
       "role": "light border",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4058" }
     },
     {
       "$comment": [
@@ -320,7 +372,8 @@
       "clamp": "neutral-gray",
       "css": "--st-void",
       "role": "below the canvas: full-bleed backdrops",
-      "surfaces": ["web-dark"]
+      "surfaces": ["web-dark"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "gold-ink",
@@ -328,7 +381,8 @@
       "clamp": "resting-gold",
       "css": "--st-gold-ink",
       "role": "gold as TEXT on the light ground, where the metal cannot clear AA",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-ground",
@@ -336,7 +390,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-ground",
       "role": "the warm paper page ground, one step under the panel",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-raised",
@@ -344,7 +399,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-raised",
       "role": "light surface raised above the page ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-row",
@@ -352,7 +408,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-row",
       "role": "light hover and selected rows",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-seam",
@@ -360,7 +417,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-seam",
       "role": "light seam: the hairline under a border",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "ink-muted",
@@ -368,7 +426,8 @@
       "clamp": "warm-paper",
       "css": "--st-ink-muted",
       "role": "secondary text on light surfaces",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "green-ink",
@@ -376,7 +435,8 @@
       "clamp": "verdict",
       "css": "--st-green-ink",
       "role": "pass, as text on the light ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "amber",
@@ -384,7 +444,8 @@
       "clamp": "verdict",
       "css": "--st-amber",
       "role": "warning: the one status the core palette does not name",
-      "surfaces": ["web-dark"]
+      "surfaces": ["web-dark"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "amber-ink",
@@ -392,7 +453,8 @@
       "clamp": "verdict",
       "css": "--st-amber-ink",
       "role": "warning, as text on the light ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "red-ink",
@@ -400,7 +462,8 @@
       "clamp": "verdict",
       "css": "--st-red-ink",
       "role": "fail, as text on the light ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     }
   ],
   "banned": {

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Guard the colour system: no retired hex anywhere, no stray hex where it matters.
 
-Three checks, deliberately different in strength, because "never use this colour
-again", "use only tokens here" and "quote this token correctly" are different
-promises and only one of them can be made about the whole tree today.
+Four checks, different in strength, because "never use this colour
+again", "use only tokens here", "quote this token correctly" and "something
+renders this" are different promises and only one of them can be made about the
+whole tree today.
 
 1. **The ban.** Every hex in `banned.values` in the token JSON fails wherever it
    appears, in any tracked file. These are the anchor values of retired brand
@@ -42,6 +43,27 @@ promises and only one of them can be made about the whole tree today.
    document names an `--st-*` token, so a marketing surface keeping its own
    accent and status hues under its own variable names is untouched. That is the
    line #2594 drew, and this check does not cross it.
+
+4. **Paint.** Every token declares a `paint` posture in the token JSON, and this
+   is what holds the declaration to the tree, in **both** directions: a
+   `"painted"` token with no site fails, and a `{ "gap": "#N" }` token with a
+   site fails too. See `paint_report` for what the sweep can and cannot see.
+
+   Checks 1-3 are all about a *value*; none of them can ask whether anything
+   renders it. That is how `comment` survived (#4946): a published token with a
+   role sentence, a `--st-comment` declaration on four surfaces, a `COMMENT`
+   constant in the generated `token.rs`, three design renderings using its hex
+   and a row in `scripts/contrast-baseline.txt` -- so one of the sub-AA pairings
+   #4063 was deciding about was a colour no reader had ever seen. Every check
+   above passed it, because every value involved was live.
+
+   This is AGENTS.md rule #10 pointed at the palette, and
+   `crates/stella-protocol/src/event/consumers.rs` is the shape it copies. The
+   difference is what enforces totality: `consumers.rs` gets it from the
+   compiler over an enum, and a colour's consumers are spread across Rust, four
+   stylesheets, HTML and SVG, so "is it painted?" is a text question. The door
+   is `scripts/gen-tokens.py`'s `check_paint`, which refuses a token with no
+   posture; this is the half that refuses a posture that is not true.
 
 `MIGRATING` is the one escape, and it is a ledger, not an allowlist: a path
 listed there is a surface this system has not reached yet, each entry carrying
@@ -207,6 +229,121 @@ TEXT_SUFFIXES = {
 }
 
 
+# Files whose reference to a token cannot tell a painted one from an unpainted
+# one, so check 4 does not read them.
+#
+# The generated artifacts are here for the obvious reason: they are emitted from
+# the token table, so they name every token by construction and would make the
+# sweep vacuously green.
+#
+# `fallback.rs` is here for a subtler version of the same reason, and it is the
+# entry that decides whether this check means anything. `ansi16` is **total over
+# `token::ALL`** -- `every_token_has_a_fallback` is the test that keeps it that
+# way -- so it names all twenty terminal tokens whether or not a cell ever takes
+# one. Counting it would have passed six tokens nothing paints, four of them
+# under values the deck does not even use (`theme::DIFF_ADD_BG` is `#1B2921`
+# where `token::DIFF_ADD_BG` is `#10201A`).
+#
+# An **alias** is NOT excluded: `pub const TEXT_EMPHASIS: Color =
+# token::SILVER_TYPE;` counts as a site. Resolving an alias down to a cell needs
+# transitive analysis this sweep does not do, and the claim it makes is
+# correspondingly bounded -- see `paint_report`.
+PAINT_BLIND = (
+    "design/tokens/stella-tokens.json",
+    "design/tokens/stella-tokens.css",
+    "crates/stella-tui-theme/src/token.rs",
+    "crates/stella-tui-theme/src/fallback.rs",
+    "scripts/gen-tokens.py",
+    "scripts/check-tokens.py",
+)
+
+# A token being *used*, in the two notations this tree writes. A declaration --
+# `--st-bg: #0A0A0C` in a mirrored stylesheet -- is not one of them:
+# `comment` had four of those and no reader ever saw the colour.
+VAR_USE = re.compile(r"var\(\s*(--st-[a-z0-9-]+)")
+RUST_USE = re.compile(r"\btoken::([A-Z][A-Z0-9_]*)\b")
+
+# How many example sites a failure prints before it stops.
+PAINT_EXAMPLES = 3
+
+
+def paint_report(root: Path, doc: dict, files: list[Path]) -> list[str]:
+    """Hold every token's `paint` posture to the tree. Returns the failures.
+
+    **What this sees.** One `var(--st-<name>)` or `token::<RUST>` outside
+    `PAINT_BLIND`, anywhere in a tracked text file. That is a NAME sweep, not a
+    render trace. A guard whose reach is guessed at is a guard that gets
+    trusted past it, so the bound is:
+
+    - It cannot follow a **value copied under another name**. The site ships
+      every one of the eleven web-only stops as a literal under `--stella-*`
+      rather than through `var(--st-*)`, so they read as gaps here and are
+      declared as gaps -- with #4978, where completing those sheets is being
+      decided, as the citation. The posture records the mechanism, not the
+      pixel.
+    - It cannot follow an **alias chain** to a cell, so an alias counts as a
+      site (see `PAINT_BLIND`).
+    - It does not care whether the site is production or a test. No token in
+      this tree is named only by tests, so no verdict here turns on that; if one
+      ever is, this is the sentence that has to change rather than a number.
+    - **Prose counts.** A doc comment writing `token::DIFF_ADD_BG` is a site as
+      far as this is concerned. That makes `painted` fractionally easier to
+      satisfy and can make a real `gap` read as stale -- the loud direction,
+      which names the file and line and is fixed by moving the sentence or
+      declaring the token painted. A structural fix means parsing Rust and CSS,
+      which is a language server rather than a guard.
+
+    **Which files.** `tracked_files` -- `git ls-files --cached --others
+    --exclude-standard` -- so an un-ignored file in a working tree counts even
+    before it is committed. Deliberate, and the same enumeration the three
+    checks above take since #4960: a file that is neither ignored nor committed
+    is still a file a `git add -A` will publish, and this check found exactly
+    that case on its own PR. The cost is that a developer's un-ignored scratch
+    note mentioning a token can turn their local run red; the failure names the
+    path, and the answer is an ignore rule.
+
+    What it does answer is exactly the question `comment` failed: does any
+    hand-written surface name this token at all?
+    """
+    used: dict[str, list[str]] = {}
+    for rel in files:
+        posix = rel.as_posix()
+        if rel.suffix not in TEXT_SUFFIXES or posix in PAINT_BLIND:
+            continue
+        try:
+            text = (root / rel).read_text(errors="ignore")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for match in VAR_USE.finditer(line):
+                used.setdefault(match.group(1), []).append(f"{posix}:{lineno}")
+            for match in RUST_USE.finditer(line):
+                used.setdefault(match.group(1), []).append(f"{posix}:{lineno}")
+
+    failures: list[str] = []
+    for tok in doc["tokens"]:
+        sites = list(used.get(tok["css"], []))
+        if tok.get("rust"):
+            sites += used.get(tok["rust"], [])
+        paint = tok.get("paint")
+        if paint == "painted" and not sites:
+            failures.append(
+                f"{tok['name']}: declares `painted`, and nothing in the tree "
+                f"names {tok['css']} or token::{tok.get('rust', '-')}. Paint it, "
+                f"retire it, or declare the gap with the issue where that is "
+                f"being decided"
+            )
+        elif isinstance(paint, dict) and sites:
+            shown = ", ".join(sites[:PAINT_EXAMPLES])
+            more = f" (+{len(sites) - PAINT_EXAMPLES} more)" if len(sites) > PAINT_EXAMPLES else ""
+            failures.append(
+                f"{tok['name']}: declares a gap citing {paint['gap']}, but "
+                f"{len(sites)} site(s) name it: {shown}{more}. A gap that has "
+                f"been closed is redeclared as `painted`, not left standing"
+            )
+    return failures
+
+
 def tracked_files(root: Path) -> list[Path]:
     out = subprocess.run(
         ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
@@ -246,7 +383,10 @@ def main(argv: list[str]) -> int:
         seen.add((posix, lineno, hexv))
         ban_hits.append(hit)
 
-    for rel in tracked_files(root):
+    files = tracked_files(root)
+    paint_hits = paint_report(root, doc, files)
+
+    for rel in files:
         posix = rel.as_posix()
         if rel.suffix not in TEXT_SUFFIXES:
             continue
@@ -356,15 +496,33 @@ def main(argv: list[str]) -> int:
             "naming the token.",
             file=sys.stderr,
         )
+    if paint_hits:
+        failed = True
+        print(
+            f"\n{len(paint_hits)} token(s) declare a `paint` posture the tree "
+            "does not bear out:\n",
+            file=sys.stderr,
+        )
+        for hit in paint_hits:
+            print(f"  {hit}", file=sys.stderr)
+        print(
+            "\n`paint` is declared per token in design/tokens/stella-tokens.json "
+            "and is the answer to \"what renders this?\" — the question nothing "
+            "asked when `comment` shipped unpainted (#4975).",
+            file=sys.stderr,
+        )
 
     if failed:
         return 1
 
     scope = len(TOKEN_ONLY)
     pending = f", {len(MIGRATING)} path(s) still migrating" if MIGRATING else ""
+    painted = sum(1 for t in doc["tokens"] if t.get("paint") == "painted")
+    gaps = len(doc["tokens"]) - painted
     print(
         f"tokens: no retired hex in the tree; {scope} token-only path(s) clean; "
-        f"{citations_ok} token citation(s) quote the palette{pending}"
+        f"{citations_ok} token citation(s) quote the palette; {painted} token(s) "
+        f"painted, {gaps} declared gap(s){pending}"
     )
     return 0
 

--- a/scripts/gen-tokens.py
+++ b/scripts/gen-tokens.py
@@ -13,15 +13,23 @@ sentence was the only thing left true -- website/src/app/tokens.css sat on the
 v1.0 ramp through the whole life of the v4.0 rebrand while still claiming to
 mirror the kit. A comment cannot hold a shared cell; a generator and a diff can.
 
+Every token also declares a `paint` posture -- whether anything renders it --
+and `check_paint` below is the door that refuses a token with no answer. The
+posture is held to the tree by `check-tokens.py`'s check 4; see #4975 and the
+`$comment` header in the token file for why the palette needs the same
+discipline AGENTS.md rule #10 applies to events.
+
 Usage:
     scripts/gen-tokens.py            # write the generated files
     scripts/gen-tokens.py --check    # fail if any is stale (gate step)
+    scripts/gen-tokens.py --check R  # ...against the tree rooted at R
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -197,8 +205,53 @@ def rust_tokens(doc: dict) -> list[dict]:
     return [tok for tok in doc["tokens"] if tok.get("rust")]
 
 
+ISSUE = re.compile(r"^#\d+$")
+
+
+def check_paint(name: str, paint: object) -> str | None:
+    """Return an error string if `paint` is not a well-formed posture.
+
+    This is the *door*: it asks whether somebody answered "what paints this?",
+    not whether the answer is true. `check-tokens.py`'s check 4 is what holds
+    the answer to the tree, from both sides.
+
+    Separated for the same reason `clamp` is a declaration and not an
+    inference: inference is what lets a warm hex in under a cool name, and a
+    default posture is what would have let `comment` in under `painted`
+    (#4975).
+    """
+    if paint is None:
+        return (
+            f"{name}: no `paint` posture. Declare `\"paint\": \"painted\"` if a "
+            f"surface names this token, or `\"paint\": {{ \"gap\": \"#N\" }}` "
+            f"citing the issue where that is being decided"
+        )
+    if isinstance(paint, str):
+        if paint != "painted":
+            return f"{name}: `paint` is {paint!r}; the only string posture is \"painted\""
+        return None
+    if isinstance(paint, dict):
+        if set(paint) != {"gap"}:
+            return (
+                f"{name}: a gap posture is exactly {{ \"gap\": \"#N\" }}; got keys "
+                f"{sorted(paint)}"
+            )
+        issue = paint["gap"]
+        if not isinstance(issue, str) or not ISSUE.match(issue):
+            return (
+                f"{name}: `paint.gap` is {issue!r}; it must cite an issue as "
+                f'"#1234". A gap with no issue is the silence this field exists '
+                f"to refuse"
+            )
+        return None
+    return f"{name}: `paint` must be a string or an object, not {type(paint).__name__}"
+
+
 def validate(doc: dict) -> list[str]:
-    """Every token against its declared clamp. Returns the failures."""
+    """Every token against its declared clamp and paint posture.
+
+    Returns the failures.
+    """
     errors: list[str] = []
     clamps = doc["clamps"]
     seen: dict[str, str] = {}
@@ -211,6 +264,9 @@ def validate(doc: dict) -> list[str]:
             errors.append(f"{tok['name']}: clamp {clamp!r} is not declared in `clamps`")
             continue
         err = check_clamp(tok["name"], tok["hex"], clamp, clamps[clamp], anchors)
+        if err:
+            errors.append(err)
+        err = check_paint(tok["name"], tok.get("paint"))
         if err:
             errors.append(err)
         # A hex used twice under two names is how a role quietly loses meaning.
@@ -412,9 +468,21 @@ def main() -> int:
         action="store_true",
         help="fail if a generated file is stale instead of writing it",
     )
+    # A root argument is what lets `scripts/test-tokens.sh` point the validator
+    # at a fixture tree, the same reason `check-tokens.py` takes one: a door
+    # nobody can show refusing anything is a door nobody knows is shut. With no
+    # argument it reads its own repository, as every caller does today.
+    ap.add_argument(
+        "root",
+        nargs="?",
+        type=Path,
+        default=REPO,
+        help="repository root to read and write (default: this one)",
+    )
     args = ap.parse_args()
 
-    doc = json.loads(TOKENS.read_text())
+    root = args.root.resolve()
+    doc = json.loads((root / TOKENS.relative_to(REPO)).read_text())
 
     errors = validate(doc)
     if errors:
@@ -427,7 +495,7 @@ def main() -> int:
 
     stale: list[Path] = []
     for rel, content in outputs.items():
-        path = REPO / rel
+        path = root / rel
         if args.check:
             if not path.exists() or path.read_text() != content:
                 stale.append(rel)

--- a/scripts/test-tokens.sh
+++ b/scripts/test-tokens.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Tests for check-tokens.py's BAN CHECK, over every notation it claims to
-# watch (#4910), and for its CITATION CHECK, whose subject is a pair (#3653).
+# watch (#4910), for its CITATION CHECK, whose subject is a pair (#3653), and
+# for its PAINT CHECK, whose subject is an absence (#4975).
 #
 #   ./scripts/test-tokens.sh    (or: make tokens-test)
 #
@@ -39,6 +40,14 @@
 # value that is some other token's: that value is live, so it passes a
 # membership test while saying something false. A name quoted at a value the
 # palette has moved past is the other failure mode, and looks nothing like it.
+#
+# The paint cases earn theirs because that check's subject is an ABSENCE, and
+# every other check here is about something present. A token nothing paints is
+# a value that is live, correctly quoted, and inside no token-only path -- so
+# all three older checks pass it, which is exactly what happened to `comment`
+# (#4946, #4975). Both directions get a case: a `painted` declaration with no
+# site must fail, and a `gap` declaration that has since acquired one must fail
+# too, or the ledger records a hole somebody already filled.
 #
 # Every fixture below reads its colours out of the real token file at run time,
 # citation fixtures included — which is why this file is in neither `SELF` nor
@@ -134,30 +143,60 @@ else:
 # A throwaway git repository holding the real token file plus one source file.
 # Real git, because the script discovers its inputs with `git ls-files` and a
 # fixture that stubbed that would be testing a path nothing runs.
-# $1 = case name, $2 = file path within the root, $3 = file contents.
+#
+# The token file arrives with every `paint` posture rewritten to a gap. A
+# fixture tree holds one source file, so it paints nothing, and the real file's
+# seventeen `painted` declarations would fail check 4 in every case below --
+# turning a suite about the ban and the citation into a suite about the paint
+# sweep. Values, names and the ban list are copied untouched, which is what the
+# other three checks read. The paint cases rewrite the posture they are about
+# and read the token names out of the same file, so nothing here is typed.
+#
+# $1 = case name, $2 = file path within the root, $3 = file contents,
+# $4 = optional `name=posture` (posture is `painted`, else an issue for a gap).
 new_root() {
   local dir="$TMP/$1"
   mkdir -p "$dir/design/tokens" "$dir/$(dirname "$2")"
-  cp "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL"
+  python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+override = sys.argv[3]
+name, _, posture = override.partition('=')
+for tok in doc['tokens']:
+    if 'name' not in tok:
+        continue
+    if tok['name'] == name:
+        tok['paint'] = 'painted' if posture == 'painted' else {'gap': posture}
+    else:
+        tok['paint'] = {'gap': '#4975'}
+open(sys.argv[2], 'w').write(json.dumps(doc, indent=2))
+" "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL" "${4:-}"
   printf '%s\n' "$3" >"$dir/$2"
   git -C "$dir" init -q 2>/dev/null
   git -C "$dir" add -A 2>/dev/null
   echo "$dir"
 }
 
-# want <name> <expect-pass|expect-ban|expect-fail> <file> <contents> [substring]
+# want <name> <expect-pass|expect-ban|expect-fail|expect-absent> <file>
+#      <contents> [substring] [token=posture]
 #
 # `expect-ban` and `expect-fail` are the same assertion — a non-zero exit — and
 # both spellings exist because a misquote is not a ban and calling it one at the
 # call site would read as a mistake.
 #
+# `expect-absent` is that assertion minus one clause: the paint check's subject
+# is a token nothing names, and an absence has no file to name. Every other
+# failure here is a value sitting at a line, so those must report where.
+#
 # The optional substring is checked on BOTH verdicts. On a failure it pins which
 # value was named and in what words; on a pass it pins what the run reported,
 # without which a guard that passed by scanning nothing satisfies the case.
+#
+# The optional `token=posture` is the paint cases' subject; see `new_root`.
 want() {
-  local name="$1" expect="$2" file="$3" contents="$4" sub="${5:-}"
+  local name="$1" expect="$2" file="$3" contents="$4" sub="${5:-}" paint="${6:-}"
   local root out rc
-  root="$(new_root "$(echo "$name" | tr ' /' '__')" "$file" "$contents")"
+  root="$(new_root "$(echo "$name" | tr ' /' '__')" "$file" "$contents" "$paint")"
   out="$(python3 "$SCRIPT" "$root" 2>&1)"
   rc=$?
   if [ "$expect" = "expect-pass" ]; then
@@ -176,17 +215,20 @@ want() {
     return
   fi
   # Naming the file is half the guard: an exit code alone sends a reader
-  # hunting through the tree for a colour the script already located.
-  case "$out" in
-  *"$file"*) ;;
-  *)
-    bad "$name — caught it but did not name $file: $out"
-    return
-    ;;
-  esac
+  # hunting through the tree for a colour the script already located. An
+  # absence is the one finding with nowhere to point.
+  if [ "$expect" != "expect-absent" ]; then
+    case "$out" in
+    *"$file"*) ;;
+    *)
+      bad "$name — caught it but did not name $file: $out"
+      return
+      ;;
+    esac
+  fi
   case "$out" in
   *"$sub"*) ok "$name" ;;
-  *) bad "$name — named $file but not '$sub': $out" ;;
+  *) bad "$name — caught it but did not report '$sub': $out" ;;
   esac
 }
 
@@ -338,6 +380,102 @@ want "SELF suppresses the ban and not the citation check" expect-fail \
 want "a stray hex in a token-only path is flagged" expect-fail \
   "docs/brand/css/tokens.css" "  --custom: $WRONG_HEX;" \
   "is not a token in"
+
+echo ""
+echo "check-tokens paint check:"
+
+# The subject of every case below: one token that carries both notations, read
+# out of the real file so a rename cannot leave these cases testing nothing.
+eval "$(python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+for t in doc['tokens']:
+    if t.get('rust'):
+        print('P_NAME=%s' % t['name'])
+        print('P_CSS=%s' % t['css'])
+        print('P_RUST=%s' % t['rust'])
+        break
+else:
+    raise SystemExit('no token declares a rust name')
+" "$repo_root/$TOKENS_REL")"
+
+# The failure this check exists for, and the one every other check here passes:
+# a token declared `painted` that nothing in the tree names. `comment` shipped
+# in exactly this state — a live value, correctly quoted, in no token-only path.
+want "a painted token nothing names is caught" expect-absent \
+  "website/src/app/page.tsx" "const x = 1;" \
+  "$P_NAME: declares \`painted\`, and nothing in the tree names $P_CSS" \
+  "$P_NAME=painted"
+
+# The other direction, and the half a one-sided check would miss: a gap that
+# somebody has since closed. Left standing, the ledger records a hole that is
+# not there any more, and the next reader trusts it.
+want "a gap the tree has closed is caught" expect-fail \
+  "website/src/app/globals.css" "  color: var($P_CSS);" \
+  "declares a gap citing #4975, but 1 site(s) name it" \
+  "$P_NAME=#4975"
+
+# Both notations satisfy a `painted` declaration. Two cases rather than one,
+# because a matcher that only sees CSS looks exactly like a clean tree on the
+# Rust side — the shape #4910 found one check over.
+want "a var() use satisfies a painted declaration" expect-pass \
+  "website/src/app/globals.css" "  color: var($P_CSS);" \
+  "1 token(s) painted" \
+  "$P_NAME=painted"
+
+want "a token:: use satisfies a painted declaration" expect-pass \
+  "crates/stella-tui/src/views/session.rs" \
+  "let s = Style::new().fg(token::$P_RUST);" \
+  "1 token(s) painted" \
+  "$P_NAME=painted"
+
+# A **declaration** is not a paint. This is the distinction the whole check
+# turns on: `comment` had four of these across four surfaces and no reader ever
+# saw the colour, so a mirrored stylesheet binding the name must not count.
+want "a declaration in a mirror sheet is not a paint" expect-absent \
+  "docs/brand/css/tokens.css" "  $P_CSS: $LIVE_HEX;" \
+  "declares \`painted\`, and nothing in the tree names $P_CSS" \
+  "$P_NAME=painted"
+
+# `fallback.rs` names every terminal token by construction — `ansi16` is total
+# over `token::ALL` — so counting it would pass six tokens nothing paints.
+want "fallback.rs's total map does not count as a paint" expect-absent \
+  "crates/stella-tui-theme/src/fallback.rs" \
+  "        token::$P_RUST => Color::Black," \
+  "declares \`painted\`, and nothing in the tree names $P_CSS" \
+  "$P_NAME=painted"
+
+# The door, in gen-tokens.py rather than here: a token with no posture at all.
+# Checked through the generator because that is what refuses it, and a suite
+# that only tested the sweep would leave the door untested.
+paint_root="$(new_root "no_posture" "website/src/app/page.tsx" "const x = 1;")"
+python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+for tok in doc['tokens']:
+    tok.pop('paint', None)
+open(sys.argv[1], 'w').write(json.dumps(doc, indent=2))
+" "$paint_root/$TOKENS_REL"
+out="$(python3 "$repo_root/scripts/gen-tokens.py" --check "$paint_root" 2>&1)"
+rc=$?
+case "$rc:$out" in
+0:*) bad "a token with no \`paint\` posture was accepted: $out" ;;
+*"no \`paint\` posture"*) ok "a token with no posture is refused at the door" ;;
+*) bad "refused with the wrong message: $out" ;;
+esac
+
+# A gap with no issue is the silence the field exists to refuse. `{"gap": ""}`
+# and `{"gap": "later"}` are both a token nobody has to explain, which is the
+# state `comment` was in for its whole life.
+gap_root="$(new_root "empty_gap" "website/src/app/page.tsx" "const x = 1;" \
+  "$P_NAME=later")"
+out="$(python3 "$repo_root/scripts/gen-tokens.py" --check "$gap_root" 2>&1)"
+rc=$?
+case "$rc:$out" in
+0:*) bad "a gap citing no issue was accepted: $out" ;;
+*"must cite an issue"*) ok "a gap that cites no issue is refused at the door" ;;
+*) bad "refused with the wrong message: $out" ;;
+esac
 
 echo ""
 echo "check-tokens, the real tree:"


### PR DESCRIPTION
## What

Every colour token now declares **what paints it**, and both halves of that claim are enforced.

Closes #4975
Refs #4946, #4063, #2701, #4058, #4978

`design/tokens/stella-tokens.json` declared a value, a clamp, a CSS name, a Rust name, a role sentence and a surface list per token — and not whether anything renders it. That is how `comment` shipped: a live value, a `--st-comment` declaration on four surfaces, a `COMMENT` constant in the generated `token.rs`, a SPEC row, three design renderings using its hex and a row in `scripts/contrast-baseline.txt`. Every colour check in the tree passed it, because every value involved was live. One of the sub-AA pairings #4063 is deciding about was a colour no reader had ever seen.

This is AGENTS.md rule #10 — *every emitted signal names its consumer* — pointed at the palette, with `crates/stella-protocol/src/event/consumers.rs` as the exemplar the issue names.

### The door (`scripts/gen-tokens.py::check_paint`) — the issue's steps 1 and 2

```json
"paint": "painted"          // a surface names this token
"paint": { "gap": "#N" }    // nothing does, and #N is where that is decided
```

A token with no posture, an unknown posture, or a gap citing no issue fails validation. This is the same door the `clamp` field already is, for the reason the JSON's header gives about `clamp`: inference is what lets a warm hex in under a cool name, and a *default* posture is what would have let `comment` in under `painted`.

### The sweep (`scripts/check-tokens.py`, check 4) — the issue's step 3

Holds the declaration to the tree in **both** directions:

- `painted` with no `var(--st-<name>)` and no `token::<RUST>` anywhere → fails.
- `{ "gap": "#N" }` with a site → fails. A hole somebody has already filled must be redeclared, not left standing for the next reader to trust.

## What the sweep found: 17 painted, 15 gaps — four of them new

| tokens | citation | why |
|---|---|---|
| `diff-add-bg`, `diff-del-bg`, `paper-panel`, `paper-border` | **#4058** | The deck paints its **own values**. `theme::DIFF_ADD_BG` is `#1B2921`; `token::DIFF_ADD_BG` is `#10201A`. A second `comment` — published, and rendered by nothing. |
| `void`, `gold-ink`, `paper-ground`, `paper-raised`, `paper-row`, `paper-seam`, `ink-muted`, `green-ink`, `amber`, `amber-ink`, `red-ink` | **#4978** | The site ships every one of these values, as a literal under `--stella-*` rather than through `var(--st-*)`. Completing the two hand-mirrored sheets is what would paint them by name. |

The four `#4058` findings are new and were not in the issue. I have commented on #4058 with the measured divergence rather than filing a duplicate — that issue is *"the terminal UI still hard-codes its own colors … instead of using the shared design tokens (Phase 2 of the color alignment)"*, which is exactly this.

## What the sweep can and cannot see

Stated at `paint_report` rather than left to be guessed at. It is a **name** sweep, not a render trace:

- It cannot follow a **value copied under another name** — hence the eleven `#4978` gaps, whose colours a reader does see.
- It cannot follow an **alias chain** to a cell, so an alias (`pub const TEXT_EMPHASIS: Color = token::SILVER_TYPE;`) counts as a site.
- It does not distinguish production from test sites. No token in this tree is named only by tests, so no verdict here turns on that; if one ever is, that sentence has to change rather than a number.

`crates/stella-tui-theme/src/fallback.rs` is excluded, and **that exclusion is what makes the check mean anything**: `ansi16` is total over `token::ALL` (kept so by `every_token_has_a_fallback`), so it names all twenty terminal tokens whether or not a cell takes one. Counting it would have passed six of the fifteen gaps.

## Witness

**A1 — reintroduce `comment` exactly as it shipped**, declared `painted` the way an author who had not looked would declare it (the token re-added, its hex unbanned, artifacts regenerated):

```
$ python3 scripts/check-tokens.py                     # this branch
1 token(s) declare a `paint` posture the tree does not bear out:

  comment: declares `painted`, and nothing in the tree names --st-comment or token::COMMENT.
  Paint it, retire it, or declare the gap with the issue where that is being decided

rc=1
```

**The control, on the same ablated tree** — `origin/main`'s guard, unchanged:

```
$ git show origin/main:scripts/check-tokens.py > /tmp/check-tokens-main.py
$ python3 /tmp/check-tokens-main.py .
tokens: no retired hex in the tree; 3 token-only path(s) clean; 138 token citation(s) quote the palette
rc=0
```

Fails on new, passes on old, and the answer is *wrong* on old rather than merely absent: the old guard affirmatively reports a clean palette while carrying the exact token this work exists to catch.

**A2 — close a gap and leave the declaration standing** (`--stella-void: var(--st-void)` in the site sheet):

```
void: declares a gap citing #4978, but 1 site(s) name it: website/src/app/tokens.css:128.
A gap that has been closed is redeclared as `painted`, not left standing
```

**Unablated**: `tokens: no retired hex in the tree; 3 token-only path(s) clean; 137 token citation(s) quote the palette; 17 token(s) painted, 15 declared gap(s)`

## Hermetic suite

`scripts/test-tokens.sh` (already wired into `guard-self-tests.yml`) gains eight cases: both sweep directions, both notations, a mirror-sheet **declaration** (not a paint — the distinction the whole check turns on, since `comment` had four of those), `fallback.rs`'s total map (not a paint), a token with no posture, and a gap citing no issue.

```
29 passed, 0 failed
```

`gen-tokens.py` gains a root argument for the same reason `check-tokens.py` already has one: a door nobody can point at a fixture tree is a door nobody can show refusing anything. `new_root` rewrites every fixture posture to a gap, because a fixture tree holds one file and paints nothing — stated at the helper, values and ban list copied untouched.

## Which files the sweep enumerates — decided, not inherited

`tracked_files` is `git ls-files --cached --others --exclude-standard`, the enumeration #4960 widened the other three checks in this file to. **Kept, deliberately.** A file that is neither ignored nor committed is still a file a `git add -A` publishes, and this check found exactly that case on this PR's own first push: a scratch commit-message file that happened to contain `token::DIFF_ADD_BG`, which is declared as a gap.

The cost is real and is stated at `paint_report`: a developer's un-ignored scratch note mentioning a token can turn their local `make tokens` red. The failure names the path and line, and the answer is an ignore rule. The alternative — `--cached` only — would make the guard blind to precisely the diff a PR is about to create, which is the shape of blindness `comment` already exploited once.

Related: that scratch file reached the branch because `.gitignore` carries `*.tmp` and the file was `.tmp-msg.txt`, which matches no pattern, and `no-scratch` only fails on a tracked file that *matches* an ignore rule. Filed as **#4996** with the fix and the open question about untracked files. It is removed from this branch.

**Prose counts as a paint site.** A doc comment writing `token::DIFF_ADD_BG` satisfies the sweep. That makes `painted` fractionally easier to claim and can make a real gap read as stale — the loud direction. A structural fix means parsing Rust and CSS, which is a language server rather than a guard. Stated at `paint_report` rather than left to be discovered.

## Notes

- **No generated artifact changes.** `paint` is metadata about consumption, not a value, so `gen-tokens.py --check` stays green with no regeneration and `token.rs` / `stella-tokens.css` are byte-identical.
- **No baseline touched, no gate step added.** The issue's DoD asks for `make tokens`, and both halves run there.
- No test deleted.

## Summary by Sourcery

Make colour-token consumption explicit and enforce that each painted claim or issue-backed gap matches the usages present in the repository.

New Features:
- Require every colour token to declare whether it is painted or tracked as an issue-backed gap.
- Add bidirectional validation that painted tokens have usage sites and declared gaps have none.
- Support repository-root fixtures for token validation and expand hermetic coverage of paint posture and usage checks.

Bug Fixes:
- Prevent unused colour tokens from appearing valid merely because their values, declarations, or generated artifacts are present.
- Detect gap declarations that have already acquired real CSS or Rust usage sites.

Enhancements:
- Document the bounded, name-based paint sweep and exclude generated or total fallback mappings that cannot prove rendering.
- Include paint coverage counts and actionable diagnostics in token-check output.

Tests:
- Expand token self-tests to cover both paint-check directions, CSS and Rust usage, mirror declarations, fallback mappings, missing postures, and invalid gap citations.
