### PR TITLE
docs(agents): a comma list closes only the first issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1177,6 +1177,13 @@ issue without finishing it — `Refs` deliberately does not close. One issue may
 be closed by exactly one PR; if a fix spans several, close on the last and
 `Refs` the rest.
 
+**One keyword per issue.** `Closes #A, #B` closes `#A` and leaves `#B` open:
+GitHub parses the keyword and the reference immediately after it, and reads the
+rest of the list as prose. Write `Closes #A, Closes #B`. This is the same
+failure the section opens with — an issue whose work shipped, staying open, with
+nothing to notice it but an audit — reached by a different wrong guess about
+what the parser reads, and #5210 is where it happened.
+
 ---
 
 ## Testing approach


### PR DESCRIPTION
A trailer reading `Closes #5203, #5210` closed #5203 and left #5210 open. GitHub parses the closing keyword and the reference immediately after it, then reads the rest of the list as prose — so a comma list closes only its first issue.

That is the same failure AGENTS.md's "Closing the issue on merge" section already exists to prevent: work that shipped, an issue that stayed open, and nothing to notice it but an audit of the backlog. The section documents the title-vs-description trap and not this one, so the rule was followed and the issue stayed open anyway. #5210 is where it happened, and it was closed by hand.

Docs-only, no witness test (AGENTS.md's own contract). Verified with `make guards-fast` and `make prose`, both green — `gate-parity` and `invariants` are in that rung, so the section's neighbours are checked too.

## Summary by Sourcery

Clarify multi-issue closing syntax to prevent referenced issues from remaining open after a merge.

Enhancements:
- Clarify the issue-closing guidance in AGENTS.md to require repeating the closing keyword for each issue reference in a comma-separated list.

Documentation:
- Document GitHub's handling of comma-separated closing references and provide the correct syntax for closing multiple issues.