### PR TITLE
fix(stella-cli,stella-model): point the xai default at grok-4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Stella is BYOK and detects the provider from whichever keys you have set.
 | **Z.ai** (GLM)         | `ZAI_API_KEY`                                 | `glm-5.2`                                                                        |
 | **Anthropic** (Claude) | `ANTHROPIC_API_KEY`                           | `claude-fable-5`                                                                 |
 | **OpenAI** (GPT)       | `OPENAI_API_KEY`                              | `gpt-5.5`                                                                        |
-| **xAI** (Grok)         | `XAI_API_KEY`                                 | `grok-4` — [past its announced retirement; pin a successor](https://stella.oxagen.sh/docs/api-providers#xai) |
+| **xAI** (Grok)         | `XAI_API_KEY`                                 | `grok-4.3`                                                                       |
 | **DeepSeek**           | `DEEPSEEK_API_KEY`                            | `deepseek-chat`                                                                  |
 | **Google Gemini**      | `GEMINI_API_KEY` (alias `GOOGLE_API_KEY`)     | `gemini-3-pro`                                                                   |
 | **Google Vertex AI**   | `VERTEX_ACCESS_TOKEN` + `VERTEX_PROJECT_ID`   | `gemini-3-pro`                                                                   |

--- a/crates/stella-cli/src/config/providers.rs
+++ b/crates/stella-cli/src/config/providers.rs
@@ -149,7 +149,12 @@ pub static PROVIDERS: &[ProviderConfig] = &[
         env_var: "XAI_API_KEY",
         env_var_aliases: &[],
         display_name: "xAI (Grok)",
-        default_model: "grok-4",
+        // grok-4 retired on 2026-08-15 (#5004). xAI's published model list
+        // carries grok-4.3 as the flagship — 1M context, the cheapest tier of
+        // the current line, and the family the retired grok-4 slugs redirect
+        // to — so it is the successor that changes least about what a bare
+        // `--model xai/…` already resolves to on the wire.
+        default_model: "grok-4.3",
         base_url: "https://api.x.ai/v1",
         dialect: Dialect::OpenaiCompatible,
         seeded: true,

--- a/crates/stella-cli/src/config/tests/parity.rs
+++ b/crates/stella-cli/src/config/tests/parity.rs
@@ -21,6 +21,34 @@ fn every_provider_default_model_resolves_against_the_catalog_seed() {
     }
 }
 
+/// **The retirement witness (#5004).** `grok-4` retired at xAI on 2026-08-15,
+/// and it was still the seeded `xai` default, so a bare `--model xai/…` or an
+/// auto-detected run that landed on xAI pointed at a model the vendor had
+/// announced it was removing.
+///
+/// The assertion is the retired slug, not the successor, because the two claims
+/// have different lifetimes. "The default is not `grok-4`" stays true through
+/// every future point release; "the default is `grok-4.3`" is a fact about
+/// today that a maintainer moving to `grok-4.6` would have to come here and
+/// edit, which turns a chosen upgrade into a red test. The catalog-seed
+/// test above already holds whatever the default *is* to something reachable.
+///
+/// A per-model retirement ledger would be the general answer and this is not
+/// it: nothing here knows a retirement date, so a successor that retires in
+/// turn will need this test edited again. #5022 is where that is tracked.
+#[test]
+fn the_seeded_xai_default_is_not_the_retired_grok_4() {
+    let xai = PROVIDERS
+        .iter()
+        .find(|p| p.id == "xai")
+        .expect("the xai provider is seeded");
+    assert_ne!(
+        xai.default_model, "grok-4",
+        "grok-4 retired at xAI on 2026-08-15; the seeded default must name a \
+         model the vendor still serves"
+    );
+}
+
 #[test]
 fn provider_ids_are_unique() {
     let mut ids: Vec<&str> = PROVIDERS.iter().map(|p| p.id).collect();

--- a/crates/stella-model/src/catalog/seed/xai.rs
+++ b/crates/stella-model/src/catalog/seed/xai.rs
@@ -14,6 +14,36 @@ use crate::catalog::{CatalogEntry, Pricing, ToolDialect};
 /// [`Catalog::seed`](crate::catalog::Catalog::seed).
 pub(super) fn rows() -> Vec<CatalogEntry> {
     vec![
+        // The seeded `xai` default since #5004, because grok-4 retired on
+        // 2026-08-15. Prices and context from xAI's published model list
+        // (2026-08-26): 1M context, and a tier boundary at 200k input —
+        // $1.25/$2.50/$0.20 below it, double above. The catalog carries one
+        // price per row, so these are the below-200k figures: a turn that
+        // crosses the boundary is under-reported rather than over-reported,
+        // and the same direction of error as an unpriced row.
+        CatalogEntry::new(
+            "grok-4.3",
+            "xai",
+            "grok",
+            1_000_000,
+            ToolDialect::OpenaiJson,
+            Pricing {
+                input_usd_per_mtok: 1.25,
+                output_usd_per_mtok: 2.50,
+                cached_input_usd_per_mtok: 0.20,
+                cache_write_usd_per_mtok: 1.25,
+            },
+        )
+        .with_reasoning(Some(true))
+        // 30000, the figure models.dev reports for this row, and the same
+        // ceiling the grok-4 row below reasons its way to. The asymmetry
+        // argument there applies unchanged: guessing low costs headroom,
+        // guessing high costs a rejection on every request.
+        .with_max_output_tokens(Some(30_000)),
+        // Retired at the vendor on 2026-08-15, kept so an existing
+        // `providers.xai.default_model = "grok-4"` pin still resolves rather
+        // than hard-erroring in `build_provider`. Retiring the row is its own
+        // change (#5022) — it breaks a pin, which moving the default does not.
         CatalogEntry::new(
             "grok-4",
             "xai",

--- a/crates/stella-model/src/provider_listing.rs
+++ b/crates/stella-model/src/provider_listing.rs
@@ -739,7 +739,7 @@ mod tests {
     fn openai_compatible_parses_bare_id_lists() {
         let body = r#"{"object": "list", "data": [
             {"id": "gpt-5.5", "object": "model", "owned_by": "openai"},
-            {"id": "grok-4"},
+            {"id": "grok-4.3"},
             {"id": ""}
         ]}"#;
         let models = parse_openai_compatible("OpenAI", body).expect("parses");

--- a/crates/stella-model/src/provider_parity.rs
+++ b/crates/stella-model/src/provider_parity.rs
@@ -407,7 +407,9 @@ pub static REASONING_POSTURE: &[(&str, ReasoningPosture)] = &[
         ReasoningPosture::Controllable {
             mechanism: "chat-completions top-level reasoning_effort (low/medium/high), gated to \
                         the xai identity on the shared adapter — and, within xai, skipped for the \
-                        original grok-4, which reasons but 400s on the param (retiring 2026-08-15)",
+                        original grok-4, which reasons but 400s on the param. That carve-out no \
+                        longer touches the default: grok-4 retired 2026-08-15 and the seeded \
+                        default is grok-4.3, which accepts the param (#5004)",
             witness: "xai_identity_maps_effort_to_reasoning_effort",
             collapses: &[("xhigh", "high"), ("max", "high")],
         },

--- a/crates/stella-model/src/zai/effort.rs
+++ b/crates/stella-model/src/zai/effort.rs
@@ -23,12 +23,20 @@ use stella_protocol::ReasoningEffort;
 /// `grok-4-<date>`) reasons but rejects the param with a hard 400 ("does not
 /// support parameter reasoning_effort") — while grok-3-mini, the grok-4 point
 /// releases (`grok-4.1`/`.3`/`.5`), and the `grok-4-fast*` cases all accept
-/// it. Sending it to the original grok-4 (the currently-seeded xai default,
-/// deprecated and retiring 2026-08-15) would 400 every reasoning turn, so it is
-/// gated out here — grok-4 keeps the pre-wiring behavior (reasons at its own
+/// it. Sending it to the original grok-4 would 400 every reasoning turn, so it
+/// is gated out here — grok-4 keeps the pre-wiring behavior (reasons at its own
 /// fixed depth, effort dropped) instead of erroring. Fail-safe direction is to
-/// send: the fleet has trended toward universal support, and only the retiring
-/// original is denied.
+/// send: the fleet has trended toward universal support, and only the original
+/// is denied.
+///
+/// grok-4 retired on 2026-08-15 and the seeded xai default moved to grok-4.3
+/// (#5004), so this carve-out no longer covers the default path — it covers a
+/// pin, and only a pin. It stays because xAI's own migration note says the
+/// retired slugs *redirect* to the current family rather than 404, and whether
+/// a redirected `grok-4` would then accept the param is unverified on the wire.
+/// Denying it costs a dropped effort hint; sending it on the strength of a
+/// redirect nobody has watched costs a 400 on every reasoning turn. #5022
+/// carries the live request that would settle it.
 pub(super) fn xai_supports_reasoning_effort(model: &str) -> bool {
     if model == "grok-4" {
         return false;

--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -26,7 +26,7 @@ you get when you name none.
 | 2 | `zai` | `ZAI_API_KEY` | `glm-5.2` | OpenAI-compatible |
 | 3 | `anthropic` | `ANTHROPIC_API_KEY` | `claude-fable-5` | Anthropic Messages |
 | 4 | `openai` | `OPENAI_API_KEY` | `gpt-5.5` | OpenAI Responses |
-| 5 | `xai` | `XAI_API_KEY` | `grok-4` | OpenAI-compatible |
+| 5 | `xai` | `XAI_API_KEY` | `grok-4.3` | OpenAI-compatible |
 | 6 | `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-chat` | OpenAI-compatible |
 | 7 | `gemini` | `GEMINI_API_KEY` (alias `GOOGLE_API_KEY`) | `gemini-3-pro` | Gemini generateContent |
 | 8 | `vertex` | `VERTEX_ACCESS_TOKEN` | `gemini-3-pro` | Gemini generateContent |
@@ -45,6 +45,7 @@ refresh` re-syncs from [models.dev](https://models.dev).
 | `anthropic/claude-opus-5` | 1M | 5.00 | 25.00 | 0.50 |
 | `anthropic/claude-sonnet-5` | 1M | 3.00 | 15.00 | 0.30 |
 | `openai/gpt-5.5` | 400k | 1.25 | 10.00 | 0.125 |
+| `xai/grok-4.3` | 1M | 1.25 | 2.50 | 0.20 |
 | `xai/grok-4` | 256k | 3.00 | 15.00 | 0.75 |
 | `deepseek/deepseek-chat` | 128k | 0.27 | 1.10 | 0.07 |
 | `gemini/gemini-3-pro` | 1M | 1.25 | 10.00 | 0.31 |
@@ -68,7 +69,7 @@ failed:
 | `openai` | `reasoning.effort` | `low`/`medium`/`high`; **`xhigh` and `max` collapse to `high`** | Also honours `verbosity` and `service_tier` |
 | `gemini` / `vertex` | `thinkingConfig.thinkingLevel` | `low`; **everything else maps to `high`** | `reasoning: "off"` gives the *minimum* level, not zero |
 | `zai` | `thinking: {type: enabled\|disabled}` | **dropped** | Differentiate a GLM verifier with `prompt`, not `effort` |
-| `xai` | `reasoning_effort` | `low`/`medium`/`high`; `xhigh`/`max` collapse | **Gated off entirely on `grok-4`** and its dated snapshots |
+| `xai` | `reasoning_effort` | `low`/`medium`/`high`; `xhigh`/`max` collapse | **Gated off entirely on `grok-4`** and its dated snapshots — not on the `grok-4.3` default |
 | `deepseek` | not sent | **dropped** | Shape it with `prompt` and `params.max_tokens` |
 | `openrouter` | `reasoning` object | all five tiers 1:1 | Gateway translates per routed vendor; an unadvertised tier is normalized, not rejected |
 | `bedrock` | legacy `budget_tokens` shape | **dropped** | Converse `inferenceConfig` has slots only for `max_tokens`, `temperature`, `top_p` |
@@ -262,11 +263,20 @@ region-scoped (`bedrock-runtime.<AWS_REGION>.amazonaws.com`) and built per reque
 
 ### xAI
 
+The seeded default is `grok-4.3`: xAI's flagship on its published model list, with the
+largest context of the current line and its lowest price. `grok-4` retired on
+2026-08-15 and was the default until then.
+
+`grok-4.3` prices in two tiers — the catalog carries the below-200k-input figures, so a
+turn that crosses that boundary is costed low rather than high. `grok-4.6` is the newer
+frontier model for coding and agentic work at roughly 1.6x input and 2.4x output; pin it
+under `providers.xai.default_model` if that trade is worth it to you.
+
 <Callout type="warn">
-  **`grok-4` retires 2026-08-15** and is still the seeded default, so a bare
-  `--model xai/…` or an unpinned auto-detected run lands on it. Pin a successor — a
-  `grok-4.x` point release or a `grok-4-fast` variant — under
-  `providers.xai.default_model`. Unlike `grok-4`, a successor also honours `effort`.
+  A `providers.xai.default_model` pinned to `grok-4` still resolves — the catalog keeps
+  the row so an existing config does not hard-error — but the model is retired at the
+  vendor and its seeded prices are stale. It is also the one xAI model stella never
+  sends `effort` to, because it answers the parameter with a 400. Repin it.
 </Callout>
 
 ### DeepSeek

--- a/website/content/docs/api-providers/models.mdx
+++ b/website/content/docs/api-providers/models.mdx
@@ -27,7 +27,7 @@ your provider before budgeting — prices and lineups drift.
 | <ProviderMark id="anthropic" /> `claude-sonnet-5` | `anthropic` | 1M | 3.00 | 15.00 | 0.30 | 2026 | Sonnet pricing with a 1M window. A strong default worker where the budget rules out the tiers above. |
 | <ProviderMark id="openai" /> `gpt-5.5` | `openai` | 400k | 1.25 | 10.00 | 0.125 | late 2025 | Top-tier reasoning with a 400k window at a mid price. Excellent cross-family verifier over a Claude or GLM worker; strong worker. |
 | <ProviderMark id="gemini" /> `gemini-3-pro` | `gemini` (also `vertex`) | 1M | 1.25 | 10.00 | 0.31 | Q4 2025 | The 1M-token window: whole-repo comprehension, long-log analysis. Solid worker, good verifier. |
-| <ProviderMark id="xai" /> `grok-4` | `xai` | 256k | 3.00 | 15.00 | 0.75 | Q3 2025 | Strong reasoning; a distinct model family, useful as an alternate verifier. |
+| <ProviderMark id="xai" /> `grok-4.3` | `xai` | 1M | 1.25 | 2.50 | 0.20 | 2026 | Strong reasoning at a low price, with a 1M window; a distinct model family, useful as an alternate verifier. Prices above are the below-200k-input tier — double them past it. |
 | <ProviderMark id="deepseek" /> `deepseek-chat` | `deepseek` | 128k | 0.27 | 1.10 | 0.07 | Q4 2024 (V3 line, revised through 2025) | The price/performance outlier. Ideal triage model; a very capable budget worker. |
 | <ProviderMark id="zai" /> `glm-5.2` | `zai` | 200k | 0.60 | 2.20 | 0.11 | 2026 | Excellent coding at a fraction of flagship price — stella's default worker tier. The coding-plan endpoint makes it a subscription workhorse. |
 | <ProviderMark id="bedrock" /> `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `bedrock` | 200k | 3.00 | 15.00 | 0.30 | Sep 2025 | Claude under AWS governance — for orgs that must keep inference inside their cloud account. |
@@ -154,7 +154,7 @@ shop on — it is the cost of entry you amortize:
 | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `bedrock` | 3.00 | 3.75 | 1.25x |
 | `gpt-5.5` | `openai` | 1.25 | 1.25 | 1x |
 | `gemini-3-pro` | `gemini`, `vertex` | 1.25 | 1.25 | 1x |
-| `grok-4` | `xai` | 3.00 | 3.00 | 1x |
+| `grok-4.3` | `xai` | 1.25 | 1.25 | 1x |
 | `glm-5.2` | `zai` | 0.60 | 0.60 | 1x |
 | `deepseek-chat` | `deepseek` | 0.27 | 0.27 | 1x |
 | `moonshotai/kimi-k3` | `openrouter` | 3.00 | 3.00 | 1x |

--- a/website/content/docs/commands/models.mdx
+++ b/website/content/docs/commands/models.mdx
@@ -112,7 +112,7 @@ Stella — Available Providers & Models
   ✓ configured zai/glm-5.2  Z.ai (GLM 5.2)  [https://api.z.ai/api/paas/v4] (env:ZAI_API_KEY)
   ✓ configured anthropic/claude-fable-5  Anthropic (Claude)  [https://api.anthropic.com] (credentials.toml)
   ✗ no key openai/gpt-5.5  OpenAI (GPT)  [https://api.openai.com/v1]
-  ✗ no key xai/grok-4  xAI (Grok)  [https://api.x.ai/v1]
+  ✗ no key xai/grok-4.3  xAI (Grok)  [https://api.x.ai/v1]
   ✗ no key deepseek/deepseek-chat  DeepSeek  [https://api.deepseek.com/v1]
   ✗ no key gemini/gemini-3-pro  Google Gemini  [https://generativelanguage.googleapis.com/v1beta]
   ✗ no key openrouter/openrouter/auto  OpenRouter  [https://openrouter.ai/api/v1]

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -397,8 +397,9 @@ maps reasoning to the provider's native mechanism:
     title="xAI (Grok)"
     meta={[{ label: "Reasoning", value: "top-level reasoning_effort" }]}
   >
-    Sent only for Grok models that accept the parameter — the original `grok-4`
-    400s on it, so it is gated by model, not just by provider.
+    Sent only for Grok models that accept the parameter — the retired `grok-4`
+    400s on it, so it is gated by model, not just by provider. The `grok-4.3`
+    default accepts it.
   </SpecCard>
   <SpecCard
     title="Anthropic"

--- a/website/src/components/provider-catalog.ts
+++ b/website/src/components/provider-catalog.ts
@@ -93,7 +93,7 @@ export const PROVIDER_CATALOG: ProviderSpec[] = [
     href: "/docs/api-providers#xai",
     blurb: "Grok, over the OpenAI-compatible dialect.",
     env: "XAI_API_KEY",
-    defaultModel: "grok-4",
+    defaultModel: "grok-4.3",
     dialect: "OpenAI-compatible",
   },
   {


### PR DESCRIPTION
## The pick, and why

`grok-4` retired at xAI on 2026-08-15 and was still the seeded `xai`
`default_model`, so a bare `--model xai/…` or an auto-detected run that landed on
xAI pointed at a model the vendor had removed.

**Settled against the vendor, not from memory.** xAI's published model list
(`https://docs.x.ai/docs/models`, read 2026-08-26) carries `grok-4.6`,
`grok-4.5`, `grok-4.3`, the `grok-4.20-0309` reasoning/non-reasoning pair,
`grok-build-0.1` and `grok-4.20-multi-agent-0309`. There is **no `grok-4` row**.

**I picked `grok-4.3`**, and the reasons are all comparative:

| | grok-4 (was) | **grok-4.3** (now) | grok-4.6 |
| --- | --- | --- | --- |
| Context | 256k | **1M** | 500k |
| In / Out $/Mtok | 3.00 / 15.00 | **1.25 / 2.50** | 2.00 / 6.00 |
| Accepts `reasoning_effort` | no (400s) | **yes** | yes |

- It is the family xAI's own migration note redirects the retired `grok-4` slugs
  to, so it changes least about what a bare `--model xai/…` already resolves to
  on the wire.
- The default gets **cheaper and wider**, not dearer.
- `grok-4.6` is the newer frontier model for coding and agentic work, and it is
  1.6x input / 2.4x output. Making the priciest row the *default* is a cost
  change nobody asked for; `--model xai/grok-4.6` is one flag away, and the docs
  now say so where a reader meets the choice.

## What changed

- `crates/stella-cli/src/config/providers.rs` — the `xai` `default_model`.
- `crates/stella-model/src/catalog/seed/xai.rs` — a `grok-4.3` row (the seed is
  what a frozen container has, so an unseeded default is *unreachable*, not
  merely unpriced). The `grok-4` row **stays**, so an existing
  `providers.xai.default_model = "grok-4"` pin still resolves rather than
  hard-erroring in `build_provider`. Retiring that row breaks a pin, which moving
  the default does not — filed as #5022.
- `crates/stella-model/src/provider_parity.rs` — the `ReasoningPosture`
  mechanism string. The witness is unchanged and did not need changing:
  `xai_identity_maps_effort_to_reasoning_effort` already exercises `grok-4.5`, a
  model that still ships. What the row now says is that the `grok-4` carve-out no
  longer touches the default.
- `crates/stella-model/src/zai/effort.rs` — `xai_supports_reasoning_effort`'s
  doc. The carve-out itself **stays**: xAI's note says the retired slugs redirect
  rather than 404, so a redirected `grok-4` might well accept the parameter — but
  that is unverified on the wire, and the error is asymmetric (a dropped hint
  versus a 400 on every reasoning turn). #5022 carries the live request.
- `crates/stella-model/src/provider_listing.rs` — the bare-id parse fixture.
- Docs, past tense throughout: the api-providers matrix, pricing table and
  reasoning table, the xAI callout, the model guide's two rows, `stella models`
  sample output, the agent-engine reasoning card,
  `website/src/components/provider-catalog.ts`, and README's provider table.

### One caveat, stated rather than buried

`grok-4.3` prices in two tiers at a 200k-input boundary ($1.25/$2.50 below,
$2.50/$5.00 above). `CatalogEntry` carries one price, so the row takes the
below-200k figures and a turn that crosses the boundary is costed **low**. That
is the same direction of error as an unpriced row, and the comment in
`xai.rs` says so.

## Witness

`the_seeded_xai_default_is_not_the_retired_grok_4` in
`crates/stella-cli/src/config/tests/parity.rs`.

**Ablation** — `default_model` reverted to `"grok-4"`, nothing else changed:

```
---- config::tests::parity::the_seeded_xai_default_is_not_the_retired_grok_4 stdout ----
thread '...' panicked at crates/stella-cli/src/config/tests/parity.rs:45:5:
assertion `left != right` failed: grok-4 retired at xAI on 2026-08-15; the seeded default must name a model the vendor still serves
  left: "grok-4"
 right: "grok-4"

test result: FAILED. 0 passed; 1 failed;
```

Restored:

```
test config::tests::parity::the_seeded_xai_default_is_not_the_retired_grok_4 ... ok
test config::tests::parity::every_provider_default_model_resolves_against_the_catalog_seed ... ok
test result: ok. 9 passed; 0 failed;
```

The test asserts the **retired slug**, not the successor, on purpose: "the
default is not `grok-4`" stays true through every future point release, while
"the default is `grok-4.3`" would turn a chosen upgrade to `grok-4.6` into a red
test. `every_provider_default_model_resolves_against_the_catalog_seed` already
holds whatever the default *is* to something reachable — which is also what
proves the new catalog row landed.

Other suites: `cargo test -p stella-model --lib` → 479 passed, 0 failed.
`cargo test -p stella-cli --bins -- config:: model_catalog::` → 91 passed, 0
failed. `cargo clippy -p stella-model -p stella-cli --all-targets` → clean.
`make guards-fast` → green.

## Filed, not left behind

**#5022 — Nothing notices when a catalog model is retired by its vendor.** The
general form of this bug: no `CatalogEntry` field records a retirement date,
`stella models refresh` discards the signal when a slug vanishes from the live
listing, and the date lived in prose in three places, all in the future tense
eleven days after it had passed. The by-name test here catches a revert of this
one change and nothing else, which is why the follow-up exists. It also carries
the two loose ends above — verifying the redirect against the `grok-4` carve-out,
and retiring the `grok-4` seed row.

Closes #5004
Refs #5022

## Summary by Sourcery

Switch the xAI default to the supported `grok-4.3` model while retaining compatibility for existing `grok-4` pins.

Bug Fixes:
- Update the seeded xAI default from retired `grok-4` to the vendor-supported `grok-4.3`.
- Preserve existing `grok-4` configuration pins while adding catalog support for `grok-4.3`.

Enhancements:
- Align xAI reasoning behavior, provider listings, model metadata, pricing, and user-facing documentation with the new default and its capabilities.

Documentation:
- Refresh provider, model, command-output, reasoning, configuration, and README documentation for `grok-4.3`, including its pricing tiers and `grok-4.6` guidance.

Tests:
- Add coverage ensuring the seeded xAI default does not regress to the retired `grok-4` model.

Chores:
- Track broader model-retirement detection and verification of redirected `grok-4` reasoning behavior separately in issue #5022.