### PR TITLE
docs(scripts): name the mention-versus-use hazard where the paint sweep hits it

### DIFF
--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -287,11 +287,21 @@ def paint_report(root: Path, doc: dict, files: list[Path]) -> list[str]:
       this tree is named only by tests, so no verdict here turns on that; if one
       ever is, this is the sentence that has to change rather than a number.
     - **Prose counts.** A doc comment writing `token::DIFF_ADD_BG` is a site as
-      far as this is concerned. That makes `painted` fractionally easier to
-      satisfy and can make a real `gap` read as stale -- the loud direction,
-      which names the file and line and is fixed by moving the sentence or
-      declaring the token painted. A structural fix means parsing Rust and CSS,
-      which is a language server rather than a guard.
+      far as this is concerned. A scanner that reads source cannot tell a
+      mention from a use without being taught to, and #4986 is the same hazard
+      on another guard: `embedder_backend_sealed_cli.rs` counted a module doc
+      naming `CARGO_BIN_EXE_stella` as a spawn site and failed a correctly
+      sealed file with a billing-leak message. Read that issue before
+      "fixing" this line -- it is the shape, and the reasoning there applies
+      here unchanged.
+
+      The asymmetry is what makes it tolerable rather than a defect to fix
+      now. A stray mention makes `painted` fractionally easier to satisfy,
+      which is quiet; it makes a real `gap` read as stale, which is loud, names
+      the file and line, and is cleared by moving the sentence or declaring the
+      token painted. That direction is how this guard found a scratch file on
+      its own PR (#4996). A structural fix means parsing Rust and CSS, which is
+      a language server rather than a guard.
 
     **Which files.** `tracked_files` -- `git ls-files --cached --others
     --exclude-standard` -- so an un-ignored file in a working tree counts even


### PR DESCRIPTION
## What

One comment in `scripts/check-tokens.py`. No predicate moves.

`paint_report`'s stated bounds already said prose counts as a paint site. They did not say this is a **known shape with a worked example one guard over** — and that example was hit the same day.

#4986: `crates/stella-cli/tests/embedder_backend_sealed_cli.rs` counted a module doc naming `CARGO_BIN_EXE_stella` as a spawn site, and failed a correctly sealed file with the most alarming message in the suite — *"a spawned child inherits VOYAGE_API_KEY and bills whoever runs the suite"*. The printed remedy was wrong for that file, and the only ways to clear it were to delete the prose or to add a seal that seals nothing.

The paint sweep has the same hazard for the same reason: a scanner that reads source cannot tell a mention from a use without being taught to. The comment now points at #4986 before the next reader reinvents the analysis, or "fixes" the line by narrowing the matcher in a way #4986 already shows the cost of.

## What it also records

Why this one is tolerable rather than a defect to fix now, which the original text left implicit. **The two directions are not symmetric:**

- A stray mention makes `painted` fractionally easier to satisfy — **quiet**, and the weaker half.
- It makes a real `gap` read as stale — **loud**, names the file and line, and is cleared by moving the sentence or declaring the token painted.

That loud direction is not hypothetical: it is how the sweep caught a scratch commit-message file on #4994's own first push, which is now #4996. A guard whose false positives are loud and located is a different proposition from one whose false positives are quiet, and the comment says which this is.

A structural fix means parsing Rust and CSS — a language server rather than a guard.

## Verification

Comment-only, so the witness is that nothing moved:

```
$ python3 ./scripts/check-tokens.py
tokens: no retired hex in the tree; 3 token-only path(s) clean; 160 token citation(s) quote the palette;
28 token(s) painted, 4 declared gap(s)

$ ./scripts/test-tokens.sh
29 passed, 0 failed

$ python3 ./scripts/check-prose.py
check-prose: OK -- 4206 grandfathered construction(s) in 1174 file(s), none added.

$ python3 ./scripts/check-line-citations.py
check-line-citations: OK -- 260 grandfathered citation(s) in 36 file(s), none added.
```

No witness test: this is a documentation change with no behaviour to witness, per CONTRIBUTING.md. No test deleted, no baseline touched.

Refs #4975, #4986, #4996

## Summary by Sourcery

Clarify the token paint report’s mention-versus-use hazard and why its current behavior remains acceptable.

Enhancements:
- Document the token paint report’s known false-positive behavior, its asymmetric impact, and the rationale for retaining the current source scanner.

Documentation:
- Add a cross-reference to a related guard failure so future changes account for mention-versus-use hazards.