### PR TITLE
feat(stella-tui,stella-cli): u on a highlighted delete restores the file from git

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -113,8 +113,8 @@ mod theme_cmd;
 mod whistle;
 mod worker_control;
 use driver_support::{
-    handle_supervisor_msg, service_registry_action, spawn_mcp_connect, spawn_notification_poller,
-    spawn_pr_monitor,
+    handle_supervisor_msg, service_registry_action, service_undo_delete, spawn_mcp_connect,
+    spawn_notification_poller, spawn_pr_monitor,
 };
 use lead_turn::run_lead_turn;
 use panel_snapshots::{engine_config_inbound, tool_policy_inbound};
@@ -1454,6 +1454,7 @@ pub async fn run_deck_session(
                                 },
                                 &in_tx,
                             )
+                            && !service_undo_delete(&other, &workspace_path, &in_tx)
                             && !inspect_service::service_inspect_action(
                                 &other,
                                 &store,
@@ -2106,6 +2107,13 @@ pub async fn run_deck_session(
                                 },
                                 &in_tx,
                             );
+                        }
+                        // `u undo` on a delete row is serviced mid-turn too:
+                        // restoring a file git already holds is the same
+                        // cheap local op idle or busy, and the reader pressing
+                        // it is looking at a deletion that just happened.
+                        Some(input @ WorkspaceInput::UndoDelete { .. }) => {
+                            service_undo_delete(&input, &workspace_path, &in_tx);
                         }
                         // INSPECT is answered mid-turn too: the receipts of
                         // earlier steps are already durable, and watching the

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -109,6 +109,59 @@ pub(super) fn spawn_mcp_connect(
     configured
 }
 
+/// Service `u undo` on a delete event: restore each path that one
+/// `delete_file` call removed, from git's reading of the file
+/// (`git checkout -- <path>`). Returns `true` if `input` was the undo verb
+/// (so the caller skips its own dispatch). A cheap local git op over files
+/// git already holds, serviced identically idle or mid-turn — and answered
+/// either way with an [`Inbound::Notice`], because an undo that says nothing
+/// leaves the reader checking the tree by hand.
+///
+/// A path git cannot restore — an untracked file, a repo-less workspace — is
+/// reported with git's own words rather than guessed at: the row's
+/// `git-backed` label states the mechanism, and the mechanism's refusal is
+/// the honest answer.
+pub(super) fn service_undo_delete(
+    input: &WorkspaceInput,
+    workspace: &str,
+    in_tx: &UnboundedSender<Inbound>,
+) -> bool {
+    let WorkspaceInput::UndoDelete { paths } = input else {
+        return false;
+    };
+    let mut restored: Vec<String> = Vec::new();
+    let mut failed: Vec<String> = Vec::new();
+    for path in paths {
+        let run = std::process::Command::new("git")
+            .args(["checkout", "--"])
+            .arg(path)
+            .current_dir(workspace)
+            .output();
+        match run {
+            Ok(out) if out.status.success() => restored.push(path.clone()),
+            Ok(out) => {
+                let why = String::from_utf8_lossy(&out.stderr);
+                failed.push(format!(
+                    "{path} ({})",
+                    why.trim().lines().next().unwrap_or("git refused")
+                ));
+            }
+            Err(err) => failed.push(format!("{path} ({err})")),
+        }
+    }
+    let notice = match (restored.is_empty(), failed.is_empty()) {
+        (false, true) => format!("undo: restored {} from git", restored.join(", ")),
+        (true, false) => format!("undo failed: {}", failed.join(" · ")),
+        _ => format!(
+            "undo: restored {} from git · failed: {}",
+            restored.join(", "),
+            failed.join(" · ")
+        ),
+    };
+    let _ = in_tx.send(Inbound::Notice(notice));
+    true
+}
+
 /// Service a session-registry / inbox verb from the deck. Returns `true` if
 /// `input` was one (so the caller skips its own dispatch). All of these are
 /// cheap local file ops, serviced identically idle or mid-turn.
@@ -489,4 +542,72 @@ pub(super) fn spawn_notification_poller(in_tx: mpsc::UnboundedSender<Inbound>) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod undo_delete_tests {
+    use super::*;
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git runs");
+        assert!(out.status.success(), "git {args:?}: {out:?}");
+    }
+
+    /// The other half of the deck's `u` binding (#5036): the driver restores
+    /// the deleted file from git and says so. A tracked, committed file comes
+    /// back byte-for-byte; an untracked path is refused with git's own reason
+    /// in the notice — both answered, never silent.
+    #[test]
+    fn undo_delete_restores_a_tracked_file_and_reports_an_untracked_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        git(root, &["init", "-q"]);
+        git(root, &["config", "user.email", "t@example.invalid"]);
+        git(root, &["config", "user.name", "t"]);
+        std::fs::write(root.join("kept.rs"), "fn kept() {}\n").expect("write");
+        git(root, &["add", "kept.rs"]);
+        git(root, &["commit", "-q", "-m", "seed"]);
+        std::fs::remove_file(root.join("kept.rs")).expect("delete");
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let workspace = root.display().to_string();
+        let input = WorkspaceInput::UndoDelete {
+            paths: vec!["kept.rs".into()],
+        };
+        assert!(service_undo_delete(&input, &workspace, &tx));
+        assert_eq!(
+            std::fs::read_to_string(root.join("kept.rs")).expect("restored"),
+            "fn kept() {}\n",
+            "the tracked file is back byte-for-byte"
+        );
+        match rx.try_recv().expect("a notice was sent") {
+            Inbound::Notice(text) => assert!(text.contains("restored kept.rs"), "{text}"),
+            other => panic!("expected a notice, got {other:?}"),
+        }
+
+        // An untracked path has no git reading to restore from: refused, with
+        // the refusal named.
+        let input = WorkspaceInput::UndoDelete {
+            paths: vec!["never-tracked.rs".into()],
+        };
+        assert!(service_undo_delete(&input, &workspace, &tx));
+        match rx.try_recv().expect("a notice was sent") {
+            Inbound::Notice(text) => {
+                assert!(text.starts_with("undo failed:"), "{text}");
+                assert!(text.contains("never-tracked.rs"), "{text}");
+            }
+            other => panic!("expected a notice, got {other:?}"),
+        }
+
+        // Any other input is not this service's verb.
+        assert!(!service_undo_delete(
+            &WorkspaceInput::McpRefresh,
+            &workspace,
+            &tx
+        ));
+    }
 }

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -119,8 +119,8 @@ pub(super) fn spawn_mcp_connect(
 ///
 /// A path git cannot restore — an untracked file, a repo-less workspace — is
 /// reported with git's own words rather than guessed at: the row's
-/// `git-backed` label states the mechanism, and the mechanism's refusal is
-/// the honest answer.
+/// `git-backed` label states the mechanism, so the mechanism's refusal is
+/// the answer to report.
 pub(super) fn service_undo_delete(
     input: &WorkspaceInput,
     workspace: &str,

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -224,6 +224,15 @@ async fn main() -> std::io::Result<()> {
                             .to_string(),
                     ));
                 }
+                // `u` on a delete row: the demo has no git workspace to
+                // restore from, so it answers with the notice the real
+                // driver would send.
+                WorkspaceInput::UndoDelete { paths } => {
+                    let _ = react_tx.send(Inbound::Notice(format!(
+                        "undo: restored {} from git",
+                        paths.join(", ")
+                    )));
+                }
                 // The budget cap folds straight back through a BudgetTick, the
                 // same stream the real driver's guard reports on.
                 WorkspaceInput::SetBudget { limit_usd } => {

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -1614,6 +1614,7 @@ mod steer;
 pub use gates::HunkMarks;
 mod nav;
 mod queue_editor;
+mod undo;
 pub use dispatch::{DispatchRoute, MidTurnPrompt, PendingDispatch};
 pub use nav::TranscriptSearch;
 pub(crate) use nav::is_folded;
@@ -3445,6 +3446,22 @@ fn handle_session_key(
         KeyCode::Esc if ui.session_selected.is_some() => {
             ui.session_selected = None;
             Some(DeckAction::Handled)
+        }
+        // `u` with a delete event highlighted is that row's own affordance
+        // (`· git-backed · u undo`). Guarded on a blank composer like every
+        // bare-letter hotkey, so a prompt containing a `u` never loses its
+        // keystroke — and on the highlight actually being a delete, so any
+        // other `u` still falls through to typing.
+        KeyCode::Char('u')
+            if !key.modifiers.intersects(
+                KeyModifiers::CONTROL
+                    | KeyModifiers::SUPER
+                    | KeyModifiers::META
+                    | KeyModifiers::ALT,
+            ) && ui.composer.is_blank() =>
+        {
+            undo::selected_delete_paths(model, ui)
+                .map(|paths| DeckAction::Send(WorkspaceInput::UndoDelete { paths }))
         }
         // The expand-ALL overlay's Esc way out (precedence rule 8): claimed
         // here, ahead of the turn-stop Esc, so closing the overlay can never

--- a/crates/stella-tui/src/deck_ui/tests/selection.rs
+++ b/crates/stella-tui/src/deck_ui/tests/selection.rs
@@ -4,6 +4,83 @@
 
 use super::*;
 
+/// A settled `delete_file` exchange on `agent` — the event whose head carries
+/// the `· git-backed · u undo` affordance.
+fn with_delete_exchange(m: &mut WorkspaceModel, agent: &str) {
+    use stella_protocol::{ToolCall, ToolOutput};
+    m.apply_inbound(&Inbound::Event {
+        agent: agent.into(),
+        event: AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: "d1".into(),
+                name: "delete_file".into(),
+                input: serde_json::json!({ "path": "src/old.rs" }),
+            },
+            sub_agent_id: None,
+        },
+    });
+    m.apply_inbound(&Inbound::Event {
+        agent: agent.into(),
+        event: AgentEvent::ToolResult {
+            call_id: "d1".into(),
+            output: ToolOutput::Ok {
+                content: "deleted src/old.rs".into(),
+                data: None,
+            },
+            duration_ms: 3,
+            speculated: false,
+            sub_agent_id: None,
+        },
+    });
+}
+
+/// The `u` binding (SPEC 11): with a delete event highlighted — its result
+/// row or its head — `u` sends [`WorkspaceInput::UndoDelete`] naming the
+/// deleted path; with anything else highlighted the same key stays typing and
+/// lands in the composer. The row has rendered `· u undo` since the head
+/// landed; this is the half that makes the label true (#5036).
+#[test]
+fn u_on_a_highlighted_delete_sends_the_undo_and_otherwise_types() {
+    let mut model = model_with(&["lead"]);
+    with_delete_exchange(&mut model, "lead");
+    let mut ui = ready_ui();
+
+    // ↑ lands on the newest entry — the delete's *result* — and `u` still
+    // resolves it back to the call it settles.
+    handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+    let action = handle_deck_key(key(KeyCode::Char('u')), &model, &mut ui);
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::UndoDelete {
+            paths: vec!["src/old.rs".into()]
+        }),
+        "u on the delete's result row sends the undo"
+    );
+
+    // On the head itself, the same.
+    handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+    let action = handle_deck_key(key(KeyCode::Char('u')), &model, &mut ui);
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::UndoDelete {
+            paths: vec!["src/old.rs".into()]
+        }),
+        "u on the delete's head sends the undo"
+    );
+
+    // A non-delete highlight leaves `u` to the composer: it types.
+    let mut model = model_with(&["lead"]);
+    with_tool_exchange(&mut model, "lead"); // read_file, not delete_file
+    let mut ui = ready_ui();
+    handle_deck_key(key(KeyCode::Up), &model, &mut ui);
+    handle_deck_key(key(KeyCode::Char('u')), &model, &mut ui);
+    assert_eq!(
+        ui.composer.buffer(),
+        "u",
+        "u with a non-delete highlight falls through to typing"
+    );
+}
+
 #[test]
 fn up_selects_the_last_message_and_ctrl_o_toggles_it() {
     let mut model = model_with(&["lead"]);

--- a/crates/stella-tui/src/deck_ui/undo.rs
+++ b/crates/stella-tui/src/deck_ui/undo.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `u` on a highlighted delete event — resolving the highlight to the paths
+//! that one `delete_file` call removed (SPEC 6.3's `· git-backed · u undo`
+//! affordance, SPEC 11's `u`). The key itself is routed in
+//! `handle_session_key`; this module answers the one question that routing
+//! needs: *is the highlight on a delete, and what did it delete?*
+
+use crate::deck::WorkspaceModel;
+use crate::deck_ui::DeckUi;
+use crate::model::TranscriptEntry;
+
+/// The delete event under the transcript highlight, as the paths that one
+/// `delete_file` call removed — `None` for any other selection, which leaves
+/// `u` to the composer.
+///
+/// Both rows of the visual block answer: the call head (which carries the
+/// `· git-backed · u undo` label) and its paired result, resolved back to the
+/// head by `call_id` — a reader's ↑ from the bottom lands on the result
+/// first, and the affordance must not depend on knowing which of the two is
+/// highlighted. A batch delete carries its targets in the call's raw argument
+/// object rather than the head's `path`.
+pub(super) fn selected_delete_paths(model: &WorkspaceModel, ui: &DeckUi) -> Option<Vec<String>> {
+    let idx = ui.session_selected?;
+    let transcript = &model.agents.get(ui.focused)?.model.transcript;
+    let (name, path, raw) =
+        match transcript.get(idx)? {
+            TranscriptEntry::ToolStart {
+                name, path, raw, ..
+            } => (name, path, raw),
+            TranscriptEntry::ToolResult { call_id, .. } => transcript
+                .iter()
+                .take(idx)
+                .rev()
+                .find_map(|entry| match entry {
+                    TranscriptEntry::ToolStart {
+                        call_id: start_id,
+                        name,
+                        path,
+                        raw,
+                        ..
+                    } if start_id == call_id => Some((name, path, raw)),
+                    _ => None,
+                })?,
+            _ => return None,
+        };
+    if name != "delete_file" {
+        return None;
+    }
+    if let Some(path) = path {
+        return Some(vec![path.clone()]);
+    }
+    let parsed: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let paths: Vec<String> = parsed
+        .get("files")?
+        .as_array()?
+        .iter()
+        .filter_map(|f| Some(f.get("path")?.as_str()?.to_string()))
+        .collect();
+    (!paths.is_empty()).then_some(paths)
+}

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -1092,6 +1092,13 @@ pub enum WorkspaceInput {
     /// the driver's next `TaskUpdate` snapshot folds back, so the card can
     /// never show a skip the engine refused.
     TaskSkip { agent: AgentId, id: String },
+    /// `u` on a highlighted delete event: restore what that one `delete_file`
+    /// call removed, from git — the row's `· git-backed · u undo` affordance
+    /// (SPEC 6.3, SPEC 11). `paths` carries the call's targets, several for a
+    /// batch delete, so the input scopes exactly one event. The driver answers
+    /// with [`Inbound::Notice`] naming what was restored or why it could not
+    /// be — an untracked file has no git reading to restore from.
+    UndoDelete { paths: Vec<String> },
     /// Plan card (`/plan`), post-approval `e`: ask the driver to open a
     /// scope-change proposal for `agent`'s locked scope. The deck never edits
     /// scope locally — a granted change arrives back as a fresh

--- a/crates/stella-tui/src/keymap.rs
+++ b/crates/stella-tui/src/keymap.rs
@@ -220,6 +220,12 @@ pub const BINDINGS: &[Binding] = &[
         &["up_selects_the_last_message_and_ctrl_o_toggles_it"],
     ),
     row(
+        "u",
+        "undo the highlighted delete — restore the file from git",
+        Tab(T::Session),
+        &["u_on_a_highlighted_delete_sends_the_undo_and_otherwise_types"],
+    ),
+    row(
         "ctrl-r",
         "expand / collapse all thinking",
         Tab(T::Session),


### PR DESCRIPTION
The delete event's head has rendered `· git-backed · u undo` since it landed, but no handler bound `u` — `keymap.rs::BINDINGS` had no row and `KeyCode::Char('u')` appeared nowhere in `stella-tui` or `stella-cli`. SPEC 11 lists `u` = undo for delete events.

**Deck half** — `deck_ui/undo.rs` (a sibling submodule; `deck_ui.rs` is closed to growth, so only the dispatcher arm lands there, +20 lines under its ceiling): the transcript highlight resolves to the paths one `delete_file` call removed — from the call head or from its paired result via `call_id`, since ↑ from the bottom lands on the result first; a batch delete's targets are read from the call's raw argument object. `u` fires only with a blank composer (the house rule for bare-letter hotkeys) and only on a delete highlight — anything else falls through to typing, witnessed.

**Driver half** — `service_undo_delete` in `driver_support.rs` restores each path with `git checkout -- <path>` and answers with an `Inbound::Notice` naming what was restored or git's own refusal (an untracked file has no git reading to restore). Serviced identically idle and mid-turn, beside the sessions-overlay verbs.

**Witnesses** (each fails without its half):
- `u_on_a_highlighted_delete_sends_the_undo_and_otherwise_types` (deck: result row, head row, and the falls-through-to-typing negative)
- `undo_delete_restores_a_tracked_file_and_reports_an_untracked_one` (driver: temp git repo, byte-for-byte restore, refusal notice)
- The keymap row names its witness, enforced by `every_binding_names_a_witness_that_exists`.

`cargo test -p stella-tui --lib` (1149) and `cargo clippy -p stella-tui -p stella-cli --all-targets` are green; the `deck_demo` example plays the driver's part for the new verb.

Closes #5036

## Summary by Sourcery

Enable undo for highlighted file deletions by restoring their paths from Git and reporting the outcome.

New Features:
- Add a `u` session hotkey that undoes a highlighted `delete_file` event, including selections on either the call or result row and batch deletions.
- Restore deleted tracked files from Git and report successful or refused restores through user-visible notices.

Bug Fixes:
- Make the existing git-backed delete undo affordance functional while preserving normal typing behavior for non-delete highlights or nonblank composers.

Enhancements:
- Handle delete undo consistently while the session is idle or a turn is in progress.

Tests:
- Add TUI coverage for delete undo selection, result-to-call resolution, batch-aware path extraction, and typing fallthrough.
- Add driver coverage for byte-for-byte restoration of tracked files and notices for untracked files.