### PR TITLE
refactor(bench-python): split the launcher's two longest key checks into named refusals

### DIFF
--- a/bench/harbor_adapter/stella_harbor/provider_key.py
+++ b/bench/harbor_adapter/stella_harbor/provider_key.py
@@ -1,0 +1,512 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+"""The dedicated OpenRouter key: its ledger history and its live state.
+
+Two questions the secure launcher asks before it spends anything.
+`prior_stage_outcome` reads the public ledger and refuses unless every paid
+stage so far bound this one key and reconciled its spend;
+`validate_live_provider_key` reads the key's live state and refuses unless it
+still matches the intent and can cover the job.
+
+Each refusal is a named predicate with one message, and those messages are the
+launcher's contract — `bench/harbor_adapter/tests/test_secure_launcher.py`
+matches on them, so change one only alongside the test that asserts it.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+from .value_shapes import (
+    aware_timestamp,
+    finite_nonnegative_number,
+    require_exact_object,
+    utc_text,
+)
+
+__all__ = [
+    "DEDICATED_KEY_HARD_LIMIT_USD",
+    "DEDICATED_KEY_LABEL",
+    "prior_stage_outcome",
+    "validate_live_provider_key",
+]
+
+DEDICATED_KEY_LABEL = "stella-tb21-dedicated-key-v1"
+
+# The label every paid stage must bind, alongside the hard limit below.
+# Binding both is what stops a run charging a key nobody preregistered.
+#
+# The only bound that can actually stop a claim run spending, now that no
+# trial carries one (#2411). It sits at the provider, so exhausting it fails
+# the run visibly rather than truncating a trial into a loss — which is the
+# whole reason a wallet is guarded here and never inside a trial.
+#
+# It is now required arithmetic rather than a backstop, and it moved from
+# $180 to $600 because of that shift. The confirmatory stage requests 445
+# trials: at the frozen $0.17 cap that projected to $75.65, comfortably
+# inside $180 *because the cap made it so*, and at the measured forecast
+# (`secure_launcher`'s `_CANONICAL_PER_TRIAL_FORECAST_USD`) it projects to
+# $534. The old limit did not bound the run's cost — it
+# bounded how much of each task the agent was allowed to finish, and the
+# projection only fit because trials were being stopped short.
+#
+# So this is not new spending appetite; it is the same run, priced at what it
+# costs. It is also a PROVISIONING REQUIREMENT, not an authorisation:
+# on 2026-08-08 the account behind this key had $35.72 left of $1,110, so a
+# confirmatory stage cannot run at any per-trial price until it is funded.
+#
+# Nothing here spends money or grants permission to. The real gate is the
+# live-credit check in `_verify_public_paid_intent`, which reads the key's
+# actual remaining credit rather than this constant — so an unfunded key fails
+# preflight instead of launching and abandoning trials that would then score as
+# losses. This number only says what the key must be provisioned to before the
+# stage is runnable at all.
+DEDICATED_KEY_HARD_LIMIT_USD = 600.0
+
+_ARTIFACT_DIGEST_RE = re.compile(r"[0-9a-f]{64}")
+
+# Which paid stages must already stand, for each stage a launch can be.
+_EXPECTED_PAID_CHAIN = {
+    "readiness": ["readiness"],
+    "calibration": ["readiness", "calibration"],
+    "confirmatory": ["readiness", "calibration", "confirmatory"],
+}
+
+_PAID_STAGES = frozenset({"readiness", "calibration", "confirmatory"})
+
+
+def _sole_unspent_current_intent(
+    ledger: Mapping[str, Any], current_digest: str
+) -> Mapping[str, Any]:
+    """The one ledger entry for this intent, refused if it already ran."""
+    current_wrappers = [
+        wrapper
+        for wrapper in ledger["intents"]
+        if wrapper["intent_sha256"] == current_digest
+    ]
+    if len(current_wrappers) != 1:
+        raise RuntimeError("public ledger does not uniquely identify current intent")
+    if any(
+        outcome.get("intent_sha256") == current_digest for outcome in ledger["outcomes"]
+    ):
+        raise RuntimeError("current paid intent already has a post-launch outcome")
+    return current_wrappers[0]
+
+
+def _paid_stage_chain(
+    ledger: Mapping[str, Any], *, stage: str, current_wrapper: Mapping[str, Any]
+) -> Sequence[Mapping[str, Any]]:
+    """The paid stages so far, refused unless they are this stage's exact prefix."""
+    paid_wrappers = [
+        wrapper
+        for wrapper in ledger["intents"]
+        if wrapper["intent"].get("historical") is False
+        and wrapper["intent"].get("stage") in _PAID_STAGES
+    ]
+    expected_stages = _EXPECTED_PAID_CHAIN[stage]
+    if [wrapper["intent"].get("stage") for wrapper in paid_wrappers] != expected_stages:
+        raise RuntimeError("public ledger paid-stage chain is not the exact prefix")
+    if paid_wrappers[-1] != current_wrapper:
+        raise RuntimeError("public ledger current intent is not the paid-stage tip")
+    return paid_wrappers
+
+
+def _paid_outcomes_for(
+    ledger: Mapping[str, Any], paid_wrappers: Sequence[Mapping[str, Any]]
+) -> Sequence[Mapping[str, Any]]:
+    """The outcomes of the prior paid stages: one each, and none for this one."""
+    paid_digests = {wrapper["intent_sha256"] for wrapper in paid_wrappers}
+    paid_outcomes = [
+        outcome
+        for outcome in ledger["outcomes"]
+        if outcome.get("intent_sha256") in paid_digests
+    ]
+    if len(paid_outcomes) != len(paid_wrappers) - 1:
+        raise RuntimeError(
+            "public ledger paid outcomes do not exactly cover prior stages"
+        )
+    return paid_outcomes
+
+
+def _continuous_usage_before(
+    intent: Mapping[str, Any],
+    *,
+    expected_key_identity: Mapping[str, Any],
+    previous_usage_after: float | None,
+    intent_stage: str,
+) -> float:
+    """This stage's opening usage, refused unless it binds the key and continues."""
+    provider = intent["provider_key"]
+    observed_key_identity = {
+        "fingerprint_sha256": provider.get("fingerprint_sha256"),
+        "label": provider.get("label"),
+        "limit_usd": provider.get("limit_usd"),
+    }
+    if observed_key_identity != dict(expected_key_identity):
+        raise RuntimeError("all paid stages must bind one exact dedicated key")
+    usage_before = finite_nonnegative_number(
+        provider.get("usage_before_usd"),
+        label=f"{intent_stage} intent provider usage_before_usd",
+    )
+    if previous_usage_after is not None and not math.isclose(
+        usage_before, previous_usage_after, rel_tol=0, abs_tol=1e-9
+    ):
+        raise RuntimeError("paid-stage provider usage is not continuous")
+    return usage_before
+
+
+def _sole_prior_outcome(
+    paid_outcomes: Sequence[Mapping[str, Any]],
+    wrapper: Mapping[str, Any],
+    intent_stage: str,
+) -> Mapping[str, Any]:
+    """The one recorded outcome for a prior stage."""
+    matches = [
+        outcome
+        for outcome in paid_outcomes
+        if outcome.get("intent_sha256") == wrapper["intent_sha256"]
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"public ledger lacks exactly one prior {intent_stage} outcome"
+        )
+    return matches[0]
+
+
+def _require_canonical_job_and_artifact(
+    outcome: Mapping[str, Any], intent_stage: str
+) -> None:
+    """A prior stage names one canonical job id and one artifact digest."""
+    try:
+        parsed_job_id = uuid.UUID(str(outcome.get("job_id")))
+    except (ValueError, AttributeError) as exc:
+        raise RuntimeError(f"prior {intent_stage} job_id is not one UUID") from exc
+    if parsed_job_id.int == 0 or str(parsed_job_id) != outcome.get("job_id"):
+        raise RuntimeError(f"prior {intent_stage} job_id is not canonical")
+    artifact_digest = outcome.get("artifact_tree_sha256")
+    if (
+        not isinstance(artifact_digest, str)
+        or _ARTIFACT_DIGEST_RE.fullmatch(artifact_digest) is None
+    ):
+        raise RuntimeError(f"prior {intent_stage} artifact digest is invalid")
+
+
+def _reconciled_spend(
+    outcome: Mapping[str, Any], *, usage_before: float, intent_stage: str
+) -> float:
+    """A prior stage's closing usage, refused unless its spend reconciled.
+
+    Returns the usage the next stage must open at, which is what makes the
+    chain continuous rather than merely each link plausible.
+    """
+    before = finite_nonnegative_number(
+        outcome.get("provider_usage_before_usd"),
+        label=f"prior {intent_stage} provider usage before",
+    )
+    after = finite_nonnegative_number(
+        outcome.get("provider_usage_after_usd"),
+        label=f"prior {intent_stage} provider usage after",
+    )
+    delta = finite_nonnegative_number(
+        outcome.get("provider_usage_delta_usd"),
+        label=f"prior {intent_stage} provider usage delta",
+    )
+    telemetry = finite_nonnegative_number(
+        outcome.get("telemetry_cost_sum_usd"),
+        label=f"prior {intent_stage} telemetry sum",
+    )
+    tolerance = finite_nonnegative_number(
+        outcome.get("reconciliation_tolerance_usd"),
+        label=f"prior {intent_stage} reconciliation tolerance",
+    )
+    if (
+        not math.isclose(before, usage_before, rel_tol=0, abs_tol=1e-9)
+        or after < before
+        or not math.isclose(delta, after - before, rel_tol=0, abs_tol=1e-9)
+        or tolerance > 0.01
+        or abs(delta - telemetry) > tolerance + 1e-12
+        or outcome.get("reconciliation_status") != "reconciled"
+    ):
+        raise RuntimeError(f"prior {intent_stage} spend is not reconciled")
+    return after
+
+
+def _require_completed_and_recorded(
+    outcome: Mapping[str, Any],
+    *,
+    intent_stage: str,
+    wrapper: Mapping[str, Any],
+    publications_by_subject: Mapping[tuple[str, str], Mapping[str, Any]],
+    next_sequence: int,
+    current_declared: datetime,
+    current_sequence: int,
+) -> None:
+    """A prior stage was published, then run, then recorded — in that order."""
+    completed_at = aware_timestamp(
+        outcome.get("completed_at"), label=f"prior {intent_stage} completed_at"
+    )
+    started_at = aware_timestamp(
+        outcome.get("started_at"), label=f"prior {intent_stage} started_at"
+    )
+    recorded_at = aware_timestamp(
+        outcome.get("recorded_at"), label=f"prior {intent_stage} recorded_at"
+    )
+    intent_publication = publications_by_subject.get(
+        ("intent", wrapper["intent_sha256"])
+    )
+    publication_sequence = (
+        intent_publication.get("sequence")
+        if isinstance(intent_publication, Mapping)
+        else None
+    )
+    expected_status = "excluded" if intent_stage == "readiness" else "complete"
+    if (
+        outcome.get("status") != expected_status
+        or not isinstance(publication_sequence, int)
+        or publication_sequence >= outcome["sequence"]
+        or outcome["sequence"] >= next_sequence
+        or started_at > completed_at
+        or completed_at > recorded_at
+        or recorded_at > current_declared
+        or outcome["sequence"] >= current_sequence
+    ):
+        raise RuntimeError(
+            f"prior {intent_stage} outcome was not completed and recorded"
+        )
+
+
+def prior_stage_outcome(
+    ledger: dict[str, Any],
+    *,
+    stage: str,
+    current_digest: str,
+    current_intent: dict[str, Any],
+    publications_by_subject: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    """The prior paid stage's outcome, or `None` when this is the first one."""
+    current_wrapper = _sole_unspent_current_intent(ledger, current_digest)
+    paid_wrappers = _paid_stage_chain(
+        ledger, stage=stage, current_wrapper=current_wrapper
+    )
+    paid_outcomes = _paid_outcomes_for(ledger, paid_wrappers)
+
+    current_sequence = current_wrapper["sequence"]
+    current_declared = aware_timestamp(
+        current_intent.get("declared_at"), label="current intent declared_at"
+    )
+    expected_key_identity = {
+        "fingerprint_sha256": current_intent["provider_key"]["fingerprint_sha256"],
+        "label": DEDICATED_KEY_LABEL,
+        "limit_usd": DEDICATED_KEY_HARD_LIMIT_USD,
+    }
+
+    prior_summary: dict[str, Any] | None = None
+    previous_usage_after: float | None = None
+    for index, wrapper in enumerate(paid_wrappers):
+        intent = wrapper["intent"]
+        intent_stage = intent["stage"]
+        usage_before = _continuous_usage_before(
+            intent,
+            expected_key_identity=expected_key_identity,
+            previous_usage_after=previous_usage_after,
+            intent_stage=intent_stage,
+        )
+        # The last wrapper is this launch's own intent: it binds the key and
+        # continues the usage chain, and has no outcome yet by construction.
+        if index == len(paid_wrappers) - 1:
+            break
+
+        outcome = _sole_prior_outcome(paid_outcomes, wrapper, intent_stage)
+        _require_canonical_job_and_artifact(outcome, intent_stage)
+        previous_usage_after = _reconciled_spend(
+            outcome, usage_before=usage_before, intent_stage=intent_stage
+        )
+        _require_completed_and_recorded(
+            outcome,
+            intent_stage=intent_stage,
+            wrapper=wrapper,
+            publications_by_subject=publications_by_subject,
+            next_sequence=paid_wrappers[index + 1]["sequence"],
+            current_declared=current_declared,
+            current_sequence=current_sequence,
+        )
+        prior_summary = {
+            "stage": intent_stage,
+            "intent_sha256": wrapper["intent_sha256"],
+            "status": outcome["status"],
+            "completed_at": outcome["completed_at"],
+            "recorded_at": outcome["recorded_at"],
+        }
+
+    if stage == "readiness":
+        return None
+    if prior_summary is None:
+        raise RuntimeError("public ledger lacks a reconciled prior-stage outcome")
+    return prior_summary
+
+
+_LIVE_KEY_FIELDS = frozenset(
+    {
+        "is_management_key",
+        "is_provisioning_key",
+        "limit",
+        "limit_reset",
+        "limit_remaining",
+        "usage",
+    }
+)
+
+_KEY_RECORD_FIELDS = frozenset(
+    {
+        "disabled",
+        "hash",
+        "include_byok_in_limit",
+        "limit",
+        "limit_remaining",
+        "limit_reset",
+        "name",
+        "usage",
+    }
+)
+
+
+def _live_key_data(response: Mapping[str, Any]) -> Mapping[str, Any]:
+    """The key's own view of itself: a normal dedicated hard-limit key."""
+    outer = require_exact_object(
+        response, frozenset({"data"}), label="OpenRouter key-control response"
+    )
+    data = outer.get("data")
+    if (
+        not isinstance(data, dict)
+        or not _LIVE_KEY_FIELDS.issubset(data)
+        or data.get("is_management_key") is not False
+        or data.get("is_provisioning_key") is not False
+        or data.get("limit_reset") is not None
+    ):
+        raise RuntimeError(
+            "OpenRouter benchmark credential must be a normal dedicated hard-limit key"
+        )
+    return data
+
+
+def _management_key_record(response: Mapping[str, Any]) -> Mapping[str, Any]:
+    """The account's view of the same key, read with the management credential."""
+    record_outer = require_exact_object(
+        response,
+        frozenset({"data"}),
+        label="OpenRouter management key-record response",
+    )
+    record = record_outer.get("data")
+    if not isinstance(record, dict) or not _KEY_RECORD_FIELDS.issubset(record):
+        raise RuntimeError("OpenRouter management key record lacks required fields")
+    return record
+
+
+def _account_credits(response: Mapping[str, Any]) -> tuple[float, float]:
+    """The account's total credits and total usage."""
+    credits_outer = require_exact_object(
+        response,
+        frozenset({"data"}),
+        label="OpenRouter credits response",
+    )
+    credits_data = require_exact_object(
+        credits_outer.get("data"),
+        frozenset({"total_credits", "total_usage"}),
+        label="OpenRouter credits data",
+    )
+    total_credits = finite_nonnegative_number(
+        credits_data.get("total_credits"), label="OpenRouter total credits"
+    )
+    total_usage = finite_nonnegative_number(
+        credits_data.get("total_usage"), label="OpenRouter total usage"
+    )
+    return total_credits, total_usage
+
+
+def validate_live_provider_key(
+    response: Mapping[str, Any],
+    key_record_response: Mapping[str, Any],
+    credits_response: Mapping[str, Any],
+    *,
+    intent: Mapping[str, Any],
+    runtime_identity: Mapping[str, Any],
+    fetched_at: datetime,
+) -> dict[str, Any]:
+    """The key's live snapshot, refused unless it matches the intent and can
+    cover the job."""
+    data = _live_key_data(response)
+    record = _management_key_record(key_record_response)
+    provider = intent["provider_key"]
+
+    live_limit = finite_nonnegative_number(data.get("limit"), label="live key limit")
+    live_usage = finite_nonnegative_number(data.get("usage"), label="live key usage")
+    live_remaining = finite_nonnegative_number(
+        data.get("limit_remaining"), label="live key limit_remaining"
+    )
+    intended_limit = finite_nonnegative_number(
+        provider.get("limit_usd"), label="intent key limit"
+    )
+    intended_usage = finite_nonnegative_number(
+        provider.get("usage_before_usd"), label="intent key usage"
+    )
+    record_limit = finite_nonnegative_number(
+        record.get("limit"), label="management key record limit"
+    )
+    record_usage = finite_nonnegative_number(
+        record.get("usage"), label="management key record usage"
+    )
+    record_remaining = finite_nonnegative_number(
+        record.get("limit_remaining"),
+        label="management key record limit_remaining",
+    )
+    label = record.get("name")
+    if (
+        record.get("hash") != runtime_identity["provider_key_fingerprint_sha256"]
+        or label != DEDICATED_KEY_LABEL
+        or label != provider.get("label")
+        or record.get("disabled") is not False
+        or record.get("include_byok_in_limit") is not True
+        or record.get("limit_reset") is not None
+        or live_limit != intended_limit
+        or live_limit != DEDICATED_KEY_HARD_LIMIT_USD
+        or record_limit != live_limit
+        or not math.isclose(live_usage, intended_usage, rel_tol=0, abs_tol=1e-9)
+        or not math.isclose(record_usage, live_usage, rel_tol=0, abs_tol=1e-9)
+        or not math.isclose(record_remaining, live_remaining, rel_tol=0, abs_tol=1e-6)
+        or not math.isclose(
+            live_remaining, live_limit - live_usage, rel_tol=0, abs_tol=1e-6
+        )
+    ):
+        raise RuntimeError("live OpenRouter management key record differs from intent")
+
+    projected = float(intent["requested_trials"]) * float(
+        intent["per_trial_forecast_usd"]
+    )
+    projected_remaining = live_remaining - projected
+    if projected_remaining < -1e-9:
+        raise RuntimeError("live OpenRouter hard limit cannot cover the registered job")
+
+    total_credits, total_usage = _account_credits(credits_response)
+    available = total_credits - total_usage
+    if available < -1e-6 or available + 1e-9 < projected:
+        raise RuntimeError("OpenRouter account credit cannot cover the registered job")
+
+    return {
+        "fingerprint_sha256": runtime_identity["provider_key_fingerprint_sha256"],
+        "label": label,
+        "limit_usd": live_limit,
+        "usage_usd": live_usage,
+        "limit_remaining_usd": live_remaining,
+        "nominal_planned_spend_usd": projected,
+        "nominal_remaining_after_usd": projected_remaining,
+        "total_credits_usd": total_credits,
+        "total_usage_usd": total_usage,
+        "available_credits_usd": available,
+        "fetched_at_utc": utc_text(fetched_at),
+    }

--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -40,6 +40,37 @@ from .host_attestation import (
     write_launch_binding_sidecar,
 )
 
+# Imported under their existing private names so every call site here, and
+# every `monkeypatch.setattr(launcher_module, ...)` in the tests, keeps
+# naming the same attribute of this module.
+from .provider_key import (
+    DEDICATED_KEY_HARD_LIMIT_USD as _DEDICATED_KEY_HARD_LIMIT_USD,
+)
+from .provider_key import (
+    DEDICATED_KEY_LABEL as _DEDICATED_KEY_LABEL,
+)
+from .provider_key import (
+    prior_stage_outcome as _prior_stage_outcome,
+)
+from .provider_key import (
+    validate_live_provider_key as _validate_live_provider_key,
+)
+from .value_shapes import (
+    aware_timestamp as _aware_timestamp,
+)
+from .value_shapes import (
+    finite_nonnegative_number as _finite_nonnegative_number,
+)
+from .value_shapes import (
+    parse_github_timestamp as _parse_github_timestamp,
+)
+from .value_shapes import (
+    require_exact_object as _require_exact_object,
+)
+from .value_shapes import (
+    utc_text as _utc_text,
+)
+
 _CANONICAL_AGENT_IMPORT_PATH = "stella_harbor:StellaAgent"
 _CANONICAL_DATASET_ARGUMENT = (
     "terminal-bench/terminal-bench-2-1@"
@@ -60,39 +91,14 @@ _CANONICAL_DATASET_ARGUMENT = (
 # whose only job is to not under-state what a run will cost.
 #
 # The old value was `0.17`, and it was an enforced cap. Reading it as a
-# forecast now would be a 7x under-statement — see `_DEDICATED_KEY_HARD_LIMIT_USD`
-# for why that arithmetic matters.
+# forecast now would be a 7x under-statement — see `provider_key`'s
+# `DEDICATED_KEY_HARD_LIMIT_USD` for why that arithmetic matters.
 _CANONICAL_PER_TRIAL_FORECAST_USD = 1.20
 _CANONICAL_DISABLE_REFLECTION = "1"
 _CANONICAL_ADAPTER_VERSION = "0.6.0"
 _CANONICAL_HARBOR_VERSION = "0.6.1"
 _CANONICAL_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _CANONICAL_PROVIDER_ROUTE_POLICY = "openrouter-auto"
-# The only bound that can actually stop a claim run spending, now that no
-# trial carries one (#2411). It sits at the provider, so exhausting it fails
-# the run visibly rather than truncating a trial into a loss — which is the
-# whole reason a wallet is guarded here and never inside a trial.
-#
-# It is now required arithmetic rather than a backstop, and it moved from
-# $180 to $600 because of that shift. The confirmatory stage requests 445
-# trials: at the frozen $0.17 cap that projected to $75.65, comfortably
-# inside $180 *because the cap made it so*, and at the measured forecast
-# above it projects to $534. The old limit did not bound the run's cost — it
-# bounded how much of each task the agent was allowed to finish, and the
-# projection only fit because trials were being stopped short.
-#
-# So this is not new spending appetite; it is the same run, priced honestly for
-# the first time. It is also a PROVISIONING REQUIREMENT, not an authorisation:
-# on 2026-08-08 the account behind this key had $35.72 left of $1,110, so a
-# confirmatory stage cannot run at any per-trial price until it is funded.
-#
-# Nothing here spends money or grants permission to. The real gate is the
-# live-credit check in `_verify_public_paid_intent`, which reads the key's
-# actual remaining credit rather than this constant — so an unfunded key fails
-# preflight instead of launching and abandoning trials that would then score as
-# losses. This number only says what the key must be provisioned to before the
-# stage is runnable at all.
-_DEDICATED_KEY_HARD_LIMIT_USD = 600.0
 _OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
 _OPENROUTER_KEYS_URL = "https://openrouter.ai/api/v1/keys"
 _OPENROUTER_CREDITS_URL = "https://openrouter.ai/api/v1/credits"
@@ -127,6 +133,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/loop_mode.py",
     "bench/harbor_adapter/stella_harbor/portability.py",
     "bench/harbor_adapter/stella_harbor/posture.py",
+    "bench/harbor_adapter/stella_harbor/provider_key.py",
     "bench/harbor_adapter/stella_harbor/secure_launcher.py",
     "bench/harbor_adapter/stella_harbor/setup_exec.py",
     "bench/harbor_adapter/stella_harbor/stream_envelope.py",
@@ -136,6 +143,7 @@ _FIXED_ADAPTER_SOURCE_PATHS = (
     "bench/harbor_adapter/stella_harbor/tool_set.py",
     "bench/harbor_adapter/stella_harbor/turn_budget.py",
     "bench/harbor_adapter/stella_harbor/upstream_pin.py",
+    "bench/harbor_adapter/stella_harbor/value_shapes.py",
 )
 _FIXED_READINESS_SOURCE_PATHS = (
     "bench/readiness/synthetic-adapter-sentinel/environment/Dockerfile",
@@ -528,7 +536,6 @@ _COMMENT_URL_RE = re.compile(
     r"https://github\.com/macanderson/stella/issues/(?P<issue>[1-9][0-9]*)"
     r"#issuecomment-(?P<comment>[1-9][0-9]*)"
 )
-_DEDICATED_KEY_LABEL = "stella-tb21-dedicated-key-v1"
 _ISOLATED_HARBOR_SHIM = """\
 import sys
 adapter_root, site_root = sys.argv[1:3]
@@ -946,28 +953,6 @@ def _canonical_payload_sha256(value: Any) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
-def _parse_github_timestamp(value: Any) -> datetime:
-    if not isinstance(value, str) or not value.endswith("Z"):
-        raise RuntimeError("GitHub comment timestamp is not canonical UTC")
-    try:
-        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
-    except ValueError as exc:
-        raise RuntimeError("GitHub comment timestamp is invalid") from exc
-    if parsed.tzinfo is None:
-        raise RuntimeError("GitHub comment timestamp lacks a timezone")
-    return parsed.astimezone(timezone.utc)
-
-
-def _utc_text(value: datetime) -> str:
-    if value.tzinfo is None:
-        raise RuntimeError("public-intent preflight clock lacks a timezone")
-    return (
-        value.astimezone(timezone.utc)
-        .isoformat(timespec="microseconds")
-        .replace("+00:00", "Z")
-    )
-
-
 def _intent_comment_url(command: Sequence[str]) -> tuple[str, int, int]:
     values = _claim_options(command).get("--intent-comment-url", [])
     match = _COMMENT_URL_RE.fullmatch(values[0]) if len(values) == 1 else None
@@ -985,38 +970,6 @@ def _paid_stage(command: Sequence[str]) -> str:
     if job_name == _CALIBRATION_JOB_NAME:
         return "calibration"
     return "confirmatory"
-
-
-def _aware_timestamp(value: Any, *, label: str) -> datetime:
-    if not isinstance(value, str) or not value:
-        raise RuntimeError(f"{label} is not a timezone-aware ISO-8601 timestamp")
-    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError as exc:
-        raise RuntimeError(
-            f"{label} is not a timezone-aware ISO-8601 timestamp"
-        ) from exc
-    if parsed.tzinfo is None:
-        raise RuntimeError(f"{label} is not a timezone-aware ISO-8601 timestamp")
-    return parsed.astimezone(timezone.utc)
-
-
-def _finite_nonnegative_number(value: Any, *, label: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise RuntimeError(f"{label} must be a finite nonnegative number")
-    result = float(value)
-    if not math.isfinite(result) or result < 0:
-        raise RuntimeError(f"{label} must be a finite nonnegative number")
-    return result
-
-
-def _require_exact_object(
-    value: Any, fields: frozenset[str], *, label: str
-) -> dict[str, Any]:
-    if not isinstance(value, dict) or set(value) != fields:
-        raise RuntimeError(f"{label} differs from the exact v2 schema")
-    return value
 
 
 def _positive_sequence(value: Any, *, label: str) -> int:
@@ -1222,190 +1175,6 @@ def _validate_current_intent(
         raise RuntimeError(
             "readiness/calibration subject commit differs from runtime source commit"
         )
-
-
-def _prior_stage_outcome(
-    ledger: dict[str, Any],
-    *,
-    stage: str,
-    current_digest: str,
-    current_intent: dict[str, Any],
-    publications_by_subject: Mapping[tuple[str, str], Mapping[str, Any]],
-) -> dict[str, Any] | None:
-    current_wrappers = [
-        wrapper
-        for wrapper in ledger["intents"]
-        if wrapper["intent_sha256"] == current_digest
-    ]
-    if len(current_wrappers) != 1:
-        raise RuntimeError("public ledger does not uniquely identify current intent")
-    if any(
-        outcome.get("intent_sha256") == current_digest for outcome in ledger["outcomes"]
-    ):
-        raise RuntimeError("current paid intent already has a post-launch outcome")
-
-    expected_stages = {
-        "readiness": ["readiness"],
-        "calibration": ["readiness", "calibration"],
-        "confirmatory": ["readiness", "calibration", "confirmatory"],
-    }[stage]
-    paid_wrappers = [
-        wrapper
-        for wrapper in ledger["intents"]
-        if wrapper["intent"].get("historical") is False
-        and wrapper["intent"].get("stage")
-        in {"readiness", "calibration", "confirmatory"}
-    ]
-    if [wrapper["intent"].get("stage") for wrapper in paid_wrappers] != expected_stages:
-        raise RuntimeError("public ledger paid-stage chain is not the exact prefix")
-    if paid_wrappers[-1] != current_wrappers[0]:
-        raise RuntimeError("public ledger current intent is not the paid-stage tip")
-
-    current_sequence = current_wrappers[0]["sequence"]
-    current_declared = _aware_timestamp(
-        current_intent.get("declared_at"), label="current intent declared_at"
-    )
-
-    current_provider = current_intent["provider_key"]
-    expected_key_identity = {
-        "fingerprint_sha256": current_provider["fingerprint_sha256"],
-        "label": _DEDICATED_KEY_LABEL,
-        "limit_usd": _DEDICATED_KEY_HARD_LIMIT_USD,
-    }
-    prior_summary: dict[str, Any] | None = None
-    previous_usage_after: float | None = None
-    paid_digests = {wrapper["intent_sha256"] for wrapper in paid_wrappers}
-    paid_outcomes = [
-        outcome
-        for outcome in ledger["outcomes"]
-        if outcome.get("intent_sha256") in paid_digests
-    ]
-    if len(paid_outcomes) != len(paid_wrappers) - 1:
-        raise RuntimeError(
-            "public ledger paid outcomes do not exactly cover prior stages"
-        )
-
-    for index, wrapper in enumerate(paid_wrappers):
-        intent = wrapper["intent"]
-        intent_stage = intent["stage"]
-        provider = intent["provider_key"]
-        observed_key_identity = {
-            "fingerprint_sha256": provider.get("fingerprint_sha256"),
-            "label": provider.get("label"),
-            "limit_usd": provider.get("limit_usd"),
-        }
-        if observed_key_identity != expected_key_identity:
-            raise RuntimeError("all paid stages must bind one exact dedicated key")
-        usage_before = _finite_nonnegative_number(
-            provider.get("usage_before_usd"),
-            label=f"{intent_stage} intent provider usage_before_usd",
-        )
-        if previous_usage_after is not None and not math.isclose(
-            usage_before, previous_usage_after, rel_tol=0, abs_tol=1e-9
-        ):
-            raise RuntimeError("paid-stage provider usage is not continuous")
-        if index == len(paid_wrappers) - 1:
-            break
-
-        matches = [
-            outcome
-            for outcome in paid_outcomes
-            if outcome.get("intent_sha256") == wrapper["intent_sha256"]
-        ]
-        if len(matches) != 1:
-            raise RuntimeError(
-                f"public ledger lacks exactly one prior {intent_stage} outcome"
-            )
-        outcome = matches[0]
-        try:
-            parsed_job_id = uuid.UUID(str(outcome.get("job_id")))
-        except (ValueError, AttributeError) as exc:
-            raise RuntimeError(f"prior {intent_stage} job_id is not one UUID") from exc
-        if parsed_job_id.int == 0 or str(parsed_job_id) != outcome.get("job_id"):
-            raise RuntimeError(f"prior {intent_stage} job_id is not canonical")
-        artifact_digest = outcome.get("artifact_tree_sha256")
-        if (
-            not isinstance(artifact_digest, str)
-            or re.fullmatch(r"[0-9a-f]{64}", artifact_digest) is None
-        ):
-            raise RuntimeError(f"prior {intent_stage} artifact digest is invalid")
-
-        before = _finite_nonnegative_number(
-            outcome.get("provider_usage_before_usd"),
-            label=f"prior {intent_stage} provider usage before",
-        )
-        after = _finite_nonnegative_number(
-            outcome.get("provider_usage_after_usd"),
-            label=f"prior {intent_stage} provider usage after",
-        )
-        delta = _finite_nonnegative_number(
-            outcome.get("provider_usage_delta_usd"),
-            label=f"prior {intent_stage} provider usage delta",
-        )
-        telemetry = _finite_nonnegative_number(
-            outcome.get("telemetry_cost_sum_usd"),
-            label=f"prior {intent_stage} telemetry sum",
-        )
-        tolerance = _finite_nonnegative_number(
-            outcome.get("reconciliation_tolerance_usd"),
-            label=f"prior {intent_stage} reconciliation tolerance",
-        )
-        if (
-            not math.isclose(before, usage_before, rel_tol=0, abs_tol=1e-9)
-            or after < before
-            or not math.isclose(delta, after - before, rel_tol=0, abs_tol=1e-9)
-            or tolerance > 0.01
-            or abs(delta - telemetry) > tolerance + 1e-12
-            or outcome.get("reconciliation_status") != "reconciled"
-        ):
-            raise RuntimeError(f"prior {intent_stage} spend is not reconciled")
-
-        completed_at = _aware_timestamp(
-            outcome.get("completed_at"), label=f"prior {intent_stage} completed_at"
-        )
-        started_at = _aware_timestamp(
-            outcome.get("started_at"), label=f"prior {intent_stage} started_at"
-        )
-        recorded_at = _aware_timestamp(
-            outcome.get("recorded_at"), label=f"prior {intent_stage} recorded_at"
-        )
-        intent_publication = publications_by_subject.get(
-            ("intent", wrapper["intent_sha256"])
-        )
-        publication_sequence = (
-            intent_publication.get("sequence")
-            if isinstance(intent_publication, Mapping)
-            else None
-        )
-        next_sequence = paid_wrappers[index + 1]["sequence"]
-        expected_status = "excluded" if intent_stage == "readiness" else "complete"
-        if (
-            outcome.get("status") != expected_status
-            or not isinstance(publication_sequence, int)
-            or publication_sequence >= outcome["sequence"]
-            or outcome["sequence"] >= next_sequence
-            or started_at > completed_at
-            or completed_at > recorded_at
-            or recorded_at > current_declared
-            or outcome["sequence"] >= current_sequence
-        ):
-            raise RuntimeError(
-                f"prior {intent_stage} outcome was not completed and recorded"
-            )
-        previous_usage_after = after
-        prior_summary = {
-            "stage": intent_stage,
-            "intent_sha256": wrapper["intent_sha256"],
-            "status": outcome["status"],
-            "completed_at": outcome["completed_at"],
-            "recorded_at": outcome["recorded_at"],
-        }
-
-    if stage == "readiness":
-        return None
-    if prior_summary is None:
-        raise RuntimeError("public ledger lacks a reconciled prior-stage outcome")
-    return prior_summary
 
 
 def _ledger_is_exact_prefix(
@@ -2757,140 +2526,6 @@ def _verify_public_runtime_sources(
             != runtime_identity["public_timing_sha256"]
         ):
             raise RuntimeError("public analysis bytes differ from runtime identity")
-
-
-def _validate_live_provider_key(
-    response: Mapping[str, Any],
-    key_record_response: Mapping[str, Any],
-    credits_response: Mapping[str, Any],
-    *,
-    intent: Mapping[str, Any],
-    runtime_identity: Mapping[str, Any],
-    fetched_at: datetime,
-) -> dict[str, Any]:
-    outer = _require_exact_object(
-        response, frozenset({"data"}), label="OpenRouter key-control response"
-    )
-    data = outer.get("data")
-    required_key_fields = frozenset(
-        {
-            "is_management_key",
-            "is_provisioning_key",
-            "limit",
-            "limit_remaining",
-            "limit_reset",
-            "usage",
-        }
-    )
-    if (
-        not isinstance(data, dict)
-        or not required_key_fields.issubset(data)
-        or data.get("is_management_key") is not False
-        or data.get("is_provisioning_key") is not False
-        or data.get("limit_reset") is not None
-    ):
-        raise RuntimeError(
-            "OpenRouter benchmark credential must be a normal dedicated hard-limit key"
-        )
-    provider = intent["provider_key"]
-    live_limit = _finite_nonnegative_number(data.get("limit"), label="live key limit")
-    live_usage = _finite_nonnegative_number(data.get("usage"), label="live key usage")
-    live_remaining = _finite_nonnegative_number(
-        data.get("limit_remaining"), label="live key limit_remaining"
-    )
-    intended_limit = _finite_nonnegative_number(
-        provider.get("limit_usd"), label="intent key limit"
-    )
-    intended_usage = _finite_nonnegative_number(
-        provider.get("usage_before_usd"), label="intent key usage"
-    )
-    record_outer = _require_exact_object(
-        key_record_response,
-        frozenset({"data"}),
-        label="OpenRouter management key-record response",
-    )
-    record = record_outer.get("data")
-    required_record_fields = frozenset(
-        {
-            "disabled",
-            "hash",
-            "include_byok_in_limit",
-            "limit",
-            "limit_remaining",
-            "limit_reset",
-            "name",
-            "usage",
-        }
-    )
-    if not isinstance(record, dict) or not required_record_fields.issubset(record):
-        raise RuntimeError("OpenRouter management key record lacks required fields")
-    record_limit = _finite_nonnegative_number(
-        record.get("limit"), label="management key record limit"
-    )
-    record_usage = _finite_nonnegative_number(
-        record.get("usage"), label="management key record usage"
-    )
-    record_remaining = _finite_nonnegative_number(
-        record.get("limit_remaining"),
-        label="management key record limit_remaining",
-    )
-    label = record.get("name")
-    if (
-        record.get("hash") != runtime_identity["provider_key_fingerprint_sha256"]
-        or label != _DEDICATED_KEY_LABEL
-        or label != provider.get("label")
-        or record.get("disabled") is not False
-        or record.get("include_byok_in_limit") is not True
-        or record.get("limit_reset") is not None
-        or live_limit != intended_limit
-        or live_limit != _DEDICATED_KEY_HARD_LIMIT_USD
-        or record_limit != live_limit
-        or not math.isclose(live_usage, intended_usage, rel_tol=0, abs_tol=1e-9)
-        or not math.isclose(record_usage, live_usage, rel_tol=0, abs_tol=1e-9)
-        or not math.isclose(record_remaining, live_remaining, rel_tol=0, abs_tol=1e-6)
-        or not math.isclose(
-            live_remaining, live_limit - live_usage, rel_tol=0, abs_tol=1e-6
-        )
-    ):
-        raise RuntimeError("live OpenRouter management key record differs from intent")
-    projected = float(intent["requested_trials"]) * float(
-        intent["per_trial_forecast_usd"]
-    )
-    projected_remaining = live_remaining - projected
-    if projected_remaining < -1e-9:
-        raise RuntimeError("live OpenRouter hard limit cannot cover the registered job")
-    credits_outer = _require_exact_object(
-        credits_response,
-        frozenset({"data"}),
-        label="OpenRouter credits response",
-    )
-    credits_data = _require_exact_object(
-        credits_outer.get("data"),
-        frozenset({"total_credits", "total_usage"}),
-        label="OpenRouter credits data",
-    )
-    total_credits = _finite_nonnegative_number(
-        credits_data.get("total_credits"), label="OpenRouter total credits"
-    )
-    total_usage = _finite_nonnegative_number(
-        credits_data.get("total_usage"), label="OpenRouter total usage"
-    )
-    available = total_credits - total_usage
-    if available < -1e-6 or available + 1e-9 < projected:
-        raise RuntimeError("OpenRouter account credit cannot cover the registered job")
-    return {
-        "fingerprint_sha256": runtime_identity["provider_key_fingerprint_sha256"],
-        "label": label,
-        "limit_usd": live_limit,
-        "usage_usd": live_usage,
-        "limit_remaining_usd": live_remaining,
-        "nominal_planned_spend_usd": projected,
-        "nominal_remaining_after_usd": projected_remaining,
-        "total_credits_usd": total_credits,
-        "total_usage_usd": total_usage,
-        "available_credits_usd": available,
-        "fetched_at_utc": _utc_text(fetched_at),
-    }
 
 
 def _verify_public_intent(

--- a/bench/harbor_adapter/stella_harbor/value_shapes.py
+++ b/bench/harbor_adapter/stella_harbor/value_shapes.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+"""Value-shape refusals shared by the secure launcher's validators.
+
+Each function either returns the value in the shape the caller asked for, or
+raises `RuntimeError` naming what was wrong. They read no clock, touch no
+network, and hold no state, so a caller can test one refusal without building
+a launch.
+
+The refusal messages are part of the launcher's contract:
+`bench/harbor_adapter/tests/test_secure_launcher.py` matches on them, so change
+one only alongside the test that asserts it.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any
+
+__all__ = [
+    "aware_timestamp",
+    "finite_nonnegative_number",
+    "parse_github_timestamp",
+    "require_exact_object",
+    "utc_text",
+]
+
+
+def parse_github_timestamp(value: Any) -> datetime:
+    """A GitHub server timestamp, which is canonical UTC or nothing."""
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise RuntimeError("GitHub comment timestamp is not canonical UTC")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise RuntimeError("GitHub comment timestamp is invalid") from exc
+    if parsed.tzinfo is None:
+        raise RuntimeError("GitHub comment timestamp lacks a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def utc_text(value: datetime) -> str:
+    """A datetime as the `Z`-suffixed microsecond ISO-8601 an attestation carries."""
+    if value.tzinfo is None:
+        raise RuntimeError("public-intent preflight clock lacks a timezone")
+    return (
+        value.astimezone(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def aware_timestamp(value: Any, *, label: str) -> datetime:
+    """A recorded timestamp, refused unless it carries a timezone.
+
+    A naive timestamp is refused rather than assumed to be UTC: the launcher
+    orders events by these, and an assumption there orders them wrongly by
+    however far the writer's clock was offset.
+    """
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"{label} is not a timezone-aware ISO-8601 timestamp")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{label} is not a timezone-aware ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise RuntimeError(f"{label} is not a timezone-aware ISO-8601 timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def finite_nonnegative_number(value: Any, *, label: str) -> float:
+    """A money or count field: a real number, at or above zero.
+
+    `bool` is rejected before the numeric check, because `True` is an `int` in
+    Python and would otherwise pass as one dollar.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RuntimeError(f"{label} must be a finite nonnegative number")
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise RuntimeError(f"{label} must be a finite nonnegative number")
+    return result
+
+
+def require_exact_object(
+    value: Any, fields: frozenset[str], *, label: str
+) -> dict[str, Any]:
+    """An object whose key set is exactly `fields` — no extras, none missing.
+
+    Exact rather than a superset check, so a payload that grew a field is
+    refused instead of parsed under an assumption about what the field means.
+    """
+    if not isinstance(value, dict) or set(value) != fields:
+        raise RuntimeError(f"{label} differs from the exact v2 schema")
+    return value

--- a/scripts/prose-baseline.txt
+++ b/scripts/prose-baseline.txt
@@ -114,7 +114,7 @@ bench/harbor_adapter/stella_harbor/locate.py filler-adverb 2
 bench/harbor_adapter/stella_harbor/loop_mode.py filler-adverb 1
 bench/harbor_adapter/stella_harbor/posture.py filler-adverb 10
 bench/harbor_adapter/stella_harbor/posture.py honesty-declaration 6
-bench/harbor_adapter/stella_harbor/secure_launcher.py honesty-declaration 2
+bench/harbor_adapter/stella_harbor/secure_launcher.py honesty-declaration 1
 bench/harbor_adapter/stella_harbor/setup_exec.py filler-adverb 1
 bench/harbor_adapter/stella_harbor/stream_release.py filler-adverb 1
 bench/harbor_adapter/stella_harbor/timeout_reap.py enumerative-announcement 1
@@ -739,10 +739,10 @@ crates/stella-cli/src/term_policy.rs interface-jargon 11
 crates/stella-cli/src/tests.rs interface-jargon 6
 crates/stella-cli/src/tests.rs rust-jargon 2
 crates/stella-cli/src/tests/flag_docs.rs filler-adverb 1
-crates/stella-cli/src/tool_docs.rs filler-adverb 4
+crates/stella-cli/src/tool_docs.rs filler-adverb 3
 crates/stella-cli/src/tool_docs.rs honesty-declaration 6
 crates/stella-cli/src/tool_docs.rs meta-writing 1
-crates/stella-cli/src/tool_docs.rs rust-jargon 7
+crates/stella-cli/src/tool_docs.rs rust-jargon 4
 crates/stella-cli/src/tool_foundry/adopt.rs filler-adverb 1
 crates/stella-cli/src/tool_foundry/adopt.rs meta-writing 1
 crates/stella-cli/src/tool_policy.rs filler-adverb 2
@@ -751,7 +751,7 @@ crates/stella-cli/src/turn_diff.rs interface-jargon 3
 crates/stella-cli/src/turn_facts.rs enumerative-announcement 1
 crates/stella-cli/src/turn_facts.rs honesty-declaration 1
 crates/stella-cli/src/turn_facts.rs rust-jargon 3
-crates/stella-cli/src/turn_files.rs filler-adverb 8
+crates/stella-cli/src/turn_files.rs filler-adverb 6
 crates/stella-cli/src/turn_files.rs honesty-declaration 5
 crates/stella-cli/src/turn_files.rs interface-jargon 7
 crates/stella-cli/src/turn_files.rs rust-jargon 2
@@ -1646,7 +1646,7 @@ crates/stella-tui/src/textline.rs filler-adverb 3
 crates/stella-tui/src/textline.rs honesty-declaration 1
 crates/stella-tui/src/textline.rs interface-jargon 3
 crates/stella-tui/src/textline.rs rust-jargon 8
-crates/stella-tui/src/theme.rs filler-adverb 8
+crates/stella-tui/src/theme.rs filler-adverb 7
 crates/stella-tui/src/theme.rs interface-jargon 5
 crates/stella-tui/src/theme.rs rust-jargon 1
 crates/stella-tui/src/theme/tests.rs filler-adverb 2
@@ -2057,7 +2057,6 @@ website/content/docs/agent-tools/mcp.mdx enumerative-announcement 1
 website/content/docs/agent-tools/mcp.mdx filler-adverb 1
 website/content/docs/agent-tools/skills.mdx interface-jargon 1
 website/content/docs/api-providers/index.mdx interface-jargon 2
-website/content/docs/api-providers/index.mdx rust-jargon 1
 website/content/docs/api-providers/models.mdx meta-writing 1
 website/content/docs/commands/auth.mdx filler-adverb 1
 website/content/docs/commands/calibration.mdx filler-adverb 1


### PR DESCRIPTION
First batch of #4759, on the file the issue names first.

## Measured first

Step 1 of the issue is "report each function's line count so the split targets
the real offenders rather than the ones that look long". Before:

| lines | function |
|---|---|
| 392 | `_verify_public_intent` |
| 231 | `_validate_confirmatory_manifest` |
| **182** | **`_prior_stage_outcome`** |
| **132** | **`_validate_live_provider_key`** |
| 132 | `_verify_public_runtime_sources` |
| 125 | `_reserve_fresh_job` |
| 123 | `exec_harbor_securely` |

101 functions, 17 of them over 80 lines. This PR takes the two bold rows.

## Split by decision

The two dedicated-key checks are now thirteen functions, none over 80 lines,
in two new modules:

- **`value_shapes.py`** — the value-shape refusals every validator in the
  launcher shares: `aware_timestamp`, `finite_nonnegative_number`,
  `require_exact_object`, `utc_text`, `parse_github_timestamp`. Pure,
  clock-free, network-free, so a caller can test one refusal without building
  a launch.
- **`provider_key.py`** — the dedicated OpenRouter key. `prior_stage_outcome`
  reads the public ledger and refuses unless every paid stage bound this one
  key and reconciled its spend; `validate_live_provider_key` reads its live
  state and refuses unless it still matches the intent and can cover the job.
  Each refusal that was a clause in a 180-line body is now a named predicate:
  `_sole_unspent_current_intent`, `_paid_stage_chain`, `_paid_outcomes_for`,
  `_continuous_usage_before`, `_sole_prior_outcome`,
  `_require_canonical_job_and_artifact`, `_reconciled_spend`,
  `_require_completed_and_recorded`, `_live_key_data`,
  `_management_key_record`, `_account_credits`.

The layering is `value_shapes` (leaf) ← `provider_key` ← `secure_launcher`,
which is what avoids the import cycle a partial extraction would have had:
the moved functions need four generic helpers that 95 call sites in
`secure_launcher` also use, so those had to land below, not beside.

`secure_launcher` imports the moved names back under the private names it
already used (`from .provider_key import prior_stage_outcome as
_prior_stage_outcome`), so every call site and every
`monkeypatch.setattr(launcher_module, ...)` target in the tests is unchanged.

`secure_launcher.py`: **4377 → 4010 lines**, 17 → 15 functions over 80.

## The refusal set is unchanged

Every refusal message is byte-identical and **no test was edited** — which is
the issue's third requirement and the only one that can be checked by running
something:

```
$ cd bench/harbor_adapter && uv run pytest tests/test_secure_launcher.py -q
145 passed, 2 failed        # both pre-existing, see below
$ cd bench/harbor_adapter && uv run pytest -q
763 passed, 2 skipped
$ make bench-test
all suites green
```

`_FIXED_ADAPTER_SOURCE_PATHS` gains both new modules. That is the
enumeration's own documented rule rather than a convenience: a file present
locally but missing from that tuple would be executed without ever being
byte-compared to its published source. The guard caught it — 31 tests failed
with `public adapter tree hash differs from runtime identity` until both were
listed, which is a good demonstration that the enumeration is doing its job.

## How this was sequenced against #4894

They collide on one shared cell, `scripts/file-size-baseline.txt`, and pull
opposite ways: #4894 says do not raise `secure_launcher.py`'s ceiling because
its wiring must pay for its own lines, and this issue splits that same file
and asks for a retighten.

Resolved by touching the row in neither direction:

- The split **lowers** the file, so nothing here wants a raise. `make
  file-size` passes untouched: *"nothing went over by this change"*.
- The baseline is **not retightened**, because AGENTS.md makes a retighten its
  own PR — the PR that is racing every other merge is the worst one to fold a
  shared-cell rewrite into (#4652/#4654). Leaving the row at 4383 also leaves
  #4894 exactly the headroom it has today, so neither issue blocks the other.
- `PRIOR_STAGE_OUTCOME_FIELDS` and `PROVIDER_KEY_LIVE_SNAPSHOT_FIELDS` —
  #4894's actual subject — **stay in `secure_launcher.py`**, where
  `test_posture.py`'s guard looks for them. Neither moved function references
  either name, which is #4894's finding confirmed rather than disturbed: they
  are unread, and the code that plausibly should read them moved without
  needing them.

The retighten is worth its own PR once this lands, from a fresh `main`.

## Two pre-existing failures, and a control run

`uv run pytest tests/test_secure_launcher.py` alone fails two tests. They fail
identically on `origin/main`, established with a control worktree at
`faad82ab2` before this branch's changes were considered:

```
$ git worktree add /tmp/ctrl-main origin/main --detach
$ cd /tmp/ctrl-main/bench/harbor_adapter && uv run pytest tests/test_secure_launcher.py -q
FAILED test_missing_prior_readiness_job_never_reserves_or_execs
FAILED test_forged_prior_readiness_artifacts_never_reserve_or_exec
2 failed, 145 passed
```

Same two names, same counts, on both trees. The cause is an import-order
dependency in `_load_frozen_replay_analyzer`, filed as **#5108** with the
minimal reproduction. The whole suite passes because something else puts
`bench/terminal_bench_analysis/` on `sys.path` first.

## Witness

None owed, and none possible: this is a pure refactor whose contract is that
nothing changed. The evidence is the existing suite passing unedited, with the
refusal messages byte-identical — the issue's own definition of done for this
step.

## What #4759 still wants

`_verify_public_intent` (392), `_validate_confirmatory_manifest` (231) and
thirteen more functions over 80 lines, plus `__init__.py`'s
`populate_context_post_run` (278). The issue stays open; this is one
reviewable batch of it.

Refs #4759
Refs #4894
Refs #4392

## Summary by Sourcery

Refactor the secure launcher’s two largest provider-key validation paths into focused modules without changing their validation contract.

Enhancements:
- Split dedicated provider-key validation and shared value-shape validation out of the secure launcher into focused modules while preserving existing behavior and refusal messages.
- Decompose prior-stage ledger and live provider-key checks into named validation predicates for clearer, more maintainable launch authorization logic.

Chores:
- Include the new provider-key and value-shape modules in the fixed adapter source enumeration.