### PR TITLE
feat(mcp): pin graph, latency, registry tiers, first-enable handshake gate

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -675,7 +675,7 @@ pub(crate) async fn record_turn_episode<T, E>(
 /// instead (applied in [`connect_mcp_servers`]) — without that override the
 /// connect bound would double as the call bound and kill every long-running
 /// tool call at 10s.
-const MCP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+pub(crate) const MCP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// The parse of `.stella/mcp.toml` **and** of every installed package's own
 /// `mcp.toml`, split from the connect so a caller that owns a UI (the deck)
@@ -802,6 +802,7 @@ pub(crate) async fn connect_mcp_servers(
     native: std::sync::Arc<dyn ToolExecutor>,
     usage: Option<stella_core::mcp_usage::McpUsageLedger>,
     disabled: Option<stella_mcp::DisabledServers>,
+    grants: Option<stella_mcp::CapabilityGrants>,
     auth: Option<std::sync::Arc<stella_mcp::OAuthManager>>,
 ) -> McpToolSet {
     let mut set = McpToolSet::connect_with_auth(servers, MCP_CONNECT_TIMEOUT, auth)
@@ -819,6 +820,12 @@ pub(crate) async fn connect_mcp_servers(
     }
     if let Some(disabled) = disabled {
         set = set.with_disabled_servers(disabled);
+    }
+    // The first-enable handshake gate (SPEC §9.3). Installing a set makes it
+    // default-deny, so every caller that can reach a human passes one — the
+    // property must not depend on which surface is driving.
+    if let Some(grants) = grants {
+        set = set.with_capability_grants(grants);
     }
     set
 }
@@ -855,8 +862,12 @@ pub(crate) async fn connect_mcp(
         }
     };
     // A one-shot run has no interactive enable/disable, so no disabled set.
+    // It DOES get the capability gate: a grant is recorded on disk, so a run
+    // with no deck attached reads the same answer the deck wrote, and a server
+    // nobody has reviewed must not become callable by being run from a script.
     let auth = crate::mcp_cmd::oauth_manager(&cfg.workspace_root)?;
-    let set = connect_mcp_servers(&servers, native, usage, None, Some(auth)).await;
+    let grants = crate::mcp_cmd::initial_grants(&cfg.workspace_root, &servers);
+    let set = connect_mcp_servers(&servers, native, usage, None, Some(grants), Some(auth)).await;
     if print_diagnostics {
         crate::mcp_cmd::print_connect_diagnostics(&set);
     }

--- a/crates/stella-cli/src/cli/subcommands.rs
+++ b/crates/stella-cli/src/cli/subcommands.rs
@@ -269,6 +269,21 @@ pub enum McpCmd {
         /// The configured server's local name
         name: String,
     },
+    /// Show what a configured server declares at handshake, and grant (or
+    /// revoke) its capabilities. A server installed from the registry
+    /// advertises nothing to the model until it is granted.
+    Grant {
+        /// The configured server's local name
+        name: String,
+        /// Record the grant without the confirmation prompt (for scripts and
+        /// provisioning; the capabilities are still printed)
+        #[arg(long)]
+        yes: bool,
+        /// Withdraw a grant given earlier: the server stays configured and
+        /// connected, and its tools stop being offered to the model
+        #[arg(long, conflicts_with = "yes")]
+        revoke: bool,
+    },
     /// OAuth login to a configured http server (opens your browser; tokens
     /// land owner-only in .stella/private/mcp_oauth.json and auto-refresh)
     Login {

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -794,10 +794,22 @@ pub async fn run_deck_session(
     //   • `mcp_disabled` — server names disabled this session; toggling it
     //     hides a server's tools from the model on the next call (live, no
     //     reconnect), because the engine re-reads schemas each call.
+    //   • `mcp_grants` — server names whose declared capabilities the operator
+    //     has granted (SPEC §9.3's first-enable handshake). Default-deny: a
+    //     connected server absent from it advertises nothing and refuses every
+    //     call. Seeded from `.stella/mcp.toml` when the connect task builds
+    //     its plan, and added to live when a grant is given, so a server
+    //     becomes usable in the session it was reviewed in.
     //   • the usage ledger (from the registry) records every MCP call for the
     //     `mcp_usage` telemetry table.
     let mcp_disabled: stella_mcp::DisabledServers =
         std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+    let mcp_grants: stella_mcp::CapabilityGrants =
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+    let mcp_session = crate::deck_mcp::McpSession {
+        disabled: mcp_disabled.clone(),
+        grants: mcp_grants.clone(),
+    };
     // `Arc<McpToolSet>` (not a bare `McpToolSet`) so a turn can cheaply clone
     // the connected set into the Best-of-N candidate surface + orchestrator
     // pre-fetch (issue #248 Phase 1) alongside its own `&dyn ToolExecutor`.
@@ -806,7 +818,7 @@ pub async fn run_deck_session(
     let mcp_configured = spawn_mcp_connect(
         cfg.clone(),
         registry.clone(),
-        mcp_disabled.clone(),
+        mcp_session.clone(),
         mcp_slot.clone(),
         in_tx.clone(),
         deck_tx.clone(),
@@ -1438,7 +1450,7 @@ pub async fn run_deck_session(
                             &other,
                             cfg,
                             mcp_slot.get().map(Arc::as_ref),
-                            &mcp_disabled,
+                            &mcp_session,
                             &in_tx,
                         )
                         .await
@@ -2044,6 +2056,16 @@ pub async fn run_deck_session(
                             if !set.remove(&name) {
                                 set.insert(name);
                             }
+                        }
+                        // A capability grant IS honored mid-turn, for the
+                        // reason the toggle is: the operator has just answered
+                        // a question that was blocking a server, and the
+                        // shared set the tool layer consults is what the next
+                        // model call reads. Deferring it would leave the tab
+                        // saying `granted` while every call kept being
+                        // refused until the turn ended.
+                        Some(WorkspaceInput::McpGrant { name }) => {
+                            crate::deck_mcp::apply_mcp_grant(cfg, &mcp_session, &name, &in_tx);
                         }
                         Some(WorkspaceInput::McpSearch { .. })
                         | Some(WorkspaceInput::McpInstall { .. })

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -37,7 +37,7 @@ use crate::subsession::{self, SubSessions, SupervisorMsg};
 pub(super) fn spawn_mcp_connect(
     cfg: Config,
     registry: Arc<ToolRegistry>,
-    disabled: stella_mcp::DisabledServers,
+    session: crate::deck_mcp::McpSession,
     slot: Arc<tokio::sync::OnceCell<Arc<stella_mcp::McpToolSet>>>,
     in_tx: UnboundedSender<Inbound>,
     chrome_tx: UnboundedSender<Inbound>,
@@ -68,11 +68,27 @@ pub(super) fn spawn_mcp_connect(
                 )));
                 match crate::mcp_cmd::oauth_manager(&cfg.workspace_root) {
                     Ok(auth) => {
+                        // The plan is what actually reaches connect (plugin
+                        // contributions included), so the grant set is built
+                        // from it rather than from `mcp.toml` alone.
+                        let grants_now =
+                            crate::mcp_cmd::initial_grants(&cfg.workspace_root, &servers);
+                        {
+                            let mut set = session.grants.lock().unwrap_or_else(|p| p.into_inner());
+                            set.extend(
+                                grants_now
+                                    .lock()
+                                    .unwrap_or_else(|p| p.into_inner())
+                                    .iter()
+                                    .cloned(),
+                            );
+                        }
                         let set = agent::connect_mcp_servers(
                             &servers,
                             registry.clone(),
                             Some(registry.mcp_usage_ledger()),
-                            Some(disabled.clone()),
+                            Some(session.disabled.clone()),
+                            Some(session.grants.clone()),
                             Some(auth),
                         )
                         .await;
@@ -100,8 +116,13 @@ pub(super) fn spawn_mcp_connect(
             }
         }
         // Seed the MCP tab with the configured servers and their live state.
-        crate::deck_mcp::send_mcp_snapshot(&cfg, slot.get().map(Arc::as_ref), &disabled, &in_tx)
-            .await;
+        crate::deck_mcp::send_mcp_snapshot(
+            &cfg,
+            slot.get().map(Arc::as_ref),
+            &session.disabled,
+            &in_tx,
+        )
+        .await;
         // MCP connect settled (or there was nothing to connect) — the other
         // init leg the launch splash waits on.
         release_splash();

--- a/crates/stella-cli/src/deck_mcp.rs
+++ b/crates/stella-cli/src/deck_mcp.rs
@@ -26,6 +26,24 @@ use tokio::sync::mpsc;
 use crate::command_deck::chrome_note;
 use crate::config::Config;
 
+/// The session-scoped MCP management state the deck shares with the live tool
+/// layer, in one value because the two halves are always passed together and
+/// always mean the same thing: what this session is allowed to call.
+///
+/// - `disabled` — servers the operator toggled off. Session-scoped by design:
+///   it changes a running conversation's tool set and is forgotten at exit.
+/// - `grants` — servers whose declared capabilities the operator granted (SPEC
+///   §9.3). Mirrors `.stella/mcp.toml`, so unlike the toggle it survives.
+///
+/// Both are `Arc<Mutex<HashSet<_>>>` shared with `McpToolSet`, which re-reads
+/// them on every advertise and every dispatch — so a toggle or a grant takes
+/// effect on the next model call with no reconnect.
+#[derive(Clone)]
+pub(crate) struct McpSession {
+    pub(crate) disabled: stella_mcp::DisabledServers,
+    pub(crate) grants: stella_mcp::CapabilityGrants,
+}
+
 /// Build the MCP tab snapshot: every configured server (`.stella/mcp.toml`)
 /// joined with its live session state — enabled (not in the disabled set),
 /// connected (in the live tool set), health, per-server tool count (derived
@@ -77,6 +95,7 @@ pub(crate) async fn mcp_snapshot(
                     stella_mcp::split_wire_name(&s.name).is_some_and(|(server, _)| server == name)
                 })
                 .count();
+            let latency_ms = crate::mcp_cmd::latency_ms(&health, name);
             let health = crate::mcp_cmd::health_label(&health, name);
             let calls: u64 = usage
                 .iter()
@@ -106,6 +125,8 @@ pub(crate) async fn mcp_snapshot(
                 enabled,
                 connected: connected_now,
                 health: connected_now.then_some(health).flatten(),
+                latency_ms: connected_now.then_some(latency_ms).flatten(),
+                granted: config.is_granted(name),
                 tool_count,
                 dropped_tools: dropped.get(name).copied().unwrap_or(0),
                 trimmed_tools: trimmed.get(name).copied().unwrap_or(0),
@@ -183,9 +204,15 @@ pub(crate) async fn mcp_detail(
         .ok_or_else(|| format!("`{name}` is not configured in .stella/mcp.toml"))?;
     let card = config.card(name).expect("name resolved above");
     let connected = mcp.is_some_and(|s| s.connected_names().contains(&name));
-    let health = match mcp {
-        Some(s) => crate::mcp_cmd::health_label(&s.health().await, name),
-        None => None,
+    let (health, latency_ms) = match mcp {
+        Some(s) => {
+            let rows = s.health().await;
+            (
+                crate::mcp_cmd::health_label(&rows, name),
+                crate::mcp_cmd::latency_ms(&rows, name),
+            )
+        }
+        None => (None, None),
     };
     let usage = crate::mcp_cmd::usage_stats(&cfg.workspace_root)?;
     let per_tool: HashMap<&str, u64> = usage
@@ -244,6 +271,8 @@ pub(crate) async fn mcp_detail(
         enabled: !disabled_now,
         connected,
         health: connected.then_some(health).flatten(),
+        latency_ms: connected.then_some(latency_ms).flatten(),
+        granted: config.is_granted(name),
         dropped_tools: crate::mcp_cmd::dropped_by_server(mcp)
             .get(name)
             .copied()
@@ -337,6 +366,9 @@ async fn run_mcp_search(cfg: &Config, query: &str) -> stella_tui::McpSearchOutco
                             || configured.contains(&alias),
                         kinds: crate::mcp_cmd::install_kinds(&e.server),
                         description: e.server.description.clone().unwrap_or_default(),
+                        tier: display_tier(e.tier),
+                        installs: e.installs,
+                        signature: display_signature(e.signature),
                         name: e.server.name,
                     }
                 })
@@ -357,6 +389,74 @@ async fn run_mcp_search(cfg: &Config, query: &str) -> stella_tui::McpSearchOutco
     }
 }
 
+/// Cross the read-model seam for a registry entry's source tier.
+///
+/// Exhaustive on purpose, and not a `From` impl: `stella-tui` takes only leaf
+/// dependencies, so the two enums cannot know about each other and this is the
+/// one place they meet. A tier added in `stella-mcp` fails to compile here
+/// rather than rendering as something it is not.
+fn display_tier(tier: stella_mcp::SourceTier) -> stella_tui::McpSourceTier {
+    match tier {
+        stella_mcp::SourceTier::Official => stella_tui::McpSourceTier::Official,
+        stella_mcp::SourceTier::Vendor => stella_tui::McpSourceTier::Vendor,
+        stella_mcp::SourceTier::Community => stella_tui::McpSourceTier::Community,
+    }
+}
+
+/// The same seam for the signature column. The blocked states stay distinct
+/// across it: `unsigned` and `withdrawn` send an operator to different places.
+fn display_signature(signature: stella_mcp::SignatureStatus) -> stella_tui::McpSignature {
+    match signature {
+        stella_mcp::SignatureStatus::Signed => stella_tui::McpSignature::Signed,
+        stella_mcp::SignatureStatus::Unsigned => stella_tui::McpSignature::Unsigned,
+        stella_mcp::SignatureStatus::Withdrawn(_) => stella_tui::McpSignature::Withdrawn,
+    }
+}
+
+/// Record a capability grant and make it effective in this session: the
+/// decision goes to `.stella/mcp.toml`, the name joins the shared grant set
+/// the tool layer consults on every model call, and the server is enabled.
+///
+/// Disk first. A grant that is live but unrecorded would evaporate at the next
+/// start, and the operator — who just read a tool list and answered for it —
+/// would be asked again with no way to tell why. A write that fails leaves the
+/// server withheld and says so, which is the safe direction.
+pub(crate) fn apply_mcp_grant(
+    cfg: &Config,
+    session: &McpSession,
+    name: &str,
+    in_tx: &mpsc::UnboundedSender<Inbound>,
+) -> bool {
+    match crate::mcp_cmd::set_granted(&cfg.workspace_root, name, true) {
+        Ok(true) => {}
+        Ok(false) => {
+            let _ = in_tx.send(chrome_note(format!(
+                "mcp: `{name}` is not configured in .stella/mcp.toml — nothing granted\n"
+            )));
+            return false;
+        }
+        Err(e) => {
+            let _ = in_tx.send(chrome_note(format!(
+                "mcp: could not record the grant for `{name}`: {e} — it stays withheld\n"
+            )));
+            return false;
+        }
+    }
+    session
+        .grants
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert(name.to_string());
+    // Granting is the first ENABLE: a server left in the disabled set would
+    // have been reviewed and still advertise nothing.
+    session
+        .disabled
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .remove(name);
+    true
+}
+
 /// Service one MCP-tab action from the deck. Returns `true` if `input` was an
 /// MCP verb (so the caller skips its own dispatch). Search/install/remove/auth
 /// touch `.stella/mcp.toml` (and, for search, the registry over HTTP); toggle
@@ -365,10 +465,15 @@ pub(crate) async fn service_mcp_action(
     input: &WorkspaceInput,
     cfg: &Config,
     mcp: Option<&stella_mcp::McpToolSet>,
-    disabled: &stella_mcp::DisabledServers,
+    session: &McpSession,
     in_tx: &mpsc::UnboundedSender<Inbound>,
 ) -> bool {
+    let disabled = &session.disabled;
     match input {
+        WorkspaceInput::McpGrant { name } => {
+            apply_mcp_grant(cfg, session, name, in_tx);
+            send_mcp_snapshot(cfg, mcp, disabled, in_tx).await;
+        }
         WorkspaceInput::McpToggle { name } => {
             {
                 let mut set = disabled.lock().unwrap_or_else(|p| p.into_inner());

--- a/crates/stella-cli/src/mcp_cmd.rs
+++ b/crates/stella-cli/src/mcp_cmd.rs
@@ -269,6 +269,73 @@ pub(crate) fn health_label(health: &[stella_mcp::ServerHealth], name: &str) -> O
     })
 }
 
+/// The measured `initialize` round trip for one server, in whole
+/// milliseconds — SPEC §9.3's latency column.
+///
+/// `None` when the server reported no health row or has no live connection
+/// that measured one. Never rounded up from zero: a sub-millisecond stdio
+/// server legitimately reads `0ms`, and that is a measurement, unlike the
+/// absent case beside it.
+pub(crate) fn latency_ms(health: &[stella_mcp::ServerHealth], name: &str) -> Option<u64> {
+    health
+        .iter()
+        .find(|h| h.name == name)
+        .and_then(|h| h.latency)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+/// The session's starting capability grants (SPEC §9.3's first-enable
+/// handshake): the names from `servers` whose recorded decision permits use.
+///
+/// Three sources reach `servers` and each answers the question differently,
+/// which is why this reads the decision rather than a flag:
+///
+/// - **A registry install** writes `granted = false`, so it starts withheld
+///   until its handshake is reviewed. That door is the one the gate exists
+///   for: a search result is a keystroke away from a `cmd` line this process
+///   spawns.
+/// - **A hand-written `mcp.toml` entry** records no decision, and is granted.
+///   Writing the transport by hand is already the review the gate asks for.
+/// - **A plugin-contributed server** is not in `mcp.toml` at all, and is
+///   granted for the same reason: installing the plugin was the decision, and
+///   there is no entry a grant could even be recorded in.
+///
+/// A config that will not parse yields an empty set — deny, because the
+/// alternative is granting everything on the strength of a file nobody could
+/// read.
+pub fn initial_grants(
+    workspace_root: &Path,
+    servers: &[stella_mcp::McpServerConfig],
+) -> stella_mcp::CapabilityGrants {
+    let cfg = load_config(workspace_root).unwrap_or_default();
+    let granted = servers
+        .iter()
+        .filter(|s| {
+            cfg.grant_decision(&s.name)
+                .is_none_or(|decision| decision.unwrap_or(true))
+        })
+        .map(|s| s.name.clone())
+        .collect();
+    std::sync::Arc::new(std::sync::Mutex::new(granted))
+}
+
+/// Record the operator's capability grant for a configured server (SPEC
+/// §9.3's first-enable handshake) and return whether the server existed to
+/// grant.
+///
+/// The decision persists in `.stella/mcp.toml`, so it survives the session it
+/// was made in — and so a run with no deck attached reads the same answer the
+/// deck recorded. The live session's grant set is the caller's to update; this is
+/// only the write to disk.
+pub fn set_granted(workspace_root: &Path, name: &str, granted: bool) -> Result<bool, String> {
+    let mut cfg = load_config(workspace_root)?;
+    if !cfg.set_granted(name, granted) {
+        return Ok(false);
+    }
+    save_config(workspace_root, &cfg)?;
+    Ok(true)
+}
+
 /// Search a registry over HTTP (async, non-blocking).
 pub async fn search(
     registry_url: &str,
@@ -286,6 +353,13 @@ pub async fn search(
 /// Install (or overwrite — MCP servers are not versioned) one server entry,
 /// recording the publisher's [`ServerCard`] beside the transport so the local
 /// alias is not the only thing the tab can show later.
+///
+/// A NEW entry lands **ungranted**: nothing it advertises is offered to the
+/// model and every call to it is refused until its handshake is reviewed
+/// (SPEC §9.3, and `stella_mcp::McpServerEntry::granted`). Re-installing over
+/// an existing alias leaves the recorded decision alone — the operator granted
+/// *that alias*, and re-fetching the same publisher's transport is not a new
+/// question.
 pub fn install(
     workspace_root: &Path,
     alias: &str,
@@ -480,8 +554,15 @@ pub fn usage_stats(workspace_root: &Path) -> Result<Vec<stella_store::McpUsageSt
 }
 
 /// Resolve a registry server name to `(alias, first install option)` — the
-/// non-interactive install path (`stella mcp install <name>`). Prefers an exact
-/// name match; a server with neither a runnable package nor a remote errors.
+/// non-interactive install path (`stella mcp install <name>` and the deck's
+/// `↵` on a search result). Prefers an exact name match; a server with neither
+/// a runnable package nor a remote errors.
+///
+/// **An entry the registry does not vouch for is refused here** (SPEC §9.3,
+/// "Unsigned blocked"). The check belongs on this path and not only in the
+/// paint: an install writes a `cmd` line that this process later spawns, and
+/// both callers reach it — so a row rendered red and a name typed at a shell
+/// get the same answer.
 pub async fn resolve_install(
     registry_url: &str,
     name: &str,
@@ -494,6 +575,9 @@ pub async fn resolve_install(
         .ok_or_else(|| {
             format!("no registry server named `{name}` — try `stella mcp search {name}`")
         })?;
+    if let Some(reason) = entry.signature.refusal() {
+        return Err(format!("`{name}`: {reason}"));
+    }
     let alias = entry.server.default_alias();
     let mut options = entry.server.install_options();
     if options.is_empty() {
@@ -521,6 +605,9 @@ pub fn run(cmd: &crate::McpCmd) -> Result<(), String> {
         ),
         crate::McpCmd::Install { name, alias } => run_install(&workspace_root, name, alias.clone()),
         crate::McpCmd::Remove { name } => run_remove(&workspace_root, name),
+        crate::McpCmd::Grant { name, yes, revoke } => {
+            run_grant(&workspace_root, name, *yes, *revoke)
+        }
         crate::McpCmd::Login { name } => run_login(&workspace_root, name),
         crate::McpCmd::Logout { name } => run_logout(&workspace_root, name),
         crate::McpCmd::Usage => run_usage(&workspace_root),
@@ -552,12 +639,20 @@ fn run_list(workspace_root: &Path) -> Result<(), String> {
         } else {
             "· no auth".dimmed()
         };
+        // Whether the model may use it at all comes before what it is: a
+        // withheld server is configured, connectable, and inert.
+        let grant = if cfg.is_granted(name) {
+            "".normal()
+        } else {
+            format!("· ungranted (stella mcp grant {name})").yellow()
+        };
         println!(
-            "  {} {} {} {}",
+            "  {} {} {} {} {}",
             "·".green(),
             card.display_name(name).bright_magenta(),
             format!("[{}]", transport.kind_label()).dimmed(),
-            auth
+            auth,
+            grant
         );
         // The alias is the routing token — the thing to type — so it stays
         // visible even when a title has taken the headline slot.
@@ -571,7 +666,8 @@ fn run_list(workspace_root: &Path) -> Result<(), String> {
     }
     println!(
         "\n  {}",
-        "enable/disable is per-session — toggle servers live in the deck's MCP tab (/mcp)."
+        "enable/disable is per-session — toggle servers live in the deck's MCP tab (/mcp). \
+         A grant is not: it is recorded in mcp.toml and read by every session."
             .dimmed()
     );
     Ok(())
@@ -596,11 +692,25 @@ fn run_search(workspace_root: &Path, query: &str, limit: u32) -> Result<(), Stri
     {
         let server = &entry.server;
         let kinds = install_kinds(server);
+        // Provenance beside the name, and in the same words the deck's MCP
+        // tab uses: tier, installs, signature — the three facts that decide
+        // whether the next line is worth reading (SPEC §9.3).
+        let signature = if entry.signature.installable() {
+            entry.signature.label().green()
+        } else {
+            entry.signature.label().red()
+        };
         println!(
-            "  {} {} {}",
+            "  {} {} {} {} {} {}",
             "·".green(),
             server.name.bright_magenta(),
-            format!("[{kinds}]").dimmed()
+            format!("[{kinds}]").dimmed(),
+            entry.tier.label().dimmed(),
+            match entry.installs {
+                Some(n) => format!("{n} installs").dimmed(),
+                None => "installs unknown".dimmed(),
+            },
+            signature
         );
         if let Some(desc) = &server.description {
             println!("      {}", truncate(desc, 100).dimmed());
@@ -609,7 +719,12 @@ fn run_search(workspace_root: &Path, query: &str, limit: u32) -> Result<(), Stri
     if page.next_cursor.is_some() {
         println!("\n  {}", "more results available (pagination)".dimmed());
     }
-    println!("\n  {}", "install with: stella mcp install <name>".dimmed());
+    println!(
+        "\n  {}",
+        "install with: stella mcp install <name> — a blocked entry is refused, then \
+         `stella mcp grant <name>` reviews what an installed one declares"
+            .dimmed()
+    );
     Ok(())
 }
 
@@ -676,6 +791,138 @@ fn run_login(workspace_root: &Path, name: &str) -> Result<(), String> {
         oauth_store_path(workspace_root)?.display()
     );
     Ok(())
+}
+
+/// `stella mcp grant <name>` — SPEC §9.3's first-enable handshake for a shell
+/// rather than the deck, and the remedy every ungranted-server refusal names.
+///
+/// It connects, prints what the server declares, and records the decision.
+/// Connecting is the point: the capabilities being granted are what the
+/// process on the other end announces right now, not what a registry card once
+/// said, and nothing short of asking it can show them.
+///
+/// `--revoke` withdraws a grant. It writes `granted = false` rather than
+/// clearing the key, because "reviewed and declined" and "never asked" are
+/// different states and only the first should survive a re-read.
+fn run_grant(workspace_root: &Path, name: &str, yes: bool, revoke: bool) -> Result<(), String> {
+    let cfg = load_config(workspace_root)?;
+    let transport = cfg.get(name).cloned().ok_or_else(|| {
+        format!(
+            "no MCP server `{name}` in {}",
+            mcp_toml_path(workspace_root).display()
+        )
+    })?;
+    if revoke {
+        set_granted(workspace_root, name, false)?;
+        println!(
+            "  {} revoked {} — its tools are no longer offered to the model",
+            "◆".bright_cyan(),
+            name.bright_magenta()
+        );
+        return Ok(());
+    }
+
+    crate::plain::section_header(&format!("MCP handshake — {name}"));
+    let server = stella_mcp::McpServerConfig {
+        name: name.to_string(),
+        transport,
+        candidate_safe: cfg.is_candidate_safe(name),
+    };
+    let auth = oauth_manager(workspace_root)?;
+    // No grant set on this client: it never calls a tool, and gating the
+    // handshake would make the capabilities unreadable — which is the one
+    // thing this command exists to prevent.
+    let set = runtime()?.block_on(stella_mcp::McpToolSet::connect_with_auth(
+        std::slice::from_ref(&server),
+        crate::agent::MCP_CONNECT_TIMEOUT,
+        Some(auth),
+    ));
+    if let Some((_, reason)) = set.failed_servers().iter().find(|(s, _)| s == name) {
+        return Err(format!(
+            "`{name}` did not connect, so it has declared nothing to grant: {reason}"
+        ));
+    }
+    if let Some((_, reason)) = set.auth_required_servers().iter().find(|(s, _)| s == name) {
+        return Err(format!(
+            "`{name}` needs a login before it will declare anything: {reason} \
+             (run `stella mcp login {name}`)"
+        ));
+    }
+
+    if let Some(identity) = set.identity(name) {
+        let announced = identity
+            .title
+            .or(identity.name)
+            .unwrap_or_else(|| "(no name announced)".to_string());
+        println!(
+            "  {} announces itself as {} {}",
+            "·".green(),
+            announced.bright_magenta(),
+            format!("[{}]", identity.protocol_version).dimmed()
+        );
+    }
+    println!(
+        "  {} reached at {}",
+        "·".green(),
+        endpoint_summary(&server.transport).dimmed()
+    );
+    let tools = set.advertised_tools(name);
+    if tools.is_empty() {
+        println!("  {}", "it declares no tools at all".yellow());
+    } else {
+        println!(
+            "\n  {}",
+            format!(
+                "it declares {} tool(s), every one of which the model may call once granted:",
+                tools.len()
+            )
+            .bold()
+        );
+        for tool in tools {
+            println!("    {} {}", "·".green(), tool.name.bright_magenta());
+            let summary = tool
+                .description
+                .lines()
+                .map(str::trim)
+                .find(|l| !l.is_empty())
+                .unwrap_or_default();
+            if !summary.is_empty() {
+                println!("        {}", truncate(summary, 100).dimmed());
+            }
+        }
+    }
+    runtime()?.block_on(set.close_all());
+
+    if !yes && !confirm_grant(name)? {
+        println!("  {} not granted — `{}` stays withheld", "·".dimmed(), name);
+        return Ok(());
+    }
+    set_granted(workspace_root, name, true)?;
+    println!(
+        "\n  {} granted {} — its tools are offered to the model from the next session",
+        "◆".bright_cyan(),
+        name.bright_magenta()
+    );
+    Ok(())
+}
+
+/// The interactive half of `stella mcp grant`. Anything but an explicit `y`
+/// declines, including an unreadable or closed stdin: a grant is the one
+/// answer that must never be arrived at by default.
+fn confirm_grant(name: &str) -> Result<bool, String> {
+    use std::io::Write as _;
+    print!("\n  grant these capabilities to `{name}`? [y/N] ");
+    std::io::stdout()
+        .flush()
+        .map_err(|e| format!("cannot write to stdout: {e}"))?;
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return Ok(false);
+    }
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
 }
 
 fn run_logout(workspace_root: &Path, name: &str) -> Result<(), String> {
@@ -834,6 +1081,88 @@ mod tests {
         assert!(load_config(&dir).unwrap().names().is_empty());
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// **The witness (#5047, persistence).** A registry install lands
+    /// withheld and stays withheld across a reload; the grant survives the
+    /// same round trip. Without the on-disk half, every session would ask
+    /// again — which is how operators learn to grant without reading.
+    #[test]
+    fn an_installed_server_lands_ungranted_and_the_grant_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let transport = McpTransport::Stdio {
+            cmd: "npx".into(),
+            args: vec!["-y".into(), "some-mcp".into()],
+            env: BTreeMap::new(),
+        };
+        install(root, "some", transport.clone(), ServerCard::default()).unwrap();
+
+        assert!(
+            !load_config(root).unwrap().is_granted("some"),
+            "a registry install must not be usable before its handshake is read"
+        );
+        assert!(set_granted(root, "some", true).unwrap());
+        assert!(load_config(root).unwrap().is_granted("some"));
+
+        // Re-installing the same alias does not re-ask: the operator granted
+        // THAT alias, and re-fetching the publisher's transport is not a new
+        // question.
+        install(root, "some", transport, ServerCard::default()).unwrap();
+        assert!(load_config(root).unwrap().is_granted("some"));
+
+        // Revoking is a recorded "no", distinguishable from never having been
+        // asked — which is what a hand-written entry looks like.
+        assert!(set_granted(root, "some", false).unwrap());
+        assert_eq!(
+            load_config(root).unwrap().grant_decision("some"),
+            Some(Some(false))
+        );
+        assert!(!set_granted(root, "absent", true).unwrap());
+    }
+
+    /// Which of the three doors a server came through decides its starting
+    /// grant. A hand-written entry and a plugin's contribution were both
+    /// chosen by the operator; a registry install is one keystroke.
+    #[test]
+    fn the_session_grants_come_from_how_each_server_was_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let transport = || McpTransport::Stdio {
+            cmd: "npx".into(),
+            args: vec![],
+            env: BTreeMap::new(),
+        };
+        // Installed from the registry: a recorded "not yet".
+        install(root, "installed", transport(), ServerCard::default()).unwrap();
+        // Hand-written: no decision recorded at all.
+        let mut cfg = load_config(root).unwrap();
+        cfg.servers.insert(
+            "handwritten".to_string(),
+            stella_mcp::config::McpServerEntry {
+                transport: transport(),
+                candidate_safe: false,
+                granted: None,
+                card: ServerCard::default(),
+            },
+        );
+        save_config(root, &cfg).unwrap();
+
+        let plan: Vec<stella_mcp::McpServerConfig> = ["installed", "handwritten", "contributed"]
+            .into_iter()
+            .map(|name| stella_mcp::McpServerConfig {
+                name: name.to_string(),
+                transport: transport(),
+                candidate_safe: false,
+            })
+            .collect();
+        let grants = initial_grants(root, &plan);
+        let granted = grants.lock().unwrap();
+        assert!(!granted.contains("installed"), "{granted:?}");
+        assert!(granted.contains("handwritten"), "{granted:?}");
+        // Not in mcp.toml at all — a plugin shipped it, and installing the
+        // plugin was the decision.
+        assert!(granted.contains("contributed"), "{granted:?}");
     }
 
     #[cfg(unix)]

--- a/crates/stella-mcp/src/client.rs
+++ b/crates/stella-mcp/src/client.rs
@@ -217,6 +217,9 @@ impl McpClient {
         self.tools = handshake.tools;
         self.dropped_tools = handshake.dropped_tools;
         self.resources_capability = handshake.resources_capability;
+        self.conn
+            .get_mut()
+            .note_handshake_latency(handshake.latency);
         // The handshake is itself a completed request round-trip
         // (`initialize` + `tools/list`), so a freshly-connected server is
         // legitimately `Live`.
@@ -481,7 +484,11 @@ impl McpClient {
         )
         .await
         {
-            Ok(Ok(_)) => {}
+            // The fresh handshake re-measures the round trip: the number
+            // describes the connection that is live now, not the one that
+            // dropped — a server that moved, or a link that degraded, would
+            // otherwise report its first-connect distance forever.
+            Ok(Ok(handshake)) => conn.note_handshake_latency(handshake.latency),
             Ok(Err(err)) => {
                 conn.note_connect_failure(&err);
                 return Err(err);
@@ -525,6 +532,7 @@ impl McpClient {
             connect_failures: conn.health.connect_failures,
             last_error: conn.health.last_error.clone(),
             retry_in: conn.retry_in(),
+            latency: conn.health.latency,
         }
     }
 
@@ -615,6 +623,8 @@ struct Handshake {
     dropped_tools: usize,
     /// The server declared the `resources` capability (#2678).
     resources_capability: bool,
+    /// How long the `initialize` request itself took to come back.
+    latency: Duration,
 }
 
 /// Build a fresh (pre-handshake) transport for `config`. Shared by the first
@@ -656,7 +666,15 @@ async fn run_handshake(name: &str, transport: &dyn Transport) -> Result<Handshak
             website_url: None,
         },
     };
+    // The measurement is this one request and nothing else. `tools/list`
+    // below pages, so folding it in would price a catalogue server as a
+    // distant one; the stdio spawn that precedes the transport is process
+    // start-up, not distance. `initialize` is the smallest round trip every
+    // server must answer, which makes the number comparable between two rows
+    // of the MCP tab (SPEC §9.3's latency column).
+    let started = Instant::now();
     let raw = transport.request("initialize", to_value(&params)?).await?;
+    let latency = started.elapsed();
     let result: InitializeResult = serde_json::from_value(raw)
         .map_err(|e| McpError::Protocol(format!("could not decode initialize result: {e}")))?;
 
@@ -698,6 +716,7 @@ async fn run_handshake(name: &str, transport: &dyn Transport) -> Result<Handshak
         tools,
         dropped_tools,
         resources_capability,
+        latency,
     })
 }
 

--- a/crates/stella-mcp/src/client/health.rs
+++ b/crates/stella-mcp/src/client/health.rs
@@ -95,6 +95,19 @@ pub struct ServerHealth {
     /// `None` when none is armed — which includes the `Down`-but-connected
     /// case (the transport is up, the calls on it are failing).
     pub retry_in: Option<Duration>,
+    /// Round-trip time of the `initialize` request measured when the *live*
+    /// connection was established — how far away the server is.
+    ///
+    /// The `initialize` request alone, not the whole handshake: `tools/list`
+    /// pages, so including it would price a catalogue server as a distant
+    /// one. A reconnect re-measures, so this always describes the connection
+    /// that is up now.
+    ///
+    /// `None` for a server that has never completed a handshake — an
+    /// auth-suppressed row, or a client wrapped around a transport that has
+    /// not been initialized. Never a synthesized zero: unknown distance and
+    /// zero distance are different facts, and the second one is a lie.
+    pub latency: Option<Duration>,
 }
 
 impl ServerHealth {
@@ -130,6 +143,12 @@ pub(super) struct Health {
     /// Earliest instant a reconnect may be attempted (set when the transport
     /// is torn down).
     pub(super) next_retry_at: Option<Instant>,
+    /// The live connection's `initialize` round trip — see
+    /// [`ServerHealth::latency`]. Lives behind the connection mutex rather
+    /// than beside the handshake's other outputs because the reconnect path
+    /// holds only `&self`, and a stale number there would be the one thing
+    /// this field must never report.
+    pub(super) latency: Option<Duration>,
 }
 
 impl Default for Health {
@@ -140,6 +159,7 @@ impl Default for Health {
             connect_failures: 0,
             last_error: None,
             next_retry_at: None,
+            latency: None,
         }
     }
 }
@@ -156,6 +176,13 @@ impl Health {
 }
 
 impl Connection {
+    /// Record the `initialize` round trip a completed handshake measured —
+    /// the first one and every reconnect's, so the reported distance is
+    /// always the live connection's ([`ServerHealth::latency`]).
+    pub(super) fn note_handshake_latency(&mut self, latency: Duration) {
+        self.health.latency = Some(latency);
+    }
+
     /// A request *returned* — the handshake or a `tools/call`. This is the
     /// only transition into [`HealthState::Live`]: it is the only evidence
     /// that the server actually serves requests.
@@ -203,6 +230,10 @@ impl Connection {
     /// backoff clock armed from the combined streak.
     fn tear_down(&mut self, err: &McpError) {
         self.transport = None;
+        // The measured distance belonged to the connection that just died.
+        // Keeping it would report a round trip nothing can make right now;
+        // the next handshake supplies a fresh one.
+        self.health.latency = None;
         self.health.last_error = Some(err.user_message());
         self.health.state = HealthState::Down;
         self.health.next_retry_at =

--- a/crates/stella-mcp/src/config.rs
+++ b/crates/stella-mcp/src/config.rs
@@ -110,6 +110,11 @@ impl McpConfig {
                     McpServerEntry {
                         transport,
                         candidate_safe: false,
+                        // A server arriving through this door has not been
+                        // reviewed, so the decision is recorded as "not
+                        // granted" rather than left absent — absent means a
+                        // human wrote the entry (see the field's doc).
+                        granted: Some(false),
                         card,
                     },
                 );
@@ -133,6 +138,52 @@ impl McpConfig {
             }
             None => false,
         }
+    }
+
+    /// Whether `name`'s tools may be advertised to the model and called —
+    /// the on-disk half of SPEC §9.3's first-enable handshake gate.
+    ///
+    /// `true` for a granted server and for one whose entry records no
+    /// decision at all; `false` only where a decision is recorded and it is
+    /// not yes. See [`McpServerEntry::granted`] for why an absent key reads as
+    /// granted. An unconfigured name is `false` — there is nothing to grant.
+    pub fn is_granted(&self, name: &str) -> bool {
+        self.servers
+            .get(name)
+            .is_some_and(|e| e.granted.unwrap_or(true))
+    }
+
+    /// The recorded grant decision for `name`, undecided (`None`) included —
+    /// what a UI needs to tell "granted" from "nobody ever asked". Use
+    /// [`McpConfig::is_granted`] for the gate itself.
+    pub fn grant_decision(&self, name: &str) -> Option<Option<bool>> {
+        self.servers.get(name).map(|e| e.granted)
+    }
+
+    /// Record the operator's answer to the first-enable handshake, returning
+    /// whether the server exists to answer for.
+    ///
+    /// Always writes a decision, never clears one: revoking is
+    /// `set_granted(name, false)`, which is a different state from the absent
+    /// key a hand-written entry carries and must stay distinguishable from it.
+    pub fn set_granted(&mut self, name: &str, granted: bool) -> bool {
+        match self.servers.get_mut(name) {
+            Some(entry) => {
+                entry.granted = Some(granted);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Every configured server whose tools may be used — the set
+    /// [`crate::McpToolSet::with_capability_grants`] is built from.
+    pub fn granted_names(&self) -> Vec<&str> {
+        self.servers
+            .iter()
+            .filter(|(_, e)| e.granted.unwrap_or(true))
+            .map(|(name, _)| name.as_str())
+            .collect()
     }
 
     /// Remove a server entry, returning whether it existed.
@@ -257,6 +308,29 @@ pub struct McpServerEntry {
     /// never inferred.
     #[serde(default)]
     pub candidate_safe: bool,
+    /// The operator's capability grant for this server (SPEC §9.3's
+    /// first-enable handshake), in three states:
+    ///
+    /// - `Some(true)` — the operator read what this server declares at
+    ///   handshake and granted it. Its tools are advertised and callable.
+    /// - `Some(false)` — a decision is recorded and it was *not yet yes*.
+    ///   This is what an install writes, so a server added from the registry
+    ///   arrives withheld: no tool of it is advertised to the model and every
+    ///   call to it is refused until the handshake is reviewed.
+    /// - `None` — no decision was ever recorded, which is what a hand-written
+    ///   `mcp.toml` entry looks like. Read as granted, because writing the
+    ///   transport into this file by hand **is** the review the gate is
+    ///   asking for. The gate exists for the other door: one keystroke on
+    ///   a registry search result, which adds a stranger's server.
+    ///
+    /// The asymmetry is the threat model rather than a convenience. Anyone who
+    /// can write `granted = true` here can equally omit the key, so reading
+    /// `None` as withheld would defend against nothing `Some(false)` does not
+    /// already cover — and would disarm every existing workspace on upgrade,
+    /// which is the failure mode that teaches operators to grant without
+    /// reading. [`McpConfig::is_granted`] is the one reader.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granted: Option<bool>,
     /// Publisher-supplied identity, recorded at install. Flattened so the
     /// fields sit beside the transport's rather than in a sub-table — an entry
     /// stays one readable block in `mcp.toml`, and an absent card writes

--- a/crates/stella-mcp/src/lib.rs
+++ b/crates/stella-mcp/src/lib.rs
@@ -108,13 +108,13 @@ pub use oauth::{
 };
 pub use registry::{
     AuthField, AuthLocation, DEFAULT_REGISTRY_URL, InstallOption, RegistryClient, RegistryEntry,
-    RegistryPage, RegistryServer,
+    RegistryPage, RegistryServer, SignatureStatus, SourceTier,
 };
 pub use stdio::StdioTransport;
 pub use suppress::{AUTH_PROBE_TTL, AuthProbeCache, ConnectGate};
 pub use toolset::{
-    DEFAULT_CALL_TIMEOUT, DisabledServers, MAX_SERVER_SCHEMA_BYTES, McpToolSet, ServerIdentity,
-    WireNameCollision, list_resources_tool_name, login_required_tool_name, namespace_prefix,
-    read_resource_tool_name, split_wire_name, wire_name,
+    CapabilityGrants, DEFAULT_CALL_TIMEOUT, DisabledServers, MAX_SERVER_SCHEMA_BYTES, McpToolSet,
+    ServerIdentity, WireNameCollision, list_resources_tool_name, login_required_tool_name,
+    namespace_prefix, read_resource_tool_name, split_wire_name, wire_name,
 };
 pub use transport::Transport;

--- a/crates/stella-mcp/src/registry.rs
+++ b/crates/stella-mcp/src/registry.rs
@@ -88,6 +88,109 @@ struct OfficialMeta {
     is_latest: Option<bool>,
     #[serde(default, rename = "updatedAt")]
     updated_at: Option<String>,
+    /// How many times this server has been installed, where the registry
+    /// counts. The frozen v0.1 schema does not define the field and the
+    /// official registry does not serve it today, so this is usually absent —
+    /// see [`RegistryEntry::installs`] for why absent stays absent.
+    #[serde(default, rename = "downloadCount")]
+    download_count: Option<u64>,
+}
+
+/// How far the registry's own publish authentication goes for an entry —
+/// SPEC §9.3's `official · vendor · community` column.
+///
+/// Derived from the entry's **namespace**, because that is what the registry
+/// actually verifies at publish time: a reverse-DNS namespace is proved with a
+/// DNS record on the domain, a code-host namespace with an account on that
+/// host, and the registry operator's own namespace is the operator itself.
+/// Nothing here is a judgement about the software; it names who had to prove
+/// what before the entry could exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SourceTier {
+    /// The registry operator's own namespace (`io.modelcontextprotocol…`).
+    Official,
+    /// A namespace under a domain the publisher proved they control — the
+    /// reverse-DNS form, `com.stripe/mcp`. The strongest claim a third party
+    /// can make here: it ties the entry to an organization, not an account.
+    Vendor,
+    /// A namespace under a code host (`io.github.…`, `io.gitlab.…`), or the
+    /// registry's anonymous namespace. An account proved it, nothing more.
+    Community,
+}
+
+impl SourceTier {
+    /// The one-word label the MCP tab renders.
+    pub fn label(self) -> &'static str {
+        match self {
+            SourceTier::Official => "official",
+            SourceTier::Vendor => "vendor",
+            SourceTier::Community => "community",
+        }
+    }
+}
+
+/// Whether the registry vouches for who published an entry — SPEC §9.3's
+/// signature column, and the gate `install` refuses on.
+///
+/// "Signed" here is a claim about **provenance**, and each answer below says
+/// exactly which evidence produced it, because the word is easy to over-read: the
+/// registry authenticates a publisher against the namespace they publish under
+/// and records the entry's lifecycle in `_meta`. Stella verifies no signature
+/// over the package bytes themselves — no MCP registry publishes one to verify
+/// yet, and claiming otherwise would be the most dangerous kind of green badge
+/// — #5176 is where verifying the artifact goes once registries publish
+/// attestations to verify.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureStatus {
+    /// The registry attributed this entry to a verified namespace and its
+    /// lifecycle record says `active`.
+    Signed,
+    /// The registry attributed the entry to nobody: no official `_meta` block
+    /// at all, or the anonymous namespace. **Blocked** — an entry nobody
+    /// vouches for is a spawn command from a stranger.
+    Unsigned,
+    /// The registry attributed the entry and then withdrew it — `deprecated`,
+    /// `deleted`, or any lifecycle state that is not `active`. **Blocked**,
+    /// and worded apart from `Unsigned` because the remedy differs: this one
+    /// was published and pulled, and the operator should find out why.
+    Withdrawn(&'static str),
+}
+
+impl SignatureStatus {
+    /// Whether stella will install a server carrying this status.
+    ///
+    /// The refusal is the point of the column (SPEC §9.3, "Unsigned
+    /// blocked"): a search result is one keystroke from a `cmd` line this
+    /// process will spawn, so the check belongs on the install path and not
+    /// only in the paint.
+    pub fn installable(self) -> bool {
+        matches!(self, SignatureStatus::Signed)
+    }
+
+    /// The short label the MCP tab renders beside the row.
+    pub fn label(self) -> &'static str {
+        match self {
+            SignatureStatus::Signed => "signed",
+            SignatureStatus::Unsigned => "unsigned · blocked",
+            SignatureStatus::Withdrawn(_) => "withdrawn · blocked",
+        }
+    }
+
+    /// Why an install was refused, phrased for the operator who pressed the
+    /// key. `None` when nothing is refused.
+    pub fn refusal(self) -> Option<String> {
+        match self {
+            SignatureStatus::Signed => None,
+            SignatureStatus::Unsigned => Some(
+                "the registry does not attribute this entry to a verified publisher — \
+                 blocked by policy"
+                    .to_string(),
+            ),
+            SignatureStatus::Withdrawn(status) => Some(format!(
+                "the registry has withdrawn this entry (status `{status}`) — blocked by policy"
+            )),
+        }
+    }
 }
 
 /// A published `server.json` document: identity, description, and the ways to
@@ -235,6 +338,20 @@ pub struct RegistryEntry {
     pub status: Option<String>,
     pub is_latest: Option<bool>,
     pub updated_at: Option<String>,
+    /// Recorded installs, where the registry counts them.
+    ///
+    /// `None` means *the registry published no count*, and it is rendered as
+    /// unknown rather than as `0`: the frozen v0.1 schema defines no such
+    /// field, so most entries are legitimately absent, and a zero would say
+    /// "nobody has ever installed this" about a server with a million users.
+    pub installs: Option<u64>,
+    /// Whether the registry attributed this entry to anyone, and whether it
+    /// stands behind it — see [`SignatureStatus`]. Stella refuses to install
+    /// anything but [`SignatureStatus::Signed`].
+    pub signature: SignatureStatus,
+    /// How far the publisher's namespace verification goes — see
+    /// [`SourceTier`].
+    pub tier: SourceTier,
 }
 
 /// A page of results with the opaque cursor for the next page (`None` = last).
@@ -350,6 +467,70 @@ impl RegistryServer {
             }
         }
         options
+    }
+}
+
+/// The registry operator's own namespace: entries published by the people who
+/// run the registry.
+const OPERATOR_NAMESPACE: &str = "io.modelcontextprotocol";
+/// The namespace the official registry files entries under when it could not
+/// attribute them to a publisher at all.
+const ANONYMOUS_NAMESPACE: &str = "io.modelcontextprotocol.anonymous";
+/// Namespace prefixes whose ownership proof is a code-host account rather than
+/// a domain. `io.github.acme/x` says an account called `acme` exists on GitHub;
+/// `com.acme/x` says somebody served a DNS record for `acme.com`.
+const CODE_HOST_NAMESPACES: [&str; 2] = ["io.github.", "io.gitlab."];
+
+/// The namespace half of a registry name: everything before the first `/`.
+/// A name with no `/` is entirely namespace — the registry rejects those, and
+/// reading one as "no namespace" is the safe direction here.
+fn namespace_of(name: &str) -> &str {
+    name.split('/').next().unwrap_or(name)
+}
+
+/// Which [`SourceTier`] a registry name's namespace earns. See the enum for
+/// what each tier claims and why the namespace is the evidence.
+pub fn source_tier(name: &str) -> SourceTier {
+    let namespace = namespace_of(name);
+    if namespace == ANONYMOUS_NAMESPACE
+        || CODE_HOST_NAMESPACES
+            .iter()
+            .any(|prefix| namespace.starts_with(prefix))
+    {
+        return SourceTier::Community;
+    }
+    if namespace == OPERATOR_NAMESPACE || namespace.starts_with(&format!("{OPERATOR_NAMESPACE}.")) {
+        return SourceTier::Official;
+    }
+    // Everything left is a reverse-DNS namespace under somebody's domain.
+    // A name with no dot at all is nobody's domain, so it is not a vendor
+    // claim either.
+    if namespace.contains('.') {
+        SourceTier::Vendor
+    } else {
+        SourceTier::Community
+    }
+}
+
+/// Whether the registry attributed and still stands behind an entry — see
+/// [`SignatureStatus`] for what the word "signed" does and does not claim.
+///
+/// `status` is the entry's lifecycle field from the official `_meta` block.
+/// Its absence is read as *unattributed*, not as *active*: an entry the
+/// registry keeps no record for is one nobody has vouched for, and this
+/// function's answer decides whether a spawn command from a stranger may be
+/// written into `mcp.toml`.
+pub fn signature_status(name: &str, status: Option<&str>) -> SignatureStatus {
+    if namespace_of(name) == ANONYMOUS_NAMESPACE {
+        return SignatureStatus::Unsigned;
+    }
+    match status.map(str::trim) {
+        Some("active") => SignatureStatus::Signed,
+        Some("deprecated") => SignatureStatus::Withdrawn("deprecated"),
+        Some("deleted") => SignatureStatus::Withdrawn("deleted"),
+        // Any other lifecycle word is one this build does not know. Unknown
+        // is not active.
+        Some(_) | None => SignatureStatus::Unsigned,
     }
 }
 
@@ -595,11 +776,17 @@ impl RegistryClient {
         let entries = response
             .servers
             .into_iter()
-            .map(|envelope| RegistryEntry {
-                server: envelope.server,
-                status: envelope.meta.official.status,
-                is_latest: envelope.meta.official.is_latest,
-                updated_at: envelope.meta.official.updated_at,
+            .map(|envelope| {
+                let official = envelope.meta.official;
+                RegistryEntry {
+                    tier: source_tier(&envelope.server.name),
+                    signature: signature_status(&envelope.server.name, official.status.as_deref()),
+                    installs: official.download_count,
+                    server: envelope.server,
+                    status: official.status,
+                    is_latest: official.is_latest,
+                    updated_at: official.updated_at,
+                }
             })
             .collect();
         Ok(RegistryPage {
@@ -632,6 +819,80 @@ mod tests {
                 .any(|e| e.status.as_deref() == Some("active"))
         );
         assert!(page.entries.iter().any(|e| e.is_latest == Some(true)));
+    }
+
+    /// The tier column reads the registry's own verification classes off the
+    /// namespace — a DNS-proved domain outranks a code-host account, and the
+    /// registry operator's own namespace is its own tier.
+    #[test]
+    fn the_source_tier_is_read_from_the_namespace_the_registry_verified() {
+        for (name, tier) in [
+            ("io.modelcontextprotocol/everything", SourceTier::Official),
+            ("io.modelcontextprotocol.registry/x", SourceTier::Official),
+            ("com.stripe/mcp", SourceTier::Vendor),
+            ("ai.smithery/obsidian", SourceTier::Vendor),
+            ("io.github.acme/thing", SourceTier::Community),
+            ("io.gitlab.acme/thing", SourceTier::Community),
+            ("io.modelcontextprotocol.anonymous/x", SourceTier::Community),
+            // No dot is nobody's domain, so it is no vendor claim either.
+            ("plain/thing", SourceTier::Community),
+        ] {
+            assert_eq!(source_tier(name), tier, "{name}");
+        }
+    }
+
+    /// Blocked is the default. Only a lifecycle record the registry keeps and
+    /// still calls `active`, under a namespace it attributed to somebody,
+    /// earns an install.
+    #[test]
+    fn only_an_active_attributed_entry_is_installable() {
+        assert_eq!(
+            signature_status("com.stripe/mcp", Some("active")),
+            SignatureStatus::Signed
+        );
+        assert!(SignatureStatus::Signed.installable());
+
+        for (name, status) in [
+            // No lifecycle record at all: nobody vouched for this.
+            ("com.stripe/mcp", None),
+            // Attributed, then withdrawn.
+            ("com.stripe/mcp", Some("deprecated")),
+            ("com.stripe/mcp", Some("deleted")),
+            // A lifecycle word this build does not know is not `active`.
+            ("com.stripe/mcp", Some("quarantined")),
+            // The registry could not attribute it, whatever the status says.
+            ("io.modelcontextprotocol.anonymous/x", Some("active")),
+        ] {
+            let verdict = signature_status(name, status);
+            assert!(
+                !verdict.installable(),
+                "{name} / {status:?} must be blocked, got {verdict:?}"
+            );
+            assert!(verdict.refusal().is_some(), "a block must say why");
+        }
+
+        // Withdrawn is worded apart from unsigned: the remedies differ.
+        assert_ne!(
+            signature_status("com.stripe/mcp", Some("deprecated")).label(),
+            signature_status("com.stripe/mcp", None).label()
+        );
+    }
+
+    /// A registry that publishes no install count leaves the row saying
+    /// "unknown". A zero would claim nobody has ever installed the server.
+    #[test]
+    fn an_absent_install_count_stays_absent() {
+        let page = RegistryClient::parse_page(SEARCH_PACKAGES).unwrap();
+        assert!(
+            page.entries.iter().all(|e| e.installs.is_none()),
+            "the recorded official-registry page carries no count"
+        );
+
+        let counted = r#"{"servers":[{"server":{"name":"com.acme/x"},
+            "_meta":{"io.modelcontextprotocol.registry/official":
+            {"status":"active","downloadCount":9123}}}],"metadata":{}}"#;
+        let page = RegistryClient::parse_page(counted).unwrap();
+        assert_eq!(page.entries[0].installs, Some(9123));
     }
 
     #[test]

--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -70,6 +70,64 @@ pub use resources::{list_resources_tool_name, read_resource_tool_name};
 /// simply disappear from the advertised set (and any stray call errors).
 pub type DisabledServers = Arc<Mutex<HashSet<String>>>;
 
+/// The session-scoped set of server names whose declared capabilities the
+/// operator has **granted** (SPEC §9.3's first-enable handshake). Shared with
+/// the deck, which adds a name the moment the grant is given, so a server
+/// becomes usable inside the session it was reviewed in.
+///
+/// An allowlist, so a host that installs one gets default-deny: every
+/// connected server not named here has its tools withheld from the model and
+/// every call to it refused. `.stella/mcp.toml` is where the decision persists
+/// ([`crate::McpConfig::granted_names`] builds the initial set); this is the
+/// live mirror of it.
+///
+/// Connecting is not gated. The handshake is *how* declared capabilities
+/// become knowable, and nobody can review a tool list that was never fetched —
+/// so the gate sits between the handshake and the first `tools/call`, which is
+/// where the spec puts it.
+///
+/// `docs/adr/0018-mcp-capability-grants.md` records why the gate lives here
+/// rather than at each call site, and why an absent on-disk decision reads as
+/// granted.
+pub type CapabilityGrants = Arc<Mutex<HashSet<String>>>;
+
+/// Why a connected server's tools are unavailable this session.
+///
+/// One enum rather than two predicates because both answers are needed at four
+/// sites (the advertised schemas, the two synthetic tool families, and
+/// dispatch), and the two reasons must never be reported as each other: a
+/// server the operator switched off and a server the operator has not yet
+/// reviewed need different remedies from whoever reads the refusal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Withheld {
+    /// Toggled off for this session (`e` on the MCP tab).
+    Disabled,
+    /// No capability grant recorded — the first-enable handshake has not been
+    /// answered.
+    Ungranted,
+}
+
+impl Withheld {
+    /// The model-visible refusal for a call to `tool` on `server`.
+    ///
+    /// `RefusedByPolicy` for both: nothing failed, a rule declined. Each
+    /// message names its own remedy, because a tool error is often the only
+    /// place the model — and through it the user — meets this state.
+    fn refusal(self, server: &str, tool: &str) -> ToolOutput {
+        let message = match self {
+            Withheld::Disabled => format!(
+                "mcp server `{server}` is disabled for this session — tool `{tool}` unavailable"
+            ),
+            Withheld::Ungranted => format!(
+                "mcp server `{server}` has not been granted its declared capabilities — tool \
+                 `{tool}` unavailable. The user must review the server's handshake and grant it \
+                 (`e` on the deck's MCP tab, or `stella mcp grant {server}`)."
+            ),
+        };
+        ToolOutput::classified_error(stella_protocol::ErrorClass::RefusedByPolicy, message)
+    }
+}
+
 /// The tool-namespace prefix.
 const NS_PREFIX: &str = "mcp__";
 /// The separator between the `mcp__`, server, and tool segments.
@@ -165,6 +223,12 @@ pub struct McpToolSet {
     /// Server names disabled for this session. A disabled server's tools are
     /// hidden from `schemas()` and its calls error, without disconnecting it.
     disabled: Option<DisabledServers>,
+    /// Server names the operator has granted (SPEC §9.3's first-enable
+    /// handshake). `None` = no gate installed, which is what a caller with no
+    /// human to ask — a test, an embedder — gets. `Some` is default-deny: a
+    /// connected server absent from the set advertises nothing and answers
+    /// every call with [`Withheld::Ungranted`].
+    grants: Option<CapabilityGrants>,
     /// Connected server names opted into the Best-of-N candidate allowlist
     /// (`.stella/mcp.toml`'s `candidate_safe = true`, issue #248 Phase 1).
     /// Populated from the configs at connect time; see
@@ -272,6 +336,7 @@ impl McpToolSet {
             native: None,
             usage: None,
             disabled: None,
+            grants: None,
             candidate_safe,
         };
         set.rebuild_routes();
@@ -308,6 +373,7 @@ impl McpToolSet {
             native: None,
             usage: None,
             disabled: None,
+            grants: None,
             candidate_safe: HashSet::new(),
         };
         set.rebuild_routes();
@@ -355,6 +421,37 @@ impl McpToolSet {
         self
     }
 
+    /// Gate this set on the operator's capability grants (SPEC §9.3's
+    /// first-enable handshake). Installing a set makes the gate **default
+    /// deny**: only servers named in it advertise tools or answer calls.
+    ///
+    /// The set is shared, so a grant given mid-session takes effect on the
+    /// next model call without a reconnect — the same live contract
+    /// [`Self::with_disabled_servers`] keeps for the toggle.
+    #[must_use]
+    pub fn with_capability_grants(mut self, grants: CapabilityGrants) -> Self {
+        self.grants = Some(grants);
+        self
+    }
+
+    /// Whether `server`'s tools are usable this session, and if not, why.
+    ///
+    /// The disable is checked first: it is the operator's most recent
+    /// instruction, and a server they just switched off should say so rather
+    /// than send them to review a handshake they will then have switched off
+    /// anyway.
+    fn withheld(&self, server: &str) -> Option<Withheld> {
+        if self.is_disabled(server) {
+            return Some(Withheld::Disabled);
+        }
+        let granted = self.grants.as_ref().is_none_or(|set| {
+            set.lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .contains(server)
+        });
+        (!granted).then_some(Withheld::Ungranted)
+    }
+
     /// Whether `server` is currently disabled for this session.
     fn is_disabled(&self, server: &str) -> bool {
         self.disabled.as_ref().is_some_and(|set| {
@@ -372,7 +469,7 @@ impl McpToolSet {
     pub fn is_candidate_safe_tool(&self, namespaced: &str) -> bool {
         self.routes.get(namespaced).is_some_and(|(idx, _)| {
             let name = self.clients[*idx].name();
-            self.candidate_safe.contains(name) && !self.is_disabled(name)
+            self.candidate_safe.contains(name) && self.withheld(name).is_none()
         })
     }
 
@@ -789,10 +886,11 @@ impl McpToolSet {
     fn mcp_segment(&self) -> Vec<ToolSchema> {
         let mut mcp = Vec::new();
         for (idx, client) in self.clients.iter().enumerate() {
-            // A disabled server advertises nothing this session — the engine
+            // A withheld server advertises nothing this session — the engine
             // re-reads schemas each model call, so the model stops seeing its
-            // tools the moment it is toggled off.
-            if self.is_disabled(client.name()) {
+            // tools the moment it is toggled off, and never sees them at all
+            // until its handshake has been granted.
+            if self.withheld(client.name()).is_some() {
                 continue;
             }
             for tool in client.tools() {
@@ -829,14 +927,8 @@ impl McpToolSet {
     async fn dispatch_namespaced(&self, name: &str, input: &Value) -> ToolOutput {
         if let Some((idx, raw_tool)) = self.routes.get(name) {
             let client = &self.clients[*idx];
-            if self.is_disabled(client.name()) {
-                return ToolOutput::classified_error(
-                    stella_protocol::ErrorClass::RefusedByPolicy,
-                    format!(
-                        "mcp server `{}` is disabled for this session — tool `{name}` unavailable",
-                        client.name()
-                    ),
-                );
+            if let Some(withheld) = self.withheld(client.name()) {
+                return withheld.refusal(client.name(), name);
             }
             return self.execute_mcp(client, raw_tool, input).await;
         }

--- a/crates/stella-mcp/src/toolset/needs_auth.rs
+++ b/crates/stella-mcp/src/toolset/needs_auth.rs
@@ -41,31 +41,27 @@ pub fn login_required_tool_name(server: &str) -> String {
     wire_name(server, LOGIN_REQUIRED_TOOL)
 }
 
-/// Append each auth-suppressed server's placeholder schema — honoring the
-/// session's live disable, exactly like a real server's tools.
+/// Append each auth-suppressed server's placeholder schema — withheld by the
+/// session disable and the capability grant, exactly like a real server's
+/// tools.
 pub(super) fn extend_schemas(set: &super::McpToolSet, schemas: &mut Vec<ToolSchema>) {
     for (name, _) in &set.auth_required {
-        if !set.is_disabled(name) {
+        if set.withheld(name).is_none() {
             schemas.push(login_required_schema(name));
         }
     }
 }
 
 /// Route `name` if it is some auth-suppressed server's synthetic tool: the
-/// login instruction — or the session-disabled error, matching how a real
-/// server's tools answer while disabled. `None` for every other name.
+/// login instruction — or the same refusal a real tool of that server would
+/// give while it is withheld. `None` for every other name.
 pub(super) fn route(set: &super::McpToolSet, name: &str) -> Option<ToolOutput> {
     let (server, _) = set
         .auth_required
         .iter()
         .find(|(server, _)| name == login_required_tool_name(server))?;
-    if set.is_disabled(server) {
-        return Some(ToolOutput::classified_error(
-            stella_protocol::ErrorClass::RefusedByPolicy,
-            format!(
-                "mcp server `{server}` is disabled for this session — tool `{name}` unavailable"
-            ),
-        ));
+    if let Some(withheld) = set.withheld(server) {
+        return Some(withheld.refusal(server, name));
     }
     Some(login_required_output(server))
 }
@@ -114,6 +110,9 @@ pub(super) fn auth_required_health(server: &str, reason: &str) -> ServerHealth {
         connect_failures: 0,
         last_error: Some(reason.to_string()),
         retry_in: None,
+        // Never dialed, so there is no round trip to report. A synthesized
+        // zero would render as the nearest server on the tab.
+        latency: None,
     }
 }
 

--- a/crates/stella-mcp/src/toolset/resources.rs
+++ b/crates/stella-mcp/src/toolset/resources.rs
@@ -70,11 +70,12 @@ pub fn read_resource_tool_name(server: &str) -> String {
 }
 
 /// Append the two resource tools for every connected server that declared the
-/// `resources` capability — honoring the session's live disable and standing
-/// aside for a real tool that claims the same wire name.
+/// `resources` capability — honoring whatever withholds the server's real
+/// tools (the session disable, the capability grant) and standing aside for a
+/// real tool that claims the same wire name.
 pub(super) fn extend_schemas(set: &super::McpToolSet, schemas: &mut Vec<ToolSchema>) {
     for client in &set.clients {
-        if !client.supports_resources() || set.is_disabled(client.name()) {
+        if !client.supports_resources() || set.withheld(client.name()).is_some() {
             continue;
         }
         for schema in [
@@ -90,9 +91,9 @@ pub(super) fn extend_schemas(set: &super::McpToolSet, schemas: &mut Vec<ToolSche
 
 /// Route `name` if it is some resources-capable server's synthetic tool:
 /// drive the wire call and render its bounded, model-visible answer — or the
-/// session-disabled error, matching how a real server's tools answer while
-/// disabled. `None` for every other name, including a wire name a real tool
-/// claims ([`shadowed_by_real_tool`] — advertise ⇔ answer).
+/// same refusal a real tool of that server would give while it is withheld.
+/// `None` for every other name, including a wire name a real tool claims
+/// ([`shadowed_by_real_tool`] — advertise ⇔ answer).
 pub(super) async fn route(
     set: &super::McpToolSet,
     name: &str,
@@ -110,13 +111,8 @@ pub(super) async fn route(
         if !is_list && name != read_resource_tool_name(server) {
             continue;
         }
-        if set.is_disabled(server) {
-            return Some(ToolOutput::classified_error(
-                stella_protocol::ErrorClass::RefusedByPolicy,
-                format!(
-                    "mcp server `{server}` is disabled for this session — tool `{name}` unavailable"
-                ),
-            ));
+        if let Some(withheld) = set.withheld(server) {
+            return Some(withheld.refusal(server, name));
         }
         let output = if is_list {
             run_list(client, input).await

--- a/crates/stella-mcp/src/toolset/tests.rs
+++ b/crates/stella-mcp/src/toolset/tests.rs
@@ -15,6 +15,8 @@ use crate::protocol::PREFERRED_PROTOCOL_VERSION;
 use crate::transport::Transport;
 use crate::transport::testkit::ScriptedTransport;
 
+mod gate;
+
 /// A fake native executor advertising one tool, `bash`.
 struct FakeNative;
 #[async_trait]
@@ -495,6 +497,7 @@ async fn colliding_wire_names_drop_every_claimant_and_are_reported() {
         native: None,
         usage: None,
         disabled: None,
+        grants: None,
         candidate_safe: HashSet::new(),
     };
     set.rebuild_routes();

--- a/crates/stella-mcp/src/toolset/tests/gate.rs
+++ b/crates/stella-mcp/src/toolset/tests/gate.rs
@@ -1,0 +1,179 @@
+//! Tests for the two session gates over a connected server's tools — the
+//! operator's enable/disable toggle and the first-enable capability grant
+//! (SPEC §9.3) — plus the connect-time latency the MCP tab renders beside them.
+//!
+//! Its own file because `tests.rs` is at the 1500-line ceiling, and because the
+//! witness below needs something the rest of that file does not: a handle on
+//! the transport's request log. Every other assertion there is about what came
+//! back; this one is about what never went out.
+
+use super::super::*;
+use super::connected_client;
+use crate::protocol::PREFERRED_PROTOCOL_VERSION;
+use crate::transport::testkit::{Log, ScriptedTransport};
+
+/// A connected client whose transport log stays readable, so a test can ask
+/// what actually went over the wire — not merely what came back.
+///
+/// [`connected_client`] drops its `ScriptedTransport` into the client, which
+/// makes "the call succeeded" observable and "no call was made" unobservable.
+/// The capability gate needs the second one.
+async fn client_with_wire_log(name: &str, tool: &str) -> (McpClient, Log) {
+    let transport = ScriptedTransport::new();
+    transport.push_ok(
+        "initialize",
+        serde_json::json!({ "protocolVersion": PREFERRED_PROTOCOL_VERSION }),
+    );
+    transport.push_ok(
+        "tools/list",
+        serde_json::json!({ "tools": [{ "name": tool, "inputSchema": { "type": "object" } }] }),
+    );
+    // Queued, and never consumed while the server is ungranted — which is
+    // what the assertions below are for.
+    transport.push_ok(
+        "tools/call",
+        serde_json::json!({ "content": [{ "type": "text", "text": "mcp ran" }] }),
+    );
+    let log = transport.requests_handle();
+    let mut client = McpClient::new(name, Box::new(transport));
+    client.initialize().await.unwrap();
+    (client, log)
+}
+
+/// How many `tools/call` requests have reached the server so far.
+fn wire_calls(log: &Log) -> usize {
+    log.lock()
+        .unwrap()
+        .iter()
+        .filter(|(method, _)| method == "tools/call")
+        .count()
+}
+
+/// **The witness (#5047).** SPEC §9.3: a server's declared capabilities are
+/// shown before its first enable, and **no tool call happens before the
+/// grant**.
+///
+/// The assertion that matters is the absence, not the refusal: a gate that
+/// refuses the caller *after* the request has gone down the pipe has already
+/// let the third-party server act, and every `ToolOutput::Error` assertion in
+/// this crate would pass over that bug. So the transport's own request log is
+/// the evidence — zero `tools/call` on the wire while ungranted, exactly one
+/// after the grant.
+///
+/// The handshake itself is expected on the wire before the grant: `initialize`
+/// and `tools/list` are how the declared capabilities the operator reviews
+/// become knowable at all.
+#[tokio::test]
+async fn no_tool_call_reaches_an_ungranted_server_before_the_grant() {
+    let (client, wire) = client_with_wire_log("files", "read").await;
+    let grants: CapabilityGrants = Arc::new(Mutex::new(HashSet::new()));
+    let set = McpToolSet::from_clients(vec![client]).with_capability_grants(grants.clone());
+
+    // The handshake ran — that is what the operator is about to review — and
+    // nothing has been called.
+    assert!(
+        !set.advertised_tools("files").is_empty(),
+        "the declared capabilities must be knowable before the grant, or there is \
+         nothing to review"
+    );
+    assert_eq!(wire_calls(&wire), 0);
+
+    // Ungranted: the model is never told the tool exists...
+    assert!(
+        set.schemas().iter().all(|s| s.name != "mcp__files__read"),
+        "an ungranted server must not be advertised: {:?}",
+        set.schemas()
+    );
+    // ...and a call issued anyway is stopped.
+    let refused = set.execute("mcp__files__read", &Value::Null).await;
+
+    // THE security property, asserted before anything about the answer: the
+    // stop happened on this side of the pipe, so the server was never asked
+    // to do anything. A gate that refuses its caller only after the request
+    // has gone out has already let a third party act, and every assertion
+    // about the returned `ToolOutput` would pass over it.
+    assert_eq!(
+        wire_calls(&wire),
+        0,
+        "a tool call reached the server before the operator granted it: {:?}",
+        wire.lock().unwrap()
+    );
+
+    // And the refusal names its remedy, since a tool error is often the only
+    // place the user meets this state.
+    match refused {
+        ToolOutput::Error { message, class } => {
+            assert_eq!(class, Some(stella_protocol::ErrorClass::RefusedByPolicy));
+            assert!(message.contains("has not been granted"), "{message}");
+            assert!(message.contains("stella mcp grant files"), "{message}");
+        }
+        other => panic!("expected the ungranted refusal, got {other:?}"),
+    }
+
+    // The grant lands live — no reconnect, no re-advertise round trip.
+    grants.lock().unwrap().insert("files".to_string());
+    assert!(
+        set.schemas().iter().any(|s| s.name == "mcp__files__read"),
+        "a granted server's tools must be advertised"
+    );
+    assert!(
+        !set.execute("mcp__files__read", &Value::Null)
+            .await
+            .is_error(),
+        "a granted server's tools must be callable"
+    );
+    assert_eq!(wire_calls(&wire), 1, "and exactly one call went out");
+}
+
+/// The gate is default-deny only where a host installs it. A set with no
+/// grants configured is ungated — the shape every embedder and one-shot
+/// caller with no human to ask gets, and the reason the field is an
+/// `Option`, not a bare `HashSet`.
+#[tokio::test]
+async fn a_set_with_no_grants_configured_is_not_gated() {
+    let client = connected_client("files", "read").await;
+    let set = McpToolSet::from_clients(vec![client]);
+    assert!(set.schemas().iter().any(|s| s.name == "mcp__files__read"));
+}
+
+/// A server that is both disabled and ungranted says it is disabled: the
+/// toggle is the operator's most recent instruction, and sending them to
+/// review a handshake for a server they just switched off is the wrong
+/// remedy.
+#[tokio::test]
+async fn the_disable_outranks_the_grant_in_the_reason_given() {
+    let client = connected_client("files", "read").await;
+    let disabled: DisabledServers = Arc::new(Mutex::new(HashSet::new()));
+    disabled.lock().unwrap().insert("files".to_string());
+    let set = McpToolSet::from_clients(vec![client])
+        .with_disabled_servers(disabled)
+        .with_capability_grants(Arc::new(Mutex::new(HashSet::new())));
+
+    match set.execute("mcp__files__read", &Value::Null).await {
+        ToolOutput::Error { message, .. } => {
+            assert!(message.contains("disabled"), "{message}");
+            assert!(!message.contains("granted"), "{message}");
+        }
+        other => panic!("expected the disabled refusal, got {other:?}"),
+    }
+}
+
+/// The connect-time latency measurement reaches the health snapshot the tab
+/// renders, and a client that never handshook reports nothing rather than a
+/// zero that would render as the nearest server on the list.
+#[tokio::test]
+async fn health_carries_the_handshake_latency_and_never_invents_one() {
+    let client = connected_client("files", "read").await;
+    let set = McpToolSet::from_clients(vec![client]);
+    let health = set.health().await;
+    assert!(
+        health[0].latency.is_some(),
+        "a connected server's `initialize` round trip is measured"
+    );
+
+    let never_dialed = McpClient::new("files", Box::new(ScriptedTransport::new()));
+    assert!(
+        never_dialed.health().await.latency.is_none(),
+        "no handshake, no measurement — never a synthesized zero"
+    );
+}

--- a/crates/stella-mcp/src/transport.rs
+++ b/crates/stella-mcp/src/transport.rs
@@ -51,7 +51,10 @@ pub(crate) mod testkit {
     use crate::error::McpError;
 
     type Queues = Arc<Mutex<HashMap<String, VecDeque<Result<Value, McpError>>>>>;
-    type Log = Arc<Mutex<Vec<(String, Value)>>>;
+    /// A shared record of what crossed the transport. Handed out by
+    /// [`ScriptedTransport::requests_handle`] so a test can assert what did
+    /// **not** go over the wire — the one claim no return value can carry.
+    pub(crate) type Log = Arc<Mutex<Vec<(String, Value)>>>;
 
     /// Enqueue responses with [`ScriptedTransport::push_ok`] /
     /// [`ScriptedTransport::push_err`]; each `request(method, …)` pops the

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -339,6 +339,7 @@ async fn main() -> std::io::Result<()> {
                 | WorkspaceInput::McpAuth { .. }
                 | WorkspaceInput::McpOauthLogin { .. }
                 | WorkspaceInput::McpInspect { .. }
+                | WorkspaceInput::McpGrant { .. }
                 | WorkspaceInput::McpRefresh => {}
                 // The SESSIONS overlay reads the machine-wide registry and the
                 // inbox reads the notification store — both live in the real

--- a/crates/stella-tui/examples/deck_film.rs
+++ b/crates/stella-tui/examples/deck_film.rs
@@ -710,6 +710,8 @@ fn fixture_mcp_servers() -> Vec<McpServerInfo> {
             tool_count: 21,
             oauth: Some(true),
             calls: 14,
+            latency_ms: Some(66),
+            granted: true,
             ..Default::default()
         },
         McpServerInfo {
@@ -720,6 +722,8 @@ fn fixture_mcp_servers() -> Vec<McpServerInfo> {
             connected: true,
             health: Some("live".into()),
             tool_count: 4,
+            latency_ms: Some(2),
+            granted: true,
             ..Default::default()
         },
         McpServerInfo {
@@ -730,6 +734,7 @@ fn fixture_mcp_servers() -> Vec<McpServerInfo> {
             kind: "http".into(),
             enabled: false,
             oauth: Some(false),
+            granted: true,
             ..Default::default()
         },
         McpServerInfo {
@@ -744,6 +749,8 @@ fn fixture_mcp_servers() -> Vec<McpServerInfo> {
             tool_count: 38,
             oauth: Some(true),
             calls: 6,
+            latency_ms: Some(88),
+            granted: true,
             ..Default::default()
         },
     ]

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -1074,8 +1074,9 @@ impl DeckUi {
                     // The secret value: NEVER the composer.
                     AuthStep::Value => push_single_line(&mut self.mcp.auth.value, text),
                 },
-                // Browse list owns no text input — start a prompt like any tab.
-                McpMode::Browse => self.composer.paste(text),
+                // Neither the browse list nor the handshake gate owns a text
+                // input — a paste starts a prompt, like any tab.
+                McpMode::Browse | McpMode::Handshake => self.composer.paste(text),
             }
             return;
         }

--- a/crates/stella-tui/src/deck_ui/mcp_keys.rs
+++ b/crates/stella-tui/src/deck_ui/mcp_keys.rs
@@ -1,11 +1,11 @@
-//! MCP-tab key handling: four modal layers over one tab.
+//! MCP-tab key handling: five modal layers over one tab.
 //!
 //! The inspector (ctrl+o) outranks everything — it is the topmost surface, so
 //! it claims keys before Browse's letter actions can fire on a row that is no
-//! longer visible. Below it, Search and Auth are modal in the same sense
-//! (every key is swallowed so nothing leaks into the composer), while Browse's
-//! letter actions gate on `composer_empty` so they never shadow the first
-//! character of a prompt.
+//! longer visible. Below it, Search, Auth and the first-enable Handshake are
+//! modal in the same sense (every key is swallowed so nothing leaks into the
+//! composer), while Browse's letter actions gate on `composer_empty` so they
+//! never shadow the first character of a prompt.
 //!
 //! Split from `deck_ui.rs` (#629's 1500-line ratchet).
 
@@ -13,12 +13,13 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::{DeckAction, DeckUi};
 use crate::envelope::{Secret, WorkspaceInput};
-use crate::views::mcp_tab::{AuthPrompt, AuthStep, McpInspector, McpMode};
+use crate::views::mcp_tab::{AuthPrompt, AuthStep, HandshakeGate, McpInspector, McpMode};
 
-/// MCP tab keys. Three sub-modes: Browse (navigate the configured servers and
+/// MCP tab keys. Four sub-modes: Browse (navigate the configured servers and
 /// act on the selection), Search (type a registry query, then Enter to search
-/// and Enter again to install the highlighted result), and Auth (a two-step
-/// masked credential prompt). Search/Auth are modal — they claim every key so
+/// and Enter again to install the highlighted result), Auth (a two-step masked
+/// credential prompt), and Handshake (read one server's declared capabilities
+/// and grant or deny them). The last three are modal — they claim every key so
 /// typing never leaks into the composer — while Browse's letter actions gate on
 /// `composer_empty` so they don't shadow the first character of a prompt.
 pub(super) fn handle_mcp_key(
@@ -36,7 +37,48 @@ pub(super) fn handle_mcp_key(
         McpMode::Browse => handle_mcp_browse_key(key, ui, composer_empty),
         McpMode::Search => Some(handle_mcp_search_key(key, ui)),
         McpMode::Auth => Some(handle_mcp_auth_key(key, ui)),
+        McpMode::Handshake => Some(handle_mcp_handshake_key(key, ui)),
     }
+}
+
+/// Keys while the first-enable handshake is up: read it, grant it, or walk
+/// away.
+///
+/// Modal, and there is no toggle here — `e` from Browse is what opened this,
+/// and offering it again inside would give the operator a second way to enable
+/// the server that skips the page they were sent here to read.
+///
+/// `g` stands down until the detail has arrived: a grant is a decision about
+/// declared capabilities, and capabilities nobody has been shown cannot be
+/// granted. Anything else — Esc, or leaving the tab — denies by omission,
+/// which is the safe direction and needs no keystroke of its own.
+fn handle_mcp_handshake_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
+    if super::list_nav::closes(key) {
+        ui.mcp.handshake = None;
+        ui.mcp.mode = McpMode::Browse;
+        return DeckAction::Handled;
+    }
+    let Some(gate) = ui.mcp.handshake.as_mut() else {
+        // No gate to answer: fall back rather than swallow every key forever.
+        ui.mcp.mode = McpMode::Browse;
+        return DeckAction::Handled;
+    };
+    let mut top = usize::from(gate.scroll);
+    if super::list_nav::offset(key, &mut top, true) {
+        gate.scroll = u16::try_from(top).unwrap_or(u16::MAX);
+        return DeckAction::Handled;
+    }
+    if matches!(key.code, KeyCode::Char('g')) {
+        if gate.detail.is_none() {
+            return DeckAction::Handled;
+        }
+        let name = gate.server.clone();
+        ui.mcp.handshake = None;
+        ui.mcp.mode = McpMode::Browse;
+        ui.mcp.status = Some(format!("granted {name} — enabling"));
+        return DeckAction::Send(WorkspaceInput::McpGrant { name });
+    }
+    DeckAction::Handled
 }
 
 /// Keys while the ctrl+o inspector is up: scroll, ask the registry, close.
@@ -121,13 +163,30 @@ fn handle_mcp_browse_key(
             ui.mcp.status = None;
             Some(DeckAction::Handled)
         }
-        // Enable/disable the selected server (session-scoped, live).
+        // Enable/disable the selected server (session-scoped, live) — unless
+        // it has never been granted, in which case this is its FIRST enable
+        // and SPEC §9.3 says the handshake comes first. The toggle is not
+        // sent: enabling a server whose tools are withheld anyway would only
+        // flip a flag and leave the operator wondering why nothing happened.
         KeyCode::Char('e') | KeyCode::Char(' ') if composer_empty => {
-            ui.mcp.selected_server().map(|s| {
-                DeckAction::Send(WorkspaceInput::McpToggle {
-                    name: s.name.clone(),
-                })
-            })
+            let server = ui.mcp.selected_server()?;
+            let name = server.name.clone();
+            if !server.granted {
+                ui.mcp.handshake = Some(HandshakeGate {
+                    server: name.clone(),
+                    detail: None,
+                    scroll: 0,
+                });
+                ui.mcp.mode = McpMode::Handshake;
+                ui.mcp.status = None;
+                // `lookup: false` — reviewing what a server declares must not
+                // reach out to a third-party registry.
+                return Some(DeckAction::Send(WorkspaceInput::McpInspect {
+                    name,
+                    lookup: false,
+                }));
+            }
+            Some(DeckAction::Send(WorkspaceInput::McpToggle { name }))
         }
         // Enter the auth prompt for the selected server, prefilled with its
         // first configured credential field (if any).
@@ -199,6 +258,13 @@ fn handle_mcp_search_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
             // Results already match the query → Enter installs the highlight;
             // otherwise Enter runs the search.
             if ui.mcp.results_match_query() {
+                // A blocked entry never becomes an install. The driver refuses
+                // it too — this arm is what stops the row from *offering* a
+                // spawn command the registry vouches for nobody on.
+                if let Some(refusal) = ui.mcp.selected_search_refusal() {
+                    ui.mcp.status = Some(refusal);
+                    return DeckAction::Handled;
+                }
                 match ui.mcp.selected_search_name().map(str::to_string) {
                     Some(name) => {
                         ui.mcp.status = Some(format!("installing {name}…"));

--- a/crates/stella-tui/src/deck_ui/tests/mcp.rs
+++ b/crates/stella-tui/src/deck_ui/tests/mcp.rs
@@ -9,7 +9,8 @@
 //! claim about an arm no test had ever entered.
 
 use super::*;
-use crate::envelope::McpServerInfo;
+use crate::envelope::{McpServerDetail, McpServerInfo, McpToolRow};
+use crate::views::mcp_tab::McpMode;
 
 fn server(name: &str, oauth: Option<bool>) -> McpServerInfo {
     McpServerInfo {
@@ -17,6 +18,7 @@ fn server(name: &str, oauth: Option<bool>) -> McpServerInfo {
         kind: if oauth.is_some() { "http" } else { "stdio" }.into(),
         enabled: true,
         connected: true,
+        granted: true,
         oauth,
         ..Default::default()
     }
@@ -84,4 +86,103 @@ fn mcp_x_removes_the_selected_server_and_r_refreshes() {
         "zoxr",
         "with a prompt in progress the verbs are letters"
     );
+}
+
+/// **The witness (#5047).** SPEC §9.3: the first enable of a server shows what
+/// it declares and requires the grant. `e` on an ungranted row must NOT reach
+/// the wire as a toggle — it opens the handshake and asks the driver for the
+/// declared capabilities instead.
+///
+/// The `assert_ne` is the point: the old arm sent `McpToggle` for every row,
+/// so enabling an unreviewed third-party server was one keystroke with nothing
+/// in between.
+#[test]
+fn e_on_an_ungranted_server_opens_the_handshake_instead_of_enabling_it() {
+    let mut fresh = server("stripe", Some(false));
+    fresh.granted = false;
+    let (model, mut ui) = mcp_ui(vec![fresh]);
+
+    let action = handle_deck_key(ch('e'), &model, &mut ui);
+    assert_ne!(
+        action,
+        DeckAction::Send(WorkspaceInput::McpToggle {
+            name: "stripe".into()
+        }),
+        "an unreviewed server must not be enabled by one keystroke"
+    );
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::McpInspect {
+            name: "stripe".into(),
+            // Reviewing what a server declares must not call a registry.
+            lookup: false,
+        })
+    );
+    assert_eq!(ui.mcp.mode, McpMode::Handshake);
+    assert_eq!(
+        ui.mcp.handshake.as_ref().map(|g| g.server.as_str()),
+        Some("stripe")
+    );
+
+    // The grant stands down until there is something to grant: a decision
+    // about capabilities nobody was shown is not a decision.
+    assert_eq!(
+        handle_deck_key(ch('g'), &model, &mut ui),
+        DeckAction::Handled
+    );
+    assert_eq!(ui.mcp.mode, McpMode::Handshake, "still asking");
+
+    ui.mcp.apply_detail(McpServerDetail {
+        name: "stripe".into(),
+        tools: vec![McpToolRow {
+            name: "create_refund".into(),
+            ..McpToolRow::default()
+        }],
+        ..McpServerDetail::default()
+    });
+    assert_eq!(
+        handle_deck_key(ch('g'), &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::McpGrant {
+            name: "stripe".into()
+        })
+    );
+    assert_eq!(ui.mcp.mode, McpMode::Browse);
+    assert!(ui.mcp.handshake.is_none());
+}
+
+/// Walking away from the gate grants nothing. Esc is the only exit that is not
+/// the grant, and it must reach no wire — the withheld state is the default,
+/// so denying costs no message.
+#[test]
+fn esc_denies_the_handshake_and_sends_nothing() {
+    let mut fresh = server("stripe", Some(false));
+    fresh.granted = false;
+    let (model, mut ui) = mcp_ui(vec![fresh]);
+    handle_deck_key(ch('e'), &model, &mut ui);
+
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Esc), &model, &mut ui),
+        DeckAction::Handled
+    );
+    assert_eq!(ui.mcp.mode, McpMode::Browse);
+    assert!(ui.mcp.handshake.is_none());
+}
+
+/// The gate is modal: a stray letter while it is up must not act on the list
+/// behind it. `x` there would remove the very server being reviewed.
+#[test]
+fn the_handshake_swallows_the_browse_verbs_behind_it() {
+    let mut fresh = server("stripe", Some(false));
+    fresh.granted = false;
+    let (model, mut ui) = mcp_ui(vec![fresh]);
+    handle_deck_key(ch('e'), &model, &mut ui);
+
+    for verb in ['x', 'o', 'a', 'r', 's', 'e'] {
+        assert_eq!(
+            handle_deck_key(ch(verb), &model, &mut ui),
+            DeckAction::Handled,
+            "`{verb}` reached the list behind the handshake"
+        );
+    }
+    assert_eq!(ui.mcp.mode, McpMode::Handshake);
 }

--- a/crates/stella-tui/src/deck_ui/tests/queue.rs
+++ b/crates/stella-tui/src/deck_ui/tests/queue.rs
@@ -417,6 +417,9 @@ fn mcp_tab_navigates_toggles_and_enters_search() {
             auth_fields: vec!["Authorization".into()],
             oauth: Some(false),
             calls: 5,
+            // Already reviewed, so `e` is the plain toggle this test is
+            // about — the first-enable handshake has its own test.
+            granted: true,
             ..Default::default()
         },
         McpServerInfo {
@@ -430,6 +433,7 @@ fn mcp_tab_navigates_toggles_and_enters_search() {
             auth_fields: vec![],
             oauth: None,
             calls: 0,
+            granted: true,
             ..Default::default()
         },
     ];
@@ -439,7 +443,7 @@ fn mcp_tab_navigates_toggles_and_enters_search() {
     handle_deck_key(key(KeyCode::Up), &model, &mut ui);
     assert_eq!(ui.mcp.selected, 0);
 
-    // `e` toggles the selected server (session enable/disable).
+    // `e` toggles an already-granted server (session enable/disable).
     let action = handle_deck_key(ch('e'), &model, &mut ui);
     assert_eq!(
         action,

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -953,6 +953,20 @@ pub enum WorkspaceInput {
         field: String,
         value: Secret,
     },
+    /// MCP tab: record the operator's capability grant for a configured
+    /// server, after the first-enable handshake showed what it declares
+    /// (SPEC §9.3).
+    ///
+    /// The driver writes `granted = true` into `.stella/mcp.toml`, adds the
+    /// name to the session's shared grant set — so the server becomes usable
+    /// in the session it was reviewed in, without a reconnect — enables it,
+    /// and pushes a fresh [`Inbound::McpServers`] snapshot.
+    ///
+    /// Only ever sent for a grant. There is no `McpGrant { granted: false }`:
+    /// declining is not answering, the gate's default is withheld, and a
+    /// parameter that selects between granting and revoking would be two verbs
+    /// wearing one name — the single-purpose rule AGENTS.md #9 states.
+    McpGrant { name: String },
     /// MCP tab: rebuild and re-push the [`Inbound::McpServers`] snapshot.
     McpRefresh,
     /// MCP tab: assemble the ctrl+o inspector detail for one configured server
@@ -1125,8 +1139,8 @@ pub mod steering;
 mod tool_policy;
 pub use engine_config::{EngineAgentState, EngineConfigState, EngineRole, RoleWiringRow, SeatRow};
 pub use mcp::{
-    McpLiveIdentity, McpLookupState, McpSearchItem, McpSearchOutcome, McpServerDetail,
-    McpServerInfo, McpToolRow,
+    GRAPH_SERVER, McpLiveIdentity, McpLookupState, McpSearchItem, McpSearchOutcome,
+    McpServerDetail, McpServerInfo, McpSignature, McpSourceTier, McpToolRow,
 };
 pub use roles::{RoleTableEntry, role_table};
 pub use skills::{SkillOp, SkillRow, SkillScope, SkillSearchHit, SkillsView};

--- a/crates/stella-tui/src/envelope/mcp.rs
+++ b/crates/stella-tui/src/envelope/mcp.rs
@@ -42,6 +42,13 @@ pub struct McpServerInfo {
     pub connected: bool,
     /// Short health label when connected (e.g. `live`, `reconnecting`).
     pub health: Option<String>,
+    /// Round-trip time of the connect handshake's `initialize` request, in
+    /// whole milliseconds — SPEC §9.3's latency column.
+    ///
+    /// `None` for a server with no live connection to have measured, and the
+    /// row then shows nothing rather than `0ms`: an unmeasured server would
+    /// otherwise sort and read as the nearest one on the list.
+    pub latency_ms: Option<u64>,
     /// How many tools it advertises this session (0 when disabled/unconnected).
     pub tool_count: usize,
     /// Tools this server advertised that were **refused** past the per-server
@@ -77,7 +84,34 @@ pub struct McpServerInfo {
     /// The `candidate_safe = true` opt-in (issue #248 Phase 1) — this server's
     /// tools are shared into Best-of-N candidate workspaces.
     pub candidate_safe: bool,
+    /// Whether the operator has granted this server its declared capabilities
+    /// (SPEC §9.3's first-enable handshake). An ungranted server advertises no
+    /// tools to the model and answers every call with a refusal, so the row
+    /// says so and `e` opens the handshake instead of toggling.
+    ///
+    /// `true` for a hand-written `mcp.toml` entry that records no decision —
+    /// see `stella_mcp::McpServerEntry::granted` for why writing the transport
+    /// by hand is itself the grant.
+    pub granted: bool,
 }
+
+impl McpServerInfo {
+    /// Whether this row is the pinned graph server — SPEC §9.3's
+    /// `graph is pinned · it is the product, not an integration`.
+    ///
+    /// Matched on the alias, which is the tool-namespace segment: the graph's
+    /// tools are reachable as `mcp__graph__…` or they are not the graph's, so
+    /// the alias is the only name that can decide this. A row named `graph`
+    /// that is somebody else's server still pins, and correctly — that name is
+    /// what every tool call in the session will route through.
+    pub fn is_graph(&self) -> bool {
+        self.name == GRAPH_SERVER
+    }
+}
+
+/// The alias stella's own graph server is configured under. The MCP tab pins
+/// it above every third-party row.
+pub const GRAPH_SERVER: &str = "graph";
 
 /// The outcome of an MCP registry search requested from the tab.
 #[derive(Clone, Debug, PartialEq)]
@@ -91,7 +125,80 @@ pub struct McpSearchOutcome {
     pub has_more: bool,
 }
 
+/// How far a registry's own publisher verification goes for one entry — SPEC
+/// §9.3's `official · vendor · community` column.
+///
+/// A display mirror of `stella_mcp::SourceTier`, which is where the derivation
+/// and its evidence live. This crate takes only leaf dependencies (see its
+/// `Cargo.toml`), and `stella-mcp` is not one; the driver maps across the seam
+/// with an exhaustive `match`, so a tier added there fails to compile here
+/// rather than rendering as something it is not.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum McpSourceTier {
+    /// The registry operator's own namespace.
+    Official,
+    /// A namespace under a domain the publisher proved they control.
+    Vendor,
+    /// A code-host account's namespace, or the registry's anonymous one.
+    #[default]
+    Community,
+}
+
+impl McpSourceTier {
+    /// The one word the row renders.
+    pub fn label(self) -> &'static str {
+        match self {
+            McpSourceTier::Official => "official",
+            McpSourceTier::Vendor => "vendor",
+            McpSourceTier::Community => "community",
+        }
+    }
+}
+
+/// Whether the registry attributes an entry to a verified publisher and still
+/// stands behind it — SPEC §9.3's signature column, and the reason a row is
+/// blocked.
+///
+/// The display mirror of `stella_mcp::SignatureStatus`; see that type for what
+/// "signed" claims (the publisher's namespace was verified at publish time)
+/// and what it does not (nothing verifies the package bytes). `Unsigned` is
+/// the default so a row assembled without an answer is refused rather than
+/// installed.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum McpSignature {
+    /// Attributed to a verified namespace, lifecycle `active`.
+    Signed,
+    /// Attributed to nobody.
+    #[default]
+    Unsigned,
+    /// Published, then withdrawn by the registry.
+    Withdrawn,
+}
+
+impl McpSignature {
+    /// Whether install may proceed. The driver enforces the same rule against
+    /// the `stella-mcp` value; this is what stops the row from *offering* it.
+    pub fn installable(self) -> bool {
+        matches!(self, McpSignature::Signed)
+    }
+
+    /// The label the row renders. The blocked states carry the word `blocked`
+    /// rather than relying on the red alone (SPEC §13).
+    pub fn label(self) -> &'static str {
+        match self {
+            McpSignature::Signed => "signed",
+            McpSignature::Unsigned => "unsigned · blocked",
+            McpSignature::Withdrawn => "withdrawn · blocked",
+        }
+    }
+}
+
 /// One registry search result row.
+///
+/// The three provenance fields are what SPEC §9.3 asks a registry row to carry
+/// before an operator spends a keystroke on it: who the registry says
+/// published this, how many people run it, and whether the registry vouches
+/// for it at all.
 #[derive(Clone, Debug, PartialEq)]
 pub struct McpSearchItem {
     pub name: String,
@@ -100,6 +207,24 @@ pub struct McpSearchItem {
     pub kinds: String,
     /// Whether a server of this name is already configured locally.
     pub installed: bool,
+    /// How far the registry's publisher verification goes for this entry.
+    pub tier: McpSourceTier,
+    /// Recorded installs, where the registry publishes a count. `None` renders
+    /// as unknown, never as `0` — a registry that counts nothing must not make
+    /// every server look unused.
+    pub installs: Option<u64>,
+    /// Whether the registry attributes and stands behind this entry. Anything
+    /// but [`McpSignature::Signed`] is refused by the install path, and the row
+    /// says so in words as well as colour (SPEC §13).
+    pub signature: McpSignature,
+}
+
+impl McpSearchItem {
+    /// Whether pressing install on this row can do anything — the row's own
+    /// copy of the policy the driver enforces.
+    pub fn installable(&self) -> bool {
+        self.signature.installable()
+    }
 }
 
 /// What the live server said about itself during the `initialize` handshake.
@@ -190,6 +315,12 @@ pub struct McpServerDetail {
     pub enabled: bool,
     pub connected: bool,
     pub health: Option<String>,
+    /// The connect handshake's `initialize` round trip in whole milliseconds —
+    /// see [`McpServerInfo::latency_ms`].
+    pub latency_ms: Option<u64>,
+    /// Whether the operator has granted this server its declared capabilities
+    /// — see [`McpServerInfo::granted`].
+    pub granted: bool,
     /// Tools refused past the per-server cap (a floor — see
     /// [`McpServerInfo::dropped_tools`]).
     pub dropped_tools: usize,

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -115,12 +115,12 @@ pub use deck_ui::{
 };
 pub use envelope::{
     AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, EngineAgentState,
-    EngineConfigState, EngineRole, EntityField, EntityHit, Inbound, InspectMessage, InspectSection,
-    InspectView, InstalledAgentEntry, IssueAction, IssueRow, JournalEra, McpLiveIdentity,
-    McpLookupState, McpSearchItem, McpSearchOutcome, McpServerDetail, McpServerInfo, McpToolRow,
-    NotificationInfo, RecordedCallInfo, SeatRow, Secret, SessionInfo, SessionPhase, SkillOp,
-    SkillRow, SkillScope, SkillSearchHit, SkillsView, SplashCue, ToolDenial, ToolPolicyState,
-    ToolRow, ToolScope, WorkspaceInput,
+    EngineConfigState, EngineRole, EntityField, EntityHit, GRAPH_SERVER, Inbound, InspectMessage,
+    InspectSection, InspectView, InstalledAgentEntry, IssueAction, IssueRow, JournalEra,
+    McpLiveIdentity, McpLookupState, McpSearchItem, McpSearchOutcome, McpServerDetail,
+    McpServerInfo, McpSignature, McpSourceTier, McpToolRow, NotificationInfo, RecordedCallInfo,
+    SeatRow, Secret, SessionInfo, SessionPhase, SkillOp, SkillRow, SkillScope, SkillSearchHit,
+    SkillsView, SplashCue, ToolDenial, ToolPolicyState, ToolRow, ToolScope, WorkspaceInput,
 };
 pub use fleet_dashboard::{
     FleetControl, FleetDashResult, FleetMsg, FleetStatus, TaskSummary, run as run_fleet_dashboard,

--- a/crates/stella-tui/src/views/mcp_tab.rs
+++ b/crates/stella-tui/src/views/mcp_tab.rs
@@ -54,6 +54,10 @@ use crate::envelope::{McpSearchOutcome, McpServerDetail, McpServerInfo};
 
 /// The ctrl+o inspector overlay.
 pub mod detail;
+/// The first-enable capability handshake (SPEC §9.3).
+pub mod handshake;
+
+pub use handshake::HandshakeGate;
 
 // ───────────────────────────── the tab's state ─────────────────────────────
 //
@@ -63,13 +67,17 @@ pub mod detail;
 // the question of where per-tab state belongs).
 
 /// Which sub-mode the MCP tab is in — browsing the configured list, typing a
-/// registry search, or entering an auth credential.
+/// registry search, entering an auth credential, or reading a server's
+/// declared capabilities before its first enable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum McpMode {
     #[default]
     Browse,
     Search,
     Auth,
+    /// SPEC §9.3's first-enable handshake: what this server declares, and the
+    /// grant it cannot be used without.
+    Handshake,
 }
 
 /// The two steps of the in-tab auth prompt: name the credential, then enter its
@@ -158,6 +166,9 @@ pub struct McpTabState {
     /// The open ctrl+o inspector, if any. Modal over every mode: it is the
     /// topmost surface and Esc closes it.
     pub inspector: Option<McpInspector>,
+    /// The open first-enable handshake gate, if any — set together with
+    /// [`McpMode::Handshake`].
+    pub handshake: Option<HandshakeGate>,
 }
 
 impl McpTabState {
@@ -174,11 +185,22 @@ impl McpTabState {
     /// opened another server's, and painting the late reply over it would
     /// silently mislabel every field on screen.
     pub fn apply_detail(&mut self, detail: McpServerDetail) {
+        if let Some(gate) = self.handshake.as_mut()
+            && gate.server == detail.name
+        {
+            gate.detail = Some(detail.clone());
+        }
         if let Some(inspector) = self.inspector.as_mut()
             && inspector.server == detail.name
         {
             inspector.detail = Some(detail);
         }
+    }
+
+    /// Whether the highlighted server still owes a capability grant, so `e`
+    /// opens the handshake instead of toggling it.
+    pub fn selection_needs_grant(&self) -> bool {
+        self.selected_server().is_some_and(|s| !s.granted)
     }
 
     /// The currently-highlighted search result name, if any.
@@ -187,6 +209,21 @@ impl McpTabState {
             .as_ref()
             .and_then(|o| o.items.get(self.search_selected))
             .map(|i| i.name.as_str())
+    }
+
+    /// Why the highlighted search result cannot be installed, or `None` when
+    /// it can.
+    ///
+    /// Phrased for the operator who just pressed the key, and named after the
+    /// refusal rather than the state, because the caller's question is "may I
+    /// install this" and every answer to it belongs in one place.
+    pub fn selected_search_refusal(&self) -> Option<String> {
+        let item = self
+            .search
+            .as_ref()
+            .and_then(|o| o.items.get(self.search_selected))?;
+        (!item.installable())
+            .then(|| format!("{}: {} — not installed", item.name, item.signature.label()))
     }
 
     /// Whether the current search results match the current query (so a second
@@ -243,6 +280,7 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
         }
         McpMode::Search => render_search(state, &mut lines),
         McpMode::Auth => render_auth(state, &mut lines),
+        McpMode::Handshake => handshake::render(state, &mut lines, bands[0].height as usize),
     }
     Paragraph::new(lines)
         .wrap(Wrap { trim: false })
@@ -294,6 +332,27 @@ fn render_keys(state: &McpTabState, area: Rect, buf: &mut Buffer) {
 /// other one — the common case is short aliases and one long outlier.
 const NAME_COLUMN: usize = 22;
 
+/// SPEC §9.3's caption under the pinned graph row. It sits with the row it
+/// explains rather than at the foot of the pane: a sentence about why one
+/// entry outranks the others says nothing four rows away from it.
+pub(super) const PIN_CAPTION: &str = "graph is pinned · it is the product, not an integration";
+
+/// The order the list is painted in: the graph server first, then everything
+/// else in the order the driver delivered (`mcp.toml`'s stable alphabetical
+/// keys).
+///
+/// Indices rather than rows, because [`McpTabState::selected`] indexes the
+/// unsorted snapshot — every key verb acts on `state.servers[selected]`, so
+/// re-ordering the paint must not re-order what the keys address. The
+/// alternative, sorting the snapshot itself, would make `x` remove whichever
+/// server happened to be painted where the cursor was.
+fn paint_order(servers: &[McpServerInfo]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..servers.len()).collect();
+    // Stable, so the delivered order survives underneath the pin.
+    order.sort_by_key(|&i| !servers[i].is_graph());
+    order
+}
+
 fn render_browse(state: &McpTabState, lines: &mut Vec<Line<'static>>, width: usize) {
     let muted = Style::new().fg(token::MUTED);
     if state.servers.is_empty() {
@@ -303,10 +362,17 @@ fn render_browse(state: &McpTabState, lines: &mut Vec<Line<'static>>, width: usi
         )));
         return;
     }
-    for (i, server) in state.servers.iter().enumerate() {
+    for i in paint_order(&state.servers) {
+        let server = &state.servers[i];
         let selected = i == state.selected;
         lines.push(headline(server, selected));
         lines.push(subline(server, selected, width));
+        if server.is_graph() {
+            lines.push(Line::from(Span::styled(
+                format!("      {PIN_CAPTION}"),
+                Style::new().fg(token::DIM),
+            )));
+        }
     }
 }
 
@@ -414,8 +480,26 @@ fn headline(server: &McpServerInfo, selected: bool) -> Line<'static> {
         Span::raw("  "),
         Span::styled(format!("{tools:<9}"), text),
         Span::raw("  "),
+        // SPEC §9.3's latency column, between the tool count and the state.
+        // A fixed-width slot whether or not there is a number, so the state
+        // word starts on the same column for every row — the whole point of
+        // padding the name column above.
+        Span::styled(format!("{:>6}", latency(server)), muted),
+        Span::raw("  "),
         conn,
     ];
+    // The graph is stella's own, and the pin is only legible if the row says
+    // why it is at the top.
+    if server.is_graph() {
+        spans.push(Span::styled("  · pinned", Style::new().fg(token::GOLD)));
+    }
+    // A server whose handshake has not been granted is connected and useless:
+    // the model is never told its tools exist. Red and in words, because this
+    // is the row's most consequential state and the operator has to be able to
+    // tell it from a healthy one at a glance (SPEC §13 — never colour alone).
+    if !server.granted {
+        spans.push(Span::styled("  · ungranted", Style::new().fg(token::RED)));
+    }
     if !server.auth_fields.is_empty() {
         spans.push(Span::styled(
             format!("  ⚿ {}", server.auth_fields.join(",")),
@@ -454,6 +538,20 @@ fn headline(server: &McpServerInfo, selected: bool) -> Line<'static> {
         spans.push(Span::styled("  · candidate-safe", dim));
     }
     Line::from(spans)
+}
+
+/// The latency cell: whole milliseconds of the connect handshake's round trip,
+/// or blank.
+///
+/// Blank rather than a dash or a zero when the number is unknown, and blank
+/// for a server that is not connected even if one was once measured — the
+/// column answers "how far away is this server right now", and a stale figure
+/// beside `not connected` would answer a question nobody asked.
+fn latency(server: &McpServerInfo) -> String {
+    match server.latency_ms {
+        Some(ms) if server.connected && server.enabled => format!("{ms}ms"),
+        _ => String::new(),
+    }
 }
 
 /// A server's second row: what it is, in words.
@@ -559,7 +657,25 @@ fn render_search(state: &McpTabState, lines: &mut Vec<Line<'static>>) {
             ),
             Span::styled(item.name.clone(), name_style),
             Span::styled(format!("  [{}]", item.kinds), muted),
+            // Who the registry says published this. Ahead of the counts,
+            // because it is the one that decides whether the rest matters.
+            Span::styled(format!("  {}", item.tier.label()), muted),
+            Span::styled(format!("  {}", installs(item.installs)), dim),
         ];
+        // Signed is the only state that lets `↵` do anything, so it is the
+        // only green here; the two blocked states are red and say `blocked`
+        // in words.
+        spans.push(if item.installable() {
+            Span::styled(
+                format!("  {}", item.signature.label()),
+                Style::new().fg(token::GREEN),
+            )
+        } else {
+            Span::styled(
+                format!("  {}", item.signature.label()),
+                Style::new().fg(token::RED),
+            )
+        });
         if item.installed {
             spans.push(Span::styled("  installed", Style::new().fg(token::GREEN)));
         }
@@ -577,8 +693,35 @@ fn render_search(state: &McpTabState, lines: &mut Vec<Line<'static>>) {
             dim,
         )));
     }
+    // Why a red row cannot be installed, once, under the list — and only when
+    // the page actually holds one.
+    if outcome.items.iter().any(|i| !i.installable()) {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            "  a blocked entry is one the registry does not vouch for · installing it would \
+             spawn a stranger's command",
+            dim,
+        )));
+    }
 }
 
+/// The installs cell. An absent count says so; it never becomes a `0`, which
+/// would claim nobody runs a server the registry simply does not count.
+///
+/// Thousands are abbreviated (`9.1k`) so the column stays one width for a
+/// registry that counts in millions.
+fn installs(count: Option<u64>) -> String {
+    let Some(count) = count else {
+        return "installs unknown".to_string();
+    };
+    match count {
+        n if n < 1_000 => format!("{n} installs"),
+        n if n < 1_000_000 => format!("{:.1}k installs", n as f64 / 1_000.0),
+        n => format!("{:.1}M installs", n as f64 / 1_000_000.0),
+    }
+}
+
+/// The two-step credential prompt: which field, then its value.
 fn render_auth(state: &McpTabState, lines: &mut Vec<Line<'static>>) {
     lines.push(Line::from(vec![
         Span::styled("  auth ", Style::new().fg(token::GOLD)),
@@ -641,6 +784,7 @@ fn footer(mode: McpMode) -> Line<'static> {
             ("esc", "back"),
         ],
         McpMode::Auth => &[("↵", "next / save"), ("esc", "cancel")],
+        McpMode::Handshake => &[("↑↓", "read"), ("g", "grant & enable"), ("esc", "deny")],
     };
     let key = Style::new().fg(token::MUTED);
     let dim = Style::new().fg(token::DIM);
@@ -658,7 +802,7 @@ fn footer(mode: McpMode) -> Line<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::envelope::McpSearchItem;
+    use crate::envelope::{GRAPH_SERVER, McpSearchItem, McpSignature, McpSourceTier};
 
     fn flat(line: &Line<'_>) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
@@ -680,9 +824,65 @@ mod tests {
             kind: "http".into(),
             endpoint: "https://mcp.stripe.com/v1".into(),
             enabled: true,
+            granted: true,
             oauth: Some(false),
             ..McpServerInfo::default()
         }
+    }
+
+    /// The pinned row: stella's own graph server, connected and measured.
+    fn graph() -> McpServerInfo {
+        McpServerInfo {
+            name: GRAPH_SERVER.into(),
+            kind: "stdio".into(),
+            endpoint: "stella-graph-mcp".into(),
+            enabled: true,
+            connected: true,
+            granted: true,
+            latency_ms: Some(8),
+            tool_count: 14,
+            ..McpServerInfo::default()
+        }
+    }
+
+    fn signed(name: &str) -> McpSearchItem {
+        McpSearchItem {
+            name: name.into(),
+            description: "Payments.".into(),
+            kinds: "http".into(),
+            installed: true,
+            tier: McpSourceTier::Vendor,
+            installs: Some(9_140),
+            signature: McpSignature::Signed,
+        }
+    }
+
+    fn blocked(name: &str) -> McpSearchItem {
+        McpSearchItem {
+            name: name.into(),
+            description: "Anything at all.".into(),
+            kinds: "npm".into(),
+            installed: false,
+            tier: McpSourceTier::Community,
+            installs: Some(112),
+            signature: McpSignature::Unsigned,
+        }
+    }
+
+    fn search_rows(items: Vec<McpSearchItem>) -> Vec<String> {
+        let state = McpTabState {
+            query: "postgres".into(),
+            search: Some(McpSearchOutcome {
+                query: "postgres".into(),
+                items,
+                error: None,
+                has_more: false,
+            }),
+            ..McpTabState::default()
+        };
+        let mut lines = Vec::new();
+        render_search(&state, &mut lines);
+        lines.iter().map(flat).collect()
     }
 
     /// The reported bug: an aliased server rendered as `mcp [http] not
@@ -776,6 +976,166 @@ mod tests {
         let text = rows(&[both]).join("\n");
         assert!(text.contains("12 dropped past cap"), "{text}");
         assert!(text.contains("4 trimmed over budget"), "{text}");
+    }
+
+    /// **The witness (#5047, pin).** SPEC §9.3: the graph server is pinned
+    /// first, with the caption that says why. The old `render_browse` walked
+    /// the delivered order, so the graph landed wherever `mcp.toml`'s
+    /// alphabetical keys put it — under `github`, and under any alias
+    /// starting with a letter before `g`.
+    #[test]
+    fn the_graph_server_is_pinned_first_and_says_why() {
+        let alpha = McpServerInfo {
+            name: "aaa".into(),
+            granted: true,
+            ..stripe()
+        };
+        let lines = rows(&[alpha, graph(), stripe()]);
+        assert!(
+            lines[0].contains(GRAPH_SERVER),
+            "the graph must head the list whatever order it arrived in: {lines:?}"
+        );
+        assert!(
+            lines[2].contains(PIN_CAPTION),
+            "the caption sits with the row it explains: {lines:?}"
+        );
+        assert!(lines[0].contains("· pinned"), "{lines:?}");
+        // Everything else keeps the delivered order underneath the pin.
+        assert!(lines[3].contains("aaa"), "{lines:?}");
+    }
+
+    /// The pin re-orders the paint, never the selection: `state.selected`
+    /// indexes the delivered snapshot, and every key verb acts on that index.
+    /// Sorting the rows themselves would make `x` remove whichever server
+    /// happened to be painted under the cursor.
+    #[test]
+    fn pinning_moves_the_paint_and_never_the_selection() {
+        let servers = vec![stripe(), graph()];
+        assert_eq!(paint_order(&servers), vec![1, 0]);
+
+        let state = McpTabState {
+            servers,
+            selected: 0,
+            ..McpTabState::default()
+        };
+        assert_eq!(
+            state.selected_server().map(|s| s.name.as_str()),
+            Some("mcp"),
+            "index 0 is still the row the driver delivered first"
+        );
+        let mut lines = Vec::new();
+        render_browse(&state, &mut lines, 80);
+        let painted: Vec<String> = lines.iter().map(flat).collect();
+        let marked = painted
+            .iter()
+            .find(|l| l.contains('▸'))
+            .unwrap_or_else(|| panic!("nothing is marked selected: {painted:?}"));
+        assert!(
+            marked.contains("mcp"),
+            "the marker follows the selection into its new row: {painted:?}"
+        );
+    }
+
+    /// **The witness (#5047, latency).** SPEC §9.3's latency column. A
+    /// connected server shows its measured round trip; one that is not
+    /// connected shows nothing at all, because a stale number beside `not
+    /// connected` answers a question nobody asked — and a `0ms` would read as
+    /// the nearest server on the list.
+    #[test]
+    fn a_connected_row_shows_its_latency_and_an_unmeasured_one_shows_none() {
+        assert!(
+            rows(&[graph()])[0].contains("8ms"),
+            "{:?}",
+            rows(&[graph()])
+        );
+
+        let mut dropped = graph();
+        dropped.connected = false;
+        dropped.latency_ms = Some(8);
+        let text = rows(&[dropped]).join("\n");
+        assert!(text.contains("not connected"), "{text}");
+        assert!(
+            !text.contains("8ms"),
+            "a dead connection has no distance: {text}"
+        );
+
+        let mut unmeasured = graph();
+        unmeasured.latency_ms = None;
+        assert!(
+            !rows(&[unmeasured])[0].contains("0ms"),
+            "unknown is not zero"
+        );
+    }
+
+    /// **The witness (#5047, registry).** SPEC §9.3: a registry row carries
+    /// its source tier, its install count and its signature — and an unsigned
+    /// entry is BLOCKED, not merely labelled. The row was
+    /// `{name, description, kinds, installed}`, so every one of these was
+    /// unanswerable before an operator pressed install.
+    #[test]
+    fn a_registry_row_carries_tier_installs_and_a_signature_that_can_block() {
+        let text = search_rows(vec![signed("com.stripe/mcp")]).join("\n");
+        assert!(text.contains("vendor"), "source tier: {text}");
+        assert!(text.contains("9.1k installs"), "install count: {text}");
+        assert!(text.contains("signed"), "signature: {text}");
+
+        let text = search_rows(vec![blocked("io.github.x/y")]).join("\n");
+        assert!(text.contains("community"), "{text}");
+        assert!(text.contains("112 installs"), "{text}");
+        // The word, not only the colour (SPEC §13).
+        assert!(text.contains("unsigned · blocked"), "{text}");
+        assert!(text.contains("does not vouch for"), "and why: {text}");
+    }
+
+    /// A blocked row refuses the keystroke, and the refusal names the row —
+    /// the state the paint shows and the state the key enforces are read from
+    /// one value.
+    #[test]
+    fn install_stands_down_on_a_blocked_row_and_says_so() {
+        let state = |item: McpSearchItem| McpTabState {
+            query: "q".into(),
+            search: Some(McpSearchOutcome {
+                query: "q".into(),
+                items: vec![item],
+                error: None,
+                has_more: false,
+            }),
+            ..McpTabState::default()
+        };
+        let refusal = state(blocked("io.github.x/y"))
+            .selected_search_refusal()
+            .expect("a blocked row must refuse");
+        assert!(refusal.contains("io.github.x/y"), "{refusal}");
+        assert!(refusal.contains("blocked"), "{refusal}");
+        assert!(
+            state(signed("com.stripe/mcp"))
+                .selected_search_refusal()
+                .is_none(),
+            "a signed row installs"
+        );
+    }
+
+    /// A registry that publishes no count says so. `0 installs` would claim
+    /// nobody runs a server the registry simply does not count.
+    #[test]
+    fn an_unknown_install_count_is_never_rendered_as_zero() {
+        assert_eq!(installs(None), "installs unknown");
+        assert_eq!(installs(Some(0)), "0 installs");
+        assert_eq!(installs(Some(9_140)), "9.1k installs");
+        assert_eq!(installs(Some(2_400_000)), "2.4M installs");
+    }
+
+    /// A connected server the model cannot use says so on its row, in words —
+    /// otherwise `● 14 tools live` reads as healthy while every call to it is
+    /// refused.
+    #[test]
+    fn an_ungranted_row_says_so_rather_than_reading_as_healthy() {
+        let mut ungranted = graph();
+        ungranted.granted = false;
+        let text = rows(&[ungranted]).join("\n");
+        assert!(text.contains("ungranted"), "{text}");
+        assert!(rows(&[graph()]).join("\n").contains("live"));
+        assert!(!rows(&[graph()]).join("\n").contains("ungranted"));
     }
 
     #[test]
@@ -884,28 +1244,47 @@ mod tests {
             token::BORDER,
         ];
         let mut state = McpTabState {
-            servers: vec![stripe()],
+            servers: vec![stripe(), graph()],
             query: "stripe".into(),
             search: Some(McpSearchOutcome {
                 query: "stripe".into(),
-                items: vec![McpSearchItem {
-                    name: "com.stripe/mcp".into(),
-                    description: "Payments.".into(),
-                    kinds: "http".into(),
-                    installed: true,
-                }],
+                // One installable row and one blocked one, so the search
+                // pane's red arm is painted too.
+                items: vec![signed("com.stripe/mcp"), blocked("io.github.x/y")],
                 has_more: true,
                 error: None,
             }),
+            handshake: Some(HandshakeGate {
+                server: "mcp".into(),
+                detail: Some(McpServerDetail {
+                    name: "mcp".into(),
+                    connected: true,
+                    tools: vec![crate::envelope::McpToolRow {
+                        name: "create_refund".into(),
+                        description: "Refund a charge.".into(),
+                        safe_to_retry: true,
+                        calls: 0,
+                    }],
+                    auth_fields: vec!["Authorization".into()],
+                    ..McpServerDetail::default()
+                }),
+                scroll: 0,
+            }),
             ..McpTabState::default()
         };
-        for mode in [McpMode::Browse, McpMode::Search, McpMode::Auth] {
+        for mode in [
+            McpMode::Browse,
+            McpMode::Search,
+            McpMode::Auth,
+            McpMode::Handshake,
+        ] {
             state.mode = mode;
             let mut lines = Vec::new();
             match mode {
                 McpMode::Browse => render_browse(&state, &mut lines, 80),
                 McpMode::Search => render_search(&state, &mut lines),
                 McpMode::Auth => render_auth(&state, &mut lines),
+                McpMode::Handshake => handshake::render(&state, &mut lines, 24),
             }
             for line in &lines {
                 for span in &line.spans {

--- a/crates/stella-tui/src/views/mcp_tab/detail.rs
+++ b/crates/stella-tui/src/views/mcp_tab/detail.rs
@@ -130,12 +130,27 @@ fn subtitle(detail: &McpServerDetail) -> Line<'static> {
     } else {
         Span::styled("not connected", Style::new().fg(token::RED))
     };
-    Line::from(vec![
+    let mut spans = vec![
         Span::raw(" "),
         Span::styled(detail.name.clone(), Style::new().fg(token::TEXT)),
         Span::styled(format!("  ·  {}  ·  ", detail.kind), muted),
         status,
-    ])
+    ];
+    // The same latency the list row shows, on the same terms: only while
+    // there is a live connection that measured it.
+    if let Some(ms) = detail
+        .latency_ms
+        .filter(|_| detail.connected && detail.enabled)
+    {
+        spans.push(Span::styled(format!("  ·  {ms}ms"), muted));
+    }
+    // A connected, healthy-looking server whose tools the model is never told
+    // about. The inspector is where an operator comes to ask why, so it must
+    // answer here as plainly as the row does.
+    if !detail.granted {
+        spans.push(Span::styled("  ·  ungranted", Style::new().fg(token::RED)));
+    }
+    Line::from(spans)
 }
 
 fn body_lines(detail: &McpServerDetail, width: usize) -> Vec<Line<'static>> {
@@ -210,6 +225,17 @@ fn body_lines(detail: &McpServerDetail, width: usize) -> Vec<Line<'static>> {
         Some(false) => lines.push(field("oauth", "not logged in (o on the list to log in)")),
         None => lines.push(field("oauth", "n/a — stdio server")),
     }
+    // The capability grant sits with auth because it answers the same
+    // question — what is this server allowed to do here — and because an
+    // ungranted server's empty effect on the model is otherwise unexplained.
+    lines.push(field(
+        "granted",
+        if detail.granted {
+            "yes — its tools are offered to the model"
+        } else {
+            "no — every call is refused (e on the list opens the handshake)"
+        },
+    ));
     if detail.candidate_safe {
         lines.push(field("candidates", "shared into Best-of-N workspaces"));
     }
@@ -404,6 +430,8 @@ mod tests {
     fn stripe() -> McpServerDetail {
         McpServerDetail {
             name: "mcp".into(),
+            granted: true,
+            latency_ms: Some(41),
             title: Some("Stripe".into()),
             description: Some("Payments, refunds, and balance reads.".into()),
             registry_name: Some("com.stripe/mcp".into()),
@@ -446,6 +474,20 @@ mod tests {
         assert!(text.contains("Refund a charge."), "tool summary: {text}");
         assert!(text.contains("3×"), "call count: {text}");
         assert!(text.contains("logged in"), "oauth state: {text}");
+    }
+
+    /// The inspector answers "why is the model not using this" as plainly as
+    /// the row does: an ungranted server says so, a granted one says the
+    /// opposite, and neither leaves it to be inferred from an empty tool list.
+    #[test]
+    fn the_inspector_says_whether_the_server_is_granted() {
+        assert!(rendered(&stripe()).contains("its tools are offered to the model"));
+
+        let mut ungranted = stripe();
+        ungranted.granted = false;
+        let text = rendered(&ungranted);
+        assert!(text.contains("every call is refused"), "{text}");
+        assert!(text.contains("opens the handshake"), "the remedy: {text}");
     }
 
     #[test]

--- a/crates/stella-tui/src/views/mcp_tab/handshake.rs
+++ b/crates/stella-tui/src/views/mcp_tab/handshake.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The MCP tab's first-enable handshake (SPEC §9.3): what a server declares,
+//! and the grant it cannot be used without.
+//!
+//! A **mode**, not an overlay — the answer is required before the server is
+//! usable at all, and an overlay reads as something you can dismiss.
+//!
+//! Every declared tool is rendered by name and the pane scrolls, because a
+//! capability grant whose subject is "14 tools" is a grant nobody read. Denying
+//! costs no keystroke: withheld is the default, so walking away is the answer.
+//!
+//! Nothing here withholds anything. `stella_mcp::CapabilityGrants` is what the
+//! tool layer consults and `stella_mcp::McpServerEntry::granted` is where the
+//! answer persists; this module is the question.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use stella_tui_theme::token;
+
+use super::McpTabState;
+use crate::envelope::McpServerDetail;
+
+/// The first-enable handshake gate: one server's declared capabilities, and
+/// the question.
+///
+/// SPEC §9.3 promises "the handshake shows capabilities before first enable",
+/// and this is the surface that keeps it. It reuses [`McpServerDetail`] rather
+/// than a shape of its own because the operator is being asked about exactly
+/// what the inspector shows — what the server announced at handshake and every
+/// tool it advertises — and a second, thinner summary of the same facts is how
+/// the two drift into disagreeing about what was granted.
+///
+/// A mode rather than an overlay: the answer is required before the server is
+/// usable at all, and an overlay reads as something you can dismiss.
+#[derive(Debug, Clone)]
+pub struct HandshakeGate {
+    /// The alias being reviewed. Kept before `detail` arrives so a late reply
+    /// for another server cannot repaint this one.
+    pub server: String,
+    /// The assembled detail; `None` renders a loading state, and the grant key
+    /// stands down until it lands — nobody can grant capabilities they have
+    /// not been shown.
+    pub detail: Option<McpServerDetail>,
+    /// Vertical scroll offset in lines, clamped to content at render time. A
+    /// server with forty tools must not be grantable by a reader who could
+    /// only ever see the first six.
+    pub scroll: u16,
+}
+
+/// Paint the gate: what this server declares, then what granting costs.
+///
+/// Who the process on the other end says it is, then every tool it wants the
+/// model to be able to call, then what withholding costs — the order the
+/// question is answered in. The tool list is the substance (a capability grant
+/// whose subject is a count is a grant nobody read), so it is rendered in full
+/// and scrolled rather than truncated.
+///
+/// `height` is the pane's, used only to say how much is left to read; the
+/// scroll itself is [`crate::deck_ui::list_nav`]'s business in the key handler.
+pub(super) fn render(state: &McpTabState, lines: &mut Vec<Line<'static>>, height: usize) {
+    let dim = Style::new().fg(token::DIM);
+    let muted = Style::new().fg(token::MUTED);
+    let text = Style::new().fg(token::TEXT);
+    let Some(gate) = &state.handshake else {
+        return;
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  handshake ", Style::new().fg(token::GOLD)),
+        Span::styled(gate.server.clone(), text),
+        Span::styled("  ·  first enable", muted),
+    ]));
+    lines.push(Line::default());
+
+    let Some(detail) = &gate.detail else {
+        lines.push(Line::from(Span::styled(
+            "  reading what the server declares…",
+            muted,
+        )));
+        return;
+    };
+
+    let mut body: Vec<Line<'static>> = Vec::new();
+
+    // Who answered the pipe. The alias is a local nickname; this is the only
+    // identity the process itself offered, and a disagreement between the two
+    // is exactly what a reviewer is looking for.
+    let announced = detail
+        .live
+        .as_ref()
+        .and_then(|l| {
+            [l.title.as_deref(), l.name.as_deref()]
+                .into_iter()
+                .flatten()
+                .find(|s| !s.trim().is_empty())
+        })
+        .unwrap_or("(the server announced no name)");
+    body.push(Line::from(vec![
+        Span::styled("  announces itself as  ", muted),
+        Span::styled(announced.to_string(), text),
+    ]));
+    body.push(Line::from(vec![
+        Span::styled("  reached at           ", muted),
+        Span::styled(detail.endpoint.clone(), text),
+    ]));
+    if let Some(live) = &detail.live
+        && !live.protocol_version.is_empty()
+    {
+        body.push(Line::from(vec![
+            Span::styled("  speaking             ", muted),
+            Span::styled(live.protocol_version.clone(), text),
+        ]));
+    }
+    if !detail.auth_fields.is_empty() {
+        body.push(Line::from(vec![
+            Span::styled("  sending credentials  ", muted),
+            Span::styled(detail.auth_fields.join(", "), text),
+        ]));
+    }
+    body.push(Line::default());
+
+    // The capabilities themselves.
+    if detail.tools.is_empty() {
+        body.push(Line::from(Span::styled(
+            if detail.connected {
+                "  it declares no tools at all"
+            } else {
+                "  it is not connected, so it has declared nothing to grant"
+            },
+            Style::new().fg(token::RED),
+        )));
+    } else {
+        body.push(Line::from(vec![
+            Span::styled("  it declares ", muted),
+            Span::styled(detail.tools.len().to_string(), text),
+            Span::styled(
+                if detail.tools.len() == 1 {
+                    " tool, which the model may call once granted:"
+                } else {
+                    " tools, every one of which the model may call once granted:"
+                },
+                muted,
+            ),
+        ]));
+    }
+    for tool in &detail.tools {
+        let mut spans = vec![
+            Span::raw("    "),
+            Span::styled(tool.name.clone(), text.add_modifier(Modifier::BOLD)),
+        ];
+        if tool.safe_to_retry {
+            // The server's own claim about its own tool, and worth exactly
+            // that much — the word is here so the reviewer weighs it, not so
+            // they trust it.
+            spans.push(Span::styled("  read-only (self-reported)", dim));
+        }
+        body.push(Line::from(spans));
+        let summary = tool
+            .description
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .unwrap_or_default();
+        if !summary.is_empty() {
+            body.push(Line::from(Span::styled(format!("      {summary}"), dim)));
+        }
+    }
+
+    body.push(Line::default());
+    body.push(Line::from(Span::styled(
+        "  granting records the decision in .stella/mcp.toml · until then no tool of this \
+         server is offered to the model and every call to it is refused",
+        dim,
+    )));
+
+    // Scroll the capability list rather than truncating it: a grant whose
+    // subject is a count ("14 tools") is a grant nobody read, and a forty-tool
+    // server must not be grantable by a reader who could only see six.
+    let scroll = usize::from(gate.scroll).min(body.len().saturating_sub(1));
+    let room = height.saturating_sub(lines.len());
+    let more = body.len().saturating_sub(scroll) > room;
+    lines.extend(body.into_iter().skip(scroll));
+    if more {
+        lines.push(Line::from(Span::styled("  ↑↓ more to read", muted)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::views::mcp_tab::{McpMode, footer};
+
+    fn flat(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn rendered(state: &McpTabState, height: usize) -> String {
+        let mut lines = Vec::new();
+        render(state, &mut lines, height);
+        lines.iter().map(flat).collect::<Vec<_>>().join("\n")
+    }
+
+    /// **The witness (#5047, handshake).** The caption promised "the handshake
+    /// shows capabilities before first enable" and nothing showed them: the
+    /// declared tool list was reachable only afterwards, in the ctrl+o
+    /// inspector. The gate renders every declared tool by name, and says what
+    /// withholding costs.
+    #[test]
+    fn the_first_enable_handshake_names_every_declared_capability() {
+        let state = McpTabState {
+            mode: McpMode::Handshake,
+            handshake: Some(HandshakeGate {
+                server: "mcp".into(),
+                detail: Some(McpServerDetail {
+                    name: "mcp".into(),
+                    endpoint: "https://mcp.stripe.com/v1".into(),
+                    connected: true,
+                    live: Some(crate::envelope::McpLiveIdentity {
+                        name: Some("stripe-mcp".into()),
+                        protocol_version: "2025-06-18".into(),
+                        ..crate::envelope::McpLiveIdentity::default()
+                    }),
+                    auth_fields: vec!["Authorization".into()],
+                    tools: vec![
+                        crate::envelope::McpToolRow {
+                            name: "create_refund".into(),
+                            description: "Refund a charge.".into(),
+                            ..crate::envelope::McpToolRow::default()
+                        },
+                        crate::envelope::McpToolRow {
+                            name: "list_charges".into(),
+                            description: "List charges.".into(),
+                            safe_to_retry: true,
+                            ..crate::envelope::McpToolRow::default()
+                        },
+                    ],
+                    ..McpServerDetail::default()
+                }),
+                scroll: 0,
+            }),
+            ..McpTabState::default()
+        };
+        let text = rendered(&state, 40);
+
+        assert!(text.contains("stripe-mcp"), "who answered: {text}");
+        assert!(text.contains("mcp.stripe.com"), "where: {text}");
+        assert!(text.contains("2025-06-18"), "protocol: {text}");
+        assert!(text.contains("Authorization"), "credentials sent: {text}");
+        // Every declared tool by name — a grant whose subject is a count is a
+        // grant nobody read.
+        assert!(text.contains("create_refund"), "{text}");
+        assert!(text.contains("list_charges"), "{text}");
+        assert!(
+            text.contains("self-reported"),
+            "a server's read-only claim is its own: {text}"
+        );
+        assert!(
+            text.contains("every call to it is refused"),
+            "the gate says what withholding costs: {text}"
+        );
+        assert!(flat(&footer(McpMode::Handshake)).contains("g grant"));
+    }
+
+    /// The gate cannot be answered before it has anything to show. A "grant"
+    /// keystroke over a loading pane would be a decision about capabilities
+    /// nobody was shown.
+    #[test]
+    fn the_handshake_says_it_is_still_reading_before_the_detail_lands() {
+        let state = McpTabState {
+            mode: McpMode::Handshake,
+            handshake: Some(HandshakeGate {
+                server: "mcp".into(),
+                detail: None,
+                scroll: 0,
+            }),
+            ..McpTabState::default()
+        };
+        let text = rendered(&state, 40);
+        assert!(text.contains("reading what the server declares"), "{text}");
+        assert!(!text.contains("declares 0"), "{text}");
+    }
+
+    /// A late detail addressed to another server never repaints the open gate,
+    /// for the same reason it never repaints the inspector: every field on
+    /// screen would silently be mislabelled.
+    #[test]
+    fn a_late_detail_for_another_server_never_fills_the_open_gate() {
+        let mut state = McpTabState {
+            mode: McpMode::Handshake,
+            handshake: Some(HandshakeGate {
+                server: "fs".into(),
+                detail: None,
+                scroll: 0,
+            }),
+            ..McpTabState::default()
+        };
+        state.apply_detail(McpServerDetail {
+            name: "mcp".into(),
+            ..McpServerDetail::default()
+        });
+        assert!(state.handshake.as_ref().unwrap().detail.is_none());
+        state.apply_detail(McpServerDetail {
+            name: "fs".into(),
+            ..McpServerDetail::default()
+        });
+        assert!(state.handshake.unwrap().detail.is_some());
+    }
+}

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -88,6 +88,11 @@ mod attribution;
 #[path = "deck_render_snapshots/task_zoom.rs"]
 mod task_zoom;
 
+/// The MCP tab's golden fixture. See [`graph`]'s doc for why this is
+/// `#[path]` rather than a plain `mod`.
+#[path = "deck_render_snapshots/mcp.rs"]
+mod mcp;
+
 /// The command used to regenerate every golden in this file. Quoted verbatim in
 /// each snapshot header and in every failure message, so nobody has to go
 /// looking for it.
@@ -495,45 +500,6 @@ fn fixture_tool_policy() -> ToolPolicyState {
     }
 }
 
-fn fixture_mcp_servers() -> Vec<stella_tui::McpServerInfo> {
-    vec![
-        stella_tui::McpServerInfo {
-            name: "stripe".into(),
-            title: Some("Stripe".into()),
-            description: Some("Payments, refunds, and balance reads.".into()),
-            endpoint: "https://mcp.stripe.com/v1".into(),
-            kind: "http".into(),
-            enabled: true,
-            connected: true,
-            health: Some("live".into()),
-            tool_count: 21,
-            oauth: Some(true),
-            calls: 14,
-            ..Default::default()
-        },
-        stella_tui::McpServerInfo {
-            name: "fs".into(),
-            endpoint: "npx -y @modelcontextprotocol/server-filesystem /w".into(),
-            kind: "stdio".into(),
-            enabled: true,
-            connected: true,
-            health: Some("live".into()),
-            tool_count: 4,
-            ..Default::default()
-        },
-        stella_tui::McpServerInfo {
-            name: "linear".into(),
-            title: Some("Linear".into()),
-            description: Some("Issues, projects, cycles, and documents.".into()),
-            endpoint: "https://mcp.linear.app/mcp".into(),
-            kind: "http".into(),
-            enabled: false,
-            oauth: Some(false),
-            ..Default::default()
-        },
-    ]
-}
-
 /// The representative state for each tab: populated entries, a moved cursor,
 /// and whatever out-of-band snapshot that tab reads. A tab rendered from
 /// `DeckUi::default()` would pin its empty state and nothing else.
@@ -557,7 +523,7 @@ fn ui_for(tab: DeckTab) -> DeckUi {
             ui.skills.view = fixture_skills();
             ui.skills.sel = 1;
         }
-        DeckTab::Mcp => ui.mcp.servers = fixture_mcp_servers(),
+        DeckTab::Mcp => ui.mcp.servers = mcp::fixture_mcp_servers(),
         DeckTab::Issues => {
             ui.issues.rows = fixture_issues();
             ui.issues.loaded = true;

--- a/crates/stella-tui/tests/deck_render_snapshots/mcp.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots/mcp.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The MCP tab's golden fixture: four configured servers, chosen so the
+//! golden pins every claim SPEC §9.3 makes about the list.
+//!
+//! A submodule of `deck_render_snapshots` rather than more lines in it: the
+//! parent had already reached the 1500-line ceiling, so this fixture goes
+//! here instead of pushing it over.
+//!
+//! The parent renders the golden and owns the assertion, so the snapshot
+//! lives in one directory and is blessed by one command:
+//! `BLESS=1 cargo test -p stella-tui --test deck_render_snapshots`.
+
+/// The MCP tab's servers, as the driver delivers them — which is the point of
+/// the ordering below.
+///
+/// The four rows are not decoration. Between them they pin the whole of SPEC
+/// §9.3's list: the graph server arrives *second* (`mcp.toml`'s keys are
+/// alphabetical, so that is where it really lands) and the golden proves the
+/// paint moves it to the top with its caption; every connected row carries a
+/// measured latency; and `linear` is a server just installed from the
+/// registry — connected, and useless until its handshake is reviewed, so the
+/// golden proves the row says `ungranted` in words.
+pub(super) fn fixture_mcp_servers() -> Vec<stella_tui::McpServerInfo> {
+    vec![
+        stella_tui::McpServerInfo {
+            name: "stripe".into(),
+            title: Some("Stripe".into()),
+            description: Some("Payments, refunds, and balance reads.".into()),
+            endpoint: "https://mcp.stripe.com/v1".into(),
+            kind: "http".into(),
+            enabled: true,
+            connected: true,
+            health: Some("live".into()),
+            tool_count: 21,
+            oauth: Some(true),
+            calls: 14,
+            latency_ms: Some(66),
+            granted: true,
+            ..Default::default()
+        },
+        stella_tui::McpServerInfo {
+            name: stella_tui::GRAPH_SERVER.into(),
+            description: Some("stella's own code graph — nodes, edges, coupling.".into()),
+            endpoint: "stella-graph-mcp".into(),
+            kind: "stdio".into(),
+            enabled: true,
+            connected: true,
+            health: Some("live".into()),
+            tool_count: 14,
+            latency_ms: Some(8),
+            granted: true,
+            ..Default::default()
+        },
+        stella_tui::McpServerInfo {
+            name: "fs".into(),
+            endpoint: "npx -y @modelcontextprotocol/server-filesystem /w".into(),
+            kind: "stdio".into(),
+            enabled: true,
+            connected: true,
+            health: Some("live".into()),
+            tool_count: 4,
+            latency_ms: Some(2),
+            granted: true,
+            ..Default::default()
+        },
+        stella_tui::McpServerInfo {
+            name: "linear".into(),
+            title: Some("Linear".into()),
+            description: Some("Issues, projects, cycles, and documents.".into()),
+            endpoint: "https://mcp.linear.app/mcp".into(),
+            kind: "http".into(),
+            enabled: true,
+            connected: true,
+            health: Some("live".into()),
+            tool_count: 9,
+            latency_ms: Some(41),
+            oauth: Some(false),
+            granted: false,
+            ..Default::default()
+        },
+    ]
+}

--- a/crates/stella-tui/tests/snapshots/deck/tab_mcp.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_mcp.txt
@@ -4,18 +4,18 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION AGENTS TRACES GRAPH FILES SKILLS   MCP   ISSUES SETTINGS                                                                                       stella*
- servers · 3 · 2 connected
-▸ ● Stripe                 http   21 tools   live  oauth ✓  · 14×
+ servers · 4 · 4 connected
+  ● graph                  stdio  14 tools      8ms  live  · pinned
+      stella's own code graph — nodes, edges, coupling.
+      graph is pinned · it is the product, not an integration
+▸ ● Stripe                 http   21 tools     66ms  live  oauth ✓  · 14×
       stripe  ·  Payments, refunds, and balance reads.
-  ● fs                     stdio  4 tools    live
+  ● fs                     stdio  4 tools       2ms  live
       npx -y @modelcontextprotocol/server-filesystem /w
-  ○ Linear                 http   0 tools    disabled  o login
+  ● Linear                 http   9 tools      41ms  live  · ungranted  o login
       linear  ·  Issues, projects, cycles, and documents.
 
  registry · web · s search · new servers land disabled · the handshake shows capabilities before first enable
-
-
-
 
 
 

--- a/docs/adr/0018-mcp-capability-grants.md
+++ b/docs/adr/0018-mcp-capability-grants.md
@@ -1,0 +1,116 @@
+---
+id: adr/0018-mcp-capability-grants
+title: "ADR 0018: MCP servers are withheld until their handshake is granted"
+status: proposed
+---
+
+# ADR 0018: MCP servers are withheld until their handshake is granted
+
+- Status: **Proposed** — awaiting ratification by the repository owner.
+- Date: 2026-08-26
+- Deciders: repository owner (pending)
+- Tracking: [issue #5047](https://github.com/macanderson/stella/issues/5047)
+- Scope note: outside the Phase 0 series. It decides a gate on an existing
+  surface — the MCP tool set — rather than a new feature.
+
+## Context
+
+`design/tui-v2/SPEC.md` §9.3 says new MCP servers land disabled and "the
+first-enable handshake shows declared capabilities before any tool call". The
+MCP tab printed that promise in its registry caption and kept none of it: `e`
+sent `McpToggle` for every row, and a server's declared tool list was reachable
+only *afterwards*, through the `ctrl+o` inspector.
+
+So the shipped path from a registry search to a third party executing code in
+the operator's session was two keystrokes — `↵` to install, `e` to enable —
+with nothing in between that named what the server could do.
+
+Three questions had to be answered together.
+
+**Where does the gate sit?** Between the handshake and the first `tools/call`,
+not before connect. The declared capabilities *are* the handshake's output; a
+gate that refused to connect would make the thing under review unreadable, and
+the operator would be granting a name.
+
+**Where does the decision live?** In `.stella/mcp.toml`, beside the transport it
+governs. A session-only grant evaporates at the next start, and an operator
+asked the same question every morning learns to answer it without reading —
+which is worse than no gate, because it manufactures consent and records it as
+review.
+
+**What does an entry with no recorded decision mean?** The two obvious answers
+are both wrong. Reading absence as *granted*
+for every entry leaves the gate governing nothing. Reading it as *withheld*
+disarms every existing workspace on upgrade — every MCP server in every
+`mcp.toml` on earth stops working at once, and the fastest way through is to
+grant them all unread.
+
+## Decision
+
+`McpServerEntry::granted` is `Option<bool>` with three states, and each names
+the door the server came through:
+
+| State | Written by | Gate |
+| --- | --- | --- |
+| `Some(true)` | a grant, from the tab or `stella mcp grant` | usable |
+| `Some(false)` | a registry install, or `--revoke` | withheld |
+| absent | a human editing `mcp.toml` | usable |
+
+A plugin-contributed server has no entry at all and is usable, for the same
+reason the absent key is: installing the plugin was the decision.
+
+The runtime half is `stella_mcp::CapabilityGrants`, a shared set of granted
+names that `McpToolSet` consults on every advertise and every dispatch —
+default-deny wherever a host installs one, and both hosts do (the deck and the
+one-shot run), so the property does not depend on which surface is driving. An
+ungranted server's tools are absent from `schemas()` and every call to it is
+refused with `RefusedByPolicy` before anything reaches the transport.
+
+## Why this is the durable option
+
+The asymmetry is not a compromise; it is the threat model written down.
+**Anyone who can write `granted = true` into `mcp.toml` can equally omit the
+key.** So reading absence as withheld defends against nothing that `Some(false)`
+does not already cover — it only breaks working installations. The attack the
+gate actually stops is the operator's own fast keystroke on a search result
+they have not read, and that path always writes a decision.
+
+Reading absence as *granted* everywhere would be the cheap version and it
+fails the ten-year test differently: the gate would exist in the type system
+and govern nothing the moment anyone edited a file.
+
+Recording the answer where the transport lives means one file explains both
+what a server is and whether it may act — no second store, no drift between
+them, and a run with no deck attached reads the same answer the deck wrote.
+
+## Consequences
+
+- A server installed from the registry advertises nothing until it is granted.
+  Both surfaces say so: the tab renders `· ungranted` on the row and `e` opens
+  the handshake instead of toggling; `stella mcp list` prints the remedy.
+- `stella mcp grant <name>` connects, prints the declared capabilities, and
+  asks. `--yes` skips the prompt so a provisioning script can record one; `--revoke` writes
+  `Some(false)`, which is a recorded "no" and stays distinguishable from never
+  having been asked.
+- Existing workspaces are unaffected: their entries carry no `granted` key.
+- The refusal is a `ToolOutput::Error`, so the model sees it and can relay the
+  remedy. It is never an `Err` out of `execute` — MCP failures have always been
+  model-visible data here, and a policy refusal is not the place to change that.
+- Not covered: revocation does not disconnect the server, and a granted
+  server's tool list is not re-reviewed if it changes mid-session. A server
+  that advertises new tools after a reconnect keeps the surface negotiated at
+  the first handshake (`McpClient`'s existing contract), so the grant still
+  describes what was read — but a *reinstall* under the same alias does not
+  re-ask, and that is the seam to watch.
+
+## Alternatives rejected
+
+- **Session-only grants.** No disk write, no migration question, and the
+  operator is re-asked every morning until they stop reading.
+- **A separate grant store** (`.stella/private/mcp_grants.json`). Keeps
+  `mcp.toml` untouched, and splits "what this server is" from "may it act"
+  across two files that drift.
+- **Gate the connect.** Strictly safer, and it makes the capabilities under
+  review unfetchable — the operator would be granting an alias.
+- **Default-deny for absent keys.** The strictest rule available, and the one
+  that trains operators to grant unread. See the decision above.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,6 +83,7 @@ open; nothing before Phase 3 forces it.
 | [0014](0014-memories-join-the-record-control-plane.md) | Memories Join the Context-Record Control Plane | **Proposed** — awaiting ratification |
 | [0015](0015-the-task-tag-rides-the-event.md) | The Task Tag Rides the Event | Implemented — landed with #5039 |
 | [0017](0017-plan-graph-persistence.md) | The Plan Graph Is Persisted in the Store, Not the Context Plane | **Proposed** — awaiting ratification |
+| [0018](0018-mcp-capability-grants.md) | MCP Servers Are Withheld Until Their Handshake Is Granted | **Proposed** — awaiting ratification |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -108,3 +109,10 @@ graph SPEC §7.4 specifies. It routes the record to `store.db` beside the
 execution it describes rather than to the retrieval plane in `context.db`, and
 argues the shape (edge rows, not a JSON column) from the auditability the
 issue asks for. Unlike 0013 it is implemented in the change that files it.
+
+ADR 0018 makes `McpServerEntry::granted` a three-state field, so an entry says
+which door its server came through: a grant, a registry install, or a human
+editing `mcp.toml`. Only the middle one withholds, and `CapabilityGrants` then
+keeps an ungranted server out of `schemas()` and refuses its calls before the
+transport — on both hosts, so the property does not depend on which surface is
+driving.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -90,6 +90,11 @@
       "status": "proposed",
       "title": "ADR 0017: The plan graph is persisted in the store, not the context plane"
     },
+    "adr/0018-mcp-capability-grants": {
+      "path": "docs/adr/0018-mcp-capability-grants.md",
+      "status": "proposed",
+      "title": "ADR 0018: MCP servers are withheld until their handshake is granted"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",

--- a/website/content/docs/agent-tools/mcp.mdx
+++ b/website/content/docs/agent-tools/mcp.mdx
@@ -13,13 +13,24 @@ The quickest way to add a server is the [`stella mcp`](/docs/commands/mcp) comma
 
 ```bash
 stella mcp search github          # find one in the registry
-stella mcp install github         # write the .stella/mcp.toml entry
-stella mcp list                   # what's configured, and which have credentials
+stella mcp install github         # write the .stella/mcp.toml entry — withheld until granted
+stella mcp grant github           # read what it declares, then let the model call it
+stella mcp list                   # what's configured, which have credentials, which are withheld
 stella mcp usage                  # per-server, per-tool call counts from local telemetry
 stella mcp remove github          # drop one
 ```
 
 Enabling and disabling a server is deliberately *not* a CLI verb: it is session-scoped (it changes a running conversation's tool set), so it lives in the deck's MCP tab (`/mcp`).
+
+## An installed server is withheld until you grant it
+
+A server you install from a registry is a stranger's command line, and installing it takes one keystroke. So a newly installed server **connects but cannot act**: none of its tools are offered to the model, and any call to one comes back as a refusal.
+
+The handshake is what you review. Connecting is how a server's declared capabilities become knowable at all, so the gate sits between the handshake and the first tool call rather than before the connect: stella asks the server what it offers, shows you the list, and records your answer.
+
+Either surface asks the same question. `e` on an ungranted row in the deck's MCP tab (`/mcp`) shows the declared tools and grants them; [`stella mcp grant <name>`](/docs/commands/mcp) does the same from a shell, with `--yes` for provisioning and `--revoke` to withdraw.
+
+The answer is recorded as `granted` in `.stella/mcp.toml`, so it is read by every session — you are asked once, not every morning. An entry you wrote by hand carries no `granted` key and is usable without a grant: writing the transport yourself is already the review the gate is asking for.
 
 Because the tools are added at session start, connecting a new server takes effect on your next session. Each server gets a **10-second** connect budget, and connects are isolated per server — one that hangs or fails is recorded and skipped, it does not take the session down.
 
@@ -91,6 +102,12 @@ A server entry needs a `transport` discriminant — `stdio` or `http` — and th
   <OptionCard name="candidate_safe" defaultValue="false">
     Opt this server into Best-of-N candidate runs — see
     [below](#mcp-in-best-of-n-candidates). Never inferred, always human-set.
+  </OptionCard>
+  <OptionCard name="granted">
+    Whether the model may call this server's tools. Written by a grant, and by
+    an install (which writes `false`). Absent on an entry you wrote yourself,
+    which reads as granted — see
+    [above](#an-installed-server-is-withheld-until-you-grant-it).
   </OptionCard>
 </CardGrid>
 

--- a/website/content/docs/commands/mcp.mdx
+++ b/website/content/docs/commands/mcp.mdx
@@ -10,7 +10,7 @@ For how MCP tools reach the agent, see [MCP servers](/docs/agent-tools/mcp). Thi
 ## Synopsis
 
 ```bash
-stella mcp <list|search|install|remove|login|logout|usage> [args]
+stella mcp <list|search|install|remove|grant|login|logout|usage> [args]
 ```
 
 ## What it does
@@ -23,7 +23,8 @@ stella mcp <list|search|install|remove|login|logout|usage> [args]
 
 List the MCP servers configured in `.stella/mcp.toml`. Each entry shows what it
 is — the publisher's name and description, recorded at install — with its local
-alias underneath. An entry installed by hand (or before descriptions were kept)
+alias underneath, and flags any server that is still withheld pending a
+capability grant. An entry installed by hand (or before descriptions were kept)
 falls back to its endpoint: the URL or the spawn command line.
 
 ```bash
@@ -44,6 +45,23 @@ stella mcp search filesystem
 stella mcp search github --limit 5
 ```
 
+Each row carries the three facts that decide whether the description under it
+is worth reading: the **source tier** the registry verified, the **install
+count** where the registry publishes one (`installs unknown` where it does
+not — never a fabricated `0`), and the **signature**.
+
+The tier is read from the entry's namespace, which is what a registry actually
+verifies when someone publishes: `official` is the registry operator's own
+namespace, `vendor` is a reverse-DNS namespace under a domain the publisher
+proved they control (`com.stripe/mcp`), and `community` is a code-host account
+(`io.github.acme/…`) or the registry's anonymous namespace.
+
+`signed` means the registry attributes the entry to a verified publisher and
+its lifecycle record says `active`. It does **not** mean stella verified a
+signature over the package bytes; no MCP registry publishes one to verify yet.
+Anything else — an entry the registry attributes to nobody, or one it has
+withdrawn — reads `blocked`, and `stella mcp install` refuses it.
+
 ### `stella mcp install <name>`
 
 Install a registry server (by the name shown in `stella mcp search`) into `.stella/mcp.toml`, so you don't hand-edit the file. `--alias` sets a local alias / tool-namespace segment (default: a sanitized form of the name). Installing overwrites any existing entry — MCP servers are not versioned.
@@ -53,6 +71,15 @@ stella mcp install filesystem
 stella mcp install github --alias gh
 ```
 
+An entry the registry does not vouch for is refused rather than installed: an
+install writes a command line this process later spawns, so the check is on the
+install path and not only in the search listing.
+
+**A newly installed server is withheld.** None of its tools are offered to the
+model and every call to it is refused until you review what it declares and
+grant it — see `stella mcp grant` below. Re-installing over an alias you
+already granted does not re-ask.
+
 ### `stella mcp remove <name>`
 
 Remove a configured server from `.stella/mcp.toml` by its local name.
@@ -60,6 +87,42 @@ Remove a configured server from `.stella/mcp.toml` by its local name.
 ```bash
 stella mcp remove filesystem
 ```
+
+### `stella mcp grant <name>`
+
+Connect to a configured server, print what it declares at handshake, and record
+whether its tools may be used. This is the scriptable half of the deck's
+first-enable handshake; `e` on an ungranted row in the MCP tab (`/mcp`) shows
+the same capabilities and asks the same question.
+
+```bash
+stella mcp grant github            # print the capabilities, then ask
+stella mcp grant github --yes      # record the grant without the prompt
+stella mcp grant github --revoke   # withdraw a grant given earlier
+```
+
+It connects because the capabilities being granted are what the process on the
+other end announces *now*, not what a registry card once said. The prompt
+declines on anything but an explicit `y`, closed stdin included.
+
+The decision is recorded as `granted` in `.stella/mcp.toml`, so it is read by
+every session — unlike enable/disable, which is per-session. Three states are
+distinguishable, and they mean different things:
+
+| In `mcp.toml` | Written by | The model can call it |
+| --- | --- | --- |
+| `granted = true` | a grant | yes |
+| `granted = false` | an install, or `--revoke` | no |
+| no `granted` key | you, editing the file | yes |
+
+An entry you wrote by hand carries no key and is usable: writing the transport
+yourself is already the review the gate is asking for. The gate exists for the
+other door — one keystroke on a registry search result, which adds a stranger's
+server. A server contributed by an installed plugin has no entry at all and is
+usable for the same reason.
+
+While a server is withheld it still connects (that is how its capabilities
+become knowable), and a call to it comes back as a refusal naming this command.
 
 ### `stella mcp login <name>` / `stella mcp logout <name>`
 


### PR DESCRIPTION
## What & why

SPEC §9.3 named four things the MCP tab did not have. All four land here.

**The graph is pinned.** `render_browse` walked the delivered order, so stella's own graph server landed wherever `mcp.toml`'s alphabetical keys put it. It now heads the list with the caption `graph is pinned · it is the product, not an integration` under its rows. The *paint* is reordered, never the snapshot: `selected` indexes what the driver delivered, and sorting the rows would make `x` remove whichever server happened to be under the cursor.

**Rows carry latency.** `run_handshake` times the `initialize` request — that one round trip, not the whole handshake, since `tools/list` pages and would price a catalogue server as a distant one. It rides `ServerHealth::latency`, re-measured on every reconnect and cleared on teardown, so the column always describes the connection that is up. Unknown renders blank, never `0ms`.

**Registry rows carry provenance, and unsigned is blocked.** `McpSearchItem` was `{name, description, kinds, installed}`. It now carries the source tier (read from the namespace the registry actually verifies at publish time), the install count where a registry publishes one (`installs unknown` where it does not — a `0` would claim nobody runs the server), and a signature status. Anything the registry does not attribute, or has withdrawn, is **refused by `resolve_install`** as well as by the key handler: an install writes a `cmd` line this process later spawns, so the shell door and the deck door get the same answer.

**The first-enable handshake gate.** The tab's caption promised "the handshake shows capabilities before first enable" and nothing showed them — declared capabilities were visible only afterwards, in the `ctrl+o` inspector, and `e` sent `McpToggle` for every row. The path from a registry search to a stranger's code running in the session was two keystrokes with nothing in between naming what the server could do.

`stella_mcp::CapabilityGrants` is a shared allowlist `McpToolSet` consults on every advertise and every dispatch. An ungranted server's tools are absent from `schemas()` and every call to it is refused with `RefusedByPolicy` — **before anything reaches the transport**. `e` on an ungranted row opens the handshake pane (declared tools by name, scrolled, never a count) and `g` grants; `stella mcp grant <name>` does the same from a shell, with `--yes` for provisioning and `--revoke` to withdraw.

The decision persists as `granted` in `.stella/mcp.toml` in three states: an install writes `false`, a grant writes `true`, and a hand-written entry has no key at all and is usable — writing the transport yourself is already the review the gate asks for. `docs/adr/0018-mcp-capability-grants.md` argues why that third state is the threat model rather than a compromise: anyone who can write `granted = true` can equally omit the key, so reading absence as withheld would defend against nothing `Some(false)` does not already cover, and would disarm every existing workspace on upgrade — which is how operators learn to grant without reading. **Existing installs are unaffected.**

Closes #5047

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`no_tool_call_reaches_an_ungranted_server_before_the_grant` — `crates/stella-mcp/src/toolset/tests/gate.rs`.

It reads the scripted transport's own **request log** and asserts **zero** `tools/call` while ungranted, ahead of any assertion about the returned `ToolOutput`. That order is the point: a gate that refuses its caller *after* the request has gone down the pipe has already let a third party act, and every `ToolOutput::Error` assertion in this crate would pass over that bug. The handshake itself is expected on the wire before the grant — `initialize` and `tools/list` are how the capabilities under review become knowable at all.

Verified to flip, both halves independently:

- neutralizing the schema half → fails on the advertise assertion (`an ungranted server must not be advertised: [ToolSchema { name: "mcp__files__read", … }]`)
- neutralizing **only** the dispatch half → fails on the wire count, with the `tools/call` in the message (`a tool call reached the server before the operator granted it: [("initialize", …), ("tools/list", …), ("tools/call", …)]`)

Supporting witnesses: `e_on_an_ungranted_server_opens_the_handshake_instead_of_enabling_it` (deck keys — the `assert_ne!` against `McpToggle` is the old behavior), `the_first_enable_handshake_names_every_declared_capability` (the pane), `an_installed_server_lands_ungranted_and_the_grant_persists` (the on-disk half), `the_graph_server_is_pinned_first_and_says_why`, `pinning_moves_the_paint_and_never_the_selection`, `a_connected_row_shows_its_latency_and_an_unmeasured_one_shows_none`, `a_registry_row_carries_tier_installs_and_a_signature_that_can_block`, `install_stands_down_on_a_blocked_row_and_says_so`, plus the refreshed `tab_mcp` golden.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui -p stella-mcp -p stella-cli --all-targets --all-features -- -D warnings` (scoped per SD-1; the workspace run is CI's)
- [x] `cargo test -p stella-tui -p stella-mcp`, `cargo test -p stella-cli --bin stella mcp` — green
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` for the three crates
- [x] Every fast guard: `file-size`, `god-files`, `prose`, `doc-links`, `command-docs`, `invariants`, `line-citations`, `deck-paths`, `tokens`, `contrast`, `hue-separation`, `light-clamp`, `transcript-surfaces`, `css-vars`, `lockfile-sync`, `deck-fit-all-test` and the rest — all OK
- [x] Docs updated: `website/content/docs/commands/mcp.mdx` (the new `grant` subcommand, the tier/installs/signature columns, what `signed` does and does not claim), `website/content/docs/agent-tools/mcp.mdx` (the withheld-until-granted section and the `granted` config key), `docs/adr/0018-mcp-capability-grants.md`
- [x] `Closes #5047` appears both above and in the commit body

## Nothing left behind

- [x] Filed: #5176, #5182, #5183

- **#5176** — `signed` attests the publisher's namespace, not the package bytes. The word is deliberately not a green badge over the artifact, and both the enum doc and the command page say so.
- **#5182** — a reinstall over a granted alias keeps the grant, so it can repoint a granted alias at another publisher's transport. Named in the ADR's Consequences as the seam to watch.
- **#5183** — the latency column is the connect-time round trip and never refreshes, so on a long session it ages.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies at all
- [x] No new outbound network calls — the registry search that already existed is the only one, and `stella mcp grant` talks to the operator's own configured server
- [x] New cross-boundary types round-trip: `granted` is `Option<bool>` in `McpServerEntry` with `skip_serializing_if`, covered by `an_installed_server_lands_ungranted_and_the_grant_persists` (install → reload → grant → reload → revoke → reload)

## Anything reviewers should know?

**The read-model seam.** `stella-tui` takes only leaf dependencies (its `Cargo.toml` argues each one), so `stella-mcp`'s `SourceTier` and `SignatureStatus` cross into the TUI as display mirrors, mapped in `deck_mcp` with exhaustive `match`es rather than `From` impls — a state added in `stella-mcp` fails to compile here rather than rendering as something it is not.

**Where the gate sits.** Between the handshake and the first `tools/call`, not before connect. Gating the connect is strictly safer and makes the thing under review unfetchable — the operator would be granting an alias. The alternatives considered and rejected are in the ADR.

**Both hosts install the gate.** The deck and the one-shot `connect_mcp` both pass a grant set, so the property does not depend on which surface is driving. A set with no grants configured is *ungated* — that is the shape an embedder or a test with no human to ask gets, and it is why the field is an `Option` rather than a bare `HashSet`.

**File splits, not baselines.** Three files would have crossed the 1500-line ceiling: the handshake pane went to `views/mcp_tab/handshake.rs`, the gate tests to `toolset/tests/gate.rs`, and the MCP golden's fixture to `tests/deck_render_snapshots/mcp.rs`.

**Rebased onto `main`** (18 commits) — the ADR is numbered 0018 because 0015, 0016 and 0017 landed on `main` while this branch was in flight.
