### PR TITLE
feat(stella-cli,stella-plugin): stella can start an installed driver plugin

### DIFF
--- a/crates/stella-cli/src/driver_plugin.rs
+++ b/crates/stella-cli/src/driver_plugin.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Starting an installed driver plugin — the host half of the driver channel
+//! (#3783).
+//!
+//! `stella-runtime` has been able to *hold* a driver session since #3634:
+//! spawn the process, hand it a [`DriveRequest`], serve the capabilities its
+//! grant permits, and read back what it wants to happen next. Nothing in the
+//! shipping binary built one, so `[driver]` was a grant a human could read at
+//! install and no code path could turn into a running program. This module is
+//! that path, and [`crate::wrapper_plugin`] is the shape it copies: resolve
+//! argv against the installed package directory, resolve the manifest's
+//! environment allowlist through the *host's* ambient read, declare the
+//! transport, and report every name the socket withheld.
+//!
+//! # The two halves, and why they are separate here too
+//!
+//! [`resolve`] finds the plugin and binds its process; [`ResolvedDriver::serving`]
+//! attaches the capability gate. The wrapper socket splits them because the
+//! gate needs a provider that does not exist yet at bind time. Here the reason
+//! is smaller and still real: the gate is the value that must outlive the
+//! session, because [`DriverCallGate::refusals`] is the only place a refused
+//! ask is recorded, and a refusal nobody reads is the silence AGENTS.md's
+//! rule #10 exists to refuse.
+//!
+//! # What a session does today
+//!
+//! Every capability answers `unsupported` ([`NoDriverCapabilities`]), so a
+//! driver's first ask degrades rather than doing anything. That is the real
+//! state until #3599's B1–B6 land, and this module does not paper over it: the
+//! refusals are printed, in the driver's own vocabulary, so an operator sees
+//! exactly which asks this build could not serve.
+//!
+//! Scheduling is absent. One invocation opens one session and
+//! reports what the driver said to do next; who re-opens it after a
+//! [`DriveNext::Sleep`] is #3599's B2 `LoopStep` machine, and inventing a
+//! sleeper here would be inventing the loop this channel exists to be driven
+//! by.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use stella_plugin::{DriveNext, DriveRequest, PluginManifest};
+use stella_runtime::wrapper::{
+    DEFAULT_DRIVER_MAX_CALLS, DriverCallGate, NoDriverCapabilities, SubprocessDriver,
+};
+
+use crate::plugin_cmd::roster::PluginRoster;
+
+/// An installed driver, bound to the process the host will start.
+///
+/// `Debug` is safe to print: [`SubprocessDriver`]'s own is hand-written to
+/// name the environment variables it carries and never their values.
+#[derive(Debug)]
+pub(crate) struct ResolvedDriver {
+    /// The manifest that declared it — the grant the gate is built from.
+    manifest: PluginManifest,
+    /// The transport, before any gate is attached.
+    driver: SubprocessDriver,
+}
+
+/// A driver with its capability gate attached, ready to open a session.
+pub(crate) struct BoundDriver {
+    driver: SubprocessDriver,
+    gate: Arc<DriverCallGate>,
+}
+
+impl ResolvedDriver {
+    /// Attach the capability gate the manifest's grant is checked against.
+    ///
+    /// The gate is kept beside the driver rather than moved into it, for
+    /// [`crate::wrapper_plugin::BoundWrapper`]'s reason: nothing else can read
+    /// [`DriverCallGate::refusals`] once the session has ended.
+    pub(crate) fn serving(self) -> BoundDriver {
+        let grant = self.manifest.driver.clone().unwrap_or_default();
+        let gate = Arc::new(DriverCallGate::declare(
+            grant,
+            DEFAULT_DRIVER_MAX_CALLS,
+            Box::new(NoDriverCapabilities),
+        ));
+        BoundDriver {
+            driver: self.driver.serving(Arc::clone(&gate)),
+            gate,
+        }
+    }
+
+    /// The program this driver will be started as — what a caller reports
+    /// before spending anything on it.
+    pub(crate) fn program(&self) -> &str {
+        self.driver.program()
+    }
+}
+
+impl BoundDriver {
+    /// Open one session and read back what the driver wants to happen next.
+    ///
+    /// # Errors
+    ///
+    /// A message a user can act on. `stella-cli` is a binary, so a `String`
+    /// here is the finished product rather than an unnamed error (AGENTS.md
+    /// rule 5) — and every `DriverError` already names the program.
+    pub(crate) fn open(&self, session: &str) -> Result<DriveNext, String> {
+        // A runtime per session, matching `self_driving_cmd::hooks`'s dispatch:
+        // this door is otherwise synchronous, and a driver session is one
+        // bounded subprocess rather than something that needs the
+        // multi-threaded scheduler.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| format!("could not start a runtime for the driver: {error}"))?;
+        let response = runtime
+            .block_on(self.driver.drive(DriveRequest::new(session)))
+            .map_err(|error| error.to_string())?;
+        Ok(response.next)
+    }
+
+    /// Whether this session will hold a channel open for capability asks at
+    /// all — the gate's own answer, so a caller reports what the grant
+    /// actually bought rather than what the manifest asked for.
+    ///
+    /// `false` means the driver declared no capability the host may perform,
+    /// and the transport closes its stdin rather than waiting for asks that
+    /// can never come (#3561's shape, in this dispatch context).
+    pub(crate) fn offers_calls(&self) -> bool {
+        self.gate.offers_calls()
+    }
+
+    /// Every ask this session could not serve, in the order they were made,
+    /// in `RefusedDriverCall`'s own words rather than a second phrasing of
+    /// them.
+    pub(crate) fn refusals(&self) -> Vec<String> {
+        self.gate
+            .refusals()
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+}
+
+/// Load the roster and bind the installed driver plugin called `name`.
+///
+/// # Errors
+///
+/// Whatever [`bind_installed`] refuses, plus a failure to read the roster.
+pub(crate) fn resolve(
+    workspace_root: &Path,
+    name: &str,
+    warn: &mut dyn FnMut(String),
+) -> Result<ResolvedDriver, String> {
+    let settings = crate::settings::Settings::load(workspace_root).unwrap_or_default();
+    let (roster, notices) = PluginRoster::load(workspace_root, &settings);
+    // A plugin that did not load must never vanish silently: "I installed it
+    // and nothing happened" is unanswerable without the reason.
+    for notice in notices {
+        warn(notice.trim_start_matches(" ! ").to_string());
+    }
+    bind_installed(&roster, name, warn)
+}
+
+/// Find the installed plugin called `name` and bind it to its process.
+///
+/// The pure half — pure of everything but the one ambient environment read the
+/// allowlist needs, which belongs to the host because `stella-runtime` reads
+/// none by contract (`crates/stella-runtime/tests/no_ambient_reads.rs`).
+///
+/// # Errors
+///
+/// A message naming what to do instead: which plugins *do* declare a driver,
+/// that this one declares no `[driver.process]` and so is a declaration a
+/// person starts by hand, or why the process cannot be started.
+///
+/// A refused environment name is **reported, not silently dropped**, exactly as
+/// it is for a wrapper: [`SubprocessDriver::declare`] withholds model
+/// credentials at the socket for every child the host spawns (#3512), and an
+/// author whose manifest asked for one can only stop asking if they are told.
+pub(crate) fn bind_installed(
+    roster: &PluginRoster,
+    name: &str,
+    warn: &mut dyn FnMut(String),
+) -> Result<ResolvedDriver, String> {
+    bind_with(roster, name, warn, &mut |name| std::env::var(name).ok())
+}
+
+/// [`bind_installed`], with the environment lookup supplied.
+///
+/// The seam exists for the reason [`stella_plugin::Runtime::child_env`] takes
+/// a lookup rather than reading the environment itself: what the socket
+/// withholds from a child is decided by the *names* a manifest declared, and a
+/// test that had to set `ANTHROPIC_API_KEY` in the test process to prove the
+/// withholding would be mutating global state every other test shares.
+fn bind_with(
+    roster: &PluginRoster,
+    name: &str,
+    warn: &mut dyn FnMut(String),
+    lookup: &mut dyn FnMut(&str) -> Option<String>,
+) -> Result<ResolvedDriver, String> {
+    let installed = roster
+        .plugins()
+        .iter()
+        .find(|plugin| plugin.manifest.name == name && plugin.manifest.driver.is_some())
+        .ok_or_else(|| {
+            let mut available: Vec<&str> = roster
+                .plugins()
+                .iter()
+                .filter(|plugin| plugin.manifest.driver.is_some())
+                .map(|plugin| plugin.manifest.name.as_str())
+                .collect();
+            available.sort_unstable();
+            if available.is_empty() {
+                format!(
+                    "no installed plugin called \"{name}\" declares a [driver] block — \
+                     `stella plugin list` shows what is installed"
+                )
+            } else {
+                format!(
+                    "no installed plugin called \"{name}\" declares a [driver] block — \
+                     installed drivers: {}",
+                    available.join(", ")
+                )
+            }
+        })?;
+
+    let grant = installed
+        .manifest
+        .driver
+        .as_ref()
+        .expect("the search filtered on a declared [driver] block");
+    let process = grant.process.as_ref().ok_or_else(|| {
+        format!(
+            "plugin \"{name}\" declares a [driver] grant but no [driver.process] block, so \
+             Stella has no program to start — this is a declaration of what such a driver \
+             may ask for, and the loop it describes is one you start yourself"
+        )
+    })?;
+
+    warn_narrowed_driver_ceiling(&installed.manifest, warn);
+
+    // `${plugin_dir}` is the host's substitution — this crate is where the
+    // install directory is known — through the same shared expander every
+    // other argv in an installed package goes through (#4301).
+    let argv: Vec<String> = process
+        .argv
+        .iter()
+        .map(|arg| stella_plugin::expand_plugin_dir(arg, &installed.dir))
+        .collect();
+    // The one ambient read on this path, and it belongs to the host:
+    // `stella-runtime` reads no process environment by contract, so the CLI
+    // resolves the manifest's allowlist and hands over pairs.
+    let env = process.child_env(lookup);
+    let admitted = SubprocessDriver::declare(argv, env, Duration::from_secs(process.timeout_secs))
+        .map_err(|error| format!("driver \"{name}\" cannot be started: {error}"))?;
+    for refused in &admitted.refused {
+        warn(format!(
+            "driver \"{name}\" asked for {refused} and will not get it — a plugin never \
+             receives a model credential; every capability it needs is performed by Stella \
+             on request"
+        ));
+    }
+    Ok(ResolvedDriver {
+        manifest: installed.manifest.clone(),
+        driver: admitted.driver,
+    })
+}
+
+/// Say so when this host will fund fewer capability asks than the manifest
+/// declared (#3841's posture, in the driver's dispatch context).
+///
+/// Not a refusal: a driver capped below its ask still drives, just
+/// with fewer asks per session. The defect the notice exists for is the
+/// silence — a user who read "asks for up to 200 of those per driver session"
+/// at install and gets the host's ceiling has been told nothing.
+fn warn_narrowed_driver_ceiling(manifest: &PluginManifest, warn: &mut dyn FnMut(String)) {
+    let Some(asked) = manifest.driver.as_ref().and_then(|grant| grant.max_calls) else {
+        return;
+    };
+    if asked > DEFAULT_DRIVER_MAX_CALLS {
+        warn(format!(
+            "driver \"{}\" asks for up to {asked} capability calls per session; this host \
+             funds {DEFAULT_DRIVER_MAX_CALLS} (a host default, not a setting you chose)",
+            manifest.name
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/driver_plugin/tests.rs
+++ b/crates/stella-cli/src/driver_plugin/tests.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for [`crate::driver_plugin`] — the CLI-side construction of a driver
+//! session (#3783).
+//!
+//! Every test here drives the **real** binder, not a hand-built
+//! [`SubprocessDriver`]: the thing #3783 says is missing is not the transport
+//! (which `crates/stella-runtime/tests/driver_socket.rs` already covers) but a
+//! path from an installed package to one, so a test that constructed the
+//! transport itself would be testing the half that already worked.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use stella_plugin::PluginManifest;
+
+use super::*;
+use crate::plugin_cmd::roster::{InstalledPlugin, PluginScope};
+
+/// A driver Stella can start: a grant, and a process to hold it.
+///
+/// `participation = "none"` is the only grade this can carry, and the reason
+/// this manifest
+/// could not have carried a `[runtime]` block — see
+/// `stella_plugin::manifest`'s
+/// `a_driver_declares_its_own_process_and_runtime_could_not_have_carried_it`.
+const DRIVING_MANIFEST: &str = r#"
+name = "selfdriving"
+[loop]
+participation = "none"
+[driver]
+calls = ["backlog_next", "backlog_file"]
+max_calls = 4
+[driver.process]
+argv = ["${plugin_dir}/drive.sh"]
+timeout_secs = 30
+env = ["PATH", "ANTHROPIC_API_KEY"]
+"#;
+
+/// The same grant with no process — `plugins/stella-selfdriving`'s shape: a
+/// consent document for a loop a person starts by hand.
+const DECLARED_ONLY_MANIFEST: &str = r#"
+name = "selfdriving"
+[loop]
+participation = "none"
+[driver]
+calls = ["backlog_next"]
+"#;
+
+fn installed(text: &str, dir: &str) -> InstalledPlugin {
+    InstalledPlugin {
+        manifest: PluginManifest::from_toml_str(text).expect("fixture must load"),
+        dir: PathBuf::from(dir),
+        scope: PluginScope::User,
+        consent: crate::plugin_cmd::receipt::ConsentState::Receipted,
+    }
+}
+
+fn roster(plugins: Vec<InstalledPlugin>) -> PluginRoster {
+    PluginRoster::compose(plugins, Vec::new(), &BTreeMap::new())
+}
+
+/// Nothing in the operator's environment is set, so a test never depends on
+/// what the machine running it happens to export.
+fn nothing_set(_: &str) -> Option<String> {
+    None
+}
+
+/// **The witness.** Before this module nothing outside
+/// `crates/stella-runtime/tests/` built a [`SubprocessDriver`], so an installed
+/// `[driver]` block was a declaration with no path into a running program.
+///
+/// The assertion is the interpolated argv: the host is the only party that
+/// knows where the package was installed, so a program resolved against the
+/// package directory is proof the *host* bound it, not that a manifest was
+/// parsed.
+#[test]
+fn an_installed_driver_is_bound_to_the_program_its_package_declares() {
+    let roster = roster(vec![installed(DRIVING_MANIFEST, "/opt/pkgs/selfdriving")]);
+    let mut warnings = Vec::new();
+
+    let resolved = bind_with(
+        &roster,
+        "selfdriving",
+        &mut |line| warnings.push(line),
+        &mut nothing_set,
+    )
+    .expect("an installed driver with a process binds");
+
+    assert_eq!(resolved.program(), "/opt/pkgs/selfdriving/drive.sh");
+}
+
+/// The grant is what the gate is built from, so a declared capability is
+/// offered a channel and a grant with none is not — the difference the
+/// transport reads before it decides whether to keep the driver's stdin open.
+#[test]
+fn the_manifests_grant_is_what_the_session_gate_holds() {
+    let declared = bind_with(
+        &roster(vec![installed(DRIVING_MANIFEST, "/opt/pkgs/selfdriving")]),
+        "selfdriving",
+        &mut |_| {},
+        &mut nothing_set,
+    )
+    .expect("binds")
+    .serving();
+    assert!(declared.offers_calls());
+    // Nothing was asked, so nothing was refused: a refusal list that filled
+    // itself at construction would make the report meaningless.
+    assert!(declared.refusals().is_empty());
+
+    const ASKS_NOTHING: &str = r#"
+name = "quiet"
+[driver]
+[driver.process]
+argv = ["/bin/sh"]
+timeout_secs = 5
+"#;
+    let quiet = bind_with(
+        &roster(vec![installed(ASKS_NOTHING, "/opt/pkgs/quiet")]),
+        "quiet",
+        &mut |_| {},
+        &mut nothing_set,
+    )
+    .expect("binds")
+    .serving();
+    assert!(!quiet.offers_calls());
+}
+
+/// A model credential named in `[driver.process] env` is withheld at the
+/// socket and the withholding is **reported**. An author who is never told
+/// cannot stop asking, and a user who is never told believes the key was
+/// handed over.
+#[test]
+fn a_model_credential_is_withheld_from_a_driver_and_the_user_is_told() {
+    let roster = roster(vec![installed(DRIVING_MANIFEST, "/opt/pkgs/selfdriving")]);
+    let mut warnings = Vec::new();
+
+    bind_with(
+        &roster,
+        "selfdriving",
+        &mut |line| warnings.push(line),
+        // Both allowlisted names resolve, so the refusal is the socket's
+        // decision rather than an absent variable.
+        &mut |name| Some(format!("value-of-{name}")),
+    )
+    .expect("binds");
+
+    let refusal = warnings
+        .iter()
+        .find(|line| line.contains("ANTHROPIC_API_KEY"))
+        .unwrap_or_else(|| panic!("the withheld credential must be reported: {warnings:?}"));
+    assert!(refusal.contains("will not get it"), "{refusal}");
+    // `PATH` was allowlisted too and is not a credential, so it is not
+    // reported — a report that named every variable would name nothing.
+    assert!(
+        !warnings.iter().any(|line| line.contains("PATH")),
+        "{warnings:?}"
+    );
+}
+
+/// A grant with no process is refused with the sentence that says what it *is*
+/// — the state `plugins/stella-selfdriving` is in, and one a user must be able
+/// to tell from a broken install.
+#[test]
+fn a_driver_with_no_process_says_it_is_one_you_start_yourself() {
+    let roster = roster(vec![installed(
+        DECLARED_ONLY_MANIFEST,
+        "/opt/pkgs/selfdriving",
+    )]);
+
+    let error = bind_with(&roster, "selfdriving", &mut |_| {}, &mut nothing_set)
+        .expect_err("a grant with no process cannot be started");
+
+    assert!(error.contains("[driver.process]"), "{error}");
+    assert!(error.contains("one you start yourself"), "{error}");
+}
+
+/// A name that is not an installed driver names the ones that are, rather than
+/// leaving the user to guess how the plugin they installed is spelled.
+#[test]
+fn an_unknown_driver_names_the_installed_ones() {
+    let roster = roster(vec![installed(DRIVING_MANIFEST, "/opt/pkgs/selfdriving")]);
+
+    let error = bind_with(&roster, "typo", &mut |_| {}, &mut nothing_set)
+        .expect_err("an uninstalled name is refused");
+    assert!(error.contains("installed drivers: selfdriving"), "{error}");
+
+    let empty = bind_with(
+        &PluginRoster::default(),
+        "typo",
+        &mut |_| {},
+        &mut nothing_set,
+    )
+    .expect_err("an empty roster refuses too");
+    assert!(empty.contains("stella plugin list"), "{empty}");
+}
+
+/// A ceiling the host will not fund is announced before the session, not
+/// discovered when the allowance runs out (#3841's posture).
+#[test]
+fn a_ceiling_this_host_will_not_fund_is_announced() {
+    let greedy = format!(
+        "name = \"greedy\"\n[driver]\ncalls = [\"backlog_next\"]\nmax_calls = {}\n\
+         [driver.process]\nargv = [\"/bin/sh\"]\ntimeout_secs = 5\n",
+        DEFAULT_DRIVER_MAX_CALLS + 1
+    );
+    let mut warnings = Vec::new();
+    bind_with(
+        &roster(vec![installed(&greedy, "/opt/pkgs/greedy")]),
+        "greedy",
+        &mut |line| warnings.push(line),
+        &mut nothing_set,
+    )
+    .expect("binds");
+    assert!(
+        warnings
+            .iter()
+            .any(|line| line.contains("this host funds") && line.contains("greedy")),
+        "{warnings:?}"
+    );
+
+    // And a manifest asking for no more than the host funds says nothing.
+    let modest = format!(
+        "name = \"modest\"\n[driver]\ncalls = [\"backlog_next\"]\nmax_calls = {DEFAULT_DRIVER_MAX_CALLS}\n\
+         [driver.process]\nargv = [\"/bin/sh\"]\ntimeout_secs = 5\n"
+    );
+    let mut quiet = Vec::new();
+    bind_with(
+        &roster(vec![installed(&modest, "/opt/pkgs/modest")]),
+        "modest",
+        &mut |line| quiet.push(line),
+        &mut nothing_set,
+    )
+    .expect("binds");
+    assert!(quiet.is_empty(), "{quiet:?}");
+}
+
+/// The end of the path: a bound driver is actually spawned, and a program the
+/// package does not contain fails **naming the resolved path**. That is the
+/// half a construction-only assertion cannot reach — it proves the argv the
+/// host resolved is the argv the transport ran.
+#[cfg(unix)]
+#[test]
+fn opening_a_session_spawns_the_resolved_program_and_reports_what_it_was() {
+    let dir = std::env::temp_dir().join(format!("stella-driver-{}", std::process::id()));
+    let roster = roster(vec![installed(DRIVING_MANIFEST, &dir.to_string_lossy())]);
+
+    let error = bind_with(&roster, "selfdriving", &mut |_| {}, &mut nothing_set)
+        .expect("binds")
+        .serving()
+        .open("drive-test")
+        .expect_err("a program that is not there cannot be started");
+
+    assert!(
+        error.contains(dir.join("drive.sh").to_string_lossy().as_ref()),
+        "{error}"
+    );
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -53,6 +53,7 @@ mod diag_boot;
 mod diag_bridge;
 mod doctor;
 mod domains;
+mod driver_plugin;
 mod durability;
 mod engine_config;
 mod enterprise_telemetry;

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -82,6 +82,16 @@ pub enum PluginCmd {
         #[arg(value_name = "NAME")]
         name: String,
     },
+    /// Open one driver session against an installed plugin that declares
+    /// `[driver]`, and report what it says to do next.
+    ///
+    /// One session per invocation: what re-opens it after a `sleep` is the
+    /// loop the driver is describing, not this verb (#3599 B2).
+    Drive {
+        /// The plugin's `name`, as `stella plugin list` prints it.
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
 }
 
 /// The tier `--scope` selects. Mirrors [`PluginScope`], which is not a clap
@@ -114,7 +124,70 @@ pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
         }
         PluginCmd::List => list(&root, &settings),
         PluginCmd::Remove { name } => remove(&root, name),
+        PluginCmd::Drive { name } => drive(&root, name),
     }
+}
+
+/// A session identifier the driver echoes into its own records.
+///
+/// Minted the way `self_driving_cmd::state::new_run_id` mints a run id — a
+/// timestamp plus a salt off the clock's sub-second remainder and the process
+/// id — so two sessions started in the same second are still distinguishable.
+fn session_id() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let salt = (now.subsec_nanos() ^ std::process::id()) & 0xffff;
+    format!("drive-{}-{salt:04x}", now.as_secs())
+}
+
+/// `stella plugin drive <name>` — open one driver session.
+///
+/// The session's identifier is minted here and echoed into the driver's own
+/// telemetry, so a driver's records and the host's can be joined afterwards.
+///
+/// # Errors
+///
+/// Whatever [`crate::driver_plugin::bind_installed`] refuses, or the session's
+/// own failure — a driver that could not be started, timed out, died, or ended
+/// without saying what should happen next.
+fn drive(workspace_root: &Path, name: &str) -> Result<(), String> {
+    let name = checked_name(name)?;
+    let mut warn = |line: String| eprintln!("  ! {line}");
+    let resolved = crate::driver_plugin::resolve(workspace_root, name, &mut warn)?;
+    println!("driver \"{name}\": starting `{}`", resolved.program());
+
+    let session = session_id();
+    let bound = resolved.serving();
+    // Said before the session rather than inferred from the refusals after it:
+    // every capability answers `unsupported` until #3599's B1-B6 land, so a
+    // driver that asks for anything will be refused everything, and an
+    // operator should learn that from the host rather than from a driver's
+    // own halt message.
+    if bound.offers_calls() {
+        println!(
+            "  this build serves no driver capability yet, so every ask this session makes \
+             will be refused"
+        );
+    }
+    let next = bound.open(&session);
+
+    // Printed whichever way the session ended. A driver that asked for a
+    // capability and then failed is the case where the refusals matter most:
+    // they are usually why it failed.
+    for refusal in bound.refusals() {
+        eprintln!("  ! {refusal}");
+    }
+
+    match next? {
+        stella_plugin::DriveNext::Sleep { secs } => {
+            println!("session {session} ended: sleep {secs}s before the next one");
+        }
+        stella_plugin::DriveNext::Halt { reason } => {
+            println!("session {session} ended: halt — {reason}");
+        }
+    }
+    Ok(())
 }
 
 /// The directory a tier installs into, or a reason it cannot be resolved.

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -557,7 +557,10 @@ fn list(workspace_root: &Path, settings: &Settings) -> Result<(), String> {
                     runtime.env.join(", ")
                 }
             ),
-            None => println!("  runs: no [runtime] — this plugin ships no process"),
+            None => println!("  runs: no [runtime] — this plugin runs no process inside a turn"),
+        }
+        for line in driver_lines(plugin) {
+            println!("{line}");
         }
     }
 
@@ -629,6 +632,50 @@ fn list(workspace_root: &Path, settings: &Settings) -> Result<(), String> {
 /// clause rather than silence. It is a real and legitimate state (the user
 /// edited it by hand), and it changes what `remove` will do: the revert puts
 /// back the *prior* value, discarding the edit.
+/// What `stella plugin list` says about an installed `[driver.process]`, or
+/// nothing when the plugin declares none.
+///
+/// A driver's process is a second program, started outside every turn and
+/// never by the hook plane, so it gets its own line: the `runs:` line reports
+/// `[runtime]` and says nothing about this one, which would leave a package
+/// whose only program is a driver reading as though it shipped none (#3783).
+///
+/// A refused credential is named here for the reason the hook-route report
+/// names one — the author's fix is to stop asking, and they can only take it
+/// if they are told — and the two reports are separate because a driver has no
+/// route to be read off.
+fn driver_lines(plugin: &roster::InstalledPlugin) -> Vec<String> {
+    let Some(process) = plugin
+        .manifest
+        .driver
+        .as_ref()
+        .and_then(|grant| grant.process.as_ref())
+    else {
+        return Vec::new();
+    };
+    let mut lines = vec![format!(
+        "  drives: {} ({}s, env: {}) — `stella plugin drive {}`",
+        process.argv.join(" "),
+        process.timeout_secs,
+        if process.env.is_empty() {
+            "none".to_string()
+        } else {
+            process.env.join(", ")
+        },
+        plugin.manifest.name
+    )];
+    let refused = process::refused_credentials(&process.env);
+    if !refused.is_empty() {
+        lines.push(format!(
+            "  ! `{}` asks its driver to inherit {} — refused: a plugin never receives the \
+             credential that pays for the agent.",
+            plugin.manifest.name,
+            refused.join(", ")
+        ));
+    }
+    lines
+}
+
 fn configure_lines(workspace_root: &Path, plugin: &roster::InstalledPlugin) -> Vec<String> {
     let target = configure::ConfigTarget::resolve(workspace_root, plugin.scope).ok();
     configure::configured(

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1052,6 +1052,56 @@ fn filesystem_isolation_closes_both_tiers() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// A driver's program is reported by `list`, and reported as a *driver* — the
+/// `runs:` line is about `[runtime]` and says nothing about it, so a package
+/// whose only program is a driver would otherwise read as shipping none
+/// (#3783).
+#[test]
+fn list_names_a_drivers_program_and_the_credential_it_will_not_get() {
+    let root = temp_root("drives");
+    let plugins = stella_home::resolve_project_plugins_dir(&root);
+    std::fs::create_dir_all(plugins.join("selfdriving")).expect("tier");
+    std::fs::write(
+        plugins.join("selfdriving").join(roster::MANIFEST_FILE),
+        "name = \"selfdriving\"\n[loop]\nparticipation = \"none\"\n\n[driver]\n\
+         calls = [\"backlog_next\"]\n\n[driver.process]\n\
+         argv = [\"python3\", \"drive.py\"]\ntimeout_secs = 600\n\
+         env = [\"PATH\", \"ANTHROPIC_API_KEY\"]\n",
+    )
+    .expect("manifest");
+
+    let installed = read_project_tier(&root);
+    let plugin = installed.first().expect("it is on disk");
+    let lines = driver_lines(plugin);
+
+    assert!(
+        lines[0].contains("drives: python3 drive.py (600s, env: PATH, ANTHROPIC_API_KEY)")
+            && lines[0].contains("stella plugin drive selfdriving"),
+        "{lines:#?}"
+    );
+    assert!(
+        lines[1].contains("ANTHROPIC_API_KEY") && lines[1].contains("refused"),
+        "the credential the socket withholds is named: {lines:#?}"
+    );
+
+    // A plugin with no driver says nothing here rather than a line about an
+    // absence, which is what keeps the lines above meaning something.
+    std::fs::create_dir_all(plugins.join("plain")).expect("tier");
+    std::fs::write(
+        plugins.join("plain").join(roster::MANIFEST_FILE),
+        manifest_text("plain"),
+    )
+    .expect("manifest");
+    let installed = read_project_tier(&root);
+    let plain = installed
+        .iter()
+        .find(|p| p.manifest.name == "plain")
+        .expect("it is on disk");
+    assert!(driver_lines(plain).is_empty());
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 // A plugin is a package: the tools, skills and records it ships (#3380). Those
 // tests live in `contributions.rs`, split out when this file crossed the
 // 1500-line ceiling (#4440).

--- a/crates/stella-plugin/src/consent.rs
+++ b/crates/stella-plugin/src/consent.rs
@@ -47,6 +47,7 @@ use crate::error::ManifestError;
 use crate::host_call::HostCall;
 use crate::manifest::{HookEvent, Participation, PluginManifest};
 use crate::oracle::OracleProcessSource;
+use crate::runtime::Runtime;
 use crate::wire::{WIRE_FIELDS, WrapperPoint, hook_disclosures_for};
 
 /// How bad one honest call of a tool is — re-exported from
@@ -291,21 +292,7 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
     // "runs `python3 main.py`" and "runs `python3 main.py`, and hands it your
     // `GITHUB_TOKEN`" are different things to consent to.
     if let Some(runtime) = &manifest.runtime {
-        let argv: Vec<String> = runtime.argv.iter().map(|arg| one_line(arg)).collect();
-        lines.push(format!(
-            "  - runs as a process on your machine: `{}` (killed after {}s)",
-            argv.join(" "),
-            runtime.timeout_secs
-        ));
-        lines.push(if runtime.env.is_empty() {
-            "      it inherits NO environment variables".into()
-        } else {
-            let names: Vec<String> = runtime.env.iter().map(|name| one_line(name)).collect();
-            format!(
-                "      it inherits these environment variables and no others: {}",
-                names.join(", ")
-            )
-        });
+        lines.extend(process_say(runtime));
     }
 
     // The host-call channel, which until now was declared in the manifest and
@@ -440,6 +427,32 @@ fn role_spend(manifest: &PluginManifest) -> Vec<String> {
 /// requests, reads CI, and merges" is the sentence a human weighs, and
 /// `deliver_merge` on its own is not. The verbs are printed beside it so the
 /// declaration stays checkable against the block.
+/// The two bullets a declared process is worth: what runs, and what of the
+/// operator's environment it is handed.
+///
+/// Shared by `[runtime]` and `[driver.process]` because a human consenting to
+/// a subprocess is consenting to the same thing either way, and a second
+/// wording here would be a second thing to keep true (#3783).
+fn process_say(process: &Runtime) -> Vec<String> {
+    let argv: Vec<String> = process.argv.iter().map(|arg| one_line(arg)).collect();
+    vec![
+        format!(
+            "  - runs as a process on your machine: `{}` (killed after {}s)",
+            argv.join(" "),
+            process.timeout_secs
+        ),
+        if process.env.is_empty() {
+            "      it inherits NO environment variables".into()
+        } else {
+            let names: Vec<String> = process.env.iter().map(|name| one_line(name)).collect();
+            format!(
+                "      it inherits these environment variables and no others: {}",
+                names.join(", ")
+            )
+        },
+    ]
+}
+
 fn driver_say(manifest: &PluginManifest) -> Vec<String> {
     let Some(driver) = &manifest.driver else {
         return Vec::new();
@@ -452,6 +465,21 @@ fn driver_say(manifest: &PluginManifest) -> Vec<String> {
             one_line(&manifest.name)
         ),
     ];
+
+    // Before the capability list, and before the empty-list early return: a
+    // driver's process is the thing a host actually starts, so a declaration
+    // that asks for no capability at all still puts a program on the reader's
+    // machine. Absence is said too — `plugins/stella-selfdriving` declares the
+    // grant for a loop a person starts by hand, and a reader must be able to
+    // tell that from one Stella will spawn.
+    match &driver.process {
+        Some(process) => lines.extend(process_say(process)),
+        None => lines.push(
+            "  - is not started by Stella: this declares what such a driver may ask for, and \
+             nothing here runs a program"
+                .into(),
+        ),
+    }
 
     if driver.calls.is_empty() {
         // A driver that asks for nothing is a coherent declaration and a
@@ -990,497 +1018,4 @@ fn one_line(text: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn parse(text: &str) -> PluginManifest {
-        PluginManifest::from_toml_str(text).expect("fixture must parse")
-    }
-
-    #[test]
-    fn a_bundle_with_no_grant_says_so_in_both_halves() {
-        let text = consent_text(&parse("name = \"notes\""));
-        assert!(text.contains("Install `notes`?"), "{text}");
-        assert!(
-            text.contains("none — it never runs inside a turn"),
-            "{text}"
-        );
-        assert!(text.contains("It asks for no tool capabilities."), "{text}");
-    }
-
-    #[test]
-    fn the_headline_grade_is_the_widest_one_asked_for() {
-        let capabilities = [
-            Capability {
-                tool: "read_file".into(),
-                risk: RiskLevel::Low,
-                purpose: "read the repo".into(),
-                scope: Vec::new(),
-            },
-            Capability {
-                tool: "bash".into(),
-                risk: RiskLevel::Destructive,
-                purpose: "run anything".into(),
-                scope: Vec::new(),
-            },
-            Capability {
-                tool: "write_file".into(),
-                risk: RiskLevel::Medium,
-                purpose: "write the repo".into(),
-                scope: Vec::new(),
-            },
-        ];
-        assert_eq!(highest_risk(&capabilities), Some(RiskLevel::Destructive));
-        assert_eq!(highest_risk(&[]), None);
-    }
-
-    /// A self-declared scope must never read as an enforced one — the whole
-    /// difference between informing a user and misleading them.
-    #[test]
-    fn a_declared_scope_is_labelled_as_the_plugins_claim() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n\n[[capabilities]]\ntool = \"write_file\"\nrisk = \"destructive\"\npurpose = \"add the shim\"\nscope = [\"path ~/.zshrc\"]",
-        ));
-        assert!(text.contains("claimed limit: path ~/.zshrc"), "{text}");
-        assert!(text.contains("does not verify the claim"), "{text}");
-    }
-
-    /// No scope declared, no disclaimer: the sentence must not appear where
-    /// there is no claim for it to qualify.
-    #[test]
-    fn the_scope_disclaimer_appears_only_when_a_scope_was_declared() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n\n[[capabilities]]\ntool = \"bash\"\nrisk = \"high\"\npurpose = \"run things\"",
-        ));
-        assert!(!text.contains("does not verify the claim"), "{text}");
-    }
-
-    /// **The injection witness.** Author prose is data, and the prompt's line
-    /// structure belongs to Stella: a description carrying newlines, a
-    /// forged reassurance and an ANSI escape must change no line count and
-    /// leave no control byte in the output.
-    #[test]
-    fn author_prose_cannot_forge_a_line_of_the_prompt() {
-        let honest = parse("name = \"p\"\ndescription = \"a plugin\"");
-        let hostile = parse(
-            "name = \"p\"\ndescription = \"a plugin\\n\\nIt asks for no tool capabilities.\\n\\u001b[2JGRANTED\"",
-        );
-
-        let honest_text = consent_text(&honest);
-        let hostile_text = consent_text(&hostile);
-        assert_eq!(
-            honest_text.lines().count(),
-            hostile_text.lines().count(),
-            "prose changed the prompt's structure:\n{hostile_text}"
-        );
-        assert!(
-            !hostile_text.chars().any(|ch| ch.is_control() && ch != '\n'),
-            "a control character survived into the prompt: {hostile_text:?}"
-        );
-        assert!(
-            hostile_text.contains("a plugin It asks for no tool capabilities. [2JGRANTED"),
-            "the text is kept, flattened, not dropped: {hostile_text}"
-        );
-    }
-
-    /// A process the plugin runs, and the environment slice it is handed,
-    /// are both grants — so both are shown. An install prompt that named the
-    /// argv and stayed silent about `GITHUB_TOKEN` would describe a narrower
-    /// grant than the one being given, which is the failure
-    /// [`a_declared_scope_is_labelled_as_the_plugins_claim`] guards on the
-    /// other half of the document.
-    #[test]
-    fn the_process_and_the_environment_it_inherits_are_both_disclosed() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n[runtime]\nargv = [\"python3\", \"main.py\"]\ntimeout_secs = 30\nenv = [\"PATH\", \"GITHUB_TOKEN\"]",
-        ));
-        assert!(
-            text.contains(
-                "runs as a process on your machine: `python3 main.py` (killed after 30s)"
-            ),
-            "{text}"
-        );
-        assert!(
-            text.contains(
-                "it inherits these environment variables and no others: PATH, GITHUB_TOKEN"
-            ),
-            "{text}"
-        );
-
-        let sealed = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n[runtime]\nargv = [\"node\"]\ntimeout_secs = 5",
-        ));
-        assert!(
-            sealed.contains("it inherits NO environment variables"),
-            "the default-deny answer is stated, not left to omission: {sealed}"
-        );
-    }
-
-    /// **The #3511 witness.** A user installing a verification plugin is
-    /// trusting its honesty about its own work, and the prompt must say so:
-    /// the flip and the measurements a verdict turns on come back from the
-    /// plugin's process, and neither is run nor re-checked by Stella. This
-    /// prompt claimed the opposite for as long as it existed
-    /// (`manifest.rs`'s "the HOST runs this; the plugin never grades its own
-    /// work"), which is the consent defect Option 2 exists to close.
-    #[test]
-    fn an_oracle_is_disclosed_as_the_plugins_own_report() {
-        let text = consent_text(&parse(
-            "name = \"vera\"\n[loop]\nparticipation = \"arbiter\"\nhooks = [\"Stop\"]\n\
-             points = [\"after_turn\"]\n\n\
-             [requirements]\nwitness = \"a failing test flips to passing\"\n\n\
-             [oracle]\ncommand = { argv = [\"vera\", \"verify\"], timeout_secs = 60 }\n\
-             flip = \"required\"",
-        ));
-
-        assert!(
-            text.contains("reports its own evidence"),
-            "the prompt must say the evidence is the plugin's own report: {text}"
-        );
-        assert!(
-            text.contains(
-                "Stella does not run the oracle itself and does not check what comes \
-                 back"
-            ),
-            "the prompt must say Stella neither runs nor checks it: {text}"
-        );
-        assert!(
-            text.contains("trusting it to report honestly about its own work"),
-            "the prompt must name what the user is actually trusting: {text}"
-        );
-        assert!(
-            !text.contains("never grades its own work"),
-            "the retired host-run claim must not survive anywhere in the prompt: {text}"
-        );
-    }
-
-    /// The other half of the witness, on
-    /// `the_scope_disclaimer_appears_only_when_a_scope_was_declared`'s
-    /// reasoning: no oracle, no self-report paragraph.
-    #[test]
-    fn the_self_report_disclosure_appears_only_when_an_oracle_was_declared() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n[runtime]\nargv = [\"node\"]\ntimeout_secs = 5",
-        ));
-        assert!(!text.contains("reports its own evidence"), "{text}");
-    }
-
-    /// **The driver paragraph, family by family** (#3729). This is the
-    /// sentence a user reads before granting a plugin permission to push
-    /// branches, merge, and spend model calls between their turns, and until
-    /// this test nothing would have failed if a refactor had dropped it.
-    ///
-    /// Every family the block spans is named with its own consent sentence,
-    /// and every declared verb is printed beside its family — the rendering
-    /// is by family because "pushes branches, opens pull requests, reads CI,
-    /// and merges" is what a human weighs, and the verbs are what keeps that
-    /// summary checkable against the block.
-    #[test]
-    fn a_driver_grant_names_every_family_and_the_verbs_under_it() {
-        use crate::driver::DriverFamily;
-
-        let manifest = parse(
-            "name = \"loop\"\n[loop]\nparticipation = \"none\"\n\n\
-             [driver]\ncalls = [\"deliver_open\", \"backlog_next\", \"deliver_merge\"]",
-        );
-        let text = consent_text(&manifest);
-
-        assert!(
-            text.contains(
-                "`loop` DRIVES Stella. It is not a participant in a turn — it starts them."
-            ),
-            "{text}"
-        );
-        let driver = manifest.driver.as_ref().expect("the block is declared");
-        assert_eq!(
-            driver.families(),
-            vec![DriverFamily::Backlog, DriverFamily::Deliver],
-            "the fixture spans two families, or this test proves less than it says"
-        );
-        for family in driver.families() {
-            assert!(
-                text.contains(family.consent_sentence()),
-                "the `{family}` family's sentence is missing:\n{text}"
-            );
-        }
-        assert!(text.contains("(backlog_next)"), "{text}");
-        assert!(
-            text.contains("(deliver_open, deliver_merge)"),
-            "the verbs are printed beside their family, in declaration order:\n{text}"
-        );
-        assert!(
-            text.contains(
-                "performed BY Stella on request: this plugin holds no credential, no provider \
-                 and no forge token of its own."
-            ),
-            "{text}"
-        );
-    }
-
-    /// The ceiling a user is told about is the one the block declared, and an
-    /// absent one gets its own sentence — "as many as the host allows" is a
-    /// materially different consent from "up to four".
-    #[test]
-    fn a_declared_driver_ceiling_is_stated_and_so_is_its_absence() {
-        let capped = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n\
-             [driver]\ncalls = [\"backlog_next\"]\nmax_calls = 4",
-        ));
-        assert!(
-            capped.contains("asks for up to 4 of those per driver session"),
-            "{capped}"
-        );
-        assert!(!capped.contains("as many of those"), "{capped}");
-
-        let uncapped = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n\
-             [driver]\ncalls = [\"backlog_next\"]",
-        ));
-        assert!(
-            uncapped.contains("asks for as many of those per driver session as the host allows"),
-            "{uncapped}"
-        );
-        assert!(!uncapped.contains("asks for up to"), "{uncapped}");
-    }
-
-    /// A driver that asks for no capability at all is a coherent declaration,
-    /// so it is said — and nothing else from the block is, because there is no
-    /// ceiling to state and nothing for Stella to perform on its behalf.
-    #[test]
-    fn a_driver_that_asks_for_nothing_says_so_and_nothing_more() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n[driver]\ncalls = []",
-        ));
-
-        assert!(text.contains("DRIVES Stella"), "{text}");
-        assert!(
-            text.contains("asks the host for no capability at all"),
-            "{text}"
-        );
-        assert!(!text.contains("per driver session"), "{text}");
-        assert!(!text.contains("performed BY Stella on request"), "{text}");
-    }
-
-    /// The anti-vacuity half, on
-    /// `the_scope_disclaimer_appears_only_when_a_scope_was_declared`'s
-    /// reasoning: absent is not empty. A plugin that is not a driver renders
-    /// none of the paragraph, so the assertions above are about this block and
-    /// not about boilerplate every prompt carries.
-    #[test]
-    fn a_plugin_that_does_not_drive_renders_no_driving_disclosure() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"steering\"\npoints = [\"before_turn\"]",
-        ));
-
-        assert!(!text.contains("DRIVES Stella"), "{text}");
-        assert!(!text.contains("per driver session"), "{text}");
-        assert!(!text.contains("performed BY Stella on request"), "{text}");
-    }
-
-    /// **The #3565 witness.** Everything a package ships is in the document
-    /// the *crate* renders, so every host shows the same one — and the tool
-    /// line says the three things a user most needs: it is executable code,
-    /// the model calls it unprompted, and it runs as the plugin.
-    ///
-    /// Anti-vacuity is the second half: a manifest declaring nothing must
-    /// render none of these sentences, or the assertions above would pass on
-    /// boilerplate that is always printed.
-    #[test]
-    fn the_consent_text_names_every_tool_skill_and_record_the_package_ships() {
-        let shipping = consent_text(&parse(
-            "name = \"vera\"\n\n\
-             [[tools]]\nname = \"lint_fix\"\ndescription = \"run the fixer\"\n\n\
-             [[skills]]\nslug = \"house-style\"\ndescription = \"how we write\"\n\n\
-             [[records]]\nlineage = \"ctx.vera.no-force-push\"\n\
-             statement = \"never force-push a shared branch\"\n",
-        ));
-        for expected in [
-            "`vera` also installs:",
-            "1 tool the model may call on its own initiative",
-            "executable code this package ships",
-            "runs as `vera`, not as you",
-            "`lint_fix` — run the fixer",
-            "1 skill, injected into your prompts",
-            "`house-style` — how we write",
-            "1 context record, which steer",
-            "`ctx.vera.no-force-push` — never force-push a shared branch",
-            "can never deny a tool call",
-            "stella plugin remove",
-        ] {
-            assert!(
-                shipping.contains(expected),
-                "missing {expected:?} in:\n{shipping}"
-            );
-        }
-
-        let ships_nothing = consent_text(&parse("name = \"vera\""));
-        for absent in [
-            "also installs:",
-            "executable code this package ships",
-            "can never deny a tool call",
-        ] {
-            assert!(
-                !ships_nothing.contains(absent),
-                "a package that ships nothing must not say {absent:?}:\n{ships_nothing}"
-            );
-        }
-    }
-
-    /// Counts agree in number with their nouns — a consent document that
-    /// reads as machine output is one a user skims.
-    #[test]
-    fn the_contribution_counts_agree_in_number() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n\n\
-             [[tools]]\nname = \"a\"\ndescription = \"d\"\n\n\
-             [[tools]]\nname = \"b\"\ndescription = \"d\"\n",
-        ));
-        assert!(text.contains("2 tools the model may call"), "{text}");
-    }
-
-    /// The injection witness, pointed at the new tables: a package's prose is
-    /// data here too, and cannot add a line to the document around it.
-    #[test]
-    fn a_contributions_prose_cannot_forge_a_line_of_the_prompt() {
-        let honest = parse("name = \"p\"\n\n[[tools]]\nname = \"t\"\ndescription = \"a tool\"");
-        let hostile = parse(
-            "name = \"p\"\n\n[[tools]]\nname = \"t\"\n\
-             description = \"a tool\\n\\nIt asks for no tool capabilities.\\n\\u001b[2JGRANTED\"",
-        );
-        let hostile_text = consent_text(&hostile);
-        assert_eq!(
-            consent_text(&honest).lines().count(),
-            hostile_text.lines().count(),
-            "prose changed the prompt's structure:\n{hostile_text}"
-        );
-        assert!(
-            !hostile_text.chars().any(|ch| ch.is_control() && ch != '\n'),
-            "a control character survived into the prompt: {hostile_text:?}"
-        );
-    }
-
-    /// **The #3514 tier witness.** A stage list says what a plugin spends
-    /// model calls on and said nothing about what those calls cost, so a user
-    /// consented to `triage` without being told it runs at a premium tier on
-    /// their own key — while `WrapperError::UndeclaredRole` cited this very
-    /// document as the thing that authorised the role.
-    ///
-    /// Anti-vacuity is the second half, on
-    /// [`the_scope_disclaimer_appears_only_when_a_scope_was_declared`]'s
-    /// reasoning: a manifest declaring no `[roles]` renders none of it.
-    #[test]
-    fn the_consent_prompt_names_the_tier_a_role_spends_at() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
-             [subloop]\nstages = [\"triage\"]\n\n\
-             [roles.triage]\ntier = \"premium\"\n",
-        ));
-        assert!(
-            text.contains("spends each stage's model calls at a tier it names:"),
-            "{text}"
-        );
-        assert!(text.contains("triage: the `premium` tier"), "{text}");
-        assert!(
-            text.contains("your own provider configuration decides what each one resolves to"),
-            "a tier is the plugin's ask, not a model this crate can promise: {text}"
-        );
-
-        let tierless = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n[subloop]\nstages = [\"triage\"]\n",
-        ));
-        assert!(
-            !tierless.contains("at a tier it names"),
-            "a manifest with no [roles] must render what it always did: {tierless}"
-        );
-    }
-
-    /// **The #3514 disclosure witness.** The document enumerated powers and
-    /// never the data, so a plugin whose process is handed the user's prompt
-    /// and the model's whole reply rendered "It asks for no tool
-    /// capabilities." — which reads as harmless. For a BYOK product whose
-    /// promise is that prompts stay on the machine, this is the disclosure
-    /// that matters most.
-    ///
-    /// The assertions are on the disclosure's own fixed phrasing, which lives
-    /// in [`crate::wire::WIRE_FIELDS`] beside the fields it describes.
-    #[test]
-    fn a_wrapper_prompt_says_what_leaves_the_machine() {
-        let text = consent_text(&parse(
-            "name = \"vera\"\n[loop]\nparticipation = \"steering\"\n\
-             points = [\"before_turn\", \"after_turn\"]\n\n\
-             [wrapper]\nid = \"lite-v1\"\n[[wrapper.stages]]\nname = \"execute\"\n\n\
-             [runtime]\nargv = [\"python3\", \"main.py\"]\ntimeout_secs = 30\n",
-        ));
-        for expected in [
-            "Stella hands `vera`'s own process your work, as JSON on that process's standard \
-             input. What crosses:",
-            "before each turn runs (`before_turn`):",
-            "the goal you typed for this turn, in full",
-            "once each turn has finished (`after_turn`):",
-            "the model's full reply for the turn — the same text you were shown",
-            "the name of every tool the turn ran, in call order",
-            "the workspace-relative path of every file the turn changed",
-            "can still send every line of it anywhere it can reach",
-        ] {
-            assert!(text.contains(expected), "missing {expected:?} in:\n{text}");
-        }
-
-        let no_process = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"steering\"\npoints = [\"before_turn\"]\n",
-        ));
-        assert!(
-            !no_process.contains("as JSON on that process's standard input"),
-            "a plugin with no process of its own is handed nothing: {no_process}"
-        );
-    }
-
-    /// The other half of the filter: `permits_point` is what
-    /// `stella_runtime::wrapper` dispatches on, so a plugin that declares a
-    /// process and answers no point is handed none of this — and must not be
-    /// disclosed as though it were.
-    #[test]
-    fn a_process_that_answers_no_point_discloses_no_data() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n\
-             [runtime]\nargv = [\"node\"]\ntimeout_secs = 5\n",
-        ));
-        assert!(!text.contains("What crosses:"), "{text}");
-        assert!(!text.contains("the goal you typed for this turn"), "{text}");
-    }
-
-    #[test]
-    fn rendering_is_deterministic() {
-        let manifest = parse(
-            "name = \"p\"\n[loop]\nparticipation = \"steering\"\nhooks = [\"PreToolUse\", \"PostToolUse\"]\n\n[[capabilities]]\ntool = \"bash\"\nrisk = \"high\"\npurpose = \"run things\"",
-        );
-        assert_eq!(consent_text(&manifest), consent_text(&manifest));
-    }
-
-    #[test]
-    fn one_line_collapses_runs_and_trims() {
-        assert_eq!(one_line("  a \n\n b\tc  "), "a b c");
-        assert_eq!(one_line("\u{1b}[31mred\u{1b}[0m"), "[31mred[0m");
-        assert_eq!(one_line("   "), "");
-    }
-
-    /// A stage a plugin invented must not read as one Stella has always had
-    /// (#3963). The vocabulary opened, so the name alone no longer tells a
-    /// reader which of the two it is — and consent is exactly the place that
-    /// distinction has to survive.
-    #[test]
-    fn a_contributed_stage_is_named_as_the_plugins_own() {
-        let text = consent_text(&parse(
-            "name = \"p\"\n[loop]\nparticipation = \"steering\"\n[wrapper]\nid = \"lite-v1\"\n\
-             [[wrapper.stages]]\nname = \"triage-lite\"\n[[wrapper.stages]]\nname = \"execute\"\n",
-        ));
-        assert!(
-            text.contains("triage-lite (this plugin's own stage)"),
-            "{text}"
-        );
-        assert!(
-            !text.contains("execute (this plugin's own stage)"),
-            "a host stage is Stella's, and saying otherwise would be the same \
-             misreading in the other direction: {text}"
-        );
-    }
-}
+mod tests;

--- a/crates/stella-plugin/src/consent/tests.rs
+++ b/crates/stella-plugin/src/consent/tests.rs
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for [`crate::consent`] — what a human is shown before they say yes.
+//!
+//! A sibling file rather than an inline `mod tests`, for the reason AGENTS.md
+//! § "God files" gives: the parent carries the vocabulary, the validation and
+//! the whole rendering, and this suite grew past what the same file can hold
+//! under the 1500-line ratchet.
+
+use super::*;
+
+fn parse(text: &str) -> PluginManifest {
+    PluginManifest::from_toml_str(text).expect("fixture must parse")
+}
+
+#[test]
+fn a_bundle_with_no_grant_says_so_in_both_halves() {
+    let text = consent_text(&parse("name = \"notes\""));
+    assert!(text.contains("Install `notes`?"), "{text}");
+    assert!(
+        text.contains("none — it never runs inside a turn"),
+        "{text}"
+    );
+    assert!(text.contains("It asks for no tool capabilities."), "{text}");
+}
+
+#[test]
+fn the_headline_grade_is_the_widest_one_asked_for() {
+    let capabilities = [
+        Capability {
+            tool: "read_file".into(),
+            risk: RiskLevel::Low,
+            purpose: "read the repo".into(),
+            scope: Vec::new(),
+        },
+        Capability {
+            tool: "bash".into(),
+            risk: RiskLevel::Destructive,
+            purpose: "run anything".into(),
+            scope: Vec::new(),
+        },
+        Capability {
+            tool: "write_file".into(),
+            risk: RiskLevel::Medium,
+            purpose: "write the repo".into(),
+            scope: Vec::new(),
+        },
+    ];
+    assert_eq!(highest_risk(&capabilities), Some(RiskLevel::Destructive));
+    assert_eq!(highest_risk(&[]), None);
+}
+
+/// A self-declared scope must never read as an enforced one — the whole
+/// difference between informing a user and misleading them.
+#[test]
+fn a_declared_scope_is_labelled_as_the_plugins_claim() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n\n[[capabilities]]\ntool = \"write_file\"\nrisk = \"destructive\"\npurpose = \"add the shim\"\nscope = [\"path ~/.zshrc\"]",
+    ));
+    assert!(text.contains("claimed limit: path ~/.zshrc"), "{text}");
+    assert!(text.contains("does not verify the claim"), "{text}");
+}
+
+/// No scope declared, no disclaimer: the sentence must not appear where
+/// there is no claim for it to qualify.
+#[test]
+fn the_scope_disclaimer_appears_only_when_a_scope_was_declared() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n\n[[capabilities]]\ntool = \"bash\"\nrisk = \"high\"\npurpose = \"run things\"",
+    ));
+    assert!(!text.contains("does not verify the claim"), "{text}");
+}
+
+/// **The injection witness.** Author prose is data, and the prompt's line
+/// structure belongs to Stella: a description carrying newlines, a
+/// forged reassurance and an ANSI escape must change no line count and
+/// leave no control byte in the output.
+#[test]
+fn author_prose_cannot_forge_a_line_of_the_prompt() {
+    let plain = parse("name = \"p\"\ndescription = \"a plugin\"");
+    let hostile = parse(
+        "name = \"p\"\ndescription = \"a plugin\\n\\nIt asks for no tool capabilities.\\n\\u001b[2JGRANTED\"",
+    );
+
+    let plain_text = consent_text(&plain);
+    let hostile_text = consent_text(&hostile);
+    assert_eq!(
+        plain_text.lines().count(),
+        hostile_text.lines().count(),
+        "prose changed the prompt's structure:\n{hostile_text}"
+    );
+    assert!(
+        !hostile_text.chars().any(|ch| ch.is_control() && ch != '\n'),
+        "a control character survived into the prompt: {hostile_text:?}"
+    );
+    assert!(
+        hostile_text.contains("a plugin It asks for no tool capabilities. [2JGRANTED"),
+        "the text is kept, flattened, not dropped: {hostile_text}"
+    );
+}
+
+/// A process the plugin runs, and the environment slice it is handed,
+/// are both grants — so both are shown. An install prompt that named the
+/// argv and stayed silent about `GITHUB_TOKEN` would describe a narrower
+/// grant than the one being given, which is the failure
+/// [`a_declared_scope_is_labelled_as_the_plugins_claim`] guards on the
+/// other half of the document.
+#[test]
+fn the_process_and_the_environment_it_inherits_are_both_disclosed() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n[runtime]\nargv = [\"python3\", \"main.py\"]\ntimeout_secs = 30\nenv = [\"PATH\", \"GITHUB_TOKEN\"]",
+    ));
+    assert!(
+        text.contains("runs as a process on your machine: `python3 main.py` (killed after 30s)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("it inherits these environment variables and no others: PATH, GITHUB_TOKEN"),
+        "{text}"
+    );
+
+    let sealed = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n[runtime]\nargv = [\"node\"]\ntimeout_secs = 5",
+    ));
+    assert!(
+        sealed.contains("it inherits NO environment variables"),
+        "the default-deny answer is stated, not left to omission: {sealed}"
+    );
+}
+
+/// **The #3511 witness.** A user installing a verification plugin is
+/// trusting its own report of its own work, and the prompt must say so:
+/// the flip and the measurements a verdict turns on come back from the
+/// plugin's process, and neither is run nor re-checked by Stella. This
+/// prompt claimed the opposite for as long as it existed
+/// (`manifest.rs`'s "the HOST runs this; the plugin never grades its own
+/// work"), which is the consent defect Option 2 exists to close.
+#[test]
+fn an_oracle_is_disclosed_as_the_plugins_own_report() {
+    let text = consent_text(&parse(
+        "name = \"vera\"\n[loop]\nparticipation = \"arbiter\"\nhooks = [\"Stop\"]\n\
+         points = [\"after_turn\"]\n\n\
+         [requirements]\nwitness = \"a failing test flips to passing\"\n\n\
+         [oracle]\ncommand = { argv = [\"vera\", \"verify\"], timeout_secs = 60 }\n\
+         flip = \"required\"",
+    ));
+
+    assert!(
+        text.contains("reports its own evidence"),
+        "the prompt must say the evidence is the plugin's own report: {text}"
+    );
+    assert!(
+        text.contains(
+            "Stella does not run the oracle itself and does not check what comes \
+             back"
+        ),
+        "the prompt must say Stella neither runs nor checks it: {text}"
+    );
+    assert!(
+        text.contains("trusting it to report"),
+        "the prompt must name what the user is actually trusting: {text}"
+    );
+    assert!(
+        !text.contains("never grades its own work"),
+        "the retired host-run claim must not survive anywhere in the prompt: {text}"
+    );
+}
+
+/// The other half of the witness, on
+/// `the_scope_disclaimer_appears_only_when_a_scope_was_declared`'s
+/// reasoning: no oracle, no self-report paragraph.
+#[test]
+fn the_self_report_disclosure_appears_only_when_an_oracle_was_declared() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n[runtime]\nargv = [\"node\"]\ntimeout_secs = 5",
+    ));
+    assert!(!text.contains("reports its own evidence"), "{text}");
+}
+
+/// **The driver paragraph, family by family** (#3729). This is the
+/// sentence a user reads before granting a plugin permission to push
+/// branches, merge, and spend model calls between their turns, and until
+/// this test nothing would have failed if a refactor had dropped it.
+///
+/// Every family the block spans is named with its own consent sentence,
+/// and every declared verb is printed beside its family — the rendering
+/// is by family because "pushes branches, opens pull requests, reads CI,
+/// and merges" is what a human weighs, and the verbs are what keeps that
+/// summary checkable against the block.
+#[test]
+fn a_driver_grant_names_every_family_and_the_verbs_under_it() {
+    use crate::driver::DriverFamily;
+
+    let manifest = parse(
+        "name = \"loop\"\n[loop]\nparticipation = \"none\"\n\n\
+         [driver]\ncalls = [\"deliver_open\", \"backlog_next\", \"deliver_merge\"]",
+    );
+    let text = consent_text(&manifest);
+
+    assert!(
+        text.contains("`loop` DRIVES Stella. It is not a participant in a turn — it starts them."),
+        "{text}"
+    );
+    let driver = manifest.driver.as_ref().expect("the block is declared");
+    assert_eq!(
+        driver.families(),
+        vec![DriverFamily::Backlog, DriverFamily::Deliver],
+        "the fixture spans two families, or this test proves less than it says"
+    );
+    for family in driver.families() {
+        assert!(
+            text.contains(family.consent_sentence()),
+            "the `{family}` family's sentence is missing:\n{text}"
+        );
+    }
+    assert!(text.contains("(backlog_next)"), "{text}");
+    assert!(
+        text.contains("(deliver_open, deliver_merge)"),
+        "the verbs are printed beside their family, in declaration order:\n{text}"
+    );
+    assert!(
+        text.contains(
+            "performed BY Stella on request: this plugin holds no credential, no provider \
+             and no forge token of its own."
+        ),
+        "{text}"
+    );
+}
+
+/// The ceiling a user is told about is the one the block declared, and an
+/// absent one gets its own sentence — "as many as the host allows" is a
+/// materially different consent from "up to four".
+#[test]
+fn a_declared_driver_ceiling_is_stated_and_so_is_its_absence() {
+    let capped = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n\
+         [driver]\ncalls = [\"backlog_next\"]\nmax_calls = 4",
+    ));
+    assert!(
+        capped.contains("asks for up to 4 of those per driver session"),
+        "{capped}"
+    );
+    assert!(!capped.contains("as many of those"), "{capped}");
+
+    let uncapped = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n\
+         [driver]\ncalls = [\"backlog_next\"]",
+    ));
+    assert!(
+        uncapped.contains("asks for as many of those per driver session as the host allows"),
+        "{uncapped}"
+    );
+    assert!(!uncapped.contains("asks for up to"), "{uncapped}");
+}
+
+/// A driver that asks for no capability at all is a coherent declaration,
+/// so it is said — and nothing else from the block is, because there is no
+/// ceiling to state and nothing for Stella to perform on its behalf.
+#[test]
+fn a_driver_that_asks_for_nothing_says_so_and_nothing_more() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n[driver]\ncalls = []",
+    ));
+
+    assert!(text.contains("DRIVES Stella"), "{text}");
+    assert!(
+        text.contains("asks the host for no capability at all"),
+        "{text}"
+    );
+    assert!(!text.contains("per driver session"), "{text}");
+    assert!(!text.contains("performed BY Stella on request"), "{text}");
+}
+
+/// A driver's process is the program a host will actually start, so it is
+/// disclosed with the same two sentences `[runtime]` gets — and its
+/// absence is disclosed too, because "Stella starts this" and "a person
+/// starts this" are the two things a reader is deciding between (#3783).
+#[test]
+fn a_driver_that_stella_can_start_says_what_runs_and_what_it_inherits() {
+    let started = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n[driver]\n\
+         calls = [\"backlog_next\"]\n\n[driver.process]\n\
+         argv = [\"python3\", \"main.py\"]\ntimeout_secs = 600\nenv = [\"HOME\"]",
+    ));
+    assert!(
+        started
+            .contains("runs as a process on your machine: `python3 main.py` (killed after 600s)"),
+        "{started}"
+    );
+    assert!(
+        started.contains("it inherits these environment variables and no others: HOME"),
+        "{started}"
+    );
+    assert!(!started.contains("is not started by Stella"), "{started}");
+
+    // The other answer, which is what `plugins/stella-selfdriving` is.
+    let declared_only = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"none\"\n\n[driver]\ncalls = [\"backlog_next\"]",
+    ));
+    assert!(
+        declared_only.contains("is not started by Stella"),
+        "{declared_only}"
+    );
+    assert!(
+        !declared_only.contains("runs as a process on your machine"),
+        "{declared_only}"
+    );
+}
+
+/// The anti-vacuity half, on
+/// `the_scope_disclaimer_appears_only_when_a_scope_was_declared`'s
+/// reasoning: absent is not empty. A plugin that is not a driver renders
+/// none of the paragraph, so the assertions above are about this block and
+/// not about boilerplate every prompt carries.
+#[test]
+fn a_plugin_that_does_not_drive_renders_no_driving_disclosure() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\npoints = [\"before_turn\"]",
+    ));
+
+    assert!(!text.contains("DRIVES Stella"), "{text}");
+    assert!(!text.contains("per driver session"), "{text}");
+    assert!(!text.contains("performed BY Stella on request"), "{text}");
+}
+
+/// **The #3565 witness.** Everything a package ships is in the document
+/// the *crate* renders, so every host shows the same one — and the tool
+/// line says the three things a user most needs: it is executable code,
+/// the model calls it unprompted, and it runs as the plugin.
+///
+/// Anti-vacuity is the second half: a manifest declaring nothing must
+/// render none of these sentences, or the assertions above would pass on
+/// boilerplate that is always printed.
+#[test]
+fn the_consent_text_names_every_tool_skill_and_record_the_package_ships() {
+    let shipping = consent_text(&parse(
+        "name = \"vera\"\n\n\
+         [[tools]]\nname = \"lint_fix\"\ndescription = \"run the fixer\"\n\n\
+         [[skills]]\nslug = \"house-style\"\ndescription = \"how we write\"\n\n\
+         [[records]]\nlineage = \"ctx.vera.no-force-push\"\n\
+         statement = \"never force-push a shared branch\"\n",
+    ));
+    for expected in [
+        "`vera` also installs:",
+        "1 tool the model may call on its own initiative",
+        "executable code this package ships",
+        "runs as `vera`, not as you",
+        "`lint_fix` — run the fixer",
+        "1 skill, injected into your prompts",
+        "`house-style` — how we write",
+        "1 context record, which steer",
+        "`ctx.vera.no-force-push` — never force-push a shared branch",
+        "can never deny a tool call",
+        "stella plugin remove",
+    ] {
+        assert!(
+            shipping.contains(expected),
+            "missing {expected:?} in:\n{shipping}"
+        );
+    }
+
+    let ships_nothing = consent_text(&parse("name = \"vera\""));
+    for absent in [
+        "also installs:",
+        "executable code this package ships",
+        "can never deny a tool call",
+    ] {
+        assert!(
+            !ships_nothing.contains(absent),
+            "a package that ships nothing must not say {absent:?}:\n{ships_nothing}"
+        );
+    }
+}
+
+/// Counts agree in number with their nouns — a consent document that
+/// reads as machine output is one a user skims.
+#[test]
+fn the_contribution_counts_agree_in_number() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n\n\
+         [[tools]]\nname = \"a\"\ndescription = \"d\"\n\n\
+         [[tools]]\nname = \"b\"\ndescription = \"d\"\n",
+    ));
+    assert!(text.contains("2 tools the model may call"), "{text}");
+}
+
+/// The injection witness, pointed at the new tables: a package's prose is
+/// data here too, and cannot add a line to the document around it.
+#[test]
+fn a_contributions_prose_cannot_forge_a_line_of_the_prompt() {
+    let plain = parse("name = \"p\"\n\n[[tools]]\nname = \"t\"\ndescription = \"a tool\"");
+    let hostile = parse(
+        "name = \"p\"\n\n[[tools]]\nname = \"t\"\n\
+         description = \"a tool\\n\\nIt asks for no tool capabilities.\\n\\u001b[2JGRANTED\"",
+    );
+    let hostile_text = consent_text(&hostile);
+    assert_eq!(
+        consent_text(&plain).lines().count(),
+        hostile_text.lines().count(),
+        "prose changed the prompt's structure:\n{hostile_text}"
+    );
+    assert!(
+        !hostile_text.chars().any(|ch| ch.is_control() && ch != '\n'),
+        "a control character survived into the prompt: {hostile_text:?}"
+    );
+}
+
+/// **The #3514 tier witness.** A stage list says what a plugin spends
+/// model calls on and said nothing about what those calls cost, so a user
+/// consented to `triage` without being told it runs at a premium tier on
+/// their own key — while `WrapperError::UndeclaredRole` cited this very
+/// document as the thing that authorised the role.
+///
+/// Anti-vacuity is the second half, on
+/// [`the_scope_disclaimer_appears_only_when_a_scope_was_declared`]'s
+/// reasoning: a manifest declaring no `[roles]` renders none of it.
+#[test]
+fn the_consent_prompt_names_the_tier_a_role_spends_at() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
+         [subloop]\nstages = [\"triage\"]\n\n\
+         [roles.triage]\ntier = \"premium\"\n",
+    ));
+    assert!(
+        text.contains("spends each stage's model calls at a tier it names:"),
+        "{text}"
+    );
+    assert!(text.contains("triage: the `premium` tier"), "{text}");
+    assert!(
+        text.contains("your own provider configuration decides what each one resolves to"),
+        "a tier is the plugin's ask, not a model this crate can promise: {text}"
+    );
+
+    let tierless = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n[subloop]\nstages = [\"triage\"]\n",
+    ));
+    assert!(
+        !tierless.contains("at a tier it names"),
+        "a manifest with no [roles] must render what it always did: {tierless}"
+    );
+}
+
+/// **The #3514 disclosure witness.** The document enumerated powers and
+/// never the data, so a plugin whose process is handed the user's prompt
+/// and the model's whole reply rendered "It asks for no tool
+/// capabilities." — which reads as harmless. For a BYOK product whose
+/// promise is that prompts stay on the machine, this is the disclosure
+/// that matters most.
+///
+/// The assertions are on the disclosure's own fixed phrasing, which lives
+/// in [`crate::wire::WIRE_FIELDS`] beside the fields it describes.
+#[test]
+fn a_wrapper_prompt_says_what_leaves_the_machine() {
+    let text = consent_text(&parse(
+        "name = \"vera\"\n[loop]\nparticipation = \"steering\"\n\
+         points = [\"before_turn\", \"after_turn\"]\n\n\
+         [wrapper]\nid = \"lite-v1\"\n[[wrapper.stages]]\nname = \"execute\"\n\n\
+         [runtime]\nargv = [\"python3\", \"main.py\"]\ntimeout_secs = 30\n",
+    ));
+    for expected in [
+        "Stella hands `vera`'s own process your work, as JSON on that process's standard \
+         input. What crosses:",
+        "before each turn runs (`before_turn`):",
+        "the goal you typed for this turn, in full",
+        "once each turn has finished (`after_turn`):",
+        "the model's full reply for the turn — the same text you were shown",
+        "the name of every tool the turn ran, in call order",
+        "the workspace-relative path of every file the turn changed",
+        "can still send every line of it anywhere it can reach",
+    ] {
+        assert!(text.contains(expected), "missing {expected:?} in:\n{text}");
+    }
+
+    let no_process = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\npoints = [\"before_turn\"]\n",
+    ));
+    assert!(
+        !no_process.contains("as JSON on that process's standard input"),
+        "a plugin with no process of its own is handed nothing: {no_process}"
+    );
+}
+
+/// The other half of the filter: `permits_point` is what
+/// `stella_runtime::wrapper` dispatches on, so a plugin that declares a
+/// process and answers no point is handed none of this — and must not be
+/// disclosed as though it were.
+#[test]
+fn a_process_that_answers_no_point_discloses_no_data() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"observer\"\n\n\
+         [runtime]\nargv = [\"node\"]\ntimeout_secs = 5\n",
+    ));
+    assert!(!text.contains("What crosses:"), "{text}");
+    assert!(!text.contains("the goal you typed for this turn"), "{text}");
+}
+
+#[test]
+fn rendering_is_deterministic() {
+    let manifest = parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\nhooks = [\"PreToolUse\", \"PostToolUse\"]\n\n[[capabilities]]\ntool = \"bash\"\nrisk = \"high\"\npurpose = \"run things\"",
+    );
+    assert_eq!(consent_text(&manifest), consent_text(&manifest));
+}
+
+#[test]
+fn one_line_collapses_runs_and_trims() {
+    assert_eq!(one_line("  a \n\n b\tc  "), "a b c");
+    assert_eq!(one_line("\u{1b}[31mred\u{1b}[0m"), "[31mred[0m");
+    assert_eq!(one_line("   "), "");
+}
+
+/// A stage a plugin invented must not read as one Stella has always had
+/// (#3963). The vocabulary opened, so the name alone no longer tells a
+/// reader which of the two it is — and consent is exactly the place that
+/// distinction has to survive.
+#[test]
+fn a_contributed_stage_is_named_as_the_plugins_own() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\n[wrapper]\nid = \"lite-v1\"\n\
+         [[wrapper.stages]]\nname = \"triage-lite\"\n[[wrapper.stages]]\nname = \"execute\"\n",
+    ));
+    assert!(
+        text.contains("triage-lite (this plugin's own stage)"),
+        "{text}"
+    );
+    assert!(
+        !text.contains("execute (this plugin's own stage)"),
+        "a host stage is Stella's, and saying otherwise would be the same \
+         misreading in the other direction: {text}"
+    );
+}

--- a/crates/stella-plugin/src/driver.rs
+++ b/crates/stella-plugin/src/driver.rs
@@ -62,6 +62,7 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::host_call::HostCallFailure;
+use crate::runtime::Runtime;
 
 /// The capabilities a **driver** may ask the host for.
 ///
@@ -320,6 +321,37 @@ pub struct DriverGrant {
     /// Absent means "the host's ceiling", never "unbounded".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_calls: Option<u32>,
+    /// The program the host starts to open a driver session, and the exact
+    /// slice of the operator's environment it may see.
+    ///
+    /// **Absent means the host cannot start this driver**, which is a state a
+    /// manifest may want rather than a gap: `plugins/stella-selfdriving` is a
+    /// consent document for a loop a person starts by hand, so it declares the
+    /// grant and no process, and installing it still starts nothing.
+    ///
+    /// # Why this is not `[runtime]`
+    ///
+    /// `[runtime]` is the process a plugin is **inside a turn**, and the
+    /// manifest refuses it below `participation = "observer"`
+    /// ([`ManifestError::RuntimeRequiresObserver`](crate::ManifestError::RuntimeRequiresObserver))
+    /// on the argument that a content bundle is never invoked, so its process
+    /// would never start. A driver is the counterexample: it is never invoked
+    /// inside a turn *by construction* — this module's header is the argument —
+    /// and `participation = "none"` is the only grade one can carry. Reusing
+    /// `[runtime]` would therefore have made every driver either unloadable or
+    /// forced to overstate its in-turn standing to gain a process.
+    ///
+    /// Two blocks are also the shape this grant was split out on: a driver
+    /// grant and a loop grant are different consents, and neither grants any
+    /// part of the other. A plugin that both wraps turns and drives them
+    /// declares two processes and a human reads them separately.
+    ///
+    /// The *type* is shared with `[runtime]` because the decision is identical
+    /// — an argv rather than a shell string, a timeout, an environment
+    /// allowlist — and a second copy of those rules is how one copy grows a
+    /// check the other silently does not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process: Option<Runtime>,
 }
 
 impl DriverGrant {
@@ -754,6 +786,7 @@ mod tests {
         let grant = DriverGrant {
             calls: vec![DriverCall::BacklogNext],
             max_calls: None,
+            process: None,
         };
         assert!(grant.permits_call(DriverCall::BacklogNext));
         assert!(!grant.permits_call(DriverCall::DeliverMerge));
@@ -768,6 +801,7 @@ mod tests {
                 DriverCall::BacklogFile,
             ],
             max_calls: None,
+            process: None,
         };
         assert_eq!(
             grant.families(),

--- a/crates/stella-plugin/src/error.rs
+++ b/crates/stella-plugin/src/error.rs
@@ -9,6 +9,7 @@ use crate::driver::DriverCall;
 use crate::host_call::HostCall;
 use crate::manifest::{HookEvent, Participation};
 use crate::package::ContributionKind;
+use crate::runtime::ProcessBlock;
 use crate::wire::WrapperPoint;
 use crate::wrapper::{HostStage, Signal, SignalKind, StageName};
 
@@ -485,42 +486,59 @@ pub enum ManifestError {
         participation: Participation,
     },
 
-    /// `[runtime] argv` was empty — there is no program to run. The
-    /// [`Self::EmptyOracleArgv`] rule, applied to the plugin's own process.
-    #[error("[runtime] argv must name a program: it is empty")]
-    EmptyRuntimeArgv,
+    /// A process block's `argv` was empty — there is no program to run. The
+    /// [`Self::EmptyOracleArgv`] rule, applied to a plugin's own process.
+    #[error("{block} argv must name a program: it is empty")]
+    EmptyProcessArgv {
+        /// Which block declared it.
+        block: ProcessBlock,
+    },
 
-    /// A `[runtime] argv` element was blank. A blank program name spawns
-    /// nothing and a blank argument is one the author did not mean to pass.
-    #[error("[runtime] argv contains a blank entry")]
-    BlankRuntimeArg,
+    /// A process block's `argv` had a blank element. A blank program name
+    /// spawns nothing and a blank argument is one the author did not mean to
+    /// pass.
+    #[error("{block} argv contains a blank entry")]
+    BlankProcessArg {
+        /// Which block declared it.
+        block: ProcessBlock,
+    },
 
-    /// `[runtime] timeout_secs = 0` — the host would kill the process before
-    /// it ran.
-    #[error("[runtime] timeout_secs must be at least 1")]
-    ZeroRuntimeTimeout,
+    /// A process block's `timeout_secs = 0` — the host would kill the process
+    /// before it ran.
+    #[error("{block} timeout_secs must be at least 1")]
+    ZeroProcessTimeout {
+        /// Which block declared it.
+        block: ProcessBlock,
+    },
 
-    /// A `[runtime] env` entry was the empty string, which names no variable.
-    #[error("[runtime] env contains an empty variable name")]
-    EmptyRuntimeEnvName,
+    /// A process block's `env` entry was the empty string, which names no
+    /// variable.
+    #[error("{block} env contains an empty variable name")]
+    EmptyProcessEnvName {
+        /// Which block declared it.
+        block: ProcessBlock,
+    },
 
-    /// A `[runtime] env` entry could never match a variable — it carried an
-    /// `=`, a NUL, or surrounding whitespace. Dead in an allowlist is worse
+    /// A process block's `env` entry could never match a variable — it carried
+    /// an `=`, a NUL, or surrounding whitespace. Dead in an allowlist is worse
     /// than absent: it reads to its author as granted.
     #[error(
-        "[runtime] env entry `{name}` is not an environment variable name, so \
-         it can never match one"
+        "{block} env entry `{name}` is not an environment variable name, so it can never match one"
     )]
-    InvalidRuntimeEnvName {
+    InvalidProcessEnvName {
+        /// Which block declared it.
+        block: ProcessBlock,
         /// The entry that names no variable.
         name: String,
     },
 
-    /// `[runtime] env` named the same variable twice. Always an editing
-    /// mistake, and deduplicating silently would hide it — the
+    /// A process block's `env` named the same variable twice. Always an
+    /// editing mistake, and deduplicating silently would hide it — the
     /// [`Self::DuplicateHook`] rule for the other allowlist in this manifest.
-    #[error("[runtime] env declares `{name}` more than once")]
-    DuplicateRuntimeEnv {
+    #[error("{block} env declares `{name}` more than once")]
+    DuplicateProcessEnv {
+        /// Which block declared it.
+        block: ProcessBlock,
         /// The variable named twice.
         name: String,
     },

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -159,7 +159,7 @@ pub use package::{
 };
 pub use program::{SignalValues, StageProgram};
 pub use progressive::{ProgressiveResolver, StageDecision};
-pub use runtime::{PLUGIN_DIR_PLACEHOLDER, Runtime, expand_plugin_dir};
+pub use runtime::{PLUGIN_DIR_PLACEHOLDER, ProcessBlock, Runtime, expand_plugin_dir};
 pub use wire::{
     AfterTurnRequest, AfterTurnResponse, BeforeTurnRequest, BeforeTurnResponse, CandidateGrant,
     Continuation, Correction, EvidenceProvenance, EvidenceSet, FlipObservation, HOOK_FIELDS,

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -51,7 +51,7 @@ use crate::package::{
     McpContribution, RecordContribution, SkillContribution, ToolContribution,
     validate_contributions,
 };
-use crate::runtime::Runtime;
+use crate::runtime::{ProcessBlock, Runtime};
 use crate::wire::WrapperPoint;
 use crate::wrapper::{StageName, Wrapper};
 
@@ -648,6 +648,13 @@ impl PluginManifest {
                 Some(0) => return Err(ManifestError::ZeroDriverMaxCalls),
                 _ => {}
             }
+            // The process rules are `[runtime]`'s, and the grade check is
+            // again absent for the same reason: a driver's process is started
+            // outside every turn, so no standing inside one could be required
+            // of it (#3783).
+            if let Some(process) = &driver.process {
+                process.validate(ProcessBlock::DriverProcess)?;
+            }
         }
 
         if grant.hooks.contains(&HookEvent::Stop) && !participation.includes(Participation::Arbiter)
@@ -750,7 +757,7 @@ impl PluginManifest {
             if !participation.includes(Participation::Observer) {
                 return Err(ManifestError::RuntimeRequiresObserver { participation });
             }
-            runtime.validate()?;
+            runtime.validate(ProcessBlock::Runtime)?;
         }
 
         if let Some(roles) = &self.roles {
@@ -1332,5 +1339,95 @@ mod tests {
             parse("name = \"x\"\n[driver]\ncalls = [\"sweep_audit\"]\nmax_calls = 0").unwrap_err(),
             ManifestError::ZeroDriverMaxCalls
         ));
+    }
+
+    /// A driver names its own process, and `[runtime]` could not have carried
+    /// it: the same argv under `[runtime]` is refused at `participation =
+    /// "none"`, the only grade a plugin that never stands inside a turn can
+    /// carry (#3783).
+    ///
+    /// The second assertion is why the first is not enough: on its own it
+    /// would pass against a design that reused `[runtime]` and quietly
+    /// required a driver to overstate its in-turn standing to gain a process.
+    #[test]
+    fn a_driver_declares_its_own_process_and_runtime_could_not_have_carried_it() {
+        const PROCESS: &str = "argv = [\"python3\", \"${plugin_dir}/main.py\"]\n\
+                               timeout_secs = 600\nenv = [\"HOME\"]";
+
+        let driving = parse(&format!(
+            "name = \"x\"\n[loop]\nparticipation = \"none\"\n\n[driver]\n\
+             calls = [\"backlog_next\"]\n\n[driver.process]\n{PROCESS}"
+        ))
+        .expect("a driver's process loads at grade `none`");
+        let process = driving
+            .driver
+            .expect("the [driver] block is parsed")
+            .process
+            .expect("the [driver.process] block is parsed");
+        assert_eq!(process.argv[0], "python3");
+        assert_eq!(process.timeout_secs, 600);
+        assert_eq!(process.env, vec!["HOME".to_string()]);
+
+        // The same program under `[runtime]`, at the same grade, does not load.
+        assert!(matches!(
+            parse(&format!(
+                "name = \"x\"\n[loop]\nparticipation = \"none\"\n\n[runtime]\n{PROCESS}"
+            ))
+            .unwrap_err(),
+            ManifestError::RuntimeRequiresObserver {
+                participation: Participation::None
+            }
+        ));
+
+        // Absent is not empty here either: a grant with no process is a driver
+        // Stella cannot start, which `plugins/stella-selfdriving` relies on.
+        assert!(
+            parse("name = \"x\"\n[driver]\ncalls = [\"backlog_next\"]")
+                .expect("a processless driver loads")
+                .driver
+                .expect("the block is parsed")
+                .process
+                .is_none()
+        );
+    }
+
+    /// `[runtime]`'s rules, reported against the block the author actually
+    /// wrote. A refusal that named `[runtime]` would send them to a table
+    /// their manifest does not contain.
+    #[test]
+    fn a_driver_process_defect_names_the_driver_block() {
+        let err = parse(
+            "name = \"x\"\n[driver]\ncalls = [\"backlog_next\"]\n\n\
+             [driver.process]\nargv = []\ntimeout_secs = 5",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ManifestError::EmptyProcessArgv {
+                block: ProcessBlock::DriverProcess
+            }
+        ));
+        assert!(err.to_string().starts_with("[driver.process]"), "{err}");
+
+        let dead = parse(
+            "name = \"x\"\n[driver]\n\n[driver.process]\n\
+             argv = [\"node\"]\ntimeout_secs = 5\nenv = [\" PATH\"]",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            dead,
+            ManifestError::InvalidProcessEnvName {
+                block: ProcessBlock::DriverProcess,
+                ..
+            }
+        ));
+
+        // And `[runtime]`'s own refusals still name `[runtime]`.
+        let runtime = parse(
+            "name = \"x\"\n[loop]\nparticipation = \"observer\"\n\n\
+             [runtime]\nargv = []\ntimeout_secs = 5",
+        )
+        .unwrap_err();
+        assert!(runtime.to_string().starts_with("[runtime]"), "{runtime}");
     }
 }

--- a/crates/stella-plugin/src/runtime.rs
+++ b/crates/stella-plugin/src/runtime.rs
@@ -72,7 +72,44 @@ pub fn expand_plugin_dir(text: &str, dir: &Path) -> String {
     text.replace(PLUGIN_DIR_PLACEHOLDER, &dir.to_string_lossy())
 }
 
+/// Which block declared a process, so a refusal names the table to edit.
+///
+/// Two blocks describe a process in the same words — [`Runtime`] serves both —
+/// and a rule broken in one of them must not report the other's name. The
+/// alternative was a second copy of the rules under `[driver.process]`, which
+/// is how one copy grows a check the other silently does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessBlock {
+    /// `[runtime]` — the process a plugin is inside a turn.
+    Runtime,
+    /// `[driver.process]` — the process a plugin is while driving Stella.
+    DriverProcess,
+}
+
+impl ProcessBlock {
+    /// The TOML table, spelled as a manifest writes it.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Runtime => "[runtime]",
+            Self::DriverProcess => "[driver.process]",
+        }
+    }
+}
+
+impl std::fmt::Display for ProcessBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// The `[runtime]` block — how the host starts this plugin's process.
+///
+/// Also the `[driver.process]` block, which is the identical decision for the
+/// process a driver *is*: an argv rather than a shell string, a timeout, and an
+/// environment allowlist. One type rather than two, because a second copy would
+/// be a second set of rules to keep identical — and [`ProcessBlock`] is what
+/// keeps a refusal naming the block the author actually wrote.
 ///
 /// Modelled directly on [`crate::OracleCommand`]: the oracle
 /// block already settled that a plugin names a program as an argv list and
@@ -137,20 +174,24 @@ impl Runtime {
 
     /// The cross-field rules, kept beside the type they govern exactly as
     /// [`crate::consent`]'s and [`crate::wrapper`]'s are.
-    pub(crate) fn validate(&self) -> Result<(), ManifestError> {
+    ///
+    /// `block` is only ever the name in the message: the rules are the same in
+    /// both blocks, and a process that would not start is not more startable
+    /// for having been declared under a different table.
+    pub(crate) fn validate(&self, block: ProcessBlock) -> Result<(), ManifestError> {
         if self.argv.is_empty() {
-            return Err(ManifestError::EmptyRuntimeArgv);
+            return Err(ManifestError::EmptyProcessArgv { block });
         }
         if self.argv.iter().any(|arg| arg.trim().is_empty()) {
-            return Err(ManifestError::BlankRuntimeArg);
+            return Err(ManifestError::BlankProcessArg { block });
         }
         if self.timeout_secs == 0 {
-            return Err(ManifestError::ZeroRuntimeTimeout);
+            return Err(ManifestError::ZeroProcessTimeout { block });
         }
         let mut seen = std::collections::HashSet::with_capacity(self.env.len());
         for name in &self.env {
             if name.is_empty() {
-                return Err(ManifestError::EmptyRuntimeEnvName);
+                return Err(ManifestError::EmptyProcessEnvName { block });
             }
             // A name that is not a name can never match a variable, so the
             // allowlist entry is dead — and a dead entry in a security
@@ -159,10 +200,16 @@ impl Runtime {
             // platform; surrounding whitespace is the same defect wearing a
             // subtler spelling (`" PATH"` looks granted and matches nothing).
             if name.contains('=') || name.contains('\0') || name.trim() != name {
-                return Err(ManifestError::InvalidRuntimeEnvName { name: name.clone() });
+                return Err(ManifestError::InvalidProcessEnvName {
+                    block,
+                    name: name.clone(),
+                });
             }
             if !seen.insert(name) {
-                return Err(ManifestError::DuplicateRuntimeEnv { name: name.clone() });
+                return Err(ManifestError::DuplicateProcessEnv {
+                    block,
+                    name: name.clone(),
+                });
             }
         }
         Ok(())
@@ -271,16 +318,16 @@ mod tests {
     #[test]
     fn argv_and_timeout_bounds_match_the_oracle_command_they_are_modelled_on() {
         let empty = parse(&format!("{OBSERVER}argv = []\ntimeout_secs = 5")).unwrap_err();
-        assert!(matches!(empty, ManifestError::EmptyRuntimeArgv));
+        assert!(matches!(empty, ManifestError::EmptyProcessArgv { .. }));
 
         let blank = parse(&format!(
             "{OBSERVER}argv = [\"python3\", \" \"]\ntimeout_secs = 5"
         ))
         .unwrap_err();
-        assert!(matches!(blank, ManifestError::BlankRuntimeArg));
+        assert!(matches!(blank, ManifestError::BlankProcessArg { .. }));
 
         let zero = parse(&format!("{OBSERVER}argv = [\"python3\"]\ntimeout_secs = 0")).unwrap_err();
-        assert!(matches!(zero, ManifestError::ZeroRuntimeTimeout));
+        assert!(matches!(zero, ManifestError::ZeroProcessTimeout { .. }));
     }
 
     /// A dead allowlist entry reads to its author as a granted one, so each
@@ -301,8 +348,8 @@ mod tests {
             assert!(
                 matches!(
                     err,
-                    ManifestError::EmptyRuntimeEnvName
-                        | ManifestError::InvalidRuntimeEnvName { .. }
+                    ManifestError::EmptyProcessEnvName { .. }
+                        | ManifestError::InvalidProcessEnvName { .. }
                 ),
                 "{why} must be refused, got {err:?}"
             );
@@ -312,7 +359,7 @@ mod tests {
             "{OBSERVER}argv = [\"node\"]\ntimeout_secs = 5\nenv = [\"PATH\", \"PATH\"]"
         ))
         .unwrap_err();
-        assert!(matches!(dupe, ManifestError::DuplicateRuntimeEnv { .. }));
+        assert!(matches!(dupe, ManifestError::DuplicateProcessEnv { .. }));
     }
 
     /// A `none`-grade content bundle is never invoked at any point, so a

--- a/crates/stella-plugin/tests/one_oracle_story.rs
+++ b/crates/stella-plugin/tests/one_oracle_story.rs
@@ -61,14 +61,19 @@ const RETIRED: [&str; 5] = [
 ///   said without saying it. The paragraph lived in `manifest.rs` until the
 ///   `[oracle]` block moved to its own module (#3730), and the exemption
 ///   followed it rather than being kept for a file that no longer carries it.
-/// - `consent.rs` carries the same history paragraph plus the assertion string
-///   in `an_oracle_is_disclosed_as_the_plugins_own_report`, the test that
-///   proves the retired claim reaches no install prompt.
+/// - `consent.rs` narrates the same decision above the paragraph the prompt
+///   now prints — "the manifest used to document `[oracle]` as host-run and
+///   this prompt repeated it".
+/// - `consent/tests.rs` carries the history paragraph plus the assertion
+///   string in `an_oracle_is_disclosed_as_the_plugins_own_report`, the test
+///   that proves the retired claim reaches no install prompt. It was inside
+///   `consent.rs` until that file's suite moved to a sibling under the
+///   1500-line ratchet (#3783), and the exemption followed it.
 ///
 /// `manifest.rs`'s `[subloop]` line ("stages the host runs as bounded child
 /// turns") is a different subject and is correct; it matches none of
 /// [`RETIRED`] and needs no exemption of its own.
-const ABOUT_THE_RETIRED_CLAIM: [&str; 2] = ["oracle.rs", "consent.rs"];
+const ABOUT_THE_RETIRED_CLAIM: [&str; 3] = ["oracle.rs", "consent.rs", "consent/tests.rs"];
 
 /// One file's text with every run of whitespace collapsed to a single space,
 /// so a claim split across two lines reads as the sentence it is.

--- a/crates/stella-runtime/src/wrapper/driver_call.rs
+++ b/crates/stella-runtime/src/wrapper/driver_call.rs
@@ -330,6 +330,9 @@ mod tests {
         DriverGrant {
             calls: calls.to_vec(),
             max_calls,
+            // The gate reads the grant's call list; which program the host
+            // starts is `stella-cli`'s question and never this one's.
+            process: None,
         }
     }
 

--- a/plugins/stella-selfdriving/README.md
+++ b/plugins/stella-selfdriving/README.md
@@ -23,6 +23,11 @@ would widen that socket for a single caller. So the manifest declares
 `participation = "none"` and no `[runtime]`, no `[oracle]`, no `[wrapper]`:
 Stella never starts this program. A person does, and then it starts Stella.
 
+Since #3783 a driver *can* be started by Stella — `[driver.process]` names the
+program and `stella plugin drive <name>` opens one session against it. This
+package declares no such block, because there is no program here to name (see
+below), and the install prompt says so in as many words.
+
 **The authority question is settled** (run playbook §3, D-3). The loop already
 holds `gh`, the AWS CLI, `brew`, a line in `~/.zshrc` and a daemon, today, as
 a shell script running with your full authority. Packaging it **relocates**

--- a/plugins/stella-selfdriving/plugin.toml
+++ b/plugins/stella-selfdriving/plugin.toml
@@ -8,6 +8,13 @@
 # no `[oracle]` and no `[wrapper]`: none of them would be true. Stella never
 # starts this program — a person does, and then it starts Stella.
 #
+# Stella CAN start a driver, since #3783: a `[driver.process]` block names the
+# program and `stella plugin drive <name>` opens one session against it. This
+# package still declares none, because there is no program here to name — see
+# WHAT THIS FILE IS NOT below. The absence is now itself disclosed at install
+# ("is not started by Stella"), so a reader can tell this declaration from a
+# driver the host will spawn.
+#
 # WHAT THIS FILE IS FOR. The run playbook's D-3 settles the authority
 # question: making the loop a plugin RELOCATES the authority it already holds
 # as a shell script running as you, and grants nothing new. The requirement

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella plugin
-description: Install, list, and remove plugins — and see the whole grant a plugin asks for before any of it is granted.
+description: Install, list, remove, and drive plugins — and see the whole grant a plugin asks for before any of it is granted.
 ---
 
 `stella plugin` is the loader. A plugin declares, in one `plugin.toml`, exactly how much say it wants in your turn loop — a participation grade, the hook points it may act at, the process it runs as, and the precise list of environment variables that process inherits. This command shows you that declaration and installs nothing until you accept it.
@@ -13,6 +13,7 @@ Offline: reads and writes local files, no API key.
 stella plugin install <dir> [--scope project|user] [--yes]
 stella plugin list
 stella plugin remove <name>
+stella plugin drive <name>
 ```
 
 ## What a plugin declares
@@ -127,6 +128,33 @@ stella plugin remove vera
 Deletes the plugin's directory in **every** tier that holds the name — project scope first, then user — and names each copy it removed. Stopping at the first would report success while the other tier's copy was still dispatched on every tool call, which is the one failure uninstall may not have. The name is the one in the manifest, not the directory's, so a package that was unpacked or renamed into a differently named directory is still removable under the name `stella plugin list` prints for it.
 
 Its hook dispatches stop immediately: the roster is recomputed from disk every time it is read, so there is no second place a stale grant can survive.
+
+## `stella plugin drive`
+
+```bash
+stella plugin drive selfdriving
+```
+
+Opens **one driver session** against an installed plugin that declares a `[driver]` block, and prints what the driver said should happen next — `sleep <n>s` or `halt — <reason>`.
+
+A driver is the inverse of everything else on this page. A `[loop]` plugin is asked something during your turn; a driver has no turn to stand in, because it is what starts them. So it carries no participation grade at all — `participation = "none"` is the only answer one can give — and its capabilities live in their own block:
+
+```toml
+[driver]
+calls = ["backlog_next", "backlog_file"]   # exhaustive, like [loop] hooks
+max_calls = 4                              # an ask; the host clamps it
+
+[driver.process]
+argv = ["python3", "${plugin_dir}/drive.py"]
+timeout_secs = 600
+env = ["PATH"]                             # default-deny, exactly as [runtime]
+```
+
+`[driver.process]` rather than `[runtime]` because the two are different consents: `[runtime]` is the process a plugin is *inside* a turn, and stella refuses it below `participation = "observer"` on the grounds that such a plugin is never invoked. A driver is never invoked inside a turn either, and that is not a reason to refuse it a program — it is the definition of what it is.
+
+**A `[driver]` block with no `[driver.process]` is a declaration, not a program.** It says what such a driver would ask for, and stella starts nothing: `plugins/stella-selfdriving` is exactly this, and the install prompt says so rather than leaving you to infer it.
+
+Every capability a driver asks for is performed **by stella, on request** — the plugin holds no provider, no credential and no forge token of its own. Today every one of them answers `unsupported`, so a session that asks for anything is refused everything and says so; the verbs are being implemented one at a time. What re-opens a session after a `sleep` is the loop itself, not this command: one invocation is one session.
 
 ## Scopes, shadowing, and switching one off
 


### PR DESCRIPTION
## What & why

`stella-runtime` has been able to *hold* a driver session since #3634 — spawn the process, hand it a `DriveRequest`, serve the capabilities its grant permits, read back its `next`. Nothing in the shipping binary built one, so `[driver]` was a grant a human could read at install and no code path could turn into a running program.

Closes #3783

### The manifest decision, and the evidence that settles it

The issue asks for a three-way choice before code: reuse `[runtime]`, give `[driver]` its own argv/env/timeout keys, or something else. **Option 1 is not available**, and that is a fact about the tree rather than a preference:

`PluginManifest::validate` refuses `[runtime]` below `participation = "observer"` (`ManifestError::RuntimeRequiresObserver`, witnessed by `a_runtime_below_observer_is_rejected`), on the argument that a content bundle is never invoked so its process would never start. `participation = "none"` is the only grade a driver can carry — `crates/stella-plugin/src/driver.rs`'s header is the argument, and `plugins/stella-selfdriving` declares exactly that. Reusing `[runtime]` would therefore have made every driver either unloadable or forced to overstate its in-turn standing to gain a process.

So option 2: **`[driver.process]`**, which is also the shape the grant was split out on — a driver grant and a loop grant are different consents, and neither grants any part of the other.

The *type* is shared with `[runtime]` (`stella_plugin::Runtime`) rather than copied. The decision is identical — an argv rather than a shell string, a timeout, an environment allowlist — and a second copy of those rules is how one copy grows a check the other silently does not. What is not shared is the *name in the message*: the six process rules now carry a `ProcessBlock`, so a `[driver.process]` defect does not send an author to a table their manifest does not contain.

### What ships

- **`[driver.process]`** on `DriverGrant`, validated by `[runtime]`'s own rules and with no grade check, for the reason `[driver]` itself has none.
- **`stella plugin drive <name>`** — resolves argv against the installed package directory, resolves the environment allowlist through the host's own ambient read, declares the transport, attaches the capability gate, opens one session and reports what the driver said to do next. Every refused ask is printed, in `RefusedDriverCall`'s own words.
- **Consent** discloses a driver's process with the same two sentences `[runtime]` gets — and discloses its *absence* too: `plugins/stella-selfdriving` now renders "is not started by Stella", so a reader can tell a declaration from a program.
- **`stella plugin list`** names a driver's program on its own line. Its `runs:` line is about `[runtime]` and said "this plugin ships no process" for a package whose only program is a driver.

Scheduling is out of scope, as the issue says: one invocation is one session. Every capability still answers `unsupported`, and the verb says so before spending anything rather than papering over it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-cli/src/driver_plugin/tests.rs` — seven tests driving the **real** binder, never a hand-built `SubprocessDriver`, because the missing half was the path from an installed package to one and not the transport (`crates/stella-runtime/tests/driver_socket.rs` already covers that).

Two ablations, each making the answer **wrong** rather than absent:

**1. Drop the `expand_plugin_dir` call** (`let argv = process.argv.clone();`):

```
---- an_installed_driver_is_bound_to_the_program_its_package_declares stdout ----
assertion `left == right` failed
  left: "${plugin_dir}/drive.sh"
 right: "/opt/pkgs/selfdriving/drive.sh"

---- opening_a_session_spawns_the_resolved_program_and_reports_what_it_was stdout ----
cannot start driver `${plugin_dir}/drive.sh`: No such file or directory (os error 2)

test result: FAILED. 5 passed; 2 failed
```

**2. Drop the refused-credential report:**

```
---- a_model_credential_is_withheld_from_a_driver_and_the_user_is_told ----
test result: FAILED. 6 passed; 1 failed
```

Restored: `test result: ok. 7 passed; 0 failed`.

Plus, on the manifest side, `a_driver_declares_its_own_process_and_runtime_could_not_have_carried_it` asserts **both** halves — the process loads at grade `none`, and the same argv under `[runtime]` does not. The first alone would pass against a design that reused `[runtime]`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-plugin -p stella-cli -p stella-runtime --all-targets -- -D warnings`
- [x] `cargo test -p stella-plugin`, `-p stella-runtime`, `-p stella-cli` (full suites, green)
- [x] `make guards-fast` (including `check-file-size`, `check-prose`, `check-wire-schema`)
- [x] Docs updated: `website/content/docs/commands/plugin.mdx`, `plugins/stella-selfdriving/{plugin.toml,README.md}`

CI is the evidence; the local runs above are what the pre-push rungs cover.

## Reviewers should know

**`consent.rs` crossed the 1500-line ratchet**, so its test suite moved to `consent/tests.rs` — the sibling-file pattern AGENTS.md names and `wrapper_plugin/tests.rs` already uses. No test was deleted or renamed. `one_oracle_story`'s `ABOUT_THE_RETIRED_CLAIM` exemption followed the file it exempts, exactly as it did for `oracle.rs` in #3730.

**Six `ManifestError` variants were renamed** (`EmptyRuntimeArgv` → `EmptyProcessArgv { block }`, and its five siblings). Their rendered messages are unchanged for `[runtime]`; only the block name is now a field. The only call sites were in `runtime.rs`.

**`bind_installed` grew a `bind_with` seam** taking the environment lookup, so the credential-withholding test does not have to set `ANTHROPIC_API_KEY` in the test process. It is the shape `Runtime::child_env` already uses.

## Nothing left behind

- [x] Filed: #5109 — a driver session leaves no durable record; what it asked for and how it ended are printed and then lost.

The rest of what this touches is already tracked: the capabilities themselves are #3599 B1–B6, and the loop that re-opens a session after a `sleep` is B2. `plugins/stella-selfdriving` deliberately still declares no `[driver.process]` — there is no program in this repository to name, and `scripts/self-driving.sh` remains the working driver until its replacement is proven (`doc:pipeline-as-plugins` §10).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] New manifest field round-trips through serde (`[driver.process]` is `stella_plugin::Runtime`, already covered)

## Summary by Sourcery

Enable Stella to start installed driver plugins through a dedicated `[driver.process]` declaration and expose the resulting session behavior and consent details to users.

New Features:
- Add `[driver.process]` manifest support so Stella can start installed driver plugins with declared arguments, timeout, and environment allowlists.
- Add `stella plugin drive <name>` to open a single driver session and report its requested next action and refused capability calls.

Bug Fixes:
- Report withheld credentials and host capability limits instead of leaving driver authors and operators unaware.
- Ensure process validation errors identify whether they came from `[runtime]` or `[driver.process]`.

Enhancements:
- Expose driver programs and credential disclosures in plugin listings and consent prompts, including explicit messaging when a driver is declaration-only.
- Share process configuration and validation behavior between runtime and driver processes while preserving distinct manifest block names.

Documentation:
- Document driver process declarations, one-session execution, capability limitations, and the new drive command.
- Clarify that the self-driving plugin is not started by Stella because it declares no driver process.

Tests:
- Add end-to-end CLI tests covering installed-driver binding, path resolution, process startup, capability gating, credential withholding, and host call ceilings.
- Expand manifest, consent, and plugin-list coverage for driver process declarations and disclosures.
- Move the consent test suite into a sibling test module to keep the source file within size limits.

Chores:
- Rename process-related manifest errors to support both runtime and driver process blocks without changing rendered runtime messages.