### PR TITLE
fix(ci): unbreak main — SCR doc identities, prose, and an unpinned action

### DIFF
--- a/.claude/hooks/no-full-test-builds.sh
+++ b/.claude/hooks/no-full-test-builds.sh
@@ -5,7 +5,7 @@
 # JSON on stdin; exit 2 blocks the call and shows stderr to the agent.
 # This is a teaching guard, not a security boundary — it catches the common
 # full-suite invocations across the org's stacks (the same script ships in
-# every macanderson repo); a deliberate CI reproduction can be phrased
+# every macanderson repo); a stated CI reproduction can be phrased
 # around it, and SCR-001 says to do exactly that out loud.
 set -euo pipefail
 

--- a/.github/workflows/triage-guard.yml
+++ b/.github/workflows/triage-guard.yml
@@ -12,7 +12,7 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           # Logins allowed to set P-labels. `macanderson` is the interim
           # triage authority until the dedicated triage-agent identity

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -589,6 +589,36 @@
       "status": "implemented",
       "title": "Design: Schema-Aware Code Graph for Zero Schema Drift"
     },
+    "scr/001-no-full-suite-builds": {
+      "path": "docs/scr/SCR-001-no-full-suite-builds.md",
+      "status": "living",
+      "title": "Never compile the full test suite in the inner loop"
+    },
+    "scr/002-durability-first-architecture": {
+      "path": "docs/scr/SCR-002-durability-first-architecture.md",
+      "status": "living",
+      "title": "Architecture: durability-first, decide-and-record, never ask"
+    },
+    "scr/003-dod-verified-close": {
+      "path": "docs/scr/SCR-003-dod-verified-close.md",
+      "status": "living",
+      "title": "Close issues only against a verified definition of done"
+    },
+    "scr/004-residue-becomes-issues": {
+      "path": "docs/scr/SCR-004-residue-becomes-issues.md",
+      "status": "living",
+      "title": "File all residue as issues before declaring done"
+    },
+    "scr/005-triage-separation-of-duties": {
+      "path": "docs/scr/SCR-005-triage-separation-of-duties.md",
+      "status": "living",
+      "title": "Creators label triage only; the triage agent owns priority"
+    },
+    "scr/readme": {
+      "path": "docs/scr/README.md",
+      "status": "living",
+      "title": "Steering Context Records"
+    },
     "self-driving-foundry": {
       "path": "docs/spec/self-driving-foundry.md",
       "sections": [

--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -1,3 +1,9 @@
+---
+id: scr/readme
+title: Steering Context Records
+status: living
+---
+
 # Steering Context Records
 
 An SCR is to steering what an ADR is to architecture: a numbered, versioned
@@ -31,24 +37,25 @@ agent bug.
 ## Lifecycle
 
 1. **Capture** — second occurrence of a manual steer → draft an SCR. Any
-   agent may draft; status `active`, autonomy `L1`.
+   agent may draft; status `living`, autonomy `L1`.
 2. **Promote** — attach an enforcement mechanism; update the `autonomy` and
    `enforcement` fields. The SCR is the changelog of its own automation.
 3. **Load** — agents receive the SCR corpus as context at session start. A
    steer that exists as an SCR should never need to be typed again.
 4. **Audit** — a periodic meta-review flags SCRs stuck at L1 whose directive
    keeps appearing in transcripts; that is the promotion backlog.
-5. **Retire / supersede** — SCRs are never deleted; they are marked
-   `superseded-by:SCR-0NN` so the 10-year reader can trace why the process
-   looks the way it does. Durability-first applies to the process itself.
+5. **Retire / supersede** — SCRs are never deleted; they take `status:
+   superseded` with a `superseded_by:` naming the replacement's id, so the
+   10-year reader can trace why the process looks the way it does.
+   Durability-first applies to the process itself.
 
 ## Template
 
 ```markdown
 ---
-id: SCR-0NN
+id: scr/0NN-<kebab-slug>  # `ns/name`, lowercase-kebab, as ADRs carry
 title: <directive as an imperative sentence>
-status: active            # active | superseded-by:SCR-0NN | retired
+status: living            # living | superseded (+ superseded_by:) | archived
 origin: <how/why this became a standing steer>
 trigger: <the situation in which an agent must apply it>
 autonomy: L1              # current rung on the ladder

--- a/docs/scr/SCR-001-no-full-suite-builds.md
+++ b/docs/scr/SCR-001-no-full-suite-builds.md
@@ -1,7 +1,7 @@
 ---
-id: SCR-001
+id: scr/001-no-full-suite-builds
 title: Never compile the full test suite in the inner loop
-status: active
+status: living
 origin: repeated manual prompt, ~daily, 2025–2026
 trigger: any build/test invocation during development
 autonomy: L2
@@ -32,10 +32,10 @@ Scope every test command to the touched unit, using the repo's stack:
 | Python / uv (arenabench) | `uv run pytest tests/test_x.py -q` | bare `pytest`, `make test` |
 | Next.js (cgp-website) | scope any future suite to the touched module | any bare full-suite `test` script |
 
-Reproduce full CI locally only when deliberately debugging a CI-only
-failure, and say so out loud in the session.
+Reproduce full CI locally only when debugging a CI-only failure, and say so
+out loud in the session.
 
 ## Exceptions
 
-Release verification; explicit maintainer request; deliberate, stated
-reproduction of a CI-only failure.
+Release verification; explicit maintainer request; stated reproduction of a
+CI-only failure.

--- a/docs/scr/SCR-002-durability-first-architecture.md
+++ b/docs/scr/SCR-002-durability-first-architecture.md
@@ -1,7 +1,7 @@
 ---
-id: SCR-002
+id: scr/002-durability-first-architecture
 title: "Architecture: durability-first, decide-and-record, never ask"
-status: active
+status: living
 origin: 100%-deterministic answer to every architecture question, 2025–2026
 trigger: any architectural or design decision arising mid-task
 autonomy: L1

--- a/docs/scr/SCR-003-dod-verified-close.md
+++ b/docs/scr/SCR-003-dod-verified-close.md
@@ -1,7 +1,7 @@
 ---
-id: SCR-003
+id: scr/003-dod-verified-close
 title: Close issues only against a verified definition of done
-status: active
+status: living
 origin: delegation-to-DoD steering pattern, 2025–2026
 trigger: declaring any issue or task complete
 autonomy: L2

--- a/docs/scr/SCR-004-residue-becomes-issues.md
+++ b/docs/scr/SCR-004-residue-becomes-issues.md
@@ -1,7 +1,7 @@
 ---
-id: SCR-004
+id: scr/004-residue-becomes-issues
 title: File all residue as issues before declaring done
-status: active
+status: living
 origin: "north-star requirement: nothing evaporates in a chat transcript"
 trigger: the end of every completed task
 autonomy: L1

--- a/docs/scr/SCR-005-triage-separation-of-duties.md
+++ b/docs/scr/SCR-005-triage-separation-of-duties.md
@@ -1,7 +1,7 @@
 ---
-id: SCR-005
+id: scr/005-triage-separation-of-duties
 title: Creators label triage only; the triage agent owns priority
-status: active
+status: living
 origin: separation-of-duties rule on the backlog, 2025–2026
 trigger: creating or labeling any GitHub issue
 autonomy: L2
@@ -16,15 +16,15 @@ agent, sizes the work, assigns exactly one priority label, optionally a
 size, removes `triage`, and comments a one-line rationale.
 
 Priority scheme: `P0` drop everything · `P1` this cycle · `P2` next cycle ·
-`P3` backlog. Invariant: every open issue carries either a priority label or
+`P3` backlog. Rule: every open issue carries either a priority label or
 `triage` — never neither, never both.
 
 ## Rationale
 
 Whoever creates an issue is the worst-placed party to rank it — creators
 systematically over-weight their own findings. Separating creation from
-prioritization keeps the backlog ordering honest and gives the maintainer
-one place (the triage agent's rationale comments) to audit it.
+prioritization keeps backlog order independent of who filed, and gives
+the maintainer one place (the triage agent's rationale comments) to audit it.
 
 ## How an agent complies
 


### PR DESCRIPTION
`main` is red on three separate guards, all introduced by the SCR corpus that
landed recently. Between them they hold every PR's required
`fmt + clippy + test` check plus `docs guards`, so nothing can merge.

## What was broken

| Guard | Failure |
|-------|---------|
| `doc-links` | All five SCR files declare `id: SCR-00N` (must be lowercase-kebab) and `status: active` (not in the allowed set), so none is an *identified* document — and AGENTS.md's five citations to them fail. `docs/scr/README.md` has no frontmatter at all, yet ADR 0015 cites it. |
| `prose` | Three banned constructions: two filler adverbs in SCR-001, one in `.claude/hooks/no-full-test-builds.sh`, plus `honest` and `Invariant` in SCR-005. |
| `action-pins` | `.github/workflows/triage-guard.yml` uses `actions/github-script@v7`, unpinned. |

## What this does

- **SCR ids take the `ns/name` shape ADRs already use** — `scr/001-no-full-suite-builds`
  and friends — with `status: living`, the status 49 other documents use for
  "maintained, describes current behaviour". The five records become citable
  and AGENTS.md resolves again.
- **`docs/scr/README.md` gains frontmatter**, because ADR 0015 cites it and
  nothing under `docs/` is citable without an identity. Its **template is
  updated too**, so the next SCR is born valid instead of reproducing this
  break — that is the half that stops this recurring.
- **The three flagged constructions are deleted**, each sentence keeping its
  meaning rather than losing the clause.
- **`actions/github-script` is pinned** to its v7 commit, tag kept in a comment
  as the guard's message prescribes.
- `docs/manifest.json` regenerated via `make doc-links-fix` (the documented
  remedy) — no document moved and nothing needed healing; it is the id change.

## Verification

`make guards-fast` passes on this branch — the whole toolchain-free tier,
including the three guards above:

```
check-prose: OK -- 4173 grandfathered construction(s) in 1173 file(s), none added
check-doc-links: OK -- 1113 citation(s) resolve across 91 identified document(s)
check-action-pins: OK
```

No test was added: this is a docs/CI repair with no behaviour change, so there
is no witness to flip. No test was deleted or renamed.

Labelled `unblocks-main` per the hold's own instructions.

Closes #5140

## Summary by Sourcery

Repair SCR documentation metadata, guarded prose, and workflow action pinning to restore the repository's required checks.

Bug Fixes:
- Restore documentation-link, prose, and action-pinning guards so the main branch and dependent pull requests can pass required checks.

Enhancements:
- Standardize SCR identities and lifecycle metadata, add a citable identity for the SCR README, and update its template to prevent invalid future records.
- Regenerate the documentation manifest with the corrected SCR and README entries.

CI:
- Pin the triage workflow's GitHub Script action to a commit while retaining its version annotation.

Documentation:
- Revise SCR prose and terminology to satisfy repository writing rules without changing the documented guidance.