### PR TITLE
feat(gate): ratchet module-header density per crate in `make prose`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,14 @@
     pattern's pre-existing hits, once, and refuses to touch any other
     pattern's numbers. A backticked span or a fenced block is exempt: naming
     a banned construction in order to ban it is a citation.
+  - **The same command holds density**, over
+    `scripts/prose-density-baseline.txt`: the mean length of every crate's
+    leading `//!` blocks, ratcheted down only. A count of banned phrases
+    cannot see a forty-line header of unobjectionable sentences, which is
+    what #4392 actually measured. Mean header length rather than comment
+    share, because a pure-function crate should be comment-heavy and share
+    cannot tell that from an essay. A crate with no entry is held to 12.00
+    mean lines, so a new one cannot arrive carrying essays.
 - **AGENTS.md is the orientation document.** Commands, architectural
   invariants, workspace routing, testing approach, and gotchas all live there
   (imported above). When this file and AGENTS.md disagree, AGENTS.md wins —

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,7 @@ tool-error-class-test: ## Test the #3167 ratchet's direction (hermetic; not part
 	./scripts/test-tool-error-class.sh
 
 .PHONY: prose
-prose: ## Assert no content-free prose or banned vocabulary was added (down-only ratchet)
+prose: ## Assert no content-free prose was added, and no crate's module headers got longer
 	@python3 ./scripts/check-prose.py
 
 .PHONY: prose-report
@@ -460,7 +460,7 @@ prose-report: ## Name every remaining content-free construction, with its remedy
 	@python3 ./scripts/check-prose.py --report
 
 .PHONY: prose-update
-prose-update: ## Retighten the prose ratchet (run after deleting some)
+prose-update: ## Retighten both prose ratchets — the counts and the header-length means
 	@python3 ./scripts/check-prose.py --update
 
 .PHONY: line-citations

--- a/docs/prose-guidelines.md
+++ b/docs/prose-guidelines.md
@@ -234,6 +234,22 @@ and it needs three properties to survive contact with a real repository:
 The first time you turn such a checker on you will find thousands of hits.
 That is the point. Record them, then take the count down.
 
+A count of banned phrases says nothing about **density**, which is the other
+half of the problem: a module header can be entirely within the ratchet and
+still be three times longer than it needs to be, because forty lines of
+unobjectionable sentences score zero. So record a second number per unit — the
+mean length of that unit's module headers — and ratchet it the same way, with
+the same refusal to raise. Mean header length rather than comment share: a
+well-documented pure-function module *should* be comment-heavy, and share
+cannot tell that apart from an essay.
+
+In this repository the two live in `scripts/prose-baseline.txt` and
+`scripts/prose-density-baseline.txt`, both written and checked by
+`scripts/check-prose.py`. It scans every tracked text file — prose, Rust doc
+comments, Python docstrings, shell headers — and a bare code identifier on a
+code line counts as prose, which is why a share of the remaining entries can
+only be cleared by renaming code rather than by editing text (#4940).
+
 ---
 
 ## A checklist for review

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -41,18 +41,30 @@ The ratchet is legitimate here for the one reason a ratchet ever is: the rule
 predates the guard. The baseline records debt that already existed; it grants
 no new permission.
 
+A second ratchet, `scripts/prose-density-baseline.txt`, asks the other
+question: not whether a sentence is content-free, but whether there are too
+many of them. It records the mean length of every crate's leading `//!`
+blocks, and a unit may lower that mean and never raise it. A file can be
+entirely within the count ratchet and still be three times longer than it
+needs to be.
+
 Usage:
 
     ./scripts/check-prose.py [--update] [--adopt=NAME] [--report] [ROOT]
 
-    --update      rewrite the baseline downward only (`make prose-update`)
+    --update      rewrite both baselines downward only (`make prose-update`)
     --adopt=NAME  record the pre-existing debt of a pattern added to PATTERNS
                   after the baseline was written, and nothing else. Once per
                   pattern: a pattern already in the baseline is refused
                   (`make prose-adopt PATTERN=NAME`)
-    --bootstrap   create the baseline from the current tree; one-time, and
-                  refuses to run when the baseline already exists
-    --report      print every offending line, grouped by file; changes nothing
+    --bootstrap   create both baselines from the current tree; one-time, and
+                  refuses to run when the count baseline already exists
+    --bootstrap-density
+                  create the density baseline alone; the same one-time door,
+                  for the tree that already had a count baseline when the
+                  density ratchet arrived
+    --report      print every offending line, grouped by file, then each
+                  unit's mean header length; changes nothing
 """
 
 from __future__ import annotations
@@ -185,6 +197,39 @@ HEADER = """\
 # the exact lines.
 """
 
+DENSITY_BASELINE = "scripts/prose-density-baseline.txt"
+
+# Which units the density ratchet measures. A unit is one crate directory.
+DENSITY_UNIT_ROOT = "crates/"
+
+# What a unit with no baseline entry -- a crate added after this file was
+# written -- is held to, in hundredths of a line. A two-to-four sentence header
+# wraps to four to eight `//!` lines, so 12.00 leaves room for a short table or
+# list without leaving room for an essay. The tightest unit in the tree when
+# this ratchet was written averaged 18.00, so nothing existing is held to this
+# number; it is the target a new crate starts at rather than one it inherits.
+NEW_UNIT_MEAN = 1200
+
+DENSITY_HEADER = """\
+# Down-only ratchet on module-header density, per crate (#4760).
+#
+# Each line is `<unit> <mean>` -- the mean length, in lines, of every leading
+# `//!` block in that crate's Rust files, recorded in hundredths so the
+# comparison is integer arithmetic. A unit may lower its mean; it may never
+# raise it, and a unit absent from this list is held to 12.00. Regenerate with
+# `make prose-update`, which refuses to raise a number.
+#
+# Mean header length rather than comment share, because share is a bad proxy on
+# its own: a well-documented pure-function crate should be comment-heavy, and
+# stella-diff scored 74/100 at 26% share. What #4392 measured and #4758 is
+# fixing is the forty-line header, which is what this counts.
+#
+# It answers a different question from scripts/prose-baseline.txt: that one
+# asks whether a sentence is content-free, this one asks whether there are too
+# many sentences. A file can be entirely within the first and three times
+# longer than it needs to be.
+"""
+
 
 def tracked_files(root: Path) -> list[str]:
     out = subprocess.run(
@@ -260,6 +305,67 @@ def counts(root: Path) -> tuple[dict[tuple[str, str], int], dict[str, list]]:
     return per_pair, detail
 
 
+def header_length(text: str) -> int:
+    """Lines in a Rust file's leading `//!` block, 0 when it has none.
+
+    The licence banner and any blank line above the block are skipped; the
+    first line that is neither `//!` nor part of that preamble ends it.
+    """
+    length = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("//!"):
+            length += 1
+            continue
+        if length:
+            break
+        if stripped.startswith("//") or not stripped:
+            continue
+        break
+    return length
+
+
+def density(root: Path, paths: list[str]) -> dict[str, int]:
+    """Per-unit mean module-header length, in hundredths of a line."""
+    total: dict[str, int] = {}
+    files: dict[str, int] = {}
+    for path in paths:
+        if not path.endswith(".rs") or not path.startswith(DENSITY_UNIT_ROOT):
+            continue
+        unit = "/".join(path.split("/")[:2])
+        try:
+            text = (root / path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        length = header_length(text)
+        if not length:
+            continue
+        total[unit] = total.get(unit, 0) + length
+        files[unit] = files.get(unit, 0) + 1
+    return {unit: round(total[unit] * 100 / files[unit]) for unit in total}
+
+
+def read_density_baseline(path: Path) -> dict[str, int]:
+    baseline: dict[str, int] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        if len(fields) != 2:
+            raise SystemExit(
+                f"check-prose: {path} line {line!r} is not `<unit> <mean>`. "
+                "Regenerate it with `make prose-update`."
+            )
+        baseline[fields[0]] = int(round(float(fields[1]) * 100))
+    return baseline
+
+
+def write_density_baseline(path: Path, data: dict[str, int]) -> None:
+    body = "".join(f"{unit} {n / 100:.2f}\n" for unit, n in sorted(data.items()))
+    path.write_text(DENSITY_HEADER + body, encoding="utf-8")
+
+
 def read_baseline(path: Path) -> dict[tuple[str, str], int]:
     if not path.exists():
         return {}
@@ -296,9 +402,12 @@ def main() -> int:
     root = Path(argv[0]) if argv else Path(__file__).resolve().parent.parent
     root = root.resolve()
 
+    tracked = tracked_files(root)
     per_pair, detail = counts(root)
     files = {path for path, _ in per_pair}
     baseline_path = root / BASELINE
+    density_path = root / DENSITY_BASELINE
+    per_unit = density(root, tracked)
 
     if "--report" in flagset:
         total = sum(per_pair.values())
@@ -313,6 +422,12 @@ def main() -> int:
         print(f"\n{total} construction(s) in {len(files)} file(s)")
         for name, n in by_pattern.most_common():
             print(f"  {n:>5}  {name}")
+        allowed = read_density_baseline(density_path) if density_path.exists() else {}
+        print("\nmean module-header length, worst first")
+        for unit, mean in sorted(per_unit.items(), key=lambda kv: -kv[1]):
+            ceiling = allowed.get(unit, NEW_UNIT_MEAN)
+            mark = "  OVER" if mean > ceiling else ""
+            print(f"  {mean / 100:>7.2f}  (ceiling {ceiling / 100:.2f})  {unit}{mark}")
         return 0
 
     if "--bootstrap" in flagset:
@@ -326,13 +441,49 @@ def main() -> int:
             )
             return 1
         write_baseline(baseline_path, per_pair)
+        write_density_baseline(density_path, per_unit)
         print(
             f"check-prose: wrote {BASELINE} with "
-            f"{sum(per_pair.values())} construction(s) in {len(files)} file(s)."
+            f"{sum(per_pair.values())} construction(s) in {len(files)} file(s), "
+            f"and {DENSITY_BASELINE} with {len(per_unit)} unit(s)."
         )
         return 0
 
+    # The density ratchet arrived after the count ratchet, so `--bootstrap`
+    # (which refuses once scripts/prose-baseline.txt exists) could not
+    # introduce it. This is that one-time door, and it closes behind itself
+    # for the reason `--bootstrap` does: a regenerated baseline records
+    # today's tree as the ceiling.
+    if "--bootstrap-density" in flagset:
+        if density_path.exists():
+            print(
+                "check-prose: refusing to bootstrap -- "
+                f"{DENSITY_BASELINE} already exists. Use --update, which only "
+                "ever lowers a mean.",
+                file=sys.stderr,
+            )
+            return 1
+        write_density_baseline(density_path, per_unit)
+        print(
+            f"check-prose: wrote {DENSITY_BASELINE} with "
+            f"{len(per_unit)} unit(s)."
+        )
+        return 0
+
+    if not density_path.exists():
+        print(
+            f"check-prose: {DENSITY_BASELINE} is missing. It records what each "
+            "crate's module headers already average, and without it every unit "
+            f"is held to {NEW_UNIT_MEAN / 100:.2f}. Restore it from git rather "
+            "than regenerating it: a fresh one records today's tree as the "
+            "ceiling, which is the grandfathering this ratchet exists to "
+            "refuse.",
+            file=sys.stderr,
+        )
+        return 2
+
     baseline = read_baseline(baseline_path)
+    density_baseline = read_density_baseline(density_path)
 
     # `--adopt=<pattern>[,<pattern>]` records the debt of a pattern added to
     # PATTERNS after the baseline was written, and touches no other pattern's
@@ -408,13 +559,52 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
+        # A unit absent from the density baseline is held to NEW_UNIT_MEAN, so
+        # `.get(unit, NEW_UNIT_MEAN)` is what stops a new crate grandfathering
+        # its own headers the first time anyone runs --update.
+        loosened = {
+            unit: (density_baseline.get(unit, NEW_UNIT_MEAN), mean)
+            for unit, mean in per_unit.items()
+            if mean > density_baseline.get(unit, NEW_UNIT_MEAN)
+        }
+        if loosened:
+            print(
+                "check-prose: refusing to update -- these units' module "
+                "headers grew:",
+                file=sys.stderr,
+            )
+            for unit, (was, now) in sorted(loosened.items()):
+                print(
+                    f"  {unit}: {was / 100:.2f} -> {now / 100:.2f} mean lines",
+                    file=sys.stderr,
+                )
+            print(
+                "\nCut the headers instead. "
+                "`./scripts/check-prose.py --report` lists every unit's mean.",
+                file=sys.stderr,
+            )
+            return 1
         # Pairs that reached zero drop out entirely; the ratchet retightens.
         for pair in baseline:
             if pair not in per_pair:
                 merged.pop(pair, None)
         write_baseline(baseline_path, merged)
-        print(f"check-prose: {BASELINE} retightened to {sum(merged.values())}.")
+        tightened = {
+            unit: min(mean, density_baseline.get(unit, NEW_UNIT_MEAN))
+            for unit, mean in per_unit.items()
+        }
+        write_density_baseline(density_path, tightened)
+        print(
+            f"check-prose: {BASELINE} retightened to {sum(merged.values())}, "
+            f"{DENSITY_BASELINE} to {len(tightened)} unit(s)."
+        )
         return 0
+
+    over = [
+        (unit, density_baseline.get(unit, NEW_UNIT_MEAN), mean)
+        for unit, mean in sorted(per_unit.items())
+        if mean > density_baseline.get(unit, NEW_UNIT_MEAN)
+    ]
 
     failures = []
     for pair in sorted(set(per_pair) | set(baseline)):
@@ -443,10 +633,32 @@ def main() -> int:
         )
         return 1
 
+    if over:
+        print(
+            "check-prose: FAIL -- module headers got longer.\n",
+            file=sys.stderr,
+        )
+        for unit, ceiling, mean in over:
+            print(
+                f"  {unit}: {ceiling / 100:.2f} allowed, "
+                f"{mean / 100:.2f} mean header lines",
+                file=sys.stderr,
+            )
+        print(
+            "\nA header is what this file does and what a reader must not do "
+            "to it -- two to four sentences. History belongs in the pull "
+            "request, a design document, or the tracker.\n"
+            "Cut a header. Do not raise the number in "
+            f"{DENSITY_BASELINE}.",
+            file=sys.stderr,
+        )
+        return 1
+
     total = sum(per_pair.values())
     print(
         f"check-prose: OK -- {total} grandfathered construction(s) "
-        f"in {len(files)} file(s), none added."
+        f"in {len(files)} file(s), none added; "
+        f"{len(per_unit)} unit(s) within their header-length ceiling."
     )
     return 0
 

--- a/scripts/prose-baseline.txt
+++ b/scripts/prose-baseline.txt
@@ -2052,7 +2052,6 @@ website/content/docs/agent-tools/mcp.mdx enumerative-announcement 1
 website/content/docs/agent-tools/mcp.mdx filler-adverb 1
 website/content/docs/agent-tools/skills.mdx interface-jargon 1
 website/content/docs/api-providers/index.mdx interface-jargon 2
-website/content/docs/api-providers/index.mdx rust-jargon 1
 website/content/docs/api-providers/models.mdx meta-writing 1
 website/content/docs/commands/auth.mdx filler-adverb 1
 website/content/docs/commands/calibration.mdx filler-adverb 1

--- a/scripts/prose-density-baseline.txt
+++ b/scripts/prose-density-baseline.txt
@@ -1,0 +1,42 @@
+# Down-only ratchet on module-header density, per crate (#4760).
+#
+# Each line is `<unit> <mean>` -- the mean length, in lines, of every leading
+# `//!` block in that crate's Rust files, recorded in hundredths so the
+# comparison is integer arithmetic. A unit may lower its mean; it may never
+# raise it, and a unit absent from this list is held to 12.00. Regenerate with
+# `make prose-update`, which refuses to raise a number.
+#
+# Mean header length rather than comment share, because share is a bad proxy on
+# its own: a well-documented pure-function crate should be comment-heavy, and
+# stella-diff scored 74/100 at 26% share. What #4392 measured and #4758 is
+# fixing is the forty-line header, which is what this counts.
+#
+# It answers a different question from scripts/prose-baseline.txt: that one
+# asks whether a sentence is content-free, this one asks whether there are too
+# many sentences. A file can be entirely within the first and three times
+# longer than it needs to be.
+crates/stella-autonomy 38.25
+crates/stella-cli 23.67
+crates/stella-context 18.19
+crates/stella-core 27.99
+crates/stella-diag 25.12
+crates/stella-diff 27.80
+crates/stella-embed 18.00
+crates/stella-engine 71.00
+crates/stella-fleet 24.15
+crates/stella-graph 21.88
+crates/stella-home 33.00
+crates/stella-mcp 19.10
+crates/stella-model 18.08
+crates/stella-observatory 22.77
+crates/stella-parity 35.00
+crates/stella-plugin 39.69
+crates/stella-protocol 28.94
+crates/stella-runtime 35.90
+crates/stella-serve 25.96
+crates/stella-store 25.86
+crates/stella-tools 35.69
+crates/stella-transcript 26.18
+crates/stella-tty 21.00
+crates/stella-tui 20.32
+crates/stella-tui-theme 28.12

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -71,15 +71,46 @@ doc_untracked() {
   cat >"$1/$2"
 }
 
-# $1 = root, then `path pattern count` triples.
+# $1 = root, then `path pattern count` triples. Also writes an empty density
+# baseline, so a case that says nothing about header length holds every unit to
+# the new-unit ceiling rather than tripping the missing-file refusal.
 baseline() {
   root="$1"
   shift
   printf '# test baseline\n' >"$root/scripts/prose-baseline.txt"
+  if [ ! -f "$root/scripts/prose-density-baseline.txt" ]; then
+    printf '# test density baseline\n' >"$root/scripts/prose-density-baseline.txt"
+  fi
   while [ $# -gt 2 ]; do
     printf '%s %s %s\n' "$1" "$2" "$3" >>"$root/scripts/prose-baseline.txt"
     shift 3
   done
+}
+
+# $1 = root, then `unit mean` pairs.
+density_baseline() {
+  root="$1"
+  shift
+  printf '# test density baseline\n' >"$root/scripts/prose-density-baseline.txt"
+  while [ $# -gt 1 ]; do
+    printf '%s %s\n' "$1" "$2" >>"$root/scripts/prose-density-baseline.txt"
+    shift 2
+  done
+}
+
+# A Rust file whose module header is $3 lines long, under crate $2.
+# $1 = root, $2 = crate name, $3 = header lines, $4 = file stem.
+rs_with_header() {
+  mkdir -p "$1/crates/$2/src"
+  path="$1/crates/$2/src/$4.rs"
+  : >"$path"
+  i=0
+  while [ "$i" -lt "$3" ]; do
+    printf '//! A header line about what this file does.\n' >>"$path"
+    i=$((i + 1))
+  done
+  printf '\npub fn f() {}\n' >>"$path"
+  (cd "$1" && git add -A) >/dev/null 2>&1
 }
 
 # $1 = case name, $2 = root. The guard must exit 0.
@@ -310,6 +341,107 @@ if python3 "$SCRIPT" "$r" >/dev/null 2>&1; then
   ok "P15 a gitignored file stays out of the scan"
 else
   no "P15 a gitignored file stays out of the scan" "the guard read an ignored file"
+fi
+
+# ── The density ratchet (#4760) ─────────────────────────────────────────────
+# A different question from every case above: not whether a sentence is
+# content-free, but whether there are too many of them. D1 is its witness --
+# a crate whose headers grew past what it recorded fails, and nothing in the
+# count ratchet can see that, because a forty-line header of unobjectionable
+# sentences scores zero there.
+
+r="$(new_root d1)"
+baseline "$r"
+density_baseline "$r" crates/alpha 10.00
+rs_with_header "$r" alpha 20 lib
+expect_fail "D1 a unit whose headers grew fails" "$r"
+
+r="$(new_root d2)"
+baseline "$r"
+density_baseline "$r" crates/alpha 20.00
+rs_with_header "$r" alpha 20 lib
+expect_pass "D2 a unit at its ceiling passes" "$r"
+
+# The mean, not the worst file: one long header is paid for by short siblings,
+# which is what makes the ceiling a density measure rather than a file-size one.
+r="$(new_root d3)"
+baseline "$r"
+density_baseline "$r" crates/alpha 10.00
+rs_with_header "$r" alpha 28 long
+rs_with_header "$r" alpha 4 short_a
+rs_with_header "$r" alpha 4 short_b
+rs_with_header "$r" alpha 4 short_c
+expect_pass "D3 the ceiling is a mean, not a worst case" "$r"
+
+# --update is the half a ratchet usually gets wrong: refusing loudly and
+# writing the looser number anyway turns the gate green with no header cut.
+r="$(new_root d4)"
+baseline "$r"
+density_baseline "$r" crates/alpha 10.00
+rs_with_header "$r" alpha 20 lib
+expect_update_refused "D4 --update refuses to raise a mean" "$r"
+if grep -qx "crates/alpha 10.00" "$r/scripts/prose-density-baseline.txt"; then
+  ok "D4 --update left the ceiling alone"
+else
+  no "D4 --update left the ceiling alone" "the ceiling moved"
+fi
+
+r="$(new_root d5)"
+baseline "$r"
+density_baseline "$r" crates/alpha 20.00
+rs_with_header "$r" alpha 6 lib
+if python3 "$SCRIPT" --update "$r" >/dev/null 2>&1; then
+  if grep -qx "crates/alpha 6.00" "$r/scripts/prose-density-baseline.txt"; then
+    ok "D5 --update retightens a shortened header"
+  else
+    no "D5 --update retightens a shortened header" "the ceiling did not fall"
+  fi
+else
+  no "D5 --update retightens a shortened header" "--update exited non-zero"
+fi
+
+# A crate with no entry is held to the new-unit ceiling, so a new crate cannot
+# arrive carrying essays and grandfather itself the first time --update runs.
+r="$(new_root d6)"
+baseline "$r"
+density_baseline "$r"
+rs_with_header "$r" newcrate 30 lib
+expect_fail "D6 an unrecorded unit is held to the new-unit ceiling" "$r"
+expect_update_refused "D6 --update refuses to record it" "$r"
+
+r="$(new_root d7)"
+baseline "$r"
+density_baseline "$r"
+rs_with_header "$r" newcrate 6 lib
+expect_pass "D7 an unrecorded unit within the ceiling passes" "$r"
+
+# --bootstrap-density is one-time, for the reason --bootstrap is: a regenerated
+# baseline records today's tree as the ceiling.
+r="$(new_root d8)"
+baseline "$r"
+density_baseline "$r" crates/alpha 10.00
+rs_with_header "$r" alpha 20 lib
+if python3 "$SCRIPT" --bootstrap-density "$r" >/dev/null 2>&1; then
+  no "D8 --bootstrap-density refuses to overwrite" "it exited 0"
+else
+  ok "D8 --bootstrap-density refuses to overwrite"
+fi
+if grep -qx "crates/alpha 10.00" "$r/scripts/prose-density-baseline.txt"; then
+  ok "D8 --bootstrap-density wrote nothing"
+else
+  no "D8 --bootstrap-density wrote nothing" "the ceiling moved"
+fi
+
+# A missing density baseline is a refusal, never a silent pass: without it
+# every unit would be judged against the new-unit ceiling and a real tree would
+# fail for a reason that has nothing to do with the change under review.
+r="$(new_root d9)"
+printf '# test baseline\n' >"$r/scripts/prose-baseline.txt"
+rs_with_header "$r" alpha 6 lib
+if python3 "$SCRIPT" "$r" >/dev/null 2>&1; then
+  no "D9 a missing density baseline refuses" "the guard passed"
+else
+  ok "D9 a missing density baseline refuses"
 fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"


### PR DESCRIPTION
Part 1 of #4760. Part 2 cannot be done from this repository — see below.

## What this adds

`make prose` counted banned constructions per (file, pattern) and said nothing
about **density**. A forty-line module header of entirely unobjectionable
sentences scores zero there, and that is what the #4392 audit measured and what
#4758 is cutting.

`scripts/prose-density-baseline.txt` records the mean length of every crate's
leading `//!` blocks, in hundredths of a line so the comparison is integer
arithmetic rather than a float compare. A unit may lower its mean and never
raise it. `make prose-update` refuses to raise one — the same refusal it
already makes for a count — and a crate with no entry is held to 12.00 mean
lines, so a new crate cannot arrive carrying essays and grandfather itself the
first time anyone runs `--update`.

## The open question #4760 raised

The issue asks which measure to use and answers most of it itself: comment
share is a bad proxy alone, because `stella-diff` scores 74/100 at 26% share
and a well-documented pure-function crate *should* be comment-heavy. So this
ratchets **mean header length**, which is what the audit's finding was about
and what #4758 is fixing. Comment share is not measured at all — a second
number that cannot distinguish good from bad would only add noise to a gate.

Where the tree stands today, worst first (`make prose-report` prints this):

```
    71.00  crates/stella-engine
    39.69  crates/stella-plugin
    38.25  crates/stella-autonomy
    35.90  crates/stella-runtime
    35.69  crates/stella-tools
     ...
    18.00  crates/stella-embed
```

Nothing existing is held to 12.00; every unit is held to what it already
averages. The 12.00 is the number a *new* crate starts at, which is why the
tightest crate in the tree (18.00) is not the default — inheriting the tree's
current best would still be inheriting an essay.

## Witness

`scripts/test-prose-guard.sh` gains nine cases, and they are the witness:
**7 of the new assertions fail on `origin/main`'s `check-prose.py` and pass on
this one.**

```
$ git show origin/main:scripts/check-prose.py > /tmp/old-check-prose.py
$ SCRIPT=/tmp/old-check-prose.py bash scripts/test-prose-guard.sh
FAIL D1 a unit whose headers grew fails -- the guard exited 0
FAIL D4 --update refuses to raise a mean -- --update exited 0
FAIL D5 --update retightens a shortened header -- the ceiling did not fall
FAIL D6 an unrecorded unit is held to the new-unit ceiling -- the guard exited 0
FAIL D6 --update refuses to record it -- --update exited 0
FAIL D8 --bootstrap-density refuses to overwrite -- it exited 0
FAIL D9 a missing density baseline refuses -- the guard passed
25 passed, 7 failed

$ bash scripts/test-prose-guard.sh
32 passed, 0 failed
```

D4 is the half a ratchet usually gets wrong, and it asserts twice: `--update`
must refuse **and** must leave the ceiling where it was. Refusing loudly and
writing the looser number anyway turns the gate green with no header cut, which
is the expedient the rule forbids performed by the guard on the author's
behalf. D3 pins that the ceiling is a mean rather than a worst case — one long
header paid for by short siblings passes, which is what makes it a density
measure and not a second file-size gate.

## Part 2 — the audit re-run — is blocked here

#4760's second half asks for a new scoreboard from a re-run "that a third party
could reproduce from this repository". Nothing in this repository can produce
one: the issue itself records that the 30-unit workflow (job `cff7b40f`) and
its per-unit `stella-quality-audit.json` are both outside this tree. Committing
an audit definition that does not exist here is a maintainer's call about what
this repository owns, not a change this PR can make honestly, so #4760 stays
open for it and I have said so on the issue.

## Evidence

```
make guards-fast          # green, prose included
make prose                # OK -- 4206 constructions, 25 units within ceiling
make prose-test           # 32 passed, 0 failed
```

The count baseline is untouched at 4206: this PR adds a measure, it does not
edit prose.

Refs #4760
Refs #4392

## It fired on its first contact with a moving `main`

Rebasing onto `origin/main` turned this PR red, on its own guard:

```
check-prose: FAIL -- module headers got longer.
  crates/stella-transcript: 25.95 allowed, 26.18 mean header lines
```

#5076 merged between the bootstrap and the rebase and grew a
`stella-transcript` module header. `make prose-update` then did the thing it
was built to do:

```
check-prose: refusing to update -- these units' module headers grew:
  crates/stella-transcript: 25.95 -> 26.18 mean lines
Cut the headers instead.
```

Which is the right refusal and the wrong verdict here, for one reason: #5076
landed before this ratchet existed anywhere, so 25.95 was a ceiling recorded
from a tree that never contained that change. Holding it to a number taken
before it existed judges it against a rule that did not exist. That is what
`--bootstrap-density` is for, and why it is a separate door from `--update`:
a bootstrap records debt that already existed, an update may only lower it.

So the baseline was re-bootstrapped on the rebased tree, and the diff is one
line:

```
-crates/stella-transcript 25.95
+crates/stella-transcript 26.18
```

No other crate moved. From here `--update` is the only door, and it refuses to
raise any of these numbers — including that one.

The failure is worth keeping in view rather than editing out of the history: a
new ratchet that catches a real header growth the first time `main` moves under
it is better evidence that it works than a green run would have been.

## Rebased again after #5092 merged

#5092 (the #4758 header trim) landed and shortened five `stella-cli` headers.
That left the recorded `crates/stella-cli 24.58` looser than the tree, which is
a ratchet holding open slack another PR had already earned. `make prose-update`
retightened it — one line, in the direction the ratchet allows:

```
-crates/stella-cli 24.58
+crates/stella-cli 23.67
```

The count baseline came down with it, 4187 → 4186.

## Summary by Sourcery

Enforce a down-only per-crate mean module-header-length ratchet alongside the existing prose construction count.

New Features:
- Add a per-crate module-header density ratchet to `make prose`, enforcing down-only mean lengths for leading Rust `//!` blocks.
- Provide density reporting, one-time bootstrapping, and a protected 12.00-line ceiling for unrecorded crates.

Bug Fixes:
- Prevent prose baseline updates from silently recording increased module-header density or operating without a density baseline.

Enhancements:
- Extend prose guidance and command output to distinguish banned-construction counts from mean module-header length.
- Expand prose guard coverage with nine density-ratchet scenarios, including mean-based evaluation, update refusal, bootstrapping protection, and new-crate handling.

Documentation:
- Document module-header density as a separate prose-quality measure and explain its baseline and ratcheting behavior.

Tests:
- Add coverage for module-header density enforcement and down-only baseline updates.

Chores:
- Add the per-crate density baseline for the current repository state.