### PR TITLE
docs(stella-cli): cut the five longest module headers to what a reader needs

### DIFF
--- a/crates/stella-cli/src/daemon/boot.rs
+++ b/crates/stella-cli/src/daemon/boot.rs
@@ -2,128 +2,50 @@
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
 //! `stella daemon resume-all` and `stella daemon install --resume-all`:
-//! resume-at-boot (#1627).
+//! resume-at-boot.
 //!
-//! [`crate::daemon::service`] (#1587) registers one explicit invocation with launchd /
-//! `systemd --user`, and a service manager re-**starts** what it registered —
-//! a fresh turn and a fresh spend at every boot. That is the wrong verb for
-//! the machine that rebooted mid-turn: the killed run left a resume point at
-//! its last committed step, and [`crate::daemon::resume_supervised`] (#1586) continues
-//! from it. This module is the wire between the two, so a rebooted machine
-//! comes back **continuing** its work rather than repeating it.
+//! A service manager re-*starts* what [`crate::daemon::service`] registered,
+//! which is the wrong verb for a machine that rebooted mid-turn — the killed
+//! run left a resume point at its last committed step, and
+//! [`crate::daemon::resume_supervised`] continues from it. This module is the
+//! wire between the two, and it is a standing sweep rather than a one-shot
+//! `install --resume <id>`, because an id chosen at install time is an id
+//! chosen for the wrong run.
 //!
-//! # Which of the two shapes #1627 offered, and why
+//! It continues exactly the rows `stella daemon list` paints `Crashed ↩`: a
+//! **supervised** run whose stored status is still live (`SessionStatus::is_live`)
+//! or is `Error`, while its liveness lock is not held, whose workspace still
+//! exists, and which left a resume point this build can see. The stored status
+//! is the decisive half — every deliberate ending writes one on the way out
+//! (`Complete`, `Cancelled`, `Stopped`, `Paused`), so a live status with a dead
+//! lock is the signature of interruption, and `Error` means only "it fell
+//! over". A deliberate stop also retracts its resume point, so a row from a
+//! build old enough to have stored `Error` for a policy stop is filtered by
+//! [`crate::daemon::boot::SkipReason::NoResumePoint`] without this module
+//! trusting its status.
 //!
-//! The issue offered a one-shot `install --resume <id>` or a standing sweep.
-//! It is the **sweep**: nobody knows, before the crash, which run the crash
-//! will take, so an id chosen at install time is an id chosen for the wrong
-//! run. `stella daemon install --resume-all` registers exactly one thing —
-//! `stella daemon resume-all` — and that verb decides at load, from the
-//! registry, what this boot should continue.
+//! Two bounds keep a sweep from running forever:
 //!
-//! # Which runs it continues — the conservative rule
-//!
-//! Exactly the rows `stella daemon list` paints `Crashed ↩`: a **supervised**
-//! run whose stored status is still *live* (`SessionStatus::is_live`) — or is
-//! `Error`, a crash that lived just long enough to say so (#1696) — while its
-//! liveness lock is not held, whose workspace still exists, and which left a
-//! resume point this build can see.
-//!
-//! The decisive half is the stored status. Every deliberate end writes
-//! one on the way out — `Complete` when it finished, `Cancelled` when `stella
-//! daemon stop` or a Ctrl-C ended it, `Stopped` when the run ended itself by
-//! policy, `Paused` when a deck set it aside. A process the kernel took
-//! mid-turn writes nothing, so a live status with a dead lock is the
-//! signature of interruption.
-//!
-//! # Why an `Error` is continued too, and why that is safe (#1696)
-//!
-//! This rule used to skip *every* terminal status, `Error` included. That was
-//! a compromise forced by #1653: a deliberate policy stop (a stuck-loop
-//! escalation, the step cap, an enforced budget, an ended scope review) was
-//! recorded as `Error`, identical to a genuine crash, so continuing an
-//! `Error` could have restarted — unattended, at the operator's expense —
-//! work the operator ended on purpose. The cost was the honest one: a real
-//! crash that *did* manage to write `Error` before dying was left stranded.
-//!
-//! #1653 removed the ambiguity. A policy stop now records
-//! [`SessionStatus::Stopped`] with every other deliberate ending, which
-//! leaves `Error` meaning only "it fell over" — a run exactly as entitled to
-//! be continued as one the kernel took without warning. Two independent
-//! facts make the widening safe rather than merely intended:
-//!
-//! - **A deliberate stop has no resume point.** The engine driver discards
-//!   the checkpoint on every terminal path, abort included, so a policy stop
-//!   retracts its resume point on the way out. A row written by a build that
-//!   predates #1653 — where a policy stop really did store `Error` — is
-//!   therefore filtered by [`crate::daemon::boot::SkipReason::NoResumePoint`]
-//!   anyway, without this module having to trust its status.
-//! - **The attempt bound still applies.** An `Error` that resumes into
-//!   another `Error` is counted like any other continuation and retired
-//!   after `MAX_BOOT_ATTEMPTS`.
-//!
-//! # What stops a boot loop
-//!
-//! A run that wedges the machine on resume would otherwise resume on every
-//! boot forever. Two brakes, and the second is the decisive one:
-//!
-//! - The resume point is consumed by the turn that continues (#1586), so the
-//!   ordinary case self-terminates after one pass.
-//! - That is not enough when the *resumed* turn is itself killed, because it
-//!   writes a fresh resume point before it dies. So every continued run is
-//!   counted in a durable ledger at `~/.stella/services/resume-boot.json`
-//!   **before** it is spawned, and the `MAX_BOOT_ATTEMPTS`th failure retires
-//!   it: the row is still listed, still says why, and is still resumable by
-//!   hand with `stella daemon resume <id>` — a human deciding to try again is
-//!   exactly what the bound exists to require.
-//!
-//! # What stops a stalled *sweep* — the per-run ceiling (#1921)
-//!
-//! The brakes above bound how many boots one run can spend; nothing in them
-//! bounds how long one run can hold *this* boot. The sweep is sequential and
-//! streams each resumed turn to completion, so any turn that never ends — a
-//! wedged tool, a provider that never returns, a model call retrying forever
-//! — used to stall every id after it, silently. (#1920 fixed the one such
-//! state visible on disk before spawning, a parked approval; the ceiling
-//! covers every way a turn fails to end that only running it reveals.)
-//!
-//! So each resumed run gets a wall-clock ceiling (`--ceiling`, minutes).
-//! Expiry never kills the child outright — a `SIGKILL` at the ceiling would
-//! land mid-edit, which is worse than the stall it fixes. It goes through the
-//! same graceful discipline as Ctrl-C and `stella daemon stop`: `SIGTERM`,
-//! then `STOP_GRACE` for the engine to abort at a safe boundary (invariant 6)
-//! and write its own terminal status, escalation only then. The two ways that
-//! ends compose with the brakes above rather than needing new ones:
-//!
-//! - A child that **responds** to the stop ends deliberately — checkpoint
-//!   discarded, `Cancelled` recorded, exactly as if an operator had stopped
-//!   it — so the next sweep skips it as ended and returns its attempts.
-//! - A child so wedged it had to be **killed** wrote nothing, keeps its
-//!   resume point, and is swept again next boot — where the attempt already
-//!   charged for this resume counts against `MAX_BOOT_ATTEMPTS`.
-//!
-//! That is also the answer to whether a timed-out run is **charged a boot
-//! attempt: yes**. The attempt was recorded before the spawn (as every
-//! attempt is), and it stays spent, because the only run still resumable
-//! after a timeout is the wedged one — the exact recurring failure the
-//! three-attempt bound exists to stop. A run that was merely slower than the
-//! ceiling ended deliberately at a safe boundary, and slower-than-the-ceiling
-//! by hand is what `stella daemon resume <id>` — which has no ceiling — is
-//! for.
-//!
-//! # What the operator sees
+//! - **`MAX_BOOT_ATTEMPTS`.** Consuming the resume point self-terminates the
+//!   ordinary case after one pass, but a resumed turn that is itself killed
+//!   writes a fresh one — so every continued run is counted in
+//!   `~/.stella/services/resume-boot.json` *before* it is spawned, and the
+//!   last failure retires it. The row stays listed, still says why, and is
+//!   still resumable by hand with `stella daemon resume <id>`.
+//! - **A per-run wall-clock ceiling** (`--ceiling`, minutes), because the sweep
+//!   is sequential and one turn that never ends holds every id behind it.
+//!   Expiry never kills the child outright: `SIGTERM`, then `STOP_GRACE` for
+//!   the engine to abort at a safe boundary (invariant 6) and write its own
+//!   terminal status, escalation only then. A child that responds ends as
+//!   `Cancelled` and the next sweep skips it; a child that had to be killed
+//!   keeps its resume point and is swept again, having already spent the
+//!   attempt charged before the spawn.
 //!
 //! Every candidate, continued or skipped, prints one line with its reason —
 //! into `~/.stella/services/resume-boot.log` when a service is driving, into
-//! the terminal when a human is. A run silently resumed at boot would be as
-//! bad as one silently lost, so nothing here is quiet, and
-//! `stella daemon resume-all --dry-run` prints the same decisions while
-//! spawning and spending nothing.
-//!
-//! The resumed child is an ordinary `stella daemon resume <id> --foreground`,
-//! so it inherits that path's own honesty unchanged: #1615's resume frame
-//! still names the pipeline stages a resumed turn is not restoring, into the
-//! service console rather than a terminal.
+//! the terminal when a human is; `--dry-run` prints the same decisions and
+//! spends nothing. The resumed child is an ordinary `stella daemon resume <id>
+//! --foreground`, so it inherits that path's resume frame unchanged.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};

--- a/crates/stella-cli/src/dataset_cmd.rs
+++ b/crates/stella-cli/src/dataset_cmd.rs
@@ -1,104 +1,60 @@
 //! `stella dataset export` — a curated, redacted trajectory dataset from the
-//! local receipt store (#872, the first slice of #836's weight-space track).
+//! local receipt store.
 //!
 //! One JSONL record per **accepted** turn — the prompt, the tool calls with
 //! their arguments and outputs, the change that landed, and the verifier's
-//! verdict — beside a `manifest.json` that states exactly which filter
-//! produced it. That manifest is the point: a dataset nobody can re-derive
-//! the extraction rule for is not auditable, and #836 requires human sign-off
+//! verdict — beside a `manifest.json` stating exactly which filter produced
+//! it. The manifest is the point: a dataset nobody can re-derive the
+//! extraction rule for is not auditable, and #836 requires human sign-off
 //! before any of this reaches a training run.
 //!
-//! ## A fold over the store, not a second capture path
+//! The fold is over `store.db` directly — the `executions` header for
+//! provenance, the per-execution `events` journal for everything else. That
+//! journal is the only place tool *outputs* survive (`tool_calls` records
+//! `bytes_out` and deliberately never the content), so it is the only possible
+//! source.
 //!
-//! A separate `trace.rs` (#1042) once assembled a redacted trajectory record
-//! from a live pipeline run, but its one call site was the staged pipeline's
-//! one-shot driver — gone from this build (#3865) along with the crate that
-//! drove it — so `.stella/private/traces.jsonl` was already absent in
-//! essentially every real workspace before that removal and carries nothing
-//! historical either way. This module therefore folds `store.db` directly:
-//! the `executions` header for provenance and the
-//! per-execution `events` journal for everything else. That journal is the
-//! only place tool OUTPUTS survive (`tool_calls` records `bytes_out` and
-//! deliberately never the content), so it is the only possible source.
+//! **"Accepted" is a judgement, not a column.** The settled signals are
+//! `executions.outcome` and `AgentEvent::Verdict`, so the predicate is named
+//! ([`is_accepted`]), documented, and echoed verbatim into the manifest rather
+//! than left implicit in a `WHERE` clause. Each record is labelled by
+//! [`crate::reward`] under the workspace's resolved [`RewardPolicy`], which
+//! rides on every label so differently-weighted workspaces stay comparable,
+//! and the raw verdict is emitted beside it so a reader can re-derive a label
+//! under other weights.
 //!
-//! ## "Accepted" is a judgement, not a column
-//!
-//! The store has no accepted flag. The settled signals are
-//! `executions.outcome` — whose observed vocabulary is `completed`,
-//! `goal_met`, `goal_unmet`, `verification_failed`, `aborted`, `cancelled`,
-//! `failed`, `error`, `interrupted` — and `AgentEvent::Verdict`. So the
-//! predicate is named ([`is_accepted`]), documented, and echoed **verbatim**
-//! into the manifest, rather than left implicit in a `WHERE` clause.
-//!
-//! ## Rewards and transcripts (#2083)
-//!
-//! Two things #872 shipped without now exist in tree and are carried. The
-//! verdict → scalar mapping (#1043, [`crate::reward`]) labels each
-//! record from the journal's settled verdict under the workspace's resolved
-//! [`RewardPolicy`] — and the policy rides on every label, so records from
-//! differently-weighted workspaces stay comparable. And the receipts plane
-//! rebuilds any model call byte-exactly
-//! ([`stella_store::Store::reconstruct_call`] — the same source `trace.rs`
-//! reads, so SFT pairs need no other source), so each record carries every
-//! call's exact `prompt_messages`, admitted only when the reconstruction
-//! digest-verifies. An execution that cannot vouch for its own transcripts —
-//! no recorded call at all, or any call short of
-//! [`stella_store::Reconstruction::is_verified`] — is excluded under the
-//! default filter and **counted** in the manifest, the same named-predicate
-//! discipline as the rest of the acceptance rule. The raw verdict is still
-//! emitted beside the label, so a reader can re-derive a label under other
-//! weights without trusting this one.
-//!
-//! ## The unvouched turns are reachable, never silently (#2123)
-//!
-//! "Excluded under the default filter" implies a non-default path, and
-//! `--include-unverified-transcripts` is it: a store whose history predates
-//! the receipts plane holds no `step_receipt` row at all, so the default
-//! filter exports **zero** records from it even though the journal fold can
-//! still recover every one of those turns' prompt/tool-call/change
-//! trajectories. Under the flag those turns are exported with
-//! [`DatasetRecord::calls`] empty and
-//! [`DatasetRecord::transcript_verified`] false — the trajectory without the
-//! transcript, never unverified bytes wearing a verified transcript's shape.
-//! The gate itself stays era-blind, exactly as
-//! [`stella_store::Reconstruction::is_verified`] is: the benign
+//! **A record's transcripts either digest-verify or are absent.** Each record
+//! carries every call's exact `prompt_messages` from
+//! [`stella_store::Store::reconstruct_call`], admitted only when the
+//! reconstruction verifies; an execution that cannot vouch for its own — no
+//! recorded call, or any call short of
+//! [`stella_store::Reconstruction::is_verified`] — is excluded by default and
+//! counted in the manifest. `--include-unverified-transcripts` exports those
+//! turns' trajectories with [`DatasetRecord::calls`] empty and
+//! [`DatasetRecord::transcript_verified`] false, never unverified bytes
+//! wearing a verified transcript's shape. The gate stays era-blind: the benign
 //! compaction-era explanation for a mismatch is *reported* on the record
-//! ([`DatasetRecord::transcript_mismatch_severity`], read from
-//! [`stella_store::Reconstruction::mismatch_severity`] rather than
-//! re-derived), never used to admit one.
+//! ([`DatasetRecord::transcript_mismatch_severity`]), never used to admit one.
+//! Admitting compaction-era executions *with* their calls was declined in
+//! #3613 — a dataset whose records mean two things depending on a flag inside
+//! them is worth less than a smaller one whose records all mean the same
+//! thing — and re-opening it is a decision about what a default training
+//! dataset contains, not a predicate edit.
 //!
-//! A middle tier that admitted `compaction`-severity executions *with* their
-//! reconstructed [`DatasetRecord::calls`], marked compaction-era, was
-//! considered and declined (#3613). It would recover legacy transcript data
-//! for SFT and it would cost the one property every emitted `calls` array has
-//! today: that it digest-verified. A dataset whose records mean two different
-//! things depending on a flag inside them is worth less than a smaller one
-//! whose records all mean the same thing, and the trajectory of those turns
-//! is exported already under `--include-unverified-transcripts`. Re-opening
-//! this is a decision about what a default training dataset contains, not a
-//! predicate edit.
-//!
-//! ## What a "diff" can honestly be here
-//!
-//! There is no unified diff anywhere in `store.db`. `files_touched` holds
-//! path/ops/line-counts and no content; `AgentEvent::FileChange::diff` is one
-//! coarse changed-region hunk, bounded at 200 lines per side by the recorder.
-//! [`DatasetChange`] therefore carries the recorder's authoritative
-//! `added`/`removed` counts, that bounded hunk, and a `diff_truncated` flag —
-//! and the exact bytes the model produced are still recoverable from the
-//! edit/write tool arguments in `tool_calls`. A field promising a full diff
-//! would be lying.
-//!
-//! ## Privacy and determinism
+//! **A "diff" here is a bounded hunk, and says so.** No unified diff exists
+//! anywhere in `store.db`: `files_touched` holds paths, ops and line counts
+//! with no content, and `AgentEvent::FileChange::diff` is one coarse changed
+//! region bounded at 200 lines per side. [`DatasetChange`] carries the
+//! recorder's authoritative counts, that hunk, and a `diff_truncated` flag;
+//! the exact bytes the model produced stay recoverable from the edit/write
+//! tool arguments in `tool_calls`.
 //!
 //! Every string leaf of every record and of the manifest passes through
-//! [`stella_core::redact::redact_secrets`] AFTER assembly, so a field added
-//! later cannot route around it. Output is written 0600 into a 0700
-//! directory: redacted prompts plus full tool outputs are at least as
-//! sensitive as the session archive that was hardened for the same reason.
-//! Nothing here reads a clock — the manifest's watermark comes from the store
-//! — and every ordering is a stable key, so the same store and filter produce
-//! byte-identical files on every run.
+//! [`stella_core::redact::redact_secrets`] *after* assembly, so a field added
+//! later cannot route around it, and output is written 0600 into a 0700
+//! directory. Nothing here reads a clock — the manifest's watermark comes from
+//! the store — and every ordering is a stable key, so the same store and
+//! filter produce byte-identical files on every run.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/stella-cli/src/reward.rs
+++ b/crates/stella-cli/src/reward.rs
@@ -1,104 +1,53 @@
-//! Reward extraction (#1043) — turning the verification ladder's verdict into
-//! the scalar a training loop can learn from, or into a stated refusal to
-//! label it at all.
+//! Reward extraction — turning the verification ladder's verdict into the
+//! scalar a training loop can learn from, or into a stated refusal to label it
+//! at all.
 //!
-//! The verify stage already computes a tiered, evidence-based verdict for
-//! every outcome: deterministic evidence when an instrument could observe the
-//! turn, an abstention when nothing could see. That verdict *is* the reward
-//! signal this project has been generating all along. This module is the
-//! (pure, I/O-free) mapping from it to a label, and the rules it encodes are
-//! all about **what not to claim**.
-//!
-//! # One tier of confidence, and every other rung refused
+//! A pure, I/O-free mapping, and every rule in it is about what not to claim.
 //!
 //! | Rung | Label | Why |
 //! |---|---|---|
-//! | [`LadderRung::SubmitFast`] | **+1.0** | A fail→pass flip of the tracked command. A hard label: a test observed it. |
+//! | [`LadderRung::SubmitFast`] | **+1.0** | A fail→pass flip of the tracked command: a test observed it. |
 //! | [`LadderRung::Revise`] | **−1.0** | Touched tests red. Equally hard, in the other direction. |
-//! | [`LadderRung::Unverified`] | **discarded** | Verification ran and did not settle it. There is no model opinion to fall back on — see below. |
-//! | everything else | **discarded** | See below. |
+//! | everything else | **discarded** | Nothing observed the work, so there is no scalar to state. |
 //!
-//! # One tier, because there is one kind of evidence left
+//! [`OutcomeWeights`] carries a single magnitude, because one kind of evidence
+//! is left: no rung's magnitude comes from a model (#2584 removed the verdict
+//! call), so a second, judged tier would be a claim that a tier exists.
+//! [`DiscardReason::VerifierDistrusted`] and
+//! [`DiscardReason::VerifierUnavailable`] are kept anyway — they name stored
+//! records, and a label already written must keep parsing.
 //!
-//! [`OutcomeWeights`] carries a single magnitude. It used to carry two: a
-//! *judged* weight priced a model verifier's opinion at half a test's
-//! observation, and a workspace could lower that half — never raise it past the
-//! deterministic weight, because above that line an opinion outranks an
-//! observation and the ladder inverts.
-//!
-//! That whole apparatus described a tier with no members once the verdict call
-//! was removed (#2584): no rung's magnitude comes from a model any more, so a
-//! judged weight priced nothing, and the ceiling it was checked against refused
-//! launches over a knob that could not change a single label (#2616). Both are
-//! gone rather than retained, because a weight is not decode-compatibility
-//! trivia — it is stamped onto every new label as the scale a reader
-//! renormalizes by, and a scale with no members on it is a claim that a tier
-//! exists.
-//!
-//! Labels written before the removal still carry `outcome.judged` in their
-//! stamped policy, which is exactly what makes their `±0.5` outcome terms
-//! readable; this type ignores the field on the way back in. The retired
-//! discard reasons ([`DiscardReason::VerifierDistrusted`],
-//! [`DiscardReason::VerifierUnavailable`]) are kept for the opposite reason —
-//! they name stored records, and a label already written must keep parsing.
-//!
-//! What survives of the argument is the posture: an unusable weight is
-//! **refused, not clamped** — deliberately the opposite of `stella_context`'s
-//! retrieval tuning, which sanitizes an out-of-range knob rather than failing.
-//! The postures differ because the failures do. A bad retrieval knob degrades
-//! one turn, visibly, and the next turn recovers; the worse answer there is
-//! failing a person's work over a typo. A bad reward weight writes permanently
-//! mislabelled training data that is perfectly well-formed — there is no turn
-//! to fail, and nothing downstream can tell that a substituted weight was ever
-//! applied. So this one fails at launch, naming the key, before any work
-//! starts.
-//!
-//! # The policy travels with the label
+//! An unusable weight is **refused, not clamped**, which is the opposite of
+//! `stella_context`'s retrieval tuning. A bad retrieval knob degrades one turn
+//! visibly and the next recovers; a bad reward weight writes permanently
+//! mislabelled training data that is perfectly well-formed, with no turn to
+//! fail and nothing downstream able to tell a substituted weight was applied.
+//! So this fails at launch, naming the key, before any work starts.
 //!
 //! Every [`RewardLabel`] carries the [`RewardPolicy`] it was computed under.
 //! Without it, two workspaces on different weights emit rows that are
-//! arithmetically indistinguishable and silently incomparable — pooling them
-//! would average a reward shaped at `per_usd = 0.5` against one shaped at
-//! `0.05` as though they were the same measurement, and would read an older
-//! row's `±0.5` judged outcome as a deterministic one. With it, a reader can
-//! renormalize, or select one policy and drop the rest.
-//! `stella_core::comparison::ComparisonReport` already stamps its own
-//! `RewardWeights` for the same reason; this is that rule applied to the
-//! per-turn label.
+//! arithmetically indistinguishable and silently incomparable; with it, a
+//! reader can renormalize or select one policy and drop the rest.
 //!
-//! # Why the abstain rungs are discarded rather than punished
+//! **The abstain rungs are discarded rather than punished**, and this is the
+//! rule the module exists to enforce. [`LadderRung::Unverifiable`] and
+//! [`LadderRung::NothingAttempted`] end a turn without a claim about the work,
+//! and "no pass, therefore a fail" is exactly the inference the ladder refuses
+//! — a Terminal-Bench trial that wrote its answer through shell redirects
+//! recorded no touch, abstained, and scored 1.0 against its own verifier.
+//! [`LadderRung::Unverified`] says the deterministic instruments ran and did
+//! not settle it; [`LadderRung::Waived`] says no proof was owed. A discard is
+//! not a dropped record: the rung and the [`DiscardReason`] always ride along,
+//! so a consumer wanting the no-op trajectories can select them. Only the
+//! scalar is withheld, which is the only part that would be a lie.
 //!
-//! This is the rule the whole module exists to enforce. [`LadderRung::Unverifiable`]
-//! and [`LadderRung::NothingAttempted`] both end a turn *without* a claim about
-//! the work, and the tempting shortcut — "no pass, therefore a fail" — is
-//! exactly the inference the ladder was built to refuse. A Terminal-Bench trial
-//! that wrote its answer through shell redirects recorded no touch, could not
-//! be diffed, abstained, and scored 1.0 against its own verifier. Training on
-//! that trajectory as a −1.0 would teach the model that a correct solution was
-//! wrong.
-//!
-//! [`LadderRung::Unverified`] is discarded for a different reason: it is not a
-//! statement about the work at all, it is a statement that the deterministic
-//! instruments ran and did not reach one. [`LadderRung::Waived`] likewise — no
-//! proof was owed, so nothing was determined either way.
-//!
-//! A discard is **not** a dropped record. [`RewardLabel`] always carries the
-//! rung and always carries the [`DiscardReason`], so a consumer that
-//! specifically wants the no-op trajectories (a curriculum, a failure-mode
-//! study) can select them by outcome. What is withheld is the *scalar*, which
-//! is the only part that would be a lie.
-//!
-//! # The airlock: labels carry no prose
-//!
-//! Verifier reasoning and distress-guidance text are **steering**, never training
-//! targets — the same discipline as the witness airlock
-//! (the deleted pipeline's witness airlock, #3865). Here that is enforced structurally rather
-//! than by review: [`RewardLabel`] and everything it contains hold no
-//! free-form `String` field, only enums and numbers, so there is no field a
-//! model-authored sentence could be assigned to. [`Settlement::from_evidence`]
-//! is deliberately the seam that proves it — it is handed the whole
-//! [`VerdictEvidence`], summary included, and returns a value with no strings in
-//! it. `tests::verifier_prose_never_reaches_a_label` is the property test.
+//! **Labels carry no prose.** Verifier reasoning and distress guidance are
+//! steering, never training targets, and that is structural here rather than a
+//! review question: [`RewardLabel`] and everything it contains hold no
+//! free-form `String` field. [`Settlement::from_evidence`] is the seam that
+//! proves it — handed the whole [`VerdictEvidence`], summary included, it
+//! returns a value with no strings in it, and
+//! `tests::verifier_prose_never_reaches_a_label` is the property test.
 
 use serde::{Deserialize, Serialize};
 use stella_protocol::{LadderRung, VerdictEvidence};

--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -1,167 +1,49 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! The session's sub-agent dispatcher — the host half of the `delegate` tool
-//! (#922).
+//! The session's sub-agent dispatcher — the host half of the `delegate` tool.
 //!
 //! `stella-tools`' [`SpawnSubAgent`](stella_tools::subagent::SpawnSubAgent)
-//! knows *what* to delegate; this knows *how* to run it. It owns the four
+//! knows *what* to delegate; this knows *how* to run it, and owns the four
 //! things a child turn needs that a tool cannot reach from inside
-//! `ToolExecutor::execute`: a provider, a sleeper, the workspace tool set,
-//! and a budget.
+//! `ToolExecutor::execute`: a provider, a sleeper, the workspace tool set, and
+//! a budget.
 //!
-//! # Breaking the ownership cycle
+//! - **The registry handle is [`Weak`].** The child's tool set is the
+//!   [`ToolRegistry`] that owns this dispatcher, so an `Arc` back would leak
+//!   both forever; a registry already dropped yields
+//!   [`SubAgentOutcome::Refused`] rather than a panic.
+//! - **Turn-scoped wiring is read at dispatch time, never attached per turn.**
+//!   The event sender and `stella_core::ports::TurnControls` live in registry
+//!   slots each driver publishes for the span of its turn, so a child inherits
+//!   the pause gate and the latched soft stop — but never `drain_steering`,
+//!   which is destructive by contract and addressed to the parent. A child
+//!   dispatched between turns emits into a sink instead of failing.
+//! - **The pool is not the ceiling.** [`SessionSubAgents::with_pool_limit`]
+//!   bounds what sub-agents may cost in total; `--spend-limit` is enforced by
+//!   the parent's guard, which folds each child's cost in at the next
+//!   step-boundary check. The pool lock is not held across a child's run, so
+//!   siblings in one dispatch group each carve against the same headroom — an
+//!   overshoot of one child's cap per concurrent sibling, caught at that
+//!   boundary regardless.
+//! - **The child's own thread settles both ledgers the moment its turn ends.**
+//!   Charging after `wait.await`, or from the `delegate` tool once
+//!   `dispatch()` returns, loses a child whose parent was cancelled
+//!   mid-`delegate`; the thread is also what keeps the charge exactly once.
+//! - **A child runs on a fresh OS thread with a current-thread runtime**,
+//!   because an engine turn's future is not `Send` and every tool-call path
+//!   above it requires one. `catch_unwind` around the child turn contains a
+//!   panic **only where builds unwind**: the workspace sets `panic = "abort"`,
+//!   so in release a child panic takes the process, and only a process
+//!   boundary could contain it.
 //!
-//! The child's tool set is the very [`ToolRegistry`] that owns this
-//! dispatcher, so holding an `Arc` back would leak both forever. The handle
-//! is therefore [`Weak`]: a dispatch upgrades it, and a registry that has
-//! already been dropped yields
-//! [`SubAgentOutcome::Refused`]
-//! rather than a panic on a torn-down session.
-//!
-//! # Session-scoped object, turn-scoped wiring
-//!
-//! One dispatcher serves the whole session, but a child's metering must land
-//! in the stream of the turn that asked for it — and every driver path in
-//! this crate already re-points that stream per turn via
-//! `ToolRegistry::attach_events`. So rather than re-attaching a dispatcher
-//! on every turn (five call sites, each easy to forget), this reads the
-//! registry's *current* sender at dispatch time. A child that somehow runs
-//! between turns emits into a sink instead of failing.
-//!
-//! The turn's boundary controls ride the same shape and are read in the same
-//! breath — see below.
-//!
-//! # Budget: a pool, and why it is not the ceiling
-//!
-//! Each child is carved from a session-scoped pool
-//! ([`SessionSubAgents::with_pool_limit`]), which bounds what sub-agents may
-//! cost in total. That pool is **not** what enforces `--spend-limit`: every child's
-//! cost is also pushed onto the registry's spend ledger, and the engine folds
-//! it into the *parent's* guard at the next step-boundary check
-//! (`ToolExecutor::drain_sub_agent_spend_usd`). The parent's guard stays the
-//! hard ceiling; the pool is a second, tighter bound on this one category of
-//! spend.
-//!
-//! The pool lock is deliberately not held across the child's run, so sibling
-//! `delegate` calls from one step execute concurrently — reachable since the
-//! engine's dispatch scheduler groups the spawn tool with read-only calls
-//! (`Tool::parallel_safe`; before that claim existed, every non-read-only
-//! call was its own barrier and this concurrency was dead code). Every
-//! sibling in one dispatch group can therefore carve against the same
-//! headroom before any settles — an overshoot bounded by one child's cap per
-//! concurrently-running sibling (up to the engine's dispatch cap of 8, so
-//! seven extra caps in the worst case, not one), and caught by the parent's
-//! guard at the next step boundary regardless.
-//!
-//! ## Settling is the child's job
-//!
-//! Both ledgers are charged from the child's own thread, the moment its turn
-//! ends — not after the `wait.await` below, and not by the `delegate` tool after
-//! `dispatch()` returns. Those were the original homes, and both share a
-//! defect: a parent hard cancelled mid-`delegate` never resumes either line, so a
-//! child that had really spent money landed in *no* ledger at all. Whatever is
-//! still running when the parent goes away has to be what settles, and that is
-//! the thread. Charging late to the session is this ledger's existing doctrine
-//! ("charging the same dollars twice is worse than charging them late");
-//! never charging is not.
-//!
-//! The thread being the sole writer is also what keeps it exactly once.
-//!
-//! # Why a child runs on its own thread
-//!
-//! An engine turn's future is deliberately **not** `Send` (the speculation
-//! pump boxes futures without the bound), while every tool-call path above
-//! it — `Tool::execute`, `ToolExecutor::execute` — is `#[async_trait]` and
-//! therefore requires one. A tool consequently cannot simply `.await` a
-//! turn. Adding `Send` to the engine's boxed futures does compile, but then
-//! proving the whole nested future `Send` trips a rustc higher-ranked
-//! lifetime limitation inside `execute_tool_calls` ("implementation of
-//! `FnOnce` is not general enough"), so the engine's own hot path is left
-//! alone.
-//!
-//! Instead each child gets a fresh OS thread with a current-thread runtime:
-//! `block_on` imposes no `Send` bound, everything handed across is owned
-//! (`Arc`s and `Copy` values), and this task only awaits a oneshot. It also
-//! buys isolation from a panicking child — **in builds that unwind**. The
-//! child turn runs under `catch_unwind`, so a panic settles the child's spend
-//! and reports as a refusal instead of tearing the parent's turn down.
-//!
-//! That claim used to be unqualified, and it was wrong for the builds users
-//! actually run: the workspace sets `panic = "abort"` (root `Cargo.toml`), so
-//! in release there is no unwind to catch and a child panic takes the whole
-//! process with it. A thread boundary cannot contain that; only a process
-//! boundary could. Stated rather than quietly implied, because the difference
-//! is invisible until it is a crash report (#1850).
-//!
-//! The cost is one thread per live `delegate` call, bounded by the engine's own
-//! tool-call concurrency cap.
-//!
-//! # Pause and stop reach these children too
-//!
-//! `TurnGate`/`TurnSteering` are turn-scoped: each driver builds them on the
-//! stack of the turn it is about to run, and `Engine` takes both as `&'a dyn`.
-//! A session-scoped dispatcher cannot name that lifetime, which is why the
-//! first cut of this module could not carry them at all — a paused session
-//! kept spending inside a tool-dispatched child, the direct analogue of the
-//! `goal.rs::assess` defect #922 named.
-//!
-//! So each driver now publishes its seams in owned form
-//! (`stella_core::ports::TurnControls`) into the registry slot this reads at
-//! dispatch time — the same "session-scoped object, turn-scoped wiring"
-//! treatment the event sender already gets, for the same reason and at the
-//! same call site. The controls come back down when the driver's guard drops,
-//! including on an unwind, so a latched soft stop cannot leak into the next
-//! turn's children.
-//!
-//! What a child actually inherits is asymmetric, and deliberately so:
-//!
-//! - **The pause gate, as-is.** A paused session parks its children at their
-//!   own step boundaries. Note that a parked child holds the parent's
-//!   `delegate` tool call open, which is exactly right — pause means pause — and
-//!   that both release together on resume.
-//! - **The soft stop, but not the steering messages.** The child engine is
-//!   built through `run_sub_agent`, which wraps whatever steering the parent
-//!   has in `stella_core::subagent::ChildSteering`: the stop flag is latched
-//!   and non-destructive so forwarding it is free, while `drain_steering` is
-//!   destructive by contract and a child that inherited it would eat a
-//!   message the user addressed to the parent.
-//!
-//! Every driver that runs turns installs a dispatcher and publishes what it
-//! has: the deck's lead and pipeline turns publish both a steering tap and a
-//! `WatchGate` (#1219 — `p` on the lead row parks the turn and, through this
-//! dispatcher, every child it dispatched), and deck worker lanes and fleet
-//! workers publish their own `WatchGate`, and the wrapped one-shot path
-//! publishes whatever its caller supplied for the span of the wrapper's whole
-//! dispatch rather than for one round, because a plugin spends its children
-//! from the points *between* the rounds (#3803,
-//! `crate::wrapper_plugin::dispatch_under_turn_controls`). A driver that
-//! publishes nothing is
-//! still not a failure state — a child then runs bounded by its step cap and
-//! its carve, exactly as before.
-//!
-//! # A cancelled parent: cascade the intent, not the mechanism
-//!
-//! A hard cancel is the *dropping of a future*. That is the entire mechanism,
-//! and it cannot propagate here: the child is an OS thread running `block_on`,
-//! deliberately off the parent's future graph (see above), and a thread cannot
-//! be killed safely in Rust. Nor should it be, even if it could — an abrupt
-//! kill can land mid-tool, which is exactly the half-finished write the
-//! step-boundary rule (L-E6) exists to prevent, and it would discard the
-//! salvaged text an aborted child is specifically designed to hand back.
-//!
-//! So the intent cascades instead of the mechanism. [`ParentGone`] is a drop
-//! guard living in the suspended `dispatch` body; when the parent's turn
-//! future is dropped, it is dropped too, and [`OrphanStop`] reports that to
-//! the child as a soft stop alongside the turn's own. The child ends at its
-//! next boundary with its work salvaged and its spend settled — an orphan
-//! bounded by the model call already in flight, rather than by its whole step
-//! cap.
-//!
-//! The one thing that genuinely cannot be recovered is the child's *report*:
-//! the oneshot receiver went with the cancelled future, so the finding is
-//! written to the event stream and nowhere else. Paying for it and stopping
-//! promptly beats paying for it and running on.
+//! A hard cancel is the dropping of a future, which cannot reach a thread, so
+//! the intent cascades instead of the mechanism. [`ParentGone`] drops with the
+//! parent's turn and [`OrphanStop`] reports that to the child as a soft stop;
+//! the child ends at its next boundary with its work salvaged and its spend
+//! settled. Its *report* is the one thing unrecoverable — the oneshot receiver
+//! went with the cancelled future, so the finding reaches the event stream and
+//! nowhere else.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -1,138 +1,66 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! `stella-cli` as a **driver** of the wrapper socket (#3494).
+//! `stella-cli` as a **driver** of the wrapper socket.
 //!
-//! `stella_runtime::wrapper` shipped four points, two transports and the two
-//! host functions, and nothing in the shipping binary called any of them — so
-//! `doc:wrapper-socket` §6's first driver was unmet and an installed wrapper
-//! plugin participated in nothing. This module is that driver: it resolves
-//! `--pipeline <variant>` against what is installed, builds the transport the
-//! manifest's `[runtime]` block declares, and implements
-//! [`TurnDriver`] over the raw engine turn.
+//! This module resolves `--pipeline <variant>` against what is installed,
+//! builds the transport the manifest's `[runtime]` block declares, and
+//! implements [`TurnDriver`] over the raw engine turn. The **sequence** —
+//! before_turn per stage, the turn, after_turn, judge, again — stays in
+//! `stella_runtime::WrapperDispatch`, because `doc:wrapper-socket` §6 requires
+//! the same plugin to run under `stella-serve` and an embedded `stella-engine`
+//! host, and a sequence living in this binary is one neither can reach. The
+//! engine never learns plugins exist: this module binds the grants and hands
+//! it plain messages.
 //!
-//! # What is here and what is deliberately one crate down
+//! It is a sibling of `crate::agent`, not a part of it, because `agent.rs`
+//! sits close to the 1500-line ratchet (AGENTS.md § "God files").
 //!
-//! The **sequence** — before_turn per stage, the turn, after_turn, judge,
-//! again — is `stella_runtime::WrapperDispatch` and stays there, because §6
-//! requires the same plugin to run under `stella-serve` and an embedded
-//! `stella-engine` host too, and a sequence living in this binary is one
-//! neither can reach. What is here is only the part that is genuinely the
-//! CLI's: which plugins are installed, how this process resolves an
-//! environment allowlist, and what one turn of *this* engine is.
+//! What a plugin is handed, and the limit on each:
 //!
-//! `stella-core` gains nothing from any of it. The engine never learns plugins
-//! exist; this module binds the grants and hands the engine plain messages.
+//! - **A candidate grant** naming the shared work tree the turn runs in, with
+//!   `--test-command` parsed into a [`stella_plugin::TestPlan`], so an
+//!   `[oracle]` declaring `flip = "required"` can observe red before and green
+//!   after. [`crate::wrapper_candidate`] holds the invocation shapes whose
+//!   tamper finding stays [`stella_plugin::TamperFinding::NotChecked`].
+//! - **Turn facts** folded from the turn's own event stream by
+//!   [`crate::turn_facts`]. `Some(vec![])` means the turn touched nothing;
+//!   `None` means this host does not report it.
+//! - **A host-call gate**, always — a host with no context plane attaches one
+//!   and answers with no frames, because an empty answer is something a plugin
+//!   can degrade on and an absent gate is not.
+//! - **A child-turn plane**, spent by this session's own `SubAgentDispatcher`,
+//!   so the plugin never holds a provider, an `Engine` or a credential
+//!   (invariant 3, `doc:turn-loop-wrappers` §9.3). The `verifier` tier binds to
+//!   `ModelCallRole::Verdict`; a point runs between the parent's turns where
+//!   the tool registry's event slot is empty, so its spend reaches the
+//!   session's guard and this run's report but not the store's receipt; and
+//!   [`dispatch_under_turn_controls`] publishes the turn's boundary controls
+//!   for the whole dispatch, so a plugin's child parks with a paused parent.
+//!   This door supplies [`TurnControls::none`], being headless.
 //!
-//! # It lives beside `agent.rs`, not inside it
+//! [`bind_installed`] and [`ResolvedWrapper::serving`] are separate moments
+//! rather than one function with an `Option` in it: a `--pipeline` naming
+//! nothing installed must fail as a typo before a paid call, a child-turn
+//! plane needs a dispatcher and therefore the provider, and [`HostPlanes`] is
+//! consumed by value at [`HostCallGate::declare`] so no plane can be added to
+//! a gate afterwards.
 //!
-//! `crates/stella-cli/src/agent.rs` sits close to the 1500-line ratchet
-//! (AGENTS.md § "God files"), so this is a sibling module — the same
-//! placement, for the same reason, as `crate::turn_files`.
+//! Two scope limits. A plugin's `Unmet` fails the process only under
+//! `--require-verdict` — see `verdict_gate` for what the default defends — and
+//! this is the only one of `doc:wrapper-socket` §6's three drivers that
+//! exists, though `--pipeline` itself reaches every door that takes it.
 //!
-//! # What a plugin is handed, and what it is told it cannot have
-//!
-//! The three holes this module shipped with are closed, and each closure names
-//! the limit that remains rather than implying there is none:
-//!
-//! 1. **A real candidate grant and a real tamper finding** (#3553). The grant
-//!    names the **shared work tree** — the tree the turn actually runs in — and
-//!    carries the parsed `--test-command` as a [`stella_plugin::TestPlan`], so a wrapper whose
-//!    `[oracle]` declares `flip = "required"` can observe red before and green
-//!    after and reach a *decided* verdict. The host pins the identity of the
-//!    artifacts that invocation names and vouches for them itself. See
-//!    [`crate::wrapper_candidate`] for why the grant is not an isolated
-//!    worktree, and for the invocation shapes whose tamper finding is still
-//!    [`stella_plugin::TamperFinding::NotChecked`].
-//! 2. **Real turn facts** (#3552). `TurnOutcome::tools` and `changed_files` are
-//!    folded from the turn's own event stream by [`crate::turn_facts`] and sent
-//!    as `Some(..)` — so `Some(vec![])` is "the turn touched nothing" and the
-//!    `None` the wire now also carries is "this host does not report it", which
-//!    is what a plugin could not tell apart before.
-//! 3. **A host-call gate** (#3561). Every wrapper is bound with one, so a
-//!    plugin's `recall` reaches this workspace's context plane
-//!    ([`crate::wrapper_recall`]) instead of finding no channel at all. A host
-//!    with no plane still attaches the gate and answers with no frames: an
-//!    empty answer is something a plugin can degrade on, and an absent gate is
-//!    the one thing it cannot be told about.
-//! 4. **A child-turn plane** (#3576). A plugin that declares
-//!    `[loop] calls = ["child_turn"]` and a `[roles.<name>]` gets a real model
-//!    call at that role intent — spent by **this session's own**
-//!    `SubAgentDispatcher`, the one `task_assign` runs on, so the plugin never
-//!    holds a provider, an `Engine` or a credential (invariant 3,
-//!    `doc:turn-loop-wrappers` §9.3). The seat it resolves to is the receipt's
-//!    attribution, the child is read-only, the allowance is the host's, and
-//!    what it spent is printed beside what it was refused. Two things stated
-//!    rather than implied: the `verifier` tier **is** bound here, to
-//!    `ModelCallRole::Verdict`, so an arbiter plugin's assessment turn runs
-//!    and is booked as what it is (#3838 — [`child_turn_plane`](planes::child_turn_plane) argues why,
-//!    including why the refusal that stood here before was right when it was
-//!    written and is not any more); and a point runs between the parent's
-//!    turns, where the tool registry's event slot is empty — so the spend
-//!    reaches the session's guard and this run's report, but not the store's
-//!    receipt (#3802). The turn's boundary controls **do** cross (#3803):
-//!    [`dispatch_under_turn_controls`] publishes them for the span of the
-//!    dispatch — every round and every point between them — so a plugin's
-//!    child parks with a paused parent and stops with a stopped one. What
-//!    this door supplies is [`TurnControls::none`], because it is headless
-//!    and has no pause gate or steering tap to publish; the seam is what
-//!    #3554 needs, and a controlled surface fills it by passing its own.
-//!
-//! The ordering that makes 4 possible is worth naming, because it is the shape
-//! of the split between [`bind_installed`] and [`ResolvedWrapper::serving`]: a
-//! `--pipeline` naming nothing installed must fail as a typo before a paid
-//! call, while a child-turn plane needs a dispatcher, which needs the provider.
-//! [`HostPlanes`] is consumed by value at [`HostCallGate::declare`], so a plane
-//! cannot be added to a gate afterwards — the two halves are therefore separate
-//! moments, not one function with an `Option` in it.
-//!
-//! And two scope limits. A plugin's `Unmet` fails the process only under
-//! `--require-verdict`, which every wrapper-driving door now offers (#3554
-//! shipped the gate on `stella run`; #4543 took it to `stella goal` — the
-//! LAST round's verdict decides — and to `stella fleet`, where an unmet
-//! verdict fails that ATTEMPT and a failed attempt fails the run; see
-//! `verdict_gate` for what the default is defending). And
-//! only this driver of `doc:wrapper-socket` §6's three exists
-//! (#3551). `--pipeline <variant>` itself now reaches every door that takes
-//! it — `stella run` here, `stella goal` per judged round
-//! (`crate::agent::goal::goal_wrapped`), and `stella fleet` per worker
-//! attempt (`crate::fleet_cmd::wrapped`, #3695) — so there is no door left
-//! refusing a named variant for want of a driver.
-//!
-//! # `stella goal`'s driver is a second call site, not a second sequence
-//!
-//! `crate::agent::goal::goal_wrapped::run_goal_wrapped_turn` binds a wrapper exactly as
-//! this module's [`resolve`]/[`ResolvedWrapper::serving`] do, then calls
-//! [`WrapperDispatch::run`] once per judged round — the goal loop's own
-//! round loop, not the wrapper's, decides how many rounds run, because the
-//! goal verifier (`stella_core::Engine::assess`) is untouched (#3695, goal
-//! half). That only stays true because [`reject_arbiter_wrapper_on_goal`]
-//! refuses an arbiter-grade wrapper on this door before any of the above ever
-//! runs (#3832): `WrapperDispatch`'s own hold loop only holds a round open
-//! for an arbiter-grade plugin, and a hold-open round dispatched *inside* one
-//! already-judged goal round is a second round-holder judging the same
-//! round, which the goal loop's own `Engine::assess` was already doing —
-//! `run_goal_wrapped_turn` used to only discover this after billing
-//! `1 + DEFAULT_HOST_MAX_HOLDS` worker turns for it, then discard the whole
-//! run (`DispatchReport::rounds != 1`, still checked as a defense-in-depth
-//! assertion — see that module's doc comment). So for the steering/observer
-//! wrappers this door does accept, a round's dispatch always drives exactly
-//! one internal turn, at the round's own `turn_instance`; and the goal
-//! round's own execution row (opened once, before the loop, exactly like
-//! [`RawTurnDriver`]'s door opens one) records the id `bound` resolved for the
-//! whole run, which is true of it because every round under that row really was
-//! dispatched through it.
-//!
-//! The goal door serves `child_turn` too, through [`round_driver_host`]
-//! (#3833). It could not while this module pinned the plane to a fixed
-//! `turn_instance`: `stella run`'s one-shot worker never uses more than slot 0,
-//! but a goal round's own worker/verifier pair claims a slot beside every
-//! round, so a fixed child slot collided with whichever round landed on it.
-//! [`stella_core::turn_slots`] is the allocation that settles it, and it is
-//! stated once there rather than per door — `turn_instance` is read as a lane
-//! plus a sequence within that lane, so a plane counting only its own calls
-//! can never land where a door's rounds will. `stella fleet` reaches
-//! `child_turn` through the same assembly and the same rule (#3882).
+//! `stella goal` is a second call site, not a second sequence:
+//! `crate::agent::goal::goal_wrapped` binds a wrapper the same way and calls
+//! [`WrapperDispatch::run`] once per judged round, the goal loop's own round
+//! loop deciding how many rounds run. [`reject_arbiter_wrapper_on_goal`]
+//! refuses an arbiter-grade wrapper there, because a hold-open round inside an
+//! already-judged goal round is a second round-holder judging the same round.
+//! Child slots come from [`stella_core::turn_slots`], which reads
+//! `turn_instance` as a lane plus a sequence within it, so a plane counting
+//! only its own calls can never land where a door's rounds will; `stella
+//! fleet` reaches `child_turn` through the same assembly.
 
 use std::sync::Arc;
 

--- a/scripts/prose-baseline.txt
+++ b/scripts/prose-baseline.txt
@@ -418,9 +418,8 @@ crates/stella-cli/src/daemon.rs enumerative-announcement 1
 crates/stella-cli/src/daemon.rs filler-adverb 11
 crates/stella-cli/src/daemon.rs honesty-declaration 1
 crates/stella-cli/src/daemon.rs rust-jargon 3
-crates/stella-cli/src/daemon/boot.rs filler-adverb 13
-crates/stella-cli/src/daemon/boot.rs honesty-declaration 4
-crates/stella-cli/src/daemon/boot.rs ranking-flourish 1
+crates/stella-cli/src/daemon/boot.rs filler-adverb 9
+crates/stella-cli/src/daemon/boot.rs honesty-declaration 2
 crates/stella-cli/src/daemon/boot.rs rust-jargon 2
 crates/stella-cli/src/daemon/boot/tests.rs filler-adverb 3
 crates/stella-cli/src/daemon/boot/tests.rs honesty-declaration 1
@@ -435,9 +434,7 @@ crates/stella-cli/src/daemon/tests.rs enumerative-announcement 1
 crates/stella-cli/src/daemon/tests.rs filler-adverb 5
 crates/stella-cli/src/daemon/tests.rs honesty-declaration 1
 crates/stella-cli/src/daemon/tests.rs rust-jargon 1
-crates/stella-cli/src/dataset_cmd.rs enumerative-announcement 1
 crates/stella-cli/src/dataset_cmd.rs filler-adverb 3
-crates/stella-cli/src/dataset_cmd.rs honesty-declaration 1
 crates/stella-cli/src/dataset_cmd.rs rust-jargon 2
 crates/stella-cli/src/dataset_cmd/tests.rs honesty-declaration 1
 crates/stella-cli/src/diag_boot.rs filler-adverb 3
@@ -633,7 +630,7 @@ crates/stella-cli/src/question.rs filler-adverb 2
 crates/stella-cli/src/question.rs interface-jargon 5
 crates/stella-cli/src/resume_frame.rs honesty-declaration 1
 crates/stella-cli/src/resume_frame.rs rust-jargon 15
-crates/stella-cli/src/reward.rs filler-adverb 4
+crates/stella-cli/src/reward.rs filler-adverb 2
 crates/stella-cli/src/reward.rs meta-writing 1
 crates/stella-cli/src/reward.rs rust-jargon 4
 crates/stella-cli/src/reward/tests.rs filler-adverb 1
@@ -723,7 +720,7 @@ crates/stella-cli/src/stats.rs filler-adverb 2
 crates/stella-cli/src/stats.rs honesty-declaration 3
 crates/stella-cli/src/stats.rs rust-jargon 1
 crates/stella-cli/src/storage_cmd.rs rust-jargon 1
-crates/stella-cli/src/subagent.rs filler-adverb 10
+crates/stella-cli/src/subagent.rs filler-adverb 6
 crates/stella-cli/src/subagent.rs honesty-declaration 2
 crates/stella-cli/src/subagent/tests.rs enumerative-announcement 1
 crates/stella-cli/src/subagent/tests.rs honesty-declaration 1
@@ -739,10 +736,10 @@ crates/stella-cli/src/term_policy.rs interface-jargon 11
 crates/stella-cli/src/tests.rs interface-jargon 6
 crates/stella-cli/src/tests.rs rust-jargon 2
 crates/stella-cli/src/tests/flag_docs.rs filler-adverb 1
-crates/stella-cli/src/tool_docs.rs filler-adverb 4
+crates/stella-cli/src/tool_docs.rs filler-adverb 3
 crates/stella-cli/src/tool_docs.rs honesty-declaration 6
 crates/stella-cli/src/tool_docs.rs meta-writing 1
-crates/stella-cli/src/tool_docs.rs rust-jargon 7
+crates/stella-cli/src/tool_docs.rs rust-jargon 4
 crates/stella-cli/src/tool_foundry/adopt.rs filler-adverb 1
 crates/stella-cli/src/tool_foundry/adopt.rs meta-writing 1
 crates/stella-cli/src/tool_policy.rs filler-adverb 2
@@ -751,7 +748,7 @@ crates/stella-cli/src/turn_diff.rs interface-jargon 3
 crates/stella-cli/src/turn_facts.rs enumerative-announcement 1
 crates/stella-cli/src/turn_facts.rs honesty-declaration 1
 crates/stella-cli/src/turn_facts.rs rust-jargon 3
-crates/stella-cli/src/turn_files.rs filler-adverb 8
+crates/stella-cli/src/turn_files.rs filler-adverb 6
 crates/stella-cli/src/turn_files.rs honesty-declaration 5
 crates/stella-cli/src/turn_files.rs interface-jargon 7
 crates/stella-cli/src/turn_files.rs rust-jargon 2
@@ -760,12 +757,10 @@ crates/stella-cli/src/usage_cmd.rs rust-jargon 1
 crates/stella-cli/src/wrapper_candidate.rs filler-adverb 2
 crates/stella-cli/src/wrapper_candidate.rs honesty-declaration 2
 crates/stella-cli/src/wrapper_candidate.rs rust-jargon 1
-crates/stella-cli/src/wrapper_plugin.rs enumerative-announcement 1
-crates/stella-cli/src/wrapper_plugin.rs filler-adverb 4
+crates/stella-cli/src/wrapper_plugin.rs filler-adverb 3
 crates/stella-cli/src/wrapper_plugin.rs honesty-declaration 2
 crates/stella-cli/src/wrapper_plugin.rs interface-jargon 2
-crates/stella-cli/src/wrapper_plugin.rs meta-writing 1
-crates/stella-cli/src/wrapper_plugin.rs rust-jargon 58
+crates/stella-cli/src/wrapper_plugin.rs rust-jargon 57
 crates/stella-cli/src/wrapper_plugin/planes.rs filler-adverb 2
 crates/stella-cli/src/wrapper_plugin/planes.rs honesty-declaration 2
 crates/stella-cli/src/wrapper_plugin/report.rs rust-jargon 1
@@ -1646,7 +1641,7 @@ crates/stella-tui/src/textline.rs filler-adverb 3
 crates/stella-tui/src/textline.rs honesty-declaration 1
 crates/stella-tui/src/textline.rs interface-jargon 3
 crates/stella-tui/src/textline.rs rust-jargon 8
-crates/stella-tui/src/theme.rs filler-adverb 8
+crates/stella-tui/src/theme.rs filler-adverb 7
 crates/stella-tui/src/theme.rs interface-jargon 5
 crates/stella-tui/src/theme.rs rust-jargon 1
 crates/stella-tui/src/theme/tests.rs filler-adverb 2


### PR DESCRIPTION
First batch of #4758, on `stella-cli` — the unit the issue names first, along
with `docs`.

## What changed

The five longest `//!` headers in the crate, 618 lines down to 254:

| file | before | after |
|---|---|---|
| `src/subagent.rs` | 161 | 43 |
| `src/wrapper_plugin.rs` | 132 | 60 |
| `src/daemon/boot.rs` | 123 | 44 |
| `src/reward.rs` | 101 | 50 |
| `src/dataset_cmd.rs` | 101 | 57 |

Every rule survives, in the present tense. What goes is the narration around
it: which of two designs an issue offered and why the other lost
(`daemon/boot.rs`'s "Which of the two shapes #1627 offered"), what a rule used
to be before it was widened (`reward.rs`'s two-tier `OutcomeWeights` and the
argument for removing the second tier), and the retelling of the defect a rule
now prevents (`wrapper_plugin.rs`'s account of what `run_goal_wrapped_turn`
used to bill before the arbiter check). Each is a sentence a reader walks past
to reach the constraint that binds their change.

Two of these headers also carried constructions this repository bans outright:
`wrapper_plugin.rs` had both "Two things stated rather than implied" — the
specimen CLAUDE.md names the deletion rule after — and "is worth naming".

Nothing was moved to a README or a design document, because no rule here was
the only record of itself: every deleted paragraph either restated a rule kept
above it, or narrated an issue that is still open in the tracker and reachable
by its number.

## Why five files and not the crate

The issue calls for one crate per PR; `stella-cli` alone has 213 module
headers of fourteen lines or more, which is several thousand changed lines and
past both a reviewable diff and Sourcery's limit (#4959). This is the top of
that list by header length. #4758 stays open.

## Witness

None owed: docs-only. The evidence is the guard numbers.

- `scripts/prose-baseline.txt`: **4206 → 4187**, retightened with
  `make prose-update`, which refuses to raise a count. No entry was added.
- `make guards-fast` green, including `prose`, `line-citations`, `file-size`
  and `doc-links`.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps` clean — this
  is the check that matters for a header edit, since every intra-doc link in
  the rewritten text has to still resolve. It caught one: `SkipReason` is
  `pub(super)`, so the shortened link had to keep its full path.
- `cargo clippy -p stella-cli --all-targets -- -D warnings` clean.

One construction slipped in during the rewrite — "both are load-bearing" in
`daemon/boot.rs` — and `make prose` failed on it before this was pushed. It is
gone; the guard is doing its job on new prose as well as old.

Refs #4758
Refs #4392

## Summary by Sourcery

Shorten the five longest stella-cli module headers to retain essential reader guidance while removing redundant historical narrative.

Enhancements:
- Condense the five longest stella-cli module headers while preserving the constraints, invariants, and user-relevant guidance they document.

Documentation:
- Remove historical issue narration, superseded design discussion, and redundant explanations from the subagent, wrapper plugin, daemon boot, reward, and dataset command module documentation.

Tests:
- Verify the documentation-only changes with prose guards, documentation link and warning checks, fast guards, and clippy.