### PR TITLE
fix(ci): label the release write-back PR so the DoD gate stops failing it

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -321,8 +321,32 @@ jobs:
           existing="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')"
           if [ -n "${existing}" ]; then
             gh pr edit "${existing}" --title "${title}" --body "${body}"
+            pr="${existing}"
           else
             gh pr create --base main --head "${branch}" --title "${title}" --body "${body}"
+            pr="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')"
+          fi
+
+          # `no-issue` is SCR-003's escape hatch, and this PR is what it is for:
+          # a write-back of a version that was already released closes nothing,
+          # so it can never name an issue whose definition of done a human
+          # ticks. Without the label `dod` fails every release PR with "this PR
+          # links no issue" — a red that recurs on each release and that no
+          # author can clear, because there is no issue to link. The label keeps
+          # the waiver auditable (`is:pr label:no-issue`) instead of exempting
+          # the workflow somewhere only its own source records.
+          #
+          # Applied as its own non-fatal step rather than `gh pr create
+          # --label`: that flag aborts the whole command when the label is
+          # missing from the repository, which would turn a deleted label into
+          # "the release write-back never opened" instead of "the write-back is
+          # red on one advisory check". The weaker failure is the right one
+          # here, so this warns and carries on.
+          if [ -n "${pr}" ]; then
+            gh pr edit "${pr}" --add-label no-issue \
+              || echo "::warning::could not apply the no-issue label to #${pr}; dod will be red until it is applied by hand"
+          else
+            echo "::warning::could not resolve the write-back PR number; no-issue not applied"
           fi
 
       # Merging a Cargo-only bot/version-sync PR the normal way never


### PR DESCRIPTION
## What & why

The DoD merge check went live on `main` with #5180. `auto-tag.yml`'s version
write-back **closes no issue and never can** — it records a version that is
already released — so `dod` fails it with *"this PR links no issue"* on every
release, and no author can clear that: there is no issue to link.

Seen live on #5202 (`chore(release): sync versions to 0.9.251`), which was red
on `dod` for exactly this until the label was applied by hand.

`no-issue` is SCR-003's escape hatch for this case, and applying it keeps the
waiver enumerable (`is:pr label:no-issue`) rather than exempting the workflow
somewhere only its own source records.

## Why a separate step rather than `gh pr create --label`

`--label` aborts the whole command when the label is missing from the
repository. That would turn a deleted label into *"the release write-back never
opened"* instead of *"the write-back is red on one advisory check"* — a strictly
worse failure for a step whose job is to record a release that already
happened. So the label is applied afterwards, non-fatally, and warns rather than
exits.

It is applied on the **edit** path too: a re-run reuses the open PR, and a label
removed by hand must come back rather than leave the next write-back red.

## Verification

There is no unit test here, and I do not want to claim one: a test asserting
that `auto-tag.yml` contains the string `--add-label no-issue` restates the diff
rather than proving anything about behaviour. What was actually checked:

- **The failure reproduces** — #5202's `dod` check failed with `This PR links no
  issue. Add a closing reference (Closes #123) …`, and went green after
  `no-issue` was applied by hand. That is the fail→pass this change automates.
- `make guards-fast` is green on this tree, `shellcheck` and `action-pins`
  included.
- `actionlint .github/workflows/auto-tag.yml` reports one SC2129 style warning
  at line 112, which is **pre-existing** — the identical warning on the identical
  line reproduces against `origin/main`'s copy of the file.
- The real witness is the next release: its write-back PR should open already
  carrying `no-issue`, with `dod` green.

Deleted tests: none.

## Related

`no-issue` did not exist in any of the five repos when the gate shipped — the
escape hatch could not be applied by anyone. It has since been created in all
five. macanderson/oxagen#1330 tracks the sibling gap: a PR that closes a
*machine-filed* issue (the `main-red` canary issue, the SCR corpus-drift issue)
cannot satisfy `dod` either, because those bodies carry no DoD section and the
check's advice — "refile it with the task template" — is wrong for an issue a
workflow owns.

This PR itself closes no issue, so it carries `no-issue`.

## Summary by Sourcery

Label automated release write-back pull requests with the auditable `no-issue` waiver so they can pass the DoD gate without blocking release bookkeeping.

Bug Fixes:
- Ensure automated release write-back pull requests receive the `no-issue` label so the DoD check no longer fails on PRs that cannot link to an issue.

Enhancements:
- Apply the label to both newly created and reused write-back pull requests while allowing label-application failures to remain non-fatal and visible as warnings.