### PR TITLE
feat(stella-store): record whether a run shipped, apart from how it ended

### DIFF
--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -1266,6 +1266,12 @@ async fn run_task(
     }
 
     let spent = budget.session_spent_usd();
+    // Read the attempt's commits BEFORE closing its execution row, so the row
+    // records what the attempt shipped as well as how it ended (#2808). This
+    // door is the one that owes no attribution guess: the execution and the
+    // commit set belong to the same attempt, measured against its own
+    // `start_sha`. `for_attempt` drains the observer, so it stays called once.
+    let commits = crate::fleet_commits::for_attempt(&committed, root, &start_sha, task).await;
     let _ = finalize_fleet_execution(
         &execution,
         &registry,
@@ -1273,8 +1279,8 @@ async fn run_task(
         spent,
         rendered.persistence_complete,
         force_incomplete,
+        crate::fleet_commits::delivery_of(&commits),
     );
-    let commits = crate::fleet_commits::for_attempt(&committed, root, &start_sha, task).await;
     Ok(WorkerOutcome {
         cost_usd: spent,
         commits,
@@ -1283,6 +1289,11 @@ async fn run_task(
     })
 }
 
+/// Close the attempt's execution row: how it ended, and what it shipped.
+///
+/// `delivery` is written whatever the outcome, because the two are independent
+/// — an attempt can error or be stopped after landing commits, which is the
+/// case that used to be recorded as having delivered nothing (#2808).
 fn finalize_fleet_execution(
     execution: &crate::fleet_spend::ExecutionHandle,
     registry: &ToolRegistry,
@@ -1290,10 +1301,12 @@ fn finalize_fleet_execution(
     cost_usd: f64,
     persistence_complete: bool,
     force_incomplete: bool,
+    delivery: stella_store::Delivery,
 ) -> bool {
     let Some((store, execution_id)) = execution else {
         return false;
     };
+    let _ = store.record_delivery(*execution_id, delivery);
     agent::record_execution_end(
         store,
         *execution_id,

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -193,6 +193,7 @@ async fn fleet_attempt_persists_usage_before_complete_closeout() {
         0.25,
         rendered.persistence_complete,
         false,
+        stella_store::Delivery::Nothing,
     ));
     assert_eq!(store.count("telemetry").unwrap(), 1);
     assert!(store.execution_usage_complete(id).unwrap());
@@ -215,6 +216,7 @@ fn stopped_fleet_attempt_never_becomes_exportable() {
         0.0,
         true,
         true,
+        stella_store::Delivery::Nothing,
     ));
     assert!(!store.execution_usage_complete(id).unwrap());
     // The flag is what withholds it from the enterprise export
@@ -229,6 +231,73 @@ fn stopped_fleet_attempt_never_becomes_exportable() {
         .unwrap()
         .expect("a stopped attempt rolls up as a floor");
     assert!(!rollup.usage_complete, "and is marked as one");
+}
+
+/// **The witness for #2808.** How an attempt ended and whether it shipped are
+/// two readings, and the attempt close writes both.
+///
+/// Execution 99 is the case: recorded `outcome = 'cancelled'`, and what
+/// actually happened is that the worker pushed and merged a pull request
+/// before the cancel landed. `outcome` alone cannot hold that, so every
+/// analysis filtering on `'completed'` scored a $5.29 delivered run as zero.
+///
+/// Two stopped attempts here, identical in outcome and cost, differing only in
+/// what they landed — and the store now tells them apart. The third reading,
+/// `None`, is what a door that cannot see its own commits leaves behind, and
+/// `stella-store`'s `delivery` module owns that case.
+#[test]
+fn a_stopped_attempt_that_landed_commits_is_not_a_stopped_attempt_that_landed_none() {
+    let root = tempfile::tempdir().expect("root");
+    let store = Arc::new(stella_store::Store::open(root.path()).expect("store"));
+    let registry = ToolRegistry::new(root.path().to_path_buf());
+
+    let shipped = store
+        .begin_execution("fleet", "task", "anthropic", "claude")
+        .expect("begin");
+    finalize_fleet_execution(
+        &Some((store.clone(), shipped)),
+        &registry,
+        "cancelled",
+        5.29,
+        true,
+        true,
+        crate::fleet_commits::delivery_of(&[commit_record("a1b2c3d")]),
+    );
+
+    let empty = store
+        .begin_execution("fleet", "task", "anthropic", "claude")
+        .expect("begin");
+    finalize_fleet_execution(
+        &Some((store.clone(), empty)),
+        &registry,
+        "cancelled",
+        5.29,
+        true,
+        true,
+        crate::fleet_commits::delivery_of(&[]),
+    );
+
+    assert_eq!(
+        store.delivery(shipped).expect("read"),
+        Some(stella_store::Delivery::Commits),
+        "a cancelled attempt that landed a commit must record that it shipped"
+    );
+    assert_eq!(
+        store.delivery(empty).expect("read"),
+        Some(stella_store::Delivery::Nothing),
+        "and one that landed nothing must say so, not fall silent"
+    );
+}
+
+/// One landed commit, in the shape the fleet ledger records them.
+fn commit_record(sha: &str) -> stella_fleet::CommitRecord {
+    stella_fleet::CommitRecord {
+        sha: sha.to_string(),
+        branch: "stella/task".to_string(),
+        task_id: "task".to_string(),
+        message: "fix the router".to_string(),
+        timestamp_ms: 0,
+    }
 }
 
 // the post-fanout PR/CI watch (--watch)

--- a/crates/stella-cli/src/fleet_commits.rs
+++ b/crates/stella-cli/src/fleet_commits.rs
@@ -198,11 +198,9 @@ pub(crate) async fn for_attempt(
 /// The distinction this records is between *observed and empty* and *not
 /// observed at all*, so it is only ever called where the commits are known:
 /// this door reads them against the attempt's own `start_sha`, so an empty set
-/// is a measurement rather than a silence. A worker whose thread died before
-/// it could report leaves the column NULL instead — see
-/// `crate::fleet_spend::unreported_outcome`, which closes such a row and
-/// claims nothing about delivery, because its worker died before it could
-/// report.
+/// is a measurement rather than a silence. A worker whose thread died never
+/// reaches here: `crate::fleet_spend::unreported_outcome` closes that row from
+/// the dispatch side, saw no commits, and leaves the column NULL.
 pub(crate) fn delivery_of(commits: &[CommitRecord]) -> stella_store::Delivery {
     if commits.is_empty() {
         stella_store::Delivery::Nothing

--- a/crates/stella-cli/src/fleet_commits.rs
+++ b/crates/stella-cli/src/fleet_commits.rs
@@ -193,6 +193,24 @@ pub(crate) async fn for_attempt(
     }
 }
 
+/// What an attempt shipped, from the commits [`for_attempt`] found (#2808).
+///
+/// The distinction this records is between *observed and empty* and *not
+/// observed at all*, so it is only ever called where the commits are known:
+/// this door reads them against the attempt's own `start_sha`, so an empty set
+/// is a measurement rather than a silence. A worker whose thread died before
+/// it could report leaves the column NULL instead — see
+/// `crate::fleet_spend::unreported_outcome`, which closes such a row and
+/// claims nothing about delivery, because its worker died before it could
+/// report.
+pub(crate) fn delivery_of(commits: &[CommitRecord]) -> stella_store::Delivery {
+    if commits.is_empty() {
+        stella_store::Delivery::Nothing
+    } else {
+        stella_store::Delivery::Commits
+    }
+}
+
 /// The commits `root` gained between `from` and its current `HEAD`, oldest
 /// first, as ledger-ready records.
 ///

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -91,6 +91,16 @@ pub(crate) const TABLES: [&str; 21] = [
 ///   by `accounted_call::complete_standalone`. NULL means "this row is a
 ///   turn", which is likewise a fact and not a gap.
 ///
+/// # `outcome` and `delivery` — two facts, not one label
+///
+/// `outcome` says how the run **ended**; `delivery` says whether it **shipped**
+/// anything. They are independent: a completed run can deliver nothing, and a
+/// cancelled one can have merged a pull request before the cancel landed
+/// (#2808). NULL `delivery` is "nothing observed this run's delivery", which is
+/// most rows and is not the same answer as `'none'`. See
+/// `crate::telemetry::delivery` for the tokens and `migrations::delivered_runs`
+/// for why there is no default and no backfill.
+///
 /// Those role rows carry `kind = 'system'`, the one value that is not a door.
 /// It exists because `kind` is `NOT NULL` and so cannot spell "no door" as
 /// NULL; since the column has never had an unrecorded state, the sentinel
@@ -114,7 +124,8 @@ pub(crate) const EXECUTIONS_DDL: &str = "CREATE TABLE IF NOT EXISTS executions (
        journal_era INTEGER NOT NULL DEFAULT 0,
        pipeline_variant TEXT,
        role TEXT,
-       parent_execution_id INTEGER
+       parent_execution_id INTEGER,
+       delivery TEXT
      );
      CREATE INDEX IF NOT EXISTS executions_by_session
        ON executions(session_id, id);

--- a/crates/stella-store/src/export.rs
+++ b/crates/stella-store/src/export.rs
@@ -198,6 +198,15 @@ impl Store {
     ///   execution before the join so a multi-step run can never fan out the
     ///   executions side.
     /// - `cost_per_resolved_usd` is `None` when `resolved = 0`.
+    ///
+    /// `resolved` still means `outcome = 'completed'` and nothing else, now
+    /// that `executions.delivery` exists beside it (#2808). Folding a
+    /// delivered-but-cancelled run in here would move every published
+    /// cost-per-resolved number on the strength of a signal only some doors
+    /// write, so the two stay separable: read `delivery` when the question is
+    /// what shipped, and `outcome` when it is how the run ended. Promoting
+    /// delivery into this count is a decision about published figures, and it
+    /// belongs to whoever owns them.
     /// - Rows are ordered by total cost descending (ties broken by
     ///   provider, then model, so output is deterministic).
     ///
@@ -337,7 +346,7 @@ impl Store {
         {
             let sql = format!(
                 "SELECT id, kind, prompt, provider, model, started_at, finished_at, outcome, \
-                 cost_usd, usage_complete FROM executions {} ORDER BY id ASC",
+                 cost_usd, usage_complete, delivery FROM executions {} ORDER BY id ASC",
                 scope.executions_where("")
             );
             let mut stmt = conn.prepare(&sql)?;
@@ -353,6 +362,11 @@ impl Store {
                     "outcome": row.get::<_, Option<String>>(7)?,
                     "cost_usd": row.get::<_, f64>(8)?,
                     "usage_complete": row.get::<_, bool>(9)?,
+                    // Null rather than absent when unobserved: the three
+                    // readings of `delivery` are `null` / `"none"` /
+                    // `"commits"`, and an analysis must be able to tell the
+                    // first from the second (#2808).
+                    "delivery": row.get::<_, Option<String>>(10)?,
                 }))
             })?;
             let mut arr = Vec::new();

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -225,7 +225,7 @@ pub use sessions::{SessionRecord, SessionRegistry, SessionStatus, SupervisorInfo
 /// in [`task_board`] speaks in these, and a caller should not have to name
 /// `stella-protocol` to call one.
 pub use stella_protocol::TaskItem;
-pub use telemetry::{SourceTelemetryRow, TelemetryRow};
+pub use telemetry::{Delivery, SourceTelemetryRow, TelemetryRow};
 pub use tool_calls::{ToolCallRow, ToolCallState};
 
 /// FNV-1a/64 hex — a stable, dependency-free digest for prompt hashes and

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -51,6 +51,7 @@ mod abandoned_state;
 mod additive_tables;
 mod agent_use_kind;
 mod call_identity;
+mod delivered_runs;
 mod dispatched_executions;
 mod error_class;
 mod execution_plane;
@@ -104,7 +105,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 37] = [
+pub(crate) const MIGRATIONS: [Migration; 38] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -305,6 +306,14 @@ pub(crate) const MIGRATIONS: [Migration; 37] = [
     // joined to the receipt of the call that produced it (#4924). NULL is
     // "this row cannot say", never 0. See the module's own doc.
     telemetry_call_identity::migrate_v36_to_v37,
+    // v37 → v38: `executions` grows `delivery` — whether the run shipped
+    // anything, recorded apart from how it ended, because a cancelled run can
+    // have merged a pull request before the cancel landed (#2808). Additive,
+    // column-guarded ADD COLUMN, nullable with no default and no backfill:
+    // NULL is "nothing observed this run's delivery", never "shipped
+    // nothing" — the whole point is that those two are different answers.
+    // See the module's own doc.
+    delivered_runs::migrate_v37_to_v38,
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `SCHEMA_VERSION` is its length, so
     // a slot is claimed by position, not by name. Two branches that each
@@ -357,7 +366,8 @@ pub(crate) const MIGRATIONS: [Migration; 37] = [
     //   v35 → v36: CLAIMED above by `executions.parent_execution_id` (#4628).
     //   v36 → v37: CLAIMED above by `telemetry.stream_seq` + the receipt join
     //              columns (#4924).
-    // Nothing is reserved now: take v37 → v38 and add your own line here.
+    //   v37 → v38: CLAIMED above by `executions.delivery` (#2808).
+    // Nothing is reserved now: take v38 → v39 and add your own line here.
     // If a reserved phase ships without needing its slot, delete its line
     // rather than leaving a hole — index order is the contract.
 ];

--- a/crates/stella-store/src/migrations/delivered_runs.rs
+++ b/crates/stella-store/src/migrations/delivered_runs.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! v37 → v38: `executions` grows `delivery` — whether the run shipped
+//! anything, recorded apart from how it ended (#2808).
+//!
+//! `outcome` is one final label carrying two independent facts. How a run
+//! ended — completed, aborted, cancelled, failed, error — says nothing about
+//! whether it delivered, and a cancelled run can have pushed and merged a pull
+//! request before the cancel landed. Execution 99 did exactly that: recorded
+//! `cancelled`, and the truth was a $5.29 run that shipped a merged PR. Every
+//! analysis filtering on `outcome = 'completed'` scores that as zero.
+//!
+//! # Nullable, no default, no backfill
+//!
+//! `NULL` means **nothing observed this run's delivery** — not "shipped
+//! nothing". The two must stay apart, or the column answers the question the
+//! `outcome` overload already answers badly: a reader must be able to tell
+//! "ended early and shipped nothing" from "ended early and nobody looked".
+//! Only a door that can see an attempt's commits writes here, so most rows are
+//! `NULL` and will stay that way.
+//!
+//! There is no backfill because nothing recorded the fact. `pull_requests` is
+//! keyed by URL and linked to a session, never to an execution; the fleet's
+//! commit ledger lives in a different database (`fleet.db`) with no execution
+//! id on it. Picking whichever run of a session was open when a PR appeared
+//! would be a guess dressed as a record.
+//!
+//! Not to be confused with `execution_reflection.delivered`, which is the
+//! model's own self-report about its turn. This column is an observation.
+
+use crate::Result;
+use crate::migrations::{column_exists, table_exists};
+
+/// Add `executions.delivery`, column-guarded so a file that already has it is
+/// untouched.
+pub(super) fn migrate_v37_to_v38(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    if table_exists(tx, "executions")? && !column_exists(tx, "executions", "delivery")? {
+        tx.execute_batch("ALTER TABLE executions ADD COLUMN delivery TEXT;")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::apply_migration;
+    use rusqlite::Connection;
+
+    fn v37_file() -> Connection {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE executions (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               kind TEXT NOT NULL,
+               prompt TEXT NOT NULL,
+               provider TEXT NOT NULL,
+               model TEXT NOT NULL,
+               outcome TEXT,
+               session_id TEXT
+             );
+             INSERT INTO executions (kind, prompt, provider, model, outcome, session_id)
+               VALUES ('fleet', 'fix the router', 'zai', 'glm-5.2', 'cancelled', 'ses-1');",
+        )
+        .expect("seed a v37 file");
+        conn
+    }
+
+    /// A row written before the column existed reads as **unobserved**, never
+    /// as "shipped nothing". Nothing looked at that run's delivery, and a
+    /// default would convert an absence of evidence into a record of failure —
+    /// which is the reading `outcome` already forces and the reason this column
+    /// exists.
+    #[test]
+    fn a_run_from_before_the_column_reads_as_unobserved() {
+        let mut conn = v37_file();
+        apply_migration(&mut conn, migrate_v37_to_v38, 38).expect("migrate");
+        let delivery: Option<String> = conn
+            .query_row("SELECT delivery FROM executions WHERE id = 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read back");
+        assert_eq!(delivery, None);
+    }
+
+    /// Running it twice is a no-op — the column guard, not the error handler,
+    /// is what makes that true.
+    #[test]
+    fn the_migration_is_idempotent() {
+        let mut conn = v37_file();
+        apply_migration(&mut conn, migrate_v37_to_v38, 38).expect("first");
+        apply_migration(&mut conn, migrate_v37_to_v38, 38).expect("second");
+    }
+
+    /// A file with no `executions` table at all still climbs the ladder — the
+    /// rebuild path can present exactly that shape.
+    #[test]
+    fn a_file_with_no_executions_table_still_migrates() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        apply_migration(&mut conn, migrate_v37_to_v38, 38).expect("migrate");
+    }
+}

--- a/crates/stella-store/src/telemetry.rs
+++ b/crates/stella-store/src/telemetry.rs
@@ -5,6 +5,12 @@ use rusqlite::params;
 
 use crate::{Result, Store, sqlite_i64};
 
+/// Whether a run shipped anything — the other half of what `executions` says
+/// about a finished run, apart from how it ended (#2808).
+mod delivery;
+
+pub use delivery::Delivery;
+
 #[cfg(test)]
 pub(crate) mod fixtures;
 

--- a/crates/stella-store/src/telemetry/delivery.rs
+++ b/crates/stella-store/src/telemetry/delivery.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Whether a run shipped anything — recorded apart from how it ended (#2808).
+//!
+//! `executions.outcome` is one final label carrying two independent facts.
+//! *How a run ended* (completed / aborted / cancelled / failed / error) says
+//! nothing about *whether it delivered*, and the two really do come apart in
+//! both directions: a completed run can deliver nothing, and a cancelled run
+//! can have pushed and merged a pull request before the cancel landed. Every
+//! analysis that filters on `outcome = 'completed'` scores the second case as
+//! zero — `Store::usage_stats`' `resolved` count, the scoreboard, and every
+//! cost-per-resolved-task receipt derived from them.
+//!
+//! # Three answers, not two
+//!
+//! The column is nullable, and the absent state is one of the three answers:
+//!
+//! | Reading | Means |
+//! |---|---|
+//! | `None` | Nothing observed this run's delivery. |
+//! | `Some(Delivery::Nothing)` | Something looked, and the run shipped nothing. |
+//! | `Some(Delivery::Commits)` | The run landed at least one commit. |
+//!
+//! Collapsing `None` into `Nothing` would rebuild the defect this column
+//! exists to fix: an absence of evidence read as a record of failure. Most
+//! rows are `None` and will stay that way, because only a door that can see an
+//! attempt's own commits writes here — today the fleet attempt, whose
+//! execution row and commit set are the same attempt's and need no attribution
+//! guess.
+//!
+//! # Why the token set is this short
+//!
+//! A token is declared when a door writes it, not when one can be imagined.
+//! `Nothing` and `Commits` are both written by the fleet attempt close; a PR
+//! or merge token waits for a door that can join a pull request to the
+//! execution that opened it, which `pull_requests` cannot do today (it is keyed
+//! by URL and linked to a session).
+//!
+//! Not to be confused with `execution_reflection.delivered`, which is the
+//! model's own self-report about its turn. This is an observation.
+
+use rusqlite::OptionalExtension as _;
+use rusqlite::params;
+
+use crate::{Result, Store};
+
+/// What a run shipped, as observed by the door that ran it.
+///
+/// The *absence* of a value is a third answer and is spelled `Option::None` by
+/// every reader — see the module doc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delivery {
+    /// The run's delivery was observed and it shipped nothing.
+    Nothing,
+    /// The run landed at least one commit.
+    Commits,
+}
+
+impl Delivery {
+    /// The stored token. Closed set; `parse` is its inverse.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Nothing => "none",
+            Self::Commits => "commits",
+        }
+    }
+
+    /// Read a stored token back.
+    ///
+    /// `None` for anything this build does not know. That is not a silent
+    /// widening: the only writer is [`Store::record_delivery`], and a file
+    /// written by a newer build is refused at open by
+    /// [`crate::StoreError::SchemaTooNew`] before any read gets here — so an
+    /// unrecognised token means a hand-edited database, and reading it as
+    /// "unobserved" is the safe direction.
+    pub fn parse(token: &str) -> Option<Self> {
+        match token {
+            "none" => Some(Self::Nothing),
+            "commits" => Some(Self::Commits),
+            _ => None,
+        }
+    }
+
+    /// Whether this reading says the run shipped something.
+    pub fn shipped(self) -> bool {
+        matches!(self, Self::Commits)
+    }
+}
+
+impl Store {
+    /// Record what a run shipped.
+    ///
+    /// Separate from [`Store::finish_execution_accounted`] rather than another
+    /// parameter on it, because the two facts are observed by different code at
+    /// different moments: every door can name an outcome, and only some can see
+    /// a delivery. A door that cannot leaves the column `NULL`, which is a
+    /// different answer from [`Delivery::Nothing`] and must stay one.
+    ///
+    /// Writing is idempotent and last-writer-wins; a run's delivery is observed
+    /// once, at its close.
+    pub fn record_delivery(&self, execution_id: i64, delivery: Delivery) -> Result<()> {
+        self.lock().execute(
+            "UPDATE executions SET delivery = ?2 WHERE id = ?1",
+            params![execution_id, delivery.as_str()],
+        )?;
+        Ok(())
+    }
+
+    /// What a run shipped, or `None` when nothing observed it.
+    ///
+    /// `None` also covers an execution id that names no row — both are "this
+    /// store cannot say", and a caller that needs to tell a missing run from an
+    /// unobserved one is asking a question about the `executions` spine rather
+    /// than about delivery.
+    pub fn delivery(&self, execution_id: i64) -> Result<Option<Delivery>> {
+        let token: Option<Option<String>> = self
+            .lock()
+            .query_row(
+                "SELECT delivery FROM executions WHERE id = ?1",
+                params![execution_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(token.flatten().as_deref().and_then(Delivery::parse))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_with_run(outcome: &str) -> (Store, i64) {
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("fleet", "fix the router", "zai", "glm-5.2")
+            .expect("open a run");
+        store
+            .finish_execution(id, outcome, 5.29)
+            .expect("close the run");
+        (store, id)
+    }
+
+    /// **The witness.** A cancelled run that shipped a merged pull request is
+    /// not the same record as a cancelled run that shipped nothing, and neither
+    /// is the same as one nobody looked at. Before this column the three were
+    /// one row: `outcome = 'cancelled'`.
+    #[test]
+    fn how_a_run_ended_and_whether_it_shipped_are_two_separate_readings() {
+        let (shipped, shipped_id) = store_with_run("cancelled");
+        shipped
+            .record_delivery(shipped_id, Delivery::Commits)
+            .expect("record");
+
+        let (empty, empty_id) = store_with_run("cancelled");
+        empty
+            .record_delivery(empty_id, Delivery::Nothing)
+            .expect("record");
+
+        let (unobserved, unobserved_id) = store_with_run("cancelled");
+
+        assert_eq!(
+            shipped.delivery(shipped_id).expect("read"),
+            Some(Delivery::Commits),
+            "a cancelled run that landed commits must read as having shipped"
+        );
+        assert_eq!(
+            empty.delivery(empty_id).expect("read"),
+            Some(Delivery::Nothing),
+            "a cancelled run that shipped nothing must say so, not stay silent"
+        );
+        assert_eq!(
+            unobserved.delivery(unobserved_id).expect("read"),
+            None,
+            "a run nobody observed must not read as having shipped nothing"
+        );
+        assert!(Delivery::Commits.shipped());
+        assert!(!Delivery::Nothing.shipped());
+    }
+
+    /// Recording delivery does not disturb the outcome, and closing a run does
+    /// not disturb the delivery. Two columns, two writers, no ordering rule
+    /// between them.
+    #[test]
+    fn the_two_facts_do_not_overwrite_each_other() {
+        let (store, id) = store_with_run("cancelled");
+        store
+            .record_delivery(id, Delivery::Commits)
+            .expect("record");
+        store
+            .finish_execution(id, "cancelled", 5.29)
+            .expect("close again");
+        assert_eq!(store.delivery(id).expect("read"), Some(Delivery::Commits));
+    }
+
+    /// Every token round-trips, and nothing else parses.
+    #[test]
+    fn the_token_set_is_closed_and_round_trips() {
+        for delivery in [Delivery::Nothing, Delivery::Commits] {
+            assert_eq!(Delivery::parse(delivery.as_str()), Some(delivery));
+        }
+        assert_eq!(Delivery::parse("merged"), None);
+        assert_eq!(Delivery::parse(""), None);
+    }
+
+    /// An execution id that names no row reads as unobserved rather than
+    /// erroring — see the reader's own doc for why that is the right shape.
+    #[test]
+    fn an_unknown_execution_reads_as_unobserved() {
+        let store = Store::in_memory().expect("store");
+        assert_eq!(store.delivery(9_999).expect("read"), None);
+    }
+}

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -1052,8 +1052,11 @@ fn skill_usage_records_per_execution_version_rows() {
     //       it did. v36 `executions.parent_execution_id` (#4628) — which turn
     //       dispatched a deck lane, NULL when nobody's turn did. v37
     //       `telemetry.step` becomes `stream_seq` and gains the receipt join
-    //       key (#4924) — the column never held the engine's step.
-    assert_eq!(SCHEMA_VERSION, 37);
+    //       key (#4924) — the column never held the engine's step. v38
+    //       `executions.delivery` (#2808) — whether the run SHIPPED, apart
+    //       from how it ended; NULL is "nobody looked", not "shipped
+    //       nothing".
+    assert_eq!(SCHEMA_VERSION, 38);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")


### PR DESCRIPTION
## What

`executions.outcome` was one final label carrying two independent facts:

- **how a run ended** — completed / aborted / cancelled / failed / error
- **whether it delivered anything**

They are independent in both directions. Execution 99 is the case #2808 opens with: recorded `outcome = 'cancelled'`, and what actually happened is that the worker pushed and merged pull request #2554 before the cancel landed. `resolved` in `usage_stats`, the scoreboard, and every cost-per-resolved receipt derived from them score that $5.29 delivered run as zero.

## Schema v38 — `executions.delivery`

Nullable, no default, no backfill, column-guarded `ADD COLUMN`, following v36's `parent_execution_id` shape. **The absent state is one of three answers, not a gap:**

| Reading | Means |
|---|---|
| `NULL` | Nothing observed this run's delivery. |
| `'none'` | Something looked, and the run shipped nothing. |
| `'commits'` | The run landed at least one commit. |

Collapsing the first two rebuilds the defect the column exists to fix — an absence of evidence read as a record of failure. There is no backfill because nothing recorded the fact: `pull_requests` is keyed by URL and linked to a *session*, never an execution, and the fleet's commit ledger lives in a different database (`fleet.db`) with no execution id on it. Picking whichever run of a session was open when a PR appeared would be a guess dressed as a record.

## The writer

The **fleet attempt close**, and only it — the one door that owes no attribution guess, because the execution row and the commit set belong to the same attempt, measured against its own `start_sha`. `fleet_commits::for_attempt` now runs *before* `finalize_fleet_execution` rather than after, so the row records what the attempt shipped as well as how it ended. `for_attempt` drains the observer, so it stays called exactly once.

A worker whose thread died leaves `NULL`: `fleet_spend::unreported_outcome` closes the row it could not close itself and claims nothing about delivery, which is the honest reading.

Every other door — `stella run`, the deck, self-driving — is untouched and reads `NULL`. Wiring them needs an attribution decision this PR does not make; filed as #5094.

## The reader

The analytics export's `executions` spine, where the fact leaves the store as `null` / `"none"` / `"commits"`.

## The decision #2808 asks for, made explicitly

**`usage_stats.resolved` still means `outcome = 'completed'` and nothing else.** Folding a delivered-but-cancelled run into it would move every published cost-per-resolved number on the strength of a signal only one door writes today. The two stay separable — read `delivery` for what shipped, `outcome` for how it ended — and promoting delivery into that count is a decision about published figures that belongs to whoever owns them. Stated in `usage_stats`' own doc comment so the next reader finds it there.

## Invariant 3 — telemetry egress

Nothing here reaches the hub or a drain. `HUB_TELEMETRY_COLUMNS` covers the hub `telemetry` table, which this does not touch; `ExecutionRollupRow` is unchanged, so the exhaustive-struct-literal guard in `content_free.rs` is not engaged and no allowlist is widened. That is deliberate scope, not an oversight: whether a delivery token should ride the enterprise operational rollup is a privacy review for a maintainer, and no consumer needs it yet.

## God files

`stella-store`'s `lib.rs` is at 1711 against a 1712 ceiling. It gains **no line** — `Delivery` is added to the existing `pub use telemetry::{…}`. `Store::record_delivery` / `Store::delivery` live in the new `telemetry/delivery.rs`; the migration body lives in the new `migrations/delivered_runs.rs`. `tests.rs` gains three comment lines in the one test that pins `SCHEMA_VERSION`, which is where that ledger lives.

## Witnesses, ablated

**1. The absent state is not "shipped nothing"** — `migrations::delivered_runs::a_run_from_before_the_column_reads_as_unobserved`. Ablated by giving the column `NOT NULL DEFAULT 'none'`:

```
---- migrations::delivered_runs::tests::a_run_from_before_the_column_reads_as_unobserved stdout ----
assertion `left == right` failed
  left: Some("none")
 right: None

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 432 filtered out
```

**2. The fleet door records what it shipped** — `fleet_cmd::tests::a_stopped_attempt_that_landed_commits_is_not_a_stopped_attempt_that_landed_none`. Two stopped attempts, identical in outcome and cost, differing only in what they landed. Ablated by making `delivery_of` ignore its commits:

```
---- fleet_cmd::tests::a_stopped_attempt_that_landed_commits_is_not_a_stopped_attempt_that_landed_none stdout ----
assertion `left == right` failed: a cancelled attempt that landed a commit must record that it shipped
  left: Some(Nothing)
 right: Some(Commits)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2332 filtered out
```

Both ablations make the answer **wrong**, not merely constant.

**3.** `telemetry::delivery::how_a_run_ended_and_whether_it_shipped_are_two_separate_readings` pins all three readings against one `outcome = 'cancelled'`, plus round-trip and no-such-row cases.

## Local runs

- `cargo test -p stella-store` — `435 passed; 0 failed`
- `cargo test -p stella-cli fleet` — `59 passed; 0 failed`
- `cargo test -p stella-observatory` — `142 passed; 0 failed` (schema conformance unaffected)
- `cargo clippy -p stella-store -p stella-cli --all-targets -- -D warnings` — clean
- `make guards-fast` — clean

CI is the evidence; the workspace build is not run here.

Closes #2808
Refs #2570, #2374, #5094

## Summary by Sourcery

Record fleet execution delivery separately from termination outcome so analytics can distinguish what a run shipped from how it ended.

New Features:
- Record whether fleet executions shipped commits independently from how they ended, distinguishing unobserved delivery from observed empty delivery.
- Expose execution delivery status through the analytics export as null, none, or commits.

Bug Fixes:
- Prevent delivered-but-cancelled fleet runs from being treated as having delivered nothing in downstream analysis.

Enhancements:
- Keep delivery observations separate from outcome-based resolved usage statistics.
- Add store APIs and closed delivery tokens for recording and reading execution delivery status.

Tests:
- Add migration, delivery-state, and fleet closeout coverage for shipped, empty, and unobserved executions.

Chores:
- Bump the store schema to v38 with a nullable executions.delivery column and no backfill.