### PR TITLE
feat(stella-tui): the ISSUES tab's linked plan, evidence summary and heat sort (#4336)

### DIFF
--- a/crates/stella-cli/src/command_deck/issues.rs
+++ b/crates/stella-cli/src/command_deck/issues.rs
@@ -192,7 +192,16 @@ fn issue_row(issue: &Issue) -> IssueRow {
         // the field to the port first, for every tracker.
         assignee: None,
         url: issue.url.clone(),
+        // The port carries a creation stamp and no update stamp, and the two
+        // are different facts — the row would rather say nothing than date an
+        // issue by when it was filed (#5196).
         updated_at: None,
+        // A tracker knows nothing about a session's claim, so a tracker read
+        // never fills this. Its producer is the self-driving loop's dispatch
+        // ledger, which [`issues_act`] refuses to stand in for —
+        // `IssueAction::StartWork` is that refusal — and which has no read
+        // path to the deck yet (#5197).
+        linked: None,
     }
 }
 

--- a/crates/stella-tui/examples/deck_film.rs
+++ b/crates/stella-tui/examples/deck_film.rs
@@ -72,7 +72,7 @@ use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::style::{Color, Modifier};
 
-use stella_tui::scenario::{demo_engine_config, demo_graph, demo_inbound};
+use stella_tui::scenario::{demo_engine_config, demo_graph, demo_inbound, demo_linked_work};
 use stella_tui::views::engine_panel::EngineTab;
 use stella_tui::{
     AgentScope, AgentVersionInfo, DeckTab, DeckUi, EngineRole, InstalledAgentEntry, IssueRow,
@@ -645,6 +645,7 @@ fn fixture_issues() -> Vec<IssueRow> {
             assignee: assignee.map(|s| s.to_string()),
             url: format!("https://github.com/example/repo/issues/{}", &key[1..]),
             updated_at: Some("2026-01-14T09:30:00Z".to_string()),
+            linked: None,
         };
     vec![
         issue(
@@ -654,13 +655,20 @@ fn fixture_issues() -> Vec<IssueRow> {
             &["enhancement", "area:tui"],
             Some("dev"),
         ),
-        issue(
-            "#826",
-            "run_deck event-loop pty harness",
-            "open",
-            &["enhancement"],
-            None,
-        ),
+        IssueRow {
+            // The one row this session claimed, so the film shows the inline
+            // plan tag, the detail pane's `linked` line, and the heat sort
+            // lifting it above the rest of the backlog. `driver.rs` is a file
+            // node in `demo_graph`, which is where its coupling comes from.
+            linked: Some(demo_linked_work()),
+            ..issue(
+                "#826",
+                "run_deck event-loop pty harness",
+                "in progress",
+                &["enhancement"],
+                None,
+            )
+        },
         issue(
             "#791",
             "Compaction drops the last tool result",
@@ -809,7 +817,9 @@ fn ui_for(scene: Scene, sel: usize, model: &WorkspaceModel, splash_ms: u64) -> D
                     ui.mcp.selected = sel;
                 }
                 DeckTab::Issues => {
-                    ui.issues.rows = fixture_issues();
+                    let graph = ui.graph.clone();
+                    ui.issues
+                        .adopt_rows(fixture_issues(), graph.as_ref(), model.now_ms);
                     ui.issues.loaded = true;
                     ui.issues.sel = sel;
                 }

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -399,8 +399,14 @@ impl TypeAhead {
 /// split as [`InstalledPanel`].
 #[derive(Debug, Clone)]
 pub struct IssuesPanel {
-    /// Newest driver snapshot of the issue list.
+    /// Newest driver snapshot of the issue list, in heat order once
+    /// [`IssuesPanel::adopt_rows`] has been able to compute one.
     pub rows: Vec<IssueRow>,
+    /// Whether [`rows`](Self::rows) is in heat order rather than the
+    /// tracker's. The tab captions the ordering from this, so it is false
+    /// whenever the graph could rank nothing — a caption over an unsorted
+    /// backlog would name a source the order does not have.
+    pub heat_sorted: bool,
     /// Selected row in the browse list.
     pub sel: usize,
     /// True once the first [`Inbound::IssuesList`] arrived.
@@ -455,6 +461,7 @@ impl Default for IssuesPanel {
     fn default() -> Self {
         Self {
             rows: Vec::new(),
+            heat_sorted: false,
             sel: 0,
             loaded: false,
             busy: false,
@@ -483,6 +490,26 @@ impl IssuesPanel {
     /// The browse list's selected row, if any.
     pub fn selected(&self) -> Option<&IssueRow> {
         self.rows.get(self.sel)
+    }
+
+    /// Adopt a fresh list of rows, in SPEC 9.4's heat order
+    /// ([`crate::views::issues::sort_by_heat`]).
+    ///
+    /// The ordering happens once, as the rows arrive — not per frame, and not
+    /// again when a later [`Inbound::GraphSnapshot`] lands. A list that
+    /// re-sorted under a reader mid-browse would move the cursor off the row
+    /// they were looking at, and the graph is re-queried on the Graph tab's
+    /// own schedule; `r` re-fetches the backlog against whatever graph the
+    /// deck holds by then.
+    ///
+    /// The selection is clamped rather than kept on its key, matching what a
+    /// refresh already did: the rows are a new page from the tracker, and the
+    /// row that was selected may not be among them.
+    pub fn adopt_rows(&mut self, rows: Vec<IssueRow>, graph: Option<&GraphSnapshot>, now_ms: u64) {
+        self.rows = rows;
+        self.heat_sorted = crate::views::issues::sort_by_heat(&mut self.rows, graph, now_ms);
+        self.sel = self.sel.min(self.rows.len().saturating_sub(1));
+        self.prune_picks();
     }
 
     /// The next request seq (monotonic; starts at 1 so the `0` defaults of
@@ -1380,9 +1407,10 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
         ui.issues.loaded = true;
         match outcome {
             Ok(rows) => {
-                ui.issues.rows = rows.clone();
-                ui.issues.sel = ui.issues.sel.min(rows.len().saturating_sub(1));
-                ui.issues.prune_picks();
+                // Split the borrow by hand: the sort reads the graph snapshot
+                // while it writes the panel, and both hang off `ui`.
+                let (issues, graph) = (&mut ui.issues, ui.graph.as_ref());
+                issues.adopt_rows(rows.clone(), graph, model.now_ms);
                 // The title reads from this, never from `page`: `page` is what
                 // was *asked for* and moves on the keypress, so a fetch that
                 // failed would leave the header naming a page whose rows are

--- a/crates/stella-tui/src/deck_ui/tests/issues.rs
+++ b/crates/stella-tui/src/deck_ui/tests/issues.rs
@@ -21,6 +21,7 @@ fn a_issue(key: &str) -> IssueRow {
         assignee: Some("@octocat".into()),
         url: format!("https://github.com/o/r/issues/{key}"),
         updated_at: None,
+        linked: None,
     }
 }
 
@@ -461,6 +462,68 @@ fn issues_list_ingest_folds_rows_clears_busy_and_drops_stale() {
         "{:?}",
         ui.issues.notice
     );
+}
+
+/// The witness for SPEC 9.4's heat sort: a list reply arrives in the tracker's
+/// order and is adopted in the graph's, heaviest first, with the caption flag
+/// the tab reads set. The graph is the deck's own snapshot — the same one the
+/// GRAPH tab ranks coupling from — so the ordering has a source to name.
+#[test]
+fn issues_list_ingest_orders_the_backlog_by_the_graphs_coupling() {
+    let mut model = WorkspaceModel::new();
+    model.now_ms = 1_770_940_800_000; // 2026-02-13T00:00:00Z
+    let mut ui = issues_ui();
+    ui.graph = Some(crate::scenario::demo_graph());
+    ui.issues.list_wait = 1;
+
+    let claimed = |key: &str, files: &[&str]| IssueRow {
+        updated_at: Some("2026-01-14T09:30:00Z".into()),
+        linked: Some(crate::envelope::LinkedWork {
+            touched_files: files.iter().map(|f| (*f).to_string()).collect(),
+            ..crate::scenario::demo_linked_work()
+        }),
+        ..a_issue(key)
+    };
+
+    ingest_inbound(
+        &Inbound::IssuesList {
+            seq: 1,
+            outcome: Ok(vec![
+                // The graph has never heard of this file, so the row keeps the
+                // tracker's place rather than being ranked against a guess.
+                claimed("#unknown", &["src/nowhere.rs"]),
+                a_issue("#unclaimed"),
+                claimed("#coupled", &["stella-core/src/driver.rs"]),
+            ]),
+        },
+        &mut model,
+        &mut ui,
+    );
+
+    let keys: Vec<&str> = ui.issues.rows.iter().map(|r| r.key.as_str()).collect();
+    assert_eq!(keys, vec!["#coupled", "#unknown", "#unclaimed"]);
+    assert!(ui.issues.heat_sorted, "the tab may caption this ordering");
+}
+
+/// With no graph loaded there is no coupling to sort by, so the tracker's own
+/// order stands and the tab draws no caption over it.
+#[test]
+fn issues_list_ingest_keeps_the_tracker_order_when_no_graph_is_loaded() {
+    let mut model = WorkspaceModel::new();
+    let mut ui = issues_ui();
+    ui.graph = None;
+    ui.issues.list_wait = 1;
+    ingest_inbound(
+        &Inbound::IssuesList {
+            seq: 1,
+            outcome: Ok(vec![a_issue("#3"), a_issue("#1"), a_issue("#2")]),
+        },
+        &mut model,
+        &mut ui,
+    );
+    let keys: Vec<&str> = ui.issues.rows.iter().map(|r| r.key.as_str()).collect();
+    assert_eq!(keys, vec!["#3", "#1", "#2"]);
+    assert!(!ui.issues.heat_sorted);
 }
 
 #[test]

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -541,6 +541,49 @@ pub struct IssueRow {
     pub assignee: Option<String>,
     pub url: String,
     pub updated_at: Option<String>,
+    /// The work this session started for the issue, once it has started any.
+    pub linked: Option<LinkedWork>,
+}
+
+/// The work one session claimed for an issue: what `w start work` opened, and
+/// what that claim's evidence ledger has recorded since (SPEC 9.4).
+///
+/// The ISSUES tab reads this three ways — the inline `plan r3 · task 3 live`
+/// tag on a row, the detail pane's `linked` line, and the
+/// [`touched_files`](Self::touched_files) the heat sort joins against the code
+/// graph (`crate::views::issues`).
+///
+/// **No producer fills it yet.** The deck's own start-work key is refused by
+/// name in `stella-cli`'s `command_deck::issues`'s `issues_act`, because the
+/// claim belongs to the self-driving loop's dispatch ledger rather than to a
+/// tracker status, and the plan-opening event that would name a round lost its
+/// producer when the staged pipeline was removed (#3865). #5197 is the read
+/// path from those ledgers to the deck. Until it lands, every row carries
+/// `None` here and the tab draws the tracker's own fields alone — which is why
+/// each field below is dropped from rendering when it is empty rather than
+/// printed as a zero.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LinkedWork {
+    /// The plan's round label, spelled as the plan panel spells it (`r3`).
+    /// Empty when the claim opened a branch before any plan existed.
+    pub plan: String,
+    /// Tasks that plan has finished.
+    pub tasks_done: usize,
+    /// Tasks that plan holds. Zero means "no plan to count", so the `2/6`
+    /// clause is dropped rather than rendered as `0/0`.
+    pub tasks_total: usize,
+    /// The 1-based task the loop is executing right now, when one is live.
+    pub live_task: Option<usize>,
+    /// The branch the claim opened. Empty when it has opened none.
+    pub branch: String,
+    /// Root-relative paths the evidence ledger recorded the work as touching.
+    /// The heat sort looks each one up in the code graph.
+    pub touched_files: Vec<String>,
+    /// Tests the evidence ledger holds passing.
+    pub tests_passed: usize,
+    /// Tests it ran. Zero drops the `4/4 tests` clause, for the same reason
+    /// [`tasks_total`](Self::tasks_total) does.
+    pub tests_total: usize,
 }
 
 /// One row of the create form's type-ahead popup. `kind` is a display type

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -117,7 +117,7 @@ pub use envelope::{
     AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, EngineAgentState,
     EngineConfigState, EngineRole, EntityField, EntityHit, GRAPH_SERVER, Inbound, InspectMessage,
     InspectSection, InspectView, InstalledAgentEntry, IssueAction, IssueRow, JournalEra,
-    LearnedProvenance, LearnedSource, McpLiveIdentity, McpLookupState, McpSearchItem,
+    LearnedProvenance, LearnedSource, LinkedWork, McpLiveIdentity, McpLookupState, McpSearchItem,
     McpSearchOutcome, McpServerDetail, McpServerInfo, McpSignature, McpSourceTier, McpToolRow,
     NotificationInfo, RecordedCallInfo, SeatRow, Secret, SessionInfo, SessionPhase, SkillOp,
     SkillRow, SkillScope, SkillSearchHit, SkillsView, SplashCue, ToolDenial, ToolPolicyState,

--- a/crates/stella-tui/src/scenario.rs
+++ b/crates/stella-tui/src/scenario.rs
@@ -12,7 +12,7 @@ use stella_protocol::{
     ScopeProposal, StageKind, ToolCall, ToolOutput, VerdictEvidence,
 };
 
-use crate::envelope::{AgentMeta, AgentStatus, Inbound};
+use crate::envelope::{AgentMeta, AgentStatus, Inbound, LinkedWork};
 use crate::graph::{GraphEdge, GraphNode, GraphSnapshot};
 use crate::plan::{ActualStep, EvidenceKind, EvidenceRow, PlanLanes, StepLedger, StepSpend};
 
@@ -94,6 +94,29 @@ pub fn demo_graph() -> GraphSnapshot {
         // than a made-up one.
         query_ms: None,
         query: None,
+    }
+}
+
+/// A sample claim for the ISSUES tab: the plan, branch and evidence one
+/// session opened for an issue (SPEC 9.4's `linked` line).
+///
+/// The touched file is a file node of [`demo_graph`], so a demo backlog
+/// carrying this link has a coupling the heat sort can actually read
+/// ([`crate::views::issues::heat`]) rather than a path the graph has never
+/// heard of.
+pub fn demo_linked_work() -> LinkedWork {
+    LinkedWork {
+        plan: "r3".into(),
+        tasks_done: 2,
+        tasks_total: 6,
+        live_task: Some(3),
+        branch: "fix/token-race".into(),
+        touched_files: vec![
+            "stella-core/src/driver.rs".into(),
+            "stella-core/src/engine.rs".into(),
+        ],
+        tests_passed: 4,
+        tests_total: 4,
     }
 }
 

--- a/crates/stella-tui/src/views.rs
+++ b/crates/stella-tui/src/views.rs
@@ -24,6 +24,7 @@ pub mod frame;
 pub mod graph;
 pub mod graph_tab;
 pub mod installed;
+pub mod issues;
 pub mod issues_tab;
 pub mod mcp_tab;
 pub mod models_card;

--- a/crates/stella-tui/src/views/issues.rs
+++ b/crates/stella-tui/src/views/issues.rs
@@ -378,6 +378,74 @@ mod tests {
         assert_eq!(keys, vec!["#3", "#1", "#2"]);
     }
 
+    /// Age multiplies: a lightly-coupled issue the tracker has not moved in
+    /// three months outranks a heavily-coupled one it moved last week.
+    ///
+    /// This is the half [`the_sort_ranks_by_heat_and_leaves_unranked_rows_in_tracker_order`]
+    /// cannot see — every row there shares one stamp, so a sort that dropped
+    /// the age term entirely would still pass it.
+    #[test]
+    fn an_old_lightly_coupled_issue_outranks_a_fresh_heavily_coupled_one() {
+        let snap = snapshot();
+        // One edge, ninety days: 2025-11-15 is 15 + 31 + 31 + 13 days before
+        // the 2026-02-13 the clock reads.
+        let aged = row(
+            "#aged",
+            Some("2025-11-15T00:00:00Z"),
+            Some(&["src/cold.rs"]),
+        );
+        assert_eq!(heat(&aged, Some(&snap), NOW_MS), Some(90));
+        // Three edges, ten days.
+        let fresh = row(
+            "#fresh",
+            Some("2026-02-03T00:00:00Z"),
+            Some(&["src/hot.rs"]),
+        );
+        assert_eq!(heat(&fresh, Some(&snap), NOW_MS), Some(3 * 10));
+
+        let mut rows = vec![fresh, aged];
+        assert!(sort_by_heat(&mut rows, Some(&snap), NOW_MS));
+        let keys: Vec<&str> = rows.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(keys, vec!["#aged", "#fresh"]);
+    }
+
+    /// Two rows of equal heat keep the order the tracker delivered them in,
+    /// whichever order that was.
+    ///
+    /// Asserted from both sides on purpose: an ordering that always emitted
+    /// `#by-coupling` first would satisfy one arrangement by accident. Running
+    /// the same pair swapped is what distinguishes a stable sort from a lucky
+    /// one, and stability is the whole reason a tie is not a reshuffle the
+    /// reader sees on every refresh.
+    #[test]
+    fn rows_of_equal_heat_keep_the_tracker_order_in_either_arrangement() {
+        let snap = snapshot();
+        // Three edges times ten days, and one edge times thirty: the same heat
+        // by two different routes.
+        let by_coupling = row(
+            "#by-coupling",
+            Some("2026-02-03T00:00:00Z"),
+            Some(&["src/hot.rs"]),
+        );
+        let by_age = row(
+            "#by-age",
+            Some("2026-01-14T09:30:00Z"),
+            Some(&["src/cold.rs"]),
+        );
+        assert_eq!(heat(&by_coupling, Some(&snap), NOW_MS), Some(30));
+        assert_eq!(heat(&by_age, Some(&snap), NOW_MS), Some(30));
+
+        let mut rows = vec![by_coupling.clone(), by_age.clone()];
+        assert!(sort_by_heat(&mut rows, Some(&snap), NOW_MS));
+        let keys: Vec<&str> = rows.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(keys, vec!["#by-coupling", "#by-age"]);
+
+        let mut rows = vec![by_age, by_coupling];
+        assert!(sort_by_heat(&mut rows, Some(&snap), NOW_MS));
+        let keys: Vec<&str> = rows.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(keys, vec!["#by-age", "#by-coupling"]);
+    }
+
     #[test]
     fn the_plan_tag_names_the_round_and_the_live_task() {
         let mut work = linked(&["src/hot.rs"]);

--- a/crates/stella-tui/src/views/issues.rs
+++ b/crates/stella-tui/src/views/issues.rs
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The ISSUES tab's heat sort and its linked-work text — SPEC 9.4.
+//!
+//! Heat is the code graph's coupling for the files an issue's linked work
+//! touched, times how long the issue has sat. Both terms are read off data the
+//! deck was handed: the coupling is an edge count in the [`GraphSnapshot`] the
+//! driver queried out of `codegraph.db`, and the age is the tracker's own
+//! stamp. Nothing here estimates, which is what earns [`HEAT_CAPTION`] — the
+//! same caption over a local heuristic would be a claim the code cannot keep.
+//!
+//! Split from [`super::issues_tab`] the way [`super::graph`] is split from
+//! [`super::graph_tab`]: a pure fold with no buffer and no terminal, of which
+//! the tab draws a projection.
+
+use crate::envelope::{IssueRow, LinkedWork};
+use crate::graph::{GraphNode, GraphSnapshot};
+
+/// What the tab prints under a heat-sorted backlog (SPEC 9.4).
+pub const HEAT_CAPTION: &str = "from the graph, not vibes";
+
+/// Milliseconds in a day.
+const DAY_MS: u64 = 86_400_000;
+
+/// The heat of one issue: the graph's coupling for every file its linked work
+/// touched, times the issue's age in days.
+///
+/// `None` when the question cannot be asked — the issue has no linked work, no
+/// graph has been loaded, or the loaded neighborhood holds none of the files
+/// the work touched. An unanswerable question is not a zero, and the sort
+/// below keeps those rows in the tracker's own order rather than ranking them
+/// against a number nobody computed.
+#[must_use]
+pub fn heat(row: &IssueRow, graph: Option<&GraphSnapshot>, now_ms: u64) -> Option<u64> {
+    let linked = row.linked.as_ref()?;
+    let graph = graph?;
+    let mut coupling: u64 = 0;
+    let mut answered = false;
+    for path in &linked.touched_files {
+        if let Some(edges) = file_coupling(graph, path) {
+            coupling += edges as u64;
+            answered = true;
+        }
+    }
+    if !answered {
+        return None;
+    }
+    Some(coupling.saturating_mul(age_days(row.updated_at.as_deref(), now_ms)))
+}
+
+/// The graph's coupling for one root-relative file: how many edges touch its
+/// node, in either direction.
+///
+/// Undirected for the reason [`super::graph::coupling`] states — blast radius
+/// counts an edge that points *at* the file as surely as one it points out
+/// with.
+///
+/// `None` when the loaded neighborhood holds no such file, which is a
+/// different answer from zero: an unqueried file has no coupling to report,
+/// and ranking it at the bottom would be a guess dressed as a measurement.
+#[must_use]
+pub fn file_coupling(graph: &GraphSnapshot, path: &str) -> Option<usize> {
+    graph
+        .nodes
+        .iter()
+        .position(|node| is_file(node, path))
+        .map(|index| graph.degree(index))
+}
+
+/// Whether `node` is the file at `path`.
+///
+/// A file node carries its root-relative path in
+/// [`location`](GraphNode::location) — `stella-cli`'s `agent::graph_view`
+/// builds every one of them that way — while
+/// [`label`](GraphNode::label) is a display name a producer may shorten to a
+/// basename. Matching on the location is what keeps `src/a/mod.rs` and
+/// `src/b/mod.rs` two files.
+fn is_file(node: &GraphNode, path: &str) -> bool {
+    node.kind == "file" && node.location.as_deref().unwrap_or(&node.label) == path
+}
+
+/// Days between the tracker's `updated` stamp and `now_ms`, floored at one.
+///
+/// One day rather than zero for an issue the tracker moved today: age is a
+/// multiplier, and a zero would rank the most coupled file in the workspace
+/// below an untouched one that happens to be a day older. An absent stamp gets
+/// the same floor, so an issue whose tracker reports no timestamp is ordered
+/// on its coupling alone instead of on a date nobody supplied.
+#[must_use]
+pub fn age_days(updated: Option<&str>, now_ms: u64) -> u64 {
+    let today = now_ms / DAY_MS;
+    updated
+        .and_then(civil_days)
+        .map(|then| today.saturating_sub(then))
+        .unwrap_or(0)
+        .max(1)
+}
+
+/// Days from 1970-01-01 to the `YYYY-MM-DD` prefix of `stamp`, or `None` when
+/// it does not begin with a well-formed one.
+///
+/// Howard Hinnant's `days_from_civil` closed form
+/// (<https://howardhinnant.github.io/date_algorithms.html>), so the one piece
+/// of calendar arithmetic this crate does costs it no date dependency.
+fn civil_days(stamp: &str) -> Option<u64> {
+    let mut parts = stamp.get(..10)?.split('-');
+    let year: i64 = parts.next()?.parse().ok()?;
+    let month: i64 = parts.next()?.parse().ok()?;
+    let day: i64 = parts.next()?.parse().ok()?;
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    // The era arithmetic shifts the year so that a leap day lands at the end.
+    let year = year - i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let day_of_year = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    u64::try_from(era * 146_097 + day_of_era - 719_468).ok()
+}
+
+/// Order `rows` by heat, heaviest first, and report whether any heat existed.
+///
+/// Rows the graph cannot speak for keep the tracker's order and sit below
+/// every row that has heat: the tracker's order is a real answer, and
+/// reshuffling it against a number that does not exist is exactly the vibes
+/// [`HEAT_CAPTION`] denies. The sort is stable, so rows sharing a heat keep
+/// that order too.
+///
+/// `false` means nothing moved — no row had a linked file the graph knows —
+/// and the tab then draws no caption, because there is no heat sort to caption.
+pub fn sort_by_heat(rows: &mut Vec<IssueRow>, graph: Option<&GraphSnapshot>, now_ms: u64) -> bool {
+    let mut ranked: Vec<(Option<u64>, IssueRow)> = std::mem::take(rows)
+        .into_iter()
+        .map(|row| (heat(&row, graph, now_ms), row))
+        .collect();
+    let sorted = ranked.iter().any(|(heat, _)| heat.is_some());
+    if sorted {
+        // `None` orders below `Some` for `Option`, so reversing the key puts
+        // the heaviest first and every unranked row last. `sort_by_key` is
+        // stable, which is what keeps the tracker's order inside a tie.
+        ranked.sort_by_key(|(heat, _)| std::cmp::Reverse(*heat));
+    }
+    rows.extend(ranked.into_iter().map(|(_, row)| row));
+    sorted
+}
+
+/// The inline plan tag an in-progress row carries: `plan r3 · task 3 live`.
+///
+/// Empty when the link names no plan — a claim that opened a branch before the
+/// first plan existed draws nothing here rather than a bare keyword.
+#[must_use]
+pub fn plan_tag(linked: &LinkedWork) -> String {
+    if linked.plan.is_empty() {
+        return String::new();
+    }
+    match linked.live_task {
+        Some(task) => format!("plan {} · task {task} live", linked.plan),
+        None => format!("plan {}", linked.plan),
+    }
+}
+
+/// The detail pane's `linked` line without its keyword:
+/// `plan r3 · 2/6 · branch fix/token-race · evidence 2 files · 4/4 tests`.
+///
+/// A clause whose fact is missing is dropped rather than printed empty: a link
+/// that opened a branch before its first plan reads `branch …` alone, and one
+/// whose evidence ledger is still empty says nothing about files or tests
+/// instead of claiming zero of them.
+#[must_use]
+pub fn linked_summary(linked: &LinkedWork) -> String {
+    let mut clauses: Vec<String> = Vec::new();
+    if !linked.plan.is_empty() {
+        clauses.push(format!("plan {}", linked.plan));
+        if linked.tasks_total > 0 {
+            clauses.push(format!("{}/{}", linked.tasks_done, linked.tasks_total));
+        }
+    }
+    if !linked.branch.is_empty() {
+        clauses.push(format!("branch {}", linked.branch));
+    }
+    let files = linked.touched_files.len();
+    if files > 0 {
+        clauses.push(format!(
+            "evidence {files} file{}",
+            if files == 1 { "" } else { "s" }
+        ));
+    }
+    if linked.tests_total > 0 {
+        clauses.push(format!(
+            "{}/{} tests",
+            linked.tests_passed, linked.tests_total
+        ));
+    }
+    clauses.join(" · ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::GraphEdge;
+
+    /// A neighborhood holding two file nodes: `hot.rs` with three edges,
+    /// `cold.rs` with one.
+    fn snapshot() -> GraphSnapshot {
+        let file = |path: &str| GraphNode {
+            label: path.to_string(),
+            kind: "file".into(),
+            location: Some(path.to_string()),
+        };
+        GraphSnapshot {
+            focus: "src/hot.rs".into(),
+            nodes: vec![
+                file("src/hot.rs"),
+                file("src/cold.rs"),
+                GraphNode {
+                    label: "run_turn".into(),
+                    kind: "function".into(),
+                    location: Some("src/hot.rs:12".into()),
+                },
+                GraphNode {
+                    label: "Engine".into(),
+                    kind: "struct".into(),
+                    location: Some("src/hot.rs:40".into()),
+                },
+            ],
+            edges: vec![
+                GraphEdge {
+                    from: 0,
+                    to: 2,
+                    kind: "defines".into(),
+                },
+                GraphEdge {
+                    from: 0,
+                    to: 3,
+                    kind: "defines".into(),
+                },
+                GraphEdge {
+                    from: 1,
+                    to: 0,
+                    kind: "imports".into(),
+                },
+            ],
+            files: vec!["src/hot.rs".into(), "src/cold.rs".into()],
+            query_ms: None,
+            query: None,
+        }
+    }
+
+    fn linked(files: &[&str]) -> LinkedWork {
+        LinkedWork {
+            plan: "r3".into(),
+            tasks_done: 2,
+            tasks_total: 6,
+            live_task: Some(3),
+            branch: "fix/token-race".into(),
+            touched_files: files.iter().map(|f| (*f).to_string()).collect(),
+            tests_passed: 4,
+            tests_total: 4,
+        }
+    }
+
+    fn row(key: &str, updated: Option<&str>, files: Option<&[&str]>) -> IssueRow {
+        IssueRow {
+            key: key.into(),
+            title: format!("title of {key}"),
+            state: "open".into(),
+            labels: Vec::new(),
+            assignee: None,
+            url: String::new(),
+            updated_at: updated.map(str::to_string),
+            linked: files.map(linked),
+        }
+    }
+
+    /// 2026-02-13T00:00:00Z — thirty days after the stamps below.
+    const NOW_MS: u64 = 1_770_940_800_000;
+
+    #[test]
+    fn coupling_counts_every_edge_touching_a_file_in_either_direction() {
+        let snap = snapshot();
+        // `src/hot.rs` defines two symbols and is imported once.
+        assert_eq!(file_coupling(&snap, "src/hot.rs"), Some(3));
+        assert_eq!(file_coupling(&snap, "src/cold.rs"), Some(1));
+        // A file the loaded neighborhood never mentions has no coupling to
+        // report, which is not the same statement as "no coupling".
+        assert_eq!(file_coupling(&snap, "src/absent.rs"), None);
+        // A symbol node is not its file, even though its location names one.
+        assert_eq!(file_coupling(&snap, "src/hot.rs:12"), None);
+    }
+
+    #[test]
+    fn heat_is_coupling_times_age_in_days() {
+        let snap = snapshot();
+        let hot = row("#1", Some("2026-01-14T09:30:00Z"), Some(&["src/hot.rs"]));
+        assert_eq!(heat(&hot, Some(&snap), NOW_MS), Some(3 * 30));
+
+        // Two touched files add their coupling before the age multiplies it.
+        let both = row(
+            "#2",
+            Some("2026-01-14T09:30:00Z"),
+            Some(&["src/hot.rs", "src/cold.rs"]),
+        );
+        assert_eq!(heat(&both, Some(&snap), NOW_MS), Some((3 + 1) * 30));
+    }
+
+    #[test]
+    fn heat_is_unanswerable_without_a_link_a_graph_or_a_known_file() {
+        let snap = snapshot();
+        let unlinked = row("#1", Some("2026-01-14T09:30:00Z"), None);
+        assert_eq!(heat(&unlinked, Some(&snap), NOW_MS), None);
+
+        let linked = row("#2", Some("2026-01-14T09:30:00Z"), Some(&["src/hot.rs"]));
+        assert_eq!(heat(&linked, None, NOW_MS), None, "no graph loaded");
+
+        let elsewhere = row("#3", Some("2026-01-14T09:30:00Z"), Some(&["src/absent.rs"]));
+        assert_eq!(heat(&elsewhere, Some(&snap), NOW_MS), None);
+    }
+
+    #[test]
+    fn age_floors_at_a_day_so_a_fresh_issue_still_ranks_on_coupling() {
+        // Moved today: zero days elapsed, and a zero multiplier would erase
+        // the coupling term entirely.
+        assert_eq!(age_days(Some("2026-02-13T00:00:00Z"), NOW_MS), 1);
+        // Never stamped: the same floor, so the ordering is coupling alone.
+        assert_eq!(age_days(None, NOW_MS), 1);
+        // A stamp in the future is not a negative age.
+        assert_eq!(age_days(Some("2030-01-01"), NOW_MS), 1);
+        // Unparseable text is treated as no stamp at all.
+        assert_eq!(age_days(Some("last tuesday"), NOW_MS), 1);
+        assert_eq!(age_days(Some("2026-13-01T00:00:00Z"), NOW_MS), 1);
+
+        assert_eq!(age_days(Some("2026-01-14T09:30:00Z"), NOW_MS), 30);
+        assert_eq!(age_days(Some("2025-02-13T00:00:00Z"), NOW_MS), 365);
+    }
+
+    #[test]
+    fn civil_days_matches_known_epoch_days() {
+        assert_eq!(civil_days("1970-01-01"), Some(0));
+        // 2000-03-01 crosses the century leap rule the era arithmetic exists
+        // for: 2000 is a leap year, 1900 was not.
+        assert_eq!(civil_days("2000-03-01"), Some(11017));
+        assert_eq!(civil_days("2026-01-01"), Some(20454));
+        // Before the epoch there is no non-negative day count to return.
+        assert_eq!(civil_days("1969-12-31"), None);
+        assert_eq!(civil_days("2026-01"), None);
+    }
+
+    #[test]
+    fn the_sort_ranks_by_heat_and_leaves_unranked_rows_in_tracker_order() {
+        let snap = snapshot();
+        let mut rows = vec![
+            row(
+                "#cold",
+                Some("2026-01-14T09:30:00Z"),
+                Some(&["src/cold.rs"]),
+            ),
+            row("#none-a", Some("2020-01-01T00:00:00Z"), None),
+            row("#hot", Some("2026-01-14T09:30:00Z"), Some(&["src/hot.rs"])),
+            row("#none-b", Some("2019-01-01T00:00:00Z"), None),
+        ];
+        assert!(sort_by_heat(&mut rows, Some(&snap), NOW_MS));
+        let keys: Vec<&str> = rows.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(keys, vec!["#hot", "#cold", "#none-a", "#none-b"]);
+    }
+
+    #[test]
+    fn a_backlog_the_graph_cannot_speak_for_keeps_its_order_and_reports_no_sort() {
+        let snap = snapshot();
+        let mut rows = vec![
+            row("#3", Some("2020-01-01T00:00:00Z"), None),
+            row("#1", Some("2026-01-14T09:30:00Z"), None),
+            row("#2", None, Some(&["src/absent.rs"])),
+        ];
+        assert!(!sort_by_heat(&mut rows, Some(&snap), NOW_MS));
+        let keys: Vec<&str> = rows.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(keys, vec!["#3", "#1", "#2"]);
+    }
+
+    #[test]
+    fn the_plan_tag_names_the_round_and_the_live_task() {
+        let mut work = linked(&["src/hot.rs"]);
+        assert_eq!(plan_tag(&work), "plan r3 · task 3 live");
+
+        // Nothing running: the round alone, with no dangling separator.
+        work.live_task = None;
+        assert_eq!(plan_tag(&work), "plan r3");
+
+        // A branch claimed before any plan draws no tag at all.
+        work.plan = String::new();
+        assert!(plan_tag(&work).is_empty());
+    }
+
+    #[test]
+    fn the_linked_line_reads_plan_progress_branch_and_evidence() {
+        let work = linked(&["src/hot.rs", "src/cold.rs"]);
+        assert_eq!(
+            linked_summary(&work),
+            "plan r3 · 2/6 · branch fix/token-race · evidence 2 files · 4/4 tests"
+        );
+    }
+
+    #[test]
+    fn an_empty_evidence_ledger_says_nothing_rather_than_claiming_zero() {
+        let work = LinkedWork {
+            plan: String::new(),
+            tasks_done: 0,
+            tasks_total: 0,
+            live_task: None,
+            branch: "fix/token-race".into(),
+            touched_files: Vec::new(),
+            tests_passed: 0,
+            tests_total: 0,
+        };
+        assert_eq!(linked_summary(&work), "branch fix/token-race");
+
+        // One file is one file, not "1 files".
+        let one = LinkedWork {
+            touched_files: vec!["src/hot.rs".into()],
+            ..work
+        };
+        assert_eq!(
+            linked_summary(&one),
+            "branch fix/token-race · evidence 1 file"
+        );
+    }
+}

--- a/crates/stella-tui/src/views/issues_tab.rs
+++ b/crates/stella-tui/src/views/issues_tab.rs
@@ -6,39 +6,35 @@
 //! status, and start work — all without leaving the deck.
 //!
 //! ```text
-//!  backlog · 3 listed
+//!  backlog · 3 listed · heat sort
+//!    from the graph, not vibes
 //!   ⇢ #981 open · CI … running
 //!
-//!     ○ #874   Command-deck render golden tests   open · dev · enhancement
-//! ▸   ○ #826   run_deck event-loop pty harness     open · enhancement
+//! ▸   ▶ #826   run_deck event-loop pty harness   in progress · enhancement  plan r3 · task 3 live
+//!     ○ #874   Command-deck render golden tests  open · dev · enhancement
 //!
-//!  ○ #826  run_deck event-loop pty harness
-//!    open · enhancement · updated 2026-01-14T09:30:00Z
+//!  ▶ #826  run_deck event-loop pty harness
+//!    in progress · enhancement · updated 2026-01-14T09:30:00Z
+//!    linked plan r3 · 2/6 · branch fix/token-race · evidence 2 files · 4/4 tests
 //!    ↵ open · c comment · s status · p to prompt
 //! ```
 //!
-//! Renders from [`crate::deck_ui::IssuesPanel`] and the session's own PR — a
-//! pure fold over both, taking no `DeckUi` and mutating nothing, so a mode,
-//! a form field or a type-ahead window can be pinned in a test without a
-//! terminal. The driver services the [`crate::envelope::WorkspaceInput`]
-//! requests the key handlers emit and answers with out-of-band
-//! [`crate::envelope::Inbound::IssuesList`] / `IssueActDone` / `EntityHits`
-//! snapshots.
+//! A pure fold over [`crate::deck_ui::IssuesPanel`] and the session's own PR,
+//! taking no `DeckUi` and mutating nothing, so a mode, a form field or a
+//! type-ahead window can be pinned in a test without a terminal; the driver
+//! answers the key handlers' requests with out-of-band
+//! [`crate::envelope::Inbound::IssuesList`] snapshots. The row order is
+//! [`super::issues`]'s heat sort, applied as a list arrives
+//! ([`IssuesPanel::adopt_rows`](crate::deck_ui::IssuesPanel::adopt_rows)) and
+//! captioned here only while it is in force. The tab draws no frame: the tab
+//! row, hint row, pulse row and status bar are [`super::frame`]'s.
 //!
-//! The tab draws no frame of its own: the tab row, hint row, pulse row and
-//! status bar are [`super::frame`]'s, and the content fills the band they
-//! leave. The two popups below — the create form's type-ahead and the
-//! send-to-prompt confirmation — are floating cards over that band, not
-//! chrome around it.
-//!
-//! ## State glyphs
-//!
-//! SPEC 9.4 gives the tracker its own four-state alphabet — `▶` in progress,
-//! `○` open or triage, `✓` done, `◇` blocked — kept here as literals rather
-//! than mapped onto [`stella_tui_theme::glyph`]. Three of the four coincide
-//! with an agent-status glyph by shape alone: taking `glyph::GATE` for
-//! "blocked" would assert that a tracker state and an engine gate must move
-//! together, which is not true of either.
+//! SPEC 9.4's four tracker states — `▶` in progress, `○` open or triage, `✓`
+//! done, `◇` blocked — are literals here rather than
+//! [`stella_tui_theme::glyph`] entries. Three coincide with an agent-status
+//! glyph by shape alone, and taking `glyph::GATE` for "blocked" would assert
+//! that a tracker state and an engine gate must move together, which is true
+//! of neither.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -94,7 +90,19 @@ pub fn render(
             muted,
         ));
     }
+    if issues.heat_sorted {
+        head.push(Span::styled(" · heat sort", muted));
+    }
     let mut lines: Vec<Line<'static>> = vec![Line::from(head)];
+    // The caption only exists while the ordering it describes does: a backlog
+    // the graph could not rank is in the tracker's order, and captioning that
+    // `from the graph` would be the claim SPEC 9.4 wrote the caption against.
+    if issues.heat_sorted {
+        lines.push(Line::from(Span::styled(
+            format!("   {}", super::issues::HEAT_CAPTION),
+            dim,
+        )));
+    }
     // The session's own PR, above whatever mode the tab is in — it is a fact
     // about this session, not about the list, so a search or a half-filled
     // create form must not hide it.
@@ -344,11 +352,23 @@ fn render_list(issues: &IssuesPanel, accessible: bool, area: Rect, lines: &mut V
 /// bare trailing `· octocat · bug, p1` has the same problem: two lists with no
 /// indication of which is which.
 fn issue_record(row: &IssueRow, selected: bool, width: usize) -> Line<'static> {
+    let linked = row.linked.as_ref();
     let fields = [
         ("state", row.state.clone()),
         ("title", row.title.clone()),
         ("assignee", row.assignee.clone().unwrap_or_default()),
         ("labels", row.labels.join(", ")),
+        // The plan and its live task as two labelled values rather than the
+        // sighted row's `plan r3 · task 3 live` tag, which read aloud after a
+        // `plan` label would say the word twice.
+        ("plan", linked.map(|l| l.plan.clone()).unwrap_or_default()),
+        (
+            "task",
+            linked
+                .and_then(|l| l.live_task)
+                .map(|task| format!("{task} live"))
+                .unwrap_or_default(),
+        ),
     ];
     super::record::record_line(
         super::record::identity(row.key.clone(), selected, token::GOLD),
@@ -357,9 +377,14 @@ fn issue_record(row: &IssueRow, selected: bool, width: usize) -> Line<'static> {
     )
 }
 
-/// One issue row: `▸ ▶ KEY  title   state   assignee · labels   age` — the
-/// state's glyph beside the key, `●` marking a multiselect pick, `▸` the
-/// cursor.
+/// One issue row: `▸ ▶ KEY  title   state   assignee · labels  plan r3 · task
+/// 3 live   age` — the state's glyph beside the key, `●` marking a multiselect
+/// pick, `▸` the cursor.
+///
+/// The plan tag appears only on a row whose work this session claimed (SPEC
+/// 9.4's inline linked plan), and it is gold while a task is live: the word
+/// `live` carries the same claim, so the tone is never the only thing saying
+/// so (SPEC 2).
 fn issue_line(row: &IssueRow, selected: bool, picked: bool, width: usize) -> Line<'static> {
     let dim = Style::new().fg(token::DIM);
     let muted = Style::new().fg(token::MUTED);
@@ -388,12 +413,32 @@ fn issue_line(row: &IssueRow, selected: bool, picked: bool, width: usize) -> Lin
     let head = format!("{marker}{pick}");
     let key = format!("{:<10}", row.key);
     let state = format!("  {}", row.state);
+    let (plan, plan_style) = match &row.linked {
+        Some(linked) => {
+            let tag = super::issues::plan_tag(linked);
+            let style = if linked.live_task.is_some() {
+                Style::new().fg(token::GOLD)
+            } else {
+                muted
+            };
+            (
+                if tag.is_empty() {
+                    String::new()
+                } else {
+                    format!("  {tag}")
+                },
+                style,
+            )
+        }
+        None => (String::new(), muted),
+    };
     let budget = width
         .saturating_sub(
             head.chars().count()
                 + 2
                 + key.chars().count()
                 + state.chars().count()
+                + plan.chars().count()
                 + tail.chars().count()
                 + age.chars().count()
                 + 3,
@@ -407,6 +452,10 @@ fn issue_line(row: &IssueRow, selected: bool, picked: bool, width: usize) -> Lin
         Span::styled(title.clone(), body_style),
         Span::styled(state, glyph_style),
         Span::styled(tail, muted),
+        // After the tracker's own fields, not among them: the tail is a run of
+        // `·`-joined clauses, and a plan dropped into the middle of it reads as
+        // one more label.
+        Span::styled(plan, plan_style),
     ];
     if !age.is_empty() {
         let used: usize = spans.iter().map(Span::width).sum();
@@ -438,12 +487,21 @@ fn state_mark(state: &str) -> (char, Style) {
 }
 
 /// Rows the detail pane spends under the list.
-const DETAIL_ROWS: usize = 5;
+const DETAIL_ROWS: usize = 6;
 
 /// The selected issue, in full: key and title, then assignee, labels, the
-/// tracker URL and when it last moved — the fields the one-line row
-/// truncates. SPEC 9.4's linked-plan and evidence lines have no producer
-/// yet (#4336).
+/// tracker URL, when it last moved, and the `linked` line naming the work this
+/// session claimed for it — the fields the one-line row truncates.
+///
+/// SPEC 9.4 pairs that `linked` line with a sync rule reading `status syncs
+/// back to <tracker> on gate green · no manual updates`. **The rule is not
+/// drawn here, because nothing in this workspace keeps it.** No outbound
+/// update writes a tracker status when a gate goes green: `stella-cli`'s
+/// `command_deck::issues`'s `issues_act` reaches the tracker only for a
+/// comment, a close and a re-open, each on a keypress a human made, and it
+/// refuses `IssueAction::SetStatus` outright. Printing the sentence anyway
+/// would promise a reader that closing their terminal still moves the ticket.
+/// #5195 is the outbound update; the line lands with it.
 fn render_detail(issues: &IssuesPanel, width: usize, lines: &mut Vec<Line<'static>>) {
     let Some(row) = issues.selected() else {
         return;
@@ -481,6 +539,15 @@ fn render_detail(issues: &IssuesPanel, width: usize, lines: &mut Vec<Line<'stati
             Span::raw("   "),
             Span::styled(truncate(&row.url, width.saturating_sub(4)), dim),
         ]));
+    }
+    if let Some(linked) = &row.linked {
+        let summary = super::issues::linked_summary(linked);
+        if !summary.is_empty() {
+            lines.push(Line::from(vec![
+                Span::styled("   linked ", muted),
+                Span::styled(truncate(&summary, width.saturating_sub(11)), text),
+            ]));
+        }
     }
     lines.push(Line::from(vec![
         Span::styled("   ↵", muted),
@@ -812,6 +879,23 @@ mod tests {
             assignee: Some("mona@example.com".into()),
             url: String::new(),
             updated_at: None,
+            linked: None,
+        }
+    }
+
+    /// SPEC 9.4's claim: plan `r3`, two of six tasks done with the third live,
+    /// a branch, and an evidence ledger holding two files and four passing
+    /// tests.
+    fn claimed() -> crate::envelope::LinkedWork {
+        crate::envelope::LinkedWork {
+            plan: "r3".into(),
+            tasks_done: 2,
+            tasks_total: 6,
+            live_task: Some(3),
+            branch: "fix/token-race".into(),
+            touched_files: vec!["src/token.rs".into(), "src/race.rs".into()],
+            tests_passed: 4,
+            tests_total: 4,
         }
     }
 
@@ -852,5 +936,119 @@ mod tests {
         assert!(drawn.contains("backlog · 1 listed"), "{drawn}");
         assert!(drawn.contains("ENG-42"), "{drawn}");
         assert!(drawn.contains("start work"), "{drawn}");
+    }
+
+    /// Render the whole tab and return its character grid, one string.
+    fn drawn(issues: &IssuesPanel, accessible: bool) -> String {
+        let area = Rect::new(0, 0, 120, 24);
+        let mut buf = Buffer::empty(area);
+        render(None, issues, accessible, area, &mut buf);
+        (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The witness for SPEC 9.4's linked plan and evidence summary: a row whose
+    /// work this session claimed carries the plan and its live task inline, and
+    /// the detail pane spells the whole claim out on its `linked` line. Both
+    /// assertions read rendered cells, so a tab that holds the link and draws
+    /// none of it fails here.
+    #[test]
+    fn a_claimed_row_draws_its_plan_inline_and_its_evidence_in_the_detail_pane() {
+        let mut issues = IssuesPanel::default();
+        issues.rows = vec![IssueRow {
+            linked: Some(claimed()),
+            ..eng_42()
+        }];
+        issues.loaded = true;
+        let frame = drawn(&issues, false);
+
+        assert!(frame.contains("plan r3 · task 3 live"), "{frame}");
+        assert!(
+            frame.contains(
+                "linked plan r3 · 2/6 · branch fix/token-race · evidence 2 files · 4/4 tests"
+            ),
+            "{frame}"
+        );
+    }
+
+    /// The sync rule SPEC 9.4 pairs with the `linked` line is not drawn: no
+    /// outbound update writes a tracker status when a gate goes green (#5195),
+    /// and a promise the code cannot keep is worse than a missing line.
+    #[test]
+    fn the_detail_pane_promises_no_sync_it_cannot_perform() {
+        let mut issues = IssuesPanel::default();
+        issues.rows = vec![IssueRow {
+            linked: Some(claimed()),
+            ..eng_42()
+        }];
+        issues.loaded = true;
+        let frame = drawn(&issues, false);
+        assert!(!frame.contains("syncs back"), "{frame}");
+        assert!(!frame.contains("gate green"), "{frame}");
+    }
+
+    /// A row nobody claimed draws exactly what it drew before — no keyword
+    /// with nothing after it, and no caption over a tracker-ordered list.
+    #[test]
+    fn an_unclaimed_backlog_draws_no_linked_line_and_no_heat_caption() {
+        let mut issues = IssuesPanel::default();
+        issues.rows = vec![eng_42()];
+        issues.loaded = true;
+        let frame = drawn(&issues, false);
+        assert!(!frame.contains("linked"), "{frame}");
+        assert!(
+            !frame.contains(crate::views::issues::HEAT_CAPTION),
+            "{frame}"
+        );
+        assert!(!frame.contains("heat sort"), "{frame}");
+    }
+
+    /// The caption is a claim about where the ordering came from, so it is
+    /// drawn only while the heat sort is the ordering in force.
+    #[test]
+    fn a_heat_sorted_backlog_says_where_the_order_came_from() {
+        let mut issues = IssuesPanel::default();
+        issues.rows = vec![IssueRow {
+            linked: Some(claimed()),
+            ..eng_42()
+        }];
+        issues.loaded = true;
+        issues.heat_sorted = true;
+        let frame = drawn(&issues, false);
+        assert!(frame.contains("heat sort"), "{frame}");
+        assert!(
+            frame.contains(crate::views::issues::HEAT_CAPTION),
+            "{frame}"
+        );
+    }
+
+    #[test]
+    fn a_claimed_row_names_its_plan_and_live_task_as_labelled_values() {
+        let row = IssueRow {
+            linked: Some(claimed()),
+            ..eng_42()
+        };
+        let record = text(issue_record(&row, false, 200));
+        assert!(record.contains("· plan r3"), "{record}");
+        assert!(record.contains("· task 3 live"), "{record}");
+        // A claim with no plan drops both labels rather than speaking them
+        // with nothing after.
+        let bare = IssueRow {
+            linked: Some(crate::envelope::LinkedWork {
+                plan: String::new(),
+                live_task: None,
+                ..claimed()
+            }),
+            ..eng_42()
+        };
+        let record = text(issue_record(&bare, false, 200));
+        assert!(!record.contains("plan"), "{record}");
+        assert!(!record.contains("task"), "{record}");
     }
 }

--- a/crates/stella-tui/tests/accessible_tables.rs
+++ b/crates/stella-tui/tests/accessible_tables.rs
@@ -21,6 +21,7 @@ use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 
 use stella_protocol::AgentEvent;
+use stella_tui::scenario::demo_linked_work;
 use stella_tui::{
     AgentMeta, AgentScope, DeckTab, DeckUi, Inbound, InstalledAgentEntry, IssueRow, SettingsPane,
     ToolPolicyState, ToolRow, WorkspaceModel, ingest_inbound, render_deck,
@@ -149,6 +150,7 @@ fn the_issues_list_reads_as_labelled_records() {
                 assignee: Some("macanderson".into()),
                 url: "https://example.invalid/1258".into(),
                 updated_at: None,
+                linked: Some(demo_linked_work()),
             }]),
         },
         &mut model,
@@ -156,7 +158,18 @@ fn the_issues_list_reads_as_labelled_records() {
     );
 
     let row = record_row(&frame(&model, &mut ui), "make the command deck accessible");
-    assert_labelled(&row, &["state", "title", "assignee", "labels"]);
+    // The linked plan and its live task are labelled values here, never the
+    // sighted row's `plan r3 · task 3 live` tag: a `plan` label in front of
+    // that tag says the word twice, and the bare `3` after it is a number a
+    // reader has to guess the meaning of.
+    assert_labelled(
+        &row,
+        &["state", "title", "assignee", "labels", "plan", "task"],
+    );
+    assert!(
+        !row.contains("plan plan"),
+        "the label carries the word, the value does not repeat it: {row:?}"
+    );
     assert!(
         !row.contains("[open]"),
         "the state chip's brackets are punctuation read aloud: {row:?}"

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -61,7 +61,7 @@ use ratatui::backend::TestBackend;
 
 use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
 use stella_tui::Inbound;
-use stella_tui::scenario::{demo_graph, demo_inbound};
+use stella_tui::scenario::{demo_graph, demo_inbound, demo_linked_work};
 use stella_tui::{
     DeckTab, DeckUi, IssueRow, ResourceSample, ScopeAction, SettingsPane, SkillPrompt, SkillRow,
     SkillScope, SkillsView, ToolDenial, ToolPolicyState, ToolRow, ToolScope, WorkspaceModel,
@@ -436,6 +436,12 @@ fn fixture_agents() -> Vec<stella_tui::InstalledAgentEntry> {
     ]
 }
 
+/// The wall clock the ISSUES golden's heat sort ages against:
+/// 2026-02-13T00:00:00Z, thirty days after `fixture_issues`' fixed stamp. A
+/// live clock would make the age term — and so the ordering — drift with the
+/// calendar under a golden that is meant to be exact.
+const GOLDEN_NOW_MS: u64 = 1_770_940_800_000;
+
 fn fixture_issues() -> Vec<IssueRow> {
     let issue = |key: &str, title: &str, state: &str, labels: &[&str], assignee: Option<&str>| {
         IssueRow {
@@ -448,6 +454,7 @@ fn fixture_issues() -> Vec<IssueRow> {
             // A fixed stamp: `updated_at` is a rendered string, so a live one
             // would age the golden out from under the suite.
             updated_at: Some("2026-01-14T09:30:00Z".to_string()),
+            linked: None,
         }
     };
     vec![
@@ -458,13 +465,20 @@ fn fixture_issues() -> Vec<IssueRow> {
             &["enhancement", "area:tui"],
             Some("dev"),
         ),
-        issue(
-            "#826",
-            "run_deck event-loop pty harness",
-            "open",
-            &["enhancement"],
-            None,
-        ),
+        IssueRow {
+            // The one claimed row, so the golden pins SPEC 9.4's three linked
+            // surfaces at once: the inline `plan r3 · task 3 live` tag, the
+            // detail pane's `linked` line, and the heat sort lifting it over
+            // a backlog the graph cannot rank.
+            linked: Some(demo_linked_work()),
+            ..issue(
+                "#826",
+                "run_deck event-loop pty harness",
+                "in progress",
+                &["enhancement"],
+                None,
+            )
+        },
         issue(
             "#689",
             "Surface per-server MCP tool truncation",
@@ -525,10 +539,17 @@ fn ui_for(tab: DeckTab) -> DeckUi {
             ui.skills.sel = 1;
         }
         DeckTab::Mcp => ui.mcp.servers = mcp::fixture_mcp_servers(),
+        // Through `adopt_rows` rather than by assignment, so the golden is of
+        // the ordering the deck actually applies (`views::issues::sort_by_heat`)
+        // rather than of a list a fixture hand-ordered. The claimed row sorts
+        // to the top, and the cursor sits on it so the detail pane draws its
+        // `linked` line.
         DeckTab::Issues => {
-            ui.issues.rows = fixture_issues();
+            let graph = ui.graph.clone();
+            ui.issues
+                .adopt_rows(fixture_issues(), graph.as_ref(), GOLDEN_NOW_MS);
             ui.issues.loaded = true;
-            ui.issues.sel = 1;
+            ui.issues.sel = 0;
         }
         // Lands on the AGENTS pane; `settings_tools_pane` pins the other one.
         DeckTab::Settings => ui.tools.state = Some(fixture_tool_policy()),

--- a/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_issues.txt
@@ -4,22 +4,22 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION AGENTS TRACES GRAPH FILES SKILLS MCP   ISSUES   SETTINGS                                                                                       stella*
- backlog · 3 listed
+ backlog · 3 listed · heat sort
+   from the graph, not vibes
   ⇢ #981 open · CI … running
 
+▸   ▶ #826      run_deck event-loop pty harness  in progress · enhancement  plan r3 · task 3 live                                                    2026-01-14
     ○ #874      Command-deck render golden tests  open · dev · enhancement, area:tui                                                                 2026-01-14
-▸   ○ #826      run_deck event-loop pty harness  open · enhancement                                                                                  2026-01-14
     ✓ #689      Surface per-server MCP tool truncation  closed · dev · bug                                                                           2026-01-14
 
- ○ #826  run_deck event-loop pty harness
-   open · enhancement · updated 2026-01-14T09:30:00Z
+ ▶ #826  run_deck event-loop pty harness
+   in progress · enhancement · updated 2026-01-14T09:30:00Z
    https://github.com/example/repo/issues/826
+   linked plan r3 · 2/6 · branch fix/token-race · evidence 2 files · 4/4 tests
    ↵ open · c comment · s status · p to prompt
 
  w start work   on the selected issue → stella drafts the plan from the issue and the graph, and waits for your approval before touching code
  ↑↓ select · w start work · n new issue · / search tracker · r refresh · ]/[ page · space pick · p send to prompt · x close / reopen
-
-
 
 
 


### PR DESCRIPTION
## What & why

SPEC 9.4 asks the ISSUES backlog for three things the tab did not have: an
inline `plan r3 · task 3 live` tag on a claimed row, a `linked` line in the
detail pane naming that claim's branch and evidence, and a default ordering by
the code graph's coupling for the files the claim touched, times the issue's
age — captioned `from the graph, not vibes`.

- **`IssueRow` gains `linked: Option<LinkedWork>`** (`crates/stella-tui/src/envelope.rs`):
  the plan round and its live task, tasks done/total, the branch, the files the
  evidence ledger recorded as touched, and tests passed/total.
- **`crates/stella-tui/src/views/issues.rs`** is the pure fold over it —
  coupling, age, the sort, and the two text formats. Split from `issues_tab.rs`
  the way `views/graph.rs` is split from `views/graph_tab.rs`, which is the
  neighbour this file is modelled on: a ranking with no buffer and no terminal,
  of which the tab draws a projection.
- **`IssuesPanel::adopt_rows`** applies the ordering once, as a list arrives,
  and reports whether it ran.

### The heat genuinely comes from the graph

`heat = Σ coupling(touched file) × age in days`.

The coupling term is an edge count on a **file node of the deck's own
`GraphSnapshot`** — the neighborhood `stella-cli`'s `agent::graph_view` queried
out of `codegraph.db` and handed over, the same read-model the GRAPH tab ranks
coupling from. Matching is on the node's `location` (its root-relative path),
not its `label`, so `src/a/mod.rs` and `src/b/mod.rs` stay two files. A file the
loaded neighborhood does not hold returns `None`, not zero — an unqueried file
has no coupling to report, and ranking it at the bottom would be a guess dressed
as a measurement. A row with no coupling at all keeps the tracker's order, below
every ranked row, and `heat_sorted` comes back `false`, which is what suppresses
the caption. Nothing here estimates, so the caption is a claim the code keeps.

The age term reads the `YYYY-MM-DD` prefix of the tracker's stamp through
Howard Hinnant's `days_from_civil` closed form, so the one piece of calendar
arithmetic this crate does costs it no date dependency. It floors at one day:
age is a multiplier, and a zero would rank the most coupled file in the
workspace below an untouched one that happens to be a day older.

`stella-tui` still links no graph backend — the join is against data the driver
already gives the deck.

Closes #4336 — with the remainder split into #5195, #5196 and #5197 rather than
carried, which is the path SCR-004 asks for. Read the next section before
merging: the surfaces this issue names are complete and tested; the data behind
two of them is a separate piece of work.

## What is deliberately not here

This issue carries `blocked`, and two of its parts have no producer in the tree.
Neither is stubbed:

- **The sync rule is not drawn.** SPEC 9.4 pairs the `linked` line with
  `status syncs back to <tracker> on gate green · no manual updates`. Nothing
  writes a tracker status on a gate verdict: `issues_act`
  (`crates/stella-cli/src/command_deck/issues.rs`) reaches the tracker for a
  comment, a close and a re-open, each on a keypress a human made, and refuses
  `IssueAction::SetStatus` outright. Drawing the sentence would promise a reader
  that closing their terminal still moves the ticket. `render_detail`'s doc
  comment records the elision and `the_detail_pane_promises_no_sync_it_cannot_perform`
  pins it, so the line cannot creep back in without deleting that test. **#5195.**
- **`IssueRow::linked` has no producer.** The claim lives in the self-driving
  loop's dispatch ledger; the deck's `w start work` is refused by name from
  standing in for it, and the plan-opening event lost its producer with the
  staged pipeline (#3865). Every row is `None` today, so in the running product
  the tab draws the tracker's fields alone and the backlog keeps the tracker's
  order. Every consumer is built and tested; the wiring is **#5197**.
- **`IssueRow::updated_at` is never populated** either — the port carries
  `created_at` and no update stamp, and dating an issue by when it was filed is
  a different fact. The age term therefore sits on its floor even once a link
  exists, and the ordering is coupling alone. **#5196.**

So `Closes #4336` here means the *view* work is done — the row tag, the `linked`
line, the heat sort and its caption are in the tree and pinned by tests. Until
#5197 lands there is nothing to link, so a user running against a real tracker
sees the backlog exactly as they do today. If you would rather #4336 stay open
until the tab visibly changes for a user, say so on the PR and I will drop the
closing keyword.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Three, in `crates/stella-tui/src/views/issues_tab.rs` and
`crates/stella-tui/src/deck_ui/tests/issues.rs`:

- `a_claimed_row_draws_its_plan_inline_and_its_evidence_in_the_detail_pane` —
  reads the rendered character grid for `plan r3 · task 3 live` and for
  `linked plan r3 · 2/6 · branch fix/token-race · evidence 2 files · 4/4 tests`.
- `issues_list_ingest_orders_the_backlog_by_the_graphs_coupling` — a list reply
  arrives in the tracker's order and is adopted in the graph's.
- `a_heat_sorted_backlog_says_where_the_order_came_from`, with
  `an_unclaimed_backlog_draws_no_linked_line_and_no_heat_caption` as its other
  half: the caption exists exactly while the ordering it names does.

Commit `3d7570fa3` adds two more over `sort_by_heat` and touches no production
code — `an_old_lightly_coupled_issue_outranks_a_fresh_heavily_coupled_one` (the
first witness shares one stamp across every row, so a sort that dropped the age
term passed it) and
`rows_of_equal_heat_keep_the_tracker_order_in_either_arrangement`. Its own PR
comment carries the reasoning.

The field they read is new, so they cannot compile against `main`. The flip was
verified against the *behaviour* instead: with the `linked` line and the plan
tag replaced by empty strings and `adopt_rows`' sort call removed, the first two
fail and the rest of the suite stays green; restoring the three lines turns them
back. `a_heat_sorted_backlog_says_where_the_order_came_from` sets the flag by
hand, so it survives that neutering by design — the ingest test is what proves
the flag is earned.

The ISSUES golden (`tests/snapshots/deck/tab_issues.txt`) is re-blessed and
reads as SPEC 9.4's own sketch: the claimed row lifted to the top, the caption
under the header, and the `linked` line in the detail pane. Its fixture goes
through `adopt_rows` rather than assigning rows by hand, so the golden is of the
ordering the deck actually applies; `GOLDEN_NOW_MS` freezes the clock at
2026-02-13 so the age term cannot drift with the calendar. Accessible mode gets
the plan and its live task as two labelled values rather than the sighted row's
tag, pinned in `tests/accessible_tables.rs`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-tui` (1225 lib + every integration suite), plus
      `cargo check -p stella-cli --all-targets`. The workspace build is CI's —
      this branch's evidence is its run.
- [x] `make guards-fast` (13/13, including `prose` and `module-reachability`)
      and `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps
      --document-private-items`
- [x] Docs updated: `LinkedWork`, `views::issues`, `issues_tab`'s header and
      `render_detail`'s doc comment. `issues_tab`'s header was cut back while I
      was in it, which is what keeps `stella-tui` under the density ratchet.
- [x] `Closes #4336` appears in this description **and** as a commit trailer.

## Nothing left behind

- [x] Filed: #5195 (the outbound update behind the sync rule), #5196
      (`updated_at` never populated), #5197 (the `LinkedWork` producer).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies — the calendar
      arithmetic is written out rather than pulling a date crate into a
      render-layer crate.
- [x] No new outbound network calls.
- [x] `stella-tui` still links no graph backend; the coupling join is against
      the `GraphSnapshot` the driver already hands the deck.

## Anything reviewers should know?

- **Why the sort is applied on arrival, not per frame.** A list that re-sorted
  when a later `GraphSnapshot` landed would move the cursor off the row the
  reader was on. `r` re-fetches against whatever graph the deck holds by then.
  `adopt_rows`' doc comment says so.
- **The `#826` fixture row moved to `in progress`** in the golden and the demo
  film, so `▶` — one of SPEC 9.4's four state glyphs, and previously drawn by no
  golden — is now pinned.
- No test was deleted in this PR.