### PR TITLE
process: standing decisions + Steering Context Records (SCR-001…005)

### DIFF
--- a/.claude/hooks/no-full-test-builds.sh
+++ b/.claude/hooks/no-full-test-builds.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Reject full-suite test compiles in the inner loop (SCR-001).
+#
+# PreToolUse hook for Claude Code's Bash tool: receives the tool input as
+# JSON on stdin; exit 2 blocks the call and shows stderr to the agent.
+# This is a teaching guard, not a security boundary — it catches the common
+# full-suite invocations across the org's stacks (the same script ships in
+# every macanderson repo); a deliberate CI reproduction can be phrased
+# around it, and SCR-001 says to do exactly that out loud.
+set -euo pipefail
+
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+block() {
+  echo "Blocked (SCR-001): full test-suite builds are CI's job. Scope it: $1 — see docs/scr/SCR-001-no-full-suite-builds.md" >&2
+  exit 2
+}
+
+# Rust: cargo test / nextest, workspace-wide or without a package scope.
+if [[ "$cmd" =~ cargo[[:space:]]+(test|nextest[[:space:]]+run) ]]; then
+  if [[ "$cmd" =~ --workspace ]] || [[ "$cmd" =~ --all([[:space:]]|$) ]]; then
+    block "cargo test -p <crate> [filter]"
+  fi
+  if ! [[ "$cmd" =~ [[:space:]](-p|--package)[[:space:]] ]]; then
+    block "cargo test -p <crate> [filter]"
+  fi
+fi
+
+# JS package managers: bare test scripts with no --filter scope.
+if [[ "$cmd" =~ (^|[[:space:]])(pnpm|npm|yarn|bun)([[:space:]]+run)?[[:space:]]+(test|test:unit|test:coverage)([[:space:]]|$) ]] \
+   && ! [[ "$cmd" =~ --filter ]]; then
+  block "pnpm --filter <package> test"
+fi
+
+# Turborepo: any test task fanned out across the whole graph.
+if [[ "$cmd" =~ (^|[[:space:]])turbo[[:space:]]+(run[[:space:]]+)?test ]] \
+   && ! [[ "$cmd" =~ --filter ]]; then
+  block "turbo run <task> --filter <package>"
+fi
+
+# Python: pytest with flags only — no path or node selector.
+if [[ "$cmd" =~ (^|[[:space:]])pytest([[:space:]]+-[a-zA-Z-]+)*[[:space:]]*$ ]]; then
+  block "pytest path/to/test_x.py"
+fi
+
+# Full-suite make targets.
+if [[ "$cmd" =~ (^|[[:space:]])make[[:space:]]+test([[:space:]]|$) ]]; then
+  block "the scoped runner for the touched unit (see AGENTS.md)"
+fi
+
+# Go: whole-tree test sweeps.
+if [[ "$cmd" =~ go[[:space:]]+test[[:space:]]+\./\.\.\. ]]; then
+  block "go test ./pkg/..."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-full-test-builds.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/triage-guard.yml
+++ b/.github/workflows/triage-guard.yml
@@ -1,0 +1,44 @@
+# Triage separation of duties (SCR-005): issue creators get exactly one
+# label — `triage`. Priority labels come only from the triage identity.
+# Invariant: every open issue carries a P-label or `triage`, never neither,
+# never both.
+name: triage-guard
+on:
+  issues:
+    types: [opened, labeled]
+permissions:
+  issues: write
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          # Logins allowed to set P-labels. `macanderson` is the interim
+          # triage authority until the dedicated triage-agent identity
+          # stands up (SCR-005 §Exceptions) — remove it then.
+          TRIAGE_LOGINS: triage-bot macanderson
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const P = /^P[0-3]$/;
+            const allowed = process.env.TRIAGE_LOGINS.split(/\s+/);
+            const names = issue.labels.map(l => (typeof l === 'string' ? l : l.name));
+            if (context.payload.action === 'opened'
+                && !names.includes('triage')
+                && !names.some(n => P.test(n))) {
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: issue.number, labels: ['triage'] });
+            }
+            if (context.payload.action === 'labeled'
+                && P.test(context.payload.label.name)
+                && !allowed.includes(context.payload.sender.login)) {
+              await github.rest.issues.removeLabel({
+                ...context.repo, issue_number: issue.number,
+                name: context.payload.label.name });
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: issue.number, labels: ['triage'] });
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: 'Priority labels are assigned only by the triage agent (SCR-005). Re-queued as `triage`.' });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,12 @@ Thumbs.db
 !bench/readiness/synthetic-adapter-sentinel/environment/app/.stella/settings.json
 
 # Claude/Agents
-.claude/
+# Claude Code: project settings + hooks are checked in (SCR-001 L2 guard);
+# only per-user local overrides stay ignored.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
 .agents/
 .agents.d/
 # Singular ".agent" too — it held tracked agent reflections/lessons until #448.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1266,3 +1266,37 @@ something it is building. It is sales/marketing material.
   something else that happens to run without credentials.
 - Before recording anything intended for an audience (demo, docs, social),
   confirm what the video must *show*, not just what command to run.
+
+---
+
+## Standing decisions — apply without asking
+
+Each directive below is a Steering Context Record in [`docs/scr/`](docs/scr/);
+the SCR is canonical — it carries the rationale, exceptions, and enforcement
+status. This block is the compiled summary that every agent — Claude Code
+(via CLAUDE.md's `@AGENTS.md` import) and Stella (which reads AGENTS.md
+directly) — loads at session start. The corpus is identical across the
+macanderson org repos.
+
+- **[SCR-001](docs/scr/SCR-001-no-full-suite-builds.md) — Tests/builds
+  (inner loop):** Never compile or run the full test suite while developing.
+  Build and test only the crates/packages/modules touched by the change
+  (plus direct dependents on interface changes). The full suite is CI's job.
+  Here: `cargo test -p <crate> [filter]`, never bare `cargo test` / `cargo test --workspace`.
+- **[SCR-002](docs/scr/SCR-002-durability-first-architecture.md) —
+  Architecture decisions:** Do not ask. Choose the most durable option — the
+  one that can't be questioned in 10 years as the right move. Cheap-and-easy
+  only wins when it is also the excellent durable choice. Record every such
+  decision as an ADR in `docs/adr/`; the ADR replaces the question.
+- **[SCR-003](docs/scr/SCR-003-dod-verified-close.md) — Definition of
+  done:** An issue closes only when every DoD checklist item is satisfied
+  and verified. Reference-grade includes tests, code comments, docs, and
+  CI — not just the implementation.
+- **[SCR-004](docs/scr/SCR-004-residue-becomes-issues.md) — Residue:**
+  Before declaring any task complete, file a GitHub issue for every
+  follow-up, tech-debt item, or logical next step you noticed. Apply ONLY
+  the `triage` label.
+- **[SCR-005](docs/scr/SCR-005-triage-separation-of-duties.md) — Triage
+  separation of duties:** Never apply priority (`P0`–`P3`) or size labels —
+  a dedicated triage agent owns sizing and priority; a guard workflow
+  strips creator-applied priorities.

--- a/docs/adr/0015-adopt-standing-decisions-scr-corpus.md
+++ b/docs/adr/0015-adopt-standing-decisions-scr-corpus.md
@@ -1,0 +1,52 @@
+# ADR 0015: Adopt org standing decisions as a Steering Context Record corpus
+
+- Status: accepted
+- Date: 2026-08-26
+
+## Context
+
+The maintainer steers coding agents with a small set of directives that never
+vary — scoped test builds, durability-first architecture, DoD-verified
+closes, residue-to-issues, triage separation of duties. Re-typing them every
+session is waste, and knowledge that lives only in one person's habits does
+not survive that person's absence. The maintainer/agent collaboration
+process (see the process doc in the oxagen org) mandates promoting each
+repeated steer up an autonomy ladder: L1 written rule → L2 enforced →
+L3 delegated → L4 recorded.
+
+Two placement questions had to be settled for this repository:
+
+1. **Where does the steering context live so that both Claude Code and
+   Stella load it?** Options: (a) duplicate the block in CLAUDE.md and
+   AGENTS.md; (b) canonical block in AGENTS.md, imported by CLAUDE.md via
+   `@AGENTS.md`; (c) CLAUDE.md only.
+2. **Where does the SCR corpus live?** Options: (a) a dedicated shared
+   steering repo; (b) replicated `docs/scr/` in each org repo.
+
+## Decision
+
+- The standing-decisions block is canonical in `AGENTS.md`; `CLAUDE.md`
+  imports it with `@AGENTS.md` (option 1b). One source, two consumers, zero
+  drift between them — the pattern the stella repo already proved.
+- The five seed SCRs (SCR-001…SCR-005) are replicated identically in
+  `docs/scr/` across the five org repos: oxagen, context-graph-protocol,
+  cgp-website, arenabench, stella (option 2b). The rollout was scoped to
+  exactly these repositories — no new steering repo. Cross-repo drift is a
+  known cost, accepted and named in `docs/scr/README.md`; a periodic sync
+  check is filed as residue.
+- Enforcement shipped alongside the rules: a Claude Code `PreToolUse` hook
+  blocking full-suite test builds (SCR-001, L2), an issue template with a
+  mandatory DoD that applies only the `triage` label (SCR-003/005, L2), and
+  a `triage-guard` workflow stripping creator-applied priority labels
+  (SCR-005, L2). The maintainer is whitelisted in the guard as the interim
+  triage authority until a dedicated triage-agent identity exists.
+
+## Why durable
+
+Agent-context files come and go with agent products; a numbered, versioned
+corpus of plain-markdown records with explicit frontmatter (`status`,
+`autonomy`, `enforcement`) is boring technology that any future agent — or
+human — can read, diff, and supersede. SCRs are never deleted, only marked
+superseded, so the 10-year reader can trace why the process looks the way
+it does. Enforcement lives in the harness (hooks, templates, Actions), not
+in anyone's memory.

--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -1,0 +1,62 @@
+# Steering Context Records
+
+An SCR is to steering what an ADR is to architecture: a numbered, versioned
+record of a directive the maintainer would otherwise deliver by hand. The SCR
+corpus is the steering context loaded by every agent working in this
+repository — Claude Code loads it through the standing-decisions block in
+`AGENTS.md` (imported by `CLAUDE.md`), Stella loads `AGENTS.md` directly — and
+the ledger showing where each behavior sits on the autonomy ladder.
+
+The corpus is replicated identically across the macanderson org repos
+(oxagen, context-graph-protocol, cgp-website, arenabench, stella). Propose
+changes once and roll them out everywhere; drift between copies is a bug.
+
+## The autonomy ladder
+
+Each SCR carries an `autonomy` field naming its current rung:
+
+| Rung | Meaning | Failure mode it removes |
+|------|---------|-------------------------|
+| L0 | Manual prompt | — |
+| L1 | Written rule | Forgetting to say it |
+| L2 | Enforced (hook, template, CI guard) | Agents forgetting to follow it |
+| L3 | Delegated (an agent owns it) | The maintainer in the loop |
+| L4 | Recorded (SCR is the source of truth) | Knowledge living in one person's habits |
+
+**Promotion rules.** The second time the same steering prompt is typed, it
+becomes an SCR at L1 minimum — write it down. The third time, it must acquire
+an L2 or L3 mechanism. Typing it a fourth time is a process bug, not an
+agent bug.
+
+## Lifecycle
+
+1. **Capture** — second occurrence of a manual steer → draft an SCR. Any
+   agent may draft; status `active`, autonomy `L1`.
+2. **Promote** — attach an enforcement mechanism; update the `autonomy` and
+   `enforcement` fields. The SCR is the changelog of its own automation.
+3. **Load** — agents receive the SCR corpus as context at session start. A
+   steer that exists as an SCR should never need to be typed again.
+4. **Audit** — a periodic meta-review flags SCRs stuck at L1 whose directive
+   keeps appearing in transcripts; that is the promotion backlog.
+5. **Retire / supersede** — SCRs are never deleted; they are marked
+   `superseded-by:SCR-0NN` so the 10-year reader can trace why the process
+   looks the way it does. Durability-first applies to the process itself.
+
+## Template
+
+```markdown
+---
+id: SCR-0NN
+title: <directive as an imperative sentence>
+status: active            # active | superseded-by:SCR-0NN | retired
+origin: <how/why this became a standing steer>
+trigger: <the situation in which an agent must apply it>
+autonomy: L1              # current rung on the ladder
+enforcement: <mechanisms that deliver it without the maintainer>
+---
+
+## Directive
+## Rationale
+## How an agent complies
+## Exceptions
+```

--- a/docs/scr/SCR-001-no-full-suite-builds.md
+++ b/docs/scr/SCR-001-no-full-suite-builds.md
@@ -1,0 +1,41 @@
+---
+id: SCR-001
+title: Never compile the full test suite in the inner loop
+status: active
+origin: repeated manual prompt, ~daily, 2025–2026
+trigger: any build/test invocation during development
+autonomy: L2
+enforcement: AGENTS.md standing-decisions block (imported by CLAUDE.md); .claude/hooks/no-full-test-builds.sh PreToolUse guard for Claude Code
+---
+
+## Directive
+
+Compile and run only the tests relevant to the change — the touched
+crate/package/module, plus direct dependents when an interface changed. The
+full suite is CI's job.
+
+## Rationale
+
+Full-suite compiles dominate inner-loop latency and add no signal the scoped
+run doesn't provide; CI already runs everything on push. On this org's
+hardware, concurrent full-suite runs have saturated RAM and ballooned
+swap into the ~100 GB range.
+
+## How an agent complies
+
+Scope every test command to the touched unit, using the repo's stack:
+
+| Stack | Scoped (do this) | Full-suite (CI's job) |
+|-------|------------------|------------------------|
+| Rust workspace (stella, context-graph-protocol) | `cargo test -p <crate> [filter]` · `cargo nextest run -p <crate>` | bare `cargo test`, `--workspace`, `--all` |
+| pnpm/turbo monorepo (oxagen) | `pnpm --filter <package> test` · `turbo run test:unit --filter <package>` | bare `pnpm test`, `turbo run test:unit` |
+| Python / uv (arenabench) | `uv run pytest tests/test_x.py -q` | bare `pytest`, `make test` |
+| Next.js (cgp-website) | scope any future suite to the touched module | any bare full-suite `test` script |
+
+Reproduce full CI locally only when deliberately debugging a CI-only
+failure, and say so out loud in the session.
+
+## Exceptions
+
+Release verification; explicit maintainer request; deliberate, stated
+reproduction of a CI-only failure.

--- a/docs/scr/SCR-002-durability-first-architecture.md
+++ b/docs/scr/SCR-002-durability-first-architecture.md
@@ -1,0 +1,39 @@
+---
+id: SCR-002
+title: "Architecture: durability-first, decide-and-record, never ask"
+status: active
+origin: 100%-deterministic answer to every architecture question, 2025–2026
+trigger: any architectural or design decision arising mid-task
+autonomy: L1
+enforcement: AGENTS.md standing-decisions block (imported by CLAUDE.md); ADR trail in docs/adr/
+---
+
+## Directive
+
+Do not ask the maintainer. Choose the most durable option — the one that
+reads as obviously correct in 10 years. Cheap-and-easy wins only when it is
+*also* the excellent durable option. Record every such decision as a short
+ADR; the ADR replaces the question.
+
+## Rationale
+
+Every architecture question the maintainer has been asked has received the
+same answer. Because the answer never varies, the question itself is waste —
+it blocks the agent, interrupts the maintainer, and leaves no record. The
+ADR moves review to asynchronous time and leaves a trace the 2036 reader
+can follow.
+
+## How an agent complies
+
+- Apply the rule: fewest future regrets, standard over clever, boring
+  technology, explicit over implicit, designed for the reader in 2036.
+- Write an ADR in `docs/adr/` (context, options, choice, why-durable),
+  following the repo's existing numbering scheme.
+- Keep moving — review of the ADR happens asynchronously, never as a
+  blocking question.
+
+## Exceptions
+
+Decisions that change the product's externally observable contract or spend
+real money still go to the maintainer — those are scope changes, not
+architecture choices.

--- a/docs/scr/SCR-003-dod-verified-close.md
+++ b/docs/scr/SCR-003-dod-verified-close.md
@@ -1,0 +1,40 @@
+---
+id: SCR-003
+title: Close issues only against a verified definition of done
+status: active
+origin: delegation-to-DoD steering pattern, 2025–2026
+trigger: declaring any issue or task complete
+autonomy: L2
+enforcement: AGENTS.md standing-decisions block (imported by CLAUDE.md); .github/ISSUE_TEMPLATE/task.yml with mandatory DoD checklist
+---
+
+## Directive
+
+An issue closes only when every item in its definition of done is satisfied
+and **verified** — tests pass, docs updated, CI green, whatever the checklist
+says. Reference-grade covers the whole deliverable: implementation, tests,
+code comments, docs, CI config. None is optional polish.
+
+## Rationale
+
+The maintainer delegates to the DoD, not to progress reports or
+permission-seeking. A close that hasn't been verified line-by-line converts
+the backlog from a contract into a guess, and the gap surfaces later as a
+regression someone else pays for.
+
+## How an agent complies
+
+Before closing (or declaring done), run the end-of-task checklist:
+
+1. Re-read the issue's DoD; verify each item with evidence — test output, a
+   doc diff, a CI link. A sentence of assertion is not evidence.
+2. Sweep for residue; file each item as its own issue via the task template,
+   `triage` label only (SCR-004, SCR-005).
+3. Confirm every architectural choice made during the task has an ADR
+   (SCR-002).
+4. Report: what shipped, where it lives, which issues were filed.
+
+## Exceptions
+
+Issues closed as wont-fix / superseded — state the reason in a closing
+comment instead of verifying a DoD.

--- a/docs/scr/SCR-004-residue-becomes-issues.md
+++ b/docs/scr/SCR-004-residue-becomes-issues.md
@@ -1,0 +1,35 @@
+---
+id: SCR-004
+title: File all residue as issues before declaring done
+status: active
+origin: "north-star requirement: nothing evaporates in a chat transcript"
+trigger: the end of every completed task
+autonomy: L1
+enforcement: AGENTS.md standing-decisions block (imported by CLAUDE.md); end-of-task checklist in SCR-003; target L3 — a sweep agent auditing merged PRs for unfiled residue
+---
+
+## Directive
+
+Every completed task ends with a residue sweep: anything noticed but not
+done — follow-ups, tech debt, ideas, flaky behavior, doc gaps — is filed as
+a GitHub issue before the task is declared complete. A task that ends
+without its residue filed is not done, even if the code is merged.
+
+## Rationale
+
+The backlog stays alive only if observations survive the session that made
+them. Chat transcripts are write-only memory; issues are the durable store
+the triage agent (SCR-005) can order and the next session can pick up.
+
+## How an agent complies
+
+- At end of task, list everything noticed but not done, however small.
+- File each item as its own issue using the task template
+  (`.github/ISSUE_TEMPLATE/task.yml`), with context linking back to the
+  origin task and a concrete DoD.
+- Apply ONLY the `triage` label — never a priority or size (SCR-005).
+
+## Exceptions
+
+None. A task with zero residue states that explicitly ("no residue") in its
+final report, so silence is never ambiguous.

--- a/docs/scr/SCR-005-triage-separation-of-duties.md
+++ b/docs/scr/SCR-005-triage-separation-of-duties.md
@@ -1,0 +1,43 @@
+---
+id: SCR-005
+title: Creators label triage only; the triage agent owns priority
+status: active
+origin: separation-of-duties rule on the backlog, 2025–2026
+trigger: creating or labeling any GitHub issue
+autonomy: L2
+enforcement: task template applies only the triage label; .github/workflows/triage-guard.yml strips creator-applied P-labels; target L3 — a scheduled triage agent with its own whitelisted identity
+---
+
+## Directive
+
+Issue creators — human or agent — may apply exactly one label: `triage`.
+No priority, no size, nothing else. A dedicated triage agent, and only that
+agent, sizes the work, assigns exactly one priority label, optionally a
+size, removes `triage`, and comments a one-line rationale.
+
+Priority scheme: `P0` drop everything · `P1` this cycle · `P2` next cycle ·
+`P3` backlog. Invariant: every open issue carries either a priority label or
+`triage` — never neither, never both.
+
+## Rationale
+
+Whoever creates an issue is the worst-placed party to rank it — creators
+systematically over-weight their own findings. Separating creation from
+prioritization keeps the backlog ordering honest and gives the maintainer
+one place (the triage agent's rationale comments) to audit it.
+
+## How an agent complies
+
+- When filing any issue: use the task template; touch no labels beyond the
+  `triage` it applies automatically.
+- Never add, remove, or change `P0`–`P3` or `size/*` labels — the
+  triage-guard workflow strips such labels and re-queues the issue.
+- The triage agent (once stood up) never implements anything and never
+  closes issues — it only sizes and orders. Mixing roles collapses the
+  separation of duties.
+
+## Exceptions
+
+Until the dedicated triage-agent identity exists, the maintainer
+(macanderson) acts as the interim triage authority and is whitelisted in
+the guard workflow; remove that whitelist entry when the bot stands up.


### PR DESCRIPTION
Implements the maintainer/agent collaboration process rollout (§7 of the process doc): the standing decisions become written rules (L1) with enforcement machinery (L2), recorded as a Steering Context Record corpus that both Claude Code and Stella load.

## What's in this PR

- **`docs/scr/`** — the five seed SCRs (SCR-001…SCR-005) plus a README covering the autonomy ladder, promotion rules, and lifecycle. The corpus is identical across the five macanderson org repos (oxagen, context-graph-protocol, cgp-website, arenabench, stella); drift between copies is a bug.
- **`AGENTS.md`** — canonical "Standing decisions — apply without asking" block, linking each entry to its SCR. `CLAUDE.md` imports it via `@AGENTS.md`, so Claude Code and Stella read one source. (This placement decision is recorded in the ADR below.)
- **`.claude/hooks/no-full-test-builds.sh` + `settings.json` PreToolUse hook** — SCR-001 at L2 for Claude Code: blocks full-suite test builds (`cargo test --workspace`, bare `pnpm test`/`turbo run test*` without `--filter`, bare `pytest`, `make test`, `go test ./...`) and names the scoped alternative, citing the SCR.
- **`.github/ISSUE_TEMPLATE/task.yml`** — SCR-003/005 at L2: mandatory definition-of-done checklist; the template applies only the `triage` label.
- **`.github/workflows/triage-guard.yml`** — SCR-005 at L2: auto-labels new issues `triage`, strips priority labels applied by anyone outside the triage allowlist and re-queues with a comment. `macanderson` is whitelisted as the *interim* triage authority until the dedicated triage-agent identity stands up (tracked as residue).
- **ADR** — records the adoption, the AGENTS.md-canonical placement, and the per-repo replication choice.

## Verification

- Hook exercised against ten representative commands — all full-suite forms blocked with the SCR-001 message, all scoped forms allowed (`cargo test -p <crate>`, `pnpm --filter <pkg> test`, `uv run pytest tests/test_x.py`).
- `bash -n` clean on the hook; workflow + issue-template YAML parse; `.claude/settings.json` parses as JSON (oxagen: hook merged into existing settings, everything else preserved).

Part of the five-repo rollout; residue (triage-agent identity, Stella-native hook enforcement, corpus sync check, DoD merge check, residue sweep agent) is filed as issues per SCR-004.

## Summary by Sourcery

Establish the standing-decision process as a shared, documented, and partially enforced operating model for maintainers and coding agents.

New Features:
- Add a versioned Steering Context Record corpus defining five standing maintainer and agent collaboration decisions.
- Provide shared agent context through a canonical AGENTS.md standing-decisions block consumed by Claude Code and Stella.
- Add automated enforcement for scoped testing, issue completion criteria, and triage label separation of duties.

Enhancements:
- Document the autonomy ladder, SCR lifecycle, promotion rules, and cross-repository corpus replication policy.
- Record the standing-decisions adoption and context placement in an ADR.

CI:
- Add a GitHub Actions triage guard that assigns new issues to triage and removes unauthorized priority labels.

Documentation:
- Add SCR documentation for durability-first architecture, verified issue closure, residue tracking, triage ownership, and test-scope guidance.