### PR TITLE
fix(ci): unbreak main — SHA-pin the DoD callers and clear the prose gate

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -5,8 +5,13 @@
 # copies of an enforcement rule into an org whose sibling check exists to
 # detect exactly that kind of drift.
 #
-# There is deliberately no logic in this file. A change to *what* the check
-# does never touches it; only adding or removing a check does.
+# There is no logic in this file. A change to *what* the check does never
+# touches it; only adding or removing a check does.
+#
+# The ref is a commit SHA, not `@main`: a cross-repo `uses:` resolved through
+# a moving ref both fails `action-pins` and lets another repository change
+# what runs here without a commit in this one. Re-pin when the implementation
+# changes, which is a reviewable one-line diff naming the version it moved to.
 name: dod-check
 
 on:
@@ -20,4 +25,4 @@ permissions:
 
 jobs:
   dod:
-    uses: macanderson/oxagen/.github/workflows/dod-check.yml@main
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # oxagen main, #1323

--- a/.github/workflows/dod-close-guard.yml
+++ b/.github/workflows/dod-close-guard.yml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   guard:
-    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@main
+    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # oxagen main, #1323

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -33,7 +33,7 @@
 //!   positive match, which cannot express the shape most command rules
 //!   actually have: *this family is forbidden **except** in its scoped
 //!   form*. Approximating that with a list of deny globs only enumerates
-//!   the spellings someone thought of, and the first unlisted variant walks
+//!   the spellings someone thought of, and the first unlisted one walks
 //!   through while the rule still looks enforced. Write the broad deny and
 //!   name the narrow exception — a missing exception shows up at once as a
 //!   false block, where a missing deny pattern is silent. Command-scoped by
@@ -277,9 +277,9 @@ pub(crate) fn load_workspace_rules(
 /// The rules the tool boundary evaluates: the markdown rules exactly as the trust-
 /// tier merge resolved them, plus the guards TOML records earned.
 ///
-/// The split is deliberate and the reason is blast radius. The markdown path carries
-/// an invariant with teeth — a user-global hard guard is *monotonic*, and a project
-/// rule with the same id can never remove it — and that invariant is enforced by
+/// The split is there for blast radius. The markdown path carries a guarantee with
+/// teeth — a user-global hard guard is *monotonic*, and a project
+/// rule with the same id can never remove it — and that guarantee is enforced by
 /// [`merge_rule_trust_tiers`] over `Vec<Rule>`. Re-expressing it inside the record
 /// registry's lineage merge would mean rewriting security-relevant merge logic to
 /// add a feature, so the markdown result is passed through untouched and only the

--- a/crates/stella-core/src/records/bridge.rs
+++ b/crates/stella-core/src/records/bridge.rs
@@ -149,7 +149,7 @@ fn self_attested(record: &Record, trust: Trust) -> bool {
 ///
 /// [ev]: super::super::rules::evaluate_guards
 fn concrete(guard: &RuleGuard) -> bool {
-    // `allow_command_glob` is deliberately absent: an exception alone denies
+    // `allow_command_glob` is absent: an exception alone denies
     // nothing, so a record carrying only one would advertise Tier 2 while
     // being structurally unable to fire — the defect this function exists to
     // prevent, arriving through a newer field.

--- a/crates/stella-core/src/rules.rs
+++ b/crates/stella-core/src/rules.rs
@@ -88,7 +88,7 @@ pub struct RuleGuard {
     /// its scoped form*. "No workspace-wide test compiles, but
     /// `cargo test -p <crate>` is fine" is not writable as a single glob,
     /// and approximating it with a list of deny globs only enumerates the
-    /// spellings someone thought of — the first unlisted variant walks
+    /// spellings someone thought of — the first unlisted one walks
     /// straight through, and the rule looks enforced while it is not.
     ///
     /// Hence a first-class exception rather than a cleverer deny pattern:

--- a/crates/stella-core/src/rules/tests.rs
+++ b/crates/stella-core/src/rules/tests.rs
@@ -808,8 +808,8 @@ fn guard_allow_command_exempts_the_scoped_form_and_blocks_the_rest() {
 
     assert!(evaluate_guards(&rules, &bash("cargo test")).is_blocked());
     assert!(evaluate_guards(&rules, &bash("cargo test --workspace")).is_blocked());
-    // The variant a list of deny globs would have missed: scoped to nothing,
-    // but not spelled with any of the flags someone thought to enumerate.
+    // The spelling a list of deny globs would have missed: scoped to nothing,
+    // but not written with any of the flags someone thought to enumerate.
     assert!(evaluate_guards(&rules, &bash("cargo test some_filter")).is_blocked());
 
     assert!(!evaluate_guards(&rules, &bash("cargo test -p stella-core")).is_blocked());

--- a/docs/adr/0016-guard-exceptions-are-a-field-not-a-pattern.md
+++ b/docs/adr/0016-guard-exceptions-are-a-field-not-a-pattern.md
@@ -32,7 +32,7 @@ Three ways around it were considered, and each fails in the same direction:
 
 2. **Extend the glob language** with negation or alternation. This changes the
    matcher shared by rule guards *and* hook matchers (`glob.rs` is used by
-   both), turning a deliberately tiny, auditable language into a small regex
+   both), turning a tiny, auditable language into a small regex
    dialect — and every existing pattern would have to be re-read under the new
    grammar to be sure none changed meaning.
 
@@ -99,12 +99,12 @@ rules are written in.
   `concrete()` and the frontmatter parser both had to learn that it does not,
   by itself, constitute a guard; both are covered by tests.
 - Authoring the SCR-001 record itself is follow-up work, not part of this
-  decision. A repository-published record with a hard guard deliberately does
+  decision. A repository-published record with a hard guard does
   not arm on clone — it reaches the tool boundary only through the local
   decision ledger (`stella context promote`), which is a human act by design
   and correctly so: a repository must not be able to arm blocking rules on
   everyone who checks it out.
-- `guard-allow-path` is the obvious symmetric question and is deliberately
+- `guard-allow-path` is the obvious symmetric question and is
   not answered here. Path guards have not yet shown the same
   broad-family-with-a-carve-out shape, and adding an unused subtractive field
   to the file surface is how a vocabulary accretes. Filed as residue; add it

--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -29,7 +29,7 @@ Divergence files (or updates) a `triage`-labelled issue in oxagen naming every
 differing, missing, and extra file, and fails the run. The reference copy is
 oxagen's, because ADR-038 and the rollout originated there — but a report
 means *the copies disagree*, not *the others are wrong*. Resolve it by
-deciding what the corpus should say and re-syncing all five deliberately;
+deciding what the corpus should say and re-syncing all five from that decision;
 blindly overwriting from oxagen can silently discard the very edit that was
 correct.
 


### PR DESCRIPTION
fix(ci): unbreak main — SHA-pin the DoD callers and clear the prose gate

`main` is red at 5857241b6 on two independent gate steps. #5167 diagnosed both
correctly and was closed unmerged, so both are still red; this repairs them,
taking the other option on the second.

## 1. `action-pins` — a required check

`.github/workflows/dod-check.yml` and `dod-close-guard.yml` (#5142) called
`macanderson/oxagen/…@main`. A cross-repo `uses:` must be pinned to a 40-hex
SHA, so the guard failed inside `ci.yml`'s `fmt + clippy + test` job and
reddened every open PR.

When #5167 was written there was no commit to pin to — neither workflow
existed in oxagen, and its implementation (macanderson/oxagen#1323) was still
open. That is no longer true: #1323 merged, and both files are present at
oxagen `319b0a97`. So the callers are **pinned rather than deleted**, which
keeps SCR-003 enforcement instead of removing it to turn a gate green.

Verified before pinning — both files resolve at that SHA, and a `dod` job now
runs and passes in each of the three sibling repos that carry the same caller
(macanderson/cgp-website#18, macanderson/arenabench#11,
macanderson/context-graph-protocol#83, all merged). `make action-pins` reports
all 88 references pinned.

Re-pinning when the implementation changes is a one-line diff naming the
version it moved to — which is the property `@main` gave away: another
repository could change what runs here with no commit in this one.

## 2. `prose`

The ten flagged constructions from #5127, #5146 and #5142, fixed the same way
#5167 fixed them: three `rust-jargon` `variant`/`invariant` uses reworded, six
`deliberately` adverbs deleted where the reason already follows in the same
sentence, and `docs/scr/README.md`'s reworded to "from that decision". No
baseline entry added and none raised.

Verified: `make prose` OK, `make action-pins` OK, `make guards-fast` passes,
`cargo test -p stella-core --lib rules::` 52 passed, and
`cargo test -p stella-cli --bin stella rules` 36 passed.

Closes #5166

## Summary by Sourcery

Unblock the main CI gates by pinning shared DoD workflows and removing flagged prose violations.

Bug Fixes:
- Restore required CI checks by pinning the shared DoD workflows to a stable oxagen commit.
- Clear prose-gate violations across code comments, documentation, and rule explanations.

Enhancements:
- Retain cross-repository DoD enforcement while making workflow changes reviewable and reproducible.

CI:
- Pin both cross-repository reusable workflow callers to the oxagen implementation commit so action-pins validation succeeds.

Documentation:
- Clarify that SCR copies should be re-synchronized based on an explicit corpus decision rather than blindly overwritten.