### PR TITLE
feat(stella-tui): live tool heads carry their wall time, and reads fold by default

### DIFF
--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -216,15 +216,17 @@ fn projected_rows(
             path,
             sub_agent_id,
         } => {
-            let scope = source::measured_scope(call_id, view.following, view.files);
-            let read = source::read_size(call_id, view.following);
             out.extend(source::head_rows(
                 name,
                 path.as_deref(),
                 input,
-                scope,
-                read,
-                sub_agent_id.as_deref(),
+                source::CallFacts {
+                    scope: source::measured_scope(call_id, view.following, view.files),
+                    read: source::read_size(call_id, view.following),
+                    duration_ms: source::call_duration(call_id, view.following),
+                    sub_agent_id: sub_agent_id.clone(),
+                    expanded,
+                },
                 width,
             ));
             if expanded {

--- a/crates/stella-tui/src/views/transcript_source.rs
+++ b/crates/stella-tui/src/views/transcript_source.rs
@@ -34,38 +34,60 @@ use super::transcript::{
 };
 use crate::model::{FileState, ReadSize, TranscriptEntry};
 
-/// The metal-bearing head of a dispatched call (SPEC 6.2).
+/// What is known about one call at the moment its head renders — each field
+/// filled by its own resolver, or its `None`/default while nothing has
+/// answered.
 ///
-/// `scope` is what the emitter measured for this call — the paths it claimed
-/// and the delta summed across them — or `None` while it is still in flight.
-/// [`measured_scope`] is what resolves it, and a head row is never asked to
-/// guess. `read` is the line coverage the tool reported for itself, resolved by
-/// [`read_size`] — a separate channel, because a read's number is a coverage
-/// the producer states, never a delta a mutation stamps.
+/// Bundled the way [`crate::render::EntryView`] bundles the draw-side pair:
+/// the facts travel together into every head, and a positional list this long
+/// is a call site that can pair one call's scope with another call's timing
+/// by ordering its arguments wrongly.
+#[derive(Default)]
+pub struct CallFacts {
+    /// What the emitter measured for this call — the paths it claimed and the
+    /// delta summed across them ([`measured_scope`]).
+    pub scope: Option<Touched>,
+    /// The line coverage a read reported for itself ([`read_size`]) — a
+    /// separate channel, because a read's number is a coverage the producer
+    /// states, never a delta a mutation stamps.
+    pub read: Option<ReadSize>,
+    /// Wall time from the call's paired result ([`call_duration`]), rendered
+    /// `⚡3ms`. `None` — still in flight, failed, or never answered — renders
+    /// no metric at all.
+    pub duration_ms: Option<u64>,
+    /// The delegate that made the call, `None` for the lead's own — carried
+    /// straight from `TranscriptEntry::ToolStart` so a fan-out call renders
+    /// visibly apart from the lead's (#4699).
+    pub sub_agent_id: Option<String>,
+    /// Whether the reader has expanded this entry (`ctrl+o`). A read head is
+    /// folded until they do; every other kind ignores it here (its reveal is
+    /// the argument body the caller hangs beneath).
+    pub expanded: bool,
+}
+
+/// The metal-bearing head of a dispatched call (SPEC 6.2).
 ///
 /// Always at least one row: a tool with no recognised verb still names itself,
 /// because a call that rendered nothing would be a call the reader cannot see
 /// happened.
-///
-/// `sub_agent_id` is the delegate that made the call, `None` for the lead's
-/// own — carried straight from `TranscriptEntry::ToolStart` so a fan-out call
-/// renders visibly apart from the lead's (#4699).
 #[must_use]
 pub fn head_rows(
     name: &str,
     path: Option<&str>,
     input: &str,
-    scope: Option<Touched>,
-    read: Option<ReadSize>,
-    sub_agent_id: Option<&str>,
+    facts: CallFacts,
     width: usize,
 ) -> Vec<Line<'static>> {
-    let kind = kind_for(name, scope, read);
+    let kind = kind_for(name, facts.scope, facts.read);
     let mut event = Event::new(kind, subject_for(name, path, input));
-    // The head is drawn the moment the call dispatches, so it is never
-    // "collapsed" in the fold sense — there is no body under it yet.
-    event.collapsed = Some(false);
-    event.sub_agent_id = sub_agent_id.map(str::to_string);
+    // A read folds by default (SPEC 6.3): `▸ read … · ↵ open` until the
+    // reader opens it. Every other head draws its kind glyph — its body is
+    // the result row beneath, so the head itself has no fold state. This
+    // used to be `Some(false)` across the board, which made the live path
+    // the one place a read never folded (#5030).
+    event.collapsed = Some(matches!(event.kind, EventKind::Read { .. }) && !facts.expanded);
+    event.duration_ms = facts.duration_ms.unwrap_or(0);
+    event.sub_agent_id = facts.sub_agent_id;
     event_rows(&event, width)
 }
 
@@ -170,6 +192,30 @@ pub fn read_size(call_id: &str, following: &[TranscriptEntry]) -> Option<ReadSiz
             _ => None,
         })
         .flatten()
+}
+
+/// Wall time of the call `call_id`, from its paired result — or `None` while
+/// nothing has answered it.
+///
+/// The same bounded scan as [`measured_scope`] and [`read_size`], read off the
+/// result entry's own `duration_ms`. A zero reading maps to `None` rather than
+/// to a `⚡0ms` metric: the emitters stamp zero for a synthetic echo (a gate
+/// answer, a demo reply), and "answered instantly" and "not a timed call" are
+/// not worth a column that cannot tell them apart.
+#[must_use]
+pub fn call_duration(call_id: &str, following: &[TranscriptEntry]) -> Option<u64> {
+    following
+        .iter()
+        .take_while(|e| !matches!(e, TranscriptEntry::Complete { .. }))
+        .find_map(|e| match e {
+            TranscriptEntry::ToolResult {
+                call_id: cid,
+                duration_ms,
+                ..
+            } if cid == call_id => Some(*duration_ms),
+            _ => None,
+        })
+        .filter(|ms| *ms > 0)
 }
 
 /// One dim line, no rail (SPEC 6.3).
@@ -405,6 +451,90 @@ mod tests {
         }
     }
 
+    /// The witness for #5030's fold half: a read head folds by default
+    /// (SPEC 6.3) — `▸` with `↵ open` — and the reader's expand opens it.
+    /// The live path used to force `collapsed = Some(false)` on every head,
+    /// so no live read ever folded and `↵ open` was reachable only from
+    /// fixtures.
+    #[test]
+    fn a_read_head_folds_by_default_and_opens_on_expand() {
+        let folded = text_of_rows(&head_rows(
+            "read_file",
+            Some("src/lib.rs"),
+            "{}",
+            CallFacts::default(),
+            120,
+        ));
+        assert!(folded.contains('▸'), "{folded}");
+        assert!(folded.contains("↵ open"), "{folded}");
+        let opened = text_of_rows(&head_rows(
+            "read_file",
+            Some("src/lib.rs"),
+            "{}",
+            CallFacts {
+                expanded: true,
+                ..Default::default()
+            },
+            120,
+        ));
+        assert!(!opened.contains('▸'), "{opened}");
+        assert!(!opened.contains("↵ open"), "{opened}");
+        // Every other kind keeps its own glyph either way — an edit head does
+        // not fold, because its body is the result row beneath it.
+        let edit = text_of_rows(&head_rows(
+            "edit_file",
+            Some("src/lib.rs"),
+            "{}",
+            CallFacts::default(),
+            120,
+        ));
+        assert!(!edit.contains('▸'), "{edit}");
+    }
+
+    /// The witness for #5030's timing half: a settled call's head states the
+    /// wall time its paired result measured, `⚡7ms`; an unanswered call and a
+    /// zero-stamped synthetic echo render no metric at all.
+    #[test]
+    fn a_settled_call_head_carries_its_wall_time() {
+        let timed = text_of_rows(&head_rows(
+            "edit_file",
+            Some("src/lib.rs"),
+            "{}",
+            CallFacts {
+                duration_ms: Some(7),
+                ..Default::default()
+            },
+            120,
+        ));
+        assert!(timed.contains("⚡7ms"), "{timed}");
+        let unanswered = text_of_rows(&head_rows(
+            "edit_file",
+            Some("src/lib.rs"),
+            "{}",
+            CallFacts::default(),
+            120,
+        ));
+        assert!(!unanswered.contains('⚡'), "{unanswered}");
+        // And the resolver itself: the paired result's stamp, zero mapped to
+        // `None`, the scan bounded at the turn's close.
+        let result = |id: &str, ms: u64| TranscriptEntry::ToolResult {
+            call_id: id.into(),
+            name: "edit_file".into(),
+            path: None,
+            ok: true,
+            summary: String::new(),
+            full: String::new(),
+            duration_ms: ms,
+            speculated: false,
+            diff: Vec::new(),
+            read_size: None,
+            sub_agent_id: None,
+        };
+        assert_eq!(call_duration("c1", &[result("c1", 7)]), Some(7));
+        assert_eq!(call_duration("c1", &[result("c1", 0)]), None);
+        assert_eq!(call_duration("c1", &[result("c2", 7)]), None);
+    }
+
     /// An unknown tool still renders — the vocabulary is open (MCP, custom
     /// tools), and a missing row is the failure this guards against.
     #[test]
@@ -413,9 +543,7 @@ mod tests {
             "mcp__fs__read_file",
             None,
             "apps/page.tsx",
-            None,
-            None,
-            None,
+            CallFacts::default(),
             80,
         );
         assert_eq!(rows.len(), 1);
@@ -435,12 +563,21 @@ mod tests {
     /// the lead's, and the lead's own renders no tag at all.
     #[test]
     fn a_delegates_head_names_the_delegate() {
-        let delegated = text_of_rows(&head_rows("bash", None, "ls", None, None, Some("d:1"), 80));
+        let delegated = text_of_rows(&head_rows(
+            "bash",
+            None,
+            "ls",
+            CallFacts {
+                sub_agent_id: Some("d:1".into()),
+                ..Default::default()
+            },
+            80,
+        ));
         assert!(
             delegated.contains("d:1"),
             "the delegate's own call did not name it: {delegated}"
         );
-        let lead = text_of_rows(&head_rows("bash", None, "ls", None, None, None, 80));
+        let lead = text_of_rows(&head_rows("bash", None, "ls", CallFacts::default(), 80));
         assert!(
             !lead.contains("d:1"),
             "the lead's own call must carry no delegate tag: {lead}"
@@ -454,9 +591,7 @@ mod tests {
             "read_file",
             Some("src/main.rs"),
             "{\"path\":\"…\"}",
-            None,
-            None,
-            None,
+            CallFacts::default(),
             80,
         );
         let text = text_of(&rows[0]);
@@ -484,7 +619,13 @@ mod tests {
             ("write_file", "src/new.rs"),
             ("delete_file", "src/old.rs"),
         ] {
-            let text = text_of_rows(&head_rows(tool, Some(path), "{}", None, None, None, 120));
+            let text = text_of_rows(&head_rows(
+                tool,
+                Some(path),
+                "{}",
+                CallFacts::default(),
+                120,
+            ));
             for zero in ["+0", "-0", "0 lines"] {
                 assert!(
                     !text.contains(zero),
@@ -504,9 +645,11 @@ mod tests {
             "write_file",
             Some("src/new.rs"),
             "{}",
-            Some(one_file(42, 0)),
-            None,
-            None,
+            CallFacts {
+                scope: Some(one_file(42, 0)),
+
+                ..Default::default()
+            },
             120,
         ));
         assert!(write.contains("new file"), "{write}");
@@ -515,9 +658,11 @@ mod tests {
             "delete_file",
             Some("src/old.rs"),
             "{}",
-            Some(one_file(0, 17)),
-            None,
-            None,
+            CallFacts {
+                scope: Some(one_file(0, 17)),
+
+                ..Default::default()
+            },
             120,
         ));
         assert!(delete.contains("-17 lines"), "{delete}");
@@ -533,9 +678,7 @@ mod tests {
             "write_file",
             Some("src/new.rs"),
             "{}",
-            None,
-            None,
-            None,
+            CallFacts::default(),
             120,
         ));
         assert!(write.contains("new file"), "{write}");
@@ -543,9 +686,7 @@ mod tests {
             "delete_file",
             Some("src/old.rs"),
             "{}",
-            None,
-            None,
-            None,
+            CallFacts::default(),
             120,
         ));
         assert!(delete.contains("git-backed"), "{delete}");
@@ -617,9 +758,11 @@ mod tests {
             name,
             path.as_deref(),
             input,
-            scope,
-            read,
-            None,
+            CallFacts {
+                scope,
+                read,
+                ..Default::default()
+            },
             120,
         ))
     }
@@ -774,9 +917,7 @@ mod tests {
             "read_file",
             Some("a/b/c.rs"),
             "{}",
-            None,
-            None,
-            None,
+            CallFacts::default(),
             120,
         ));
         let cut = spans
@@ -805,9 +946,7 @@ mod tests {
             "bash",
             None,
             "grep -r foo/ .",
-            None,
-            None,
-            None,
+            CallFacts::default(),
             120,
         ));
         let subject: Vec<_> = spans
@@ -869,15 +1008,22 @@ mod tests {
             ("delete_file", "src/old.rs"),
         ] {
             let declares_a_size = format!("{:?}", kind_for(tool, None, None)).contains("Extent");
-            let unmeasured =
-                text_of_rows(&head_rows(tool, Some(path), "{}", None, None, None, 120));
+            let unmeasured = text_of_rows(&head_rows(
+                tool,
+                Some(path),
+                "{}",
+                CallFacts::default(),
+                120,
+            ));
             let measured = text_of_rows(&head_rows(
                 tool,
                 Some(path),
                 "{}",
-                Some(one_file(7, 3)),
-                None,
-                None,
+                CallFacts {
+                    scope: Some(one_file(7, 3)),
+
+                    ..Default::default()
+                },
                 120,
             ));
             assert_eq!(
@@ -909,7 +1055,7 @@ mod tests {
     /// The glyph cell of a head row: the rail is span 0, the glyph span 1
     /// (`" x "`), which `head_row` composes in that order.
     fn head_glyph_of(name: &str) -> char {
-        let rows = head_rows(name, None, "{}", None, None, None, 120);
+        let rows = head_rows(name, None, "{}", CallFacts::default(), 120);
         let row = rows
             .first()
             .expect("a head always renders at least one row");
@@ -968,7 +1114,7 @@ mod tests {
             ("orchid", crate::theme::ORCHID),
         ];
         for (name, _) in CLASS_CASES {
-            let rows = head_rows(name, None, "{}", None, None, None, 120);
+            let rows = head_rows(name, None, "{}", CallFacts::default(), 120);
             let row = rows
                 .first()
                 .expect("a head always renders at least one row");

--- a/crates/stella-tui/src/views/transcript_source.rs
+++ b/crates/stella-tui/src/views/transcript_source.rs
@@ -38,7 +38,8 @@ use crate::model::{FileState, ReadSize, TranscriptEntry};
 /// filled by its own resolver, or its `None`/default while nothing has
 /// answered.
 ///
-/// Bundled the way [`crate::render::EntryView`] bundles the draw-side pair:
+/// Bundled the way `render::EntryView` bundles the draw-side pair (named
+/// rather than linked: that type is crate-private, and this item is public):
 /// the facts travel together into every head, and a positional list this long
 /// is a call site that can pair one call's scope with another call's timing
 /// by ordering its arguments wrongly.

--- a/crates/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx          ╭ models  resolved routing ────────────────────────────────────────────╮
+ │ ⊙ apps/app/automations/page.tsx          ╭ models  resolved routing ────────────────────────────────────────────╮                                      ⚡ 42ms
  │ ⎿ 312 lines                              │session   glm-5.2                                                     │                         42ms
                                             │auto      model off · effort on · thinking off                        │
- │ ● edit apps/app/automations/page.tsx +4 -│                                                                      │
+ │ ● edit apps/app/automations/page.tsx +4 -│                                                                      │                                      ⚡ 18ms
  │ ⎿                                        │lead      zai/glm-5.2-air                                             │                 +4 −1 · 18ms
  │     10 -  const items = []               │          medium · thinking on · from default_model                   │
  │     10 +  const items = useAutomations() │think     z-ai/glm-5.2                                    unassigned  │

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                ╭ plan  pending approval · 3 steps ────────────────────╮                         +4 −1 · 18ms
  │     10 -  const items = []                       │Refactor the automations store into a shared worksp…  │
  │     10 +  const items = useAutomations()         │                                                      │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ───────────────────────────────╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮──────────────────────────────────────────
                                           │ bash  mutating                                                           │
- │ ⊙ apps/app/automations/page.tsx        │   rm -rf build/                                                          │
+ │ ⊙ apps/app/automations/page.tsx        │   rm -rf build/                                                          │                                    ⚡ 42ms
  │ ⎿ 312 lines                            │                                                                          │                       42ms
                                           │ gate command.started                                                     │
- │ ● edit apps/app/automations/page.tsx +4│ reason matched rule no-destructive-shell                                 │
+ │ ● edit apps/app/automations/page.tsx +4│ reason matched rule no-destructive-shell                                 │                                    ⚡ 18ms
  │ ⎿                                      │                                                                          │               +4 −1 · 18ms
  │     10 -  const items = []             │   Allow this call, once                                                  │
  │     10 +  const items = useAutomations(│ ▸ Deny                                                                   │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ───────────────────────────────╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮──────────────────────────────────────────
                                           │ read_file  read-only                                                     │
- │ ⊙ apps/app/automations/page.tsx        │   .stella/private/credentials.toml                                       │
+ │ ⊙ apps/app/automations/page.tsx        │   .stella/private/credentials.toml                                       │                                    ⚡ 42ms
  │ ⎿ 312 lines                            │                                                                          │                       42ms
                                           │ gate tool.call.requested                                                 │
- │ ● edit apps/app/automations/page.tsx +4│ reason matched rule secrets-are-off-limits                               │
+ │ ● edit apps/app/automations/page.tsx +4│ reason matched rule secrets-are-off-limits                               │                                    ⚡ 18ms
  │ ⎿                                      │                                                                          │               +4 −1 · 18ms
  │     10 -  const items = []             │   Allow this call, once                                                  │
  │     10 +  const items = useAutomations(│ ▸ Deny                                                                   │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                           ╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮
- │ ⊙ apps/app/automations/page.tsx        │ bash  mutating                                                           │
+ │ ⊙ apps/app/automations/page.tsx        │ bash  mutating                                                           │                                    ⚡ 42ms
  │ ⎿ 312 lines                            │   rm -rf build/                                                          │                       42ms
                                           │                                                                          │
- │ ● edit apps/app/automations/page.tsx +4│ gate command.started                                                     │
+ │ ● edit apps/app/automations/page.tsx +4│ gate command.started                                                     │                                    ⚡ 18ms
  │ ⎿                                      │ reason matched rule no-destructive-shell                                 │               +4 −1 · 18ms
  │     10 -  const items = []             │                                                                          │
  │     10 +  const items = useAutomations(│ denying — say why (the model is told, verbatim):                         │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
                                           ╭ question ────────────────────────────────────────────────────────────────╮
- │ ● edit apps/app/automations/page.tsx +4│from the `research-child` sub-agent                                       │
+ │ ● edit apps/app/automations/page.tsx +4│from the `research-child` sub-agent                                       │                                    ⚡ 18ms
  │ ⎿                                      │                                                                          │               +4 −1 · 18ms
  │     10 -  const items = []             │Review your answers                                                       │
  │     10 +  const items = useAutomations(│                                                                          │

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations(╭ question ────────────────────────────────────────────────────────────────╮

--- a/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
@@ -19,10 +19,10 @@
                          │                                                                                                            │
 ── EXECUTE ──────────────│                                                                                                            │─────────────────────────
                          │                                                                                                            │
- │ ⊙ apps/app/automations│                                                                                                            │
+ │ ⊙ apps/app/automations│                                                                                                            │                   ⚡ 42ms
  │ ⎿ 312 lines           │                                                                                                            │      42ms
                          │                                                                                                            │
- │ ● edit apps/app/automa│                                                                                                            │
+ │ ● edit apps/app/automa│                                                                                                            │                   ⚡ 18ms
  │ ⎿                     │                                                                                                            │ −1 · 18ms
  │     10 -  const items │                                                                                                            │
  │     10 +  const items │                                                                                                            │

--- a/crates/stella-tui/tests/snapshots/deck/session_delegate_tool_call.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_delegate_tool_call.txt
@@ -17,10 +17,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()
@@ -32,11 +32,11 @@
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
- │ ◌ get_state verify
+ │ ◌ get_state verify                                                                                                                                      ⚡ 4ms
  │ ⎿                                                                                                                                          4ms
  │   verify true
 
- │ ◌ search sub_agent_id                                                                                                                                   ↳ d:1
+ │ ◌ search sub_agent_id                                                                                                                           ⚡ 9ms · ↳ d:1
  │ ⎿ crates/stella-tui/src/model/entry.rs:105                                                                                         9ms · ↳ d:1
 
 

--- a/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
@@ -6,10 +6,10 @@
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()
@@ -21,7 +21,7 @@
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
- │ ◌ search fold_output
+ │ ◌ search fold_output                                                                                                                                   ⚡ 61ms
  │ ⎿ crates/stella-transcript/src/digest.rs:100                                                                                              61ms
  │   crates/stella-transcript/src/grid.rs:436
  │   crates/stella-transcript/src/html.rs:310
@@ -30,7 +30,7 @@
  │   crates/stella-observatory/src/lib.rs:212
  │   ⋯ 2 lines · ctrl+o
 
- │ ◌ get_state verify
+ │ ◌ get_state verify                                                                                                                                      ⚡ 8ms
  │ ⎿                                                                                                                                          8ms
  │   attempts 3
  │   cost_usd 0.0412

--- a/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
+++ b/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()

--- a/crates/stella-tui/tests/snapshots/deck/tab_session.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_session.txt
@@ -19,10 +19,10 @@
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
- │ ● edit apps/app/automations/page.tsx +4 -1
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()


### PR DESCRIPTION
Two of #5030's four gaps, the two with live producers today:

- **`⚡ms` on every settled head.** `call_duration` resolves the paired result's own `duration_ms` through the same bounded scan as `read_size` — zero maps to no metric (synthetic echoes stamp zero, and 'answered instantly' vs 'not timed' is not worth an ambiguous column). Every settled call in the deck now states its wall time on the head, per SPEC 6.3.
- **Reads fold by default.** `head_rows` forced `collapsed = Some(false)` on every live head, so `EventKind::collapses_by_default()` was consulted nowhere live and `▸ read … · ↵ open` was reachable only from fixtures. A read head now folds until the reader expands it; every other kind keeps its glyph (its body is the result row beneath).

The per-call facts travel as one `CallFacts` struct (the `EntryView` pattern) instead of a 9-positional list.

**Scope adjustment against #5030's text, stated rather than slipped:** the issue asked this PR to also add `TranscriptEntry` variants for Skill/Memory/Gate/Model with no fold constructor behind them. That is the exact expressible-but-unreachable shape #4180 removed from this same module, so each variant lands with its producer instead — noted on #5031–#5034, which are unblocked regardless (their upstream emit sites are disjoint). The `→ task N` tag stays with #5039, its only real producer.

**Witnesses:** `a_settled_call_head_carries_its_wall_time` (renders `⚡7ms`, elides unanswered/zero/mismatched ids) and `a_read_head_folds_by_default_and_opens_on_expand` — both fail on the old `Some(false)`/no-duration path. Deck goldens re-blessed and the diff read: the only changes are `⚡ Nms` appearing right-aligned on settled heads (18 files); the scenario's read is `mcp__fs__read_file` (open-vocabulary `Other`), so no golden fold shift. Full `cargo test -p stella-tui` (12 suites) and clippy `--all-targets` green.

The head's `⚡ms` sits above the v1 result row's own `Nms` — one fact on two rows until the result row is ported (#4721 owns that seam).

Refs #5030

## Summary by Sourcery

Show wall-time metrics on settled live tool heads and restore default folding for read heads.

New Features:
- Display settled tool-call wall time on live transcript heads when a nonzero duration is available.
- Fold live read heads by default and allow them to open when expanded.

Enhancements:
- Bundle per-call rendering data into a named CallFacts structure for safer head rendering inputs.

Tests:
- Add coverage for duration resolution, zero or mismatched call handling, and live read-head folding behavior.
- Refresh deck snapshots to include duration metrics on settled heads.