### PR TITLE
fix(stella-core): gate compaction retention on the reclaim ratio, not the budget fraction

### DIFF
--- a/crates/stella-core/src/compaction.rs
+++ b/crates/stella-core/src/compaction.rs
@@ -12,11 +12,12 @@
 //!    An old tool output has usually been consumed within a few steps; past
 //!    the horizon its head and tail carry the framing and the errors, and the
 //!    stub says how to get the rest back. Aging fires only once at least
-//!    `RETENTION_MIN_RECLAIM_CHARS` are reclaimable **and** the conversation
-//!    is at least `RETENTION_TRIGGER_BUDGET_DIVISOR`-th of the way into its
-//!    budget, so the prompt-cache prefix is mutated only when the rewrite
-//!    buys real bytes in a conversation big enough to need them (the same
-//!    discipline as the budget hysteresis below — AGENTS.md #7, #372, #4381).
+//!    `RETENTION_MIN_RECLAIM_CHARS` are reclaimable **and** the batch would
+//!    remove at least `RETENTION_TRIGGER_RECLAIM_PERCENT` of what the
+//!    conversation would be left holding, so the prompt-cache prefix is
+//!    mutated only when the rewrite takes back a real share of the
+//!    transcript it invalidates (the same discipline as the budget
+//!    hysteresis below — AGENTS.md #7, #372, #4381, #4753).
 //!
 //! The budget passes:
 //!
@@ -43,6 +44,8 @@
 //! The system message and the latest user message are never touched.
 
 use stella_protocol::{CompactionRewrite, CompletionMessage, MessageRole, ToolOutput};
+
+use stella_protocol::tokens::estimate_tokens_for_bytes;
 
 use crate::estimator::{estimate_conversation_tokens, estimate_message_tokens};
 use crate::receipts::{tool_result_block_id, tool_result_rewrite};
@@ -273,73 +276,65 @@ pub(crate) fn elide_truncated_partial(content: &str) -> Option<String> {
 /// hysteresis — AGENTS.md #7).
 const RETENTION_MIN_RECLAIM_CHARS: usize = 12_000;
 
-/// How far into its budget a conversation must be before the retention pass
-/// is allowed to rewrite anything: `budget_tokens / this`, i.e. half.
+/// The share of the surviving conversation a retention batch must take back
+/// before it is allowed to rewrite anything: `reclaimed * 100 >= after * this`,
+/// i.e. fifteen percent.
 ///
 /// The reclaim floor above prices the rewrite in *bytes reclaimed* and stops
 /// there, which prices only one side of the trade. The other side is the
 /// prompt-cache miss the rewrite causes, and that scales with the whole
 /// conversation behind the rewrite point — so the same 12 KB batch is a good
-/// trade near the ceiling and a bad one in a conversation using a quarter of
-/// its window. Measured (#4381, execution 242 of session
-/// `ses-1787465453163-60967`): a 163 014-token budget, context never above
-/// 42 K, five pass-0 firings saving 4–8 K tokens each and re-billing 137 K at
-/// the miss rate, with 90–97% cache hits on every step between them.
+/// trade against a 40 K-token transcript and a bad one against a 400 K one.
 ///
-/// Half, because that is the widest band that still leaves pass 0 the job
-/// #1285 gave it. The budget passes trigger at the full budget and reclaim to
-/// seven-eighths of it, so gating retention anywhere near them would make it
-/// a duplicate of pass 3; gating it at half leaves the entire 50–100% band —
-/// which is where a long turn's standing context actually accumulates — for
-/// retention to shape, and charges nothing at all to a turn that never gets
-/// there. A conversation below half its budget has room for the bytes it is
-/// carrying, and paying a full prefix invalidation to take some of them back
-/// buys nothing it needs yet.
+/// This gate used to ask how far into its budget the conversation was
+/// (`budget_tokens / 2`, #4381). The census that priced it says that key
+/// selects the wrong firings — not that it was set to the wrong number
+/// (#4452, `scripts/retention-census.py` over the session journals of
+/// binaries that had no gate at all, so the counterfactual is askable). A
+/// firing re-bills the whole surviving prefix uncached — the miss is
+/// measured, a median cached fraction of 0.487 on the call before a firing
+/// and 0.196 on the call after — and buys back `reclaimed` tokens at the
+/// cache-read price on every later call of the turn, so its net in
+/// uncached-equivalent tokens is `after − r·before − r·reclaimed·(N−1)` for
+/// `N` further worker calls and a cache read priced at `r`. Summed over 370
+/// pure pass-0 firings at `r = 0.10`, the gate at half cost **+5.63 M**
+/// tokens against **+2.92 M** for no gate at all; at `r = 0.25` it saved
+/// 3.04 M where no gate saved 24.6 M; at `r = 0.50`, 17.5 M against 70.6 M.
+/// At every price it was the worse of the two.
 ///
-/// **That is an argument, and the census that answered it says the argument
-/// picked the wrong quantity to gate on** (#4452,
-/// `scripts/retention-census.py` over 96 session journals from binaries with
-/// no gate, so the counterfactual is askable). Of 370 pure pass-0 firings the
-/// conversation sat at a median 0.370 of its budget, so half suppresses 258 of
-/// them — 69.7%, forgoing 1.76 M of the 2.77 M tokens the pass reclaimed. A
-/// divisor of 3 suppresses 42.2%, 4 suppresses 23.8%.
+/// It lost because budget fraction is *anti-correlated* with the trade.
+/// Profitable firings sat at a median 0.266 of budget and unprofitable ones at
+/// 0.425, because what decides a firing is how far the turn runs past it — a
+/// median 90 further worker calls where it profits against 26 where it does
+/// not — and a turn is furthest from its ceiling early, which is exactly the
+/// band half suppressed. It admitted 112 firings of which 15 profited:
+/// precision 0.13 against a 0.32 base rate, so it selected worse than
+/// admitting everything.
 ///
-/// Priced, the picture reverses and then indicts the key. A firing re-bills
-/// the whole surviving prefix uncached (the measured miss is real: the cached
-/// fraction is a median 0.487 on the call before a firing and 0.196 on the
-/// call after) and buys back `reclaimed` tokens at the cache-read price on
-/// every later call of the turn, so its net in uncached-equivalent tokens is
-/// `after − r·before − r·reclaimed·(N−1)` for `N` further worker calls and a
-/// cache read priced at `r`. Summed over the same 370 firings, at `r = 0.10`
-/// the gate at half costs **+5.63 M** tokens against **+2.92 M** for no gate
-/// at all; at `r = 0.25` it saves 3.04 M where no gate saves 24.6 M, and at
-/// `r = 0.50`, 17.5 M against 70.6 M. At every price the gate at half is the
-/// worse of the two.
+/// The reclaim ratio `reclaimed / after` is the other term of that break-even
+/// expression, and unlike the remaining call count it is known at firing time.
+/// Over the same corpus at `r = 0.10`:
 ///
-/// It loses because budget fraction is *anti-correlated* with the trade.
-/// Profitable firings sit at a median 0.266 of budget and unprofitable ones at
-/// 0.425, because what actually decides a firing is how far the turn runs past
-/// it — a median 90 further worker calls where it profits against 26 where it
-/// does not — and a turn is furthest from its ceiling early, which is exactly
-/// the band half suppresses. At `r = 0.10` the gate admits 112 firings of
-/// which 15 profit: precision 0.13 against a 0.32 base rate, so it selects
-/// worse than admitting everything.
+/// | gate | admits | profitable | precision | recall | net |
+/// |---|---|---|---|---|---|
+/// | none | 370 | 120 | 0.32 | 1.00 | +2 923 748 |
+/// | budget fraction >= 1/2 | 112 | 15 | 0.13 | 0.12 | +5 634 585 |
+/// | ratio >= 0.05 | 317 | 119 | 0.38 | 0.99 | −1 473 917 |
+/// | ratio >= 0.10 | 226 | 112 | 0.50 | 0.93 | −4 701 610 |
+/// | ratio >= 0.15 | 152 | 91 | 0.60 | 0.76 | **−5 609 242** |
+/// | ratio >= 0.25 | 79 | 61 | 0.77 | 0.51 | −5 361 572 |
 ///
-/// The divisor stays at 2 anyway, because the census disqualifies the key and
-/// names no replacement value for it: every divisor is a worse classifier than
-/// no gate, so moving to 3 or 4 would trade one unmeasured number for another.
-/// What the census does name is the gate to build instead — the reclaim ratio
-/// `reclaimed / after`, which is the other term of the break-even expression
-/// and, unlike the remaining call count, is known at firing time. A gate at
-/// `ratio >= 0.15` admits 152 firings at precision 0.60 and turns the same
-/// corpus from +5.63 M into **−5.61 M**. That is #4753, and it is a new gate
-/// with its own witness rather than a new value for this one.
+/// Fifteen percent is the minimum of the net column. It fires 40 times more
+/// than the budget gate did over this corpus and 218 times less than no gate,
+/// and the net already prices every one of those invalidations — a threshold
+/// that fired less (0.25) gave back 248 K tokens of the saving.
 ///
-/// MEASURED: 370 pure pass-0 retention firings across 96 session journals,
-/// 2026-08-24 (#4452, `scripts/retention-census.py`). The census is why the
-/// divisor is still 2 rather than 3 or 4, so a merge that changed it would be
-/// discarding the measurement, not disagreeing with it.
-const RETENTION_TRIGGER_BUDGET_DIVISOR: u64 = 2;
+/// MEASURED: 370 pure pass-0 retention firings across 95 session journals,
+/// re-run 2026-08-26 and unchanged from the 2026-08-24 census (#4452, #4753,
+/// `scripts/retention-census.py`). Every number above is a cell of that
+/// output, so a merge that moved this constant would be discarding the
+/// measurement rather than disagreeing with it.
+const RETENTION_TRIGGER_RECLAIM_PERCENT: u64 = 15;
 
 /// The bytes one aged payload retains: both kept ends plus the elision
 /// marker. What aging reclaims from a payload is its length minus this.
@@ -350,15 +345,17 @@ const AGE_RETAINED_CHARS: usize = 2 * AGE_KEEP_CHARS + AGE_ELISION_MARKER.len();
 ///
 /// Results in older Tool messages are middle-out aged (`age_content`) once
 /// two conditions hold together: at least `RETENTION_MIN_RECLAIM_CHARS` of
-/// them are reclaimable, and the conversation already occupies at least
-/// `budget_tokens / RETENTION_TRIGGER_BUDGET_DIVISOR`.
+/// them are reclaimable, and that batch is worth at least
+/// `RETENTION_TRIGGER_RECLAIM_PERCENT` of what the conversation would be left
+/// carrying.
 ///
-/// The second condition is what relates this pass to the budget without
-/// making it one of the budget passes. They fire *at* the ceiling and reclaim
-/// down from it; this one starts working at half the budget, so it still
-/// shapes the standing context from the middle of a long turn — the whole
-/// point of #1285 — while a conversation nowhere near its ceiling keeps a
-/// byte-stable prefix and its prompt-cache hits (#4381).
+/// The second condition is what keeps this pass off the prompt-cache prefix
+/// of a conversation the rewrite would not visibly shrink. It reads no budget
+/// at all, so the pass is free of the budget passes rather than a smaller
+/// version of them: they fire *at* the ceiling and reclaim down from it,
+/// while this one shapes the standing context from wherever in a long turn
+/// the batch has accumulated — the point of #1285, and the band #4753's
+/// census found the old budget-fraction gate was suppressing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RetentionPolicy {
     /// Tool messages within this distance of the newest one are never touched
@@ -368,9 +365,9 @@ pub struct RetentionPolicy {
 }
 
 /// Pass 0: age every large tool result older than the policy's horizon,
-/// gated on [`RETENTION_MIN_RECLAIM_CHARS`] and on the conversation having
-/// reached [`RETENTION_TRIGGER_BUDGET_DIVISOR`]-th of `budget_tokens`.
-/// Returns `(aged, aged_blocks,
+/// gated on [`RETENTION_MIN_RECLAIM_CHARS`] and on the batch clearing
+/// [`RETENTION_TRIGGER_RECLAIM_PERCENT`] of the conversation it would leave
+/// behind. Returns `(aged, aged_blocks,
 /// rewrites, tokens_saved)`; block ids are captured before mutation so the
 /// report cites the identity the previous step's manifest recorded (§6.2),
 /// and each rewrite's replacement record is captured right after it (#1667) —
@@ -384,14 +381,7 @@ fn age_stale_tool_results(
     messages: &mut [CompletionMessage],
     policy: RetentionPolicy,
     current_tokens: u64,
-    budget_tokens: u64,
 ) -> (usize, Vec<String>, Vec<CompactionRewrite>, u64) {
-    // The budget precondition, before the transcript is walked at all: this
-    // runs on every step, and a conversation with room to spare must cost
-    // nothing here beyond the comparison.
-    if current_tokens <= budget_tokens / RETENTION_TRIGGER_BUDGET_DIVISOR {
-        return (0, Vec::new(), Vec::new(), 0);
-    }
     let tool_positions: Vec<usize> = messages
         .iter()
         .enumerate()
@@ -428,6 +418,22 @@ fn age_stale_tool_results(
         })
         .sum();
     if reclaimable < RETENTION_MIN_RECLAIM_CHARS {
+        return (0, Vec::new(), Vec::new(), 0);
+    }
+    // The reclaim-ratio gate (#4753). `reclaimable` is the batch priced in
+    // bytes and every ageable payload is plain text, so the shared byte
+    // heuristic converts it to the same units `current_tokens` is in; the
+    // per-message diffs below then measure what was actually saved, and the
+    // two agree to within the estimator's rounding. `after` is what the
+    // conversation would carry once the batch is gone, which is the
+    // denominator the census priced — a batch that takes back a tenth of a
+    // 400 K transcript is the same bytes and a far worse trade than one that
+    // takes back a tenth of a 40 K one.
+    let reclaimable_tokens = estimate_tokens_for_bytes(reclaimable as u64);
+    let after = current_tokens.saturating_sub(reclaimable_tokens);
+    if reclaimable_tokens.saturating_mul(100)
+        < after.saturating_mul(RETENTION_TRIGGER_RECLAIM_PERCENT)
+    {
         return (0, Vec::new(), Vec::new(), 0);
     }
     let mut aged = 0usize;
@@ -508,13 +514,13 @@ pub fn compact_measured(
     retention: Option<RetentionPolicy>,
 ) -> (u64, Option<CompactionReport>) {
     let before_tokens = estimate_conversation_tokens(messages);
-    // Pass 0: age-based retention, before the budget comparison and on its own
-    // (lower) trigger. Its savings feed the comparison, so a retention pass
-    // that shrinks the transcript under budget also spares it the budget
-    // passes' deeper rewrites this step.
+    // Pass 0: age-based retention, before the budget comparison and on a
+    // trigger that reads no budget at all. Its savings feed the comparison, so
+    // a retention pass that shrinks the transcript under budget also spares it
+    // the budget passes' deeper rewrites this step.
     let (retention_aged, retention_aged_blocks, retention_rewrites, retention_saved) =
         match retention {
-            Some(policy) => age_stale_tool_results(messages, policy, before_tokens, budget_tokens),
+            Some(policy) => age_stale_tool_results(messages, policy, before_tokens),
             None => (0, Vec::new(), Vec::new(), 0),
         };
     let current_tokens = before_tokens.saturating_sub(retention_saved);

--- a/crates/stella-core/src/compaction/read_digest/tests.rs
+++ b/crates/stella-core/src/compaction/read_digest/tests.rs
@@ -619,8 +619,8 @@ fn a_result_aged_by_the_retention_pass_is_digested() {
         ("c2", "src/mid.rs"),
         ("c3", "src/new.rs"),
     ]);
-    // Past half the budget, so pass 0 fires (#4381), but under the budget
-    // itself, so only the age-based pass can.
+    // Under the budget, so only the age-based pass can fire; the batch is
+    // most of this transcript, so it clears pass 0's reclaim gate (#4753).
     let budget = crate::estimator::estimate_conversation_tokens(&messages) * 3 / 2;
     compact_and_digest(
         &mut messages,

--- a/crates/stella-core/src/compaction/tests.rs
+++ b/crates/stella-core/src/compaction/tests.rs
@@ -92,12 +92,82 @@ fn long_turn(count: usize, size: usize) -> Vec<CompletionMessage> {
     messages
 }
 
-/// A budget this conversation is over half of and still under: pass 0's own
-/// trigger is met, the budget passes' is not (#4381). Derived from the
-/// transcript rather than written as a literal, so a change to the estimator
-/// moves both sides of the comparison together.
-fn retention_pressure_budget(messages: &[CompletionMessage]) -> u64 {
+/// A budget the conversation fits inside, so the budget passes stay silent
+/// and any report a test sees came from pass 0. Derived from the transcript
+/// rather than written as a literal, so a change to the estimator moves both
+/// sides of the comparison together.
+///
+/// Two thirds of the budget also puts the conversation past the half-budget
+/// gate pass 0 used to carry (#4381), which #4753 replaced — so a test using
+/// this budget and asserting *silence* is asserting the new gate held where
+/// the old one would have opened.
+fn budget_the_transcript_fits_under(messages: &[CompletionMessage]) -> u64 {
     estimate_conversation_tokens(messages) * 3 / 2
+}
+
+/// A transcript whose recent, protected window carries far more bytes than
+/// the ageable batch behind it: `stale` results of `stale_size` bytes past
+/// the horizon, then `recent` of `recent_size` that the horizon protects.
+/// Used with `keep_recent_steps: recent`, the batch clears the reclaim floor
+/// while being a thin slice of what the rewrite would invalidate.
+fn top_heavy_turn(
+    stale: usize,
+    stale_size: usize,
+    recent: usize,
+    recent_size: usize,
+) -> Vec<CompletionMessage> {
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do things"),
+    ];
+    for i in 0..stale + recent {
+        let id = format!("c{i}");
+        let size = if i < stale { stale_size } else { recent_size };
+        messages.push(assistant_with_call(&id));
+        messages.push(tool_msg(
+            &id,
+            format!("STEP{i}-HEAD\n{}\nSTEP{i}-TAIL", "x".repeat(size)),
+        ));
+    }
+    messages
+}
+
+/// What pass 0's gate will price a fixture at: the reclaimable batch past the
+/// horizon in tokens, over what the conversation is left carrying once that
+/// batch is aged. Recomputed from the transcript so a test can report where a
+/// fixture actually sits instead of asserting a byte size somebody guessed.
+fn reclaim_ratio(messages: &[CompletionMessage], keep_recent_steps: usize) -> f64 {
+    let tool_positions: Vec<usize> = messages
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| m.role == MessageRole::Tool)
+        .map(|(idx, _)| idx)
+        .collect();
+    let keep = keep_recent_steps.max(1);
+    let stale = &tool_positions[..tool_positions.len().saturating_sub(keep)];
+    let reclaimable: usize = stale
+        .iter()
+        .map(|&idx| {
+            messages[idx]
+                .tool_results
+                .iter()
+                .map(|result| {
+                    let payload = match &result.output {
+                        ToolOutput::Ok { content, .. } => content,
+                        ToolOutput::Error { message, .. } => message,
+                    };
+                    if payload.len() > AGE_THRESHOLD_CHARS {
+                        payload.len().saturating_sub(AGE_RETAINED_CHARS)
+                    } else {
+                        0
+                    }
+                })
+                .sum::<usize>()
+        })
+        .sum();
+    let reclaimable_tokens = estimate_tokens_for_bytes(reclaimable as u64);
+    let after = estimate_conversation_tokens(messages).saturating_sub(reclaimable_tokens);
+    reclaimable_tokens as f64 / after.max(1) as f64
 }
 
 #[test]
@@ -106,9 +176,10 @@ fn retention_ages_results_past_the_horizon_before_the_budget_passes_engage() {
     // long turn re-sent every old tool output verbatim on every step
     // until the transcript crossed ~100k tokens. Pass 0 must age results
     // older than the horizon while the budget passes are still silent —
-    // which since #4381 means "past half the budget", not "at any size".
+    // which since #4753 means "once the batch is worth a real share of the
+    // transcript", not "at any size".
     let mut messages = long_turn(12, 5_000);
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, report) = compact_measured(
         &mut messages,
         budget,
@@ -149,7 +220,7 @@ fn retention_reports_the_block_identity_the_manifest_cited() {
     // §6.2 for pass 0: the aged block is named by its PRE-mutation id.
     let mut messages = long_turn(6, 5_000);
     let expected = tool_result_block_id(&messages[3].tool_results[0].output);
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, report) = compact_measured(
         &mut messages,
         budget,
@@ -173,7 +244,7 @@ fn every_in_place_rewrite_journals_its_replacement_bytes() {
     // distinct outputs here, so 8 distinct replacement records must ride the
     // report — each one the record OF THE CURRENT (post-rewrite) output.
     let mut messages = long_turn(12, 5_000);
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, report) = compact_measured(
         &mut messages,
         budget,
@@ -230,7 +301,7 @@ fn retention_waits_for_a_batch_before_touching_the_prefix() {
     // Horizon leaves 3 stale results reclaiming ~10 KB: below the floor.
     // The budget is one retention pressure would clear, so the
     // reclaim floor is the only thing that can be holding the pass back.
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, report) = compact_measured(
         &mut messages,
         budget,
@@ -252,7 +323,7 @@ fn retention_fires_on_reclaimable_bytes_before_any_count_floor() {
     // reclaim pays for the prefix rewrite — a count gate (the original
     // four-result floor) held them verbatim for the rest of the turn.
     let mut messages = long_turn(4, 100_000);
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, report) = compact_measured(
         &mut messages,
         budget,
@@ -271,7 +342,7 @@ fn retention_skips_a_trickle_of_barely_ageable_results() {
     // cache-invalidating prefix rewrite for under 4 KB back. The bytes
     // gate must leave the transcript byte-stable instead.
     let mut messages = long_turn(12, 2_100);
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, report) = compact_measured(
         &mut messages,
         budget,
@@ -291,125 +362,135 @@ fn retention_is_idempotent_between_batches() {
     // immediately following pass finds no candidates and mutates nothing
     // — the prefix stays byte-stable until a NEW batch accumulates.
     //
-    // Driven through the pass itself rather than `compact_measured`, and the
-    // budget is pinned so both calls are past the #4381 pressure gate
-    // (`current_tokens > budget_tokens / 2` holds for any non-empty
-    // transcript at a budget of 2). Aging this batch reclaims most of the
-    // transcript, so a realistic budget would put the second call under the
-    // pressure gate and its silence would prove nothing about the reclaim
-    // floor this test is about.
+    // Driven through the pass itself rather than `compact_measured`, so the
+    // second call is measured against the transcript the first one left
+    // rather than against a budget comparison that would end the turn first.
     let mut messages = long_turn(12, 5_000);
     let policy = RetentionPolicy {
         keep_recent_steps: 4,
     };
-    let pinned_past_the_pressure_gate = 2u64;
     let tokens = estimate_conversation_tokens(&messages);
-    let (aged, _, _, _) =
-        age_stale_tool_results(&mut messages, policy, tokens, pinned_past_the_pressure_gate);
+    let (aged, _, _, _) = age_stale_tool_results(&mut messages, policy, tokens);
     assert_eq!(aged, 8, "the first batch must fire");
     let snapshot: Vec<String> = messages.iter().map(|m| format!("{m:?}")).collect();
     let tokens = estimate_conversation_tokens(&messages);
-    let (again, _, _, _) =
-        age_stale_tool_results(&mut messages, policy, tokens, pinned_past_the_pressure_gate);
+    let (again, _, _, _) = age_stale_tool_results(&mut messages, policy, tokens);
     assert_eq!(again, 0, "second pass must be a no-op");
     let after: Vec<String> = messages.iter().map(|m| format!("{m:?}")).collect();
     assert_eq!(snapshot, after, "no bytes may move between batches");
 }
 
-/// The pressure gate's divisor is a measurement, and this is what stops a
-/// merge reverting it in silence (#2495).
+/// The gate's threshold is a measurement, and this is what stops a merge
+/// reverting it in silence (#2495).
 ///
-/// The two tests either side of this one pin the *behaviour* at half the
-/// budget and at a quarter, with the ratios hand-rolled — so a divisor of 3
-/// would leave both of them passing while suppressing 42.2% of the firings the
-/// census counted. Naming the constant is the difference between "half is a
-/// sensible-looking trigger" and "half is what 370 firings across 96 journals
-/// produced".
-///
-/// The value survived the census that priced it (#4452,
-/// `scripts/retention-census.py`) for a reason worth keeping in view: the
-/// census found *every* divisor a worse classifier of a profitable firing than
-/// no gate at all, so it disqualified the key rather than naming a better
-/// number for it. Moving this to 3 or 4 trades one unmeasured value for
-/// another; the measured replacement is a reclaim-ratio gate, #4753.
+/// The literal is the anti-revert half. The behavioural half searches for the
+/// bulk at which the pass stops firing and asserts the fixture's measured
+/// ratio there is fifteen percent — so the constant is pinned against the two
+/// thresholds either side of it in the census (0.10 and 0.25), not merely
+/// named. Both were live candidates: 0.10 recalls more (0.93 against 0.76) and
+/// 0.25 is more precise (0.77 against 0.60), and 0.15 is the minimum of the
+/// net column between them.
 #[test]
-fn the_retention_pressure_gate_stays_at_the_divisor_the_census_produced() {
+fn the_retention_reclaim_gate_stays_at_the_threshold_the_census_produced() {
     assert_eq!(
-        RETENTION_TRIGGER_BUDGET_DIVISOR, 2,
-        "the trigger is half the budget until #4753's reclaim-ratio gate replaces \
-         the key; a divisor of 3 suppresses 42.2% of the measured firings and 4 \
-         suppresses 23.8%, and neither classifies better than no gate at all"
+        RETENTION_TRIGGER_RECLAIM_PERCENT, 15,
+        "fifteen percent is the minimum of the census's net column (#4753); 10 \
+         admits 74 more firings for 1.1 M fewer tokens saved and 25 admits 73 \
+         fewer for 248 K fewer"
     );
-    // And the gate is actually derived from it, so the assertion above is not
-    // pinning a constant nothing consults.
-    let mut messages = long_turn(12, 5_000);
-    let tokens = estimate_conversation_tokens(&messages);
+    let keep = 4;
     let policy = Some(RetentionPolicy {
-        keep_recent_steps: 4,
+        keep_recent_steps: keep,
     });
-    let at_the_gate = tokens * RETENTION_TRIGGER_BUDGET_DIVISOR;
-    let (_, report) = compact_measured(&mut messages.clone(), at_the_gate, policy);
+    // A fixture whose ageable batch is fixed and whose protected bulk grows:
+    // the ratio falls monotonically with `recent_size`, so the pass fires
+    // below some bulk and is silent above it.
+    let fixture = |recent_size: usize| top_heavy_turn(4, 6_000, keep, recent_size);
+    let fires = |recent_size: usize| {
+        let mut messages = fixture(recent_size);
+        let budget = u64::MAX;
+        compact_measured(&mut messages, budget, policy).1.is_some()
+    };
     assert!(
-        report.is_none(),
-        "exactly at the gate the transcript must not move: {report:?}"
+        fires(2_100),
+        "a thin protected window must leave the gate open"
     );
-    let (_, report) = compact_measured(&mut messages, at_the_gate - 1, policy);
+    assert!(!fires(600_000), "a vast protected window must close it");
+    let (mut open, mut shut) = (2_100usize, 600_000usize);
+    while shut - open > 1 {
+        let mid = open + (shut - open) / 2;
+        if fires(mid) { open = mid } else { shut = mid }
+    }
+    let ratio = reclaim_ratio(&fixture(shut), keep);
     assert!(
-        report.is_some(),
-        "one token past the gate retention must engage"
+        (0.145..0.155).contains(&ratio),
+        "the pass must stop firing as the reclaim ratio crosses \
+         {RETENTION_TRIGGER_RECLAIM_PERCENT}%, and it stopped at {ratio:.4}"
     );
 }
 
-/// **Witness (#4381).** The measured shape: a conversation at a quarter of its
-/// budget with well over [`RETENTION_MIN_RECLAIM_CHARS`] reclaimable past the
-/// horizon. Pass 0 used to rewrite mid-history there on an absolute trigger,
-/// which cost a near-total prompt-cache miss on the next call — 137 K tokens
-/// re-billed across five firings to save 4–8 K per call, against 90–97% hit
-/// rates on the steps between them. Below the pressure gate the transcript
-/// must not move a byte.
+/// **Witness (#4753).** The shape the census says the old budget-fraction gate
+/// was suppressing: a large ageable batch early in a long turn, at a quarter
+/// of the budget. Profitable firings sat at a median 0.266 of budget with a
+/// median 90 further worker calls to amortize the rewrite over, and a gate at
+/// half the budget admitted none of them. Keyed on what the batch is worth,
+/// this ages.
 #[test]
-fn retention_does_not_fire_at_a_quarter_of_the_budget() {
+fn retention_ages_a_large_batch_early_in_a_long_turn() {
     let mut messages = long_turn(12, 5_000);
     let budget = estimate_conversation_tokens(&messages) * 4;
+    let keep = 4;
+    assert!(
+        reclaim_ratio(&messages, keep) >= 0.15,
+        "fixture must clear the reclaim gate"
+    );
+    let (_, report) = compact_measured(
+        &mut messages,
+        budget,
+        Some(RetentionPolicy {
+            keep_recent_steps: keep,
+        }),
+    );
+    let report = report.expect("a quarter into the budget is where the batch is worth most");
+    assert_eq!(report.aged, 8, "{report:?}");
+}
+
+/// **Witness (#4753), the other direction.** A batch well past the reclaim
+/// floor that is still a thin slice of what the rewrite would invalidate: the
+/// old gate saw only that the conversation was two thirds of the way into its
+/// budget and fired, re-billing a 200 K-token protected window uncached to
+/// take back 17 KB. This is the firing class the census priced at precision
+/// 0.13, and the transcript must not move a byte.
+#[test]
+fn retention_does_not_fire_when_the_batch_is_a_thin_slice_of_the_transcript() {
+    let keep = 4;
+    let mut messages = top_heavy_turn(4, 6_000, keep, 200_000);
+    let budget = budget_the_transcript_fits_under(&messages);
+    let ratio = reclaim_ratio(&messages, keep);
+    assert!(
+        ratio < 0.15,
+        "fixture must sit under the gate, sits at {ratio}"
+    );
     let before: Vec<String> = messages.iter().map(|m| format!("{m:?}")).collect();
     let (_, report) = compact_measured(
         &mut messages,
         budget,
         Some(RetentionPolicy {
-            keep_recent_steps: 4,
+            keep_recent_steps: keep,
         }),
     );
     assert!(
         report.is_none(),
-        "a conversation at 25% of budget must keep its cache prefix: {report:?}"
+        "a thin batch must not buy a prefix rewrite: {report:?}"
     );
     let after: Vec<String> = messages.iter().map(|m| format!("{m:?}")).collect();
-    assert_eq!(before, after, "no bytes may move below the pressure gate");
-}
-
-/// The other side of the same gate: the identical transcript, the identical
-/// reclaimable batch, a budget it is over half of — and the pass fires. Two
-/// tests rather than one because the pair is what shows the gate reads the
-/// budget and nothing else changed between them.
-#[test]
-fn retention_fires_once_the_conversation_passes_half_its_budget() {
-    let mut messages = long_turn(12, 5_000);
-    let budget = retention_pressure_budget(&messages);
-    let (_, report) = compact_measured(
-        &mut messages,
-        budget,
-        Some(RetentionPolicy {
-            keep_recent_steps: 4,
-        }),
-    );
-    let report = report.expect("past half the budget the batch must age");
-    assert_eq!(report.aged, 8, "{report:?}");
+    assert_eq!(before, after, "no bytes may move below the reclaim gate");
 }
 
 #[test]
 fn retention_never_touches_the_newest_tool_message_even_at_horizon_zero() {
     let mut messages = long_turn(6, 5_000);
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, _) = compact_measured(
         &mut messages,
         budget,
@@ -432,7 +513,7 @@ fn small_recent_and_already_aged_results_are_not_retention_candidates() {
     // long turn of small outputs never triggers the batch — and never
     // churns the cache prefix.
     let mut messages = long_turn(20, 100);
-    let budget = retention_pressure_budget(&messages);
+    let budget = budget_the_transcript_fits_under(&messages);
     let (_, report) = compact_measured(
         &mut messages,
         budget,

--- a/crates/stella-core/src/driver/tests/context_efficiency.rs
+++ b/crates/stella-core/src/driver/tests/context_efficiency.rs
@@ -42,11 +42,11 @@ async fn a_long_turn_ages_old_tool_results_far_below_the_compaction_budget() {
     // results MID-TURN, report them in a `Compaction` event, and leave the
     // recent horizon verbatim.
     //
-    // The budget is 20k rather than the default 150k because #4381 gave pass 0
-    // a pressure gate: it fires past half the budget, not at any size. 20k
-    // puts this turn over that half while still leaving it comfortably under
-    // the budget itself, so the aging below is the retention pass's and the
-    // `evicted == 0` assertion still says the budget passes never ran.
+    // The budget is 20k rather than the default 150k so the turn stays
+    // comfortably under it: the aging below is then the retention pass's, and
+    // the `evicted == 0` assertion still says the budget passes never ran.
+    // Pass 0's own gate reads no budget since #4753 — it asks whether the
+    // batch is worth a real share of the transcript, which here it is.
     let mut script: Vec<Result<CompletionResultAlias, ProviderError>> = (0..13)
         .map(|i| Ok(tool_call_result(&format!("c{i}"), "bash")))
         .collect();

--- a/scripts/retention-census.py
+++ b/scripts/retention-census.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 """Census: what one compaction pass-0 (retention) firing costs and buys (#4452).
 
-`RETENTION_TRIGGER_BUDGET_DIVISOR` in `crates/stella-core/src/compaction.rs`
-gates the retention pass on how far into its budget a conversation is. #4452
-asked whether half is the right fraction, and required the answer to be a
-number over recorded runs rather than an argument. This is that census.
+The retention pass in `crates/stella-core/src/compaction.rs` used to be gated
+on how far into its budget a conversation was. #4452 asked whether half was
+the right fraction, and required the answer to be a number over recorded runs
+rather than an argument. This is that census, and its answer was that the key
+was wrong at every value: the last table below prices the reclaim ratio
+instead, and #4753 shipped `RETENTION_TRIGGER_RECLAIM_PERCENT` from its
+minimum-net row.
+
+The budget-divisor tables are kept because they are the evidence for that
+replacement. Re-run this to re-measure either gate; the journals it reads are
+still from binaries that had no gate at all, so both counterfactuals stay
+askable.
 
 It reads `~/.stella/sessions/*/journal.jsonl` -- the durable session journals,
 not `store.db`, because the maintainer's project store is corrupt


### PR DESCRIPTION
Closes #4753

## What changed

Compaction pass 0 (tool-result retention) fired once the conversation occupied
`budget_tokens / RETENTION_TRIGGER_BUDGET_DIVISOR`, i.e. half its budget. That
constant is deleted and `age_stale_tool_results` no longer takes a budget at
all. The gate is now the **reclaim ratio**: the batch it would age, in tokens,
over what the conversation would be left carrying.

```rust
let reclaimable_tokens = estimate_tokens_for_bytes(reclaimable as u64);
let after = current_tokens.saturating_sub(reclaimable_tokens);
if reclaimable_tokens.saturating_mul(100)
    < after.saturating_mul(RETENTION_TRIGGER_RECLAIM_PERCENT)
{
    return (0, Vec::new(), Vec::new(), 0);
}
```

`RETENTION_TRIGGER_RECLAIM_PERCENT = 15` carries a `/// MEASURED:` marker and
is named by `the_retention_reclaim_gate_stays_at_the_threshold_the_census_produced`
(`make measured-constants` passes). The reclaim-*bytes* floor
(`RETENTION_MIN_RECLAIM_CHARS`) is unchanged and still runs first.

**The divisor is deleted rather than kept beside the ratio.** The issue offers
"instead of, or in addition to". Keeping it suppresses exactly the firings the
new gate exists to admit — profitable firings sit at a median 0.266 of budget,
below the old gate — so the witness below could not pass with a divisor of 2
still in place. The census disqualified the key, not the value.

## The census, re-run (item 3 of the issue's "verify")

`python3 scripts/retention-census.py`, 2026-08-26. Byte-identical to the
2026-08-24 run the issue quotes: 95 journals, 370 pure pass-0 firings, same
every cell.

```
pure pass-0 firings (aged > 0, nothing else): 370
divisor 2: keeps 112/370 firings (69.7% suppressed)
net billed input (uncached-equivalent tokens), firing minus not firing;
negative is a saving. Summed over the firings each gate admits:
  r=0.10  nogate +2923748  d=2 +5634585  d=3 +4655662  d=4 +5308813  d=6 +3371667
  r=0.25  nogate -24640347  d=2 -3041435  d=3 -13558213  d=4 -15708469  d=6 -22925688
  r=0.50  nogate -70580506  d=2 -17501468  d=3 -43914672  d=4 -50737272  d=6 -66754612
  profitable firings: 120 of 370 (32.4%)
  reclaim ratio: median 0.125  p25 0.074  p75 0.224  p90 0.368
  ratio >= 0.05 admits 317 firings, 119 profitable (precision 0.38, recall 0.99), net -1473917
  ratio >= 0.10 admits 226 firings, 112 profitable (precision 0.50, recall 0.93), net -4701610
  ratio >= 0.15 admits 152 firings,  91 profitable (precision 0.60, recall 0.76), net -5609242
  ratio >= 0.25 admits  79 firings,  61 profitable (precision 0.77, recall 0.51), net -5361572
```

**Did the firing count go up? Yes, and this reports it rather than burying it.**
152 against the old gate's 112 — 36% more firings, each one a prefix
invalidation. The net column already prices every one of those invalidations
(the `after - r*before` term is exactly the miss), and it still swings 11.2 M
tokens in the saving direction. Against *no* gate the count falls from 370 to
152. The next threshold up (0.25) fires 79 times and gives back 248 K of the
saving, so firing less is not free either; 0.15 is the minimum of the column.

**Item 4 — does a replay agree?** I did not build one, so I do not know. The
census is first-order and says so in its own header: suppressing a firing
changes the transcript the next one sees, and a conversation left un-aged can
reach the lossier budget passes. #4797 is that replay. Direction of the
residual bias is not obvious to me either way, so I am not claiming one.

## Witness tests

Two, in opposite directions, both failing on the old gate.

Ablation: restore `if current_tokens <= budget_tokens / 2 { return … }` and
delete the ratio check, keeping the tests.

```
test compaction::tests::retention_ages_a_large_batch_early_in_a_long_turn ... FAILED
test compaction::tests::retention_does_not_fire_when_the_batch_is_a_thin_slice_of_the_transcript ... FAILED

---- retention_ages_a_large_batch_early_in_a_long_turn stdout ----
panicked at crates/stella-core/src/compaction/tests.rs:450:25:
a quarter into the budget is where the batch is worth most

---- retention_does_not_fire_when_the_batch_is_a_thin_slice_of_the_transcript stdout ----
panicked at crates/stella-core/src/compaction/tests.rs:475:5:
a thin batch must not buy a prefix rewrite: Some(CompactionReport {
  before_tokens: 235620, after_tokens: 230660, evicted: 0, aged: 4, … })

test result: FAILED. 7 passed; 2 failed
```

That second report is the defect in one line: 4 960 tokens taken back by
re-billing a 230 660-token prefix uncached — ratio 0.021, precision-0.13
territory — because the conversation happened to be two thirds of the way into
its budget.

With the ratio gate in place:

```
$ cargo test -p stella-core --lib compaction
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 1392 filtered out
$ cargo test -p stella-core --lib driver::tests::context_efficiency
test result: ok. 4 passed; 0 failed
```

The pinning test is not only an `assert_eq!` on the literal: it binary-searches
the protected bulk at which the pass stops firing and asserts the fixture's
measured ratio there is within 0.145..0.155, so a move to either neighbouring
census candidate (0.10, 0.25) fails it.

## Renamed tests (`check-deleted-tests`)

Three `#[test]`s that pinned the old gate's *effect* do not survive under their
old names. Nothing was dropped — each is replaced by its counterpart for the
new key:

| Removed | Replaced by |
|---|---|
| `the_retention_pressure_gate_stays_at_the_divisor_the_census_produced` | `the_retention_reclaim_gate_stays_at_the_threshold_the_census_produced` |
| `retention_fires_once_the_conversation_passes_half_its_budget` | `retention_ages_a_large_batch_early_in_a_long_turn` |
| `retention_does_not_fire_at_a_quarter_of_the_budget` | `retention_does_not_fire_when_the_batch_is_a_thin_slice_of_the_transcript` |

The helper `retention_pressure_budget` is renamed `budget_the_transcript_fits_under`,
which is what it now computes.

## Invariants

- **#2 (no I/O in the engine):** the gate is still a pure function over the
  transcript; it reads one fewer input than before.
- **#7 (byte-stable prompts):** between firings the prefix does not move, and
  the firing count is reported above rather than assumed.

## Also fixed

Three comments in tests I did not otherwise change described the deleted
half-budget gate (`compaction/read_digest/tests.rs`,
`driver/tests/context_efficiency.rs`, and one in `compaction/tests.rs`), and
`scripts/retention-census.py`'s header cited the deleted constant by name.

## Guards run locally

`make guards-fast`, `make measured-constants`, `make prose`, `cargo fmt --all`,
`cargo clippy -p stella-core --all-targets -- -D warnings` — all green. The
workspace build and suite are CI's, per CLAUDE.md.

## Summary by Sourcery

Replace the budget-fraction retention trigger with a measured reclaim-ratio gate for more cost-effective tool-result compaction.

Bug Fixes:
- Gate tool-result retention on the reclaim ratio instead of conversation budget utilization, preventing low-value prefix rewrites while allowing worthwhile early-turn compaction.

Enhancements:
- Remove the obsolete budget-divisor retention trigger and make the retention pass independent of the compaction budget.
- Add measured threshold and behavioral witness tests covering profitable large batches and unprofitable thin batches.

Documentation:
- Update retention documentation, test comments, and census-script guidance to describe the reclaim-ratio gate and its measured threshold.

Tests:
- Revise compaction tests to validate the new reclaim-ratio behavior and threshold selection.