### PR TITLE
feat(stella-observatory,stella-cli): the rules panel lists a plugin's records

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
@@ -1031,7 +1031,7 @@ fn a_contributed_skills_tier_is_read_off_contributed_by_not_off_its_path() {
 }
 
 /// **The dashboard's trust witness** (#4917). The Observatory lists a
-/// package's skills through `storage_cmd::RosterSkills`, and an untrusted
+/// package's skills through `storage_cmd::RosterContributions`, and an untrusted
 /// checkout's package contributes nothing there either.
 ///
 /// The untrusted half is the point. A dashboard that resolved the roster
@@ -1046,11 +1046,11 @@ fn a_contributed_skills_tier_is_read_off_contributed_by_not_off_its_path() {
 /// `an_untrusted_projects_contributed_tool_never_loads`.
 #[test]
 fn the_dashboards_plugin_skills_honour_the_project_trust_gate() {
-    use stella_observatory::PluginSkills as _;
+    use stella_observatory::PluginContributions as _;
 
     /// The dashboard's `/api/skills` body, through the route the page fetches
     /// rather than through an inner function only this test would call.
-    fn skills_json(root: &Path, source: &crate::storage_cmd::RosterSkills) -> String {
+    fn skills_json(root: &Path, source: &crate::storage_cmd::RosterContributions) -> String {
         let response = stella_observatory::respond_with(root, "/api/skills", source);
         String::from_utf8_lossy(&response.body).into_owned()
     }
@@ -1074,7 +1074,7 @@ fn the_dashboards_plugin_skills_honour_the_project_trust_gate() {
     plant(&stella_home::resolve_project_plugins_dir(&root), "vera");
     ships_a_package(&planted, "vera");
 
-    let source = crate::storage_cmd::RosterSkills;
+    let source = crate::storage_cmd::RosterContributions;
 
     // SAFETY: the env lock is held for the whole mutate-read-restore window.
     unsafe {
@@ -1111,6 +1111,88 @@ fn the_dashboards_plugin_skills_honour_the_project_trust_gate() {
     assert!(
         source.contributed_skill_dirs(&root).is_empty(),
         "and it leaves with the package — nothing was ever copied into .stella/skills"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **The dashboard's trust witness for records** (#4974), the sibling of the
+/// skills one above and gating the same answer.
+///
+/// A record is the surface that steers *quietly*: it shapes every matching
+/// turn and appears in no transcript as something the agent did. So a rules
+/// panel that reads as the complete list of what steers this workspace and
+/// omits a third party's records is worse than absent — and a panel that
+/// listed them out of a checkout nobody has trusted would be worse still,
+/// which is why the untrusted half is asserted first.
+#[test]
+fn the_dashboards_plugin_records_honour_the_project_trust_gate() {
+    use stella_observatory::PluginContributions as _;
+
+    /// The dashboard's `/api/rules` body, through the route the page fetches.
+    fn rules_json(root: &Path, source: &crate::storage_cmd::RosterContributions) -> String {
+        let response = stella_observatory::respond_with(root, "/api/rules", source);
+        String::from_utf8_lossy(&response.body).into_owned()
+    }
+
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[
+        "STELLA_TRUST_PROJECT",
+        "STELLA_PROJECT_HOOKS",
+        "STELLA_HOME",
+    ]);
+    let root = temp_root("package-observatory-records-trust");
+    let _paths = crate::paths::test_user_home(root.join("home"));
+    // The user-tier half of the roster is `stella_home::stella_home()`, which
+    // `test_user_home` does not move — without this the roster resolves the
+    // developer's real `~/.stella/plugins` (#4980).
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe { std::env::set_var("STELLA_HOME", root.join("home")) };
+
+    let planted = stella_home::resolve_project_plugins_dir(&root).join("vera");
+    plant(&stella_home::resolve_project_plugins_dir(&root), "vera");
+    ships_a_package(&planted, "vera");
+
+    let source = crate::storage_cmd::RosterContributions;
+
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe {
+        std::env::remove_var("STELLA_TRUST_PROJECT");
+        std::env::remove_var("STELLA_PROJECT_HOOKS");
+    }
+    assert!(
+        source.contributed_record_dirs(&root).is_empty(),
+        "an untrusted checkout contributes no records to the dashboard"
+    );
+    let listed = rules_json(&root, &source);
+    assert!(
+        !listed.contains("PACKAGE_RECORD_MARKER"),
+        "and nothing of the package's reaches the rules panel: {listed}"
+    );
+
+    // SAFETY: as above.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+    let dirs = source.contributed_record_dirs(&root);
+    assert_eq!(dirs.len(), 1, "the same bytes contribute once trusted");
+    assert_eq!(dirs[0].plugin, "vera");
+    let listed = rules_json(&root, &source);
+    assert!(
+        listed.contains("PACKAGE_RECORD_MARKER"),
+        "and the rules panel lists it: {listed}"
+    );
+    assert!(
+        listed.contains("\"contributed_by\":\"vera\""),
+        "naming the package that shipped it: {listed}"
+    );
+
+    remove(&root, "vera").expect("remove must succeed");
+    assert!(
+        source.contributed_record_dirs(&root).is_empty(),
+        "and it leaves with the package — nothing was ever copied into .stella/rules"
+    );
+    assert!(
+        !rules_json(&root, &source).contains("PACKAGE_RECORD_MARKER"),
+        "which the panel reports too"
     );
 
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/stella-cli/src/storage_cmd.rs
+++ b/crates/stella-cli/src/storage_cmd.rs
@@ -98,45 +98,71 @@ pub(crate) fn preflight_observatory_stores(
     })
 }
 
-/// The dashboard's answer for "which plugin-contributed skills would a session
-/// started in this workspace load?", read off the one roster the session's own
-/// skill load reads (#4917).
+/// The dashboard's answer for "what would a session started in this workspace
+/// load out of its installed plugins?", read off the one roster the session's
+/// own skill load and context-record registry read (#4917, #4974).
 ///
 /// A plugin's skills are contributed by derivation from `<plugin_dir>/skills`
-/// and are never copied into `.stella/skills`, so the observatory — which
-/// derives what it shows from the filesystem and may not link this crate —
-/// could not see them at all. It resolves them here instead of there because
-/// reaching them means answering the project-tier trust gate (#3509), the
-/// `plugins.<name> = "off"` retraction, the install receipt and the
-/// reconcile-on-every-load check, and a second implementation of those is a
-/// second answer.
+/// and its context records from `<plugin_dir>/rules`; neither is ever copied
+/// into `.stella/`, so the observatory — which derives what it shows from the
+/// filesystem and may not link this crate — could not see them at all. It
+/// resolves them here instead of there because reaching them means answering
+/// the project-tier trust gate (#3509), the `plugins.<name> = "off"`
+/// retraction, the install receipt and the reconcile-on-every-load check, and
+/// a second implementation of those is a second answer.
 ///
-/// [`package::contributed_skill_dirs`](crate::plugin_cmd::package) is that one
-/// answer, called per request rather than once at startup so a package
+/// [`package::contributed_skill_dirs`](crate::plugin_cmd::package) and
+/// [`package::contributed_record_dirs`](crate::plugin_cmd::package) are that
+/// one answer, called per request rather than once at startup so a package
 /// installed while the dashboard is open appears on the next refresh — and
 /// answering an empty roster in a workspace nobody has trusted, which is the
-/// property `the_dashboards_plugin_skills_honour_the_project_trust_gate` pins.
-pub(crate) struct RosterSkills;
+/// property `the_dashboards_plugin_skills_honour_the_project_trust_gate` and
+/// `the_dashboards_plugin_records_honour_the_project_trust_gate` pin.
+///
+/// Both methods go through `package`'s own resolver rather than one shared
+/// list, because a plugin ships the two kinds in two directories and only that
+/// module knows which is which.
+pub(crate) struct RosterContributions;
 
-impl stella_observatory::PluginSkills for RosterSkills {
+impl RosterContributions {
+    /// Restate one `ContributedDir` in the observatory's own vocabulary, which
+    /// is the whole of what crossing this port costs.
+    fn as_port_dir(
+        contributed: crate::plugin_cmd::package::ContributedDir,
+    ) -> stella_observatory::ContributedDir {
+        stella_observatory::ContributedDir {
+            plugin: contributed.plugin,
+            tier: match contributed.scope {
+                crate::plugin_cmd::roster::PluginScope::Project => {
+                    stella_observatory::PluginTier::Project
+                }
+                crate::plugin_cmd::roster::PluginScope::User => {
+                    stella_observatory::PluginTier::User
+                }
+            },
+            dir: contributed.dir,
+        }
+    }
+}
+
+impl stella_observatory::PluginContributions for RosterContributions {
     fn contributed_skill_dirs(
         &self,
         workspace_root: &std::path::Path,
-    ) -> Vec<stella_observatory::ContributedSkills> {
+    ) -> Vec<stella_observatory::ContributedDir> {
         crate::plugin_cmd::package::contributed_skill_dirs(workspace_root)
             .into_iter()
-            .map(|contributed| stella_observatory::ContributedSkills {
-                plugin: contributed.plugin,
-                tier: match contributed.scope {
-                    crate::plugin_cmd::roster::PluginScope::Project => {
-                        stella_observatory::PluginTier::Project
-                    }
-                    crate::plugin_cmd::roster::PluginScope::User => {
-                        stella_observatory::PluginTier::User
-                    }
-                },
-                dir: contributed.dir,
-            })
+            .map(Self::as_port_dir)
+            .collect()
+    }
+
+    fn contributed_record_dirs(
+        &self,
+        workspace_root: &std::path::Path,
+    ) -> Vec<stella_observatory::ContributedDir> {
+        crate::plugin_cmd::package::contributed_record_dirs(workspace_root)
+            .into_iter()
+            .map(Self::as_port_dir)
             .collect()
     }
 }
@@ -152,8 +178,8 @@ pub fn run_observe(port: u16, open: bool) -> Result<(), String> {
         .enable_all()
         .build()
         .map_err(|e| format!("failed to start runtime: {e}"))?;
-    let plugins: std::sync::Arc<dyn stella_observatory::PluginSkills> =
-        std::sync::Arc::new(RosterSkills);
+    let plugins: std::sync::Arc<dyn stella_observatory::PluginContributions> =
+        std::sync::Arc::new(RosterContributions);
     rt.block_on(stella_observatory::serve(
         root,
         port,

--- a/crates/stella-observatory/examples/serve.rs
+++ b/crates/stella-observatory/examples/serve.rs
@@ -18,7 +18,7 @@ async fn main() {
     // No roster: resolving one means the project-tier trust gate and the rest
     // of `stella-cli`'s plugin machinery, which is the whole reason this
     // harness exists without it. The skills tab shows the workspace's own.
-    let plugins = std::sync::Arc::new(stella_observatory::NoPluginSkills);
+    let plugins = std::sync::Arc::new(stella_observatory::NoContributions);
     stella_observatory::serve(root, port, plugins, |addr| {
         println!("observatory: http://{addr}");
     })

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -3264,8 +3264,14 @@ function renderMemoryTab(files, rules) {
         .map(c => `<span class="chip">${esc(c)}</span>`).join("");
       const tags = Array.isArray(f.tags) && f.tags.length
         ? `<div class="when">${esc(f.tags.join(" · "))}</div>` : "";
+      // A record shipped by an installed package steers this workspace and
+      // lives in the package, never in .stella/rules — so the panel says which
+      // package, the way the skills table's `via` column does.
+      const via = f.contributed_by
+        ? `<span class="badge dim" title="shipped by an installed plugin — read from its package, never copied into your .stella/">via ${esc(f.contributed_by)}</span>`
+        : "";
       return `<div class="feed-item">
-      <b>${record ? "^" : "§"} ${esc(f.name)}</b>${chips}
+      <b>${record ? "^" : "§"} ${esc(f.name)}</b>${chips}${via}
       <span class="when">${agoUnix(f.modified_unix)}</span>
       <div>${esc(f.snippet)}</div>${tags}</div>`;
     }).join("");

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -14,12 +14,16 @@
 //!    sensitive-looking key (and every value under `env`/`headers` maps)
 //!    before the JSON is serialized into a response.
 
+mod contributions;
+
 use std::collections::HashMap;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use serde_json::{Value, json};
+
+pub use contributions::{ContributedDir, NoContributions, PluginContributions, PluginTier};
 
 /// Entries read from any one directory before the scan stops.
 ///
@@ -282,87 +286,6 @@ fn skill_evidence_grades(workspace_root: &Path) -> HashMap<String, &'static str>
         .collect()
 }
 
-/// The tier an installed plugin sits at, which is also the tier its
-/// contributed skills are governed by (`stella_cli::skill_manager`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PluginTier {
-    /// `<workspace>/.stella/plugins` — the tier behind the project trust gate.
-    Project,
-    /// `~/.stella/plugins` — the operator's own machine-scope tier.
-    User,
-}
-
-impl PluginTier {
-    /// The scope label the skills view already uses for the user's own rows.
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Project => "project",
-            Self::User => "user",
-        }
-    }
-}
-
-/// One installed plugin's `skills/` directory, as the host that resolved the
-/// roster reports it.
-#[derive(Debug, Clone)]
-pub struct ContributedSkills {
-    /// The contributing plugin's manifest `name`.
-    pub plugin: String,
-    /// The tier its package is installed at.
-    pub tier: PluginTier,
-    /// `<plugin_dir>/skills`. It need not exist; an absent directory is an
-    /// empty one, the same as every other root this module scans.
-    pub dir: PathBuf,
-}
-
-/// The port a host implements to say which plugin-contributed skills a session
-/// started in this workspace would load (#4917).
-///
-/// # Why a port and not a directory scan
-///
-/// A plugin's skills live under `<plugin_dir>/skills` and are contributed *by
-/// derivation* — nothing is ever copied into the user's own `.stella/`, which
-/// is the property that makes `stella plugin remove` total
-/// (`stella_cli::plugin_cmd::roster`). So the dashboard cannot find them by
-/// widening the roots it walks: it would have to resolve the roster itself,
-/// and with it the project-tier trust gate (#3509), the `plugins.<name> =
-/// "off"` retraction, the install receipt, and the reconcile-on-every-load
-/// check. Every one of those is a security answer, and a second implementation
-/// of a security answer is a second answer — the shape this area exists to
-/// avoid.
-///
-/// So the host that already computes that answer hands it over instead —
-/// ports, not direct dependencies (AGENTS.md rule 1). `stella observe`
-/// implements this over
-/// `plugin_cmd::package::contributed_skill_dirs`, the same call the session's
-/// own skill load makes, so the dashboard and the loader cannot disagree about
-/// what is in force — including about a workspace nobody has trusted, where
-/// both answer nothing.
-///
-/// The port is asked per request rather than once at startup, so a package
-/// installed while the dashboard is open shows up on the next refresh.
-///
-/// **The observer's environment is the observer's.** `STELLA_TRUST_PROJECT`
-/// is read from the process asking, so a `stella observe` launched without it
-/// reports the project tier empty while an agent session launched with it
-/// loads those skills. That is the same authority answering in two
-/// environments rather than two authorities, and what the dashboard reports is
-/// what a session started *here* would load.
-pub trait PluginSkills: Send + Sync {
-    /// The contributed skills directories in force for `workspace_root`.
-    fn contributed_skill_dirs(&self, workspace_root: &Path) -> Vec<ContributedSkills>;
-}
-
-/// The answer for a caller with no roster to report — every unit test that
-/// drives [`crate::respond`], and any host that does not implement the port.
-pub struct NoPluginSkills;
-
-impl PluginSkills for NoPluginSkills {
-    fn contributed_skill_dirs(&self, _workspace_root: &Path) -> Vec<ContributedSkills> {
-        Vec::new()
-    }
-}
-
 /// Every skill visible to this workspace: project `.stella/skills`, the
 /// user-scope skills dir, and every installed plugin's contributed skills,
 /// with learned (self-extracted) skills flagged.
@@ -382,7 +305,7 @@ impl PluginSkills for NoPluginSkills {
 /// A contributed skill whose name is already taken by one of the user's is
 /// omitted, matching the recall loader: it never reaches the prompt, so
 /// listing it would show a steer that is not in force.
-pub fn skills(workspace_root: &Path, plugins: &dyn PluginSkills) -> Value {
+pub fn skills(workspace_root: &Path, plugins: &dyn PluginContributions) -> Value {
     let grades = skill_evidence_grades(workspace_root);
     let mut rows = Vec::new();
     scan_skills_dir(
@@ -575,18 +498,78 @@ const RESERVED_RULE_FILENAMES: &[&str] = &["governance.toml"];
 /// workspace whose whole steering policy is published as TOML records meant an
 /// empty panel beside two enforced rules.
 ///
-/// **A plugin's contributed records are not here**, and the same asymmetry
-/// [`skills`] closed is still open for them: a package's `rules/` steers the
-/// session (`stella context explain` prints `contributed by the \`vera\`
-/// plugin`) and this panel scans one directory. It is a second port of the
-/// [`PluginSkills`] shape, not a second design, and #4974 carries it — kept
-/// separate so the skills half ships against one test rather than two panels
-/// against none.
-pub fn rules_files(workspace_root: &Path) -> Value {
-    let dir = workspace_root.join(".stella/rules");
-    let mut rows = markdown_cards(&dir, 400);
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return json!(rows);
+/// Installed plugins' contributed `<plugin_dir>/rules` are read too, through
+/// [`PluginContributions`] and for the reason that port exists (#4974). A
+/// package's records steer every matching turn in the workspace — `stella
+/// context explain` prints `contributed by the \`vera\` plugin` — and are
+/// never copied into `.stella/rules`, so a panel that scanned one directory
+/// read as the complete list of what steers the session while a third party's
+/// records steered it unlisted.
+///
+/// # Which copy is listed when both exist
+///
+/// `stella_cli::context_records::plugin_first` is the authority and this
+/// follows it rather than inventing a second precedence: contributed
+/// directories are read **first** and both merges downstream are later-wins by
+/// lineage, so the workspace's own copy of a lineage is the one that steers. A
+/// contributed card whose identity is already on the panel is therefore
+/// dropped — listing it would show a steer that is not in force, which is the
+/// same rule [`skills`] applies by name one panel over.
+///
+/// Identity is the lineage id where there is one and the file stem otherwise,
+/// because a `.toml` in a rules directory is a record **set** — one file may
+/// declare several `[[record]]` entries, each with its own lineage — while a
+/// markdown rule has only its name. Deduping the file would drop records
+/// nothing collided with.
+///
+/// # No tier column
+///
+/// A contributed record enters the **project** tier whatever tier its package
+/// is installed at (`plugin_first`: "Project tier, never user"), so the
+/// package's tier is not the record's trust and showing it here would say
+/// something false. `contributed_by` is what the panel gains.
+pub fn rules_files(workspace_root: &Path, plugins: &dyn PluginContributions) -> Value {
+    let mut rows = rule_cards(&workspace_root.join(".stella/rules"));
+    for row in &mut rows {
+        // Null here and set below for a contributed row, so the page never has
+        // to tell an absent field from a null one.
+        row["contributed_by"] = Value::Null;
+    }
+    for contributed in plugins.contributed_record_dirs(workspace_root) {
+        for mut row in rule_cards(&contributed.dir) {
+            if rows
+                .iter()
+                .any(|seen| card_identity(seen) == card_identity(&row))
+            {
+                continue;
+            }
+            row["contributed_by"] = json!(contributed.plugin);
+            rows.push(row);
+        }
+    }
+    rows.sort_by_key(|r| -r["modified_unix"].as_i64().unwrap_or(0));
+    json!(rows)
+}
+
+/// What makes two rule cards the same steer: the lineage id a published record
+/// carries, else the markdown rule's own name. Never the file, because one
+/// `.toml` is a set of records.
+fn card_identity(card: &Value) -> (&str, &str) {
+    match card["lineage_id"].as_str() {
+        Some(lineage) => ("lineage", lineage),
+        None => ("name", card["name"].as_str().unwrap_or_default()),
+    }
+}
+
+/// Every rule card in one rules directory: `*.md` plus each `[[record]]` in
+/// the published context records at `*.toml`.
+///
+/// One function for the workspace's own directory and for each plugin's, so
+/// the two cannot come to differ about which files count.
+fn rule_cards(dir: &Path) -> Vec<Value> {
+    let mut rows = markdown_cards(dir, 400);
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return rows;
     };
     for entry in entries.flatten().take(MAX_DIR_ENTRIES) {
         let path = entry.path();
@@ -602,8 +585,7 @@ pub fn rules_files(workspace_root: &Path) -> Value {
         }
         rows.extend(toml_record_cards(&path));
     }
-    rows.sort_by_key(|r| -r["modified_unix"].as_i64().unwrap_or(0));
-    json!(rows)
+    rows
 }
 
 /// The governance mode from `.stella/rules/governance.toml` (`solo` / `team` /
@@ -925,7 +907,7 @@ tags       = ["testing", "pins"]
         // reserves it and so must this view.
         std::fs::write(rules_dir.join("governance.toml"), "mode = \"regulated\"\n").unwrap();
 
-        let rows = rules_files(dir.path());
+        let rows = rules_files(dir.path(), &NoContributions);
         let rows = rows.as_array().expect("rules_files returns an array");
 
         let toml_card = rows
@@ -1144,7 +1126,7 @@ tags       = ["testing", "pins"]
             .unwrap();
         drop(store);
 
-        let rows = skills(workspace_root, &NoPluginSkills);
+        let rows = skills(workspace_root, &NoContributions);
         let rows = rows.as_array().expect("skills returns an array");
         let find = |name: &str| {
             rows.iter()
@@ -1251,143 +1233,5 @@ tags       = ["testing", "pins"]
         );
         assert!(!s.contains("ghp_nested"), "nested tables under env");
         assert!(s.contains("glm-5.2"), "ordinary lists are untouched");
-    }
-
-    /// A fake roster, so the skills view can be tested without this crate
-    /// linking the one that resolves rosters (which it may not).
-    struct FakeRoster(Vec<ContributedSkills>);
-
-    impl PluginSkills for FakeRoster {
-        fn contributed_skill_dirs(&self, _workspace_root: &Path) -> Vec<ContributedSkills> {
-            self.0.clone()
-        }
-    }
-
-    /// Write a `<dir>/<slug>/SKILL.md`, the layout a package ships.
-    fn plant_skill(dir: &Path, slug: &str, description: &str, body: &str) {
-        let entry = dir.join(slug);
-        std::fs::create_dir_all(&entry).unwrap();
-        std::fs::write(
-            entry.join("SKILL.md"),
-            format!("---\nname: {slug}\ndescription: {description}\n---\n\n{body}\n"),
-        )
-        .unwrap();
-    }
-
-    /// **The parity witness** (#4917). A plugin's skill is listed in the
-    /// dashboard's skills view and names the package that shipped it.
-    ///
-    /// #3567 gave a contributed skill an attribution field and put it on
-    /// screen in the SKILLS tab; this view scanned exactly two roots —
-    /// `<workspace>/.stella/skills` and `<user_config>/skills` — and a
-    /// package's skills live under `<plugin_dir>/skills` and are never copied
-    /// into either. So a user who installed a package for its skills saw them
-    /// in the deck and could not find them in the dashboard, which reads as
-    /// the complete list.
-    #[test]
-    fn a_plugins_skill_is_listed_and_names_the_plugin() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-        let own = root.join(".stella/skills");
-        std::fs::create_dir_all(&own).unwrap();
-        plant_skill(&own, "our-own", "the workspace's own", "OWN_BODY");
-
-        let package = root.join(".stella/plugins/vera/skills");
-        std::fs::create_dir_all(&package).unwrap();
-        plant_skill(
-            &package,
-            "house-style",
-            "how this shop writes code",
-            "PKG_BODY",
-        );
-
-        // Named rather than counted: the user-scope root this view also scans
-        // is the developer's real `~/.stella/skills`, and this crate has no
-        // env lock to move it.
-        let named = |rows: &Value, name: &str| -> Vec<Value> {
-            rows.as_array()
-                .expect("skills returns an array")
-                .iter()
-                .filter(|row| row["name"] == name)
-                .cloned()
-                .collect()
-        };
-        let empty = skills(root, &NoPluginSkills);
-        assert!(
-            named(&empty, "house-style").is_empty(),
-            "anti-vacuity — the package's skill is absent before the roster is asked"
-        );
-        assert_eq!(
-            named(&empty, "our-own").len(),
-            1,
-            "and the workspace's own is there either way"
-        );
-
-        let listed = skills(
-            root,
-            &FakeRoster(vec![ContributedSkills {
-                plugin: "vera".to_string(),
-                tier: PluginTier::Project,
-                dir: package.clone(),
-            }]),
-        );
-        let found = named(&listed, "house-style");
-        let row = found
-            .first()
-            .unwrap_or_else(|| panic!("the package's skill is listed: {listed:#?}"));
-        assert_eq!(row["contributed_by"], "vera", "and names the package");
-        assert_eq!(
-            row["scope"], "project",
-            "at the tier its package is installed at, which is the tier whose \
-             state file governs it"
-        );
-        assert_eq!(
-            row["learned"], false,
-            "a package's skill was not mined by this workspace's loop, whatever \
-             its frontmatter says — counted as learned it would inflate the tile"
-        );
-        assert!(
-            row["evidence_grade"].is_null(),
-            "no proposal here to grade it"
-        );
-        assert!(
-            named(&listed, "our-own")[0]["contributed_by"].is_null(),
-            "and the user's own row names nobody"
-        );
-    }
-
-    /// **The precedence witness.** A package may not silently take over a name
-    /// the user wrote: the recall loader drops the plugin's same-named skill
-    /// before it reaches the prompt, so listing it would show a steer that is
-    /// not in force.
-    #[test]
-    fn a_plugins_skill_never_displaces_one_the_user_wrote_in_the_listing() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-        let own = root.join(".stella/skills");
-        std::fs::create_dir_all(&own).unwrap();
-        plant_skill(&own, "house-style", "the user's own wording", "OWN_BODY");
-
-        let package = root.join(".stella/plugins/vera/skills");
-        std::fs::create_dir_all(&package).unwrap();
-        plant_skill(&package, "house-style", "the package's wording", "PKG_BODY");
-
-        let listed = skills(
-            root,
-            &FakeRoster(vec![ContributedSkills {
-                plugin: "vera".to_string(),
-                tier: PluginTier::Project,
-                dir: package,
-            }]),
-        );
-        let rows: Vec<&Value> = listed
-            .as_array()
-            .expect("skills returns an array")
-            .iter()
-            .filter(|row| row["name"] == "house-style")
-            .collect();
-        assert_eq!(rows.len(), 1, "one row for one name: {rows:#?}");
-        assert_eq!(rows[0]["description"], "the user's own wording");
-        assert!(rows[0]["contributed_by"].is_null());
     }
 }

--- a/crates/stella-observatory/src/fsview/contributions.rs
+++ b/crates/stella-observatory/src/fsview/contributions.rs
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The port through which a host tells the dashboard what a workspace's
+//! installed plugins contribute (#4917, #4974), and the witnesses for the two
+//! views that read it.
+//!
+//! A sibling of [`super`] rather than part of it because the two answer
+//! different questions. Everything in `fsview` derives what it shows from
+//! files this process can see; nothing here can be derived that way at all —
+//! a package's skills and records are contributed by derivation from
+//! `<plugin_dir>`, and reaching them means resolving a roster and a trust
+//! gate that live in `stella-cli`, which this crate may not link. The
+//! trait's own doc comment carries that argument in full.
+
+use std::path::{Path, PathBuf};
+
+/// The tier an installed plugin sits at, which is also the tier its
+/// contributed skills are governed by (`stella_cli::skill_manager`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginTier {
+    /// `<workspace>/.stella/plugins` — the tier behind the project trust gate.
+    Project,
+    /// `~/.stella/plugins` — the operator's own machine-scope tier.
+    User,
+}
+
+impl PluginTier {
+    /// The scope label the skills view already uses for the user's own rows.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::User => "user",
+        }
+    }
+}
+
+/// One installed plugin's contributed directory of one kind, as the host that
+/// resolved the roster reports it.
+///
+/// Mirrors `stella_cli::plugin_cmd::package::ContributedDir`, which is what
+/// every host answering this port already holds.
+#[derive(Debug, Clone)]
+pub struct ContributedDir {
+    /// The contributing plugin's manifest `name`.
+    pub plugin: String,
+    /// The tier its package is installed at.
+    pub tier: PluginTier,
+    /// `<plugin_dir>/skills` or `<plugin_dir>/rules`. It need not exist; an
+    /// absent directory is an empty one, the same as every other root this
+    /// module scans.
+    pub dir: PathBuf,
+}
+
+/// The port a host implements to say what a session started in this workspace
+/// would load out of its installed plugins (#4917, #4974).
+///
+/// # Why a port and not a directory scan
+///
+/// A plugin's skills live under `<plugin_dir>/skills` and its context records
+/// under `<plugin_dir>/rules`, and both are contributed *by derivation* —
+/// nothing is ever copied into the user's own `.stella/`, which is the
+/// property that makes `stella plugin remove` total
+/// (`stella_cli::plugin_cmd::roster`). So the dashboard cannot find them by
+/// widening the roots it walks: it would have to resolve the roster itself,
+/// and with it the project-tier trust gate (#3509), the `plugins.<name> =
+/// "off"` retraction, the install receipt, and the reconcile-on-every-load
+/// check. Every one of those is a security answer, and a second implementation
+/// of a security answer is a second answer — the shape this area exists to
+/// avoid.
+///
+/// So the host that already computes that answer hands it over instead —
+/// ports, not direct dependencies (AGENTS.md rule 1). `stella observe`
+/// implements this over `plugin_cmd::package::contributed_skill_dirs` and
+/// `contributed_record_dirs`, the same two calls the session's own skill load
+/// and context-record registry make, so the dashboard and the loader cannot
+/// disagree about what is in force — including about a workspace nobody has
+/// trusted, where both answer nothing.
+///
+/// # Why one port with two questions rather than two ports
+///
+/// Both questions have one answer-holder — the resolved roster — and one
+/// wrong answer: a roster the host resolved for skills and did not resolve for
+/// records would put the dashboard's two panels on different trust decisions.
+/// A host implements the roster once and answers both from it. It is also what
+/// keeps [`crate::serve`] to one `Arc`: a third contributed surface already
+/// exists (`contributed_mcp_servers`, #4733), and a port per surface would
+/// have the plumbing grow with it.
+///
+/// The port is asked per request rather than once at startup, so a package
+/// installed while the dashboard is open shows up on the next refresh.
+///
+/// **The observer's environment is the observer's.** `STELLA_TRUST_PROJECT`
+/// is read from the process asking, so a `stella observe` launched without it
+/// reports the project tier empty while an agent session launched with it
+/// loads those skills. That is the same authority answering in two
+/// environments rather than two authorities, and what the dashboard reports is
+/// what a session started *here* would load.
+pub trait PluginContributions: Send + Sync {
+    /// The contributed skills directories in force for `workspace_root`.
+    fn contributed_skill_dirs(&self, workspace_root: &Path) -> Vec<ContributedDir>;
+
+    /// The contributed context-record directories in force for
+    /// `workspace_root`.
+    fn contributed_record_dirs(&self, workspace_root: &Path) -> Vec<ContributedDir>;
+}
+
+/// The answer for a caller with no roster to report — every unit test that
+/// drives [`crate::respond`], and any host that does not implement the port.
+pub struct NoContributions;
+
+impl PluginContributions for NoContributions {
+    fn contributed_skill_dirs(&self, _workspace_root: &Path) -> Vec<ContributedDir> {
+        Vec::new()
+    }
+
+    fn contributed_record_dirs(&self, _workspace_root: &Path) -> Vec<ContributedDir> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::super::{rules_files, skills};
+    use super::*;
+    /// A fake roster, so the contributed views can be tested without this
+    /// crate linking the one that resolves rosters (which it may not).
+    ///
+    /// The two kinds are held separately because the real roster answers them
+    /// from two different package subdirectories, and a fake that returned one
+    /// list for both would let a view read the other kind's directory and
+    /// still pass.
+    #[derive(Default)]
+    struct FakeRoster {
+        skills: Vec<ContributedDir>,
+        records: Vec<ContributedDir>,
+    }
+
+    impl FakeRoster {
+        fn with_skills(dirs: Vec<ContributedDir>) -> Self {
+            Self {
+                skills: dirs,
+                records: Vec::new(),
+            }
+        }
+
+        fn with_records(dirs: Vec<ContributedDir>) -> Self {
+            Self {
+                skills: Vec::new(),
+                records: dirs,
+            }
+        }
+    }
+
+    impl PluginContributions for FakeRoster {
+        fn contributed_skill_dirs(&self, _workspace_root: &Path) -> Vec<ContributedDir> {
+            self.skills.clone()
+        }
+
+        fn contributed_record_dirs(&self, _workspace_root: &Path) -> Vec<ContributedDir> {
+            self.records.clone()
+        }
+    }
+
+    /// Write a `<dir>/<slug>/SKILL.md`, the layout a package ships.
+    fn plant_skill(dir: &Path, slug: &str, description: &str, body: &str) {
+        let entry = dir.join(slug);
+        std::fs::create_dir_all(&entry).unwrap();
+        std::fs::write(
+            entry.join("SKILL.md"),
+            format!("---\nname: {slug}\ndescription: {description}\n---\n\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    /// **The parity witness** (#4917). A plugin's skill is listed in the
+    /// dashboard's skills view and names the package that shipped it.
+    ///
+    /// #3567 gave a contributed skill an attribution field and put it on
+    /// screen in the SKILLS tab; this view scanned exactly two roots —
+    /// `<workspace>/.stella/skills` and `<user_config>/skills` — and a
+    /// package's skills live under `<plugin_dir>/skills` and are never copied
+    /// into either. So a user who installed a package for its skills saw them
+    /// in the deck and could not find them in the dashboard, which reads as
+    /// the complete list.
+    #[test]
+    fn a_plugins_skill_is_listed_and_names_the_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let own = root.join(".stella/skills");
+        std::fs::create_dir_all(&own).unwrap();
+        plant_skill(&own, "our-own", "the workspace's own", "OWN_BODY");
+
+        let package = root.join(".stella/plugins/vera/skills");
+        std::fs::create_dir_all(&package).unwrap();
+        plant_skill(
+            &package,
+            "house-style",
+            "how this shop writes code",
+            "PKG_BODY",
+        );
+
+        // Named rather than counted: the user-scope root this view also scans
+        // is the developer's real `~/.stella/skills`, and this crate has no
+        // env lock to move it.
+        let named = |rows: &Value, name: &str| -> Vec<Value> {
+            rows.as_array()
+                .expect("skills returns an array")
+                .iter()
+                .filter(|row| row["name"] == name)
+                .cloned()
+                .collect()
+        };
+        let empty = skills(root, &NoContributions);
+        assert!(
+            named(&empty, "house-style").is_empty(),
+            "anti-vacuity — the package's skill is absent before the roster is asked"
+        );
+        assert_eq!(
+            named(&empty, "our-own").len(),
+            1,
+            "and the workspace's own is there either way"
+        );
+
+        let listed = skills(
+            root,
+            &FakeRoster::with_skills(vec![ContributedDir {
+                plugin: "vera".to_string(),
+                tier: PluginTier::Project,
+                dir: package.clone(),
+            }]),
+        );
+        let found = named(&listed, "house-style");
+        let row = found
+            .first()
+            .unwrap_or_else(|| panic!("the package's skill is listed: {listed:#?}"));
+        assert_eq!(row["contributed_by"], "vera", "and names the package");
+        assert_eq!(
+            row["scope"], "project",
+            "at the tier its package is installed at, which is the tier whose \
+             state file governs it"
+        );
+        assert_eq!(
+            row["learned"], false,
+            "a package's skill was not mined by this workspace's loop, whatever \
+             its frontmatter says — counted as learned it would inflate the tile"
+        );
+        assert!(
+            row["evidence_grade"].is_null(),
+            "no proposal here to grade it"
+        );
+        assert!(
+            named(&listed, "our-own")[0]["contributed_by"].is_null(),
+            "and the user's own row names nobody"
+        );
+    }
+
+    /// **The precedence witness.** A package may not silently take over a name
+    /// the user wrote: the recall loader drops the plugin's same-named skill
+    /// before it reaches the prompt, so listing it would show a steer that is
+    /// not in force.
+    #[test]
+    fn a_plugins_skill_never_displaces_one_the_user_wrote_in_the_listing() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let own = root.join(".stella/skills");
+        std::fs::create_dir_all(&own).unwrap();
+        plant_skill(&own, "house-style", "the user's own wording", "OWN_BODY");
+
+        let package = root.join(".stella/plugins/vera/skills");
+        std::fs::create_dir_all(&package).unwrap();
+        plant_skill(&package, "house-style", "the package's wording", "PKG_BODY");
+
+        let listed = skills(
+            root,
+            &FakeRoster::with_skills(vec![ContributedDir {
+                plugin: "vera".to_string(),
+                tier: PluginTier::Project,
+                dir: package,
+            }]),
+        );
+        let rows: Vec<&Value> = listed
+            .as_array()
+            .expect("skills returns an array")
+            .iter()
+            .filter(|row| row["name"] == "house-style")
+            .collect();
+        assert_eq!(rows.len(), 1, "one row for one name: {rows:#?}");
+        assert_eq!(rows[0]["description"], "the user's own wording");
+        assert!(rows[0]["contributed_by"].is_null());
+    }
+
+    /// Write a record set at `<dir>/<file>.toml` — one file, one
+    /// `[[record]]` per `(lineage, statement)` pair.
+    fn plant_records(dir: &Path, file: &str, records: &[(&str, &str)]) {
+        std::fs::create_dir_all(dir).unwrap();
+        let mut text = String::from("schema = \"context-record/v0.1\"\nset_id = \"house\"\n");
+        for (lineage, statement) in records {
+            text.push_str(&format!(
+                "\n[[record]]\nlineage_id = \"{lineage}\"\nkind = \"constraint\"\n\
+                 statement = \"{statement}\"\n\n  [record.steering]\n  force = \"must\"\n"
+            ));
+        }
+        std::fs::write(dir.join(format!("{file}.toml")), text).unwrap();
+    }
+
+    /// **The parity witness** (#4974). A plugin's context record is listed in
+    /// the dashboard's rules panel and names the package that shipped it.
+    ///
+    /// A package's `rules/` steers every matching turn — `stella context
+    /// explain` prints `contributed by the \`vera\` plugin` — and this panel
+    /// scanned exactly `.stella/rules`. A record is the surface that steers
+    /// *quietly*, without appearing in a transcript as anything the agent did,
+    /// so a panel that reads as the complete list of what steers this
+    /// workspace and omits it is worse than one that showed nothing.
+    #[test]
+    fn a_plugins_record_is_listed_and_names_the_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        plant_records(
+            &root.join(".stella/rules"),
+            "ctx.house.ours",
+            &[("ctx.house.ours", "OUR_OWN_MARKER")],
+        );
+
+        let package = root.join(".stella/plugins/vera/rules");
+        plant_records(
+            &package,
+            "ctx.house.theirs",
+            &[("ctx.house.theirs", "PACKAGE_MARKER")],
+        );
+
+        let named = |rows: &Value, lineage: &str| -> Vec<Value> {
+            rows.as_array()
+                .expect("rules_files returns an array")
+                .iter()
+                .filter(|row| row["lineage_id"] == lineage)
+                .cloned()
+                .collect()
+        };
+
+        let empty = rules_files(root, &NoContributions);
+        assert!(
+            named(&empty, "ctx.house.theirs").is_empty(),
+            "anti-vacuity — the package's record is absent before the roster is asked"
+        );
+        assert_eq!(
+            named(&empty, "ctx.house.ours").len(),
+            1,
+            "and the workspace's own is there either way"
+        );
+
+        let listed = rules_files(
+            root,
+            &FakeRoster::with_records(vec![ContributedDir {
+                plugin: "vera".to_string(),
+                tier: PluginTier::Project,
+                dir: package,
+            }]),
+        );
+        let found = named(&listed, "ctx.house.theirs");
+        let row = found
+            .first()
+            .unwrap_or_else(|| panic!("the package's record is listed: {listed:#?}"));
+        assert_eq!(row["contributed_by"], "vera", "and names the package");
+        assert_eq!(
+            row["statement"], "PACKAGE_MARKER",
+            "with the fields the panel renders, not just a title"
+        );
+        assert!(
+            named(&listed, "ctx.house.ours")[0]["contributed_by"].is_null(),
+            "and the workspace's own row names nobody"
+        );
+    }
+
+    /// **The precedence witness.** A rules file is a record *set*, so the
+    /// panel dedupes by lineage and not by file: a package whose set shares
+    /// one lineage with the workspace's own must lose that lineage and keep
+    /// every other record in the same file.
+    ///
+    /// `stella_cli::context_records::plugin_first` reads contributed
+    /// directories first and every merge below it is later-wins by lineage, so
+    /// the workspace's copy is what steers — listing the package's would show
+    /// a steer that is not in force. Dropping the whole file instead would
+    /// hide records nothing collided with, which is the failure mode the set
+    /// shape introduces and the skills half never had.
+    #[test]
+    fn a_plugins_record_loses_a_shared_lineage_and_keeps_the_rest_of_its_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        plant_records(
+            &root.join(".stella/rules"),
+            "ctx.house.shared",
+            &[("ctx.house.shared", "OURS_WINS")],
+        );
+
+        let package = root.join(".stella/plugins/vera/rules");
+        plant_records(
+            &package,
+            "ctx.house.set",
+            &[
+                ("ctx.house.shared", "THEIRS_LOSES"),
+                ("ctx.house.only-theirs", "THEIRS_SURVIVES"),
+            ],
+        );
+
+        let listed = rules_files(
+            root,
+            &FakeRoster::with_records(vec![ContributedDir {
+                plugin: "vera".to_string(),
+                tier: PluginTier::Project,
+                dir: package,
+            }]),
+        );
+        let rows = listed.as_array().expect("rules_files returns an array");
+
+        let shared: Vec<&Value> = rows
+            .iter()
+            .filter(|row| row["lineage_id"] == "ctx.house.shared")
+            .collect();
+        assert_eq!(shared.len(), 1, "one row for one lineage: {shared:#?}");
+        assert_eq!(shared[0]["statement"], "OURS_WINS");
+        assert!(shared[0]["contributed_by"].is_null());
+
+        let survivor: Vec<&Value> = rows
+            .iter()
+            .filter(|row| row["lineage_id"] == "ctx.house.only-theirs")
+            .collect();
+        assert_eq!(
+            survivor.len(),
+            1,
+            "the rest of the package's set is not collateral: {rows:#?}"
+        );
+        assert_eq!(survivor[0]["contributed_by"], "vera");
+    }
+}

--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -71,9 +71,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 pub use db::{DbError, Observatory};
-/// The port a host implements to report a workspace's plugin-contributed
-/// skills, and the shapes it answers with (#4917).
-pub use fsview::{ContributedSkills, NoPluginSkills, PluginSkills, PluginTier};
+/// The port a host implements to report what a workspace's installed plugins
+/// contribute — skills and context records — and the shapes it answers with
+/// (#4917, #4974).
+pub use fsview::{ContributedDir, NoContributions, PluginContributions, PluginTier};
 
 /// The dashboard page, embedded so the binary is self-contained.
 const INDEX_HTML: &str = include_str!("assets/index.html");
@@ -261,18 +262,23 @@ fn route_of(path: &str) -> &str {
 /// mean buffering an endless one.
 #[must_use]
 pub fn respond(workspace_root: &Path, path: &str) -> Response {
-    respond_with(workspace_root, path, &NoPluginSkills)
+    respond_with(workspace_root, path, &NoContributions)
 }
 
-/// [`respond`], with the host's answer for which plugin-contributed skills a
-/// session started here would load ([`PluginSkills`], #4917).
+/// [`respond`], with the host's answer for what a session started here would
+/// load out of its installed plugins ([`PluginContributions`], #4917, #4974).
 ///
-/// Split from [`respond`] rather than added to it because only the one route
-/// that lists skills consults it: every other route is still a pure function
-/// of (workspace, path), and the dozens of unit tests that drive [`respond`]
-/// should not have to name a roster to ask about executions.
+/// Split from [`respond`] rather than added to it because only the two routes
+/// that list a contributed surface consult it — `/api/skills` and
+/// `/api/rules`: every other route is still a pure function of (workspace,
+/// path), and the dozens of unit tests that drive [`respond`] should not have
+/// to name a roster to ask about executions.
 #[must_use]
-pub fn respond_with(workspace_root: &Path, path: &str, plugins: &dyn PluginSkills) -> Response {
+pub fn respond_with(
+    workspace_root: &Path,
+    path: &str,
+    plugins: &dyn PluginContributions,
+) -> Response {
     let (route, query) = match path.split_once('?') {
         Some((r, q)) => (r, Some(q)),
         None => (path, None),
@@ -557,7 +563,7 @@ pub fn respond_with(workspace_root: &Path, path: &str, plugins: &dyn PluginSkill
         "/api/rules" => obs.rules().map(|db| {
             serde_json::json!({
                 "db": db,
-                "files": fsview::rules_files(root),
+                "files": fsview::rules_files(root, plugins),
                 "promotions": fsview::promotions(root),
                 "governance_mode": fsview::governance_mode(root),
             })
@@ -666,14 +672,14 @@ fn percent_decode(value: &str) -> String {
 /// exits. `port` 0 picks a free port. Calls `on_ready` once with the bound
 /// address (the CLI prints the URL from it).
 ///
-/// `plugins` answers which plugin-contributed skills a session started in this
-/// workspace would load — see [`PluginSkills`] for why the host is
-/// asked rather than the filesystem walked. [`NoPluginSkills`] is the
+/// `plugins` answers what a session started in this workspace would load out
+/// of its installed plugins — see [`PluginContributions`] for why the host is
+/// asked rather than the filesystem walked. [`NoContributions`] is the
 /// answer for a host with no roster.
 pub async fn serve(
     workspace_root: PathBuf,
     port: u16,
-    plugins: Arc<dyn PluginSkills>,
+    plugins: Arc<dyn PluginContributions>,
     on_ready: impl FnOnce(SocketAddr),
 ) -> Result<(), ServeError> {
     let listener = TcpListener::bind(("127.0.0.1", port))
@@ -773,7 +779,7 @@ fn host_is_local(head: &str) -> bool {
 async fn handle(
     mut stream: TcpStream,
     workspace_root: &Path,
-    plugins: Arc<dyn PluginSkills>,
+    plugins: Arc<dyn PluginContributions>,
 ) -> std::io::Result<()> {
     let head = match tokio::time::timeout(READ_TIMEOUT, read_head(&mut stream)).await {
         Ok(result) => result?,
@@ -825,7 +831,7 @@ async fn respond_to_head(
     mut stream: TcpStream,
     workspace_root: &Path,
     head: RequestHead,
-    plugins: Arc<dyn PluginSkills>,
+    plugins: Arc<dyn PluginContributions>,
 ) -> std::io::Result<()> {
     let RequestHead {
         text: head,

--- a/crates/stella-observatory/src/tests/http_surface.rs
+++ b/crates/stella-observatory/src/tests/http_surface.rs
@@ -149,7 +149,7 @@ async fn serves_over_a_real_socket() {
         let _ = serve(
             root,
             0,
-            std::sync::Arc::new(crate::NoPluginSkills),
+            std::sync::Arc::new(crate::NoContributions),
             move |addr| {
                 let _ = tx.send(addr);
             },
@@ -246,7 +246,7 @@ async fn unterminated_request_head_is_refused_not_routed() {
         let _ = serve(
             root,
             0,
-            std::sync::Arc::new(crate::NoPluginSkills),
+            std::sync::Arc::new(crate::NoContributions),
             move |addr| {
                 let _ = tx.send(addr);
             },

--- a/crates/stella-observatory/tests/live_stream.rs
+++ b/crates/stella-observatory/tests/live_stream.rs
@@ -30,7 +30,7 @@ fn serve(root: std::path::PathBuf) -> std::net::SocketAddr {
             stella_observatory::serve(
                 root,
                 0,
-                std::sync::Arc::new(stella_observatory::NoPluginSkills),
+                std::sync::Arc::new(stella_observatory::NoContributions),
                 |addr| {
                     let _ = tx.send(addr);
                 },


### PR DESCRIPTION
> **Rebased onto `main` after #4977 merged.** This was stacked on that branch; the squash landed as `219c23806`, so the stack was replayed with `git rebase --onto origin/main 6876eeffa` rather than merged, which is why the diff is one commit and no conflict remains. #4977's observatory and CLI code landed byte-identical to what this was built on (`git diff 6876eeffa origin/main -- crates/stella-observatory/ crates/stella-cli/src/storage_cmd.rs` is empty), so the shape here still matches the one it landed. Verified by name rather than by count: `cargo test -p stella-cli --bins -- plugin_cmd::tests::contributions` lists all 15 tests, including main's own `a_contributed_skills_tier_is_read_off_contributed_by_not_off_its_path` (#4965) and #4917's `the_dashboards_plugin_skills_honour_the_project_trust_gate` alongside this PR's — and a function-name diff of the file against `origin/main` removes nothing and adds exactly one.

## What

The Observatory's rules panel lists a plugin's contributed context records, names the package that shipped them, and honours the same project-tier trust gate the registry does. Nothing is copied into the user's `.stella/`.

## Same shape as the skills half, and the one place it could not be

The issue asked for a second port modelled on #4917's, and this is that — the same reasoning, the same host, the same per-request call. Two things are different, and both are because a rules file is a **record set**:

**Dedup is by lineage id, and the authority is `stella_cli::context_records::plugin_first`.** It reads contributed directories **first**, and every merge below it is later-wins by lineage, so the workspace's own copy of a lineage is the one that steers. A contributed card whose identity is already on the panel is therefore dropped — listing it would show a steer that is not in force, which is what the skills half does by name. Identity is the lineage id where there is one and the file stem otherwise, because a `.toml` may declare several `[[record]]` entries with their own lineages while a markdown rule has only its name. **Deduping the file would drop records nothing collided with**, and that is the failure mode the set shape introduces; `a_plugins_record_loses_a_shared_lineage_and_keeps_the_rest_of_its_set` is the assertion, with an ablation below.

**No tier column.** A contributed record enters the **project** tier whatever tier its package is installed at (`plugin_first`: "Project tier, never user" — a package's records are a third party's, and reading them as `Trust::User` would let one establish a guard the workspace cannot override). So the package's tier is not the record's trust, and a scope chip here would say something false. `contributed_by` is what the panel gains.

## One port with two questions rather than a second trait

`PluginSkills` becomes `PluginContributions` with `contributed_skill_dirs` **and** `contributed_record_dirs`; `NoPluginSkills` → `NoContributions`; `ContributedSkills` → `ContributedDir`, which is also what `stella_cli::plugin_cmd::package` already calls the identical shape it holds.

This edits the sibling PR's public API, so it is worth reviewing as a decision rather than a tidy-up:

- **The two questions have one answer-holder and one wrong answer.** A host that resolved the roster for skills and did not resolve it for records would put the dashboard's two panels on different trust decisions. One trait means a host implements the roster once.
- **It keeps `serve` to one `Arc`.** A third contributed surface already exists in the tree — `contributed_mcp_servers` (#4733) — and a port per surface grows `serve`, `respond_with`, `handle` and `respond_to_head` each time.
- Invariant #9's single-purpose rule is about tools, not traits; a parameter here scopes nothing and selects nothing.

`ContributedSkills` and a `ContributedRecords` beside it would have been two identical structs in a public API, which is the alternative I rejected.

## The port and its witnesses move to `fsview/contributions.rs`

`fsview.rs` would otherwise have reached 1648 lines, and the ratchet is right to refuse it. The split is a real boundary rather than a line-count dodge: everything else in `fsview` derives what it shows from files this process can see, and nothing in the new module can be derived that way at all — a package's contributions are reached through a roster and a trust gate that live in `stella-cli`, which this crate may not link. `fsview.rs` ends at 1234 lines; the new file is 438 and carries the trait, the two shapes, `NoContributions` and the four contributed-view witnesses.

## Witnesses

Observatory side, against a fake roster (this crate may not link the one that resolves real rosters). The fake holds the two kinds **separately**, because the real roster answers them from two different package subdirectories and a fake returning one list for both would let a view read the other kind's directory and still pass:

- `a_plugins_record_is_listed_and_names_the_plugin` — absent before the roster is asked, listed after, naming the plugin, carrying the fields the panel renders, and the workspace's own row still naming nobody.
- `a_plugins_record_loses_a_shared_lineage_and_keeps_the_rest_of_its_set`.

CLI side, against the real one, through `/api/rules` (the route the page fetches):

- `the_dashboards_plugin_records_honour_the_project_trust_gate` — untrusted checkout contributes nothing and `PACKAGE_RECORD_MARKER` is absent from the response body; trusted, the same bytes contribute once and the body carries `"contributed_by":"vera"`; removed, it is gone from the port and from the panel.

### Ablations

**1. Drop the contributed rows, keep the port call** (so the ablation removes the answer, not the compile):

```
---- fsview::tests::a_plugins_record_is_listed_and_names_the_plugin ----
panicked at crates/stella-observatory/src/fsview.rs:1566:32:
the package's record is listed: Array [ { "contributed_by": Null, "lineage_id": "ctx.house.ours", … } ]

test result: FAILED. 0 passed; 2 failed
```

Both observatory witnesses fail, which is what a total removal should do.

**2. Remove the dedup alone** — the precedence claim on its own:

```
running 2 tests
test fsview::tests::a_plugins_record_is_listed_and_names_the_plugin ... ok
test fsview::tests::a_plugins_record_loses_a_shared_lineage_and_keeps_the_rest_of_its_set ... FAILED

panicked at .../fsview.rs:1631:9: assertion `left == right` failed: one row for one lineage: [
  { "contributed_by": Null,          "lineage_id": "ctx.house.shared", "statement": "OURS_WINS"   },
  { "contributed_by": String("vera"), "lineage_id": "ctx.house.shared", "statement": "THEIRS_LOSES" } ]
  left: 2  right: 1
```

**3. Dedupe by file instead of by lineage** — the failure the set shape introduces, and the reason assertion 2 is not enough on its own:

```
running 2 tests
test fsview::tests::a_plugins_record_is_listed_and_names_the_plugin ... ok
test fsview::tests::a_plugins_record_loses_a_shared_lineage_and_keeps_the_rest_of_its_set ... FAILED

panicked at .../fsview.rs:1643:9: assertion `left == right` failed:
the rest of the package's set is not collateral: [ { "lineage_id": "ctx.house.shared", "statement": "OURS_WINS" } ]
  left: 0  right: 1
```

Ablations 2 and 3 are opposite errors and each fails a different assertion inside the same test, with the parity witness green through both.

**4. Answer the host port from the plugin directory layout instead of from the roster** — the directory scan the port exists to avoid:

```
running 2 tests
test the_dashboards_plugin_records_honour_the_project_trust_gate ... FAILED
test the_dashboards_plugin_skills_honour_the_project_trust_gate ... ok

panicked at crates/stella-cli/src/plugin_cmd/tests/contributions.rs:1089:5:
an untrusted checkout contributes no records to the dashboard
```

It fails at the **untrusted** assertion, which is the one that matters, and the skills witness beside it stays green — so the pair separates the records port from the skills port rather than measuring the same thing twice.

## The page

The rules panel is a card list rather than a table, so `via <plugin>` is a chip beside the record's chips, with the same title text the skills table's `via` column uses.

## Not fixed here
`the_dashboards_plugin_skills_honour_the_project_trust_gate`'s `STELLA_HOME` workaround, and the one this PR's own witness carries for the same reason, both stay. #4980's fix landed as #4992 while this was in review, so the two lines are now dead weight rather than load-bearing — but deleting them is a change with its own verification step (a green run on a machine with no `~/.stella/skills/house-style` proves nothing), and widening a rebased PR to carry it is how a small cleanup becomes the reason a merge slips. #5002 has it, with both of its preconditions now met.

## No deleted or renamed tests

Nothing removed; two added. Four existing tests moved file (`fsview.rs` → `fsview/contributions.rs`) with no change to their bodies; the deleted-test guard compares names across the merge and moves are not deletions, but naming them here anyway.

## Verification

`cargo fmt --all --check`, `cargo clippy -p stella-observatory -p stella-cli --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc -p stella-observatory`, `make guards-fast` (prose and the file-size ratchet included), `cargo test -p stella-observatory` (exit 0) and `cargo test -p stella-cli --bins` (2328 passed), plus the rebase-onto-`main` composition check described at the top. CI is the evidence.

Closes #4974
Refs #4917, #3567, #3509, #4980, #4992, #5002
