### PR TITLE
fix(ci): unbreak main — pin the two DoD reusable workflows and clear seven prose hits

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -20,4 +20,4 @@ permissions:
 
 jobs:
   dod:
-    uses: macanderson/oxagen/.github/workflows/dod-check.yml@main
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # main

--- a/.github/workflows/dod-close-guard.yml
+++ b/.github/workflows/dod-close-guard.yml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   guard:
-    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@main
+    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # main

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -33,7 +33,7 @@
 //!   positive match, which cannot express the shape most command rules
 //!   actually have: *this family is forbidden **except** in its scoped
 //!   form*. Approximating that with a list of deny globs only enumerates
-//!   the spellings someone thought of, and the first unlisted variant walks
+//!   the spellings someone thought of, and the first unlisted one walks
 //!   through while the rule still looks enforced. Write the broad deny and
 //!   name the narrow exception — a missing exception shows up at once as a
 //!   false block, where a missing deny pattern is silent. Command-scoped by
@@ -278,8 +278,8 @@ pub(crate) fn load_workspace_rules(
 /// tier merge resolved them, plus the guards TOML records earned.
 ///
 /// The split is deliberate and the reason is blast radius. The markdown path carries
-/// an invariant with teeth — a user-global hard guard is *monotonic*, and a project
-/// rule with the same id can never remove it — and that invariant is enforced by
+/// a rule with teeth — a user-global hard guard is *monotonic*, and a project
+/// rule with the same id can never remove it — and that rule is enforced by
 /// [`merge_rule_trust_tiers`] over `Vec<Rule>`. Re-expressing it inside the record
 /// registry's lineage merge would mean rewriting security-relevant merge logic to
 /// add a feature, so the markdown result is passed through untouched and only the

--- a/crates/stella-core/src/records/bridge.rs
+++ b/crates/stella-core/src/records/bridge.rs
@@ -149,7 +149,7 @@ fn self_attested(record: &Record, trust: Trust) -> bool {
 ///
 /// [ev]: super::super::rules::evaluate_guards
 fn concrete(guard: &RuleGuard) -> bool {
-    // `allow_command_glob` is deliberately absent: an exception alone denies
+    // `allow_command_glob` is absent: an exception alone denies
     // nothing, so a record carrying only one would advertise Tier 2 while
     // being structurally unable to fire — the defect this function exists to
     // prevent, arriving through a newer field.

--- a/crates/stella-core/src/rules.rs
+++ b/crates/stella-core/src/rules.rs
@@ -88,7 +88,7 @@ pub struct RuleGuard {
     /// its scoped form*. "No workspace-wide test compiles, but
     /// `cargo test -p <crate>` is fine" is not writable as a single glob,
     /// and approximating it with a list of deny globs only enumerates the
-    /// spellings someone thought of — the first unlisted variant walks
+    /// spellings someone thought of — the first unlisted one walks
     /// straight through, and the rule looks enforced while it is not.
     ///
     /// Hence a first-class exception rather than a cleverer deny pattern:

--- a/crates/stella-core/src/rules/tests.rs
+++ b/crates/stella-core/src/rules/tests.rs
@@ -808,7 +808,7 @@ fn guard_allow_command_exempts_the_scoped_form_and_blocks_the_rest() {
 
     assert!(evaluate_guards(&rules, &bash("cargo test")).is_blocked());
     assert!(evaluate_guards(&rules, &bash("cargo test --workspace")).is_blocked());
-    // The variant a list of deny globs would have missed: scoped to nothing,
+    // The spelling a list of deny globs would have missed: scoped to nothing,
     // but not spelled with any of the flags someone thought to enumerate.
     assert!(evaluate_guards(&rules, &bash("cargo test some_filter")).is_blocked());
 

--- a/docs/adr/0016-guard-exceptions-are-a-field-not-a-pattern.md
+++ b/docs/adr/0016-guard-exceptions-are-a-field-not-a-pattern.md
@@ -32,7 +32,7 @@ Three ways around it were considered, and each fails in the same direction:
 
 2. **Extend the glob language** with negation or alternation. This changes the
    matcher shared by rule guards *and* hook matchers (`glob.rs` is used by
-   both), turning a deliberately tiny, auditable language into a small regex
+   both), turning a tiny, auditable language into a small regex
    dialect — and every existing pattern would have to be re-read under the new
    grammar to be sure none changed meaning.
 
@@ -99,13 +99,13 @@ rules are written in.
   `concrete()` and the frontmatter parser both had to learn that it does not,
   by itself, constitute a guard; both are covered by tests.
 - Authoring the SCR-001 record itself is follow-up work, not part of this
-  decision. A repository-published record with a hard guard deliberately does
-  not arm on clone — it reaches the tool boundary only through the local
+  decision. A repository-published record with a hard guard does not arm on
+  clone — it reaches the tool boundary only through the local
   decision ledger (`stella context promote`), which is a human act by design
   and correctly so: a repository must not be able to arm blocking rules on
   everyone who checks it out.
-- `guard-allow-path` is the obvious symmetric question and is deliberately
-  not answered here. Path guards have not yet shown the same
+- `guard-allow-path` is the obvious symmetric question and is not answered
+  here. Path guards have not yet shown the same
   broad-family-with-a-carve-out shape, and adding an unused subtractive field
   to the file surface is how a vocabulary accretes. Filed as residue; add it
   when a real rule needs it.

--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -29,7 +29,7 @@ Divergence files (or updates) a `triage`-labelled issue in oxagen naming every
 differing, missing, and extra file, and fails the run. The reference copy is
 oxagen's, because ADR-038 and the rollout originated there — but a report
 means *the copies disagree*, not *the others are wrong*. Resolve it by
-deciding what the corpus should say and re-syncing all five deliberately;
+deciding what the corpus should say and re-syncing all five from that;
 blindly overwriting from oxagen can silently discard the very edit that was
 correct.
 


### PR DESCRIPTION
`main` is red at `5857241b6` on two guards, from two merges that each passed their own checks. Canary issue: #5166.

## `action-pins`

#5142 added `.github/workflows/dod-check.yml` and `dod-close-guard.yml`, both calling a reusable workflow in `macanderson/oxagen` at `@main`. A moving ref is what the guard exists to refuse — the callee can change under us between one run and the next. Both now name the commit (`319b0a97…`), with the branch kept in a trailing comment, which is the form the guard's own error message prescribes.

## `prose`

Seven constructions across five files, from #5142 and #5146:

- Four `deliberately` where the reason follows in the same sentence, so the adverb carries nothing (`records/bridge.rs`, the ADR twice, `docs/scr/README.md`).
- Three `variant`/`invariant` where the plain word is the clearer one: a deny list that misses a spelling misses a *spelling*, and a monotonic user-global hard guard is a *rule*.

## What is deliberately not in this PR

The prose baseline is left as it stands, so `crates/stella-cli/src/rules.rs [rust-jargon]` still reads `2` against `0` found. Retightening is a PR of its own, safe when nothing is blocked on it. Folding it in here would make the repair every open PR is waiting on the one racing every other merge for a shared cell — the shape that produced #4654.

## Evidence

- `make guards-fast` passes end to end on this branch, `action-pins` and `prose` included.
- `make prose` — `OK -- 4171 grandfathered construction(s) in 1173 file(s), none added`.
- `cargo check -p stella-core -p stella-cli --all-targets` — clean; the Rust edits are doc comments and one test comment, no code.

No witness test: this is a CI/prose repair, and the guards themselves are the witness — each fails on `main` and passes here.

Closes #5166

## Summary by Sourcery

Restore the main branch guards by pinning reusable DoD workflows and cleaning the newly flagged prose.

Bug Fixes:
- Pin the two DoD reusable workflows to a fixed commit so CI guard behavior is stable and reproducible.
- Remove seven prose constructions flagged by the repository prose guard.

CI:
- Stabilize DoD CI checks by replacing moving workflow references with a pinned revision.