### PR TITLE
feat(scripts): catch an edit undone inside a branch before a rebase replays it

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -218,6 +218,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-releases-published.sh
 
+      - name: rebase-replay guard directions, and the hazard itself
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-rebase-replay.sh
+
       - name: the shellcheck step's presence guard
         if: ${{ !cancelled() }}
         run: ./scripts/test-shellcheck-guard.sh

--- a/.github/workflows/rebase-replay.yml
+++ b/.github/workflows/rebase-replay.yml
@@ -1,0 +1,51 @@
+name: rebase-replay
+
+# The one question about a branch's HISTORY rather than its tree (#4979).
+#
+# A branch that edits a file and later undoes the edit has an empty diff for
+# that path, so it reads as never having touched it. Rebase it onto a base that
+# already carries the same edit — which a mechanical sweep split across several
+# pull requests produces by construction — and git drops the branch's copy
+# ("skipped previously applied commit") while keeping the undo. The inert pair
+# becomes a live revert of whatever landed upstream, and it merges cleanly.
+#
+# Its own workflow rather than a step in ci.yml, for the reason wire-schema.yml
+# has one: ci.yml's guards job checks out at `fetch-depth: 2`, which is exactly
+# right for check-deleted-tests.sh (a two-TREE question) and useless here — this
+# reads every commit on the branch. Widening that checkout would make every
+# other guard in that job pay for a full clone it has no use for.
+#
+# `pull_request` only, and no path filter: any diff can carry this shape, and
+# the guard is a few `git log` invocations over a range with no toolchain
+# behind it.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rebase-replay-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: no edit is undone inside the branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Full depth: the guard reads the branch's commits, and a shallow clone
+      # makes it report a missing base rather than a clean branch — loudly, but
+      # it still has not answered the question.
+      - id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      # On a `pull_request` event the checkout is `refs/pull/N/merge`, so HEAD
+      # is the merge commit: the guard reads HEAD^1 and HEAD^2 itself and needs
+      # no ref name from the event payload.
+      - name: no path is edited and then undone inside this branch
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-rebase-replay.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,44 @@ existed. `reserved-paths` (`scripts/check-reserved-paths.sh`) is the fast
 half of that finding, because a failed checkout reports one bad path per run
 and there were two.
 
+A ninth, `rebase-replay.yml`, is the only check here that reads a branch's
+**history** rather than its tree, and it exists for a composition hazard the
+shared-cell paragraph above does not cover: **rebasing a stale branch can
+silently revert somebody else's change** (#4979).
+
+Two branches make the same edit to one file — which a mechanical sweep split
+across several pull requests does by construction. Branch B then undoes its
+copy, so B's tree matches base and `git diff base -- <file>` is empty: B reads
+as never having touched the file. Once A lands, rebasing B onto the new base
+deduplicates B's edit (`warning: skipped previously applied commit`) and keeps
+B's undo. The inert pair becomes a bare revert of A's change, B's diff for that
+path goes from empty to a live revert, and it squash-merges cleanly. Merging B
+*without* rebasing is safe, which is what makes this a rebase hazard rather
+than a merge one — and this repository rebases constantly, because branches go
+stale behind required checks. It happened to #4954 against #4951, and
+`check-rebase-replay.sh` fires on #4939's merged head today.
+
+**The remedy is to flatten**, so the path is absent from the branch's history
+rather than present as an edit and an undo. The branch's tree is identical
+either way, so flattening costs nothing and the guard offers no
+acknowledgement. `make rebase-replay` asks by hand;
+`make rebase-replay-test` covers it, and reproduces the rebase itself so the
+hazard is demonstrated rather than asserted. Its own workflow because ci.yml's
+guards job checks out at `fetch-depth: 2` — right for `check-deleted-tests.sh`,
+which compares two trees, and useless for a question about every commit on a
+branch.
+
+**A partition can also split something atomic**, which per-pull-request CI does
+catch — each branch fails on its own — but only after the plan is already
+wrong. `crates/stella-serve/src/accept.rs` and
+`crates/stella-observatory/src/accept.rs` are byte-identical duplicates whose
+`the_two_copies_of_this_policy_have_not_drifted` compares them with
+`include_str!` from **both** crates, so a per-crate split of a repo-wide sweep
+put one copy in #4951 and the other in #4954 and reddened both. Before
+partitioning by crate, directory or owner, ask whether anything in the set has
+to change atomically. `rg -l 'INTENTIONALLY DUPLICATED'` names today's only
+such twin.
+
 **Cite a document by its id, not its path.** Every document under `docs/` that
 anything cites carries frontmatter with a stable `id`, and a citation names that
 id — `doc:context-reuse §4`. Moving the file cannot break it. A document with no

--- a/Makefile
+++ b/Makefile
@@ -852,6 +852,17 @@ website-inputs-test: ## Test the website-inputs guard's three failure directions
 diagnostic-codes-test: ## Test the diagnostic-code registry's failure directions (#4948; hermetic; not part of `gate`)
 	./scripts/test-diagnostic-codes.sh
 
+# Not a gate step: `make gate` judges a working tree, and this asks about a
+# range of commits — a question a pull request has and a dirty checkout does
+# not. It runs in .github/workflows/rebase-replay.yml on every pull request.
+.PHONY: rebase-replay
+rebase-replay: ## Assert no path is edited and then undone inside this branch (#4979; against origin/main)
+	./scripts/check-rebase-replay.sh
+
+.PHONY: rebase-replay-test
+rebase-replay-test: ## Test the rebase-replay guard, and the rebase hazard it is about (#4979; hermetic; not part of `gate`)
+	./scripts/test-rebase-replay.sh
+
 .PHONY: ci-rust-scope-test
 ci-rust-scope-test: ## Test which diffs run the Rust gate, prose skips and fail-open included (hermetic; not part of `gate`)
 	./scripts/test-ci-rust-scope.sh

--- a/scripts/check-rebase-replay.sh
+++ b/scripts/check-rebase-replay.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# Guard: a branch that edits a file and then undoes the edit must flatten the
+# pair, because a rebase turns it into a live revert of somebody else's work.
+# See #4979.
+#
+# ── The defect ───────────────────────────────────────────────────────────────
+#
+# Two branches make the same edit to one file — which a mechanical sweep does by
+# construction. Branch B then reverts its copy, so B's tree matches base and
+# `git diff base -- <file>` is empty. B looks like it never touched the file.
+#
+# Once A lands, rebasing B onto the new base deduplicates B's edit and keeps
+# B's revert:
+#
+#     warning: skipped previously applied commit 541a41f
+#
+# Git recognises B's edit as already upstream and drops it. It has no reason to
+# drop the revert. The inert pair becomes a bare revert of A's change, B's diff
+# for that file goes from empty to `-beta +alpha`, and it squash-merges cleanly.
+#
+# Merging B without rebasing keeps A's edit, because B contributes no change to
+# that file relative to the merge base. Only the rebase path reverts — and this
+# repository rebases constantly, because branches go stale behind required
+# checks.
+#
+# The real instance: #4954 edited crates/stella-observatory/src/accept.rs and
+# reverted it in a later commit, because both copies of that file had to travel
+# in #4951 instead. Rebasing #4954 onto a tree carrying #4951 replayed the
+# revert and `make prose` on the composed tree went red. Both branches were
+# green on their own.
+#
+# ── Why nothing else can see it ──────────────────────────────────────────────
+#
+# The branch's diff for that file is empty in BOTH cases — before the rebase
+# and, as far as any per-branch check is concerned, in the tree it was green
+# against. So no check that reads a diff can tell the two apart. This one reads
+# the branch's HISTORY instead: a path some commit on the branch touched, which
+# the branch's own final diff no longer mentions, is an edit and an undo with
+# nothing between them but a rebase waiting to happen.
+#
+# Purely local — it needs no other branch, no network and no toolchain, which is
+# what makes it cheap enough to run before every merge. #4979 lists three other
+# answers to the same defect (a periodic composer, a merge queue, documenting
+# the shape); this is the one that runs on the pull request itself.
+#
+# ── No acknowledgement, unlike check-deleted-tests.sh ────────────────────────
+#
+# That guard lets a deletion pass once it is named in the pull-request
+# description, because a deleted test is sometimes right and a script cannot
+# adjudicate which. This one has no such escape, and does not need one: the
+# branch's tree is identical either way, so flattening the pair changes nothing
+# a reviewer can see and loses nothing. There is no version of this finding
+# where keeping the pair is the better answer, so an acknowledgement would only
+# offer the wrong remedy in reviewable-looking clothes.
+#
+# ── NOT in `make gate` ───────────────────────────────────────────────────────
+#
+# `make gate` runs on a working tree; this asks about a range of commits, which
+# is a question a pull request has and a dirty checkout does not. It runs in
+# .github/workflows/rebase-replay.yml, and by hand as:
+#
+#     ./scripts/check-rebase-replay.sh                 # against origin/main
+#     ./scripts/check-rebase-replay.sh origin/main HEAD
+#
+# scripts/test-rebase-replay.sh is its self-test, and reproduces #4979's
+# from-empty-repository repro as one of its cases, so the suite proves the
+# hazard is real as well as that the guard fires on it.
+#
+# Portable POSIX tools, no toolchain, bash 3.2 compatible (macOS ships it).
+set -euo pipefail
+
+# The verdict is decided before anything is written (#1815): buffer the report
+# and emit it once, so a reader that closes the pipe can change neither the
+# report nor the exit status.
+report=""
+note() { report="${report}check-rebase-replay: $1"$'\n'; }
+emit() {
+  trap '' PIPE
+  printf '%s' "$report" >&2 || true
+}
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "check-rebase-replay: not a git repository; THIS CHECK DID NOT RUN."
+  exit 0
+fi
+
+# The repository the caller is standing in, not the one this script is filed in.
+# Every other guard here reads the tree around its own path, but this one reads a
+# range of commits — so pointing it at another checkout is the whole mechanism
+# scripts/test-rebase-replay.sh needs, and copying the script into a fixture
+# would test the copy. Toplevel rather than the caller's cwd, so `git log
+# --name-only` reports one set of paths regardless of the subdirectory it is
+# invoked from.
+cd "$(git rev-parse --show-toplevel)"
+
+# Resolve the range. An explicit base (and optional head) wins. Otherwise, a
+# merge HEAD means a `refs/pull/N/merge` checkout, whose second parent is the
+# branch and whose first is the base branch tip — the pair this guard is about.
+# Failing both, compare against the default branch.
+if [ -n "${1:-}" ]; then
+  base_ref="$1"
+  head_ref="${2:-HEAD}"
+elif git rev-parse --verify --quiet "HEAD^2" >/dev/null; then
+  base_ref="HEAD^1"
+  head_ref="HEAD^2"
+else
+  head_ref="HEAD"
+  if git rev-parse --verify --quiet "origin/main" >/dev/null; then
+    base_ref="origin/main"
+  elif git rev-parse --verify --quiet "main" >/dev/null; then
+    base_ref="main"
+  else
+    echo "check-rebase-replay: no base ref (origin/main and main are both absent);"
+    echo "check-rebase-replay: pass one explicitly. THIS CHECK DID NOT RUN."
+    exit 0
+  fi
+fi
+
+for ref in "$base_ref" "$head_ref"; do
+  if ! git rev-parse --verify --quiet "$ref" >/dev/null; then
+    note "FAIL — ref '$ref' is not present in this clone."
+    note "     In CI this means the checkout was too shallow: this guard reads a"
+    note "     whole branch's history, so it needs fetch-depth 0."
+    emit
+    exit 1
+  fi
+done
+
+# The branch point, never the base tip: a commit that landed upstream after the
+# branch started is not this branch's doing, and reading the range from the tip
+# would attribute it here.
+if ! base="$(git merge-base "$base_ref" "$head_ref" 2>/dev/null)"; then
+  note "FAIL — '$base_ref' and '$head_ref' share no history."
+  note "     In CI this means the checkout was too shallow (fetch-depth 0)."
+  emit
+  exit 1
+fi
+head="$(git rev-parse "$head_ref")"
+
+# `core.quotePath=false` so a non-ASCII path arrives as itself rather than as an
+# escaped string that would not match the other list.
+git_c() { git -c core.quotePath=false "$@"; }
+
+# What the branch's final diff mentions, and what its commits touched. Merges
+# are excluded: `--name-only` reports nothing for one anyway, and a conflict
+# resolution that happened to match base is not this branch editing a file.
+net="$(git_c diff --name-only "$base" "$head")"
+touched="$(git_c log --no-merges --name-only --pretty=format: "$base..$head" |
+  sed '/^$/d' | sort -u)"
+
+if [ -z "$touched" ]; then
+  echo "check-rebase-replay: OK — no commit between $(git rev-parse --short "$base") and $(git rev-parse --short "$head") touches a file."
+  exit 0
+fi
+
+# A path some commit touched that the final diff does not mention. `comm` needs
+# both sides sorted; `net` may be empty, which is the pathological case rather
+# than an excuse to skip.
+suspects="$(comm -23 <(printf '%s\n' "$touched") <(printf '%s\n' "$net" | sed '/^$/d' | sort -u))"
+
+if [ -z "$suspects" ]; then
+  count="$(printf '%s\n' "$touched" | wc -l | tr -d ' ')"
+  echo "check-rebase-replay: OK — $count path(s) touched, every one of them still in the branch's diff."
+  exit 0
+fi
+
+found=0
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  found=$((found + 1))
+  note ""
+  note "  $path"
+  # Captured rather than piped into the loop: a pipeline's right-hand side runs
+  # in a subshell, where `note`'s appends to `report` would be discarded.
+  commits="$(git_c log --no-merges --format='      %h  %s' "$base..$head" -- "$path")"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    note "$line"
+  done <<COMMITS
+$commits
+COMMITS
+done <<EOF
+$suspects
+EOF
+
+report="check-rebase-replay: FAIL — $found path(s) edited and then undone inside this branch."$'\n'"$report"
+note ""
+note "     The branch's diff against $(git rev-parse --short "$base") does not mention those"
+note "     paths, so they read as untouched. Rebase onto a base that already"
+note "     carries the same edit and git drops the branch's copy (\"skipped"
+note "     previously applied commit\") while keeping the undo — which leaves a"
+note "     live revert of whatever landed upstream, and it merges cleanly (#4979)."
+note ""
+note "     Flatten it, so the branch's history stops mentioning the path at all:"
+note "       git rebase -i $(git rev-parse --short "$base")   # drop the pair"
+note "       git reset --soft $(git rev-parse --short "$base") && git commit   # or recommit as one"
+emit
+exit 1

--- a/scripts/test-rebase-replay.sh
+++ b/scripts/test-rebase-replay.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Tests for check-rebase-replay.sh — the guard that catches an edit-and-undo
+# pair before a rebase turns it into a live revert (#4979).
+#
+#   ./scripts/test-rebase-replay.sh
+#
+# Not part of `make gate`: it builds throwaway git repositories, the same
+# posture as scripts/test-website-inputs.sh.
+#
+# ── Why this suite exists ────────────────────────────────────────────────────
+#
+# The guard's subject is invisible by construction — the branch's diff for the
+# path is empty whether or not the hazard is present — so nothing about a green
+# run distinguishes a healthy branch from a guard that has stopped looking. R2
+# below is the other half: it runs #4979's own reproduction to completion and
+# asserts the rebase really does eat the upstream edit, so the suite proves the
+# hazard is real rather than assuming the issue was right about it.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+GUARD="$repo_root/scripts/check-rebase-replay.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# A throwaway repository on `main` with one committed file. $1 = case name;
+# echoes the repository path.
+new_repo() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email t@t.invalid
+  git -C "$dir" config user.name t
+  git -C "$dir" config commit.gpgsign false
+  printf 'alpha\n' >"$dir/f.txt"
+  git -C "$dir" add f.txt
+  git -C "$dir" commit -qm base
+  echo "$dir"
+}
+
+# want <name> <expect-pass|expect-fail> <repo> <base> [substring]
+want() {
+  local name="$1" expect="$2" dir="$3" base="$4" sub="${5:-}" out rc
+  out="$(cd "$dir" && "$GUARD" "$base" HEAD 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ] && [ "$rc" -ne 0 ]; then
+    fail=$((fail + 1))
+    echo "FAIL $name — expected OK, got:"
+    echo "$out"
+    return
+  fi
+  if [ "$expect" = "expect-fail" ] && [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1))
+    echo "FAIL $name — the guard passed something it should have flagged:"
+    echo "$out"
+    return
+  fi
+  case "$out" in
+  *"$sub"*)
+    pass=$((pass + 1))
+    echo "ok   $name"
+    ;;
+  *)
+    fail=$((fail + 1))
+    echo "FAIL $name — verdict was right, report was not (wanted '$sub'):"
+    echo "$out"
+    ;;
+  esac
+}
+
+# ── An ordinary branch ───────────────────────────────────────────────────────
+#
+# Without this the suite would prove the guard can fail and nothing else.
+r="$(new_repo kept)"
+git -C "$r" checkout -q -b b
+printf 'beta\n' >"$r/f.txt"
+git -C "$r" commit -qam "edit f"
+want "R0 a branch that edits a file and keeps the edit passes" \
+  expect-pass "$r" main "check-rebase-replay: OK"
+
+# ── 1. The shape ─────────────────────────────────────────────────────────────
+r="$(new_repo reverted)"
+git -C "$r" checkout -q -b b
+printf 'beta\n' >"$r/f.txt"
+git -C "$r" commit -qam "edit f"
+printf 'alpha\n' >"$r/f.txt"
+git -C "$r" commit -qam "revert it"
+want "R1 an edit undone later in the same branch is flagged" \
+  expect-fail "$r" main "f.txt"
+
+# ...and the report names the remedy rather than only the finding.
+want "R1b the report names the flatten remedy" \
+  expect-fail "$r" main "git rebase -i"
+
+# ── 2. The hazard is real ────────────────────────────────────────────────────
+#
+# #4979's reproduction, run to its conclusion. This asserts nothing about the
+# guard: it asserts the premise the guard rests on, so a future reader does not
+# have to take the issue's word for it.
+r="$(new_repo replay)"
+git -C "$r" checkout -q -b a
+printf 'beta\n' >"$r/f.txt"
+git -C "$r" commit -qam "A: edit"
+
+git -C "$r" checkout -q main
+git -C "$r" checkout -q -b b
+printf 'beta\n' >"$r/f.txt"
+git -C "$r" commit -qam "B: same edit"
+printf 'alpha\n' >"$r/f.txt"
+git -C "$r" commit -qam "B: revert it"
+
+# B contributes nothing to that file, which is what makes the pair invisible.
+if [ -n "$(git -C "$r" diff --name-only main b -- f.txt)" ]; then
+  fail=$((fail + 1))
+  echo "FAIL R2a B's diff against main should be empty for f.txt"
+else
+  pass=$((pass + 1))
+  echo "ok   R2a B's diff against main does not mention the file at all"
+fi
+
+git -C "$r" checkout -q main
+git -C "$r" merge -q --no-edit a
+git -C "$r" checkout -q b
+git -C "$r" rebase main >"$TMP/rebase.log" 2>&1
+if [ "$(cat "$r/f.txt")" = "alpha" ]; then
+  pass=$((pass + 1))
+  echo "ok   R2b rebasing B onto A's landing reverts A (skipped the edit, kept the undo)"
+else
+  fail=$((fail + 1))
+  echo "FAIL R2b the rebase did not reproduce the hazard; f.txt reads $(cat "$r/f.txt")"
+  cat "$TMP/rebase.log"
+fi
+
+# ── 3. A branch that leaves the file alone ───────────────────────────────────
+r="$(new_repo untouched)"
+git -C "$r" checkout -q -b b
+printf 'x\n' >"$r/other.txt"
+git -C "$r" add other.txt
+git -C "$r" commit -qm "add other"
+want "R3 a branch that never touches the file passes" \
+  expect-pass "$r" main "check-rebase-replay: OK"
+
+# ── 4. Created and deleted inside the branch ─────────────────────────────────
+#
+# The same hazard wearing different clothes: rebase drops the creation as
+# already upstream and keeps the deletion, which deletes somebody else's file.
+r="$(new_repo added_then_removed)"
+git -C "$r" checkout -q -b b
+printf 'new\n' >"$r/g.txt"
+git -C "$r" add g.txt
+git -C "$r" commit -qm "add g"
+git -C "$r" rm -q g.txt
+git -C "$r" commit -qm "drop g again"
+want "R4 a file created and deleted inside the branch is flagged" \
+  expect-fail "$r" main "g.txt"
+
+# ── 5. The remedy clears it ──────────────────────────────────────────────────
+#
+# The same tree, flattened. If this failed, the guard would be unsatisfiable
+# and the remedy it prints would be a lie.
+r="$(new_repo flattened)"
+git -C "$r" checkout -q -b b
+printf 'beta\n' >"$r/f.txt"
+git -C "$r" commit -qam "edit f"
+printf 'alpha\n' >"$r/f.txt"
+git -C "$r" commit -qam "revert it"
+git -C "$r" reset -q --soft main
+git -C "$r" commit -q --allow-empty -m "flattened: the pair is gone"
+want "R5 flattening the pair clears the finding" \
+  expect-pass "$r" main "check-rebase-replay: OK"
+
+# ── 6. An undo the final diff still mentions ─────────────────────────────────
+#
+# Edited, reverted, then edited to something else. The path IS in the branch's
+# diff, so a rebase has a real change to carry and nothing is invisible. The
+# guard must not fire on every revert — only on one the diff has swallowed.
+r="$(new_repo reverted_then_changed)"
+git -C "$r" checkout -q -b b
+printf 'beta\n' >"$r/f.txt"
+git -C "$r" commit -qam "edit f"
+printf 'alpha\n' >"$r/f.txt"
+git -C "$r" commit -qam "revert it"
+printf 'gamma\n' >"$r/f.txt"
+git -C "$r" commit -qam "edit it differently"
+want "R6 a revert the final diff still mentions is not flagged" \
+  expect-pass "$r" main "check-rebase-replay: OK"
+
+# ── 7. Nothing to judge ──────────────────────────────────────────────────────
+r="$(new_repo no_commits)"
+git -C "$r" checkout -q -b b
+want "R7 a branch with no commits of its own passes" \
+  expect-pass "$r" main "touches a file"
+
+# ── 8. A base that is not there ──────────────────────────────────────────────
+#
+# Loud rather than green: a guard that cannot see its range must not report the
+# same line as one that looked and found nothing.
+r="$(new_repo missing_base)"
+git -C "$r" checkout -q -b b
+printf 'beta\n' >"$r/f.txt"
+git -C "$r" commit -qam "edit f"
+want "R8 an absent base ref is a failure naming the shallow checkout" \
+  expect-fail "$r" origin/nonexistent "fetch-depth"
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #4979

## Which option, and why not the others

**Option 1** — the guard on the pull request itself. It is the only one that
runs before a merge without a repository setting, it needs no other branch, and
it names its own remedy.

- **Option 2 (a periodic composer)** reports after the fact and would not have
  stopped #4954's rebase from replaying.
- **Option 3 (a merge queue)** catches it directly and is a repository setting
  plus a workflow — the constraint #3932 and #3887 both ran into. Still the
  right long-term answer; nothing here forecloses it.
- **Option 4 (write the shapes down)** is done in this PR as well, because the
  issue asks for it regardless of which of 1–3 lands.

## The guard

`scripts/check-rebase-replay.sh`. The key implementation fact from the issue is
that **the branch's diff for the path is empty in both cases**, so nothing that
reads a diff can distinguish them. This reads the branch's *history*: a path
some commit on the branch touched, which the branch's own final diff no longer
mentions.

Base resolution mirrors `check-deleted-tests.sh` — an explicit argument, else
`HEAD^1`/`HEAD^2` on a `refs/pull/N/merge` checkout, else `origin/main` — and
the range is taken from the **merge base**, never the base tip, so a commit that
landed upstream after the branch started is not attributed here.

**No acknowledgement**, unlike `check-deleted-tests.sh`. That guard lets a
deletion pass once it is named in the description, because a deleted test is
sometimes right. This one has no such escape and does not need one: the branch's
tree is byte-identical whether the pair is flattened or not, so flattening loses
nothing and there is no version of this finding where keeping the pair is
better. An acknowledgement would only offer the wrong remedy in
reviewable-looking clothes.

## Where it runs

Its own workflow, `rebase-replay.yml`, on `pull_request` at `fetch-depth: 0`.
`ci.yml`'s guards job checks out at `fetch-depth: 2`, which is exactly right for
`check-deleted-tests.sh` beside it (a two-**tree** question) and useless here —
this reads every commit on the branch. Widening that checkout would make every
other guard in that job pay for a full clone it has no use for, which is
`wire-schema.yml`'s reasoning. No path filter: any diff can carry this shape,
and the check is a few `git log` invocations with no toolchain behind it.

`make rebase-replay` runs it by hand; `make rebase-replay-test` is the suite.
Neither is a `GATE_STEPS` member — `make gate` judges a working tree, and this
asks about a range of commits.

## It fires on the real instance

Run over the head of each of the **last 40 merged pull requests**:

```
green=39 flagged=1 skipped=0

=== #4939
check-rebase-replay: FAIL — 20 path(s) edited and then undone inside this branch.

  docs/tools/bash.toml
      3a5a6c481  docs(tools): leave the generated tool reference to its generator
      3f7765a90  docs(prose): plain language across the design documents
  ...
```

#4939 is one of the nine prose branches #4979 was found on. Confirmed a true
positive rather than taken on trust:

```
$ git diff --stat origin/main pr4939 -- docs/tools/bash.toml
(empty — the branch's diff does not mention the path)

$ git show --stat 3f7765a90 -- docs/tools/bash.toml
 docs/tools/bash.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

$ git show --stat 3a5a6c481 -- docs/tools/bash.toml
 docs/tools/bash.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Every **open** pull request is green under it, including this one:

```
test/diagnostic-codes-self-test-4948   OK — 5 path(s) touched, every one still in the branch's diff.
fix/4980-test-user-home-isolation      OK — 8 path(s) touched, …
fix/4976-spec-palette-parity           OK — 2 path(s) touched, …
bot/version-sync                       OK — 3 path(s) touched, …
ci/clippy-schema-gated-4949            OK — 6 path(s) touched, …
fix/4966-theme-muted-tier              OK — 19 path(s) touched, …
fix/embedder-seal-guard-4986           OK — 2 path(s) touched, …
fix/4917-observatory-plugin-skills     OK — 8 path(s) touched, …
```

**One thing I could not show:** #4954's own branch. Its merged head is a single
commit — it was flattened for exactly this reason, which the issue says — so the
guard is green on it. The pre-flatten history is not recoverable from the remote.

## The self-test

`scripts/test-rebase-replay.sh`, eleven cases over throwaway repositories.

```
$ make rebase-replay-test
ok   R0 a branch that edits a file and keeps the edit passes
ok   R1 an edit undone later in the same branch is flagged
ok   R1b the report names the flatten remedy
ok   R2a B's diff against main does not mention the file at all
ok   R2b rebasing B onto A's landing reverts A (skipped the edit, kept the undo)
ok   R3 a branch that never touches the file passes
ok   R4 a file created and deleted inside the branch is flagged
ok   R5 flattening the pair clears the finding
ok   R6 a revert the final diff still mentions is not flagged
ok   R7 a branch with no commits of its own passes
ok   R8 an absent base ref is a failure naming the shallow checkout

passed 11, failed 0
```

**R2 is #4979's from-empty-repository reproduction, run to its conclusion.** It
asserts nothing about the guard — it asserts the premise the guard rests on, so
a future reader does not have to take the issue's word for it. R5 matters for
the opposite reason: if flattening did not clear the finding, the guard would be
unsatisfiable and the remedy it prints would be a lie. R6 keeps it narrow — a
revert the final diff still mentions is not this defect and is not flagged.

### Ablation 1 — the guard cannot fail (`suspects=""`)

The green cases stay green and every failure direction goes red, so the ablation
makes the answer wrong rather than merely constant:

```
ok   R0 a branch that edits a file and keeps the edit passes
FAIL R1 an edit undone later in the same branch is flagged — the guard passed something it should have flagged:
check-rebase-replay: OK — 1 path(s) touched, every one of them still in the branch's diff.
FAIL R1b the report names the flatten remedy — the guard passed something it should have flagged:
FAIL R4 a file created and deleted inside the branch is flagged — the guard passed something it should have flagged:
ok   R2a / R2b / R3 / R5 / R6 / R7 / R8

passed 8, failed 3
```

R2a and R2b stay green under the ablation, which is correct: they are about git,
not about the guard.

### Ablation 2 — the suite is unwired

```
$ make gate-parity
check-gate-parity: FAIL — no workflow runs the guard self-test 'scripts/test-rebase-replay.sh'.
check-gate-parity:      Add it to a workflow, or name it in UNHOSTED_SELF_TESTS in
check-gate-parity:      the Makefile with the reason it is excluded.
```

## Option 4 — the shapes, written down

AGENTS.md's workflow chain gains `rebase-replay.yml` as its ninth entry,
carrying shape A with the flatten remedy, and shape B — "a partition can also
split something atomic", with the `accept.rs` twin and the
`rg -l 'INTENTIONALLY DUPLICATED'` check to run before partitioning by crate,
directory or owner.

## Gates

```
$ make guards-fast
EXIT=0

$ shellcheck scripts/check-rebase-replay.sh scripts/test-rebase-replay.sh
(silent)

$ make gate-parity
check-gate-parity: OK — 48 (forty-eight) gate steps, named in AGENTS.md and CONTRIBUTING.md, each run by a workflow.
```

`GATE_STEPS` is untouched, deliberately: it is a shared cell, and another open
pull request (#4989) is already writing it.

## Deleted tests

None. No `#[test]` was added, removed or renamed — this PR touches no Rust.

## Summary by Sourcery

Add history-aware CI protection against edit-and-undo commit pairs that can become unintended reverts when stale branches are rebased.

New Features:
- Add a pull-request guard that detects files edited and subsequently undone within a branch before rebasing can replay the undo as an upstream revert.

Bug Fixes:
- Prevent silent rebase-induced reversions of changes that have already landed upstream.

Enhancements:
- Document rebase-replay and repository-wide atomicity hazards, including the flattening remedy and duplicated-file guidance.

Build:
- Add Makefile targets for running the rebase-replay guard and its hermetic test suite.

CI:
- Run the new guard in a dedicated full-history pull-request workflow and wire its self-test into guard self-test CI.

Documentation:
- Expand AGENTS.md with the rebase-replay workflow and guidance for identifying changes that must remain atomic.

Tests:
- Add an eleven-case shell test suite covering detection, remediation, rebase reproduction, edge cases, and shallow-checkout failures.