### PR TITLE
feat(scripts): hold the two published palette tables to the palette

### DIFF
--- a/docs/brand/brand-guidelines.html
+++ b/docs/brand/brand-guidelines.html
@@ -255,6 +255,7 @@ retired or is not a live token.</p>
   <div class="sw"><div class="swc" style="background:#141416"></div>
   <div class="swi"><b>Ink</b><span>#141416</span><span class="m">primary text — and brand text — on light</span></div></div>
 </div>
+<!-- BEGIN palette -->
 <h3>Dark — the default theme</h3>
 <table>
 <tr><th>token</th><th>value</th><th>role</th></tr>
@@ -267,7 +268,8 @@ retired or is not a live token.</p>
 <tr><td>--st-gold-bright</td><td>#F7D96B</td><td>tiny live indicators only — spinner, hot marker</td></tr>
 <tr><td>--st-silver</td><td>#A9AAB5</td><td>secondary emphasis, syntax strings</td></tr>
 <tr><td>--st-silver-type</td><td>#BFC1CC</td><td>syntax types, tertiary labels</td></tr>
-<tr><td>--st-text</td><td>#E8E8EC</td><td>primary text on dark</td></tr>
+<tr><td>--st-text</td><td>#E8E8EC</td><td>primary text on dark, in the deck</td></tr>
+<tr><td>--st-paper-text</td><td>#F4F1EA</td><td>primary text on dark, off the deck: the web surfaces and the cut assets — the wordmark SVGs and the OG card</td></tr>
 <tr><td>--st-muted</td><td>#777782</td><td>secondary text</td></tr>
 <tr><td>--st-dim</td><td>#4B4B56</td><td>hints, captions, line numbers</td></tr>
 <tr><td>--st-green</td><td>#74C991</td><td>pass, additive diff sign</td></tr>
@@ -297,6 +299,7 @@ paper tints appear.</p>
 <tr><td>--st-amber-ink</td><td>#8A3F00</td><td>warning, as text on light</td></tr>
 <tr><td>--st-red-ink</td><td>#96213C</td><td>fail, as text on light</td></tr>
 </table>
+<!-- END palette -->
 <h3>The two clamps</h3>
 <p>Any colour work on top of this system is held to two predicates, and both are
 enforced as unit tests against the shipped table rather than argued about:</p>

--- a/docs/brand/prompts/stella-design-system-prompt.md
+++ b/docs/brand/prompts/stella-design-system-prompt.md
@@ -22,6 +22,8 @@ The system is **flat**. There are no 50→950 ramps: v5.0 deletes both the brand
 
 **Dark (the default theme).** CSS variable names are normative.
 
+<!-- BEGIN palette -->
+
 | token | hex | role |
 |---|---|---|
 | `--st-bg` | `#0A0A0C` | canvas — the near-black ground |
@@ -33,12 +35,15 @@ The system is **flat**. There are no 50→950 ramps: v5.0 deletes both the brand
 | `--st-gold-bright` | `#F7D96B` | tiny live indicators only — spinner, hot marker |
 | `--st-silver` | `#A9AAB5` | secondary emphasis, syntax strings |
 | `--st-silver-type` | `#BFC1CC` | syntax types, tertiary labels |
-| `--st-text` | `#E8E8EC` | primary text on dark |
+| `--st-text` | `#E8E8EC` | primary text on dark, in the deck |
+| `--st-paper-text` | `#F4F1EA` | primary text on dark, off the deck — the web surfaces and the cut assets, so this is the one you want for a page |
 | `--st-muted` | `#777782` | secondary text |
 | `--st-dim` | `#4B4B56` | hints, captions, line numbers |
 | `--st-green` | `#74C991` | pass, additive diff sign |
 | `--st-red` | `#E0687A` | fail, destructive, removal diff sign |
 | `--st-amber` | `#E78D54` | warning — the one status the core palette does not otherwise name |
+| `--st-diff-add` | `#10201A` | added diff row background |
+| `--st-diff-del` | `#241019` | removed diff row background |
 | `--st-void` | `#050507` | below the canvas: full-bleed backdrops |
 
 **Light.** Not a recolour of the dark set — its own stops, and the only theme where `ink` and the paper tints appear.
@@ -58,6 +63,8 @@ The system is **flat**. There are no 50→950 ramps: v5.0 deletes both the brand
 | `--st-green-ink` | `#006933` | pass, as text on light |
 | `--st-amber-ink` | `#8A3F00` | warning, as text on light |
 | `--st-red-ink` | `#96213C` | fail, as text on light |
+
+<!-- END palette -->
 
 Two clamps govern any colour work you do on top of this: gold must satisfy `g >= 0.78 r` or it is orange, and orange on a near-black ground reads brown on uncalibrated panels; grays must be neutral or blue-tipped (`r == g`, `b >= g`) or the scheme reads sepia. Both are enforced against the shipped table, so a hand-mixed value that misses them is a build failure, not a taste argument.
 

--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -65,6 +65,34 @@ whole tree today.
    is `scripts/gen-tokens.py`'s `check_paint`, which refuses a token with no
    posture; this is the half that refuses a posture that is not true.
 
+5. **Publication.** The two documents a designer is handed to learn the palette
+   -- the brand kit page and the design brief -- carry a hand-written table of
+   tokens and hexes each, and inside a marker pair every token must have a row.
+
+   Check 3 already holds the rows they *do* carry to the palette's values, and
+   that is a membership question about a **pair**, so it cannot see a token
+   with no row at all. Both documents were already short when this was written
+   (#5007): the kit page tabulated 31 of 32 and the brief 29, and the token
+   missing from both was `--st-paper-text`, the primary text stop off the deck
+   -- the value the wordmark SVGs and the OG card are cut in. A designer
+   reading either document would have reached for `--st-text`, which declares
+   only the `tui` surface.
+
+   Same blind spot as `website/src/lib/brand-parity.test.ts`'s
+   `ramp.length >= 20` floor over the kit's CSS sheet, where twelve tokens had
+   never been mirrored (#4978), and the shape is
+   `crates/stella-tui/tests/spec_palette.rs` (#4991): markers, parse the rows,
+   assert both directions.
+
+   Equality, not a declared subset. #4978's argument for the kit's sheet -- *"a
+   published subset is a defensible thing for the marketing site to be, and is
+   not what the kit is"* -- settles the kit page, and the brief is held to it
+   too: the two rows a shorter prompt would drop (`--st-diff-add`,
+   `--st-diff-del`) cost a line each, and the exclusion mechanism that would
+   let a maintainer drop them is the same mechanism that let
+   `--st-paper-text` go missing. If a subset is wanted later it has to be
+   *declared*, as #4978 required.
+
 `MIGRATING` is the one escape, and it is a ledger, not an allowlist: a path
 listed there is a surface this system has not reached yet, each entry carrying
 the issue that finishes it. The guard **refuses to add entries** -- there is no
@@ -344,6 +372,75 @@ def paint_report(root: Path, doc: dict, files: list[Path]) -> list[str]:
     return failures
 
 
+# ── Check 5: publication ────────────────────────────────────────────────────
+#
+# The documents that publish the palette, each as `(path, begin, end)` around
+# the table(s) that do it. Markers rather than a whole-file sweep, because both
+# documents name tokens in running prose outside their tables -- the kit page
+# spells `--st-gold-ink` in a paragraph about the mark -- and a prose mention
+# is not a published row.
+PUBLICATION = (
+    (
+        "docs/brand/brand-guidelines.html",
+        "<!-- BEGIN palette -->",
+        "<!-- END palette -->",
+    ),
+    (
+        "docs/brand/prompts/stella-design-system-prompt.md",
+        "<!-- BEGIN palette -->",
+        "<!-- END palette -->",
+    ),
+)
+
+PUBLISHED_NAME = re.compile(r"--st-[a-z0-9-]+")
+
+
+def publication_report(root: Path, doc: dict) -> tuple[list[str], int]:
+    """Hold each publishing document to the palette. Returns `(failures, rows)`.
+
+    Both directions, because they fail differently: a token with no row is a
+    colour the document's reader never learns about, and a row naming nothing
+    is a colour they will reach for and not find.
+
+    A listed document that is missing, or that carries no marker pair, fails.
+    A guard that skips its own subject when the subject disappears is a guard
+    satisfied by deleting the file.
+    """
+    declared = {t["css"] for t in doc["tokens"] if "css" in t}
+    failures: list[str] = []
+    rows = 0
+
+    for rel, begin, end in PUBLICATION:
+        path = root / rel
+        if not path.is_file():
+            failures.append(f"{rel}: publishes the palette and is not in the tree")
+            continue
+        text = path.read_text(errors="ignore")
+        head = text.find(begin)
+        if head < 0:
+            failures.append(f"{rel}: carries no `{begin}` marker")
+            continue
+        head += len(begin)
+        tail = text[head:].find(end)
+        if tail < 0:
+            failures.append(f"{rel}: carries no `{end}` after `{begin}`")
+            continue
+
+        published = set(PUBLISHED_NAME.findall(text[head : head + tail]))
+        rows += len(published)
+        for name in sorted(declared - published):
+            failures.append(
+                f"{rel}: publishes no row for {name}, which "
+                f"{TOKENS_REL} declares"
+            )
+        for name in sorted(published - declared):
+            failures.append(
+                f"{rel}: publishes a row for {name}, which no token declares"
+            )
+
+    return failures, rows
+
+
 def tracked_files(root: Path) -> list[Path]:
     out = subprocess.run(
         ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
@@ -385,6 +482,7 @@ def main(argv: list[str]) -> int:
 
     files = tracked_files(root)
     paint_hits = paint_report(root, doc, files)
+    publication_hits, published_rows = publication_report(root, doc)
 
     for rel in files:
         posix = rel.as_posix()
@@ -512,6 +610,22 @@ def main(argv: list[str]) -> int:
             file=sys.stderr,
         )
 
+    if publication_hits:
+        failed = True
+        print(
+            f"\n{len(publication_hits)} gap(s) between the palette and the "
+            "documents that publish it:\n",
+            file=sys.stderr,
+        )
+        for hit in publication_hits:
+            print(f"  {hit}", file=sys.stderr)
+        print(
+            "\nthese two documents are what a designer is handed to learn the "
+            "palette, so a token with no row is a colour nobody reaches for "
+            "(#5007).",
+            file=sys.stderr,
+        )
+
     if failed:
         return 1
 
@@ -522,7 +636,8 @@ def main(argv: list[str]) -> int:
     print(
         f"tokens: no retired hex in the tree; {scope} token-only path(s) clean; "
         f"{citations_ok} token citation(s) quote the palette; {painted} token(s) "
-        f"painted, {gaps} declared gap(s){pending}"
+        f"painted, {gaps} declared gap(s); {len(PUBLICATION)} document(s) "
+        f"publish the palette in {published_rows} row(s){pending}"
     )
     return 0
 

--- a/scripts/test-tokens.sh
+++ b/scripts/test-tokens.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # Tests for check-tokens.py's BAN CHECK, over every notation it claims to
-# watch (#4910), for its CITATION CHECK, whose subject is a pair (#3653), and
-# for its PAINT CHECK, whose subject is an absence (#4975).
+# watch (#4910), for its CITATION CHECK, whose subject is a pair (#3653), for
+# its PAINT CHECK, whose subject is an absence (#4975), and for its
+# PUBLICATION CHECK, whose subject is a different absence (#5007).
 #
 #   ./scripts/test-tokens.sh    (or: make tokens-test)
 #
@@ -48,6 +49,11 @@
 # (#4946, #4975). Both directions get a case: a `painted` declaration with no
 # site must fail, and a `gap` declaration that has since acquired one must fail
 # too, or the ledger records a hole somebody already filled.
+#
+# The publication cases are about the absence one layer out: not a token
+# nothing paints, a token no document tells a designer about. `--st-paper-text`
+# was missing from both published tables at once, and every check above passed
+# it, because a value that is nowhere is correctly quoted everywhere.
 #
 # Every fixture below reads its colours out of the real token file at run time,
 # citation fixtures included — which is why this file is in neither `SELF` nor
@@ -171,6 +177,25 @@ for tok in doc['tokens']:
         tok['paint'] = {'gap': '#4975'}
 open(sys.argv[2], 'w').write(json.dumps(doc, indent=2))
 " "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL" "${4:-}"
+  # Check 5 reads the two documents that publish the palette, and a missing one
+  # is a failure rather than a skip -- a guard satisfied by deleting its subject
+  # is not a guard. So every tree gets both, complete, generated from the token
+  # file it was given. The paths and markers are read out of check-tokens.py
+  # rather than typed here, so the fixtures cannot name a document the guard has
+  # stopped reading. A case that is *about* one of them writes it after this and
+  # wins.
+  python3 -c "
+import importlib.util, json, pathlib, sys
+spec = importlib.util.spec_from_file_location('stella_check_tokens', sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+doc = json.loads(open(sys.argv[2]).read())
+names = [t['css'] for t in doc['tokens'] if 'css' in t]
+for rel, begin, end in module.PUBLICATION:
+    path = pathlib.Path(sys.argv[3]) / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('%s\n%s\n%s\n' % (begin, '\n'.join(names), end))
+" "$SCRIPT" "$dir/$TOKENS_REL" "$dir"
   printf '%s\n' "$3" >"$dir/$2"
   git -C "$dir" init -q 2>/dev/null
   git -C "$dir" add -A 2>/dev/null
@@ -476,6 +501,64 @@ case "$rc:$out" in
 *"must cite an issue"*) ok "a gap that cites no issue is refused at the door" ;;
 *) bad "refused with the wrong message: $out" ;;
 esac
+
+echo ""
+echo "check-tokens publication check:"
+
+# Check 5's subject is an absence too, but a different one from check 4's: not
+# a token nothing paints, a token no document tells a designer about. Every
+# other check here is about a value that is present somewhere and wrong; this
+# one is about a row that is not there, which is how `--st-paper-text` went
+# unpublished by both documents at once (#5007).
+#
+# The fixtures write the publishing document itself, so `$3` replaces the
+# complete table `new_root` generated. `PUB_FILE` and the names come out of
+# check-tokens.py and the token file, never typed.
+eval "$(python3 -c "
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location('stella_check_tokens', sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+rel, begin, end = module.PUBLICATION[0]
+doc = json.loads(open(sys.argv[2]).read())
+names = [t['css'] for t in doc['tokens'] if 'css' in t]
+import shlex
+def emit(key, value):
+    print('%s=%s' % (key, shlex.quote(value)))
+emit('PUB_FILE', rel)
+emit('PUB_BEGIN', begin)
+emit('PUB_END', end)
+emit('PUB_DROPPED', names[-1])
+emit('PUB_KEPT_ROWS', '\n'.join(names[:-1]))
+emit('PUB_ALL_ROWS', '\n'.join(names))
+" "$SCRIPT" "$repo_root/$TOKENS_REL")"
+
+want "a published table missing one token is caught" expect-fail \
+  "$PUB_FILE" \
+  "$PUB_BEGIN
+$PUB_KEPT_ROWS
+$PUB_END" \
+  "publishes no row for $PUB_DROPPED"
+
+want "a published table naming no token is caught" expect-fail \
+  "$PUB_FILE" \
+  "$PUB_BEGIN
+$PUB_ALL_ROWS
+$UNKNOWN_CSS
+$PUB_END" \
+  "publishes a row for $UNKNOWN_CSS"
+
+want "a document with no marker pair is caught" expect-fail \
+  "$PUB_FILE" \
+  "$PUB_ALL_ROWS" \
+  "carries no \`$PUB_BEGIN\` marker"
+
+want "a complete published table passes" expect-pass \
+  "$PUB_FILE" \
+  "$PUB_BEGIN
+$PUB_ALL_ROWS
+$PUB_END" \
+  "document(s) publish the palette"
 
 echo ""
 echo "check-tokens, the real tree:"


### PR DESCRIPTION
## What

The two documents a designer is handed to learn the palette each carry a hand-written token table, and nothing compared either to `design/tokens/stella-tokens.json`. Measured on this branch's base:

| document | tabulated | missing |
|---|---|---|
| `docs/brand/brand-guidelines.html` | 31 of 32 | `--st-paper-text` |
| `docs/brand/prompts/stella-design-system-prompt.md` | 29 of 32 | `--st-diff-add`, `--st-diff-del`, `--st-paper-text` |

The durable fix is a check, so this is a check plus the four rows it demands.

## Why `--st-paper-text` mattered most

It is the primary text stop **off** the deck (`surfaces: ["web-dark", "asset"]`), and it is what `website/src/app/tokens.css` binds `--stella-text` to:

```
website/src/app/tokens.css:152:  --stella-text: var(--st-paper-text);
```

It is also the value the wordmark SVGs and lockups are cut in (`rg -l F4F1EA` names `website/public/brand/wordmark-*.svg` among others). A designer reading either document would have reached for `--st-text` `#E8E8EC`, which declares only the `tui` surface. So the token missing from both was the one a web designer needs most.

## Why the existing guard could not see it

`scripts/check-tokens.py`'s citation check (#3653) already reads both files, which is why the rows they *do* carry are correct. Its subject is a **pair** — a `--st-name` with a hex beside it — so a token with no row at all presents nothing to judge. Membership questions cannot see an absence. Same blind spot `website/src/lib/brand-parity.test.ts`'s `ramp.length >= 20` floor had over the kit's CSS sheet (#4978), and the same shape as `comment` shipping unpainted (#4975).

## Check 5: publication

On `crates/stella-tui/tests/spec_palette.rs`'s shape (#4991) — markers, parse the rows, assert both directions:

- every token the palette declares has a row inside the markers;
- every `--st-*` name inside the markers is a token;
- a listed document that is **missing**, or that has lost its markers, fails rather than being skipped.

It lives in `check-tokens.py` rather than in a Rust test for a workflow reason: `ci.yml` skips its Rust job for a diff confined to `docs/**`, and `docs-guards.yml` already runs `check-tokens.py` on exactly those paths (its "the colour system is the one in the tree" step, added by #3653 for this same class of hole). A Rust test reading these two files would not run on the diff that changes them.

## The scope question the issue left open

The issue asked whether the design brief should be equality or a declared subset, noting a model designing a marketing page has no use for a diff-row tint.

**Equality, for both.** #4978's argument settles the kit page — *"a published subset is a defensible thing for the marketing site to be, and is not what the kit is"*. The brief is held to it too, and the reasoning is stated in the script's own header so it can be argued with: the two rows a shorter prompt would drop cost a line each, and the exclusion mechanism that would let a maintainer drop them is the same mechanism that let `--st-paper-text` go missing from **both** tables at once. If a subset is wanted later it has to be declared, exactly as #4978 required — this does not close that door, it declines to open it before anyone has asked.

Flagging it as a maintainer's call: if you would rather the brief carry a declared subset, say so and I will land the declaration.

## Witness

The issue named it: delete a row and the check must name it. Both directions, run on the real tree.

**Absence** — one row removed from each document:

```
$ python3 scripts/check-tokens.py
2 gap(s) between the palette and the documents that publish it:

  docs/brand/brand-guidelines.html: publishes no row for --st-paper-text,
    which design/tokens/stella-tokens.json declares
  docs/brand/prompts/stella-design-system-prompt.md: publishes no row for
    --st-diff-add, which design/tokens/stella-tokens.json declares

these two documents are what a designer is handed to learn the palette, so a
token with no row is a colour nobody reaches for (#5007).
exit=1
```

**A row naming nothing** — `--st-taupe` added to the brief's table:

```
  docs/brand/prompts/stella-design-system-prompt.md: publishes a row for
    --st-taupe, which no token declares
```

Both ablations make the answer wrong and name the offending token; neither is merely a constant flipping.

## Guard self-test

`scripts/test-tokens.sh` grows four cases — a table missing a token, a table naming a non-token, a document with no marker pair, and a complete table that passes and reports what it counted. 29 cases before, 33 now, 0 failed.

One harness change came with them: `new_root` now writes both publishing documents into every fixture tree, complete, generated from the token file that tree was given, with the paths and markers imported from `check-tokens.py` rather than typed. Without it every case would fail check 5 on documents that were never there — and skipping a missing subject would make the guard satisfiable by deleting the file.

## Verified locally

```
$ python3 scripts/gen-tokens.py --check
tokens: 32 validated, 2 artifacts in sync
$ python3 scripts/check-tokens.py
tokens: no retired hex in the tree; 3 token-only path(s) clean; 164 token
citation(s) quote the palette; 28 token(s) painted, 4 declared gap(s);
2 document(s) publish the palette in 64 row(s)
$ bash scripts/test-tokens.sh
  33 passed, 0 failed
```

Plus `check-prose.py`, `check-doc-links.py check`, `check-brand-case.sh`, `check-css-vars.py`, `check-contrast.py`, `check-hue-separation.py`, `check-light-clamp.py` and `shellcheck scripts/test-tokens.sh` — all exit 0. No baseline was touched.

Closes #5007

## Summary by Sourcery

Keep the published palette tables synchronized with the canonical token set through bidirectional publication validation.

New Features:
- Add publication coverage checks for the brand guidelines and design-system prompt palette tables.

Bug Fixes:
- Ensure both published palette documents include every declared token and no undeclared tokens, including previously omitted text and diff colors.

Enhancements:
- Require publication markers and fail when either document is missing or malformed.
- Extend token-check fixtures and self-tests to cover missing rows, unknown rows, missing markers, and complete publications.

Documentation:
- Update the brand guidelines and design-system prompt with complete, marked palette tables and clarified token usage.

Tests:
- Expand the token guard suite from 29 to 33 cases with publication validation scenarios.