### PR TITLE
fix(website,docs,design): the two hand-mirrored token sheets carry the whole palette (#4978)

### DIFF
--- a/design/tokens/stella-tokens.json
+++ b/design/tokens/stella-tokens.json
@@ -41,10 +41,12 @@
     "",
     "What the sweep can and cannot see is stated at check 4 in",
     "scripts/check-tokens.py. The short version: it is a NAME sweep, not a render",
-    "trace. It cannot follow a value copied under another name, which is why the",
-    "eleven web stops below sit at `gap` while the site ships every one of their",
-    "values -- as literals under --stella-* rather than through var(--st-*). That",
-    "is #4978's subject and completing those sheets is what would paint them."
+    "trace, so it cannot follow a value copied under another name. Eleven of the",
+    "web stops below sat at `gap` for exactly that reason -- the site shipped",
+    "their values as literals under --stella-* rather than through var(--st-*).",
+    "#4978 completed the two hand-mirrored sheets and repointed those roles, so",
+    "they are `painted` now: the fix the posture asked for, rather than a posture",
+    "written to match the code."
   ],
   "version": "5.1.0",
   "name": "stella black and gold",
@@ -373,7 +375,7 @@
       "css": "--st-void",
       "role": "below the canvas: full-bleed backdrops",
       "surfaces": ["web-dark"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "gold-ink",
@@ -382,7 +384,7 @@
       "css": "--st-gold-ink",
       "role": "gold as TEXT on the light ground, where the metal cannot clear AA",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "paper-ground",
@@ -391,7 +393,7 @@
       "css": "--st-paper-ground",
       "role": "the warm paper page ground, one step under the panel",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "paper-raised",
@@ -400,7 +402,7 @@
       "css": "--st-paper-raised",
       "role": "light surface raised above the page ground",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "paper-row",
@@ -409,7 +411,7 @@
       "css": "--st-paper-row",
       "role": "light hover and selected rows",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "paper-seam",
@@ -418,7 +420,7 @@
       "css": "--st-paper-seam",
       "role": "light seam: the hairline under a border",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "ink-muted",
@@ -427,7 +429,7 @@
       "css": "--st-ink-muted",
       "role": "secondary text on light surfaces",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "green-ink",
@@ -436,7 +438,7 @@
       "css": "--st-green-ink",
       "role": "pass, as text on the light ground",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "amber",
@@ -445,7 +447,7 @@
       "css": "--st-amber",
       "role": "warning: the one status the core palette does not name",
       "surfaces": ["web-dark"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "amber-ink",
@@ -454,7 +456,7 @@
       "css": "--st-amber-ink",
       "role": "warning, as text on the light ground",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     },
     {
       "name": "red-ink",
@@ -463,7 +465,7 @@
       "css": "--st-red-ink",
       "role": "fail, as text on the light ground",
       "surfaces": ["web-light"],
-      "paint": { "gap": "#4978" }
+      "paint": "painted"
     }
   ],
   "banned": {

--- a/design/tokens/stella-tokens.json
+++ b/design/tokens/stella-tokens.json
@@ -13,7 +13,38 @@
     "kind of colour it is -- and the warm-drift predicates reject the choice that",
     "kills a gold-on-black scheme. The predicates are defined once in",
     "crates/stella-tui-theme/src/clamp.rs and mirrored by scripts/check-tokens.py;",
-    "both are held to this file's `clamps` block below."
+    "both are held to this file's `clamps` block below.",
+    "",
+    "Every token also declares a `paint` posture, for the same reason and against a",
+    "different failure. `clamp` asks what KIND of colour this is; `paint` asks",
+    "WHETHER ANYTHING RENDERS IT. Nothing asked that until #4975, and `comment`",
+    "is what got through: a published token with a role sentence, a --st-comment",
+    "declaration on four surfaces, a COMMENT constant in the generated token.rs,",
+    "a row in the SPEC's palette table, three design renderings using its hex, a",
+    "row in the contrast ratchet -- and no call site anywhere. One of the sub-AA",
+    "pairings #4063 was deciding about was a colour no reader had ever seen. This",
+    "is AGENTS.md invariant #10 (`every emitted signal names its consumer`) pointed",
+    "at the palette, and crates/stella-protocol/src/event/consumers.rs is the shape",
+    "it copies: a declared posture per row, enforced from both sides.",
+    "",
+    "Two postures, and the guard checks each against the tree rather than trusting",
+    "it -- a declaration nothing verifies is what `comment`'s `role` field already",
+    "was:",
+    "",
+    "  \"paint\": \"painted\"          some hand-written surface names this token,",
+    "                              as var(--st-<css>) or as token::<rust>. The",
+    "                              sweep fails if it finds none.",
+    "  \"paint\": { \"gap\": \"#N\" }   nothing names it, and #N is where that is being",
+    "                              decided. The sweep fails if it finds a site --",
+    "                              a gap that has been closed must be redeclared,",
+    "                              not left standing.",
+    "",
+    "What the sweep can and cannot see is stated at check 4 in",
+    "scripts/check-tokens.py. The short version: it is a NAME sweep, not a render",
+    "trace. It cannot follow a value copied under another name, which is why the",
+    "eleven web stops below sit at `gap` while the site ships every one of their",
+    "values -- as literals under --stella-* rather than through var(--st-*). That",
+    "is #4978's subject and completing those sheets is what would paint them."
   ],
   "version": "5.1.0",
   "name": "stella black and gold",
@@ -115,7 +146,8 @@
       "css": "--st-bg",
       "rust": "BG",
       "role": "canvas",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "panel",
@@ -124,7 +156,8 @@
       "css": "--st-panel",
       "rust": "PANEL",
       "role": "panels, cards, code blocks",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "hl",
@@ -133,7 +166,8 @@
       "css": "--st-hl",
       "rust": "HL",
       "role": "selected and hover rows",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "border",
@@ -142,7 +176,8 @@
       "css": "--st-border",
       "rust": "BORDER",
       "role": "hairlines, dividers, unfilled meter track",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "rule",
@@ -151,7 +186,8 @@
       "css": "--st-rule",
       "rust": "RULE",
       "role": "section rules, turn boundaries",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "gold",
@@ -160,7 +196,8 @@
       "css": "--st-gold",
       "rust": "GOLD",
       "role": "the brand metal: actions, active states, money, the mark",
-      "surfaces": ["tui", "web-dark", "web-light", "asset"]
+      "surfaces": ["tui", "web-dark", "web-light", "asset"],
+      "paint": "painted"
     },
     {
       "name": "gold-bright",
@@ -169,7 +206,8 @@
       "css": "--st-gold-bright",
       "rust": "GOLD_BRIGHT",
       "role": "tiny live indicators only: spinner, hot marker, drift glyph",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "silver",
@@ -178,7 +216,8 @@
       "css": "--st-silver",
       "rust": "SILVER",
       "role": "secondary emphasis, incoming context, syntax strings",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "silver-type",
@@ -187,7 +226,8 @@
       "css": "--st-silver-type",
       "rust": "SILVER_TYPE",
       "role": "syntax types, tertiary labels",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "text",
@@ -196,7 +236,8 @@
       "css": "--st-text",
       "rust": "TEXT",
       "role": "primary text on dark, in the deck",
-      "surfaces": ["tui"]
+      "surfaces": ["tui"],
+      "paint": "painted"
     },
     {
       "name": "paper-text",
@@ -204,7 +245,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-text",
       "role": "primary text on dark, off the deck",
-      "surfaces": ["web-dark", "asset"]
+      "surfaces": ["web-dark", "asset"],
+      "paint": "painted"
     },
     {
       "name": "muted",
@@ -213,7 +255,8 @@
       "css": "--st-muted",
       "rust": "MUTED",
       "role": "secondary text",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "dim",
@@ -222,7 +265,8 @@
       "css": "--st-dim",
       "rust": "DIM",
       "role": "hints, captions, line numbers",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": "painted"
     },
     {
       "name": "green",
@@ -231,7 +275,8 @@
       "css": "--st-green",
       "rust": "GREEN",
       "role": "pass, additive diff sign",
-      "surfaces": ["tui", "web-dark", "web-light"]
+      "surfaces": ["tui", "web-dark", "web-light"],
+      "paint": "painted"
     },
     {
       "name": "red",
@@ -240,7 +285,8 @@
       "css": "--st-red",
       "rust": "RED",
       "role": "fail, destructive, removal diff sign",
-      "surfaces": ["tui", "web-dark", "web-light"]
+      "surfaces": ["tui", "web-dark", "web-light"],
+      "paint": "painted"
     },
     {
       "name": "diff-add-bg",
@@ -249,7 +295,8 @@
       "css": "--st-diff-add",
       "rust": "DIFF_ADD_BG",
       "role": "added diff row background",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": { "gap": "#4058" }
     },
     {
       "name": "diff-del-bg",
@@ -258,7 +305,8 @@
       "css": "--st-diff-del",
       "rust": "DIFF_DEL_BG",
       "role": "removed diff row background",
-      "surfaces": ["tui", "web-dark"]
+      "surfaces": ["tui", "web-dark"],
+      "paint": { "gap": "#4058" }
     },
     {
       "name": "ink",
@@ -267,7 +315,8 @@
       "css": "--st-ink",
       "rust": "INK",
       "role": "primary text on light surfaces (web light mode only)",
-      "surfaces": ["web-light", "asset"]
+      "surfaces": ["web-light", "asset"],
+      "paint": "painted"
     },
     {
       "name": "paper",
@@ -276,7 +325,8 @@
       "css": "--st-paper",
       "rust": "PAPER",
       "role": "the warm light canvas",
-      "surfaces": ["web-light", "asset"]
+      "surfaces": ["web-light", "asset"],
+      "paint": "painted"
     },
     {
       "name": "paper-panel",
@@ -285,7 +335,8 @@
       "css": "--st-paper-panel",
       "rust": "PAPER_PANEL",
       "role": "light panel",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4058" }
     },
     {
       "name": "paper-border",
@@ -294,7 +345,8 @@
       "css": "--st-paper-border",
       "rust": "PAPER_BORDER",
       "role": "light border",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4058" }
     },
     {
       "$comment": [
@@ -320,7 +372,8 @@
       "clamp": "neutral-gray",
       "css": "--st-void",
       "role": "below the canvas: full-bleed backdrops",
-      "surfaces": ["web-dark"]
+      "surfaces": ["web-dark"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "gold-ink",
@@ -328,7 +381,8 @@
       "clamp": "resting-gold",
       "css": "--st-gold-ink",
       "role": "gold as TEXT on the light ground, where the metal cannot clear AA",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-ground",
@@ -336,7 +390,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-ground",
       "role": "the warm paper page ground, one step under the panel",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-raised",
@@ -344,7 +399,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-raised",
       "role": "light surface raised above the page ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-row",
@@ -352,7 +408,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-row",
       "role": "light hover and selected rows",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "paper-seam",
@@ -360,7 +417,8 @@
       "clamp": "warm-paper",
       "css": "--st-paper-seam",
       "role": "light seam: the hairline under a border",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "ink-muted",
@@ -368,7 +426,8 @@
       "clamp": "warm-paper",
       "css": "--st-ink-muted",
       "role": "secondary text on light surfaces",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "green-ink",
@@ -376,7 +435,8 @@
       "clamp": "verdict",
       "css": "--st-green-ink",
       "role": "pass, as text on the light ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "amber",
@@ -384,7 +444,8 @@
       "clamp": "verdict",
       "css": "--st-amber",
       "role": "warning: the one status the core palette does not name",
-      "surfaces": ["web-dark"]
+      "surfaces": ["web-dark"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "amber-ink",
@@ -392,7 +453,8 @@
       "clamp": "verdict",
       "css": "--st-amber-ink",
       "role": "warning, as text on the light ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     },
     {
       "name": "red-ink",
@@ -400,7 +462,8 @@
       "clamp": "verdict",
       "css": "--st-red-ink",
       "role": "fail, as text on the light ground",
-      "surfaces": ["web-light"]
+      "surfaces": ["web-light"],
+      "paint": { "gap": "#4978" }
     }
   ],
   "banned": {

--- a/docs/brand/css/tokens.css
+++ b/docs/brand/css/tokens.css
@@ -1,25 +1,29 @@
 /* ==========================================================================
    stella — design tokens
-   One color, owned: Gold on Obsidian. Everything else is restraint.
+   One color, owned: Gold on a cool near-black. Everything else is restraint.
    Drop this file in before any component styles. Pure CSS custom properties;
    no build step required. Pair with globals.css for shadcn/ui + Tailwind v4.
 
-   v4.0 returns the brand hue to gold, reversing v3.0's Ion recolour (#3658)
-   and restoring v2.0's bronze ramp value-for-value. The cool neutral
-   ramp and the Obsidian ground that v3.0 introduced are kept: the complaint
-   the recolour answered was the *neutrals*, which were warm and muddy, and
-   only the brand hue is being taken back. Gold on a cool black is the
-   yellow-and-black standard, and it is what this system is called.
+   The `--st-*` block is the WHOLE palette, and is the content of
+   design/tokens/stella-tokens.css, which scripts/gen-tokens.py emits from
+   design/tokens/stella-tokens.json. Every hex here must be a live token
+   (scripts/check-tokens.py's TOKEN_ONLY), every name must be one
+   (website/src/lib/brand-parity.test.ts), and the set must be complete —
+   the same test compares it against the palette both ways.
 
-   The token family stays `--stella-brand-*`, NOT `--stella-gold-*`. That
-   lesson survives the reversal and is in fact confirmed by it: a hue in a
-   token name falsifies itself the first time the hue moves, and this ramp has
-   now moved four times. Name the role; put the hue in the value. Renaming
-   back would also break `design_token_parity.rs`, which reads role names for
+   It was not complete until #4978: this sheet carried 20 of 32, and the
+   twelve it dropped were the entire light-ground half plus `void`. Nothing
+   noticed, because every check over it was a MEMBERSHIP question — is this
+   hex a token, is this name a token — and none of them can see a token that
+   was never mirrored. The kit's own guidelines page and design brief already
+   published all thirty-two as tables, so the sheet was the one kit artifact
+   that disagreed with the kit.
+
+   The token family stays `--stella-brand-*`, NOT `--stella-gold-*`: a hue in
+   a token name falsifies itself the first time the hue moves, and this ramp
+   has now moved five times. Name the role; put the hue in the value. Renaming
+   would also break `design_token_parity.rs`, which reads role names for
    exactly this reason.
-
-   Both ramps are generated in OKLCH — the brand at hue 73, the neutrals at
-   hue 250 — so the steps are perceptually even rather than eyeballed in sRGB.
    ========================================================================== */
 
 :root {
@@ -49,8 +53,20 @@
   --st-diff-del: #241019;
   --st-ink: #141413;
   --st-paper: #FFFCF5;
+  --st-paper-text: #F4F1EA;
   --st-paper-panel: #F9F6EF;
   --st-paper-border: #E6E3DD;
+  --st-void: #050507;
+  --st-gold-ink: #725A00;
+  --st-paper-ground: #F7F4ED;
+  --st-paper-raised: #FDFAF3;
+  --st-paper-row: #E9E6E0;
+  --st-paper-seam: #E0DDD7;
+  --st-ink-muted: #605F5C;
+  --st-green-ink: #006933;
+  --st-amber: #E78D54;
+  --st-amber-ink: #8A3F00;
+  --st-red-ink: #96213C;
 
   /* ---- typography ------------------------------------------------------ */
   /* JetBrains Mono is the brand voice — the product lives in a terminal,

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Guard the colour system: no retired hex anywhere, no stray hex where it matters.
 
-Three checks, deliberately different in strength, because "never use this colour
-again", "use only tokens here" and "quote this token correctly" are different
-promises and only one of them can be made about the whole tree today.
+Four checks, different in strength, because "never use this colour
+again", "use only tokens here", "quote this token correctly" and "something
+renders this" are different promises and only one of them can be made about the
+whole tree today.
 
 1. **The ban.** Every hex in `banned.values` in the token JSON fails wherever it
    appears, in any tracked file. These are the anchor values of retired brand
@@ -42,6 +43,27 @@ promises and only one of them can be made about the whole tree today.
    document names an `--st-*` token, so a marketing surface keeping its own
    accent and status hues under its own variable names is untouched. That is the
    line #2594 drew, and this check does not cross it.
+
+4. **Paint.** Every token declares a `paint` posture in the token JSON, and this
+   is what holds the declaration to the tree, in **both** directions: a
+   `"painted"` token with no site fails, and a `{ "gap": "#N" }` token with a
+   site fails too. See `paint_report` for what the sweep can and cannot see.
+
+   Checks 1-3 are all about a *value*; none of them can ask whether anything
+   renders it. That is how `comment` survived (#4946): a published token with a
+   role sentence, a `--st-comment` declaration on four surfaces, a `COMMENT`
+   constant in the generated `token.rs`, three design renderings using its hex
+   and a row in `scripts/contrast-baseline.txt` -- so one of the sub-AA pairings
+   #4063 was deciding about was a colour no reader had ever seen. Every check
+   above passed it, because every value involved was live.
+
+   This is AGENTS.md rule #10 pointed at the palette, and
+   `crates/stella-protocol/src/event/consumers.rs` is the shape it copies. The
+   difference is what enforces totality: `consumers.rs` gets it from the
+   compiler over an enum, and a colour's consumers are spread across Rust, four
+   stylesheets, HTML and SVG, so "is it painted?" is a text question. The door
+   is `scripts/gen-tokens.py`'s `check_paint`, which refuses a token with no
+   posture; this is the half that refuses a posture that is not true.
 
 `MIGRATING` is the one escape, and it is a ledger, not an allowlist: a path
 listed there is a surface this system has not reached yet, each entry carrying
@@ -207,6 +229,121 @@ TEXT_SUFFIXES = {
 }
 
 
+# Files whose reference to a token cannot tell a painted one from an unpainted
+# one, so check 4 does not read them.
+#
+# The generated artifacts are here for the obvious reason: they are emitted from
+# the token table, so they name every token by construction and would make the
+# sweep vacuously green.
+#
+# `fallback.rs` is here for a subtler version of the same reason, and it is the
+# entry that decides whether this check means anything. `ansi16` is **total over
+# `token::ALL`** -- `every_token_has_a_fallback` is the test that keeps it that
+# way -- so it names all twenty terminal tokens whether or not a cell ever takes
+# one. Counting it would have passed six tokens nothing paints, four of them
+# under values the deck does not even use (`theme::DIFF_ADD_BG` is `#1B2921`
+# where `token::DIFF_ADD_BG` is `#10201A`).
+#
+# An **alias** is NOT excluded: `pub const TEXT_EMPHASIS: Color =
+# token::SILVER_TYPE;` counts as a site. Resolving an alias down to a cell needs
+# transitive analysis this sweep does not do, and the claim it makes is
+# correspondingly bounded -- see `paint_report`.
+PAINT_BLIND = (
+    "design/tokens/stella-tokens.json",
+    "design/tokens/stella-tokens.css",
+    "crates/stella-tui-theme/src/token.rs",
+    "crates/stella-tui-theme/src/fallback.rs",
+    "scripts/gen-tokens.py",
+    "scripts/check-tokens.py",
+)
+
+# A token being *used*, in the two notations this tree writes. A declaration --
+# `--st-bg: #0A0A0C` in a mirrored stylesheet -- is not one of them:
+# `comment` had four of those and no reader ever saw the colour.
+VAR_USE = re.compile(r"var\(\s*(--st-[a-z0-9-]+)")
+RUST_USE = re.compile(r"\btoken::([A-Z][A-Z0-9_]*)\b")
+
+# How many example sites a failure prints before it stops.
+PAINT_EXAMPLES = 3
+
+
+def paint_report(root: Path, doc: dict, files: list[Path]) -> list[str]:
+    """Hold every token's `paint` posture to the tree. Returns the failures.
+
+    **What this sees.** One `var(--st-<name>)` or `token::<RUST>` outside
+    `PAINT_BLIND`, anywhere in a tracked text file. That is a NAME sweep, not a
+    render trace. A guard whose reach is guessed at is a guard that gets
+    trusted past it, so the bound is:
+
+    - It cannot follow a **value copied under another name**. The site ships
+      every one of the eleven web-only stops as a literal under `--stella-*`
+      rather than through `var(--st-*)`, so they read as gaps here and are
+      declared as gaps -- with #4978, where completing those sheets is being
+      decided, as the citation. The posture records the mechanism, not the
+      pixel.
+    - It cannot follow an **alias chain** to a cell, so an alias counts as a
+      site (see `PAINT_BLIND`).
+    - It does not care whether the site is production or a test. No token in
+      this tree is named only by tests, so no verdict here turns on that; if one
+      ever is, this is the sentence that has to change rather than a number.
+    - **Prose counts.** A doc comment writing `token::DIFF_ADD_BG` is a site as
+      far as this is concerned. That makes `painted` fractionally easier to
+      satisfy and can make a real `gap` read as stale -- the loud direction,
+      which names the file and line and is fixed by moving the sentence or
+      declaring the token painted. A structural fix means parsing Rust and CSS,
+      which is a language server rather than a guard.
+
+    **Which files.** `tracked_files` -- `git ls-files --cached --others
+    --exclude-standard` -- so an un-ignored file in a working tree counts even
+    before it is committed. Deliberate, and the same enumeration the three
+    checks above take since #4960: a file that is neither ignored nor committed
+    is still a file a `git add -A` will publish, and this check found exactly
+    that case on its own PR. The cost is that a developer's un-ignored scratch
+    note mentioning a token can turn their local run red; the failure names the
+    path, and the answer is an ignore rule.
+
+    What it does answer is exactly the question `comment` failed: does any
+    hand-written surface name this token at all?
+    """
+    used: dict[str, list[str]] = {}
+    for rel in files:
+        posix = rel.as_posix()
+        if rel.suffix not in TEXT_SUFFIXES or posix in PAINT_BLIND:
+            continue
+        try:
+            text = (root / rel).read_text(errors="ignore")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for match in VAR_USE.finditer(line):
+                used.setdefault(match.group(1), []).append(f"{posix}:{lineno}")
+            for match in RUST_USE.finditer(line):
+                used.setdefault(match.group(1), []).append(f"{posix}:{lineno}")
+
+    failures: list[str] = []
+    for tok in doc["tokens"]:
+        sites = list(used.get(tok["css"], []))
+        if tok.get("rust"):
+            sites += used.get(tok["rust"], [])
+        paint = tok.get("paint")
+        if paint == "painted" and not sites:
+            failures.append(
+                f"{tok['name']}: declares `painted`, and nothing in the tree "
+                f"names {tok['css']} or token::{tok.get('rust', '-')}. Paint it, "
+                f"retire it, or declare the gap with the issue where that is "
+                f"being decided"
+            )
+        elif isinstance(paint, dict) and sites:
+            shown = ", ".join(sites[:PAINT_EXAMPLES])
+            more = f" (+{len(sites) - PAINT_EXAMPLES} more)" if len(sites) > PAINT_EXAMPLES else ""
+            failures.append(
+                f"{tok['name']}: declares a gap citing {paint['gap']}, but "
+                f"{len(sites)} site(s) name it: {shown}{more}. A gap that has "
+                f"been closed is redeclared as `painted`, not left standing"
+            )
+    return failures
+
+
 def tracked_files(root: Path) -> list[Path]:
     out = subprocess.run(
         ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
@@ -246,7 +383,10 @@ def main(argv: list[str]) -> int:
         seen.add((posix, lineno, hexv))
         ban_hits.append(hit)
 
-    for rel in tracked_files(root):
+    files = tracked_files(root)
+    paint_hits = paint_report(root, doc, files)
+
+    for rel in files:
         posix = rel.as_posix()
         if rel.suffix not in TEXT_SUFFIXES:
             continue
@@ -356,15 +496,33 @@ def main(argv: list[str]) -> int:
             "naming the token.",
             file=sys.stderr,
         )
+    if paint_hits:
+        failed = True
+        print(
+            f"\n{len(paint_hits)} token(s) declare a `paint` posture the tree "
+            "does not bear out:\n",
+            file=sys.stderr,
+        )
+        for hit in paint_hits:
+            print(f"  {hit}", file=sys.stderr)
+        print(
+            "\n`paint` is declared per token in design/tokens/stella-tokens.json "
+            "and is the answer to \"what renders this?\" — the question nothing "
+            "asked when `comment` shipped unpainted (#4975).",
+            file=sys.stderr,
+        )
 
     if failed:
         return 1
 
     scope = len(TOKEN_ONLY)
     pending = f", {len(MIGRATING)} path(s) still migrating" if MIGRATING else ""
+    painted = sum(1 for t in doc["tokens"] if t.get("paint") == "painted")
+    gaps = len(doc["tokens"]) - painted
     print(
         f"tokens: no retired hex in the tree; {scope} token-only path(s) clean; "
-        f"{citations_ok} token citation(s) quote the palette{pending}"
+        f"{citations_ok} token citation(s) quote the palette; {painted} token(s) "
+        f"painted, {gaps} declared gap(s){pending}"
     )
     return 0
 

--- a/scripts/gen-tokens.py
+++ b/scripts/gen-tokens.py
@@ -13,15 +13,23 @@ sentence was the only thing left true -- website/src/app/tokens.css sat on the
 v1.0 ramp through the whole life of the v4.0 rebrand while still claiming to
 mirror the kit. A comment cannot hold a shared cell; a generator and a diff can.
 
+Every token also declares a `paint` posture -- whether anything renders it --
+and `check_paint` below is the door that refuses a token with no answer. The
+posture is held to the tree by `check-tokens.py`'s check 4; see #4975 and the
+`$comment` header in the token file for why the palette needs the same
+discipline AGENTS.md rule #10 applies to events.
+
 Usage:
     scripts/gen-tokens.py            # write the generated files
     scripts/gen-tokens.py --check    # fail if any is stale (gate step)
+    scripts/gen-tokens.py --check R  # ...against the tree rooted at R
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -197,8 +205,53 @@ def rust_tokens(doc: dict) -> list[dict]:
     return [tok for tok in doc["tokens"] if tok.get("rust")]
 
 
+ISSUE = re.compile(r"^#\d+$")
+
+
+def check_paint(name: str, paint: object) -> str | None:
+    """Return an error string if `paint` is not a well-formed posture.
+
+    This is the *door*: it asks whether somebody answered "what paints this?",
+    not whether the answer is true. `check-tokens.py`'s check 4 is what holds
+    the answer to the tree, from both sides.
+
+    Separated for the same reason `clamp` is a declaration and not an
+    inference: inference is what lets a warm hex in under a cool name, and a
+    default posture is what would have let `comment` in under `painted`
+    (#4975).
+    """
+    if paint is None:
+        return (
+            f"{name}: no `paint` posture. Declare `\"paint\": \"painted\"` if a "
+            f"surface names this token, or `\"paint\": {{ \"gap\": \"#N\" }}` "
+            f"citing the issue where that is being decided"
+        )
+    if isinstance(paint, str):
+        if paint != "painted":
+            return f"{name}: `paint` is {paint!r}; the only string posture is \"painted\""
+        return None
+    if isinstance(paint, dict):
+        if set(paint) != {"gap"}:
+            return (
+                f"{name}: a gap posture is exactly {{ \"gap\": \"#N\" }}; got keys "
+                f"{sorted(paint)}"
+            )
+        issue = paint["gap"]
+        if not isinstance(issue, str) or not ISSUE.match(issue):
+            return (
+                f"{name}: `paint.gap` is {issue!r}; it must cite an issue as "
+                f'"#1234". A gap with no issue is the silence this field exists '
+                f"to refuse"
+            )
+        return None
+    return f"{name}: `paint` must be a string or an object, not {type(paint).__name__}"
+
+
 def validate(doc: dict) -> list[str]:
-    """Every token against its declared clamp. Returns the failures."""
+    """Every token against its declared clamp and paint posture.
+
+    Returns the failures.
+    """
     errors: list[str] = []
     clamps = doc["clamps"]
     seen: dict[str, str] = {}
@@ -211,6 +264,9 @@ def validate(doc: dict) -> list[str]:
             errors.append(f"{tok['name']}: clamp {clamp!r} is not declared in `clamps`")
             continue
         err = check_clamp(tok["name"], tok["hex"], clamp, clamps[clamp], anchors)
+        if err:
+            errors.append(err)
+        err = check_paint(tok["name"], tok.get("paint"))
         if err:
             errors.append(err)
         # A hex used twice under two names is how a role quietly loses meaning.
@@ -412,9 +468,21 @@ def main() -> int:
         action="store_true",
         help="fail if a generated file is stale instead of writing it",
     )
+    # A root argument is what lets `scripts/test-tokens.sh` point the validator
+    # at a fixture tree, the same reason `check-tokens.py` takes one: a door
+    # nobody can show refusing anything is a door nobody knows is shut. With no
+    # argument it reads its own repository, as every caller does today.
+    ap.add_argument(
+        "root",
+        nargs="?",
+        type=Path,
+        default=REPO,
+        help="repository root to read and write (default: this one)",
+    )
     args = ap.parse_args()
 
-    doc = json.loads(TOKENS.read_text())
+    root = args.root.resolve()
+    doc = json.loads((root / TOKENS.relative_to(REPO)).read_text())
 
     errors = validate(doc)
     if errors:
@@ -427,7 +495,7 @@ def main() -> int:
 
     stale: list[Path] = []
     for rel, content in outputs.items():
-        path = REPO / rel
+        path = root / rel
         if args.check:
             if not path.exists() or path.read_text() != content:
                 stale.append(rel)

--- a/scripts/test-tokens.sh
+++ b/scripts/test-tokens.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Tests for check-tokens.py's BAN CHECK, over every notation it claims to
-# watch (#4910), and for its CITATION CHECK, whose subject is a pair (#3653).
+# watch (#4910), for its CITATION CHECK, whose subject is a pair (#3653), and
+# for its PAINT CHECK, whose subject is an absence (#4975).
 #
 #   ./scripts/test-tokens.sh    (or: make tokens-test)
 #
@@ -39,6 +40,14 @@
 # value that is some other token's: that value is live, so it passes a
 # membership test while saying something false. A name quoted at a value the
 # palette has moved past is the other failure mode, and looks nothing like it.
+#
+# The paint cases earn theirs because that check's subject is an ABSENCE, and
+# every other check here is about something present. A token nothing paints is
+# a value that is live, correctly quoted, and inside no token-only path -- so
+# all three older checks pass it, which is exactly what happened to `comment`
+# (#4946, #4975). Both directions get a case: a `painted` declaration with no
+# site must fail, and a `gap` declaration that has since acquired one must fail
+# too, or the ledger records a hole somebody already filled.
 #
 # Every fixture below reads its colours out of the real token file at run time,
 # citation fixtures included — which is why this file is in neither `SELF` nor
@@ -134,30 +143,60 @@ else:
 # A throwaway git repository holding the real token file plus one source file.
 # Real git, because the script discovers its inputs with `git ls-files` and a
 # fixture that stubbed that would be testing a path nothing runs.
-# $1 = case name, $2 = file path within the root, $3 = file contents.
+#
+# The token file arrives with every `paint` posture rewritten to a gap. A
+# fixture tree holds one source file, so it paints nothing, and the real file's
+# seventeen `painted` declarations would fail check 4 in every case below --
+# turning a suite about the ban and the citation into a suite about the paint
+# sweep. Values, names and the ban list are copied untouched, which is what the
+# other three checks read. The paint cases rewrite the posture they are about
+# and read the token names out of the same file, so nothing here is typed.
+#
+# $1 = case name, $2 = file path within the root, $3 = file contents,
+# $4 = optional `name=posture` (posture is `painted`, else an issue for a gap).
 new_root() {
   local dir="$TMP/$1"
   mkdir -p "$dir/design/tokens" "$dir/$(dirname "$2")"
-  cp "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL"
+  python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+override = sys.argv[3]
+name, _, posture = override.partition('=')
+for tok in doc['tokens']:
+    if 'name' not in tok:
+        continue
+    if tok['name'] == name:
+        tok['paint'] = 'painted' if posture == 'painted' else {'gap': posture}
+    else:
+        tok['paint'] = {'gap': '#4975'}
+open(sys.argv[2], 'w').write(json.dumps(doc, indent=2))
+" "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL" "${4:-}"
   printf '%s\n' "$3" >"$dir/$2"
   git -C "$dir" init -q 2>/dev/null
   git -C "$dir" add -A 2>/dev/null
   echo "$dir"
 }
 
-# want <name> <expect-pass|expect-ban|expect-fail> <file> <contents> [substring]
+# want <name> <expect-pass|expect-ban|expect-fail|expect-absent> <file>
+#      <contents> [substring] [token=posture]
 #
 # `expect-ban` and `expect-fail` are the same assertion — a non-zero exit — and
 # both spellings exist because a misquote is not a ban and calling it one at the
 # call site would read as a mistake.
 #
+# `expect-absent` is that assertion minus one clause: the paint check's subject
+# is a token nothing names, and an absence has no file to name. Every other
+# failure here is a value sitting at a line, so those must report where.
+#
 # The optional substring is checked on BOTH verdicts. On a failure it pins which
 # value was named and in what words; on a pass it pins what the run reported,
 # without which a guard that passed by scanning nothing satisfies the case.
+#
+# The optional `token=posture` is the paint cases' subject; see `new_root`.
 want() {
-  local name="$1" expect="$2" file="$3" contents="$4" sub="${5:-}"
+  local name="$1" expect="$2" file="$3" contents="$4" sub="${5:-}" paint="${6:-}"
   local root out rc
-  root="$(new_root "$(echo "$name" | tr ' /' '__')" "$file" "$contents")"
+  root="$(new_root "$(echo "$name" | tr ' /' '__')" "$file" "$contents" "$paint")"
   out="$(python3 "$SCRIPT" "$root" 2>&1)"
   rc=$?
   if [ "$expect" = "expect-pass" ]; then
@@ -176,17 +215,20 @@ want() {
     return
   fi
   # Naming the file is half the guard: an exit code alone sends a reader
-  # hunting through the tree for a colour the script already located.
-  case "$out" in
-  *"$file"*) ;;
-  *)
-    bad "$name — caught it but did not name $file: $out"
-    return
-    ;;
-  esac
+  # hunting through the tree for a colour the script already located. An
+  # absence is the one finding with nowhere to point.
+  if [ "$expect" != "expect-absent" ]; then
+    case "$out" in
+    *"$file"*) ;;
+    *)
+      bad "$name — caught it but did not name $file: $out"
+      return
+      ;;
+    esac
+  fi
   case "$out" in
   *"$sub"*) ok "$name" ;;
-  *) bad "$name — named $file but not '$sub': $out" ;;
+  *) bad "$name — caught it but did not report '$sub': $out" ;;
   esac
 }
 
@@ -338,6 +380,102 @@ want "SELF suppresses the ban and not the citation check" expect-fail \
 want "a stray hex in a token-only path is flagged" expect-fail \
   "docs/brand/css/tokens.css" "  --custom: $WRONG_HEX;" \
   "is not a token in"
+
+echo ""
+echo "check-tokens paint check:"
+
+# The subject of every case below: one token that carries both notations, read
+# out of the real file so a rename cannot leave these cases testing nothing.
+eval "$(python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+for t in doc['tokens']:
+    if t.get('rust'):
+        print('P_NAME=%s' % t['name'])
+        print('P_CSS=%s' % t['css'])
+        print('P_RUST=%s' % t['rust'])
+        break
+else:
+    raise SystemExit('no token declares a rust name')
+" "$repo_root/$TOKENS_REL")"
+
+# The failure this check exists for, and the one every other check here passes:
+# a token declared `painted` that nothing in the tree names. `comment` shipped
+# in exactly this state — a live value, correctly quoted, in no token-only path.
+want "a painted token nothing names is caught" expect-absent \
+  "website/src/app/page.tsx" "const x = 1;" \
+  "$P_NAME: declares \`painted\`, and nothing in the tree names $P_CSS" \
+  "$P_NAME=painted"
+
+# The other direction, and the half a one-sided check would miss: a gap that
+# somebody has since closed. Left standing, the ledger records a hole that is
+# not there any more, and the next reader trusts it.
+want "a gap the tree has closed is caught" expect-fail \
+  "website/src/app/globals.css" "  color: var($P_CSS);" \
+  "declares a gap citing #4975, but 1 site(s) name it" \
+  "$P_NAME=#4975"
+
+# Both notations satisfy a `painted` declaration. Two cases rather than one,
+# because a matcher that only sees CSS looks exactly like a clean tree on the
+# Rust side — the shape #4910 found one check over.
+want "a var() use satisfies a painted declaration" expect-pass \
+  "website/src/app/globals.css" "  color: var($P_CSS);" \
+  "1 token(s) painted" \
+  "$P_NAME=painted"
+
+want "a token:: use satisfies a painted declaration" expect-pass \
+  "crates/stella-tui/src/views/session.rs" \
+  "let s = Style::new().fg(token::$P_RUST);" \
+  "1 token(s) painted" \
+  "$P_NAME=painted"
+
+# A **declaration** is not a paint. This is the distinction the whole check
+# turns on: `comment` had four of these across four surfaces and no reader ever
+# saw the colour, so a mirrored stylesheet binding the name must not count.
+want "a declaration in a mirror sheet is not a paint" expect-absent \
+  "docs/brand/css/tokens.css" "  $P_CSS: $LIVE_HEX;" \
+  "declares \`painted\`, and nothing in the tree names $P_CSS" \
+  "$P_NAME=painted"
+
+# `fallback.rs` names every terminal token by construction — `ansi16` is total
+# over `token::ALL` — so counting it would pass six tokens nothing paints.
+want "fallback.rs's total map does not count as a paint" expect-absent \
+  "crates/stella-tui-theme/src/fallback.rs" \
+  "        token::$P_RUST => Color::Black," \
+  "declares \`painted\`, and nothing in the tree names $P_CSS" \
+  "$P_NAME=painted"
+
+# The door, in gen-tokens.py rather than here: a token with no posture at all.
+# Checked through the generator because that is what refuses it, and a suite
+# that only tested the sweep would leave the door untested.
+paint_root="$(new_root "no_posture" "website/src/app/page.tsx" "const x = 1;")"
+python3 -c "
+import json, sys
+doc = json.loads(open(sys.argv[1]).read())
+for tok in doc['tokens']:
+    tok.pop('paint', None)
+open(sys.argv[1], 'w').write(json.dumps(doc, indent=2))
+" "$paint_root/$TOKENS_REL"
+out="$(python3 "$repo_root/scripts/gen-tokens.py" --check "$paint_root" 2>&1)"
+rc=$?
+case "$rc:$out" in
+0:*) bad "a token with no \`paint\` posture was accepted: $out" ;;
+*"no \`paint\` posture"*) ok "a token with no posture is refused at the door" ;;
+*) bad "refused with the wrong message: $out" ;;
+esac
+
+# A gap with no issue is the silence the field exists to refuse. `{"gap": ""}`
+# and `{"gap": "later"}` are both a token nobody has to explain, which is the
+# state `comment` was in for its whole life.
+gap_root="$(new_root "empty_gap" "website/src/app/page.tsx" "const x = 1;" \
+  "$P_NAME=later")"
+out="$(python3 "$repo_root/scripts/gen-tokens.py" --check "$gap_root" 2>&1)"
+rc=$?
+case "$rc:$out" in
+0:*) bad "a gap citing no issue was accepted: $out" ;;
+*"must cite an issue"*) ok "a gap that cites no issue is refused at the door" ;;
+*) bad "refused with the wrong message: $out" ;;
+esac
 
 echo ""
 echo "check-tokens, the real tree:"

--- a/website/src/app/tokens.css
+++ b/website/src/app/tokens.css
@@ -40,11 +40,11 @@
  *  - `--stella-glow-brand`. Rule 5 retires gradients, glows and coloured
  *    shadows on every surface; a glow is a gradient with a soft edge.
  *
- * WHAT IS AN OPEN EXCEPTION. `--stella-warning` has no token. The system ships
- * two verdicts, pass and fail, and a warning is neither — and the colour a
- * warning wants is an amber, which is precisely the hue the clamp exists to
- * reject. It is aliased to gold here so nothing renders an undefined value, and
- * that choice needs a human: see the note at its definition.
+ * WHAT WAS AN OPEN EXCEPTION, and is not. `--stella-warning` had no token: the
+ * system ships two verdicts, pass and fail, and a warning is neither. PR #4086
+ * settled it — `amber` and `amber-ink` are tokens now, under the `verdict`
+ * clamp, and the 30° separation law that governs the hue is enforced by
+ * `scripts/check-hue-separation.py` rather than argued in this comment.
  *
  * The token family stays role-named. A hue in a token name falsifies itself the
  * first time the hue moves, and this one has moved five times.
@@ -73,6 +73,17 @@
   --st-paper-text: #f4f1ea; /* primary text on dark, off the deck */
   --st-paper-panel: #f9f6ef; /* light panel */
   --st-paper-border: #e6e3dd; /* light border */
+  --st-void: #050507; /* below the canvas: full-bleed backdrops */
+  --st-gold-ink: #725a00; /* gold as TEXT on the light ground */
+  --st-paper-ground: #f7f4ed; /* the warm paper page ground */
+  --st-paper-raised: #fdfaf3; /* light surface raised above the page ground */
+  --st-paper-row: #e9e6e0; /* light hover and selected rows */
+  --st-paper-seam: #e0ddd7; /* light seam: the hairline under a border */
+  --st-ink-muted: #605f5c; /* secondary text on light surfaces */
+  --st-green-ink: #006933; /* pass, as text on the light ground */
+  --st-amber: #e78d54; /* warning */
+  --st-amber-ink: #8a3f00; /* warning, as text on the light ground */
+  --st-red-ink: #96213c; /* fail, as text on the light ground */
 
   /* ── brand core, named by role ──────────────────────────────────────── */
   --stella-brand: var(--st-gold);
@@ -115,33 +126,38 @@
    * moving. Role names, not hue names, for the same reason the ramp above
    * uses them. */
   /* Roles, pointed at the generated ramp above rather than restating its
-   * values. Twelve of these were literals identical to an `--st-*` a few lines
-   * up — duplication rather than drift, since `check-tokens.py` would have
-   * caught a value that was not a live token. But it would NOT have caught a
-   * role quietly re-pointed at a different one: the guard asks "is this hex a
-   * token?", never "is this role still the token it names". `var()` makes that
-   * unaskable, which is what the token system is for, and is what the five
-   * brand-core roles above already do.
+   * values. Every one of these was once a literal identical to an `--st-*` a
+   * few lines up — duplication rather than drift, since `check-tokens.py`
+   * would have caught a value that was not a live token. But it would NOT have
+   * caught a role quietly re-pointed at a different one: the guard asks "is
+   * this hex a token?", never "is this role still the token it names". `var()`
+   * makes that unaskable, which is what the token system is for.
+   *
+   * Twelve were repointed first; the last eleven had no `--st-*` to point at,
+   * because the ramp above stopped at twenty-one of the palette's thirty-two
+   * and every missing one was a light-ground stop, an ink or `void` (#4978).
+   * They were the whole warm-paper half of the system, hand-copied. The ramp
+   * is complete now, so nothing here restates a value.
    *
    * The contrast ratios stay in the comments: a measurement is a fact about
    * this pairing that a `var()` cannot carry. */
-  --stella-void: #050507; /* below the canvas — full-bleed backdrops */
+  --stella-void: var(--st-void); /* below the canvas — full-bleed backdrops */
   --stella-canvas: var(--st-bg); /* the page ground */
   --stella-canvas-code: var(--st-panel); /* cards, code blocks */
   --stella-canvas-row: var(--st-hl); /* highlight rows, hover surfaces */
   --stella-canvas-edge: var(--st-border); /* borders */
   --stella-signal: var(--st-gold); /* 11.99:1 on canvas */
   --stella-signal-live: var(--st-gold-bright); /* 14.22:1 — small, and moving */
-  --stella-signal-ink: #725a00; /* gold TEXT on the paper ground, 6.02:1 */
+  --stella-signal-ink: var(--st-gold-ink); /* gold TEXT on the paper ground, 6.02:1 */
   --stella-text: var(--st-paper-text); /* 16.19:1 on canvas */
   --stella-text-2: var(--st-silver); /* 8.58:1 — the safe small-text tone */
   --stella-text-3: var(--st-muted); /* 4.47:1 — caption/UI tier, under AA body */
   --stella-text-dim: var(--st-dim); /* 2.30:1 — chrome only, never words */
-  --stella-paper-2: #f7f4ed; /* the warm paper ground */
-  --stella-paper-3: #fdfaf3; /* paper surface */
-  --stella-paper-row: #e9e6e0; /* paper hover / raised */
-  --stella-paper-edge: #e0ddd7; /* paper seam */
-  --stella-ink-2: #605f5c; /* paper secondary text, 5.83:1 */
+  --stella-paper-2: var(--st-paper-ground); /* the warm paper ground */
+  --stella-paper-3: var(--st-paper-raised); /* paper surface */
+  --stella-paper-row: var(--st-paper-row); /* paper hover / raised */
+  --stella-paper-edge: var(--st-paper-seam); /* paper seam */
+  --stella-ink-2: var(--st-ink-muted); /* paper secondary text, 5.83:1 */
 
   /* ── status. Not part of the brand kit's one-color law: these are
    *    FUNCTIONAL hues (a warning must not read as decoration), and each has
@@ -169,11 +185,11 @@
    *    they sit 63.1° and 78.0° from it. Each `-ink` variant holds its dark
    *    twin's hue to within 2° and clears AA on the paper ground. */
   --stella-success: var(--st-green);
-  --stella-success-ink: #006933;
-  --stella-warning: #e78d54;
-  --stella-warning-ink: #8a3f00;
+  --stella-success-ink: var(--st-green-ink);
+  --stella-warning: var(--st-amber);
+  --stella-warning-ink: var(--st-amber-ink);
   --stella-danger: var(--st-red);
-  --stella-danger-ink: #96213c;
+  --stella-danger-ink: var(--st-red-ink);
 
   /* ── motion — assemble, don't spin ──────────────────────────────────── */
   --stella-ease-arrive: cubic-bezier(0.22, 0.9, 0.35, 1);

--- a/website/src/lib/brand-parity.test.ts
+++ b/website/src/lib/brand-parity.test.ts
@@ -282,18 +282,26 @@ test("the site's brand tokens are the kit's, value for value", () => {
       `stella-tokens.json does not define: ${unknown.join(", ")}`,
   );
 
-  // And the sheet has not quietly lost rows, which would make the loop below
-  // pass over less than it thinks. The number moved 21 -> 20 when #4946
-  // retired `comment`, a token nothing painted; it is a floor on the mirror's
-  // size, so it moves only when the palette itself shrinks and the reason goes
-  // here beside it.
+  // And the other direction: every token the palette declares has a row here.
   //
-  // The sheet is a subset by design: it carries 20 of the palette's 32, and
-  // the twelve it has never mirrored are #4978.
-  assert.ok(
-    ramp.length >= 20,
-    `docs/brand/css/tokens.css defines the generated --st-* ramp ` +
-      `(found ${ramp.length})`,
+  // This used to be `ramp.length >= 20`, a floor on the count — which cannot
+  // see a token that was never mirrored in the first place, and twelve had not
+  // been. The sheet carried 20 of the palette's 32, and the missing twelve were
+  // the entire warm-paper half plus `void`: the two documents a designer reads
+  // to learn the palette did not contain the light scheme (#4978). A count
+  // could not have found that, and no other check over this file could either
+  // — `check-tokens.py` asks whether every hex here is a live token, never
+  // whether a live token is absent.
+  //
+  // Equality rather than a floor, because the kit is the kit. A published
+  // *subset* is a defensible thing for the marketing site to be, and it is not
+  // what this file is: `docs/brand/` is what a designer is handed.
+  const missing = [...live].filter((name) => !kit.has(name));
+  assert.deepEqual(
+    missing,
+    [],
+    `docs/brand/css/tokens.css must carry every token in ` +
+      `design/tokens/stella-tokens.json; it is missing: ${missing.join(", ")}`,
   );
 
   for (const name of [...MIRRORED_CORE, ...ramp]) {


### PR DESCRIPTION
> **Stacked on #4994** (`feat/4975-token-paint-posture`). The base is `main` and the first commit is #4994's; review only the second. Repointing the site's roles through `var(--st-*)` gives eleven tokens a paint site, so their `paint` postures have to move in the same change — `make tokens` fails on a gap the tree has closed. Once #4994 merges this rebases to a single commit.

## What

`docs/brand/css/tokens.css` carried **20** of the palette's 32 and `website/src/app/tokens.css` carried **21**. Both now carry all 32, and a test says so.

Closes #4978

The twelve missing from the kit were not a random dozen — they were the entire warm-paper half plus `void`. The two documents a designer reads to learn the palette did not contain the light scheme.

## The decision: complete, not a declared subset

The issue asks whether the kit sheet is meant to be complete or a published subset. Three findings settle it, two of which correct the issue's own premises:

- **The kit already publishes almost all of them elsewhere.** `docs/brand/brand-guidelines.html` tabulates **31 of the palette's 32** and `docs/brand/prompts/stella-design-system-prompt.md` **29** — including eleven of the twelve the sheet was missing (`--st-amber`, `--st-void`, the five paper stops, the four inks):

  ```
  $ rg -n -e '--st-void' -e '--st-paper-ground' -e '--st-amber' docs/brand/
  docs/brand/brand-guidelines.html:275:<tr><td>--st-amber</td><td>#E78D54</td>…
  docs/brand/brand-guidelines.html:278:<tr><td>--st-void</td><td>#050507</td>…
  docs/brand/brand-guidelines.html:287:<tr><td>--st-paper-ground</td>…
  docs/brand/prompts/stella-design-system-prompt.md:41,42,49 …
  ```

  ```
  $ python3 -c "import json,re,pathlib
  auth={t['css'] for t in json.load(open('design/tokens/stella-tokens.json'))['tokens']}
  for p in ('docs/brand/brand-guidelines.html','docs/brand/prompts/stella-design-system-prompt.md'):
      n={x for x in re.findall(r'(--st-[a-z0-9-]+)', pathlib.Path(p).read_text())} & auth
      print(p, len(n), 'of', len(auth), '| missing:', sorted(auth-n))"
  docs/brand/brand-guidelines.html 31 of 32 | missing: ['--st-paper-text']
  docs/brand/prompts/stella-design-system-prompt.md 29 of 32 | missing: ['--st-diff-add', '--st-diff-del', '--st-paper-text']
  ```

  **Correction to an earlier draft of this description**, which said the guidelines page "tabulates every one of the twelve". It does not: `--st-paper-text` is one of the twelve and neither kit document carries it. Those two tables are hand-maintained and checked by nothing — the same defect §3.1 had before #4991 — and that is filed as **#5007** rather than fixed here, because a hand-added row nothing verifies is what this PR is arguing against.

  The CSS sheet was the one kit artifact that disagreed with the kit — the residue of a hand copy, not a considered subset. **This also answers the #4072 interaction the issue raises**: publishing the warm-paper values in the brand kit is not a new statement about which light scheme is the real one, because the kit made that statement in two documents already. This change makes the kit self-consistent; it does not decide #4072.

- **"A marketing site has no use for `--st-diff-add-bg`" does not hold.** The site sheet declared `--st-diff-add` and `--st-diff-del` before this PR (lines 69–70). What it was missing was the light ground the site actually renders.

- **The site was shipping all eleven values anyway**, as literals under `--stella-*` names: `--stella-void: #050507`, `--stella-paper-2: #f7f4ed`, `--stella-signal-ink: #725a00`, `--stella-warning: #e78d54`, … The sheet's own comment already explains why that shape is wrong: *"the guard asks 'is this hex a token?', never 'is this role still the token it names'. `var()` makes that unaskable, which is what the token system is for."* Eleven roles are now repointed, so nothing in that file restates a value.

## Enforced, not promised

`website/src/lib/brand-parity.test.ts`'s `ramp.length >= 20` floor becomes an **equality**: every `--st-*` the palette declares must have a row in the kit sheet. Equality rather than a floor because `docs/brand/` is what a designer is handed — a published subset is a defensible thing for the *marketing site* to be, and is not what the kit is.

A floor could never have caught this. It is a count, and a count says nothing about a token that was never mirrored.

## Witness

**Ablation** — delete one row (`--st-paper-ground`) from `docs/brand/css/tokens.css`:

```
✖ the site's brand tokens are the kit's, value for value
  AssertionError [ERR_ASSERTION]: docs/brand/css/tokens.css must carry every token in
  design/tokens/stella-tokens.json; it is missing: --st-paper-ground
  + actual - expected
  + [ '--st-paper-ground' ]
  - []
```

**The control** — the same ablated sheet, with the test as it stands on the parent commit (the `>= 20` floor):

```
✔ the site's brand tokens are the kit's, value for value
ℹ pass 8   ℹ fail 0
```

31 rows clears a floor of 20, so the old assertion reports green on a sheet with a token missing. That is the failure this replaces, in miniature — and it is why the ablation makes the answer *wrong* rather than merely absent.

**Unablated**: `pass 8, fail 0`.

## Eleven paint gaps close

The `paint` postures for `void`, `gold-ink`, `paper-ground`, `paper-raised`, `paper-row`, `paper-seam`, `ink-muted`, `green-ink`, `amber`, `amber-ink` and `red-ink` move from `{ "gap": "#4978" }` to `"painted"`. `make tokens` requires it — a gap the tree has closed fails #4994's sweep — so this is the ledger working rather than bookkeeping:

```
before: 17 token(s) painted, 15 declared gap(s)
after:  28 token(s) painted,  4 declared gap(s)
```

The four remaining are `diff-add-bg`, `diff-del-bg`, `paper-panel` and `paper-border`, citing **#4058**: the deck hard-codes its own value for each (`theme::DIFF_ADD_BG` is `#1B2921` where the token is `#10201A`). Commented on #4058 with the measurements.

## Prose corrected in the files touched

- The kit sheet's header described **v4.0** over a v5.1 ramp: *"Gold on Obsidian"*, *"restoring v2.0's bronze ramp value-for-value"*, *"the neutrals at hue 250"*. None of that is the shipped system.
- The site sheet still carried `--stella-warning` as an *"OPEN EXCEPTION … It is aliased to gold here"* — it is `#e78d54`, and PR #4086 made `amber`/`amber-ink` real tokens under the `verdict` clamp.

## Guards

```
check-tokens:         28 painted, 4 declared gaps; 160 citations quote the palette
check-css-vars:       2 token sheet(s), every var() resolves
check-hue-separation: 12 role pairs, all ≥30° OKLCH
check-contrast:       21 licensed pairings, 3 held by the ratchet, none darker
check-light-clamp:    6 light surfaces, 34 held, none off its clamp
design_token_parity:  12 passed
brand-parity:         8 passed
```

No baseline raised, no test deleted.

## Summary by Sourcery

Make the brand kit and website token surfaces complete and enforce that every declared palette token has an accurate paint posture.

New Features:
- Complete the brand and website token sheets with the full 32-token palette and route website roles through the shared tokens.

Bug Fixes:
- Prevent incomplete kit token mirrors from passing parity checks by requiring every palette token to be represented.
- Close paint-posture gaps for tokens that now have rendering sites while preserving issue-backed gaps for unresolved consumers.

Enhancements:
- Add bidirectional paint-posture validation that detects both unpainted tokens and stale declared gaps.
- Strengthen token posture validation and expand token guard fixtures to cover CSS, Rust, declarations, fallback maps, and malformed postures.
- Correct outdated palette and warning-exception prose in the affected token documentation.

Documentation:
- Update the brand token documentation to describe the complete current palette and its validation requirements.

Tests:
- Replace the kit mirror count floor with an exact completeness assertion.
- Add regression coverage for missing mirrored tokens and paint-posture validation in both directions.
