### PR TITLE
ci: restore the two DoD workflow callers, SHA-pinned to oxagen 319b0a97

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -1,0 +1,28 @@
+# DoD merge check (SCR-003) — caller stub.
+#
+# The implementation lives once in oxagen and is called from here. ADR-039:
+# copying the check into each repo would put five independently-drifting
+# copies of an enforcement rule into an org whose sibling check exists to
+# detect exactly that kind of drift.
+#
+# There is no logic in this file. A change to *what* the check does never
+# touches it; only adding or removing a check does.
+#
+# The ref is a commit SHA, not `@main`: a cross-repo `uses:` resolved through
+# a moving ref both fails `action-pins` and lets another repository change
+# what runs here without a commit in this one. Re-pin when the implementation
+# changes, which is a reviewable one-line diff naming the version it moved to.
+name: dod-check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  dod:
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # oxagen main, #1323

--- a/.github/workflows/dod-close-guard.yml
+++ b/.github/workflows/dod-close-guard.yml
@@ -1,0 +1,20 @@
+# DoD close guard (SCR-003) — caller stub.
+#
+# Reopens an issue closed as *completed* while its definition-of-done still
+# has unchecked items. The merge gate in dod-check.yml carries the load; this
+# covers the hand-closed path, after the fact, because GitHub has no pre-close
+# hook to veto.
+#
+# Implementation lives once in oxagen — see ADR-039.
+name: dod-close-guard
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  guard:
+    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # oxagen main, #1323


### PR DESCRIPTION
#5167 removed the two DoD workflow callers to unbreak `main`, and said the
re-add had to wait for a commit to pin to. That commit now exists.

`macanderson/oxagen#1323` merged, so `dod-check.yml` and `dod-close-guard.yml`
are present in oxagen. Both callers come back pinned to `319b0a97`, which is
what `action-pins` requires of a cross-repo `uses:` and what `@main` could
never satisfy — #5167's own note says the re-add must be SHA-pinned.

## Why pinned rather than `@main`

Two separate reasons, and only the first is a gate:

- `check-action-pins.sh` fails any cross-repo `uses:` that is not a 40-hex SHA.
  Its only exemption is a local `./` reference.
- A moving ref lets another repository change what runs here with no commit in
  this one. Re-pinning is a one-line diff naming the version it moved to, which
  is the reviewable form.

## Evidence

- Both files exist at `319b0a97`: `dod-check.yml` 6019 bytes,
  `dod-close-guard.yml` 4408 bytes (`gh api .../contents/...?ref=319b0a97`).
- The same caller, at the same implementation, now runs a real `dod` job and
  passes in all three sibling repos — verified before merging each:
  `macanderson/cgp-website#18`, `macanderson/arenabench#11`,
  `macanderson/context-graph-protocol#83`. Each run reports `JOB: dod / dod
  success` rather than the zero-job startup failure the unpinned `@main`
  callers produced here.
- `make action-pins` passes with these two files present — 88 references, all
  pinned. That is the witness: it fails on `@main` and passes on the SHA.

## Known follow-up, not introduced here

A PR that closes a machine-filed issue (the canary's `main-red`, the corpus
drift report) still fails `dod`, because those issues carry no DoD checklist —
`macanderson/oxagen#1330`. `dod` is not a required check on this repo, so it
reddens such a PR without blocking it. Restoring the caller does not change
that; it is named here so the first person to hit it does not re-diagnose it.

Deleted tests: none. No behavior change outside CI configuration.

Closes #5168

## Summary by Sourcery

Restore the DoD workflow callers with SHA-pinned references to the oxagen implementation.

Enhancements:
- Restore the DoD pull-request merge check and issue close guard as reusable workflow callers backed by a fixed oxagen revision.

CI:
- Pin both cross-repository DoD workflow references to the oxagen commit required by action-pins.