### PR TITLE
feat(stella-plugin): a panel capability and the frame contract behind it

### DIFF
--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -266,6 +266,14 @@ before it crosses.
 - `src/driver.rs` — the `[driver]` block and the drive-session wire shapes
   (`DriverGrant`, `DriverCall`, `DriveRequest`/`DriveResponse`): a plugin that
   starts turns rather than taking part in one.
+- `src/panel.rs` — the `[panel]` block and the panel channel's wire shapes
+  (`PanelGrant`, `PanelDenial`, `PanelLease`, `PanelFrame`): a plugin leased a
+  rectangle of the screen, returning styled lines or a cell diff each tick
+  (`design/tui-v2/SPEC.md` §12). Two of that section's rules are the types
+  rather than a host's care — `PanelText` wraps a private `String` that refuses
+  every control character, so no plugin emits an escape sequence in any
+  language, and `PanelRect` carries an extent with no origin, so a frame cannot
+  name a cell of Stella's own chrome.
 - `src/error.rs` — `ManifestError`, typed per rule (AGENTS.md #5).
 - `tests/manifest_grades.rs` + `tests/fixtures/*.toml` — slice A's
   acceptance: one fixture per grade, round-tripped through both TOML and

--- a/crates/stella-plugin/src/consent.rs
+++ b/crates/stella-plugin/src/consent.rs
@@ -47,6 +47,7 @@ use crate::error::ManifestError;
 use crate::host_call::HostCall;
 use crate::manifest::{Participation, PluginManifest};
 use crate::oracle::OracleProcessSource;
+use crate::panel::PanelDenial;
 use crate::runtime::Runtime;
 use crate::wire::{WIRE_FIELDS, WrapperPoint, hook_disclosures_for};
 
@@ -202,6 +203,7 @@ pub fn consent_text(manifest: &PluginManifest) -> String {
     lines.push(String::new());
     lines.extend(loop_say(manifest));
     lines.extend(driver_say(manifest));
+    lines.extend(panel_say(manifest));
     lines.extend(oracle_self_report(manifest));
     lines.extend(data_that_leaves_the_process(manifest));
     lines.push(String::new());
@@ -515,6 +517,56 @@ fn driver_say(manifest: &PluginManifest) -> Vec<String> {
          credential, no provider and no forge token of its own."
             .into(),
     );
+    lines
+}
+
+/// The "what it draws on your screen" half: that this plugin owns a rectangle
+/// of the interface, and every limit it accepts in exchange.
+///
+/// A paragraph of its own, for [`driver_say`]'s reason: a panel is a third
+/// dispatch context, and folding it into the grade would tell a reader that
+/// `none` means "no say and nothing on screen".
+///
+/// `design/tui-v2/SPEC.md` §12 puts the denials in the handshake, so they are
+/// printed here as sentences a person weighs — the mirror of
+/// [`crate::DriverFamily::consent_sentence`], which prints powers. The order is
+/// [`PanelDenial::all`]'s and not the manifest's, so two plugins that accept
+/// the same limits render the same lines whichever order their authors typed;
+/// the *content* is still the grant's own list, so a hand-built grant that
+/// names fewer cannot print a limit it never accepted.
+fn panel_say(manifest: &PluginManifest) -> Vec<String> {
+    let Some(panel) = &manifest.panel else {
+        return Vec::new();
+    };
+    let name = one_line(&manifest.name);
+    let mut lines = vec![
+        String::new(),
+        format!(
+            "Draws part of your screen: `{name}` is leased a rectangle of terminal cells and \
+             returns the glyphs to fill it, every tick. Stella draws the border and the title \
+             around it, and writes every escape sequence your terminal ever sees — a panel \
+             sends glyphs, so it cannot repaint anything outside the rectangle it was given."
+        ),
+    ];
+
+    // Before the limits, and before any early return: a panel's process is the
+    // thing a host starts, so a declaration accepting every limit still puts a
+    // program on the reader's machine. Absence is said too, on `driver_say`'s
+    // reasoning — a grant nothing starts is a different thing to agree to.
+    match &panel.process {
+        Some(process) => lines.extend(process_say(process)),
+        None => lines.push(
+            "  - is not started by Stella: this declares what such a panel accepts, and \
+             nothing here runs a program"
+                .into(),
+        ),
+    }
+
+    for denial in PanelDenial::all() {
+        if panel.denies(*denial) {
+            lines.push(format!("  - {}", denial.consent_sentence()));
+        }
+    }
     lines
 }
 

--- a/crates/stella-plugin/src/error.rs
+++ b/crates/stella-plugin/src/error.rs
@@ -9,6 +9,7 @@ use crate::driver::DriverCall;
 use crate::host_call::HostCall;
 use crate::manifest::{HookEvent, Participation};
 use crate::package::ContributionKind;
+use crate::panel::PanelDenial;
 use crate::runtime::ProcessBlock;
 use crate::wire::WrapperPoint;
 use crate::wrapper::{HostStage, Signal, SignalKind, StageName};
@@ -141,6 +142,31 @@ pub enum ManifestError {
          declares: asking for none is an empty list, not a zero allowance"
     )]
     ZeroDriverMaxCalls,
+
+    /// `[panel] denies` did not name every limit a panel accepts.
+    ///
+    /// The set is Stella's rather than the author's
+    /// ([`PanelDenial`]), so a block that names fewer than
+    /// all of them is not a narrower panel — it is a consent document missing
+    /// a sentence the install prompt is supposed to show. The manifest is what
+    /// a signature covers, so the limits are checked into it rather than left
+    /// to whichever host happens to load it.
+    #[error(
+        "[panel] denies does not name \"{denial}\": a panel accepts every one of Stella's \
+         declared denials, and the manifest a human consents to has to say each of them"
+    )]
+    PanelDenialMissing {
+        /// The limit the block failed to name.
+        denial: PanelDenial,
+    },
+
+    /// `[panel] denies` listed the same limit twice — the
+    /// [`ManifestError::DuplicateHook`] rule, for the panel's denial list.
+    #[error("[panel] denies declares \"{denial}\" more than once")]
+    DuplicatePanelDenial {
+        /// The limit that appeared twice.
+        denial: PanelDenial,
+    },
 
     /// `[loop] max_calls` was declared with no `[loop] calls` to bound.
     #[error(

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -84,6 +84,16 @@
 //! [`RecordEnforcement`] for why a package may ship a record that steers and
 //! never one that denies.
 //!
+//! `panel.rs` (`design/tui-v2/SPEC.md` §12) is the third dispatch context: a
+//! plugin leased a rectangle of the screen, returning styled lines or a cell
+//! diff each tick. Two of that section's rules are held by the types —
+//! [`PanelText`] wraps a private `String` that refuses every control character,
+//! so no plugin can emit an escape sequence in any language, and [`PanelRect`]
+//! carries an extent with no origin, so a frame has no way to name a cell of
+//! Stella's own chrome. [`PanelFrame::fits`] refuses one that runs past the
+//! lease's edge, and `[panel] denies` must name every [`PanelDenial`] before
+//! the manifest loads.
+//!
 //! The three functions a host must not bypass are [`LoopGrant::permits_hook`],
 //! [`LoopGrant::permits_point`] and [`LoopGrant::permits_call`]: they are the
 //! authoritative filters behind the epic's rule that an undeclared hook is never
@@ -102,6 +112,7 @@ mod manifest;
 mod observed;
 mod oracle;
 mod package;
+mod panel;
 mod program;
 mod progressive;
 mod runtime;
@@ -156,6 +167,11 @@ pub use oracle::{
 pub use package::{
     ContributionKind, KindMismatch, McpContribution, PackageListing, PackageMismatch,
     RecordContribution, RecordEnforcement, SkillContribution, ToolContribution,
+};
+pub use panel::{
+    PanelDenial, PanelEmphasis, PanelFrame, PanelGrant, PanelInk, PanelLease, PanelLine,
+    PanelOverflow, PanelPaint, PanelPatch, PanelPoint, PanelRect, PanelRequest, PanelResponse,
+    PanelSpan, PanelStyle, PanelText, PanelTextError,
 };
 pub use program::{SignalValues, StageProgram};
 pub use progressive::{ProgressiveResolver, StageDecision};

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -51,6 +51,7 @@ use crate::package::{
     McpContribution, RecordContribution, SkillContribution, ToolContribution,
     validate_contributions,
 };
+use crate::panel::PanelGrant;
 use crate::runtime::{ProcessBlock, Runtime};
 use crate::wire::WrapperPoint;
 use crate::wrapper::{StageName, Wrapper};
@@ -385,6 +386,17 @@ pub struct PluginManifest {
     /// grade buys no driver capability.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub driver: Option<DriverGrant>,
+    /// The `[panel]` registration — this plugin draws a rectangle of the
+    /// screen, and accepts the limits that come with one ([`PanelGrant`],
+    /// `design/tui-v2/SPEC.md` §12). **Absent = no panel**, as an absent
+    /// `[driver]` is no driver: the host leases no rectangle, so there is
+    /// nothing for a frame to be checked against.
+    ///
+    /// Independent of the ladder in both directions: drawing is not a say in a
+    /// turn, so no [`Participation`] grade buys a panel and holding one buys no
+    /// grade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub panel: Option<PanelGrant>,
     /// Arbiter only: the enumerable definition of done. Keys are the names
     /// a hold cites; values are the human-readable statement of each
     /// requirement. A `BTreeMap` so iteration order is deterministic
@@ -661,6 +673,14 @@ impl PluginManifest {
             if let Some(process) = &driver.process {
                 process.validate(ProcessBlock::DriverProcess)?;
             }
+        }
+
+        // The panel block's rules live on the grant itself, beside the type
+        // they govern (`PanelGrant::validate`), and there is no grade check
+        // among them: a panel is drawn between turns, so no standing inside one
+        // could be required of it.
+        if let Some(panel) = &self.panel {
+            panel.validate()?;
         }
 
         if grant.hooks.contains(&HookEvent::Stop) && !participation.includes(Participation::Arbiter)

--- a/crates/stella-plugin/src/panel.rs
+++ b/crates/stella-plugin/src/panel.rs
@@ -1,0 +1,1039 @@
+//! The panel channel — a plugin that **draws** a rectangle of the screen,
+//! and the frame it returns for each one it is leased.
+//!
+//! `design/tui-v2/SPEC.md` §12 is the design and this module is its wire half,
+//! built on [`crate::driver`]'s shape: a third dispatch context, with its own
+//! point, its own grant, and no rung on the [`crate::Participation`] ladder,
+//! because drawing is not influence over a turn.
+//!
+//! Two rules from that section are held by the types instead of by a host's
+//! care, and they are the reason this is a contract at all:
+//!
+//! - **A panel never emits an escape sequence.** [`PanelText`] wraps a private
+//!   `String` whose only constructor refuses every control character, so
+//!   `\x1b[2J` is a decode error on the frame that carries it. The host draws
+//!   the border, the title and every escape byte the terminal ever sees.
+//! - **A panel cannot address a cell it was not leased.** [`PanelRect`] carries
+//!   an extent and no origin, so the coordinates a plugin writes are its own
+//!   rectangle's; there is no number it could put in a frame that names a cell
+//!   of Stella's chrome. [`PanelFrame::fits`] refuses one that starts or runs
+//!   past the lease's own edge, naming the row and column that did it.
+//!
+//! The `[panel]` block is the consent half: [`PanelGrant`], whose `denies` list
+//! must name every [`PanelDenial`] before the manifest loads, so the two limits
+//! §12's handshake shows a human ride in the signed document they consent to.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::ManifestError;
+use crate::runtime::{ProcessBlock, Runtime};
+use crate::wire::PROTOCOL_VERSION;
+
+/// What a `[panel]` block gives up, and must say it gives up.
+///
+/// Closed, and the closure is the point: the set is Stella's, not the author's,
+/// so a plugin cannot ship a panel that denies less. An unknown word here is a
+/// parse error for [`crate::DriverCall`]'s reason — a limit a host does not
+/// recognise must refuse the manifest, never read as a limit that is absent.
+///
+/// Both are §12's own: a panel is a renderer, and a renderer that reaches the
+/// network or writes outside its sandbox is asking for authority its drawing
+/// does not need.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PanelDenial {
+    /// No socket, no request, no name lookup, for the panel's own process.
+    Network,
+    /// No write outside the sandbox directory the host hands the panel.
+    WriteOutsideSandbox,
+}
+
+impl PanelDenial {
+    /// Every denial a `[panel]` block must name, in the order a prompt prints
+    /// them.
+    ///
+    /// Exhaustive by construction, as [`crate::DriverCall::all`] is: the
+    /// `match` in [`PanelDenial::as_str`] stops compiling when a case is added
+    /// and left out of this list, so a new limit reaches the consent rendering
+    /// and the manifest check in the change that introduces it.
+    #[must_use]
+    pub const fn all() -> &'static [Self] {
+        &[Self::Network, Self::WriteOutsideSandbox]
+    }
+
+    /// The name this denial is written as in `[panel] denies`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Network => "network",
+            Self::WriteOutsideSandbox => "write-outside-sandbox",
+        }
+    }
+
+    /// The sentence a human reads at install for this denial.
+    ///
+    /// Written as what the panel **may not do to their machine**, which is
+    /// [`crate::DriverFamily::consent_sentence`]'s rule with the sign flipped:
+    /// a grant and a refusal are both things a reader is agreeing to, and only
+    /// one of them was previously spellable.
+    #[must_use]
+    pub fn consent_sentence(self) -> &'static str {
+        match self {
+            Self::Network => "may not reach the network from its panel process",
+            Self::WriteOutsideSandbox => {
+                "may not write anywhere but the sandbox directory Stella hands it"
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for PanelDenial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The `[panel]` block — a plugin's declaration that it draws a panel, and of
+/// the limits it accepts in order to be allowed one.
+///
+/// **Absent means a plugin has no panel at all**, which is
+/// [`crate::DriverGrant`]'s outer half restated for this context: with no
+/// `[panel]` block the host leases no rectangle, so there is nothing for a
+/// frame to be checked against.
+///
+/// # There is no title field, and that absence is the anti-spoofing rule
+///
+/// §12 gives the border and the title to the host, labelled `◳ panel ·
+/// <plugin>`. A `title` key here would let a panel call itself `GATES` or
+/// `stella*`, which is the one thing chrome a user trusts must not be able to
+/// say about itself. The host writes [`crate::PluginManifest::name`] into that
+/// label, so the label is the identity a human already consented to.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelGrant {
+    /// The limits this panel accepts, which must be every [`PanelDenial`].
+    ///
+    /// Spelled in the block instead of assumed, because the manifest is the
+    /// document a signature covers and a human reads: a limit that exists only
+    /// inside the host's build is a limit the reader's own copy of the plugin
+    /// does not carry. A block naming fewer than all of them is
+    /// [`ManifestError::PanelDenialMissing`], so the completeness is checked at
+    /// load and never left to the reader to notice.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub denies: Vec<PanelDenial>,
+    /// The program the host starts to draw this panel, and the exact slice of
+    /// the operator's environment it may see.
+    ///
+    /// **Absent means the host cannot draw this panel**, the state
+    /// [`crate::DriverGrant::process`] describes for a driver nobody starts:
+    /// the declaration is still a complete consent document, and installing it
+    /// still runs nothing.
+    ///
+    /// Not `[runtime]`, for that field's own reason — `[runtime]` is the
+    /// process a plugin is *inside a turn* and the manifest refuses it below
+    /// `observer`, while a panel is drawn between turns and on every tick. The
+    /// type is shared because the decision is identical: an argv, a timeout,
+    /// and an environment allowlist.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process: Option<Runtime>,
+}
+
+impl PanelGrant {
+    /// Whether this grant names `denial`.
+    #[must_use]
+    pub fn denies(&self, denial: PanelDenial) -> bool {
+        self.denies.contains(&denial)
+    }
+
+    /// The first denial this grant fails to name, in [`PanelDenial::all`]
+    /// order, or `None` when it names all of them.
+    ///
+    /// [`PanelGrant::validate`] reads this, and so may a host that built a
+    /// grant in Rust instead of parsing one.
+    #[must_use]
+    pub fn missing_denial(&self) -> Option<PanelDenial> {
+        PanelDenial::all()
+            .iter()
+            .copied()
+            .find(|denial| !self.denies(*denial))
+    }
+
+    /// Every load rule a `[panel]` block has to pass.
+    ///
+    /// Here rather than inside
+    /// [`PluginManifest::validate`](crate::PluginManifest) so the rules sit
+    /// beside the type they are about: a reader of `PanelGrant` sees what makes
+    /// one legal without crossing to another module, and a host that assembles
+    /// a grant in Rust can ask the same question the parser asks.
+    ///
+    /// Two rules are the ones every other block has — a repeated entry is an
+    /// editing mistake rather than an emphasis, and a declared process is held
+    /// to [`Runtime`]'s rules under its own block name. The third belongs to
+    /// this block alone: the denial set is Stella's, so a block may not name a
+    /// subset of it and call the result a narrower panel
+    /// (`design/tui-v2/SPEC.md` §12's handshake).
+    ///
+    /// # Errors
+    ///
+    /// [`ManifestError::DuplicatePanelDenial`] for a repeated limit,
+    /// [`ManifestError::PanelDenialMissing`] for one the block never names, and
+    /// whatever `[panel.process]` refuses.
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        let mut seen = HashSet::with_capacity(self.denies.len());
+        for denial in &self.denies {
+            if !seen.insert(*denial) {
+                return Err(ManifestError::DuplicatePanelDenial { denial: *denial });
+            }
+        }
+        if let Some(denial) = self.missing_denial() {
+            return Err(ManifestError::PanelDenialMissing { denial });
+        }
+        if let Some(process) = &self.process {
+            process.validate(ProcessBlock::PanelProcess)?;
+        }
+        Ok(())
+    }
+}
+
+/// The one point a panel answers.
+///
+/// A closed single-case enum rather than a bare string, as
+/// [`crate::DrivePoint`] is: `{"point": "before_turn"}` written into a panel
+/// exchange is a decode error instead of something a reader shrugs at. A second
+/// panel point would be a reviewable addition here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelPoint {
+    /// The host asks for one frame, and leases the rectangle to draw it in.
+    Frame,
+}
+
+impl PanelPoint {
+    /// The name this point is written as on the wire.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Frame => "frame",
+        }
+    }
+}
+
+impl std::fmt::Display for PanelPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The host's request for one frame: `{"point": "frame", "body": {…}}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelRequest {
+    /// Which point is open. Always [`PanelPoint::Frame`]; present so the
+    /// request is self-describing on the wire.
+    pub point: PanelPoint,
+    /// The lease this frame is drawn against.
+    pub body: PanelLease,
+}
+
+impl PanelRequest {
+    /// Ask for one frame against `lease`.
+    #[must_use]
+    pub fn new(lease: PanelLease) -> Self {
+        Self {
+            point: PanelPoint::Frame,
+            body: lease,
+        }
+    }
+}
+
+/// The rectangle a panel is leased for one tick, and the budget it has to fill
+/// it in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelLease {
+    /// The version this message is written at.
+    pub protocol_version: u32,
+    /// Which panel this lease is for — [`crate::PluginManifest::name`], echoed
+    /// so a process drawing more than one panel can tell them apart.
+    pub panel: String,
+    /// The host's counter for this frame. A panel echoes it on
+    /// [`PanelFrame::tick`], so a frame that arrives after the host has moved
+    /// on is discardable without guessing.
+    pub tick: u64,
+    /// The cells this panel may address, and the only ones it can name.
+    pub rect: PanelRect,
+    /// How long the host will wait for the frame before it draws the previous
+    /// one and tags the panel as over budget (§12's frame budget).
+    ///
+    /// A fact about the host, never a promise the panel is asked to keep: a
+    /// slow panel is throttled with a visible tag, and is not killed for
+    /// missing a number it was told.
+    pub budget_ms: u32,
+}
+
+impl PanelLease {
+    /// A lease at the current [`PROTOCOL_VERSION`].
+    #[must_use]
+    pub fn new(panel: impl Into<String>, tick: u64, rect: PanelRect, budget_ms: u32) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            panel: panel.into(),
+            tick,
+            rect,
+            budget_ms,
+        }
+    }
+
+    /// Whether `frame` stays inside this lease.
+    ///
+    /// # Errors
+    ///
+    /// [`PanelOverflow`], naming the row or the cell that ran past the edge.
+    pub fn admits(&self, frame: &PanelFrame) -> Result<(), PanelOverflow> {
+        frame.fits(self.rect)
+    }
+}
+
+/// The extent of a panel's lease, in terminal cells.
+///
+/// **An extent and no origin**, which is what makes addressing outside the
+/// lease unrepresentable rather than refused after the fact: a panel counts
+/// rows and columns from its own top-left corner, so the host's buffer
+/// coordinates are a number it is never told and can never write. The host adds
+/// its own origin when it blits, and the border it drew is outside the
+/// translation entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelRect {
+    /// How many columns wide, inside the host's border.
+    pub cols: u16,
+    /// How many rows tall, inside the host's border and below its title.
+    pub rows: u16,
+}
+
+impl PanelRect {
+    /// A rectangle of `cols` by `rows` cells.
+    #[must_use]
+    pub const fn new(cols: u16, rows: u16) -> Self {
+        Self { cols, rows }
+    }
+
+    /// Whether `row` and `col` name a cell of this rectangle.
+    #[must_use]
+    pub const fn holds(self, row: u16, col: u16) -> bool {
+        row < self.rows && col < self.cols
+    }
+}
+
+/// The panel's answer: `{"point": "frame", "body": {…}}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelResponse {
+    /// Which point this answers. Always [`PanelPoint::Frame`].
+    pub point: PanelPoint,
+    /// The frame itself.
+    pub body: PanelFrame,
+}
+
+impl PanelResponse {
+    /// Answer a frame request.
+    #[must_use]
+    pub fn new(frame: PanelFrame) -> Self {
+        Self {
+            point: PanelPoint::Frame,
+            body: frame,
+        }
+    }
+}
+
+/// One frame a panel draws into the rectangle it was leased.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelFrame {
+    /// The version this message is written at.
+    pub protocol_version: u32,
+    /// The [`PanelLease::tick`] this frame answers.
+    pub tick: u64,
+    /// What to draw.
+    pub paint: PanelPaint,
+}
+
+impl PanelFrame {
+    /// A frame at the current [`PROTOCOL_VERSION`].
+    #[must_use]
+    pub fn new(tick: u64, paint: PanelPaint) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            tick,
+            paint,
+        }
+    }
+
+    /// Whether every cell this frame addresses is inside `rect`.
+    ///
+    /// # Errors
+    ///
+    /// [`PanelOverflow`], naming the first row or cell that ran past the edge.
+    pub fn fits(&self, rect: PanelRect) -> Result<(), PanelOverflow> {
+        self.paint.fits(rect)
+    }
+}
+
+/// The two shapes a frame comes in — §12's "styled lines or a cell diff".
+///
+/// Externally tagged, so `{"lines": […]}` and `{"diff": […]}` are the two
+/// legal frames and a table carrying both keys is a decode error. A panel that
+/// redraws everything writes lines; one that changed four cells writes a diff,
+/// and the host blits either into the same leased rectangle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelPaint {
+    /// Every row of the lease, from its top, each row a run of styled spans. A
+    /// list shorter than the lease leaves the rows below it untouched.
+    Lines(Vec<PanelLine>),
+    /// Only the cells that changed since the last frame, each patch a run
+    /// starting at one addressed cell.
+    Diff(Vec<PanelPatch>),
+}
+
+impl PanelPaint {
+    /// Whether every cell this paint addresses is inside `rect`.
+    ///
+    /// # Errors
+    ///
+    /// [`PanelOverflow`], naming the first row or cell that ran past the edge.
+    pub fn fits(&self, rect: PanelRect) -> Result<(), PanelOverflow> {
+        match self {
+            Self::Lines(lines) => {
+                if lines.len() > usize::from(rect.rows) {
+                    return Err(PanelOverflow::Rows {
+                        lines: lines.len(),
+                        rows: rect.rows,
+                    });
+                }
+                for (index, line) in lines.iter().enumerate() {
+                    let cells = line.cells();
+                    if cells > usize::from(rect.cols) {
+                        return Err(PanelOverflow::Line {
+                            line: index,
+                            cells,
+                            cols: rect.cols,
+                        });
+                    }
+                }
+                Ok(())
+            }
+            Self::Diff(patches) => {
+                for patch in patches {
+                    if patch.row >= rect.rows {
+                        return Err(PanelOverflow::Row {
+                            row: patch.row,
+                            rows: rect.rows,
+                        });
+                    }
+                    let cells = patch.text.cells();
+                    // A run of *no* glyphs anchored past the right edge
+                    // satisfies `col + 0 <= cols` for every column a `u16` can
+                    // hold, so the sum on its own admits a patch whose origin
+                    // names a column the lease does not have. It writes
+                    // nothing, and this function is still the whole guarantee a
+                    // host indexes against, so the anchor is checked as well as
+                    // the extent. That check is also what makes a zero-column
+                    // lease admit no patch rather than every empty one.
+                    //
+                    // The sum is in `usize` throughout: a `u16` column plus a
+                    // run longer than the rest of the row is exactly the
+                    // addition that wraps, and a wrapped sum reads as a cell
+                    // inside the lease.
+                    if patch.col >= rect.cols
+                        || usize::from(patch.col) + cells > usize::from(rect.cols)
+                    {
+                        return Err(PanelOverflow::Patch {
+                            row: patch.row,
+                            col: patch.col,
+                            cells,
+                            cols: rect.cols,
+                        });
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// One row of a [`PanelPaint::Lines`] frame.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelLine {
+    /// The runs of this row, left to right. Empty clears the row.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub spans: Vec<PanelSpan>,
+}
+
+impl PanelLine {
+    /// A row of one styled run.
+    #[must_use]
+    pub fn new(spans: Vec<PanelSpan>) -> Self {
+        Self { spans }
+    }
+
+    /// How many cells this row occupies.
+    #[must_use]
+    pub fn cells(&self) -> usize {
+        self.spans.iter().map(|span| span.text.cells()).sum()
+    }
+}
+
+/// One run of text in a row, drawn in one style.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelSpan {
+    /// The glyphs, which carry no escape sequence — see [`PanelText`].
+    pub text: PanelText,
+    /// How to draw them. Omitted on the wire when nothing is asked for, which
+    /// is the deck's own resting `text` on `bg`.
+    #[serde(default, skip_serializing_if = "PanelStyle::is_plain")]
+    pub style: PanelStyle,
+}
+
+impl PanelSpan {
+    /// A run in one style.
+    #[must_use]
+    pub fn new(text: PanelText, style: PanelStyle) -> Self {
+        Self { text, style }
+    }
+}
+
+/// One run of a [`PanelPaint::Diff`] frame, starting at the cell it addresses.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelPatch {
+    /// Which row of the lease, counted from its top.
+    pub row: u16,
+    /// Which column of the lease, counted from its left edge.
+    pub col: u16,
+    /// The glyphs to write from that cell rightwards.
+    pub text: PanelText,
+    /// How to draw them.
+    #[serde(default, skip_serializing_if = "PanelStyle::is_plain")]
+    pub style: PanelStyle,
+}
+
+impl PanelPatch {
+    /// A run starting at one cell of the lease.
+    #[must_use]
+    pub fn new(row: u16, col: u16, text: PanelText, style: PanelStyle) -> Self {
+        Self {
+            row,
+            col,
+            text,
+            style,
+        }
+    }
+}
+
+/// Glyphs a panel writes into cells it was leased.
+///
+/// **The no-raw-escapes rule, held by the type.** The body is a private
+/// `String` whose only constructor is [`PanelText::new`], and that constructor
+/// refuses every control character — `\x1b`, and with it every CSI, OSC and SGR
+/// sequence a plugin could use to move the cursor out of its rectangle, clear
+/// the screen, repaint Stella's own chrome, or set a window title. `\n`, `\r`
+/// and `\t` go with them: a row's structure is the frame's, and a tab's width
+/// is the terminal's rather than this contract's.
+///
+/// The privacy is what makes it a rule and not a request, exactly as
+/// [`crate::VolatileContext`]'s is. A public field would let a host write
+/// `PanelText("\x1b[2J".into())` in one line, change no type, and stay green:
+///
+/// ```compile_fail
+/// let text = stella_plugin::PanelText("\u{1b}[2J".to_string());
+/// ```
+///
+/// The sanctioned reads, and all of them — the glyphs, and how many cells they
+/// take:
+///
+/// ```
+/// use stella_plugin::PanelText;
+/// let text = PanelText::new("gates: 3 green").expect("plain glyphs");
+/// assert_eq!(text.as_str(), "gates: 3 green");
+/// assert_eq!(text.cells(), 14);
+/// assert!(PanelText::new("\u{1b}[31mred").is_err());
+/// ```
+///
+/// # What a cell is here, and what it is not
+///
+/// [`PanelText::cells`] counts `char`s. A double-width glyph therefore draws
+/// wider than this contract counts, and the frame that carries it misaligns
+/// **its own interior** — never anything outside it, because the host clips
+/// every blit at the leased rectangle whatever a frame claims. Measuring
+/// display width would mean a Unicode width table, and this crate is a
+/// near-leaf that takes one workspace dependency on argument (see its
+/// `Cargo.toml`); the host already owns the clip that makes the difference
+/// safe.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PanelText(String);
+
+impl PanelText {
+    /// Build a run of glyphs.
+    ///
+    /// # Errors
+    ///
+    /// [`PanelTextError::ControlCharacter`] when the text carries a control
+    /// character, naming the character and where it sits.
+    pub fn new(text: impl Into<String>) -> Result<Self, PanelTextError> {
+        let text = text.into();
+        if let Some((index, found)) = text
+            .chars()
+            .enumerate()
+            .find(|(_, found)| found.is_control())
+        {
+            return Err(PanelTextError::ControlCharacter {
+                index,
+                code: found as u32,
+            });
+        }
+        Ok(Self(text))
+    }
+
+    /// The glyphs.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// How many cells these glyphs occupy — see the type docs on what a cell
+    /// counts as here.
+    #[must_use]
+    pub fn cells(&self) -> usize {
+        self.0.chars().count()
+    }
+
+    /// Whether this run draws nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for PanelText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Serialize for PanelText {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for PanelText {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Through the same constructor the Rust side uses, so a frame carrying
+        // an escape sequence fails to decode instead of arriving as a value the
+        // host is trusted to inspect.
+        let text = String::deserialize(deserializer)?;
+        Self::new(text).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Why a run of glyphs is not drawable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PanelTextError {
+    /// The text carries a control character. A panel writes glyphs into cells;
+    /// every escape byte the terminal sees is the host's.
+    #[error(
+        "panel text carries the control character U+{code:04X} at position {index}: a panel \
+         writes glyphs into the cells it was leased, and Stella writes every escape sequence \
+         the terminal sees"
+    )]
+    ControlCharacter {
+        /// Which character of the text, counted in `char`s from zero.
+        index: usize,
+        /// The Unicode scalar value that was refused.
+        code: u32,
+    },
+}
+
+/// How a run of glyphs is drawn.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PanelStyle {
+    /// The ink. `None` is the deck's resting `text`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fg: Option<PanelInk>,
+    /// The ground. `None` is whatever the host already painted there.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bg: Option<PanelInk>,
+    /// Everything else, from a closed list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub emphasis: Vec<PanelEmphasis>,
+}
+
+impl PanelStyle {
+    /// The style that asks for nothing.
+    #[must_use]
+    pub fn plain() -> Self {
+        Self::default()
+    }
+
+    /// A style in one ink.
+    #[must_use]
+    pub fn ink(fg: PanelInk) -> Self {
+        Self {
+            fg: Some(fg),
+            ..Self::default()
+        }
+    }
+
+    /// Whether this style asks for nothing — the predicate the wire's
+    /// `skip_serializing_if` needs, so an unstyled span omits the key.
+    #[must_use]
+    pub fn is_plain(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// The colours a panel may paint with.
+///
+/// Token names and never an RGB triple, which is what keeps §2's two-metal rule
+/// and §3.2's hue clamp true of a plugin's pixels as well as Stella's: the host
+/// resolves each name against the live theme, so a panel follows a degraded
+/// sixteen-colour terminal (§3.5) without knowing one exists, and no plugin can
+/// author the warm hue the clamp exists to refuse.
+///
+/// The set is `design/tui-v2/SPEC.md` §3.1's `tui` surface exactly. This crate
+/// spells its own copy because it is a near-leaf that may not depend on the
+/// interactive-mode crates; the copy is checkable against the SPEC table by
+/// eye, and a name that is not in it is a decode error rather than a colour
+/// nobody chose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelInk {
+    /// The canvas.
+    Bg,
+    /// Code blocks, panels, tables.
+    Panel,
+    /// Selected and highlighted rows.
+    Hl,
+    /// Panel borders and dividers.
+    Border,
+    /// Turn boundary rules.
+    Rule,
+    /// Stella acting on the world: edit, write, gate, brand, money.
+    Gold,
+    /// Live indicators only: spinner, hot marker, drift glyph.
+    GoldBright,
+    /// The world coming in: read, skill, memory, secondary emphasis.
+    Silver,
+    /// Syntax types.
+    SilverType,
+    /// Primary text.
+    Text,
+    /// Secondary text.
+    Muted,
+    /// Hints, keybinding rows, line numbers.
+    Dim,
+    /// Pass, and the `+` diff sign.
+    Green,
+    /// Fail, the `-` diff sign, delete and destructive events. §2 makes this
+    /// the rarest colour on screen; a panel that paints it everywhere spends
+    /// the alarm the whole deck depends on.
+    Red,
+    /// Added diff row background.
+    DiffAddBg,
+    /// Removed diff row background.
+    DiffDelBg,
+}
+
+/// Everything a style may ask for beyond its two colours.
+///
+/// Closed, and two familiar attributes are absent. `reverse` swaps a span's ink
+/// and ground, which is how a panel would paint a bar the same shape as the
+/// host's own selected row; `blink` is not a property of a character cell at
+/// all, and §14 rules out motion that carries meaning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelEmphasis {
+    /// Heavier weight.
+    Bold,
+    /// Lighter weight.
+    Dim,
+    /// Slanted.
+    Italic,
+    /// Ruled underneath.
+    Underline,
+}
+
+/// Why a frame does not fit the rectangle it was leased.
+///
+/// Four cases because the two frame shapes fail in two ways each, and a host
+/// refusing a frame should be able to print which row, which column and which
+/// edge without re-deriving any of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PanelOverflow {
+    /// A [`PanelPaint::Lines`] frame carries more rows than the lease has.
+    #[error("a panel frame of {lines} line(s) does not fit a lease {rows} row(s) tall")]
+    Rows {
+        /// How many rows the frame carries.
+        lines: usize,
+        /// How many the lease holds.
+        rows: u16,
+    },
+    /// A row of a [`PanelPaint::Lines`] frame runs past the lease's right edge.
+    #[error("line {line} of a panel frame is {cells} cell(s) wide, past a {cols}-column lease")]
+    Line {
+        /// Which row, counted from the top of the frame.
+        line: usize,
+        /// How wide it is.
+        cells: usize,
+        /// How wide the lease is.
+        cols: u16,
+    },
+    /// A [`PanelPaint::Diff`] patch addresses a row the lease does not have.
+    #[error("a panel frame patches row {row}, past a lease {rows} row(s) tall")]
+    Row {
+        /// The row the patch addressed.
+        row: u16,
+        /// How many rows the lease holds.
+        rows: u16,
+    },
+    /// A [`PanelPaint::Diff`] patch starts past the lease's right edge, or runs
+    /// past it. Both are this one case because both are answered by the same
+    /// edit — move the patch left or shorten it — and a host printing the
+    /// refusal wants the column and the run length either way.
+    #[error(
+        "a panel frame patches {cells} cell(s) from column {col} of row {row}, past a \
+         {cols}-column lease"
+    )]
+    Patch {
+        /// The row the patch addressed.
+        row: u16,
+        /// The column it started at.
+        col: u16,
+        /// How many cells it writes.
+        cells: usize,
+        /// How wide the lease is.
+        cols: u16,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(glyphs: &str) -> PanelText {
+        PanelText::new(glyphs).expect("plain glyphs")
+    }
+
+    #[test]
+    fn every_denial_has_a_distinct_wire_name_and_a_sentence() {
+        let mut names: Vec<&str> = PanelDenial::all()
+            .iter()
+            .map(|denial| denial.as_str())
+            .collect();
+        let count = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), count, "two denials share a wire name");
+        for denial in PanelDenial::all() {
+            assert!(!denial.consent_sentence().trim().is_empty(), "{denial}");
+        }
+    }
+
+    #[test]
+    fn all_is_exhaustive_over_the_denial_set() {
+        // Round-tripping every wire name back through the deserializer proves
+        // `all()` and the enum agree, without a hand-maintained count.
+        for denial in PanelDenial::all() {
+            let json = serde_json::to_string(denial).expect("a denial serializes");
+            let back: PanelDenial = serde_json::from_str(&json).expect("and reads back");
+            assert_eq!(back, *denial);
+        }
+        assert!(
+            serde_json::from_str::<PanelDenial>("\"read-anything\"").is_err(),
+            "the denial set is Stella's, so an unknown limit is a refusal"
+        );
+    }
+
+    #[test]
+    fn a_grant_reports_the_first_denial_it_fails_to_name() {
+        let partial = PanelGrant {
+            denies: vec![PanelDenial::WriteOutsideSandbox],
+            process: None,
+        };
+        assert_eq!(partial.missing_denial(), Some(PanelDenial::Network));
+        let complete = PanelGrant {
+            denies: PanelDenial::all().to_vec(),
+            process: None,
+        };
+        assert_eq!(complete.missing_denial(), None);
+        assert!(complete.denies(PanelDenial::Network));
+    }
+
+    #[test]
+    fn a_run_of_glyphs_refuses_every_control_character() {
+        for hazard in ["\u{1b}[2J", "a\nb", "a\rb", "a\tb", "a\u{9b}c"] {
+            assert!(
+                PanelText::new(hazard).is_err(),
+                "{hazard:?} decoded as drawable glyphs"
+            );
+        }
+        assert_eq!(
+            PanelText::new("\u{1b}").unwrap_err(),
+            PanelTextError::ControlCharacter { index: 0, code: 27 }
+        );
+        // The index counts `char`s, so a multi-byte glyph before the hazard
+        // does not shift it into a byte offset a reader cannot navigate by.
+        assert_eq!(
+            PanelText::new("✦\u{1b}").unwrap_err(),
+            PanelTextError::ControlCharacter { index: 1, code: 27 }
+        );
+    }
+
+    #[test]
+    fn a_frame_of_lines_that_overruns_its_lease_is_refused() {
+        let rect = PanelRect::new(8, 2);
+        let one = || PanelLine::new(vec![PanelSpan::new(text("gates"), PanelStyle::plain())]);
+        let fits = PanelPaint::Lines(vec![one(), one()]);
+        assert_eq!(fits.fits(rect), Ok(()));
+
+        let too_tall = PanelPaint::Lines(vec![one(), one(), one()]);
+        assert_eq!(
+            too_tall.fits(rect),
+            Err(PanelOverflow::Rows { lines: 3, rows: 2 })
+        );
+
+        let too_wide = PanelPaint::Lines(vec![PanelLine::new(vec![PanelSpan::new(
+            text("nine cells"),
+            PanelStyle::plain(),
+        )])]);
+        assert_eq!(
+            too_wide.fits(rect),
+            Err(PanelOverflow::Line {
+                line: 0,
+                cells: 10,
+                cols: 8,
+            })
+        );
+    }
+
+    #[test]
+    fn a_cell_diff_outside_the_lease_is_refused() {
+        let rect = PanelRect::new(8, 2);
+        let patch = |row, col, glyphs| PanelPatch::new(row, col, text(glyphs), PanelStyle::plain());
+
+        assert_eq!(PanelPaint::Diff(vec![patch(1, 7, "x")]).fits(rect), Ok(()));
+        assert_eq!(
+            PanelPaint::Diff(vec![patch(2, 0, "x")]).fits(rect),
+            Err(PanelOverflow::Row { row: 2, rows: 2 })
+        );
+        assert_eq!(
+            PanelPaint::Diff(vec![patch(0, 6, "abc")]).fits(rect),
+            Err(PanelOverflow::Patch {
+                row: 0,
+                col: 6,
+                cells: 3,
+                cols: 8,
+            })
+        );
+    }
+
+    #[test]
+    fn a_column_plus_a_long_run_cannot_wrap_back_into_the_lease() {
+        // `u16::MAX` cells past the right edge is the addition that wraps in
+        // `u16` and lands back inside a small rectangle. The check runs in
+        // `usize`, so it refuses.
+        let rect = PanelRect::new(4, 1);
+        let long = text(&"x".repeat(usize::from(u16::MAX) + 8));
+        let paint = PanelPaint::Diff(vec![PanelPatch::new(0, 2, long, PanelStyle::plain())]);
+        assert!(matches!(
+            paint.fits(rect),
+            Err(PanelOverflow::Patch {
+                col: 2,
+                cols: 4,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn an_empty_frame_fits_every_lease_including_an_empty_one() {
+        let empty = PanelRect::new(0, 0);
+        assert_eq!(PanelPaint::Lines(Vec::new()).fits(empty), Ok(()));
+        assert_eq!(PanelPaint::Diff(Vec::new()).fits(empty), Ok(()));
+        // And a lease with no cells admits no patch at all.
+        let paint = PanelPaint::Diff(vec![PanelPatch::new(0, 0, text("x"), PanelStyle::plain())]);
+        assert_eq!(
+            paint.fits(empty),
+            Err(PanelOverflow::Row { row: 0, rows: 0 })
+        );
+    }
+
+    #[test]
+    fn a_patch_of_no_glyphs_is_still_anchored_inside_the_lease() {
+        // A run of nothing writes nothing, so the *extent* check has no opinion
+        // about where it starts: `col + 0` is inside every lease. A host that
+        // reads the column before it measures the run is handed one its buffer
+        // does not have, and `fits` is the only thing standing between the two.
+        let rect = PanelRect::new(8, 2);
+        let empty_run = |col| PanelPatch::new(0, col, text(""), PanelStyle::plain());
+
+        assert_eq!(PanelPaint::Diff(vec![empty_run(7)]).fits(rect), Ok(()));
+        assert_eq!(
+            PanelPaint::Diff(vec![empty_run(8)]).fits(rect),
+            Err(PanelOverflow::Patch {
+                row: 0,
+                col: 8,
+                cells: 0,
+                cols: 8,
+            })
+        );
+        assert_eq!(
+            PanelPaint::Diff(vec![empty_run(u16::MAX)]).fits(rect),
+            Err(PanelOverflow::Patch {
+                row: 0,
+                col: u16::MAX,
+                cells: 0,
+                cols: 8,
+            })
+        );
+
+        // The same rule read from the other end: a lease with rows but no
+        // columns is a lease with no cells, so it admits no patch either.
+        let columnless = PanelRect::new(0, 2);
+        assert_eq!(
+            PanelPaint::Diff(vec![empty_run(0)]).fits(columnless),
+            Err(PanelOverflow::Patch {
+                row: 0,
+                col: 0,
+                cells: 0,
+                cols: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn a_lease_admits_the_frame_that_answers_it() {
+        let lease = PanelLease::new("gates", 7, PanelRect::new(12, 1), 33);
+        let frame = PanelFrame::new(
+            7,
+            PanelPaint::Lines(vec![PanelLine::new(vec![PanelSpan::new(
+                text("3 green"),
+                PanelStyle::ink(PanelInk::Green),
+            )])]),
+        );
+        assert_eq!(lease.admits(&frame), Ok(()));
+        assert_eq!(frame.protocol_version, PROTOCOL_VERSION);
+    }
+}

--- a/crates/stella-plugin/src/runtime.rs
+++ b/crates/stella-plugin/src/runtime.rs
@@ -74,8 +74,8 @@ pub fn expand_plugin_dir(text: &str, dir: &Path) -> String {
 
 /// Which block declared a process, so a refusal names the table to edit.
 ///
-/// Two blocks describe a process in the same words — [`Runtime`] serves both —
-/// and a rule broken in one of them must not report the other's name. The
+/// Three blocks describe a process in the same words — [`Runtime`] serves all
+/// of them — and a rule broken in one must not report another's name. The
 /// alternative was a second copy of the rules under `[driver.process]`, which
 /// is how one copy grows a check the other silently does not.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +84,8 @@ pub enum ProcessBlock {
     Runtime,
     /// `[driver.process]` — the process a plugin is while driving Stella.
     DriverProcess,
+    /// `[panel.process]` — the process a plugin is while drawing its panel.
+    PanelProcess,
 }
 
 impl ProcessBlock {
@@ -93,6 +95,7 @@ impl ProcessBlock {
         match self {
             Self::Runtime => "[runtime]",
             Self::DriverProcess => "[driver.process]",
+            Self::PanelProcess => "[panel.process]",
         }
     }
 }

--- a/crates/stella-plugin/src/wire.rs
+++ b/crates/stella-plugin/src/wire.rs
@@ -50,6 +50,15 @@
 //!   byte-for-byte; `tests/wire_contract.rs` asserts it rather than promising
 //!   it.
 //!
+//! # The channels beside this one
+//!
+//! [`crate::host_call`] is the plugin's own asks mid-point, [`crate::driver`]
+//! is the session a plugin opens when it drives turns instead of sitting inside
+//! one, and [`crate::panel`] is the frame it draws when the interface leases it
+//! a rectangle. Each carries its own point vocabulary for
+//! [`WrapperPoint`]'s reason: a third value here would say a panel is something
+//! a turn dispatches, and it is not.
+//!
 //! # AGENTS.md #7 is encoded, not remembered
 //!
 //! Contributed context is a [`VolatileContext`], whose body is a private field

--- a/crates/stella-plugin/src/wire_corpus.rs
+++ b/crates/stella-plugin/src/wire_corpus.rs
@@ -83,7 +83,9 @@ use crate::{
     CandidateGrant, ChildTurnArgs, ChildTurnResult, DriveNext, DriveRequest, DriveResponse,
     DriverCall, DriverCallRequest, DriverCallResponse, DriverOk, FanoutCandidate, FlipObservation,
     HostCall, HostCallArgs, HostCallFailure, HostCallOk, HostCallRefusal, HostCallRequest,
-    HostCallResponse, HostStage, ObservedEvidence, PROTOCOL_VERSION, PublishedSignal, RecallArgs,
+    HostCallResponse, HostStage, ObservedEvidence, PROTOCOL_VERSION, PanelDenial, PanelEmphasis,
+    PanelFrame, PanelInk, PanelLease, PanelLine, PanelPaint, PanelPatch, PanelPoint, PanelRect,
+    PanelRequest, PanelResponse, PanelSpan, PanelStyle, PanelText, PublishedSignal, RecallArgs,
     RecallFrame, RecallResult, RunTestArgs, Signal, SignalKind, SignalValue, StageName,
     TestBaseline, TestPlan, TestRunResult, TurnOutcome, VolatileContext, WrapperPoint,
     WrapperRequest, WrapperResponse,
@@ -97,8 +99,8 @@ const NOTE: &str = "GENERATED FILE — DO NOT EDIT. Every message the wrapper \
      socket carries, serialized by the same impls stella_runtime's subprocess \
      transport uses. Regenerate with `bash scripts/export-agentevent-schema.sh`; \
      guarded by `scripts/check-wire-schema.sh` (`make wire-schema`). Source of \
-     truth: crates/stella-plugin/src/wire.rs, src/host_call.rs and \
-     src/driver.rs. A message \
+     truth: crates/stella-plugin/src/wire.rs, src/host_call.rs, \
+     src/driver.rs and src/panel.rs. A message \
      with an optional member appears twice — `full` populates every optional \
      field, `minimal` omits every one that may be omitted — so a field \
      changing between required and optional is a diff here. This is a corpus, \
@@ -137,6 +139,8 @@ pub fn corpus() -> Result<Value, serde_json::Error> {
         "driver_session": driver_session()?,
         "driver_calls": driver_calls()?,
         "driver_results": driver_results()?,
+        "panel_leases": panel_leases()?,
+        "panel_frames": panel_frames()?,
         "parts": parts()?,
         "vocabulary": vocabulary()?,
     }))
@@ -344,6 +348,39 @@ fn driver_results() -> Result<Value, serde_json::Error> {
     ]))
 }
 
+/// The panel channel's request — the rectangle the interface leases a plugin
+/// for one tick (`design/tui-v2/SPEC.md` §12, #5054).
+///
+/// A third dispatch context, published beside the other two on the same terms:
+/// a renamed field here is a panel that draws nothing, and the corpus is where
+/// that lands on the author's screen. No `full`/`minimal` pair, because a lease
+/// has no omissible member — every one of its five fields is what a panel needs
+/// before it can draw a single cell.
+fn panel_leases() -> Result<Value, serde_json::Error> {
+    Ok(Value::Array(vec![case(
+        "frame",
+        &PanelRequest::new(panel_lease()),
+    )?]))
+}
+
+/// The two shapes a panel answers with.
+///
+/// Both, because §12 offers a panel styled lines or a cell diff and neither is
+/// the other's default: a host has to handle both, and a reader of this file
+/// learns the tags that tell them apart. The `lines` case appears twice, since
+/// a span's style is omitted from the wire when it asks for nothing — the
+/// `minimal` case is what makes that omission a diff if it stops happening.
+fn panel_frames() -> Result<Value, serde_json::Error> {
+    Ok(Value::Array(vec![
+        case("lines/full", &PanelResponse::new(panel_frame_lines_full()))?,
+        case(
+            "lines/minimal",
+            &PanelResponse::new(panel_frame_lines_minimal()),
+        )?,
+        case("diff", &PanelResponse::new(panel_frame_diff()))?,
+    ]))
+}
+
 /// The nested types, in the forms the four messages above do not reach.
 ///
 /// A message's `minimal` case omits its optional members entirely, so the
@@ -400,6 +437,13 @@ fn vocabulary() -> Result<Value, serde_json::Error> {
         // truth for the consent rendering, and a second walk would be a second
         // thing to keep exhaustive.
         "driver_call": values(DriverCall::all().to_vec())?,
+        "panel_point": values(enumerate(PanelPoint::Frame, panel_point_after))?,
+        // From `PanelDenial::all()`, for `DriverCall`'s reason: the manifest
+        // check and the consent rendering already read that list, so walking it
+        // twice would be a second thing to keep exhaustive.
+        "panel_denial": values(PanelDenial::all().to_vec())?,
+        "panel_ink": values(enumerate(PanelInk::Bg, panel_ink_after))?,
+        "panel_emphasis": values(enumerate(PanelEmphasis::Bold, panel_emphasis_after))?,
     }))
 }
 
@@ -544,6 +588,47 @@ fn host_call_refusal_after(refusal: HostCallRefusal) -> Option<HostCallRefusal> 
         R::AllowanceSpent => Some(R::Unavailable),
         R::Unavailable => Some(R::Failed),
         R::Failed => None,
+    }
+}
+
+fn panel_point_after(point: PanelPoint) -> Option<PanelPoint> {
+    match point {
+        PanelPoint::Frame => None,
+    }
+}
+
+/// The colours a panel may paint with — `design/tui-v2/SPEC.md` §3.1's `tui`
+/// surface. A token added there and not here would be a colour the deck has and
+/// no panel can ask for, which this chain turns into a compile error.
+fn panel_ink_after(ink: PanelInk) -> Option<PanelInk> {
+    use PanelInk as I;
+    match ink {
+        I::Bg => Some(I::Panel),
+        I::Panel => Some(I::Hl),
+        I::Hl => Some(I::Border),
+        I::Border => Some(I::Rule),
+        I::Rule => Some(I::Gold),
+        I::Gold => Some(I::GoldBright),
+        I::GoldBright => Some(I::Silver),
+        I::Silver => Some(I::SilverType),
+        I::SilverType => Some(I::Text),
+        I::Text => Some(I::Muted),
+        I::Muted => Some(I::Dim),
+        I::Dim => Some(I::Green),
+        I::Green => Some(I::Red),
+        I::Red => Some(I::DiffAddBg),
+        I::DiffAddBg => Some(I::DiffDelBg),
+        I::DiffDelBg => None,
+    }
+}
+
+fn panel_emphasis_after(emphasis: PanelEmphasis) -> Option<PanelEmphasis> {
+    use PanelEmphasis as E;
+    match emphasis {
+        E::Bold => Some(E::Dim),
+        E::Dim => Some(E::Italic),
+        E::Italic => Some(E::Underline),
+        E::Underline => None,
     }
 }
 
@@ -902,6 +987,85 @@ fn recall_frame_minimal() -> RecallFrame {
     }
 }
 
+/// The lease a host mints for one tick of an eight-by-two panel.
+fn panel_lease() -> PanelLease {
+    PanelLease {
+        protocol_version: PROTOCOL_VERSION,
+        panel: "gates".to_string(),
+        tick: 42,
+        rect: PanelRect { cols: 8, rows: 2 },
+        // 30fps, which is the equivalent §12 names as the example budget.
+        budget_ms: 33,
+    }
+}
+
+fn panel_frame_lines_full() -> PanelFrame {
+    PanelFrame {
+        protocol_version: PROTOCOL_VERSION,
+        tick: 42,
+        paint: PanelPaint::Lines(vec![PanelLine {
+            spans: vec![PanelSpan {
+                text: panel_text("3 green"),
+                style: PanelStyle {
+                    fg: Some(PanelInk::Green),
+                    bg: Some(PanelInk::Panel),
+                    emphasis: vec![PanelEmphasis::Bold],
+                },
+            }],
+        }]),
+    }
+}
+
+/// A frame that asks for no style at all, so the `style` key is absent from the
+/// span and the `spans` key from an empty row. A reader who started requiring
+/// either would show up as a diff here.
+fn panel_frame_lines_minimal() -> PanelFrame {
+    PanelFrame {
+        protocol_version: PROTOCOL_VERSION,
+        tick: 42,
+        paint: PanelPaint::Lines(vec![
+            PanelLine {
+                spans: vec![PanelSpan {
+                    text: panel_text("3 green"),
+                    style: PanelStyle {
+                        fg: None,
+                        bg: None,
+                        emphasis: Vec::new(),
+                    },
+                }],
+            },
+            PanelLine { spans: Vec::new() },
+        ]),
+    }
+}
+
+/// The other frame shape: two cells of the same lease, addressed from the
+/// panel's own top-left corner.
+fn panel_frame_diff() -> PanelFrame {
+    PanelFrame {
+        protocol_version: PROTOCOL_VERSION,
+        tick: 43,
+        paint: PanelPaint::Diff(vec![PanelPatch {
+            row: 1,
+            col: 6,
+            text: panel_text("ok"),
+            style: PanelStyle {
+                fg: Some(PanelInk::Silver),
+                bg: None,
+                emphasis: Vec::new(),
+            },
+        }]),
+    }
+}
+
+/// Built through the constructor because [`PanelText`]'s body is private: the
+/// only way to hold one is to have passed the check that refuses every control
+/// character, which is what keeps an escape sequence off this wire in any
+/// language (#5054).
+fn panel_text(glyphs: &str) -> PanelText {
+    PanelText::new(glyphs).expect("the corpus publishes drawable glyphs")
+}
+
 /// Built through the constructor rather than as a literal, because
 /// [`VolatileContext`]'s fields are private: the body is reachable only by
 /// spending the value as a user message, which is AGENTS.md #7 held by the
@@ -973,6 +1137,48 @@ mod tests {
                 message
             );
         }
+        for entry in doc["panel_leases"]
+            .as_array()
+            .expect("panel_leases is an array")
+        {
+            let message = &entry["message"];
+            let decoded: PanelRequest =
+                serde_json::from_value(message.clone()).expect("a published lease decodes");
+            assert_eq!(
+                &serde_json::to_value(&decoded).expect("re-encodes"),
+                message
+            );
+        }
+        for entry in doc["panel_frames"]
+            .as_array()
+            .expect("panel_frames is an array")
+        {
+            let message = &entry["message"];
+            let decoded: PanelResponse =
+                serde_json::from_value(message.clone()).expect("a published frame decodes");
+            assert_eq!(
+                &serde_json::to_value(&decoded).expect("re-encodes"),
+                message
+            );
+        }
+    }
+
+    /// Every frame the corpus publishes fits the lease it publishes beside it.
+    ///
+    /// A corpus of frames a host would refuse would teach a plugin author to
+    /// write one, which is the failure `every_published_message_is_one_the_
+    /// socket_would_accept` prevents for the other channels — a decode is not
+    /// the whole of what a panel frame has to pass.
+    #[test]
+    fn every_published_frame_fits_the_published_lease() {
+        let lease = panel_lease();
+        for frame in [
+            panel_frame_lines_full(),
+            panel_frame_lines_minimal(),
+            panel_frame_diff(),
+        ] {
+            assert_eq!(lease.admits(&frame), Ok(()), "{frame:?}");
+        }
     }
 
     /// The `minimal` half of each pair is what makes optionality visible, and
@@ -992,7 +1198,13 @@ mod tests {
     #[test]
     fn a_minimal_case_never_carries_a_key_its_full_case_omits() {
         let doc = corpus().expect("the corpus encodes");
-        for section in ["requests", "responses", "host_calls", "host_results"] {
+        for section in [
+            "requests",
+            "responses",
+            "host_calls",
+            "host_results",
+            "panel_frames",
+        ] {
             let cases = doc[section].as_array().expect("a section is an array");
             // Paired by name rather than by position. A `chunks(2)` walk was
             // enough while every message had exactly two cases; the host-call

--- a/crates/stella-plugin/tests/install_consent.rs
+++ b/crates/stella-plugin/tests/install_consent.rs
@@ -390,3 +390,70 @@ fn a_package_declaration_round_trips_through_toml_and_json() {
         "JSON round-trip diverged"
     );
 }
+
+/// The panel handshake, in the install prompt (`design/tui-v2/SPEC.md` §12).
+///
+/// §12 puts the declared denials in front of a human before any panel is
+/// granted, so a `[panel]` block that the prompt did not render would be the
+/// grant this whole module exists to make visible — one that changes what is
+/// on a person's screen and says nothing about it.
+///
+/// The process is disclosed for the same reason `driver_say` discloses one: a
+/// panel is a program on the reader's machine, and "draws a box" and "draws a
+/// box, with your `GITHUB_TOKEN`" are different things to agree to.
+#[test]
+fn the_consent_text_shows_the_panel_and_every_limit_it_accepts() {
+    let manifest = PluginManifest::from_toml_str(
+        "name = \"gates\"\ndescription = \"live gate status\"\n\
+         [panel]\ndenies = [\"network\", \"write-outside-sandbox\"]\n\
+         [panel.process]\nargv = [\"python3\", \"panel.py\"]\ntimeout_secs = 2\n\
+         env = [\"GATE_URL\"]\n",
+    )
+    .expect("a panel is expressible");
+    let text = consent_text(&manifest);
+
+    assert!(text.contains("Draws part of your screen"), "{text}");
+    assert!(
+        text.contains("may not reach the network from its panel process"),
+        "{text}"
+    );
+    assert!(
+        text.contains("may not write anywhere but the sandbox directory Stella hands it"),
+        "{text}"
+    );
+    assert!(
+        text.contains("runs as a process on your machine: `python3 panel.py`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("it inherits these environment variables and no others: GATE_URL"),
+        "{text}"
+    );
+
+    // A plugin with no panel says nothing about one, which is what keeps the
+    // section meaningful where it does appear.
+    let bundle = PluginManifest::from_toml_str("name = \"bundle\"").expect("loads");
+    assert!(!consent_text(&bundle).contains("Draws part of your screen"));
+}
+
+/// AGENTS.md #4 for the `[panel]` block: what a host renders that handshake
+/// from must survive the wire a `stella-serve` host reads it over.
+#[test]
+fn a_panel_declaration_round_trips_through_toml_and_json() {
+    let parsed = PluginManifest::from_toml_str(
+        "name = \"gates\"\n[panel]\ndenies = [\"network\", \"write-outside-sandbox\"]\n",
+    )
+    .expect("a panel is expressible");
+    let toml_text = toml::to_string(&parsed).unwrap();
+    assert_eq!(
+        PluginManifest::from_toml_str(&toml_text).unwrap(),
+        parsed,
+        "TOML round-trip diverged"
+    );
+    let json = serde_json::to_string(&parsed).unwrap();
+    assert_eq!(
+        serde_json::from_str::<PluginManifest>(&json).unwrap(),
+        parsed,
+        "JSON round-trip diverged"
+    );
+}

--- a/crates/stella-plugin/tests/wire_contract.rs
+++ b/crates/stella-plugin/tests/wire_contract.rs
@@ -29,10 +29,13 @@ use stella_plugin::{
     BeforeTurnRequest, BeforeTurnResponse, CandidateFanoutArgs, CandidateFanoutResult,
     CandidateGrant, ChildTurnResult, Continuation, Correction, EvidenceProvenance, EvidenceSet,
     FanoutCandidate, FlipObservation, HostCall, HostCallOk, HostCallResponse, HostStage,
-    ObservedEvidence, Outcome, PROTOCOL_VERSION, PluginManifest, PublishedSignal, RecallResult,
-    RoundState, Signal, SignalValue, StageName, StopReason, TamperFinding, TestBaseline, TestPlan,
-    TestRunResult, TurnOutcome, UndecidedReason, UnmetBecause, UnmetRequirement, Verdict,
-    VerdictRule, VolatileContext, WrapperPoint, WrapperRequest, WrapperResponse,
+    ObservedEvidence, Outcome, PROTOCOL_VERSION, PanelDenial, PanelEmphasis, PanelFrame, PanelInk,
+    PanelLease, PanelLine, PanelOverflow, PanelPaint, PanelPatch, PanelPoint, PanelRect,
+    PanelRequest, PanelResponse, PanelSpan, PanelStyle, PanelText, PluginManifest, PublishedSignal,
+    RecallResult, RoundState, Signal, SignalValue, StageName, StopReason, TamperFinding,
+    TestBaseline, TestPlan, TestRunResult, TurnOutcome, UndecidedReason, UnmetBecause,
+    UnmetRequirement, Verdict, VerdictRule, VolatileContext, WrapperPoint, WrapperRequest,
+    WrapperResponse,
 };
 use stella_protocol::CandidateHandle;
 
@@ -896,5 +899,370 @@ fn a_child_turn_ceiling_must_bound_a_call_this_manifest_can_actually_make() {
             .max_child_turns,
         None,
         "absent falls back to max_calls, and then to the host's ceiling"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The panel channel (`design/tui-v2/SPEC.md` §12, #5054). A third dispatch
+// context, held to the identical contract: byte-for-byte in both directions,
+// every closed vocabulary pinned, and every table refusing a key it does not
+// know.
+// ---------------------------------------------------------------------------
+
+/// The rectangle a host leases an eight-by-two panel for one tick.
+fn lease() -> PanelLease {
+    PanelLease::new("gates", 42, PanelRect::new(8, 2), 33)
+}
+
+/// Glyphs the contract accepts, for a test that is about something else.
+fn glyphs(text: &str) -> PanelText {
+    PanelText::new(text).expect("plain glyphs")
+}
+
+/// One row of one style.
+fn row(text: &str) -> PanelLine {
+    PanelLine::new(vec![PanelSpan::new(glyphs(text), PanelStyle::plain())])
+}
+
+/// Both frame shapes, the styled span and the unstyled one, the populated row
+/// and the empty one — every optional member of the panel wire in both of its
+/// states, in one pass.
+#[test]
+fn every_panel_message_round_trips_byte_for_byte() {
+    let request = round_trip(&PanelRequest::new(lease()));
+    let value: serde_json::Value = serde_json::from_str(&request).unwrap();
+    assert_eq!(value["point"], "frame");
+    assert_eq!(value["body"]["protocol_version"], PROTOCOL_VERSION);
+    assert_eq!(value["body"]["rect"]["cols"], 8);
+    assert_eq!(value["body"]["rect"]["rows"], 2);
+
+    let styled = PanelPaint::Lines(vec![
+        PanelLine::new(vec![
+            PanelSpan::new(
+                glyphs("3 "),
+                PanelStyle {
+                    fg: Some(PanelInk::Green),
+                    bg: Some(PanelInk::Panel),
+                    emphasis: vec![PanelEmphasis::Bold, PanelEmphasis::Underline],
+                },
+            ),
+            PanelSpan::new(glyphs("green"), PanelStyle::plain()),
+        ]),
+        PanelLine::default(),
+    ]);
+    let lines = round_trip(&PanelResponse::new(PanelFrame::new(42, styled)));
+    let value: serde_json::Value = serde_json::from_str(&lines).unwrap();
+    assert_eq!(value["point"], "frame");
+    // An unstyled span omits the key and an empty row omits its spans, so the
+    // emptiest legal frame is smaller than a reader of the type would guess.
+    assert!(
+        value["body"]["paint"]["lines"][0]["spans"][1]
+            .get("style")
+            .is_none()
+    );
+    assert!(value["body"]["paint"]["lines"][1].get("spans").is_none());
+
+    let diff = PanelPaint::Diff(vec![PanelPatch::new(
+        1,
+        6,
+        glyphs("ok"),
+        PanelStyle::ink(PanelInk::Silver),
+    )]);
+    let patched = round_trip(&PanelResponse::new(PanelFrame::new(43, diff)));
+    let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
+    assert_eq!(value["body"]["paint"]["diff"][0]["row"], 1);
+    assert_eq!(value["body"]["paint"]["diff"][0]["col"], 6);
+    assert_eq!(value["body"]["paint"]["diff"][0]["text"], "ok");
+
+    round_trip(&PanelRect::new(0, 0));
+    round_trip(&PanelStyle::plain());
+    round_trip(&glyphs("stella*"));
+}
+
+/// **The witness for #5054.** A frame may address the cells it was leased and
+/// no others, and the refusal names the cell that ran past the edge instead of
+/// reporting that something, somewhere, did not fit.
+///
+/// Four directions, because a rectangle has four ways out and a check that
+/// counted only rows would pass a row of the right count and the wrong width.
+#[test]
+fn a_panel_frame_addressing_a_cell_outside_its_lease_is_refused() {
+    let lease = lease();
+
+    // Exactly filling the lease is inside it: the edge is addressable, and a
+    // panel that could not use its last column would be leased a lie.
+    let full = PanelFrame::new(
+        42,
+        PanelPaint::Lines(vec![row("12345678"), row("12345678")]),
+    );
+    assert_eq!(lease.admits(&full), Ok(()));
+    let corner = PanelFrame::new(
+        42,
+        PanelPaint::Diff(vec![PanelPatch::new(
+            1,
+            7,
+            glyphs("x"),
+            PanelStyle::plain(),
+        )]),
+    );
+    assert_eq!(lease.admits(&corner), Ok(()));
+
+    let tall = PanelFrame::new(42, PanelPaint::Lines(vec![row("a"), row("b"), row("c")]));
+    assert_eq!(
+        lease.admits(&tall),
+        Err(PanelOverflow::Rows { lines: 3, rows: 2 })
+    );
+
+    let wide = PanelFrame::new(42, PanelPaint::Lines(vec![row("123456789")]));
+    assert_eq!(
+        lease.admits(&wide),
+        Err(PanelOverflow::Line {
+            line: 0,
+            cells: 9,
+            cols: 8,
+        })
+    );
+
+    let below = PanelFrame::new(
+        42,
+        PanelPaint::Diff(vec![PanelPatch::new(
+            2,
+            0,
+            glyphs("x"),
+            PanelStyle::plain(),
+        )]),
+    );
+    assert_eq!(
+        lease.admits(&below),
+        Err(PanelOverflow::Row { row: 2, rows: 2 })
+    );
+
+    let past = PanelFrame::new(
+        42,
+        PanelPaint::Diff(vec![PanelPatch::new(
+            0,
+            7,
+            glyphs("no"),
+            PanelStyle::plain(),
+        )]),
+    );
+    assert_eq!(
+        lease.admits(&past),
+        Err(PanelOverflow::Patch {
+            row: 0,
+            col: 7,
+            cells: 2,
+            cols: 8,
+        })
+    );
+
+    // A run of no glyphs is anchored too. `col + 0` is inside every lease, so
+    // an extent check on its own would admit a patch naming a column the host's
+    // buffer does not have — nothing to blit, and exactly the coordinate a host
+    // that reads the column before it measures the run would index with.
+    let anchored_out = PanelFrame::new(
+        42,
+        PanelPaint::Diff(vec![PanelPatch::new(0, 8, glyphs(""), PanelStyle::plain())]),
+    );
+    assert_eq!(
+        lease.admits(&anchored_out),
+        Err(PanelOverflow::Patch {
+            row: 0,
+            col: 8,
+            cells: 0,
+            cols: 8,
+        })
+    );
+
+    // And the refusal is readable: a host printing it names the coordinates a
+    // plugin author has to change.
+    let printed = lease
+        .admits(&past)
+        .expect_err("the patch runs past the edge")
+        .to_string();
+    assert!(printed.contains("column 7"), "got {printed}");
+}
+
+/// A panel writes glyphs and never an escape sequence, in Rust and on the wire.
+///
+/// The Rust half is the type: [`PanelText`]'s body is private, so a value can
+/// only come from the constructor that refuses control characters. The wire
+/// half is this — a frame carrying `ESC [ 2 J` is a **decode error**, so a host
+/// never holds one to inspect and no amount of care about how it blits could
+/// have mattered.
+#[test]
+fn a_panel_frame_carrying_an_escape_sequence_does_not_decode() {
+    // Written as JSON escapes, so the hazard is what a plugin's own encoder
+    // would put on the pipe and not something only a Rust literal can say.
+    for hazard in [
+        "\\u001b[2J",
+        "\\u001b]0;stella\\u0007",
+        "\\u001b[1;1H",
+        "a\\nb",
+        "col\\u0009umn",
+    ] {
+        let json = format!(
+            "{{\"point\":\"frame\",\"body\":{{\"protocol_version\":1,\"tick\":1,\
+             \"paint\":{{\"diff\":[{{\"row\":0,\"col\":0,\"text\":\"{hazard}\"}}]}}}}}}"
+        );
+        let err = serde_json::from_str::<PanelResponse>(&json)
+            .expect_err("an escape sequence must not decode as drawable glyphs");
+        assert!(
+            err.to_string().contains("control character"),
+            "the refusal must say why, got {err}"
+        );
+    }
+
+    // The same refusal on the other frame shape, so neither of them is the
+    // soft one.
+    let json = "{\"point\":\"frame\",\"body\":{\"protocol_version\":1,\"tick\":1,\
+                \"paint\":{\"lines\":[{\"spans\":[{\"text\":\"\\u001b[31mred\"}]}]}}}";
+    assert!(serde_json::from_str::<PanelResponse>(json).is_err());
+}
+
+/// Every closed vocabulary the panel channel adds, on both sides.
+#[test]
+fn every_panel_vocabulary_is_pinned_on_both_sides() {
+    assert_eq!(serde_json::to_value(PanelPoint::Frame).unwrap(), "frame");
+    assert_eq!(PanelPoint::Frame.to_string(), "frame");
+    round_trip(&PanelPoint::Frame);
+
+    for (denial, wire) in [
+        (PanelDenial::Network, "network"),
+        (PanelDenial::WriteOutsideSandbox, "write-outside-sandbox"),
+    ] {
+        assert_eq!(serde_json::to_value(denial).unwrap(), wire);
+        assert_eq!(denial.to_string(), wire);
+        round_trip(&denial);
+    }
+    assert_eq!(
+        PanelDenial::all(),
+        &[PanelDenial::Network, PanelDenial::WriteOutsideSandbox],
+        "the denial set is closed, and its order is the one a prompt prints"
+    );
+
+    // The spellings are `design/tui-v2/SPEC.md` §3.1's own token names, so a
+    // panel asks for the same colour the palette table publishes and a reader
+    // crosses between the two documents without a mapping.
+    for (ink, wire) in [
+        (PanelInk::Bg, "bg"),
+        (PanelInk::Panel, "panel"),
+        (PanelInk::Hl, "hl"),
+        (PanelInk::Border, "border"),
+        (PanelInk::Rule, "rule"),
+        (PanelInk::Gold, "gold"),
+        (PanelInk::GoldBright, "gold_bright"),
+        (PanelInk::Silver, "silver"),
+        (PanelInk::SilverType, "silver_type"),
+        (PanelInk::Text, "text"),
+        (PanelInk::Muted, "muted"),
+        (PanelInk::Dim, "dim"),
+        (PanelInk::Green, "green"),
+        (PanelInk::Red, "red"),
+        (PanelInk::DiffAddBg, "diff_add_bg"),
+        (PanelInk::DiffDelBg, "diff_del_bg"),
+    ] {
+        assert_eq!(serde_json::to_value(ink).unwrap(), wire);
+        round_trip(&ink);
+    }
+    assert!(
+        serde_json::from_str::<PanelInk>("\"#EFC53F\"").is_err(),
+        "a panel names a token and never a colour of its own, so the hue clamp \
+         holds over plugin pixels too"
+    );
+
+    for (emphasis, wire) in [
+        (PanelEmphasis::Bold, "bold"),
+        (PanelEmphasis::Dim, "dim"),
+        (PanelEmphasis::Italic, "italic"),
+        (PanelEmphasis::Underline, "underline"),
+    ] {
+        assert_eq!(serde_json::to_value(emphasis).unwrap(), wire);
+        round_trip(&emphasis);
+    }
+    for absent in ["reverse", "blink"] {
+        assert!(
+            serde_json::from_str::<PanelEmphasis>(&format!("\"{absent}\"")).is_err(),
+            "\"{absent}\" is not a panel's to ask for"
+        );
+    }
+}
+
+/// The panel tables refuse a key they do not know, as every other table on this
+/// wire does — and one of those keys is the title, whose absence is the
+/// anti-spoofing rule: the host writes the label from the name a human
+/// consented to, so a plugin cannot call itself `GATES`.
+#[test]
+fn a_panel_may_not_name_itself_or_carry_a_key_the_contract_lacks() {
+    let err = serde_json::from_str::<PanelResponse>(
+        "{\"point\":\"frame\",\"body\":{\"protocol_version\":1,\"tick\":1,\
+         \"title\":\"GATES\",\"paint\":{\"lines\":[]}}}",
+    )
+    .expect_err("a frame does not name the panel");
+    assert!(err.to_string().contains("title"), "got {err}");
+
+    let err = PluginManifest::from_toml_str(
+        "name = \"gates\"\n[panel]\ntitle = \"GATES\"\ndenies = [\"network\", \
+         \"write-outside-sandbox\"]",
+    )
+    .expect_err("a [panel] block does not name the panel either");
+    assert!(err.to_string().contains("title"), "got {err}");
+
+    let err = serde_json::from_str::<PanelRequest>(
+        "{\"point\":\"frame\",\"body\":{\"protocol_version\":1,\"panel\":\"gates\",\
+         \"tick\":1,\"rect\":{\"cols\":4,\"rows\":1,\"x\":9},\"budget_ms\":33}}",
+    )
+    .expect_err("a leased rectangle carries an extent and no origin");
+    assert!(err.to_string().contains("`x`"), "got {err}");
+}
+
+/// The `[panel]` block is a consent document, so it names every limit a panel
+/// accepts before it loads — a block naming fewer is refused by the denial it
+/// left out instead of being read as a narrower panel.
+#[test]
+fn a_panel_block_must_name_every_denial_it_accepts() {
+    let manifest = |denies: &str| {
+        PluginManifest::from_toml_str(&format!("name = \"gates\"\n[panel]\ndenies = [{denies}]"))
+    };
+
+    let loaded = manifest("\"network\", \"write-outside-sandbox\"").expect("loads");
+    let panel = loaded.panel.expect("the block parsed");
+    assert!(panel.denies(PanelDenial::Network));
+    assert!(panel.denies(PanelDenial::WriteOutsideSandbox));
+    assert_eq!(panel.missing_denial(), None);
+    // Declaring a panel buys no say in a turn, and needs none.
+    assert_eq!(
+        loaded.loop_grant.participation,
+        stella_plugin::Participation::None
+    );
+
+    assert!(matches!(
+        manifest("\"network\"").expect_err("a panel that keeps its filesystem"),
+        stella_plugin::ManifestError::PanelDenialMissing {
+            denial: PanelDenial::WriteOutsideSandbox
+        }
+    ));
+    assert!(matches!(
+        manifest("").expect_err("a panel that accepts nothing"),
+        stella_plugin::ManifestError::PanelDenialMissing {
+            denial: PanelDenial::Network
+        }
+    ));
+    assert!(matches!(
+        manifest("\"network\", \"network\", \"write-outside-sandbox\"")
+            .expect_err("a repeated limit is an editing mistake"),
+        stella_plugin::ManifestError::DuplicatePanelDenial {
+            denial: PanelDenial::Network
+        }
+    ));
+    let err = manifest("\"read-anything\"").expect_err("the denial set is Stella's");
+    assert!(err.to_string().contains("read-anything"), "got {err}");
+
+    assert!(
+        PluginManifest::from_toml_str("name = \"bundle\"")
+            .expect("loads")
+            .panel
+            .is_none(),
+        "no [panel] block is no panel, and never an empty one"
     );
 }

--- a/docs/wire/wrapper.wire.json
+++ b/docs/wire/wrapper.wire.json
@@ -258,7 +258,99 @@
       }
     }
   ],
-  "note": "GENERATED FILE — DO NOT EDIT. Every message the wrapper socket carries, serialized by the same impls stella_runtime's subprocess transport uses. Regenerate with `bash scripts/export-agentevent-schema.sh`; guarded by `scripts/check-wire-schema.sh` (`make wire-schema`). Source of truth: crates/stella-plugin/src/wire.rs, src/host_call.rs and src/driver.rs. A message with an optional member appears twice — `full` populates every optional field, `minimal` omits every one that may be omitted — so a field changing between required and optional is a diff here. This is a corpus, not a JSON Schema; wrapper.schema.json is the derived schema beside it, and neither subsumes the other — see crates/stella-plugin/src/wire_corpus.rs and src/wire_schema.rs for what each does and does not catch (#3532).",
+  "note": "GENERATED FILE — DO NOT EDIT. Every message the wrapper socket carries, serialized by the same impls stella_runtime's subprocess transport uses. Regenerate with `bash scripts/export-agentevent-schema.sh`; guarded by `scripts/check-wire-schema.sh` (`make wire-schema`). Source of truth: crates/stella-plugin/src/wire.rs, src/host_call.rs, src/driver.rs and src/panel.rs. A message with an optional member appears twice — `full` populates every optional field, `minimal` omits every one that may be omitted — so a field changing between required and optional is a diff here. This is a corpus, not a JSON Schema; wrapper.schema.json is the derived schema beside it, and neither subsumes the other — see crates/stella-plugin/src/wire_corpus.rs and src/wire_schema.rs for what each does and does not catch (#3532).",
+  "panel_frames": [
+    {
+      "case": "lines/full",
+      "message": {
+        "body": {
+          "paint": {
+            "lines": [
+              {
+                "spans": [
+                  {
+                    "style": {
+                      "bg": "panel",
+                      "emphasis": [
+                        "bold"
+                      ],
+                      "fg": "green"
+                    },
+                    "text": "3 green"
+                  }
+                ]
+              }
+            ]
+          },
+          "protocol_version": 1,
+          "tick": 42
+        },
+        "point": "frame"
+      }
+    },
+    {
+      "case": "lines/minimal",
+      "message": {
+        "body": {
+          "paint": {
+            "lines": [
+              {
+                "spans": [
+                  {
+                    "text": "3 green"
+                  }
+                ]
+              },
+              {}
+            ]
+          },
+          "protocol_version": 1,
+          "tick": 42
+        },
+        "point": "frame"
+      }
+    },
+    {
+      "case": "diff",
+      "message": {
+        "body": {
+          "paint": {
+            "diff": [
+              {
+                "col": 6,
+                "row": 1,
+                "style": {
+                  "fg": "silver"
+                },
+                "text": "ok"
+              }
+            ]
+          },
+          "protocol_version": 1,
+          "tick": 43
+        },
+        "point": "frame"
+      }
+    }
+  ],
+  "panel_leases": [
+    {
+      "case": "frame",
+      "message": {
+        "body": {
+          "budget_ms": 33,
+          "panel": "gates",
+          "protocol_version": 1,
+          "rect": {
+            "cols": 8,
+            "rows": 2
+          },
+          "tick": 42
+        },
+        "point": "frame"
+      }
+    }
+  ],
   "parts": [
     {
       "case": "candidate_grant/full",
@@ -587,6 +679,37 @@
       "allowance-spent",
       "unavailable",
       "failed"
+    ],
+    "panel_denial": [
+      "network",
+      "write-outside-sandbox"
+    ],
+    "panel_emphasis": [
+      "bold",
+      "dim",
+      "italic",
+      "underline"
+    ],
+    "panel_ink": [
+      "bg",
+      "panel",
+      "hl",
+      "border",
+      "rule",
+      "gold",
+      "gold_bright",
+      "silver",
+      "silver_type",
+      "text",
+      "muted",
+      "dim",
+      "green",
+      "red",
+      "diff_add_bg",
+      "diff_del_bg"
+    ],
+    "panel_point": [
+      "frame"
     ],
     "published_signal": [
       {


### PR DESCRIPTION
Closes #5054

## What & why

SPEC 12 (plugin panel protocol) had no wire half. `stella-plugin`'s capability set is closed and carried no panel: no `Rect` lease shape, no styled-line or cell-diff return type, and no way for a manifest to say a plugin draws anything at all.

This is that contract and only that contract. **There is no host in this PR** — no renderer, nothing wired into `stella-tui`, no dispatch. That is #5055. Everything here lives inside `crates/stella-plugin/` plus the regenerated `docs/wire/` corpus.

### The two rules the types hold

§12 says plugins never emit raw ANSI, and that a plugin is leased a `Rect` it cannot draw outside of. Both are held by the types rather than by a host's care, because a host is the wrong place to keep either promise:

- **`PanelText` wraps a private `String`** whose only constructor refuses every control character, and `Deserialize` routes through that same constructor. `\x1b[2J` inside a frame is a **decode error**, so no host ever holds one to inspect and no plugin in any language can put an escape sequence on the wire. The privacy is what makes it a rule instead of a request — a `compile_fail` doctest pins it, the way `VolatileContext` is pinned.
- **`PanelRect` carries an extent and no origin.** A panel counts rows and columns from its own top-left corner, so the host's buffer coordinates are a number it is never told. There is no value a plugin could write that names a cell of Stella's chrome.

`PanelFrame::fits` closes the rest: a `lines` frame taller or wider than the lease is refused, and a `diff` patch is refused when it **starts** past the right edge as well as when it runs past it. The anchor is checked separately because a run of no glyphs satisfies `col + 0 <= cols` for every column a `u16` can hold — it writes nothing, but `fits` is the whole guarantee a host will index against, so it holds for the origin too. The sum runs in `usize` so a column plus a `u16::MAX`-long run cannot wrap back inside the lease.

`PanelGrant` has **no `title` field**, and that absence is the anti-spoofing rule: §12 gives the border and the label to the host (`◳ panel · <plugin>`), so a panel cannot call itself `GATES`. A `title` key is refused in the `[panel]` block and in the frame.

### The consent half

`[panel] denies` must name every `PanelDenial` — `network` and `write-outside-sandbox` — before the manifest loads. This follows the pattern `[driver] calls` established, where the set is Stella's and `release` is deliberately unspellable: an unknown word is a parse error, a repeat is `DuplicatePanelDenial`, and a **subset is `PanelDenialMissing` rather than a narrower panel**. The limits belong in the signed document a human reads, not in whichever host happens to load it. `consent_text` prints them as sentences.

Those three rules live on `PanelGrant::validate`, beside the type they govern, rather than inside `PluginManifest::validate`: a reader of the grant sees what makes one legal without crossing modules, and a host that assembles a grant in Rust can ask the parser's own question. It also keeps `manifest.rs` — a god file at 1492/1500 lines — out of the file-size ceiling.

`PanelInk` names `design/tui-v2/SPEC.md` §3.1 palette tokens and never an RGB triple, so §2's two-metal rule and §3.2's hue clamp hold over plugin pixels too. `reverse` and `blink` are absent from `PanelEmphasis` on purpose — the first is how a panel would paint a bar the shape of the host's selected row, and the second is ruled out by §14.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_panel_frame_addressing_a_cell_outside_its_lease_is_refused` — `crates/stella-plugin/tests/wire_contract.rs`.

Verified the artisanal way: reverting `crates/stella-plugin/src/` and `docs/wire/` to `main` while keeping the tests fails to compile on sixteen unresolved `stella_plugin::Panel*` imports, `no field `panel` on type `PluginManifest``, and two missing `ManifestError` variants — the contract is genuinely absent. It passes on this branch.

Beside it: `every_panel_message_round_trips_byte_for_byte` (fullest and emptiest legal shape of every message), `a_panel_frame_carrying_an_escape_sequence_does_not_decode` (both frame shapes, hazards written as JSON escapes so they are what a non-Rust encoder would emit), `every_panel_vocabulary_is_pinned_on_both_sides`, `a_panel_may_not_name_itself_or_carry_a_key_the_contract_lacks`, and `a_panel_block_must_name_every_denial_it_accepts`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-plugin --all-targets -- -D warnings`, plus `make lint-schema` (`wire_corpus` is behind the `schema` feature, so the default clippy run does not reach it)
- [x] `cargo test -p stella-plugin --features schema` — 11 test binaries, 0 failures
- [x] `cargo clippy -p stella-cli -p stella-tools -p stella-runtime --all-targets -- -D warnings` — `ProcessBlock` and `ManifestError` each gained a variant, so every direct dependent was compiled
- [x] `make doc-warnings CARGO_SCOPE="-p stella-plugin"` and `make doc-warnings-schema`
- [x] `make wire-schema` green; `docs/wire/wrapper.wire.json` regenerated via `make wire-schema-update` and the diff committed
- [x] `make guards` — every guard green
- [x] Docs updated: the crate README's file list gains `src/panel.rs`, and `lib.rs`'s crate header gains the panel paragraph

### Rebased once, for the file-size ratchet

The first push failed `file size ratchet`: `manifest.rs` grew by 4 lines on `main` while this branch was in flight, and 1472 + this PR's original 35 crossed the 1500-line ceiling. Rebased onto `8b6877251` and moved the `[panel]` load rules out of `PluginManifest::validate` onto `PanelGrant::validate` — a better home for them independently, and it brings the net addition to `manifest.rs` down to 20 lines (1492/1500). No baseline entry was added; the guard is explicit that a crossing gets a split, not a ratchet bump.

## Nothing left behind

- [x] Filed: #5184, #5185

- **#5184** — `PanelText::new` refuses Unicode `Cc` (every escape-sequence byte) but not `Cf`, so bidi overrides like `U+202E` and zero-width characters pass. Nothing escapes the leased rectangle, but a panel is chrome a user consented to trust, and text that reads one way and means another is what that handshake exists to prevent. Left out of this PR because it is a widening of the rule with a real design question attached (ZWJ is load-bearing in emoji), not a hole in what this PR committed to.
- **#5185** — `PanelText::cells()` counts `char`s, so a CJK glyph measures 1 and draws 2. The type documents this and argues it is safe because the host clips every blit at the leased rectangle — a sound argument that makes the safety property conditional on a host behaviour that does not exist yet and is asserted nowhere. Belongs to #5055, and `stella-plugin`'s manifest requires a fresh argument for a third workspace dependency that `unicode-width` does not have here.

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependencies at all** — `stella-plugin`'s near-leaf argument is untouched
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde (byte-for-byte, both directions, tests included)

## Anything reviewers should know?

**The types live in `src/panel.rs`, not `src/wire.rs`.** The issue names `wire.rs`, but this crate's idiom is a module per dispatch context — `wire.rs` is the wrapper socket, `host_call.rs` is the plugin's asks, `driver.rs` is the drive session, each holding its own grant block and its own wire shapes. Adding a fourth channel's types to `wire.rs` would have crossed the file-size ceiling too: it sits at 1468/1500 lines. `wire.rs` gains a paragraph pointing at the new module.

**`wrapper.schema.json` and `wrapper.d.ts` are unchanged, deliberately.** They publish the wrapper socket alone — `wire_schema.rs`'s header already explains why the host-call and driver channels appear in the corpus and not the schema. The panel channel is published the same way, and `make wire-schema` is green.

**Overlap to watch with #5056.** That issue owns the visible handshake and the `[a]llow [d]eny` grant in the CLI/TUI. This PR touches `consent.rs` only to add `panel_say`, the install-consent paragraph rendering the declared denials as sentences — the manifest's own document, inside `stella-plugin`, with nothing in `stella-cli` or `stella-tui`. #5056's agent should build on those sentences rather than write a second copy, and should expect a small conflict in `consent_text`'s line assembly if it lands after this.

## Summary by Sourcery

Establish the stella-plugin panel protocol contract for consented, bounded, and styled plugin rendering without adding host-side rendering or dispatch.

New Features:
- Add the plugin panel manifest capability and wire contract for leased screen rectangles, styled-line frames, and cell-diff frames.
- Expose panel palette, styling, consent, lease, request, response, and frame types through the plugin API.

Bug Fixes:
- Reject panel frames that contain control characters or address cells outside their leased rectangle.
- Reject incomplete or duplicate panel denial declarations and unknown panel contract fields.

Enhancements:
- Enforce panel consent limits, anti-spoofing rules, bounded frame validation, and closed styling vocabularies at the type and manifest layers.

Documentation:
- Document the panel module and regenerate the wire-format corpus with panel messages and vocabularies.

Tests:
- Add round-trip, vocabulary, manifest-consent, escape-sequence, and lease-boundary contract coverage for panel messages.
