### PR TITLE
fix(stella-store): corruption found past page 1 carries the repair too

### DIFF
--- a/crates/stella-store/src/integrity.rs
+++ b/crates/stella-store/src/integrity.rs
@@ -87,6 +87,52 @@ pub(crate) fn corrupt_store_error(error: rusqlite::Error, db_path: Option<&Path>
     }
 }
 
+/// Re-classify an error raised anywhere in the open sequence, so corruption
+/// found after page 1 carries the same remedy corruption found *on* page 1
+/// already does.
+///
+/// [`corrupt_store_error`] maps the pragma batch, which is the first statement
+/// to touch page 1 — so it catches a file whose header is gone or overwritten.
+/// It cannot catch the shape that occurs in the field: a header that reads back
+/// perfectly and damaged pages further in, which SQLite reports only once some
+/// statement walks them. On the maintainer's 1 GB store that statement was
+/// `migrate`'s `CREATE INDEX` over `events` (v38 → v39), several hundred
+/// thousand rows past the header, and the failure reached the user as the bare
+/// `database disk image is malformed` with no remedy attached — while
+/// `PRAGMA user_version` on the same file answered 38 without complaint (#4564).
+///
+/// Re-classifying at the boundary buys the diagnosis for nothing: the statement
+/// has already failed and SQLite has already put the code on the error, so this
+/// reads a field rather than scanning a file. That is why the fix here is not
+/// the `quick_check`-on-open that #4564 floated — a scan spends time on every
+/// healthy open to learn what the failing open is already being told.
+pub(crate) fn classify_store_corruption(error: StoreError, db_path: Option<&Path>) -> StoreError {
+    match error {
+        StoreError::Sqlite(sqlite) if is_sqlite_corruption(&sqlite) => {
+            corrupt_store_error(sqlite, db_path)
+        }
+        other => other,
+    }
+}
+
+impl Store {
+    /// The rest of opening, after the pragma batch has proved page 1 readable:
+    /// bring the schema up to date, then give the enterprise export its tables.
+    ///
+    /// Both steps run under [`classify_store_corruption`], because page 1 reading
+    /// cleanly says nothing about the rest of the file and these are the first
+    /// statements that walk it — `migrate`'s `CREATE INDEX` reads every row of
+    /// the table it indexes. It lives beside the classifier rather than inline in
+    /// `Store::init` so that `lib.rs`, which is closed to growth, does not carry
+    /// the explanation as well as the call (AGENTS.md § "God files").
+    pub(crate) fn migrate_and_prepare_exports(&self, db_path: Option<&Path>) -> Result<()> {
+        self.migrate()
+            .map_err(|error| classify_store_corruption(error, db_path))?;
+        crate::enterprise_telemetry::initialize_store_export_schema(&mut self.lock())
+            .map_err(|error| classify_store_corruption(error, db_path))
+    }
+}
+
 /// How many problem rows a report keeps. `PRAGMA integrity_check` stops at 100
 /// findings by default and a wall of them tells the user nothing the first few
 /// don't — but the count is never truncated, only the listing.
@@ -439,13 +485,23 @@ pub struct StoreQuarantine {
 ///    successful repair would turn into new corruption. Renames come first
 ///    because they are the part that has to work — after this step the
 ///    workspace is usable again even if everything below fails.
-/// 2. `VACUUM INTO` a new `store.db.salvaged-<epoch>` — a page-by-page copy of
-///    everything SQLite can still read out of the quarantined file. Localized
-///    damage (a torn index, an unreadable page in one table) often salvages
-///    nearly everything; a shredded header salvages nothing, and that is
+/// 2. `VACUUM INTO` a new `store.db.salvaged-<epoch>` — a copy of the quarantined
+///    file that succeeds only when SQLite can walk it end to end. Salvage is
 ///    recorded in [`StoreQuarantine::salvage_error`] rather than failing the
 ///    repair. The read is immutable, so the quarantined evidence is never
 ///    modified by the attempt to read it.
+///
+///    **`VACUUM INTO` is all-or-nothing, and on real damage the answer is
+///    usually nothing.** It reads through the b-tree, so one unreadable page on
+///    any path it takes aborts the whole copy — a shredded header and a handful
+///    of bad pages in the middle of a healthy 1 GB file fail it alike. Measured
+///    on the maintainer's store (#4564): six damaged pages across four trees,
+///    `VACUUM INTO` salvaged zero rows, while `.recover` — which rebuilds from
+///    surviving cell records instead of walking the tree — returned 376,129 of
+///    376,140 events and every row of `executions`, `telemetry` and
+///    `tool_calls`. That is why the caller prints the by-hand `.recover` line
+///    beside this result and does not present the salvage attempt as the
+///    recovery: replacing this step with `.recover` is #5282.
 ///
 /// Nothing is deleted and nothing is overwritten — every target name is made
 /// unique first — so the whole operation is undoable with `mv`, and the caller
@@ -654,6 +710,108 @@ mod tests {
         file.seek(SeekFrom::Start(0)).expect("seek");
         file.write_all(&[0x7f; 128]).expect("write garbage");
         file.sync_all().expect("sync");
+    }
+
+    /// A store whose `events` table spans enough pages that damage can be put
+    /// past the header without touching it, staged so that reopening rebuilds
+    /// the `events_by_task` index — the v38 → v39 step, and the full table scan
+    /// that walked the maintainer's damaged pages in #4564.
+    fn workspace_needing_an_index_rebuild(rows: usize) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path()).expect("store");
+        let id = store
+            .begin_execution("run", "fill enough pages to corrupt", "zai", "glm-5.2")
+            .expect("execution");
+        for seq in 0..rows {
+            store
+                .record_event(
+                    id,
+                    seq as u64,
+                    &AgentEvent::Text {
+                        // Wide enough that the rows cannot all share a page.
+                        text: format!("{seq:06} {}", "payload ".repeat(24)),
+                    },
+                )
+                .expect("event");
+        }
+        store
+            .finish_execution(id, "completed", 0.5)
+            .expect("finish");
+        {
+            // Drop the index and wind the stamp back, so the reopen genuinely
+            // re-runs the migration rather than skipping an index that is
+            // already there. Checkpointed so every row is in the main file and
+            // not in a `-wal` the corruption below would miss.
+            let conn = store.lock();
+            conn.execute_batch("DROP INDEX IF EXISTS events_by_task;")
+                .expect("drop the index the migration rebuilds");
+            conn.pragma_update(None, "user_version", 38i64)
+                .expect("wind the schema stamp back to v38");
+            conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+                .expect("checkpoint");
+        }
+        drop(store);
+        let db_path = dir.path().join(".stella/private/store.db");
+        assert!(db_path.is_file(), "fixture store exists");
+        (dir, db_path)
+    }
+
+    /// Overwrite a run of pages in the middle of the file, leaving page 1 — the
+    /// header — byte-for-byte intact. This is the field shape: the file still
+    /// identifies as SQLite and answers `PRAGMA user_version`, and only a
+    /// statement that walks the damaged pages ever notices.
+    fn shred_pages_past_the_header(db_path: &Path) {
+        use std::io::{Seek, SeekFrom, Write};
+        let len = std::fs::metadata(db_path).expect("stat").len();
+        assert!(
+            len > 256 * 1024,
+            "fixture must be large enough to damage past the header: {len} bytes"
+        );
+        let start = len / 3;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(db_path)
+            .expect("open db for corruption");
+        file.seek(SeekFrom::Start(start)).expect("seek");
+        file.write_all(&vec![0x7f; (len / 3) as usize])
+            .expect("write garbage");
+        file.sync_all().expect("sync");
+    }
+
+    /// The witness for #4564. Corruption that page 1 cannot reveal must still
+    /// reach the user as the error that names the repair.
+    ///
+    /// Before the fix this failed on the `Corrupt` arm: `Store::open` returned
+    /// `Sqlite(SqliteFailure(DatabaseCorrupt, 11))`, whose whole message is
+    /// "database disk image is malformed" — an accurate sentence that leaves
+    /// the user with no next move, and the exact message a real 1 GB store
+    /// produced while its header read back perfectly.
+    #[test]
+    fn corruption_below_the_header_still_names_the_repair() {
+        let (dir, db_path) = workspace_needing_an_index_rebuild(4_000);
+        shred_pages_past_the_header(&db_path);
+
+        // The premise: the header survived, so nothing about page 1 is what
+        // makes this file fail. If this ever stops holding, the test has
+        // stopped covering the case it was written for.
+        let header = Connection::open(&db_path).expect("a damaged file still opens");
+        let stamped: i64 = header
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("the header still answers its version");
+        assert_eq!(stamped, 38, "page 1 is intact and still readable");
+        drop(header);
+
+        match Store::open(dir.path()) {
+            Ok(_) => panic!("a store with shredded pages must not open"),
+            Err(error @ StoreError::Corrupt { .. }) => assert!(
+                error.to_string().contains("stella doctor"),
+                "corruption found after page 1 carries the remedy too: {error}"
+            ),
+            Err(other) => panic!(
+                "corruption below the header must classify as Corrupt, not as a \
+                 bare SQLite failure: {other:?}"
+            ),
+        }
     }
 
     #[test]

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -671,7 +671,8 @@ impl Store {
 
     /// `db_path` is the on-disk file behind `conn` (`None` for in-memory), and
     /// exists only so an unreadable file can be named in the error — see
-    /// [`corrupt_store_error`]. [`Store::integrity_check`] needs no path: its
+    /// [`corrupt_store_error`], and [`Store::migrate_and_prepare_exports`] for
+    /// damage past page 1. [`Store::integrity_check`] needs no path: its
     /// verdicts carry SQLite's own wording, and the caller located the file.
     fn init(conn: Connection, root: Option<PathBuf>, db_path: Option<&Path>) -> Result<Self> {
         // execute_batch tolerates the row PRAGMA journal_mode returns (a
@@ -697,8 +698,7 @@ impl Store {
             conn: Mutex::new(conn),
             root,
         };
-        store.migrate()?;
-        enterprise_telemetry::initialize_store_export_schema(&mut store.lock())?;
+        store.migrate_and_prepare_exports(db_path)?;
         Ok(store)
     }
 

--- a/website/content/docs/commands/doctor.mdx
+++ b/website/content/docs/commands/doctor.mdx
@@ -104,7 +104,11 @@ When it does act, in this order:
 
    The sidecars must travel with the database. A stale WAL left beside the fresh store your next session creates is how a successful repair turns into new corruption. Renames come first because once they land the workspace is usable again even if everything after them fails.
 
-2. **Whatever is still readable is copied out** to a separate database beside the original — `store.db.salvaged-1769472000` — restricted to your user. If nothing can be salvaged, that is reported and the quarantine still stands; a failed salvage is never fatal.
+2. **A copy of whatever SQLite can still read** is written to a separate database beside the original — `store.db.salvaged-1769472000` — restricted to your user. If nothing can be salvaged, that is reported and the quarantine still stands; a failed salvage is never fatal.
+
+   <Callout type="warn">
+   Expect this step to salvage nothing, and use the `by hand:` line instead. The copy is a `VACUUM INTO`, which walks the database and so gives up entirely at the first page it cannot read — on a store measured at six damaged pages in an otherwise healthy 1 GB file it returned zero rows, while the `sqlite3 .recover` command printed in the `by hand:` line returned 376,129 of 376,140 events and every row of `executions`, `telemetry` and `tool_calls`. `.recover` rebuilds from surviving records rather than walking the tree, which is why it survives damage this step cannot. Making `--repair` use it is [#5282](https://github.com/macanderson/stella/issues/5282).
+   </Callout>
 
 3. **Your next session starts a fresh store.** Nothing was deleted.
 


### PR DESCRIPTION
Closes #4564.

## The decision the issue asked for: (a), one-off crash damage

#4564 asked whether the maintainer's corrupt `store.db` is one-time damage or a defect in how the store writes. The evidence says **(a)**, and the reasoning is below so it can be disagreed with rather than taken on faith.

**The damage did not grow.** The issue was filed 2026-08-23 against this file; I recovered the same file on 2026-08-26. Between them the store took ~2,108 new events and the loss stayed at exactly 11 rows:

| | 2026-08-23 (issue body) | 2026-08-26 |
|---|---|---|
| `events` before recovery | 374,032 | 376,140 |
| after `.recover` | 374,021 | 376,129 |
| rows lost | 11 | 11 |

A write path still corrupting under normal use would be expected to move that number over three days of writing. **Labelled as an inference:** I compared counts, not row identities, so this is consistent with static damage rather than proof of it. The corrupt original is retained at `.stella/private/store.db.corrupt-20260826` if anyone wants to settle it by identity.

**Its four siblings are clean.** On the same machine, same writer patterns: `catalog.db`, `usage.db`, `context.db` and `codegraph.db` each return `ok` from `PRAGMA integrity_check`. Only `store.db` — much the most written — is damaged.

**The settings were already the conservative ones**: WAL, a `busy_timeout` matching the sibling stores, and `synchronous=FULL` by default. There is no obvious durability hole to close, which is the (b) this rules out rather than assumes away.

So the work owed is (a)'s: make the recovery path something a user can find and follow. That turned out to have a hole in it.

## The defect this actually fixes

The store's corruption diagnosis (`stella doctor`) and repair (`--repair`) already existed, and the open path already mapped corruption to an error naming them. That mapping is applied to the pragma batch — **the first statement to touch page 1** — so it catches a file whose header is gone.

It does not catch what happened here. The header read back perfectly (`PRAGMA user_version` answered 38), and the damage was six pages across four b-trees deeper in the file. SQLite only reports that once a statement walks those pages, which on this store was `migrate`'s `CREATE INDEX` over `events` for v38 → v39.

Verified against the real 1 GB file — before:

```
Debug   = Sqlite(SqliteFailure(Error { code: DatabaseCorrupt, extended_code: 11 }, Some("database disk image is malformed")))
Display = database disk image is malformed
names stella doctor? false
```

and after:

```
Debug   = Corrupt { path: "…/.stella/private/store.db", source: SqliteFailure(…DatabaseCorrupt…) }
Display = store.db cannot be read as a SQLite database (database disk image is malformed), so it is
          corrupt or was overwritten. Run `stella doctor` to confirm, then `stella doctor --repair` …
names stella doctor? true
```

Same file, same corruption; the difference is only whether the code SQLite already set was read before `From<rusqlite::Error>` flattened it away.

**Why not the `quick_check`-on-open #4564 floated.** Re-classifying at the boundary is free: the statement has already failed and the error already carries the code, so this reads a field. A scan spends time on every healthy open to learn what the failing open is being told anyway.

## Witness

`corruption_below_the_header_still_names_the_repair` builds a store whose `events` table spans many pages, drops the `events_by_task` index and winds `user_version` back to 38 so the reopen genuinely re-runs the migration that scans, then shreds a run of pages starting a third of the way in.

It asserts page 1 still answers `user_version` **before** opening, so the test cannot quietly decay into the header case the existing `a_corrupt_file_is_matchable_apart_from_an_ordinary_sqlite_failure` already covers.

Checked both ways. With the classification removed it fails with the same signature the real store produced:

```
corruption below the header must classify as Corrupt, not as a bare SQLite failure:
Sqlite(SqliteFailure(Error { code: DatabaseCorrupt, extended_code: 11 }, Some("database disk image is malformed")))
```

## Two corrected claims, and a new issue

Testing `--repair` on the real file found it salvaged **nothing**: `VACUUM INTO failed: database disk image is malformed`. `VACUUM INTO` walks the b-tree, so one unreadable page on its path aborts the whole copy — a shredded header and six bad pages in a healthy 1 GB file fail it alike. The `.recover` in the `by hand:` line returned 376,129 of 376,140 events and every row of `executions`, `telemetry` and `tool_calls`.

Both `salvage`'s doc comment and `doctor.mdx` claimed localized damage "salvages nearly everything". They now state the measurement instead. Making `--repair` actually use `.recover` is **#5282** — it is not a one-line swap, because `.recover` is a feature of the `sqlite3` shell rather than of `rusqlite`.

The user is not stranded meanwhile: the quarantine rename works, nothing is ever deleted, and the effective command is printed.

## Placement

`Store::migrate_and_prepare_exports` lives in `integrity.rs` beside the classifier rather than inline in `Store::init`, because `lib.rs` is a grandfathered god file. The first cut put it inline and pushed the file 12 lines over its ceiling; this version leaves `lib.rs` one line *shorter* than it found it, and no baseline was touched.

## Evidence

- `cargo test -p stella-store` — 457 lib + 31 integration, 0 failed (exit 0)
- `cargo clippy -p stella-store --all-targets -- -D warnings` — exit 0
- `make guards-fast` — exit 0, `check-file-size` and `check-prose` included
- The before/after against the real corrupt store, above

Not run locally, per CLAUDE.md: the workspace build and test suite. CI is the evidence for those.

## Deleted tests

None.

## Summary by Sourcery

Ensure corruption found anywhere during store startup is classified with actionable recovery guidance and accurately document the limitations of automatic salvage.

Bug Fixes:
- Classify SQLite corruption discovered during migrations and export-schema setup so users receive the existing `stella doctor` and `--repair` guidance even when page 1 remains readable.

Enhancements:
- Clarify that repair salvage uses an all-or-nothing SQLite copy and may recover nothing when pages are damaged, while directing users to the printed `.recover` procedure for more effective manual recovery.

Documentation:
- Update the doctor documentation to accurately describe salvage limitations and recommend the manual recovery command.

Tests:
- Add coverage for corruption beyond the database header, including a fixture that damages pages encountered while rebuilding an index.