### PR TITLE
docs(prose): cut three module headers under the density ceiling

### DIFF
--- a/crates/stella-cli/src/candidate_workspaces.rs
+++ b/crates/stella-cli/src/candidate_workspaces.rs
@@ -3,103 +3,47 @@
 
 //! The isolation substrate a `candidate_fanout` runs on: one git worktree per
 //! candidate, one writing worker turn inside each, and one all-or-nothing
-//! adoption that lands a winner on the real tree (#3892).
+//! adoption that lands a winner on the real tree — the [`CandidateWorkspaces`]
+//! port's implementation (#3892; the port and wire types are #3844's).
 //!
-//! #3844 landed the socket half of best-of-N — the wire types, the
-//! `[loop] max_fanout_width` ceiling, and
-//! [`CandidateFanouts`](stella_runtime::wrapper::CandidateFanouts) over a
-//! [`CandidateWorkspaces`] port — and **nothing implemented the port**, so
-//! every shipped host answered both capabilities
-//! [`Unavailable`](stella_plugin::HostCallRefusal::Unavailable) and
-//! `plugins/stella-candidates` (`doc:pipeline-as-plugins` §3/§7 item 4) still
-//! could not be written as best-of-N. This is that implementation.
-//!
-//! # What is reused, and the one thing that is not
-//!
-//! Almost everything here is somebody else's machinery held together:
-//!
-//! | Concern | Whose |
-//! |---|---|
-//! | `worktree add` / `remove --force`, the slug that survives `git check-ref-format` | [`WorktreeManager`] |
-//! | the child's provider, seat map, spend pool, ledger, orphan cascade, settle-on-the-thread | [`SessionSubAgents`] |
-//! | the write-directory grant | [`crate::write_dirs::registry_rooted_at`] |
-//! | the operator's tool switches and the authorization gate | [`crate::agent::tool_stack`] |
-//!
-//! The one genuinely new decision is **which registry a candidate's turn runs
-//! against**, and it is the reason this could not be a field on
-//! [`SubAgentSpec`]. A fan-out runs N candidates *concurrently* in N disjoint
-//! trees, and [`ToolRegistry`](stella_tools::ToolRegistry)'s `root` is what
-//! every path fence resolves against — so there is no single root a shared
-//! registry could hold that
-//! would be true for all of them. A registry **per candidate**, rooted once at
-//! construction and never moved, is the only shape that is. Everything else
-//! about the turn stays the session's, which is what keeps one pool and one
-//! ledger over one session's money
+//! Worktrees, the child turn's plumbing, the write grant and the tool gate are
+//! all reused ([`WorktreeManager`], [`SessionSubAgents`],
+//! [`crate::write_dirs::registry_rooted_at`], [`crate::agent::tool_stack`]).
+//! The one new decision is **a registry per candidate**: N candidates run
+//! concurrently in N disjoint trees, and a
+//! [`ToolRegistry`](stella_tools::ToolRegistry)'s `root` is what every path
+//! fence resolves against, so no single shared root could be true for all of
+//! them. Each is rooted once at construction and never moved; everything else
+//! about the turn stays the session's, one pool and one ledger
 //! ([`SessionSubAgents::dispatch_in_workspace`]).
 //!
 //! # Adoption applies a patch; it does not merge, commit, or rebase
 //!
-//! A candidate's output is **uncommitted working-tree bytes**, so adoption is
-//! `git diff` in the candidate and `git apply` on the real tree. Three
-//! properties follow, and each is the reason this shape was chosen over
-//! `cherry-pick`/`merge`:
+//! A candidate's output is uncommitted working-tree bytes, so adoption is
+//! `git diff` in the candidate and `git apply` on the real tree — atomic by
+//! construction (no `--reject`: a patch that does not fit changes nothing),
+//! indistinguishable from the worker having done it, applied at the
+//! repository's top level ([`Layout`] exists because `git apply` from a
+//! subdirectory silently filters paths and exits 0), and **refusing rather
+//! than resolving**: no `--3way`, no merge driver — a candidate that no
+//! longer applies is reported as an `err` with the losers still on disk
+//! ([`SessionCandidateWorkspaces::adopt`] names the refusals). Resolving a
+//! conflict is a judgement a host must not make silently.
 //!
-//! - **It is indistinguishable from the worker having done it.** The user's
-//!   own turn leaves working-tree changes; so does an adopted candidate. A
-//!   plugin cannot use best-of-N to put a commit in someone's history that
-//!   they did not write.
-//! - **It is all-or-nothing without needing to be made so.** `git apply` is
-//!   already atomic — it validates every hunk before writing any, and this
-//!   deliberately passes no `--reject`, so a patch that does not fit changes
-//!   nothing at all. The two refusals it produces are named on
-//!   [`SessionCandidateWorkspaces::adopt`].
-//! - **It applies at the repository's top level, never at the session's own
-//!   directory.** A patch's paths are top-relative, and `git apply` run from a
-//!   subdirectory filters them to what lies below the current directory —
-//!   finding nothing, applying nothing, and exiting **0**. See [`Layout`],
-//!   which exists for that one silent failure.
-//! - **It refuses rather than resolves.** There is no `--3way`, no merge
-//!   driver and no conflict-marker path: a candidate that no longer applies is
-//!   reported to the plugin as an `err`, and
-//!   [`CandidateFanouts::adopt`](stella_runtime::wrapper::CandidateFanouts)
-//!   guarantees the losing candidates are still on disk when it is. Resolving
-//!   a conflict is a judgement, and a host that made it silently would be
-//!   editing the user's tree on its own authority.
+//! # Boundaries a maintainer must keep
 //!
-//! # It needs a git repository, and says so rather than pretending
-//!
-//! A workspace that is not a repository, or one with no commit for `HEAD` to
-//! name, fails at `git worktree add` — which surfaces as
-//! [`CandidateFanoutError::NotCreated`], then as a `Failed` answer carrying
-//! git's own words. That is the honest outcome for *this* substrate: what it
-//! promotes is a patch, and a patch is a statement about a commit.
-//!
-//! Copying the tree instead is the other answer, and it is a second substrate
-//! rather than a fallback here ([`copy_tree`], #1383). It is not
-//! interchangeable: a copy carries no `.gitignore` semantics, so its adoption
-//! carries a candidate's `target/` too — right where the tree is a disposable
-//! container whose ignored state the task's own tests execute, wrong where
-//! the tree is
-//! somebody's working copy. Which one a workspace gets is
-//! [`CandidateIsolation`](crate::settings::CandidateIsolation), an operator's
-//! setting that defaults to this one and is never inferred.
-//!
-//! # What is left behind, and by what
-//!
-//! Every candidate this substrate mints is registered in the plane's live
-//! table, and a wrapped run sweeps that table when it ends
-//! (`crate::wrapper_plugin::run_wrapped`). That table is process memory, so a
-//! process **killed** mid-fan-out used to take the only name its checkouts had
-//! with it — `stella fleet gc` cannot reclaim them either, because this
-//! substrate moves out of the `.stella/worktrees/` + `fleet/` namespace on
-//! purpose ([`WorktreeManager::with_worktrees_root`]) rather than borrow a
-//! sweeper that would then also delete checkouts it did not create. Each
-//! candidate now writes a [`record`] beside its checkout, and a later run in
-//! the same workspace names what a dead owner left rather than deleting it
-//! (#2813).
+//! It needs a git repository: a workspace with no repo or no `HEAD` commit
+//! fails at `git worktree add` as [`CandidateFanoutError::NotCreated`],
+//! carrying git's own words — a patch is a statement about a commit. The
+//! copying substrate ([`copy_tree`], #1383) is a second substrate selected by
+//! [`CandidateIsolation`](crate::settings::CandidateIsolation), never a
+//! fallback, because a copy carries no `.gitignore` semantics. And each
+//! candidate writes a [`record`] beside its checkout so a killed process
+//! leaves a name rather than an orphan (#2813) — this substrate deliberately
+//! lives outside the `fleet/` namespace, so `stella fleet gc` must not be
+//! taught to sweep it.
 //!
 //! [`CandidateWorkspaces`]: stella_runtime::wrapper::CandidateWorkspaces
-//! [`SubAgentSpec`]: stella_core::subagent::SubAgentSpec
 //! [`SessionSubAgents`]: crate::subagent::SessionSubAgents
 //! [`SessionSubAgents::dispatch_in_workspace`]: crate::subagent::SessionSubAgents::dispatch_in_workspace
 

--- a/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
+++ b/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
@@ -49,70 +49,29 @@
 //! | `compacted_through_execution_id` | is it already settled and reclaimed? | durable, per sink | [`Store::compact_enterprise_export_ledger`](crate::Store::compact_enterprise_export_ledger), monotonically |
 //! | `after_execution_id` | where did this drain get to? | transient, per pass | the caller, between pages |
 //!
-//! ## 1. `enrolled_after_execution_id` — consent
+//! **Consent** is `MAX(executions.id)` at first enrollment, stamped once by
+//! `INSERT OR IGNORE` and never rewritten: re-stamp it with today's max and
+//! everything since the original enrollment is dropped with no counter;
+//! stamp it `0` on a workspace with history and the first drain back-exports
+//! what predates the opt-in. (No enrollment row at all exports *nothing* —
+//! the eligibility check joins against it.)
 //!
-//! `MAX(executions.id)` as it stood when the sink was first enrolled.
-//! Everything at or below it predates the operator's decision to export and
-//! must never leave the workspace. Stamped once by `INSERT OR IGNORE` and never
-//! rewritten.
+//! **Compacted-through** remembers ids whose settled ledger rows were
+//! reclaimed, written only by compaction as `MAX(existing, cutoff)`. Leave it
+//! behind the reclaim and the ids look un-exported, get re-admitted with
+//! *fresh* nonces (the row holding the original nonce is exactly what was
+//! deleted), and one execution double-counts downstream; advance it past an
+//! unfinished execution and that execution is refused forever, uncounted —
+//! so compact only when the backlog below the cutoff is settled. It gates
+//! re-admission only: pending rows are never deleted and paging does not
+//! consult it.
 //!
-//! Advance it **early** — a re-enrollment that re-stamped it with today's
-//! `MAX(id)` — and every execution recorded since the original enrollment is
-//! dropped without a trace: those rows never enter the ledger, so no skip
-//! counter records them and no backlog shows them missing. Stamp it **low** —
-//! `0` on a workspace that already has history — and the first drain
-//! back-exports everything recorded before the operator opted in. Both
-//! directions are unrecoverable: one loses data silently, the other discloses
-//! it. (Dropping the enrollment row entirely is a third thing again, and not a
-//! low watermark: the eligibility check joins against that row, so a sink with
-//! no enrollment exports *nothing* rather than everything.)
-//!
-//! ## 2. `compacted_through_execution_id` — memory of deleted rows
-//!
-//! Every id at or below it has already settled *and* had its ledger row
-//! reclaimed. It exists because the row that would otherwise prove "this was
-//! exported" is gone, so the scalar has to remember in its place. Compaction is
-//! its only writer, and writes it as `MAX(existing, cutoff)` so it can only
-//! rise.
-//!
-//! Leave it **late** — reclaim rows without raising it — and the reclaimed ids
-//! look un-exported to
-//! [`Store::mark_enterprise_export_pending`](crate::Store::mark_enterprise_export_pending),
-//! which re-admits them and mints *fresh* nonces. Nonce idempotence cannot save
-//! this: the row that stored the original nonce is exactly what was deleted, so
-//! one execution becomes two distinct event ids and is double-counted
-//! downstream. Advance it **early** — past an execution that had not finished
-//! when the cutoff was chosen — and that execution is refused forever when it
-//! does finish, again with no counter. So compaction carries a precondition:
-//! run it only when the backlog below the cutoff is settled. The cutoff is
-//! drawn from settled rows alone, which makes an early advance narrow but not
-//! impossible — an execution can finish after ids above it already have.
-//!
-//! Note what this watermark does *not* gate: pending rows are never deleted by
-//! compaction, and
-//! [`Store::pending_enterprise_export_page`](crate::Store::pending_enterprise_export_page)
-//! does not consult it. An execution already admitted still drains normally.
-//! The floor governs re-admission only.
-//!
-//! ## 3. `after_execution_id` — a position, not a promise
-//!
-//! The keyset cursor within one drain pass, supplied by the caller and stored
-//! nowhere. A pass that ends mid-backlog simply starts again from the beginning
-//! next time.
-//!
-//! Advance it **early**, skipping rows, and nothing is lost — the skipped rows
-//! are still `pending`, and the next pass lists them again. Leave it **late**,
-//! or reset it to `0`, and the same rows are re-listed and re-spooled — also
-//! harmless, because their nonces are stable, so the event ids are byte-for-byte
-//! the ones already enqueued and the spool dedups them. Both directions are
-//! absorbed.
-//!
-//! That is precisely why it must stay transient. Persisting it would buy
-//! nothing (a re-read is already free) and would convert its harmless failure
-//! into watermark 2's: a durable cursor that advanced past undrained rows would
-//! hide them permanently, with no counter to show for it. The two floors are
-//! durable because their failures are permanent and silent; the cursor is not,
-//! because its safety comes from being re-derivable.
+//! **The drain cursor** is the caller's keyset position within one pass,
+//! stored nowhere. Skipping or repeating rows is absorbed (pending rows
+//! re-list; stable nonces make re-spooled event ids byte-identical, and the
+//! spool dedups). It must stay transient: persisted, its harmless failure
+//! becomes the compacted-through one — undrained rows hidden permanently
+//! with no counter.
 
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 

--- a/crates/stella-tools/tests/relevance_calibration.rs
+++ b/crates/stella-tools/tests/relevance_calibration.rs
@@ -29,24 +29,17 @@
 //! per-`HttpEmbedder` field, so `voyage-code-3` and a local model may
 //! legitimately differ.
 //!
-//! ## `STELLA_CALIBRATION_INDEX` — what made this affordable to run
+//! ## `STELLA_CALIBRATION_INDEX` — rank an existing index
 //!
-//! Without it the harness builds an index into a temporary directory and
-//! embeds this whole repository first, which is the ~11M paid tokens the
-//! session that wrote this file declined to spend. With it, the harness ranks
-//! against an index that is **already filled under the same fingerprint** —
-//! the one a working checkout's `search::backfill` pass has been filling all
-//! along — and the run's entire cost is one query embedding per labelled
-//! query. Four, at the time of writing.
-//!
-//! It changes nothing about what is measured. The distribution is a property
-//! of the embedder and the corpus, and the corpus is the same rows either way;
-//! what the flag removes is the re-embedding of rows that already exist. The
-//! harness prints the chunk count it ranked over, so a thin index cannot be
-//! mistaken for a full one, and it still refuses to report a distribution over
-//! zero rows. Point it at a **copy** of a live session's database rather than
-//! the live file: it opens the graph for writing (`CodeGraph::open`), and a
-//! session's own indexer is already writing to that one.
+//! Without it the harness embeds this whole repository into a temporary
+//! index first (~11M paid tokens); with it, it ranks against an index
+//! already filled under the same fingerprint and the run costs one query
+//! embedding per labelled query. What is measured is unchanged — the flag
+//! only removes re-embedding — and the harness prints the chunk count it
+//! ranked over, refusing a distribution over zero rows. Point it at a
+//! **copy** of a live session's database, never the live file: it opens the
+//! graph for writing (`CodeGraph::open`), and the session's own indexer is
+//! already writing there.
 //!
 //! # What it prints, and what to do with it
 //!


### PR DESCRIPTION
Repairs red `main` (#5124). The header-density ratchet (#5096) went red on the merged tree: several Rust-only PRs added `//!` lines, and the prose gate is path-filtered off exactly those diffs, so the canary was first to see the composition.

The remedy the check itself names — cut headers, never raise the baseline:

- `crates/stella-cli/src/candidate_workspaces.rs`: the #3844 history paragraph and the adoption bullets' narrative compress; the reuse table becomes a sentence; every contract (patch-not-merge, refuse-not-resolve, the `Layout` silent-failure, the fleet-gc boundary) survives.
- `crates/stella-store/src/enterprise_telemetry/export_ledger.rs`: the three watermark subsections compress to one paragraph each; every failure direction and precondition is still stated.
- `crates/stella-tools/tests/relevance_calibration.rs`: the `STELLA_CALIBRATION_INDEX` section loses its cost anecdote, keeps the copy-not-live-file warning.

Comment-only diff. Verified: `make prose` green (`25 unit(s) within their header-length ceiling`), `cargo doc -D warnings --document-private-items` green on all three crates. Prose-only per AGENTS.md: no witness test.

Closes #5124

## Summary by Sourcery

Trim oversized Rust module headers to restore the prose density check without changing code behavior.

Enhancements:
- Reduce Rust module documentation while preserving the behavioral contracts and operational guidance for candidate workspace adoption, enterprise telemetry watermarks, and relevance calibration.

Documentation:
- Compress module headers in candidate workspace isolation, enterprise telemetry export ledger, and relevance calibration documentation to meet the prose header-density ceiling.