### PR TITLE
refactor(stella-tui): name the paper theme's secondary ink for its ground

### DIFF
--- a/crates/stella-tui/src/palette.rs
+++ b/crates/stella-tui/src/palette.rs
@@ -26,7 +26,7 @@
 //! has no home for yet rather than an oversight (#4058):
 //!
 //! - **The light theme.** `PAPER`, `SNOW`, `PAPER_RAISED`, `PAPER_HAIRLINE`,
-//!   `MUTED`, `INK_DIM`, `INK_EMPHASIS`, and the three ink golds
+//!   `INK_MUTED`, `INK_DIM`, `INK_EMPHASIS`, and the three ink golds
 //!   (`BRAND_INK`, `BRAND_INK_DEEP`, `GOLD_INK`). The JSON declares four
 //!   `web-light` stops and they disagree with these: its `paper` is pure
 //!   white where the deck paints `#F4F4F6`, and its `ink` is `#141416`
@@ -298,7 +298,14 @@ pub const INK: Color = token::BG;
 
 /// Secondary text on paper -- 5.83:1, the paper counterpart of
 /// [`TEXT_SECONDARY`].
-pub const MUTED: Color = Color::Rgb(0x5E, 0x5E, 0x69);
+///
+/// Named for its ground, like [`INK_DIM`] and [`INK_EMPHASIS`]. It was
+/// `MUTED` until #5001, which put it one word away from
+/// `stella_tui_theme::token::MUTED` `#777782` -- the dark ramp's tier below
+/// silver, a different colour on a different ground, with nothing at a call
+/// site to say which one a line had reached. #4966 removed the third
+/// constant of that name; this is the last of them.
+pub const INK_MUTED: Color = Color::Rgb(0x5E, 0x5E, 0x69);
 
 /// Tertiary text on paper -- 4.72:1 on [`PAPER`], the counterpart of
 /// [`TEXT_TERTIARY`]. On [`PAPER_RAISED`] it drops to 4.16:1 and is a
@@ -384,7 +391,7 @@ pub const ALL: [(&str, Color); 37] = [
     ("paper-raised", PAPER_RAISED),
     ("paper-hairline", PAPER_HAIRLINE),
     ("ink", INK),
-    ("muted", MUTED),
+    ("ink-muted", INK_MUTED),
     ("ink-dim", INK_DIM),
     ("ink-emphasis", INK_EMPHASIS),
     ("data-1", DATA_1),

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -84,8 +84,10 @@ pub const TEXT_PRIMARY: Color = palette::TEXT_PRIMARY;
 /// This tier is `silver`, and it used to answer to a second name — `MUTED`,
 /// with [`text_secondary`] spelled `muted()`. That name was one tier off its
 /// own value: it resolved here, to `stella_tui_theme::token::SILVER` `#A9AAB5`,
-/// while `token::MUTED` `#777782` is the tier below and `crate::palette::MUTED`
-/// `#5E5E69` is a third colour again — three constants, one word. A call site
+/// while `token::MUTED` `#777782` is the tier below and the paper theme's
+/// secondary ink `#5E5E69` was a third colour again — three constants, one
+/// word, until #4966 removed this one and #5001 renamed the paper stop to
+/// [`crate::palette::INK_MUTED`]. A call site
 /// reaching for "the muted tier" and writing `muted()` got silver, and
 /// `crate::diff`'s `gutter` is where that happened: `design/tui-v2/SPEC.md`
 /// §6.4 recorded the result as *"Line number gutter in `dim`"*, wrong by two
@@ -632,7 +634,7 @@ const LIGHT_REMAP: &[(Color, Color)] = &[
     // SYNTAX_KEYWORD the emphasis one).
     (TEXT_PRIMARY, palette::INK),
     (palette::TEXT_EMPHASIS, palette::INK_EMPHASIS),
-    (TEXT_SECONDARY, palette::MUTED),
+    (TEXT_SECONDARY, palette::INK_MUTED),
     (TEXT_TERTIARY, palette::INK_DIM),
     // The dim tier is chrome, and on paper the groove has to darken rather
     // than lighten to stay visible; the tertiary ink is the quietest tone

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -10,7 +10,8 @@ use stella_tui_theme::oklch;
 ///
 /// The ladder used to carry a fifth name, `MUTED`, aliased to
 /// `TEXT_SECONDARY` — so `theme::MUTED` was silver while `token::MUTED` was
-/// the tier below it and `palette::MUTED` was a third colour again. A call
+/// the tier below it and the paper theme's secondary ink (`palette::INK_MUTED`
+/// since #5001) was a third colour again. A call
 /// site could not tell which one it had reached, and `crate::diff`'s `gutter`
 /// is where it went wrong. There is no name left here that resolves to a tier
 /// other than its own, and this test is what says so: the ladder is pinned to
@@ -125,7 +126,7 @@ const LIGHT_ONLY_PALETTE_TOKENS: &[&str] = &[
     "paper-raised",
     "paper-hairline",
     "ink",
-    "muted",
+    "ink-muted",
     "ink-dim",
     "ink-emphasis",
 ];
@@ -159,6 +160,34 @@ fn every_dark_palette_value_has_a_fallback() {
         assert!(
             !palette::ALL[..i].iter().any(|(other, _)| other == name),
             "duplicate palette token name `{name}`"
+        );
+    }
+}
+
+/// Every light-only palette value names the ground it belongs to (#5001).
+///
+/// `palette` is the raw layer — "name the role; put the hue in the value" —
+/// and the paper stops say which ground they are for: `paper`/`snow` for the
+/// surfaces, `ink…` for the text ramp, `…-ink` for the accent and status
+/// stops. `muted` was the one that did not, and it collided with
+/// `stella_tui_theme::token::MUTED`, the dark ramp's tier below silver — two
+/// colours, one word, on two different grounds. That is the trap
+/// [`every_text_tier_resolves_to_the_token_it_names`] describes one layer up:
+/// a call site cannot tell from the name which one it reached.
+#[test]
+fn every_light_only_palette_token_names_its_ground() {
+    for name in LIGHT_ONLY_PALETTE_TOKENS {
+        assert!(
+            name.starts_with("paper")
+                || name.starts_with("snow")
+                || name.starts_with("ink")
+                || name.contains("-ink"),
+            "light-only palette token `{name}` does not name its ground — a \
+             paper stop is `paper…`/`snow…` (surfaces), `ink…` (the text \
+             ramp), or `…-ink` (accent and status). A bare role name here \
+             collides with the dark ramp's vocabulary, which is how \
+             `palette::MUTED` and `token::MUTED` came to be two colours \
+             answering to one word (#5001)"
         );
     }
 }
@@ -675,7 +704,7 @@ fn palette_law_gold_is_the_brand() {
         (palette::PAPER_RAISED, "PAPER_RAISED"),
         (palette::PAPER_HAIRLINE, "PAPER_HAIRLINE"),
         (palette::INK, "INK"),
-        (palette::MUTED, "MUTED"),
+        (palette::INK_MUTED, "INK_MUTED"),
         (palette::INK_DIM, "INK_DIM"),
         (palette::INK_EMPHASIS, "INK_EMPHASIS"),
     ] {

--- a/scripts/check-light-clamp.py
+++ b/scripts/check-light-clamp.py
@@ -227,7 +227,7 @@ SURFACES = (
             "SNOW": "warm-paper",
             "PAPER_RAISED": "warm-paper",
             "PAPER_HAIRLINE": "warm-paper",
-            "MUTED": "warm-paper",
+            "INK_MUTED": "warm-paper",
             "INK_DIM": "warm-paper",
             "INK_EMPHASIS": "warm-paper",
         },

--- a/scripts/light-clamp-baseline.txt
+++ b/scripts/light-clamp-baseline.txt
@@ -32,7 +32,7 @@ crates/stella-transcript/src/html/transcript.css --sunken #F2F5F9
 crates/stella-transcript/src/html/transcript.css --sunken-2 #EEF2F7
 crates/stella-tui/src/palette.rs INK_DIM #6C6C78
 crates/stella-tui/src/palette.rs INK_EMPHASIS #3C3C46
-crates/stella-tui/src/palette.rs MUTED #5E5E69
+crates/stella-tui/src/palette.rs INK_MUTED #5E5E69
 crates/stella-tui/src/palette.rs PAPER #F4F4F6
 crates/stella-tui/src/palette.rs PAPER_HAIRLINE #DDDDE3
 crates/stella-tui/src/palette.rs PAPER_RAISED #E6E6EA


### PR DESCRIPTION
## What

`crates/stella-tui/src/palette.rs`'s `MUTED` — the light theme's secondary ink `#5E5E69`, reached only through `theme::apply_theme`'s paper remap — is now `INK_MUTED`. `stella_tui_theme::token::MUTED` `#777782`, the dark ramp's tier below silver, keeps its name and its value.

Two constants answering to one word on two different grounds, with nothing at a call site to say which one a line reached. #4966 removed the third constant of that name (`theme::MUTED`, aliasing silver) and left the doc naming all three; two were left, and this is the second.

`INK_MUTED` is the family the other paper stops already sit in: `PAPER`, `SNOW`, `PAPER_RAISED`, `PAPER_HAIRLINE`, `INK_DIM`, `INK_EMPHASIS`.

## The seven edit sites

The filer's correction comment named them, and they read three different things:

| site | reads |
|---|---|
| `palette.rs`'s `pub const` | the constant name |
| `palette.rs`'s `ALL` row | the string `"muted"` |
| `theme.rs`'s `LIGHT_REMAP` | the constant |
| `theme/tests.rs`'s `LIGHT_ONLY_PALETTE_TOKENS` | the `ALL` row's string |
| `theme/tests.rs`'s cool-neutral pair list | the constant |
| `scripts/check-light-clamp.py`'s `SURFACES["families"]` | the constant name, via `RUST_DECL` |
| `scripts/light-clamp-baseline.txt` | the constant name, as the `role` half of its `(file, role)` key |

Missing either script reader is not a silent no-op, which is worth saying: leave the `families` key at `MUTED` and the constant becomes **unclassifiable** under the guard's rule 3 (a hard fail, not a skip); leave the baseline row and it goes **stale** (`role satisfies its clamp now`). Both were checked by running the guard.

## The baseline row is a rename, not a raise

`scripts/light-clamp-baseline.txt` keeps the same number of rows, the same file, and the same hex — only the `role` half of the key moves:

```
-crates/stella-tui/src/palette.rs MUTED #5E5E69
+crates/stella-tui/src/palette.rs INK_MUTED #5E5E69
```

Hand-edited rather than regenerated: `make light-clamp-update` reads the new role as a *new* key and refuses to grandfather it, which is the ratchet behaving correctly. No floor moved.

```
$ python3 scripts/check-light-clamp.py
check-light-clamp: 6 shipped light surface(s) judged, 34 held by the ratchet, none off its declared clamp.
```

34 held before and after.

## Witness

`every_light_only_palette_token_names_its_ground` in `crates/stella-tui/src/theme/tests.rs`. Every entry of `LIGHT_ONLY_PALETTE_TOKENS` names the ground it belongs to — `paper…`/`snow…` for the surfaces, `ink…` for the text ramp, `…-ink` for the accent and status stops. `muted` was the only one that did not.

Ablated by reverting the rename across `crates/stella-tui/src` and keeping the test:

```
running 1 test
test theme::tests::every_light_only_palette_token_names_its_ground ... FAILED

---- theme::tests::every_light_only_palette_token_names_its_ground stdout ----
thread '...' panicked at crates/stella-tui/src/theme/tests.rs:180:9:
light-only palette token `muted` does not name its ground — a paper stop is
`paper…`/`snow…` (surfaces), `ink…` (the text ramp), or `…-ink` (accent and
status). A bare role name here collides with the dark ramp's vocabulary, which
is how `palette::MUTED` and `token::MUTED` came to be two colours answering to
one word (#5001)

test result: FAILED. 0 passed; 1 failed
```

The ablation makes the answer wrong (it names the offending token), not merely constant.

## Verified locally

- `cargo test -p stella-tui --lib` — 1148 passed, 0 failed
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps` — clean
- `cargo fmt --check -p stella-tui`, `check-light-clamp.py`, `check-prose.py`, `check-line-citations.py` — clean

CI is the evidence; no workspace build was run here.

Closes #5001

## Summary by Sourcery

Disambiguate the light theme’s secondary ink naming and preserve its palette validation coverage.

Enhancements:
- Rename the light theme’s secondary paper ink from `MUTED` to `INK_MUTED` so its name clearly distinguishes it from the dark theme’s `MUTED` token.
- Add coverage ensuring light-only palette tokens identify their visual ground.

Documentation:
- Update palette and theme documentation to reflect the unambiguous ink-specific name.

Tests:
- Update palette and light-theme expectations for `INK_MUTED` and add a naming-invariant test for light-only palette tokens.

Chores:
- Update light-clamp classification and baseline metadata for the renamed palette role without changing clamp values.