### PR TITLE
test(stella-cli): drop the STELLA_HOME workaround from the dashboard trust test

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
@@ -1056,19 +1056,14 @@ fn the_dashboards_plugin_skills_honour_the_project_trust_gate() {
     }
 
     let _env = crate::test_env::lock();
-    let _restore = crate::test_env::EnvRestore::capture(&[
-        "STELLA_TRUST_PROJECT",
-        "STELLA_PROJECT_HOOKS",
-        "STELLA_HOME",
-    ]);
+    let _restore =
+        crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT", "STELLA_PROJECT_HOOKS"]);
     let root = temp_root("package-observatory-trust");
+    // Moves `stella_home::stella_home()` as well as this crate's thread-local
+    // (#4992), so the dashboard's own user-scope root is the fixture and a
+    // `house-style` in the developer's real `~/.stella/skills` cannot answer
+    // for the assertions below.
     let _paths = crate::paths::test_user_home(root.join("home"));
-    // The dashboard's own user-scope root is `stella_home::stella_home()`,
-    // which `test_user_home` does not move — without this the assertions read
-    // the developer's real `~/.stella/skills` and a `house-style` sitting
-    // there would answer for them.
-    // SAFETY: the env lock is held for the whole mutate-read-restore window.
-    unsafe { std::env::set_var("STELLA_HOME", root.join("home")) };
 
     let planted = stella_home::resolve_project_plugins_dir(&root).join("vera");
     plant(&stella_home::resolve_project_plugins_dir(&root), "vera");


### PR DESCRIPTION
## What

Removes the hand-rolled `STELLA_HOME` workaround from
`the_dashboards_plugin_skills_honour_the_project_trust_gate` in
`crates/stella-cli/src/plugin_cmd/tests/contributions.rs`, and drops
`"STELLA_HOME"` from that test's `EnvRestore::capture` list.

## Why it is safe now

`crate::paths::test_user_home` (`crates/stella-cli/src/paths.rs`) calls
`crate::test_env::home_sandbox`, which sets `HOME` and clears every
`stella_home::OVERRIDE_ENV_VARS` entry — `STELLA_HOME` included — and captures
them for restore. That is #4992, merged. So `stella_home::stella_home()`, which
`stella_observatory::fsview::user_config_dir` uses to find the skills directory,
already resolves inside the fixture.

The workaround was also slightly wrong in the other direction: it pointed the
stella home at `<fixture>/home`, while every other resolver in the test agrees
on `<fixture>/home/.stella`. Removing it makes the two agree.

## Evidence — checked against the hazard, not against green

A green run on a machine with no `~/.stella/skills/house-style` proves nothing,
so the run was poisoned first. `STELLA_HOME` was pointed at a fixture home
carrying `.stella/skills/house-style/SKILL.md` — the same contamination #4980
describes, via the override that outranks `HOME`:

```
$ STELLA_HOME=/tmp/stella-5002-poison-home/.stella \
    cargo test -p stella-cli --bins -- contributions::the_dashboards_plugin
test plugin_cmd::tests::contributions::the_dashboards_plugin_skills_honour_the_project_trust_gate ... ok
test result: ok. 1 passed; 0 failed; ...
```

**Ablation** — `test_user_home`'s `home_sandbox(&home)` reverted to the
pre-#4992 capture-only form, same poisoned run:

```
test plugin_cmd::tests::contributions::the_dashboards_plugin_skills_honour_the_project_trust_gate ... FAILED

panicked at crates/stella-cli/src/plugin_cmd/tests/contributions.rs:1084:5:
and nothing of the package's reaches the skills view: [{"contributed_by":null,
"description":"contamination canary for #5002 — must never reach a test assertion",
"evidence_grade":null,"learned":false,"modified_unix":1787732075,"name":"house-style",
"path":"/tmp/stella-5002-poison-home/.stella/skills/house-style/SKILL.md","scope":"user"}]
```

The ablation makes the answer *wrong*, naming the planted skill by path — so the
control separates a working redirect from a leaking one.

Whole module, unpoisoned: `cargo test -p stella-cli --bins -- contributions::`
→ 14 passed, 0 failed.

## The other half of #5002

#5002 names two tests. Only one is on `main`.
`the_dashboards_plugin_records_honour_the_project_trust_gate` arrives with
**#5003**, which is still open and still adds the same two lines. That copy is
answered on #5003 rather than pre-empted here, so this PR uses `Refs` and #5002
stays open until #5003 lands without the workaround.

## Witness

Test-only change; no behaviour change to ship a witness for. The ablation above
is the proof the test still isolates.

Refs #5002, #4980, #4992, #4977

## Summary by Sourcery

Rely on the shared test home sandbox to keep the dashboard trust-gate test isolated from the developer's user skills.

Enhancements:
- Simplify the dashboard trust-gate test by relying on the shared test home sandbox to isolate the stella home directory.

Tests:
- Remove the test-specific STELLA_HOME override and environment capture while preserving isolation from user skill configuration.