### PR TITLE
feat(stella-protocol,stella-tui): the six task states the spec draws

### DIFF
--- a/crates/stella-core/src/tasks.rs
+++ b/crates/stella-core/src/tasks.rs
@@ -656,6 +656,8 @@ mod tests {
             Just(TaskStatus::InProgress),
             Just(TaskStatus::Completed),
             Just(TaskStatus::Cancelled),
+            Just(TaskStatus::Verify),
+            Just(TaskStatus::Blocked),
         ]
     }
 

--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -328,8 +328,37 @@ pub struct TaskItem {
 /// Lifecycle of a `TaskItem`. Terminal states are `Completed` and
 /// `Cancelled`; a cancelled task keeps its row (the board is an audit
 /// surface, not just a scheduler).
+///
+/// Each case is appended, never reordered or removed: `stella-store` writes
+/// the serde token into `tasks.status`, so a renumbering rewrites the meaning
+/// of every row already on disk.
+///
+/// SPEC 7.2 draws six task states. Five are lifecycle positions and live here.
+/// The sixth, `⌥ drift-inserted`, does not, for two reasons. Drift is
+/// *derived* from the plan graph — [`crate::plan_graph::Divergence`] has no
+/// constructor, so a producer cannot assert drift the graph does not show
+/// (#5037) — and it is orthogonal to lifecycle, since an inserted task is also
+/// queued, running or done. A `DriftInserted` status would be an assertable
+/// fact and an exclusive one at once.
+/// `stella_tui::plan::PlanStepState` carries it as a render state instead,
+/// because a row has one glyph cell and something has to win it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+// The doc above is written for someone reading this crate, and cites a Rust
+// path a wire consumer cannot resolve. This is the same fact said to that
+// other reader.
+#[cfg_attr(
+    feature = "schema",
+    schemars(description = "Where one task on the board is in its lifecycle. \
+                            `completed` and `cancelled` are terminal; the rest \
+                            can still change. `verify` means the work is done \
+                            and its checks are running, and `blocked` means \
+                            something outside the task stopped it — a red \
+                            gate, an unmet dependency — which is a different \
+                            fact from `cancelled`, a decision to abandon it. \
+                            Tokens are only ever added, so a reader that does \
+                            not recognise one is reading a newer stream.")
+)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
     /// Created and not yet started.
@@ -341,13 +370,46 @@ pub enum TaskStatus {
     /// Abandoned. Terminal, and the row is kept — the board is an audit
     /// surface, not just a scheduler.
     Cancelled,
+    /// The work is done and its checks are running or awaiting a verdict —
+    /// SPEC 7.2's `◇ verify`, the window between "the worker stopped" and "the
+    /// gates are green" that the board had no word for.
+    ///
+    /// Open, because the verdict is what moves it: to [`Self::Completed`] on
+    /// green, to [`Self::Blocked`] on red. Closing on entry here would be the
+    /// model marking its own homework, which SPEC 7.1 exists to stop.
+    ///
+    /// Nothing sets it yet — the gate board is #5042.
+    Verify,
+    /// Stopped by something the task does not control: a red gate, an unmet
+    /// dependency.
+    ///
+    /// Open rather than terminal, because SPEC 8.1's receipt reads `merge
+    /// blocked · unblocks on green`. A blocked task that could never move
+    /// again would be a dead row wearing a live word.
+    ///
+    /// A different fact from [`Self::Cancelled`], which is a decision to
+    /// abandon the work. Both draw SPEC 4's one `✗`, and until this case
+    /// existed the board could not tell a reader which had happened.
+    ///
+    /// Nothing sets it yet — the gate that would is #5042.
+    Blocked,
 }
 
 impl TaskStatus {
     /// Whether the task can still change state. Terminal tasks reject
     /// further transitions (enforced by the board logic in `stella-core`).
+    ///
+    /// An exhaustive match rather than a `matches!`: the macro's implicit
+    /// false arm would file a new case under *terminal* without asking, and
+    /// terminal is the answer that stops a task moving.
     #[must_use]
     pub fn is_open(self) -> bool {
-        matches!(self, TaskStatus::Pending | TaskStatus::InProgress)
+        match self {
+            TaskStatus::Pending
+            | TaskStatus::InProgress
+            | TaskStatus::Verify
+            | TaskStatus::Blocked => true,
+            TaskStatus::Completed | TaskStatus::Cancelled => false,
+        }
     }
 }

--- a/crates/stella-protocol/src/event/tests.rs
+++ b/crates/stella-protocol/src/event/tests.rs
@@ -6,6 +6,8 @@
 use super::*;
 use crate::FlipOutcome;
 
+mod task_status;
+
 #[test]
 fn agent_event_roundtrips_with_type_tag() {
     let event = AgentEvent::ToolStart {
@@ -787,59 +789,6 @@ fn pr_event_from_a_pre_ci_stream_still_parses() {
         }
         other => panic!("old stream must parse: {other:?}"),
     }
-}
-
-#[test]
-fn task_update_roundtrips_a_full_board_snapshot() {
-    let event = AgentEvent::TaskUpdate {
-        tasks: vec![
-            TaskItem {
-                id: "1".into(),
-                subject: "Map the auth module".into(),
-                description: None,
-                status: TaskStatus::Completed,
-                owner: Some("lead".into()),
-                contract: None,
-            },
-            TaskItem {
-                id: "2".into(),
-                subject: "Fix the redirect loop".into(),
-                description: Some("token refresh races the redirect".into()),
-                status: TaskStatus::InProgress,
-                owner: Some("sub:2".into()),
-                contract: None,
-            },
-            TaskItem {
-                id: "3".into(),
-                subject: "Add a witness test".into(),
-                description: None,
-                status: TaskStatus::Pending,
-                owner: None,
-                contract: None,
-            },
-        ],
-    };
-    let json = serde_json::to_string(&event).unwrap();
-    assert!(json.contains("\"type\":\"task_update\""), "{json}");
-    // Absent optionals are omitted, not serialized as null.
-    assert!(!json.contains("null"), "{json}");
-    let back: AgentEvent = serde_json::from_str(&json).unwrap();
-    match back {
-        AgentEvent::TaskUpdate { tasks } => {
-            assert_eq!(tasks.len(), 3);
-            assert_eq!(tasks[1].status, TaskStatus::InProgress);
-            assert_eq!(tasks[1].owner.as_deref(), Some("sub:2"));
-        }
-        other => panic!("unexpected case: {other:?}"),
-    }
-}
-
-#[test]
-fn task_status_open_vs_terminal() {
-    assert!(TaskStatus::Pending.is_open());
-    assert!(TaskStatus::InProgress.is_open());
-    assert!(!TaskStatus::Completed.is_open());
-    assert!(!TaskStatus::Cancelled.is_open());
 }
 
 /// The research stage's two wire tokens (#1778), pinned in both directions

--- a/crates/stella-protocol/src/event/tests/task_status.rs
+++ b/crates/stella-protocol/src/event/tests/task_status.rs
@@ -1,0 +1,124 @@
+//! The task board's wire vocabulary: [`TaskStatus`] and the board snapshots
+//! that carry it.
+//!
+//! A child of [`super`] rather than more lines in `tests.rs`, which sits
+//! against the 1500-line ratchet — the same `registry.rs` precedent that file
+//! itself cites (#1122).
+
+use super::super::*;
+
+#[test]
+fn task_update_roundtrips_a_full_board_snapshot() {
+    let event = AgentEvent::TaskUpdate {
+        tasks: vec![
+            TaskItem {
+                id: "1".into(),
+                subject: "Map the auth module".into(),
+                description: None,
+                status: TaskStatus::Completed,
+                owner: Some("lead".into()),
+                contract: None,
+            },
+            TaskItem {
+                id: "2".into(),
+                subject: "Fix the redirect loop".into(),
+                description: Some("token refresh races the redirect".into()),
+                status: TaskStatus::InProgress,
+                owner: Some("sub:2".into()),
+                contract: None,
+            },
+            TaskItem {
+                id: "3".into(),
+                subject: "Add a witness test".into(),
+                description: None,
+                status: TaskStatus::Pending,
+                owner: None,
+                contract: None,
+            },
+        ],
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"type\":\"task_update\""), "{json}");
+    // Absent optionals are omitted, not serialized as null.
+    assert!(!json.contains("null"), "{json}");
+    let back: AgentEvent = serde_json::from_str(&json).unwrap();
+    match back {
+        AgentEvent::TaskUpdate { tasks } => {
+            assert_eq!(tasks.len(), 3);
+            assert_eq!(tasks[1].status, TaskStatus::InProgress);
+            assert_eq!(tasks[1].owner.as_deref(), Some("sub:2"));
+        }
+        other => panic!("unexpected case: {other:?}"),
+    }
+}
+
+#[test]
+fn task_status_open_vs_terminal() {
+    assert!(TaskStatus::Pending.is_open());
+    assert!(TaskStatus::InProgress.is_open());
+    assert!(!TaskStatus::Completed.is_open());
+    assert!(!TaskStatus::Cancelled.is_open());
+    // A gate awaiting its verdict, and a task a red gate stopped, both still
+    // move: SPEC 8.1's `merge blocked · unblocks on green` is the transition
+    // that a terminal answer here would forbid.
+    assert!(TaskStatus::Verify.is_open());
+    assert!(TaskStatus::Blocked.is_open());
+}
+
+/// Every status crosses the crate boundary byte-for-byte (AGENTS.md #4),
+/// under the snake_case token `stella-store` writes into `tasks.status`. Each
+/// token is written out here: a round-trip through `to_string`/`from_str`
+/// alone passes just as happily on a renamed one.
+#[test]
+fn every_task_status_roundtrips_under_its_wire_token() {
+    for (status, token) in [
+        (TaskStatus::Pending, "pending"),
+        (TaskStatus::InProgress, "in_progress"),
+        (TaskStatus::Completed, "completed"),
+        (TaskStatus::Cancelled, "cancelled"),
+        (TaskStatus::Verify, "verify"),
+        (TaskStatus::Blocked, "blocked"),
+    ] {
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, format!("\"{token}\""));
+        let back: TaskStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, status);
+    }
+}
+
+/// The board snapshot carries the two new states over the wire, not just the
+/// enum in isolation — a `TaskItem` is what a surface actually receives.
+#[test]
+fn a_board_snapshot_carries_a_verifying_and_a_blocked_task() {
+    let event = AgentEvent::TaskUpdate {
+        tasks: vec![
+            TaskItem {
+                id: "1".into(),
+                subject: "Run the gates".into(),
+                description: None,
+                status: TaskStatus::Verify,
+                owner: None,
+                contract: None,
+            },
+            TaskItem {
+                id: "2".into(),
+                subject: "Ship it".into(),
+                description: None,
+                status: TaskStatus::Blocked,
+                owner: None,
+                contract: None,
+            },
+        ],
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"status\":\"verify\""), "{json}");
+    assert!(json.contains("\"status\":\"blocked\""), "{json}");
+    let back: AgentEvent = serde_json::from_str(&json).unwrap();
+    match back {
+        AgentEvent::TaskUpdate { tasks } => {
+            assert_eq!(tasks[0].status, TaskStatus::Verify);
+            assert_eq!(tasks[1].status, TaskStatus::Blocked);
+        }
+        other => panic!("unexpected case: {other:?}"),
+    }
+}

--- a/crates/stella-protocol/tests/wire_contract/samples.rs
+++ b/crates/stella-protocol/tests/wire_contract/samples.rs
@@ -178,7 +178,7 @@ pub(crate) fn all_ci_statuses() -> Vec<CiStatus> {
 
 pub(crate) fn all_task_statuses() -> Vec<TaskStatus> {
     use TaskStatus::*;
-    vec![Pending, InProgress, Completed, Cancelled]
+    vec![Pending, InProgress, Completed, Cancelled, Verify, Blocked]
 }
 
 pub(crate) fn all_block_kinds() -> Vec<BlockKind> {

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -114,12 +114,21 @@ fn optional_str(input: &Value, field: &str) -> Option<String> {
 }
 
 /// One-character board glyph per status, for `task_list` lines.
+///
+/// ASCII, unlike SPEC 4's glyph vocabulary: this string is model context, and
+/// a mark the model has to guess at is worse than a letter it does not.
+/// `?` and `!` are unreachable today — nothing sets [`TaskStatus::Verify`] or
+/// [`TaskStatus::Blocked`], so `task_list`'s own legend does not advertise
+/// them (#5042 is the gate board that would). They exist because a total
+/// mapping is what makes the next status a compile error here.
 fn glyph(status: TaskStatus) -> char {
     match status {
         TaskStatus::Pending => ' ',
         TaskStatus::InProgress => '~',
         TaskStatus::Completed => 'x',
         TaskStatus::Cancelled => '-',
+        TaskStatus::Verify => '?',
+        TaskStatus::Blocked => '!',
     }
 }
 

--- a/crates/stella-tui/src/plan.rs
+++ b/crates/stella-tui/src/plan.rs
@@ -39,33 +39,77 @@ use std::collections::BTreeMap;
 
 use stella_protocol::{ScopeProposal, TaskContract, TaskItem, TaskStatus};
 
-/// Where one plan step is in its lifecycle.
+/// What a plan-step row says about itself — SPEC 7.2's six states, one per
+/// glyph cell.
 ///
-/// Four states, deliberately. A step is *going to happen*, *happening*,
-/// *happened*, or *went wrong*; anything finer is scheduler detail the reader
-/// of a rail does not need.
+/// This is the *render* vocabulary, not the wire one. Five of the six are
+/// lifecycle positions and fold straight from [`TaskStatus`]; the sixth,
+/// [`Self::DriftInserted`], is a fact about the plan graph rather than about
+/// the step's progress, and it takes the glyph cell because a row has one.
+/// See [`stella_protocol::TaskStatus`] for why the wire refuses to carry it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PlanStepState {
-    /// Agreed and not yet begun. The default for every step of a fresh plan.
+    /// Agreed and not yet begun — SPEC 7.2's `○ queued`. The default for every
+    /// step of a fresh plan.
     #[default]
     Planned,
-    /// Being worked right now.
+    /// Being worked right now — `◐ running`.
     Started,
-    /// Finished successfully. Terminal.
+    /// Finished successfully — `✓ done`. Terminal.
     Complete,
-    /// Failed, or was abandoned before finishing. Terminal.
+    /// Stopped short — `✗ blocked`.
     ///
-    /// A cancelled step lands here too: the four-state vocabulary has one slot
-    /// for "terminal and not done", and a dropped step is not a completed one.
-    /// [`PlanStep::note`] carries the distinction in words so the row never
-    /// reads as a crash when it was a decision.
-    Error,
+    /// A cancelled step lands here too: SPEC 4 spends one `✗` on every way a
+    /// step can end badly, so [`PlanStep::note`] carries the distinction in
+    /// words and the row never reads as a crash when it was a decision. The
+    /// wire tells the two apart now ([`TaskStatus::Blocked`] against
+    /// [`TaskStatus::Cancelled`]) even though the glyph cannot.
+    Blocked,
+    /// Its checks are running or awaiting a verdict — `◇ verify`, a gate task
+    /// that blocks the merge.
+    Verify,
+    /// A step the approved plan did not contain — `⌥ drift-inserted`.
+    ///
+    /// Nothing folds into this state yet: drift lives on the plan graph's
+    /// `[:THEN]` lane ([`PlanLanes`]), which #5037 landed as
+    /// `stella_protocol::plan_graph::DivergenceKind::Inserted`, and no
+    /// [`TaskStatus`] asserts it. Until something joins those divergences to
+    /// this fold, a step reaches this state only from a caller that builds the
+    /// [`PlanStep`] itself — the tests below and the scenario fixture.
+    DriftInserted,
 }
 
 impl PlanStepState {
     /// Whether the step can still change state.
+    ///
+    /// [`Self::Blocked`] is open: SPEC 8.1 unblocks a red gate on green, and
+    /// the card offers `x` on an open row, which is the dismiss that section
+    /// asks for. An exhaustive match, so a seventh state has to answer this
+    /// rather than inherit an answer.
     pub fn is_open(self) -> bool {
-        matches!(self, PlanStepState::Planned | PlanStepState::Started)
+        match self {
+            PlanStepState::Planned
+            | PlanStepState::Started
+            | PlanStepState::Blocked
+            | PlanStepState::Verify
+            | PlanStepState::DriftInserted => true,
+            PlanStepState::Complete => false,
+        }
+    }
+
+    /// Whether work has begun on this step — what makes the plan as a whole
+    /// `started` rather than `approved`.
+    ///
+    /// A drift-inserted step is queued work that arrived late, so its presence
+    /// is not progress; it answers this the same way [`Self::Planned`] does.
+    fn has_begun(self) -> bool {
+        match self {
+            PlanStepState::Planned | PlanStepState::DriftInserted => false,
+            PlanStepState::Started
+            | PlanStepState::Complete
+            | PlanStepState::Blocked
+            | PlanStepState::Verify => true,
+        }
     }
 }
 
@@ -366,11 +410,11 @@ impl Plan {
             }
             return;
         }
-        self.state = if steps.iter().any(|s| s.state == PlanStepState::Error) {
+        self.state = if steps.iter().any(|s| s.state == PlanStepState::Blocked) {
             PlanState::Error
         } else if steps.iter().all(|s| s.state == PlanStepState::Complete) {
             PlanState::Completed
-        } else if steps.iter().any(|s| s.state != PlanStepState::Planned) {
+        } else if steps.iter().any(|s| s.state.has_begun()) {
             PlanState::Started
         } else if self.decided {
             PlanState::Approved
@@ -387,7 +431,10 @@ impl Plan {
     /// run ending, and a non-retryable error ending it early.
     pub fn finish(&mut self) {
         for item in &mut self.board {
-            if item.status == TaskStatus::InProgress {
+            // `Verify` counts as in flight: a gate that never returned a
+            // verdict is not a pass, and leaving the row on `◇` would imply
+            // one is still coming.
+            if matches!(item.status, TaskStatus::InProgress | TaskStatus::Verify) {
                 item.status = TaskStatus::Cancelled;
             }
         }
@@ -420,11 +467,18 @@ impl Plan {
             })
             .collect();
         for item in &self.board {
+            // No arm reaches `DriftInserted`: see its doc comment — the wire
+            // deliberately carries no status that asserts drift.
             let (state, note) = match item.status {
                 TaskStatus::Pending => (PlanStepState::Planned, None),
                 TaskStatus::InProgress => (PlanStepState::Started, None),
+                TaskStatus::Verify => (PlanStepState::Verify, None),
                 TaskStatus::Completed => (PlanStepState::Complete, None),
-                TaskStatus::Cancelled => (PlanStepState::Error, Some("cancelled".to_string())),
+                TaskStatus::Blocked => (PlanStepState::Blocked, None),
+                // Both draw `✗`; the note is the only thing that tells a
+                // reader a person dropped this step rather than a gate
+                // stopping it.
+                TaskStatus::Cancelled => (PlanStepState::Blocked, Some("cancelled".to_string())),
             };
             match steps.iter_mut().find(|s| s.id == item.id) {
                 Some(step) => {
@@ -750,6 +804,113 @@ mod tests {
             TaskStatus::InProgress,
         )]);
         assert_eq!(plan.steps()[0].title, "the concrete restatement");
+    }
+
+    /// **The de-conflation.** `✗` is the only red mark SPEC 4 has, so a
+    /// blocked step and an abandoned one draw the same glyph — but they are no
+    /// longer the same fact, and the row says which. Before this the board had
+    /// one word for both and the note always read `cancelled`, including for
+    /// work a red gate had stopped.
+    #[test]
+    fn a_blocked_step_and_a_cancelled_one_are_told_apart_by_their_note() {
+        let mut plan = Plan::default();
+        plan.propose(&proposal(&["one", "two"]));
+        plan.approve();
+        plan.apply_board(&[
+            item("1", "one", TaskStatus::Blocked),
+            item("2", "two", TaskStatus::Cancelled),
+        ]);
+        let steps = plan.steps();
+        assert_eq!(steps[0].state, PlanStepState::Blocked);
+        assert_eq!(steps[1].state, PlanStepState::Blocked);
+        assert_eq!(steps[0].note, None, "a gate stopped it; nobody dropped it");
+        assert_eq!(steps[1].note.as_deref(), Some("cancelled"));
+        assert_eq!(plan.state, PlanState::Error);
+    }
+
+    /// A task whose checks are running is neither working nor done: it folds
+    /// to its own state, and the plan reads as started rather than complete.
+    #[test]
+    fn a_verifying_step_folds_to_its_own_state_and_is_not_yet_complete() {
+        let mut plan = Plan::default();
+        plan.propose(&proposal(&["one", "two"]));
+        plan.approve();
+        plan.apply_board(&[
+            item("1", "one", TaskStatus::Completed),
+            item("2", "two", TaskStatus::Verify),
+        ]);
+        let steps = plan.steps();
+        assert_eq!(steps[1].state, PlanStepState::Verify);
+        assert_eq!(plan.progress(), (1, 2), "a gate in flight is not a pass");
+        assert_eq!(plan.state, PlanState::Started);
+        assert!(steps[1].state.is_open());
+    }
+
+    /// `finish` reaches the gate too: a verdict that never arrived is not a
+    /// green one, so the row must stop implying one is coming.
+    #[test]
+    fn a_turn_ending_mid_gate_does_not_leave_the_step_verifying() {
+        let mut plan = Plan::default();
+        plan.propose(&proposal(&["one"]));
+        plan.approve();
+        plan.apply_board(&[item("1", "one", TaskStatus::Verify)]);
+        plan.finish();
+        let steps = plan.steps();
+        assert_eq!(steps[0].state, PlanStepState::Blocked);
+        assert_eq!(steps[0].note.as_deref(), Some("cancelled"));
+    }
+
+    /// SPEC 8.1 unblocks a red gate on green, so a blocked step is still
+    /// moveable — and the card's `x` is offered on exactly the open rows.
+    #[test]
+    fn only_a_complete_step_is_settled() {
+        for state in [
+            PlanStepState::Planned,
+            PlanStepState::Started,
+            PlanStepState::Verify,
+            PlanStepState::Blocked,
+            PlanStepState::DriftInserted,
+        ] {
+            assert!(state.is_open(), "{state:?} can still move");
+        }
+        assert!(!PlanStepState::Complete.is_open());
+    }
+
+    /// A step the plan did not contain is queued work that arrived late, so
+    /// its presence alone must not promote an approved plan to `working` —
+    /// nothing has been done yet.
+    #[test]
+    fn a_drift_inserted_step_is_not_progress() {
+        assert!(!PlanStepState::DriftInserted.has_begun());
+        assert!(!PlanStepState::Planned.has_begun());
+        for state in [
+            PlanStepState::Started,
+            PlanStepState::Verify,
+            PlanStepState::Complete,
+            PlanStepState::Blocked,
+        ] {
+            assert!(state.has_begun(), "{state:?} means work happened");
+        }
+    }
+
+    /// The wire carries no status that asserts drift, so no board snapshot can
+    /// fold into it — see [`PlanStepState::DriftInserted`]. Pinned because the
+    /// obvious "add a `TaskStatus::DriftInserted`" would let a producer claim
+    /// drift the plan graph does not show (#5037).
+    #[test]
+    fn no_board_snapshot_can_fold_a_step_into_drift_inserted() {
+        for status in [
+            TaskStatus::Pending,
+            TaskStatus::InProgress,
+            TaskStatus::Completed,
+            TaskStatus::Cancelled,
+            TaskStatus::Verify,
+            TaskStatus::Blocked,
+        ] {
+            let mut plan = Plan::default();
+            plan.apply_board(&[item("1", "one", status)]);
+            assert_ne!(plan.steps()[0].state, PlanStepState::DriftInserted);
+        }
     }
 
     #[test]

--- a/crates/stella-tui/src/views/plan_card.rs
+++ b/crates/stella-tui/src/views/plan_card.rs
@@ -95,6 +95,9 @@ fn models_value(model: &WorkspaceModel) -> Vec<Span<'static>> {
 /// Returns the rows and the *row index* of `selected` (a step index), which the
 /// caller needs for the selection tint — a step can occupy several rows once
 /// its detail wraps, so the two indices are not the same number.
+///
+/// [`step_row`] draws one row; this walks the plan and adds the detail rows
+/// under it.
 pub fn step_rows(
     plan: &Plan,
     width: usize,
@@ -122,20 +125,7 @@ pub fn step_rows(
         if Some(i) == selected {
             selected_row = Some(rows.len());
         }
-        let v = step_style::step_visual(step.state, now_ms, animate);
-        let mut spans = vec![
-            cards::marker(Some(i) == selected),
-            Span::styled(v.glyph, v.ring),
-            Span::styled(" ", v.gap),
-            Span::styled(format!("{:<3}", format!("{}.", step.id)), v.num),
-            Span::styled(step.title.clone(), v.text),
-        ];
-        if let Some(note) = &step.note {
-            spans.push(Span::styled(format!("  ({note})"), v.meta));
-        } else if let Some(owner) = &step.owner {
-            spans.push(Span::styled(format!("  ({owner})"), v.meta));
-        }
-        rows.push(Line::from(spans));
+        rows.push(step_row(step, Some(i) == selected, now_ms, animate));
         // The elaboration, wrapped under the title at the title's indent.
         if let Some(detail) = &step.detail {
             let indent = 7usize;
@@ -148,6 +138,36 @@ pub fn step_rows(
         }
     }
     (rows, selected_row)
+}
+
+/// One step's own row: selection marker, state glyph, ordinal, title, and the
+/// trailing `(note)` / `(owner)` tag.
+///
+/// Split out of [`step_rows`] so a state can be goldened as the row it draws
+/// rather than as the styles behind it — [`Plan`] folds five of the six states
+/// from the board and cannot produce
+/// [`crate::plan::PlanStepState::DriftInserted`] at all, so the whole
+/// vocabulary is only reachable a step at a time.
+pub fn step_row(
+    step: &crate::plan::PlanStep,
+    selected: bool,
+    now_ms: u64,
+    animate: bool,
+) -> Line<'static> {
+    let v = step_style::step_visual(step.state, now_ms, animate);
+    let mut spans = vec![
+        cards::marker(selected),
+        Span::styled(v.glyph.to_string(), v.ring),
+        Span::styled(" ", v.gap),
+        Span::styled(format!("{:<3}", format!("{}.", step.id)), v.num),
+        Span::styled(step.title.clone(), v.text),
+    ];
+    if let Some(note) = &step.note {
+        spans.push(Span::styled(format!("  ({note})"), v.meta));
+    } else if let Some(owner) = &step.owner {
+        spans.push(Span::styled(format!("  ({owner})"), v.meta));
+    }
+    Line::from(spans)
 }
 
 /// The operating-envelope grid: where the plan may write, what it may spend,
@@ -288,7 +308,7 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, frame: Rect, buf: &mut Buffer
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plan::Plan;
+    use crate::plan::{Plan, PlanStep, PlanStepState};
     use stella_protocol::{TaskItem, TaskStatus};
 
     fn proposal(steps: &[&str]) -> ScopeProposal {
@@ -375,6 +395,70 @@ mod tests {
                 text_of(row)
             );
         }
+    }
+
+    /// **The golden row per state (SPEC 7.2).** Six states, six rows, spelled
+    /// out as the text a reader sees rather than as the styles behind it.
+    ///
+    /// A `contains` assertion would not have caught what this is for: `✗` used
+    /// to be the whole story for a step that ended badly, and `●` stood where
+    /// SPEC 4 asks for `◐`. Both read fine one row at a time and wrong side by
+    /// side.
+    #[test]
+    fn every_state_draws_its_specced_row() {
+        let step = |id: &str, title: &str, state: PlanStepState, note: Option<&str>| PlanStep {
+            id: id.into(),
+            title: title.into(),
+            detail: None,
+            state,
+            owner: None,
+            note: note.map(str::to_string),
+            contract: None,
+        };
+        let rows = [
+            (
+                step("1", "extract types", PlanStepState::Complete, None),
+                "  ✓ 1. extract types",
+            ),
+            (
+                step("2", "move hooks", PlanStepState::Started, None),
+                "  ◐ 2. move hooks",
+            ),
+            (
+                step("3", "update imports", PlanStepState::Planned, None),
+                "  ○ 3. update imports",
+            ),
+            (
+                step("4", "run the gates", PlanStepState::Verify, None),
+                "  ◇ 4. run the gates",
+            ),
+            (
+                step("5", "ship it", PlanStepState::Blocked, None),
+                "  ✗ 5. ship it",
+            ),
+            (
+                step(
+                    "6",
+                    "fix borrow err",
+                    PlanStepState::DriftInserted,
+                    Some("inserted"),
+                ),
+                "  ⌥ 6. fix borrow err  (inserted)",
+            ),
+        ];
+        for (step, expected) in rows {
+            assert_eq!(text_of(&step_row(&step, false, 0, false)), expected);
+        }
+        // And the one row the glyph cannot disambiguate says it in words.
+        assert_eq!(
+            text_of(&step_row(
+                &step("7", "drop it", PlanStepState::Blocked, Some("cancelled")),
+                false,
+                0,
+                false
+            )),
+            "  ✗ 7. drop it  (cancelled)"
+        );
     }
 
     #[test]

--- a/crates/stella-tui/src/views/plan_card/step_style.rs
+++ b/crates/stella-tui/src/views/plan_card/step_style.rs
@@ -9,14 +9,17 @@
 //! the rail folded into the tab row's breadcrumb (SPEC 5, [`crate::views::frame`]),
 //! so the card is the surface that draws steps and this is its vocabulary. It
 //! stays a module of its own because the mapping below is a product decision
-//! with four states and a clock in it, and it is testable without a buffer.
+//! with six states and a clock in it, and it is testable without a buffer.
+//!
+//! Every glyph comes from [`stella_tui_theme::glyph`], the SPEC 4 table the
+//! whole product draws from, rather than being typed in again here.
 //!
 //! The mapping is the product spec:
 //!
-//! - **Planned** — the whole row in the muted grey, always. Un-started work is
-//!   background, whatever the plan's own state; the moment of approval must
-//!   not light up nine rows nobody is working on.
-//! - **Started** — the ring, the step number, and the title all *pulse*
+//! - **Planned** (`○`) — the whole row in the muted grey, always. Un-started
+//!   work is background, whatever the plan's own state; the moment of approval
+//!   must not light up nine rows nobody is working on.
+//! - **Started** (`◐`) — the ring, the step number, and the title all *pulse*
 //!   between the primary text tone and the muted steps. The pulse is a pure
 //!   function of the deck clock (`model.now_ms`), like every other motion in
 //!   this crate — no timer state, and `no_anim` pins it to the bright frame.
@@ -26,16 +29,25 @@
 //!   white would stay white on paper and vanish. [`token::TEXT`] is white on
 //!   `stella-dark` and ink on `stella-light` by construction, which is the
 //!   whole contract.
-//! - **Complete** — a `✓` sitting on the green indicator cell, and the title
-//!   keeps the primary tone with a strike through it: done, but still legible
-//!   as what was done.
-//! - **Error** (a failed or cancelled step) — the entire row painted red, with
-//!   the ground-colour `✗` on the red indicator cell. The ground colour is the
-//!   theme's canvas (near-black on `stella-dark`, paper on `stella-light`), so
-//!   the mark reads as cut *out of* the red in both themes.
+//! - **Verify** (`◇`) — the gate diamond in gold on the indicator cell, and
+//!   the row in the primary tone. Gold rather than green: the checks have not
+//!   answered yet, and a row that already reads as pass is the self-report
+//!   SPEC 7.1 refuses.
+//! - **Complete** (`✓`) — a check sitting on the green indicator cell, and the
+//!   title keeps the primary tone with a strike through it: done, but still
+//!   legible as what was done.
+//! - **Blocked** (`✗`) — the entire row painted red, with the ground-colour
+//!   cross on the red indicator cell. The ground colour is the theme's canvas
+//!   (near-black on `stella-dark`, paper on `stella-light`), so the mark reads
+//!   as cut *out of* the red in both themes. A cancelled step draws the same
+//!   row and says `(cancelled)` in its metadata.
+//! - **DriftInserted** (`⌥`) — the option glyph in gold-bright, with the
+//!   `(inserted)` tag beside it in the same metal (SPEC 7.3). The row itself
+//!   stays in the primary tone: the step is ordinary work, and what is worth
+//!   marking is that the approved plan did not contain it.
 
 use ratatui::style::{Modifier, Style};
-use stella_tui_theme::token;
+use stella_tui_theme::{glyph, token};
 
 use crate::plan::PlanStepState;
 
@@ -52,9 +64,9 @@ const PULSE_PHASES: [ratatui::style::Color; 4] =
 /// title, and the trailing `(note)` / `(owner)` metadata.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct StepVisual {
-    /// The status indicator's glyph (`○` planned, `●` working, `✓` done,
-    /// `✗` failed/cancelled).
-    pub glyph: &'static str,
+    /// The status indicator's glyph, from the SPEC 4 table in
+    /// [`stella_tui_theme::glyph`].
+    pub glyph: char,
     /// The indicator cell's style.
     pub ring: Style,
     /// The step number's style — it follows the title through every state so
@@ -62,11 +74,12 @@ pub(crate) struct StepVisual {
     pub num: Style,
     /// The title's style.
     pub text: Style,
-    /// The `(note)` / `(owner)` suffix — dim everywhere except an error row,
-    /// which paints the whole row including the reason it is red.
+    /// The `(note)` / `(owner)` suffix — dim, except on a blocked row, which
+    /// paints the whole row including the reason it is red, and on a
+    /// drift-inserted one, whose `(inserted)` tag takes the drift metal.
     pub meta: Style,
     /// The spacer cell between the indicator and the number: styleless
-    /// everywhere except an error row, where "the entire row" includes the
+    /// everywhere except a blocked row, where "the entire row" includes the
     /// gaps.
     pub gap: Style,
 }
@@ -84,7 +97,7 @@ pub(crate) fn step_visual(state: PlanStepState, now_ms: u64, animate: bool) -> S
     let dim = Style::new().fg(token::MUTED);
     match state {
         PlanStepState::Planned => StepVisual {
-            glyph: "○",
+            glyph: glyph::QUEUED,
             ring: dim,
             num: dim,
             text: dim,
@@ -99,7 +112,7 @@ pub(crate) fn step_visual(state: PlanStepState, now_ms: u64, animate: bool) -> S
             };
             let live = Style::new().fg(tone).add_modifier(Modifier::BOLD);
             StepVisual {
-                glyph: "●",
+                glyph: glyph::RUNNING,
                 ring: live,
                 num: live,
                 text: live,
@@ -107,8 +120,33 @@ pub(crate) fn step_visual(state: PlanStepState, now_ms: u64, animate: bool) -> S
                 gap: Style::new(),
             }
         }
+        PlanStepState::Verify => {
+            let live = Style::new().fg(token::TEXT);
+            StepVisual {
+                glyph: glyph::GATE,
+                ring: Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD),
+                num: live,
+                text: live,
+                meta: dim,
+                gap: Style::new(),
+            }
+        }
+        PlanStepState::DriftInserted => {
+            let live = Style::new().fg(token::TEXT);
+            let drift = Style::new().fg(token::GOLD_BRIGHT);
+            StepVisual {
+                glyph: glyph::DRIFT,
+                ring: drift.add_modifier(Modifier::BOLD),
+                num: live,
+                text: live,
+                // The `(inserted)` tag is half the signal, so it carries the
+                // drift metal rather than fading into the row's metadata.
+                meta: drift,
+                gap: Style::new(),
+            }
+        }
         PlanStepState::Complete => StepVisual {
-            glyph: "✓",
+            glyph: glyph::DONE,
             // The checkmark ON the green indicator: ground-colour mark, green
             // cell — one terminal cell can hold one glyph, so the overlay is
             // fg-on-bg rather than two stacked marks.
@@ -122,13 +160,13 @@ pub(crate) fn step_visual(state: PlanStepState, now_ms: u64, animate: bool) -> S
             meta: dim,
             gap: Style::new(),
         },
-        PlanStepState::Error => {
+        PlanStepState::Blocked => {
             // The whole row painted red, the ✗ cut out of the indicator in
-            // the ground colour — a failed or cancelled step is the one row
+            // the ground colour — a blocked or cancelled step is the one row
             // allowed to shout.
             let row = Style::new().fg(token::BG).bg(token::RED);
             StepVisual {
-                glyph: "✗",
+                glyph: glyph::FAILED,
                 ring: row.add_modifier(Modifier::BOLD),
                 num: row,
                 text: row,
@@ -150,7 +188,7 @@ mod tests {
     #[test]
     fn a_planned_step_is_muted_grey() {
         let v = step_visual(PlanStepState::Planned, 0, true);
-        assert_eq!(v.glyph, "○");
+        assert_eq!(v.glyph, glyph::QUEUED);
         for style in [v.ring, v.num, v.text] {
             assert_eq!(style.fg, Some(token::MUTED));
             assert_eq!(style.bg, None);
@@ -167,7 +205,7 @@ mod tests {
         let dimmed = step_visual(PlanStepState::Started, PULSE_PERIOD_MS / 2, true);
         assert_ne!(bright.text.fg, dimmed.text.fg, "the pulse must move");
         for v in [bright, dimmed] {
-            assert_eq!(v.glyph, "●");
+            assert_eq!(v.glyph, glyph::RUNNING);
             assert_eq!(v.ring.fg, v.text.fg, "the indicator pulses with the text");
             assert_eq!(v.num.fg, v.text.fg, "the number pulses with the text");
             assert!(
@@ -193,22 +231,92 @@ mod tests {
     #[test]
     fn a_complete_step_is_a_check_on_green_with_struck_primary_text() {
         let v = step_visual(PlanStepState::Complete, 0, true);
-        assert_eq!(v.glyph, "✓");
+        assert_eq!(v.glyph, glyph::DONE);
         assert_eq!(v.ring.bg, Some(token::GREEN), "the indicator cell is green");
         assert_eq!(v.text.fg, Some(token::TEXT), "the text stays bright");
         assert!(v.text.add_modifier.contains(Modifier::CROSSED_OUT));
         assert!(v.num.add_modifier.contains(Modifier::CROSSED_OUT));
     }
 
-    /// Failed or cancelled: the whole row is painted red, with the ✗ cut out
+    /// Blocked or cancelled: the whole row is painted red, with the ✗ cut out
     /// of the indicator in the ground colour.
     #[test]
-    fn an_error_step_paints_the_entire_row_red_with_a_ground_cross() {
-        let v = step_visual(PlanStepState::Error, 0, true);
-        assert_eq!(v.glyph, "✗");
+    fn a_blocked_step_paints_the_entire_row_red_with_a_ground_cross() {
+        let v = step_visual(PlanStepState::Blocked, 0, true);
+        assert_eq!(v.glyph, glyph::FAILED);
         for style in [v.ring, v.num, v.text, v.meta, v.gap] {
             assert_eq!(style.bg, Some(token::RED), "the row is red end to end");
             assert_eq!(style.fg, Some(token::BG));
+        }
+    }
+
+    /// A gate task waiting on its checks: SPEC 4's `◇` in gold, and a row that
+    /// still reads as live work.
+    ///
+    /// Gold rather than green is the whole point — a verify row that already
+    /// looked like a pass would be the surface answering a question only the
+    /// gate can answer (SPEC 7.1).
+    #[test]
+    fn a_verify_step_is_a_gold_diamond_over_a_live_row() {
+        let v = step_visual(PlanStepState::Verify, 0, true);
+        assert_eq!(v.glyph, glyph::GATE);
+        assert_eq!(v.ring.fg, Some(token::GOLD), "the gate diamond is gold");
+        assert_ne!(
+            v.ring.fg,
+            Some(token::GREEN),
+            "the checks have not answered"
+        );
+        assert_eq!(v.ring.bg, None, "no filled cell — nothing has passed yet");
+        assert_eq!(v.text.fg, Some(token::TEXT));
+        assert_eq!(v.num.fg, v.text.fg, "the number reads with the title");
+    }
+
+    /// A step the approved plan did not contain: SPEC 7.3's `⌥` in
+    /// gold-bright, with the `inserted` tag in the same metal so the mark and
+    /// its word read as one signal.
+    #[test]
+    fn a_drift_inserted_step_is_gold_bright_glyph_and_tag() {
+        let v = step_visual(PlanStepState::DriftInserted, 0, true);
+        assert_eq!(v.glyph, glyph::DRIFT);
+        assert_eq!(v.ring.fg, Some(token::GOLD_BRIGHT));
+        assert_eq!(
+            v.meta.fg,
+            Some(token::GOLD_BRIGHT),
+            "the tag carries it too"
+        );
+        assert_eq!(v.text.fg, Some(token::TEXT), "the work itself is ordinary");
+        assert_eq!(v.ring.bg, None);
+    }
+
+    /// The six states draw six different glyphs, every one of them from the
+    /// SPEC 4 table. Nothing else in this module would notice two states
+    /// collapsing onto one mark — which is exactly how `✗` came to mean both
+    /// *blocked* and *cancelled*.
+    #[test]
+    fn every_state_draws_a_distinct_glyph_from_the_spec_table() {
+        let states = [
+            PlanStepState::Planned,
+            PlanStepState::Started,
+            PlanStepState::Verify,
+            PlanStepState::Complete,
+            PlanStepState::Blocked,
+            PlanStepState::DriftInserted,
+        ];
+        let drawn: Vec<char> = states
+            .iter()
+            .map(|s| step_visual(*s, 0, false).glyph)
+            .collect();
+        let unique: std::collections::BTreeSet<char> = drawn.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            states.len(),
+            "two states share a glyph: {drawn:?}"
+        );
+        for g in drawn {
+            assert!(
+                glyph::ALL.iter().any(|(_, c)| *c == g),
+                "{g:?} was typed in here rather than taken from the SPEC 4 table"
+            );
         }
     }
 }

--- a/crates/stella-tui/src/views/task_zoom.rs
+++ b/crates/stella-tui/src/views/task_zoom.rs
@@ -444,10 +444,12 @@ fn state_word(step: &PlanStep) -> String {
     match step.state {
         PlanStepState::Planned => "queued".to_string(),
         PlanStepState::Started => "working".to_string(),
+        PlanStepState::Verify => "verify".to_string(),
         PlanStepState::Complete => "done".to_string(),
-        // A cancelled step carries its reason in the note, and "failed" would
-        // read as a crash when it was a decision.
-        PlanStepState::Error => step.note.clone().unwrap_or_else(|| "failed".to_string()),
+        // A cancelled step carries its reason in the note, and "blocked" would
+        // read as a gate stopping it when it was a decision.
+        PlanStepState::Blocked => step.note.clone().unwrap_or_else(|| "blocked".to_string()),
+        PlanStepState::DriftInserted => "inserted".to_string(),
     }
 }
 

--- a/crates/stella-tui/tests/snapshots/deck/zoom_scripted.txt
+++ b/crates/stella-tui/tests/snapshots/deck/zoom_scripted.txt
@@ -4,7 +4,7 @@
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
  SESSION  ▸ plan · task 5 Wire the triggers API · 4/7                                                                                         ⌃S plan   stella*
-task 5 · Wire the triggers API                                                                                             ● working · lead · glm-5.2 · esc back
+task 5 · Wire the triggers API                                                                                             ◐ working · lead · glm-5.2 · esc back
 
 done means · the contract, checked not vibed
   ✓ no inbound refs to the removed trigger route                                                                                                     graph · det

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1293,11 +1293,9 @@ export interface TaskItem {
 }
 
 /**
- * Lifecycle of a `TaskItem`. Terminal states are `Completed` and
- * `Cancelled`; a cancelled task keeps its row (the board is an audit
- * surface, not just a scheduler).
+ * Where one task on the board is in its lifecycle. `completed` and `cancelled` are terminal; the rest can still change. `verify` means the work is done and its checks are running, and `blocked` means something outside the task stopped it — a red gate, an unmet dependency — which is a different fact from `cancelled`, a decision to abandon it. Tokens are only ever added, so a reader that does not recognise one is reading a newer stream.
  */
-export type TaskStatus = "pending" | "in_progress" | "completed" | "cancelled";
+export type TaskStatus = "pending" | "in_progress" | "completed" | "cancelled" | "verify" | "blocked";
 
 /**
  * One tool invocation the model requested.

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -2078,7 +2078,7 @@
       "type": "object"
     },
     "TaskStatus": {
-      "description": "Lifecycle of a `TaskItem`. Terminal states are `Completed` and\n`Cancelled`; a cancelled task keeps its row (the board is an audit\nsurface, not just a scheduler).",
+      "description": "Where one task on the board is in its lifecycle. `completed` and `cancelled` are terminal; the rest can still change. `verify` means the work is done and its checks are running, and `blocked` means something outside the task stopped it — a red gate, an unmet dependency — which is a different fact from `cancelled`, a decision to abandon it. Tokens are only ever added, so a reader that does not recognise one is reading a newer stream.",
       "oneOf": [
         {
           "const": "pending",
@@ -2098,6 +2098,16 @@
         {
           "const": "cancelled",
           "description": "Abandoned. Terminal, and the row is kept — the board is an audit\nsurface, not just a scheduler.",
+          "type": "string"
+        },
+        {
+          "const": "verify",
+          "description": "The work is done and its checks are running or awaiting a verdict —\nSPEC 7.2's `◇ verify`, the window between \"the worker stopped\" and \"the\ngates are green\" that the board had no word for.\n\nOpen, because the verdict is what moves it: to [`Self::Completed`] on\ngreen, to [`Self::Blocked`] on red. Closing on entry here would be the\nmodel marking its own homework, which SPEC 7.1 exists to stop.\n\nNothing sets it yet — the gate board is #5042.",
+          "type": "string"
+        },
+        {
+          "const": "blocked",
+          "description": "Stopped by something the task does not control: a red gate, an unmet\ndependency.\n\nOpen rather than terminal, because SPEC 8.1's receipt reads `merge\nblocked · unblocks on green`. A blocked task that could never move\nagain would be a dead row wearing a live word.\n\nA different fact from [`Self::Cancelled`], which is a decision to\nabandon the work. Both draw SPEC 4's one `✗`, and until this case\nexisted the board could not tell a reader which had happened.\n\nNothing sets it yet — the gate that would is #5042.",
           "type": "string"
         }
       ]

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -2286,11 +2286,9 @@ export interface TaskItem {
 }
 
 /**
- * Lifecycle of a `TaskItem`. Terminal states are `Completed` and
- * `Cancelled`; a cancelled task keeps its row (the board is an audit
- * surface, not just a scheduler).
+ * Where one task on the board is in its lifecycle. `completed` and `cancelled` are terminal; the rest can still change. `verify` means the work is done and its checks are running, and `blocked` means something outside the task stopped it — a red gate, an unmet dependency — which is a different fact from `cancelled`, a decision to abandon it. Tokens are only ever added, so a reader that does not recognise one is reading a newer stream.
  */
-export type TaskStatus = "pending" | "in_progress" | "completed" | "cancelled";
+export type TaskStatus = "pending" | "in_progress" | "completed" | "cancelled" | "verify" | "blocked";
 
 /**
  * One tool invocation the model requested.

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -3903,7 +3903,7 @@
       "type": "object"
     },
     "TaskStatus": {
-      "description": "Lifecycle of a `TaskItem`. Terminal states are `Completed` and\n`Cancelled`; a cancelled task keeps its row (the board is an audit\nsurface, not just a scheduler).",
+      "description": "Where one task on the board is in its lifecycle. `completed` and `cancelled` are terminal; the rest can still change. `verify` means the work is done and its checks are running, and `blocked` means something outside the task stopped it — a red gate, an unmet dependency — which is a different fact from `cancelled`, a decision to abandon it. Tokens are only ever added, so a reader that does not recognise one is reading a newer stream.",
       "oneOf": [
         {
           "const": "pending",
@@ -3923,6 +3923,16 @@
         {
           "const": "cancelled",
           "description": "Abandoned. Terminal, and the row is kept — the board is an audit\nsurface, not just a scheduler.",
+          "type": "string"
+        },
+        {
+          "const": "verify",
+          "description": "The work is done and its checks are running or awaiting a verdict —\nSPEC 7.2's `◇ verify`, the window between \"the worker stopped\" and \"the\ngates are green\" that the board had no word for.\n\nOpen, because the verdict is what moves it: to [`Self::Completed`] on\ngreen, to [`Self::Blocked`] on red. Closing on entry here would be the\nmodel marking its own homework, which SPEC 7.1 exists to stop.\n\nNothing sets it yet — the gate board is #5042.",
+          "type": "string"
+        },
+        {
+          "const": "blocked",
+          "description": "Stopped by something the task does not control: a red gate, an unmet\ndependency.\n\nOpen rather than terminal, because SPEC 8.1's receipt reads `merge\nblocked · unblocks on green`. A blocked task that could never move\nagain would be a dead row wearing a live word.\n\nA different fact from [`Self::Cancelled`], which is a decision to\nabandon the work. Both draw SPEC 4's one `✗`, and until this case\nexisted the board could not tell a reader which had happened.\n\nNothing sets it yet — the gate that would is #5042.",
           "type": "string"
         }
       ]


### PR DESCRIPTION
Closes #5038

SPEC 7.2 draws six task states. The board knew four, and the deck narrowed
them to four more: a running step drew `●` where SPEC 4 asks for `◐`, `✗`
meant both *blocked* and *cancelled* with nothing to tell them apart, and
`◇ verify` and `⌥ drift-inserted` had no representation at all.

## What landed

**Wire** — `TaskStatus` gains `verify` and `blocked`, appended after
`cancelled` so the tokens already written into `tasks.status` keep their
meaning. `is_open` becomes an exhaustive match rather than a `matches!`:
both new states are **open**, because a gate's verdict is what moves a
verifying task, and SPEC 8.1's `merge blocked · unblocks on green` is a
transition a terminal answer would forbid. The macro's implicit false arm
would have filed both under *terminal* without asking.

**Render** — `PlanStepState` is SPEC 7.2's six: `Planned` `○`, `Started`
`◐`, `Verify` `◇` gold, `Complete` `✓` green, `Blocked` `✗` red (renamed
from `Error`, which was not what SPEC calls it), `DriftInserted` `⌥`
gold-bright with its `(inserted)` tag in the same metal (SPEC 7.3). Every
glyph now comes from `stella_tui_theme::glyph` — the SPEC 4 table — instead
of being typed in again as a string literal, and a test holds it there.

`◇` is gold rather than green on purpose: a verify row that already read as
a pass would be the surface answering the question only the gate can answer
(SPEC 7.1).

## `⌥ drift-inserted` is not a `TaskStatus`, and that is the design

The issue asked for the state enum to be extended with drift declared but
unproduced. Checking what #5037 actually landed changed the shape of that.
It added `DivergenceKind::Inserted`, and `plan_graph.rs` is explicit about
why it is a value with no constructor:

> A `Divergence` value is an answer somebody computed, never a fact
> somebody wrote down, so there is no constructor here that lets a producer
> assert drift that the graph does not show.

A `TaskStatus::DriftInserted` would be exactly the thing that module
forbids — and exclusive with `running`/`done` besides, when an inserted
task is also one of those. So drift lives on `PlanStepState`, where a row's
one glyph cell has to be decided anyway, and the wire refuses to carry it.
`no_board_snapshot_can_fold_a_step_into_drift_inserted` pins that: no
status folds into it, from any of the six.

Adding `blocked` beside `verify` is the other judgement worth flagging. The
issue names the `✗` conflation as a defect; without a `blocked` on the wire
the only way a producer could ever say "a gate stopped this" is to say
"cancelled", which bakes the conflation in permanently. Both are cheap and
append-only.

## Live producers vs. scripted fold

Stated plainly, because three of these render from nothing today:

| state | glyph | producer |
|---|---|---|
| `Planned` | `○` | live — `TaskStatus::Pending` |
| `Started` | `◐` | live — `TaskStatus::InProgress` |
| `Complete` | `✓` | live — `TaskStatus::Completed` |
| `Blocked` | `✗` | live *from `Cancelled`*; `TaskStatus::Blocked` itself has no producer (#5042) |
| `Verify` | `◇` | fold arm exists; nothing sets `TaskStatus::Verify` (#5042, the gate board, in flight) |
| `DriftInserted` | `⌥` | no fold arm at all — a caller constructs the `PlanStep`, which today is the tests. Joining the plan graph's `DivergenceKind::Inserted` to `Plan` is filed as #5270 |

No producer was invented for any of them.

## Witnesses, and the flips verified by hand

Each one reverted on disk, the named test watched to fail, then restored.

| witness | flip |
|---|---|
| `views::plan_card::tests::every_state_draws_its_specced_row` | `glyph::RUNNING` → `'●'` — FAILED (`◐` vs `●` on the golden row) |
| `step_style::tests::a_verify_step_is_a_gold_diamond_over_a_live_row` | ring `token::GOLD` → `token::GREEN` — FAILED |
| `step_style::tests::a_drift_inserted_step_is_gold_bright_glyph_and_tag` | `meta: drift` → `meta: dim` — FAILED |
| `plan::tests::a_blocked_step_and_a_cancelled_one_are_told_apart_by_their_note` | `Blocked` arm re-given `Some("cancelled")` — FAILED |
| `plan::tests::a_turn_ending_mid_gate_does_not_leave_the_step_verifying` | `finish()` back to `InProgress` only — FAILED |
| `task_status::every_task_status_roundtrips_under_its_wire_token` and `a_board_snapshot_carries_a_verifying_and_a_blocked_task` | `#[serde(rename = "verifying")]` on `Verify` — both FAILED |

`step_style::tests::every_state_draws_a_distinct_glyph_from_the_spec_table`
and `plan::tests::no_board_snapshot_can_fold_a_step_into_drift_inserted`
guard negative space (no two states share a mark; no status asserts drift),
so their flip is adding the thing they forbid rather than removing a line.

A new enum case is a compile-level witness at the two exhaustive match
sites — `stella_tools::tasks::glyph` and `Plan::steps` — which is stated
rather than claimed as an assertion-level one.

## Golden diff

One character, read before blessing:

```
-task 5 · Wire the triggers API   ● working · lead · glm-5.2 · esc back
+task 5 · Wire the triggers API   ◐ working · lead · glm-5.2 · esc back
```

`card_plan.txt` did not move — its steps are all `○`.

`docs/wire/` regenerated with `make wire-schema-update`; the `TaskStatus`
`oneOf` gains its two tokens. It also needed a `schemars(description = …)`,
because the Rust doc cites `crate::plan_graph::Divergence` and
`check-wire-schema` rejects a Rust path in a published artifact.

## Checks

`cargo fmt` · `cargo clippy --all-targets -D warnings` on
`stella-protocol` (also `--features schema`), `stella-tui`, `stella-tools`,
`stella-core`, `stella-cli`, `stella-observatory` — all exit 0 ·
`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`
on each, schema feature included · `make prose` OK, no baseline edited ·
`make line-citations`, `make left-behind`, `make measured-constants`,
`make wire-schema` OK · scoped tests green (`stella-tui` 1270,
`stella-protocol` 246 + the wire-contract suites, `stella-tools`,
`stella-core`, `stella-store` task tests).

`crates/stella-protocol/src/event/tests.rs` crossed 1500 lines, so the task
board's wire tests moved to a child module
(`event/tests/task_status.rs`) — a split, not a baseline entry.

## Noticed, not fixed

- `main` is red on `file-size` for `crates/stella-tui/src/views/transcript_source.rs`
  (#5256, repair in flight as #5260). Untouched here, per AGENTS.md on not
  folding a baseline repair into an unrelated PR — which means this PR's
  `main-red-hold` stays red until #5260 lands.
- #5270 — the plan graph's `DivergenceKind::Inserted` never reaches
  `Plan`, so `⌥` cannot be produced.
- #5271 — `step_row`'s `{:<3}` ordinal column leaves no space before the
  title once a step id is two characters (`10.update imports`).
- #5272 — SPEC 4 asks for the running glyph in gold_bright when acting and
  silver when observing; the pulse paints the text ramp, and the fold
  carries no acting/observing signal to choose between them.

## Deleted tests

`task_update_roundtrips_a_full_board_snapshot` and
`task_status_open_vs_terminal` were **moved**, not removed —
`crates/stella-protocol/src/event/tests.rs` →
`crates/stella-protocol/src/event/tests/task_status.rs`, unchanged apart
from the two assertions appended to the second.

`an_error_step_paints_the_entire_row_red_with_a_ground_cross`
(`crates/stella-tui/src/views/plan_card/step_style.rs`) was **renamed**, not
removed: the state it covers is now called `Blocked`, so the test is
`a_blocked_step_paints_the_entire_row_red_with_a_ground_cross` and asserts
the same red row and ground-colour `✗`.
