### PR TITLE
fix(stella-cli): drain the lead lane before a cancelled turn closes its row

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -1714,6 +1714,8 @@ pub async fn run_deck_session(
         // The lead lane's pause seam — `p` on the lead row (#1219).
         let lead_pause = lead_control::LeadPause::new();
         let mut friction = TurnFriction::default(); // #3962
+        // Outlives the turn future, so a cancel can still drain it (#4853).
+        let drain = forwarder::forwarder_slot();
         let end = {
             // Both arms return `Result<(), CliFailure>`, so one pinned future
             // drives either path through the same select loop.
@@ -1735,6 +1737,7 @@ pub async fn run_deck_session(
                 recall,
                 memory.as_ref(),
                 &mut friction,
+                &drain,
             );
             tokio::pin!(turn);
             loop {
@@ -2362,14 +2365,16 @@ pub async fn run_deck_session(
                     // requeue and park on (see [`HoldState`]).
                     dispatch.cancelled(&submitted);
                 }
-                dropped_turn::close_dropped_execution(
+                dropped_turn::close_dropped_turn(
+                    &drain,
                     execution.as_ref(),
                     registry.as_ref(),
                     "cancelled",
                     dispatch_spend_usd,
                     &mut budget,
                     &in_tx,
-                );
+                )
+                .await;
                 // Must stay AFTER the store warning above: the warning is
                 // retryable (folds to Running) while this one is not (folds
                 // to Failed), so this event is what leaves the lead in a
@@ -2400,14 +2405,16 @@ pub async fn run_deck_session(
                 }
                 dispatch.reset();
                 queue.clear();
-                dropped_turn::close_dropped_execution(
+                dropped_turn::close_dropped_turn(
+                    &drain,
                     execution.as_ref(),
                     registry.as_ref(),
                     "cleared",
                     dispatch_spend_usd,
                     &mut budget,
                     &in_tx,
-                );
+                )
+                .await;
                 session_clear::reset_lead(
                     &mut messages,
                     &system_prompt,

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -23,12 +23,15 @@
 //! the deck's own running total stops under-reporting the turn the user just
 //! stopped.
 //!
-//! Not fixed here, and tracked as #4853: nothing awaits the forwarder drain
-//! before the row closes, so a `StepUsage` can still be priced after
-//! `record_execution_end` has run. The read-back heals whatever landed by the
-//! time it runs and no more. Draining first must not reintroduce the #2290
-//! wedge `detach_event_stream` exists to fix, which is why it is a separate
-//! change.
+//! That read-back heals whatever the forwarder had already persisted and no
+//! more, which left #4853: a `StepUsage` still sitting in the turn's channel at
+//! the instant of the cancel is priced *after* `record_execution_end` closed
+//! the row, so there is nothing to read back yet. [`close_dropped_turn`] waits
+//! the forwarder out first, through
+//! [`super::forwarder::drain_dropped_stream`], and only then closes. The two
+//! halves are ordered rather than merged because each answers a different
+//! question: the drain decides what the row *contains*, the read-back decides
+//! what the guard *reports*.
 //!
 //! Lives here rather than inline in the driver's `TurnEnd` arms: those are in
 //! a god file closed to growth.
@@ -36,6 +39,27 @@
 use stella_core::BudgetGuard;
 
 use super::*;
+
+/// Wait out the dropped turn's forwarder, then close its execution.
+///
+/// The order is the fix (#4853). `close_dropped_execution` alone reports what
+/// the store already knew at the instant the future was dropped; the events
+/// still in the turn's channel are exactly the ones the driver's own running
+/// total is missing, and they are priced by the forwarder rather than by
+/// anything the driver holds. Draining first is what makes the row — and so
+/// the read-back below — include them.
+pub(super) async fn close_dropped_turn(
+    drain: &forwarder::ForwarderSlot,
+    execution: Option<&(Arc<Store>, i64)>,
+    registry: &ToolRegistry,
+    noun: &str,
+    dispatch_spend_usd: f64,
+    budget: &mut BudgetGuard,
+    in_tx: &UnboundedSender<Inbound>,
+) {
+    forwarder::drain_dropped_stream(registry, drain).await;
+    close_dropped_execution(execution, registry, noun, dispatch_spend_usd, budget, in_tx);
+}
 
 /// Close the execution a dropped turn left open, correct the guard from the
 /// closed row, and surface a failed store write.
@@ -195,6 +219,129 @@ mod tests {
             (budget.session_spent_usd() - 14.5).abs() < 1e-9,
             "the guard must report the $4.50 the receipts prove, not the $0.25 \
              prefix it accumulated: {}",
+            budget.session_spent_usd()
+        );
+    }
+
+    /// One priced `StepUsage`, as the engine would emit it.
+    fn priced_step_usage(cost_usd: f64) -> AgentEvent {
+        AgentEvent::StepUsage {
+            step: 0,
+            turn_instance: Some(0),
+            call_seq: Some(0),
+            role: stella_protocol::ModelCallRole::Worker,
+            provider: "zai".into(),
+            upstream_provider: None,
+            output_text: None,
+            model: "glm-5.2".into(),
+            input_tokens: 12_000,
+            output_tokens: 450,
+            cached_input_tokens: 0,
+            cache_write_tokens: 0,
+            reasoning_tokens: None,
+            estimated_input_tokens: 12_000,
+            cost_usd,
+            duration_ms: 1_830,
+            retries: 0,
+            tool_calls: 0,
+            complete: true,
+            finish_reason: None,
+            effort: None,
+            max_output_tokens: None,
+            temperature: None,
+            params: None,
+            sub_agent_id: None,
+        }
+    }
+
+    /// A cancelled turn's live lane: a forwarder parked in the slot with one
+    /// priced `StepUsage` still unread in its channel, and the turn's own `tx`
+    /// already gone the way the dropped future takes it.
+    ///
+    /// The registry keeps an `EventSender` clone, which is what makes the
+    /// channel outlive `drop(tx)` — the #2290 condition, and the reason the
+    /// drain has to detach before it awaits.
+    fn cancelled_lane(
+        registry: &ToolRegistry,
+        store: &Arc<Store>,
+        id: i64,
+        cost_usd: f64,
+    ) -> (
+        forwarder::ForwarderSlot,
+        tokio::sync::mpsc::UnboundedReceiver<Inbound>,
+    ) {
+        let (in_tx, in_rx) = tokio::sync::mpsc::unbounded_channel::<Inbound>();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
+        let forwarder = spawn_forwarder(
+            rx,
+            Some((Arc::clone(store), id)),
+            crate::cache_insight::InsightScope {
+                provider_id: "zai".into(),
+                cache_ttl: stella_model::CacheTtl::default(),
+                opens_execute_stage: true,
+            },
+            in_tx,
+            LEAD.to_string(),
+            None,
+        );
+        registry.attach_events(stella_core::EventSender::new(tx.clone()));
+        tx.send(priced_step_usage(cost_usd)).expect("in flight");
+        // The turn future is dropped: its own sender goes with it, the
+        // registry's clone does not, and the event is still in the channel.
+        drop(tx);
+        let slot = forwarder::forwarder_slot();
+        *slot.lock().expect("slot") = Some(forwarder);
+        (slot, in_rx)
+    }
+
+    /// **Witness (#4853).** A `StepUsage` still in flight when the user
+    /// cancels is priced before the row closes, not after it.
+    ///
+    /// Nothing awaits between the send and the close-out, so on a
+    /// current-thread runtime the forwarder cannot have run: the receipt is
+    /// unwritten unless something drains the stream first. #2807's read-back
+    /// heals only what the store already holds, so without the drain it reads
+    /// back a row that knows nothing about this call and the deck reports the
+    /// pre-cancel prefix — the same one-directional under-report as #2570, on
+    /// exactly the turn the user is looking at.
+    #[tokio::test]
+    async fn a_usage_event_still_in_flight_at_the_cancel_is_priced_into_the_closed_row() {
+        let root = tempfile::tempdir().expect("workspace");
+        let store = Arc::new(Store::open(root.path()).expect("store"));
+        let id = store
+            .begin_execution("chat", "a prompt", "zai", "glm-5.2")
+            .expect("execution");
+        let registry = ToolRegistry::new(std::env::temp_dir());
+        let (drain, _in_rx) = cancelled_lane(&registry, &store, id, 3.75);
+
+        let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+        budget.reseed_session_spend(10.0);
+        let (in_tx, _tx_rx) = tokio::sync::mpsc::unbounded_channel::<Inbound>();
+
+        close_dropped_turn(
+            &drain,
+            Some(&(Arc::clone(&store), id)),
+            &registry,
+            "cancelled",
+            10.0,
+            &mut budget,
+            &in_tx,
+        )
+        .await;
+
+        let summary = store
+            .execution_summary(id)
+            .expect("readable")
+            .expect("a closed row");
+        assert!(
+            (summary.cost_usd - 3.75).abs() < 1e-9,
+            "the row must carry the receipt the drain settled, not $0: {}",
+            summary.cost_usd
+        );
+        assert!(
+            (budget.session_spent_usd() - 13.75).abs() < 1e-9,
+            "the deck must report the $3.75 this turn actually cost, not the \
+             $0 prefix the guard held when the future was dropped: {}",
             budget.session_spent_usd()
         );
     }

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -349,6 +349,53 @@ pub(crate) async fn close_turn_stream(
     forwarder.await.unwrap_or_default()
 }
 
+/// Where a lane parks its live forwarder so that a turn future dropped from
+/// outside can still be waited out (#4853).
+///
+/// [`close_turn_stream`] is the only thing that awaits the drain, and it lives
+/// inside the turn future — so a cancel, which drops that future, never reaches
+/// it. The handle is parked here at spawn instead, in a cell the driver loop
+/// owns and the turn only borrows, which is what gives the cancel arm something
+/// to await.
+pub(crate) type ForwarderSlot = std::sync::Mutex<Option<tokio::task::JoinHandle<LaneStreamEnd>>>;
+
+/// An empty slot for one lane's forwarders, reused across that lane's turns.
+pub(crate) fn forwarder_slot() -> ForwarderSlot {
+    std::sync::Mutex::new(None)
+}
+
+/// Wait out the forwarder of a turn whose future was dropped mid-flight.
+///
+/// This is [`close_turn_stream`] minus its `drop(tx)`, and the difference is
+/// the whole point: the dropped future took every sender it owned with it —
+/// the turn's own `tx`, the re-query adapter's clone (#3366), the task tap's —
+/// so the only clones left are the ones the registry holds, and detaching
+/// releases exactly those. The channel then closes, `recv()` returns `None`,
+/// and the forwarder finishes persisting what was still in flight.
+///
+/// Awaiting is what #4853 is: a `StepUsage` sitting unread in the channel at
+/// the instant of the cancel is priced *after* `record_execution_end` closed
+/// the row, so the read-back #2807 added has nothing to read back yet and the
+/// deck shows the pre-cancel prefix. It is the same one-directional
+/// under-report as #2570, at the moment the user is looking at the number.
+///
+/// The wait is unbounded for the reason [`close_turn_stream`]'s is: the sender
+/// set is identical on both paths, so a wedge here would be a wedge there, and
+/// `the_turn_tail_completes_with_the_registry_still_attached` is the guard on
+/// both. Returns [`LaneStreamEnd::default`] when the slot is empty (no turn
+/// ever spawned a forwarder) or the forwarder panicked.
+pub(crate) async fn drain_dropped_stream(
+    registry: &stella_tools::ToolRegistry,
+    slot: &ForwarderSlot,
+) -> LaneStreamEnd {
+    let parked = slot.lock().unwrap_or_else(|p| p.into_inner()).take();
+    let Some(forwarder) = parked else {
+        return LaneStreamEnd::default();
+    };
+    registry.detach_event_stream();
+    forwarder.await.unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -60,6 +60,9 @@ pub(super) async fn run_lead_turn(
     recall: crate::memory::OpeningRecall,
     session_memory: Option<&SessionMemory>, // #3243 Phase 3: behind the re-query
     friction: &mut TurnFriction,            // #3962: filled from the lane's own stream
+    // Owned by the driver loop so a cancel — which drops this whole future —
+    // can still wait the forwarder out (#4853).
+    drain: &forwarder::ForwarderSlot,
 ) -> Result<(), crate::failure::CliFailure> {
     budget.begin_turn();
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
@@ -77,6 +80,10 @@ pub(super) async fn run_lead_turn(
         LEAD.to_string(),
         Some(registry.task_board()),
     );
+    // Park it where the driver's cancel arm can reach it, and take it back on
+    // the path that ends normally — whichever of the two runs, exactly one
+    // holds the handle, because the future either completes or is dropped.
+    *drain.lock().unwrap_or_else(|p| p.into_inner()) = Some(forwarder);
     // First event of the turn: what recall put in front of the model.
     if let Some(event) = recall.event {
         let _ = tx.send(event);
@@ -140,7 +147,17 @@ pub(super) async fn run_lead_turn(
     // requires gone; otherwise the forwarder's `recv()` stays pending forever
     // and the turn future wedges after the deck painted the turn done (#2290).
     drop(requery);
-    let ended = close_turn_stream(registry, tx, forwarder).await;
+    // Taken out of the slot before the await, never held across it: the lock is
+    // a plain `std::sync::Mutex` and a guard alive over a yield point would be
+    // one held by a task the runtime may park.
+    let parked = drain.lock().unwrap_or_else(|p| p.into_inner()).take();
+    let ended = match parked {
+        Some(forwarder) => close_turn_stream(registry, tx, forwarder).await,
+        // Unreachable while this function is the only writer of the slot; a
+        // drained slot means the driver already closed the stream, and the
+        // right answer then is the one a cancelled forwarder owes.
+        None => forwarder::LaneStreamEnd::default(),
+    };
     let persistence_complete = ended.persistence_complete;
     *friction = ended.friction; // this turn's reflection evidence (#3962)
     claims.release_all();


### PR DESCRIPTION
## Problem

#2807's second half, left out deliberately and named in `dropped_turn.rs`'s
module doc: nothing awaits the forwarder drain before a cancelled turn's row
closes.

`close_turn_stream` (`crates/stella-cli/src/command_deck/forwarder.rs`) is the
only thing that waits a lane's forwarder out, and on the lead path it is called
from inside `run_lead_turn`'s own future. A cancel drops that future, so the
call never runs. A `StepUsage` still in the turn's channel at that instant is
persisted and priced *after* `record_execution_end` has closed the row, and the
read-back #2807 added reads a row that does not know about it yet.

The bias is one-directional, exactly as in #2570 and #2807: it only ever
under-reports, and worst on the runs that cost the most, at the moment the user
is looking at the number.

## Fix

The forwarder's `JoinHandle` is parked in a `ForwarderSlot` — a cell the driver
loop owns and the turn only borrows. `run_lead_turn` parks it at spawn and
takes it back on the path that ends normally; the cancel and `/clear` arms take
it when the future was dropped instead. Exactly one of the two ever holds it,
because the future either completes or is dropped.

`forwarder::drain_dropped_stream` is `close_turn_stream` minus its `drop(tx)`,
and the difference is the point: the dropped future already took every sender
it owned (the turn's `tx`, the re-query adapter's clone, the task tap's), so
`registry.detach_event_stream()` releases the last remaining clones, the
channel closes, and the forwarder finishes persisting what was in flight.

`dropped_turn::close_dropped_turn` orders the two halves — drain, then close —
because each answers a different question: the drain decides what the row
*contains*, #2807's read-back decides what the guard *reports*.

### No #2290 regression

`detach_event_stream` exists because a registry-held `EventSender` kept the
channel open forever and awaiting the forwarder wedged the turn future after
the deck had painted it done. The sender set is identical on both paths, so a
wedge in the new drain would be a wedge in `close_turn_stream` too;
`the_turn_tail_completes_with_the_registry_still_attached` is the guard on
both, and it still passes. The wait is unbounded for the same reason
`close_turn_stream`'s is. The lane still exits cleanly after a cancel — the
whole `command_deck::` suite is green (164 tests).

`command_deck.rs` is a god file closed to growth: the new logic is in
`forwarder.rs` and `dropped_turn.rs`, and the diff there is the slot
declaration plus the argument and `.await` on the two existing call sites.

## Witness

`a_usage_event_still_in_flight_at_the_cancel_is_priced_into_the_closed_row`
(`crates/stella-cli/src/command_deck/dropped_turn.rs`). It builds a real
`Store`, spawns a forwarder against it, sends one priced `StepUsage`, drops the
turn's `tx` while the registry still holds its clone, parks the handle, and
closes out. Nothing awaits between the send and the close-out, so on the
current-thread test runtime the forwarder cannot have run: the receipt is
unwritten unless something drains first.

**Ablation** — `forwarder::drain_dropped_stream(registry, drain).await;`
replaced with `let _ = drain;` in `close_dropped_turn`:

```
running 5 tests
test command_deck::dropped_turn::tests::a_guard_that_saw_more_than_the_row_proves_is_kept ... ok
test command_deck::dropped_turn::tests::a_row_that_proves_more_than_the_guard_saw_raises_the_total ... ok
test command_deck::dropped_turn::tests::the_correction_never_subtracts ... ok
test command_deck::dropped_turn::tests::the_guard_is_corrected_from_the_row_the_closeout_settled ... ok
test command_deck::dropped_turn::tests::a_usage_event_still_in_flight_at_the_cancel_is_priced_into_the_closed_row ... FAILED

---- ... stdout ----
thread '...' panicked at crates/stella-cli/src/command_deck/dropped_turn.rs:340:9:
the row must carry the receipt the drain settled, not $0: 0

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 2327 filtered out
```

With the drain restored:

```
running 5 tests
test command_deck::dropped_turn::tests::a_usage_event_still_in_flight_at_the_cancel_is_priced_into_the_closed_row ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2327 filtered out
```

The ablation makes the answer wrong ($0 instead of $3.75), not merely constant.

## Tests deleted or renamed

None.

## Related

Refs #2807, #2290, #2570.

Closes #4853

## Summary by Sourcery

Drain dropped turn forwarders before closing execution records so cancellation no longer under-reports usage and cost.

Bug Fixes:
- Ensure usage events still in flight when a turn is cancelled are persisted and included in the closed execution row and reported spend.

Enhancements:
- Allow cancelled and cleared turns to drain their forwarder before closing execution records while preserving normal turn cleanup and avoiding registry-related hangs.

Tests:
- Add coverage proving an in-flight priced usage event is included in both the execution summary and session budget after cancellation.