### PR TITLE
feat(stella-tui): the pipeline line above the composer

### DIFF
--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -105,7 +105,7 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     let bands = Layout::vertical([
         Constraint::Length(1),          // tab row / breadcrumb
         Constraint::Min(1),             // active view
-        Constraint::Length(1),          // air above the prompt, or the pulse row
+        Constraint::Length(1),          // pipeline line, or the pulse row, or air
         Constraint::Length(composer_h), // composer
         Constraint::Length(1),          // keybinding hint row
         Constraint::Length(statline_h), // status bar (+ diagnosis)
@@ -136,11 +136,26 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         DeckTab::Settings => crate::views::settings::render(model, ui, content, b),
     });
 
-    // The pulse row (`views::pulse`) draws in the air row off the SESSION tab,
-    // and at an opened lane: the live agent's status, quiet time, place and
-    // last words, so no tab is blind to the turn.
-    guarded_band(buf, bands[2], "pulse", |b| {
-        crate::views::pulse::render_row(model, ui, bands[2], b)
+    // The row above the composer carries two facts that are never both
+    // available, so they share it rather than costing a row each (#5050).
+    //
+    // `views::pulse` draws off the SESSION tab and at an opened lane: the live
+    // agent's status, quiet time, place and last words, so no tab is blind to
+    // the turn. It returns `None` on SESSION at the lead, where the transcript
+    // is already the pulse — and that is exactly the state SPEC 5 draws its
+    // prompt block in, so `views::pipeline` takes the row there and nowhere
+    // else. Neither displaced the other and pulse's information did not move.
+    //
+    // The precedence is written out rather than left to the two `None`s to
+    // arrange between them: they are disjoint today, and a band that painted
+    // twice because one of them widened would be a bug nothing here could
+    // see. `the_two_row_claimants_are_disjoint` holds the disjointness itself.
+    guarded_band(buf, bands[2], "pulse or pipeline", |b| {
+        if crate::views::pipeline::pipeline(model, ui).is_some() {
+            crate::views::pipeline::render_row(model, ui, bands[2], b);
+        } else {
+            crate::views::pulse::render_row(model, ui, bands[2], b);
+        }
     });
     guarded_band(buf, bands[3], "composer", |b| {
         render_composer(&c_layout, bands[3], b)

--- a/crates/stella-tui/src/deck_render/tests.rs
+++ b/crates/stella-tui/src/deck_render/tests.rs
@@ -767,3 +767,96 @@ fn a_panicking_deck_view_renders_an_error_card_and_the_session_survives() {
         "the frame after a caught panic matches one that never saw it"
     );
 }
+
+/// SPEC 5's prompt block opens with the pipeline line, and it draws in the row
+/// immediately above the composer (#5050).
+///
+/// Positional rather than a `contains` over the frame: the word `execute` is
+/// already on the status bar and on the turn's opening rule, so a frame-wide
+/// search would pass on a stepper that rendered nowhere near the composer, or
+/// on no stepper at all.
+#[test]
+fn a_turn_mid_execute_draws_the_pipeline_line_above_the_composer() {
+    let model = running_model_with_queue();
+    let mut ui = DeckUi::default();
+    ui.splash.skip();
+    let mut term = Terminal::new(TestBackend::new(120, 24)).unwrap();
+    term.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
+    let text = buffer_text(term.backend().buffer());
+    let rows: Vec<&str> = text.lines().collect();
+    let composer = rows
+        .iter()
+        .position(|r| r.starts_with(">>>"))
+        .expect("the composer draws");
+    let pipeline = rows[composer - 1];
+    assert!(
+        pipeline.contains("✓ plan") && pipeline.contains("▸ execute"),
+        "the row above the composer is SPEC 5's pipeline line: {pipeline:?}\n{text}"
+    );
+    assert!(
+        pipeline.contains("50%") && pipeline.contains("· verify"),
+        "…with the meter and the phase ahead: {pipeline:?}"
+    );
+}
+
+/// A run that announces no stage draws no stepper — the row stays air.
+///
+/// A plain `stella run` is the raw step-loop and emits no stage boundaries
+/// (AGENTS.md's opening), so a stepper that always drew would be describing a
+/// pipeline this binary cannot run. The same refusal the status bar's stage
+/// cell makes when it renders `—` rather than the word `idle`.
+#[test]
+fn a_run_that_announces_no_stage_draws_no_stepper() {
+    let mut model = WorkspaceModel::new();
+    model.now_ms = 1_000;
+    model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+    let mut ui = DeckUi::default();
+    ui.splash.skip();
+    let mut term = Terminal::new(TestBackend::new(120, 24)).unwrap();
+    term.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
+    let text = buffer_text(term.backend().buffer());
+    let rows: Vec<&str> = text.lines().collect();
+    let composer = rows
+        .iter()
+        .position(|r| r.starts_with(">>>"))
+        .expect("the composer draws");
+    assert!(
+        rows[composer - 1].trim().is_empty(),
+        "no stage announced, so the row stays air: {:?}",
+        rows[composer - 1]
+    );
+}
+
+/// The pipeline line and the pulse row share one band and never both claim it
+/// (#5050), across every tab and every focus the two decisions read.
+///
+/// The band is drawn once, by whichever of them answers; this is the property
+/// that makes that single draw correct rather than lucky.
+#[test]
+fn the_two_row_claimants_are_disjoint() {
+    let mut model = running_model_with_queue();
+    model.apply_inbound(&Inbound::Register(
+        AgentMeta::new("sub:1", "task 1", 0)
+            .with_role("subagent")
+            .with_parent("lead"),
+    ));
+    model.apply_inbound(&Inbound::Status {
+        agent: "sub:1".into(),
+        status: crate::AgentStatus::Running,
+    });
+    for tab in DeckTab::ALL {
+        for focused in 0..model.agents.len() {
+            let mut ui = DeckUi {
+                tab,
+                ..Default::default()
+            };
+            ui.focus_agent(focused);
+            let pipeline = crate::views::pipeline::pipeline(&model, &ui).is_some();
+            let pulse = crate::views::pulse::pulse(&model, &ui).is_some();
+            assert!(
+                !(pipeline && pulse),
+                "{tab:?} focused on {focused} has both claiming the row"
+            );
+        }
+    }
+}

--- a/crates/stella-tui/src/model/turn.rs
+++ b/crates/stella-tui/src/model/turn.rs
@@ -385,8 +385,8 @@ pub struct Hud {
     /// and one field cannot answer both once the vocabulary is open. `stage` is
     /// "what is happening right now", which is what the statline says out loud.
     /// This is "how far through its own shape the turn has got", which is what
-    /// the three-segment progress bar draws — and the bar has only the host's
-    /// three phases to draw with.
+    /// [`crate::views::pipeline`]'s three-segment bar draws — and the bar has
+    /// only the host's three phases to draw with.
     ///
     /// Keeping it is what stops a contributed stage reading as a regression: a
     /// plugin stage arriving after `execute` leaves this at `Execute`, so the

--- a/crates/stella-tui/src/views.rs
+++ b/crates/stella-tui/src/views.rs
@@ -30,6 +30,7 @@ pub mod issues_tab;
 pub mod mcp_tab;
 pub mod models_card;
 pub mod picker;
+pub mod pipeline;
 pub mod plan_card;
 pub mod pulse;
 pub mod question;

--- a/crates/stella-tui/src/views/pipeline.rs
+++ b/crates/stella-tui/src/views/pipeline.rs
@@ -130,10 +130,10 @@ impl Phase {
 /// What the row says, or `None` when the turn has announced no host stage and
 /// the row stays air.
 ///
-/// Reads [`crate::model::turn::Hud::host_stage`] rather than `Hud::stage` for
-/// the reason that field exists: a contributed stage leaves it alone, so a
-/// plugin boundary arriving mid-execute cannot make the meter snap back to
-/// `plan` and claim the turn regressed.
+/// Reads `Hud::host_stage` rather than `Hud::stage` for the reason that field
+/// exists: a contributed stage leaves it alone, so a plugin boundary arriving
+/// mid-execute cannot make the meter snap back to `plan` and claim the turn
+/// regressed.
 pub fn pipeline(model: &WorkspaceModel, ui: &DeckUi) -> Option<Phase> {
     if ui.tab != crate::deck::DeckTab::Session {
         return None;

--- a/crates/stella-tui/src/views/pipeline.rs
+++ b/crates/stella-tui/src/views/pipeline.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! SPEC 5's pipeline line — the first row of the prompt block (#5050).
+//!
+//! ```text
+//! ✓ plan ▸ execute ██████░░░░░░ 50% · verify
+//! ```
+//!
+//! Where the turn has got to, in the host's own three phases: the ones it has
+//! passed marked `✓`, the one it is in lit gold behind the meter, the ones
+//! ahead dim. The stage word is on the status bar and on each turn's opening
+//! rule; neither says how far through a turn that stage is, which is the one
+//! fact this row adds.
+//!
+//! ## Three phases, and where they come from
+//!
+//! [`StageKind::ALL`] is the twelve boundaries this host emits, in turn order,
+//! and its doc names itself the list a renderer takes a reading order from.
+//! Twelve is too many to draw and most of them never announce themselves on a
+//! given run, so [`Phase`] groups them into three contiguous runs of that same
+//! list — deciding, doing, proving. Contiguous is the property that matters:
+//! the phase is monotonic in `ALL`'s order, so the meter can only ever move
+//! forwards, and `the_phase_never_goes_backwards_along_the_host_order` holds
+//! it there.
+//!
+//! The meter reads `50%` in `execute` because a turn in the middle phase of
+//! three is halfway through the host's shape — position, not a prediction of
+//! work remaining, which nothing here can know.
+//!
+//! ## Why it can be blank, and why that is the point
+//!
+//! The row draws only once the turn has announced a host stage. A plain
+//! `stella run` is the raw step-loop and emits no stage boundaries at all
+//! (AGENTS.md's opening), and the staged pipeline that used to emit them is
+//! deleted from this workspace (#3865) — so on most runs there is no pipeline
+//! to draw and this row stays air.
+//!
+//! That is the same refusal [`crate::views::status_source`]'s stage cell
+//! already makes when it renders `—` rather than the word `idle`: a stepper
+//! that drew `plan ▸ execute ▸ verify` over a run emitting none of them would
+//! be describing a pipeline the binary cannot run. The phases ahead are drawn
+//! dim rather than absent because a turn may settle before it reaches them —
+//! the row says where the turn has got, never where it will get to.
+//!
+//! ## Which row
+//!
+//! [`crate::views::pulse`] and this share the band above the composer, and
+//! they never contend for it: pulse holds the row off SESSION and at an
+//! opened lane, and returns `None` on SESSION at the lead — the state SPEC 5's
+//! prompt block is drawn in — where this row draws instead. Nothing moved and
+//! nothing is displaced; the pipeline line took air that was already there.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget};
+use stella_protocol::StageKind;
+use stella_tui_theme::{glyph, token};
+
+use crate::deck::WorkspaceModel;
+use crate::deck_ui::DeckUi;
+
+/// The width of the pipeline row's meter, in cells.
+///
+/// Narrower than the status bar's twelve: this meter divides three phases, so
+/// its whole range is three readings and a wider bar would spend columns
+/// implying a precision the phases do not carry.
+const METER_CELLS: usize = 8;
+
+/// One of the host's three turn phases — a contiguous run of [`StageKind::ALL`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum Phase {
+    /// Deciding what to do: triage, context recall, research, plan, scope review.
+    Plan,
+    /// Doing it: the witness that will prove it, then the work itself.
+    Execute,
+    /// Proving and recording it: verify, verdict, reflect, context write, complete.
+    Verify,
+}
+
+impl Phase {
+    /// The three, in turn order.
+    pub const ALL: [Phase; 3] = [Phase::Plan, Phase::Execute, Phase::Verify];
+
+    /// The word the row prints, which is SPEC 5's own.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Phase::Plan => "plan",
+            Phase::Execute => "execute",
+            Phase::Verify => "verify",
+        }
+    }
+
+    /// The phase a host boundary belongs to.
+    ///
+    /// Exhaustive over [`StageKind`] on purpose: a thirteenth boundary must
+    /// not compile until somebody decides which phase it is in, because the
+    /// alternative is a stage that silently reads as `plan` and makes the
+    /// meter claim the turn went backwards.
+    pub const fn of(kind: StageKind) -> Phase {
+        match kind {
+            StageKind::Triage
+            | StageKind::ContextRecall
+            | StageKind::Research
+            | StageKind::Plan
+            | StageKind::ScopeReview => Phase::Plan,
+            StageKind::Witness | StageKind::Execute => Phase::Execute,
+            StageKind::Verify
+            | StageKind::Verdict
+            | StageKind::Reflect
+            | StageKind::ContextWrite
+            | StageKind::Complete => Phase::Verify,
+        }
+    }
+
+    /// How far through the host's shape a turn in this phase is: `0.0` in the
+    /// first, `1.0` in the last.
+    ///
+    /// Position among the phases, which is why `execute` reads the `50%` SPEC
+    /// 5 writes. Work remaining is not knowable — a turn can settle in any
+    /// phase — so the meter does not pretend to measure it.
+    fn ratio(self) -> f64 {
+        let last = Phase::ALL.len() - 1;
+        Phase::ALL.iter().position(|p| *p == self).unwrap_or(0) as f64 / last as f64
+    }
+}
+
+/// What the row says, or `None` when the turn has announced no host stage and
+/// the row stays air.
+///
+/// Reads [`crate::model::turn::Hud::host_stage`] rather than `Hud::stage` for
+/// the reason that field exists: a contributed stage leaves it alone, so a
+/// plugin boundary arriving mid-execute cannot make the meter snap back to
+/// `plan` and claim the turn regressed.
+pub fn pipeline(model: &WorkspaceModel, ui: &DeckUi) -> Option<Phase> {
+    if ui.tab != crate::deck::DeckTab::Session {
+        return None;
+    }
+    let entry = model.agents.get(ui.focused)?;
+    // At an opened lane the row belongs to pulse, which carries the lead there
+    // so walking into a lane never costs sight of the conversation.
+    if entry.is_subagent() {
+        return None;
+    }
+    entry.model.hud.host_stage.map(Phase::of)
+}
+
+/// Draw the row into the top row of `area`. Draws nothing when the row should
+/// stay air.
+pub fn render_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let Some(current) = pipeline(model, ui) else {
+        return;
+    };
+    Paragraph::new(Line::from(spans(current))).render(Rect { height: 1, ..area }, buf);
+}
+
+/// The row's spans for a turn in `current`.
+fn spans(current: Phase) -> Vec<Span<'static>> {
+    let done = Style::new().fg(token::MUTED);
+    let lit = Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD);
+    let ahead = Style::new().fg(token::DIM);
+    let mut spans = vec![Span::raw(" ")];
+    for phase in Phase::ALL {
+        match phase.cmp(&current) {
+            std::cmp::Ordering::Less => {
+                spans.push(Span::styled(format!("{} ", glyph::DONE), done));
+                spans.push(Span::styled(phase.label(), done));
+                spans.push(Span::raw(" "));
+            }
+            std::cmp::Ordering::Equal => {
+                spans.push(Span::styled(format!("{} ", glyph::COLLAPSED), lit));
+                spans.push(Span::styled(phase.label(), lit));
+                spans.push(Span::raw(" "));
+                spans.extend(super::status_bar::meter(phase.ratio(), METER_CELLS));
+                spans.push(Span::styled(
+                    format!(" {}%", (phase.ratio() * 100.0).round() as u32),
+                    done,
+                ));
+            }
+            std::cmp::Ordering::Greater => {
+                spans.push(Span::styled(" · ", ahead));
+                spans.push(Span::styled(phase.label(), ahead));
+            }
+        }
+    }
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(current: Phase) -> String {
+        spans(current)
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<String>()
+    }
+
+    /// SPEC 5's own line: a turn mid-execute has plan behind it, execute lit
+    /// with the meter at halfway, and verify ahead.
+    #[test]
+    fn a_turn_mid_execute_renders_the_line_spec_5_writes() {
+        let row = text(Phase::Execute);
+        assert!(row.starts_with(" ✓ plan ▸ execute "), "{row}");
+        assert!(row.contains("50%"), "{row}");
+        assert!(row.trim_end().ends_with("· verify"), "{row}");
+    }
+
+    /// Every host boundary lands in a phase, and the phase only ever moves
+    /// forwards along [`StageKind::ALL`] — the property that lets the meter be
+    /// a position rather than a guess, and the one a thirteenth stage in the
+    /// wrong group would break.
+    #[test]
+    fn the_phase_never_goes_backwards_along_the_host_order() {
+        let mut seen = Phase::Plan;
+        for kind in StageKind::ALL {
+            let phase = Phase::of(kind);
+            assert!(
+                phase >= seen,
+                "{kind:?} maps to {phase:?} after {seen:?}, so the meter would go backwards"
+            );
+            seen = phase;
+        }
+        assert_eq!(Phase::of(StageKind::ALL[0]), Phase::Plan);
+        assert_eq!(
+            Phase::of(StageKind::ALL[StageKind::ALL.len() - 1]),
+            Phase::Verify
+        );
+    }
+
+    /// The meter is a position among three phases, so it reads 0, 50 and 100
+    /// and nothing between.
+    #[test]
+    fn the_meter_reads_the_phases_position() {
+        for (phase, pct) in [
+            (Phase::Plan, "0%"),
+            (Phase::Execute, "50%"),
+            (Phase::Verify, "100%"),
+        ] {
+            assert!(text(phase).contains(pct), "{phase:?} should read {pct}");
+        }
+    }
+
+    /// The first phase has nothing behind it and the last nothing ahead, so
+    /// the row never draws a `✓` or a `·` with no word after it.
+    #[test]
+    fn the_ends_of_the_ladder_draw_no_empty_marks() {
+        let first = text(Phase::Plan);
+        assert!(!first.contains('✓'), "nothing is done yet: {first}");
+        assert!(first.contains("· execute"), "{first}");
+        assert!(first.contains("· verify"), "{first}");
+
+        let last = text(Phase::Verify);
+        assert!(last.starts_with(" ✓ plan ✓ execute ▸ verify "), "{last}");
+        assert!(!last.contains(" · "), "nothing is ahead: {last}");
+    }
+}

--- a/crates/stella-tui/src/views/status_bar.rs
+++ b/crates/stella-tui/src/views/status_bar.rs
@@ -135,19 +135,23 @@ fn partial_cell(filled: f64) -> char {
 }
 
 /// The meter's spans: gold fill on `border` gray (SPEC 5).
-fn meter(frac: f64) -> Vec<Span<'static>> {
-    let exact = ratio(frac) * METER_CELLS as f64;
+///
+/// `cells` because the deck draws meters at two lengths — this bar's twelve
+/// and the pipeline row's eight ([`super::pipeline`]) — and SPEC 5 states the
+/// fill and track colours once, for every meter. A second implementation for
+/// the shorter bar is how the two would come to disagree about which gray the
+/// track is.
+pub(super) fn meter(frac: f64, cells: usize) -> Vec<Span<'static>> {
+    let exact = ratio(frac) * cells as f64;
     let full = exact.trunc() as usize;
     let mut spans = Vec::with_capacity(3);
     if full > 0 {
         spans.push(Span::styled(
-            glyph::BLOCK_EIGHTHS[8]
-                .to_string()
-                .repeat(full.min(METER_CELLS)),
+            glyph::BLOCK_EIGHTHS[8].to_string().repeat(full.min(cells)),
             Style::new().fg(token::GOLD),
         ));
     }
-    if full < METER_CELLS {
+    if full < cells {
         let partial = partial_cell(exact.fract());
         if partial != ' ' {
             spans.push(Span::styled(
@@ -155,7 +159,7 @@ fn meter(frac: f64) -> Vec<Span<'static>> {
                 Style::new().fg(token::GOLD),
             ));
         }
-        let track = METER_CELLS - full - usize::from(partial != ' ');
+        let track = cells - full - usize::from(partial != ' ');
         if track > 0 {
             spans.push(Span::styled(
                 glyph::METER_TRACK.to_string().repeat(track),
@@ -207,7 +211,7 @@ pub fn cells(status: &Status<'_>) -> Vec<Vec<Span<'static>>> {
     cells.extend([
         {
             let mut ctx = vec![Span::styled("ctx ", label)];
-            ctx.extend(meter(status.ctx_used));
+            ctx.extend(meter(status.ctx_used, METER_CELLS));
             ctx.push(Span::styled(format!(" {}%", pct(status.ctx_used)), text));
             ctx
         },

--- a/crates/stella-tui/tests/deck_snapshot.rs
+++ b/crates/stella-tui/tests/deck_snapshot.rs
@@ -103,6 +103,9 @@ fn deck_renders_every_tab_with_real_content() {
         "stella*",   // the wordmark on the tab row (SPEC 3.3)
         "⏎ queue",   // the hint row under the composer (SPEC 5)
         "sub-agent", // …and its `↓ N sub-agents` hint: the lanes exist
+        // The stage stepper this comment has named since SPEC 5 landed, and
+        // which nothing here asserted until it was built (#5050).
+        "▸ execute",
     ] {
         assert!(
             session.contains(needle),

--- a/crates/stella-tui/tests/snapshots/deck/card_budget.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_budget.txt
@@ -39,7 +39,7 @@
                                                     ╰────────────────────────── ⏎ set · ⌫ edit · esc close ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/card_models.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models.txt
@@ -39,7 +39,7 @@
                                             ╰─────────────────────────────────────────────────────────── esc close ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/card_plan.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan.txt
@@ -39,7 +39,7 @@
                                                     ╰────────────────────────────────── x skip · esc close ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
@@ -39,7 +39,7 @@
                                                 │▸ reviewer  project  reviews a diff against the house rules   │
 ⏸ plan  Refactor the automations store into a sh│  release-captain  user  cuts a release: bump, changelog, tag │
                                                 ╰──────────────────────────────────── ↑↓ move · ⏎ assume · esc ╯
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval.txt
@@ -39,7 +39,7 @@
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_read_only.txt
@@ -39,7 +39,7 @@
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_approval_reason.txt
@@ -39,7 +39,7 @@
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
@@ -39,7 +39,7 @@
                                                 │  anthropic/claude-fable-5                                    │
 ⏸ plan  Refactor the automations store into a sh│  openrouter/openai/gpt-5.5                                   │
                                                 ╰─────────────────────────────────────── ↑↓ move · ⏎ use · esc ╯
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_accessible.txt
@@ -39,7 +39,7 @@
 ╰────────────────────────────────────────────────────────────────────────────────────────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_note.txt
@@ -39,7 +39,7 @@
                                           ╰─────────────────────────────────────────────── ⏎ save note · esc discard ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_review.txt
@@ -39,7 +39,7 @@
                                           ╰──────────────────────────────── ↑↓ move · ⏎ choose · ⇥ back · esc cancel ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_single.txt
@@ -39,7 +39,7 @@
                                           ╰────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_question_tabstrip.txt
@@ -39,7 +39,7 @@
                                           ╰────────────── ↑↓ move · ⏎ pick · ⇥ next · n note · r review · esc cancel ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_subagents.txt
@@ -39,7 +39,7 @@
                          │                                                                                                            │
 ⏸ plan  Refactor the auto│                                                                                                            │
                          │                                                                                                            │
-                         │                                                                                                            │
+ ✓ plan ▸ execute ████░░░│                                                                                                            │
 >>>                      ╰───────── ↑↓ · o↵ open · n nudge · f flag · l lead · x stop·xx delete · r resume·rr restart · p pause · esc ╯
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/session_delegate_tool_call.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_delegate_tool_call.txt
@@ -39,7 +39,7 @@
  │ ◌ search sub_agent_id                                                                                                                           ⚡ 9ms · ↳ d:1
  │ ⎿ crates/stella-tui/src/model/entry.rs:105                                                                                         9ms · ↳ d:1
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · esc steer · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/session_gate_board_failure.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_gate_board_failure.txt
@@ -39,7 +39,7 @@
  │   ✓ doc-warnings · green · $0.00 · det
  │   ✓ witness-flip · green · $0.00 · det
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_tool_result_multiline.txt
@@ -39,7 +39,7 @@
  │   stage verify
  │   witness tests/overfull.rs
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · esc steer · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
+++ b/crates/stella-tui/tests/snapshots/deck/statline_deadline_armed.txt
@@ -39,7 +39,7 @@
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · deadline 12m 34s · ctx ▌░░░░░░░░░░░ 4% · $3.79 · saved $0.00 · ✉ 0                                                            ? help

--- a/crates/stella-tui/tests/snapshots/deck/tab_session.txt
+++ b/crates/stella-tui/tests/snapshots/deck/tab_session.txt
@@ -39,7 +39,7 @@
 
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/zoom_elided.txt
+++ b/crates/stella-tui/tests/snapshots/deck/zoom_elided.txt
@@ -39,7 +39,7 @@ spend · what this task has cost so far
 
 r re-run checks · s split task · b hand to worker · i promote to issue · ⌥ diff plan
 a task closes when its checks pass, not when the model says so.
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/zoom_scripted.txt
+++ b/crates/stella-tui/tests/snapshots/deck/zoom_scripted.txt
@@ -39,7 +39,7 @@ spend · what this task has cost so far
 
 r re-run checks · s split task · b hand to worker · i promote to issue · ⌥ diff plan
 a task closes when its checks pass, not when the model says so.
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help


### PR DESCRIPTION
## What this changes

SPEC 5's prompt block opens with a pipeline line — `✓ plan ▸ execute [bar] 50% · verify` — and nothing rendered it. The stage word survived only as a status-bar cell and on each turn's opening rule, and neither says *how far through a turn* that stage is, which is the one fact this row adds.

`crates/stella-tui/src/views/pipeline.rs` draws it: the phases the turn has passed marked `✓` in `muted`, the one it is in lit gold behind the meter, the ones ahead in `dim`.

```
 ✓ plan ▸ execute ████░░░░ 50% · verify
>>>
 ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · / commands
zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0    ? help
```

## Three phases, and where the numbers come from

`StageKind::ALL` is the twelve boundaries this host emits in turn order, and its own doc names itself "the list a renderer that needs a stable reading order for the host's own stages takes it from". Twelve is too many to draw, so `Phase` groups them into **three contiguous runs of that same list** — deciding, doing, proving:

| Phase | Boundaries |
|---|---|
| `plan` | triage, context recall, research, plan, scope review |
| `execute` | witness, execute |
| `verify` | verify, verdict, reflect, context write, complete |

Contiguity is the property that matters: the phase is monotonic in `ALL`'s order, so the meter can only move forwards, and `the_phase_never_goes_backwards_along_the_host_order` holds it there. `Phase::of` is exhaustive over `StageKind` on purpose — a thirteenth boundary must not compile until somebody decides which phase it is in, because the alternative is a stage that silently reads as `plan` and makes the meter claim the turn regressed.

`execute` reads **50%** because a turn in the middle phase of three is halfway through the host's shape. That is position, not a prediction of work remaining, which nothing here can know — and it is exactly the number SPEC 5 writes.

It reads `Hud::host_stage`, which **was folded with no consumer at all** and whose doc already described "the three-segment progress bar" and "the host's three phases". This is the renderer that field was folded for. Reading it rather than `Hud::stage` is what its doc asks for: a contributed stage leaves it alone, so a plugin boundary arriving mid-execute cannot make the meter snap back to `plan`.

## Why it can be blank, and why that is the point

**The row draws only once the turn has announced a host stage.** A plain `stella run` is the raw step-loop and emits no stage boundaries at all (AGENTS.md's opening), and the staged pipeline that used to emit them is deleted from this workspace (#3865). On most runs there is no pipeline to draw and the row stays air.

That is the same refusal `views::status_source`'s stage cell already makes, and its comment is the argument:

> An unannounced stage reads `—`, never a word. […] a plain `stella run` is the raw step-loop and emits no stage boundaries at all, so the bar would call a working turn idle for its whole length. A bar that guesses where the run is has spent the credibility the whole row exists to hold.

The phases *ahead* are drawn dim rather than absent because a turn may settle before it reaches them. The row says where the turn has got, never where it will get to.

## The pulse-row decision: it does not move

The issue asks where the pulse row goes. **Nowhere — nothing was displaced.**

`views::pulse::subject` already returns `None` on SESSION at the lead ("On SESSION the transcript is the pulse, so the row stays air"), and that is precisely the state SPEC 5 draws its prompt block in. So the two are disjoint by construction: pulse holds the band off SESSION and at an opened lane, the pipeline line takes the air pulse was already leaving. Pulse's information survives unchanged, on every tab it ever drew on.

The precedence is written out in `deck_render.rs` rather than left to the two `None`s to arrange between them — they are disjoint today, and a band that painted twice because one of them widened would be a bug nothing there could see. `the_two_row_claimants_are_disjoint` holds the disjointness across every tab and every focus.

## Witness table

Verified by hand: `git show origin/main:…/deck_render.rs > …/deck_render.rs`, run, restore.

| Test | On `main` | With this change |
|---|---|---|
| `deck_render::tests::a_turn_mid_execute_draws_the_pipeline_line_above_the_composer` | **FAILS** — `the row above the composer is SPEC 5's pipeline line: "                    …"` (the row is blank) | passes |
| `deck_render_snapshots_cover_every_tab` | **FAILS** — `tab_session` line 42: golden `✓ plan ▸ execute ████░░░░ 50% · verify`, actual empty | passes |
| `deck_render::tests::a_run_that_announces_no_stage_draws_no_stepper` | passes (guard, not a witness — named as such) | passes |
| `deck_render::tests::the_two_row_claimants_are_disjoint` | passes (guard) | passes |

The first is positional on purpose: `execute` is already on the status bar and on the turn's opening rule, so a frame-wide `contains` would pass on a stepper that rendered nowhere near the composer — or on no stepper at all.

## Goldens

21 frames changed. **Every one of them is the same single edit** — a blank row became the pipeline line:

```
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
```

`git diff -U0 | rg '^[+-][^+-]' | sort -u` returns three lines total (the third is the same row clipped by an overlay border drawn above it). Nothing shifted, no layout moved, no row vanished. Read before committing.

## Shared meter

`status_bar::meter` now takes a cell count and is `pub(super)`. SPEC 5 states "gold fill on `border` gray" once, for every meter; a second implementation for the shorter bar is how the two would come to disagree about which gray the track is. The pipeline meter is eight cells rather than twelve — it divides three phases, and a wider bar would spend columns implying precision the phases do not carry.

## The `PROMPT_PREFIX` fold-in is already done

The issue asks to dedup `PROMPT_PREFIX`/`PROMPT_PREFIX_W` between `deck_render.rs:30` and `views/frame.rs:41`. **#5051 already did it**: there is one definition, in `views/frame.rs`, and `deck_render.rs` line 26 is `use crate::views::frame::{PROMPT_PREFIX, PROMPT_PREFIX_W};`. `rg PROMPT_PREFIX` finds one `const` in the tree. No change was needed and none was made.

## A disagreement worth recording

The issue cites **rendering `01`** as the source of the pipeline line. It is not there: `01-session-turn-lifecycle.svg` goes straight from the transcript tail to `>>>` to the hint row to the status bar, and no rendering in `design/tui-v2/renderings/` draws a stepper. The word "pipeline" appears exactly once in the whole SPEC — the item 4 line this PR implements.

Built to the SPEC prose, since that is the normative text and it survived #5194's docs-vs-tree sweep untouched. Flagging it because the renderings are known to have drifted from the prose elsewhere too (rendering 01 still draws `det 86%` on the status bar, which SPEC §5 says is gone "here, or anywhere"). Filed as #5291 rather than fixed here.

## Checks

`cargo test -p stella-tui` (14 suites green), `cargo clippy -p stella-tui --all-targets -D warnings`, `make guards-fast`, `make prose`, `./scripts/check-file-size.sh`. No workspace build or suite ran on the maintainer's laptop (CLAUDE.md); CI is the evidence.

## Deleted tests

None.

Closes #5050

## Summary by Sourcery

Render the host turn pipeline above the composer while preserving pulse-row behavior and accurately reflecting announced progress.

New Features:
- Add a pipeline progress line above the composer showing completed, current, and upcoming host phases with a progress meter.

Enhancements:
- Share the existing status-bar meter rendering between the status bar and pipeline line.
- Coordinate pipeline and pulse rendering so they share the row without overlapping and leave the row blank when no host stage is announced.

Tests:
- Add coverage for pipeline rendering, stage-less runs, phase ordering, meter positions, row-claimant exclusivity, and updated deck snapshots.