### PR TITLE
fix(stella-tui): the dead v1 compaction arm delegates to the projection

### DIFF
--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -506,25 +506,14 @@ fn entry_body(
                 out,
             );
         }
-        TranscriptEntry::Compaction {
-            before_tokens,
-            after_tokens,
-            evicted,
-            deduped,
-        } => {
-            push_note(
-                "⇣ compacted",
-                quiet(),
-                vec![
-                    Span::styled(format!("{before_tokens}→{after_tokens} tok"), value()),
-                    Span::styled(
-                        format!("  ·  {evicted} evicted · {deduped} deduped"),
-                        quiet(),
-                    ),
-                ],
-                width,
-                out,
-            );
+        // The router's (SPEC 6.3's one quiet line). This arm delegates for the
+        // same reason `ToolStart` below does: it used to hold a live-looking
+        // v1 row (`⇣ compacted … tok`) that `projected_rows` had made
+        // unreachable, and a dead match arm drifts silently — neither
+        // `dead-code-allows` nor `module-reachability` sees inside a match
+        // (#4157's lesson, restated at the router).
+        TranscriptEntry::Compaction { .. } => {
+            projected_rows(entry, view, expanded, width, out);
         }
         TranscriptEntry::BudgetTick {
             spent_usd,
@@ -941,5 +930,62 @@ fn ci_status_color(status: CiStatus) -> Color {
         CiStatus::Running => theme::WARNING_BRIGHT,
         CiStatus::Passing => theme::OK,
         CiStatus::Failing => theme::BAD,
+    }
+}
+
+#[cfg(test)]
+mod entry_body_tests {
+    use super::*;
+
+    fn text_of(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    /// The witness for the dead-arm hazard (#4157's shape): `entry_body`'s
+    /// compaction arm must draw exactly what the router's projection draws,
+    /// because the router intercepts `Compaction` and the long-form arm is
+    /// otherwise unreachable — where it sat drawing a stale `⇣ compacted … tok`
+    /// row that nothing could ever see, until the day the router narrowed and
+    /// it silently could.
+    #[test]
+    fn the_compaction_arm_agrees_with_the_projection_it_shadows() {
+        let entry = TranscriptEntry::Compaction {
+            before_tokens: 74_000,
+            after_tokens: 69_000,
+            evicted: 0,
+            deduped: 0,
+        };
+        let width = 100;
+        let mut via_router = Vec::new();
+        assert!(projected_rows(
+            &entry,
+            EntryView::default(),
+            false,
+            width,
+            &mut via_router,
+        ));
+        let mut via_body = Vec::new();
+        entry_body(
+            &entry,
+            EntryView::default(),
+            false,
+            false,
+            false,
+            width,
+            &mut via_body,
+        );
+        assert_eq!(
+            text_of(&via_body),
+            text_of(&via_router),
+            "entry_body's compaction arm drifted from the projection"
+        );
     }
 }

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -987,5 +987,48 @@ mod entry_body_tests {
             text_of(&via_router),
             "entry_body's compaction arm drifted from the projection"
         );
+        // One quiet line — SPEC 6.3's whole ask for compaction — from the
+        // projection, and the same one line through both routes.
+        assert_eq!(via_router.len(), 1, "{:?}", text_of(&via_router));
+        assert!(
+            text_of(&via_router)[0].contains("compacted 74k→69k"),
+            "{:?}",
+            text_of(&via_router)
+        );
+    }
+
+    /// The same event through [`entry_lines`] — the path every frame actually
+    /// takes: the one quiet line plus the block-closing spacer, and nothing
+    /// else, so neither route can double-print a compaction.
+    #[test]
+    fn a_compaction_renders_one_quiet_line_through_the_full_path() {
+        let entry = TranscriptEntry::Compaction {
+            before_tokens: 74_000,
+            after_tokens: 69_000,
+            evicted: 0,
+            deduped: 0,
+        };
+        let mut out = Vec::new();
+        entry_lines(
+            &entry,
+            EntryView::default(),
+            false,
+            false,
+            false,
+            100,
+            &mut out,
+        );
+        let rows = text_of(&out);
+        assert_eq!(
+            rows.iter().filter(|r| r.contains("compacted")).count(),
+            1,
+            "{rows:?}"
+        );
+        assert_eq!(
+            out.len(),
+            2,
+            "one quiet line and its trailing spacer: {rows:?}"
+        );
+        assert!(rows[1].trim().is_empty(), "{rows:?}");
     }
 }


### PR DESCRIPTION
The audit behind #5035 read this as a possible double print; the truth is the opposite defect. `projected_rows` (render/entry.rs) intercepts every `Compaction` entry and returns `true`, so `entry_body`'s long-form arm was unreachable — while still drawing the retired `⇣ compacted … tok` row. A dead match arm is invisible to `dead-code-allows` and `module-reachability` (both see items), which is exactly the #4157 shape the router's own doc comment warns about: it sits looking live until the router narrows, then silently ships stale rendering.

The arm now **delegates** to the projection, the pattern the `ToolStart` arm already established, so there is one compaction renderer and no second one to rot.

Witness: `the_compaction_arm_agrees_with_the_projection_it_shadows` calls `entry_body` directly and asserts its rows equal the projection's. Verified the flip artisanally: with the old arm restored the test fails on the drifted text; with the delegation it passes. `cargo clippy -p stella-tui --all-targets` exits 0.

Closes #5035

## Summary by Sourcery

Route compaction entries through the canonical projection and verify that they render exactly one consistent quiet line.

Bug Fixes:
- Ensure compaction entries use the single projected quiet-line renderer instead of retaining an unreachable stale rendering path.

Enhancements:
- Add regression coverage confirming compaction output matches the projection and renders only one quiet line through the full entry path.

Tests:
- Add tests that detect drift between direct entry rendering and projected compaction rendering, and prevent duplicate compaction output.