### PR TITLE
test(stella-cli): drop the STELLA_HOME workaround from the records trust test

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests/contributions.rs
@@ -1131,18 +1131,16 @@ fn the_dashboards_plugin_records_honour_the_project_trust_gate() {
     }
 
     let _env = crate::test_env::lock();
-    let _restore = crate::test_env::EnvRestore::capture(&[
-        "STELLA_TRUST_PROJECT",
-        "STELLA_PROJECT_HOOKS",
-        "STELLA_HOME",
-    ]);
+    let _restore =
+        crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT", "STELLA_PROJECT_HOOKS"]);
     let root = temp_root("package-observatory-records-trust");
+    // The user tier of the roster is `paths::user_extension_root()` — the
+    // thread-local, which in a test build answers `None` until a test installs
+    // a home — so this one call is the whole isolation, and a package in the
+    // developer's real `~/.stella/plugins` cannot answer for the assertions
+    // below. It moves `stella_home::stella_home()` too since #4992, which is
+    // what the sibling skills test needs.
     let _paths = crate::paths::test_user_home(root.join("home"));
-    // The user-tier half of the roster is `stella_home::stella_home()`, which
-    // `test_user_home` does not move — without this the roster resolves the
-    // developer's real `~/.stella/plugins` (#4980).
-    // SAFETY: the env lock is held for the whole mutate-read-restore window.
-    unsafe { std::env::set_var("STELLA_HOME", root.join("home")) };
 
     let planted = stella_home::resolve_project_plugins_dir(&root).join("vera");
     plant(&stella_home::resolve_project_plugins_dir(&root), "vera");


### PR DESCRIPTION
## What

The second of the two tests #5002 names. #5012 removed the copy in
`the_dashboards_plugin_skills_honour_the_project_trust_gate`; #5003 merged after
it and brought this one, so `main` now has the pair and this finishes them.
#5002 closes here.

## The line was inert, and its comment was wrong about why

The removed comment said:

> The user-tier half of the roster is `stella_home::stella_home()`, which
> `test_user_home` does not move — without this the roster resolves the
> developer's real `~/.stella/plugins` (#4980).

`PluginRoster::load` (`crates/stella-cli/src/plugin_cmd/roster.rs`) reads
`crate::paths::user_extension_root()` — the thread-local — not
`stella_home::stella_home()`. And `user_extension_root`'s own doc in
`crates/stella-cli/src/paths.rs` says what that means for a test build:

> In a test build it answers `None` until the test installs a home, so a suite
> never reads the developer's own `~/.stella`.

`test_user_home` installs one. The environment variable was never on this
test's path.

That is not true of the sibling: `stella_observatory::fsview::user_config_dir`
**is** `stella_home::stella_home()`, which is why the skills test genuinely
needed the seam and why #4992 exists. The line here was copied across from a
test where it did something.

## Evidence

Poisoned first, because green on a clean machine proves nothing: an ambient
`STELLA_HOME` pointed at a fixture home carrying an installed `canary` package
with records under `.stella/plugins/canary/`, built through the crate's own
`plant_installed` + `ships_a_package` so it is a package the roster would
actually accept.

Probing both resolvers inside the test, **with the workaround still in place**:

```
PROBE user_extension_root=Some(".../home/.stella")  stella_home=Some(".../home")
```

They disagree — and the one the roster reads is *not* the one `set_var` moved.
The workaround pointed the stella home one directory above the path that
mattered.

**With it removed** (this PR):

```
PROBE user_extension_root=Some(".../home/.stella")  stella_home=Some(".../home/.stella")
```

They agree, on the roster's answer.

Under that same poisoned home:

```
$ STELLA_HOME=/tmp/stella-5002-poison-home2/.stella \
    cargo test -p stella-cli --bins -- contributions::
test plugin_cmd::tests::contributions::the_dashboards_plugin_records_honour_the_project_trust_gate ... ok
test plugin_cmd::tests::contributions::the_dashboards_plugin_skills_honour_the_project_trust_gate ... ok
test result: ok. 15 passed; 0 failed;
```

### What I could not produce, said plainly

I could not make this test **fail** by poisoning the environment, and that is
the finding rather than a gap in the attempt. Ablating `test_user_home`'s
`home_sandbox` call — the ablation that does break the skills test, shown in
#5012 — leaves this one green, because the roster never consults the
environment. In a test build `user_extension_root()` is either the installed
fixture or `None`; there is no third answer that reaches a real `~/.stella`.
The probe above is the evidence that separates the claim from its opposite:
it shows the two resolvers diverging under the workaround and converging
without it.

`STELLA_HOME` also leaves the test's own `EnvRestore::capture` list, since
`test_user_home`'s guard captures and restores every
`stella_home::OVERRIDE_ENV_VARS` entry itself.

`make guards-fast`: green.

## Witness

Test-only change; no behaviour change to ship a witness for.

Closes #5002
Refs #4980, #4992, #5003, #5012

## Summary by Sourcery

Simplify the records trust-gate test by relying on its test-home isolation instead of the unnecessary STELLA_HOME override.

Enhancements:
- Remove the redundant STELLA_HOME workaround from the records trust-gate test and clarify that test isolation is provided by the configured user extension root.

Tests:
- Update the records trust-gate test's environment restoration scope to match the variables it actually uses.