### PR TITLE
fix(ci): triage-guard admits the maintainer SCR-005 whitelists

### DIFF
--- a/.github/workflows/triage-guard.yml
+++ b/.github/workflows/triage-guard.yml
@@ -1,3 +1,7 @@
+# Triage separation of duties (SCR-005): issue creators get exactly one
+# label — `triage`. Priority labels come only from the triage identity.
+# Invariant: every open issue carries a P-label or `triage`, never neither,
+# never both.
 name: triage-guard
 on:
   issues:
@@ -10,18 +14,32 @@ jobs:
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
-          TRIAGE_AGENT: triage-bot   # the only login allowed to set P-labels
+          # Logins allowed to set P-labels. `macanderson` is the interim
+          # triage authority until the dedicated triage-agent identity
+          # stands up (SCR-005 §Exceptions) — remove it then.
+          #
+          # This is a list rather than one login because the exception is
+          # part of the rule: SCR-005 says the maintainer holds the triage
+          # authority *until* the bot exists, and the bot does not exist.
+          # A guard naming only `triage-bot` does not enforce SCR-005 — it
+          # locks every login out of a facet SCR-005 requires somebody to
+          # set, which is how #5205 made the whole backlog unprioritisable.
+          TRIAGE_LOGINS: triage-bot macanderson
         with:
           script: |
             const issue = context.payload.issue;
             const P = /^P[0-3]$/;
-            if (context.payload.action === 'opened') {
+            const allowed = process.env.TRIAGE_LOGINS.split(/\s+/);
+            const names = issue.labels.map(l => (typeof l === 'string' ? l : l.name));
+            if (context.payload.action === 'opened'
+                && !names.includes('triage')
+                && !names.some(n => P.test(n))) {
               await github.rest.issues.addLabels({
                 ...context.repo, issue_number: issue.number, labels: ['triage'] });
             }
             if (context.payload.action === 'labeled'
                 && P.test(context.payload.label.name)
-                && context.payload.sender.login !== process.env.TRIAGE_AGENT) {
+                && !allowed.includes(context.payload.sender.login)) {
               await github.rest.issues.removeLabel({
                 ...context.repo, issue_number: issue.number,
                 name: context.payload.label.name });


### PR DESCRIPTION
## What

`triage-guard` admitted only `triage-bot` — an identity this organization does
not have — so **no login could set a priority label on any issue**. Every
`P0`–`P3` was added and stripped again seconds later, the maintainer's included.
SCR-005 §Exceptions says the opposite:

> Until the dedicated triage-agent identity exists, the maintainer
> (macanderson) acts as the interim triage authority and is whitelisted in the
> guard workflow.

This restores the list form the workflow already had, and with it the
idempotent `opened` arm that went with it.

## Why it regressed

| commit | merged | value |
| --- | --- | --- |
| `9d216b63f` (#5148) | 2026-08-26 16:20:53 -0700 | `TRIAGE_LOGINS: triage-bot macanderson` |
| `727f28479` (#5112) | 2026-08-26 16:41:07 -0700 | `TRIAGE_AGENT: triage-bot` |

#5112 was authored against a base predating #5148 and carried an older copy of
the whole file, landing twenty minutes after it. Neither tree was wrong, git
reported no conflict, and `check-rebase-replay.sh` cannot see it — #5112 never
edited-and-undid the path *inside* its own branch. The shared-cell composition
hazard AGENTS.md describes for `Cargo.lock`; the shape #4979 named.

## Witness

This is a workflow change, so there is no Rust witness. Verified against the
live repository, which is the only place this behaviour exists:

**Before** (on `main`, during a backlog-triage sweep on 2026-08-27) — P-labels
applied to #5173, #5169, #5175, #4997 and ~30 others were each removed by
`github-actions[bot]` within seconds, with the SCR-005 comment. The timeline
for #5173:

\`\`\`
labeled   P1    macanderson
unlabeled P1    github-actions[bot]
\`\`\`

**After** — the same edit must leave the label in place. That check is the first
box on #5205 and is verifiable the moment this merges, by running the repro in
the issue.

## Tests deleted

None.

Closes #5205

## Summary by Sourcery

Restore SCR-005 triage authorization so maintainers can prioritize issues until the dedicated triage identity exists.

Bug Fixes:
- Allow the interim maintainer triage authority to set and retain priority labels alongside the future triage bot.
- Prevent the workflow from removing authorized P-labels and preserve the default triage label on newly opened issues only when no triage or priority label exists.

Enhancements:
- Document the SCR-005 triage separation-of-duties invariant and interim authorization rule.