### PR TITLE
fix(ci): cover the .tmp- scratch shape no-scratch cannot see

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ build/
 
 # Editors
 *.bak
-*.tmp
 .*.sw?
 .*.pw?
 
@@ -110,6 +109,15 @@ Thumbs.db
 # Unanchored, like .agent/ above: a session writing scratch inside a worktree
 # subdirectory is the same hazard at a different path.
 .scratch/
+# A loose scratch file at the root, which no suffix pattern reaches:
+# `.tmp-msg.txt` starts with `.tmp` and ends with `.txt`, so `*.tmp` and `tmp/`
+# both missed it and it rode a `git add -A` into PR #4994 (#4996). What found
+# it was an unrelated colour sweep reading its text, which is not a guard.
+# Both spellings, because sessions write both. A real file wanting one of these
+# names fails `no-scratch` loudly the moment it is tracked, and the remedy
+# there is a `!` negation beside it.
+.tmp-*
+tmp-*
 
 # Testing
 *.profraw

--- a/scripts/check-no-scratch.sh
+++ b/scripts/check-no-scratch.sh
@@ -24,6 +24,16 @@
 # invisible; here `--cached` is the subject. An untracked scratch file is the
 # correct outcome, not a miss, and adding `--others` would fail the gate on
 # every session's own working directory. Do not "fix" it to match the others.
+# #4996 re-asked it and settled the same way; `scripts/test-no-scratch.sh`'s
+# case F pins the answer so the next reader finds it as a test rather than as
+# an argument.
+#
+# The consequence is that this guard's reach is exactly .gitignore's, so a
+# scratch name nothing ignores is invisible here. That is not a hole to patch
+# with a name list — the whole point of the rule above is that there is no
+# pattern list here to drift — it is a reason to keep .gitignore covering the
+# shapes sessions actually write. `.tmp-*` is there because `.tmp-msg.txt`
+# matched neither `*.tmp` nor `tmp/` and rode a `git add -A` onto PR #4994.
 #
 # Uses portable POSIX tools so it runs on a bare CI runner.
 set -euo pipefail

--- a/scripts/test-no-scratch.sh
+++ b/scripts/test-no-scratch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Tests for the session-scratch boundary (#448, #2888).
+# Tests for the session-scratch boundary (#448, #2888, #4996).
 #
 #   ./scripts/test-no-scratch.sh
 #
@@ -17,7 +17,8 @@
 # .scratch/ was that path. On 2026-08-11 a session wrote a commit message to
 # .scratch/msg.txt, amended with `git add -A`, and pushed; `git check-ignore`
 # exited 1, the guard printed OK, `make gate` and CI were green, and the file
-# reached the remote. Nothing in the toolchain said so.
+# reached the remote. Nothing in the toolchain said so. `.tmp-msg.txt` was the
+# same story two weeks later at a different name shape (#4996, cases E).
 #
 # The fix was one .gitignore line, which is why the subject here is the PAIR:
 # the ignore rule and the guard together. Testing the script alone would pass
@@ -121,6 +122,80 @@ if git -C "$D" ls-files --error-unmatch crates/stella-core/.scratch/plan.md >/de
     "     The .gitignore entry is anchored and only covers the repository root."
 else
   ok "D1 a nested .scratch/ is ignored too"
+fi
+
+# ── E: the same hazard one file-name shape over ──────────────────────────────
+#
+# .scratch/ was a directory, and the rule that covers it is a directory entry.
+# A loose scratch *file* at the root is the same motion with nothing to anchor
+# on: on 2026-08-25 a session wrote its commit message to `.tmp-msg.txt` and
+# `git add -A` swept it into PR #4994. `*.tmp` did not match — the name starts
+# with `.tmp` and ends with `.txt` — so the guard printed OK while the file sat
+# in the diff, and what found it was an unrelated colour sweep reading its text
+# (#4996).
+#
+# The `.tmp-*`/`tmp-*` entries are what close it, and E1/E2 fail on a tree
+# without them.
+
+E="$(fixture tmp-prefix-sweep)"
+echo scratch >"$E/.tmp-msg.txt"
+echo scratch >"$E/tmp-msg.txt"
+git -C "$E" add -A >/dev/null 2>&1
+if git -C "$E" ls-files --error-unmatch .tmp-msg.txt >/dev/null 2>&1; then
+  no "E1 \`git add -A\` leaves .tmp-msg.txt alone" \
+    "     No .gitignore entry matches a .tmp- prefix, so #4996's sweep still works."
+else
+  ok "E1 \`git add -A\` leaves .tmp-msg.txt alone"
+fi
+if git -C "$E" ls-files --error-unmatch tmp-msg.txt >/dev/null 2>&1; then
+  no "E2 the dotless spelling is covered too" \
+    "     Only .tmp-* is entered; a session writing tmp-msg.txt still commits it."
+else
+  ok "E2 the dotless spelling is covered too"
+fi
+
+E2="$(fixture tmp-prefix-forced)"
+echo scratch >"$E2/.tmp-msg.txt"
+git -C "$E2" add -f .tmp-msg.txt >/dev/null 2>&1
+out="$(cd "$E2" && bash scripts/check-no-scratch.sh 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  no "E3 a tracked .tmp-msg.txt fails the guard" "$out"
+else
+  ok "E3 a tracked .tmp-msg.txt fails the guard"
+fi
+case "$out" in
+*".tmp-msg.txt"*) ok "E4 the guard names it" ;;
+*) no "E4 the guard names it" "$out" ;;
+esac
+
+E3="$(fixture tmp-prefix-nested)"
+mkdir -p "$E3/crates/stella-core"
+echo scratch >"$E3/crates/stella-core/.tmp-plan.md"
+git -C "$E3" add -A >/dev/null 2>&1
+if git -C "$E3" ls-files --error-unmatch crates/stella-core/.tmp-plan.md >/dev/null 2>&1; then
+  no "E5 a nested .tmp-* is ignored too" \
+    "     The entry is anchored and only covers the repository root."
+else
+  ok "E5 a nested .tmp-* is ignored too"
+fi
+
+# ── F: untracked scratch is not the subject ──────────────────────────────────
+#
+# check-no-scratch.sh's header names this as the one guard #4952 left on
+# `--cached` rather than widening, and #4996 re-asked whether it should flag untracked
+# scratch names. This pins the answer so nobody "fixes" it into the others'
+# shape: with an ignored file present but never added, the guard passes. Its
+# reach starts at the index, and an ignored-but-untracked file is the working
+# tree behaving correctly — failing on one would fail every session's own
+# directory.
+
+F="$(fixture untracked-scratch)"
+echo scratch >"$F/.tmp-msg.txt"
+if out="$(cd "$F" && bash scripts/check-no-scratch.sh 2>&1)"; then
+  ok "F1 an ignored file that was never added passes"
+else
+  no "F1 an ignored file that was never added passes" "$out"
 fi
 
 echo


### PR DESCRIPTION
## What

`no-scratch`'s reach is exactly `.gitignore`'s — its rule is "if a path is
ignored, it must not be tracked" — so a scratch name nothing ignores is
invisible to it. `.tmp-msg.txt` was that name: it starts with `.tmp` and ends
with `.txt`, so `*.tmp` and `tmp/` both missed it, `git add -A` swept it into
PR #4994, and `check-no-scratch` printed `OK` while the file sat in the diff.

- `.gitignore` gains `.tmp-*` and `tmp-*`, in the agent-session-scratch block
  beside `.scratch/` — that block's own prose already says that listing a path
  there is what makes the guard able to see it.
- The duplicate `*.tmp` under `# Editors` goes; `# Temporary` already carries it.
- Six cases in `scripts/test-no-scratch.sh`.
- `scripts/check-no-scratch.sh`'s header gains the consequence it did not state:
  its reach is the ignore list, which is a reason to keep `.gitignore` covering
  the shapes sessions write — not a hole to patch with a name list here.

## The open question, answered rather than inherited

#4996 asks whether `no-scratch` should also flag **untracked** scratch-shaped
names. It should not, and this PR pins that as a test (case F1) rather than
leaving it as an argument two readers can settle differently:

- `check-no-scratch.sh`'s header already decided the `--others` half — "an
  untracked scratch file is the correct outcome, not a miss, and adding
  `--others` would fail the gate on every session's own working directory."
  That was #4952's explicit exclusion.
- The middle position (warn on untracked, fail on staged) buys nothing here now.
  With `.tmp-*` ignored, `git add -A` **skips** the file, and a `git add -f`
  makes it tracked-and-ignored, which is precisely what `--cached --ignored`
  already catches. Both halves of the live failure are closed without the guard
  learning any names.
- A name list inside the guard would be the second copy of the scratch path list
  that the guard's own header rejects, and it would drift against `.gitignore`.

I have not filed a follow-up for this: the question is answered, not deferred.
If a maintainer wants the staged-warning variant anyway, that is a new decision
and I would rather it be argued fresh than inherited from a "TODO" here.

## Evidence

```
$ ./scripts/test-no-scratch.sh
ok   A1 `git add -A` leaves .scratch/ alone
ok   B1 a tracked .scratch/ file fails the guard
ok   B2 the guard names the offending path
ok   C1 a tracked, unignored file passes
ok   D1 a nested .scratch/ is ignored too
ok   E1 `git add -A` leaves .tmp-msg.txt alone
ok   E2 the dotless spelling is covered too
ok   E3 a tracked .tmp-msg.txt fails the guard
ok   E4 the guard names it
ok   E5 a nested .tmp-* is ignored too
ok   F1 an ignored file that was never added passes

passed 11, failed 0
```

**Ablation** — the two `.gitignore` entries reverted, suite re-run unchanged:

```
ok   A1 `git add -A` leaves .scratch/ alone
ok   B1 a tracked .scratch/ file fails the guard
ok   B2 the guard names the offending path
ok   C1 a tracked, unignored file passes
ok   D1 a nested .scratch/ is ignored too
FAIL E1 `git add -A` leaves .tmp-msg.txt alone
     No .gitignore entry matches a .tmp- prefix, so #4996's sweep still works.
FAIL E2 the dotless spelling is covered too
     Only .tmp-* is entered; a session writing tmp-msg.txt still commits it.
FAIL E3 a tracked .tmp-msg.txt fails the guard
check-no-scratch: OK — no tracked file is gitignored.
FAIL E4 the guard names it
check-no-scratch: OK — no tracked file is gitignored.
FAIL E5 a nested .tmp-* is ignored too
     The entry is anchored and only covers the repository root.
ok   F1 an ignored file that was never added passes

passed 6, failed 5     (exit 1)
```

The answer changes — five cases flip, and E3/E4 print the guard's own reassuring
`OK` line as the evidence of the miss. A/B/C/D/F stay green under the ablation,
so the new cases fail on the missing rule rather than on the fixture.

`make guards-fast`: green (`no-scratch`, `prose`, `line-citations`, `shellcheck`,
`gate-parity` included). `shellcheck` on both modified scripts: clean.

## Witness

Cases E1–E5 in `scripts/test-no-scratch.sh` — they fail on `main` and pass here,
demonstrated above. The suite is already wired into
`.github/workflows/guard-self-tests.yml` as "the session-scratch boundary", so
they run server-side with the rest.

Closes #4996

## Summary by Sourcery

Expand session-scratch protection to cover .tmp-* and tmp-* filename patterns while preserving the guard’s intended treatment of untracked files.

Bug Fixes:
- Prevent .tmp-* and tmp-* scratch files from being accidentally committed by ensuring Git ignores these session-created paths.
- Extend the no-scratch guard tests to detect tracked .tmp-* files and confirm the guard reports the offending path.

Enhancements:
- Document that the no-scratch guard intentionally covers only paths represented by .gitignore and does not flag ignored, untracked scratch files.
- Clarify and test the boundary between ignored untracked scratch files and tracked-and-ignored files.

Tests:
- Add coverage for root and nested .tmp-* scratch files, dotless tmp-* variants, forced additions, guard diagnostics, and ignored untracked files.