### PR TITLE
fix(stella-cli): a resumed session stops re-minting its dead lanes' ids

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -867,7 +867,7 @@ pub async fn run_deck_session(
     let mut pending_settings_reload = false;
     // Sub-session bookkeeping: live-worker slots, and `task_assign` requests
     // waiting for one (drained oldest-first as workers end).
-    let mut subs = SubSessions::new();
+    let mut subs = SubSessions::resuming(&cfg.durability, &session_record.id);
     let mut pending_spawns: VecDeque<subsession::QueuedSpawn> = VecDeque::new();
     // Lanes whose Restart arrived while the worker was still live: stop
     // first, respawn on its Ended.

--- a/crates/stella-cli/src/durability.rs
+++ b/crates/stella-cli/src/durability.rs
@@ -300,6 +300,19 @@ impl SessionDurability {
         self.journal()?.pipeline_frame()
     }
 
+    /// Every journal key in this workspace's store beginning with `prefix`,
+    /// sorted; empty while unbound or when the store cannot be read.
+    ///
+    /// Best-effort by design, like every other read on this handle: a caller
+    /// asking which keys exist is deciding what to *avoid*, and a store that
+    /// will not answer must not stop a session starting. The cost of an empty
+    /// answer is the behaviour that stood before anything asked.
+    pub fn recorded_keys(&self, prefix: &str) -> Vec<String> {
+        self.journal()
+            .and_then(|journal| journal.recorded_keys(prefix).ok())
+            .unwrap_or_default()
+    }
+
     /// The sink to hand [`stella_core::EngineConfig::checkpoint_sink`], or
     /// `None` while this handle is unbound.
     ///

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -130,6 +130,43 @@ impl SubSessions {
         }
     }
 
+    /// A board for a session that may already have run `req:<n>` lanes —
+    /// every deck session, since a resumed one keeps its id.
+    ///
+    /// [`Self::new`] starts `next_req` at 0, so the first prompt lane of a
+    /// resumed session mints `req:1` again. That id is not cosmetic: it is
+    /// half of the lane's journal key ([`lane_journal_key`]), and
+    /// [`run_worker`] re-enters whatever transcript it finds there rather than
+    /// starting from the prompt. A fresh dispatch would therefore wake up
+    /// inside a dead lane's conversation — the one thing per-lane durability
+    /// (#3233) must not make possible.
+    ///
+    /// So the counter starts above the highest `req:<n>` the store has already
+    /// recorded for this session. The refs under `{session}__…` are that
+    /// record, and they are the same refs the collision would have read, which
+    /// is why they are asked rather than the session event journal: a signal
+    /// that merely correlates with the hazard is not the hazard.
+    ///
+    /// Unreadable or unbound reads as none recorded, which is
+    /// [`Self::new`]'s behaviour — a store that will not answer must not stop
+    /// a session starting.
+    pub(crate) fn resuming(
+        durability: &crate::durability::SessionDurability,
+        session_id: &str,
+    ) -> Self {
+        let prefix = lane_journal_key(session_id, "req:");
+        let highest = durability
+            .recorded_keys(&prefix)
+            .iter()
+            .filter_map(|key| key.strip_prefix(&prefix)?.parse::<u64>().ok())
+            .max()
+            .unwrap_or(0);
+        Self {
+            next_req: highest,
+            ..Self::new()
+        }
+    }
+
     pub(crate) fn has_slot(&self) -> bool {
         self.active < MAX_CONCURRENT
     }

--- a/crates/stella-cli/src/subsession/tests.rs
+++ b/crates/stella-cli/src/subsession/tests.rs
@@ -647,3 +647,111 @@ fn an_unparsable_checkpoint_degrades_to_fresh_rather_than_a_userless_transcript(
     );
     assert_eq!(messages[0].content, "fresh system prompt");
 }
+
+/// **The witness for #3233's second half.** A resumed session must not mint a
+/// lane id whose journal key already holds a dead lane's transcript.
+///
+/// [`SubSessions::new`] starts `next_req` at 0, and a resumed deck keeps its
+/// session id — `command_deck` says so where it adopts the record: "the
+/// registry never forks a resumed session's identity". So the first prompt
+/// lane after a resume minted `req:1`, bound `{session}__req-1`, found the
+/// killed lane's checkpoint sitting there, and [`initial_messages`] re-entered
+/// an unrelated conversation instead of starting on the prompt the user had
+/// just typed. Per-lane durability is what made that reachable; the recorded
+/// lanes are what closes it.
+#[test]
+fn a_resumed_session_never_re_mints_a_lane_id_that_already_has_a_transcript() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let session = "ses-resumed";
+
+    // A lane of the previous run, killed mid-turn with a checkpoint on its
+    // own key — the state per-lane durability leaves behind.
+    let dead = crate::durability::SessionDurability::default();
+    let dead_key = lane_journal_key(session, "req:1");
+    assert!(
+        crate::durability::bind_session(&dead, workspace.path(), &dead_key).is_none(),
+        "the dead lane binds"
+    );
+    dead.sink().expect("bound").persist(r#"{"lane":"req:1"}"#);
+
+    let lead = crate::durability::SessionDurability::default();
+    assert!(
+        crate::durability::bind_session(&lead, workspace.path(), session).is_none(),
+        "the lead binds"
+    );
+
+    let mut subs = SubSessions::resuming(&lead, session);
+    let lane = subs.next_req_lane();
+    assert_eq!(
+        lane, "req:2",
+        "a resumed session must step over the lane ids it already recorded"
+    );
+
+    let fresh = crate::durability::SessionDurability::default();
+    let fresh_key = lane_journal_key(session, &lane);
+    assert!(
+        crate::durability::bind_session(&fresh, workspace.path(), &fresh_key).is_none(),
+        "the new lane binds"
+    );
+    assert_eq!(
+        fresh.checkpoint(),
+        None,
+        "and lands on a key carrying no transcript"
+    );
+}
+
+/// The counter steps over lanes of *this* session only. Sessions share one
+/// store, so reading every recorded key would start a fresh deck's lane
+/// numbering wherever the busiest neighbour left off.
+#[test]
+fn another_sessions_lanes_do_not_move_this_sessions_counter() {
+    let workspace = tempfile::tempdir().expect("workspace");
+
+    let other = crate::durability::SessionDurability::default();
+    let other_key = lane_journal_key("ses-other", "req:7");
+    crate::durability::bind_session(&other, workspace.path(), &other_key);
+    other.sink().expect("bound").persist(r#"{"lane":"req:7"}"#);
+
+    let lead = crate::durability::SessionDurability::default();
+    crate::durability::bind_session(&lead, workspace.path(), "ses-mine");
+
+    let mut subs = SubSessions::resuming(&lead, "ses-mine");
+    assert_eq!(subs.next_req_lane(), "req:1");
+}
+
+/// **The fence.** The deck's board is built by [`SubSessions::resuming`], and
+/// nothing else in the crate's shipping code may build one.
+///
+/// The witness above proves the mechanism; only this proves the driver uses
+/// it, and the two come apart cleanly — reverting the deck's one call site to
+/// [`SubSessions::new`] leaves every assertion above passing. Anything that
+/// starts a deck session owns a session id that may already have lanes under
+/// it, so `new` is for tests and for `resuming` itself.
+#[test]
+fn the_deck_builds_its_lane_board_through_the_resuming_seam() {
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/command_deck.rs");
+    let body = std::fs::read_to_string(&src).expect("command_deck.rs");
+    // Built rather than written, so this fence is not its own match.
+    let bare = format!("SubSessions::{}(", "new");
+    assert!(
+        !body.contains(&bare),
+        "command_deck.rs builds a lane board with `SubSessions::new`. A deck \
+         session id may already have `req:<n>` lanes recorded under it, and \
+         re-minting one lands the next dispatch inside a dead lane's \
+         transcript (#3233). Use `SubSessions::resuming`."
+    );
+    assert!(
+        body.contains("SubSessions::resuming("),
+        "command_deck.rs must build its lane board through the seam"
+    );
+}
+
+/// An unbound handle reads as "nothing recorded", which is
+/// [`SubSessions::new`]'s numbering — a store that will not answer must not
+/// stop a session starting.
+#[test]
+fn an_unbound_session_starts_its_lane_numbering_where_a_fresh_one_does() {
+    let unbound = crate::durability::SessionDurability::default();
+    let mut subs = SubSessions::resuming(&unbound, "ses-1");
+    assert_eq!(subs.next_req_lane(), "req:1");
+}

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -96,6 +96,22 @@ fn snapshot_ref(session: &str) -> String {
     format!("refs/stella/{session}/tree")
 }
 
+/// The journal key a lineage-tip refname belongs to, or `None` for a refname
+/// this module did not write in that shape.
+///
+/// Both tips, [`session_ref`]'s `head` and [`snapshot_ref`]'s `tree`, because
+/// the two lineages are independent: a session that only ever snapshotted the
+/// work tree has a `tree` ref and no `head`, so reading `head` alone would
+/// leave it invisible to both readers below. A turn mark points at an ancestor
+/// and says nothing a tip does not, which is what the `/` rejection excludes.
+fn journal_key_of(refname: &str) -> Option<&str> {
+    let key = refname.strip_prefix("refs/stella/").and_then(|rest| {
+        rest.strip_suffix("/head")
+            .or_else(|| rest.strip_suffix("/tree"))
+    })?;
+    (!key.is_empty() && !key.contains('/')).then_some(key)
+}
+
 /// The reserved directory stella's own records live under, so a blob can
 /// never collide with a real workspace path — and so a per-turn diff can
 /// filter the records back out ([`WorkJournal::changed_paths_at_turn`]).
@@ -770,6 +786,36 @@ impl WorkJournal {
         Ok(report)
     }
 
+    /// Every journal key in this store whose name begins with `prefix`,
+    /// sorted, each listed once.
+    ///
+    /// A key is a namespace, and a caller that mints keys by composing one —
+    /// `stella-cli`'s deck derives a worker lane's key from the lead session's
+    /// (#3233) — needs to read back the ones it already minted. Every ref this
+    /// module writes lives under its key, so the refs *are* that record; until
+    /// this, nothing could ask them for it. [`Self::recorded_sessions`] is the
+    /// retention half of the same question and stays private, because an age
+    /// cutoff is [`Self::prune`]'s business alone.
+    ///
+    /// This module learns no composition rule. A prefix is whatever the caller
+    /// says it is, so the convention that separates a session from a lane
+    /// stays in the crate that mints it.
+    ///
+    /// An empty result is a real answer — nothing recorded under that prefix —
+    /// and is not distinguished from a store with no history at all.
+    pub fn recorded_keys(&self, prefix: &str) -> Result<Vec<String>> {
+        let listing = self.git(&["for-each-ref", "--format=%(refname)", "refs/stella/"])?;
+        let mut keys: Vec<String> = listing
+            .lines()
+            .filter_map(|line| journal_key_of(line.trim()))
+            .filter(|key| key.starts_with(prefix))
+            .map(str::to_string)
+            .collect();
+        keys.sort();
+        keys.dedup();
+        Ok(keys)
+    }
+
     /// Every session this store holds history for, oldest tip first, paired
     /// with that tip's committer time.
     ///
@@ -796,15 +842,9 @@ impl WorkJournal {
             let Some((at, refname)) = line.trim().split_once(' ') else {
                 continue;
             };
-            let Some(session) = refname.strip_prefix("refs/stella/").and_then(|rest| {
-                rest.strip_suffix("/head")
-                    .or_else(|| rest.strip_suffix("/tree"))
-            }) else {
+            let Some(session) = journal_key_of(refname) else {
                 continue;
             };
-            if session.is_empty() || session.contains('/') {
-                continue;
-            }
             let Ok(at) = at.parse::<i64>() else {
                 continue;
             };

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -793,7 +793,7 @@ impl WorkJournal {
     /// `stella-cli`'s deck derives a worker lane's key from the lead session's
     /// (#3233) — needs to read back the ones it already minted. Every ref this
     /// module writes lives under its key, so the refs *are* that record; until
-    /// this, nothing could ask them for it. [`Self::recorded_sessions`] is the
+    /// this, nothing could ask them for it. `recorded_sessions` is the
     /// retention half of the same question and stays private, because an age
     /// cutoff is [`Self::prune`]'s business alone.
     ///

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -991,6 +991,53 @@ mod tests {
         );
     }
 
+    /// A key's own refs are the record that it exists, and `recorded_keys`
+    /// reads them back under whatever prefix the caller composes.
+    ///
+    /// Both lineages count. A key that only ever checkpointed has a `head` and
+    /// no `tree`; one that only ever snapshotted has the reverse; reading
+    /// either alone would report a live key as absent, and a caller avoiding a
+    /// name it must not reuse (#3233) would then reuse it. A key with both is
+    /// listed once. Turn marks name no key of their own.
+    #[test]
+    fn a_prefix_finds_every_key_recorded_under_it_and_nothing_else() {
+        let (_guard, ws, store) = scratch();
+        std::fs::write(ws.join("a.txt"), "code\n").unwrap();
+
+        // A checkpoint (the `head` lineage) and a snapshot (the `tree` one),
+        // on different keys, plus a turn mark that must name no key.
+        let checkpointed = WorkJournal::open_in(&store, &ws, "ses-1__req-1").unwrap();
+        let commit = checkpointed
+            .record(&["a.txt".into()], &[], "stella(req:1): edit")
+            .unwrap();
+        checkpointed.mark_turn(1, &commit).unwrap();
+
+        let snapshotted = WorkJournal::open_in(&store, &ws, "ses-1__req-2").unwrap();
+        snapshotted.snapshot_worktree().unwrap();
+
+        let neighbour = WorkJournal::open_in(&store, &ws, "ses-2__req-9").unwrap();
+        neighbour
+            .record(&["a.txt".into()], &[], "stella(req:9): edit")
+            .unwrap();
+
+        let reader = WorkJournal::open_in(&store, &ws, "ses-1").unwrap();
+        assert_eq!(
+            reader.recorded_keys("ses-1__").unwrap(),
+            vec!["ses-1__req-1".to_string(), "ses-1__req-2".to_string()],
+            "a checkpointed key and a snapshotted one are both recorded, and a \
+             turn mark names no key of its own"
+        );
+        assert_eq!(
+            reader.recorded_keys("ses-2__").unwrap(),
+            vec!["ses-2__req-9".to_string()],
+            "the prefix is the whole filter — a neighbour's keys stay its own"
+        );
+        assert!(
+            reader.recorded_keys("ses-3__").unwrap().is_empty(),
+            "a prefix nothing was recorded under is an empty answer, not an error"
+        );
+    }
+
     #[test]
     fn a_checkpoint_blob_rides_along_and_replays_per_turn() {
         // Turn state and workspace state land in ONE object, so "restart turn


### PR DESCRIPTION
## What #3233 asked for, and what was left

PR #4725 landed the first half: each deck sub-session lane binds its own `SessionDurability` under `lane_journal_key(session, lane)` = `{session}__{lane}`, so a lane checkpoints into its own `refs/stella/…` namespace and its terminal `discard` cannot reach the lead's resume point. `agent/tests/durability_isolation.rs` holds that with four tests and a lexical fence.

What remained is item 1's other half — **the durable record of which lanes a session had running** — and it turns out that gap is not merely a missing feature. It is a live way for the durability #4725 added to hand a fresh dispatch the wrong transcript.

## The defect

`SubSessions::new` starts `next_req` at 0 on every launch, and a resumed deck **keeps its session id** — `command_deck.rs` says so where it adopts the record: *"the registry never forks a resumed session's identity."* So:

1. A session runs `req:1`, which is killed mid-turn. Per #4725 it leaves a checkpoint at `{session}__req-1`.
2. The deck is resumed. `session_persist::replay_session` restores the transcript; `SubSessions::new()` resets the counter.
3. The user types a new, unrelated prompt. `next_req_lane()` mints `req:1` again.
4. `run_worker` binds `{session}__req-1`, and `initial_messages` finds the dead lane's checkpoint and **re-enters that conversation** rather than starting on the prompt just typed.

Nothing guarded this. It is reachable only because lanes gained durable identity, which makes it #3233's own remainder rather than a separate bug.

## The record already existed

Every ref this store writes lives under its key, so `refs/stella/{session}__req-<n>/…` **is** the list of lanes a session ran. Nothing could ask for it: `WorkJournal::recorded_sessions` is private, unfiltered, and exists for retention.

- `WorkJournal::recorded_keys(prefix)` is the read path. It learns **no composition rule** — a prefix is whatever the caller says — so the `__` convention stays in the crate that mints it, and the store does not acquire a concept of a lane.
- `recorded_sessions` stays private (an age cutoff is `prune`'s business alone) and now shares one refname parse, `journal_key_of`, with the new reader instead of carrying a second copy of the `head`/`tree`/no-`/` rule.
- `SessionDurability::recorded_keys` is the best-effort passthrough, empty while unbound — a store that will not answer must not stop a session starting.
- `SubSessions::resuming` starts the counter above the highest `req:<n>` already recorded, and the deck builds its board through it (one line, so `command_deck.rs`'s ratchet is unmoved).

**Why the refs and not the session event journal.** `session_persist::journal_lanes` already names a resumed session's lanes and is in scope three hundred lines above, which makes it the tempting source. It is the wrong one: the hazard is a *checkpoint* being picked up, checkpoints live in the work journal, and the event journal only correlates with it. A signal that merely correlates with the hazard is not the hazard.

## Witnesses, ablated

**1. The mechanism** — `a_resumed_session_never_re_mints_a_lane_id_that_already_has_a_transcript`. It writes a checkpoint under `{session}__req-1`, asks for the next lane, and then binds the lane it got to prove that key is clean. Ablated by making `resuming` ignore the store:

```
---- subsession::tests::a_resumed_session_never_re_mints_a_lane_id_that_already_has_a_transcript ----
assertion `left == right` failed: a resumed session must step over the lane ids it already recorded
  left: "req:1"
 right: "req:2"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2351 filtered out
```

**2. The call site** — `the_deck_builds_its_lane_board_through_the_resuming_seam`. This one is here because the first ablation exposed a gap in my own test: reverting the deck's single call site to `SubSessions::new()` left **every assertion in test 1 passing**. The mechanism witness proves the mechanism; only a fence proves the driver uses it. Ablated by that revert:

```
---- subsession::tests::the_deck_builds_its_lane_board_through_the_resuming_seam ----
command_deck.rs builds a lane board with `SubSessions::new`. A deck session id may
already have `req:<n>` lanes recorded under it, and re-minting one lands the next
dispatch inside a dead lane's transcript (#3233). Use `SubSessions::resuming`.

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2351 filtered out
```

Both ablations make the answer **wrong**, not merely constant.

**3.** `work_journal::tests::a_prefix_finds_every_key_recorded_under_it_and_nothing_else` covers the new store API directly: a key that only checkpointed (a `head`), one that only snapshotted (a `tree`), a neighbour session's key, and a turn mark that must name no key. Ablated by dropping the `tree` arm from `journal_key_of` — the snapshotted key vanishes, which is a live key reported as absent and exactly the reading that would let a caller reuse a name it must not:

```
assertion `left == right` failed: a checkpointed key and a snapshotted one are both
recorded, and a turn mark names no key of its own
  left: ["ses-1__req-1"]
 right: ["ses-1__req-1", "ses-1__req-2"]
```

**4.** `another_sessions_lanes_do_not_move_this_sessions_counter` — sessions share one store, so an unprefixed read would start a fresh deck's numbering wherever the busiest neighbour left off. **5.** `an_unbound_session_starts_its_lane_numbering_where_a_fresh_one_does` — the degradation path.

## Scope: `Refs`, not `Closes`

#3233's item 2 asks for a read path that can **re-enter** an interrupted lane's turn — `stella daemon resume` targeting a lane. That is not here, and it is a larger thing than this: lane keys are not in the `SessionRegistry`, so `daemon::resolve` can never produce one. Filed as #5102 with what this PR established about where the record lives. What this PR settles is that the record is now readable, and that reading it closes the way per-lane durability could corrupt a fresh dispatch.

Two smaller findings filed rather than folded in: #5103 (stale prose — two doc comments still say the lane key is `{session}/{lane}`, which `lane_journal_key`'s own doc explains is the one shape it cannot be) and #5104 (nothing reaps a dead session's lane refs; only the age-based prune eventually does).

## Local runs

- `cargo test -p stella-store` — `435 passed; 0 failed`
- `cargo test -p stella-cli --bin stella` — `2352 passed; 0 failed`
- `cargo clippy -p stella-store -p stella-cli --all-targets -- -D warnings` — clean
- `make guards-fast` — clean

CI is the evidence; the workspace build is not run here.

Refs #3233, #4725, #3232

## Summary by Sourcery

Ensure resumed deck sessions mint fresh lane IDs by deriving the next number from their recorded durability refs.

New Features:
- Add a work-journal API for discovering recorded keys by prefix.

Bug Fixes:
- Prevent resumed sessions from reusing lane IDs with existing transcripts, avoiding accidental re-entry into dead lane conversations.

Enhancements:
- Initialize resumed deck lane numbering above the highest previously recorded lane for that session.
- Centralize journal reference parsing for recorded-key and retention queries.

Tests:
- Add coverage for lane ID advancement, session isolation, unbound durability fallback, deck integration, and journal key discovery.