### PR TITLE
fix(stella-tui): the tab list yields as the frame narrows, the wordmark never does

### DIFF
--- a/crates/stella-tui/src/views/frame.rs
+++ b/crates/stella-tui/src/views/frame.rs
@@ -35,9 +35,10 @@
 //! also the form the renderings draw.
 //!
 //! The nine titles cost 65 columns and the mark eight more, so a frame under
-//! 74 cannot draw both at full length. [`tab_list`] resolves that in the list's
-//! favour: it is handed the columns left once the mark is paid for and yields
-//! rungs until it fits, so the mark holds the right edge at every width (#5072).
+//! 74 cannot draw both at full length. The `tab_list` submodule resolves that
+//! in the list's favour: it is handed the columns left once the mark is paid
+//! for and yields rungs until it fits, so the mark holds the right edge at
+//! every width (#5072).
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;

--- a/crates/stella-tui/src/views/frame.rs
+++ b/crates/stella-tui/src/views/frame.rs
@@ -33,6 +33,11 @@
 //! learned the other eight tabs exist (#5049). The moment a plan or a lane
 //! gives the breadcrumb something to say, it takes the row back — which is
 //! also the form the renderings draw.
+//!
+//! The nine titles cost 65 columns and the mark eight more, so a frame under
+//! 74 cannot draw both at full length. [`tab_list`] resolves that in the list's
+//! favour: it is handed the columns left once the mark is paid for and yields
+//! rungs until it fits, so the mark holds the right edge at every width (#5072).
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -44,6 +49,8 @@ use stella_tui_theme::{glyph, token};
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::deck_ui::DeckUi;
 use crate::plan::{Plan, PlanState};
+
+mod tab_list;
 
 /// The accent prompt prefix on every composer row. Chrome, never content — it
 /// is never part of the submitted string and the caret cannot enter it.
@@ -97,13 +104,6 @@ pub fn render_chrome_row(
 
 /// Draw the tab row into the top row of `area`.
 pub fn render_tab_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer) {
-    let left = match ui.tab {
-        DeckTab::Session => {
-            breadcrumb_spans(model, ui).unwrap_or_else(|| tab_list_spans(DeckTab::Session))
-        }
-        tab => tab_list_spans(tab),
-    };
-
     let mut trailing: Vec<Span<'static>> = Vec::new();
     if ui.tab == DeckTab::Session && plan_of(model, ui).is_some_and(|p| !p.is_empty()) {
         // The chord comes from the keymap, never from a literal here: this
@@ -115,26 +115,36 @@ pub fn render_tab_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut
         ));
         trailing.push(Span::raw("   "));
     }
+
+    let budget = (area.width as usize).saturating_sub(right_edge_reserve(&trailing));
+    let left = match ui.tab {
+        DeckTab::Session => {
+            breadcrumb_spans(model, ui).unwrap_or_else(|| tab_list::spans(DeckTab::Session, budget))
+        }
+        tab => tab_list::spans(tab, budget),
+    };
     render_chrome_row(left, trailing, area, buf);
 }
 
-/// `SESSION AGENTS TRACES   GRAPH   FILES SKILLS MCP ISSUES SETTINGS` — the
-/// active tab in gold with a cell of air either side, the rest muted.
-fn tab_list_spans(active: DeckTab) -> Vec<Span<'static>> {
-    let muted = Style::new().fg(token::MUTED);
-    let lit = Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD);
-    let mut spans = vec![Span::raw(" ")];
-    for (i, tab) in DeckTab::ALL.iter().enumerate() {
-        if i > 0 {
-            spans.push(Span::raw(" "));
-        }
-        if *tab == active {
-            spans.push(Span::styled(format!("  {}  ", tab.title()), lit));
-        } else {
-            spans.push(Span::styled(tab.title(), muted));
-        }
-    }
-    spans
+/// The columns [`tab_list::spans`] may not spend: the wordmark, whatever rides
+/// inside it, the cell of air [`render_chrome_row`] adds after it, and one
+/// column of air before it.
+///
+/// That last column is what makes the reserve a guarantee rather than an
+/// estimate. [`render_chrome_row`] draws the mark only while the two sides are
+/// strictly narrower than the row, so a list sized to the exact remainder
+/// would meet the edge and lose the mark at the one width the ladder exists to
+/// survive. It is also the gap the row is drawn with everywhere else.
+///
+/// Derived from [`stella_tui_theme::wordmark::spans`] rather than written as a
+/// number, so the reserve follows the mark if the mark ever changes.
+fn right_edge_reserve(trailing: &[Span<'static>]) -> usize {
+    let mark: usize = stella_tui_theme::wordmark::spans()
+        .iter()
+        .map(Span::width)
+        .sum();
+    let trailing: usize = trailing.iter().map(Span::width).sum();
+    mark + trailing + 2
 }
 
 /// The SESSION tab's breadcrumb: `SESSION  ▸ plan · task 3 wire dedup digest

--- a/crates/stella-tui/src/views/frame/tab_list.rs
+++ b/crates/stella-tui/src/views/frame/tab_list.rs
@@ -167,6 +167,45 @@ mod tests {
         assert!(row.contains("9/9"), "{row}");
     }
 
+    /// [`Rung::Solo`] is reachable from a real frame width, not only by
+    /// handing [`spans`] a budget by hand.
+    ///
+    /// The goldens stop at 56 columns, where [`Rung::Short`] still fits, so
+    /// without this the narrowest rung would be exercised only by a caller
+    /// that does not exist — and a rung nothing reaches is a rung that rots.
+    /// The budget comes from `right_edge_reserve`, the shipped arithmetic, so
+    /// this is the frame width a terminal would actually have to be.
+    #[test]
+    fn the_narrowest_rung_is_reachable_from_a_real_frame_width() {
+        let reserve = crate::views::frame::right_edge_reserve(&[]);
+        // One column under the *narrowest* `Short` rendering, so every tab is
+        // past its own threshold rather than only the widest-titled one.
+        let narrowest_short = DeckTab::ALL
+            .iter()
+            .map(|t| width(&rung_spans(*t, Rung::Short)))
+            .min()
+            .expect("nine tabs");
+        let frame = narrowest_short + reserve - 1;
+        assert!(
+            frame < 56,
+            "Solo sits at {frame} columns, which the 56-column golden would already cover"
+        );
+
+        for tab in DeckTab::ALL {
+            let row: String = spans(tab, frame - reserve)
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect();
+            assert_eq!(
+                spans(tab, frame - reserve),
+                rung_spans(tab, Rung::Solo),
+                "{tab:?} is not on the last rung at {frame} columns: {row}"
+            );
+            assert!(row.contains(tab.title()), "{row}");
+            assert!(row.contains(&format!("/{}", DeckTab::ALL.len())), "{row}");
+        }
+    }
+
     /// The abbreviated rung still names all nine tabs, and the active one in
     /// full: the rung exists to keep the list readable, not to shorten it.
     #[test]

--- a/crates/stella-tui/src/views/frame/tab_list.rs
+++ b/crates/stella-tui/src/views/frame/tab_list.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The tab row's width ladder: what the nine-tab list gives up, and in what
+//! order, as the frame narrows (#5072).
+//!
+//! The list at full length costs 65 columns and the wordmark eight more, so
+//! under 74 something has to go. The rule is that **the list yields and the
+//! mark never does**: [`spans`] is handed the columns left once the mark is
+//! paid for and returns the widest rendering that fits inside them, so
+//! [`super::render_chrome_row`]'s own drop rule — which other frames still
+//! need — is never reached from this row.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+use stella_tui_theme::token;
+
+use crate::deck::DeckTab;
+
+/// One rendering of the tab list, in the order [`spans`] tries them.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Rung {
+    /// Every title in full: 65 columns.
+    Full,
+    /// Inactive titles to their three-letter form, the active tab in full, so
+    /// the one name a reader needs right now is never the abbreviated one: 45
+    /// columns at the widest active tab.
+    Short,
+    /// The active tab alone, with its place in the list: 17 columns at the
+    /// widest. `4/9` stays because it is the fact a reader loses when the
+    /// other eight names go — this row is the only place the deck says how
+    /// many tabs there are, and `tab`/`⇧tab` walk them drawn or not.
+    Solo,
+}
+
+/// The rungs, widest first. [`spans`] takes the first one that fits.
+const RUNGS: [Rung; 3] = [Rung::Full, Rung::Short, Rung::Solo];
+
+/// The tab list rendered into `budget` columns: the widest rung that fits, or
+/// [`Rung::Solo`] when nothing does.
+///
+/// `budget` is what [`super::right_edge_reserve`] leaves — never the whole
+/// row, which is what makes the mark survive every width.
+pub(super) fn spans(active: DeckTab, budget: usize) -> Vec<Span<'static>> {
+    RUNGS
+        .iter()
+        .map(|rung| rung_spans(active, *rung))
+        .find(|spans| width(spans) <= budget)
+        .unwrap_or_else(|| rung_spans(active, Rung::Solo))
+}
+
+/// The columns a rendering occupies.
+fn width(spans: &[Span<'static>]) -> usize {
+    spans.iter().map(Span::width).sum()
+}
+
+/// The active tab in gold with a cell of air either side, the rest muted.
+fn rung_spans(active: DeckTab, rung: Rung) -> Vec<Span<'static>> {
+    let muted = Style::new().fg(token::MUTED);
+    let dim = Style::new().fg(token::DIM);
+    let lit = Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD);
+    let mut spans = vec![Span::raw(" ")];
+    if rung == Rung::Solo {
+        spans.push(Span::styled(format!("  {}  ", active.title()), lit));
+        spans.push(Span::styled(
+            format!("{}/{}", active.index() + 1, DeckTab::ALL.len()),
+            dim,
+        ));
+        return spans;
+    }
+    for (i, tab) in DeckTab::ALL.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw(" "));
+        }
+        if *tab == active {
+            spans.push(Span::styled(format!("  {}  ", tab.title()), lit));
+        } else if rung == Rung::Short {
+            spans.push(Span::styled(short_title(*tab).to_string(), muted));
+        } else {
+            spans.push(Span::styled(tab.title(), muted));
+        }
+    }
+    spans
+}
+
+/// A tab's three-letter form: the first three letters of [`DeckTab::title`].
+///
+/// Computed rather than tabled. Nine tabs give nine distinct prefixes (`SES`
+/// `AGE` `TRA` `GRA` `FIL` `SKI` `MCP` `ISS` `SET`), which a reader works out
+/// once, and a table here would be a second list of tab names to keep in step
+/// with the first. `three_letter_forms_stay_distinct` holds the computed form
+/// to the property [`Rung::Short`] needs.
+///
+/// Every title is ASCII and at least three letters, so the slice lands on a
+/// character boundary; `get` rather than an index anyway, because a title
+/// short enough to make that untrue should render whole, not panic.
+fn short_title(tab: DeckTab) -> &'static str {
+    let title = tab.title();
+    title.get(..3).unwrap_or(title)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(active: DeckTab, budget: usize) -> String {
+        spans(active, budget)
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
+    /// The property [`Rung::Short`] rests on: nine tabs, nine distinct
+    /// three-letter forms, so an abbreviated row still names nine things.
+    #[test]
+    fn three_letter_forms_stay_distinct() {
+        let mut forms: Vec<&str> = DeckTab::ALL.iter().map(|t| short_title(*t)).collect();
+        let all = forms.clone();
+        forms.sort_unstable();
+        forms.dedup();
+        assert_eq!(forms.len(), DeckTab::ALL.len(), "collision in {all:?}");
+        for tab in DeckTab::ALL {
+            assert!(
+                tab.title().starts_with(short_title(tab)),
+                "{} is not a prefix of {}",
+                short_title(tab),
+                tab.title()
+            );
+        }
+    }
+
+    /// Every rung fits the width its doc comment claims, at every active tab —
+    /// arithmetic nobody would otherwise re-do after adding a tab.
+    #[test]
+    fn each_rung_fits_the_width_it_claims() {
+        for tab in DeckTab::ALL {
+            assert!(width(&rung_spans(tab, Rung::Full)) <= 65);
+            assert!(width(&rung_spans(tab, Rung::Short)) <= 45);
+            assert!(width(&rung_spans(tab, Rung::Solo)) <= 17);
+        }
+    }
+
+    /// The ladder descends a rung at a time, and never returns a row wider
+    /// than the columns it was given while a narrower rung exists.
+    #[test]
+    fn the_ladder_takes_the_widest_rung_that_fits() {
+        for tab in DeckTab::ALL {
+            assert_eq!(spans(tab, 65), rung_spans(tab, Rung::Full));
+            assert_eq!(spans(tab, 64), rung_spans(tab, Rung::Short));
+            assert_eq!(spans(tab, 45), rung_spans(tab, Rung::Short));
+            assert_eq!(spans(tab, 17), rung_spans(tab, Rung::Solo));
+            for budget in [17, 45, 64, 65, 200] {
+                assert!(
+                    width(&spans(tab, budget)) <= budget,
+                    "{tab:?} overflows {budget}"
+                );
+            }
+        }
+    }
+
+    /// Below the last rung the row is still the active tab and its place —
+    /// clipped by the terminal, never by a rung that gave up naming anything.
+    #[test]
+    fn a_frame_under_the_last_rung_still_names_where_it_is() {
+        let row = text(DeckTab::Settings, 4);
+        assert!(row.contains("SETTINGS"), "{row}");
+        assert!(row.contains("9/9"), "{row}");
+    }
+
+    /// The abbreviated rung still names all nine tabs, and the active one in
+    /// full: the rung exists to keep the list readable, not to shorten it.
+    #[test]
+    fn the_short_rung_names_every_tab_and_spells_the_active_one() {
+        let row = text(DeckTab::Graph, 50);
+        assert!(row.contains("  GRAPH  "), "{row}");
+        for tab in DeckTab::ALL.iter().filter(|t| **t != DeckTab::Graph) {
+            assert!(row.contains(short_title(*tab)), "{} in {row}", tab.title());
+        }
+        assert!(!row.contains("SETTINGS"), "still abbreviated: {row}");
+    }
+}

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -102,6 +102,11 @@ mod start_work;
 #[path = "deck_render_snapshots/mcp.rs"]
 mod mcp;
 
+/// The tab row's width ladder (#5072). See [`graph`]'s doc for why this is
+/// `#[path]` rather than a plain `mod`.
+#[path = "deck_render_snapshots/tab_row.rs"]
+mod tab_row;
+
 /// The command used to regenerate every golden in this file. Quoted verbatim in
 /// each snapshot header and in every failure message, so nobody has to go
 /// looking for it.

--- a/crates/stella-tui/tests/deck_render_snapshots/tab_row.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots/tab_row.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The tab row as the frame narrows (#5072).
+//!
+//! A submodule of `deck_render_snapshots` rather than more lines in it: the
+//! parent is the file that reaches the 1500-line ceiling first, so a new
+//! golden goes here. Every helper comes from the parent, and the goldens are
+//! blessed by the same command:
+//! `BLESS=1 cargo test -p stella-tui --test deck_render_snapshots`.
+//!
+//! Four widths, because the row is a ladder and a golden at one width pins one
+//! rung. 120 and 100 are the widths #5072 was filed about; 72 is the first
+//! width at which the full list and the wordmark cannot both be drawn; 56 is
+//! where the full list cannot be drawn at all.
+
+use super::*;
+
+/// The frame height these goldens render at. Short on purpose: the subject is
+/// row 0, and a 40-row frame at four widths is 160 lines of committed body to
+/// review for a change that can only move one of them. The bands below still
+/// render, so a narrow-frame break in the composer or the status bar shows up
+/// here too.
+const LADDER_H: u16 = 12;
+
+/// The widths, and what the tab row is expected to look like at each.
+///
+/// `SETTINGS` is the needle throughout because it is the last tab in
+/// `DeckTab::ALL` and therefore the first casualty of a row drawn at full
+/// length into a frame that cannot hold it — which is exactly what it was
+/// before the ladder: at 72 columns the list fit and the *wordmark* was
+/// dropped, and at 56 the list itself ran off the edge as `…ISSUES SE`.
+const LADDER: [(u16, &str, &str); 4] = [
+    (120, "tab_row_120", "SETTINGS"),
+    (100, "tab_row_100", "SETTINGS"),
+    (72, "tab_row_72", "SET"),
+    (56, "tab_row_56", "SET"),
+];
+
+/// The whole frame at each rung of the ladder.
+#[test]
+fn deck_render_snapshots_cover_the_tab_row_width_ladder() {
+    let model = fixture_model();
+    for (w, name, _) in LADDER {
+        let mut ui = ui_for(DeckTab::Files);
+        let frame = render_frame(&model, &mut ui, w, LADDER_H);
+        assert_golden(
+            name,
+            &format!("the tab row's width ladder at {w} columns (#5072)"),
+            w,
+            LADDER_H,
+            &frame,
+        );
+    }
+}
+
+/// The witness for #5072: at every width on the ladder the row names all nine
+/// tabs and the wordmark holds the right edge.
+///
+/// Before the ladder both failed, at different widths and in different ways.
+/// At 72 columns `views::frame::render_chrome_row` found no room for the list
+/// and the mark together and dropped the mark, per its own rule — correct for
+/// a frame that cannot shorten its left side, wrong for the tab row, which
+/// can. At 56 the list was drawn at full length into a frame nine columns too
+/// narrow, so `SETTINGS` was clipped mid-word by the terminal.
+///
+/// A named assertion beside the goldens for the reason
+/// `the_help_overlay_carries_the_metrics_spec_5_sends_behind_it` gives: a
+/// golden pins the whole frame, so a row that stops rendering moves it and the
+/// reviewer's job becomes noticing an absence inside a hundred-line diff.
+#[test]
+fn every_tab_survives_the_width_ladder_and_so_does_the_wordmark() {
+    let model = fixture_model();
+    for (w, _, settings) in LADDER {
+        let mut ui = ui_for(DeckTab::Files);
+        let frame = render_frame(&model, &mut ui, w, LADDER_H);
+        let row = frame.lines().next().unwrap_or_default().to_string();
+
+        assert!(
+            row.contains(settings),
+            "at {w} columns SETTINGS is not named as {settings:?}: {row}"
+        );
+        // Uncut, not merely present: a clipped `SETTINGS` still contains
+        // `SET`, so the row has to end with the mark rather than with the
+        // ragged tail of a name.
+        assert!(
+            row.trim_end().ends_with("stella*"),
+            "at {w} columns the wordmark was dropped: {row}"
+        );
+        // …and every other tab is identifiable too — in full above the
+        // abbreviating rung, by its three-letter form below it.
+        for tab in DeckTab::ALL {
+            let needle = if settings.len() == 3 {
+                &tab.title()[..3]
+            } else {
+                tab.title()
+            };
+            assert!(
+                row.contains(needle),
+                "at {w} columns {} is not named as {needle:?}: {row}",
+                tab.title()
+            );
+        }
+    }
+}

--- a/crates/stella-tui/tests/deck_snapshot.rs
+++ b/crates/stella-tui/tests/deck_snapshot.rs
@@ -79,10 +79,21 @@ fn deck_renders_every_tab_with_real_content() {
             text.contains(needle),
             "the {tab:?} tab should show {needle:?}, got:\n{text}"
         );
-        // The comfy-tabs bar labels are always present — UPPERCASE by the
-        // deck's tab-label convention. (Assert on a left-anchored label: at
-        // 120 cols the 9-tab bar overflows, so the rightmost SETTINGS clips.)
+        // The tab-bar labels are always present — UPPERCASE by the deck's
+        // tab-label convention.
+        //
+        // The parenthetical here used to claim the bar overflowed at 120
+        // columns and clipped SETTINGS, which is why #5072 was filed against
+        // a width that renders the list whole. It was true of v1's padded
+        // comfy-tabs bar and was left behind when #4822 replaced that widget
+        // with the 65-column list; the widths where the row actually gives
+        // something up are golden-tested in `deck_render_snapshots/tab_row.rs`.
         assert!(text.contains("SESSION"), "tab bar should render on {tab:?}");
+        // SESSION is excluded because this model has a plan, so its row is the
+        // breadcrumb and names no other tab (#5049).
+        if tab != DeckTab::Session {
+            assert!(text.contains("SETTINGS"), "the last tab draws on {tab:?}");
+        }
     }
 
     // The redesigned chrome, on the same scripted session (D1/D2/D5): the

--- a/crates/stella-tui/tests/snapshots/deck/tab_row_100.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_row_100.txt
@@ -1,0 +1,17 @@
+# deck golden · tab_row_100
+# the tab row's width ladder at 100 columns (#5072)
+# viewport 100×12 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SESSION AGENTS TRACES GRAPH   FILES   SKILLS MCP ISSUES SETTINGS                           stella*
+ ▤ 2 files · +7 -1 · 0 reads
+  File                                                 Agent         Op +       -         reads    ×
+  apps/app/automations/page.tsx                        lead          U  +4      -1            0   ×1
+▸ apps/api/routes/v1/automations.ts                    sub:auth      C  +3      -0            0   ×1
+
+
+ ↵ diff · ↑↓ pick
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
+>>>
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                   ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_row_120.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_row_120.txt
@@ -1,0 +1,17 @@
+# deck golden · tab_row_120
+# the tab row's width ladder at 120 columns (#5072)
+# viewport 120×12 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SESSION AGENTS TRACES GRAPH   FILES   SKILLS MCP ISSUES SETTINGS                                               stella*
+ ▤ 2 files · +7 -1 · 0 reads
+  File                                                                     Agent         Op +       -         reads    ×
+  apps/app/automations/page.tsx                                            lead          U  +4      -1            0   ×1
+▸ apps/api/routes/v1/automations.ts                                        sub:auth      C  +3      -0            0   ×1
+
+
+ ↵ diff · ↑↓ pick
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
+>>>
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                       ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_row_56.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_row_56.txt
@@ -1,0 +1,17 @@
+# deck golden · tab_row_56
+# the tab row's width ladder at 56 columns (#5072)
+# viewport 56×12 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SES AGE TRA GRA   FILES   SKI MCP ISS SET      stella*
+ ▤ 2 files · +7 -1 · 0 reads
+  File      Agent         Op +       -         reads
+  …/page.tsxlead          U  +4      -1            0   ×
+▸ …ations.tssub:auth      C  +3      -0            0   ×
+
+
+ ↵ diff · ↑↓ pick
+ ▶ sub:ci  running · quiet 0:00 · starting: no model cal
+>>>
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4%   ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_row_72.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_row_72.txt
@@ -1,0 +1,17 @@
+# deck golden · tab_row_72
+# the tab row's width ladder at 72 columns (#5072)
+# viewport 72×12 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SES AGE TRA GRA   FILES   SKI MCP ISS SET                      stella*
+ ▤ 2 files · +7 -1 · 0 reads
+  File                     Agent         Op +       -         reads    ×
+  …app/automations/page.tsxlead          U  +4      -1            0   ×1
+▸ …routes/v1/automations.tssub:auth      C  +3      -0            0   ×1
+
+
+ ↵ diff · ↑↓ pick
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
+>>>
+ ⏎ queue · ↓ 2 sub-agents · ! shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05           ? help


### PR DESCRIPTION
## What this changes

SPEC 3.3 puts `stella*` in the upper right corner of the tab bar **on every screen**. Under 74 columns it was not there. The nine tab titles cost 65 columns and the mark eight more, and `render_chrome_row`'s drop rule — correct for a frame whose left side cannot shorten, which is why the AGENTS page and the fleet dashboard still need it — dropped the mark rather than the tabs. Below 65 columns the list was drawn at full length into a frame too narrow for it, so `SETTINGS` was clipped mid-word by the terminal with nothing on the row to say it had been.

`crates/stella-tui/src/views/frame/tab_list.rs` is the width-degradation rule the issue asks for. It is handed the columns left once the mark is paid for and returns the widest rung that fits:

| Rung | Cost | What it gives up |
|---|---|---|
| `Full` | 65 | nothing |
| `Short` | ≤45 | inactive titles to their three-letter form; the active tab is still spelled out, so the one name a reader needs now is never the abbreviated one |
| `Solo` | ≤17 | the other eight names, replaced by `4/9` — the fact a reader loses when they go, and this row is the only place the deck says how many tabs there are |

The tab row therefore never reaches `render_chrome_row`'s drop rule at all. `right_edge_reserve` derives the reserve from `wordmark::spans()` rather than writing `8`, so it follows the mark if the mark changes, and holds back one further column: `render_chrome_row` draws the mark only while both sides are *strictly* narrower than the row, so a list sized to the exact remainder would meet the edge and lose the mark at the one width the ladder exists to survive.

## The issue's premise is false, and the PR corrects the source of it

**#5072 was filed against 120 columns. At 120 — and at 100 — the list already renders whole with `SETTINGS` uncut and the wordmark on the right.** Verified before building anything, and re-verified as the witness below: at those two widths the ladder tests pass on `main`.

The issue's evidence was this comment in `crates/stella-tui/tests/deck_snapshot.rs`:

> (Assert on a left-anchored label: at 120 cols the 9-tab bar overflows, so the rightmost SETTINGS clips.)

That was true of v1's *padded* comfy-tabs bar — the comment predates the crate move (#1385) and names the widget by its v1 name. #4822 replaced that widget with today's 65-column list and left the comment behind, so it has been describing a deleted bar for two generations. This PR corrects it, says why, and adds the assertion it was excusing (`SETTINGS` does draw at 120), scoped past SESSION because that fixture has a plan and its row is the breadcrumb (#5049).

**The real defect is the issue's second sentence** — "`render_tab_row` drops the wordmark rather than the tabs when tight — so narrow terminals lose the brand mark silently" — which is a genuine SPEC 3.3 violation, and that is what is fixed. The "Done means" bar is met at 120 and 100 (they were already met) and extended to 72 and 56, where the row genuinely had to give something up.

## Witness table

Verified by hand: `git show origin/main:…/frame.rs > …/frame.rs`, run, restore.

| Test | On `main` | With this change |
|---|---|---|
| `tab_row::every_tab_survives_the_width_ladder_and_so_does_the_wordmark` | **FAILS** — `at 72 columns the wordmark was dropped:  SESSION AGENTS TRACES GRAPH   FILES   SKILLS MCP ISSUES SETTINGS` | passes |
| `tab_row::deck_render_snapshots_cover_the_tab_row_width_ladder` | **FAILS** — `tab_row_72` golden: `SES AGE TRA GRA   FILES   SKI MCP ISS SET …stella*` vs actual `SESSION AGENTS … SETTINGS` with no mark | passes |

Both tests iterate 120 → 100 → 72 → 56 and the first failure on `main` is at **72**, which is the evidence that 120 and 100 were never broken.

Unit tests in `tab_list.rs` cover the ladder itself — that each rung fits the width its doc claims at every active tab, that the ladder takes the widest rung that fits, that the nine three-letter forms stay distinct (the property `Short` rests on), and that below the last rung the row still names where it is. Those are contract tests, not witnesses, and are named as such here rather than counted as evidence for the bug.

## Goldens

Four new frames under `tests/snapshots/deck/`, at 120, 100, 72 and 56 columns, rendered at 12 rows on purpose — the subject is row 0, and 40 rows at four widths is 160 lines of committed body to review for a change that can only move one of them.

They were **read, not blessed**: 120 and 100 show the full list plus the mark; 72 and 56 show `SES AGE TRA GRA   FILES   SKI MCP ISS SET` with `FILES` spelled out in gold and `stella*` holding the right edge. They regenerate byte-for-byte identical.

The test module is a `#[path]` submodule because `deck_render_snapshots.rs` is at 1479/1500 and is the file that reaches the ceiling first.

## Salvage

Built on `wip/5072-tab-row-salvage` (an earlier session's work lost to a shared-worktree collision). **Kept**: `tab_list.rs`, the snapshot module, and all four goldens — the design is right and the goldens show the intended layout. **Rejected**: the module's claim that `budget` is the width less the mark and the air after it, which is one column short of a guarantee for the reason above.

## Checks

`cargo test -p stella-tui` (14 suites green), `cargo clippy -p stella-tui --all-targets -D warnings`, `make guards-fast`, `make prose`, `./scripts/check-file-size.sh`. Nothing ran the workspace build on the maintainer's laptop; CI is the evidence.

## Also worth knowing

The issue's fold-in is not needed: `PROMPT_PREFIX`/`PROMPT_PREFIX_W` were already deduplicated by #5051 and `deck_render.rs` imports them from `views::frame`. That is #5050's fold-in, noted there too.

Closes #5072

## Summary by Sourcery

Make the tab row yield space to keep the wordmark visible and tab navigation readable as the terminal narrows.

Bug Fixes:
- Preserve the Stella wordmark while the tab row adapts to narrower terminal widths.
- Prevent narrow tab rows from overflowing or clipping the active and final tab labels.

Enhancements:
- Add a width-based tab rendering ladder that progressively abbreviates inactive tabs and falls back to an active-tab position indicator.
- Derive the tab row's wordmark reserve dynamically and update stale width-related assertions.

Tests:
- Add unit coverage for tab-list width thresholds, abbreviated-label uniqueness, and narrow-frame behavior.
- Add snapshot coverage and explicit witnesses for the tab row at 120, 100, 72, and 56 columns.