### PR TITLE
feat(website): showcase the deck renderings across the site

### DIFF
--- a/website/content/docs/agent-modes.mdx
+++ b/website/content/docs/agent-modes.mdx
@@ -119,6 +119,20 @@ immediately, inline in the session transcript, skipping the queue. A single **Es
 **double-Esc** cancels *and holds* dispatch so what you type next runs first.
 Prefer a plain line-based REPL? `stella --plain` (or `STELLA_PLAIN=1`).
 
+### The transcript, and the palette
+
+The turn is the unit of the transcript. It opens with a rule, folds every read
+that changed nothing, keeps the edits expanded with their diffs, and closes on
+a receipt — what the turn cost, what it proved, and how much of it never
+reached a model.
+
+<DeckShot id="turn" />
+
+Slash commands open a fuzzy palette that knows what is running: while a verify
+turn is in flight, the gate commands sort to the top.
+
+<DeckShot id="palette" />
+
 ## One-shot: `stella run`
 
 The non-interactive workhorse: one prompt in, the finished work and an exit

--- a/website/content/docs/agent-tools/mcp.mdx
+++ b/website/content/docs/agent-tools/mcp.mdx
@@ -36,6 +36,13 @@ Because the tools are added at session start, connecting a new server takes effe
 
 <McpTopologyDiagram />
 
+The MCP tab is where that review happens. Each server shows its transport,
+tool count, handshake latency and auth state, and a new one arrives disabled
+with its capabilities on show. The code graph sits pinned at the top because
+it is the product rather than an integration.
+
+<DeckShot id="mcp" />
+
 <Callout type="warn">
 `stella tools` does **not** enumerate MCP tools — it prints a note that MCP servers merge more tools at session start. Confirm a server is wired up with `stella mcp list`, or verify its tools from inside a session (the deck's MCP tab, `/mcp`).
 </Callout>

--- a/website/content/docs/agent-tools/skills.mdx
+++ b/website/content/docs/agent-tools/skills.mdx
@@ -114,7 +114,14 @@ The underlying commands are overridable (`STELLA_SKILLS_SEARCH_CMD`,
 
 ## Managing skills in the Command Deck
 
-`/skills` opens the SKILLS tab:
+`/skills` opens the SKILLS tab. Installed skills carry their own injection
+counts and token cost, so the ones that never fire are visible and can be
+pruned; the learned rows below them are the ones stella wrote from its own
+traces; and an unsigned registry result installs disabled.
+
+<DeckShot id="skills" />
+
+The keys:
 
 <CardGrid size="sm">
   <OptionCard name="space">

--- a/website/content/docs/context-engine.mdx
+++ b/website/content/docs/context-engine.mdx
@@ -273,6 +273,13 @@ a native **tree-sitter** index of your code:
   [`stella search`](/docs/commands/search) is the door onto the index:
   a single ranked query rather than seven individual operations.
 
+The deck puts the whole index behind one tab. Every answer on it is computed
+rather than asked for, which is why it prices at `$0.00`; the coupling ranking
+at the bottom is the useful one, because it is the blast radius if you edit
+the file you are looking at.
+
+<DeckShot id="graph" />
+
 The index builds automatically: [`stella init`](/docs/getting-started/initialization)
 builds it eagerly, and recall's graph-backed retrieval refreshes it as it
 reads. An in-process file watcher (200 ms debounce, no daemon) keeps it

--- a/website/content/docs/plugins.mdx
+++ b/website/content/docs/plugins.mdx
@@ -26,6 +26,13 @@ This is a feature, not a limitation, and it is worth being explicit about why. A
 Every capability a plugin needs arrives **in the request**. There is no ambient authority to reach for — no environment variable beyond what its manifest declared, no working directory, no terminal, no credential. That is what lets the identical plugin process run under the CLI, a headless server, or an application that embedded the loop, unchanged.
 </Callout>
 
+What that looks like from the driver's seat. A red gate is not something the
+model can talk its way past: it answers with a proposed plan revision naming
+the cause, the merge stays blocked until the board is green, and nothing runs
+until you approve it.
+
+<DeckShot id="gate" />
+
 ## The participation ladder
 
 `[loop].participation` is how much say a plugin has asked for, on a four-rung ladder. Each grade includes every grade below it, and the power that separates two rungs is rejected below the rung that grants it — a manifest cannot quietly hold more than its declared grade.

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -113,6 +113,13 @@ rate-limit, never hallucinate, and give the *same answer twice* — which is
 exactly what you want from the parts of an agent that decide whether to
 trust it.
 
+The deck shows that split rather than describing it. A task opens to its
+contract: what "done" means, which of its checks are computed and which need a
+model, and what the work actually cost. Below the contract, the plan it was
+given sits beside what happened — a divergence is recorded, not smoothed over.
+
+<DeckShot id="task" />
+
 And because the distinction is structural rather than rhetorical, it is
 machine-readable. A raw run reports what it did and nothing about proof —
 `status`, what it spent, and the files it touched:

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -173,6 +173,25 @@ reversible, nothing is ever deleted, and the agent's own self-reports are explic
 driving a retirement. Self-improvement inherits that posture rather than inventing one.
 </Callout>
 
+## What the loop looks like
+
+The deck is where the self-maintenance track becomes something you watch
+rather than read about.
+
+A tracker backlog arrives over [MCP](/docs/agent-tools/mcp) and sorts by
+heat: the coupling of the files an issue touches, weighted by its age, read
+off the [code graph](/docs/context-engine) rather than guessed at.
+
+<DeckShot id="issues" />
+
+Starting work on one drafts a plan and stops. The sources line names exactly
+what went into it — the issue text, the coupled files, the memory rules that
+applied — every task carries a "done means" clause before any of them runs,
+and the estimate is on the table. Nothing is touched until the plan is
+approved.
+
+<DeckShot id="start-work" />
+
 ## Following along
 
 Each component has an issue carrying its vision, grounded mechanism, success metric, guardrail, and first slice:

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -159,6 +159,16 @@ line up with the decision that was actually made.
   probe runs. They exist only where a managed enrollment does.
 </Callout>
 
+### The same stream, on screen
+
+The event stream is what the deck's transcript renders, and each kind of event
+carries its own rail: gold where stella acted on the world, silver where the
+world came in, red for failure and nothing else. A delete shows the graph
+check that ran before the tool did; a memory shows its promotion from
+observation to rule; a compaction is one dim line rather than a wall of text.
+
+<DeckShot id="events" />
+
 ### Querying it yourself
 
 It is an ordinary SQLite file, so anything that speaks SQLite speaks to it. The five most

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -109,6 +109,18 @@ const nextConfig = {
         source: "/icons/:path*",
         headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
       },
+      // The deck renderings share the un-hashed URLs above but not their
+      // stability: they track a design that is still being built, and a
+      // re-render lands at the same filename. `immutable` would pin a
+      // superseded frame in every visitor's browser for a year with no way
+      // to reach it, so these revalidate — quickly enough that a redraw is
+      // picked up, slowly enough that a scrolled page does not refetch them.
+      {
+        source: "/tui/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=300, stale-while-revalidate=604800" },
+        ],
+      },
     ];
   },
   async redirects() {

--- a/website/public/tui/01-session-turn-lifecycle.svg
+++ b/website/public/tui/01-session-turn-lifecycle.svg
@@ -1,0 +1,93 @@
+<svg viewBox="0 0 680 520" width="680" height="520" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="520" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="22" font-size="11" fill="#EFC53F" font-weight="500">SESSION</text>
+<text x="80" y="22" font-size="11" fill="#777782">▸ plan r3 · task 3 wire dedup digest · 2/6</text>
+<text x="500" y="22" font-size="11" fill="#4B4B56">tab expand</text>
+<text x="600" y="22" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="22" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="32" x2="680" y2="32" stroke="#26262C" stroke-width="1"/>
+<line x1="16" y1="52" x2="664" y2="52" stroke="#2C2C33" stroke-width="1"/>
+<rect x="24" y="44" width="300" height="14" fill="#0A0A0C"/>
+<text x="28" y="56" font-size="11" fill="#EFC53F">turn 14</text>
+<text x="82" y="56" font-size="11" fill="#777782">execute · kimi-k3 · budget $0.60</text>
+<line x1="20" y1="70" x2="20" y2="100" stroke="#A9AAB5" stroke-width="2"/>
+<text x="32" y="82" font-size="12" fill="#A9AAB5">✦ skill</text>
+<text x="96" y="82" font-size="12" fill="#E8E8EC">oxagen-feature</text>
+<text x="222" y="82" font-size="11" fill="#4B4B56">auto</text>
+<text x="600" y="82" font-size="11" fill="#777782">1.2k tok</text>
+<text x="32" y="100" font-size="11" fill="#777782">injected 10-layer feature contract · used 42× this repo</text>
+<line x1="20" y1="116" x2="20" y2="126" stroke="#55555E" stroke-width="2"/>
+<text x="32" y="126" font-size="12" fill="#A9AAB5">▸ read</text>
+<text x="92" y="126" font-size="11" fill="#E8E8EC">…/self_driving_cmd/lifecycle.rs</text>
+<text x="342" y="126" font-size="11" fill="#4B4B56">221 lines</text>
+<text x="558" y="126" font-size="11" fill="#777782">⚡3ms · ↵ open</text>
+<line x1="20" y1="142" x2="20" y2="298" stroke="#EFC53F" stroke-width="2"/>
+<text x="32" y="154" font-size="12" fill="#EFC53F">● edit</text>
+<text x="92" y="154" font-size="11" fill="#E8E8EC">…/self_driving_cmd.rs</text>
+<text x="272" y="154" font-size="11" fill="#74C991">+3</text>
+<text x="296" y="154" font-size="11" fill="#E0687A">-1</text>
+<text x="560" y="154" font-size="11" fill="#777782">⚡2ms · → task 3</text>
+<rect x="32" y="162" width="632" height="118" fill="#0F0F12"/>
+<text x="40" y="180" font-size="11" fill="#4B4B56">120</text>
+<text x="72" y="180" font-size="11" fill="#BFC1CC">Seen</text>
+<text x="112" y="180" font-size="11" fill="#E8E8EC">{</text>
+<text x="40" y="198" font-size="11" fill="#4B4B56">121</text>
+<text x="72" y="198" font-size="11" fill="#777782">/// Digest a finding into its dedup key.</text>
+<rect x="32" y="204" width="632" height="18" fill="#241019"/>
+<text x="40" y="217" font-size="11" fill="#E0687A">122 -</text>
+<text x="88" y="217" font-size="11" fill="#E8E8EC">digest:</text>
+<text x="148" y="217" font-size="11" fill="#BFC1CC">Vec</text>
+<text x="172" y="217" font-size="11" fill="#E8E8EC">&lt;</text>
+<text x="180" y="217" font-size="11" fill="#BFC1CC">String</text>
+<text x="228" y="217" font-size="11" fill="#E8E8EC">&gt;,</text>
+<rect x="32" y="222" width="632" height="18" fill="#10201A"/>
+<text x="40" y="235" font-size="11" fill="#74C991">122 +</text>
+<text x="88" y="235" font-size="11" fill="#E8E8EC">digest:</text>
+<text x="148" y="235" font-size="11" fill="#BFC1CC">BTreeSet</text>
+<text x="212" y="235" font-size="11" fill="#E8E8EC">&lt;</text>
+<text x="220" y="235" font-size="11" fill="#BFC1CC">DigestKey</text>
+<text x="292" y="235" font-size="11" fill="#E8E8EC">&gt;,</text>
+<rect x="32" y="240" width="632" height="18" fill="#10201A"/>
+<text x="40" y="253" font-size="11" fill="#74C991">123 +</text>
+<text x="88" y="253" font-size="11" fill="#E8E8EC">seen_path:</text>
+<text x="172" y="253" font-size="11" fill="#BFC1CC">PathBuf</text>
+<text x="228" y="253" font-size="11" fill="#E8E8EC">,</text>
+<text x="40" y="273" font-size="11" fill="#4B4B56">124</text>
+<text x="72" y="273" font-size="11" fill="#E8E8EC">}</text>
+<text x="32" y="296" font-size="11" fill="#4B4B56">rust · → task 3 · ↵ open in FILES</text>
+<line x1="16" y1="318" x2="664" y2="318" stroke="#2C2C33" stroke-width="1"/>
+<rect x="24" y="310" width="196" height="14" fill="#0A0A0C"/>
+<text x="28" y="322" font-size="11" fill="#EFC53F">turn 14 done</text>
+<text x="126" y="322" font-size="11" fill="#777782">· 0:42</text>
+<text x="32" y="342" font-size="11" fill="#777782">receipt</text>
+<text x="92" y="342" font-size="11" fill="#EFC53F">$0.11</text>
+<text x="140" y="342" font-size="11" fill="#E8E8EC">18k tok</text>
+<text x="204" y="342" font-size="11" fill="#A9AAB5">det 86%</text>
+<text x="272" y="342" font-size="11" fill="#74C991">4/4 tests</text>
+<text x="350" y="342" font-size="11" fill="#E8E8EC">2 files</text>
+<text x="412" y="342" font-size="11" fill="#A9AAB5">1 memory</text>
+<text x="490" y="342" font-size="11" fill="#777782">· ↵ audit</text>
+<line x1="16" y1="366" x2="664" y2="366" stroke="#2C2C33" stroke-width="1"/>
+<rect x="24" y="358" width="270" height="14" fill="#0A0A0C"/>
+<text x="28" y="370" font-size="11" fill="#EFC53F">turn 15</text>
+<text x="82" y="370" font-size="11" fill="#777782">verify · gates 0/5 · det only</text>
+<line x1="20" y1="384" x2="20" y2="394" stroke="#EFC53F" stroke-width="2"/>
+<text x="32" y="394" font-size="12" fill="#EFC53F">◇ gate</text>
+<text x="92" y="394" font-size="11" fill="#E8E8EC">types</text>
+<text x="140" y="394" font-size="11" fill="#F7D96B">◐ running</text>
+<text x="588" y="394" font-size="11" fill="#4B4B56">$0.00</text>
+<text x="16" y="428" font-size="12" fill="#EFC53F" font-weight="500">&gt;&gt;&gt;</text>
+<rect x="46" y="418" width="7" height="13" fill="#E8E8EC"/>
+<text x="16" y="452" font-size="11" fill="#4B4B56">⏎ queue · esc steer · ^N failure · ^Z fold turn · / commands</text>
+<line x1="0" y1="464" x2="680" y2="464" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="486" font-size="11" fill="#777782">kimi-k3 · execute · ctx</text>
+<text x="196" y="486" font-size="12" fill="#EFC53F">███▊</text>
+<text x="236" y="486" font-size="12" fill="#26262C">░░░░░░</text>
+<text x="292" y="486" font-size="11" fill="#E8E8EC">35%</text>
+<text x="330" y="486" font-size="11" fill="#EFC53F">$0.45</text>
+<text x="386" y="486" font-size="11" fill="#777782">saved</text>
+<text x="428" y="486" font-size="11" fill="#EFC53F">$0.69</text>
+<text x="486" y="486" font-size="11" fill="#A9AAB5">det 86%</text>
+<text x="560" y="486" font-size="11" fill="#A9AAB5">✉ 21</text>
+<text x="606" y="486" font-size="11" fill="#777782">? help</text>
+</svg>

--- a/website/public/tui/02-event-vocabulary.svg
+++ b/website/public/tui/02-event-vocabulary.svg
@@ -1,0 +1,77 @@
+<svg viewBox="0 0 680 508" width="680" height="508" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="508" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<line x1="20" y1="20" x2="20" y2="176" stroke="#EFC53F" stroke-width="2"/>
+<text x="32" y="32" font-size="12" fill="#EFC53F">＋ write</text>
+<text x="100" y="32" font-size="11" fill="#E8E8EC">crates/stella-cli/src/dedup.rs</text>
+<text x="342" y="32" font-size="11" fill="#74C991">new file · 34 lines</text>
+<text x="600" y="32" font-size="11" fill="#777782">⚡1ms</text>
+<rect x="32" y="40" width="632" height="112" fill="#0F0F12"/>
+<text x="40" y="58" font-size="11" fill="#4B4B56">1</text>
+<text x="64" y="58" font-size="11" fill="#EFC53F">use</text>
+<text x="94" y="58" font-size="11" fill="#E8E8EC">std::collections::</text>
+<text x="238" y="58" font-size="11" fill="#BFC1CC">BTreeSet</text>
+<text x="302" y="58" font-size="11" fill="#E8E8EC">;</text>
+<text x="40" y="76" font-size="11" fill="#4B4B56">2</text>
+<text x="64" y="76" font-size="11" fill="#777782">/// Stable dedup key for findings.</text>
+<text x="40" y="94" font-size="11" fill="#4B4B56">3</text>
+<text x="64" y="94" font-size="11" fill="#EFC53F">pub struct</text>
+<text x="150" y="94" font-size="11" fill="#BFC1CC">DigestKey</text>
+<text x="222" y="94" font-size="11" fill="#E8E8EC">(</text>
+<text x="230" y="94" font-size="11" fill="#EFC53F">pub</text>
+<text x="260" y="94" font-size="11" fill="#BFC1CC">u64</text>
+<text x="286" y="94" font-size="11" fill="#E8E8EC">);</text>
+<text x="40" y="112" font-size="11" fill="#4B4B56">4</text>
+<text x="64" y="112" font-size="11" fill="#EFC53F">impl</text>
+<text x="100" y="112" font-size="11" fill="#BFC1CC">DigestKey</text>
+<text x="172" y="112" font-size="11" fill="#E8E8EC">{</text>
+<text x="40" y="130" font-size="11" fill="#4B4B56">5</text>
+<text x="64" y="130" font-size="11" fill="#EFC53F">  pub fn</text>
+<text x="128" y="130" font-size="11" fill="#E8E8EC">of(text: &amp;</text>
+<text x="208" y="130" font-size="11" fill="#BFC1CC">str</text>
+<text x="232" y="130" font-size="11" fill="#E8E8EC">) -&gt; </text>
+<text x="270" y="130" font-size="11" fill="#BFC1CC">Self</text>
+<text x="302" y="130" font-size="11" fill="#E8E8EC"> {</text>
+<text x="40" y="148" font-size="11" fill="#4B4B56">⋯ 29 more · ↵ expand</text>
+<text x="32" y="170" font-size="11" fill="#4B4B56">→ task 4 · registered in graph as module node</text>
+<line x1="20" y1="192" x2="20" y2="222" stroke="#E0687A" stroke-width="2"/>
+<text x="32" y="204" font-size="12" fill="#E0687A">✗ delete</text>
+<text x="102" y="204" font-size="11" fill="#E8E8EC">src/old_digest.rs</text>
+<text x="242" y="204" font-size="11" fill="#E0687A">-118 lines</text>
+<text x="528" y="204" font-size="11" fill="#777782">git-backed · u undo</text>
+<text x="32" y="222" font-size="11" fill="#777782">graph check</text>
+<text x="122" y="222" font-size="11" fill="#A9AAB5">0 inbound refs · det</text>
+<text x="286" y="222" font-size="11" fill="#4B4B56">safe to remove, verified before the tool ran</text>
+<line x1="20" y1="238" x2="20" y2="300" stroke="#A9AAB5" stroke-width="2"/>
+<text x="32" y="250" font-size="12" fill="#A9AAB5">◆ memory</text>
+<text x="112" y="250" font-size="11" fill="#E8E8EC">logged</text>
+<text x="566" y="250" font-size="11" fill="#4B4B56">mem_83b3…d29a</text>
+<text x="32" y="268" font-size="11" fill="#E8E8EC">"dedup keys must be stable across runs; hash finding text only"</text>
+<text x="32" y="286" font-size="11" fill="#E8E8EC">OBSERVATION</text>
+<text x="126" y="286" font-size="11" fill="#4B4B56">▸ RULE ▸ FACT</text>
+<text x="240" y="286" font-size="11" fill="#777782">conf 0.62 · kind PERFORMANCE · decays</text>
+<text x="32" y="302" font-size="11" fill="#4B4B56">promotes to RULE at 0.85 · e edit · x reject</text>
+<line x1="20" y1="318" x2="20" y2="330" stroke="#A9AAB5" stroke-width="2"/>
+<text x="32" y="330" font-size="12" fill="#A9AAB5">◆ memory</text>
+<text x="112" y="330" font-size="11" fill="#E8E8EC">promoted</text>
+<text x="186" y="330" font-size="11" fill="#777782">OBSERVATION → RULE</text>
+<text x="342" y="330" font-size="11" fill="#74C991">conf 0.87</text>
+<text x="420" y="330" font-size="11" fill="#4B4B56">· audit event mem_evt_112 · now prompt-injected</text>
+<text x="32" y="360" font-size="11" fill="#4B4B56">↓ compacted 74k→69k · 0 evicted · 0 deduped</text>
+<line x1="16" y1="384" x2="664" y2="384" stroke="#2C2C33" stroke-width="1"/>
+<rect x="24" y="376" width="340" height="14" fill="#0A0A0C"/>
+<text x="28" y="388" font-size="11" fill="#EFC53F">turn 16</text>
+<text x="82" y="388" font-size="11" fill="#777782">execute · queued: "also persist across CI runs"</text>
+<line x1="20" y1="402" x2="20" y2="432" stroke="#F7D96B" stroke-width="2"/>
+<text x="32" y="414" font-size="12" fill="#F7D96B">◐ model</text>
+<text x="102" y="414" font-size="11" fill="#E8E8EC">applying queued steer to task 4</text>
+<text x="588" y="414" font-size="11" fill="#777782">6 tok/s</text>
+<text x="32" y="432" font-size="11" fill="#4B4B56">irreducible generation · 1 of 2 budgeted model calls this turn</text>
+<text x="16" y="464" font-size="12" fill="#EFC53F" font-weight="500">&gt;&gt;&gt;</text>
+<rect x="46" y="454" width="7" height="13" fill="#E8E8EC"/>
+<text x="16" y="490" font-size="11" fill="#4B4B56">rails:</text>
+<text x="62" y="490" font-size="11" fill="#EFC53F">gold = stella acting</text>
+<text x="220" y="490" font-size="11" fill="#A9AAB5">silver = world in</text>
+<text x="356" y="490" font-size="11" fill="#E0687A">red fail</text>
+<text x="424" y="490" font-size="11" fill="#74C991">green pass</text>
+<text x="510" y="490" font-size="11" fill="#4B4B56">· one glance, no reading</text>
+</svg>

--- a/website/public/tui/03-task-zoom.svg
+++ b/website/public/tui/03-task-zoom.svg
@@ -1,0 +1,90 @@
+<svg viewBox="0 0 680 520" width="680" height="520" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="520" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="24" font-size="11" fill="#777782">SESSION › plan r3 ›</text>
+<text x="168" y="24" font-size="11" fill="#E8E8EC">task 3</text>
+<text x="600" y="24" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="24" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="34" x2="680" y2="34" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="60" font-size="13" fill="#F7D96B">◐</text>
+<text x="34" y="60" font-size="13" fill="#E8E8EC" font-weight="500">3 wire dedup digest</text>
+<text x="216" y="60" font-size="11" fill="#777782">owner lead · kimi-k3 · execute · 0:01:12</text>
+<text x="560" y="60" font-size="11" fill="#EFC53F">esc back</text>
+<rect x="16" y="76" width="322" height="128" rx="6" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="28" y="96" font-size="11" fill="#E8E8EC" font-weight="500">done means</text>
+<text x="120" y="96" font-size="11" fill="#4B4B56">the contract, checked not vibed</text>
+<line x1="16" y1="104" x2="338" y2="104" stroke="#26262C" stroke-width="1"/>
+<text x="28" y="124" font-size="12" fill="#74C991">✓</text>
+<text x="44" y="124" font-size="12" fill="#E8E8EC">digest() exists, typed</text>
+<text x="252" y="124" font-size="11" fill="#A9AAB5">graph · det</text>
+<text x="28" y="146" font-size="12" fill="#F7D96B">◐</text>
+<text x="44" y="146" font-size="12" fill="#E8E8EC">unit digest_* green</text>
+<text x="252" y="146" font-size="11" fill="#F7D96B">2/4 · det</text>
+<text x="28" y="168" font-size="12" fill="#4B4B56">○</text>
+<text x="44" y="168" font-size="12" fill="#777782">no dup findings, 3 runs</text>
+<text x="252" y="168" font-size="11" fill="#4B4B56">harness</text>
+<text x="28" y="192" font-size="11" fill="#4B4B56">3 checks · 2 deterministic · 0 model-judged</text>
+<rect x="348" y="76" width="320" height="128" rx="6" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="360" y="96" font-size="11" fill="#E8E8EC" font-weight="500">evidence</text>
+<text x="432" y="96" font-size="11" fill="#4B4B56">every event tagged task:3</text>
+<line x1="348" y1="104" x2="668" y2="104" stroke="#26262C" stroke-width="1"/>
+<text x="360" y="124" font-size="12" fill="#EFC53F">edit</text>
+<text x="404" y="124" font-size="11" fill="#E8E8EC">self_driving_cmd.rs</text>
+<text x="576" y="124" font-size="11" fill="#74C991">+41</text>
+<text x="608" y="124" font-size="11" fill="#E0687A">-6</text>
+<text x="360" y="146" font-size="12" fill="#EFC53F">run</text>
+<text x="404" y="146" font-size="11" fill="#E8E8EC">cargo test digest</text>
+<text x="576" y="146" font-size="11" fill="#F7D96B">2/4</text>
+<text x="360" y="168" font-size="12" fill="#EFC53F">graph</text>
+<text x="404" y="168" font-size="11" fill="#E8E8EC">3 nodes · Seen, dedup key</text>
+<text x="576" y="168" font-size="11" fill="#777782">wr</text>
+<text x="360" y="192" font-size="11" fill="#4B4B56">↵ open event · f follow live</text>
+<rect x="16" y="216" width="652" height="132" rx="6" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="28" y="236" font-size="11" fill="#E8E8EC" font-weight="500">planned vs actual</text>
+<text x="164" y="236" font-size="11" fill="#4B4B56">[:NEXT] is the plan · [:THEN] is what happened</text>
+<line x1="16" y1="244" x2="668" y2="244" stroke="#26262C" stroke-width="1"/>
+<text x="28" y="268" font-size="11" fill="#777782">planned</text>
+<rect x="96" y="256" width="104" height="20" rx="4" fill="#17171B" stroke="#26262C" stroke-width="1"/>
+<text x="110" y="270" font-size="11" fill="#E8E8EC">read sources</text>
+<line x1="200" y1="266" x2="228" y2="266" stroke="#4B4B56" stroke-width="1"/>
+<rect x="228" y="256" width="96" height="20" rx="4" fill="#17171B" stroke="#26262C" stroke-width="1"/>
+<text x="242" y="270" font-size="11" fill="#E8E8EC">implement</text>
+<line x1="324" y1="266" x2="352" y2="266" stroke="#4B4B56" stroke-width="1"/>
+<rect x="352" y="256" width="72" height="20" rx="4" fill="#17171B" stroke="#26262C" stroke-width="1"/>
+<text x="366" y="270" font-size="11" fill="#E8E8EC">test</text>
+<text x="28" y="306" font-size="11" fill="#777782">actual</text>
+<rect x="96" y="294" width="104" height="20" rx="4" fill="#17171B" stroke="#26262C" stroke-width="1"/>
+<text x="110" y="308" font-size="11" fill="#E8E8EC">read sources</text>
+<line x1="200" y1="304" x2="228" y2="304" stroke="#4B4B56" stroke-width="1"/>
+<rect x="228" y="294" width="96" height="20" rx="4" fill="#17171B" stroke="#26262C" stroke-width="1"/>
+<text x="242" y="308" font-size="11" fill="#E8E8EC">implement</text>
+<line x1="324" y1="304" x2="352" y2="304" stroke="#F7D96B" stroke-width="1"/>
+<rect x="352" y="294" width="128" height="20" rx="4" fill="#17171B" stroke="#F7D96B" stroke-width="1"/>
+<text x="366" y="308" font-size="11" fill="#F7D96B">↯ fix borrow err</text>
+<line x1="480" y1="304" x2="508" y2="304" stroke="#4B4B56" stroke-width="1"/>
+<rect x="508" y="294" width="72" height="20" rx="4" fill="#17171B" stroke="#26262C" stroke-width="1"/>
+<text x="522" y="308" font-size="11" fill="#E8E8EC">test</text>
+<text x="28" y="338" font-size="11" fill="#F7D96B">1 divergence · cause: E0502 borrow</text>
+<text x="316" y="338" font-size="11" fill="#4B4B56">recorded as a trace outcome · feeds learn</text>
+<rect x="16" y="360" width="652" height="52" rx="6" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="28" y="380" font-size="11" fill="#777782">SPEND</text>
+<text x="28" y="398" font-size="12" fill="#EFC53F">$0.12</text>
+<text x="112" y="380" font-size="11" fill="#777782">TOKENS</text>
+<text x="112" y="398" font-size="12" fill="#E8E8EC">41k</text>
+<text x="196" y="380" font-size="11" fill="#777782">CACHE RD</text>
+<text x="196" y="398" font-size="12" fill="#E8E8EC">71%</text>
+<text x="292" y="380" font-size="11" fill="#777782">DET / MODEL</text>
+<text x="292" y="398" font-size="12" fill="#A9AAB5">88 / 12</text>
+<text x="400" y="380" font-size="11" fill="#777782">MODEL CALLS</text>
+<text x="400" y="398" font-size="12" fill="#E8E8EC">2</text>
+<text x="508" y="380" font-size="11" fill="#777782">EST REMAIN</text>
+<text x="508" y="398" font-size="12" fill="#E8E8EC">~$0.05</text>
+<line x1="0" y1="428" x2="680" y2="428" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="450" font-size="11" fill="#777782">r re-run checks · s split task · b hand to worker · i promote to issue · ↯ diff plan</text>
+<text x="16" y="472" font-size="11" fill="#4B4B56">a task closes when its checks pass, not when the model says so.</text>
+<line x1="0" y1="486" x2="680" y2="486" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="506" font-size="11" fill="#A9AAB5">det 88%</text>
+<text x="96" y="506" font-size="11" fill="#4B4B56">CONTEXT 70k/200k · SPEND</text>
+<text x="290" y="506" font-size="11" fill="#EFC53F">$0.45</text>
+<text x="342" y="506" font-size="11" fill="#4B4B56">· SAVED</text>
+<text x="404" y="506" font-size="11" fill="#EFC53F">$0.69</text>
+</svg>

--- a/website/public/tui/04-graph.svg
+++ b/website/public/tui/04-graph.svg
@@ -1,0 +1,80 @@
+<svg viewBox="0 0 680 468" width="680" height="468" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="468" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="22" font-size="11" fill="#777782">SESSION  AGENTS  TRACES</text>
+<text x="212" y="22" font-size="11" fill="#EFC53F" font-weight="500">GRAPH</text>
+<text x="262" y="22" font-size="11" fill="#777782">FILES  SKILLS  MCP  ISSUES</text>
+<text x="600" y="22" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="22" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="32" x2="680" y2="32" stroke="#26262C" stroke-width="1"/>
+<rect x="12" y="42" width="656" height="24" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="22" y="59" font-size="11" fill="#EFC53F">⌕</text>
+<text x="38" y="59" font-size="11" fill="#E8E8EC">file:stella-protocol/src/lib.rs</text>
+<text x="290" y="59" font-size="11" fill="#4B4B56">q free-form query</text>
+<text x="518" y="59" font-size="11" fill="#777782">438 nodes · 12ms · det</text>
+<text x="16" y="88" font-size="11" fill="#777782">nodes · 27 in file</text>
+<rect x="12" y="96" width="244" height="296" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<rect x="13" y="102" width="242" height="18" fill="#17171B"/>
+<text x="22" y="115" font-size="11" fill="#EFC53F">▤ lib.rs</text>
+<text x="160" y="115" font-size="11" fill="#F7D96B">● hot</text>
+<text x="22" y="137" font-size="11" fill="#BFC1CC">▢ Attachment</text>
+<text x="196" y="137" font-size="11" fill="#4B4B56">18</text>
+<text x="22" y="155" font-size="11" fill="#BFC1CC">▢ AttachmentKind</text>
+<text x="196" y="155" font-size="11" fill="#4B4B56">7</text>
+<text x="22" y="173" font-size="11" fill="#BFC1CC">▢ AttachmentSource</text>
+<text x="196" y="173" font-size="11" fill="#4B4B56">5</text>
+<text x="22" y="191" font-size="11" fill="#A9AAB5">ƒ classify_media_type</text>
+<text x="196" y="191" font-size="11" fill="#4B4B56">4</text>
+<text x="22" y="209" font-size="11" fill="#A9AAB5">ƒ human_bytes</text>
+<text x="196" y="209" font-size="11" fill="#4B4B56">3</text>
+<text x="22" y="227" font-size="11" fill="#BFC1CC">▢ CandidateDenial</text>
+<text x="196" y="227" font-size="11" fill="#4B4B56">6</text>
+<text x="22" y="245" font-size="11" fill="#BFC1CC">▢ CandidateHandle</text>
+<text x="196" y="245" font-size="11" fill="#4B4B56">9</text>
+<text x="22" y="263" font-size="11" fill="#BFC1CC">▢ CompactionRewrite</text>
+<text x="196" y="263" font-size="11" fill="#4B4B56">11</text>
+<text x="22" y="281" font-size="11" fill="#BFC1CC">▢ CompletionRequest</text>
+<text x="196" y="281" font-size="11" fill="#4B4B56">14</text>
+<text x="22" y="299" font-size="11" fill="#BFC1CC">▢ CompletionResult</text>
+<text x="196" y="299" font-size="11" fill="#4B4B56">8</text>
+<text x="22" y="317" font-size="11" fill="#A9AAB5">ƒ media_type_for_path</text>
+<text x="196" y="317" font-size="11" fill="#4B4B56">2</text>
+<text x="22" y="335" font-size="11" fill="#4B4B56">⋯ 16 more</text>
+<text x="22" y="362" font-size="11" fill="#4B4B56">▤ file · ▢ type · ƒ fn</text>
+<text x="22" y="380" font-size="11" fill="#4B4B56">right column = edge count</text>
+<rect x="268" y="96" width="400" height="150" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="280" y="116" font-size="11" fill="#EFC53F">▤ crates/stella-protocol/src/lib.rs</text>
+<text x="576" y="116" font-size="11" fill="#F7D96B">turn 14</text>
+<line x1="268" y1="124" x2="668" y2="124" stroke="#26262C" stroke-width="1"/>
+<text x="280" y="144" font-size="11" fill="#E8E8EC">imports 24 →</text>
+<text x="386" y="144" font-size="11" fill="#E8E8EC">← imported-by 12</text>
+<text x="524" y="144" font-size="11" fill="#E8E8EC">writes 2 · tests 6</text>
+<text x="280" y="166" font-size="11" fill="#777782">→</text>
+<text x="296" y="166" font-size="11" fill="#A9AAB5">attachment::Attachment</text>
+<text x="280" y="184" font-size="11" fill="#777782">→</text>
+<text x="296" y="184" font-size="11" fill="#A9AAB5">cache::CacheCause</text>
+<text x="280" y="202" font-size="11" fill="#777782">←</text>
+<text x="296" y="202" font-size="11" fill="#A9AAB5">stella-cli::self_driving_cmd</text>
+<text x="510" y="202" font-size="11" fill="#F7D96B">edited turn 14</text>
+<text x="280" y="220" font-size="11" fill="#777782">←</text>
+<text x="296" y="220" font-size="11" fill="#A9AAB5">stella-engine::compaction</text>
+<text x="280" y="238" font-size="11" fill="#4B4B56">⋯ e expand all edges</text>
+<rect x="268" y="256" width="400" height="136" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="280" y="276" font-size="11" fill="#777782">coupling · neighbors by edge count</text>
+<line x1="268" y1="284" x2="668" y2="284" stroke="#26262C" stroke-width="1"/>
+<text x="280" y="304" font-size="11" fill="#A9AAB5">attachment::Attachment</text>
+<text x="472" y="304" font-size="11" fill="#EFC53F">████████▌</text>
+<text x="586" y="304" font-size="11" fill="#777782">18</text>
+<text x="280" y="322" font-size="11" fill="#A9AAB5">completion::Request</text>
+<text x="472" y="322" font-size="11" fill="#EFC53F">█████▎</text>
+<text x="586" y="322" font-size="11" fill="#777782">11</text>
+<text x="280" y="340" font-size="11" fill="#A9AAB5">compaction::Rewrite</text>
+<text x="472" y="340" font-size="11" fill="#EFC53F">███▊</text>
+<text x="586" y="340" font-size="11" fill="#777782">8</text>
+<text x="280" y="358" font-size="11" fill="#A9AAB5">cache::CacheCause</text>
+<text x="472" y="358" font-size="11" fill="#EFC53F">██▉</text>
+<text x="586" y="358" font-size="11" fill="#777782">6</text>
+<text x="280" y="380" font-size="11" fill="#4B4B56">high coupling = blast radius if you edit this file</text>
+<line x1="0" y1="404" x2="680" y2="404" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="426" font-size="11" fill="#4B4B56">↵ open file · e edges · q query · t touched this session · ⇥ panes</text>
+<text x="16" y="450" font-size="11" fill="#777782">every answer here is deterministic · $0.00 · 12ms</text>
+</svg>

--- a/website/public/tui/05-skills.svg
+++ b/website/public/tui/05-skills.svg
@@ -1,0 +1,62 @@
+<svg viewBox="0 0 680 480" width="680" height="480" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="480" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="22" font-size="11" fill="#777782">SESSION  AGENTS  TRACES  GRAPH  FILES</text>
+<text x="306" y="22" font-size="11" fill="#EFC53F" font-weight="500">SKILLS</text>
+<text x="366" y="22" font-size="11" fill="#777782">MCP  ISSUES</text>
+<text x="600" y="22" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="22" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="32" x2="680" y2="32" stroke="#26262C" stroke-width="1"/>
+<rect x="12" y="42" width="656" height="24" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="22" y="59" font-size="11" fill="#EFC53F">⌕</text>
+<text x="38" y="59" font-size="11" fill="#E8E8EC">rust async</text>
+<rect x="122" y="47" width="7" height="13" fill="#E8E8EC"/>
+<text x="440" y="59" font-size="11" fill="#777782">installed + registry · web · 6 hits</text>
+<text x="16" y="90" font-size="11" fill="#777782">installed · 43 · 2 match</text>
+<rect x="12" y="98" width="656" height="82" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<rect x="13" y="104" width="654" height="18" fill="#17171B"/>
+<text x="22" y="117" font-size="11" fill="#EFC53F">[x]</text>
+<text x="50" y="117" font-size="11" fill="#E8E8EC">rust-async-patterns</text>
+<text x="212" y="117" font-size="11" fill="#4B4B56">v1 · user</text>
+<text x="330" y="117" font-size="11" fill="#777782">tokio, pinning, cancel safety</text>
+<text x="560" y="117" font-size="11" fill="#777782">18× · 0.9k</text>
+<text x="22" y="139" font-size="11" fill="#EFC53F">[x]</text>
+<text x="50" y="139" font-size="11" fill="#A9AAB5">oxagen-testing</text>
+<text x="212" y="139" font-size="11" fill="#4B4B56">v1 · user</text>
+<text x="330" y="139" font-size="11" fill="#777782">async test conventions, co-located</text>
+<text x="560" y="139" font-size="11" fill="#777782">7× · 0.6k</text>
+<text x="22" y="161" font-size="11" fill="#4B4B56">uses · avg tok per inject → prune what never fires</text>
+<text x="16" y="204" font-size="11" fill="#777782">learned from traces · 3</text>
+<text x="196" y="204" font-size="11" fill="#4B4B56">stella wrote these after repeated wins</text>
+<rect x="12" y="212" width="656" height="64" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="22" y="232" font-size="11" fill="#EFC53F">[x]</text>
+<text x="50" y="232" font-size="11" fill="#E8E8EC">search-by-meaning-first</text>
+<text x="244" y="232" font-size="11" fill="#F7D96B">learned</text>
+<text x="310" y="232" font-size="11" fill="#777782">from 9 traces · turn 212 · was c6818842</text>
+<text x="612" y="232" font-size="11" fill="#777782">31×</text>
+<text x="22" y="252" font-size="11" fill="#EFC53F">[x]</text>
+<text x="50" y="252" font-size="11" fill="#A9AAB5">prefer-graph-over-grep</text>
+<text x="244" y="252" font-size="11" fill="#F7D96B">learned</text>
+<text x="310" y="252" font-size="11" fill="#777782">from 14 traces · turn 187</text>
+<text x="612" y="252" font-size="11" fill="#777782">44×</text>
+<text x="22" y="270" font-size="11" fill="#4B4B56">r rename · ctrl+o show source traces · x reject teaches the learner</text>
+<text x="16" y="300" font-size="11" fill="#777782">registry · web · 4 results</text>
+<rect x="12" y="308" width="656" height="104" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="22" y="328" font-size="11" fill="#A9AAB5">tokio-console-debugging</text>
+<text x="216" y="328" font-size="11" fill="#4B4B56">4.2k installs</text>
+<text x="322" y="328" font-size="11" fill="#74C991">signed · oxagen</text>
+<text x="588" y="328" font-size="11" fill="#EFC53F">i install</text>
+<text x="22" y="348" font-size="11" fill="#A9AAB5">async-tracing-discipline</text>
+<text x="216" y="348" font-size="11" fill="#4B4B56">1.1k installs</text>
+<text x="322" y="348" font-size="11" fill="#74C991">signed · community</text>
+<text x="588" y="348" font-size="11" fill="#EFC53F">i install</text>
+<text x="22" y="368" font-size="11" fill="#4B4B56">rust-async-patterns</text>
+<text x="216" y="368" font-size="11" fill="#4B4B56">✓ already installed</text>
+<text x="22" y="388" font-size="11" fill="#4B4B56">raw-async-hacks</text>
+<text x="216" y="388" font-size="11" fill="#4B4B56">300 installs</text>
+<text x="322" y="388" font-size="11" fill="#E0687A">unsigned · blocked by policy</text>
+<text x="560" y="388" font-size="11" fill="#4B4B56">v view anyway</text>
+<text x="22" y="406" font-size="11" fill="#4B4B56">installs land disabled until you preview and enable</text>
+<line x1="0" y1="424" x2="680" y2="424" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="446" font-size="11" fill="#4B4B56">space on/off · ctrl+o preview · i install · p pin · n new from prompt · esc</text>
+<text x="16" y="468" font-size="11" fill="#777782">43 installed · 3 learned · 12 active this session</text>
+</svg>

--- a/website/public/tui/06-mcp.svg
+++ b/website/public/tui/06-mcp.svg
@@ -1,0 +1,67 @@
+<svg viewBox="0 0 680 420" width="680" height="420" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="420" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="22" font-size="11" fill="#777782">SESSION  AGENTS  TRACES  GRAPH  FILES  SKILLS</text>
+<text x="360" y="22" font-size="11" fill="#EFC53F" font-weight="500">MCP</text>
+<text x="398" y="22" font-size="11" fill="#777782">ISSUES</text>
+<text x="600" y="22" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="22" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="32" x2="680" y2="32" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="56" font-size="11" fill="#777782">servers · 4 · 3 connected</text>
+<rect x="12" y="64" width="656" height="130" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="24" y="84" font-size="11" fill="#EFC53F">●</text>
+<text x="40" y="84" font-size="11" fill="#E8E8EC">graph</text>
+<text x="130" y="84" font-size="11" fill="#4B4B56">stdio</text>
+<text x="216" y="84" font-size="11" fill="#777782">14 tools</text>
+<text x="310" y="84" font-size="11" fill="#777782">8ms</text>
+<text x="392" y="84" font-size="11" fill="#4B4B56">oxagen · pinned</text>
+<line x1="12" y1="92" x2="668" y2="92" stroke="#17171B" stroke-width="1"/>
+<text x="24" y="110" font-size="11" fill="#EFC53F">●</text>
+<text x="40" y="110" font-size="11" fill="#A9AAB5">linear</text>
+<text x="130" y="110" font-size="11" fill="#4B4B56">http</text>
+<text x="216" y="110" font-size="11" fill="#777782">9 tools</text>
+<text x="310" y="110" font-size="11" fill="#777782">41ms</text>
+<text x="392" y="110" font-size="11" fill="#74C991">oauth ✓</text>
+<line x1="12" y1="118" x2="668" y2="118" stroke="#17171B" stroke-width="1"/>
+<text x="24" y="136" font-size="11" fill="#EFC53F">●</text>
+<text x="40" y="136" font-size="11" fill="#A9AAB5">github</text>
+<text x="130" y="136" font-size="11" fill="#4B4B56">http</text>
+<text x="216" y="136" font-size="11" fill="#777782">12 tools</text>
+<text x="310" y="136" font-size="11" fill="#777782">66ms</text>
+<text x="392" y="136" font-size="11" fill="#74C991">oauth ✓</text>
+<line x1="12" y1="144" x2="668" y2="144" stroke="#17171B" stroke-width="1"/>
+<rect x="13" y="150" width="654" height="18" fill="#17171B"/>
+<text x="24" y="163" font-size="11" fill="#4B4B56">○</text>
+<text x="40" y="163" font-size="11" fill="#E8E8EC">stripe</text>
+<text x="130" y="163" font-size="11" fill="#4B4B56">http</text>
+<text x="216" y="163" font-size="11" fill="#777782">1 tool</text>
+<text x="310" y="163" font-size="11" fill="#E0687A">not connected</text>
+<text x="440" y="163" font-size="11" fill="#EFC53F">o login</text>
+<text x="24" y="186" font-size="11" fill="#4B4B56">login opens the browser · returns via stella:// deep link · token stays in keychain</text>
+<text x="16" y="218" font-size="11" fill="#777782">registry · web</text>
+<rect x="12" y="226" width="656" height="24" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="22" y="243" font-size="11" fill="#EFC53F">⌕</text>
+<text x="38" y="243" font-size="11" fill="#E8E8EC">postgres</text>
+<rect x="112" y="231" width="7" height="13" fill="#E8E8EC"/>
+<text x="560" y="243" font-size="11" fill="#777782">3 results</text>
+<rect x="12" y="258" width="656" height="86" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="22" y="278" font-size="11" fill="#A9AAB5">postgres-mcp</text>
+<text x="150" y="278" font-size="11" fill="#4B4B56">official</text>
+<text x="222" y="278" font-size="11" fill="#777782">12 tools</text>
+<text x="300" y="278" font-size="11" fill="#4B4B56">9.1k installs</text>
+<text x="410" y="278" font-size="11" fill="#74C991">signed</text>
+<text x="588" y="278" font-size="11" fill="#EFC53F">i install</text>
+<text x="22" y="298" font-size="11" fill="#A9AAB5">supabase-mcp</text>
+<text x="150" y="298" font-size="11" fill="#4B4B56">vendor</text>
+<text x="222" y="298" font-size="11" fill="#777782">22 tools</text>
+<text x="300" y="298" font-size="11" fill="#4B4B56">6.4k installs</text>
+<text x="410" y="298" font-size="11" fill="#74C991">signed</text>
+<text x="588" y="298" font-size="11" fill="#EFC53F">i install</text>
+<text x="22" y="318" font-size="11" fill="#4B4B56">pg-anything</text>
+<text x="150" y="318" font-size="11" fill="#4B4B56">community</text>
+<text x="300" y="318" font-size="11" fill="#4B4B56">112 installs</text>
+<text x="410" y="318" font-size="11" fill="#E0687A">unsigned · blocked</text>
+<text x="22" y="336" font-size="11" fill="#4B4B56">new servers land disabled · handshake shows capabilities before first enable</text>
+<line x1="0" y1="358" x2="680" y2="358" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="380" font-size="11" fill="#4B4B56">↵ tools · a auth · e enable · x remove · r refresh · i install · esc</text>
+<text x="16" y="404" font-size="11" fill="#777782">graph is pinned · it is the product, not an integration</text>
+</svg>

--- a/website/public/tui/07-issues.svg
+++ b/website/public/tui/07-issues.svg
@@ -1,0 +1,57 @@
+<svg viewBox="0 0 680 470" width="680" height="470" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="470" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="22" font-size="11" fill="#777782">SESSION  AGENTS  TRACES  GRAPH  FILES  SKILLS  MCP</text>
+<text x="400" y="22" font-size="11" fill="#EFC53F" font-weight="500">ISSUES</text>
+<text x="600" y="22" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="22" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="32" x2="680" y2="32" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="56" font-size="11" fill="#777782">backlog · linear via mcp · 14 open</text>
+<text x="300" y="56" font-size="11" fill="#4B4B56">f filter: mine · sort: heat</text>
+<rect x="12" y="64" width="656" height="152" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<rect x="13" y="70" width="654" height="18" fill="#17171B"/>
+<text x="24" y="83" font-size="11" fill="#EFC53F">▶</text>
+<text x="40" y="83" font-size="11" fill="#E8E8EC">OXA-142</text>
+<text x="108" y="83" font-size="11" fill="#E8E8EC">token refresh race</text>
+<text x="330" y="83" font-size="11" fill="#EFC53F">in progress</text>
+<text x="428" y="83" font-size="11" fill="#777782">plan r3 · task 3 live</text>
+<text x="612" y="83" font-size="11" fill="#4B4B56">3d</text>
+<text x="24" y="107" font-size="11" fill="#4B4B56">○</text>
+<text x="40" y="107" font-size="11" fill="#A9AAB5">OXA-151</text>
+<text x="108" y="107" font-size="11" fill="#A9AAB5">dedup digest persists across CI runs</text>
+<text x="410" y="107" font-size="11" fill="#4B4B56">triage</text>
+<text x="612" y="107" font-size="11" fill="#4B4B56">2d</text>
+<text x="24" y="129" font-size="11" fill="#EFC53F">◇</text>
+<text x="40" y="129" font-size="11" fill="#A9AAB5">OXA-148</text>
+<text x="108" y="129" font-size="11" fill="#A9AAB5">flaky e2e on auth suite</text>
+<text x="330" y="129" font-size="11" fill="#E0687A">blocked · gate e2e red</text>
+<text x="612" y="129" font-size="11" fill="#4B4B56">6d</text>
+<text x="24" y="151" font-size="11" fill="#4B4B56">○</text>
+<text x="40" y="151" font-size="11" fill="#A9AAB5">OXA-150</text>
+<text x="108" y="151" font-size="11" fill="#A9AAB5">graph parity slow on cold cache</text>
+<text x="410" y="151" font-size="11" fill="#4B4B56">triage</text>
+<text x="612" y="151" font-size="11" fill="#4B4B56">5h</text>
+<text x="24" y="173" font-size="11" fill="#74C991">✓</text>
+<text x="40" y="173" font-size="11" fill="#4B4B56">OXA-139</text>
+<text x="108" y="173" font-size="11" fill="#4B4B56">seen-set eviction on restart</text>
+<text x="410" y="173" font-size="11" fill="#4B4B56">done · merged #211</text>
+<text x="612" y="173" font-size="11" fill="#4B4B56">1d</text>
+<text x="24" y="198" font-size="11" fill="#4B4B56">heat = coupling of touched files × age · from the graph, not vibes</text>
+<rect x="12" y="228" width="656" height="150" fill="#0F0F12" stroke="#26262C" stroke-width="1"/>
+<text x="24" y="248" font-size="11" fill="#EFC53F">▶ OXA-142</text>
+<text x="112" y="248" font-size="11" fill="#E8E8EC">token refresh race</text>
+<text x="540" y="248" font-size="11" fill="#4B4B56">assignee mac</text>
+<line x1="12" y1="256" x2="668" y2="256" stroke="#26262C" stroke-width="1"/>
+<text x="24" y="276" font-size="11" fill="#777782">"session store refresh is not locked; two workers refreshing the</text>
+<text x="24" y="292" font-size="11" fill="#777782">same key produce duplicate findings and flaky CI."</text>
+<text x="24" y="316" font-size="11" fill="#A9AAB5">linked</text>
+<text x="80" y="316" font-size="11" fill="#EFC53F">plan r3 · 2/6</text>
+<text x="192" y="316" font-size="11" fill="#777782">branch fix/token-race</text>
+<text x="376" y="316" font-size="11" fill="#777782">evidence 2 files · 4/4 tests</text>
+<text x="24" y="338" font-size="11" fill="#A9AAB5">status syncs back to linear on gate green · no manual updates</text>
+<text x="24" y="362" font-size="11" fill="#4B4B56">↵ open plan · c comment · s status · b branch</text>
+<line x1="0" y1="392" x2="680" y2="392" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="414" font-size="11" fill="#EFC53F">w start work</text>
+<text x="116" y="414" font-size="11" fill="#777782">on a triaged issue → stella drafts plan r1 from the issue + graph context,</text>
+<text x="116" y="430" font-size="11" fill="#777782">shows the task contracts, and waits for your approval before touching code</text>
+<text x="16" y="456" font-size="11" fill="#4B4B56">↑↓ select · w start work · n new issue · / search tracker · r refresh · esc</text>
+</svg>

--- a/website/public/tui/08-command-palette.svg
+++ b/website/public/tui/08-command-palette.svg
@@ -1,0 +1,39 @@
+<svg viewBox="0 0 680 312" width="680" height="312" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="312" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<rect x="40" y="16" width="600" height="222" fill="#0F0F12" stroke="#2C2C33" stroke-width="1"/>
+<text x="54" y="36" font-size="11" fill="#EFC53F">/ commands</text>
+<text x="150" y="36" font-size="11" fill="#4B4B56">6 of 129 · fuzzy</text>
+<text x="452" y="36" font-size="11" fill="#4B4B56">↑↓ move · ↵ run · ⇥ args</text>
+<line x1="40" y1="44" x2="640" y2="44" stroke="#26262C" stroke-width="1"/>
+<text x="54" y="64" font-size="11" fill="#4B4B56">relevant now · verify is running</text>
+<rect x="41" y="70" width="598" height="18" fill="#17171B"/>
+<text x="54" y="83" font-size="11" fill="#EFC53F">/g</text>
+<text x="70" y="83" font-size="11" fill="#EFC53F">a</text>
+<text x="78" y="83" font-size="11" fill="#E8E8EC">tes</text>
+<text x="180" y="83" font-size="11" fill="#777782">show the gate board</text>
+<text x="524" y="83" font-size="11" fill="#F7D96B">◐ 2/5 green</text>
+<text x="54" y="105" font-size="11" fill="#EFC53F">/g</text>
+<text x="70" y="105" font-size="11" fill="#EFC53F">a</text>
+<text x="78" y="105" font-size="11" fill="#A9AAB5">te rerun</text>
+<text x="180" y="105" font-size="11" fill="#777782">rerun one gate</text>
+<text x="500" y="105" font-size="11" fill="#4B4B56">⇥ &lt;name&gt;</text>
+<text x="54" y="129" font-size="11" fill="#4B4B56">plan</text>
+<text x="54" y="149" font-size="11" fill="#EFC53F">/</text>
+<text x="62" y="149" font-size="11" fill="#A9AAB5">plan diff</text>
+<text x="180" y="149" font-size="11" fill="#777782">planned vs actual · ↯ 1 drift</text>
+<text x="54" y="173" font-size="11" fill="#4B4B56">graph</text>
+<text x="54" y="193" font-size="11" fill="#EFC53F">/g</text>
+<text x="70" y="193" font-size="11" fill="#A9AAB5">r</text>
+<text x="78" y="193" font-size="11" fill="#EFC53F">a</text>
+<text x="86" y="193" font-size="11" fill="#A9AAB5">ph query</text>
+<text x="180" y="193" font-size="11" fill="#777782">free-form graph query</text>
+<text x="524" y="193" font-size="11" fill="#4B4B56">det · $0.00</text>
+<text x="54" y="217" font-size="11" fill="#4B4B56">recent</text>
+<text x="54" y="233" font-size="11" fill="#EFC53F">/</text>
+<text x="62" y="233" font-size="11" fill="#A9AAB5">theme stella-gold</text>
+<text x="220" y="233" font-size="11" fill="#777782">2m ago</text>
+<text x="40" y="266" font-size="12" fill="#EFC53F" font-weight="500">&gt;&gt;&gt;</text>
+<text x="70" y="266" font-size="12" fill="#E8E8EC">/ga</text>
+<rect x="98" y="256" width="7" height="13" fill="#E8E8EC"/>
+<text x="40" y="294" font-size="11" fill="#4B4B56">palette = Clear widget over a centered Rect · stock ratatui</text>
+</svg>

--- a/website/public/tui/09-gate-failure.svg
+++ b/website/public/tui/09-gate-failure.svg
@@ -1,0 +1,63 @@
+<svg viewBox="0 0 680 520" width="680" height="520" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="520" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="22" font-size="11" fill="#EFC53F" font-weight="500">SESSION</text>
+<text x="80" y="22" font-size="11" fill="#777782">▸ plan r3 · task 6 verify · 5/6</text>
+<text x="600" y="22" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="22" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="32" x2="680" y2="32" stroke="#26262C" stroke-width="1"/>
+<line x1="16" y1="52" x2="664" y2="52" stroke="#2C2C33" stroke-width="1"/>
+<rect x="24" y="44" width="290" height="14" fill="#0A0A0C"/>
+<text x="28" y="56" font-size="11" fill="#EFC53F">turn 15</text>
+<text x="82" y="56" font-size="11" fill="#777782">verify · gates · det only · $0.00</text>
+<line x1="20" y1="70" x2="20" y2="196" stroke="#EFC53F" stroke-width="2"/>
+<text x="32" y="82" font-size="12" fill="#EFC53F">◇ gate board</text>
+<text x="146" y="82" font-size="11" fill="#777782">patch-7 · 4/5 green</text>
+<text x="588" y="82" font-size="11" fill="#4B4B56">$0.00</text>
+<text x="32" y="106" font-size="12" fill="#74C991">✓</text>
+<text x="48" y="106" font-size="12" fill="#777782">types</text>
+<text x="588" y="106" font-size="11" fill="#74C991">pass</text>
+<text x="32" y="126" font-size="12" fill="#74C991">✓</text>
+<text x="48" y="126" font-size="12" fill="#777782">lint + format</text>
+<text x="588" y="126" font-size="11" fill="#74C991">pass</text>
+<text x="32" y="146" font-size="12" fill="#74C991">✓</text>
+<text x="48" y="146" font-size="12" fill="#777782">unit 214/214</text>
+<text x="588" y="146" font-size="11" fill="#74C991">pass</text>
+<text x="32" y="166" font-size="12" fill="#74C991">✓</text>
+<text x="48" y="166" font-size="12" fill="#777782">graph parity</text>
+<text x="588" y="166" font-size="11" fill="#74C991">pass</text>
+<rect x="26" y="174" width="638" height="18" fill="#241019"/>
+<text x="32" y="187" font-size="12" fill="#E0687A">✗</text>
+<text x="48" y="187" font-size="12" fill="#E8E8EC" font-weight="500">e2e smoke</text>
+<text x="140" y="187" font-size="11" fill="#E0687A">failed · 1/3 cases · 41s</text>
+<text x="560" y="187" font-size="11" fill="#E0687A">blocking</text>
+<line x1="20" y1="204" x2="20" y2="278" stroke="#E0687A" stroke-width="2"/>
+<rect x="32" y="208" width="632" height="72" fill="#0F0F12" stroke="#E0687A" stroke-width="1"/>
+<text x="44" y="228" font-size="11" fill="#E0687A">✗ case auth_refresh_parallel</text>
+<text x="44" y="248" font-size="11" fill="#777782">assertion failed: findings.len() == 1</text>
+<text x="44" y="264" font-size="11" fill="#777782">expected 1 finding, got 2 (duplicate digest)</text>
+<text x="380" y="228" font-size="11" fill="#4B4B56">^N jump · l full log · r rerun gate</text>
+<line x1="20" y1="292" x2="20" y2="384" stroke="#F7D96B" stroke-width="2"/>
+<rect x="32" y="296" width="632" height="92" fill="#0F0F12" stroke="#EFC53F" stroke-width="1"/>
+<text x="44" y="316" font-size="12" fill="#F7D96B">↯ propose r4</text>
+<text x="156" y="316" font-size="11" fill="#E8E8EC">add task 3b "stabilize auth fixture; assert single writer"</text>
+<text x="44" y="338" font-size="11" fill="#777782">cause: duplicate digest under parallel refresh</text>
+<text x="404" y="338" font-size="11" fill="#777782">linked OXA-142</text>
+<text x="44" y="360" font-size="11" fill="#EFC53F">a approve r4</text>
+<text x="152" y="360" font-size="11" fill="#A9AAB5">e edit</text>
+<text x="212" y="360" font-size="11" fill="#A9AAB5">x dismiss</text>
+<text x="44" y="380" font-size="11" fill="#4B4B56">nothing runs until approval · the model cannot argue with a red gate</text>
+<rect x="16" y="400" width="648" height="34" fill="#17171B" stroke="#EFC53F" stroke-width="1"/>
+<text x="28" y="422" font-size="12" fill="#EFC53F" font-weight="500">◇ merge blocked</text>
+<text x="164" y="422" font-size="11" fill="#777782">unblocks on green · verify remains $0.00 · det</text>
+<text x="16" y="460" font-size="12" fill="#EFC53F" font-weight="500">&gt;&gt;&gt;</text>
+<rect x="46" y="450" width="7" height="13" fill="#E8E8EC"/>
+<line x1="0" y1="472" x2="680" y2="472" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="494" font-size="11" fill="#777782">kimi-k3 · verify · ctx</text>
+<text x="182" y="494" font-size="12" fill="#EFC53F">████▏</text>
+<text x="232" y="494" font-size="12" fill="#26262C">░░░░░</text>
+<text x="284" y="494" font-size="11" fill="#E8E8EC">42%</text>
+<text x="324" y="494" font-size="11" fill="#EFC53F">$0.45</text>
+<text x="382" y="494" font-size="11" fill="#A9AAB5">det 87%</text>
+<text x="456" y="494" font-size="11" fill="#E0687A">1 gate red</text>
+<text x="606" y="494" font-size="11" fill="#777782">? help</text>
+</svg>

--- a/website/public/tui/10-start-work.svg
+++ b/website/public/tui/10-start-work.svg
@@ -1,0 +1,54 @@
+<svg viewBox="0 0 680 520" width="680" height="520" xmlns="http://www.w3.org/2000/svg" font-family="DejaVu Sans Mono, JetBrains Mono, monospace">
+<rect x="0" y="0" width="680" height="520" rx="6" fill="#0A0A0C" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="22" font-size="11" fill="#777782">SESSION  AGENTS  TRACES  GRAPH  FILES  SKILLS  MCP</text>
+<text x="400" y="22" font-size="11" fill="#EFC53F" font-weight="500">ISSUES</text>
+<text x="600" y="22" font-size="12" fill="#E8E8EC" font-weight="500">stella</text>
+<text x="645" y="22" font-size="12" fill="#EFC53F" font-weight="500">*</text>
+<line x1="0" y1="32" x2="680" y2="32" stroke="#26262C" stroke-width="1"/>
+<text x="24" y="56" font-size="11" fill="#4B4B56">▶ OXA-142  token refresh race            in progress   plan r3</text>
+<text x="24" y="76" font-size="11" fill="#4B4B56">○ OXA-151  dedup digest persists across CI runs   triage</text>
+<rect x="56" y="90" width="568" height="374" fill="#0F0F12" stroke="#EFC53F" stroke-width="1"/>
+<text x="72" y="114" font-size="12" fill="#EFC53F" font-weight="500">w start work</text>
+<text x="180" y="114" font-size="12" fill="#E8E8EC">OXA-151 dedup digest persists across CI runs</text>
+<text x="72" y="134" font-size="11" fill="#777782">draft plan r1 · built from issue text + graph + memory</text>
+<line x1="56" y1="144" x2="624" y2="144" stroke="#26262C" stroke-width="1"/>
+<text x="72" y="164" font-size="11" fill="#A9AAB5">sources</text>
+<text x="140" y="164" font-size="11" fill="#777782">issue OXA-151 · graph: 3 coupled files · memory RULE:</text>
+<text x="140" y="180" font-size="11" fill="#777782">"dedup keys must be stable across runs"</text>
+<line x1="56" y1="192" x2="624" y2="192" stroke="#26262C" stroke-width="1"/>
+<text x="72" y="214" font-size="12" fill="#4B4B56">○</text>
+<text x="88" y="214" font-size="12" fill="#E8E8EC">1 read seen-set write path</text>
+<text x="404" y="214" font-size="11" fill="#4B4B56">read only · no contract</text>
+<text x="72" y="240" font-size="12" fill="#4B4B56">○</text>
+<text x="88" y="240" font-size="12" fill="#E8E8EC">2 persist digest set to .stella/seen</text>
+<text x="104" y="258" font-size="11" fill="#777782">done means: file exists after run</text>
+<text x="404" y="258" font-size="11" fill="#A9AAB5">graph · det</text>
+<text x="72" y="284" font-size="12" fill="#4B4B56">○</text>
+<text x="88" y="284" font-size="12" fill="#E8E8EC">3 restore on start</text>
+<text x="104" y="302" font-size="11" fill="#777782">done means: unit seen_restore green</text>
+<text x="404" y="302" font-size="11" fill="#A9AAB5">unit · det</text>
+<text x="72" y="328" font-size="12" fill="#EFC53F">◇</text>
+<text x="88" y="328" font-size="12" fill="#EFC53F">4 verify · 5 gates</text>
+<text x="404" y="328" font-size="11" fill="#777782">blocks merge</text>
+<line x1="56" y1="344" x2="624" y2="344" stroke="#26262C" stroke-width="1"/>
+<text x="72" y="366" font-size="11" fill="#777782">estimate</text>
+<text x="144" y="366" font-size="11" fill="#EFC53F">~$0.40</text>
+<text x="204" y="366" font-size="11" fill="#E8E8EC">~60k tok</text>
+<text x="282" y="366" font-size="11" fill="#A9AAB5">det est 84%</text>
+<text x="384" y="366" font-size="11" fill="#E8E8EC">~8 min</text>
+<line x1="56" y1="382" x2="624" y2="382" stroke="#26262C" stroke-width="1"/>
+<text x="72" y="406" font-size="12" fill="#EFC53F">a approve and start</text>
+<text x="240" y="406" font-size="11" fill="#A9AAB5">e edit tasks</text>
+<text x="344" y="406" font-size="11" fill="#A9AAB5">x cancel</text>
+<text x="72" y="430" font-size="11" fill="#4B4B56">nothing runs before approval · on a: branch created, plan becomes r1,</text>
+<text x="72" y="446" font-size="11" fill="#4B4B56">[:NEXT] edges written, breadcrumb updates</text>
+<line x1="0" y1="474" x2="680" y2="474" stroke="#26262C" stroke-width="1"/>
+<text x="16" y="496" font-size="11" fill="#777782">kimi-k3 · idle · ctx</text>
+<text x="166" y="496" font-size="12" fill="#EFC53F">██▊</text>
+<text x="196" y="496" font-size="12" fill="#26262C">░░░░░░░</text>
+<text x="258" y="496" font-size="11" fill="#E8E8EC">27%</text>
+<text x="298" y="496" font-size="11" fill="#EFC53F">$0.45</text>
+<text x="356" y="496" font-size="11" fill="#A9AAB5">det 86%</text>
+<text x="430" y="496" font-size="11" fill="#A9AAB5">✉ 21</text>
+<text x="606" y="496" font-size="11" fill="#777782">? help</text>
+</svg>

--- a/website/source.config.ts
+++ b/website/source.config.ts
@@ -9,13 +9,15 @@ export const docs = defineDocs({
     postprocess: {
       // Export each page's rendered markdown as `_markdown` (see
       // src/lib/page-markdown.ts — the Copy page menu and /llms.mdx serve it).
-      // The three component kinds whose meaning lives outside their children
-      // are emitted as placeholders and re-rendered to markdown there.
+      // A component whose meaning lives outside its children is emitted as a
+      // placeholder and re-rendered to markdown there; the ones listed below
+      // are those.
       includeProcessedMarkdown: {
         mdxAsPlaceholder: [
           ...DIAGRAM_PLACEHOLDER_NAMES,
           "ProviderGrid",
           "CommandDeckExplorer",
+          "DeckShot",
         ],
         // The default stringifier keeps unknown JSX elements as literal tags
         // in the output (only their children are dropped) — so a page full of

--- a/website/src/app/(home)/page.tsx
+++ b/website/src/app/(home)/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { HeroTerminal } from "@/components/command-deck";
 import { AnimatedLockup } from "@/components/animated-lockup";
 import { Mark } from "@/components/brand";
+import { DeckShot } from "@/components/deck-shot";
 import { InstallBlock } from "@/components/install-block";
 import { PROVIDER_CATALOG } from "@/components/provider-catalog";
 import { REPO_URL, SITE_URL } from "@/lib/site";
@@ -63,9 +64,9 @@ const softwareJsonLd = {
  * The landing page.
  *
  * One sentence saying what stella is, the command that installs it, a
- * transcript of a real run, the list of providers it speaks to, and the four
- * doors into the docs. Everything else is one click away and better written
- * there.
+ * transcript of a real run, two frames of the interactive deck, the list of
+ * providers it speaks to, and the four doors into the docs. Everything else is
+ * one click away and better written there.
  *
  * Brand notes (docs/brand): the name is lowercase always; the comet flies
  * left→right into the wordmark; gold is the signal (the lockup, the prompt,
@@ -218,8 +219,36 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── The tour ───────────────────────────────────────────────────── */}
+      {/* ── The deck ───────────────────────────────────────────────────── */}
       <section className="lp-section">
+        <div className="mx-auto w-full max-w-3xl px-4 py-16">
+          <h2 className="lp-eyebrow mb-5">The deck</h2>
+          <p className="max-w-prose text-base">
+            Two moments decide whether you can trust an agent with a branch:
+            what it does before it starts, and what it does when a check goes
+            red. Running <span className="lp-brand-face">stella</span> with no
+            subcommand opens the interactive deck, where both of them look
+            like this —{" "}
+            <Link
+              href="/docs/agent-modes#interactive-the-command-deck"
+              className="underline underline-offset-4"
+            >
+              every tab, and what each one holds
+            </Link>
+            .
+          </p>
+
+          <div className="mt-8">
+            <DeckShot id="start-work" />
+          </div>
+          <div className="mt-10">
+            <DeckShot id="gate" />
+          </div>
+        </div>
+      </section>
+
+      {/* ── The tour ───────────────────────────────────────────────────── */}
+      <section className="lp-section lp-band">
         <div className="mx-auto w-full max-w-3xl px-4 py-16">
           <h2 className="lp-eyebrow mb-5">Step inside</h2>
           <p className="max-w-prose text-base">
@@ -246,7 +275,7 @@ export default function HomePage() {
       </section>
 
       {/* ── Providers ──────────────────────────────────────────────────── */}
-      <section className="lp-section lp-band">
+      <section className="lp-section">
         <div className="mx-auto w-full max-w-3xl px-4 py-16">
           <h2 className="lp-eyebrow mb-5">Providers</h2>
           <p className="max-w-prose text-base">
@@ -282,7 +311,7 @@ export default function HomePage() {
       </section>
 
       {/* ── Doors into the docs ────────────────────────────────────────── */}
-      <section className="lp-section">
+      <section className="lp-section lp-band">
         <div className="mx-auto w-full max-w-3xl px-4 py-16">
           <h2 className="lp-eyebrow mb-5">Start here</h2>
           <ul className="border-t border-fd-border">

--- a/website/src/app/engine/engine.css
+++ b/website/src/app/engine/engine.css
@@ -492,6 +492,17 @@
  * Telemetry feed — the shape of stella-events.jsonl, typed on
  * ═════════════════════════════════════════════════════════════════════════ */
 
+/* A deck rendering on the tour, on the same rhythm as the telemetry strip
+ * below it. The figure paints its own frame (see .deck-shot in global.css),
+ * so this only places it and sets the caption's measure. */
+.eng-deck {
+  margin: 2.5rem 0 0;
+}
+
+.eng-deck .deck-shot-cap {
+  max-width: 62ch;
+}
+
 .eng-feed {
   margin: 2.5rem 0 0;
   border: 1px solid var(--eng-rule);

--- a/website/src/app/engine/stations-aft.tsx
+++ b/website/src/app/engine/stations-aft.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { DeckShot } from "@/components/deck-shot";
 import { InstallBlock } from "@/components/install-block";
 import { REPO_URL } from "@/lib/site";
 import {
@@ -184,6 +185,13 @@ export function VeraStation() {
       </blockquote>
 
       <EventFeed lines={VERA_FEED} />
+
+      {/* A verdict nobody can argue with, from the driver's seat. Red is the
+          rarest colour on the deck, which is what lets one red row read as an
+          alarm without anything blinking. */}
+      <div className="eng-deck">
+        <DeckShot id="gate" />
+      </div>
     </Station>
   );
 }
@@ -395,6 +403,13 @@ export function EvolutionStation() {
             secrets or PII.
           </li>
         </ul>
+      </div>
+
+      {/* What a trace turns into, once it has earned it: the learned rows in
+          the deck's skills tab are the ones stella wrote from its own
+          successful runs, and they carry the trace count that promoted them. */}
+      <div className="eng-deck">
+        <DeckShot id="skills" />
       </div>
 
       <p className="eng-evo-honest">

--- a/website/src/app/engine/stations-fore.tsx
+++ b/website/src/app/engine/stations-fore.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { DeckShot } from "@/components/deck-shot";
 import {
   BrandFace,
   EventFeed,
@@ -158,6 +159,13 @@ export function TurnLoopStation() {
       </div>
 
       <EventFeed lines={LOOP_FEED} />
+
+      {/* The same loop with a reader in front of it. The deck makes the turn
+          the unit of the transcript, which is the shape the station above
+          argues for, drawn. */}
+      <div className="eng-deck">
+        <DeckShot id="turn" />
+      </div>
     </Station>
   );
 }

--- a/website/src/app/global.css
+++ b/website/src/app/global.css
@@ -604,8 +604,8 @@ figure.shiki ::selection,
  * surface on ink. It is the alternation that does the work, so which sections
  * carry the class is positional: inserting a section flips the parity of
  * every one after it, and two banded sections in a row merge into one panel,
- * which is the failure this is meant to prevent. Today: the run and the
- * providers are banded; the tour, the doors, and the hero are not. */
+ * which is the failure this is meant to prevent. Today: the run, the tour and
+ * the doors are banded; the hero, the deck and the providers are not. */
 .lp-band {
   background: var(--color-fd-muted);
 }
@@ -845,6 +845,73 @@ html[data-home-nav="hidden"] #nd-nav {
   line-height: 1.7;
   white-space: pre;
   overflow-x: auto;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Deck shots — the Command Deck, rendered.
+ *
+ * The only `<img>` on this site. The SVG already draws the terminal — ink
+ * ground, hairline border, rounded corners, all from the same tokens this
+ * sheet reads — so the rules here add depth and a caption and nothing else.
+ * A second border around it would read as a screenshot of a screenshot.
+ *
+ * The frame keeps its ink in both themes, on the same argument as `.term`
+ * above: the deck lives in a dark terminal, and the figure is a window into
+ * it rather than a panel of the page.
+ * ═════════════════════════════════════════════════════════════════════════ */
+
+.deck-shot {
+  margin: 0;
+}
+
+.deck-shot-img {
+  display: block;
+  width: 100%;
+  /* The record's intrinsic height reserves the box; once the file lands the
+     aspect ratio governs, so the frame scales to whatever column holds it. */
+  height: auto;
+  border-radius: 0.5rem;
+  box-shadow: var(--stella-shadow-card);
+  /* These load lazily, so the reserved box is on screen before the SVG is.
+     Painting it the deck's own ground means what appears is an unlit terminal
+     rather than a page-coloured hole — and on the light page, that hole was
+     the brightest rectangle on screen. */
+  background: var(--stella-canvas);
+}
+
+.deck-shot-cap {
+  margin-top: 0.75rem;
+  max-width: var(--stella-measure);
+  font-size: var(--stella-type-sm);
+  line-height: 1.6;
+  color: var(--color-fd-muted-foreground);
+}
+
+/* The wordmark, chipped onto every frame: these travel — a caption gets
+ * screenshotted away from its page — and the name is what should ride with
+ * them. Lowercase mono per the brand, and a chip rather than running text so
+ * it cannot be misread as the caption's first word. */
+.deck-shot-tag {
+  display: inline-block;
+  margin-inline-end: 0.55em;
+  padding: 0.1em 0.45em;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.25rem;
+  font-family: var(--font-mono);
+  font-size: var(--stella-type-xs);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  text-transform: lowercase;
+  white-space: nowrap;
+  color: var(--stella-accent-text);
+  vertical-align: 0.08em;
+}
+
+/* In docs prose the figure needs the vertical rhythm the surrounding block
+ * elements have; on the landing page and the engine tour the caller spaces it. */
+.fd-prose .deck-shot,
+article .deck-shot {
+  margin: 1.5rem 0;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/website/src/components/deck-shot.tsx
+++ b/website/src/components/deck-shot.tsx
@@ -1,0 +1,53 @@
+import { DECK_SHOTS, type DeckShotId } from "./deck-shots";
+
+/**
+ * One command-deck rendering, framed.
+ *
+ * The SVG draws its own terminal — rounded ink panel, hairline border, the
+ * deck's own palette — so this adds a shadow and a caption and otherwise gets
+ * out of the way. Wrapping it in a second bordered card would double the
+ * border and make the frame look like a screenshot of a screenshot.
+ *
+ * A plain `<img>` rather than `next/image`: the site sets
+ * `images: { unoptimized: true }` (it is fully static), so the component would
+ * add a wrapper and a srcset over a vector that needs neither. The CSP allows
+ * `img-src 'self'`, which is where these are served from.
+ *
+ * `width`/`height` come from the record and are the SVG's own viewBox, so the
+ * browser reserves the right box before the file lands and the page does not
+ * jump. The CSS overrides both — the frame scales to its column.
+ */
+export function DeckShot({
+  id,
+  caption,
+  priority = false,
+}: {
+  id: DeckShotId;
+  /** Overrides the record's caption. Pass `null` for a bare frame. */
+  caption?: string | null;
+  /** Set on a shot above the fold, so it is not lazily loaded. */
+  priority?: boolean;
+}) {
+  const shot = DECK_SHOTS[id];
+  const text = caption === undefined ? shot.caption : caption;
+  return (
+    <figure className="deck-shot">
+      <img
+        className="deck-shot-img"
+        src={`/tui/${shot.file}.svg`}
+        alt={shot.alt}
+        width={shot.width}
+        height={shot.height}
+        loading={priority ? "eager" : "lazy"}
+        decoding="async"
+        fetchPriority={priority ? "high" : "auto"}
+      />
+      {text ? (
+        <figcaption className="deck-shot-cap">
+          <span className="deck-shot-tag">stella</span>
+          {text}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/website/src/components/deck-shots.ts
+++ b/website/src/components/deck-shots.ts
@@ -1,0 +1,128 @@
+/**
+ * The command deck, rendered — one SVG per scenario, drawn at the character
+ * grid the terminal paints on, served from `public/tui/`.
+ *
+ * These are the first page-referenced files under `public/`. Every other
+ * graphic on this site is an inline SVG React component, and the reason these
+ * are not is that they are not this site's drawings: they are renderings of a
+ * terminal, authored against the deck spec, and inlining 60KB of `<text>` nodes
+ * into `diagrams.tsx` would cost the file its size ceiling and buy nothing a
+ * reader can see.
+ *
+ * The chip on every caption is the wordmark. These frames travel — one gets
+ * screenshotted away from the page that framed it — so the name rides with
+ * them rather than living only in the surrounding prose.
+ *
+ * The palette is not a coincidence: every hex in these files is a live token
+ * from `design/tokens/stella-tokens.json` (`#0a0a0c` canvas, `#0f0f12` panel,
+ * `#26262c` border, `#efc53f` gold), so `scripts/check-tokens.py` sweeps them
+ * with everything else and a retired value cannot hide in one.
+ *
+ * This module is pure and `.ts`-only, like `diagram-descriptions.ts`, because
+ * `src/lib/page-markdown.ts` imports it under `node --test`, which strips types
+ * but cannot parse JSX.
+ */
+
+export interface DeckShot {
+  /** File under `public/tui/`, without the directory or the extension. */
+  file: string;
+  /** Intrinsic size, so the browser reserves the box before the SVG lands. */
+  width: number;
+  height: number;
+  /**
+   * What the frame shows, as one sentence. Serves the `alt` attribute and the
+   * markdown export both — a reader who cannot see the picture and a reader
+   * who is handed the page as text get the same sentence.
+   */
+  alt: string;
+  /** The line under the frame. Says what the frame proves, not what it is. */
+  caption: string;
+}
+
+export const DECK_SHOTS = {
+  turn: {
+    file: "01-session-turn-lifecycle",
+    width: 680,
+    height: 520,
+    alt: "A turn in the deck's session view: a skill injected, a folded read, an expanded edit diff, and a closing receipt carrying the turn's cost, token count, deterministic share, and test result.",
+    caption:
+      "The turn is the unit of the transcript. It opens with a rule, folds the reads that changed nothing, keeps the edit expanded, and closes on a receipt — cost, tokens, tests, and the share of the work that never reached a model.",
+  },
+  events: {
+    file: "02-event-vocabulary",
+    width: 680,
+    height: 508,
+    alt: "The deck's event vocabulary: a file write, a delete checked against the code graph before it ran, a memory logged and then promoted from observation to rule, and a one-line compaction whisper.",
+    caption:
+      "One rail colour per origin: gold is stella acting on the world, silver is the world coming in. Red appears only for failure, which is what makes a red row an alarm without anything blinking.",
+  },
+  task: {
+    file: "03-task-zoom",
+    width: 680,
+    height: 520,
+    alt: "A task opened to its contract: the done-means clause, three checks marked deterministic or model-judged, the planned sequence beside what actually happened, and a spend strip.",
+    caption:
+      "A task closes when its checks pass, not when the model says so. The contract is written before the work starts, the divergence between planned and actual is recorded rather than smoothed over, and the spend rides alongside.",
+  },
+  graph: {
+    file: "04-graph",
+    width: 680,
+    height: 468,
+    alt: "The deck's graph tab: symbols in a file ranked by edge count, inbound and outbound edges grouped by kind, and neighbours ranked by coupling.",
+    caption:
+      "Every answer on this tab is computed, so it costs $0.00 and returns in milliseconds. Coupling is the useful column: it is the blast radius if you edit this file.",
+  },
+  skills: {
+    file: "05-skills",
+    width: 680,
+    height: 480,
+    alt: "The deck's skills tab: installed skills with their injection counts and token cost, skills stella wrote itself after repeated wins, and a registry search showing signed and unsigned results.",
+    caption:
+      "Skills carry their own usage counts, so the ones that never fire are visible and can be pruned. The learned rows are the ones stella wrote from its own traces; an unsigned registry result installs disabled.",
+  },
+  mcp: {
+    file: "06-mcp",
+    width: 680,
+    height: 420,
+    alt: "The deck's MCP tab: four servers with transport, tool count, handshake latency and auth state, above a registry search offering signed and unsigned servers.",
+    caption:
+      "A new server lands disabled and shows you its capabilities before its first enable. The code graph is pinned at the top because it is the product rather than an integration.",
+  },
+  issues: {
+    file: "07-issues",
+    width: 680,
+    height: 470,
+    alt: "The deck's issues tab: a tracker backlog sorted by heat, one issue expanded to show its linked plan, branch and evidence, and a start-work strip.",
+    caption:
+      "The backlog arrives over MCP and sorts by heat — the coupling of the files an issue touches against its age, read off the graph. Status syncs back when the gates go green.",
+  },
+  palette: {
+    file: "08-command-palette",
+    width: 680,
+    height: 312,
+    alt: "The deck's command palette: a fuzzy-matched list of commands with the matched characters highlighted, a section of commands relevant to what is running now, and a recent section.",
+    caption:
+      "Fuzzy match over every command, with a section for the ones that make sense right now — while a verify turn is running, the gate commands come first.",
+  },
+  gate: {
+    file: "09-gate-failure",
+    width: 680,
+    height: 520,
+    alt: "A gate board with four gates green and an end-to-end smoke test red, the failing case and its assertion quoted underneath, and a proposed plan revision awaiting approval while the merge stays blocked.",
+    caption:
+      "A red gate is not something the model can argue with. It answers with a proposed plan revision naming the cause, and nothing runs until you approve it — while the merge stays blocked and the verify work keeps costing $0.00.",
+  },
+  "start-work": {
+    file: "10-start-work",
+    width: 680,
+    height: 520,
+    alt: "An issue being turned into a draft plan: the sources it was built from, four tasks each with a done-means clause, and an estimate of cost, tokens and time above an approval row.",
+    caption:
+      "An issue becomes a plan while you watch. The sources line names exactly what went in — the issue text, the coupled files from the graph, the memory rules that applied — and nothing is touched before you approve it.",
+  },
+} as const satisfies Record<string, DeckShot>;
+
+export type DeckShotId = keyof typeof DECK_SHOTS;
+
+/** Stable id list, for tests and for anything that iterates the set. */
+export const DECK_SHOT_IDS = Object.keys(DECK_SHOTS) as DeckShotId[];

--- a/website/src/lib/page-markdown.test.ts
+++ b/website/src/lib/page-markdown.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 
 import { DIAGRAM_DESCRIPTIONS } from "../components/diagram-descriptions.ts";
 import { COMMAND_DECK_TABS } from "../components/command-deck-tabs.ts";
+import { DECK_SHOTS, DECK_SHOT_IDS } from "../components/deck-shots.ts";
 import { PROVIDER_CATALOG } from "../components/provider-catalog.ts";
 import {
   DIAGRAM_PLACEHOLDER_NAMES,
@@ -39,9 +40,15 @@ test("every placeholder name source.config.ts emits has a renderer", () => {
   // exactly the renderer set, so neither side can drift.
   assert.match(SOURCE_CONFIG, /"ProviderGrid"/);
   assert.match(SOURCE_CONFIG, /"CommandDeckExplorer"/);
+  assert.match(SOURCE_CONFIG, /"DeckShot"/);
   assert.deepEqual(
     Object.keys(PLACEHOLDER_RENDERERS).sort(),
-    [...DIAGRAM_PLACEHOLDER_NAMES, "ProviderGrid", "CommandDeckExplorer"].sort(),
+    [
+      ...DIAGRAM_PLACEHOLDER_NAMES,
+      "ProviderGrid",
+      "CommandDeckExplorer",
+      "DeckShot",
+    ].sort(),
   );
 });
 
@@ -52,6 +59,38 @@ test("every diagram placeholder renders its aria-label sentence", async () => {
     const out = await render({ name, attributes: {}, children: "" });
     assert.equal(out, `*${DIAGRAM_DESCRIPTIONS[name]}*`);
     assert.ok(out.length > 20, `${name} rendered suspiciously short`);
+  }
+});
+
+test("every deck shot renders its alt sentence", async () => {
+  for (const id of DECK_SHOT_IDS) {
+    const out = await PLACEHOLDER_RENDERERS.DeckShot({
+      name: "DeckShot",
+      attributes: { id },
+      children: "",
+    });
+    assert.equal(out, `*${DECK_SHOTS[id].alt}*`);
+    assert.ok(out.length > 20, `${id} rendered suspiciously short`);
+  }
+});
+
+/**
+ * The record names a file; nothing else does. A typo in `file` renders a
+ * broken image on a marketing page and fails no build — the `<img>` 404s and
+ * React is perfectly happy. This is the only place that can catch it.
+ */
+test("every deck shot names a file that exists under public/tui", () => {
+  for (const id of DECK_SHOT_IDS) {
+    const shot = DECK_SHOTS[id];
+    const path = join(HERE, "../../public/tui", `${shot.file}.svg`);
+    const svg = readFileSync(path, "utf8");
+    // The declared size is what reserves the box before the file lands, so a
+    // record that disagrees with the viewBox makes the page jump on load.
+    assert.match(
+      svg,
+      new RegExp(`viewBox="0 0 ${shot.width} ${shot.height}"`),
+      `${id}: record says ${shot.width}x${shot.height}, the SVG disagrees`,
+    );
   }
 });
 

--- a/website/src/lib/page-markdown.ts
+++ b/website/src/lib/page-markdown.ts
@@ -9,9 +9,10 @@
  * GFM tables survive. Reading the raw `.mdx` off disk instead would leak JSX
  * tags a markdown consumer cannot read.
  *
- * Three component kinds carry meaning outside their children — the SVG
- * diagrams (their content is the picture), `ProviderGrid` (its content is the
- * catalog data), and `CommandDeckExplorer` (nine tabbed panes). Those are
+ * Some components carry meaning outside their children — the SVG diagrams
+ * (their content is the picture), `ProviderGrid` (its content is the catalog
+ * data), `CommandDeckExplorer` (the tabbed panes), and `DeckShot` (a rendering
+ * of the deck, whose content is a file this module cannot read). Those are
  * emitted as placeholders at build time and re-rendered to markdown here by
  * `renderPlaceholder`, from the same records the components render from, so
  * the export can never drift from what the page shows.
@@ -25,6 +26,7 @@ import { renderPlaceholder } from "fumadocs-core/mdx-plugins/remark-llms.runtime
 
 import { DIAGRAM_DESCRIPTIONS } from "../components/diagram-descriptions.ts";
 import { COMMAND_DECK_TABS } from "../components/command-deck-tabs.ts";
+import { DECK_SHOTS } from "../components/deck-shots.ts";
 import { PROVIDER_CATALOG } from "../components/provider-catalog.ts";
 
 /**
@@ -56,6 +58,20 @@ function providerGridMarkdown(only: unknown): string {
   ].join("\n");
 }
 
+/**
+ * A deck rendering exports as its own alt sentence, the way a diagram exports
+ * as its description: the picture is the content, and the sentence is what a
+ * reader who is handed the page as text gets instead of it.
+ *
+ * An `id` that names no shot exports nothing rather than a broken italic — the
+ * page still renders in that case (the component would throw first), so this
+ * is the belt on a brace, not a supported call.
+ */
+function deckShotMarkdown(id: unknown): string {
+  const shot = typeof id === "string" ? DECK_SHOTS[id as keyof typeof DECK_SHOTS] : undefined;
+  return shot ? `*${shot.alt}*` : "";
+}
+
 function commandDeckMarkdown(): string {
   return COMMAND_DECK_TABS.map(
     (tab) => `### ${tab.label}\n\n${tab.blurb}\n\n\`\`\`text\n${tab.lines.join("\n")}\n\`\`\``,
@@ -65,8 +81,8 @@ function commandDeckMarkdown(): string {
 /**
  * Renderers for the placeholders `includeProcessedMarkdown` emits. A name
  * absent here degrades to the placeholder's children (fumadocs' default),
- * which for these three would be nothing — so the record is exhaustive by
- * construction: the placeholder list in `source.config.ts` is exactly these
+ * which for every one of these would be nothing — so the record is exhaustive
+ * by construction: the placeholder list in `source.config.ts` is exactly these
  * keys, and `page-markdown.test.ts` asserts it.
  */
 export const PLACEHOLDER_RENDERERS: Record<
@@ -79,6 +95,7 @@ export const PLACEHOLDER_RENDERERS: Record<
   ]),
   ["ProviderGrid", (data: { attributes: Record<string, unknown> }) => providerGridMarkdown(data.attributes.only)],
   ["CommandDeckExplorer", () => commandDeckMarkdown()],
+  ["DeckShot", (data: { attributes: Record<string, unknown> }) => deckShotMarkdown(data.attributes.id)],
 ]);
 
 export interface PageMarkdownInput {

--- a/website/src/mdx-components.tsx
+++ b/website/src/mdx-components.tsx
@@ -5,6 +5,7 @@ import type { ComponentProps } from "react";
 
 import { Badge, CardGrid, OptionCard, SpecCard, ToolCard } from "@/components/cards";
 import { CommandDeckExplorer } from "@/components/command-deck-explorer";
+import { DeckShot } from "@/components/deck-shot";
 import { DocsCodeBlock } from "@/components/docs-code-block";
 import {
   BudgetGuardDiagram,
@@ -79,6 +80,9 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     CostChainDiagram,
     ClaimLockDiagram,
     CommandDeckExplorer,
+    // The interactive deck, rendered — see components/deck-shots.ts for why
+    // these are files under public/ rather than inline SVG like the diagrams.
+    DeckShot,
     // Cards — the mobile-first replacement for reference tables
     CardGrid,
     SpecCard,


### PR DESCRIPTION
Closes #5240

Ten SVG renderings of the interactive deck, placed where each one carries the claim the surrounding page is already making.

## Where they go

| Shot | Page | Why there |
|---|---|---|
| start-work, gate-failure | landing page, new "The deck" section | the two moments that decide whether you trust an agent with a branch |
| session-turn-lifecycle | `/engine` turn-loop station, `agent-modes` | the turn as the unit of the transcript, beside the station that argues for it |
| gate-failure | `/engine` vera station, `plugins` | a verdict the model cannot talk past — the page's own thesis, drawn |
| skills | `/engine` evolution station, `agent-tools/skills` | learned-from-traces rows are what that station is about |
| command-palette | `agent-modes` | beside the slash-command reference |
| graph | `context-engine` | the code-graph section, `$0.00 · 12ms · det` |
| mcp | `agent-tools/mcp` | beside "an installed server is withheld until you grant it" |
| task-zoom | `principles/determinism` | the det/model split shown rather than described |
| event-vocabulary | `telemetry` | the same event stream the page queries, rendered |
| issues, start-work | `self-improvement` | the issue-to-plan loop the track is about |

## Notes for review

**They ship as files under `public/tui/`, the first page-referenced assets there.** Every other graphic on this site is an inline SVG component. These are not, because they are not this site's drawings — they are renderings of a terminal, and inlining ~60KB of `<text>` nodes would push `diagrams.tsx` (1228 lines) over the 1500 ceiling to buy a reader nothing. Plain `<img>` rather than `next/image` because the site sets `images: { unoptimized: true }`.

**A retired hex was caught before CI.** Three renderings used `#565660`, the v5.1 `comment` colour retired in #4946. `check-tokens.py` sweeps `.svg`, so they are repainted in `muted` (`#777782`) — the token the retirement note names as carrying that role, and the one that preserves the hierarchy in the gate shot, where the assertion excerpt sits a step above the `dim` key hints. Every other hex in all ten was already a live token.

**One record, two consumers.** `DeckShot` reads `deck-shots.ts`, so the alt sentence serves the `alt` attribute and the markdown export both — a page copied as text carries the sentence instead of silently losing the figure. Registered as an `mdxAsPlaceholder` alongside the diagrams, `ProviderGrid` and `CommandDeckExplorer`.

**The reserved box paints ink.** These load lazily; until the file landed, the reserved box was the brightest rectangle on the light page.

**Band parity moved.** The landing page's new section flips `lp-band` for every section after it, per the rule in `global.css` — the tour, the providers and the doors all move, and that comment is updated.

## Witness

Two tests in `page-markdown.test.ts`:

- `every deck shot renders its alt sentence`
- `every deck shot names a file that exists under public/tui` — also asserts the record's declared size matches the SVG's `viewBox`, since a wrong size makes the page jump on load

Checked the artisanal way: changing one record height 468 → 469 fails with `graph: record says 680x469, the SVG disagrees`. That is the only thing that can catch a typo'd filename, which would ship a broken image on a marketing page and fail no build.

## Verified

- `next build` — 202 pages, clean; all ten shots present in the built HTML, 15 placements
- `tsc --noEmit` clean; 22 website tests pass
- `check-tokens`, `check-css-vars`, `check-brand-case`, `check-website-inputs`, `check-file-size`, `check-prose`, `check-line-citations` — all green
- Rendered in a browser on the landing page and `/docs/plugins` in light mode

`check-prose` rejected "Command Deck" in three places I wrote (it asks for "interactive mode"); those are reworded.

## Remaining work

- #5237 — nothing regenerates these from the TUI, so they can drift from the shipping deck. `command-deck-tabs.ts` solves the same problem by trimming from the golden render tests; these have no such tie, and the test added here only proves the file exists at the declared size.
