### PR TITLE
Repair the two checks red on main: prose, and the unpinnable DoD callers

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -5,8 +5,8 @@
 # copies of an enforcement rule into an org whose sibling check exists to
 # detect exactly that kind of drift.
 #
-# There is deliberately no logic in this file. A change to *what* the check
-# does never touches it; only adding or removing a check does.
+# There is no logic in this file. A change to *what* the check does never
+# touches it; only adding or removing a check does.
 name: dod-check
 
 on:
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   dod:
-    uses: macanderson/oxagen/.github/workflows/dod-check.yml@main
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@a26bac4001eb5501f9d93f1deec240faecff7f1d # main

--- a/.github/workflows/dod-close-guard.yml
+++ b/.github/workflows/dod-close-guard.yml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   guard:
-    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@main
+    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@a26bac4001eb5501f9d93f1deec240faecff7f1d # main

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -33,7 +33,7 @@
 //!   positive match, which cannot express the shape most command rules
 //!   actually have: *this family is forbidden **except** in its scoped
 //!   form*. Approximating that with a list of deny globs only enumerates
-//!   the spellings someone thought of, and the first unlisted variant walks
+//!   the spellings someone thought of, and the first one they missed walks
 //!   through while the rule still looks enforced. Write the broad deny and
 //!   name the narrow exception — a missing exception shows up at once as a
 //!   false block, where a missing deny pattern is silent. Command-scoped by
@@ -278,8 +278,8 @@ pub(crate) fn load_workspace_rules(
 /// tier merge resolved them, plus the guards TOML records earned.
 ///
 /// The split is deliberate and the reason is blast radius. The markdown path carries
-/// an invariant with teeth — a user-global hard guard is *monotonic*, and a project
-/// rule with the same id can never remove it — and that invariant is enforced by
+/// a guarantee with teeth — a user-global hard guard is *monotonic*, and a project
+/// rule with the same id can never remove it — and that guarantee is enforced by
 /// [`merge_rule_trust_tiers`] over `Vec<Rule>`. Re-expressing it inside the record
 /// registry's lineage merge would mean rewriting security-relevant merge logic to
 /// add a feature, so the markdown result is passed through untouched and only the

--- a/crates/stella-core/src/records/bridge.rs
+++ b/crates/stella-core/src/records/bridge.rs
@@ -149,7 +149,7 @@ fn self_attested(record: &Record, trust: Trust) -> bool {
 ///
 /// [ev]: super::super::rules::evaluate_guards
 fn concrete(guard: &RuleGuard) -> bool {
-    // `allow_command_glob` is deliberately absent: an exception alone denies
+    // `allow_command_glob` is absent: an exception alone denies
     // nothing, so a record carrying only one would advertise Tier 2 while
     // being structurally unable to fire — the defect this function exists to
     // prevent, arriving through a newer field.

--- a/crates/stella-core/src/rules.rs
+++ b/crates/stella-core/src/rules.rs
@@ -88,7 +88,7 @@ pub struct RuleGuard {
     /// its scoped form*. "No workspace-wide test compiles, but
     /// `cargo test -p <crate>` is fine" is not writable as a single glob,
     /// and approximating it with a list of deny globs only enumerates the
-    /// spellings someone thought of — the first unlisted variant walks
+    /// spellings someone thought of — the first one they missed walks
     /// straight through, and the rule looks enforced while it is not.
     ///
     /// Hence a first-class exception rather than a cleverer deny pattern:

--- a/crates/stella-core/src/rules/tests.rs
+++ b/crates/stella-core/src/rules/tests.rs
@@ -808,7 +808,7 @@ fn guard_allow_command_exempts_the_scoped_form_and_blocks_the_rest() {
 
     assert!(evaluate_guards(&rules, &bash("cargo test")).is_blocked());
     assert!(evaluate_guards(&rules, &bash("cargo test --workspace")).is_blocked());
-    // The variant a list of deny globs would have missed: scoped to nothing,
+    // The spelling a list of deny globs would have missed: scoped to nothing,
     // but not spelled with any of the flags someone thought to enumerate.
     assert!(evaluate_guards(&rules, &bash("cargo test some_filter")).is_blocked());
 

--- a/docs/adr/0016-guard-exceptions-are-a-field-not-a-pattern.md
+++ b/docs/adr/0016-guard-exceptions-are-a-field-not-a-pattern.md
@@ -32,7 +32,7 @@ Three ways around it were considered, and each fails in the same direction:
 
 2. **Extend the glob language** with negation or alternation. This changes the
    matcher shared by rule guards *and* hook matchers (`glob.rs` is used by
-   both), turning a deliberately tiny, auditable language into a small regex
+   both), turning a tiny, auditable language into a small regex
    dialect — and every existing pattern would have to be re-read under the new
    grammar to be sure none changed meaning.
 
@@ -99,13 +99,13 @@ rules are written in.
   `concrete()` and the frontmatter parser both had to learn that it does not,
   by itself, constitute a guard; both are covered by tests.
 - Authoring the SCR-001 record itself is follow-up work, not part of this
-  decision. A repository-published record with a hard guard deliberately does
-  not arm on clone — it reaches the tool boundary only through the local
+  decision. A repository-published record with a hard guard does not arm on
+  clone — it reaches the tool boundary only through the local
   decision ledger (`stella context promote`), which is a human act by design
   and correctly so: a repository must not be able to arm blocking rules on
   everyone who checks it out.
-- `guard-allow-path` is the obvious symmetric question and is deliberately
-  not answered here. Path guards have not yet shown the same
+- `guard-allow-path` is the obvious symmetric question and is not answered
+  here. Path guards have not yet shown the same
   broad-family-with-a-carve-out shape, and adding an unused subtractive field
   to the file surface is how a vocabulary accretes. Filed as residue; add it
   when a real rule needs it.

--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -29,7 +29,7 @@ Divergence files (or updates) a `triage`-labelled issue in oxagen naming every
 differing, missing, and extra file, and fails the run. The reference copy is
 oxagen's, because ADR-038 and the rollout originated there — but a report
 means *the copies disagree*, not *the others are wrong*. Resolve it by
-deciding what the corpus should say and re-syncing all five deliberately;
+deciding what the corpus should say and re-syncing all five;
 blindly overwriting from oxagen can silently discard the very edit that was
 correct.
 


### PR DESCRIPTION
`main` is red, and on **two** checks rather than the one the canary named. #5166 reports `prose`; running the gate locally on `5857241b6` found `action-pins` failing underneath it.

## 1. `prose` — ten constructions, six files

A different set from #5140's, landed by the `guard-allow-command` work and the SCR corpus sync:

```
crates/stella-cli/src/rules.rs            [rust-jargon]    3   (2 allowed)
crates/stella-core/src/records/bridge.rs  [filler-adverb]  1
crates/stella-core/src/rules.rs           [rust-jargon]    1
crates/stella-core/src/rules/tests.rs     [rust-jargon]    1
docs/adr/0016-...-a-field-not-a-pattern.md [filler-adverb] 3
docs/scr/README.md                        [filler-adverb]  1
```

Every `deliberately` sat in front of a reason its own sentence already gave, so deleting it costs the reader nothing. Each `variant`/`invariant` becomes the plain word the guard asks for — a missed spelling, and a guarantee.

## 2. `action-pins` — and why it could not have been fixed before now

Two `uses:` refs point at a sibling repo's default branch:

```
.github/workflows/dod-check.yml:23        macanderson/oxagen/...@main
.github/workflows/dod-close-guard.yml:20  macanderson/oxagen/...@main
```

**These were unpinnable when they landed, because the workflows they call did not exist.** #5142 merged the *caller* half of oxagen #1321 while the *callee* half was still open as oxagen #1323. The consequence was not theoretical — stella's `dod-close-guard` dispatched against a missing target and failed:

```
.github/workflows/dod-close-guard.yml   failure   2026-08-26T23:42:07Z
```

oxagen #1323 has since merged, so both reusable workflows now exist on oxagen `main`. Both refs are pinned to `a26bac4001eb5501f9d93f1deec240faecff7f1d` — the commit checked, via the contents API, to carry both files — with the branch kept in a comment as the guard's own message asks.

## Evidence

```
check-prose:       OK -- 4171 grandfathered, none added
check-action-pins: OK — all 88 'uses:' references are pinned to a commit SHA
make guards-fast   exit 0
```

The grandfathered prose count moves **down** (4173 → 4171). No baseline entry was added or raised; no `deny.toml` or file-size ceiling was touched.

Comments, docs and CI wiring only — no behaviour changes, so no witness test is owed. The guards' verdicts are the evidence.

## For whoever hits this next

This is the **third** red `main` from `check-prose` in a few hours (#5124 density, #5140 phrases, #5166 phrases again), and #5140's repair was closed without landing — its content is not on `main`, so those five constructions are still outstanding separately from this PR's ten.

The `action-pins` half is a different shape and a sharper one: a cross-repo caller merged ahead of its callee. Nothing pre-merge could catch it, because the guard can only ask *is this ref a SHA* — it cannot ask *does the target exist*. Filed as #5169.

Refs #5166 — **not** `Closes`, and the `no-issue` waiver is applied. #5166 is
machine-filed by `main-canary.yml`, so it has no Definition-of-done section and
by construction never can; `dod-check` fails any PR that closes a DoD-less
issue. The canary closes its own issue when `main` recovers (AGENTS.md), so the
lifecycle is already owned. The gap this exposes is filed as #5172.
