### PR TITLE
fix(stella-tui): the no-plan SESSION row shows the tab list, not dead chrome

### DIFF
--- a/crates/stella-tui/src/views/frame.rs
+++ b/crates/stella-tui/src/views/frame.rs
@@ -22,10 +22,17 @@
 //!
 //! ## The tab row
 //!
-//! One row, no border. On the SESSION tab it is the breadcrumb strip: the tab
-//! name, then the plan's position. Everywhere else it is the tab list with the
-//! active tab in gold. `stella*` holds the right edge on every screen
-//! (SPEC 3.3).
+//! One row, no border. On the SESSION tab it is the breadcrumb strip — the tab
+//! name, then the plan's position, or the agent path inside a lane — and the
+//! tab list everywhere else, with the active tab in gold. `stella*` holds the
+//! right edge on every screen (SPEC 3.3).
+//!
+//! A SESSION with **no plan and no opened lane** shows the tab list too: the
+//! breadcrumb had nothing to say there (`▸ no plan yet`, dead chrome on the
+//! default screen), and that row was the only place a new reader could have
+//! learned the other eight tabs exist (#5049). The moment a plan or a lane
+//! gives the breadcrumb something to say, it takes the row back — which is
+//! also the form the renderings draw.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -52,7 +59,9 @@ pub fn render_tab_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut
     let width = row.width as usize;
 
     let left = match ui.tab {
-        DeckTab::Session => breadcrumb_spans(model, ui),
+        DeckTab::Session => {
+            breadcrumb_spans(model, ui).unwrap_or_else(|| tab_list_spans(DeckTab::Session))
+        }
         tab => tab_list_spans(tab),
     };
 
@@ -104,7 +113,8 @@ fn tab_list_spans(active: DeckTab) -> Vec<Span<'static>> {
 }
 
 /// The SESSION tab's breadcrumb: `SESSION  ▸ plan · task 3 wire dedup digest
-/// · 2/6`, or `SESSION  ▸ no plan yet` (SPEC 5 item 2).
+/// · 2/6` (SPEC 5 item 2), or `None` when it has nothing to say — no plan and
+/// no opened lane — which hands the row back to the tab list (#5049).
 ///
 /// At an opened lane it is the **agent path** instead — `SESSION  ▸ lead ▸
 /// sub:2 · running · ⌫ back` — because the plan is the lead's and a reader
@@ -115,7 +125,7 @@ fn tab_list_spans(active: DeckTab) -> Vec<Span<'static>> {
 /// The plan carries no revision number yet — the `r3` of the renderings is a
 /// plan-graph fact this deck does not fold (#4333) — so the strip names the
 /// plan by its state word when it is not simply running.
-fn breadcrumb_spans(model: &WorkspaceModel, ui: &DeckUi) -> Vec<Span<'static>> {
+fn breadcrumb_spans(model: &WorkspaceModel, ui: &DeckUi) -> Option<Vec<Span<'static>>> {
     let lit = Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD);
     let dim = Style::new().fg(token::DIM);
     let muted = Style::new().fg(token::MUTED);
@@ -143,12 +153,9 @@ fn breadcrumb_spans(model: &WorkspaceModel, ui: &DeckUi) -> Vec<Span<'static>> {
         spans.push(Span::styled(" · ", dim));
         spans.push(Span::styled("⌫", muted));
         spans.push(Span::styled(" back", dim));
-        return spans;
+        return Some(spans);
     }
-    let Some(plan) = plan_of(model, ui).filter(|p| !p.is_empty()) else {
-        spans.push(Span::styled("no plan yet", dim));
-        return spans;
-    };
+    let plan = plan_of(model, ui).filter(|p| !p.is_empty())?;
     spans.push(Span::styled("plan", muted));
     if plan.state != PlanState::Started {
         spans.push(Span::styled(format!(" {}", plan.state.label()), muted));
@@ -161,7 +168,7 @@ fn breadcrumb_spans(model: &WorkspaceModel, ui: &DeckUi) -> Vec<Span<'static>> {
     let (done, total) = plan.progress();
     spans.push(Span::styled(" · ", dim));
     spans.push(Span::styled(format!("{done}/{total}"), muted));
-    spans
+    Some(spans)
 }
 
 /// The focused agent's plan, if there is a focused agent.
@@ -311,6 +318,39 @@ mod tests {
             ],
         }));
         m
+    }
+
+    /// With no plan and no opened lane, SESSION's tab row is the tab list —
+    /// the breadcrumb had nothing to say, and the default screen must not be
+    /// the one place the other eight tabs are invisible (#5049).
+    #[test]
+    fn with_no_plan_the_session_row_is_the_tab_list() {
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        let ui = DeckUi {
+            tab: DeckTab::Session,
+            ..Default::default()
+        };
+        let area = Rect::new(0, 0, 100, 1);
+        let mut buf = Buffer::empty(area);
+        render_tab_row(&model, &ui, area, &mut buf);
+        let row = text(&buf);
+        for tab in DeckTab::ALL {
+            assert!(
+                row.contains(tab.title()),
+                "{} missing from {row}",
+                tab.title()
+            );
+        }
+        assert!(!row.contains("no plan yet"), "{row}");
+        assert!(row.trim_end().ends_with("stella*"), "{row}");
+        // SESSION is the lit tab: gold and bold, like every active tab.
+        let x = row.find("SESSION").expect("SESSION on the row") as u16;
+        assert_eq!(
+            buf.cell((x, 0)).expect("cell").fg,
+            token::GOLD,
+            "the active tab is lit"
+        );
     }
 
     /// SPEC 5 item 2: on SESSION the tab row is the breadcrumb, naming the

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -230,7 +230,7 @@ uv run --with fonttools --with pyobjc-framework-CoreText \
 Top to bottom:
 
 1. **Tab bar** (1 row): `SESSION AGENTS TRACES GRAPH FILES SKILLS MCP ISSUES SETTINGS`, active tab gold, wordmark right-aligned.
-2. **Plan breadcrumb strip** (1 row, SESSION only): `▸ plan r3 · task 3 wire dedup digest · 2/6`. `^S` expands to the full plan panel. The transcript gets full width by default; the old permanent side panel is gone.
+2. **Plan breadcrumb strip** (1 row, SESSION only): `▸ plan r3 · task 3 wire dedup digest · 2/6`. `^S` expands to the full plan panel. The transcript gets full width by default; the old permanent side panel is gone. On SESSION the strip and the tab bar share one row: the breadcrumb takes it while a plan or an opened lane gives it something to say, and the tab list takes it back when neither does — a default screen whose only chrome said `no plan yet` was also the only screen that never named the other eight tabs.
 3. **Body**: tab content.
 4. **Prompt block**: pipeline line (`✓ plan ▸ execute [bar] 50% · verify`), input line `>>>`, keybinding hint row.
 5. **Status bar** (1 row, replaces the old two-row wall): `worker · stage · ctx [bar] 35% · $spend · saved $x · ✉ n · ? help`. MODEL detail, CPU, MEM, WARMTH, and ENGINE move behind `?` and the AGENTS tab. Money renders gold. Meters render gold fill on `border` gray. No pink, no green meters.


### PR DESCRIPTION
The SESSION tab merges the tab bar and the plan breadcrumb into one row (the form the renderings draw), which left the default screen with no tab list at all: a new reader saw `SESSION  ▸ no plan yet` and had no on-screen evidence that AGENTS/TRACES/GRAPH/FILES/SKILLS/MCP/ISSUES/SETTINGS exist (#5049).

`breadcrumb_spans` now returns `Option`: `Some` for the agent path inside a lane and for a non-empty plan — unchanged — and `None` otherwise, which hands the row to `tab_list_spans(DeckTab::Session)`. The moment a plan is proposed or a lane opens, the breadcrumb takes the row back, so mid-work density matches the renderings exactly.

`design/tui-v2/SPEC.md` §5 item 2 is amended in the same PR to record the shared-row rule, the way §11's `^S` amendment recorded that decision.

Witness: `with_no_plan_the_session_row_is_the_tab_list` — all nine tab titles present, `no plan yet` absent, wordmark on the right edge, SESSION lit gold. Verified the flip artisanally: with the old `no plan yet` fallback restored at the call site the test fails naming the first missing tab; with the fix it passes. Full `cargo test -p stella-tui` (12 suites, deck goldens included — the golden scenario carries a plan, so no snapshot churn), clippy `--all-targets`, and `make prose` (spec edit) are green.

Not addressed here, still open under #5049's sibling scope: the 120-column overflow that clips SETTINGS on the widest tab list — that is a width-degradation design for `tab_list_spans` and worth its own small PR; noted on the issue.

Closes #5049

## Summary by Sourcery

Restore the SESSION tab list when its breadcrumb has no content to display.

Bug Fixes:
- Show the SESSION tab list when no plan is active and no lane is open, making all available tabs visible on the default screen.

Enhancements:
- Clarify the shared SESSION breadcrumb/tab-row behavior in the TUI specification and view documentation.

Documentation:
- Document the SESSION row fallback rule in the TUI v2 specification.

Tests:
- Add coverage verifying the no-plan SESSION row displays all tabs, preserves the wordmark, and highlights SESSION.