### PR TITLE
fix(workspace): settle every unwired public API row the #4392 audit found

### DIFF
--- a/crates/stella-cli/src/memory/appraisals.rs
+++ b/crates/stella-cli/src/memory/appraisals.rs
@@ -28,11 +28,15 @@
 //!
 //! [`record_turn`], [`sweep`], [`record_appraisal`] and [`queued_candidates`]
 //! are the retirement half, and they carry `#[allow(dead_code)]` because they
-//! have no production caller yet. The two seams they need are a turn-end hook
-//! that knows both the offered and the selected skill sets, and the retirement
-//! sweep that writes the tombstone. Wiring them is tracked in #4754; every
-//! function here is exercised by `tests.rs` and the shapes are the ones that
-//! wiring will call.
+//! have no production caller yet. They are kept rather than deleted because
+//! the decision half they call — `appraise` and `decide_demotion` in
+//! `stella-core::skills::appraisal` — is live, tested and has no other caller,
+//! so deleting these would leave that logic unreachable from the binary that
+//! owns the ledger. The two seams they need are a turn-end hook that knows
+//! both the offered and the selected skill sets, and the retirement sweep that
+//! writes the tombstone; #5086 tracks building them, and records the
+//! consequence of not having them — [`latest_verdicts`] reads a file nothing
+//! writes, so the creation gate sees `Unevaluated` in every real session.
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/stella-diag/README.md
+++ b/crates/stella-diag/README.md
@@ -243,6 +243,7 @@ hands correlation over for nothing.
 For a whole vocabulary rather than a call site, implement `Facet` on a per-crate
 enum: the crate that owns the events owns their rendering, so nobody edits a
 shared enum and no new option recompiles the world. Nothing in this workspace
-implements it yet — `stella-cli`'s `diag_bridge` builds `Record::new` by hand
-across about twenty sites — so read this as an offer, not as a description of
-what the tree does (#4754).
+implements it — `stella-cli`'s `diag_bridge` builds `Record::new` by hand,
+because it is a binary and no other crate renders its records — so read this
+as an offer to a library crate that owns a vocabulary, not as a description of
+what the tree does.

--- a/crates/stella-diag/src/dx.rs
+++ b/crates/stella-diag/src/dx.rs
@@ -289,9 +289,10 @@ macro_rules! diag {
 /// worth of fields, so the crate that owns the vocabulary owns the rendering
 /// too and nobody edits a shared enum.
 ///
-/// No production crate implements it yet — `stella-cli`'s `diag_bridge`
-/// builds [`Record::new`] by hand. #4754 decides whether it gets an
-/// implementer or goes.
+/// It ships without an in-tree implementer on purpose: the facet belongs to
+/// the crate that owns the vocabulary (`doc:diagnostics` §5.1), and the only
+/// heavy emitter today is `stella-cli`'s `diag_bridge`, a binary whose records
+/// nothing else renders, so a trait buys it nothing.
 pub trait Facet {
     /// This event's stable diagnostic code (§11).
     fn code(&self) -> &'static str;

--- a/crates/stella-diag/src/lib.rs
+++ b/crates/stella-diag/src/lib.rs
@@ -114,8 +114,7 @@ pub use ring::{
     prune_crash_files,
 };
 pub use sink::{
-    Bound, Capture, FailingSink, JsonlSink, NullSink, Sink, SinkError, TerminalGated, TerminalHold,
-    TextSink,
+    Bound, Capture, FailingSink, JsonlSink, Sink, SinkError, TerminalGated, TerminalHold, TextSink,
 };
 
 mod redact;

--- a/crates/stella-diag/src/sink.rs
+++ b/crates/stella-diag/src/sink.rs
@@ -316,22 +316,6 @@ impl Sink for TerminalGated {
     }
 }
 
-/// Discards everything.
-///
-/// The default when a caller does not care, and what keeps every library type
-/// in the workspace usable without wiring a sink — the same job
-/// `stella-serve::observe::sink::NullSink` does today.
-///
-/// No crate outside this one selects it yet; #4754 decides whether it stays
-/// shipped API.
-pub struct NullSink;
-
-impl Sink for NullSink {
-    fn write(&self, _record: &Record) -> Result<(), SinkError> {
-        Ok(())
-    }
-}
-
 /// Records in memory, for assertions.
 ///
 /// This is what makes acceptance criteria testable: a test matches on a

--- a/crates/stella-fleet/README.md
+++ b/crates/stella-fleet/README.md
@@ -266,11 +266,15 @@ table-tested with an injected `Clock` instead of a real wait (L-E4).
   judges a branch against the `base_ref` its `Worktree` value carries, which
   the ledger does not record, and it has no `--force` rung. Consolidating the
   two is tracked separately.
-- **Some of this crate's surface has no product caller yet.**
-  `WorktreeManager::list` and `commit_paths` are exercised only by this crate's
-  own tests. They are API and tests, not shipped behavior; treat their coverage
-  as a contract for the wiring still to come, not as evidence the feature is
-  live; #4754 decides whether they get wired or go.
+- **`WorktreeManager::commit_paths` has no product caller yet.** It is
+  exercised only by this crate's own tests, and it ships anyway because it is
+  the only place here that encodes the pathspec discipline — `git add --
+  <paths>` and never `-A` — in a checkout that shares an index with a human's.
+  Treat its coverage as a contract for the wiring still to come, not as
+  evidence the feature is live. `WorktreeManager::list` used to sit beside it
+  and is gone: `Gc::sweep` is the only production sweep over worktrees, it runs
+  `git worktree list --porcelain` itself, and both parse the result through the
+  same `parse_worktree_list`.
 
   `WorktreeManager::remove` has left this list: `stella-cli`'s
   `candidate_workspaces` and `self_driving_cmd::work` both call it. So has the

--- a/crates/stella-fleet/src/git.rs
+++ b/crates/stella-fleet/src/git.rs
@@ -487,21 +487,16 @@ impl<G: GitCli> WorktreeManager<G> {
         removed.and(branch)
     }
 
-    /// List the repository's worktrees (`git worktree list --porcelain`).
-    pub async fn list(&self) -> Result<Vec<WorktreeEntry>, WorktreeError> {
-        let out = self
-            .git
-            .run(&self.repo_root, &["worktree", "list", "--porcelain"])
-            .await?;
-        let out = ensure_ok(out, "worktree list --porcelain")?;
-        Ok(parse_worktree_list(&out.stdout))
-    }
-
     /// Stage exactly `paths` and commit them — **always** an explicit
     /// pathspec (`git add -- <paths>`, then `git commit -m <message> --
     /// <paths>`), never `-a` and never a pathspec-less commit that would sweep
     /// the whole index. Returns the new commit sha. Rejects an empty pathspec
     /// ([`WorktreeError::EmptyPathspec`]).
+    ///
+    /// No product path commits yet; this ships anyway because it is the only
+    /// place in the crate that encodes the pathspec discipline, and its tests
+    /// are what stop a later caller reaching for `git add -A` in a worktree
+    /// that shares an index with a human's checkout.
     pub async fn commit_paths(
         &self,
         repo: &Path,
@@ -997,8 +992,12 @@ detached
             "A should be clean: {status_a:?}"
         );
 
-        // list sees the base repo plus both task worktrees.
-        let listed = mgr.list().await.unwrap();
+        // Git registered both worktrees on their own `fleet/` branches.
+        let out = SystemGitCli
+            .run(repo, &["worktree", "list", "--porcelain"])
+            .await
+            .unwrap();
+        let listed = parse_worktree_list(&out.stdout);
         let branches: Vec<String> = listed.iter().filter_map(|e| e.branch.clone()).collect();
         assert!(
             branches.iter().any(|b| b.starts_with("fleet/task-a-")),

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -324,7 +324,7 @@ evolution_surfaces! {
         ImpactClass::AdvisoryRecord,
         "none wired. The demotion half — `record_turn`, `sweep`, `record_appraisal`, \
          `queued_candidates` — carries `#[allow(dead_code)]` for want of a production caller, \
-         so a promoted skill that later regresses is demoted by nothing. Tracked in #4754";
+         so a promoted skill that later regresses is demoted by nothing. Tracked in #5086";
 
     /// Executable capability Stella adds to its own working surface.
     Tool => "tool",

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -148,7 +148,7 @@ pub use provider::{Provider, ToolCallObserver};
 // The context-recall port every door's memory injection shares (removal
 // census for `stella-pipeline`, `docs/spec/pipeline-as-plugins.md` §7) — see
 // the module doc for why it lives here rather than in a pipeline-shaped crate.
-pub use recall::{ContextRecallPort, NoContextRecall, Recall, RecalledFrame};
+pub use recall::{ContextRecallPort, Recall, RecalledFrame};
 pub use role::{ModelRef, Role};
 pub use subagent_event::{SubAgentPhase, SubAgentStatus};
 pub use tokens::{

--- a/crates/stella-protocol/src/recall.rs
+++ b/crates/stella-protocol/src/recall.rs
@@ -122,8 +122,9 @@ impl RecalledFrame {
 /// Context recall at turn start (L-E8): a *live provider query*, never a
 /// cached prompt block. The recalled frames ride as a volatile message
 /// **after** the byte-stable system prefix so prompt-cache hits on that
-/// prefix are preserved. A caller with no context plane wired yet supplies
-/// [`NoContextRecall`].
+/// prefix are preserved. A caller with no context plane wired yet implements
+/// this to return [`Recall::default`], which is four lines and keeps the
+/// no-op where its owner can see it.
 #[async_trait]
 pub trait ContextRecallPort: Send + Sync {
     /// Recall material relevant to `goal`. Returns an empty frame list when
@@ -244,54 +245,9 @@ impl Recall {
     }
 }
 
-/// A [`ContextRecallPort`] that recalls nothing — the default before a
-/// context plane is wired, and for tasks where context grounding is off.
-///
-/// Nothing in this workspace instantiates it; it is here for an external host
-/// driving `stella-engine` with no context plane of its own. #4754 decides
-/// whether that is reason enough to keep shipping it.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct NoContextRecall;
-
-#[async_trait]
-impl ContextRecallPort for NoContextRecall {
-    async fn recall(&self, _goal: &str) -> Recall {
-        Recall::default()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Drives a future to completion on the current thread with no runtime.
-    ///
-    /// This crate is a zero-logic, zero-I/O leaf (`AGENTS.md` AGENTS.md #4) and
-    /// pulls in no async executor — [`ContextRecallPort::recall`] is `async`
-    /// only because the trait must accommodate an implementer that really
-    /// does await a query, and [`NoContextRecall`]'s own body never does.
-    /// `Waker::noop` (stable since 1.90) is enough to poll a future that
-    /// completes on its first poll; a future that genuinely parks would hang
-    /// here, which is the correct failure mode for a "no-op port" test.
-    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
-        use std::task::{Context, Poll};
-
-        let mut fut = std::pin::pin!(fut);
-        let waker = std::task::Waker::noop();
-        match fut.as_mut().poll(&mut Context::from_waker(waker)) {
-            Poll::Ready(value) => value,
-            Poll::Pending => panic!("test future did not complete on its first poll"),
-        }
-    }
-
-    #[test]
-    fn no_context_recall_is_inert() {
-        assert!(block_on(NoContextRecall.recall("anything")).is_empty());
-        assert!(
-            block_on(NoContextRecall.recall("anything")).usage.is_none(),
-            "a port with no CGP host behind it reports no usage"
-        );
-    }
 
     fn recalled(provider: &str, id: &str, digest: Option<&str>) -> RecalledFrame {
         RecalledFrame {

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -24,9 +24,9 @@
 //! - **pull_requests** — tracked pull requests keyed by URL: lifecycle
 //!   status, CI verdict, and the session that produced them. Write-ahead
 //!   state: the deck's PR tracking writes rows
-//!   ([`Store::upsert_pull_request`]) and [`Store::list_pull_requests`] is
-//!   the read API reserved for a future PR panel. No shipped reader consumes
-//!   it yet; #4754 decides whether it gets one or goes.
+//!   ([`Store::upsert_pull_request`]), [`scoreboard`] joins its `status` in
+//!   SQL for a session's verdict, and [`Store::list_pull_requests`] is the
+//!   row-level read kept for the PR panel that will want whole rows.
 //! - **telemetry** — one row per committed model call (from `StepUsage`):
 //!   provider, model, tokens in/out, the engine's pre-call input estimate
 //!   (the drift sample [`Store::drift_samples`] serves back to calibrate

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -502,7 +502,8 @@ are the ones that change a user's life.
 
 | # | Contents | Why this order |
 |---|---|---|
-| **1** | `stella-diag`: envelope, `Level`, `Filter`, `Loggable`, `log_enum!`, `Diag` port, `JsonlSink`, `Capture`, `NullSink`, ring. Properties 3, 4, 8 and the `trybuild` case | the leaf crate everything else needs |
+| **1** | `stella-diag`: envelope, `Level`, `Filter`, `Loggable`, `log_enum!`, `Diag` port, `JsonlSink`, `Capture`, ring (a no-op sink was planned here and
+is not shipped: `Dx::disabled()` is the handle with no sinks at all). Properties 3, 4, 8 and the `trybuild` case | the leaf crate everything else needs |
 | **2** | CLI wiring: `-v`/`--log-level`/`--log-file`, `STELLA_LOG`, panic hook, crash ring on disk, `stella doctor --last-failure`. Property 5 | the moment the project can say "attach the log" |
 | **3** | `crates/stella-serve/observe` re-based on `stella-diag`; `ServeEvent` becomes a facet; `STELLA_SERVE_LOG` kept as an alias | proves generality against the one real existing consumer, and retires the duplicate |
 | **4** | `or_diag`, `check-silent-discards.sh`, ceilings, and the first crate cleaned (`stella-store`) | starts the ratchet falling |


### PR DESCRIPTION
Settles every row of #4754. Each one is now wired, deleted, or kept with a
reason that describes the tree instead of pointing at the issue deciding it.

## The framing fact

Nothing in this workspace is published: `publish = false` in
`[workspace.package]`, and every member takes `publish.workspace = true`. So
"deleting a public name is an API change" has no crates.io consumer here — the
only downstream is in-tree, plus an external host vendoring a path dependency,
which the repository documents for `stella-engine` alone. That is what made
deletion the cheap answer where the name's own stated reason turned out to be
false.

## Deleted — the documented reason was falsified

| symbol | why it goes |
|---|---|
| `stella_protocol::NoContextRecall` | Its doc said it exists "for an external host driving `stella-engine`". `crates/stella-engine/src/lib.rs` re-exports neither `NoContextRecall` nor `ContextRecallPort`, so no host driving the facade could reach it. A host with no context plane implements the port to return `Recall::default()` in four lines, where its owner can see it. |
| `stella_diag::NullSink` | Its doc said it "keeps every library type in the workspace usable without wiring a sink". `Dx::disabled()` is that, and says so in its own doc — a discarding sink costs a `Bound` and a filter evaluation `disabled()` does not. `docs/spec/diagnostics.md`'s phase-1 list, which planned it, now says it was not shipped and names `Dx::disabled()`. |
| `WorktreeManager::list` | `Gc::sweep` is the only production sweep over worktrees and runs `git worktree list --porcelain` itself, parsing it with the same `parse_worktree_list`. The manager's copy had no caller outside its own test. That test now enumerates through `parse_worktree_list` directly, so the porcelain contract keeps its real-git coverage. |

## Kept — with the reason in the doc

| symbol | reason |
|---|---|
| `appraisals.rs`'s `record_turn` / `sweep` / `record_appraisal` / `queued_candidates` | The decision half they call — `appraise` and `decide_demotion` in `stella-core::skills::appraisal` — is live and tested and has no other caller, so deleting these strands it. |
| `Store::list_pull_requests` | The table is not write-only: `stella-store`'s `scoreboard` joins `pull_requests.status` in SQL for a session's verdict. This is the row-level read a PR panel will want. |
| `stella_diag::Facet` | The facet belongs to the crate that owns the vocabulary (`doc:diagnostics` §5.1); the one heavy emitter is `stella-cli`'s `diag_bridge`, a binary whose records nothing else renders, so a trait buys it nothing. The README's pitch is now written as an offer to a library crate, not as a description of the tree. |
| `WorktreeManager::commit_paths` | The only place in the crate that encodes the pathspec discipline (`git add -- <paths>`, never `-A`), and its tests are what stop a later caller reaching for `-A` in a checkout sharing an index with a human's. |

`CapturingSink`, named in the issue's fifth row, does not exist — the type is
`Capture`, and its doc already carries the reason it is public rather than
test-only ("a downstream crate asserts on *its own* wiring with it"). Nothing
to settle there.

## A finding this turned up

`latest_verdicts` **is** live: `learning.rs`'s creation gate calls it, and it
reads `.stella/private/skill_appraisals.jsonl`, which only the unwired
`record_appraisal` writes. So in a real session the ledger is always empty and
the gate can only ever see `EvalEvidence::Unevaluated` — a promoted skill that
stops helping is demoted by nothing. Both originating issues (#1067, #1068)
are closed, so nothing open tracked it. Filed as #5086 and cited from the
module doc; `crates/stella-parity/src/evolution.rs`'s `Skill` row now names
#5086 instead of #4754, which closes with this PR.

## Witness

No witness test. Three deletions (the compiler is the proof that nothing
called them) and four doc-comment decisions; behaviour is unchanged. The one
code edit that is not a deletion is the isolation test's enumeration, which
asserts exactly what it asserted before through the parser gc already uses.

## Evidence

```
cargo check -p stella-protocol -p stella-diag -p stella-fleet --all-targets   # exit 0
cargo check -p stella-store -p stella-parity -p stella-cli --all-targets      # exit 0
cargo test  -p stella-protocol -p stella-diag -p stella-fleet                 # 12 binaries, 0 failed
cargo clippy -p stella-protocol -p stella-diag -p stella-fleet \
             -p stella-store -p stella-parity --all-targets -- -D warnings    # clean
make guards-fast                                                              # green
```

`make file-size` caught the store module doc growing `lib.rs` past its ceiling
by two lines; the doc was shortened to fit rather than the baseline raised.

Closes #4754
Refs #4392

## Tests deleted

`no_context_recall_is_inert`, in `crates/stella-protocol/src/recall.rs`. It
asserted that `NoContextRecall` recalls nothing and reports no usage. This PR
deletes the type it tested, so the test goes with it; nothing else covered it,
and no other test referenced the `block_on` helper that lived beside it.

This is a deliberate removal, not the cross-merge drop `check-deleted-tests`
case 1 exists to catch. The evidence: `git show
origin/main:crates/stella-protocol/src/recall.rs` still contains both
`NoContextRecall` and this test, and the deletion is in this branch's own
diff of that file — the guard sees a test in the base that is not in the merge
result, which is exactly what an intended removal looks like to it. Naming it
here is the remedy the guard's own message asks for.

## Summary by Sourcery

Close the unwired public API audit by removing unsupported surfaces, documenting justified exceptions, and recording the newly identified appraisal wiring issue.

Enhancements:
- Resolve the workspace audit’s unwired public API findings by deleting unsupported exports and documenting the intentional retention of live or contract-defining APIs.

Documentation:
- Update API and diagnostics documentation to reflect removed symbols, current usage, and the reasons retained surfaces remain public.

Tests:
- Preserve worktree enumeration coverage by testing the shared parser directly after removing the unused manager API.

Chores:
- Remove the unused `NoContextRecall`, `NullSink`, and `WorktreeManager::list` APIs and update related issue references, including tracking the discovered appraisal-ledger wiring gap separately.