### PR TITLE
test(stella-tui): compare the two shipping 16-colour tables to each other

### DIFF
--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -214,6 +214,172 @@ fn every_named_token_has_a_fallback() {
     );
 }
 
+/// The ANSI index ratatui's `Color` names.
+///
+/// Spelled out because ratatui's names are not the ANSI ones, and
+/// reading one for the other is how #4976 turned a correct mapping into a bug
+/// report: `Color::Gray` is ANSI 7, the standard white, and `Color::White` is
+/// ANSI 15, bright white. `FALLBACKS` stores the index directly, so this is
+/// what puts the two tables in one vocabulary.
+/// `crates/stella-tui/tests/spec_palette.rs`'s `ansi_name` is the same
+/// translation for the spec's words.
+fn ansi_index(color: Color) -> Option<u8> {
+    Some(match color {
+        Color::Black => 0,
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Yellow => 3,
+        Color::Blue => 4,
+        Color::Magenta => 5,
+        Color::Cyan => 6,
+        Color::Gray => 7,
+        Color::DarkGray => 8,
+        Color::LightRed => 9,
+        Color::LightGreen => 10,
+        Color::LightYellow => 11,
+        Color::LightBlue => 12,
+        Color::LightMagenta => 13,
+        Color::LightCyan => 14,
+        Color::White => 15,
+        // `ansi16`'s catch-all passes a non-token through, so a truecolor
+        // value here means the token was not one it maps.
+        _ => return None,
+    })
+}
+
+/// Where `FALLBACKS` and `stella_tui_theme::fallback::ansi16` give one value
+/// two answers, as `(token, FALLBACKS index, ansi16 index, why it stands)`.
+///
+/// The two tables answer the same question — *what does this colour become on
+/// a 16-colour terminal?* — about the same hex, reached by different paths:
+/// `degrade_buffer` for the v1 deck, `fallback::ansi16` for the v2 surfaces.
+/// Each had a coverage test and neither had ever been compared to the other,
+/// so five rows disagree and nothing said so (#5000).
+///
+/// It is one decision made twice, not five: `FALLBACKS` takes the **bright**
+/// half of the sixteen for every chromatic token and `ansi16` takes the
+/// **standard** half. `design/tui-v2/SPEC.md` §3.5 states `ansi16`'s answers
+/// and `crates/stella-tui/tests/spec_palette.rs` holds it there, so the spec
+/// governs one table and nothing governs the other.
+///
+/// Which half ships is a design call and #5000 is where it is being made — the
+/// values a reader sees on a 16-colour terminal are a product decision, not a
+/// tidy-up. Declaring the rows is the half that is not: a sixth divergence
+/// cannot now arrive unnoticed, and repainting one table without the other
+/// fails here rather than in someone's `xterm`. That is
+/// `crates/stella-model/src/provider_parity.rs`'s posture — a matrix checked
+/// from both sides, with every gap named and issue-cited (AGENTS.md #10).
+const DEGRADATION_DIVERGENCE: &[(&str, u8, u8, &str)] = &[
+    (
+        "gold",
+        11,
+        3,
+        "the deck lifts the identity to bright yellow so the mark still reads \
+         as the mark; §3.5 says yellow. #5000",
+    ),
+    (
+        "gold-bright",
+        11,
+        3,
+        "the live stop collapses onto whichever yellow `gold` takes, so this \
+         row is decided by the one above it. #5000",
+    ),
+    (
+        "silver-type",
+        15,
+        7,
+        "the deck shares bright white with `text` — the two are one value step \
+         apart and there is no third white; §3.5 drops it to white beside \
+         `silver` instead. Same two values, opposite collapse. #5000",
+    ),
+    (
+        "green",
+        10,
+        2,
+        "bright green against §3.5's green: the palette's `#74C991` is a pale \
+         mint, and which ANSI green is nearer depends on the reader's own \
+         sixteen. #5000",
+    ),
+    (
+        "red",
+        9,
+        1,
+        "bright red against §3.5's red, the same question as `green` and the \
+         one row where the deck's answer is the nearer of the two against \
+         xterm's defaults. #5000",
+    ),
+];
+
+/// **The two 16-colour tables agree, or the row says why not.**
+///
+/// Both are total over their own domain and each has a test that proves it —
+/// [`every_dark_palette_value_has_a_fallback`] here and
+/// `every_token_has_a_fallback` in `stella-tui-theme`. Both are *coverage*
+/// checks, so two complete tables that contradict each other are two green
+/// tests, which is the state this ends.
+///
+/// A token with no `FALLBACKS` row is one the v1 deck never paints — the
+/// v2-only `rule`, the diff tints, the paper stops — and is not compared.
+/// What the deck *does* paint is covered by
+/// [`every_dark_palette_value_has_a_fallback`], so the two tests compose
+/// rather than overlap.
+#[test]
+fn the_two_16_colour_tables_agree_or_declare_why_not() {
+    use stella_tui_theme::{fallback, token};
+
+    let declared = |name: &str| DEGRADATION_DIVERGENCE.iter().find(|(n, ..)| *n == name);
+    let mut drift = Vec::new();
+
+    for (name, color, _) in token::ALL {
+        let Some((_, _, deck)) = FALLBACKS.iter().find(|(rgb, ..)| rgb == color) else {
+            continue;
+        };
+        let Some(v2) = ansi_index(fallback::ansi16(*color)) else {
+            drift.push(format!(
+                "`ansi16` passed `{name}` through instead of standing it down \
+                 to one of the sixteen"
+            ));
+            continue;
+        };
+        match (deck == &v2, declared(name)) {
+            (true, None) => {}
+            (true, Some(_)) => drift.push(format!(
+                "`{name}` is declared as a divergence and both tables now say \
+                 {v2} — settle the row by deleting it"
+            )),
+            (false, None) => drift.push(format!(
+                "`{name}`: FALLBACKS stands it down to {deck} and `ansi16` to \
+                 {v2}, and no row of DEGRADATION_DIVERGENCE says why"
+            )),
+            (false, Some((_, want_deck, want_v2, _))) if deck != want_deck || v2 != *want_v2 => {
+                drift.push(format!(
+                    "`{name}` is declared as {want_deck} against {want_v2} and \
+                     is now {deck} against {v2} — one table moved, so the \
+                     declaration is stale"
+                ));
+            }
+            (false, Some(_)) => {}
+        }
+    }
+
+    for (name, ..) in DEGRADATION_DIVERGENCE {
+        assert!(
+            token::ALL.iter().any(|(n, ..)| n == name),
+            "DEGRADATION_DIVERGENCE names `{name}`, which is not a token"
+        );
+    }
+
+    assert!(
+        drift.is_empty(),
+        "the deck's `FALLBACKS` and `stella_tui_theme::fallback::ansi16` \
+         answer the same question about the same value in {} place(s) the \
+         table does not account for:\n  {}\n\nOne value may not degrade two \
+         ways unnoticed — settle the row or declare it (#5000).",
+        drift.len(),
+        drift.join("\n  ")
+    );
+}
+
 #[test]
 fn role_aliases_track_their_palette_token() {
     // Brand roles resolve to the generated palette, not to a local literal.


### PR DESCRIPTION
## What this does, and what it deliberately does not

#5000 offers two ways to close. Option 1 (one table) needs a dependency-graph change and a design call; option 2 (three tables, one checked against another, *"with any deliberate divergence carrying a named reason at the row — the shape `provider_parity.rs` uses"*) is what this lands.

**The design call is left open and #5000 stays open for it.** Which yellow the identity degrades to on a 16-colour terminal is a product decision, and the issue says so. What is not a design call — and is what shipped here — is that the disagreement was invisible.

## Two premises of the issue are wrong, and the measurement is below

Measured by walking `token::ALL` and looking up both tables (throwaway probe, removed before commit):

```
token           hex        FALLBACKS.16  ansi16  agree
bg              #0A0A0C    0             0       yes
panel           #0F0F12    0             0       yes
hl              #17171B    8             8       yes
border          #26262C    8             8       yes
rule            #2C2C33    -             8       (no FALLBACKS row)
gold            #EFC53F    11            3       NO
gold-bright     #F7D96B    11            3       NO
silver          #A9AAB5    7             7       yes
silver-type     #BFC1CC    15            7       NO
text            #E8E8EC    15            15      yes
muted           #777782    8             8       yes
dim             #4B4B56    8             8       yes
green           #74C991    10            2       NO
red             #E0687A    9             1       NO
diff-add-bg     #10201A    -             0       (no FALLBACKS row)
diff-del-bg     #241019    -             0       (no FALLBACKS row)
ink             #141413    -             0       (no FALLBACKS row)
paper           #FFFCF5    -             15      (no FALLBACKS row)
paper-panel     #F9F6EF    -             15      (no FALLBACKS row)
paper-border    #E6E3DD    -             7       (no FALLBACKS row)
```

**1. Five rows disagree, not one.** The issue names gold and the `TEXT_EMPHASIS`/`SILVER_TYPE` collapse. `green` and `red` also disagree, and they were not mentioned. More usefully, this is **one decision made twice, not five taste calls**: `FALLBACKS` takes the *bright* half of the sixteen for every chromatic token, `ansi16` takes the *standard* half. That reframes the design call from five arguments into one.

**2. The third table reaches no reader.** `crates/stella-transcript/src/grid.rs`'s `to_ansi16` has exactly one caller in the tree, and it is a test:

```
$ rg -n 'to_ansi16' crates/
crates/stella-transcript/src/tests.rs:1069:    let ansi = grid::to_ansi16(&grid::render(...));
crates/stella-transcript/src/grid.rs:1069:pub fn to_ansi16(lines: &[Line]) -> String {
```

`crates/stella-cli/src/plain/transcript.rs` calls `to_ansi256`. So *"a reader … sees the brand as bright yellow in the deck and as plain yellow in an exported transcript of the same session"* is not something that can happen today — nothing exports a 16-colour transcript. Filed as #5019.

Its `Amber` ink is also not the brand gold: it is produced for `Status::Warn`, `Tok::Keyword`, `FileStatus::Modified`, the `ef` tool class and output lines matching "warn". Gold does not reach that enum.

## Which answer is nearer, measured

OKLab ΔE from each token to xterm's default 16-colour values, for both candidate stand-ins:

```
token        hex       FALLBACKS  dE      ansi16  dE      closer
gold         #EFC53F   11         0.155   3       0.063   ansi16
gold-bright  #F7D96B   11         0.120   3       0.092   ansi16
silver-type  #BFC1CC   15         0.188   7       0.110   ansi16
green        #74C991   10         0.208   2       0.142   ansi16
red          #E0687A   9          0.127   1       0.159   FALLBACKS
```

Counter-intuitive and worth stating plainly: the v5.0 stops are desaturated pastels, and xterm's *bright* half is the fully-saturated primaries (`#FFFF00`, `#00FF00`), so the standard half (`#CDCD00`, `#00CD00`) is nearer in four of five. That points at `ansi16` — which is also what `design/tui-v2/SPEC.md` §3.5 normatively states, and what `spec_palette.rs` already holds.

**The evidence is indicative, not decisive**, and I am not repainting on it: a terminal's sixteen colours are user-configurable, and this is measured against one default. The issue's own argument for the other direction — "bright yellow reads as the identity on a dark 16-colour terminal" — is about the schemes people actually run, which this number does not sample.

## What landed

`DEGRADATION_DIVERGENCE` in `crates/stella-tui/src/theme/tests.rs`: the five rows, each with its two indices and a reason citing #5000. `the_two_16_colour_tables_agree_or_declare_why_not` checks it from both sides —

- tables differ and the row is missing → fail;
- tables differ and the row's indices are stale → fail (one table moved alone);
- tables now agree and the row is still declared → fail (settle it by deleting the row);
- `DEGRADATION_DIVERGENCE` names a token that does not exist → fail.

A token with no `FALLBACKS` row is one the v1 deck never paints (`rule`, the diff tints, the paper stops) and is not compared; what the deck *does* paint is `every_dark_palette_value_has_a_fallback`'s job, so the two tests compose rather than overlap.

## Witness

**A: a new, undeclared divergence** — `silver`'s deck fallback moved 7 → 15:

```
thread '...' panicked at crates/stella-tui/src/theme/tests.rs:343:5:
the deck's `FALLBACKS` and `stella_tui_theme::fallback::ansi16` answer the same
question about the same value in 1 place(s) the table does not account for:
  `silver`: FALLBACKS stands it down to 15 and `ansi16` to 7, and no row of
  DEGRADATION_DIVERGENCE says why

test result: FAILED. 0 passed; 1 failed
```

**B: one table settling alone** — the deck moves gold to 3, matching `ansi16`, and the declaration is left behind:

```
thread '...' panicked at crates/stella-tui/src/theme/tests.rs:343:5:
... in 1 place(s) the table does not account for:
  `gold` is declared as a divergence and both tables now say 3 — settle the
  row by deleting it

test result: FAILED. 0 passed; 1 failed
```

Each ablation makes the answer wrong in a different direction and names the token, rather than flipping a constant.

## Verified locally

- `cargo test -p stella-tui --lib` — 1148 passed, 0 failed
- `cargo clippy -p stella-tui --all-targets -- -D warnings` — clean
- `cargo fmt --check -p stella-tui`, `check-prose.py`, `check-line-citations.py`, `check-file-size.sh` — clean, no baseline touched

## Left behind, filed

- **#5019** — `grid::to_ansi16` has no production caller.
- **#5020** — `#141416` ships as the light-ground ink across the wordmark SVGs, the guidelines page, the Observatory and `website/README.md`, while `--st-ink` holds `#141413`.

Refs #5000

## Summary by Sourcery

Enforce explicit accountability for differences between the two 16-colour degradation tables without resolving the underlying palette design decision.

Enhancements:
- Add a bidirectional consistency check between the deck and v2 16-colour fallback tables, requiring every intentional divergence to be documented and kept current.

Tests:
- Cover undocumented divergences, stale declarations, resolved declarations, pass-through colours, and invalid token names with targeted failure messages.