### PR TITLE
fix(stella-tui): money and its meter render gold, not green

### DIFF
--- a/crates/stella-tui/src/views/budget_card.rs
+++ b/crates/stella-tui/src/views/budget_card.rs
@@ -45,15 +45,18 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, frame: Rect, buf: &mut Buffer
             primary,
         )));
     } else {
+        // Money renders gold, and its meter is gold on the border gray —
+        // SPEC 5's rule for every spend figure. Green is verdict ink here,
+        // and spend is a fact, not a pass.
         let mut spend_row = vec![
             Span::styled("run     ", dim),
-            Span::styled(format!("${spent:.2}"), Style::new().fg(token::GREEN)),
+            Span::styled(format!("${spent:.2}"), Style::new().fg(token::GOLD)),
         ];
         match model.budget_cap_usd {
             Some(cap) if cap > 0.0 => {
                 spend_row.push(Span::styled(format!(" of ${cap:.2} "), dim));
                 let pct = ((spent / cap).clamp(0.0, 1.0) * 100.0).round() as usize;
-                spend_row.extend(cards::mini_fraction_bar(pct, 100, 9, token::GREEN));
+                spend_row.extend(cards::mini_fraction_bar(pct, 100, 9, token::GOLD));
             }
             _ => spend_row.push(Span::styled(" · no cap set", dim)),
         }
@@ -79,4 +82,43 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, frame: Rect, buf: &mut Buffer
         buf,
     );
     cards::render_body(rows, None, inner, buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{AgentMeta, Inbound};
+
+    /// SPEC 5: money renders gold and its meter is gold on the border gray.
+    /// Green is verdict ink; a spend figure is a fact, not a pass, so the
+    /// card may not paint a single green cell.
+    #[test]
+    fn money_and_its_meter_are_gold_never_green() {
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        model.agents[0].cost_usd = 0.42;
+        model.budget_cap_usd = Some(1.0);
+        let ui = DeckUi::default();
+        let frame = Rect::new(0, 0, 80, 12);
+        let mut buf = Buffer::empty(frame);
+        render(&model, &ui, frame, &mut buf);
+
+        let mut golds = 0usize;
+        for y in 0..frame.height {
+            for x in 0..frame.width {
+                let cell = buf.cell((x, y)).expect("cell in area");
+                assert_ne!(
+                    cell.fg,
+                    token::GREEN,
+                    "green cell at ({x},{y}): {:?}",
+                    cell.symbol()
+                );
+                if cell.fg == token::GOLD && cell.symbol().trim() != "" {
+                    golds += 1;
+                }
+            }
+        }
+        // The spend figure and the filled meter cells are gold.
+        assert!(golds > 0, "no gold cell rendered for money or meter");
+    }
 }

--- a/crates/stella-tui/src/views/budget_card.rs
+++ b/crates/stella-tui/src/views/budget_card.rs
@@ -103,7 +103,11 @@ mod tests {
         let mut buf = Buffer::empty(frame);
         render(&model, &ui, frame, &mut buf);
 
-        let mut golds = 0usize;
+        // A metal map of the card: every visible cell's symbol with the token
+        // it wears, so each half of the rule is pinned by the cells that
+        // carry it — the `▰` fill gold, the `▱` groove gray, the `$` money
+        // gold, and no green anywhere.
+        let (mut fills, mut grooves, mut money) = (0usize, 0usize, 0usize);
         for y in 0..frame.height {
             for x in 0..frame.width {
                 let cell = buf.cell((x, y)).expect("cell in area");
@@ -113,12 +117,26 @@ mod tests {
                     "green cell at ({x},{y}): {:?}",
                     cell.symbol()
                 );
-                if cell.fg == token::GOLD && cell.symbol().trim() != "" {
-                    golds += 1;
+                match cell.symbol() {
+                    "▰" => {
+                        assert_eq!(cell.fg, token::GOLD, "meter fill at ({x},{y}) is not gold");
+                        fills += 1;
+                    }
+                    "▱" => {
+                        assert_eq!(
+                            cell.fg,
+                            token::MUTED,
+                            "meter groove at ({x},{y}) is not the gray groove"
+                        );
+                        grooves += 1;
+                    }
+                    "$" if cell.fg == token::GOLD => money += 1,
+                    _ => {}
                 }
             }
         }
-        // The spend figure and the filled meter cells are gold.
-        assert!(golds > 0, "no gold cell rendered for money or meter");
+        assert!(fills > 0, "no gold meter fill rendered");
+        assert!(grooves > 0, "no meter groove rendered");
+        assert!(money > 0, "no gold money cell rendered");
     }
 }

--- a/crates/stella-tui/src/views/plan_card.rs
+++ b/crates/stella-tui/src/views/plan_card.rs
@@ -210,17 +210,19 @@ pub fn grid_rows(
         accessible,
     ));
 
-    // Budget: spent (success — money spent is a fact) `of $cap` dim, plus a
-    // mini fraction bar. The cap is the agent's own metered limit.
+    // Budget: spent in gold — money renders gold and its meter is gold on
+    // the border gray (SPEC 5); spend is a fact, not a pass, so it takes no
+    // verdict ink — `of $cap` dim, plus a mini fraction bar. The cap is the
+    // agent's own metered limit.
     let mut budget: Vec<Span<'static>> = vec![Span::styled(
         format!("${:.2}", agent.cost_usd),
-        Style::new().fg(token::GREEN),
+        Style::new().fg(token::GOLD),
     )];
     if let Some(cap) = agent.model.hud.limit_usd.filter(|cap| *cap > 0.0) {
         budget.push(Span::styled(format!(" of ${cap:.2} "), dim));
         if !accessible {
             let pct = ((agent.cost_usd / cap).clamp(0.0, 1.0) * 100.0).round() as usize;
-            budget.extend(cards::mini_fraction_bar(pct, 100, 7, token::GREEN));
+            budget.extend(cards::mini_fraction_bar(pct, 100, 7, token::GOLD));
         }
     } else if let Some(estimate) = proposal.estimated_cost_usd {
         budget.push(Span::styled(format!(" · est ${estimate:.2}"), dim));


### PR DESCRIPTION
SPEC 5 (`design/tui-v2/SPEC.md`): money renders gold, meters render gold fill on `border` gray, no green meters. Two rows violated it — the `/budget` card's spend row and the plan card's budget row — both painting the figure and the `mini_fraction_bar` in `token::GREEN`.

Witness: `money_and_its_meter_are_gold_never_green` (in `views/budget_card.rs`) renders the card and asserts zero green cells and at least one gold one. Verified the flip artisanally: with the spans reverted to `GREEN` the test fails; with the fix it passes. `deck_render_snapshots` (25) and `plan_card_grid` (4) stay green — the deck goldens are style-stripped, so no snapshot churn.

The plan-card half was listed in #5046's sibling #5040 as a fold-in; done here instead since it is the same two-line defect — noted on that issue.

Closes #5052
Refs #5040

## Summary by Sourcery

Align budget and plan card money and meter colors with the TUI visual specification.

Bug Fixes:
- Render budget spend amounts and their meter fills in gold instead of green, while preserving gray meter grooves.

Tests:
- Add coverage ensuring budget cards contain no green cells and render gold money and meter fills.