### PR TITLE
feat(stella-tui): the palette lights matched letters and keeps a recent list

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -186,6 +186,18 @@ fn system_notice(text: String) -> Inbound {
     Inbound::Notice(text)
 }
 
+/// Where this workspace keeps the command palette's `recent` section
+/// (SPEC 10). It sits under `.stella/private/` with the rest of the generated
+/// local state, so it is gitignored and never travels: the last five commands
+/// a person ran are theirs, and a clone that inherited someone else's would be
+/// wrong as well as private (AGENTS.md § the `.stella/` directory).
+fn palette_recent_path(workspace_root: &std::path::Path) -> PathBuf {
+    workspace_root
+        .join(".stella")
+        .join("private")
+        .join("palette-recent.json")
+}
+
 /// `STELLA_DEBUG=1` → the structured deck log path (L-T8), mirroring the
 /// location `stella_tui::DeckOptions` documents. `None` otherwise, and
 /// on any failure to create the directory — a lost debug log never gates the
@@ -721,6 +733,7 @@ pub async fn run_deck_session(
         debug_log_path: debug_log_path(),
         slash_commands: deck_slash_commands(&custom),
         initial_graph: agent::graph_snapshot(&cfg.workspace_root),
+        recent_path: Some(palette_recent_path(&cfg.workspace_root)),
         no_anim,
         accessible,
         mid_turn_prompt: steer::mid_turn_prompt_policy(cfg),

--- a/crates/stella-tui/src/composer.rs
+++ b/crates/stella-tui/src/composer.rs
@@ -32,9 +32,12 @@ use stella_protocol::{Attachment, AttachmentKind};
 use unicode_width::UnicodeWidthChar;
 
 pub mod args;
+pub mod fuzzy;
 pub mod palette;
+pub mod recent;
 
 pub use palette::{PaletteState, RelevantNow, SlashDomain};
+pub use recent::Recents;
 
 /// Below this many lines a paste is inserted inline; at or above it, the
 /// paste collapses to a chip. Small on purpose (L-T3).
@@ -198,6 +201,13 @@ pub struct Composer {
     cursor: usize,
     /// Paste-collapse threshold in lines.
     paste_threshold: usize,
+    /// Commands run from this composer's slash popup, most recent first —
+    /// SPEC 10's `recent` section. It rides the composer because the composer
+    /// already owns the slash-menu view ([`Composer::slash_menu`]), so the
+    /// key handler and the renderer read one list without either surface
+    /// having to pass it between them. A surface that hands it no path keeps
+    /// an in-session list; see [`recent::Recents`].
+    recent: Recents,
 }
 
 impl Composer {
@@ -215,6 +225,25 @@ impl Composer {
             paste_threshold: threshold.max(1),
             ..Self::default()
         }
+    }
+
+    /// Keep the `recent` section in `path` from now on, seeded with what is
+    /// already there. Called once by the surface that knows which workspace
+    /// this composer belongs to (`DeckOptions::recent_path`).
+    pub fn keep_recent_in(&mut self, path: impl Into<std::path::PathBuf>) {
+        self.recent = Recents::kept_in(path);
+    }
+
+    /// The commands this composer has run, most recent first.
+    pub fn recent(&self) -> &[String] {
+        self.recent.names()
+    }
+
+    /// Write the `recent` list back if a dispatch has changed it. Cheap
+    /// enough to call on every keystroke — it returns at once when nothing
+    /// has moved.
+    pub fn flush_recent(&mut self) {
+        self.recent.flush();
     }
 
     /// The live buffer text (what is being typed, chips excluded).
@@ -451,7 +480,7 @@ impl Composer {
         if !q.starts_with('/') || q.contains(char::is_whitespace) {
             return None;
         }
-        Some(SlashMenu::filter_with(commands, q, state))
+        Some(SlashMenu::filter_with(commands, q, state, self.recent()))
     }
 }
 
@@ -626,12 +655,23 @@ pub fn split_row_at(row: &str, col: usize) -> (String, Option<char>, String) {
     (before, None, String::new())
 }
 
+/// One palette row: the command, and where the query lit up inside its name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashMatch<'a> {
+    pub command: &'a SlashCommand,
+    /// Char offsets into [`SlashCommand::name`], the leading `/` counted, so
+    /// the renderer walks the string it prints instead of re-deriving a bare
+    /// slug from it. Empty when the query matched only the description, and
+    /// for the browse list's `recent` rows.
+    pub highlights: Vec<usize>,
+}
+
 /// The filtered slash-command list for the current query. Borrows the
 /// caller's command vocabulary — the menu owns no command list of its own.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SlashMenu<'a> {
     pub query: String,
-    pub matches: Vec<&'a SlashCommand>,
+    pub matches: Vec<SlashMatch<'a>>,
     /// Headings the palette draws above [`Self::matches`], as
     /// `(index of the first match under it, heading)`. Ascending, and only
     /// ever populated for the browse list — see [`Self::filter_with`].
@@ -645,16 +685,18 @@ impl<'a> SlashMenu<'a> {
     /// so it gets the ranking it always had rather than a relevance block
     /// derived from zeroes.
     pub fn filter(commands: &'a [SlashCommand], query: &str) -> Self {
-        Self::filter_with(commands, query, &PaletteState::default())
+        Self::filter_with(commands, query, &PaletteState::default(), &[])
     }
 
     /// Fuzzy filter over `commands`, ordered by what the session is doing.
     ///
-    /// Matching is unchanged and decides *what appears*: a name-prefix match
-    /// ranks first, a name-substring match second, a description-substring
-    /// match third. An empty query (just `/`) matches everything.
-    /// Case-insensitive on the ASCII fold; command names are ASCII slugs, so
-    /// the cheap fold is exact for every name the CLI actually registers.
+    /// Matching decides *what appears* and where each row lights up
+    /// ([`fuzzy::match_name`]): a name-prefix match ranks first, a
+    /// name-substring match second, a name-subsequence match third, and a
+    /// description-substring match last. An empty query (just `/`) matches
+    /// everything and lights nothing. Case-insensitive on the ASCII fold;
+    /// command names are ASCII slugs, so the cheap fold is exact for every
+    /// name the CLI actually registers.
     ///
     /// `state` decides *the order*, and the two cases are deliberately
     /// different surfaces rather than one compromise (#4338):
@@ -668,19 +710,43 @@ impl<'a> SlashMenu<'a> {
     ///   grouping a three-row result buries the rows under their own
     ///   captions — but a relevant command still leads *within its rank*, so
     ///   `/pl` mid-turn opens on `/plan`.
-    pub fn filter_with(commands: &'a [SlashCommand], query: &str, state: &PaletteState) -> Self {
+    ///
+    /// `recent` closes the browse list under its own heading — the commands
+    /// this workspace ran last, most recent first. A recent row is a second
+    /// appearance of a command a domain group already lists, which is what a
+    /// shortcut is, so it is appended rather than lifted out of its group
+    /// (SPEC 10 puts the section last).
+    pub fn filter_with(
+        commands: &'a [SlashCommand],
+        query: &str,
+        state: &PaletteState,
+        recent: &[String],
+    ) -> Self {
         let needle = query.trim_start_matches('/').to_ascii_lowercase();
-        let rank = |c: &SlashCommand| -> Option<u8> {
-            let name = c.name.trim_start_matches('/').to_ascii_lowercase();
-            if name.starts_with(&needle) {
-                Some(0)
-            } else if name.contains(&needle) {
-                Some(1)
-            } else if c.description.to_ascii_lowercase().contains(&needle) {
-                Some(2)
-            } else {
-                None
+        let matched = |c: &'a SlashCommand| -> Option<(u8, SlashMatch<'a>)> {
+            let bare = c.name.trim_start_matches('/');
+            // What the slash cost, so the offsets index the printed name.
+            let slash = c.name.chars().count() - bare.chars().count();
+            match fuzzy::match_name(&bare.to_ascii_lowercase(), &needle) {
+                Some(m) => Some((
+                    m.kind.rank(),
+                    m.indices.iter().map(|i| i + slash).collect::<Vec<_>>(),
+                )),
+                None => c
+                    .description
+                    .to_ascii_lowercase()
+                    .contains(&needle)
+                    .then(|| (fuzzy::DESCRIPTION_RANK, Vec::new())),
             }
+            .map(|(rank, highlights)| {
+                (
+                    rank,
+                    SlashMatch {
+                        command: c,
+                        highlights,
+                    },
+                )
+            })
         };
         let relevant = palette::relevant_now(state);
         // Where a command sits in the relevance block, or past every one of
@@ -693,31 +759,28 @@ impl<'a> SlashMenu<'a> {
                 .unwrap_or(usize::MAX)
         };
 
-        let mut ranked: Vec<(u8, &SlashCommand)> = commands
-            .iter()
-            .filter_map(|c| rank(c).map(|r| (r, c)))
-            .collect();
+        let mut ranked: Vec<(u8, SlashMatch<'a>)> = commands.iter().filter_map(matched).collect();
 
         if !needle.is_empty() {
             // Stable within a key, so the vocabulary order survives among
             // commands the session says nothing about.
-            ranked.sort_by_key(|(r, c)| (*r, relevance(c)));
+            ranked.sort_by_key(|(r, m)| (*r, relevance(m.command)));
             return Self {
                 query: query.to_string(),
-                matches: ranked.into_iter().map(|(_, c)| c).collect(),
+                matches: ranked.into_iter().map(|(_, m)| m).collect(),
                 sections: Vec::new(),
             };
         }
 
         // The browse list: relevance block, then a group per domain.
-        ranked.sort_by_key(|(_, c)| (relevance(c), c.domain.order()));
-        let matches: Vec<&SlashCommand> = ranked.into_iter().map(|(_, c)| c).collect();
+        ranked.sort_by_key(|(_, m)| (relevance(m.command), m.command.domain.order()));
+        let mut matches: Vec<SlashMatch<'a>> = ranked.into_iter().map(|(_, m)| m).collect();
 
         let mut sections = Vec::new();
         let promoted = relevant.as_ref().map_or(0, |r| {
             matches
                 .iter()
-                .filter(|c| r.commands.iter().any(|n| *n == c.name))
+                .filter(|m| r.commands.iter().any(|n| *n == m.command.name))
                 .count()
         });
         if let Some(relevant) = relevant.as_ref()
@@ -726,11 +789,26 @@ impl<'a> SlashMenu<'a> {
             sections.push((0, format!("relevant now · {}", relevant.reason)));
         }
         let mut group = None;
-        for (i, command) in matches.iter().enumerate().skip(promoted) {
-            if group != Some(command.domain) {
-                group = Some(command.domain);
-                sections.push((i, command.domain.label().to_string()));
+        for (i, m) in matches.iter().enumerate().skip(promoted) {
+            if group != Some(m.command.domain) {
+                group = Some(m.command.domain);
+                sections.push((i, m.command.domain.label().to_string()));
             }
+        }
+        // `recent` closes the list. A name the vocabulary no longer answers to
+        // is skipped rather than drawn: the file outlives any one build's
+        // command set.
+        let recent_rows: Vec<SlashMatch<'a>> = recent
+            .iter()
+            .filter_map(|name| commands.iter().find(|c| c.name == *name))
+            .map(|command| SlashMatch {
+                command,
+                highlights: Vec::new(),
+            })
+            .collect();
+        if !recent_rows.is_empty() {
+            sections.push((matches.len(), "recent".to_string()));
+            matches.extend(recent_rows);
         }
         Self {
             query: query.to_string(),
@@ -758,7 +836,7 @@ pub fn slash_popup_matches(
 ) -> Vec<String> {
     composer
         .slash_menu(slash_commands, state)
-        .map(|m| m.matches.iter().map(|c| c.name.clone()).collect())
+        .map(|m| m.matches.iter().map(|m| m.command.name.clone()).collect())
         .unwrap_or_default()
 }
 
@@ -812,9 +890,14 @@ pub fn handle_slash_popup_key(
             Some(SlashPopupOutcome::Handled)
         }
         KeyCode::Enter => {
+            let chosen = matches[selected].clone();
+            // The one place a palette row is *run*, which is what the `recent`
+            // section reports. Tab completes instead of running, so it records
+            // nothing.
+            composer.recent.record(&chosen);
             composer.clear();
             *slash_selected = 0;
-            Some(SlashPopupOutcome::Submit(matches[selected].clone()))
+            Some(SlashPopupOutcome::Submit(chosen))
         }
         KeyCode::Esc => {
             composer.clear();
@@ -835,501 +918,4 @@ fn line_count(text: &str) -> usize {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn commands() -> Vec<SlashCommand> {
-        vec![
-            SlashCommand::new("/help", "show help"),
-            SlashCommand::new("/clear", "clear the transcript"),
-            SlashCommand::new("/models", "list models"),
-            SlashCommand::new("/diff", "open the diff viewer"),
-            SlashCommand::new("/files", "focus the files panel"),
-        ]
-    }
-
-    #[test]
-    fn small_paste_inserts_inline() {
-        let mut c = Composer::with_paste_threshold(6);
-        c.paste("one\ntwo\nthree");
-        assert!(c.chips().is_empty());
-        assert_eq!(c.buffer(), "one\ntwo\nthree");
-    }
-
-    #[test]
-    fn large_paste_collapses_to_a_chip_but_keeps_the_payload() {
-        let mut c = Composer::with_paste_threshold(3);
-        let payload = "a\nb\nc\nd\ne";
-        c.paste(payload);
-        assert_eq!(c.chips().len(), 1);
-        // The real display path (what the renderers draw) shows the chip form.
-        assert_eq!(layout(&c, 80).rows, vec!["[pasted: 5 lines] ".to_string()]);
-        // The full payload survives to submission.
-        let msg = c.take_submission().unwrap().text;
-        assert_eq!(msg, payload);
-    }
-
-    #[test]
-    fn typed_text_before_a_chip_keeps_its_order_on_submit() {
-        let mut c = Composer::with_paste_threshold(3);
-        for ch in "review this: ".chars() {
-            c.insert_char(ch);
-        }
-        c.paste("x\ny\nz\nw");
-        for ch in " thanks".chars() {
-            c.insert_char(ch);
-        }
-        let msg = c.take_submission().unwrap().text;
-        assert_eq!(msg, "review this: \nx\ny\nz\nw\n thanks");
-        assert!(c.is_empty(), "submission clears the composer");
-    }
-
-    #[test]
-    fn display_never_leaks_the_raw_payload() {
-        let mut c = Composer::with_paste_threshold(2);
-        c.paste("secret-line-1\nsecret-line-2\nsecret-line-3");
-        let shown = layout(&c, 200).rows.join("\n");
-        assert!(
-            !shown.contains("secret"),
-            "chip must hide the payload: {shown}"
-        );
-    }
-
-    fn test_attachment(name: &str) -> Attachment {
-        Attachment::from_path(name, "image/png", 1024, format!("/tmp/{name}"))
-    }
-
-    #[test]
-    fn attachments_ride_the_submission_not_its_text() {
-        let mut c = Composer::new();
-        for ch in "see ".chars() {
-            c.insert_char(ch);
-        }
-        c.attach(test_attachment("shot.png"));
-        for ch in "what broke?".chars() {
-            c.insert_char(ch);
-        }
-        let shown = layout(&c, 200).rows.join("\n");
-        assert!(shown.contains("[image: shot.png"), "{shown}");
-        let submission = c.take_submission().unwrap();
-        assert_eq!(submission.text, "see \nwhat broke?");
-        assert_eq!(submission.attachments.len(), 1);
-        assert_eq!(submission.attachments[0].name, "shot.png");
-        assert!(c.is_empty(), "submission clears attachments too");
-    }
-
-    #[test]
-    fn attachment_only_submission_is_submittable() {
-        let mut c = Composer::new();
-        c.attach(test_attachment("clip.png"));
-        assert!(!c.is_empty());
-        let submission = c.take_submission().unwrap();
-        assert_eq!(submission.text, "");
-        assert_eq!(submission.attachments.len(), 1);
-    }
-
-    #[test]
-    fn backspace_pops_an_attachment_chip_when_the_buffer_is_empty() {
-        let mut c = Composer::new();
-        c.attach(test_attachment("oops.png"));
-        c.backspace();
-        assert!(c.is_blank(), "backspace removes the pending attachment");
-    }
-
-    #[test]
-    fn backspace_pops_a_chip_when_the_buffer_is_empty() {
-        let mut c = Composer::with_paste_threshold(2);
-        c.paste("a\nb\nc");
-        assert_eq!(c.chips().len(), 1);
-        c.backspace(); // buffer empty → removes the chip
-        assert!(c.chips().is_empty());
-    }
-
-    /// The vocabulary with domains, for the palette tests.
-    fn classified_commands() -> Vec<SlashCommand> {
-        vec![
-            SlashCommand::new("/help", "show help").in_domain(SlashDomain::Session),
-            SlashCommand::new("/clear", "clear the transcript").in_domain(SlashDomain::Session),
-            SlashCommand::new("/plan", "the plan").in_domain(SlashDomain::Plan),
-            SlashCommand::new("/budget", "set the spend cap").in_domain(SlashDomain::Plan),
-            SlashCommand::new("/diff", "open the diff viewer").in_domain(SlashDomain::Code),
-            SlashCommand::custom("/fix-bug", "fix a bug end to end"),
-        ]
-    }
-
-    /// **The witness (#4338).** The browse list opens on what the session
-    /// makes relevant, under a heading that says why, then one group per
-    /// domain — not thirty rows in vocabulary order.
-    #[test]
-    fn the_browse_list_leads_with_relevance_then_groups_by_domain() {
-        let cmds = classified_commands();
-        let state = PaletteState {
-            turn_running: true,
-            ..PaletteState::default()
-        };
-        let mut c = Composer::new();
-        c.insert_char('/');
-        let menu = c.slash_menu(&cmds, &state).expect("slash menu active");
-
-        let names: Vec<&str> = menu.matches.iter().map(|m| m.name.as_str()).collect();
-        assert_eq!(
-            &names[..2],
-            &["/plan", "/budget"],
-            "the running turn's commands lead: {names:?}"
-        );
-        assert_eq!(
-            menu.sections.first(),
-            Some(&(0, "relevant now · a turn is running".to_string())),
-            "the heading says why: {:?}",
-            menu.sections
-        );
-        assert_eq!(
-            menu.sections[1..].to_vec(),
-            vec![
-                (2, "session".to_string()),
-                (4, "workspace".to_string()),
-                (5, "custom".to_string()),
-            ],
-            "one heading per remaining group, in domain order"
-        );
-    }
-
-    /// A quiet session has no relevance block at all — the list is the domain
-    /// groups alone, with no heading claiming a reason that does not exist.
-    #[test]
-    fn a_quiet_browse_list_is_groups_only() {
-        let cmds = classified_commands();
-        let mut c = Composer::new();
-        c.insert_char('/');
-        let menu = c
-            .slash_menu(&cmds, &PaletteState::default())
-            .expect("slash menu active");
-        assert!(
-            !menu.sections.iter().any(|(_, h)| h.starts_with("relevant")),
-            "nothing to be relevant about: {:?}",
-            menu.sections
-        );
-        assert_eq!(menu.sections.first().map(|(at, _)| *at), Some(0));
-        let names: Vec<&str> = menu.matches.iter().map(|m| m.name.as_str()).collect();
-        assert_eq!(
-            names,
-            vec!["/help", "/clear", "/plan", "/budget", "/diff", "/fix-bug"],
-            "domain order, vocabulary order within a group"
-        );
-    }
-
-    /// A typed query keeps one flat ranked list — but a relevant command
-    /// leads its rank, so `/b` mid-turn opens on `/budget` rather than on
-    /// whatever the vocabulary happened to list first.
-    #[test]
-    fn a_typed_query_promotes_the_relevant_match_without_headings() {
-        let cmds = classified_commands();
-        let state = PaletteState {
-            turn_running: true,
-            ..PaletteState::default()
-        };
-        let mut c = Composer::new();
-        for ch in "/p".chars() {
-            c.insert_char(ch);
-        }
-        let menu = c.slash_menu(&cmds, &state).expect("slash menu active");
-        assert!(menu.sections.is_empty(), "no headings under a query");
-        let names: Vec<&str> = menu.matches.iter().map(|m| m.name.as_str()).collect();
-        assert_eq!(
-            names.first(),
-            Some(&"/plan"),
-            "the prefix match still leads: {names:?}"
-        );
-        assert_eq!(
-            names.iter().position(|n| *n == "/budget"),
-            Some(2),
-            "and the relevant one leads its own (weaker) rank: {names:?}"
-        );
-
-        // Idle, the same query is the plain fuzzy ranking: `/budget` sits
-        // where the vocabulary put it, behind the two rows above it.
-        let idle = c
-            .slash_menu(&cmds, &PaletteState::default())
-            .expect("slash menu active");
-        let idle_names: Vec<&str> = idle.matches.iter().map(|m| m.name.as_str()).collect();
-        assert_eq!(idle_names.first(), Some(&"/plan"));
-        assert_eq!(
-            idle_names.iter().position(|n| *n == "/budget"),
-            Some(3),
-            "relevance is what moved it: {idle_names:?}"
-        );
-    }
-
-    #[test]
-    fn slash_menu_fuzzy_ranks_name_prefix_over_substring_over_description() {
-        let cmds = commands();
-        let mut c = Composer::new();
-        for ch in "/f".chars() {
-            c.insert_char(ch);
-        }
-        let menu = c
-            .slash_menu(&cmds, &PaletteState::default())
-            .expect("slash menu active");
-        let names: Vec<&str> = menu.matches.iter().map(|m| m.name.as_str()).collect();
-        // `/files` starts with the query; `/diff` merely contains it — the
-        // prefix match must lead.
-        assert_eq!(names, vec!["/files", "/diff"]);
-    }
-
-    #[test]
-    fn slash_menu_falls_back_to_description_matches() {
-        let cmds = commands();
-        let mut c = Composer::new();
-        for ch in "/transcript".chars() {
-            c.insert_char(ch);
-        }
-        let menu = c
-            .slash_menu(&cmds, &PaletteState::default())
-            .expect("slash menu active");
-        let names: Vec<&str> = menu.matches.iter().map(|m| m.name.as_str()).collect();
-        // No name contains "transcript"; `/clear`'s description does.
-        assert_eq!(names, vec!["/clear"]);
-    }
-
-    #[test]
-    fn bare_slash_lists_every_command() {
-        let cmds = commands();
-        let mut c = Composer::new();
-        c.insert_char('/');
-        let menu = c.slash_menu(&cmds, &PaletteState::default()).unwrap();
-        assert_eq!(menu.matches.len(), cmds.len());
-    }
-
-    #[test]
-    fn slash_menu_is_inactive_once_a_space_is_typed() {
-        let cmds = commands();
-        let mut c = Composer::new();
-        for ch in "/models ".chars() {
-            c.insert_char(ch);
-        }
-        assert!(c.slash_menu(&cmds, &PaletteState::default()).is_none());
-    }
-
-    #[test]
-    fn slash_command_constructors_set_the_kind() {
-        assert_eq!(SlashCommand::new("/help", "d").kind, SlashKind::Builtin);
-        assert_eq!(SlashCommand::custom("/x", "d").kind, SlashKind::Custom);
-    }
-
-    #[test]
-    fn slash_menu_is_inactive_when_chips_are_present() {
-        let cmds = commands();
-        let mut c = Composer::with_paste_threshold(2);
-        c.paste("a\nb\nc");
-        c.insert_char('/');
-        assert!(c.slash_menu(&cmds, &PaletteState::default()).is_none());
-    }
-
-    #[test]
-    fn line_count_ignores_a_trailing_newline() {
-        assert_eq!(line_count("a\nb\n"), 2);
-        assert_eq!(line_count("a\nb"), 2);
-        assert_eq!(line_count(""), 0);
-        assert_eq!(line_count("solo"), 1);
-    }
-
-    // Textarea semantics
-
-    fn typed(text: &str) -> Composer {
-        let mut c = Composer::new();
-        for ch in text.chars() {
-            c.insert_char(ch);
-        }
-        c
-    }
-
-    #[test]
-    fn newlines_typed_into_the_buffer_survive_submission_verbatim() {
-        let mut c = typed("first line");
-        c.insert_newline();
-        for ch in "second line".chars() {
-            c.insert_char(ch);
-        }
-        assert_eq!(c.take_submission().unwrap().text, "first line\nsecond line");
-    }
-
-    #[test]
-    fn insert_and_backspace_act_at_the_cursor() {
-        let mut c = typed("hello");
-        c.move_left();
-        c.move_left();
-        c.insert_char('X'); // hel X lo
-        assert_eq!(c.buffer(), "helXlo");
-        c.backspace(); // removes the X, not the tail
-        assert_eq!(c.buffer(), "hello");
-        assert_eq!(c.cursor(), 3);
-    }
-
-    #[test]
-    fn move_to_start_and_end_bound_the_whole_buffer() {
-        let mut c = typed("a\nb\nc");
-        c.move_to_start();
-        assert_eq!(c.cursor(), 0, "before the first character");
-        c.move_to_end();
-        assert_eq!(c.cursor(), c.buffer().len(), "one past the last character");
-    }
-
-    #[test]
-    fn vertical_motion_keeps_the_column_and_clamps_to_short_lines() {
-        let mut c = typed("long line\nab\nlonger line");
-        // Cursor at end of "longer line"; up lands clamped to "ab"'s end.
-        c.move_up();
-        assert_eq!(&c.buffer()[..c.cursor()], "long line\nab");
-        // Up again: column carried from the clamp point (2) into "long line".
-        c.move_up();
-        assert_eq!(&c.buffer()[..c.cursor()], "lo");
-        // Down from the first line's column 2 → "ab" clamps to its end again.
-        c.move_down();
-        assert_eq!(&c.buffer()[..c.cursor()], "long line\nab");
-        // Down on the last line jumps to the very end.
-        c.move_down();
-        c.move_down();
-        assert_eq!(c.cursor(), c.buffer().len());
-    }
-
-    #[test]
-    fn line_start_and_end_stay_within_the_logical_line() {
-        let mut c = typed("one\ntwo three");
-        // Cursor at end; Home goes to the start of "two three", not offset 0.
-        c.move_line_start();
-        assert_eq!(&c.buffer()[..c.cursor()], "one\n");
-        c.move_line_end();
-        assert_eq!(c.cursor(), c.buffer().len());
-    }
-
-    #[test]
-    fn paste_lands_at_the_cursor_and_normalizes_line_endings() {
-        let mut c = typed("ac");
-        c.move_left();
-        c.paste("b\r\nB"); // small paste: inline, CRLF → LF
-        assert_eq!(c.buffer(), "ab\nBc");
-    }
-
-    #[test]
-    fn big_paste_mid_buffer_keeps_the_tail_after_the_chip() {
-        let mut c = Composer::with_paste_threshold(2);
-        for ch in "headtail".chars() {
-            c.insert_char(ch);
-        }
-        for _ in 0..4 {
-            c.move_left(); // cursor between "head" and "tail"
-        }
-        c.paste("x\ny\nz");
-        let msg = c.take_submission().unwrap().text;
-        assert_eq!(msg, "head\nx\ny\nz\ntail", "order: before, chip, after");
-    }
-
-    #[test]
-    fn classify_enter_submits_bare_and_breaks_on_a_modifier() {
-        let plain = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        let cmd = KeyEvent::new(KeyCode::Enter, KeyModifiers::SUPER);
-        let meta = KeyEvent::new(KeyCode::Enter, KeyModifiers::META);
-        let ctrl = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
-        let alt = KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT);
-        // Bare Enter always submits (never blocks).
-        assert_eq!(classify_enter(&plain), EnterAction::Submit);
-        // Every newline modifier inserts a line break instead.
-        assert_eq!(classify_enter(&cmd), EnterAction::Newline);
-        assert_eq!(classify_enter(&meta), EnterAction::Newline);
-        assert_eq!(classify_enter(&ctrl), EnterAction::Newline);
-        assert_eq!(classify_enter(&alt), EnterAction::Newline);
-        // A non-Enter key is not this function's concern.
-        let other = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
-        assert_eq!(classify_enter(&other), EnterAction::NotEnter);
-    }
-
-    #[test]
-    fn edit_keys_leave_an_empty_composer_to_the_surface() {
-        // Arrows on an empty buffer must fall through (they scroll views).
-        let mut c = Composer::new();
-        for code in [KeyCode::Left, KeyCode::Right, KeyCode::Up, KeyCode::Down] {
-            assert!(!handle_edit_key(
-                KeyEvent::new(code, KeyModifiers::NONE),
-                &mut c
-            ));
-        }
-        // ↑/↓ on a single-line buffer also fall through (transcript scroll).
-        let mut single = typed("one line");
-        assert!(!handle_edit_key(
-            KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
-            &mut single
-        ));
-        assert!(handle_edit_key(
-            KeyEvent::new(KeyCode::Left, KeyModifiers::NONE),
-            &mut single
-        ));
-    }
-
-    // Soft-wrap layout
-
-    #[test]
-    fn layout_soft_wraps_long_lines_and_hard_breaks_newlines() {
-        let c = typed("abcdef\ngh");
-        let l = layout(&c, 4);
-        assert_eq!(l.rows, vec!["abcd", "ef", "gh"]);
-        // Cursor at the end: one past 'h' on the last row.
-        assert_eq!((l.cursor_row, l.cursor_col), (2, 2));
-    }
-
-    #[test]
-    fn layout_places_the_cursor_mid_text() {
-        let mut c = typed("abcdef");
-        for _ in 0..2 {
-            c.move_left(); // cursor before 'e' (offset 4)
-        }
-        let l = layout(&c, 4);
-        assert_eq!(l.rows, vec!["abcd", "ef"]);
-        assert_eq!((l.cursor_row, l.cursor_col), (1, 0), "'e' starts row 1");
-    }
-
-    #[test]
-    fn layout_gives_the_cursor_a_fresh_row_when_the_last_row_is_full() {
-        let c = typed("abcd");
-        let l = layout(&c, 4);
-        assert_eq!(l.rows, vec!["abcd", ""]);
-        assert_eq!((l.cursor_row, l.cursor_col), (1, 0));
-    }
-
-    #[test]
-    fn layout_shows_chips_as_their_display_form() {
-        let mut c = Composer::with_paste_threshold(2);
-        c.paste("a\nb\nc");
-        for ch in "ok".chars() {
-            c.insert_char(ch);
-        }
-        let l = layout(&c, 40);
-        assert_eq!(l.rows, vec!["[pasted: 3 lines] ok"]);
-        assert_eq!((l.cursor_row, l.cursor_col), (0, 20));
-    }
-
-    #[test]
-    fn layout_is_wide_char_aware() {
-        let c = typed("日本語"); // width 2 each
-        let l = layout(&c, 4);
-        assert_eq!(l.rows, vec!["日本", "語"]);
-        assert_eq!((l.cursor_row, l.cursor_col), (1, 2));
-    }
-
-    #[test]
-    fn split_row_at_returns_the_char_under_the_cursor() {
-        assert_eq!(split_row_at("abc", 1), ("a".into(), Some('b'), "c".into()));
-        assert_eq!(split_row_at("abc", 3), ("abc".into(), None, String::new()));
-        assert_eq!(
-            split_row_at("日本", 2),
-            ("日".into(), Some('本'), String::new())
-        );
-    }
-
-    #[test]
-    fn empty_composer_lays_out_as_one_empty_row_with_the_cursor_home() {
-        let c = Composer::new();
-        let l = layout(&c, 10);
-        assert_eq!(l.rows, vec![""]);
-        assert_eq!((l.cursor_row, l.cursor_col), (0, 0));
-    }
-}
+mod tests;

--- a/crates/stella-tui/src/composer/fuzzy.rs
+++ b/crates/stella-tui/src/composer/fuzzy.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where a palette query met a command name — the positions SPEC 10's gold
+//! letters are painted at.
+//!
+//! The filter used to answer one question, "does this row survive?", so the
+//! renderer had nothing to light but the typed prefix it could re-derive
+//! itself. A match here carries the char offsets it consumed, which is what
+//! lets `ga` light the `g` and the `a` of `/graph query`.
+//!
+//! SPEC 10 names `nucleo` and this is not it. A command name is a short ASCII
+//! slug and the palette's order is decided by [`Kind`] and by what the
+//! session is doing (`super::palette::relevant_now`), so the scoring model a
+//! fuzzy-finder crate exists for would be computed and then discarded. What
+//! remains is the subsequence walk below.
+
+/// How a query met a name, strongest reading first — the palette's first sort
+/// key, ahead of session relevance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Kind {
+    /// The name begins with the query: `/pl` → `/plan`.
+    Prefix,
+    /// The query appears whole, somewhere later: `/iff` → `/diff`.
+    Substring,
+    /// The query's letters appear in order with gaps between them: `ga` →
+    /// the `g` and the `a` of `/graph query`.
+    Scattered,
+}
+
+/// The rank a description-substring match sorts at: below every name match,
+/// including a scattered one. A name is what the user is typing at; a word
+/// that happens to sit in an explanation is the weakest reason to offer a row.
+pub const DESCRIPTION_RANK: u8 = 3;
+
+impl Kind {
+    /// The sort key, ascending. Kept below [`DESCRIPTION_RANK`] by
+    /// construction — the tests hold that.
+    #[must_use]
+    pub fn rank(self) -> u8 {
+        match self {
+            Kind::Prefix => 0,
+            Kind::Substring => 1,
+            Kind::Scattered => 2,
+        }
+    }
+}
+
+/// One name match: how it matched, and where.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NameMatch {
+    pub kind: Kind,
+    /// Char offsets into the haystack the needle consumed, ascending. Empty
+    /// for an empty needle, which matches everything and lights nothing.
+    pub indices: Vec<usize>,
+}
+
+/// Match `needle` against `haystack`, both already folded to the same case by
+/// the caller. `None` when the needle's letters are not all present in order.
+///
+/// A contiguous run wins before the scattered walk is tried, so a query that
+/// is a substring keeps the rank and the highlight it always had — `at` in
+/// `/a cat` lights the `at` of `cat` rather than the first `a` and the last
+/// `t`.
+#[must_use]
+pub fn match_name(haystack: &str, needle: &str) -> Option<NameMatch> {
+    if needle.is_empty() {
+        return Some(NameMatch {
+            kind: Kind::Prefix,
+            indices: Vec::new(),
+        });
+    }
+    let hay: Vec<char> = haystack.chars().collect();
+    let ndl: Vec<char> = needle.chars().collect();
+    if let Some(at) = hay.windows(ndl.len()).position(|w| w == ndl.as_slice()) {
+        let kind = if at == 0 {
+            Kind::Prefix
+        } else {
+            Kind::Substring
+        };
+        return Some(NameMatch {
+            kind,
+            indices: (at..at + ndl.len()).collect(),
+        });
+    }
+    // Greedy from the left: the earliest letter that can serve is the one
+    // taken. For a slug this is also the tightest run available, and it is
+    // what a reader expects — the highlight walks the name in reading order.
+    let mut indices = Vec::with_capacity(ndl.len());
+    let mut chars = hay.iter().enumerate();
+    for want in &ndl {
+        let at = chars.by_ref().find(|(_, c)| *c == want).map(|(i, _)| i)?;
+        indices.push(at);
+    }
+    Some(NameMatch {
+        kind: Kind::Scattered,
+        indices,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_needle_matches_everything_and_lights_nothing() {
+        let m = match_name("plan", "").expect("everything matches");
+        assert_eq!(m.kind, Kind::Prefix);
+        assert!(m.indices.is_empty());
+    }
+
+    #[test]
+    fn a_prefix_and_a_substring_are_told_apart_and_both_are_contiguous() {
+        let prefix = match_name("plan", "pl").expect("prefix");
+        assert_eq!(prefix.kind, Kind::Prefix);
+        assert_eq!(prefix.indices, vec![0, 1]);
+
+        let inner = match_name("diff", "iff").expect("substring");
+        assert_eq!(inner.kind, Kind::Substring);
+        assert_eq!(inner.indices, vec![1, 2, 3]);
+    }
+
+    /// **The witness (#5048).** Scattered letters match and report where they
+    /// landed — `ga` is neither a prefix nor a substring of `graph query`,
+    /// and it is what the palette must light.
+    #[test]
+    fn scattered_letters_match_and_name_their_positions() {
+        let m = match_name("graph query", "ga").expect("ga is in graph");
+        assert_eq!(m.kind, Kind::Scattered);
+        assert_eq!(m.indices, vec![0, 2], "the g and the a of graph");
+    }
+
+    #[test]
+    fn a_contiguous_run_beats_the_scattered_walk() {
+        let m = match_name("a cat", "at").expect("at is in cat");
+        assert_eq!(m.kind, Kind::Substring);
+        assert_eq!(m.indices, vec![3, 4], "the at of cat, not a…t");
+    }
+
+    #[test]
+    fn letters_out_of_order_or_absent_do_not_match() {
+        assert_eq!(match_name("graph", "ag"), None, "order is required");
+        assert_eq!(match_name("graph", "gz"), None);
+        assert_eq!(match_name("gr", "graph"), None, "needle longer than name");
+    }
+
+    #[test]
+    fn every_name_rank_sorts_above_a_description_match() {
+        for kind in [Kind::Prefix, Kind::Substring, Kind::Scattered] {
+            assert!(kind.rank() < DESCRIPTION_RANK, "{kind:?}");
+        }
+    }
+}

--- a/crates/stella-tui/src/composer/recent.rs
+++ b/crates/stella-tui/src/composer/recent.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The palette's `recent` section — SPEC 10's third band, and the reason it
+//! needs somewhere to write.
+//!
+//! A `recent` list that empties every time the deck restarts is a list of what
+//! you did in the last five minutes, which you already remember. So the names
+//! ride a small JSON array in the workspace's own private directory
+//! (`.stella/private/palette-recent.json`), resolved by whoever launches the
+//! deck and handed in as a path — the smallest store that survives a restart
+//! and the only one this crate can reach without taking a dependency on
+//! `stella-store` (see AGENTS.md § the `.stella/` directory).
+//!
+//! Both file operations are best-effort and silent. A palette that refused to
+//! open because a convenience list would not parse has traded a feature for an
+//! ornament; a torn write reads back as malformed and starts the list again,
+//! which costs a user five command names.
+
+use std::path::{Path, PathBuf};
+
+/// Commands the `recent` section shows. Short on purpose: a shortcut list long
+/// enough to need reading is a second copy of the menu below it.
+pub const MAX_RECENT: usize = 5;
+
+/// The commands this workspace ran from the palette, most recent first.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Recents {
+    names: Vec<String>,
+    /// Where the list is kept, or `None` for a surface that was handed no
+    /// path — it keeps an in-session list and writes nothing.
+    path: Option<PathBuf>,
+    /// Set by [`Self::record`], cleared by [`Self::flush`], so the deck can
+    /// call `flush` on every keystroke and pay for a write only on a dispatch.
+    dirty: bool,
+}
+
+impl Recents {
+    /// The list kept in `path`, seeded with whatever is already there.
+    #[must_use]
+    pub fn kept_in(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let mut names = read_names(&path);
+        names.truncate(MAX_RECENT);
+        Self {
+            names,
+            path: Some(path),
+            dirty: false,
+        }
+    }
+
+    /// The commands, most recent first.
+    #[must_use]
+    pub fn names(&self) -> &[String] {
+        &self.names
+    }
+
+    /// Record `name` as the command just run: it moves to the front, and the
+    /// list keeps its cap. A submission that is not a slash command is
+    /// ignored, so prose typed at the composer never reaches the section.
+    pub fn record(&mut self, name: &str) {
+        let name = name.trim();
+        if !name.starts_with('/') {
+            return;
+        }
+        self.names.retain(|kept| kept != name);
+        self.names.insert(0, name.to_string());
+        self.names.truncate(MAX_RECENT);
+        self.dirty = true;
+    }
+
+    /// Write the list back when it has changed and it has somewhere to go.
+    pub fn flush(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        self.dirty = false;
+        let Some(path) = self.path.as_ref() else {
+            return;
+        };
+        let Ok(text) = serde_json::to_string(&self.names) else {
+            return;
+        };
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let _ = std::fs::write(path, text);
+    }
+}
+
+/// The names already in `path`, or none — a missing, unreadable or malformed
+/// file is an empty list.
+fn read_names(path: &Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str::<Vec<String>>(&text).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_newest_command_leads_and_a_repeat_moves_rather_than_duplicates() {
+        let mut recents = Recents::default();
+        recents.record("/plan");
+        recents.record("/diff");
+        recents.record("/plan");
+        assert_eq!(recents.names(), ["/plan", "/diff"]);
+    }
+
+    #[test]
+    fn the_list_keeps_its_cap_and_drops_the_oldest() {
+        let mut recents = Recents::default();
+        for i in 0..MAX_RECENT + 3 {
+            recents.record(&format!("/cmd{i}"));
+        }
+        assert_eq!(recents.names().len(), MAX_RECENT);
+        assert_eq!(recents.names()[0], format!("/cmd{}", MAX_RECENT + 2));
+        assert!(!recents.names().iter().any(|n| n == "/cmd0"));
+    }
+
+    #[test]
+    fn prose_is_not_a_command_and_is_not_recorded() {
+        let mut recents = Recents::default();
+        recents.record("fix the parser");
+        assert!(recents.names().is_empty());
+    }
+
+    /// **The witness (#5048).** The list survives the process that wrote it —
+    /// which is the whole difference between a `recent` section and a list of
+    /// what you did in the last five minutes.
+    #[test]
+    fn the_list_survives_the_session_that_wrote_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("private").join("palette-recent.json");
+
+        let mut session = Recents::kept_in(&path);
+        session.record("/plan");
+        session.record("/graph");
+        session.flush();
+
+        let next = Recents::kept_in(&path);
+        assert_eq!(next.names(), ["/graph", "/plan"]);
+    }
+
+    #[test]
+    fn a_surface_with_no_path_keeps_an_in_session_list_and_writes_nothing() {
+        let mut recents = Recents::default();
+        recents.record("/plan");
+        recents.flush();
+        assert_eq!(recents.names(), ["/plan"]);
+    }
+
+    #[test]
+    fn a_malformed_file_reads_as_an_empty_list_rather_than_refusing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("palette-recent.json");
+        std::fs::write(&path, "{ this is not a list").expect("write");
+        assert!(Recents::kept_in(&path).names().is_empty());
+    }
+}

--- a/crates/stella-tui/src/composer/tests.rs
+++ b/crates/stella-tui/src/composer/tests.rs
@@ -1,0 +1,617 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The composer's own suite: the textarea, paste-chip collapse, Enter
+//! classification, and the slash menu's filter, ranking and sections.
+//!
+//! Split out of `composer.rs` when that file crossed the 1500-line guard —
+//! the pattern `render/tests.rs` and `deck_ui/tests/` already follow. The
+//! module under test is `super`, glob-imported here so every assertion below
+//! reads exactly as it did inside the file.
+
+use super::*;
+
+fn commands() -> Vec<SlashCommand> {
+    vec![
+        SlashCommand::new("/help", "show help"),
+        SlashCommand::new("/clear", "clear the transcript"),
+        SlashCommand::new("/models", "list models"),
+        SlashCommand::new("/diff", "open the diff viewer"),
+        SlashCommand::new("/files", "focus the files panel"),
+    ]
+}
+
+#[test]
+fn small_paste_inserts_inline() {
+    let mut c = Composer::with_paste_threshold(6);
+    c.paste("one\ntwo\nthree");
+    assert!(c.chips().is_empty());
+    assert_eq!(c.buffer(), "one\ntwo\nthree");
+}
+
+#[test]
+fn large_paste_collapses_to_a_chip_but_keeps_the_payload() {
+    let mut c = Composer::with_paste_threshold(3);
+    let payload = "a\nb\nc\nd\ne";
+    c.paste(payload);
+    assert_eq!(c.chips().len(), 1);
+    // The real display path (what the renderers draw) shows the chip form.
+    assert_eq!(layout(&c, 80).rows, vec!["[pasted: 5 lines] ".to_string()]);
+    // The full payload survives to submission.
+    let msg = c.take_submission().unwrap().text;
+    assert_eq!(msg, payload);
+}
+
+#[test]
+fn typed_text_before_a_chip_keeps_its_order_on_submit() {
+    let mut c = Composer::with_paste_threshold(3);
+    for ch in "review this: ".chars() {
+        c.insert_char(ch);
+    }
+    c.paste("x\ny\nz\nw");
+    for ch in " thanks".chars() {
+        c.insert_char(ch);
+    }
+    let msg = c.take_submission().unwrap().text;
+    assert_eq!(msg, "review this: \nx\ny\nz\nw\n thanks");
+    assert!(c.is_empty(), "submission clears the composer");
+}
+
+#[test]
+fn display_never_leaks_the_raw_payload() {
+    let mut c = Composer::with_paste_threshold(2);
+    c.paste("secret-line-1\nsecret-line-2\nsecret-line-3");
+    let shown = layout(&c, 200).rows.join("\n");
+    assert!(
+        !shown.contains("secret"),
+        "chip must hide the payload: {shown}"
+    );
+}
+
+fn test_attachment(name: &str) -> Attachment {
+    Attachment::from_path(name, "image/png", 1024, format!("/tmp/{name}"))
+}
+
+#[test]
+fn attachments_ride_the_submission_not_its_text() {
+    let mut c = Composer::new();
+    for ch in "see ".chars() {
+        c.insert_char(ch);
+    }
+    c.attach(test_attachment("shot.png"));
+    for ch in "what broke?".chars() {
+        c.insert_char(ch);
+    }
+    let shown = layout(&c, 200).rows.join("\n");
+    assert!(shown.contains("[image: shot.png"), "{shown}");
+    let submission = c.take_submission().unwrap();
+    assert_eq!(submission.text, "see \nwhat broke?");
+    assert_eq!(submission.attachments.len(), 1);
+    assert_eq!(submission.attachments[0].name, "shot.png");
+    assert!(c.is_empty(), "submission clears attachments too");
+}
+
+#[test]
+fn attachment_only_submission_is_submittable() {
+    let mut c = Composer::new();
+    c.attach(test_attachment("clip.png"));
+    assert!(!c.is_empty());
+    let submission = c.take_submission().unwrap();
+    assert_eq!(submission.text, "");
+    assert_eq!(submission.attachments.len(), 1);
+}
+
+#[test]
+fn backspace_pops_an_attachment_chip_when_the_buffer_is_empty() {
+    let mut c = Composer::new();
+    c.attach(test_attachment("oops.png"));
+    c.backspace();
+    assert!(c.is_blank(), "backspace removes the pending attachment");
+}
+
+#[test]
+fn backspace_pops_a_chip_when_the_buffer_is_empty() {
+    let mut c = Composer::with_paste_threshold(2);
+    c.paste("a\nb\nc");
+    assert_eq!(c.chips().len(), 1);
+    c.backspace(); // buffer empty → removes the chip
+    assert!(c.chips().is_empty());
+}
+
+/// The vocabulary with domains, for the palette tests.
+fn classified_commands() -> Vec<SlashCommand> {
+    vec![
+        SlashCommand::new("/help", "show help").in_domain(SlashDomain::Session),
+        SlashCommand::new("/clear", "clear the transcript").in_domain(SlashDomain::Session),
+        SlashCommand::new("/plan", "the plan").in_domain(SlashDomain::Plan),
+        SlashCommand::new("/budget", "set the spend cap").in_domain(SlashDomain::Plan),
+        SlashCommand::new("/diff", "open the diff viewer").in_domain(SlashDomain::Code),
+        SlashCommand::custom("/fix-bug", "fix a bug end to end"),
+    ]
+}
+
+/// **The witness (#5048).** A query whose letters are scattered through a
+/// name matches it, and the menu says where each letter landed so the
+/// renderer can light them. `ga` is neither a prefix nor a substring of
+/// `graph query`, so before this the row did not appear at all.
+#[test]
+fn a_scattered_query_matches_and_reports_where_its_letters_landed() {
+    let cmds = vec![
+        SlashCommand::new("/graph query", "free-form graph query").in_domain(SlashDomain::Code),
+    ];
+    let mut c = Composer::new();
+    for ch in "/ga".chars() {
+        c.insert_char(ch);
+    }
+    let menu = c.slash_menu(&cmds, &PaletteState::default()).expect("menu");
+    let m = menu.matches.first().expect("`ga` reaches `/graph query`");
+    assert_eq!(m.command.name, "/graph query");
+    assert_eq!(
+        m.highlights,
+        vec![1, 3],
+        "the `g` and the `a` of `/graph`, counted from the slash"
+    );
+}
+
+/// A scattered match is the weakest name match, so it sorts under every
+/// prefix and substring one — and a description match sorts under it.
+#[test]
+fn a_scattered_name_match_sorts_under_the_contiguous_ones() {
+    let cmds = vec![
+        SlashCommand::new("/graph", "the code graph"),
+        SlashCommand::new("/gates", "the gate board"),
+        SlashCommand::new("/models", "pick a model, gateway included"),
+    ];
+    let mut c = Composer::new();
+    for ch in "/ga".chars() {
+        c.insert_char(ch);
+    }
+    let menu = c.slash_menu(&cmds, &PaletteState::default()).expect("menu");
+    let names: Vec<&str> = menu
+        .matches
+        .iter()
+        .map(|m| m.command.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["/gates", "/graph", "/models"],
+        "prefix, then scattered, then description-only: {names:?}"
+    );
+}
+
+/// **The witness (#5048).** Running a row from the palette records it, so
+/// the next browse list can offer it back under `recent`. Tab completes
+/// rather than runs, and records nothing.
+#[test]
+fn running_a_row_records_it_and_completing_one_does_not() {
+    use crossterm::event::{KeyCode, KeyEvent};
+    let cmds = classified_commands();
+    let mut c = Composer::new();
+    let names = vec!["/plan".to_string(), "/diff".to_string()];
+    let mut selected = 1usize;
+
+    handle_slash_popup_key(KeyEvent::from(KeyCode::Tab), &names, &mut c, &mut selected);
+    assert!(c.recent().is_empty(), "completing is not running");
+
+    selected = 1;
+    handle_slash_popup_key(
+        KeyEvent::from(KeyCode::Enter),
+        &names,
+        &mut c,
+        &mut selected,
+    );
+    assert_eq!(c.recent(), ["/diff"]);
+
+    c.insert_char('/');
+    let menu = c.slash_menu(&cmds, &PaletteState::default()).expect("menu");
+    assert!(
+        menu.sections.iter().any(|(_, h)| h == "recent"),
+        "the section appears once there is something in it: {:?}",
+        menu.sections
+    );
+    assert_eq!(
+        menu.matches.last().map(|m| m.command.name.as_str()),
+        Some("/diff"),
+        "and it closes the list"
+    );
+}
+
+/// **The witness (#4338).** The browse list opens on what the session
+/// makes relevant, under a heading that says why, then one group per
+/// domain — not thirty rows in vocabulary order.
+#[test]
+fn the_browse_list_leads_with_relevance_then_groups_by_domain() {
+    let cmds = classified_commands();
+    let state = PaletteState {
+        turn_running: true,
+        ..PaletteState::default()
+    };
+    let mut c = Composer::new();
+    c.insert_char('/');
+    let menu = c.slash_menu(&cmds, &state).expect("slash menu active");
+
+    let names: Vec<&str> = menu
+        .matches
+        .iter()
+        .map(|m| m.command.name.as_str())
+        .collect();
+    assert_eq!(
+        &names[..2],
+        &["/plan", "/budget"],
+        "the running turn's commands lead: {names:?}"
+    );
+    assert_eq!(
+        menu.sections.first(),
+        Some(&(0, "relevant now · a turn is running".to_string())),
+        "the heading says why: {:?}",
+        menu.sections
+    );
+    assert_eq!(
+        menu.sections[1..].to_vec(),
+        vec![
+            (2, "session".to_string()),
+            (4, "workspace".to_string()),
+            (5, "custom".to_string()),
+        ],
+        "one heading per remaining group, in domain order"
+    );
+}
+
+/// A quiet session has no relevance block at all — the list is the domain
+/// groups alone, with no heading claiming a reason that does not exist.
+#[test]
+fn a_quiet_browse_list_is_groups_only() {
+    let cmds = classified_commands();
+    let mut c = Composer::new();
+    c.insert_char('/');
+    let menu = c
+        .slash_menu(&cmds, &PaletteState::default())
+        .expect("slash menu active");
+    assert!(
+        !menu.sections.iter().any(|(_, h)| h.starts_with("relevant")),
+        "nothing to be relevant about: {:?}",
+        menu.sections
+    );
+    assert_eq!(menu.sections.first().map(|(at, _)| *at), Some(0));
+    let names: Vec<&str> = menu
+        .matches
+        .iter()
+        .map(|m| m.command.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["/help", "/clear", "/plan", "/budget", "/diff", "/fix-bug"],
+        "domain order, vocabulary order within a group"
+    );
+}
+
+/// A typed query keeps one flat ranked list — but a relevant command
+/// leads its rank, so `/b` mid-turn opens on `/budget` rather than on
+/// whatever the vocabulary happened to list first.
+#[test]
+fn a_typed_query_promotes_the_relevant_match_without_headings() {
+    let cmds = classified_commands();
+    let state = PaletteState {
+        turn_running: true,
+        ..PaletteState::default()
+    };
+    let mut c = Composer::new();
+    for ch in "/p".chars() {
+        c.insert_char(ch);
+    }
+    let menu = c.slash_menu(&cmds, &state).expect("slash menu active");
+    assert!(menu.sections.is_empty(), "no headings under a query");
+    let names: Vec<&str> = menu
+        .matches
+        .iter()
+        .map(|m| m.command.name.as_str())
+        .collect();
+    assert_eq!(
+        names.first(),
+        Some(&"/plan"),
+        "the prefix match still leads: {names:?}"
+    );
+    assert_eq!(
+        names.iter().position(|n| *n == "/budget"),
+        Some(2),
+        "and the relevant one leads its own (weaker) rank: {names:?}"
+    );
+
+    // Idle, the same query is the plain fuzzy ranking: `/budget` sits
+    // where the vocabulary put it, behind the two rows above it.
+    let idle = c
+        .slash_menu(&cmds, &PaletteState::default())
+        .expect("slash menu active");
+    let idle_names: Vec<&str> = idle
+        .matches
+        .iter()
+        .map(|m| m.command.name.as_str())
+        .collect();
+    assert_eq!(idle_names.first(), Some(&"/plan"));
+    assert_eq!(
+        idle_names.iter().position(|n| *n == "/budget"),
+        Some(3),
+        "relevance is what moved it: {idle_names:?}"
+    );
+}
+
+#[test]
+fn slash_menu_fuzzy_ranks_name_prefix_over_substring_over_description() {
+    let cmds = commands();
+    let mut c = Composer::new();
+    for ch in "/f".chars() {
+        c.insert_char(ch);
+    }
+    let menu = c
+        .slash_menu(&cmds, &PaletteState::default())
+        .expect("slash menu active");
+    let names: Vec<&str> = menu
+        .matches
+        .iter()
+        .map(|m| m.command.name.as_str())
+        .collect();
+    // `/files` starts with the query; `/diff` merely contains it — the
+    // prefix match must lead.
+    assert_eq!(names, vec!["/files", "/diff"]);
+}
+
+#[test]
+fn slash_menu_falls_back_to_description_matches() {
+    let cmds = commands();
+    let mut c = Composer::new();
+    for ch in "/transcript".chars() {
+        c.insert_char(ch);
+    }
+    let menu = c
+        .slash_menu(&cmds, &PaletteState::default())
+        .expect("slash menu active");
+    let names: Vec<&str> = menu
+        .matches
+        .iter()
+        .map(|m| m.command.name.as_str())
+        .collect();
+    // No name contains "transcript"; `/clear`'s description does.
+    assert_eq!(names, vec!["/clear"]);
+}
+
+#[test]
+fn bare_slash_lists_every_command() {
+    let cmds = commands();
+    let mut c = Composer::new();
+    c.insert_char('/');
+    let menu = c.slash_menu(&cmds, &PaletteState::default()).unwrap();
+    assert_eq!(menu.matches.len(), cmds.len());
+}
+
+#[test]
+fn slash_menu_is_inactive_once_a_space_is_typed() {
+    let cmds = commands();
+    let mut c = Composer::new();
+    for ch in "/models ".chars() {
+        c.insert_char(ch);
+    }
+    assert!(c.slash_menu(&cmds, &PaletteState::default()).is_none());
+}
+
+#[test]
+fn slash_command_constructors_set_the_kind() {
+    assert_eq!(SlashCommand::new("/help", "d").kind, SlashKind::Builtin);
+    assert_eq!(SlashCommand::custom("/x", "d").kind, SlashKind::Custom);
+}
+
+#[test]
+fn slash_menu_is_inactive_when_chips_are_present() {
+    let cmds = commands();
+    let mut c = Composer::with_paste_threshold(2);
+    c.paste("a\nb\nc");
+    c.insert_char('/');
+    assert!(c.slash_menu(&cmds, &PaletteState::default()).is_none());
+}
+
+#[test]
+fn line_count_ignores_a_trailing_newline() {
+    assert_eq!(line_count("a\nb\n"), 2);
+    assert_eq!(line_count("a\nb"), 2);
+    assert_eq!(line_count(""), 0);
+    assert_eq!(line_count("solo"), 1);
+}
+
+// Textarea semantics
+
+fn typed(text: &str) -> Composer {
+    let mut c = Composer::new();
+    for ch in text.chars() {
+        c.insert_char(ch);
+    }
+    c
+}
+
+#[test]
+fn newlines_typed_into_the_buffer_survive_submission_verbatim() {
+    let mut c = typed("first line");
+    c.insert_newline();
+    for ch in "second line".chars() {
+        c.insert_char(ch);
+    }
+    assert_eq!(c.take_submission().unwrap().text, "first line\nsecond line");
+}
+
+#[test]
+fn insert_and_backspace_act_at_the_cursor() {
+    let mut c = typed("hello");
+    c.move_left();
+    c.move_left();
+    c.insert_char('X'); // hel X lo
+    assert_eq!(c.buffer(), "helXlo");
+    c.backspace(); // removes the X, not the tail
+    assert_eq!(c.buffer(), "hello");
+    assert_eq!(c.cursor(), 3);
+}
+
+#[test]
+fn move_to_start_and_end_bound_the_whole_buffer() {
+    let mut c = typed("a\nb\nc");
+    c.move_to_start();
+    assert_eq!(c.cursor(), 0, "before the first character");
+    c.move_to_end();
+    assert_eq!(c.cursor(), c.buffer().len(), "one past the last character");
+}
+
+#[test]
+fn vertical_motion_keeps_the_column_and_clamps_to_short_lines() {
+    let mut c = typed("long line\nab\nlonger line");
+    // Cursor at end of "longer line"; up lands clamped to "ab"'s end.
+    c.move_up();
+    assert_eq!(&c.buffer()[..c.cursor()], "long line\nab");
+    // Up again: column carried from the clamp point (2) into "long line".
+    c.move_up();
+    assert_eq!(&c.buffer()[..c.cursor()], "lo");
+    // Down from the first line's column 2 → "ab" clamps to its end again.
+    c.move_down();
+    assert_eq!(&c.buffer()[..c.cursor()], "long line\nab");
+    // Down on the last line jumps to the very end.
+    c.move_down();
+    c.move_down();
+    assert_eq!(c.cursor(), c.buffer().len());
+}
+
+#[test]
+fn line_start_and_end_stay_within_the_logical_line() {
+    let mut c = typed("one\ntwo three");
+    // Cursor at end; Home goes to the start of "two three", not offset 0.
+    c.move_line_start();
+    assert_eq!(&c.buffer()[..c.cursor()], "one\n");
+    c.move_line_end();
+    assert_eq!(c.cursor(), c.buffer().len());
+}
+
+#[test]
+fn paste_lands_at_the_cursor_and_normalizes_line_endings() {
+    let mut c = typed("ac");
+    c.move_left();
+    c.paste("b\r\nB"); // small paste: inline, CRLF → LF
+    assert_eq!(c.buffer(), "ab\nBc");
+}
+
+#[test]
+fn big_paste_mid_buffer_keeps_the_tail_after_the_chip() {
+    let mut c = Composer::with_paste_threshold(2);
+    for ch in "headtail".chars() {
+        c.insert_char(ch);
+    }
+    for _ in 0..4 {
+        c.move_left(); // cursor between "head" and "tail"
+    }
+    c.paste("x\ny\nz");
+    let msg = c.take_submission().unwrap().text;
+    assert_eq!(msg, "head\nx\ny\nz\ntail", "order: before, chip, after");
+}
+
+#[test]
+fn classify_enter_submits_bare_and_breaks_on_a_modifier() {
+    let plain = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+    let cmd = KeyEvent::new(KeyCode::Enter, KeyModifiers::SUPER);
+    let meta = KeyEvent::new(KeyCode::Enter, KeyModifiers::META);
+    let ctrl = KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL);
+    let alt = KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT);
+    // Bare Enter always submits (never blocks).
+    assert_eq!(classify_enter(&plain), EnterAction::Submit);
+    // Every newline modifier inserts a line break instead.
+    assert_eq!(classify_enter(&cmd), EnterAction::Newline);
+    assert_eq!(classify_enter(&meta), EnterAction::Newline);
+    assert_eq!(classify_enter(&ctrl), EnterAction::Newline);
+    assert_eq!(classify_enter(&alt), EnterAction::Newline);
+    // A non-Enter key is not this function's concern.
+    let other = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
+    assert_eq!(classify_enter(&other), EnterAction::NotEnter);
+}
+
+#[test]
+fn edit_keys_leave_an_empty_composer_to_the_surface() {
+    // Arrows on an empty buffer must fall through (they scroll views).
+    let mut c = Composer::new();
+    for code in [KeyCode::Left, KeyCode::Right, KeyCode::Up, KeyCode::Down] {
+        assert!(!handle_edit_key(
+            KeyEvent::new(code, KeyModifiers::NONE),
+            &mut c
+        ));
+    }
+    // ↑/↓ on a single-line buffer also fall through (transcript scroll).
+    let mut single = typed("one line");
+    assert!(!handle_edit_key(
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+        &mut single
+    ));
+    assert!(handle_edit_key(
+        KeyEvent::new(KeyCode::Left, KeyModifiers::NONE),
+        &mut single
+    ));
+}
+
+// Soft-wrap layout
+
+#[test]
+fn layout_soft_wraps_long_lines_and_hard_breaks_newlines() {
+    let c = typed("abcdef\ngh");
+    let l = layout(&c, 4);
+    assert_eq!(l.rows, vec!["abcd", "ef", "gh"]);
+    // Cursor at the end: one past 'h' on the last row.
+    assert_eq!((l.cursor_row, l.cursor_col), (2, 2));
+}
+
+#[test]
+fn layout_places_the_cursor_mid_text() {
+    let mut c = typed("abcdef");
+    for _ in 0..2 {
+        c.move_left(); // cursor before 'e' (offset 4)
+    }
+    let l = layout(&c, 4);
+    assert_eq!(l.rows, vec!["abcd", "ef"]);
+    assert_eq!((l.cursor_row, l.cursor_col), (1, 0), "'e' starts row 1");
+}
+
+#[test]
+fn layout_gives_the_cursor_a_fresh_row_when_the_last_row_is_full() {
+    let c = typed("abcd");
+    let l = layout(&c, 4);
+    assert_eq!(l.rows, vec!["abcd", ""]);
+    assert_eq!((l.cursor_row, l.cursor_col), (1, 0));
+}
+
+#[test]
+fn layout_shows_chips_as_their_display_form() {
+    let mut c = Composer::with_paste_threshold(2);
+    c.paste("a\nb\nc");
+    for ch in "ok".chars() {
+        c.insert_char(ch);
+    }
+    let l = layout(&c, 40);
+    assert_eq!(l.rows, vec!["[pasted: 3 lines] ok"]);
+    assert_eq!((l.cursor_row, l.cursor_col), (0, 20));
+}
+
+#[test]
+fn layout_is_wide_char_aware() {
+    let c = typed("日本語"); // width 2 each
+    let l = layout(&c, 4);
+    assert_eq!(l.rows, vec!["日本", "語"]);
+    assert_eq!((l.cursor_row, l.cursor_col), (1, 2));
+}
+
+#[test]
+fn split_row_at_returns_the_char_under_the_cursor() {
+    assert_eq!(split_row_at("abc", 1), ("a".into(), Some('b'), "c".into()));
+    assert_eq!(split_row_at("abc", 3), ("abc".into(), None, String::new()));
+    assert_eq!(
+        split_row_at("日本", 2),
+        ("日".into(), Some('本'), String::new())
+    );
+}
+
+#[test]
+fn empty_composer_lays_out_as_one_empty_row_with_the_cursor_home() {
+    let c = Composer::new();
+    let l = layout(&c, 10);
+    assert_eq!(l.rows, vec![""]);
+    assert_eq!((l.cursor_row, l.cursor_col), (0, 0));
+}

--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -97,6 +97,13 @@ pub struct DeckOptions {
     ///
     /// `--plain` is unaffected and stays what it is: the no-terminal path.
     pub accessible: bool,
+    /// Where the palette's `recent` section is kept for this workspace
+    /// (`.stella/private/palette-recent.json`), or `None` for a caller that
+    /// has no workspace to keep it in — the section is then in-session only.
+    /// The caller resolves the path for the reason it resolves
+    /// [`Self::debug_log_path`]: this crate does not decide where a workspace
+    /// lives.
+    pub recent_path: Option<PathBuf>,
     /// What a plain prompt typed at a running agent does (`ui.mid_turn_prompt`):
     /// queue for the lead so Esc can steer it (the default), raise the routing
     /// card, or fork a sidecar. See [`crate::deck_ui::MidTurnPrompt`].
@@ -547,6 +554,9 @@ pub async fn run_deck(
     ));
     ui.graph = opts.initial_graph.clone();
     ui.slash_commands = opts.slash_commands.clone();
+    if let Some(path) = opts.recent_path.as_ref() {
+        ui.composer.keep_recent_in(path);
+    }
     ui.color_mode = color_mode;
     ui.no_anim = no_anim;
     ui.accessible = opts.accessible;
@@ -751,6 +761,9 @@ pub async fn run_deck(
                             }
                             DeckAction::Handled | DeckAction::Ignored => {}
                         }
+                        // A dispatched palette row changed the `recent` list;
+                        // every other keystroke leaves this a no-op.
+                        ui.composer.flush_recent();
                     }
                     // Bracketed paste: the whole paste arrives as one event
                     // (the guard enabled it), so the composer can fold it

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -93,8 +93,8 @@ pub use ansi::strip_ansi;
 pub use attach::probe_path_attachment;
 pub use clipboard::{ClipboardPaste, default_attachments_dir};
 pub use composer::{
-    Composer, ComposerEntry, DEFAULT_PASTE_LINE_THRESHOLD, PaletteState, SlashCommand, SlashDomain,
-    SlashKind, SlashMenu, Submission,
+    Composer, ComposerEntry, DEFAULT_PASTE_LINE_THRESHOLD, PaletteState, Recents, SlashCommand,
+    SlashDomain, SlashKind, SlashMatch, SlashMenu, Submission,
 };
 pub use debug_log::DebugLog;
 pub use input::UserInput;

--- a/crates/stella-tui/src/render.rs
+++ b/crates/stella-tui/src/render.rs
@@ -250,6 +250,14 @@ pub(crate) const SLASH_POPUP_MAX_ROWS: usize = 8;
 /// under the matches — the key hints ride the top border, so no interior row
 /// but the hint is chrome (SPEC 10).
 ///
+/// SPEC 10 asked for a centered `Rect` and was amended to this instead
+/// (#5048), the way SPEC 11's `tab` binding was amended to
+/// [`crate::keymap::PLAN_CARD_KEYS`]. The palette completes the word under the
+/// cursor, and centering moves the completions away from the letters that
+/// produced them — every terminal and editor autocomplete anchors to the caret
+/// for that reason. The `panel` ground and the `rule` border the same bullet
+/// asks for are unchanged, and [`render_slash_popup`] now paints them.
+///
 /// `rows` counts group headings as well as matches ([`display_rows`]): a
 /// sectioned browse list that sized itself on matches alone would clip its
 /// last commands behind their own captions.
@@ -274,6 +282,21 @@ pub(crate) fn slash_popup_area(root: Rect, composer: Rect, rows: usize) -> Rect 
 pub(crate) enum PopupRow {
     Heading(String),
     Command(usize),
+}
+
+/// `text` split into `(matched, run)` pairs against a set of char offsets:
+/// consecutive characters on the same side of the match share a run, so a
+/// contiguous highlight costs one span rather than one per character.
+pub(crate) fn highlight_runs(text: &str, highlights: &[usize]) -> Vec<(bool, String)> {
+    let mut runs: Vec<(bool, String)> = Vec::new();
+    for (i, ch) in text.chars().enumerate() {
+        let hot = highlights.contains(&i);
+        match runs.last_mut() {
+            Some((was, run)) if *was == hot => run.push(ch),
+            _ => runs.push((hot, ch.to_string())),
+        }
+    }
+    runs
 }
 
 /// The palette's interior rows: every match, with its section heading above
@@ -316,12 +339,15 @@ pub(crate) fn scroll_window_start(len: usize, selected: usize, visible: usize) -
 /// ╰────────────────────────────────────────────────────────────────╯
 /// ```
 ///
-/// Each row is the command in gold — the typed prefix lit bright, the rest
-/// gold — its one-line effect dim, and a live value on the right when the
-/// model has one (`/inbox · 3 unread`). The selected row carries the `▸`
-/// marker *plus* the highlight ground: the golden suite strips style, so a
-/// style-only selection would be invisible to it. User-authored commands keep
-/// their `SlashKind` glyph.
+/// Each row is the command in gold — the letters the query matched lit
+/// bright wherever they fell, the rest gold — its one-line effect dim, and a
+/// live value on the right when the model has one (`/inbox · 3 unread`). The
+/// letters come from [`crate::composer::SlashMatch::highlights`], so `ga`
+/// lights the `g` and the `a` of `/graph query` rather than only a typed
+/// prefix (#5048). The selected row carries the `▸` marker *plus* the
+/// highlight ground: the golden suite strips style, so a style-only selection
+/// would be invisible to it. User-authored commands keep their `SlashKind`
+/// glyph.
 ///
 /// `live` overrides descriptions with values read from the model at render
 /// time, keyed by command name — computed by the caller each frame, never
@@ -334,12 +360,11 @@ pub(crate) fn scroll_window_start(len: usize, selected: usize, visible: usize) -
 /// With no query typed, the list is sectioned: [`SlashMenu::sections`] puts
 /// `relevant now · <why>` over the commands the session's own state makes
 /// worth reaching for, then a heading per [`crate::composer::SlashDomain`]
-/// group (#4338). A typed query drops the headings — grouping a three-row
-/// result buries the rows under their own captions — and keeps the flat
-/// ranking, in which a relevant command still leads its rank.
-///
-/// The renderings' `recent` section is still absent: it needs per-workspace
-/// persistence, which the deck has no store for (#4338).
+/// group (#4338), and closes with `recent` — the commands this workspace ran
+/// last, kept across restarts by [`crate::composer::Recents`] (#5048). A typed
+/// query drops the headings — grouping a three-row result buries the rows
+/// under their own captions — and keeps the flat ranking, in which a relevant
+/// command still leads its rank.
 pub(crate) fn render_slash_popup(
     menu: &SlashMenu,
     selected: usize,
@@ -371,7 +396,6 @@ pub(crate) fn render_slash_popup(
     let first = scroll_window_start(rows.len(), selected_row, visible);
     let last = (first + visible).min(rows.len());
     let inner_w = inner_width(area);
-    let query = menu.query.trim_start_matches('/').to_ascii_lowercase();
 
     let mut lines: Vec<Line<'static>> = rows[first..last]
         .iter()
@@ -384,7 +408,8 @@ pub(crate) fn render_slash_popup(
                 }
                 PopupRow::Command(index) => *index,
             };
-            let c = menu.matches[index];
+            let m = &menu.matches[index];
+            let c = m.command;
             let is_sel = index == selected;
             let marker = if is_sel { "▸ " } else { "  " };
             let live_value = live
@@ -392,24 +417,18 @@ pub(crate) fn render_slash_popup(
                 .find(|(name, _)| *name == c.name)
                 .map(|(_, v)| v.clone());
             let description = c.description.clone();
-            // The typed prefix lights up inside the name — `/ga` → `/ga`tes.
             let name = c.name.clone();
-            let bare = name.trim_start_matches('/').to_ascii_lowercase();
-            let (head, tail) = if !query.is_empty() && bare.starts_with(&query) {
-                let cut = 1 + query.len();
-                (name[..cut].to_string(), name[cut..].to_string())
-            } else {
-                (String::new(), name.clone())
-            };
             let mut spans = vec![Span::styled(marker.to_string(), gold)];
             if c.kind != crate::composer::SlashKind::Builtin {
                 spans.push(Span::styled(format!("{} ", c.kind.glyph()), muted));
             }
-            if !head.is_empty() {
-                spans.push(Span::styled(head.clone(), lit));
+            // The matched letters light wherever they fell. Runs are coalesced
+            // so a contiguous match is one span rather than one per character.
+            for (hot, run) in highlight_runs(&name, &m.highlights) {
+                spans.push(Span::styled(run, if hot { lit } else { gold }));
             }
-            let pad = 16usize.saturating_sub(head.chars().count() + tail.chars().count());
-            spans.push(Span::styled(format!("{tail}{}", " ".repeat(pad)), gold));
+            let pad = 16usize.saturating_sub(name.chars().count());
+            spans.push(Span::styled(" ".repeat(pad), gold));
             spans.push(Span::styled(format!(" {description}"), dim));
             if let Some(value) = live_value {
                 let used: usize = spans.iter().map(Span::width).sum();
@@ -451,6 +470,10 @@ pub(crate) fn render_slash_popup(
         .borders(Borders::ALL)
         .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(Style::new().fg(token::RULE))
+        // SPEC 10's `panel` ground. `Clear` alone leaves the terminal's own
+        // background showing through a floating overlay, so the palette read
+        // as a hole in the deck rather than as a panel over it (#5048).
+        .style(Style::new().bg(token::PANEL))
         .title(Line::from(vec![
             Span::styled(" / commands", gold),
             Span::styled(format!("  {shown} of {total} · fuzzy "), muted),
@@ -533,6 +556,9 @@ pub(crate) fn render_arg_popup(
         .borders(Borders::ALL)
         .border_type(ratatui::widgets::BorderType::Rounded)
         .border_style(Style::new().fg(token::RULE))
+        // The same `panel` ground the command palette floats on — the two
+        // overlays are one shape and must not differ in their ground.
+        .style(Style::new().bg(token::PANEL))
         .title(Line::from(vec![
             Span::styled(format!(" {command}"), gold),
             Span::styled(format!("  {} of {total} ", last - first), muted),

--- a/crates/stella-tui/src/render/tests/slash.rs
+++ b/crates/stella-tui/src/render/tests/slash.rs
@@ -3,11 +3,30 @@
 //! Split out of `render/tests.rs` when that file crossed the 1500-line guard,
 //! following `thinking`. One topic per file: these are the only tests that
 //! drive a `Composer` through its `SlashCommand` list, and between them they
-//! pin the popup's two separable jobs — which commands survive the filter (and
-//! which glyph marks a custom one), and the window that holds still until the
-//! selection actually leaves its edge.
+//! pin the popup's separable jobs — which commands survive the filter (and
+//! which glyph marks a custom one), the window that holds still until the
+//! selection actually leaves its edge, which letters light gold, and the
+//! ground the whole overlay floats on.
 
 use super::*;
+use ratatui::style::Color;
+use stella_tui_theme::token;
+
+/// The row and column of the first cell of `needle`, or `None`.
+fn find_cell(buf: &Buffer, needle: &str) -> Option<(u16, u16)> {
+    let rows = buffer_rows(buf);
+    rows.iter().enumerate().find_map(|(y, row)| {
+        row.find(needle)
+            .map(|byte| (row[..byte].chars().count() as u16, y as u16))
+    })
+}
+
+/// The foreground colours of the `len` cells starting at `(x, y)`.
+fn foregrounds(buf: &Buffer, x: u16, y: u16, len: u16) -> Vec<Option<Color>> {
+    (x..x + len)
+        .map(|at| buf.cell((at, y)).map(|c| c.fg))
+        .collect()
+}
 
 #[test]
 fn scroll_window_start_holds_still_until_the_selection_leaves_the_edge() {
@@ -111,7 +130,7 @@ fn the_browse_popup_draws_the_relevance_heading_and_the_domain_groups() {
         turn_running: true,
         ..PaletteState::default()
     };
-    let menu = SlashMenu::filter_with(&cmds, "/", &state);
+    let menu = SlashMenu::filter_with(&cmds, "/", &state, &[]);
     let rows = crate::render::display_rows(&menu);
     let area = Rect {
         x: 0,
@@ -138,6 +157,152 @@ fn the_browse_popup_draws_the_relevance_heading_and_the_domain_groups() {
     assert!(
         !text.contains('\u{25b2}') && !text.contains('\u{25bc}'),
         "everything fit, so no scroll affordance:\n{text}"
+    );
+}
+
+/// **The witness (#5048).** The matched letters light gold *inside* the name,
+/// wherever they landed. `ga` is neither a prefix nor a substring of
+/// `graph query`, so the old prefix-only lighting painted the whole row one
+/// colour and the palette's own `· fuzzy` title was a claim nothing on screen
+/// backed.
+#[test]
+fn scattered_matched_letters_light_gold_inside_the_name() {
+    let cmds = vec![SlashCommand::new("/graph query", "free-form graph query")];
+    let menu = SlashMenu::filter(&cmds, "/ga");
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 64,
+        height: 5,
+    };
+    let mut buf = Buffer::empty(area);
+    render_slash_popup(&menu, 0, &[], area, &mut buf);
+
+    let (x, y) = find_cell(&buf, "/graph").expect("the row is drawn");
+    // `/ g r a p h` — the `g` at +1 and the `a` at +3 are the two matched
+    // letters; the slash and everything between and after them stay resting
+    // gold.
+    let fg = foregrounds(&buf, x, y, 6);
+    assert_eq!(
+        fg,
+        vec![
+            Some(token::GOLD),
+            Some(token::GOLD_BRIGHT),
+            Some(token::GOLD),
+            Some(token::GOLD_BRIGHT),
+            Some(token::GOLD),
+            Some(token::GOLD),
+        ],
+        "the g and the a light, and only them:\n{}",
+        buffer_text(&buf)
+    );
+}
+
+/// A prefix keeps lighting as one contiguous run, which is the behaviour the
+/// scattered walk had to preserve rather than replace. The leading `/` is the
+/// sigil that opened the palette and no longer lights with the letters after
+/// it — a matched letter is one the query actually consumed, and the
+/// scattered case cannot pretend otherwise.
+#[test]
+fn a_prefix_still_lights_as_one_run() {
+    let cmds = vec![SlashCommand::new("/plan", "the plan")];
+    let menu = SlashMenu::filter(&cmds, "/pl");
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 48,
+        height: 5,
+    };
+    let mut buf = Buffer::empty(area);
+    render_slash_popup(&menu, 0, &[], area, &mut buf);
+
+    let (x, y) = find_cell(&buf, "/plan").expect("the row is drawn");
+    assert_eq!(
+        foregrounds(&buf, x, y, 5),
+        vec![
+            Some(token::GOLD),
+            Some(token::GOLD_BRIGHT),
+            Some(token::GOLD_BRIGHT),
+            Some(token::GOLD),
+            Some(token::GOLD),
+        ],
+        "`pl` lights, the sigil and `an` do not:\n{}",
+        buffer_text(&buf)
+    );
+}
+
+/// **The witness (#5048).** SPEC 10 asks for a `panel` ground under the
+/// overlay. `Clear` alone leaves the terminal's own background showing, so a
+/// palette over a dark deck read as a hole punched in it.
+#[test]
+fn the_palette_floats_on_the_panel_ground() {
+    let cmds = vec![SlashCommand::new("/plan", "the plan")];
+    let menu = SlashMenu::filter(&cmds, "/pl");
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 48,
+        height: 5,
+    };
+    let mut buf = Buffer::empty(area);
+    render_slash_popup(&menu, 0, &[], area, &mut buf);
+
+    let (x, y) = find_cell(&buf, "/plan").expect("the row is drawn");
+    // A row that is not selected: the selected one carries `hl` over the top.
+    let unselected_row = buf.cell((x, y + 1)).map(|c| c.bg);
+    assert_eq!(
+        buf.cell((0, 0)).map(|c| c.bg),
+        Some(token::PANEL),
+        "the border corner sits on panel:\n{}",
+        buffer_text(&buf)
+    );
+    assert!(
+        unselected_row.is_none() || unselected_row == Some(token::PANEL),
+        "and so does the interior: {unselected_row:?}\n{}",
+        buffer_text(&buf)
+    );
+    assert_eq!(
+        buf.cell((x, y)).map(|c| c.bg),
+        Some(token::HL),
+        "the selected row keeps its own ground over the panel:\n{}",
+        buffer_text(&buf)
+    );
+}
+
+/// **The witness (#5048).** The browse list closes with SPEC 10's `recent`
+/// section, listing the commands this workspace ran last. A recent row is a
+/// second appearance of a command a domain group already carries — that is
+/// what a shortcut is — so both are drawn.
+#[test]
+fn the_browse_popup_closes_with_the_recent_section() {
+    use crate::composer::{PaletteState, SlashDomain};
+    let cmds = vec![
+        SlashCommand::new("/clear", "reset").in_domain(SlashDomain::Session),
+        SlashCommand::new("/diff", "the diff").in_domain(SlashDomain::Code),
+    ];
+    let recent = vec!["/diff".to_string()];
+    let menu = SlashMenu::filter_with(&cmds, "/", &PaletteState::default(), &recent);
+    let rows = crate::render::display_rows(&menu);
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 72,
+        height: (rows.len() as u16) + 3,
+    };
+    let mut buf = Buffer::empty(area);
+    render_slash_popup(&menu, 0, &[], area, &mut buf);
+    let text = buffer_text(&buf);
+    assert!(text.contains("recent"), "the heading is drawn:\n{text}");
+    assert_eq!(
+        text.matches("/diff").count(),
+        2,
+        "the shortcut and the group row both appear:\n{text}"
+    );
+    let recent_at = text.find("recent").expect("heading");
+    let workspace_at = text.find("workspace").expect("domain heading");
+    assert!(
+        workspace_at < recent_at,
+        "`recent` closes the list rather than opening it:\n{text}"
     );
 }
 

--- a/design/tui-v2/IMPLEMENTATION-PLAN.md
+++ b/design/tui-v2/IMPLEMENTATION-PLAN.md
@@ -24,7 +24,7 @@ Companion to [`SPEC.md`](SPEC.md). Phases are ordered so each ships value alone 
 |---|---|---|
 | `ratatui` + `crossterm` | already in use | `BorderType::Rounded` for panels |
 | ~~`syntect`~~ | ~~syntax highlighting~~ | **Not taken.** The deck highlights through `stella_transcript::syntax`, which the export grid and Observatory already share. A syntect crate here would be a *fourth* lexer for the same bodies — the drift #3644 and #4036 each closed once (#4196). |
-| `nucleo` | fuzzy matching for the palette | **Not taken yet.** The palette ranks with a hand-rolled name-prefix / name-substring / description scan (`composer::SlashMenu::filter_with`), which produces no match indices — so only the typed prefix lights gold. Taking the dependency, or teaching the scan to emit indices, is the open decision in #5048. |
+| ~~`nucleo`~~ | ~~fuzzy matching for the palette~~ | **Not taken.** The palette matches through `composer::fuzzy`, which returns the char offsets a query consumed so the letters can light wherever they fell (#5048). A command name is a short ASCII slug and the row order comes from the match kind plus session relevance, so the scoring model a fuzzy-finder crate exists for would be computed and discarded. |
 | `insta` | snapshot tests | pairs with `TestBackend` |
 | `tokio` | async registry, tracker, oauth | already likely present |
 
@@ -48,7 +48,7 @@ rather than to this file's history.
 | P4 gates | not started | #5042 (board and failure block), #5043 (the proposed revision, which needs #5037). |
 | P5 issues and start work | part landed | The ISSUES tab, its state glyphs and its PR strip ship. Heat sort, the linked plan and the sync rule are #4336; `w start work` is #5044 (the key routes to a stub that errors today). |
 | P6 graph, skills, MCP | mostly landed | All three tabs ship. Reverse-edge session tags are #5045; the learned-skill lifecycle is #5046 and its economics and signatures #4337; the MCP pin, latency, tier and first-enable handshake are #5047. |
-| P7 palette and plugins | part landed | The palette overlay ships with a context section and a hand-rolled matcher. Scattered match letters, recents and the overlay's position are #5048. The plugin panel protocol does not exist in any form — #5054 (wire contract), #5055 (host), #5056 (handshake). |
+| P7 palette and plugins | part landed | The palette overlay ships whole: a context section, scattered match letters lit gold, a `recent` section kept per workspace, and the `panel` ground (#5048 — which also amended SPEC 10 to the anchored position the deck ships). Its remaining gaps are the `2m ago` column (#5213) and a rendering that still draws headings under a typed query (#5215). The plugin panel protocol does not exist in any form — #5054 (wire contract), #5055 (host), #5056 (handshake). |
 
 The epics that group these are #5057–#5062. Section 7's definition of done is
 unchanged and unmet: it is what closes those epics.
@@ -122,7 +122,7 @@ Acceptance: snapshots per tab; policy test that unsigned results never render an
 
 ### P7: palette and plugin panels
 
-- Palette overlay with nucleo matching, gold match letters, context section derived from session state, groups, recents, arg hints (SPEC 10).
+- Palette overlay with fuzzy matching, gold match letters, context section derived from session state, groups, recents, arg hints (SPEC 10).
 - Plugin panel host: `Rect` lease, styled-line blit API, host-owned chrome, handshake rendering, frame budget throttle (SPEC 12).
 
 Acceptance: palette snapshot for query `ga` during a verify turn showing `/gates` first; a test plugin that attempts to draw outside its `Rect` is clipped; over-budget plugin shows the throttle tag.

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -403,9 +403,13 @@ Keep current information architecture (executions table, installed agents, agent
 
 ## 10. Command palette (rendering `08-command-palette`)
 
-- Overlay: `Clear` over a centered `Rect`, `panel` bg, `rule` border.
-- **Fuzzy matching** via `nucleo`; matched letters render gold inside each command name.
-- **Context section first**: `relevant now` derives from session state (verify running surfaces `/gates` with live gate status on the row). Then domain groups (plan, graph, skills, ...), then `recent`.
+- Overlay: `Clear` over a `Rect` anchored to the composer's left edge and opening upward, `panel` bg, `rule` border.
+
+  **Amended (#5048).** This bullet asked for a *centered* `Rect`. The palette completes the word under the cursor, and centering moves the completions away from the letters that produced them — every terminal and editor autocomplete anchors to the caret for that reason. The deck anchors, and `slash_popup_area` in `crates/stella-tui/src/render.rs` carries the same argument beside the code. The `panel` ground and the `rule` border are unchanged and now shipped; before #5048 the overlay drew `Clear` and no ground at all, so it read as a hole in the deck.
+- **Fuzzy matching**; matched letters render gold inside each command name, scattered letters included — `ga` lights the `g` and the `a` of `/graph query`. The leading `/` is the sigil that opened the palette and never lights.
+
+  **Amended (#5048).** This bullet named `nucleo`. The matcher is `crates/stella-tui/src/composer/fuzzy.rs` instead: a command name is a short ASCII slug, and the palette's order comes from the match kind and from what the session is doing (`relevant now` below), so a fuzzy-finder crate's scoring model would be computed and discarded. Match kind ranks prefix, then substring, then scattered letters, then a description-only match.
+- **Context section first**: `relevant now` derives from session state (verify running surfaces `/gates` with live gate status on the row). Then domain groups (plan, graph, skills, ...), then `recent` — the commands this workspace ran last, kept in `.stella/private/palette-recent.json` so they survive a restart. A `recent` row is a second appearance of a command a domain group already lists, which is what a shortcut is. The section is drawn for the browse list; a typed query returns one flat ranked list with no headings at all (#4338).
 - Rows may carry live right-aligned state (`◐ 2/5 green`, `det · $0.00`) and arg hints (`⇥ <name>`).
 - Keys: `↑↓ move · ↵ run · ⇥ args · esc`.
 


### PR DESCRIPTION
Closes #5048

SPEC 10 named three things the command palette did not do. All three land here, and where the shipped design is the better one the spec is amended in the same PR rather than left disagreeing with the code.

## 1. Matched letters light gold inside the name

`ga` now lights the `g` and the `a` of `/graph query`. Before, only a typed *prefix* lit — and a scattered query matched no row at all, so the popup's own `· fuzzy` title was a claim nothing on screen backed.

**Decision: extended the matcher, did not take `nucleo`.** `crates/stella-tui/src/composer/fuzzy.rs` returns the char offsets a match consumed, ranked prefix → substring → scattered → description-only. A command name is a short ASCII slug, and the palette's order comes from that rank plus what the session is doing (`palette::relevant_now`), so a fuzzy-finder crate's scoring model would be computed and then discarded. **No new dependency; `cargo deny` is untouched.** A contiguous run still wins before the scattered walk is tried, so every existing prefix/substring rank and highlight is unchanged.

One behaviour change worth naming: the leading `/` no longer lights with the letters after it. It is the sigil that opened the palette, not a letter the query consumed, and the scattered case cannot pretend otherwise.

## 2. The `recent` section

The browse list closes with `recent` — the commands this workspace ran last, most recent first, capped at five.

**Store: `.stella/private/palette-recent.json`**, a JSON array of names. That is the smallest store that survives a restart and the only one `stella-tui` can reach without taking a dependency on `stella-store`; the CLI resolves the path (`palette_recent_path` in `command_deck.rs`) and hands it in through `DeckOptions::recent_path`, the way `debug_log_path` already works. `.stella/private/` is gitignored, so a clone never inherits someone else's last five commands. Both file operations are best-effort and silent — a palette that refused to open because a convenience list would not parse has traded a feature for an ornament.

The list rides the `Composer`, which already owns the slash-menu view, so the key handler and the renderer read one list without either surface passing it between them. A surface handed no path keeps an in-session list and writes nothing.

A `recent` row is a second appearance of a command a domain group already lists — that is what a shortcut is — so it is appended rather than lifted out of its group, which is also where SPEC 10 puts the section.

## 3. Position and background

**The `panel` ground is a real gap and is fixed.** `Clear` alone left the terminal's own background showing through the overlay, so the palette read as a hole punched in the deck. The `/model` argument popup takes the same ground — the two overlays are one shape and must not differ in it.

**The anchored position is the better design, so SPEC 10 is amended** (`design/tui-v2/SPEC.md`), following the pattern `keymap.rs`'s `PLAN_CARD_KEYS` doc records for the `^S` amendment: the reason lives both in the spec bullet and beside the code, in `slash_popup_area`'s doc comment. The palette completes the word under the cursor, and centering moves the completions away from the letters that produced them — every terminal and editor autocomplete anchors to the caret for that reason.

The same §10 edit records the matcher choice and the store, so the spec no longer names a dependency this tree does not take.

## Witnesses, and the flip verified artisanally

Every one below was checked by reverting the production change, watching the test fail, and restoring it.

| Witness | Reverted to check the flip | Result |
|---|---|---|
| `composer::fuzzy::tests::scattered_letters_match_and_name_their_positions` | the scattered walk in `match_name` | FAILED |
| `composer::tests::a_scattered_query_matches_and_reports_where_its_letters_landed` | same | FAILED |
| `composer::tests::a_scattered_name_match_sorts_under_the_contiguous_ones` | same | FAILED |
| `render::tests::slash::scattered_matched_letters_light_gold_inside_the_name` | same, and separately the per-letter span walk in `render_slash_popup` | FAILED under both |
| `render::tests::slash::a_prefix_still_lights_as_one_run` | the per-letter span walk | FAILED |
| `render::tests::slash::the_palette_floats_on_the_panel_ground` | the `.style(bg(token::PANEL))` on the block | FAILED |
| `render::tests::slash::the_browse_popup_closes_with_the_recent_section` | the `recent` section append in `filter_with` | FAILED |
| `composer::tests::running_a_row_records_it_and_completing_one_does_not` | same | FAILED |
| `composer::recent::tests::the_list_survives_the_session_that_wrote_it` | the write in `Recents::flush` | FAILED |

The fuzzy-highlight witness asserts scattered letters, not a prefix: it reads the buffer's per-cell foreground and requires `token::GOLD_BRIGHT` on exactly the `g` and the `a` of `/graph query`, with the slash and every letter between and after them at resting `token::GOLD`.

## Evidence

- `cargo test -p stella-tui` — exit 0 (1227 tests). The `deck_render_snapshots` goldens pass **unblessed**: the palette snapshots carry no recents, and the suite strips style, so neither the new section nor the new ground moves a frame.
- `cargo clippy -p stella-tui --all-targets` — exit 0. `cargo clippy -p stella-cli --all-targets` — exit 0.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps` — exit 0.
- `make guards-fast` — exit 0, `make prose` included (no baseline edited).
- CI on this branch is the PR's evidence for anything wider; nothing here was built workspace-wide on the maintainer's laptop.

## One structural change

`composer.rs` crossed the 1500-line file-size guard, so its test module moved to `composer/tests.rs` unchanged — the split `render/tests.rs` and `deck_ui/tests/` already follow. No test was deleted or renamed; the file is 921 lines now, well clear of the limit and still not in the baseline.

## Noticed, not fixed — filed

- **#5213** — the rendering puts a relative age (`2m ago`) on each `recent` row and this does not. The age needs a timestamp in the store and a clock in the renderer, and the existing right-aligned `live` slice is keyed by command name, so it would paint the age on the domain-group copy too. `P4 · area:tui · use-model:balanced · pain:user-experience`.
- **#5215** — the rendering `08-command-palette` draws section headings with `/ga` typed; the code drops headings under any query (#4338's deliberate decision, pinned by `a_queried_popup_draws_no_headings`). This PR made the spec prose state the shipped behaviour, which leaves the SVG as the only artifact claiming otherwise. Pre-existing, not introduced here. `P4 · area:tui · area:docs · use-model:cheap · pain:brand-consistency · pain:maintainability`.

## Summary by Sourcery

Complete the command palette experience with fuzzy match highlighting, workspace-persistent recents, and consistent anchored overlay styling.

New Features:
- Add fuzzy command-name matching that highlights all consumed letters, including scattered matches, in the command palette.
- Persist up to five recently executed palette commands per workspace and display them in a trailing `recent` section.

Bug Fixes:
- Give the command and argument popups an opaque panel background so terminal content does not show through the overlays.

Enhancements:
- Anchor the command palette to the composer instead of centering it, and amend the TUI specification and implementation plan to document the shipped matcher, positioning, and recents behavior.

Documentation:
- Update the TUI design documentation to reflect the completed palette behavior and the decision not to add a fuzzy-matching dependency.

Tests:
- Add coverage for scattered matching, highlight positions, recent-command recording and persistence, recent-section rendering, and popup background styling.

Chores:
- Move the composer tests into a dedicated module to remain within the file-size guard.