### PR TITLE
fix(stella-cli): stop a turn claiming file changes another live session made

### DIFF
--- a/crates/stella-cli/src/durability.rs
+++ b/crates/stella-cli/src/durability.rs
@@ -91,6 +91,16 @@ pub struct SessionDurability {
     /// belongs to. `Arc` so `sink()` hands out cheap shares rather than
     /// re-opening the record per engine.
     bound: Arc<RwLock<Option<Bound>>>,
+    /// The other live sessions writing to this work tree, as of the last
+    /// [`Self::refresh_worktree_sharers`] (#4386).
+    ///
+    /// Cached rather than asked per reading because the answer is a walk of the
+    /// session registry directory and a reading is taken after every solo
+    /// mutating tool call. Refreshed at a turn's two bookends, which is the
+    /// resolution the answer is used at: a session that starts mid-turn is
+    /// caught by the closing sweep, and the opening one is what a long turn's
+    /// per-call readings consult.
+    sharers: Arc<RwLock<Vec<String>>>,
 }
 
 /// What one work-tree measurement produced.
@@ -221,6 +231,30 @@ impl SessionDurability {
         // After the write lock is released: `snapshot_worktree` takes the read
         // lock, and this is not a re-entrant lock.
         let _ = self.snapshot_worktree();
+    }
+
+    /// Re-ask the session registry which other live sessions are writing to
+    /// this work tree, and cache the answer for this turn's readings (#4386).
+    ///
+    /// Called at a turn's bookends. An unbound handle measures nothing, so it
+    /// has nothing to attribute and the question is not asked.
+    pub fn refresh_worktree_sharers(&self) {
+        let Some(journal) = self.journal() else {
+            return;
+        };
+        let found =
+            crate::turn_files::attribution::live_sharers(journal.work_tree(), journal.session());
+        *self.sharers.write().unwrap_or_else(|p| p.into_inner()) = found;
+    }
+
+    /// The sharer set the last refresh found — empty when this session is alone
+    /// in the tree, which is the only state in which a measurement may be
+    /// claimed as this session's work.
+    pub fn worktree_sharers(&self) -> Vec<String> {
+        self.sharers
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
     }
 
     /// Declare that this session's turns are running inside a staged pipeline,

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -53,6 +53,12 @@
 //! authority on what the agent did is the pipeline's adoption, which measures
 //! a candidate against a sealed baseline and can tell the two apart.
 //!
+//! The durable half no longer *states* what it cannot know: since #4386 each
+//! `files_touched` row carries the provenance of the reading that produced it,
+//! and a row measured while another live session shared the work tree says so
+//! rather than naming this turn as the author. [`attribution`] holds that
+//! decision and the argument for labelling rather than filtering.
+//!
 //! It lives beside `agent.rs` rather than inside it because `agent.rs` sits
 //! close to the 1500-line ratchet (AGENTS.md § "God files — plan around them,
 //! never into them") — new logic lands in a sibling.
@@ -69,6 +75,10 @@ use stella_tools::own_change::{OwnChange, OwnChangeKind};
 
 use crate::config::Config;
 use crate::durability::{SessionDurability, UnmeasurableReason, WorktreeSnapshot};
+
+pub(crate) mod attribution;
+
+use attribution::Provenance;
 
 /// This module's `module_path!()`, so its records filter under one target.
 const DIAG_TARGET: &str = "stella::turn_files";
@@ -116,7 +126,7 @@ impl stella_tools::call_measure::CallMeasure for TurnCallMeasure {
     /// calls the boundary's own function rather than a per-call variant of it.
     fn measure_and_publish(&self, own: &[OwnChange]) {
         let measured =
-            emit_measured_tree_changes(&self.durability, &self.tx, self.execution.as_ref());
+            emit_measured_tree_changes(&self.durability, &self.tx, self.execution.as_ref(), own);
         emit_own_changes(&self.tx, self.execution.as_ref(), own, &measured);
     }
 }
@@ -167,14 +177,30 @@ fn own_touch_row(change: &OwnChange) -> FileTouchRow {
         .to_string(),
         lines_added: u64::from(change.added),
         lines_removed: u64::from(change.removed),
-        events_json: serde_json::json!([{
-            "event": "measured",
-            "reason": "the call's own before/after reading",
-            "lines_added": change.added,
-            "lines_removed": change.removed,
-        }])
-        .to_string(),
+        events_json: touch_events(
+            Provenance::OwnReading,
+            u64::from(change.added),
+            u64::from(change.removed),
+        ),
     }
+}
+
+/// The `events_json` both row builders write: one `measured` entry naming the
+/// reading that produced it and whether that reading can name an author.
+///
+/// One function rather than two literals because `attributed` is the field a
+/// reader has to be able to trust across both shapes — an export that renders
+/// it for a tree reading and omits it for a call's own reading would make its
+/// absence mean two things (#4386).
+fn touch_events(provenance: Provenance, added: u64, removed: u64) -> String {
+    serde_json::json!([{
+        "event": "measured",
+        "reason": provenance.reason(),
+        "attributed": provenance.attributed(),
+        "lines_added": added,
+        "lines_removed": removed,
+    }])
+    .to_string()
 }
 
 /// Everything the owner of a turn owes the **registry** when it opens the
@@ -195,12 +221,16 @@ fn own_touch_row(change: &OwnChange) -> FileTouchRow {
 ///   call that changed nothing. That is the exact shape #4155 was reported as,
 ///   and the exact shape #4160 had to repair once already at the turn
 ///   boundary.
+/// - **Who else is in the work tree** (#4386). The per-call measurements this
+///   attaches read the cached answer, so the turn's first reading has to have
+///   one; the closing bookend re-asks for a session that started mid-turn.
 pub(crate) fn open_turn_streams(
     registry: &stella_tools::registry::ToolRegistry,
     cfg: &Config,
     tx: &EventSender,
     execution: Option<&(Arc<Store>, i64)>,
 ) {
+    cfg.durability.refresh_worktree_sharers();
     registry.attach_events(tx.clone());
     registry.attach_call_measure(Arc::new(TurnCallMeasure::new(
         cfg.durability.clone(),
@@ -398,12 +428,18 @@ fn stale_lane_open_tasks(
 /// but the count is the one number a turn-boundary observation can want
 /// without re-reading the tree, and re-reading is precisely what the
 /// baseline-advancing snapshot above forbids.
+///
+/// The sharer set is re-asked here rather than reused from the turn's opening
+/// bookend, because this sweep covers the whole turn and a session that opened
+/// halfway through it wrote into the same window (#4386). No call owns this
+/// reading, so it carries no `own` paths to vouch for any of it.
 pub(crate) fn emit_shared_tree_changes(
     cfg: &Config,
     tx: &EventSender,
     execution: Option<&(Arc<Store>, i64)>,
 ) -> usize {
-    emit_measured_tree_changes(&cfg.durability, tx, execution).len()
+    cfg.durability.refresh_worktree_sharers();
+    emit_measured_tree_changes(&cfg.durability, tx, execution, &[]).len()
 }
 
 /// [`emit_shared_tree_changes`] for a driver holding the raw channel sender
@@ -455,6 +491,7 @@ pub(crate) fn emit_measured_tree_changes(
     durability: &SessionDurability,
     tx: &EventSender,
     execution: Option<&(Arc<Store>, i64)>,
+    own: &[OwnChange],
 ) -> Vec<String> {
     let measured = match durability.snapshot_worktree() {
         WorktreeSnapshot::Measured(changes) => changes,
@@ -486,7 +523,16 @@ pub(crate) fn emit_measured_tree_changes(
         return Vec::new();
     }
     if let Some((store, execution_id)) = execution {
-        let rows: Vec<FileTouchRow> = measured.iter().map(file_touch_row).collect();
+        // The sharer set is per turn, not per path, but the classification is
+        // per path: a call's own reading vouches for the path it named and for
+        // nothing else (#4386).
+        let sharers = durability.worktree_sharers();
+        let rows: Vec<FileTouchRow> = measured
+            .iter()
+            .map(|change| {
+                file_touch_row(change, attribution::provenance(&change.path, own, &sharers))
+            })
+            .collect();
         // Best-effort for the same reason `AdoptionLedger::record` is: this is
         // observability, not evidence (#2882). A telemetry write must never
         // fail a turn whose bytes are already on disk.
@@ -507,19 +553,17 @@ pub(crate) fn emit_measured_tree_changes(
 /// many it wrote. `Store::finalize_execution_reflection` reads exactly this
 /// table for its `wrote_files` flag, so the empty table also told the
 /// reflection loop that a turn which edited dozens of files had written none.
-fn file_touch_row(change: &JournalChange) -> FileTouchRow {
+fn file_touch_row(change: &JournalChange, provenance: Provenance) -> FileTouchRow {
     FileTouchRow {
         path: change.path.clone(),
         ops: ops_letter(change.kind).to_string(),
         lines_added: u64::from(change.added),
         lines_removed: u64::from(change.removed),
-        events_json: serde_json::json!([{
-            "event": "measured",
-            "reason": "turn-boundary work-tree measurement",
-            "lines_added": change.added,
-            "lines_removed": change.removed,
-        }])
-        .to_string(),
+        events_json: touch_events(
+            provenance,
+            u64::from(change.added),
+            u64::from(change.removed),
+        ),
     }
 }
 
@@ -1254,7 +1298,10 @@ mod tests {
     /// `FileChange` events and wrote no `files_touched` row at all.
     #[test]
     fn a_measured_change_becomes_a_durable_row_carrying_the_same_counts() {
-        let row = file_touch_row(&measured(JournalChangeKind::Modified));
+        let row = file_touch_row(
+            &measured(JournalChangeKind::Modified),
+            Provenance::SoleWriter,
+        );
         assert_eq!(row.path, "src/lib.rs");
         assert_eq!(row.ops, "U");
         assert_eq!((row.lines_added, row.lines_removed), (12, 3));
@@ -1268,6 +1315,95 @@ mod tests {
             !row.events_json.contains("@@"),
             "files_touched indexes paths; the diff rides the FileChange event"
         );
+    }
+
+    /// **Witness (#4386).** The reported shape: two sessions in one checkout,
+    /// one of them writing a file the other never opened. Session A's snapshot
+    /// sees it — that is what a shared work tree means and no fix changes it —
+    /// so the durable row must say the reading cannot name an author, where it
+    /// used to state "turn-boundary work-tree measurement" and let the export
+    /// present another session's file as this turn's work.
+    #[test]
+    fn a_file_another_live_session_wrote_is_not_claimed_by_this_turn() {
+        let guard = tempfile::tempdir().unwrap();
+        let ws = guard.path().join("ws");
+        std::fs::create_dir_all(&ws).unwrap();
+        let store_root = guard.path().join("store");
+        let registry_dir = guard.path().join("sessions");
+
+        // Two sessions on one tree, each with its own journal — the same
+        // arrangement `WorkJournal` gives them in a real checkout.
+        let session_a = stella_store::work_journal::WorkJournal::open_in(&store_root, &ws, "ses-a")
+            .expect("journal A");
+        let _session_b =
+            stella_store::work_journal::WorkJournal::open_in(&store_root, &ws, "ses-b")
+                .expect("journal B");
+        // A's baseline, discarded exactly as `SessionDurability::bind` does.
+        let _ = session_a.snapshot_worktree().expect("baseline");
+
+        // Session B writes. Session A does nothing at all.
+        std::fs::write(ws.join("prose_score.py"), "print('b')\n").unwrap();
+
+        let registry = stella_store::SessionRegistry::open(&registry_dir);
+        for id in ["ses-a", "ses-b"] {
+            registry
+                .upsert(&stella_store::SessionRecord {
+                    id: id.into(),
+                    pid: std::process::id(),
+                    workspace: ws.to_string_lossy().into_owned(),
+                    title: String::new(),
+                    summary: String::new(),
+                    description: None,
+                    status: stella_store::SessionStatus::InProgress,
+                    started_at_ms: 0,
+                    updated_at_ms: 0,
+                    supervisor: None,
+                })
+                .expect("register");
+        }
+        let sharers = attribution::sharers_of(&registry.list(), &ws, "ses-a");
+        assert_eq!(
+            sharers,
+            vec!["ses-b".to_string()],
+            "A must see B as sharing its tree"
+        );
+
+        let measured = session_a.snapshot_worktree().expect("A measures the tree");
+        let rows: Vec<FileTouchRow> = measured
+            .iter()
+            .map(|change| {
+                file_touch_row(change, attribution::provenance(&change.path, &[], &sharers))
+            })
+            .collect();
+        let row = rows
+            .iter()
+            .find(|row| row.path == "prose_score.py")
+            .expect("the shared tree puts B's file in A's reading — that is the defect's premise");
+        let events: serde_json::Value = serde_json::from_str(&row.events_json).expect("json");
+        assert_eq!(
+            events[0]["attributed"], false,
+            "a change measured while another session shared the tree must not be \
+             recorded as this turn's: {}",
+            row.events_json
+        );
+        assert!(
+            row.events_json.contains("another session"),
+            "the reason string is what `stella export` renders: {}",
+            row.events_json
+        );
+    }
+
+    /// The other side: the same reading, with nobody else in the tree, is still
+    /// this session's work and still says so.
+    #[test]
+    fn a_lone_session_still_claims_what_it_measured() {
+        let row = file_touch_row(
+            &measured(JournalChangeKind::Created),
+            attribution::provenance("src/lib.rs", &[], &[]),
+        );
+        let events: serde_json::Value = serde_json::from_str(&row.events_json).expect("json");
+        assert_eq!(events[0]["attributed"], true);
+        assert_eq!(events[0]["reason"], "turn-boundary work-tree measurement");
     }
 
     #[test]

--- a/crates/stella-cli/src/turn_files/attribution.rs
+++ b/crates/stella-cli/src/turn_files/attribution.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Who a measured tree change may be claimed for (#4386).
+//!
+//! # The defect
+//!
+//! [`super`]'s module doc already stated the hazard: a tree measurement
+//! answers *what changed during this turn*, not *what the agent changed*. What
+//! it treated as an edge case is the maintainer's normal way of working —
+//! several `stella` sessions in one checkout — and there the two are routinely
+//! different. `WorkJournal` gives each session its own snapshot ref and its own
+//! git index, but `git add -A` sweeps the one **shared** work tree, so every
+//! byte another session wrote since this session's last snapshot lands in this
+//! session's diff. In the reported export a read-only research turn is recorded
+//! as creating `scripts/prose_score.py`; that file is another session's work,
+//! and the agent later mined a repository "convention" out of the contamination.
+//!
+//! # Why the answer is a label rather than a filter
+//!
+//! Both sessions snapshot the same bytes, so no content the tree carries can
+//! tell their writes apart — the trees converge, and only the snapshot *times*
+//! differ. Two signals do survive:
+//!
+//! - the paths a mutating call read for itself before and after it wrote
+//!   ([`stella_tools::own_change`]), which is evidence about this session
+//!   whatever else is in the tree, and
+//! - whether any other session was live in this work tree at all, which the
+//!   session registry knows.
+//!
+//! Neither can be turned into "B wrote this". Together they are enough to stop
+//! the stream *claiming* what it cannot know, which is what [`Provenance`]
+//! records. Dropping the unattributable changes instead would be worse: `bash`,
+//! MCP servers and script tools mutate the tree without naming a path, and the
+//! reading is the only trace those leave. So every measured change is still
+//! reported; a change the reading cannot attribute now says so.
+
+use std::path::Path;
+
+use stella_store::SessionRecord;
+use stella_tools::own_change::OwnChange;
+
+/// What one measured tree change may be claimed as.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Provenance {
+    /// The mutating call that took this reading also read the bytes itself, so
+    /// this path is this session's work however many sessions share the tree.
+    OwnReading,
+    /// The tree changed and nothing else live was writing to it, so this
+    /// session is the only thing that can have changed it.
+    SoleWriter,
+    /// The tree changed while at least one other live session shared it. The
+    /// change is measured; its author is not knowable from the measurement.
+    Unattributed,
+}
+
+impl Provenance {
+    /// The sentence that rides into `files_touched.events_json`, which is what
+    /// `stella export` and the dashboard read.
+    pub(crate) fn reason(self) -> &'static str {
+        match self {
+            Self::OwnReading => "the call's own before/after reading",
+            Self::SoleWriter => "turn-boundary work-tree measurement",
+            Self::Unattributed => {
+                "measured, not attributed — another session shared this work tree"
+            }
+        }
+    }
+
+    /// Whether this session may be named as the author.
+    pub(crate) fn attributed(self) -> bool {
+        !matches!(self, Self::Unattributed)
+    }
+}
+
+/// Classify one measured path.
+///
+/// `own` is what the call that triggered this reading reported about its own
+/// writes, empty at the turn boundary where no single call owns the sweep.
+/// `sharers` is [`live_sharers`]'s answer.
+pub(crate) fn provenance(path: &str, own: &[OwnChange], sharers: &[String]) -> Provenance {
+    if own.iter().any(|change| change.path == path) {
+        return Provenance::OwnReading;
+    }
+    if sharers.is_empty() {
+        return Provenance::SoleWriter;
+    }
+    Provenance::Unattributed
+}
+
+/// The other live sessions bound to `workspace`, from a registry listing.
+///
+/// Split from the read so the rule is testable without a registry directory:
+/// `SessionRegistry::list` already drops a record whose process is gone, so
+/// liveness here is `SessionStatus::is_live` over what it returned and nothing
+/// more.
+///
+/// Paths are compared after [`std::fs::canonicalize`] where it succeeds,
+/// because a registry record holds whatever absolute path that session was
+/// launched with — `/tmp/x` and `/private/tmp/x` are the same tree on macOS,
+/// and treating them as different would silently restore the defect on the
+/// platform it was reported from. A path that cannot be canonicalized at all —
+/// the session's workspace has since been deleted — falls back to a literal
+/// comparison, which is the only answer left when the tree it named is gone.
+pub(crate) fn sharers_of(
+    records: &[SessionRecord],
+    workspace: &Path,
+    own_session: &str,
+) -> Vec<String> {
+    let ours = real_path(workspace);
+    let mut sharers: Vec<String> = records
+        .iter()
+        .filter(|record| record.id != own_session)
+        .filter(|record| record.status.is_live())
+        .filter(|record| real_path(Path::new(&record.workspace)) == ours)
+        .map(|record| record.id.clone())
+        .collect();
+    sharers.sort();
+    sharers.dedup();
+    sharers
+}
+
+/// `canonicalize`, or the path as given when it no longer resolves.
+fn real_path(path: &Path) -> std::path::PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// [`sharers_of`] over the default session registry.
+///
+/// The one impure half, and the reason this is a function rather than a method
+/// on the durability handle: reading the registry is a directory walk, so it is
+/// taken at a turn's bookends and cached, never per tool call.
+///
+/// **The residual.** `SessionRegistry::list` answers an unreadable registry
+/// directory and an empty one identically, so a workspace whose `~/.stella`
+/// is broken reports no sharers and its rows claim authorship as they did
+/// before this existed. That is the status quo on a path where the home
+/// itself is unusable, rather than a new way to be wrong — and a session
+/// bound to a journal key that is not a registry id (a fleet attempt, whose
+/// key is `{run}/{task}`) is likewise reported as alone, correctly: those run
+/// in their own worktrees, so no other session shares the tree they measure.
+pub(crate) fn live_sharers(workspace: &Path, own_session: &str) -> Vec<String> {
+    sharers_of(
+        &stella_store::SessionRegistry::open_default().list(),
+        workspace,
+        own_session,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_store::SessionStatus;
+    use stella_tools::own_change::OwnChangeKind;
+
+    fn record(id: &str, workspace: &str, status: SessionStatus) -> SessionRecord {
+        SessionRecord {
+            id: id.into(),
+            pid: std::process::id(),
+            workspace: workspace.into(),
+            title: String::new(),
+            summary: String::new(),
+            description: None,
+            status,
+            started_at_ms: 0,
+            updated_at_ms: 0,
+            supervisor: None,
+        }
+    }
+
+    fn own(path: &str) -> OwnChange {
+        OwnChange {
+            path: path.into(),
+            kind: OwnChangeKind::Modified,
+            added: 1,
+            removed: 0,
+            diff: String::new(),
+            minimal: true,
+        }
+    }
+
+    #[test]
+    fn a_live_session_in_the_same_tree_is_a_sharer() {
+        let guard = tempfile::tempdir().unwrap();
+        let ws = guard.path().join("ws");
+        std::fs::create_dir_all(&ws).unwrap();
+        let ws_str = ws.to_string_lossy().to_string();
+        let records = vec![
+            record("ses-a", &ws_str, SessionStatus::InProgress),
+            record("ses-b", &ws_str, SessionStatus::InProgress),
+        ];
+        assert_eq!(
+            sharers_of(&records, &ws, "ses-a"),
+            vec!["ses-b".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_finished_session_and_another_workspace_are_not_sharers() {
+        let guard = tempfile::tempdir().unwrap();
+        let ws = guard.path().join("ws");
+        let other = guard.path().join("other");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+        let records = vec![
+            record("ses-done", &ws.to_string_lossy(), SessionStatus::Complete),
+            record(
+                "ses-else",
+                &other.to_string_lossy(),
+                SessionStatus::InProgress,
+            ),
+        ];
+        assert!(sharers_of(&records, &ws, "ses-a").is_empty());
+    }
+
+    /// The macOS shape: `/tmp` is a symlink to `/private/tmp`, so a registry
+    /// record written by a session launched through one spelling must still
+    /// match a workspace named by the other. Without this the guard would be
+    /// inert on the platform #4386 was reported from.
+    #[test]
+    fn two_spellings_of_one_tree_are_the_same_tree() {
+        let guard = tempfile::tempdir().unwrap();
+        let ws = guard.path().join("ws");
+        std::fs::create_dir_all(&ws).unwrap();
+        let link = guard.path().join("link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&ws, &link).unwrap();
+        #[cfg(not(unix))]
+        let link = ws.clone();
+        let records = vec![record(
+            "ses-b",
+            &link.to_string_lossy(),
+            SessionStatus::InProgress,
+        )];
+        assert_eq!(
+            sharers_of(&records, &ws, "ses-a"),
+            vec!["ses-b".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_lone_session_owns_every_change_it_measures() {
+        assert_eq!(
+            provenance("src/lib.rs", &[], &[]),
+            Provenance::SoleWriter,
+            "with nobody else in the tree the measurement is this session's"
+        );
+    }
+
+    #[test]
+    fn a_shared_tree_makes_a_measured_change_unattributable() {
+        let sharers = vec!["ses-b".to_string()];
+        assert_eq!(
+            provenance("scripts/prose_score.py", &[], &sharers),
+            Provenance::Unattributed
+        );
+    }
+
+    /// The precision half: a path the call read for itself is this session's
+    /// work whoever else is in the tree, because that reading came from the
+    /// call and not from the shared snapshot.
+    #[test]
+    fn a_path_the_call_read_itself_survives_a_shared_tree() {
+        let sharers = vec!["ses-b".to_string()];
+        assert_eq!(
+            provenance("src/lib.rs", &[own("src/lib.rs")], &sharers),
+            Provenance::OwnReading
+        );
+        assert_eq!(
+            provenance("other.rs", &[own("src/lib.rs")], &sharers),
+            Provenance::Unattributed,
+            "one call's own reading must not vouch for a path it never named"
+        );
+    }
+
+    #[test]
+    fn only_the_unattributed_reason_disclaims_authorship() {
+        assert!(Provenance::OwnReading.attributed());
+        assert!(Provenance::SoleWriter.attributed());
+        assert!(!Provenance::Unattributed.attributed());
+        assert!(
+            Provenance::Unattributed
+                .reason()
+                .contains("another session"),
+            "the reason string is what the export renders, so it has to say why"
+        );
+    }
+}

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -275,6 +275,24 @@ impl WorkJournal {
         run(&mut cmd)
     }
 
+    /// The session id this handle records under — the same string the session
+    /// registry keys its record on.
+    ///
+    /// Public because attribution needs it (#4386): a snapshot measures the
+    /// *shared* work tree, so a caller asking who else is writing to that tree
+    /// has to be able to leave itself out of the answer.
+    pub fn session(&self) -> &str {
+        &self.session
+    }
+
+    /// The work tree this handle measures.
+    ///
+    /// Public for the same reason as [`Self::session`]: it is the key another
+    /// session's registry record is matched against.
+    pub fn work_tree(&self) -> &Path {
+        &self.work_tree
+    }
+
     /// The commit this session last recorded, if any.
     ///
     /// Public because marking a turn needs it: a caller that records several


### PR DESCRIPTION
Closes #4386

## The mechanism, confirmed

`crates/stella-store/src/work_journal.rs` gives each session a private
snapshot ref (`refs/stella/<session>/tree`) and a private git index
(`{workspace_id}.{session}.snapshot.index`), but one **shared** git dir over
one **shared** work tree. `WorkJournal::snapshot_worktree` then stages that
whole shared tree against its own index and diffs against its *own* previous
snapshot. So session A's boundary sweep absorbs every byte session B wrote
since A last snapshotted, and `turn_files::file_touch_row` recorded it as
`"reason": "turn-boundary work-tree measurement"` — this turn's work.

The module doc already stated the hazard ("a user editing a file in another
window mid-turn appears in this stream indistinguishable from the agent's own
writes") and treated it as an edge case. With several sessions in one checkout
it is the normal case.

## Why a label and not a filter

Both sessions snapshot the same bytes, so the trees converge and no content
they carry can tell the writers apart — only the snapshot *times* differ, and
those windows overlap. Two signals do survive:

- the paths a mutating call read for itself before and after it wrote
  (`stella_tools::own_change`), which is evidence about this session whatever
  else is in the tree;
- whether any other session was live in this work tree at all, which
  `SessionRegistry` knows (`workspace` plus `SessionStatus::is_live`, with the
  pid downgrade `list()` already applies).

Neither yields "B wrote this". Together they are enough to stop the record
*claiming* what it cannot know.

**Filtering would be worse than the defect.** `bash`, MCP servers and script
tools mutate the tree without naming a path in any schema the engine reads —
the module doc's own reason for measuring rather than hooking — so a filter
scoped to named paths would drop real changes while looking exhaustive. Every
measured change is still reported; a change the reading cannot attribute now
says so.

## What changed

New `crates/stella-cli/src/turn_files/attribution.rs` (a sibling submodule —
`turn_files.rs` is over 1300 lines and AGENTS.md's god-file rule says new
logic lands beside, not inside):

- `Provenance::{OwnReading, SoleWriter, Unattributed}` with `reason()` and
  `attributed()`.
- `provenance(path, own, sharers)` — the pure classification.
- `sharers_of(records, workspace, own_session)` — pure over a registry
  listing, so the rule is testable without a registry directory. Paths are
  compared canonicalized, because `/tmp` is a symlink to `/private/tmp` on
  macOS and #4386 was reported from macOS; a literal comparison would have
  shipped an inert guard.
- `live_sharers` — the one impure half.

`SessionDurability` caches the sharer set and refreshes it at a turn's two
bookends (`open_turn_streams`, `emit_shared_tree_changes`). Per turn, not per
reading: a reading is taken after every solo mutating call, and the answer is
a directory walk. `WorkJournal` gained `session()` and `work_tree()`
accessors so the handle can ask the question about itself.

Both row builders now go through one `touch_events(provenance, added,
removed)`, so `attributed` is present on a tree reading *and* on a call's own
reading — an export that rendered it for one and omitted it for the other
would make its absence mean two things.

## Witness

`a_file_another_live_session_wrote_is_not_claimed_by_this_turn` is the issue's
"Done when" literally: two `WorkJournal`s on one temp work tree, a live
registry record for each, session B writes a file, session A (which did
nothing at all) snapshots.

Ablation — `provenance` returns `SoleWriter` unconditionally, which is the
pre-#4386 behaviour:

```
test turn_files::attribution::tests::a_shared_tree_makes_a_measured_change_unattributable ... FAILED
test turn_files::attribution::tests::a_path_the_call_read_itself_survives_a_shared_tree ... FAILED
test turn_files::tests::a_file_another_live_session_wrote_is_not_claimed_by_this_turn ... FAILED

panicked at crates/stella-cli/src/turn_files.rs:1382:9:
assertion `left == right` failed: a change measured while another session
shared the tree must not be recorded as this turn's:
[{"attributed":true,"event":"measured","lines_added":1,"lines_removed":0,
  "reason":"turn-boundary work-tree measurement"}]

test result: FAILED. 20 passed; 3 failed
```

That JSON is the defect in one line: session B's file, in session A's ledger,
attributed to A.

With the fix:

```
$ cargo test -p stella-cli --bin stella turn_files
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 2317 filtered out
```

Seven new tests: the three above, plus
`a_live_session_in_the_same_tree_is_a_sharer`,
`a_finished_session_and_another_workspace_are_not_sharers`,
`two_spellings_of_one_tree_are_the_same_tree` (the macOS symlink shape),
`a_lone_session_owns_every_change_it_measures`,
`only_the_unattributed_reason_disclaims_authorship`, and
`a_lone_session_still_claims_what_it_measured`.

**No test was renamed or removed** (`check-deleted-tests`).

## The export

`export.rs` dumps `files_touched` wholesale as JSON, so `reason` and
`attributed` reach the archive with no further work — the issue's "at minimum"
bar. The Files *panel* does not yet render the distinction; filed as a
follow-up rather than smuggled in here.

## Residuals, stated

- **An unreadable registry reads as an empty one.** `SessionRegistry::list`
  answers both identically, so a broken `~/.stella` reports no sharers and
  rows claim authorship as they did before. That is the status quo on a path
  where the home is already unusable, not a new way to be wrong. Named in the
  module doc.
- **A session bound to a journal key that is not a registry id** (a fleet
  attempt, keyed by run and task) reports as alone. Correct here: those run in
  their own worktrees, so nothing else shares the tree they measure.
- **Two sessions genuinely editing one path** are both unattributed, which is
  the honest answer.
- Nothing is dropped and no wire event changed, so no consumer of
  `AgentEvent::FileChange` moves.

## Guards run locally

`make guards-fast`, `cargo fmt --all`,
`cargo clippy -p stella-cli -p stella-store --all-targets -- -D warnings`,
`cargo check -p stella-cli --all-targets` — all green. The workspace build and
suite are CI's, per CLAUDE.md.

## Summary by Sourcery

Prevent shared work-tree measurements from claiming another live session’s changes as the current turn’s work.

New Features:
- Add provenance metadata to file-touch records so measured changes identify whether they can be attributed to the current session.

Bug Fixes:
- Stop turns from claiming work-tree changes made by another live session sharing the same workspace.
- Preserve attribution for paths confirmed by the current call's own before-and-after reading while marking other shared-tree changes as unattributed.

Enhancements:
- Cache live workspace sharers per turn and refresh the cache at turn boundaries.
- Compare workspace paths canonically when identifying sessions sharing a work tree.
- Expose work-journal session and workspace information for attribution decisions.

Documentation:
- Document the attribution limitations and why shared-tree changes are labelled rather than filtered.

Tests:
- Add coverage for live-session detection, canonicalized workspace paths, sole-session attribution, own-path attribution, and the cross-session contamination scenario.