### PR TITLE
fix(stella-tui): seed the deck fixture's engine panel through the fold

### DIFF
--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -314,8 +314,15 @@ fn base_ui(tab: DeckTab) -> DeckUi {
     ui.tab = tab;
     ui.graph = Some(demo_graph());
     // The driver seeds this at session start, so every frame the real deck
-    // draws has it — including the one `/models` renders from.
-    ui.engine.pristine = Some(stella_tui::scenario::demo_engine_config());
+    // draws has it — including the one `/models` renders from. Seeded through
+    // the fold rather than by assignment: `ingest_config` writes `state` and
+    // `pristine` from one snapshot, so a fixture that sets either by hand can
+    // claim edits the panel does not hold (#4704).
+    stella_tui::views::engine_panel::ingest_config(
+        &mut ui,
+        &stella_tui::scenario::demo_engine_config(),
+        &None,
+    );
     ui
 }
 
@@ -1436,5 +1443,26 @@ fn deck_render_snapshots_pin_the_subagents_overlay() {
         W,
         H,
         &frame,
+    );
+}
+
+/// The fixture's engine panel holds a working copy, not just a baseline.
+///
+/// `EngineOverlay::dirty()` is `state != pristine`, so seeding `pristine`
+/// alone leaves the panel permanently modified with nothing to have modified
+/// — which is how `tab_settings.txt` came to show `modified` over `waiting
+/// for the engine config snapshot`, a pair the live deck cannot produce
+/// (#4704). `ingest_config` writes both fields from one snapshot; seeding
+/// through it is what keeps the fixture and the fold in step.
+#[test]
+fn the_fixture_engine_panel_is_seeded_the_way_the_fold_seeds_it() {
+    let ui = base_ui(DeckTab::Settings);
+    assert!(
+        ui.engine.state.is_some(),
+        "base_ui must seed the working copy, not only the baseline"
+    );
+    assert!(
+        !ui.engine.dirty(),
+        "a freshly seeded panel has no unsaved edits to claim"
     );
 }

--- a/crates/stella-tui/tests/snapshots/deck/tab_settings.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_settings.txt
@@ -5,13 +5,13 @@
 
  SESSION AGENTS TRACES GRAPH FILES SKILLS MCP ISSUES   SETTINGS                                                                                         stella*
   AGENTS  │  TOOLS  │  SEATS   ←/→
-   GLOBAL   default                                                                                                                                    modified
+   GLOBAL   default
 
-  waiting for the engine config snapshot — r to reload
-
-
-
-
+▸ auto_mode           off
+  effort_auto         on
+  reasoning_auto      off
+  minimal_prompt      off
+  allowed_models      (none — pickers offer the catalog)
 
 
 


### PR DESCRIPTION
## What

`base_ui` in the deck golden suite set `EngineOverlay::pristine` and left `state` at `None`. `dirty()` is `state != pristine`, so every fixture frame carried a permanent `modified` marker with no working copy behind it — and `tab_settings.txt` committed both halves of a pair the live deck cannot produce:

```
   GLOBAL   default                                  modified

  waiting for the engine config snapshot — r to reload
```

`views::engine_panel::ingest_config` writes `state` and `pristine` from one snapshot in one statement, so a panel with no working copy has no baseline to differ from either.

## How

Seed the fixture through `ingest_config` rather than by assignment. That function *is* the whole fold for `Inbound::EngineConfig` — `deck_ui`'s `ingest_inner` delegates to it and returns, and it touches no `WorkspaceModel` — so the fixture now cannot drift from the fold again, which is the issue's preferred remedy.

## The golden diff, read

Exactly one golden moved, `tab_settings.txt`:

```diff
-   GLOBAL   default                                                     modified
-
-  waiting for the engine config snapshot — r to reload
-
-
-
+   GLOBAL   default

+▸ auto_mode           off
+  effort_auto         on
+  reasoning_auto      off
+  minimal_prompt      off
+  allowed_models      (none — pickers offer the catalog)
```

The `modified` marker is gone and the GLOBAL rows render with their values — the five rows #4704 predicted, in that order. The issue asks to check whether any other golden reads `ui.engine`: `pane_settings_tools` did not move, and the `/model` picker fixture writes `ui.engine.state` itself, so it is unchanged. Nothing else in the suite moved.

## Witness

`the_fixture_engine_panel_is_seeded_the_way_the_fold_seeds_it` asserts `base_ui`'s panel holds a working copy and claims no unsaved edits. Ablated by restoring the `pristine`-only line:

```
---- the_fixture_engine_panel_is_seeded_the_way_the_fold_seeds_it stdout ----
thread '...' panicked at crates/stella-tui/tests/deck_render_snapshots.rs:1456:5:
base_ui must seed the working copy, not only the baseline

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 25 filtered out
```

With the fix, the whole suite: `test result: ok. 26 passed; 0 failed`.

## The decision #4704 asks for, made deliberately

**`EngineOverlay::dirty()` is left alone.** Returning `false` when `state.is_none()` would be unreachable in the live deck for exactly the reason the contradiction was impossible there — `ingest_config` writes both fields together, so no working copy means no baseline — and it would have masked this fixture bug rather than surfaced it. The guard would be dead defensive code standing where a fence test belongs.

Closes #4704

## Summary by Sourcery

Align deck snapshot fixtures with live engine configuration state initialization and update the affected settings golden.

Bug Fixes:
- Correct engine panel snapshot fixtures so they initialize both the working configuration and its pristine baseline, preventing impossible modified states and restoring the expected settings rendering.

Enhancements:
- Add a regression test that verifies freshly seeded fixture panels contain a working copy without unsaved edits.

Tests:
- Add coverage for engine panel fixture initialization consistency with the live configuration fold.