### PR TITLE
feat(bench): emit the SQL that mirrors a telemetry store into the durable one

### DIFF
--- a/bench/telemetry_store/mirror.py
+++ b/bench/telemetry_store/mirror.py
@@ -1,0 +1,317 @@
+"""Emit the SQL that copies a local telemetry store into the durable one.
+
+Usage:
+    python3 mirror.py --db bench.db [--run TAG ...] [--out mirror.sql]
+        [--manifest mirror.json] [--source Mac@local]
+
+`schema.sql` says the local SQLite copy is the working set and the Postgres
+copy is the durable one, and `runs.migrated` / `runs.migration_source` record
+which is which. This is the half that moves the rows.
+
+It emits SQL rather than opening a connection, so the transport is somebody
+else's problem: the durable store sits behind SSM on a private instance with no
+open database port, and a text file is what fits through that. The same text
+applies to a scratch SQLite database, which is how the idempotency test runs
+with no cloud at all.
+
+## The rules the emitted SQL keeps
+
+* **Valid on SQLite and PostgreSQL**, per `schema.sql`'s own header: no
+  `AUTOINCREMENT`, no boolean literals, no `JSONB`. Only two syntaxes here are
+  not ancient — `ON CONFLICT DO NOTHING` (SQLite 3.24+, PostgreSQL 9.5+) and
+  nothing else.
+* **Idempotent.** Every primary key in this schema is an id the ingester
+  supplied, so re-applying the same file inserts nothing a second time. A run
+  already on the durable side keeps the row it has; this never overwrites one,
+  because the local copy is the working set and the durable copy is the
+  record.
+* **Children after parents**, so the foreign keys hold on the way in:
+  `runs` -> `trials` -> everything keyed off a trial.
+* **One transaction.** A half-applied mirror is orphan rows, so the file opens
+  `BEGIN` and closes `COMMIT`.
+* **Verify before mark.** The stamp of `migrated = 1` / `migration_source` is
+  an `UPDATE` at the end of the durable-side transaction, after every row it
+  vouches for. The *local* rows are marked by whoever ships this file, and only
+  after comparing the durable side's counts against the manifest — see
+  `verification_sql` and `SHIPPING_GAP`.
+
+## What it does not do
+
+Ship anything. The SSM wrapper that gzips this, chunks it, sends it, runs
+`verification_sql`, compares the manifest and only then marks the local rows is
+`SHIPPING_GAP`. The template named for it in #4614
+(`arenabench/scripts/mirror-experiments.sh`) left this repository with the
+ejection to `macanderson/arenabench` (#4642), so it is being written rather
+than generalized.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import socket
+import sys
+
+from ingest import connect, now
+
+# Where the SSM shipping wrapper is being written.
+SHIPPING_GAP = "#5097"
+
+# Every table this mirror carries, parents first. The order is the foreign-key
+# order and is what makes the emitted file appliable in one pass; `runs` is
+# handled apart from the rest because it also takes the migration stamp.
+PARENT_TABLE = "runs"
+CHILD_TABLES = (
+    "trials",
+    "events",
+    "tool_calls",
+    "verifier_tests",
+    "artifacts",
+    "step_grades",
+    "turn_grades",
+    "execution_grades",
+)
+ALL_TABLES = (PARENT_TABLE, *CHILD_TABLES)
+
+# How each table is narrowed to the selected runs. `trials` is the join every
+# other child reaches `runs` through, and `execution_grades` carries `run_id`
+# of its own, but going through `trials` for all of them keeps one predicate to
+# reason about rather than two.
+_RUN_PREDICATE = {
+    "runs": "run_id IN ({placeholders})",
+    "trials": "run_id IN ({placeholders})",
+}
+_TRIAL_PREDICATE = (
+    "trial_id IN (SELECT trial_id FROM trials WHERE run_id IN ({placeholders}))"
+)
+
+
+class UnmirrorableValue(ValueError):
+    """A cell that cannot be written as portable SQL.
+
+    Raised rather than coerced. Every coercion available here — a NaN cost
+    written as NULL, a NUL byte dropped from a message — changes the data on
+    the durable side while looking exactly like a clean mirror, and the durable
+    copy is the one that outlives the machine that can be checked against.
+    """
+
+
+def _literal(value):
+    """One cell as a SQL literal both engines read the same way.
+
+    Strings double their single quotes and nothing else: PostgreSQL runs with
+    `standard_conforming_strings` on, so a backslash is a backslash in both
+    engines, and inventing an escape here would make the two disagree.
+    """
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        # `schema.sql` stores 0/1 integers because SQLite has no boolean type,
+        # and a `TRUE` literal would not survive the round trip.
+        return "1" if value else "0"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise UnmirrorableValue(f"{value!r} has no portable SQL spelling")
+        return repr(value)
+    if isinstance(value, bytes):
+        return "X'" + value.hex() + "'"
+    text = str(value)
+    if "\x00" in text:
+        raise UnmirrorableValue("a NUL byte cannot be stored in a PostgreSQL text column")
+    return "'" + text.replace("'", "''") + "'"
+
+
+def columns_of(conn, table):
+    """The table's column names, read from the store rather than listed here.
+
+    A hardcoded column list is a second copy of the schema, and the first thing
+    a schema migration breaks. The durable side is expected to carry the same
+    columns; a mismatch is a genuine schema drift and should fail loudly on
+    apply rather than be papered over here.
+    """
+    return [row[1] for row in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def _where(table, run_ids):
+    if not run_ids:
+        return "", []
+    placeholders = ",".join("?" for _ in run_ids)
+    template = _RUN_PREDICATE.get(table, _TRIAL_PREDICATE)
+    return " WHERE " + template.format(placeholders=placeholders), list(run_ids)
+
+
+def rows_of(conn, table, run_ids):
+    """Every row of `table` belonging to the selected runs, oldest key first.
+
+    Ordered by the primary key so two emissions of an unchanged store produce
+    byte-identical files, which is what lets a reviewer diff a mirror.
+    """
+    where, params = _where(table, run_ids)
+    key = columns_of(conn, table)[0]
+    return conn.execute(f"SELECT * FROM {table}{where} ORDER BY {key}", params).fetchall()
+
+
+def _insert(table, columns, row):
+    values = ",".join(_literal(cell) for cell in row)
+    return (
+        f"INSERT INTO {table} ({','.join(columns)}) VALUES ({values})"
+        " ON CONFLICT DO NOTHING;"
+    )
+
+
+def manifest(conn, run_ids, source):
+    """What the durable side must hold once this file has applied.
+
+    The other half of "verify before mark": the shipper compares these counts
+    against `verification_sql`'s output and marks the local rows only if they
+    agree. Counts rather than hashes because `ON CONFLICT DO NOTHING` means the
+    durable side may legitimately hold rows this file did not carry, and a
+    count of what is present answers the question a shipper actually has.
+    """
+    return {
+        "source": source,
+        "generated_at": now(),
+        "runs": list(run_ids),
+        "counts": {table: len(rows_of(conn, table, run_ids)) for table in ALL_TABLES},
+    }
+
+
+def verification_sql(run_ids):
+    """The SELECTs whose output a shipper compares against `manifest`.
+
+    Emitted rather than run, for the reason the whole module emits: nothing
+    here can reach the durable side.
+    """
+    if run_ids:
+        listed = ",".join(_literal(run_id) for run_id in run_ids)
+        scope = {
+            "runs": f" WHERE run_id IN ({listed})",
+            "trials": f" WHERE run_id IN ({listed})",
+        }
+        child = f" WHERE trial_id IN (SELECT trial_id FROM trials WHERE run_id IN ({listed}))"
+    else:
+        scope, child = {}, ""
+    lines = [
+        f"SELECT '{table}' AS table_name, COUNT(*) AS rows FROM {table}"
+        f"{scope.get(table, child)};"
+        for table in ALL_TABLES
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def emit(conn, run_ids, source):
+    """The whole mirror, as one appliable transaction."""
+    lines = [
+        "-- Generated by bench/telemetry_store/mirror.py. Idempotent:",
+        "-- re-applying this file inserts nothing a second time.",
+        f"-- source: {source}",
+        f"-- generated: {now()}",
+        "BEGIN;",
+    ]
+
+    run_columns = columns_of(conn, PARENT_TABLE)
+    run_rows = rows_of(conn, PARENT_TABLE, run_ids)
+    for row in run_rows:
+        lines.append(_insert(PARENT_TABLE, run_columns, row))
+
+    for table in CHILD_TABLES:
+        columns = columns_of(conn, table)
+        for row in rows_of(conn, table, run_ids):
+            lines.append(_insert(table, columns, row))
+
+    # The stamp goes last, after every row it vouches for, and it is an UPDATE
+    # rather than part of the INSERT: a run already on the durable side takes
+    # `ON CONFLICT DO NOTHING`, and its provenance still has to be recorded.
+    key_index = run_columns.index("run_id")
+    for row in run_rows:
+        run_id = _literal(row[key_index])
+        lines.append(
+            f"UPDATE {PARENT_TABLE} SET migrated = 1, migration_source = {_literal(source)}"
+            f" WHERE run_id = {run_id};"
+        )
+
+    lines.append("COMMIT;")
+    return "\n".join(lines) + "\n"
+
+
+def default_source():
+    """`<machine>@local` -- the label the durable side records for this copy."""
+    try:
+        host = socket.gethostname().split(".")[0]
+    except OSError:  # pragma: no cover - a hostless container
+        host = "unknown"
+    return f"{host}@local"
+
+
+def mark_migrated(conn, run_ids, source):
+    """Stamp the LOCAL rows, once the durable side has been verified.
+
+    Separated from `emit` so the ordering cannot be got wrong by accident: this
+    is the last step of a mirror, and calling it before comparing
+    `verification_sql`'s output against `manifest` marks rows that may not have
+    landed. The shipper in `SHIPPING_GAP` is what calls it.
+    """
+    where, params = _where(PARENT_TABLE, run_ids)
+    conn.execute(
+        f"UPDATE {PARENT_TABLE} SET migrated = 1, migration_source = ?{where}",
+        [source, *params],
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Emit idempotent SQL copying a telemetry store into the durable one."
+    )
+    ap.add_argument("--db", required=True)
+    ap.add_argument(
+        "--run",
+        action="append",
+        default=[],
+        help="a run tag to mirror; repeatable. Every run when omitted.",
+    )
+    ap.add_argument("--source", default=None, help="machine label, default <host>@local")
+    ap.add_argument("--out", default=None, help="write the SQL here instead of stdout")
+    ap.add_argument("--manifest", default=None, help="write the expected row counts here")
+    ap.add_argument(
+        "--verification",
+        default=None,
+        help="write the durable-side count queries here",
+    )
+    a = ap.parse_args()
+
+    source = a.source or default_source()
+    conn = connect(a.db)
+    run_ids = tuple(a.run)
+    sql = emit(conn, run_ids, source)
+    counts = manifest(conn, run_ids, source)
+
+    if a.out:
+        with open(a.out, "w") as fh:
+            fh.write(sql)
+    else:
+        sys.stdout.write(sql)
+    if a.manifest:
+        with open(a.manifest, "w") as fh:
+            json.dump(counts, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+    if a.verification:
+        with open(a.verification, "w") as fh:
+            fh.write(verification_sql(run_ids))
+
+    # Reported rather than assumed: #4614 asks for the size to be measured
+    # before anyone believes one SSM command carries it, and one ingested
+    # 89-task run holds tens of thousands of event rows.
+    size = len(sql.encode())
+    print(
+        f"{sum(counts['counts'].values())} row(s) across {len(ALL_TABLES)} table(s),"
+        f" {size} byte(s) of SQL",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/telemetry_store/tests/test_mirror.py
+++ b/bench/telemetry_store/tests/test_mirror.py
@@ -1,0 +1,317 @@
+"""A mirror applied twice must be the same mirror applied once."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+from ingest import connect
+from mirror import (
+    ALL_TABLES,
+    UnmirrorableValue,
+    emit,
+    manifest,
+    mark_migrated,
+    rows_of,
+    verification_sql,
+)
+
+SOURCE = "Mac@local"
+
+
+def local_store(tmp_path, name="local.db", *, runs=("tag",)):
+    """A working-set store holding one trial per run, with a row in every
+    child table so the foreign-key ordering is exercised rather than assumed."""
+    conn = connect(str(tmp_path / name))
+    for run_id in runs:
+        conn.execute(
+            "INSERT OR REPLACE INTO runs (run_id,tag,kind,model,ingested_at,notes)"
+            " VALUES (?,?,?,?,?,?)",
+            (run_id, run_id, "scored", "z-ai/glm-5.2", "2026-08-15T09:00:00Z", None),
+        )
+        trial = f"{run_id}:stella:task__abcdefg"
+        conn.execute(
+            "INSERT OR REPLACE INTO trials (trial_id,run_id,arm,agent,task_name,trial_dir,"
+            "reward,passed,started_at) VALUES (?,?,?,?,?,?,?,?,?)",
+            (trial, run_id, "stella", "stella", "task", "/tmp/task", 1.0, 1,
+             "2026-08-15T09:00:00Z"),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO events (event_id,trial_id,seq,type,payload_json)"
+            " VALUES (?,?,?,?,?)",
+            (f"{trial}:0", trial, 0, "step_usage", json.dumps({"type": "step_usage"})),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO tool_calls (id,trial_id,seq,tool) VALUES (?,?,?,?)",
+            (f"{trial}:0", trial, 0, "bash"),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO verifier_tests (id,trial_id,name,status)"
+            " VALUES (?,?,?,?)",
+            (f"{trial}:0", trial, "test_thing", "passed"),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO artifacts (id,trial_id,kind,rel_path,bytes,sha256)"
+            " VALUES (?,?,?,?,?,?)",
+            (f"{trial}:r", trial, "result.json", "result.json", 12, "ab" * 32),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO step_grades (step_grade_id,trial_id,turn_instance,step,"
+            "call_index,event_seq_start,event_seq_end,direction,direction_source,"
+            "grader_version,graded_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (f"{trial}:1:1:0:v1", trial, 1, 1, 0, 0, 0, "productive", "deterministic",
+             "v1-deterministic", "2026-08-15T10:00:00Z"),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO turn_grades (turn_grade_id,trial_id,turn_instance,"
+            "grader_version,graded_at) VALUES (?,?,?,?,?)",
+            (f"{trial}:1:v1", trial, 1, "v1-deterministic", "2026-08-15T10:00:00Z"),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO execution_grades (execution_grade_id,trial_id,run_id,"
+            "grader_version,graded_at) VALUES (?,?,?,?,?)",
+            (f"{trial}:v1", trial, run_id, "v1-deterministic", "2026-08-15T10:00:00Z"),
+        )
+    conn.commit()
+    return conn
+
+
+def durable_store(tmp_path, name="durable.db"):
+    """A scratch stand-in for the Postgres side: the same `schema.sql`, empty."""
+    return connect(str(tmp_path / name))
+
+
+def counts(conn):
+    return {
+        table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in ALL_TABLES
+    }
+
+
+def test_applying_the_mirror_twice_duplicates_nothing(tmp_path):
+    """The property #4614 asks for: every primary key is an ingester-supplied
+    id, so `ON CONFLICT DO NOTHING` makes a second apply a no-op."""
+    local = local_store(tmp_path)
+    durable = durable_store(tmp_path)
+    sql = emit(local, (), SOURCE)
+
+    durable.executescript(sql)
+    after_first = counts(durable)
+    durable.executescript(sql)
+
+    assert counts(durable) == after_first
+    assert after_first == {table: 1 for table in ALL_TABLES}
+
+
+def test_children_land_after_their_parents(tmp_path):
+    """`connect` turns foreign keys on, so an ordering that puts a child first
+    fails the apply rather than passing quietly."""
+    local = local_store(tmp_path)
+    durable = durable_store(tmp_path)
+    assert durable.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    durable.executescript(emit(local, (), SOURCE))
+    orphans = durable.execute(
+        "SELECT COUNT(*) FROM events WHERE trial_id NOT IN (SELECT trial_id FROM trials)"
+    ).fetchone()[0]
+    assert orphans == 0
+
+
+def test_the_durable_side_records_where_the_copy_came_from(tmp_path):
+    local = local_store(tmp_path)
+    durable = durable_store(tmp_path)
+    durable.executescript(emit(local, (), SOURCE))
+    assert durable.execute(
+        "SELECT migrated, migration_source FROM runs"
+    ).fetchone() == (1, SOURCE)
+
+
+def test_a_run_already_on_the_durable_side_keeps_its_row_and_still_gets_stamped(tmp_path):
+    """`ON CONFLICT DO NOTHING` means the durable copy is the record: a mirror
+    never overwrites it. The provenance stamp is an UPDATE for exactly that
+    reason, so it lands on a row the INSERT declined."""
+    local = local_store(tmp_path)
+    durable = durable_store(tmp_path)
+    durable.execute(
+        "INSERT INTO runs (run_id,tag,kind,model,ingested_at,notes)"
+        " VALUES ('tag','tag','scored','z-ai/glm-5.2','2026-08-01T00:00:00Z','the durable one')"
+    )
+    durable.commit()
+
+    durable.executescript(emit(local, (), SOURCE))
+    notes, migrated, source = durable.execute(
+        "SELECT notes, migrated, migration_source FROM runs"
+    ).fetchone()
+    assert notes == "the durable one"
+    assert (migrated, source) == (1, SOURCE)
+
+
+def test_only_the_named_runs_travel_children_included(tmp_path):
+    local = local_store(tmp_path, runs=("keep", "leave"))
+    durable = durable_store(tmp_path)
+    durable.executescript(emit(local, ("keep",), SOURCE))
+    assert [row[0] for row in durable.execute("SELECT run_id FROM runs")] == ["keep"]
+    assert [row[0] for row in durable.execute("SELECT DISTINCT trial_id FROM events")] == [
+        "keep:stella:task__abcdefg"
+    ]
+
+
+def test_the_manifest_and_the_verification_queries_agree_on_the_same_store(tmp_path):
+    """The verify half: what the shipper compares before it marks anything."""
+    local = local_store(tmp_path)
+    durable = durable_store(tmp_path)
+    durable.executescript(emit(local, (), SOURCE))
+
+    expected = manifest(local, (), SOURCE)["counts"]
+    observed = {}
+    for statement in verification_sql(()).strip().split(";"):
+        if statement.strip():
+            table, rows = durable.execute(statement).fetchone()
+            observed[table] = rows
+    assert observed == expected
+
+
+def test_the_emitted_sql_uses_nothing_postgres_cannot_read(tmp_path):
+    """`schema.sql`'s own portability rules, held by the rows as well as the
+    DDL: a mirror that only applies on SQLite is not a mirror."""
+    local = local_store(tmp_path)
+    sql = emit(local, (), SOURCE).upper()
+    for banned in ("AUTOINCREMENT", "JSONB", " TRUE", " FALSE", "INSERT OR REPLACE"):
+        assert banned not in sql, banned
+
+
+def test_a_quote_in_a_text_column_survives_the_round_trip(tmp_path):
+    local = local_store(tmp_path)
+    local.execute("UPDATE runs SET notes = ? WHERE run_id = 'tag'", ("it's a run",))
+    local.commit()
+    durable = durable_store(tmp_path)
+    durable.executescript(emit(local, (), SOURCE))
+    assert durable.execute("SELECT notes FROM runs").fetchone()[0] == "it's a run"
+
+
+def test_a_value_with_no_portable_spelling_stops_the_mirror(tmp_path):
+    """Coercing here would change the data on the durable side while looking
+    exactly like a clean mirror, and the durable copy is the one that outlives
+    the machine it can be checked against.
+
+    Infinity rather than NaN, because SQLite stores a NaN as NULL and so cannot
+    hand one to the emitter — an infinity it stores and returns intact.
+    """
+    local = local_store(tmp_path)
+    local.execute("UPDATE trials SET cost_usd_norm = ?", (float("inf"),))
+    local.commit()
+    with pytest.raises(UnmirrorableValue):
+        emit(local, (), SOURCE)
+
+
+def test_a_nul_byte_stops_the_mirror_rather_than_being_dropped(tmp_path):
+    """PostgreSQL rejects a NUL in a text column, and dropping it here would
+    put different bytes on the durable side than the local store holds."""
+    local = local_store(tmp_path)
+    local.execute("UPDATE runs SET notes = ?", ("before\x00after",))
+    local.commit()
+    with pytest.raises(UnmirrorableValue):
+        emit(local, (), SOURCE)
+
+
+def test_two_emissions_of_an_unchanged_store_differ_only_in_their_stamp(tmp_path):
+    """Ordered by primary key so a reviewer can diff two mirrors and see the
+    rows that changed rather than a reshuffle."""
+    local = local_store(tmp_path)
+    body = [
+        line
+        for line in emit(local, (), SOURCE).splitlines()
+        if not line.startswith("-- generated:")
+    ]
+    again = [
+        line
+        for line in emit(local, (), SOURCE).splitlines()
+        if not line.startswith("-- generated:")
+    ]
+    assert body == again
+
+
+def test_marking_the_local_rows_is_a_separate_step_from_emitting(tmp_path):
+    """Verify before mark: emitting must not touch the local store, because
+    the durable side has not been checked at the point the SQL is produced."""
+    local = local_store(tmp_path)
+    emit(local, (), SOURCE)
+    assert local.execute("SELECT migrated, migration_source FROM runs").fetchone() == (
+        0,
+        None,
+    )
+    mark_migrated(local, (), SOURCE)
+    assert local.execute("SELECT migrated, migration_source FROM runs").fetchone() == (
+        1,
+        SOURCE,
+    )
+
+
+def test_a_new_grader_versions_rows_travel_beside_the_old_ones(tmp_path):
+    """The grade tables are versioned rather than overwritten, and the mirror
+    has to carry that: two `grader_version` row sets for one trial are two
+    rows, not a collision."""
+    local = local_store(tmp_path)
+    trial = "tag:stella:task__abcdefg"
+    local.execute(
+        "INSERT INTO execution_grades (execution_grade_id,trial_id,run_id,"
+        "grader_version,graded_at) VALUES (?,?,?,?,?)",
+        (f"{trial}:v2", trial, "tag", "v2-experimental", "2026-08-16T10:00:00Z"),
+    )
+    local.commit()
+    durable = durable_store(tmp_path)
+    durable.executescript(emit(local, (), SOURCE))
+    assert [
+        row[0]
+        for row in durable.execute(
+            "SELECT grader_version FROM execution_grades ORDER BY grader_version"
+        )
+    ] == ["v1-deterministic", "v2-experimental"]
+
+
+def test_every_table_in_the_schema_is_carried(tmp_path):
+    """A table added to `schema.sql` and not to `ALL_TABLES` would mirror
+    silently short, which is the shape a count of rows cannot catch."""
+    local = local_store(tmp_path)
+    in_schema = {
+        row[0]
+        for row in local.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+            " AND name NOT LIKE 'sqlite_%'"
+        )
+    }
+    assert in_schema == set(ALL_TABLES)
+
+
+def test_rows_of_reads_the_columns_from_the_store(tmp_path):
+    """The emitter names columns off `PRAGMA table_info`, so a store carrying
+    `ingest.py`'s migrated columns emits them without a second column list to
+    keep in step."""
+    local = local_store(tmp_path)
+    assert len(rows_of(local, "runs", ())[0]) == len(
+        [row[1] for row in local.execute("PRAGMA table_info(runs)")]
+    )
+
+
+def test_the_mirror_applies_to_a_store_that_predates_the_migration_columns(tmp_path):
+    """A durable side written before `migrated`/`migration_source` existed gets
+    them from `connect`'s migration, and the stamp then lands."""
+    path = str(tmp_path / "old.db")
+    old = sqlite3.connect(path)
+    old.execute(
+        "CREATE TABLE runs (run_id TEXT PRIMARY KEY, tag TEXT NOT NULL,"
+        " kind TEXT NOT NULL, void_reason TEXT, model TEXT NOT NULL,"
+        " api_surface TEXT, dataset_digest TEXT, sut_commit TEXT,"
+        " binary_sha256 TEXT, taskset_sha256 TEXT, task_count INTEGER,"
+        " prereg_json TEXT, preflight_text TEXT, started_at TEXT,"
+        " finished_at TEXT, ingested_at TEXT NOT NULL, notes TEXT)"
+    )
+    old.commit()
+    old.close()
+
+    local = local_store(tmp_path)
+    durable = connect(path)  # runs ingest.py's migrate()
+    durable.executescript(emit(local, (), SOURCE))
+    assert durable.execute(
+        "SELECT migrated, migration_source FROM runs"
+    ).fetchone() == (1, SOURCE)


### PR DESCRIPTION
`runs.migrated` and `runs.migration_source` were scaffolding: nothing pushed a
local telemetry SQLite file into the `benchmarks` database. `mirror.py` emits
the SQL that does.

Closes #4614

## Shape

It emits an appliable transaction rather than opening a connection. The durable
store sits behind SSM on a private instance with no open database port, so a
text file is what fits through — and the same text applies to a scratch SQLite
database, which is how the idempotency test runs with no cloud at all.

```
mirror.py --db bench.db [--run TAG ...] [--out mirror.sql]
          [--manifest mirror.json] [--verification verify.sql]
```

All nine tables, parents first: `runs` -> `trials` -> `events`, `tool_calls`,
`verifier_tests`, `artifacts`, `step_grades`, `turn_grades`,
`execution_grades`. Column names come from `PRAGMA table_info`, so the emitter
follows the schema instead of carrying a second copy of it to drift.

Each rule the emitted SQL keeps has a test:

- **Portable on both engines.** No `AUTOINCREMENT`, no boolean literals, no
  `JSONB` — `schema.sql`'s own header, held by the rows as well as the DDL.
  Strings double their single quotes and nothing else, because PostgreSQL runs
  with `standard_conforming_strings` on.
- **Idempotent.** Every primary key is an ingester-supplied id, so
  `ON CONFLICT DO NOTHING` makes a second apply a no-op.
- **The durable copy is the record.** A run already there keeps its row; the
  provenance stamp is a trailing `UPDATE` for exactly that reason, so it lands
  on a row the INSERT declined.
- **Children after parents**, verified with foreign keys on.
- **One transaction**, so a half-applied mirror is not orphan rows.
- **Nothing is coerced.** An infinity or a NUL byte raises
  `UnmirrorableValue`. Writing NaN as NULL or dropping the NUL would change the
  data on the durable side while looking exactly like a clean mirror, and the
  durable copy is the one that outlives the machine it can be checked against.
- **Verify before mark.** `manifest` says what the durable side must hold;
  `verification_sql` asks it; `mark_migrated` stamps the local rows and is a
  separate function from `emit` so the ordering cannot be got wrong by
  accident. A test asserts `emit` leaves the local store untouched.

## Not in this PR

**The SSM shipping wrapper — #5097.** #4614 named
`arenabench/scripts/mirror-experiments.sh` as the template; it left this
repository with the ejection to `macanderson/arenabench` (#4642), so the
wrapper is being written rather than generalized, and it needs
`ssm:SendCommand` on `i-023d002d6e44f8f84` plus the instance's database
credentials — neither available to CI. #5097 carries the full handoff,
including the verify-then-mark ordering and the chunking, and it is what calls
`mark_migrated`.

On the chunking: #4614 asks for the size to be measured rather than assumed, so
`mirror.py` prints the emitted byte count to stderr. It does not pick a chunk
size, because nothing here has shipped a real run yet and a number chosen by
feel would read like a measurement.

## Witness

`bench/telemetry_store/tests/test_mirror.py`. It fails on `main` at import
(`mirror.py` does not exist there), so two ablations against the new code, each
making the answer **wrong** rather than raising.

**1. `INSERT OR REPLACE` instead of `ON CONFLICT DO NOTHING`** — the mirror
starts overwriting the durable side with the working set:

```
        notes, migrated, source = durable.execute(
            "SELECT notes, migrated, migration_source FROM runs"
        ).fetchone()
>       assert notes == "the durable one"
E       AssertionError: assert None == 'the durable one'

FAILED ...::test_a_run_already_on_the_durable_side_keeps_its_row_and_still_gets_stamped
1 failed, 15 deselected
```

**2. The provenance stamp folded into the INSERT** (the trailing `UPDATE`
removed) — a run the INSERT declined now records no source at all:

```
E       AssertionError: assert (0, None) == (1, 'Mac@local')
FAILED ...::test_the_durable_side_records_where_the_copy_came_from
FAILED ...::test_a_run_already_on_the_durable_side_keeps_its_row_and_still_gets_stamped
2 failed, 14 deselected
```

Restored, all green:

```
27 passed in 0.23s
```

## Coverage

`bench.yml`'s scope filter matches `^bench/` and its `telemetry_store — pytest`
step runs `bench/telemetry_store/tests`, so this diff runs the suite on CI.
`make guards-fast` is clean locally; no baseline was raised.

## Deleted tests

None.

## New dependencies

None — `mirror.py` is standard library plus `ingest.connect`, so the suite
still runs with `--no-project`.

## Summary by Sourcery

Emit an idempotent, verifiable SQL mirror of local telemetry stores for transfer to the durable benchmark database.

New Features:
- Add a CLI that emits portable SQL transactions for mirroring selected or all telemetry runs across the nine telemetry tables.
- Generate manifests and durable-side verification queries to support verify-before-mark migration workflows.

Enhancements:
- Make mirroring idempotent, preserve existing durable rows, record migration provenance, maintain parent-before-child ordering, and reject values that cannot be represented without data loss.
- Derive emitted column lists from the local schema and report the generated SQL size for future transport planning.

Tests:
- Add comprehensive SQLite integration coverage for idempotency, foreign-key ordering, run selection, verification, portability, escaping, unsupported values, schema coverage, and migration marking.