### PR TITLE
Cut the headers that pushed three crates over their density ceiling

### DIFF
--- a/crates/stella-cli/src/candidate_workspaces.rs
+++ b/crates/stella-cli/src/candidate_workspaces.rs
@@ -5,18 +5,11 @@
 //! candidate, one writing worker turn inside each, and one all-or-nothing
 //! adoption that lands a winner on the real tree (#3892).
 //!
-//! #3844 landed the socket half of best-of-N — the wire types, the
-//! `[loop] max_fanout_width` ceiling, and
-//! [`CandidateFanouts`](stella_runtime::wrapper::CandidateFanouts) over a
-//! [`CandidateWorkspaces`] port — and **nothing implemented the port**, so
-//! every shipped host answered both capabilities
-//! [`Unavailable`](stella_plugin::HostCallRefusal::Unavailable) and
-//! `plugins/stella-candidates` (`doc:pipeline-as-plugins` §3/§7 item 4) still
-//! could not be written as best-of-N. This is that implementation.
+//! This implements the [`CandidateWorkspaces`] port #3844's socket half left
+//! unimplemented, which had every shipped host answering both capabilities
+//! [`Unavailable`](stella_plugin::HostCallRefusal::Unavailable).
 //!
 //! # What is reused, and the one thing that is not
-//!
-//! Almost everything here is somebody else's machinery held together:
 //!
 //! | Concern | Whose |
 //! |---|---|
@@ -26,23 +19,19 @@
 //! | the operator's tool switches and the authorization gate | [`crate::agent::tool_stack`] |
 //!
 //! The one genuinely new decision is **which registry a candidate's turn runs
-//! against**, and it is the reason this could not be a field on
-//! [`SubAgentSpec`]. A fan-out runs N candidates *concurrently* in N disjoint
-//! trees, and [`ToolRegistry`](stella_tools::ToolRegistry)'s `root` is what
-//! every path fence resolves against — so there is no single root a shared
-//! registry could hold that
-//! would be true for all of them. A registry **per candidate**, rooted once at
-//! construction and never moved, is the only shape that is. Everything else
-//! about the turn stays the session's, which is what keeps one pool and one
-//! ledger over one session's money
-//! ([`SessionSubAgents::dispatch_in_workspace`]).
+//! against**, which is why it could not be a field on [`SubAgentSpec`]: N
+//! candidates run concurrently in N disjoint trees, and
+//! [`ToolRegistry`](stella_tools::ToolRegistry)'s `root` is what every path
+//! fence resolves against, so no single shared root is true for all of them. A
+//! registry **per candidate**, rooted once and never moved, is the only shape
+//! that is. Everything else stays the session's, keeping one pool and one
+//! ledger over one session's money ([`SessionSubAgents::dispatch_in_workspace`]).
 //!
 //! # Adoption applies a patch; it does not merge, commit, or rebase
 //!
 //! A candidate's output is **uncommitted working-tree bytes**, so adoption is
-//! `git diff` in the candidate and `git apply` on the real tree. Three
-//! properties follow, and each is the reason this shape was chosen over
-//! `cherry-pick`/`merge`:
+//! `git diff` in the candidate and `git apply` on the real tree — chosen over
+//! `cherry-pick`/`merge` for the properties below:
 //!
 //! - **It is indistinguishable from the worker having done it.** The user's
 //!   own turn leaves working-tree changes; so does an adopted candidate. A
@@ -54,10 +43,8 @@
 //!   nothing at all. The two refusals it produces are named on
 //!   [`SessionCandidateWorkspaces::adopt`].
 //! - **It applies at the repository's top level, never at the session's own
-//!   directory.** A patch's paths are top-relative, and `git apply` run from a
-//!   subdirectory filters them to what lies below the current directory —
-//!   finding nothing, applying nothing, and exiting **0**. See [`Layout`],
-//!   which exists for that one silent failure.
+//!   directory.** `git apply` from a subdirectory filters top-relative paths to
+//!   what lies below it, applying nothing and exiting **0**. See [`Layout`].
 //! - **It refuses rather than resolves.** There is no `--3way`, no merge
 //!   driver and no conflict-marker path: a candidate that no longer applies is
 //!   reported to the plugin as an `err`, and

--- a/crates/stella-cli/src/wrapper_candidate.rs
+++ b/crates/stella-cli/src/wrapper_candidate.rs
@@ -36,53 +36,37 @@
 //! handle is unknown, which is true.
 //!
 //! Running the raw turn *inside* an isolated candidate, with adoption behind
-//! the wrapper's verdict, is a different feature with its own blast radius (a
-//! failed adoption is the user's work stranded in a shadow worktree) and is not
-//! this slice.
+//! the wrapper's verdict, is a different feature with its own blast radius and
+//! is not this slice.
 //!
 //! # The tamper watch, and exactly what it covers
 //!
 //! `TamperPolicy::ArtifactIdentity` asks the **host** to snapshot artifact
-//! identity before the work and compare after, so that a worker which rewrote
-//! the witness does not win the flip. The host has to know which artifacts
-//! those are, and on this path it knows exactly one thing about the witness:
-//! the test invocation the user gave it. So the watch covers **the files that
-//! invocation names** — `sh tests/witness_flip.sh`, `pytest
-//! tests/test_regression.py` — snapshotted before the turn with the same
-//! no-follow identity (`crate::agent::tools::fs_artifact_identity`) and
-//! compared with the same comparator (`stella_plugin::witness_identity_matches`)
-//! the staged pipeline itself used.
+//! identity before the work and compare after, so a worker that rewrote the
+//! witness does not win the flip. On this path the host knows one thing about
+//! the witness — the test invocation the user gave it — so the watch covers
+//! **the files that invocation names** (`sh tests/witness_flip.sh`, `pytest
+//! tests/test_regression.py`), snapshotted with
+//! `crate::agent::tools::fs_artifact_identity` and compared with
+//! `stella_plugin::witness_identity_matches`.
 //!
-//! # The watch holds the tree open, and why that is the security half (#3483)
+//! # The watch holds the tree open (#3483)
 //!
 //! [`TamperWatch`] keeps a **directory descriptor** for the granted root, not
-//! its path, for the length of the turn. Everything a comparison needs — the
-//! walk to the artifact, the open, the re-check that the name still means the
-//! same file — happens off that descriptor.
+//! its path, for the length of the turn, and every comparison happens off that
+//! descriptor. A path is re-resolved on every observation, and the party the
+//! watch exists to catch has a shell inside that tree: it can rename the root
+//! aside, stand a pristine copy in its place, and the after-turn observation
+//! reads the copy and reports `Clean`. A descriptor cannot be re-pointed by
+//! renaming anything.
 //!
-//! Holding a path instead is not a smaller version of the same thing, it is a
-//! different claim. A path is re-resolved on every observation, and the party
-//! the watch exists to catch is running inside that tree with a shell. It can
-//! rename the root aside and stand a pristine copy in its place, and the
-//! after-turn observation then reads the copy, matches the pin, and reports
-//! `Clean` — the watch vouching for a witness in a directory the turn never
-//! touched. A descriptor cannot be re-pointed by renaming anything, so the
-//! comparison is about the tree that actually ran.
-//!
-//! Below the root the same discipline continues:
-//! `stella_tools::rootfd::RootHandle::open_entry` walks component by component
-//! with `O_NOFOLLOW`, so an interior directory swapped for a symlink is refused
-//! by the kernel rather than followed, and it hands back the descriptor
-//! together with the location the walk reached — one resolution, used, instead
-//! of a checked path somebody re-opens. A path the walk refuses is left out of
-//! the watch entirely.
-//!
-//! What still crosses first is the pure layer, [`stella_plugin::fence_lexical`]:
-//! text that is absolute, traverses, or carries a NUL or a backslash could
-//! never name an inside path and is refused without a syscall. `RootHandle`
-//! would *rebase* an absolute path that happens to lie under the root (#2058,
-//! right for a model naming its own workspace file), and a plugin-declared
-//! artifact is not owed that latitude.
+//! Below the root, `stella_tools::rootfd::RootHandle::open_entry` walks
+//! component by component with `O_NOFOLLOW` and returns the descriptor with
+//! the location it reached, so an interior symlink is refused by the kernel
+//! and nothing re-opens a checked path. [`stella_plugin::fence_lexical`] still
+//! crosses first: absolute, traversing or NUL-bearing text is refused without a
+//! syscall, because `RootHandle` would *rebase* an absolute path under the root
+//! (#2058) and a plugin-declared artifact is not owed that latitude.
 //!
 //! What the invocation cannot say, the plugin can. An invocation that names no
 //! path — `cargo test --test flip`, whose artifact is `tests/flip.rs` by

--- a/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
+++ b/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
@@ -56,16 +56,12 @@
 //! must never leave the workspace. Stamped once by `INSERT OR IGNORE` and never
 //! rewritten.
 //!
-//! Advance it **early** — a re-enrollment that re-stamped it with today's
-//! `MAX(id)` — and every execution recorded since the original enrollment is
-//! dropped without a trace: those rows never enter the ledger, so no skip
-//! counter records them and no backlog shows them missing. Stamp it **low** —
-//! `0` on a workspace that already has history — and the first drain
-//! back-exports everything recorded before the operator opted in. Both
-//! directions are unrecoverable: one loses data silently, the other discloses
-//! it. (Dropping the enrollment row entirely is a third thing again, and not a
-//! low watermark: the eligibility check joins against that row, so a sink with
-//! no enrollment exports *nothing* rather than everything.)
+//! Advance it **early** and every execution since the original enrollment is
+//! dropped with no counter and no backlog to show it; stamp it **low** and the
+//! first drain back-exports everything recorded before the operator opted in.
+//! Both directions are unrecoverable — one loses data silently, the other
+//! discloses it. Dropping the enrollment row is a third thing: the eligibility
+//! check joins against it, so a sink with no enrollment exports *nothing*.
 //!
 //! ## 2. `compacted_through_execution_id` — memory of deleted rows
 //!
@@ -75,24 +71,16 @@
 //! its only writer, and writes it as `MAX(existing, cutoff)` so it can only
 //! rise.
 //!
-//! Leave it **late** — reclaim rows without raising it — and the reclaimed ids
-//! look un-exported to
+//! Leave it **late** and reclaimed ids look un-exported to
 //! [`Store::mark_enterprise_export_pending`](crate::Store::mark_enterprise_export_pending),
-//! which re-admits them and mints *fresh* nonces. Nonce idempotence cannot save
-//! this: the row that stored the original nonce is exactly what was deleted, so
-//! one execution becomes two distinct event ids and is double-counted
-//! downstream. Advance it **early** — past an execution that had not finished
-//! when the cutoff was chosen — and that execution is refused forever when it
-//! does finish, again with no counter. So compaction carries a precondition:
-//! run it only when the backlog below the cutoff is settled. The cutoff is
-//! drawn from settled rows alone, which makes an early advance narrow but not
-//! impossible — an execution can finish after ids above it already have.
-//!
-//! Note what this watermark does *not* gate: pending rows are never deleted by
-//! compaction, and
+//! which re-admits them and mints *fresh* nonces — idempotence cannot save
+//! this, because the row holding the original nonce is what was deleted, so one
+//! execution becomes two event ids. Advance it **early**, past an execution
+//! that had not finished, and that execution is refused forever with no
+//! counter. So compaction runs only when the backlog below the cutoff is
+//! settled. It gates re-admission only: pending rows are never deleted, and
 //! [`Store::pending_enterprise_export_page`](crate::Store::pending_enterprise_export_page)
-//! does not consult it. An execution already admitted still drains normally.
-//! The floor governs re-admission only.
+//! does not consult it.
 //!
 //! ## 3. `after_execution_id` — a position, not a promise
 //!
@@ -100,19 +88,13 @@
 //! nowhere. A pass that ends mid-backlog simply starts again from the beginning
 //! next time.
 //!
-//! Advance it **early**, skipping rows, and nothing is lost — the skipped rows
-//! are still `pending`, and the next pass lists them again. Leave it **late**,
-//! or reset it to `0`, and the same rows are re-listed and re-spooled — also
-//! harmless, because their nonces are stable, so the event ids are byte-for-byte
-//! the ones already enqueued and the spool dedups them. Both directions are
-//! absorbed.
-//!
-//! That is precisely why it must stay transient. Persisting it would buy
-//! nothing (a re-read is already free) and would convert its harmless failure
-//! into watermark 2's: a durable cursor that advanced past undrained rows would
-//! hide them permanently, with no counter to show for it. The two floors are
-//! durable because their failures are permanent and silent; the cursor is not,
-//! because its safety comes from being re-derivable.
+//! Both directions are absorbed: skipped rows are still `pending` and the next
+//! pass lists them, and re-listed rows carry stable nonces so the spool dedups
+//! them. That is why it stays transient — persisting it would buy nothing and
+//! convert a harmless failure into watermark 2's, hiding undrained rows
+//! permanently with no counter. The two floors are durable because their
+//! failures are permanent and silent; the cursor's safety is being
+//! re-derivable.
 
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 

--- a/crates/stella-tools/src/rootfd.rs
+++ b/crates/stella-tools/src/rootfd.rs
@@ -19,12 +19,10 @@
 //! used — there is no second resolution to race, and no string that a rename
 //! can re-point after we have looked at it.
 //!
-//! [`RootHandle::open_entry`] is that walk for a caller which also has to
-//! *say* where it landed — an integrity check that pinned an artifact by path
-//! and has to notice that the artifact has since moved. It returns the
-//! descriptor and the walk's own record of the location as one value, so the
-//! location is not a second answer that a `canonicalize` produced later and
-//! could disagree with (#3483).
+//! [`RootHandle::open_entry`] is that walk for a caller which must also *say*
+//! where it landed. It returns the descriptor and the walk's record of the
+//! location as one value, so the location is not a second answer a later
+//! `canonicalize` could disagree with (#3483).
 //!
 //! # What confines the walk
 //!

--- a/crates/stella-tools/src/search/cache.rs
+++ b/crates/stella-tools/src/search/cache.rs
@@ -13,16 +13,12 @@
 //! **(path, content identity)**, where the identity is a SHA-256 over the
 //! file's bytes as read for rendering.
 //!
-//! The bytes themselves are the invalidation authority, deliberately, rather
-//! than the git blob sha #3163 opens with: a content hash needs no
-//! subprocess, works in a workspace that is not a git checkout at all, and
-//! makes the dirty-file case the issue calls out disappear instead of needing
-//! a bypass — an uncommitted edit simply *is* different bytes, so it can
-//! never be served an entry gathered from the old ones. The renderer already
-//! reads the file on every call (the source feeds the signature, doc and body
-//! facets), so the identity costs one hash over bytes that are in hand, and
-//! the source-derived facets are always rendered from the fresh read — only
-//! the graph lookups are skipped on a hit.
+//! The bytes are the invalidation authority rather than #3163's git blob sha:
+//! a content hash needs no subprocess, works outside a git checkout, and makes
+//! the dirty-file case disappear instead of needing a bypass — an uncommitted
+//! edit simply *is* different bytes. The renderer already reads the file on
+//! every call, so the identity costs one hash over bytes in hand, and only the
+//! graph lookups are skipped on a hit.
 //!
 //! A file whose bytes cannot be read as UTF-8 has no identity here and
 //! bypasses the cache entirely: it is gathered fresh every time, which is the

--- a/crates/stella-tools/tests/relevance_calibration.rs
+++ b/crates/stella-tools/tests/relevance_calibration.rs
@@ -7,11 +7,10 @@
 //!
 //! `DEFAULT_ADMISSION_FLOOR` (`stella-embed/src/http.rs`),
 //! `DEFAULT_RELEVANCE_GAP_RATIO` and `DEFAULT_MIN_BOUNDARY_GAP`
-//! (`stella-embed/src/rank.rs`) each say "provisional" in their own doc
-//! comment, and the floor is worse than provisional — `voyage-code-3` scored
-//! *unrelated* files at 0.604 in the ranking recorded on #3089, so a floor of
-//! 0.25 admits everything and drops nothing. Setting them needs a
-//! distribution, and this file is the reproducible way to get one.
+//! (`stella-embed/src/rank.rs`) each say "provisional", and the floor is worse
+//! than that — `voyage-code-3` scored *unrelated* files at 0.604 (#3089), so a
+//! floor of 0.25 drops nothing. Setting them needs a distribution; this file is
+//! the reproducible way to get one.
 //!
 //! # How to run it
 //!
@@ -21,13 +20,11 @@
 //!     --test relevance_calibration -- --ignored --nocapture
 //! ```
 //!
-//! `--nocapture` is not optional: the distribution is the output, and libtest
-//! swallows `println!` without it. Any OpenAI-shaped backend works —
-//! `STELLA_EMBED_URL` + `STELLA_EMBED_MODEL` points it at a local server —
-//! and resolution is `stella_embed::from_env`'s, so this test invents no
-//! configuration of its own. Run it once per backend: the floor is a
-//! per-`HttpEmbedder` field, so `voyage-code-3` and a local model may
-//! legitimately differ.
+//! `--nocapture` is not optional: the distribution is the output and libtest
+//! swallows `println!` without it. Any OpenAI-shaped backend works
+//! (`STELLA_EMBED_URL` + `STELLA_EMBED_MODEL`), resolved by
+//! `stella_embed::from_env`. Run it once per backend — the floor is a
+//! per-`HttpEmbedder` field, so backends may legitimately differ.
 //!
 //! ## `STELLA_CALIBRATION_INDEX` — what made this affordable to run
 //!


### PR DESCRIPTION
`main` is red on the density ratchet #5096 added (#5124). Three crates exceed their recorded mean header length:

```
stella-cli    23.67 allowed, 23.74
stella-store  25.86 allowed, 26.02
stella-tools  35.69 allowed, 35.77
```

## Where the growth came from

Measured rather than guessed — header length per file at #5096's commit versus `main`:

```
+29  (69 -> 98)  crates/stella-cli/src/wrapper_candidate.rs
+14  (38 -> 52)  crates/stella-plugin/src/candidate_grant.rs
+ 7  (64 -> 71)  crates/stella-tools/src/rootfd.rs
```

**All three are mine**, from #5100's witness-laundering fix, and stella-cli's +29 is exactly its overage. Cut back to the argument without the retelling.

## stella-store is a different case, and worth stating

Its headers **never changed** — 2108 lines at #5096's commit and 2108 now. The ceiling was recorded on #5096's branch *before* #5093 merged, so 25.86 was never a number the merged tree achieved. That is the shared-cell staleness this repo keeps hitting: a ratchet recorded against one tree, landing on another.

I cut the export ledger's watermark essay anyway rather than edit the baseline. The guard's own remedy is *"Cut a header. Do not raise the number"*, and a ceiling the tree never met is not a licence to raise one. If a maintainer thinks 25.86 was simply mis-recorded, correcting it is a separate change with its own argument.

## Evidence

```
check-prose   OK — 4178 grandfathered, none added; 25 unit(s) within their header-length ceiling
make guards-fast   exit 0
cargo fmt --all --check   exit 0
```

No baseline entry was touched. Prose-only, so no witness test is owed — the guard's own verdict is the evidence.

Closes #5124

## Summary by Sourcery

Reduce documentation header density across the affected crates without changing code behavior or baseline limits.

Enhancements:
- Shorten oversized crate documentation headers while preserving their existing explanations and behavior.

Documentation:
- Condense documentation across the candidate workspace, tamper watch, telemetry watermark, root handle, search cache, and relevance calibration areas.