### PR TITLE
feat(stella-cli,stella-plugin): a panel draws only after a handshake and an allow

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -747,13 +747,21 @@ pub async fn run_deck_session(
     // SPEC 12.4's handshake, before anything is seated (#5056). In the
     // **transcript**, which is what the spec asks for and where a consent
     // document belongs: it has to be scrollable and still there after the boot
-    // dialog is gone, which the transient notice above is not. `chrome_note`
-    // folds the lead to `Running`, so the idle assert this file already makes
-    // at startup is repeated below rather than left contradicted.
+    // dialog is gone, which the transient notice above is not.
+    //
+    // Through `deck_tx`, so it is not journaled. That is `chrome_note`'s own
+    // contract — boot narration that re-runs every launch must not replay and
+    // pile up on a resumed transcript — and it costs the audit nothing here:
+    // what a person answered is durable in the grant file beside the package,
+    // with the moment they answered it, and this block is the reminder rather
+    // than the record.
+    //
+    // `chrome_note` folds the lead to `Running`, so the idle assert this file
+    // already makes at startup is repeated below rather than left contradicted.
     let handshakes = plugin_panels::handshakes(&panel_roster);
     let spoke = !handshakes.is_empty();
     for handshake in handshakes {
-        let _ = in_tx.send(chrome_note(handshake));
+        let _ = deck_tx.send(chrome_note(handshake));
     }
     if spoke {
         let _ = in_tx.send(Inbound::Status {

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -744,6 +744,23 @@ pub async fn run_deck_session(
     for refusal in seating.refusals {
         let _ = deck_tx.send(system_notice(refusal));
     }
+    // SPEC 12.4's handshake, before anything is seated (#5056). In the
+    // **transcript**, which is what the spec asks for and where a consent
+    // document belongs: it has to be scrollable and still there after the boot
+    // dialog is gone, which the transient notice above is not. `chrome_note`
+    // folds the lead to `Running`, so the idle assert this file already makes
+    // at startup is repeated below rather than left contradicted.
+    let handshakes = plugin_panels::handshakes(&panel_roster);
+    let spoke = !handshakes.is_empty();
+    for handshake in handshakes {
+        let _ = in_tx.send(chrome_note(handshake));
+    }
+    if spoke {
+        let _ = in_tx.send(Inbound::Status {
+            agent: LEAD.to_string(),
+            status: AgentStatus::WaitingInput,
+        });
+    }
     let _ = in_tx.send(Inbound::PanelsSeated(seating.seats));
 
     // Honour the persisted colour theme (`ui.theme`) before the deck spawns its

--- a/crates/stella-cli/src/command_deck/plugin_panels.rs
+++ b/crates/stella-cli/src/command_deck/plugin_panels.rs
@@ -109,6 +109,84 @@ pub(super) fn seat(routes: &[PluginPanelRoute]) -> Seating {
     seat_with(routes, &deck_reserved())
 }
 
+/// The handshake blocks a session owes its operator before any panel draws —
+/// SPEC 12.4's first sentence (#5056).
+///
+/// One block per installed plugin that declares a `[panel]`, in roster order,
+/// and none for a workspace with no panel plugins at all.
+///
+/// # Why an allowed panel still says something, and why it is one line
+///
+/// SPEC 12.4 asks for the handshake *before any panel*, not before the first
+/// one ever. A rectangle drawn by somebody else's program on every boot is a
+/// standing grant, and a standing grant that is never restated becomes
+/// invisible — which is the same failure the install receipt exists to catch,
+/// one surface later. But the full document is what you read to *decide*, and
+/// re-reading it at every boot for a decision already made would train a reader
+/// to skip the block that matters. So an allowed panel gets the two facts that
+/// change — what it draws, and the signature the grant covers — and the verb
+/// that withdraws it.
+///
+/// A panel that is **not** allowed gets the whole document, because that
+/// reader has a decision in front of them.
+///
+/// # The signature is re-read from disk
+///
+/// Not digested from the roster's own parse: the grant on disk is keyed to the
+/// bytes `read_tier` will hash on the next load, and a signature computed from
+/// anything else would show a reader a number that decides nothing. A manifest
+/// that has become unreadable since the roster was composed yields no block
+/// rather than a block with a fabricated signature in it.
+pub(super) fn handshakes(roster: &crate::plugin_cmd::roster::PluginRoster) -> Vec<String> {
+    let mut blocks = Vec::new();
+    for plugin in roster.plugins() {
+        if plugin.manifest.panel.is_none() {
+            continue;
+        }
+        let Ok(Some((_, text))) = crate::plugin_cmd::roster::read_manifest(&plugin.dir) else {
+            continue;
+        };
+        let signature = format!(
+            "sha256:{}",
+            crate::plugin_cmd::receipt::digest(text.as_bytes())
+        );
+        let name = &plugin.manifest.name;
+        if plugin.panel_grant.admits() {
+            let surfaces: Vec<&str> = PanelSurface::all()
+                .iter()
+                .filter(|surface| {
+                    plugin
+                        .manifest
+                        .panel
+                        .as_ref()
+                        .is_some_and(|panel| panel.draws(**surface))
+                })
+                .map(|surface| surface.as_str())
+                .collect();
+            blocks.push(format!(
+                "◳ panel · {name} — you allowed this plugin to draw on your screen \
+                 ({}), under manifest signature {signature}. \
+                 `stella plugin panel {name}` withdraws it.",
+                surfaces.join(", ")
+            ));
+            continue;
+        }
+        let mut block = String::new();
+        if let Some(handshake) = stella_plugin::panel_handshake_text(&plugin.manifest, &signature) {
+            block.push_str(&handshake);
+            block.push('\n');
+        }
+        if let Some(notice) = plugin.panel_grant.notice(name) {
+            block.push('\n');
+            block.push_str(&notice);
+        }
+        if !block.is_empty() {
+            blocks.push(block);
+        }
+    }
+    blocks
+}
+
 /// Spawn the exchange for one frame request and answer the deck with exactly
 /// one panel envelope.
 ///
@@ -329,9 +407,20 @@ mod tests {
     }
 
     /// Plant that plugin into `tier`, optionally with the consent receipt
-    /// `stella plugin install` writes.
+    /// `stella plugin install` writes and the panel grant `stella plugin
+    /// panel` writes.
+    ///
+    /// The two are separate arguments because they are separate transactions
+    /// (#5056): a package can be installed and its panel denied, and the whole
+    /// point of the second gate is that the first does not answer for it.
     #[cfg(unix)]
-    fn plant_panel(tier: &std::path::Path, name: &str, marker: &std::path::Path, consented: bool) {
+    fn plant_panel(
+        tier: &std::path::Path,
+        name: &str,
+        marker: &std::path::Path,
+        consented: bool,
+        panel: Option<crate::plugin_cmd::panel_grant::PanelVerdict>,
+    ) {
         let dir = tier.join(name);
         std::fs::create_dir_all(&dir).expect("fixture plugin dir");
         let text = panel_manifest(name, marker);
@@ -347,6 +436,30 @@ mod tests {
             )
             .expect("fixture receipt");
         }
+        if let Some(verdict) = panel {
+            crate::plugin_cmd::panel_grant::record(
+                tier,
+                crate::plugin_cmd::roster::PluginScope::User,
+                name,
+                name,
+                text.as_bytes(),
+                verdict,
+            )
+            .expect("fixture panel grant");
+        }
+    }
+
+    /// Compose the user tier as a session would, and report its panel routes.
+    #[cfg(unix)]
+    fn panel_routes_of(tier: &std::path::Path) -> Vec<PluginPanelRoute> {
+        use crate::plugin_cmd::roster::{PluginRoster, PluginScope};
+
+        PluginRoster::compose(
+            crate::plugin_cmd::roster::read_tier(tier, PluginScope::User, &mut Vec::new()),
+            Vec::new(),
+            &std::collections::BTreeMap::new(),
+        )
+        .panel_routes()
     }
 
     /// **The gate witness.** No panel frame is requested before the install
@@ -366,8 +479,6 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn no_panel_frame_is_requested_before_the_install_grant() {
-        use crate::plugin_cmd::roster::{PluginRoster, PluginScope};
-
         // The lock, but **not** `paths::test_user_home`: nothing here reads the
         // ambient home — `read_tier`, `receipt::record` and
         // `resolve_user_plugins_dir` are all handed the tier explicitly — and
@@ -387,13 +498,8 @@ mod tests {
         let marker = root.join("the-panel-process-ran");
 
         // Planted, complete, and never consented to.
-        plant_panel(&tier, "unconsented", &marker, false);
-        let ungranted = PluginRoster::compose(
-            crate::plugin_cmd::roster::read_tier(&tier, PluginScope::User, &mut Vec::new()),
-            Vec::new(),
-            &std::collections::BTreeMap::new(),
-        );
-        let routes = ungranted.panel_routes();
+        plant_panel(&tier, "unconsented", &marker, false, None);
+        let routes = panel_routes_of(&tier);
         assert!(routes.is_empty(), "an ungranted plugin has no panel route");
 
         // The deck asks anyway — a request naming a slot the roster never
@@ -412,14 +518,15 @@ mod tests {
             marker.display()
         );
 
-        // Anti-vacuity: the same bytes run once the grant is on record.
-        plant_panel(&tier, "consented", &marker, true);
-        let granted = PluginRoster::compose(
-            crate::plugin_cmd::roster::read_tier(&tier, PluginScope::User, &mut Vec::new()),
-            Vec::new(),
-            &std::collections::BTreeMap::new(),
+        // Anti-vacuity: the same bytes run once both grants are on record.
+        plant_panel(
+            &tier,
+            "consented",
+            &marker,
+            true,
+            Some(crate::plugin_cmd::panel_grant::PanelVerdict::Allow),
         );
-        let routes = granted.panel_routes();
+        let routes = panel_routes_of(&tier);
         assert_eq!(routes.len(), 1, "a granted plugin's panel routes");
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         spawn_tick(&routes, 0, 1, 40, 8, &tx);
@@ -442,6 +549,263 @@ mod tests {
             "a frameless tick still rearms the seat: {got:?}"
         );
         assert!(marker.exists(), "the granted plugin's process did run");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **The panel-grant witness (#5056).** An installed, consented, perfectly
+    /// loadable plugin whose panel handshake was answered `deny` — or never
+    /// answered at all — does not have its panel program started.
+    ///
+    /// Asserted on the marker file rather than on `panel_routes()` for the
+    /// reason the install-grant witness above gives, and the reason is sharper
+    /// here: the install grant withholds the whole package, so a build that
+    /// ignored it would fail in a dozen visible ways. A panel grant withholds
+    /// one rectangle from a package that is otherwise fully in force — its
+    /// hooks fire, its tools are registered, its process is a program the host
+    /// already knows how to start — so "the route list is empty" and "nobody's
+    /// code ran" are genuinely different claims, and only the second one is the
+    /// security property.
+    ///
+    /// The three states are asserted together because they share one marker
+    /// path: if any of them started a process, the file exists, and the test
+    /// cannot pass by having checked the wrong one.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn no_panel_frame_is_requested_when_the_panel_grant_does_not_allow_it() {
+        use crate::plugin_cmd::panel_grant::PanelVerdict;
+
+        // `test_env::lock` for `spawn_tick`'s `std::env::var`, on the sibling
+        // witness's reasoning; the home is never read, so it is never moved.
+        let _env = crate::test_env::lock();
+        let root = std::env::temp_dir().join(format!("stella-panel-deny-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp root");
+        let tier = stella_home::resolve_user_plugins_dir(Some(root.join(".stella")))
+            .expect("an explicit stella root resolves its plugins tier");
+        let marker = root.join("the-panel-process-ran");
+
+        // Installed and consented to, both of them. One was answered `deny`;
+        // the other was never asked.
+        plant_panel(&tier, "denied", &marker, true, Some(PanelVerdict::Deny));
+        plant_panel(&tier, "unasked", &marker, true, None);
+
+        let routes = panel_routes_of(&tier);
+
+        // The deck asks for both slots regardless — a request naming a slot the
+        // roster never produced is exactly what a stale deck sends.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        for slot in [0, 1] {
+            spawn_tick(&routes, slot, 1, 40, 8, &tx);
+        }
+        drop(tx);
+        // Drained before anything is asserted, and that is the synchronisation
+        // rather than a check: every sender clone lives inside a spawned task,
+        // so `None` means each task has finished — which is the only moment at
+        // which "the marker does not exist" distinguishes "no process was
+        // started" from "one was started and has not touched the file yet".
+        let answered = rx.recv().await;
+
+        // THE property first, so a flip fails on somebody's code having run
+        // rather than on the route list that is only evidence about it
+        // (`a_frame_in_flight_across_a_reseat_lands_nowhere`'s ordering).
+        assert!(
+            !marker.exists(),
+            "a panel process ran without an allow: {}",
+            marker.display()
+        );
+        assert!(
+            routes.is_empty(),
+            "and no route existed for it to run from: {routes:?}"
+        );
+        assert!(
+            answered.is_none(),
+            "nothing was even answered: {answered:?}"
+        );
+
+        // Anti-vacuity, and the reason the gate is the *panel* grant rather
+        // than the install one: the same package, the same receipt, the same
+        // bytes — answered `allow` — does run.
+        plant_panel(&tier, "allowed", &marker, true, Some(PanelVerdict::Allow));
+        let routes = panel_routes_of(&tier);
+        assert_eq!(routes.len(), 1, "only the allowed panel is routed");
+        assert_eq!(routes[0].plugin, "allowed");
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        spawn_tick(&routes, 0, 1, 40, 8, &tx);
+        // Either no-frame envelope, on the sibling witness's measured reason:
+        // the fixture starts a real process and a loaded machine overruns the
+        // 33ms budget often enough that pinning one of them is a race.
+        let got = rx.recv().await;
+        assert!(
+            matches!(
+                got,
+                Some(
+                    stella_tui::envelope::Inbound::PanelSilent { slot: 0 }
+                        | stella_tui::envelope::Inbound::PanelThrottled { slot: 0, .. }
+                )
+            ),
+            "a frameless tick still rearms the seat: {got:?}"
+        );
+        assert!(marker.exists(), "the allowed plugin's process did run");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **The visible-handshake witness (#5056).** Before any panel is seated,
+    /// the session says which plugin is about to draw on the screen and under
+    /// what grant — the full SPEC 12.4 document with the `[a]llow [d]eny` ask
+    /// where the decision is still open, and the standing grant plus the way to
+    /// withdraw it where it is not.
+    #[cfg(unix)]
+    #[test]
+    fn the_first_seat_is_preceded_by_a_handshake_for_every_panel_plugin() {
+        use crate::plugin_cmd::panel_grant::PanelVerdict;
+        use crate::plugin_cmd::roster::{PluginRoster, PluginScope};
+
+        let _env = crate::test_env::lock();
+        let root = std::env::temp_dir().join(format!("stella-panel-shake-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp root");
+        let tier = stella_home::resolve_user_plugins_dir(Some(root.join(".stella")))
+            .expect("an explicit stella root resolves its plugins tier");
+        let marker = root.join("unused");
+
+        plant_panel(&tier, "granted", &marker, true, Some(PanelVerdict::Allow));
+        plant_panel(&tier, "pending", &marker, true, None);
+        // A plugin with no `[panel]` at all, so the block list is about panels
+        // rather than about the roster.
+        let quiet = tier.join("quiet");
+        std::fs::create_dir_all(&quiet).expect("fixture plugin dir");
+        let quiet_text = "name = \"quiet\"\n";
+        std::fs::write(
+            quiet.join(crate::plugin_cmd::roster::MANIFEST_FILE),
+            quiet_text,
+        )
+        .expect("fixture manifest");
+        crate::plugin_cmd::receipt::record(
+            &tier,
+            PluginScope::User,
+            "quiet",
+            "quiet",
+            quiet_text.as_bytes(),
+        )
+        .expect("fixture receipt");
+
+        let roster = PluginRoster::compose(
+            crate::plugin_cmd::roster::read_tier(&tier, PluginScope::User, &mut Vec::new()),
+            Vec::new(),
+            &std::collections::BTreeMap::new(),
+        );
+        let blocks = handshakes(&roster);
+        assert_eq!(
+            blocks.len(),
+            2,
+            "one block per panel plugin, and none for `quiet`: {blocks:?}"
+        );
+
+        // Roster order is name order: `granted`, then `pending`.
+        let granted = &blocks[0];
+        assert!(granted.contains("◳ panel · granted"), "{granted}");
+        assert!(granted.contains("sha256:"), "the signature: {granted}");
+        assert!(
+            granted.contains("stella plugin panel granted"),
+            "and the way to withdraw it: {granted}"
+        );
+        assert!(
+            !granted.contains(stella_plugin::PANEL_GRANT_ASK),
+            "a decided grant is not asked again: {granted}"
+        );
+
+        let pending = &blocks[1];
+        assert!(
+            pending.contains(stella_plugin::PANEL_GRANT_ASK),
+            "an undecided panel is asked: {pending}"
+        );
+        assert!(pending.contains("Manifest signature: sha256:"), "{pending}");
+        assert!(
+            pending.contains("stella plugin panel pending"),
+            "and named the verb that answers: {pending}"
+        );
+        assert!(
+            pending.contains("nobody has been asked yet"),
+            "and why it is not drawing: {pending}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A denial takes the rectangle and nothing else: the package still loads,
+    /// and its hook dispatches are untouched.
+    ///
+    /// Without this, "deny" could be implemented by dropping the package from
+    /// the roster and every assertion above would still pass — while the
+    /// operator who wanted to stop a panel drawing had silently lost the
+    /// plugin's tools and hooks as well.
+    #[cfg(unix)]
+    #[test]
+    fn a_denied_panel_costs_the_plugin_nothing_but_the_rectangle() {
+        use crate::plugin_cmd::panel_grant::PanelVerdict;
+        use crate::plugin_cmd::roster::{PluginRoster, PluginScope};
+
+        let _env = crate::test_env::lock();
+        let root = std::env::temp_dir().join(format!("stella-panel-kept-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp root");
+        let tier = stella_home::resolve_user_plugins_dir(Some(root.join(".stella")))
+            .expect("an explicit stella root resolves its plugins tier");
+
+        let dir = tier.join("hooked");
+        std::fs::create_dir_all(&dir).expect("fixture plugin dir");
+        let text = "name = \"hooked\"\n\
+                    \n\
+                    [loop]\n\
+                    participation = \"steering\"\n\
+                    hooks = [\"PreToolUse\"]\n\
+                    \n\
+                    [runtime]\n\
+                    argv = [\"/bin/true\"]\n\
+                    timeout_secs = 2\n\
+                    env = []\n\
+                    \n\
+                    [panel]\n\
+                    surfaces = [\"settings\"]\n\
+                    denies = [\"network\", \"write-outside-sandbox\"]\n\
+                    \n\
+                    [panel.process]\n\
+                    argv = [\"/bin/true\"]\n\
+                    timeout_secs = 2\n\
+                    env = []\n";
+        std::fs::write(dir.join(crate::plugin_cmd::roster::MANIFEST_FILE), text)
+            .expect("fixture manifest");
+        for scope in [PluginScope::User] {
+            crate::plugin_cmd::receipt::record(&tier, scope, "hooked", "hooked", text.as_bytes())
+                .expect("fixture receipt");
+            crate::plugin_cmd::panel_grant::record(
+                &tier,
+                scope,
+                "hooked",
+                "hooked",
+                text.as_bytes(),
+                PanelVerdict::Deny,
+            )
+            .expect("fixture panel grant");
+        }
+
+        let roster = PluginRoster::compose(
+            crate::plugin_cmd::roster::read_tier(&tier, PluginScope::User, &mut Vec::new()),
+            Vec::new(),
+            &std::collections::BTreeMap::new(),
+        );
+        assert_eq!(roster.plugins().len(), 1, "the package still loads");
+        assert_eq!(
+            roster.hook_routes().len(),
+            1,
+            "and its hook dispatch is untouched"
+        );
+        assert!(
+            roster.panel_routes().is_empty(),
+            "only the rectangle is gone"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/stella-cli/src/command_deck/plugin_panels.rs
+++ b/crates/stella-cli/src/command_deck/plugin_panels.rs
@@ -777,19 +777,23 @@ mod tests {
                     env = []\n";
         std::fs::write(dir.join(crate::plugin_cmd::roster::MANIFEST_FILE), text)
             .expect("fixture manifest");
-        for scope in [PluginScope::User] {
-            crate::plugin_cmd::receipt::record(&tier, scope, "hooked", "hooked", text.as_bytes())
-                .expect("fixture receipt");
-            crate::plugin_cmd::panel_grant::record(
-                &tier,
-                scope,
-                "hooked",
-                "hooked",
-                text.as_bytes(),
-                PanelVerdict::Deny,
-            )
-            .expect("fixture panel grant");
-        }
+        crate::plugin_cmd::receipt::record(
+            &tier,
+            PluginScope::User,
+            "hooked",
+            "hooked",
+            text.as_bytes(),
+        )
+        .expect("fixture receipt");
+        crate::plugin_cmd::panel_grant::record(
+            &tier,
+            PluginScope::User,
+            "hooked",
+            "hooked",
+            text.as_bytes(),
+            PanelVerdict::Deny,
+        )
+        .expect("fixture panel grant");
 
         let roster = PluginRoster::compose(
             crate::plugin_cmd::roster::read_tier(&tier, PluginScope::User, &mut Vec::new()),

--- a/crates/stella-cli/src/driver_plugin/tests.rs
+++ b/crates/stella-cli/src/driver_plugin/tests.rs
@@ -54,6 +54,7 @@ fn installed(text: &str, dir: &str) -> InstalledPlugin {
         dir: PathBuf::from(dir),
         scope: PluginScope::User,
         consent: crate::plugin_cmd::receipt::ConsentState::Receipted,
+        panel_grant: crate::plugin_cmd::panel_grant::PanelGrantState::Undecided,
     }
 }
 

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! `stella plugin install|list|remove` — the loader
+//! `stella plugin install|list|panel|remove|drive` — the loader
 //! (`doc:pipeline-as-plugins` §A4).
 //!
-//! Three verbs, one for each thing a human does with a plugin, and each one
-//! doing exactly that thing (invariant 9 — no `install --remove`).
+//! One verb for each thing a human does with a plugin, and each one doing
+//! exactly that thing (invariant 9 — no `install --remove`). `panel` is the
+//! one that decides rather than acts: it answers SPEC 12.4's `[a]llow [d]eny`
+//! for a plugin that asks to draw on the screen, and `--allow`/`--deny` are
+//! that answer given up front the way `install --yes` is, never a second verb
+//! hiding in a flag.
 //!
 //! # Install is a consent transaction, not a copy
 //!
@@ -32,6 +36,17 @@
 //! and owns that directory, could rewrite its grant into one no human ever saw
 //! (#3514). See [`receipt`] for what the receipt does and does not buy.
 //!
+//! # Drawing on the screen is a second transaction
+//!
+//! A `[panel]` block asks for a rectangle of the operator's terminal, which
+//! SPEC 12 calls the place the strongest limits belong. So it is granted
+//! separately, recorded separately ([`panel_grant`]), and withheld until
+//! somebody answers: a package can be installed with its panel denied, and
+//! denying one costs the plugin nothing but the rectangle. `install` asks it
+//! for what it is copying; [`decide_panel`] is what answers it for a package
+//! that arrived by `git clone`, one whose manifest has changed since, or one
+//! whose grant is being withdrawn.
+//!
 //! # Uninstall actually uninstalls
 //!
 //! Removing a plugin deletes its directory — in **every** tier that holds the
@@ -49,6 +64,7 @@ use crate::settings::{Settings, Toggle};
 
 pub(crate) mod configure;
 pub(crate) mod package;
+pub(crate) mod panel_grant;
 pub(crate) mod process;
 pub(crate) mod receipt;
 pub(crate) mod roster;
@@ -81,6 +97,25 @@ pub enum PluginCmd {
         /// The plugin's `name`, as `stella plugin list` prints it.
         #[arg(value_name = "NAME")]
         name: String,
+    },
+    /// Decide whether an installed plugin may draw on your screen: print its
+    /// panel handshake, and record the answer (SPEC 12.4).
+    ///
+    /// The answer is a fact about the manifest's exact bytes, so it is asked
+    /// again whenever the declaration changes — and it is a fact about the
+    /// screen alone: denying a panel leaves the package's tools, skills and
+    /// hooks running.
+    Panel {
+        /// The plugin's `name`, as `stella plugin list` prints it.
+        #[arg(value_name = "NAME")]
+        name: String,
+        /// Answer `allow` without prompting. Required when no human is
+        /// present to read the handshake.
+        #[arg(long, conflicts_with = "deny")]
+        allow: bool,
+        /// Answer `deny` without prompting.
+        #[arg(long)]
+        deny: bool,
     },
     /// Open one driver session against an installed plugin that declares
     /// `[driver]`, and report what it says to do next.
@@ -123,6 +158,9 @@ pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
             install(&root, dir, (*scope).into(), *yes, &settings)
         }
         PluginCmd::List => list(&root, &settings),
+        PluginCmd::Panel { name, allow, deny } => {
+            decide_panel(&root, name, panel_answer(*allow, *deny), &settings)
+        }
         PluginCmd::Remove { name } => remove(&root, name),
         PluginCmd::Drive { name } => drive(&root, name),
     }
@@ -408,6 +446,28 @@ fn install(
         scope.as_str(),
         destination.display()
     );
+
+    // SPEC 12.4's second transaction, and outside the one above:
+    // a package that is installed and not drawing is a coherent state, so a
+    // failure here is a notice naming the verb that resolves it rather than a
+    // rollback of a copy that succeeded. `--yes` answers this the way it
+    // answers the install — the document it accepted carries the panel section
+    // — so a scripted install of a panel plugin still yields a drawing panel.
+    if manifest.panel.is_some() {
+        let answer = if yes {
+            PanelAnswer::Given(panel_grant::PanelVerdict::Allow)
+        } else {
+            PanelAnswer::Ask
+        };
+        if let Err(reason) =
+            grant_panel_at_install(&tier, scope, name, &manifest, &consented, answer)
+        {
+            eprintln!(
+                "  ! `{name}` is installed, but its panel grant was not recorded: {reason}\n    \
+                 It will not draw until `stella plugin panel {name}` decides."
+            );
+        }
+    }
     if let Some(target) = &config_target {
         println!(
             "  set {} value(s) in {} — `stella plugin remove {name}` puts them back",
@@ -486,6 +546,199 @@ fn install_configuration(
     Ok(())
 }
 
+/// Show the panel handshake for a package [`install`] has just copied, and
+/// record the answer.
+///
+/// Split out of `install` rather than inlined so the tier, the entry name and
+/// the consented bytes are named once and cannot drift from the receipt filed
+/// beside them — and so this reads as the second transaction it is.
+fn grant_panel_at_install(
+    tier: &Path,
+    scope: PluginScope,
+    entry: &str,
+    manifest: &stella_plugin::PluginManifest,
+    consented: &str,
+    answer: PanelAnswer,
+) -> Result<(), String> {
+    let signature = format!("sha256:{}", receipt::digest(consented.as_bytes()));
+    let Some(handshake) = stella_plugin::panel_handshake_text(manifest, &signature) else {
+        return Ok(());
+    };
+    println!("\n{handshake}");
+    let verdict = match answer {
+        PanelAnswer::Given(verdict) => {
+            println!("\n(accepted with --yes)");
+            verdict
+        }
+        PanelAnswer::Ask => {
+            if !crate::interactive::human_is_present(true) {
+                return Err("no terminal is attached to answer it".to_string());
+            }
+            confirm_panel()?
+        }
+    };
+    panel_grant::record(
+        tier,
+        scope,
+        entry,
+        &manifest.name,
+        consented.as_bytes(),
+        verdict,
+    )?;
+    println!("  panel: {} for `{}`", verdict.as_str(), manifest.name);
+    Ok(())
+}
+
+/// What `stella plugin panel` was told to answer, or that it must ask.
+///
+/// Three states rather than a `bool`, because "nobody said" is the normal case
+/// and the one that has to reach a human: `--allow`/`--deny` are the answer
+/// given up front, exactly as `install --yes` is, and their absence is a
+/// question rather than a default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PanelAnswer {
+    Given(panel_grant::PanelVerdict),
+    Ask,
+}
+
+/// Fold the two flags into an answer. `clap` already refuses both at once
+/// (`conflicts_with`), so the impossible pair cannot arrive here.
+fn panel_answer(allow: bool, deny: bool) -> PanelAnswer {
+    match (allow, deny) {
+        (true, _) => PanelAnswer::Given(panel_grant::PanelVerdict::Allow),
+        (_, true) => PanelAnswer::Given(panel_grant::PanelVerdict::Deny),
+        _ => PanelAnswer::Ask,
+    }
+}
+
+/// `stella plugin panel <name>` — SPEC 12.4's handshake and the grant under it.
+///
+/// # Why this is a verb of its own rather than a question `install` asks
+///
+/// `install` does ask it, for a package it is copying (see [`install`]). This
+/// exists for the three cases that never reach an install prompt, and each one
+/// is a state a user can be in today:
+///
+///   * a package that arrived with a `git clone` into `.stella/plugins` and
+///     was never installed by this binary at all;
+///   * a plugin installed before the panel it now declares — the manifest
+///     changed, so its grant is `Drifted` and a re-ask is the only way back
+///     that is not `remove` plus `install`;
+///   * an operator withdrawing a panel they previously allowed, without
+///     uninstalling the tools and hooks they still want.
+///
+/// The plugin is resolved through the **roster** rather than by scanning the
+/// tiers, so the package answered about is the one actually in force —
+/// including the project-over-user shadowing, which is what makes an
+/// unqualified name mean one package.
+fn decide_panel(
+    workspace_root: &Path,
+    name: &str,
+    answer: PanelAnswer,
+    settings: &Settings,
+) -> Result<(), String> {
+    let name = checked_name(name)?;
+    let (roster, notices) = PluginRoster::load(workspace_root, settings);
+    for notice in &notices {
+        eprintln!("{notice}");
+    }
+    let plugin = roster.get(name).ok_or_else(|| {
+        format!("no plugin named `{name}` is installed — `stella plugin list` shows what is")
+    })?;
+    if plugin.manifest.panel.is_none() {
+        return Err(format!(
+            "`{name}` declares no `[panel]`, so there is nothing to allow or deny"
+        ));
+    }
+    // The bytes on disk, re-read here rather than carried from the roster's
+    // parse: the grant is keyed on a digest, and the digest has to be of the
+    // file the next load will read. Reading it once, now, is also what makes
+    // the handshake and the record describe the same manifest.
+    let (_, manifest_text) = roster::read_manifest(&plugin.dir)?
+        .ok_or_else(|| format!("{} holds no {MANIFEST_FILE} any more", plugin.dir.display()))?;
+    let signature = format!("sha256:{}", receipt::digest(manifest_text.as_bytes()));
+    let Some(handshake) = stella_plugin::panel_handshake_text(&plugin.manifest, &signature) else {
+        return Err(format!(
+            "`{name}` declares no `[panel]`, so there is nothing to allow or deny"
+        ));
+    };
+    println!("{handshake}");
+
+    let verdict = match answer {
+        PanelAnswer::Given(verdict) => verdict,
+        PanelAnswer::Ask => {
+            // `install`'s rule, for the same reason: the most dangerous thing a
+            // plugin does must not have "yes" as its unattended default, and an
+            // automated answer must be a flag somebody typed.
+            if !crate::interactive::human_is_present(true) {
+                return Err(
+                    "nothing here can ask you to decide that — no terminal is attached. \
+                     Re-run with --allow or --deny once you have read the handshake above."
+                        .to_string(),
+                );
+            }
+            confirm_panel()?
+        }
+    };
+
+    let tier = tier_dir(workspace_root, plugin.scope)?;
+    let entry = plugin
+        .dir
+        .file_name()
+        .and_then(|entry| entry.to_str())
+        .ok_or_else(|| format!("{} has no usable name", plugin.dir.display()))?;
+    panel_grant::record(
+        &tier,
+        plugin.scope,
+        entry,
+        &plugin.manifest.name,
+        manifest_text.as_bytes(),
+        verdict,
+    )?;
+    match verdict {
+        panel_grant::PanelVerdict::Allow => println!(
+            "\n`{name}` may draw its panel. It takes effect in the next session, or at the \
+             next `/reload`."
+        ),
+        panel_grant::PanelVerdict::Deny => println!(
+            "\n`{name}` may not draw a panel. Its tools, skills and hooks are untouched — \
+             `stella plugin remove {name}` is what takes those away."
+        ),
+    }
+    Ok(())
+}
+
+/// Ask SPEC 12.4's question once, on stdout, and accept only an explicit
+/// answer to it.
+///
+/// Neither letter is a default. [`confirm`] can treat everything that is not
+/// `y` as no because the thing being refused is an install that has not
+/// happened; here both answers are decisions that get written down, and
+/// guessing which one a stray newline meant would record a grant nobody gave.
+fn confirm_panel() -> Result<panel_grant::PanelVerdict, String> {
+    use std::io::{BufRead as _, Write as _};
+
+    loop {
+        print!("\n{} ", stella_plugin::PANEL_GRANT_ASK);
+        std::io::stdout()
+            .flush()
+            .map_err(|e| format!("cannot write the prompt: {e}"))?;
+        let mut line = String::new();
+        let read = std::io::stdin()
+            .lock()
+            .read_line(&mut line)
+            .map_err(|e| format!("cannot read your answer: {e}"))?;
+        if read == 0 {
+            return Err("stdin closed before you answered, so nothing was recorded".to_string());
+        }
+        match line.trim().to_ascii_lowercase().as_str() {
+            "a" | "allow" => return Ok(panel_grant::PanelVerdict::Allow),
+            "d" | "deny" => return Ok(panel_grant::PanelVerdict::Deny),
+            _ => println!("answer `a` to allow or `d` to deny."),
+        }
+    }
+}
+
 /// Ask once, on stdout, and accept only an explicit yes.
 fn confirm() -> Result<bool, String> {
     use std::io::{BufRead as _, Write as _};
@@ -561,6 +814,24 @@ fn list(workspace_root: &Path, settings: &Settings) -> Result<(), String> {
         }
         for line in driver_lines(plugin) {
             println!("{line}");
+        }
+        // The panel grant, for a package that declares one. The `runs:` and
+        // `drives:` lines above report the two programs a plugin can put on
+        // the machine and say nothing about the third, which is the one that
+        // draws on the operator's screen — and unlike those, this one is
+        // withheld by default, so a listing that omitted it would leave "my
+        // panel never appears" unanswerable.
+        if plugin.manifest.panel.is_some() {
+            println!(
+                "  panel: {}",
+                match plugin.panel_grant.notice(&plugin.manifest.name) {
+                    Some(notice) => notice,
+                    None => format!(
+                        "allowed — `stella plugin panel {}` changes it",
+                        plugin.manifest.name
+                    ),
+                }
+            );
         }
     }
 
@@ -808,6 +1079,11 @@ fn remove_reporting(
             // answer stands once the thing it was about is gone.
             if let Some(entry) = dir.file_name().and_then(|entry| entry.to_str()) {
                 receipt::forget(&tier, entry);
+                // And the panel grant with it, for the same reason one layer
+                // over (#5056): a grant left behind would let a later
+                // directory of the same name draw on the operator's screen
+                // under an answer given about a package that is gone.
+                panel_grant::forget(&tier, entry);
             }
             report(format!(
                 "removed `{name}` ({}) from {}",

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -92,12 +92,6 @@ pub enum PluginCmd {
     /// List installed plugins, what each is allowed to do, and where it came
     /// from.
     List,
-    /// Remove an installed plugin, by manifest name.
-    Remove {
-        /// The plugin's `name`, as `stella plugin list` prints it.
-        #[arg(value_name = "NAME")]
-        name: String,
-    },
     /// Decide whether an installed plugin may draw on your screen: print its
     /// panel handshake, and record the answer (SPEC 12.4).
     ///
@@ -116,6 +110,12 @@ pub enum PluginCmd {
         /// Answer `deny` without prompting.
         #[arg(long)]
         deny: bool,
+    },
+    /// Remove an installed plugin, by manifest name.
+    Remove {
+        /// The plugin's `name`, as `stella plugin list` prints it.
+        #[arg(value_name = "NAME")]
+        name: String,
     },
     /// Open one driver session against an installed plugin that declares
     /// `[driver]`, and report what it says to do next.

--- a/crates/stella-cli/src/plugin_cmd/panel_grant.rs
+++ b/crates/stella-cli/src/plugin_cmd/panel_grant.rs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Whether a human allowed this plugin to draw on their screen, written down
+//! beside the package — SPEC 12.4's half of the panel protocol (#5056).
+//!
+//! # Why the install receipt is not this
+//!
+//! [`super::receipt`] records that somebody accepted a package: its tools, its
+//! skills, its hooks, the process it runs inside a turn. A panel is a
+//! different grant, and SPEC 12 opens by saying why — a plugin with a panel
+//! "changes what a person **sees and touches**, so the panel is where a plugin
+//! becomes a piece of software with a face, and where the strongest limits
+//! belong". Each of these needs a record the receipt cannot be:
+//!
+//!   * **It can be withdrawn without uninstalling.** `deny` leaves the
+//!     package's tools and hooks exactly where they were and takes away the
+//!     rectangle. Folding the answer into the receipt would make the only way
+//!     to stop a panel drawing a `stella plugin remove`.
+//!   * **It can be given to a package nobody installed.** A project-tier
+//!     plugin arrives with a `git clone` and has no install transaction at all
+//!     ([`super::receipt`]'s tier asymmetry). It can still be asked for a
+//!     panel, and this is where that answer lives.
+//!   * **It is asked again when the declaration changes.** A grant is keyed on
+//!     the same digest a receipt is, so a manifest that grows a surface, a
+//!     slash name or a wider `[panel.process]` is a different document and is
+//!     [`PanelGrantState::Drifted`] until someone reads the new one.
+//!
+//! # Undecided withholds
+//!
+//! The one asymmetry with [`super::receipt::ConsentState`]: a package with no
+//! panel record does **not** draw, in either tier. The receipt's carve-out
+//! exists because an unreceipted project package is the normal state of a
+//! plugin that arrived by clone, and `STELLA_TRUST_PROJECT` is the transaction
+//! standing behind it. There is no equivalent standing behind a panel: the
+//! trust flag answers "may this repository's code run at all", and SPEC 12.4
+//! asks a second question on top of it, per plugin, about the screen. So
+//! absence is withholding rather than admission, and the operator is told so
+//! with the command that resolves it.
+//!
+//! # What this is not
+//!
+//! [`super::receipt`]'s disclaimer applies here word for word: a plugin's
+//! process runs as the user and can delete or rewrite this file exactly as it
+//! can rewrite its own manifest. What the record buys is that the two files
+//! must be kept in agreement, and that the only things that write one are the
+//! two code paths that show a human the handshake.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::receipt::digest;
+use super::roster::PluginScope;
+
+/// The directory inside a tier that holds one panel grant per package.
+///
+/// A leading dot, for [`super::receipt`]'s reason: `super::roster::read_tier`
+/// skips a dot entry, so the grants cannot themselves be read as a package.
+const GRANTS_DIR: &str = ".panel";
+
+/// What a person answered when they were shown a panel handshake.
+///
+/// Two arms and no third: SPEC 12.4 asks `[a]llow [d]eny`, and "not yet
+/// answered" is the absence of a record rather than a value inside one. A
+/// stored `Undecided` would be a file saying nothing, and the two states would
+/// then have to be kept from disagreeing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum PanelVerdict {
+    /// The panel may be leased a rectangle and asked for frames.
+    Allow,
+    /// It may not. The rest of the package is untouched.
+    Deny,
+}
+
+impl PanelVerdict {
+    /// The word `stella plugin list` prints.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allowed",
+            Self::Deny => "denied",
+        }
+    }
+}
+
+/// One panel grant, as a fact on disk.
+///
+/// Serde-first so the file is a value a test asserts on rather than a format
+/// two functions agree about by hand ([`super::receipt::ConsentReceipt`]'s
+/// reasoning).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PanelGrantRecord {
+    /// The manifest `name` the handshake named. Carried as well as digested so
+    /// a grant cannot be moved onto another package and pass by coincidence.
+    pub(crate) plugin: String,
+    /// Lowercase hex SHA-256 of the `plugin.toml` bytes the handshake was
+    /// rendered from — the same digest [`super::receipt`] records, and the
+    /// signature the handshake showed.
+    pub(crate) manifest_sha256: String,
+    /// The tier the answer was given for, as [`PluginScope::as_str`] spells it.
+    pub(crate) scope: String,
+    /// Unix seconds at which the answer was given.
+    pub(crate) decided_at: u64,
+    /// What was answered.
+    pub(crate) verdict: PanelVerdict,
+}
+
+/// Whether this package's panel may draw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PanelGrantState {
+    /// A grant covers exactly these manifest bytes and says allow.
+    Allowed,
+    /// A grant covers exactly these manifest bytes and says deny.
+    Denied,
+    /// Nobody has been asked. Withholds, in both tiers — see this module's
+    /// header.
+    Undecided,
+    /// A grant exists and this manifest is not the one it covers: the bytes
+    /// changed, the name changed, or it was written for the other tier.
+    Drifted,
+}
+
+impl PanelGrantState {
+    /// Whether a panel in this state may be leased a rectangle.
+    ///
+    /// **The authoritative panel gate**, read by
+    /// `super::roster::PluginRoster::panel_routes`. Exactly one arm admits, so
+    /// a state added later is refused until somebody decides what it means.
+    #[must_use]
+    pub(crate) fn admits(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+
+    /// The line an operator is told when this state withholds a panel, or
+    /// `None` when it does not.
+    ///
+    /// Pure, so the wording is assertable without a terminal — and it names the
+    /// command that resolves it, because a rectangle that silently never
+    /// appears is indistinguishable from a plugin that is broken.
+    #[must_use]
+    pub(crate) fn notice(self, plugin: &str) -> Option<String> {
+        let cause = match self {
+            Self::Allowed => return None,
+            Self::Denied => "you denied it",
+            Self::Undecided => "nobody has been asked yet",
+            Self::Drifted => {
+                "its `plugin.toml` has changed since the panel was granted, so what it \
+                 would draw with is not what anyone read"
+            }
+        };
+        Some(format!(
+            "! `{plugin}` declares a panel and is not drawing one — {cause}. \
+             Run `stella plugin panel {plugin}` to read the handshake and decide."
+        ))
+    }
+}
+
+/// Where `entry`'s panel grant lives inside `tier`, or `None` for a directory
+/// name that cannot hold one.
+///
+/// The name is third-party text used as a file name, so it is checked as one —
+/// [`super::checked_name`]'s argument, one directory over. A name that fails
+/// has no grant rather than a grant somewhere else.
+fn grant_path(tier: &Path, entry: &str) -> Option<PathBuf> {
+    super::checked_name(entry)
+        .ok()
+        .map(|entry| tier.join(GRANTS_DIR).join(format!("{entry}.json")))
+}
+
+/// Record that a human answered `verdict` for the panel `manifest` declares.
+///
+/// Called from the two paths that render
+/// [`stella_plugin::panel_handshake_text`] and nowhere else: a grant written
+/// anywhere but the path that shows the handshake would be a grant for a
+/// document nobody read.
+pub(crate) fn record(
+    tier: &Path,
+    scope: PluginScope,
+    entry: &str,
+    plugin: &str,
+    manifest: &[u8],
+    verdict: PanelVerdict,
+) -> Result<(), String> {
+    let path = grant_path(tier, entry)
+        .ok_or_else(|| format!("`{}` cannot hold a panel grant", entry.escape_debug()))?;
+    let record = PanelGrantRecord {
+        plugin: plugin.to_string(),
+        manifest_sha256: digest(manifest),
+        scope: scope.as_str().to_string(),
+        decided_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_secs()),
+        verdict,
+    };
+    let body = serde_json::to_string_pretty(&record)
+        .map_err(|error| format!("cannot render the panel grant: {error}"))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("cannot create {}: {error}", parent.display()))?;
+    }
+    std::fs::write(&path, body).map_err(|error| format!("cannot write {}: {error}", path.display()))
+}
+
+/// Drop `entry`'s panel grant, best effort.
+///
+/// Best effort on [`super::receipt::forget`]'s reasoning: it is only called
+/// where the package itself is already gone or being discarded, and a leaked
+/// grant admits nothing on its own — `check` reads the manifest beside it, and
+/// there is none.
+pub(crate) fn forget(tier: &Path, entry: &str) {
+    if let Some(path) = grant_path(tier, entry) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// What a human answered about the panel of the package at `dir` inside
+/// `tier`, whose manifest bytes are `manifest`.
+///
+/// `name` is checked against the record as well as the digest, which the
+/// digest already covers — comparing it explicitly is what lets a mismatch be
+/// reported as drift rather than as a hash that happens not to match
+/// ([`super::receipt::check`]).
+#[must_use]
+pub(crate) fn check(
+    tier: &Path,
+    scope: PluginScope,
+    dir: &Path,
+    name: &str,
+    manifest: &[u8],
+) -> PanelGrantState {
+    let Some(entry) = dir.file_name().and_then(|entry| entry.to_str()) else {
+        return PanelGrantState::Undecided;
+    };
+    let Some(path) = grant_path(tier, entry) else {
+        return PanelGrantState::Undecided;
+    };
+    let Ok(body) = std::fs::read_to_string(&path) else {
+        return PanelGrantState::Undecided;
+    };
+    // An unreadable grant is drift, not absence. Both withhold, so unlike the
+    // receipt's version of this rule nothing is reachable by writing garbage —
+    // but the two states say different things to the operator, and "something
+    // wrote a file there" is the true one.
+    let Ok(record) = serde_json::from_str::<PanelGrantRecord>(&body) else {
+        return PanelGrantState::Drifted;
+    };
+    if record.plugin != name
+        || record.scope != scope.as_str()
+        || record.manifest_sha256 != digest(manifest)
+    {
+        return PanelGrantState::Drifted;
+    }
+    match record.verdict {
+        PanelVerdict::Allow => PanelGrantState::Allowed,
+        PanelVerdict::Deny => PanelGrantState::Denied,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tier() -> tempfile::TempDir {
+        tempfile::tempdir().expect("a temp tier")
+    }
+
+    /// The round trip: what `record` writes, `check` reads back — and only for
+    /// the exact bytes, the exact name and the exact tier.
+    #[test]
+    fn a_grant_answers_only_for_the_manifest_the_scope_and_the_name_it_covers() {
+        let tier = tier();
+        let dir = tier.path().join("hello");
+        let manifest = b"name = \"hello\"\n[panel]\nsurfaces = [\"settings\"]\n";
+        record(
+            tier.path(),
+            PluginScope::User,
+            "hello",
+            "hello",
+            manifest,
+            PanelVerdict::Allow,
+        )
+        .expect("write");
+
+        assert_eq!(
+            check(tier.path(), PluginScope::User, &dir, "hello", manifest),
+            PanelGrantState::Allowed
+        );
+        assert_eq!(
+            check(
+                tier.path(),
+                PluginScope::User,
+                &dir,
+                "hello",
+                b"name = \"hello\"\n[panel]\nsurfaces = [\"settings\", \"overlay\"]\n"
+            ),
+            PanelGrantState::Drifted,
+            "a panel that grew a surface is not the one that was granted"
+        );
+        assert_eq!(
+            check(tier.path(), PluginScope::Project, &dir, "hello", manifest),
+            PanelGrantState::Drifted,
+            "a grant answers for the tier it was written in"
+        );
+        assert_eq!(
+            check(tier.path(), PluginScope::User, &dir, "other", manifest),
+            PanelGrantState::Drifted,
+            "and for the package it names"
+        );
+    }
+
+    /// **The withholding witness.** Only an explicit allow admits, and the
+    /// three states that do not each say why and name the way through.
+    #[test]
+    fn only_an_explicit_allow_admits_and_every_refusal_names_the_command() {
+        let tier = tier();
+        let dir = tier.path().join("hello");
+        let manifest = b"name = \"hello\"\n";
+
+        // Never asked — withheld in both tiers, unlike an install receipt.
+        let undecided = check(tier.path(), PluginScope::User, &dir, "hello", manifest);
+        assert_eq!(undecided, PanelGrantState::Undecided);
+        assert!(!undecided.admits());
+        assert_eq!(
+            check(tier.path(), PluginScope::Project, &dir, "hello", manifest),
+            PanelGrantState::Undecided,
+            "a plugin that arrived with a `git clone` is still asked about its screen"
+        );
+
+        record(
+            tier.path(),
+            PluginScope::User,
+            "hello",
+            "hello",
+            manifest,
+            PanelVerdict::Deny,
+        )
+        .expect("write");
+        let denied = check(tier.path(), PluginScope::User, &dir, "hello", manifest);
+        assert_eq!(denied, PanelGrantState::Denied);
+        assert!(!denied.admits());
+
+        for state in [
+            PanelGrantState::Undecided,
+            PanelGrantState::Denied,
+            PanelGrantState::Drifted,
+        ] {
+            let notice = state.notice("hello").expect("a withheld panel is spoken");
+            assert!(
+                notice.contains("stella plugin panel hello"),
+                "{state:?}: {notice}"
+            );
+        }
+        assert!(
+            PanelGrantState::Allowed.notice("hello").is_none(),
+            "an admitted panel is not something to tell anyone about"
+        );
+    }
+
+    /// A corrupt grant is drift rather than absence: something wrote a file at
+    /// that path, and the operator is told the true reason.
+    #[test]
+    fn an_unreadable_grant_is_drift_rather_than_absence() {
+        let tier = tier();
+        std::fs::create_dir_all(tier.path().join(GRANTS_DIR)).expect("dir");
+        std::fs::write(tier.path().join(GRANTS_DIR).join("hello.json"), "{").expect("garbage");
+        assert_eq!(
+            check(
+                tier.path(),
+                PluginScope::User,
+                &tier.path().join("hello"),
+                "hello",
+                b"name = \"hello\"\n"
+            ),
+            PanelGrantState::Drifted
+        );
+    }
+
+    /// `forget` removes exactly the one grant, and is silent about one that was
+    /// never there.
+    #[test]
+    fn forgetting_a_grant_removes_only_that_one() {
+        let tier = tier();
+        for name in ["hello", "gauge"] {
+            record(
+                tier.path(),
+                PluginScope::User,
+                name,
+                name,
+                b"x",
+                PanelVerdict::Allow,
+            )
+            .expect("write");
+        }
+        forget(tier.path(), "hello");
+        forget(tier.path(), "never-granted");
+        assert_eq!(
+            check(
+                tier.path(),
+                PluginScope::User,
+                &tier.path().join("hello"),
+                "hello",
+                b"x"
+            ),
+            PanelGrantState::Undecided
+        );
+        assert_eq!(
+            check(
+                tier.path(),
+                PluginScope::User,
+                &tier.path().join("gauge"),
+                "gauge",
+                b"x"
+            ),
+            PanelGrantState::Allowed
+        );
+    }
+}

--- a/crates/stella-cli/src/plugin_cmd/roster.rs
+++ b/crates/stella-cli/src/plugin_cmd/roster.rs
@@ -588,20 +588,24 @@ pub(crate) fn read_tier(
                 if let Some(notice) = consent.notice(scope, &manifest.name, &path) {
                     notices.push(notice);
                 }
-                // The panel grant, on the same clock and for the same reason
-                // (#5056, SPEC 12.4). Read for every package rather than only
-                // for one declaring a `[panel]`, so a manifest that grows the
-                // block between two loads is `Undecided` the moment it does
-                // instead of inheriting an answer nobody gave. It is spoken
-                // only where the package actually declares a panel — a plugin
-                // with no `[panel]` is not being withheld from anything.
+                // The panel grant, on the same clock (#5056, SPEC 12.4). Read
+                // for every package rather than only for one declaring a
+                // `[panel]`, so a manifest that grows the block between two
+                // loads is `Undecided` the moment it does instead of
+                // inheriting an answer nobody gave.
+                //
+                // Not pushed into `notices`, unlike the receipt above, and the
+                // difference is what a notice from here means: these say a
+                // **package was withheld** and name the way to load it. A
+                // panel grant withholds a rectangle from a package that is
+                // fully in force, so it is spoken by the two surfaces that
+                // have somewhere to put it — `stella plugin list`'s `panel:`
+                // line, and the deck's own handshake block
+                // (`command_deck::plugin_panels::handshakes`) — rather than
+                // through a channel whose every other line is about a plugin
+                // that did not load.
                 let panel_grant =
                     panel_grant::check(dir, scope, &path, &manifest.name, text.as_bytes());
-                if manifest.panel.is_some()
-                    && let Some(notice) = panel_grant.notice(&manifest.name)
-                {
-                    notices.push(format!("  {notice}"));
-                }
                 found.push(InstalledPlugin {
                     manifest,
                     dir: path,

--- a/crates/stella-cli/src/plugin_cmd/roster.rs
+++ b/crates/stella-cli/src/plugin_cmd/roster.rs
@@ -356,10 +356,11 @@ impl PluginRoster {
                 continue;
             };
             if !plugin.panel_grant.admits() {
-                // No route, so no lease, so no process. The operator was told
-                // why by `read_tier`, which is the only place that knows
-                // whether this package's panel was denied, drifted, or never
-                // asked about.
+                // No route, so no lease, so no process. Silent here, and said
+                // by the two surfaces that have somewhere to put it: `stella
+                // plugin list`'s `panel:` line and the deck's own handshake
+                // block. `PanelGrantState::notice` is the one wording both
+                // read, so a withheld panel cannot be explained two ways.
                 continue;
             }
             let Some(process) = &panel.process else {

--- a/crates/stella-cli/src/plugin_cmd/roster.rs
+++ b/crates/stella-cli/src/plugin_cmd/roster.rs
@@ -47,6 +47,7 @@ use std::path::{Path, PathBuf};
 use stella_core::ports::Principal;
 use stella_plugin::{HookEvent, PanelSurface, PluginManifest, Runtime};
 
+use super::panel_grant::{self, PanelGrantState};
 use super::receipt::{self, ConsentState};
 use crate::settings::{Settings, Toggle};
 
@@ -123,6 +124,17 @@ pub(crate) struct InstalledPlugin {
     /// for (#3514). Read from the tier's consent receipts by [`read_tier`];
     /// [`PluginRoster::compose`] is what acts on it.
     pub(crate) consent: ConsentState,
+    /// Whether a human allowed this package to draw on their screen (#5056,
+    /// SPEC 12.4). Read from the tier's panel grants by [`read_tier`];
+    /// [`PluginRoster::panel_routes`] is what acts on it.
+    ///
+    /// Separate from [`Self::consent`], and acted on one layer further in,
+    /// because the two withhold different things: a package whose install
+    /// grant drifted must not load at all, while one whose panel is denied
+    /// keeps every tool, skill and hook it declared and loses only the
+    /// rectangle. Folding them would make "stop drawing on my screen" mean
+    /// "uninstall".
+    pub(crate) panel_grant: PanelGrantState,
 }
 
 impl InstalledPlugin {
@@ -319,12 +331,19 @@ impl PluginRoster {
     ///
     /// **This is the authoritative panel filter, and it is what "no frame
     /// before the grant" means.** A route exists only where the manifest
-    /// declared the surface *and* a `[panel.process]` to draw it with, and only
-    /// for a plugin already in the roster — which is to say one whose install
-    /// grant is in force, since [`PluginRoster::compose`] drops every package
-    /// that fails [`InstalledPlugin::admitted`]. Nothing downstream re-checks
-    /// the grant, so nothing here may emit a route the manifest did not declare
-    /// or the operator did not consent to.
+    /// declared the surface *and* a `[panel.process]` to draw it with, only for
+    /// a plugin already in the roster — which is to say one whose install grant
+    /// is in force, since [`PluginRoster::compose`] drops every package that
+    /// fails [`InstalledPlugin::admitted`] — and only where a human answered
+    /// **allow** to that plugin's panel handshake (#5056, SPEC 12.4). Nothing
+    /// downstream re-checks any of it, so nothing here may emit a route the
+    /// manifest did not declare or the operator did not grant.
+    ///
+    /// The panel grant is asked here rather than in
+    /// [`PluginRoster::compose`] because it withholds a rectangle and not a
+    /// package: a denied plugin keeps its tools, its skills and its hooks. That
+    /// is what makes deny a usable answer rather than a euphemism for
+    /// uninstall.
     ///
     /// A grant with surfaces and no process yields nothing, which is
     /// [`hook_routes`](PluginRoster::hook_routes)'s rule restated: the
@@ -336,6 +355,13 @@ impl PluginRoster {
             let Some(panel) = &plugin.manifest.panel else {
                 continue;
             };
+            if !plugin.panel_grant.admits() {
+                // No route, so no lease, so no process. The operator was told
+                // why by `read_tier`, which is the only place that knows
+                // whether this package's panel was denied, drifted, or never
+                // asked about.
+                continue;
+            }
             let Some(process) = &panel.process else {
                 // A panel grant with no `[panel.process]` has nothing to ask
                 // for a frame.
@@ -562,11 +588,26 @@ pub(crate) fn read_tier(
                 if let Some(notice) = consent.notice(scope, &manifest.name, &path) {
                     notices.push(notice);
                 }
+                // The panel grant, on the same clock and for the same reason
+                // (#5056, SPEC 12.4). Read for every package rather than only
+                // for one declaring a `[panel]`, so a manifest that grows the
+                // block between two loads is `Undecided` the moment it does
+                // instead of inheriting an answer nobody gave. It is spoken
+                // only where the package actually declares a panel — a plugin
+                // with no `[panel]` is not being withheld from anything.
+                let panel_grant =
+                    panel_grant::check(dir, scope, &path, &manifest.name, text.as_bytes());
+                if manifest.panel.is_some()
+                    && let Some(notice) = panel_grant.notice(&manifest.name)
+                {
+                    notices.push(format!("  {notice}"));
+                }
                 found.push(InstalledPlugin {
                     manifest,
                     dir: path,
                     scope,
                     consent,
+                    panel_grant,
                 });
             }
             Ok(None) => {}
@@ -670,6 +711,7 @@ mod tests {
             dir: PathBuf::from("/ws/.stella/plugins").join(name),
             scope,
             consent: ConsentState::Receipted,
+            panel_grant: PanelGrantState::Allowed,
         }
     }
 
@@ -800,6 +842,7 @@ mod tests {
             dir: PathBuf::from("/ws/.stella/plugins/quiet"),
             scope: PluginScope::Project,
             consent: ConsentState::Receipted,
+            panel_grant: PanelGrantState::Allowed,
         };
         let roster = PluginRoster::compose(Vec::new(), vec![plugin], &BTreeMap::new());
         assert_eq!(roster.plugins().len(), 1);
@@ -927,6 +970,7 @@ mod tests {
             dir: PathBuf::from("/ws/.stella/plugins/watch"),
             scope: PluginScope::Project,
             consent: ConsentState::Receipted,
+            panel_grant: PanelGrantState::Allowed,
         };
         assert_eq!(
             plugin.manifest.loop_grant.participation,

--- a/crates/stella-cli/src/wrapper_plugin/child_turn_fixture.rs
+++ b/crates/stella-cli/src/wrapper_plugin/child_turn_fixture.rs
@@ -154,6 +154,7 @@ pub(crate) fn asking_plugin(
             dir: PathBuf::from(dir),
             scope: PluginScope::User,
             consent: crate::plugin_cmd::receipt::ConsentState::Receipted,
+            panel_grant: crate::plugin_cmd::panel_grant::PanelGrantState::Undecided,
         }],
         Vec::new(),
         &BTreeMap::new(),

--- a/crates/stella-cli/src/wrapper_plugin/tests.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests.rs
@@ -79,6 +79,7 @@ fn installed(text: &str, dir: &str) -> InstalledPlugin {
         dir: PathBuf::from(dir),
         scope: PluginScope::User,
         consent: crate::plugin_cmd::receipt::ConsentState::Receipted,
+        panel_grant: crate::plugin_cmd::panel_grant::PanelGrantState::Undecided,
     }
 }
 

--- a/crates/stella-plugin/src/consent.rs
+++ b/crates/stella-plugin/src/consent.rs
@@ -222,6 +222,128 @@ pub fn consent_text(manifest: &PluginManifest) -> String {
     lines.join("\n")
 }
 
+/// Render SPEC 12.4's panel handshake: the document a person reads before a
+/// plugin is allowed to draw on their screen, and the `[a]llow [d]eny` ask
+/// underneath it.
+///
+/// `None` for a manifest with no `[panel]` block — a handshake about a plugin
+/// that draws nothing is a document about nothing, and rendering an empty one
+/// would teach a reader that the block is decorative.
+///
+/// # Why this is a second document rather than a section of [`consent_text`]
+///
+/// Installing and drawing are different grants, decided at different moments.
+/// [`consent_text`] answers "may this package exist on my machine, with the
+/// tools, skills and hooks it declares". A panel is the plugin becoming
+/// something the operator *looks at and trusts*, which SPEC 12 opens by
+/// calling the place the strongest limits belong. So the panel grant is
+/// recorded separately, can be withdrawn without uninstalling, and can be
+/// asked for a package that arrived by `git clone` and was never installed at
+/// all — which is a thing a section of `consent_text` could not do, since
+/// nothing ever rendered one for that package.
+///
+/// # The signature is the host's fact, not the manifest's
+///
+/// `signature` is the digest of the `plugin.toml` bytes this manifest was
+/// parsed from, supplied by the caller that read them. This crate performs no
+/// I/O and hashes nothing: computing it here would mean a second workspace
+/// dependency for a near-leaf crate — one this crate's manifest asks to have
+/// argued afresh rather than cited — and the digest a grant is keyed on has to
+/// be the one the host re-derives on the next load, not one this function
+/// recomputed from a copy.
+///
+/// # There is no caption here either
+///
+/// Every string below is either Stella's own or a manifest field flattened by
+/// `one_line`. SPEC 12.3's rule is that a plugin cannot name the chrome a
+/// reader trusts, and a consent document is chrome a reader trusts more than
+/// most: a plugin-authored heading here would be the same breach one surface
+/// earlier.
+#[must_use]
+pub fn panel_handshake_text(manifest: &PluginManifest, signature: &str) -> Option<String> {
+    let panel = manifest.panel.as_ref()?;
+    let name = one_line(&manifest.name);
+    let mut lines = vec![
+        format!("◳ panel handshake · {name}"),
+        format!(
+            "`{name}` is asking to draw part of your screen. Stella draws the border and the \
+             label `◳ panel · {name}` around it and writes every escape sequence your terminal \
+             ever sees — a panel sends glyphs, and supplies no title of its own."
+        ),
+        String::new(),
+        // First, because it is what the answer is *about*: a grant covers these
+        // exact bytes, so a manifest that widens itself afterwards is a
+        // different declaration and has to be asked again.
+        format!("Manifest signature: {}", one_line(signature)),
+        "  This grant covers exactly these manifest bytes. Change them and the panel is \
+         withheld until it is granted again."
+            .into(),
+    ];
+
+    lines.push(String::new());
+    lines.extend(capability_grant(manifest));
+
+    lines.push(String::new());
+    lines.push("Limits this panel accepts:".into());
+    for denial in PanelDenial::all() {
+        lines.push(format!(
+            "  - {}",
+            if panel.denies(*denial) {
+                denial.consent_sentence().to_string()
+            } else {
+                // Unreachable through `PluginManifest::from_toml_str`, which
+                // refuses a block naming fewer than all of them
+                // (`PanelGrant::missing_denial`). Rendered rather than skipped
+                // for a grant a host built in Rust: a limit missing from the
+                // document reads as a limit that is absent, which is the
+                // failure `PanelDenial`'s closure exists to prevent.
+                format!("does NOT accept the limit `{}`", denial.as_str())
+            }
+        ));
+    }
+
+    lines.push(String::new());
+    lines.push("Where it draws:".into());
+    // `PanelSurface::all()`'s order rather than the manifest's, on the denial
+    // list's reasoning: two plugins asking for the same placements render the
+    // same lines whichever order their authors typed.
+    for surface in PanelSurface::all() {
+        if panel.draws(*surface) {
+            lines.push(format!("  - {}", surface.consent_sentence()));
+        }
+    }
+    if let Some(command) = panel.command_or(&manifest.name) {
+        lines.push(format!(
+            "  - answers to `/{}`, and to `/{name}:{}`",
+            one_line(command),
+            one_line(command)
+        ));
+    }
+
+    // Last of the declaration, because it is the sentence that turns everything
+    // above into a program running on somebody's machine.
+    match &panel.process {
+        Some(process) => lines.extend(process_say(process)),
+        None => lines.push(
+            "  - is not started by Stella: this declares what such a panel accepts, and \
+             nothing here runs a program"
+                .into(),
+        ),
+    }
+
+    lines.push(String::new());
+    lines.push(PANEL_GRANT_ASK.into());
+    lines.push(
+        "Nothing is leased a rectangle, and no panel process is started, until you allow it."
+            .into(),
+    );
+    Some(lines.join("\n"))
+}
+
+/// The choice SPEC 12.4 puts under the handshake, so a host's prompt and a
+/// deck's notice cannot spell it two ways.
+pub const PANEL_GRANT_ASK: &str = "[a]llow  [d]eny";
+
 /// The "what it does inside your turn" half: the grade, and every power the
 /// grade unlocked that this manifest actually declared.
 fn loop_say(manifest: &PluginManifest) -> Vec<String> {

--- a/crates/stella-plugin/src/consent/tests.rs
+++ b/crates/stella-plugin/src/consent/tests.rs
@@ -530,3 +530,112 @@ fn a_contributed_stage_is_named_as_the_plugins_own() {
          misreading in the other direction: {text}"
     );
 }
+
+/// A `plugin.toml` declaring all three placements, a popup name, a capability
+/// and a process — everything the handshake has to be able to say.
+fn panel_fixture() -> &'static str {
+    "name = \"hello\"\n\
+     description = \"says hello\"\n\
+     \n\
+     [[capabilities]]\n\
+     tool = \"read_file\"\n\
+     risk = \"low\"\n\
+     purpose = \"read the file it draws\"\n\
+     \n\
+     [panel]\n\
+     surfaces = [\"settings\", \"overlay\", \"command\"]\n\
+     denies = [\"network\", \"write-outside-sandbox\"]\n\
+     \n\
+     [panel.process]\n\
+     argv = [\"python3\", \"panel.py\"]\n\
+     timeout_secs = 3\n\
+     env = []\n"
+}
+
+/// **The handshake witness.** SPEC 12.4 names five things a person must be
+/// shown before a panel draws, and the document carries all five plus the
+/// choice underneath them.
+#[test]
+fn the_panel_handshake_carries_the_five_things_spec_12_4_names() {
+    let text = panel_handshake_text(&parse(panel_fixture()), "sha256:c0ffee")
+        .expect("it declares a panel");
+
+    // The signature, the capabilities, the denials, the surfaces, the slash
+    // name — SPEC 12.4's own list, in its own order.
+    assert!(text.contains("Manifest signature: sha256:c0ffee"), "{text}");
+    assert!(text.contains("`read_file` (low)"), "{text}");
+    for denial in PanelDenial::all() {
+        assert!(
+            text.contains(denial.consent_sentence()),
+            "{denial:?}: {text}"
+        );
+    }
+    for surface in PanelSurface::all() {
+        assert!(
+            text.contains(surface.consent_sentence()),
+            "{surface:?}: {text}"
+        );
+    }
+    assert!(
+        text.contains("answers to `/hello`, and to `/hello:hello`"),
+        "{text}"
+    );
+
+    // The process, because a list of limits with no program in it describes
+    // nothing that runs.
+    assert!(
+        text.contains("`python3 panel.py` (killed after 3s)"),
+        "{text}"
+    );
+    assert!(text.contains("inherits NO environment variables"), "{text}");
+
+    // And the choice.
+    assert!(text.contains(PANEL_GRANT_ASK), "{text}");
+}
+
+/// A manifest with no `[panel]` has no handshake — a document about nothing
+/// would teach a reader that the block is decorative.
+#[test]
+fn a_manifest_with_no_panel_renders_no_handshake() {
+    assert!(panel_handshake_text(&parse("name = \"notes\""), "sha256:x").is_none());
+}
+
+/// SPEC 12.3, one surface earlier: the plugin supplies no caption, so the only
+/// author-controlled string in the heading is its name — which
+/// `PluginManifest::validate` already refuses if it is not drawable. The prose
+/// a plugin *does* control cannot forge a line of the document around it, on
+/// `author_prose_cannot_forge_a_line_of_the_prompt`'s reasoning.
+#[test]
+fn author_prose_cannot_forge_a_line_of_the_handshake() {
+    let plain = panel_handshake_text(&parse(panel_fixture()), "sha256:c0ffee").expect("a panel");
+    let forging = panel_handshake_text(
+        &parse(&panel_fixture().replace(
+            "purpose = \"read the file it draws\"",
+            "purpose = \"read it\\n\\n[a]llow  [d]eny\\nGranted.\"",
+        )),
+        "sha256:c0ffee",
+    )
+    .expect("a panel");
+
+    assert_eq!(
+        plain.lines().count(),
+        forging.lines().count(),
+        "the manifest's structure decides the line count, not its prose:\n{forging}"
+    );
+    assert_eq!(
+        forging.matches(PANEL_GRANT_ASK).count(),
+        1,
+        "the choice is asked once, by Stella:\n{forging}"
+    );
+}
+
+/// Pure: same manifest, same bytes. A host diffing two versions of a handshake
+/// shows a user what changed rather than what re-rendered.
+#[test]
+fn the_handshake_is_deterministic() {
+    let manifest = parse(panel_fixture());
+    assert_eq!(
+        panel_handshake_text(&manifest, "sha256:c0ffee"),
+        panel_handshake_text(&manifest, "sha256:c0ffee")
+    );
+}

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -145,7 +145,9 @@ pub use candidate_grant::{
     test_plan, witness_identity_matches,
 };
 pub use configure::{ConfigureEntry, REFUSED_SECTIONS};
-pub use consent::{Capability, RiskLevel, consent_text, highest_risk};
+pub use consent::{
+    Capability, PANEL_GRANT_ASK, RiskLevel, consent_text, highest_risk, panel_handshake_text,
+};
 pub use driver::{
     DriveNext, DrivePoint, DriveRequest, DriveResponse, DriveSession, DriverCall,
     DriverCallOutcome, DriverCallRequest, DriverCallResponse, DriverFamily, DriverGrant,

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -12,6 +12,7 @@ Offline: reads and writes local files, no API key.
 ```bash
 stella plugin install <dir> [--scope project|user] [--yes]
 stella plugin list
+stella plugin panel <name> [--allow|--deny]
 stella plugin remove <name>
 stella plugin drive <name>
 ```
@@ -109,6 +110,7 @@ vera                     project  arbiter
   Holds a turn open until the tests pass.
   /ws/.stella/plugins/vera
   runs: python3 ${plugin_dir}/main.py (30s, env: PATH)
+  panel: ! `vera` declares a panel and is not drawing one — nobody has been asked yet. Run `stella plugin panel vera` to read the handshake and decide.
 
 hook dispatches:
   vera                     PreToolUse -> python3 /ws/.stella/plugins/vera/main.py
@@ -118,6 +120,26 @@ hook dispatches:
 The two sections answer different questions. The first is what the plugin declared; the second is what would actually run. A plugin with a hook grant but no `[runtime]` appears in the first and not the second, which is the answer to "I declared `Stop` and nothing happens".
 
 A declared environment variable that stella grades as a model credential is refused and named here rather than discovered as a missing variable at the first dispatch. A plugin never receives the key that pays for the agent; the fix is a `[roles]` tier, so the host makes the call and the spend lands on the receipt.
+
+## `stella plugin panel`
+
+Decide whether a plugin may draw on your screen.
+
+```bash
+stella plugin panel hello           # print the handshake and ask
+stella plugin panel hello --allow
+stella plugin panel hello --deny
+```
+
+A plugin with a `[panel]` block is leased a rectangle of your terminal and fills it every tick. That is a separate grant from installing the package, and it is asked separately: the handshake shows the manifest signature, the capabilities the plugin asks for, the limits its panel accepts, which of the three surfaces it draws on, the slash name it answers to, and the program the host starts to draw it. Underneath is `[a]llow  [d]eny`.
+
+Until that question is answered, **the panel does not draw and its program is never started**. `stella plugin install` asks it for a package it is copying (and `--yes` answers it along with the install), so this verb is for the three cases an install prompt never reaches:
+
+- a plugin that arrived with a `git clone` into `.stella/plugins` and was never installed by this binary;
+- a plugin whose manifest changed after the grant — the answer covers exact bytes, so a `[panel]` that grows a surface or a wider process is asked again;
+- withdrawing a panel you previously allowed.
+
+Denying is not uninstalling. The package keeps its tools, its skills and its hooks, and loses only the rectangle — `stella plugin remove` is what takes the rest away.
 
 ## `stella plugin remove`
 


### PR DESCRIPTION
## What & why

SPEC 12.4's trust half. A `[panel]` block asks for a rectangle of the operator's terminal and fills it with a third party's glyphs every tick, and until now the only thing standing in front of it was the **install** receipt — so accepting a package's tools and hooks silently accepted somebody else's program painting part of the screen, and there was no way to withdraw that without uninstalling.

Three pieces:

- **`stella_plugin::panel_handshake_text`** renders SPEC 12.4's document: the manifest signature, the declared capabilities, the declared denials, the surfaces asked for, the slash name, and the process that draws it — with `[a]llow  [d]eny` under it. Pure, no I/O, no clock; the signature is the host's digest passed in, so the near-leaf crate takes **no new dependency** (its own manifest asks for that argument to be made afresh rather than cited, and the answer here is "don't make it").
- **`plugin_cmd::panel_grant`** writes the answer beside the install receipt, keyed on the same digest, so a `[panel]` that grows a surface or a wider process is asked again. **Undecided withholds in both tiers** — `receipt`'s project-tier carve-out does not carry over, because `STELLA_TRUST_PROJECT` answers "may this repository's code run at all", not "may this plugin draw on my screen".
- **`PluginRoster::panel_routes` is gated on it**, one layer inside `compose`: a denied panel costs the plugin the rectangle and nothing else — its tools, skills and hooks keep running. That is what makes deny a usable answer rather than a euphemism for uninstall, and it has its own witness.

`stella plugin install` asks the question for what it is copying (`--yes` answers it along with the install, since the consent document it accepted already carries the panel section). **`stella plugin panel <name> [--allow|--deny]`** answers it for the three cases an install prompt never reaches: a package that arrived by `git clone` into `.stella/plugins`, one whose manifest changed after the grant, and a grant being withdrawn. `remove` forgets the grant with the receipt.

Before any panel is seated, the session renders the handshake **in the transcript**: the whole document where the decision is still open, and the standing grant plus the way to withdraw it where it is not.

Closes #5056

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Each verified by hand — revert the named change, watch the named test fail, restore.

| Test | Fails without |
| --- | --- |
| `no_panel_frame_is_requested_when_the_panel_grant_does_not_allow_it` | the `panel_routes` gate. **Asserted on the panel process's marker file**, and asserted *before* the route list, so a flip fails on "a third party's program ran on this machine" rather than on the bookkeeping that is only evidence about it — the ordering `a_frame_in_flight_across_a_reseat_lands_nowhere` uses. Verified: with the gate reverted it panics `a panel process ran without an allow: …/the-panel-process-ran`. |
| `a_denied_panel_costs_the_plugin_nothing_but_the_rectangle` | the gate being inside `panel_routes` rather than in `compose`. Without it, "deny" could be implemented by dropping the package and every other assertion would still pass — while the operator lost the plugin's tools and hooks too. |
| `the_first_seat_is_preceded_by_a_handshake_for_every_panel_plugin` | `plugin_panels::handshakes` |
| `the_panel_handshake_carries_the_five_things_spec_12_4_names` | `panel_handshake_text` (compile-level: a new function) |
| `author_prose_cannot_forge_a_line_of_the_handshake` | `one_line` over the author strings the handshake composes. **Behavioural, and it catches a gap the existing prompt tests did not**: dropping `one_line` from `capability_grant`'s `purpose` leaves `author_prose_cannot_forge_a_line_of_the_prompt` green and fails this one, because that test exercises `description` and this one exercises `purpose`. |
| `only_an_explicit_allow_admits_and_every_refusal_names_the_command` | `PanelGrantState::admits` / `notice` |
| `a_grant_answers_only_for_the_manifest_the_scope_and_the_name_it_covers` | the digest + scope + name key |
| `a_manifest_with_no_panel_renders_no_handshake`, `the_handshake_is_deterministic`, `an_unreadable_grant_is_drift_rather_than_absence`, `forgetting_a_grant_removes_only_that_one` | the surrounding rules |

## The gate

- [x] `cargo fmt --check`
- [x] `make guards-fast` (green, including `prose`, `file-size`, `command-docs`, `consumer-sites`, `diagnostic-codes`, `tokens`)
- [x] `cargo test -p stella-plugin`, `cargo test -p stella-cli --bin stella plugin` (169 + 160 green)
- [ ] `cargo clippy --workspace`, `cargo test --workspace` — CI's, per CLAUDE.md ("CI builds and tests; this laptop does not")
- [x] Docs updated: `website/content/docs/commands/plugin.mdx` gains a `stella plugin panel` section, the synopsis, and the `panel:` line in the `list` sample
- [x] `Closes #5056` in this description **and** as a commit trailer

## Where this follows the SPEC over the issue

Two places, both called out because the choice is reviewable rather than obvious:

1. **No caption, and no plugin-supplied heading in the handshake either.** The issue asks for a "handshake"; SPEC 12.3's rule is that a plugin cannot name chrome a reader trusts, and a consent document is chrome a reader trusts more than most. Every string in the document is either Stella's own or a manifest field flattened by `one_line`, and `author_prose_cannot_forge_a_line_of_the_handshake` pins it.

2. **The handshake goes in the transcript, not the boot dialog — but not on a silver rail, and that half is filed.** SPEC 12.4 says "Render the handshake in the transcript (silver rail)". `command_deck.rs`'s own `system_notice` doc argues the opposite policy for startup chrome ("the transcript is the home for agent and user messages only"), and the SPEC wins here: a consent document has to be scrollable and still there after the transient dialog is gone. `chrome_note` folds the lead to `Running`, so the idle assert this file already makes at startup is repeated after the blocks — the idiom the `InitCompleted` arm uses.

   The parenthetical SPEC 12.4 adds — "(silver rail)" — is **not** met, and saying so is the point of this paragraph. The rail metal is a property of `EventKind`, and every kind is derived from a tool call; host prose reaches the transcript as a fabricated `AgentEvent::Text`, with no rail. So the handshake currently renders as though the agent said it, which is the wrong direction for SPEC 12.3's argument. Giving host consent prose a rail of its own is a `stella-tui` transcript-vocabulary change with golden frames behind it, and it is #5300 rather than something bolted onto this PR.

The `[a]llow [d]eny` keystrokes are asked where the other consent prompt is asked: on stdout, in `stella plugin install` and `stella plugin panel`. The transcript block names that verb. An in-deck keyed card would need new envelope variants, a new overlay, and key handling in `deck_ui.rs` — a god file closed to growth — and is filed rather than smuggled in (see below).

## Nothing left behind

- [x] Filed: #5293 (the grant can only be answered from the command line, not from the deck), #5294 (`stella plugin list` has no machine-readable form), #5300 (the handshake is in the transcript but not on a silver rail)

## Ground-rule check

- [x] No I/O added to `stella-core`; **no new dependency anywhere** — the handshake takes the digest rather than computing it, precisely so `stella-plugin` does not grow a `sha2` edge
- [x] No new outbound network calls
- [x] The new cross-boundary type (`PanelGrantRecord`) is serde-first, round-tripped by `a_grant_answers_only_for_the_manifest_the_scope_and_the_name_it_covers`
- [x] No new `AgentEvent` variant, so no consumers-ledger row and no `docs/wire/` regeneration

## Anything reviewers should know?

- **Upgrade behaviour.** A plugin already installed with a `[panel]` block stops drawing after this lands, until `stella plugin panel <name>` is run. That is the intended direction for a security gate that defaults closed, and the session says so in the transcript with the verb that fixes it — but it *is* a behaviour change for an existing install, and it is called out rather than left to be discovered.
- `plugins/stella-hello` and the `hello_panel_demo` / `plugin_panel_placements` suites construct their routes from the manifest directly rather than through the roster, so the reference demo is unaffected.
- #5185 (a frame's cell count is chars rather than display width) is untouched; nothing here changes the clip that makes it safe.

## Summary by Sourcery

Gate plugin panels behind a separate, manifest-bound operator grant while preserving the rest of the plugin when screen access is denied.

New Features:
- Add a separate panel consent workflow with `stella plugin panel`, installation-time prompting, explicit allow/deny flags, and persistent grants tied to the exact manifest, scope, and plugin name.
- Render SPEC 12.4 panel handshakes for pending panels and standing-grant notices in the session transcript.
- Expose panel grant status in `stella plugin list` and document the new command and behavior.

Bug Fixes:
- Prevent unapproved or changed panel plugins from starting their drawing processes or receiving panel routes.
- Ensure denying a panel removes only its screen rectangle while preserving the plugin's tools, skills, and hooks.
- Remove panel grants when their associated plugin is removed.

Enhancements:
- Separate screen-drawing authorization from package installation consent and default panel access to withheld in every plugin tier.
- Centralize deterministic handshake and grant-state messaging, including drift and corrupt-grant handling.

Documentation:
- Document the panel command, handshake contents, grant lifecycle, and deny behavior in the plugin command guide.

Tests:
- Add coverage for panel route gating, explicit allow/deny behavior, grant scope and manifest matching, handshake contents and ordering, author-prose safety, deterministic rendering, drift handling, and grant cleanup.