### PR TITLE
docs(stella-tools): move the calibration report's columns onto the function that computes them

### DIFF
--- a/crates/stella-cli/src/candidate_workspaces.rs
+++ b/crates/stella-cli/src/candidate_workspaces.rs
@@ -37,34 +37,9 @@
 //! ledger over one session's money
 //! ([`SessionSubAgents::dispatch_in_workspace`]).
 //!
-//! # Adoption applies a patch; it does not merge, commit, or rebase
-//!
-//! A candidate's output is **uncommitted working-tree bytes**, so adoption is
-//! `git diff` in the candidate and `git apply` on the real tree. Three
-//! properties follow, and each is the reason this shape was chosen over
-//! `cherry-pick`/`merge`:
-//!
-//! - **It is indistinguishable from the worker having done it.** The user's
-//!   own turn leaves working-tree changes; so does an adopted candidate. A
-//!   plugin cannot use best-of-N to put a commit in someone's history that
-//!   they did not write.
-//! - **It is all-or-nothing without needing to be made so.** `git apply` is
-//!   already atomic — it validates every hunk before writing any, and this
-//!   deliberately passes no `--reject`, so a patch that does not fit changes
-//!   nothing at all. The two refusals it produces are named on
-//!   [`SessionCandidateWorkspaces::adopt`].
-//! - **It applies at the repository's top level, never at the session's own
-//!   directory.** A patch's paths are top-relative, and `git apply` run from a
-//!   subdirectory filters them to what lies below the current directory —
-//!   finding nothing, applying nothing, and exiting **0**. See [`Layout`],
-//!   which exists for that one silent failure.
-//! - **It refuses rather than resolves.** There is no `--3way`, no merge
-//!   driver and no conflict-marker path: a candidate that no longer applies is
-//!   reported to the plugin as an `err`, and
-//!   [`CandidateFanouts::adopt`](stella_runtime::wrapper::CandidateFanouts)
-//!   guarantees the losing candidates are still on disk when it is. Resolving
-//!   a conflict is a judgement, and a host that made it silently would be
-//!   editing the user's tree on its own authority.
+//! Adoption applies a patch rather than merging, committing or rebasing.
+//! The four properties that follow from that are on
+//! [`SessionCandidateWorkspaces::adopt`].
 //!
 //! # It needs a git repository, and says so rather than pretending
 //!
@@ -651,6 +626,36 @@ impl CandidateWorkspaces for SessionCandidateWorkspaces {
     }
 
     /// Apply this candidate's changes to the real tree, all-or-nothing.
+    ///
+    /// # It applies a patch; it does not merge, commit, or rebase
+    ///
+    /// A candidate's output is **uncommitted working-tree bytes**, so adoption is
+    /// `git diff` in the candidate and `git apply` on the real tree. Three
+    /// properties follow, and each is the reason this shape was chosen over
+    /// `cherry-pick`/`merge`:
+    ///
+    /// - **It is indistinguishable from the worker having done it.** The user's
+    ///   own turn leaves working-tree changes; so does an adopted candidate. A
+    ///   plugin cannot use best-of-N to put a commit in someone's history that
+    ///   they did not write.
+    /// - **It is all-or-nothing without needing to be made so.** `git apply` is
+    ///   already atomic — it validates every hunk before writing any, and this
+    ///   deliberately passes no `--reject`, so a patch that does not fit changes
+    ///   nothing at all. The two refusals it produces are named on
+    ///   below.
+    /// - **It applies at the repository's top level, never at the session's own
+    ///   directory.** A patch's paths are top-relative, and `git apply` run from a
+    ///   subdirectory filters them to what lies below the current directory —
+    ///   finding nothing, applying nothing, and exiting **0**. See [`Layout`],
+    ///   which exists for that one silent failure.
+    /// - **It refuses rather than resolves.** There is no `--3way`, no merge
+    ///   driver and no conflict-marker path: a candidate that no longer applies is
+    ///   reported to the plugin as an `err`, and
+    ///   [`CandidateFanouts::adopt`](stella_runtime::wrapper::CandidateFanouts)
+    ///   guarantees the losing candidates are still on disk when it is. Resolving
+    ///   a conflict is a judgement, and a host that made it silently would be
+    ///   editing the user's tree on its own authority.
+    ///
     ///
     /// # The two refusals
     ///

--- a/crates/stella-cli/src/wrapper_candidate.rs
+++ b/crates/stella-cli/src/wrapper_candidate.rs
@@ -4,17 +4,10 @@
 //! The candidate grant and the tamper snapshot the CLI's wrapper driver owes a
 //! plugin (#3553).
 //!
-//! # What was broken
-//!
-//! `crate::wrapper_plugin` sent `RoundInput { candidate: None, .. }` and
-//! reported [`TamperFinding::NotChecked`], and both were honest — the host had
-//! neither. The consequence was not honest at all: `judge` reads the flip first
-//! and `FlipObservation::Unobservable` under `flip = "required"` is
-//! `UndecidedReason::FlipUnobservable`, so **every witness-flavoured wrapper
-//! reported `Undecided` on every run, forever**. Only a measurement oracle
-//! (`flip = "not-applicable"`) worked. A plugin with no root to read and no
-//! test to run cannot observe a flip, and a flip nobody vouched for cannot be
-//! credited.
+//! Without a grant a plugin has no root to read and no test to run, so it
+//! cannot observe a flip — and under `flip = "required"` an unobservable flip
+//! is `UndecidedReason::FlipUnobservable`, which made every witness-flavoured
+//! wrapper report `Undecided` on every run.
 //!
 //! # The grant names the tree the turn actually ran in
 //!

--- a/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
+++ b/crates/stella-store/src/enterprise_telemetry/export_ledger.rs
@@ -47,7 +47,7 @@
 //! | --- | --- | --- | --- |
 //! | `enrolled_after_execution_id` | may this sink ever see it? | durable, per sink | [`Store::begin_enterprise_enrollment`](crate::Store::begin_enterprise_enrollment), once |
 //! | `compacted_through_execution_id` | is it already settled and reclaimed? | durable, per sink | [`Store::compact_enterprise_export_ledger`](crate::Store::compact_enterprise_export_ledger), monotonically |
-//! | `after_execution_id` | where did this drain get to? | transient, per pass | the caller, between pages |
+//! | `after_execution_id` | where did this drain get to? | transient, per pass | the caller, between pages — see [`Store::pending_enterprise_export_page`](crate::Store::pending_enterprise_export_page) |
 //!
 //! ## 1. `enrolled_after_execution_id` — consent
 //!
@@ -94,25 +94,6 @@
 //! does not consult it. An execution already admitted still drains normally.
 //! The floor governs re-admission only.
 //!
-//! ## 3. `after_execution_id` — a position, not a promise
-//!
-//! The keyset cursor within one drain pass, supplied by the caller and stored
-//! nowhere. A pass that ends mid-backlog simply starts again from the beginning
-//! next time.
-//!
-//! Advance it **early**, skipping rows, and nothing is lost — the skipped rows
-//! are still `pending`, and the next pass lists them again. Leave it **late**,
-//! or reset it to `0`, and the same rows are re-listed and re-spooled — also
-//! harmless, because their nonces are stable, so the event ids are byte-for-byte
-//! the ones already enqueued and the spool dedups them. Both directions are
-//! absorbed.
-//!
-//! That is precisely why it must stay transient. Persisting it would buy
-//! nothing (a re-read is already free) and would convert its harmless failure
-//! into watermark 2's: a durable cursor that advanced past undrained rows would
-//! hide them permanently, with no counter to show for it. The two floors are
-//! durable because their failures are permanent and silent; the cursor is not,
-//! because its safety comes from being re-derivable.
 
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
@@ -283,6 +264,27 @@ impl crate::Store {
     /// One page of what this store still owes `sink_fingerprint`, in ascending
     /// execution order — the keyset cursor is `after_execution_id`, so a drain
     /// walks the backlog without an OFFSET scan.
+    ///
+    /// # `after_execution_id` is a position, not a promise
+    ///
+    /// The third of the module's three watermarks, and the one that is
+    /// supplied by the caller and stored nowhere. A pass that ends mid-backlog
+    /// starts again from the beginning next time.
+    ///
+    /// Advance it **early**, skipping rows, and nothing is lost — the skipped
+    /// rows are still `pending` and the next pass lists them again. Leave it
+    /// **late**, or reset it to `0`, and the same rows are re-listed and
+    /// re-spooled — also harmless, because their nonces are stable, so the
+    /// event ids are byte-for-byte the ones already enqueued and the spool
+    /// dedups them. Both directions are absorbed.
+    ///
+    /// That is why it must stay transient. Persisting it would buy nothing (a
+    /// re-read is already free) and would convert its harmless failure into
+    /// `compacted_through_execution_id`'s: a durable cursor that advanced past
+    /// undrained rows would hide them permanently, with no counter to show for
+    /// it. The two durable floors are durable because their failures are
+    /// permanent and silent; this one is not, because its safety comes from
+    /// being re-derivable.
     ///
     /// Only executions whose local accounting is complete (`usage_complete`)
     /// are listed: the enterprise projection refuses an incomplete envelope

--- a/crates/stella-tools/tests/relevance_calibration.rs
+++ b/crates/stella-tools/tests/relevance_calibration.rs
@@ -48,38 +48,8 @@
 //! the live file: it opens the graph for writing (`CodeGraph::open`), and a
 //! session's own indexer is already writing to that one.
 //!
-//! # What it prints, and what to do with it
-//!
-//! Per query, the top [`DEPTH`] candidates, labelled relevant or irrelevant
-//! against the answers below, with their cosines. Then, per query and over the
-//! whole set:
-//!
-//! - **the recall rank** — where the best labelled answer sits in the
-//!   **whole** ranking, not in the printed window. It is first because it is
-//!   the one question a threshold cannot answer: a floor cannot rescue a
-//!   ranking that does not contain the answer, so whether the answer is in
-//!   there at all is prior to every other number here. Every other line below
-//!   is read off the window; this one is read off the corpus.
-//! - **the separation** — the lowest relevant score minus the highest
-//!   irrelevant one. Positive, and a floor between them drops the tail without
-//!   dropping an answer. Negative, and **no floor separates this corpus**: the
-//!   honest conclusion is then that the floor cannot do the job the
-//!   `SimilarityPosture` contract assigns it for this backend, which is a
-//!   result to write down rather than a number to tune around.
-//! - **the boundary gap** — the drop across the true relevant/irrelevant
-//!   frontier, as a multiple of the ranking's mean gap and in absolute
-//!   cosine. Those are exactly the two tests `relevant_prefix` applies, so the
-//!   two `rank.rs` constants are read straight off this column: the ratio must
-//!   sit below the observed multiples and `DEFAULT_MIN_BOUNDARY_GAP` below the
-//!   observed absolute drops, or the cut fires in the wrong place.
-//! - **what the shipped constants would have done** — where
-//!   `relevant_prefix` puts the cut today against where the labels say it
-//!   belongs. A row where those agree is a constant *confirmed by
-//!   measurement*, which is a result, not a non-result.
-//!
-//! Then edit the doc comments: replace each "provisional" paragraph with the
-//! measurement and its date. **Do not delete a paragraph without measuring**
-//! — that converts an honest disclosure into a silent assumption.
+//! What it prints, and how to read each column into a constant, is on
+//! [`measure`] — the function that computes every one of those numbers.
 //!
 //! # Why this asserts almost nothing
 //!
@@ -334,6 +304,39 @@ struct Measured {
 /// AGENTS.md chunk (`Code style and conventions`, 36th) was reported as the
 /// answer while the section the label's own `basis` names
 /// (`Essential commands`) sat 12th (#4784).
+/// # What the run prints, and what to do with it
+///
+/// Per query, the top [`DEPTH`] candidates, labelled relevant or irrelevant
+/// against the answers below, with their cosines. Then, per query and over the
+/// whole set:
+///
+/// - **the recall rank** — where the best labelled answer sits in the
+///   **whole** ranking, not in the printed window. It is first because it is
+///   the one question a threshold cannot answer: a floor cannot rescue a
+///   ranking that does not contain the answer, so whether the answer is in
+///   there at all is prior to every other number here. Every other line below
+///   is read off the window; this one is read off the corpus.
+/// - **the separation** — the lowest relevant score minus the highest
+///   irrelevant one. Positive, and a floor between them drops the tail without
+///   dropping an answer. Negative, and **no floor separates this corpus**: the
+///   honest conclusion is then that the floor cannot do the job the
+///   `SimilarityPosture` contract assigns it for this backend, which is a
+///   result to write down rather than a number to tune around.
+/// - **the boundary gap** — the drop across the true relevant/irrelevant
+///   frontier, as a multiple of the ranking's mean gap and in absolute
+///   cosine. Those are exactly the two tests `relevant_prefix` applies, so the
+///   two `rank.rs` constants are read straight off this column: the ratio must
+///   sit below the observed multiples and `DEFAULT_MIN_BOUNDARY_GAP` below the
+///   observed absolute drops, or the cut fires in the wrong place.
+/// - **what the shipped constants would have done** — where
+///   `relevant_prefix` puts the cut today against where the labels say it
+///   belongs. A row where those agree is a constant *confirmed by
+///   measurement*, which is a result, not a non-result.
+///
+/// Then edit the doc comments: replace each "provisional" paragraph with the
+/// measurement and its date. **Do not delete a paragraph without measuring**
+/// — that converts an honest disclosure into a silent assumption.
+///
 fn measure(candidates: &[Candidate], full: &[Candidate]) -> Measured {
     let best = full.iter().position(|c| c.relevant);
     let best_rank = best.map(|index| index + 1);


### PR DESCRIPTION
## What & why

`main` is red on the header-density ratchet, and has been since that ratchet landed. The canary filed #5124; this is the repair, on its own branch from a fresh `main`, per AGENTS.md's rule about not folding a shared-cell repair into an unrelated PR.

Closes #5124

### What actually broke, measured rather than inferred

The ratchet's **own commit was already over** for `stella-store`. Checked out `5e06f04a8` (the #5096 merge) and ran `python3 scripts/check-prose.py` there:

```
check-prose: FAIL -- module headers got longer.
  crates/stella-store: 25.86 allowed, 26.02 mean header lines
```

So the tree has never been green on this gate: #5096 shipped a baseline its own tree exceeded. `stella-cli` and `stella-tools` went over afterwards. At `a7e1d3d33` all three were over — `stella-cli` 23.74, `stella-store` 26.02, `stella-tools` 35.77.

That matters for the fix: there is no single culprit commit to revert, and the issue's own text warns against reaching for one.

### The repair is the one the gate names

> A header is what this file does and what a reader must not do to it — two to four sentences. History belongs in the pull request, a design document, or the tracker.

**No paragraph is deleted.** Each moves onto the item it is about, where a reader meets it beside the code instead of eighty lines above it:

| From | To | Why there |
| --- | --- | --- |
| `export_ledger.rs` — the third watermark | `pending_enterprise_export_page` | it is the function that takes that cursor |
| `relevance_calibration.rs` — "what it prints" | `measure` | it computes every number in the list |
| `candidate_workspaces.rs` — the four properties of patch adoption | `adopt` | the header already pointed at `adopt` for two of them |
| `wrapper_candidate.rs` — the "what was broken" narrative | condensed to the sentence that says why the grant exists | the rest is this repository's history, which the gate says belongs in the tracker |

Each header keeps a pointer to where its section went, so nothing is harder to find than it was. Three of the four are among the longest headers in their crate: 115, 166 and 101 lines.

## The witness

- [ ] This PR includes a witness test
- [x] No witness needed (docs) — because every change is a doc comment, and the check that was red is itself the test:

```
check-prose: OK -- 4177 grandfathered construction(s) in 1174 file(s), none added;
25 unit(s) within their header-length ceiling.
```

It fails on `main` (three units over) and passes here. The `make prose` step is the gate, and its output is above.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-store -p stella-cli -p stella-tools --all-targets -- -D warnings`
- [x] `cargo doc -p stella-store -p stella-cli --no-deps` — clean, so every moved intra-doc link still resolves
- [x] `make guards-fast`, including the `prose` step that was red
- [x] No test deleted or renamed; `relevance_calibration` still reports its one `#[ignore]`d measurement

## Reviewers should know

**The baseline is untouched.** `scripts/prose-density-baseline.txt` is not in this diff — the gate says a red ratchet clears by cutting prose, never by raising a number, and that is what this does.

**This is a shared cell.** It is the PR every other open branch is waiting on, so it is deliberately small, mechanical, and confined to doc comments in four files. It is also worth labelling `unblocks-main` so `main-red-hold` does not block its own repair.

I claimed #5124 through `./scripts/main-red-claim.sh claim` before starting, so a second session reading the issue sees the claim rather than writing this twice.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed here.

One observation for whoever owns #5096, recorded on the issue rather than acted on here: a bootstrap that records a baseline its own tree exceeds makes the gate red on arrival for everybody, and `--bootstrap-density` could refuse to write a number the tree does not already meet.

## Summary by Sourcery

Reduce oversized module headers by relocating design documentation to the functions and methods it describes.

Enhancements:
- Move lengthy design and historical explanations from module-level documentation into the associated functions and methods, while preserving discoverability through concise cross-references.
- Condense the wrapper candidate module documentation to focus on the behavior and rationale relevant to its public grant mechanism.

Documentation:
- Reorganize documentation across the CLI, store, and tools modules to satisfy module-header length limits without removing substantive guidance.