### PR TITLE
docs(scripts): stop the check-tokens header counting its own checks

### DIFF
--- a/scripts/check-tokens.py
+++ b/scripts/check-tokens.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Guard the colour system: no retired hex anywhere, no stray hex where it matters.
 
-Four checks, different in strength, because "never use this colour
-again", "use only tokens here", "quote this token correctly" and "something
-renders this" are different promises and only one of them can be made about the
-whole tree today.
+The checks below differ in strength, because "never use this colour again",
+"use only tokens here", "quote this token correctly", "something renders this"
+and "somebody publishes this" are different promises and only one of them can
+be made about the whole tree today. The numbered list is the count; a total
+written here as well is a second copy nobody updates.
 
 1. **The ban.** Every hex in `banned.values` in the token JSON fails wherever it
    appears, in any tracked file. These are the anchor values of retired brand


### PR DESCRIPTION
## What

#5015 added a fifth check to `scripts/check-tokens.py` (publication) and the docstring above the numbered list still opened with **"Four checks"**. The fix was pushed to that PR's branch a few minutes after it merged and so did not travel with it — this lands it on its own.

```
-Four checks, different in strength, because "never use this colour
-again", "use only tokens here", "quote this token correctly" and "something
-renders this" are different promises and only one of them can be made about the
-whole tree today.
+The checks below differ in strength, because "never use this colour again",
+"use only tokens here", "quote this token correctly", "something renders this"
+and "somebody publishes this" are different promises and only one of them can
+be made about the whole tree today. The numbered list is the count; a total
+written here as well is a second copy nobody updates.
```

The sentence still does the work it did — naming what each check promises, which is the argument for having five of them rather than one — and the fifth promise joins the list. It no longer carries a total, per CLAUDE.md: *"A count or a line number in prose is a promise to update it, and nobody does."* This is that failure in miniature, one merge old.

## No witness

Prose only, and the repository's contract exempts docs changes from a witness. The guard the sentence describes is unchanged; `check-tokens.py`'s behaviour, its exit codes and its report line are byte-identical.

## Verified locally

```
$ python3 scripts/check-tokens.py
tokens: no retired hex in the tree; 3 token-only path(s) clean; 164 token
citation(s) quote the palette; 28 token(s) painted, 4 declared gap(s);
2 document(s) publish the palette in 64 row(s)
$ bash scripts/test-tokens.sh
  33 passed, 0 failed
$ python3 scripts/check-prose.py
check-prose: OK -- 4206 grandfathered construction(s), none added.
```

Refs #5007

## Summary by Sourcery

Bug Fixes:
- Update the token-checker documentation to include the publication check without maintaining a duplicated total.