### PR TITLE
docs(claude): issue labels carry priority, area, model class, and pains in a fixed order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,8 @@
   runs it → why it matters. Pick `use-model` by the hardest step in the
   issue, not the average: templated or mechanical work is `cheap`, routine
   implementation against a clear spec is `balanced`, cross-crate design or
-  tricky invariants are `pro`, and architecture-critical or genuinely novel
-  design is `ultra`.
+  subtle correctness rules are `pro`, and architecture-critical or genuinely
+  novel design is `ultra`.
 - **Every Sourcery ❌ gets a fix or an answer before the PR is mergeable.**
   Sourcery reviews every PR, and when the PR links issues it posts an
   "Assessment against linked issues" table as a `sourcery-ai` comment — one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,22 @@
   Search for an existing issue first; link, don't duplicate. The full policy
   is AGENTS.md § "Nothing left behind — every finding becomes a fix or a
   GitHub issue". Never end a turn with untracked half-finished work.
+- **Every issue is labelled, in this order.** First a priority (`P0`–`P4`),
+  then the `area:*` tag — several when the work genuinely spans areas — then
+  exactly one `use-model:*` tag (`cheap` / `balanced` / `pro` / `ultra`)
+  naming the cheapest model class that can do the work without sacrificing
+  quality, then the `pain:*` tags for the pains the issue relieves
+  (`pain:speed`, `pain:cost`, `pain:accuracy`, `pain:context`,
+  `pain:auditability`, `pain:over-engineering`, `pain:complex-prose`,
+  `pain:tech-debt`, `pain:infra-cost`, `pain:vendor-lock`,
+  `pain:user-experience`, `pain:brand-consistency`, `pain:maintainability`,
+  `pain:test-coverage`, `pain:ci-time`, `pain:system-compatibility`). The
+  order is a habit for the reader: the list scans as urgency → where → who
+  runs it → why it matters. Pick `use-model` by the hardest step in the
+  issue, not the average: templated or mechanical work is `cheap`, routine
+  implementation against a clear spec is `balanced`, cross-crate design or
+  tricky invariants are `pro`, and architecture-critical or genuinely novel
+  design is `ultra`.
 - **Every Sourcery ❌ gets a fix or an answer before the PR is mergeable.**
   Sourcery reviews every PR, and when the PR links issues it posts an
   "Assessment against linked issues" table as a `sourcery-ai` comment — one


### PR DESCRIPTION
Adds the issue-labelling convention to CLAUDE.md's hard rules: every issue is
labelled priority first (P0–P4), then its area tag(s), then exactly one
use-model tag naming the cheapest model class that does the work without
sacrificing quality, then the pain tags for the pains it relieves.

The label families this cites now exist in the repository:
use-model:cheap|balanced|pro|ultra and sixteen pain:* labels
(speed, cost, accuracy, context, auditability, over-engineering,
complex-prose, tech-debt, infra-cost, vendor-lock, user-experience,
brand-consistency, maintainability, test-coverage, ci-time,
system-compatibility), each with a one-line description.

Docs-only: no witness test. Verified with `make prose` (green) on the branch.

## Summary by Sourcery

Document a consistent issue-labeling convention so issues clearly communicate urgency, ownership area, execution model, and the pains they address.

Enhancements:
- Document the required issue-label ordering and model-selection guidance in CLAUDE.md.

Documentation:
- Add the repository’s issue-labeling convention, including priority, area, model-class, and pain labels, to the contributor hard rules.