### PR TITLE
ci: restore the two DoD guards, repaired rather than deleted

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -1,0 +1,29 @@
+# DoD merge check (SCR-003) — caller stub.
+#
+# The implementation lives once in oxagen and is called from here. ADR-039:
+# copying the check into each repo would put five independently-drifting
+# copies of an enforcement rule into an org whose sibling check exists to
+# detect exactly that kind of drift.
+#
+# There is no logic in this file. A change to *what* the check
+# does never touches it; only adding or removing a check does.
+#
+# The ref below is a commit SHA rather than `@main`, for two reasons: a
+# cross-repo `uses:` on a moving ref fails `action-pins`, and it lets another
+# repository change what runs in this one without a commit here. Re-pinning
+# when the implementation moves is a one-line diff that names the version it
+# moved to, which is the reviewable form of the same update.
+name: dod-check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  dod:
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # oxagen main

--- a/.github/workflows/dod-close-guard.yml
+++ b/.github/workflows/dod-close-guard.yml
@@ -1,0 +1,20 @@
+# DoD close guard (SCR-003) — caller stub.
+#
+# Reopens an issue closed as *completed* while its definition-of-done still
+# has unchecked items. The merge gate in dod-check.yml carries the load; this
+# covers the hand-closed path, after the fact, because GitHub has no pre-close
+# hook to veto.
+#
+# Implementation lives once in oxagen — see ADR-039.
+name: dod-close-guard
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  guard:
+    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@319b0a97d8685abdb2721a3e95c2f766902eb4db # oxagen main


### PR DESCRIPTION
#5167 turned `action-pins` and `prose` green on the two DoD workflow callers by **deleting both files** — `dod-check.yml` 23 lines to 0, `dod-close-guard.yml` 20 to 0 — three commits after #5142 adopted the DoD merge check as SCR-003's L2 enforcement.

A deleted guard cannot fail. It also cannot hold.

## What this restores

Both files return at their pre-#5167 content, with the two real defects fixed rather than avoided:

| Defect | Fix |
|---|---|
| `action-pins`: cross-repo `uses:` on the moving `@main` ref | Pinned to `319b0a97d8685abdb2721a3e95c2f766902eb4db` (oxagen `main`), tag in a comment |
| `prose`: filler adverb in `dod-check.yml`'s header | Deleted; the sentence keeps its meaning |

The SHA pin also closes the larger hole the guard was pointing at: a cross-repo `uses:` resolved through a moving ref lets **another repository change what runs in this one with no commit here**. A comment on the pin records that reasoning and what re-pinning looks like, so the next edit updates the ref instead of reaching for `@main` again.

## Verification

`make guards-fast` passes on this branch:

```
check-action-pins: OK — all 88 'uses:' references are pinned to a commit SHA.
check-prose:       OK -- 4171 grandfathered construction(s), none added.
check-doc-links:   OK -- 1113 citation(s) resolve across 92 identified document(s).
```

No test added: this restores CI configuration with no behaviour change in the workspace, so there is no witness to flip. No test was deleted or renamed.

## Note

If these two callers are genuinely unwanted, that deserves its own PR and its own argument — not a side effect of turning a check green. This PR takes no position on that beyond restoring what was removed without one.

## Summary by Sourcery

Restore the DoD workflow guards with corrected, securely pinned references instead of disabling them.

Bug Fixes:
- Restore the DoD merge and close-guard workflow callers so the repository’s SCR-003 enforcement is active again.

Enhancements:
- Pin both cross-repository workflow references to a commit SHA and remove the prose issue from the merge-check workflow header.

CI:
- Restore the DoD GitHub Actions workflows for pull-request validation and post-close issue guarding.