### PR TITLE
feat(stella-cli,stella-parity): stella proposals retract takes a published rule back

### DIFF
--- a/crates/stella-cli/src/proposals_cmd.rs
+++ b/crates/stella-cli/src/proposals_cmd.rs
@@ -4,7 +4,9 @@
 //! becomes a skill, which is the part users cannot do today. `list` shows what
 //! the loop wants to make durable and the evidence behind it; `keep`, `edit`,
 //! and `ignore` decide, and each decision is an immutable promotion event in the
-//! lifecycle ledger.
+//! lifecycle ledger. `retract` is the reverse of `keep` for the one artifact
+//! this surface publishes to disk — see [`retract`] for why a rule needed its
+//! own rollback verb when the other evolution surfaces already had one.
 //!
 //! ## Governance lives here, and it is not configurable
 //!
@@ -75,6 +77,19 @@ pub enum ProposalsCmd {
         #[arg(long, default_value = "declined from the review surface")]
         reason: String,
     },
+    /// Take back a rule that was already published, so it stops steering.
+    ///
+    /// `ignore` prevents a write; this reverses one. The record file stays on
+    /// disk marked retracted and the retraction is appended to the governance
+    /// ledger, so what Stella believed and when it stopped stays readable.
+    Retract {
+        /// The published rule's candidate id, as shown by `stella context
+        /// list` — or its full `ctx.<set>.<id>` lineage when the short form
+        /// names more than one.
+        id: String,
+        #[arg(long, default_value = "retracted from the review surface")]
+        reason: String,
+    },
     /// Extract observations from the reflection log and induce proposals over
     /// them, without waiting for a turn to reflect.
     ///
@@ -125,6 +140,7 @@ pub fn run_proposals(cmd: &ProposalsCmd) -> Result<(), String> {
             None,
             reason,
         ),
+        ProposalsCmd::Retract { id, reason } => retract::retract_rule(&workspace_root, id, reason),
         ProposalsCmd::Refresh => refresh(&store, &workspace_root),
     }
 }
@@ -494,6 +510,8 @@ pub(crate) fn decide_for_test(
         (action == PromotionAction::Confirmed).then_some(DirectiveEnforcement::Advisory);
     decide(store, candidate_id, action, enforcement, None, reason)
 }
+
+mod retract;
 
 #[cfg(test)]
 mod tests;

--- a/crates/stella-cli/src/proposals_cmd/retract.rs
+++ b/crates/stella-cli/src/proposals_cmd/retract.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Taking back a published rule — the reverse of `stella proposals keep`
+//! (#4866).
+//!
+//! Every other evolution surface has a named rollback artifact: memory has
+//! `stella memory reaffirm` / `restore`, tools have `stella tools --disable`,
+//! workflow has `stella tune rollback`. A published rule had none. It is also
+//! the one self-modification that leaves the ledger and lands as a *file*, and
+//! files are what the ledger was designed not to need — so reversal was `rm
+//! .stella/rules/<id>.toml` or a git revert, neither of which leaves any record
+//! that Stella ever believed the thing.
+//!
+//! # Retraction appends; it never deletes
+//!
+//! Two writes, in this order:
+//!
+//! 1. the record's own file is rewritten with `status = "retracted"` and
+//!    `supersedes_record_id` pointing at the revision it replaces, re-stamped
+//!    so the file still verifies on load;
+//! 2. a `LedgerAction::Retired` event is appended to the hash-chained
+//!    `.stella/rules/promotions.jsonl`, carrying the status transition, the
+//!    approver and the reason.
+//!
+//! The file stays on disk, retired rather than gone, which is what keeps "what
+//! did Stella believe, and when did it stop" readable. `stella context
+//! validate` already treats a non-active record this way — it reports it under
+//! *Retired* and does not fail the run (#3254) — and the ledger's own
+//! latest-event fold revokes any blocking grant the lineage held, which is the
+//! right side effect for a rule that must no longer steer.
+//!
+//! # What makes it take effect
+//!
+//! `stella_core::records::registry`'s loader refuses to select a record whose
+//! status is anything but active, so the retracted rule stops reaching the
+//! cached prefix `assemble_system_prompt` renders on the next load. No new
+//! filter is needed on `load_workspace_rules`: the standing is carried on the
+//! record itself, which is the same place `stella ingest --refresh` writes it.
+//!
+//! The order matters the way `decide_in`'s does, and is the mirror image. A
+//! *decision* records its event first because the event is the authority and
+//! the file is a projection of it. A *retraction* rewrites the file first,
+//! because the file is what steers the next turn: a ledger entry with a live
+//! rule still on disk would be a retraction with no effect, while a rewritten
+//! file with no ledger entry is a rule that stopped steering and can be
+//! re-appended for.
+
+use std::path::{Path, PathBuf};
+
+use colored::Colorize;
+use stella_core::context_record::RecordStatus;
+use stella_core::ingest::record::{ContextFile, Record};
+
+/// One published record, with the file it shares and where that file lives.
+struct Published {
+    path: PathBuf,
+    file: ContextFile,
+    /// Index into `file.records` — the record this retraction is about.
+    index: usize,
+}
+
+impl Published {
+    fn record(&self) -> &Record {
+        &self.file.records[self.index]
+    }
+}
+
+/// Retract a published rule: suppress it, and record who did so and why.
+///
+/// `id` is the candidate id `stella proposals list` shows, or the record's full
+/// `ctx.<set>.<id>` lineage when the short form is ambiguous — the same two
+/// spellings [`super::resolve_proposal`] accepts, for the same reason.
+pub(super) fn retract_rule(workspace_root: &Path, id: &str, reason: &str) -> Result<(), String> {
+    if reason.trim().is_empty() {
+        return Err("a retraction must carry a reason — a governance decision \
+                    with none is not auditable"
+            .to_string());
+    }
+    let mut published = resolve_published(workspace_root, id)?;
+    let record = published.record();
+    if !matches!(record.status, None | Some(RecordStatus::Active)) {
+        return Err(format!(
+            "`{}` is already {} — nothing to retract",
+            record.lineage_id,
+            record
+                .status
+                .map(RecordStatus::as_str)
+                .unwrap_or("of unset status")
+        ));
+    }
+    let lineage_id = record.lineage_id.clone();
+
+    retract_in_place(&mut published)?;
+    record_retraction(workspace_root, &lineage_id, reason)?;
+
+    println!("  {} retracted {}", "✓".green(), lineage_id.bold());
+    println!(
+        "    {} {} keeps the record, marked retracted — the loader stops \
+         selecting it on the next load",
+        "·".dimmed(),
+        published.path.display()
+    );
+    Ok(())
+}
+
+/// Find the published record `id` names, reading `.stella/rules/` rather than
+/// deriving the path from today's set id.
+///
+/// Derivation would be shorter and wrong: `derive_set_id` reads the workspace
+/// directory name, so a renamed or cloned-into-a-different-directory workspace
+/// would compute a lineage no file on disk carries and report the rule as
+/// missing. The file is the authority for what was published, so it is what is
+/// searched.
+fn resolve_published(workspace_root: &Path, id: &str) -> Result<Published, String> {
+    let dir = crate::memory::rules_mining::workspace_rules_dir(workspace_root);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Err(format!(
+            "no published rules to retract — {} does not exist",
+            dir.display()
+        ));
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|x| x.to_str()) == Some("toml"))
+        .filter(|path| {
+            !path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| crate::rules::RESERVED_RULE_FILENAMES.contains(&name))
+        })
+        .collect();
+    paths.sort();
+
+    let mut found: Vec<Published> = Vec::new();
+    for path in paths {
+        let Ok(body) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(file) = toml::from_str::<ContextFile>(&body) else {
+            continue;
+        };
+        for index in 0..file.records.len() {
+            let lineage = &file.records[index].lineage_id;
+            let names_it = lineage == id
+                || lineage
+                    .rsplit('.')
+                    .next()
+                    .is_some_and(|candidate| candidate == id);
+            if names_it {
+                found.push(Published {
+                    path: path.clone(),
+                    file: file.clone(),
+                    index,
+                });
+            }
+        }
+    }
+
+    match found.len() {
+        0 => Err(format!(
+            "no published rule named `{id}` under {} — `stella context list` \
+             shows what is published",
+            dir.display()
+        )),
+        1 => Ok(found.remove(0)),
+        // The same ambiguity `resolve_proposal` refuses, one hop later: two
+        // sets can publish the same candidate id under different lineages, and
+        // retracting the wrong one is the failure hardest to notice.
+        _ => Err(format!(
+            "`{id}` names {} published records. Re-run with one of these \
+             lineage ids instead:\n{}",
+            found.len(),
+            found
+                .iter()
+                .map(|p| format!("      {}", p.record().lineage_id))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )),
+    }
+}
+
+/// Rewrite the file with this record retracted, keeping every sibling record in
+/// it intact.
+///
+/// The whole `ContextFile` is written back rather than rebuilt from the one
+/// record: a published file can hold several, plus its `set_id` and
+/// `[defaults]` header, and rebuilding from one resolved record silently drops
+/// the rest — the hazard `replace_context_file` exists for. Durable for the
+/// reason the ledger's own write is: this is Git-tracked governance and a crash
+/// mid-write must not leave a truncated record where a reviewed one stood.
+fn retract_in_place(published: &mut Published) -> Result<(), String> {
+    let defaults = published.file.defaults.clone().unwrap_or_default();
+    let record = &mut published.file.records[published.index];
+    record.status = Some(RecordStatus::Retracted);
+    record.supersedes_record_id = record.record_id.clone();
+    record
+        .stamp(&defaults)
+        .map_err(|e| format!("cannot re-stamp the retracted revision: {e}"))?;
+    crate::context_records::replace_context_file(&published.path, &published.file)
+}
+
+/// Append the accountable retraction event to the hash-chained ledger.
+///
+/// `from`/`to` carry the **status** transition rather than an enforcement
+/// level, which is what `LedgerAction::Retired` means on this ledger (#2728) —
+/// the same shape `stella ingest --refresh` writes when a source stops
+/// asserting a claim, and the same fold that drops any blocking grant the
+/// lineage held.
+fn record_retraction(workspace_root: &Path, lineage_id: &str, reason: &str) -> Result<(), String> {
+    let governance = crate::context_records::read_governance(workspace_root);
+    crate::context_records::append_promotion(
+        workspace_root,
+        stella_core::records::promotion::PromotionEvent {
+            seq: 0,
+            prev: String::new(),
+            at: crate::context_records::now_rfc3339(),
+            lineage_id: lineage_id.to_string(),
+            from: RecordStatus::Active.as_str().to_string(),
+            to: RecordStatus::Retracted.as_str().to_string(),
+            approver: crate::context_cmd::actor(),
+            proposer: None,
+            reason: format!("retracted by `stella proposals retract`: {}", reason.trim()),
+            mode: governance.mode.as_str().to_string(),
+            action: stella_core::records::promotion::LedgerAction::Retired,
+        },
+    )
+    .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/proposals_cmd/retract/tests.rs
+++ b/crates/stella-cli/src/proposals_cmd/retract/tests.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for `stella proposals retract`.
+//!
+//! The decisive one is `a_retracted_rule_stops_reaching_the_system_prefix`: a
+//! rollback artifact that leaves the rule steering is not a rollback, and that
+//! is the half a status flip alone could get wrong.
+
+use super::*;
+
+use stella_core::records::Channel;
+use stella_core::rules::RuleCandidate;
+
+const LESSON: &str = "Always run the database migration before starting the integration suite.";
+
+/// A workspace with one published mined rule, and the candidate behind it.
+fn published_workspace() -> (tempfile::TempDir, RuleCandidate) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidate = RuleCandidate {
+        id: "retraction-abcd1234".into(),
+        text: LESSON.into(),
+        description: "d".into(),
+        occurrences: 3,
+        salient: false,
+        evidence: Vec::new(),
+        guard: None,
+        score: 30,
+    };
+    crate::memory::rules_mining::write_rule(dir.path(), &candidate, None)
+        .expect("publishable")
+        .expect("written");
+    (dir, candidate)
+}
+
+/// The text this workspace's records put in front of the model.
+///
+/// The real prompt path: `assemble_system_prompt` renders exactly this from
+/// `load_workspace_rules`'s registry, so a rule that is absent here is absent
+/// from the system prefix.
+fn cached_prefix(root: &Path) -> String {
+    let authority = crate::settings::AuthorityPolicy {
+        project_prompts_allowed: true,
+        ..Default::default()
+    };
+    crate::rules::load_workspace_rules(root, &authority)
+        .registry()
+        .render(Channel::Cached, None)
+        .text
+}
+
+/// **Witness (#4866).** A published rule can be taken back, and taking it back
+/// stops it steering.
+///
+/// Before this command the only reversal was `rm .stella/rules/<id>.toml` or a
+/// git revert: `stella proposals` offered list/keep/edit/ignore/refresh, none
+/// of which touches a rule already on disk, and `stella memory retire` writes
+/// standings the file-backed loader never consults.
+#[test]
+fn a_retracted_rule_stops_reaching_the_system_prefix() {
+    let (dir, candidate) = published_workspace();
+
+    assert!(
+        cached_prefix(dir.path()).contains("database migration"),
+        "the published rule must reach the prefix before it is retracted: {}",
+        cached_prefix(dir.path())
+    );
+
+    retract_rule(dir.path(), &candidate.id, "it was wrong about this repo")
+        .expect("the published rule is retractable");
+
+    assert!(
+        !cached_prefix(dir.path()).contains("database migration"),
+        "a retracted rule must not steer the next turn: {}",
+        cached_prefix(dir.path())
+    );
+}
+
+/// Retraction is append-only: the record stays, marked retracted, rather than
+/// being deleted. Deleting would lose the record that Stella ever believed it,
+/// which is the thing the ledger exists to keep.
+#[test]
+fn the_retracted_record_stays_on_disk_marked_retracted() {
+    let (dir, candidate) = published_workspace();
+    let published = crate::memory::rules_mining::workspace_rules_dir(dir.path());
+    let before = resolve_published(dir.path(), &candidate.id)
+        .expect("published")
+        .record()
+        .record_id
+        .clone();
+
+    retract_rule(dir.path(), &candidate.id, "superseded by a house rule").expect("retractable");
+
+    let file = resolve_published(dir.path(), &candidate.id).expect("still findable");
+    assert_eq!(file.record().status, Some(RecordStatus::Retracted));
+    assert_eq!(
+        file.record().supersedes_record_id,
+        before,
+        "the retracted revision supersedes the active revision it replaces"
+    );
+    assert_ne!(
+        file.record().record_id,
+        before,
+        "re-stamping mints a new revision id, so the file still verifies on load"
+    );
+    assert!(
+        std::fs::read_dir(&published)
+            .expect("rules dir")
+            .flatten()
+            .any(|e| e.path().extension().and_then(|x| x.to_str()) == Some("toml")),
+        "the record file must survive its own retraction"
+    );
+}
+
+/// The hash-chained ledger records who retracted what and why, and still
+/// verifies afterwards.
+#[test]
+fn the_retraction_is_appended_to_the_hash_chained_ledger() {
+    let (dir, candidate) = published_workspace();
+
+    retract_rule(dir.path(), &candidate.id, "the migration order changed").expect("retractable");
+
+    let events = crate::context_records::read_promotions(dir.path())
+        .expect("the ledger still verifies after the append");
+    let retirement = events
+        .iter()
+        .find(|e| e.action == stella_core::records::promotion::LedgerAction::Retired)
+        .expect("a retirement event");
+    assert!(retirement.lineage_id.ends_with(&candidate.id));
+    assert_eq!(retirement.from, "active");
+    assert_eq!(retirement.to, "retracted");
+    assert!(
+        retirement.reason.contains("the migration order changed"),
+        "the reason a person gave must survive onto the event: {}",
+        retirement.reason
+    );
+    assert!(
+        !retirement.approver.trim().is_empty(),
+        "a retraction must name who made it"
+    );
+}
+
+/// Retracting twice is refused rather than appending a second event that says
+/// nothing new — and the message says what the standing already is.
+#[test]
+fn a_second_retraction_is_refused_and_says_why() {
+    let (dir, candidate) = published_workspace();
+    retract_rule(dir.path(), &candidate.id, "once").expect("retractable");
+
+    let again = retract_rule(dir.path(), &candidate.id, "twice").expect_err("already retracted");
+    assert!(
+        again.contains("already retracted"),
+        "the refusal must name the standing: {again}"
+    );
+}
+
+/// A governance decision with no reason is not auditable, so an empty one is
+/// refused before anything is written — the same rule `stella memory retire`
+/// applies.
+#[test]
+fn a_retraction_with_no_reason_is_refused_before_anything_is_written() {
+    let (dir, candidate) = published_workspace();
+
+    let refused = retract_rule(dir.path(), &candidate.id, "   ").expect_err("no reason");
+    assert!(refused.contains("reason"), "{refused}");
+    assert!(
+        cached_prefix(dir.path()).contains("database migration"),
+        "a refused retraction must leave the rule exactly as it was"
+    );
+}
+
+/// A name nothing published is an error naming where to look, not a silent
+/// success that leaves the user believing a live rule was taken back.
+#[test]
+fn retracting_an_unpublished_name_is_refused() {
+    let (dir, _candidate) = published_workspace();
+
+    let refused = retract_rule(dir.path(), "no-such-rule-0000ffff", "because")
+        .expect_err("nothing named that");
+    assert!(refused.contains("no-such-rule-0000ffff"), "{refused}");
+}

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -292,10 +292,10 @@ evolution_surfaces! {
         },
         EvolutionTiming::OfflineBatch,
         ImpactClass::SteeringDirective,
-        "no command retracts a published rule — `stella proposals` offers only \
-         list/keep/edit/ignore/refresh, and `stella memory retire` does not suppress a \
-         file-backed rule because the loader filters by authority rather than by retirement \
-         standing. Reversal today is deleting or reverting `.stella/rules/<id>.toml`";
+        "`stella proposals retract <id> --reason <why>`. Nothing is deleted: the record file \
+         is rewritten with `status = \"retracted\"` and the retraction is appended to the \
+         hash-chained `.stella/rules/promotions.jsonl`, so the registry stops selecting it on \
+         the next load while what Stella believed — and when it stopped — stays readable";
 
     /// What Stella remembers between turns.
     Memory => "memory",

--- a/website/content/docs/commands/proposals.mdx
+++ b/website/content/docs/commands/proposals.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella proposals
-description: Review what the adaptive-context loop wants to make durable — the induced proposals, the evidence behind each, and Keep/Edit/Ignore as events.
+description: Review what the adaptive-context loop wants to make durable — the induced proposals, the evidence behind each, and Keep/Edit/Ignore/Retract as events.
 ---
 
 `stella proposals` is the review surface for the adaptive-context loop. As you work, the loop reflects on turns and induces proposals: things it believes are worth making durable. This command shows you what is pending, the evidence behind each one, and lets you accept it, reword it, or decline it — **before** it steers anything.
@@ -14,6 +14,7 @@ stella proposals list [--all] [--limit <n>]
 stella proposals keep <id> [--reason <text>]
 stella proposals edit <id> <body> [--reason <text>]
 stella proposals ignore <id> [--reason <text>]
+stella proposals retract <id> [--reason <text>]
 stella proposals refresh
 ```
 
@@ -93,6 +94,27 @@ Decline a proposal. It will not be re-proposed while the decision stands — and
 
 ```bash
 stella proposals ignore cand-7ab0 --reason "true last quarter, not now"
+```
+
+### `stella proposals retract`
+
+Take back a rule that was already published, so it stops steering.
+
+`ignore` prevents a write; `retract` reverses one. A kept directive lands as a TOML record under `.stella/rules/`, which the loader reads into the system prefix — and until this verb the only way back was `rm` or a git revert, neither of which leaves any record that the rule was ever believed.
+
+Retraction appends rather than deletes. The record file stays on disk with `status = "retracted"`, and the retraction goes into the hash-chained `.stella/rules/promotions.jsonl` with who made it and why. The registry stops selecting a non-active record, so the rule is out of the prefix on the next load; `stella context validate` reports it under *Retired* and does not fail.
+
+<CardGrid size="md">
+  <OptionCard name="<id>" required>
+    The published rule's candidate id, as shown by [`stella context list`](/docs/commands/context) — or its full `ctx.<set>.<id>` lineage when the short form names more than one.
+  </OptionCard>
+  <OptionCard name="--reason <text>" defaultValue="retracted from the review surface">
+    Why. Recorded on the ledger event; an empty reason is refused.
+  </OptionCard>
+</CardGrid>
+
+```bash
+stella proposals retract migration-order-3f21 --reason "the migration order changed in 0.9"
 ```
 
 ### `stella proposals refresh`


### PR DESCRIPTION
## Problem

Stella can publish a rule that steers it, and nothing took it back.

`stella proposals keep` on a directive materializes a TOML context record under
`.stella/rules/`, which `FsRuleSource` loads into the cached system prefix — a
real self-modification, witnessed by `mined_rules_land_where_the_loader_reads`.
The reverse did not exist: `ignore` prevents a write and never touches a rule
already on disk, and `stella memory retire` writes standings into the private
ledger that the file-backed loader never consults. Reversal was
`rm .stella/rules/<id>.toml` or a git revert, neither of which leaves any record
that the rule was ever believed.

Every other evolution surface already had a named rollback artifact — memory has
`reaffirm`/`restore`, tools have `--disable`, workflow has `tune rollback`. The
Framework row in `crates/stella-parity/src/evolution.rs` recorded this gap in
prose because nothing better was true.

## What this adds

`stella proposals retract <id> [--reason <text>]`
(`crates/stella-cli/src/proposals_cmd/retract.rs`).

**Append-only, matching the rest of the lifecycle.** Two writes, in this order:

1. the record's file is rewritten with `status = "retracted"` and
   `supersedes_record_id` pointing at the revision it replaces, re-stamped so
   the file still verifies on load — the same shape `stella ingest --refresh`
   already writes when a source stops asserting a claim;
2. a `LedgerAction::Retired` event is appended to the hash-chained
   `.stella/rules/promotions.jsonl`, carrying the `active → retracted` status
   transition, the approver and the reason.

Nothing is deleted. The file stays on disk retired rather than gone, which is
what keeps "what did Stella believe, and when did it stop" readable.

**Why the loader needs no new filter.** `stella_core::records::registry` already
refuses to select a record whose status is anything but active
(`blocking_reason`), so the standing carried on the record itself is what takes
the rule out of the prefix. `stella context validate` already treats a
non-active record as retired rather than as a finding (#3254), and
`parse_and_verify` still passes after the append — asserted, not assumed.

**Order.** `decide_in` records its event first because the event is the
authority and the file is a projection. A retraction rewrites the file first,
because the file is what steers the next turn: a ledger entry with a live rule
still on disk is a retraction with no effect, while a rewritten file with no
ledger entry is a rule that has stopped steering and can be re-appended for.

**Resolution reads the directory, not `derive_set_id`.** Deriving the lineage
from the workspace directory name would report the rule missing in a renamed or
differently-cloned workspace. Ambiguity across sets is refused with the lineage
ids to disambiguate with, the same way `resolve_proposal` refuses.

The Framework row's `rollback` column now names the command.

## Witness

`a_retracted_rule_stops_reaching_the_system_prefix`
(`crates/stella-cli/src/proposals_cmd/retract/tests.rs`) publishes a mined rule,
asserts it reaches the prefix `assemble_system_prompt` renders from
`load_workspace_rules`, retracts it, and asserts it no longer does.

**Ablation** — `record.status = Some(RecordStatus::Retracted)` in
`retract_in_place` changed to `Some(RecordStatus::Active)`:

```
running 1 test
test proposals_cmd::retract::tests::a_retracted_rule_stops_reaching_the_system_prefix ... FAILED

---- ... stdout ----
thread '...' panicked at crates/stella-cli/src/proposals_cmd/retract/tests.rs:72:5:
a retracted rule must not steer the next turn:
## Workspace rules (cite the ^handle of any you apply)

### Should
- Always run the database migration before starting the integration suite. ^retraction-abcd1234

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2336 filtered out
```

The rule is still in the prefix — the answer is wrong, not merely constant.

With the retraction restored, the whole `proposals_cmd` suite:

```
running 14 tests
test proposals_cmd::retract::tests::a_retracted_rule_stops_reaching_the_system_prefix ... ok
test proposals_cmd::retract::tests::the_retracted_record_stays_on_disk_marked_retracted ... ok
test proposals_cmd::retract::tests::the_retraction_is_appended_to_the_hash_chained_ledger ... ok
test proposals_cmd::retract::tests::a_second_retraction_is_refused_and_says_why ... ok
test proposals_cmd::retract::tests::a_retraction_with_no_reason_is_refused_before_anything_is_written ... ok
test proposals_cmd::retract::tests::retracting_an_unpublished_name_is_refused ... ok
... (8 pre-existing)
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 2323 filtered out
```

`cargo test -p stella-parity`: 23 passed.

## Tests deleted or renamed

None.

## Related

Refs #2780 (the ledger recording this gap), #2728 (retirement/supersession
events), #994 and ADR 0007 (the governance ledger).

Closes #4866

## Summary by Sourcery

Add an auditable rollback command for published rules that disables their steering effect without deleting their records.

New Features:
- Add `stella proposals retract <id> [--reason <text>]` to withdraw a previously published rule while preserving its history.

Bug Fixes:
- Ensure retracted rules are excluded from the workspace system prefix on subsequent loads.

Enhancements:
- Record retractions as status transitions in the hash-chained governance ledger and retain the retracted record for auditability.
- Resolve published rules from the rules directory and reject ambiguous, missing, duplicate, or already retracted targets.

Documentation:
- Document the new `stella proposals retract` command, its arguments, and append-only behavior.

Tests:
- Add coverage for stopping retracted rules from steering, retaining and restamping records, ledger entries, validation failures, and repeated retractions.