### PR TITLE
docs: cut history out of eight module headers to clear the density ratchet

### DIFF
--- a/crates/stella-cli/src/daemon.rs
+++ b/crates/stella-cli/src/daemon.rs
@@ -17,15 +17,12 @@
 //! the terminal. Close the terminal and the parent dies; the child does not
 //! notice, because it left that session before it began.
 //!
-//! Process-level supervision is the weaker of the two properties #1552 named,
-//! and the engine-level one now stands behind it (#1586): every turn already
-//! checkpoints into the workspace's work journal at each committed step
-//! boundary, so a supervised run whose *process* is killed — OOM, `kill -9`,
-//! power loss — leaves a resume point where a mere closed terminal never
-//! needed one. [`resume_supervised`] is the verb that picks it up: it
-//! relaunches the same session under a fresh supervised child, which
-//! continues the interrupted turn from that boundary instead of restarting
-//! it (`crate::agent::resume`).
+//! Engine-level durability stands behind it: every turn checkpoints into the
+//! work journal at each committed step boundary, so a supervised run whose
+//! *process* is killed — OOM, `kill -9`, power loss — leaves a resume point.
+//! [`resume_supervised`] relaunches that session under a fresh supervised
+//! child, continuing the interrupted turn from that boundary rather than
+//! restarting it (`crate::agent::resume`).
 //!
 //! # Why supervision keys on a controlling terminal
 //!

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -5,12 +5,6 @@
 //! through an installed wrapper plugin, bound once per attempt (#3695, fleet
 //! half).
 //!
-//! A submodule of [`crate::fleet_cmd`] rather than a `mod` block inside
-//! `fleet_cmd.rs`, for the reason AGENTS.md § "God files" gives for
-//! [`crate::wrapper_plugin`] living beside `agent.rs`: this is new logic, and
-//! the parent already carries the fan-out, the dashboard tee, the claim tap
-//! and the report.
-//!
 //! # Bound per attempt, resolved from the invocation's workspace
 //!
 //! A fleet worker runs in the task's own tree — the shared work tree for a

--- a/crates/stella-cli/src/plugin_authz.rs
+++ b/crates/stella-cli/src/plugin_authz.rs
@@ -4,16 +4,11 @@
 //! Turning an accepted `[[capabilities]]` list into a gate that refuses
 //! everything else (#3482, `doc:pipeline-as-plugins` §A4).
 //!
-//! # The defect this closes
-//!
 //! `Capability` carries `tool`, `risk`, `purpose` and `scope`, and
 //! `stella_plugin::consent_text` renders all four to a human before install.
-//! **Nothing turned an accepted consent into an authorization rule.** The
-//! consent text was honest about the half a user could otherwise be misled by
-//! — it labels `scope` as the plugin's own claim — but "the gate enforces the
-//! tool and the grade" was true only in the sense that
-//! `agent::tool_stack::session_gate` returned `NoAuthz` and no plugin could be
-//! refused anything.
+//! This module is what turns that accepted consent into an authorization
+//! rule. Note `scope` is the plugin's own claim, which the consent text says;
+//! the tool and the grade are what this gate enforces.
 //!
 //! `doc:pipeline-as-plugins` §A1 states the stake without hedging: *"a
 //! marketplace shipped on top of a system that cannot distinguish an installed

--- a/crates/stella-cli/src/plugin_cmd/package.rs
+++ b/crates/stella-cli/src/plugin_cmd/package.rs
@@ -4,15 +4,13 @@
 //! What a plugin *ships*, as opposed to what it *does* in the turn loop
 //! (#3380).
 //!
-//! A plugin's manifest declares a say in the turn: hook points, wrapper
-//! points, an oracle, a process. That is the whole of `plugin.toml` and it
-//! was never the whole of a package. The three surfaces a workspace already
-//! steers itself with — script tools, skills, context records, and MCP
-//! servers — had no way to arrive with a plugin, so "install the review
-//! plugin" could deliver an arbiter that holds a turn open but not the
-//! `lint_fix` tool it wants to call, the skill that explains the house style,
-//! the record that steers toward it, or the vendor server its whole
-//! integration is. This module makes a package able to carry all four.
+//! `plugin.toml` declares a say in the turn — hook points, wrapper points, an
+//! oracle, a process — and that is not the whole of a package. A package also
+//! carries the four surfaces a workspace steers itself with: script tools,
+//! skills, context records, and MCP servers. So "install the review plugin"
+//! delivers the arbiter *and* the `lint_fix` tool it calls, the skill that
+//! explains the house style, the record that steers toward it, and the vendor
+//! server it integrates.
 //!
 //! # A package is `.stella`-shaped, and that is the whole format
 //!

--- a/crates/stella-cli/src/wrapper_candidate.rs
+++ b/crates/stella-cli/src/wrapper_candidate.rs
@@ -4,28 +4,17 @@
 //! The candidate grant and the tamper snapshot the CLI's wrapper driver owes a
 //! plugin (#3553).
 //!
-//! # What was broken
-//!
-//! `crate::wrapper_plugin` sent `RoundInput { candidate: None, .. }` and
-//! reported [`TamperFinding::NotChecked`], and both were honest — the host had
-//! neither. The consequence was not honest at all: `judge` reads the flip first
-//! and `FlipObservation::Unobservable` under `flip = "required"` is
-//! `UndecidedReason::FlipUnobservable`, so **every witness-flavoured wrapper
-//! reported `Undecided` on every run, forever**. Only a measurement oracle
-//! (`flip = "not-applicable"`) worked. A plugin with no root to read and no
-//! test to run cannot observe a flip, and a flip nobody vouched for cannot be
-//! credited.
+//! Both are required, not decorative: a plugin with no root to read and no
+//! test to run cannot observe a flip, and `judge` turns an unobservable flip
+//! under `flip = "required"` into `Undecided`. Withhold either and every
+//! witness-flavoured wrapper is undecided on every run.
 //!
 //! # The grant names the tree the turn actually ran in
 //!
 //! `stella run --pipeline <variant>` drives the raw step loop **in the shared
 //! work tree** (#3494). So the grant this module mints is over that tree, via
-//! [`stella_plugin::host_tree_grant`] — the minting logic moved here (rather
-//! than staying duplicated) before the staged pipeline's own
-//! `CandidateHandles::grant` (formerly `stella-pipeline`'s `ports/handle.rs`)
-//! was deleted along with that crate (#3865), so there was one fence, not
-//! two, for as long as both callers coexisted, and this module is now the
-//! only one.
+//! [`stella_plugin::host_tree_grant`]. This module is the only place that
+//! mints it.
 //!
 //! Minting a *worktree* instead would be worse than the gap it closes: the turn
 //! would still run in the shared tree, the plugin would read and test an

--- a/crates/stella-store/src/telemetry/delivery.rs
+++ b/crates/stella-store/src/telemetry/delivery.rs
@@ -1,44 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! Whether a run shipped anything — recorded apart from how it ended (#2808).
+//! Whether a run shipped anything, apart from how it ended (#2808).
 //!
-//! `executions.outcome` is one final label carrying two independent facts.
-//! *How a run ended* (completed / aborted / cancelled / failed / error) says
-//! nothing about *whether it delivered*, and the two really do come apart in
-//! both directions: a completed run can deliver nothing, and a cancelled run
-//! can have pushed and merged a pull request before the cancel landed. Every
-//! analysis that filters on `outcome = 'completed'` scores the second case as
-//! zero — `Store::usage_stats`' `resolved` count, the scoreboard, and every
-//! cost-per-resolved-task receipt derived from them.
+//! `executions.outcome` says how a run ended and nothing about whether it
+//! delivered. The two come apart in both directions: a completed run can ship
+//! nothing, and a cancelled one can have merged a pull request before the
+//! cancel landed.
 //!
-//! # Three answers, not two
+//! **The column reads three ways, and the absent one is an answer.** `None` is
+//! "nothing observed this run's delivery"; [`Delivery::Nothing`] is "something
+//! looked, and it shipped nothing". Do not collapse them — reading an absence
+//! of evidence as a record of failure is the defect this column exists to fix.
+//! Most rows are `None`, because only a door that can see its own commits
+//! writes here.
 //!
-//! The column is nullable, and the absent state is one of the three answers:
-//!
-//! | Reading | Means |
-//! |---|---|
-//! | `None` | Nothing observed this run's delivery. |
-//! | `Some(Delivery::Nothing)` | Something looked, and the run shipped nothing. |
-//! | `Some(Delivery::Commits)` | The run landed at least one commit. |
-//!
-//! Collapsing `None` into `Nothing` would rebuild the defect this column
-//! exists to fix: an absence of evidence read as a record of failure. Most
-//! rows are `None` and will stay that way, because only a door that can see an
-//! attempt's own commits writes here — today the fleet attempt, whose
-//! execution row and commit set are the same attempt's and need no attribution
-//! guess.
-//!
-//! # Why the token set is this short
-//!
-//! A token is declared when a door writes it, not when one can be imagined.
-//! `Nothing` and `Commits` are both written by the fleet attempt close; a PR
-//! or merge token waits for a door that can join a pull request to the
-//! execution that opened it, which `pull_requests` cannot do today (it is keyed
-//! by URL and linked to a session).
-//!
-//! Not to be confused with `execution_reflection.delivered`, which is the
-//! model's own self-report about its turn. This is an observation.
+//! Not `execution_reflection.delivered`, which is the model's self-report
+//! about its turn. This is an observation.
 
 use rusqlite::OptionalExtension as _;
 use rusqlite::params;
@@ -49,6 +27,12 @@ use crate::{Result, Store};
 ///
 /// The *absence* of a value is a third answer and is spelled `Option::None` by
 /// every reader — see the module doc.
+///
+/// A token is declared when a door writes it, not when one can be imagined.
+/// Both of these are written by the fleet attempt close; a pull-request or
+/// merge token waits for a door that can join a pull request to the execution
+/// that opened it, which `pull_requests` cannot do today — it is keyed by URL
+/// and linked to a session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Delivery {
     /// The run's delivery was observed and it shipped nothing.


### PR DESCRIPTION
Repairs red `main`. Claimed via `./scripts/main-red-claim.sh claim` before starting.

## What was red

`prose`, on the density ratchet — three crates over their mean module-header ceiling:

```
crates/stella-cli:   23.67 allowed, 23.74 mean header lines
crates/stella-store: 25.86 allowed, 26.02 mean header lines
crates/stella-tools: 35.69 allowed, 35.77 mean header lines
```

**Nobody's PR was wrong.** `scripts/prose-density-baseline.txt` holds a per-crate *mean*, which makes it a shared cell in exactly the sense AGENTS.md describes for `Cargo.lock` and the file-size baseline: several branches each adding a header above their crate's mean are each individually fine and compose into a break. No pre-merge run has both halves in front of it. That is why the canary exists (#3332).

## What I cut, and why those lines

Cut, never raised — the baseline file is untouched, which you can see in the diff stat. The guard states its own bar: *a header is what this file does and what a reader must not do to it; history belongs in the pull request, a design document, or the tracker.* So history is what went:

| File | What went |
|---|---|
| `stella-store/src/telemetry/delivery.rs` | 38 → 16. Motivation paragraph; token-set rationale moved onto the `Delivery` type |
| `stella-tools/tests/relevance_calibration.rs` | How many paid tokens a previous session declined to spend (twice — the second was a duplicate) |
| `stella-cli/src/candidate_workspaces.rs` | What #3844 landed and what did not exist yet before it |
| `stella-cli/src/wrapper_candidate.rs` | What `RoundInput` used to send; a one-fence-not-two arrangement whose other half was deleted with `stella-pipeline` (#3865) |
| `stella-cli/src/fleet_cmd/wrapped.rs` | A paragraph explaining why the file is a submodule rather than a `mod` block |
| `stella-cli/src/plugin_cmd/package.rs` | "was never the whole of a package" framing |
| `stella-cli/src/daemon.rs` | Which of #1552's two properties was the weaker one |
| `stella-cli/src/plugin_authz.rs` | "The defect this closes" section |

**Every invariant those headers carried is still there, in fewer words** — `git apply`'s atomicity and the no-`--reject` rule, `scope` being the plugin's own claim, point-it-at-a-copy-not-the-live-database, the per-task oracle, and that an absent `delivery` reading is not the same answer as `'none'`. The cuts are 113 lines removed against 58 added; nothing that told a reader what they must not do to a file was among them.

## My share of it

`stella-store` is mine. #5093 added `telemetry/delivery.rs` with a 38-line header against a crate mean of 26.02, and `migrations/delivered_runs.rs` at 27. Trimming the first to 16 clears that crate on its own, so I did that before touching anyone else's prose.

## Two fixes taken while in the text

- `plugin_cmd/package.rs` said "The three surfaces" and then listed four (script tools, skills, context records, MCP servers).
- `wrapper_candidate.rs` explained an arrangement that kept "one fence, not two" between this module and `stella-pipeline`'s `CandidateHandles::grant` — a crate deleted in #3865, so the other fence has not existed for some time.

## Verification

```
make prose
check-prose: OK -- 4176 grandfathered construction(s) in 1174 file(s), none added;
             25 unit(s) within their header-length ceiling.

make guards-fast                                        exit 0
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-store -p stella-cli -p stella-tools --no-deps
                                                        exit 0
cargo test -p stella-store delivery                     4 passed; 0 failed
```

The rustdoc run matters here beyond habit: several of these headers carry intra-doc links, and the edits moved and reworded them. It is also the check I got wrong earlier today by omitting `-D warnings` — the corrected command is on #5101.

Comments only; no behaviour change, so no witness is owed.

Closes #5124

## Summary by Sourcery

Trim historical context from eight module headers to bring crate documentation density below its enforced ceilings without changing behavior.

Enhancements:
- Condense eight Rust module headers by removing historical and obsolete context while preserving the operational guidance and invariants readers need.
- Clarify delivery-state semantics and package surface descriptions in the retained documentation.

Documentation:
- Reduce module-header density across the CLI, store, and tools crates without changing runtime behavior.

Chores:
- Correct stale documentation, including the package surface count and references to deleted pipeline components.