### PR TITLE
feat(stella-tui): the transcript shows one model row per settled call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,13 @@
   Search for an existing issue first; link, don't duplicate. The full policy
   is AGENTS.md § "Nothing left behind — every finding becomes a fix or a
   GitHub issue". Never end a turn with untracked half-finished work.
-- **Every issue is labelled, in this order.** First a priority (`P0`–`P4`),
+- **An issue you file carries the `triage` label and nothing else.** SCR-004
+  and SCR-005 (AGENTS.md's standing-decisions block) hold sizing and priority
+  for a dedicated triage agent, and `triage-guard` strips a creator-applied
+  priority — so a `P2` you add is both a rule break and a label that does not
+  survive. The taxonomy below is what **triage** applies; read it to
+  understand what the labels on an issue mean, not as a list to add yourself.
+- **The taxonomy, in this order.** First a priority (`P0`–`P4`),
   then the `area:*` tag — several when the work genuinely spans areas — then
   exactly one `use-model:*` tag (`cheap` / `balanced` / `pro` / `ultra`)
   naming the cheapest model class that can do the work without sacrificing

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -966,26 +966,28 @@ impl SessionModel {
                 };
                 self.transcript.push(entry);
             }
-            // Two facts come off a metering record, and they have different
-            // scopes — which is why this is one arm and not two.
+            // Two facts come off a metering record, and one arm folds both.
             //
-            // The **tokens** are folded for every call, whatever its role: the
+            // The **tokens** are counted for every call whatever its role: the
             // receipt accounts for the whole turn, auxiliary work included
-            // (#4184). The **model name** is folded only for a call that
-            // answers the turn (#4183). Splitting them into a guarded arm and a
-            // fallthrough would silently stop counting an answering call's
-            // tokens, because the first matching arm wins.
+            // (#4184). Guarding this arm on a role would stop counting an
+            // answering call's tokens — the first matching arm wins.
             //
-            // The cost deliberately is not folded either way. The HUD's live
-            // spend comes from `BudgetTick`, so folding `StepUsage::cost_usd`
-            // here would double-count it — that hazard is why this event was
-            // ignored outright, and the token half was collateral.
+            // The **row** is SPEC 6.3's `◐ model <activity> · tok/s`, one per
+            // settled call — see `turn::model_call_row` for why the rate is a
+            // division over this event rather than a second wire signal.
+            //
+            // The cost is folded neither way. The HUD's live spend comes from
+            // `BudgetTick`, so folding `StepUsage::cost_usd` here would
+            // double-count it — that hazard is why this event was ignored
+            // outright, and the token half was collateral.
             AgentEvent::StepUsage {
                 input_tokens,
                 output_tokens,
                 ..
             } => {
                 self.turn_counters.add_tokens(*input_tokens, *output_tokens);
+                self.transcript.extend(turn::model_call_row(event));
             }
             AgentEvent::UsageIncomplete { .. }
             // Context receipts (spec §4/§5) are consumed by the store/inspector,

--- a/crates/stella-tui/src/model/entry.rs
+++ b/crates/stella-tui/src/model/entry.rs
@@ -181,6 +181,33 @@ pub enum TranscriptEntry {
         /// that never saw the start still needs (#4699).
         sub_agent_id: Option<String>,
     },
+    /// One settled model call — SPEC 6.3's `◐ model <activity> · tok/s`.
+    ///
+    /// Folded from [`stella_protocol::AgentEvent::StepUsage`], which the driver
+    /// already emits once per call with the call's own output tokens and its
+    /// own wall clock (`turn::model_call_row`). The rate is a division
+    /// over two numbers `stella-core` measured, so nothing new rides the wire
+    /// to carry it.
+    Model {
+        /// What the call was for, as the wire spells the role — `worker`,
+        /// `plan_repair`, `summarization`.
+        ///
+        /// `None` is [`stella_protocol::ModelCallRole::Unknown`]: a stream
+        /// recorded before call-role attribution existed. The head then names
+        /// no activity at all rather than printing `unknown`, on the rule
+        /// `turn::supplies_the_turns_model` already applies to that
+        /// role — a call this build cannot identify states no fact about
+        /// itself.
+        activity: Option<String>,
+        /// Output tokens per second over the call's own wall clock, or `None`
+        /// when the division has no inputs to divide (see
+        /// `turn::model_call_row` for the three cases).
+        tokens_per_sec: Option<u32>,
+        /// The call's own wall clock, rendered `⚡Nms` like every other head.
+        duration_ms: u64,
+        /// Which delegate made the call, `None` for the lead's own (#4699).
+        sub_agent_id: Option<String>,
+    },
     /// A model call was retried (surfaced only once the step commits — the
     /// engine defers these, L-E10).
     Retry { attempt: u32, reason: String },

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -155,6 +155,15 @@ fn activity_of(role: ModelCallRole) -> Option<String> {
 /// never `0 tok/s` — the substitution [`super::ReadSize`] and
 /// [`crate::views::transcript::Extent`] both already refuse, because a zero
 /// asserts a measurement where there was none (#2290, #4150).
+///
+/// Not a second copy of `deck::AgentEntry::live_tok_per_s`, which shares the
+/// arithmetic and neither numerator nor denominator. That one is the **live**
+/// rate of a turn still running: the turn's output so far over the deck's own
+/// clock since the turn opened, tool time included, and it needs no settled
+/// record because there is none yet. This one is one **call**, settled, over
+/// the wall clock that call alone took. A turn's rate and its slowest call's
+/// rate are different readings, and either standing in for the other would
+/// answer a question nobody asked.
 fn tokens_per_sec(output_tokens: u64, duration_ms: u64, complete: bool) -> Option<u32> {
     if !complete || output_tokens == 0 || duration_ms == 0 {
         return None;

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -13,7 +13,9 @@
 //! the same cut `file_state` and `recall` already make, and along the same
 //! seam: a `TranscriptEntry`'s supporting types live beside it, not in it.
 
-use stella_protocol::{BudgetMode, ModelCallRole, StageKind, StageName};
+use stella_protocol::{AgentEvent, BudgetMode, ModelCallRole, StageKind, StageName};
+
+use super::TranscriptEntry;
 
 // Doc-link target only: named in `TurnOpening::queued_steer`'s docs, gated by
 // the fold in `super`. `cfg(doc)` keeps the intra-doc link resolving without
@@ -86,6 +88,78 @@ pub(crate) fn role_supplies_the_turns_model(role: ModelCallRole) -> bool {
         | ModelCallRole::Reflection
         | ModelCallRole::Summarization => false,
     }
+}
+
+/// SPEC 6.3's `◐ model` row for one settled model call, or `None` for any
+/// other event.
+///
+/// The rate is **derived, never invented**:
+/// [`AgentEvent::StepUsage`] is the driver's own per-call metering record
+/// (`stella-core`'s `driver::settlement::emit_step_usage`, and
+/// `accounted_call` for the management roles), and it already carries the
+/// output tokens the call produced and the wall clock it took to produce
+/// them. tok/s is a division over those two, so no second signal goes on the
+/// wire to say a thing the wire already says.
+///
+/// Total over [`AgentEvent`] so the metering record stays the only place a row
+/// can come from. The fold calls this from its `StepUsage` arm alone; a caller
+/// handing it anything else gets no row rather than a row about nothing.
+pub(crate) fn model_call_row(event: &AgentEvent) -> Option<TranscriptEntry> {
+    let AgentEvent::StepUsage {
+        role,
+        output_tokens,
+        duration_ms,
+        complete,
+        sub_agent_id,
+        ..
+    } = event
+    else {
+        return None;
+    };
+    Some(TranscriptEntry::Model {
+        activity: activity_of(*role),
+        tokens_per_sec: tokens_per_sec(*output_tokens, *duration_ms, *complete),
+        duration_ms: *duration_ms,
+        sub_agent_id: sub_agent_id.clone(),
+    })
+}
+
+/// The wire token for a call role (`plan_repair`, not `PlanRepair`), so the
+/// word on screen is the word in `stella-events.jsonl` — the record anyone
+/// checking the row will open.
+///
+/// `None` for [`ModelCallRole::Unknown`], which is the `serde` default for an
+/// *absent* role and so covers every session recorded before call-role
+/// attribution existed. `unknown` on the head would read as an activity the
+/// engine has, and it has none by that name.
+fn activity_of(role: ModelCallRole) -> Option<String> {
+    if matches!(role, ModelCallRole::Unknown) {
+        return None;
+    }
+    match serde_json::to_value(role) {
+        Ok(serde_json::Value::String(token)) => Some(token),
+        // `ModelCallRole` is a plain `#[serde(rename_all)]` enum, so no other
+        // shape is reachable. Nothing branches on the absence — it renders as
+        // a head with no activity, exactly as `Unknown` does.
+        _ => None,
+    }
+}
+
+/// Output tokens per second over the call's own wall clock, or `None` when the
+/// division has no inputs to divide.
+///
+/// Three absences, one answer. A provider that supplied no truthful usage
+/// envelope (`StepUsage::complete` false) reports zeros that are not
+/// measurements; an untimed call has nothing to divide by; a call that emitted
+/// no output tokens generated nothing to rate. Each renders as no column,
+/// never `0 tok/s` — the substitution [`super::ReadSize`] and
+/// [`crate::views::transcript::Extent`] both already refuse, because a zero
+/// asserts a measurement where there was none (#2290, #4150).
+fn tokens_per_sec(output_tokens: u64, duration_ms: u64, complete: bool) -> Option<u32> {
+    if !complete || output_tokens == 0 || duration_ms == 0 {
+        return None;
+    }
+    u32::try_from(output_tokens.saturating_mul(1_000) / duration_ms).ok()
 }
 
 /// What SPEC 6.1's opening rule says out loud, stamped onto the stage boundary

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -169,8 +169,9 @@ pub(crate) fn entry_lines(
 /// SPEC 6 rows for the entries the shared projection owns; `false` leaves the
 /// entry to [`entry_body`] below.
 ///
-/// Two arms, deliberately: a tool call's **head** and compaction's one quiet
-/// line. Everything else still draws long-form until its phase lands, which is why
+/// It owns a tool call's **head**, compaction's one quiet line, one settled
+/// model call, and the turn's own rules. Everything else still draws long-form
+/// until its phase lands, which is why
 /// this is a router rather than a replacement — a half-migrated transcript must
 /// still draw every row it holds, not drop the ones the projection has no arm for yet.
 ///
@@ -232,6 +233,21 @@ fn projected_rows(
             if expanded {
                 tool::argument_rows(source::head_metal(name), raw, width, out);
             }
+            true
+        }
+        TranscriptEntry::Model {
+            activity,
+            tokens_per_sec,
+            duration_ms,
+            sub_agent_id,
+        } => {
+            out.extend(source::model_rows(
+                activity.as_deref(),
+                *tokens_per_sec,
+                *duration_ms,
+                sub_agent_id.clone(),
+                width,
+            ));
             true
         }
         TranscriptEntry::Compaction {
@@ -515,6 +531,13 @@ fn entry_body(
         // `dead-code-allows` nor `module-reachability` sees inside a match
         // (#4157's lesson, restated at the router).
         TranscriptEntry::Compaction { .. } => {
+            projected_rows(entry, view, expanded, width, out);
+        }
+        // The router's too, and delegating for the same reason: this row is the
+        // only place a turn prices its model work against the deterministic
+        // path, so a gap here is the det/model split going quiet at the moment
+        // it happens. One implementation, no second one to rot (#4157).
+        TranscriptEntry::Model { .. } => {
             projected_rows(entry, view, expanded, width, out);
         }
         TranscriptEntry::BudgetTick {

--- a/crates/stella-tui/src/transcript_nav.rs
+++ b/crates/stella-tui/src/transcript_nav.rs
@@ -127,6 +127,10 @@ pub fn entry_fields(entry: &TranscriptEntry) -> Vec<&str> {
             ..
         } => vec![agent_id, instruction_preview],
         E::AskUser { question, .. } => vec![question],
+        // The role word, which is the only free text on the row and the one a
+        // reader types: "where did the summarizer run?". The rate and the wall
+        // clock are numbers a find box cannot ask for.
+        E::Model { activity, .. } => activity.as_deref().into_iter().collect(),
         // The tool name is the only free text on the row; the two counts are
         // numbers a search over the transcript has no way to ask for.
         E::HunkReview { tool, .. } => vec![tool],

--- a/crates/stella-tui/src/views/transcript.rs
+++ b/crates/stella-tui/src/views/transcript.rs
@@ -166,7 +166,14 @@ pub enum EventKind {
     /// `◇ gate <name> · state` — always priced, `$0.00` when deterministic.
     Gate { state: String, deterministic: bool },
     /// `◐ model <activity> · tok/s`.
-    Model { tokens_per_sec: u32 },
+    ///
+    /// The rate is an `Option` for the reason [`Extent`]'s counts are: a model
+    /// call whose provider vouched for no usage envelope, or whose wall clock
+    /// nobody took, has no rate — and `0 tok/s` states that the model generated
+    /// nothing per second, which is a louder claim than "not measured".
+    /// [`super::transcript_source::model_rows`] names the three absences it
+    /// covers.
+    Model { tokens_per_sec: Option<u32> },
     /// `↓ compacted 74k→69k · 0 evicted · 0 deduped` — one dim line, no rail.
     Compaction {
         from_tokens: u64,
@@ -733,9 +740,10 @@ fn kind_detail(kind: &EventKind) -> Vec<Span<'static>> {
             }
             spans
         }
-        EventKind::Model { tokens_per_sec } => {
-            vec![Span::styled(format!(" · {tokens_per_sec} tok/s"), dim)]
-        }
+        EventKind::Model { tokens_per_sec } => match tokens_per_sec {
+            Some(rate) => vec![Span::styled(format!(" · {rate} tok/s"), dim)],
+            None => Vec::new(),
+        },
         EventKind::Run { touched } | EventKind::Other { touched, .. } => touched_detail(*touched),
         // Named rather than swept up by a wildcard, so adding an `EventKind`
         // is an `E0004` here the way it already is in `head_glyph` (#4320).

--- a/crates/stella-tui/src/views/transcript/tests.rs
+++ b/crates/stella-tui/src/views/transcript/tests.rs
@@ -154,7 +154,12 @@ fn every_event_row_shows_its_rail_in_the_correct_metal() {
             token::SILVER,
         ),
         (EventKind::Memory, token::SILVER),
-        (EventKind::Model { tokens_per_sec: 1 }, token::GOLD_BRIGHT),
+        (
+            EventKind::Model {
+                tokens_per_sec: Some(1),
+            },
+            token::GOLD_BRIGHT,
+        ),
     ];
     for (kind, expected) in cases {
         let mut event = Event::new(kind.clone(), "x");
@@ -389,7 +394,9 @@ fn every_head_glyph_is_in_the_vocabulary() {
             state: "pass".into(),
             deterministic: true,
         },
-        EventKind::Model { tokens_per_sec: 40 },
+        EventKind::Model {
+            tokens_per_sec: Some(40),
+        },
         EventKind::Compaction {
             from_tokens: 74_000,
             to_tokens: 69_000,

--- a/crates/stella-tui/src/views/transcript_source.rs
+++ b/crates/stella-tui/src/views/transcript_source.rs
@@ -219,6 +219,51 @@ pub fn call_duration(call_id: &str, following: &[TranscriptEntry]) -> Option<u64
         .filter(|ms| *ms > 0)
 }
 
+/// What SPEC 6.3's model footer can say without inventing a number.
+///
+/// `irreducible generation` is a **fact about the call**, not a measurement:
+/// this work reached a model, so it was not the deterministic path SPEC 1
+/// prefers, and that is exactly what the deck's `$0.00 · det` gate row says in
+/// the other direction. It needs nothing behind it, so it stays on the row the
+/// way `new file` and `git-backed · u undo` stay on theirs when their counts
+/// have not arrived.
+///
+/// SPEC 6.3's second clause — `n of m budgeted model calls this turn` — is
+/// **elided**, because nothing in this workspace budgets model calls per turn.
+/// `EngineConfig::max_steps` is the nearest number and its own doc calls it a
+/// "hard backstop on step count … never the *primary* stuck-loop defense", so
+/// `3 of 200 budgeted` would report a backstop as a plan. `n` alone cannot
+/// stand in either: `n of m` is one reading, and half of it says something
+/// else. #5234 is where a real per-turn model-call budget is tracked; when one
+/// exists, the clause comes back here.
+const MODEL_FOOTER: &str = "   irreducible generation";
+
+/// One settled model call (SPEC 6.3) — `◐ model <activity> · tok/s` over the
+/// gold-bright rail that marks generation, with `MODEL_FOOTER` under it.
+///
+/// `activity` is the wire's own word for the call's role and `None` for a role
+/// this build cannot identify; the head then names no activity rather than one
+/// nothing recorded. `tokens_per_sec` is `None` for a call whose rate has no
+/// inputs to divide — see [`crate::model::TranscriptEntry::Model`], whose fold
+/// resolves both.
+#[must_use]
+pub fn model_rows(
+    activity: Option<&str>,
+    tokens_per_sec: Option<u32>,
+    duration_ms: u64,
+    sub_agent_id: Option<String>,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let mut event = Event::new(
+        EventKind::Model { tokens_per_sec },
+        activity.unwrap_or_default(),
+    );
+    event.duration_ms = duration_ms;
+    event.sub_agent_id = sub_agent_id;
+    event.footer = Some(MODEL_FOOTER.to_string());
+    event_rows(&event, width)
+}
+
 /// One dim line, no rail (SPEC 6.3).
 #[must_use]
 pub fn compaction_rows(
@@ -534,6 +579,186 @@ mod tests {
         assert_eq!(call_duration("c1", &[result("c1", 7)]), Some(7));
         assert_eq!(call_duration("c1", &[result("c1", 0)]), None);
         assert_eq!(call_duration("c1", &[result("c2", 7)]), None);
+    }
+
+    /// One settled model call, as the driver meters it — the shape
+    /// `stella-core`'s `driver::settlement::emit_step_usage` emits once per
+    /// call. Every field the row reads is a parameter, so a test that changes
+    /// one says which fact it is changing.
+    fn metered(
+        role: stella_protocol::ModelCallRole,
+        output_tokens: u64,
+        duration_ms: u64,
+        complete: bool,
+    ) -> AgentEvent {
+        AgentEvent::StepUsage {
+            step: 0,
+            turn_instance: Some(0),
+            call_seq: Some(0),
+            role,
+            provider: "openrouter".into(),
+            upstream_provider: None,
+            output_text: None,
+            model: "glm-5.2".into(),
+            input_tokens: 4_000,
+            output_tokens,
+            cached_input_tokens: 0,
+            cache_write_tokens: 0,
+            reasoning_tokens: None,
+            estimated_input_tokens: 0,
+            cost_usd: 0.01,
+            duration_ms,
+            retries: 0,
+            tool_calls: 1,
+            complete,
+            finish_reason: None,
+            effort: None,
+            max_output_tokens: None,
+            temperature: None,
+            params: None,
+            sub_agent_id: None,
+            task_id: None,
+        }
+    }
+
+    /// The whole live chain for one model call: the driver's metering record,
+    /// through the fold, out of the deck's own renderer.
+    ///
+    /// `render::entry_lines` rather than [`model_rows`] directly,
+    /// because the half that was missing was never the projection — it was
+    /// everything between the wire and it.
+    fn rendered_model_rows(usage: &AgentEvent) -> String {
+        let mut model = SessionModel::new();
+        model.apply(usage);
+        let rows: Vec<_> = model
+            .transcript
+            .iter()
+            .filter(|entry| matches!(entry, TranscriptEntry::Model { .. }))
+            .collect();
+        assert_eq!(
+            rows.len(),
+            1,
+            "one metering record must fold to exactly one model row: {:?}",
+            model.transcript
+        );
+        let mut out = Vec::new();
+        crate::render::entry_lines(
+            rows[0],
+            crate::render::EntryView::of(&model.files),
+            false,
+            false,
+            false,
+            120,
+            &mut out,
+        );
+        text_of_rows(&out)
+    }
+
+    /// **The witness (#5033).** A live turn shows SPEC 6.3's `◐ model` head
+    /// with a real tok/s figure, derived from the driver's own metering record
+    /// rather than invented.
+    ///
+    /// Nothing produced this row before: `EventKind::Model` was reachable from
+    /// fixtures only, so a turn's most expensive work — the generation the
+    /// deterministic-first thesis is measured against (SPEC 1) — left no mark
+    /// on the transcript at the moment it happened.
+    ///
+    /// 420 output tokens over 5 seconds is 84 tok/s, and the arithmetic is
+    /// what is asserted: the rate this row reports and the numbers the driver
+    /// measured have to be one reading.
+    #[test]
+    fn a_settled_model_call_renders_its_rate_from_the_drivers_own_metering() {
+        let text = rendered_model_rows(&metered(
+            stella_protocol::ModelCallRole::Worker,
+            420,
+            5_000,
+            true,
+        ));
+        assert!(text.contains(glyph::RUNNING), "{text}");
+        assert!(text.contains("model worker"), "{text}");
+        assert!(text.contains("84 tok/s"), "{text}");
+        // The call's own wall clock, which `Event::duration_ms` renders for
+        // every kind — this row gets it for free and must not drop it.
+        assert!(text.contains("⚡5000ms"), "{text}");
+    }
+
+    /// The footer states the half of SPEC 6.3's wording that has a source, and
+    /// **only** that half.
+    ///
+    /// `irreducible generation` is a fact about the call. The
+    /// `n of m budgeted model calls this turn` clause is elided because
+    /// nothing budgets model calls per turn — `EngineConfig::max_steps` is a
+    /// declared backstop, not a plan — and a fabricated `m` on the one row
+    /// that prices model work would be worse than no clause. See
+    /// `MODEL_FOOTER`.
+    #[test]
+    fn the_model_footer_claims_no_budget_nobody_set() {
+        let text = rendered_model_rows(&metered(
+            stella_protocol::ModelCallRole::Worker,
+            420,
+            5_000,
+            true,
+        ));
+        assert!(text.contains("irreducible generation"), "{text}");
+        for fabricated in ["budgeted", " of ", "200"] {
+            assert!(
+                !text.contains(fabricated),
+                "the footer states `{fabricated}`, which no source in this \
+                 workspace can back: {text}"
+            );
+        }
+    }
+
+    /// A rate with nothing to divide renders as no column, never `0 tok/s`.
+    ///
+    /// Three ways the division fails, and the row still draws for all three: a
+    /// model call happened, and that is the fact the row exists to state.
+    /// `0 tok/s` would assert the model generated nothing per second, the same
+    /// substitution `+0 -0` made over a real edit (#4150).
+    #[test]
+    fn a_call_whose_rate_has_no_source_states_no_rate() {
+        use stella_protocol::ModelCallRole::Worker;
+        for (label, usage) in [
+            (
+                "an envelope the provider did not vouch for",
+                metered(Worker, 420, 5_000, false),
+            ),
+            ("an untimed call", metered(Worker, 420, 0, true)),
+            (
+                "a call that generated nothing",
+                metered(Worker, 0, 5_000, true),
+            ),
+        ] {
+            let text = rendered_model_rows(&usage);
+            // No column, which subsumes the `0 tok/s` this exists to refuse:
+            // there is no rate the row could print that would be a
+            // measurement.
+            assert!(
+                !text.contains("tok/s"),
+                "{label} reported a rate nobody measured: {text}"
+            );
+            assert!(
+                text.contains("model"),
+                "{label} lost the row entirely — the call still happened: {text}"
+            );
+        }
+    }
+
+    /// A role this build cannot identify names no activity, rather than
+    /// printing `unknown` as though the engine had a stage by that name.
+    ///
+    /// The same refusal the turn rule's model name makes for that role
+    /// (#4124): a legacy stream keeps its blank.
+    #[test]
+    fn a_call_with_no_recorded_role_names_no_activity() {
+        let text = rendered_model_rows(&metered(
+            stella_protocol::ModelCallRole::Unknown,
+            420,
+            5_000,
+            true,
+        ));
+        assert!(!text.contains("unknown"), "{text}");
+        assert!(text.contains("model · 84 tok/s"), "{text}");
     }
 
     /// An unknown tool still renders — the vocabulary is open (MCP, custom

--- a/crates/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -16,6 +15,9 @@
   Planning the automations cluster: list, editor, triggers, workflows.
 
 ☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -30,14 +32,12 @@
  │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
 
-☰  plan  5/7  ·  Workflows canvas
-
-⏸ plan  Refactor the automations store into a shared╭ budget  session spend cap ───────────────────────────╮
-                                                    │run     $0.05 of $7.50 ▰▱▱▱▱▱▱▱▱                      │
+ │ ◐ model worker · 428 tok/s                       ╭ budget  session spend cap ───────────────────────────╮                                            ⚡ 2100ms
+ │   irreducible generation                         │run     $0.05 of $7.50 ▰▱▱▱▱▱▱▱▱                      │
                                                     │new cap $                                             │
-                                                    │the cap applies when the driver's budget stream folds │
+☰  plan  5/7  ·  Workflows canvas                   │the cap applies when the driver's budget stream folds │
                                                     ╰────────────────────────── ⏎ set · ⌫ edit · esc close ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,27 +16,28 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
-── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
 
- │ ⊙ apps/app/automations/page.tsx          ╭ models  resolved routing ────────────────────────────────────────────╮                                      ⚡ 42ms
- │ ⎿ 312 lines                              │session   glm-5.2                                                     │                         42ms
-                                            │auto      model off · effort on · thinking off                        │
- │ ● edit apps/app/automations/page.tsx +4 -│                                                                      │                                      ⚡ 18ms
- │ ⎿                                        │lead      zai/glm-5.2-air                                             │                 +4 −1 · 18ms
- │     10 -  const items = []               │          medium · thinking on · from default_model                   │
- │     10 +  const items = useAutomations() │think     z-ai/glm-5.2                                    unassigned  │
- │     11 +  const [q, setQ] = useState("") │          low · thinking off · from agents.triage.model               │
- │     12 +  const filtered = filter(items, │research  zai/glm-5.2-air                                             │
- │     13 +  const onNew = () => open()     │          low · thinking off · from default_model                     │
-                                            │plan      zai/glm-5.2-air                                             │
-☰  plan  5/7  ·  Workflows canvas           │          medium · thinking on · from default_model                   │
+── EXECUTE ─────────────────────────────────╭ models  resolved routing ────────────────────────────────────────────╮────────────────────────────────────────────
+                                            │session   glm-5.2                                                     │
+ │ ⊙ apps/app/automations/page.tsx          │auto      model off · effort on · thinking off                        │                                      ⚡ 42ms
+ │ ⎿ 312 lines                              │                                                                      │                         42ms
+                                            │lead      zai/glm-5.2-air                                             │
+ │ ● edit apps/app/automations/page.tsx +4 -│          medium · thinking on · from default_model                   │                                      ⚡ 18ms
+ │ ⎿                                        │think     z-ai/glm-5.2                                    unassigned  │                 +4 −1 · 18ms
+ │     10 -  const items = []               │          low · thinking off · from agents.triage.model               │
+ │     10 +  const items = useAutomations() │research  zai/glm-5.2-air                                             │
+ │     11 +  const [q, setQ] = useState("") │          low · thinking off · from default_model                     │
+ │     12 +  const filtered = filter(items, │plan      zai/glm-5.2-air                                             │
+ │     13 +  const onNew = () => open()     │          medium · thinking on · from default_model                   │
                                             │work      zai/glm-5.2-air                                     served  │
-⏸ plan  Refactor the automations store into │          medium · thinking on · from default_model                   │
-                                            │verify    anthropic/claude-opus-5                         unassigned  │
+ │ ◐ model worker · 428 tok/s               │          medium · thinking on · from default_model                   │                                    ⚡ 2100ms
+ │   irreducible generation                 │verify    anthropic/claude-opus-5                         unassigned  │
                                             │          high  (effort_auto replaced "max") · thinking on            │
-                                            │          from pipeline_verifier_model                                │
+☰  plan  5/7  ·  Workflows canvas           │          from pipeline_verifier_model                                │
                                             ╰─────────────────────────────────────────────────────────── esc close ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,27 +16,28 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
  │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
-
- │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
- │ ⎿                                                ╭ plan  pending approval · 3 steps ────────────────────╮                         +4 −1 · 18ms
- │     10 -  const items = []                       │Refactor the automations store into a shared worksp…  │
- │     10 +  const items = useAutomations()         │                                                      │
- │     11 +  const [q, setQ] = useState("")         │▸ ○ 1. extract types                                  │
- │     12 +  const filtered = filter(items, q)      │  ○ 2. move hooks                                     │
- │     13 +  const onNew = () => open()             │  ○ 3. update 9 imports                               │
-                                                    │                                                      │
-☰  plan  5/7  ·  Workflows canvas                   │repo      macanderson/web-app ⎇ feat/automations-store│
+                                                    ╭ plan  pending approval · 3 steps ────────────────────╮
+ │ ● edit apps/app/automations/page.tsx +4 -1       │Refactor the automations store into a shared worksp…  │                                              ⚡ 18ms
+ │ ⎿                                                │                                                      │                         +4 −1 · 18ms
+ │     10 -  const items = []                       │▸ ○ 1. extract types                                  │
+ │     10 +  const items = useAutomations()         │  ○ 2. move hooks                                     │
+ │     11 +  const [q, setQ] = useState("")         │  ○ 3. update 9 imports                               │
+ │     12 +  const filtered = filter(items, q)      │                                                      │
+ │     13 +  const onNew = () => open()             │repo      macanderson/web-app ⎇ feat/automations-store│
                                                     │write     packages/automations/** · apps/app/automatio│
-⏸ plan  Refactor the automations store into a shared│read      apps/** · packages/**  (2 globs)            │
-                                                    │budget    $0.04 of $2.50 ▰▱▱▱▱▱▱                      │
+ │ ◐ model worker · 428 tok/s                       │read      apps/** · packages/**  (2 globs)            │                                            ⚡ 2100ms
+ │   irreducible generation                         │budget    $0.04 of $2.50 ▰▱▱▱▱▱▱                      │
                                                     │models    think — · work glm-5.2-air · verify —       │
-                                                    │shell     allowlisted                                 │
+☰  plan  5/7  ·  Workflows canvas                   │shell     allowlisted                                 │
                                                     ╰────────────────────────────────── x skip · esc close ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -16,6 +15,9 @@
   Planning the automations cluster: list, editor, triggers, workflows.
 
 ☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -30,14 +32,12 @@
  │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
 
-☰  plan  5/7  ·  Workflows canvas
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
 
-⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
-
-
-                                                ╭ agent · 1/2 · this session only ─────────────────────────────╮
+☰  plan  5/7  ·  Workflows canvas               ╭ agent · 1/2 · this session only ─────────────────────────────╮
                                                 │▸ reviewer  project  reviews a diff against the house rules   │
-                                                │  release-captain  user  cuts a release: bump, changelog, tag │
+⏸ plan  Refactor the automations store into a sh│  release-captain  user  cuts a release: bump, changelog, tag │
                                                 ╰──────────────────────────────────── ↑↓ move · ⏎ assume · esc ╯
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,27 +16,28 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
-── EXECUTE ───────────────────────────────╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮──────────────────────────────────────────
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation               ╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮
                                           │ bash  mutating                                                           │
- │ ⊙ apps/app/automations/page.tsx        │   rm -rf build/                                                          │                                    ⚡ 42ms
- │ ⎿ 312 lines                            │                                                                          │                       42ms
-                                          │ gate command.started                                                     │
- │ ● edit apps/app/automations/page.tsx +4│ reason matched rule no-destructive-shell                                 │                                    ⚡ 18ms
- │ ⎿                                      │                                                                          │               +4 −1 · 18ms
- │     10 -  const items = []             │   Allow this call, once                                                  │
- │     10 +  const items = useAutomations(│ ▸ Deny                                                                   │
- │     11 +  const [q, setQ] = useState(""│   Deny, and say why                                                      │
- │     12 +  const filtered = filter(items╰───────────────────────────────────────── ↑↓ move · ⏎ choose · esc denies ╯
+── EXECUTE ───────────────────────────────│   rm -rf build/                                                          │──────────────────────────────────────────
+                                          │                                                                          │
+ │ ⊙ apps/app/automations/page.tsx        │ gate command.started                                                     │                                    ⚡ 42ms
+ │ ⎿ 312 lines                            │ reason matched rule no-destructive-shell                                 │                       42ms
+                                          │                                                                          │
+ │ ● edit apps/app/automations/page.tsx +4│   Allow this call, once                                                  │                                    ⚡ 18ms
+ │ ⎿                                      │ ▸ Deny                                                                   │               +4 −1 · 18ms
+ │     10 -  const items = []             │   Deny, and say why                                                      │
+ │     10 +  const items = useAutomations(╰───────────────────────────────────────── ↑↓ move · ⏎ choose · esc denies ╯
+ │     11 +  const [q, setQ] = useState("")
+ │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
+
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
 
 ☰  plan  5/7  ·  Workflows canvas
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
-
-
-
-
-
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,27 +16,28 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
-── EXECUTE ───────────────────────────────╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮──────────────────────────────────────────
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation               ╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮
                                           │ read_file  read-only                                                     │
- │ ⊙ apps/app/automations/page.tsx        │   .stella/private/credentials.toml                                       │                                    ⚡ 42ms
- │ ⎿ 312 lines                            │                                                                          │                       42ms
-                                          │ gate tool.call.requested                                                 │
- │ ● edit apps/app/automations/page.tsx +4│ reason matched rule secrets-are-off-limits                               │                                    ⚡ 18ms
- │ ⎿                                      │                                                                          │               +4 −1 · 18ms
- │     10 -  const items = []             │   Allow this call, once                                                  │
- │     10 +  const items = useAutomations(│ ▸ Deny                                                                   │
- │     11 +  const [q, setQ] = useState(""│   Deny, and say why                                                      │
- │     12 +  const filtered = filter(items╰───────────────────────────────────────── ↑↓ move · ⏎ choose · esc denies ╯
+── EXECUTE ───────────────────────────────│   .stella/private/credentials.toml                                       │──────────────────────────────────────────
+                                          │                                                                          │
+ │ ⊙ apps/app/automations/page.tsx        │ gate tool.call.requested                                                 │                                    ⚡ 42ms
+ │ ⎿ 312 lines                            │ reason matched rule secrets-are-off-limits                               │                       42ms
+                                          │                                                                          │
+ │ ● edit apps/app/automations/page.tsx +4│   Allow this call, once                                                  │                                    ⚡ 18ms
+ │ ⎿                                      │ ▸ Deny                                                                   │               +4 −1 · 18ms
+ │     10 -  const items = []             │   Deny, and say why                                                      │
+ │     10 +  const items = useAutomations(╰───────────────────────────────────────── ↑↓ move · ⏎ choose · esc denies ╯
+ │     11 +  const [q, setQ] = useState("")
+ │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
+
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
 
 ☰  plan  5/7  ·  Workflows canvas
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
-
-
-
-
-
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,27 +16,28 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
-── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
                                           ╭ ◇ approval · the turn is stopped ────────────────────────────────────────╮
- │ ⊙ apps/app/automations/page.tsx        │ bash  mutating                                                           │                                    ⚡ 42ms
- │ ⎿ 312 lines                            │   rm -rf build/                                                          │                       42ms
-                                          │                                                                          │
- │ ● edit apps/app/automations/page.tsx +4│ gate command.started                                                     │                                    ⚡ 18ms
- │ ⎿                                      │ reason matched rule no-destructive-shell                                 │               +4 −1 · 18ms
- │     10 -  const items = []             │                                                                          │
- │     10 +  const items = useAutomations(│ denying — say why (the model is told, verbatim):                         │
- │     11 +  const [q, setQ] = useState(""│   use the staging bucket instead▏                                        │
- │     12 +  const filtered = filter(items╰────────────────────────────────────── ⏎ deny with these words · esc back ╯
+── EXECUTE ───────────────────────────────│ bash  mutating                                                           │──────────────────────────────────────────
+                                          │   rm -rf build/                                                          │
+ │ ⊙ apps/app/automations/page.tsx        │                                                                          │                                    ⚡ 42ms
+ │ ⎿ 312 lines                            │ gate command.started                                                     │                       42ms
+                                          │ reason matched rule no-destructive-shell                                 │
+ │ ● edit apps/app/automations/page.tsx +4│                                                                          │                                    ⚡ 18ms
+ │ ⎿                                      │ denying — say why (the model is told, verbatim):                         │               +4 −1 · 18ms
+ │     10 -  const items = []             │   use the staging bucket instead▏                                        │
+ │     10 +  const items = useAutomations(╰────────────────────────────────────── ⏎ deny with these words · esc back ╯
+ │     11 +  const [q, setQ] = useState("")
+ │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
+
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
 
 ☰  plan  5/7  ·  Workflows canvas
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
-
-
-
-
-
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -16,6 +15,9 @@
   Planning the automations cluster: list, editor, triggers, workflows.
 
 ☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -30,14 +32,12 @@
  │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
 
-☰  plan  5/7  ·  Workflows canvas
-
-⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
-
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
                                                 ╭ model · 1/3 · this session only ─────────────────────────────╮
-                                                │▸ zai/glm-5.2-air  · current                                  │
+☰  plan  5/7  ·  Workflows canvas               │▸ zai/glm-5.2-air  · current                                  │
                                                 │  anthropic/claude-fable-5                                    │
-                                                │  openrouter/openai/gpt-5.5                                   │
+⏸ plan  Refactor the automations store into a sh│  openrouter/openai/gpt-5.5                                   │
                                                 ╰─────────────────────────────────────── ↑↓ move · ⏎ use · esc ╯
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,6 +16,9 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
  │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
@@ -26,8 +28,6 @@
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()
- │     11 +  const [q, setQ] = useState("")
- │     12 +  const filtered = filter(items, q)
 ╭ question ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │from the `research-child` sub-agent                                                                                                                           │
 │                                                                                                                                                              │
@@ -37,7 +37,7 @@
 │  [ ] Bearer token                                                                                                                                            │
 │  [ ] Type your own answer                                                                                                                                    │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,6 +16,9 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
  │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
@@ -24,20 +26,18 @@
 
  │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
  │ ⎿                                                                                                                                 +4 −1 · 18ms
- │     10 -  const items = []
- │     10 +  const items = useAutomations()
- │     11 +  const [q, setQ] = useState(""╭ question ────────────────────────────────────────────────────────────────╮
- │     12 +  const filtered = filter(items│from the `research-child` sub-agent                                       │
+ │     10 -  const items = []             ╭ question ────────────────────────────────────────────────────────────────╮
+ │     10 +  const items = useAutomations(│from the `research-child` sub-agent                                       │
+ │     11 +  const [q, setQ] = useState(""│                                                                          │
+ │     12 +  const filtered = filter(items│Which auth should the new endpoint use?                                   │
  │     13 +  const onNew = () => open()   │                                                                          │
-                                          │Which auth should the new endpoint use?                                   │
-☰  plan  5/7  ·  Workflows canvas         │                                                                          │
                                           │  [ ] Session cookie — Matches the rest of the app                        │
-⏸ plan  Refactor the automations store int│  [x] Bearer token                                                        │
-                                          │  [ ] Type your own answer                                                │
+ │ ◐ model worker · 428 tok/s             │  [x] Bearer token                                                        │                                  ⚡ 2100ms
+ │   irreducible generation               │  [ ] Type your own answer                                                │
                                           │                                                                          │
-                                          │  note: only for the admin routes▏                                        │
+☰  plan  5/7  ·  Workflows canvas         │  note: only for the admin routes▏                                        │
                                           ╰─────────────────────────────────────────────── ⏎ save note · esc discard ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,27 +16,28 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
- │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
- │ ⎿ 312 lines                                                                                                                               42ms
-                                          ╭ question ────────────────────────────────────────────────────────────────╮
- │ ● edit apps/app/automations/page.tsx +4│from the `research-child` sub-agent                                       │                                    ⚡ 18ms
- │ ⎿                                      │                                                                          │               +4 −1 · 18ms
- │     10 -  const items = []             │Review your answers                                                       │
- │     10 +  const items = useAutomations(│                                                                          │
- │     11 +  const [q, setQ] = useState(""│  • Which auth should the new endpoint use?                               │
- │     12 +  const filtered = filter(items│      → Session cookie                                                    │
- │     13 +  const onNew = () => open()   │        note: admin routes only                                           │
+ │ ⊙ apps/app/automations/page.tsx        ╭ question ────────────────────────────────────────────────────────────────╮                                    ⚡ 42ms
+ │ ⎿ 312 lines                            │from the `research-child` sub-agent                                       │                       42ms
                                           │                                                                          │
-☰  plan  5/7  ·  Workflows canvas         │  • Which environments should it reach first?                             │
+ │ ● edit apps/app/automations/page.tsx +4│Review your answers                                                       │                                    ⚡ 18ms
+ │ ⎿                                      │                                                                          │               +4 −1 · 18ms
+ │     10 -  const items = []             │  • Which auth should the new endpoint use?                               │
+ │     10 +  const items = useAutomations(│      → Session cookie                                                    │
+ │     11 +  const [q, setQ] = useState(""│        note: admin routes only                                           │
+ │     12 +  const filtered = filter(items│                                                                          │
+ │     13 +  const onNew = () => open()   │  • Which environments should it reach first?                             │
                                           │      → staging                                                           │
-⏸ plan  Refactor the automations store int│                                                                          │
-                                          │▸ Submit answers                                                          │
+ │ ◐ model worker · 428 tok/s             │                                                                          │                                  ⚡ 2100ms
+ │   irreducible generation               │▸ Submit answers                                                          │
                                           │  Chat about this instead                                                 │
-                                          │  Cancel — no answer                                                      │
+☰  plan  5/7  ·  Workflows canvas         │  Cancel — no answer                                                      │
                                           ╰──────────────────────────────── ↑↓ move · ⏎ choose · ⇥ back · esc cancel ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,6 +16,9 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
  │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
@@ -26,18 +28,16 @@
  │ ⎿                                                                                                                                 +4 −1 · 18ms
  │     10 -  const items = []
  │     10 +  const items = useAutomations()
- │     11 +  const [q, setQ] = useState("")
- │     12 +  const filtered = filter(items, q)
- │     13 +  const onNew = () => open()   ╭ question ────────────────────────────────────────────────────────────────╮
-                                          │from the `research-child` sub-agent                                       │
-☰  plan  5/7  ·  Workflows canvas         │                                                                          │
+ │     11 +  const [q, setQ] = useState(""╭ question ────────────────────────────────────────────────────────────────╮
+ │     12 +  const filtered = filter(items│from the `research-child` sub-agent                                       │
+ │     13 +  const onNew = () => open()   │                                                                          │
                                           │Which auth should the new endpoint use?                                   │
-⏸ plan  Refactor the automations store int│                                                                          │
-                                          │▸ [ ] Session cookie — Matches the rest of the app                        │
+ │ ◐ model worker · 428 tok/s             │                                                                          │                                  ⚡ 2100ms
+ │   irreducible generation               │▸ [ ] Session cookie — Matches the rest of the app                        │
                                           │  [ ] Bearer token                                                        │
-                                          │  [ ] Type your own answer                                                │
+☰  plan  5/7  ·  Workflows canvas         │  [ ] Type your own answer                                                │
                                           ╰────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -17,27 +16,28 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
  │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
  │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
- │ ⎿                                                                                                                                 +4 −1 · 18ms
- │     10 -  const items = []
- │     10 +  const items = useAutomations(╭ question ────────────────────────────────────────────────────────────────╮
- │     11 +  const [q, setQ] = useState(""│from the `research-child` sub-agent                                       │
+ │ ⎿                                      ╭ question ────────────────────────────────────────────────────────────────╮               +4 −1 · 18ms
+ │     10 -  const items = []             │from the `research-child` sub-agent                                       │
+ │     10 +  const items = useAutomations(│                                                                          │
+ │     11 +  const [q, setQ] = useState(""│● Auth method  ○ Rollout                                                  │
  │     12 +  const filtered = filter(items│                                                                          │
- │     13 +  const onNew = () => open()   │● Auth method  ○ Rollout                                                  │
-                                          │                                                                          │
-☰  plan  5/7  ·  Workflows canvas         │[2/2] Which environments should it reach first?                           │
+ │     13 +  const onNew = () => open()   │[2/2] Which environments should it reach first?                           │
                                           │several answers may be chosen                                             │
-⏸ plan  Refactor the automations store int│                                                                          │
-                                          │▸ [ ] staging — the usual soak                                            │
+ │ ◐ model worker · 428 tok/s             │                                                                          │                                  ⚡ 2100ms
+ │   irreducible generation               │▸ [ ] staging — the usual soak                                            │
                                           │  [ ] canary                                                              │
-                                          │  [ ] Type your own answer                                                │
+☰  plan  5/7  ·  Workflows canvas         │  [ ] Type your own answer                                                │
                                           ╰────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
-
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
@@ -4,18 +4,20 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-                         ╭ sub-agents · 1 running ────────────────────────────────────────────────────────────────────────────────────╮
-◉ recalled  2 frames · 21│▸ ◆ sub:auth  needs input · quiet 0:00 · 5:12 · glm-5.2 · effort high · $0.01                               │
-    symbol  engine step-d│     Wire the automations triggers API to the new router.                                                   │  120 tok
-    memory  event-log REP│     waiting on an answer from you                                                                          │   90 tok
-    ⋯ ctrl+o for provenan│                                                                                                            │
-                         │  ◆ sub:ci  running · quiet 0:00 · 5:12 · glm-5.2-air · $0.00                                               │
-── PLAN ─────────────────│     watch CI + open PR                                                                                     │─────────────────────────
-                         │     starting: no model call yet                                                                            │
-  Planning the automation│                                                                                                            │
+
+◉ recalled  2 frames · 21╭ sub-agents · 1 running ────────────────────────────────────────────────────────────────────────────────────╮
+    symbol  engine step-d│▸ ◆ sub:auth  needs input · quiet 0:00 · 5:12 · glm-5.2 · effort high · $0.01                               │  120 tok
+    memory  event-log REP│     Wire the automations triggers API to the new router.                                                   │   90 tok
+    ⋯ ctrl+o for provenan│     waiting on an answer from you                                                                          │
+                         │                                                                                                            │
+── PLAN ─────────────────│  ◆ sub:ci  running · quiet 0:00 · 5:12 · glm-5.2-air · $0.00                                               │─────────────────────────
+                         │     watch CI + open PR                                                                                     │
+  Planning the automation│     starting: no model call yet                                                                            │
                          │                                                                                                            │
 ☰  plan  4/7  ·  Wire the│                                                                                                            │
+                         │                                                                                                            │
+ │ ◐ model worker · 349 t│                                                                                                            │                 ⚡ 1830ms
+ │   irreducible generati│                                                                                                            │
                          │                                                                                                            │
 ── EXECUTE ──────────────│                                                                                                            │─────────────────────────
                          │                                                                                                            │
@@ -30,14 +32,12 @@
  │     12 +  const filter│                                                                                                            │
  │     13 +  const onNew │                                                                                                            │
                          │                                                                                                            │
+ │ ◐ model worker · 428 t│                                                                                                            │                 ⚡ 2100ms
+ │   irreducible generati│                                                                                                            │
+                         │                                                                                                            │
 ☰  plan  5/7  ·  Workflow│                                                                                                            │
                          │                                                                                                            │
 ⏸ plan  Refactor the auto│                                                                                                            │
-                         │                                                                                                            │
-                         │                                                                                                            │
-                         │                                                                                                            │
-                         │                                                                                                            │
-                         │                                                                                                            │
                          │                                                                                                            │
                          │                                                                                                            │
 >>>                      ╰───────── ↑↓ · o↵ open · n nudge · f flag · l lead · x stop·xx delete · r resume·rr restart · p pause · esc ╯

--- a/crates/stella-tui/tests/snapshots/deck/session_delegate_tool_call.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_delegate_tool_call.txt
@@ -4,16 +4,13 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
-    symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
-    memory  event-log REPL                                                                                                                90 tok
-    ⋯ ctrl+o for provenance and budget
-
-── PLAN ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
   Planning the automations cluster: list, editor, triggers, workflows.
 
 ☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -27,6 +24,9 @@
  │     11 +  const [q, setQ] = useState("")
  │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
+
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
 
 ☰  plan  5/7  ·  Workflows canvas
 

--- a/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
@@ -4,9 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
- │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
  │ ⎿ 312 lines                                                                                                                               42ms
 
  │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
@@ -16,6 +13,9 @@
  │     11 +  const [q, setQ] = useState("")
  │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
+
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
 
 ☰  plan  5/7  ·  Workflows canvas
 

--- a/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
+++ b/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -16,6 +15,9 @@
   Planning the automations cluster: list, editor, triggers, workflows.
 
 ☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -30,14 +32,12 @@
  │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
 
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
+
 ☰  plan  5/7  ·  Workflows canvas
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
-
-
-
-
-
 
 
 >>>

--- a/crates/stella-tui/tests/snapshots/deck/tab_session.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_session.txt
@@ -4,7 +4,6 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
-── turn 1 triage ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -16,6 +15,9 @@
   Planning the automations cluster: list, editor, triggers, workflows.
 
 ☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
 
 ── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -30,14 +32,12 @@
  │     12 +  const filtered = filter(items, q)
  │     13 +  const onNew = () => open()
 
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
+
 ☰  plan  5/7  ·  Workflows canvas
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
-
-
-
-
-
 
 
 >>>


### PR DESCRIPTION
Closes #5033

## What was missing

SPEC 6.3 (`design/tui-v2/SPEC.md` §6.3) defines the model event as `◐ model <activity> · tok/s` with a footer. `EventKind::Model` rendered the head and was tested — from fixtures. **Nothing produced one.** A turn's generation, the work SPEC 1's deterministic-first thesis is measured against, left no mark on the transcript at the moment it happened, so the det/model split was invisible exactly where it is decided.

## What this does

Adds `TranscriptEntry::Model`, its fold arm, its projection, and its live producer, in one PR — per the scope note on the issue.

**The rate is derived, not invented, and nothing new goes on the wire.** `AgentEvent::StepUsage` is already the driver's per-call metering record (`stella-core`'s `driver::settlement::emit_step_usage` for the worker, `accounted_call` for the management roles) and it already carries the output tokens the call produced and the wall clock it took. tok/s is a division over those two. So the "upstream emit" the issue asks for **already exists on `main`** — what was missing was everything between the wire and the row, and adding a second event for a fact the wire already states would have been a copy to drift and a new `consumers.rs` row for no gain. **No `AgentEvent` wire tag was added or changed, so the event-consumer ledger and `docs/wire/` are untouched.** `StepUsage`'s ledger row is already `Behavioral`, and the deck is deliberately not a `Surface` (interactive mode matches `AgentEvent` exhaustively by construction — see `Surface`'s own doc).

The chain: `StepUsage` → `model::turn::model_call_row` → `TranscriptEntry::Model` → `render::entry`'s projection router → `views::transcript_source::model_rows` → `EventKind::Model`.

## Three things stated as absent rather than as zero

1. **The rate.** `EventKind::Model::tokens_per_sec` becomes `Option<u32>`. A provider that vouched for no usage envelope (`StepUsage::complete` false) reports zeros that are not measurements; an untimed call has nothing to divide by; a call that generated nothing has no rate. All three render no column — `0 tok/s` asserts a model that generated nothing per second, the same substitution `+0 -0` made over a real edit (#4150, #2290).
2. **The activity.** `ModelCallRole::Unknown` (the serde default for an absent role, so every pre-attribution stream) names no activity rather than printing `unknown` as though the engine had a stage by that name — the refusal #4124 already made for the turn rule's model name.
3. **The footer's second clause.** SPEC 6.3 asks for `irreducible generation · n of m budgeted model calls this turn`. The first half ships: it is a fact about the call, not a measurement, and it is what the gate row's `$0.00 · det` says in the other direction. **The `n of m` half is elided and I am saying so out loud rather than fabricating it.** Nothing in this workspace budgets model calls per turn. `EngineConfig::max_steps` is the nearest number and its own doc calls it a "hard backstop on step count … never the *primary* stuck-loop defense", so `3 of 200 budgeted` would report a backstop as a plan on the one row whose job is pricing model work honestly. `BudgetTick` budgets dollars, not calls. `n` alone cannot stand in — `n of m` is one reading. **#5234** is filed with the decision that has to come first (add a real per-turn allowance, or drop the clause from the spec), and `MODEL_FOOTER`'s doc comment states the elision and cites it.

## Witness, and the flip verified artisanally

Four tests in `crates/stella-tui/src/views/transcript_source.rs`, each driving a real `AgentEvent::StepUsage` through `SessionModel::apply` and out of `render::entry_lines` — the production renderer, not `model_rows` directly, because the half that was missing was never the projection:

- `a_settled_model_call_renders_its_rate_from_the_drivers_own_metering` — 420 output tokens over 5s renders `◐ model worker · 84 tok/s` with `⚡5000ms`. The arithmetic is asserted, not the field.
- `the_model_footer_claims_no_budget_nobody_set` — the footer says `irreducible generation` and does not say `budgeted`.
- `a_call_whose_rate_has_no_source_states_no_rate` — the three absences above, each still drawing the row.
- `a_call_with_no_recorded_role_names_no_activity`.

**Flip, checked by hand:** with the fold's one-line `self.transcript.extend(turn::model_call_row(event));` removed, all four fail (`one metering record must fold to exactly one model row`); restored, all four pass. Full output of both runs was read, not inferred. The renderer half needs no manual flip — `TranscriptEntry`'s matches are exhaustive, so a missing arm is an `E0004`.

## Goldens

Re-blessed with `BLESS=1 cargo test -p stella-tui --test deck_render_snapshots` and **the diff was read line by line**. Every changed file is symmetric `+N/-N`: the only new content is the two `◐ model worker` rows plus their footers, and the equal number of removed lines at the top of each is the transcript pane scrolling by exactly the rows added. The overlay cards themselves are byte-identical. `tab_session.txt` and `session_delegate_tool_call.txt` are the clearest reads.

## Checks run

- `cargo test -p stella-tui` — 1231 + 10 target suites, all green
- `cargo clippy -p stella-tui -p stella-core --all-targets` — exit 0, no warnings
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui --no-deps --document-private-items` — exit 0
- `make prose` — OK, none added, no baseline touched
- `make guards-fast` — green, `check-file-size` / `check-god-files` / `check-left-behind` / `check-line-citations` included
- `cargo fmt`

No workspace build or `make gate` was run locally; CI is the evidence for those.

## Noticed and not fixed

- **`crates/stella-tui/src/model.rs` goes from 1497 to 1499 of its ungrandfathered 1500-line ceiling.** This spends two of the three lines it had left. I took the two lines rather than contorting the fold to avoid them, because #5225 names that contortion as a cost it already paid once ("the shape it settled on … was chosen to stay under two added lines rather than because it was the best design"). #5225 is the split; this PR does not do it, and the next change into that file will have to.
- The stale comment above `model.rs`'s `StepUsage` arm described the arm as folding a model name it has not folded since #4183 moved that to `StepManifest`. Rewritten in place, since I was editing it.
- `render::entry::projected_rows`' doc said "two arms, deliberately" and had four. Corrected.

Exemplar for the `Option`-over-zero discipline: this crate's own `Extent` and `ReadSize`, whose docs already argue the case.

## Summary by Sourcery

Render one transcript model row for every settled model call using the driver's existing metering data.

New Features:
- Add transcript model-call rows for each settled StepUsage event, including the call activity, duration, optional output rate, delegate, and generation footer.
- Support searching transcript model rows by their recorded activity.

Bug Fixes:
- Ensure model calls are no longer absent from live transcript rendering despite the existing model event presentation.

Enhancements:
- Represent unavailable model rates and unidentified activities explicitly instead of displaying misleading zero or unknown values.
- Route model entries through the shared transcript projection and preserve existing exhaustive rendering behavior.

Documentation:
- Clarify issue-label creation and triage responsibilities in the contributor guidance.

Tests:
- Add end-to-end transcript rendering coverage for settled model calls, rate derivation, unavailable rates, missing activities, and footer content.
- Refresh deck rendering snapshots to include the new transcript rows.