### PR TITLE
feat(stella-core,stella-tui,stella-cli): a failing gate proposes a plan revision, and nothing runs until it is approved

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -114,8 +114,9 @@ mod theme_cmd;
 mod whistle;
 mod worker_control;
 use driver_support::{
-    handle_supervisor_msg, service_registry_action, service_reject_memory, service_rerun_gate,
-    service_undo_delete, spawn_mcp_connect, spawn_notification_poller, spawn_pr_monitor,
+    handle_supervisor_msg, service_approve_revision, service_registry_action,
+    service_reject_memory, service_rerun_gate, service_undo_delete, spawn_mcp_connect,
+    spawn_notification_poller, spawn_pr_monitor,
 };
 use lead_turn::run_lead_turn;
 use panel_snapshots::{engine_config_inbound, tool_policy_inbound};
@@ -2220,6 +2221,15 @@ pub async fn run_deck_session(
                         // there is nothing for a busy lane to contend with.
                         Some(input @ WorkspaceInput::RerunGate { .. }) => {
                             service_rerun_gate(&input, &in_tx);
+                        }
+                        // `a approve r{n}` on a revision proposal: one row on
+                        // the task board, serviced mid-turn on the same
+                        // reasoning as the three above. The reader is looking
+                        // at a gate that just failed, and the whole point of
+                        // the proposal is that the plan changes before more
+                        // work runs against the old one.
+                        Some(input @ WorkspaceInput::ApproveRevision { .. }) => {
+                            service_approve_revision(&input, &registry, &in_tx);
                         }
                         // INSPECT is answered mid-turn too: the receipts of
                         // earlier steps are already durable, and watching the

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -296,7 +296,24 @@ pub(super) fn service_approve_revision(
             proposal.revision, existing.id, existing.subject
         )
     } else {
-        let task = guard.create(proposal.subject.clone(), None, None);
+        // The cause rides the row's description, which is where the drift
+        // outcome is recoverable from: `stella_tui::plan::Plan::steps` reads it
+        // into `PlanStep::detail`, so the plan card states under the inserted
+        // task why it exists, and the board snapshot the store records carries
+        // it too. The `DivergenceCause` the next `PlanGate::review` writes onto
+        // the revision is a separate cell that this path cannot reach (#5296) —
+        // so the reason is recorded where it *can* be, rather than lost while
+        // waiting for the place it belongs.
+        let task = guard.create(
+            proposal.subject.clone(),
+            Some(format!(
+                "added by {}: the {} gate reported {}",
+                proposal.revision,
+                proposal.gate,
+                proposal.cause.as_str()
+            )),
+            None,
+        );
         format!(
             "{} approved — task {} \"{}\", because the {} gate reported: {}",
             proposal.revision,
@@ -820,6 +837,18 @@ mod approve_revision_tests {
                 .map(|item| item.subject.as_str())
                 .collect::<Vec<_>>(),
             vec!["repair a_short_cycle_is_detected"]
+        );
+        // The row itself carries the reason, so the plan card states under the
+        // inserted task why it exists and the recorded board snapshot keeps it.
+        let reason = guard.items()[0]
+            .description
+            .as_deref()
+            .expect("the inserted row records why it was inserted");
+        assert!(reason.contains("r2"), "{reason}");
+        assert!(reason.contains("tests"), "{reason}");
+        assert!(
+            reason.contains("assertion `left == right` failed"),
+            "{reason}"
         );
     }
 

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -250,6 +250,67 @@ pub(super) fn service_rerun_gate(input: &WorkspaceInput, in_tx: &UnboundedSender
     true
 }
 
+/// Service `a approve r{n}` on a standing plan revision (SPEC 8.1 item 3).
+/// Returns `true` if `input` was that verb.
+///
+/// **It changes the plan; it settles nothing.** The gate that failed belongs
+/// to the verification plugin that reported the evidence, and stella never
+/// re-runs one (AGENTS.md's opening) — so approving a repair task adds work,
+/// and the merge stays blocked until a plugin reports a green board.
+///
+/// The board *is* the plan on this path (`task_tap::plan_gate`'s module doc),
+/// so the insertion is a board row and nothing else: the next step's
+/// `PlanGate::review` reads the changed board, authors `r{n+1}` through
+/// `PlanGraph::revise`, and the `[:NEXT]` edge falls out of the machinery that
+/// already writes every other revision. `RevisionGate::approve` decides *what*
+/// is inserted and *where* — and refuses a proposal the plan has already moved
+/// past, which is the check a bare subject could not carry.
+///
+/// A plan the board already holds is not approved twice: a second `a` on a
+/// stale row, or an approval racing the model's own `task_create`, would add
+/// the same repair step under two ids that never resolve to one task.
+///
+/// It does **not** build a `PlanGraph` here. The live one belongs to the
+/// turn's `PlanGate`, this is between turns, and a throwaway graph
+/// reconstructed from the board would restart at `r1` — so every number it
+/// produced would contradict the `r{n}` the reader just approved. The
+/// engine-side gate, where `RevisionGate::admits` withholds the *tool calls*
+/// of a turn already in flight, is #5296.
+pub(super) fn service_approve_revision(
+    input: &WorkspaceInput,
+    registry: &ToolRegistry,
+    in_tx: &UnboundedSender<Inbound>,
+) -> bool {
+    let WorkspaceInput::ApproveRevision { proposal, .. } = input else {
+        return false;
+    };
+    let board = registry.task_board();
+    let mut guard = board.lock().unwrap_or_else(|p| p.into_inner());
+    let message = if let Some(existing) = guard
+        .items()
+        .iter()
+        .find(|item| item.subject == proposal.subject)
+    {
+        format!(
+            "{} was already approved — task {} \"{}\" is on the board",
+            proposal.revision, existing.id, existing.subject
+        )
+    } else {
+        let task = guard.create(proposal.subject.clone(), None, None);
+        format!(
+            "{} approved — task {} \"{}\", because the {} gate reported: {}",
+            proposal.revision,
+            task.id,
+            task.subject,
+            proposal.gate,
+            proposal.cause.as_str()
+        )
+    };
+    drop(guard);
+    let _ = in_tx.send(Inbound::Notice(message));
+    true
+}
+
 /// Service a session-registry / inbox verb from the deck. Returns `true` if
 /// `input` was one (so the caller skips its own dispatch). All of these are
 /// cheap local file ops, serviced identically idle or mid-turn.
@@ -697,5 +758,85 @@ mod undo_delete_tests {
             &workspace,
             &tx
         ));
+    }
+}
+
+#[cfg(test)]
+mod approve_revision_tests {
+    use super::*;
+
+    fn proposal(subject: &str) -> stella_protocol::RevisionProposal {
+        stella_protocol::RevisionProposal {
+            revision: stella_protocol::PlanRevision::new(2).expect("r2"),
+            subject: subject.into(),
+            gate: "tests".into(),
+            cause: stella_protocol::DivergenceCause::new("assertion `left == right` failed")
+                .expect("a cause"),
+            issue: None,
+        }
+    }
+
+    fn approve(registry: &ToolRegistry, subject: &str) -> String {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        assert!(service_approve_revision(
+            &WorkspaceInput::ApproveRevision {
+                agent: LEAD.into(),
+                proposal: Box::new(proposal(subject)),
+            },
+            registry,
+            &tx,
+        ));
+        match rx.try_recv() {
+            Ok(Inbound::Notice(text)) => text,
+            other => panic!("an approval always answers in words: {other:?}"),
+        }
+    }
+
+    /// The deck's `a` binding, from the driver's side: the approved task lands
+    /// on the board — which *is* the plan on this path — so the next step's
+    /// `PlanGate::review` sees a changed plan and authors the revision.
+    ///
+    /// The notice names the cause, because SPEC 8.1's proposal answers a
+    /// failure and an approval that dropped the reason would leave the board
+    /// with a task nobody can trace back to it.
+    #[test]
+    fn approving_a_revision_puts_the_task_on_the_board_and_names_the_cause() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = ToolRegistry::new(dir.path().to_path_buf());
+
+        let notice = approve(&registry, "repair a_short_cycle_is_detected");
+        assert!(notice.contains("r2 approved"), "{notice}");
+        assert!(
+            notice.contains("assertion `left == right` failed"),
+            "{notice}"
+        );
+
+        let board = registry.task_board();
+        let guard = board.lock().unwrap_or_else(|p| p.into_inner());
+        assert_eq!(
+            guard
+                .items()
+                .iter()
+                .map(|item| item.subject.as_str())
+                .collect::<Vec<_>>(),
+            vec!["repair a_short_cycle_is_detected"]
+        );
+    }
+
+    /// A second `a` on the same proposal adds nothing. Two rows for one repair
+    /// would be two tasks nothing ever resolves back to one, which is the
+    /// drift the plan graph exists to make impossible.
+    #[test]
+    fn approving_the_same_revision_twice_adds_one_task() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = ToolRegistry::new(dir.path().to_path_buf());
+
+        approve(&registry, "repair a_short_cycle_is_detected");
+        let again = approve(&registry, "repair a_short_cycle_is_detected");
+        assert!(again.contains("already approved"), "{again}");
+
+        let board = registry.task_board();
+        let guard = board.lock().unwrap_or_else(|p| p.into_inner());
+        assert_eq!(guard.items().len(), 1);
     }
 }

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -93,6 +93,13 @@ pub(crate) fn spawn_forwarder(
         // forwarder, and a forwarder is one lane — every lane has a registry
         // and a channel of its own, so two lanes' thoughts cannot fuse.
         let mut reasoning = agent::ReasoningRun::default();
+        // The lane's standing plan revision, and the number the next one would
+        // take. Held here because this task is the one place a `GateBoard` and
+        // the lane's plan are both in view: the gate goes past on this stream
+        // and the plan is `plan_board`'s rows. Per lane and per turn, like the
+        // ledger above.
+        let mut revisions = stella_core::RevisionGate::default();
+        let mut plan_revision = stella_protocol::PlanRevision::FIRST;
         // Two independent latches, not one. A single shared flag meant an
         // early usage gap — the benign, self-healing condition — silenced any
         // later store-write failure, which is the one that actually points at
@@ -209,6 +216,37 @@ pub(crate) fn spawn_forwarder(
                 let mut guard = board.lock().unwrap_or_else(|p| p.into_inner());
                 guard.seed_from_plan(&proposal.steps);
             }
+            // Which revision the plan is on, read off the gate's own proposals
+            // rather than counted here — `plan_gate` owns the numbering, and a
+            // second counter would eventually disagree with the breadcrumb.
+            if let AgentEvent::ScopeReview { proposal } = &event
+                && let Some(revision) = proposal
+                    .revision
+                    .and_then(stella_protocol::PlanRevision::new)
+            {
+                plan_revision = revision;
+            }
+            // SPEC 8.1 item 3: a determinate gate failure puts a plan revision
+            // up. Authored here rather than folded into the durable stream,
+            // because it is this host's reading of evidence a verification
+            // plugin reported — stella re-ran nothing (AGENTS.md's opening) —
+            // and a reading does not belong in the journal beside the board it
+            // read. Derived before the event is moved into the send below and
+            // emitted after it, for `cache_insight_for`'s reason: the deck must
+            // fold the failing board first, or the proposal lands above the
+            // thing it answers.
+            let proposed = match (&event, &plan_board) {
+                (AgentEvent::GateBoard { board }, plan) => {
+                    let planned = plan.as_ref().map_or_else(Vec::new, |handle| {
+                        let guard = handle.lock().unwrap_or_else(|p| p.into_inner());
+                        super::task_tap::plan_gate::plan_tasks(guard.items())
+                    });
+                    revisions
+                        .observe(plan_revision.next(), &planned, board)
+                        .cloned()
+                }
+                _ => None,
+            };
             let event = if let Some((store, id)) = &execution {
                 // Fold a streamed reasoning fragment into the open run rather
                 // than spending a row, a `seq` and a blocking hop on each one
@@ -301,6 +339,12 @@ pub(crate) fn spawn_forwarder(
             });
             if let Some(insight) = cache_insight {
                 let _ = inbound.send(insight);
+            }
+            if let Some(proposal) = proposed {
+                let _ = inbound.send(Inbound::RevisionProposed {
+                    agent: lane.clone(),
+                    proposal: Box::new(proposal),
+                });
             }
         }
         // The lane's stream is closed, so its open reasoning run is final: a
@@ -635,5 +679,83 @@ mod tests {
             stages(&events).is_empty(),
             "a staged lane's boundaries are the pipeline's alone: {events:?}"
         );
+    }
+
+    /// A board with one gate failing puts a plan revision up — SPEC 8.1 item
+    /// 3's producer.
+    ///
+    /// The ordering is asserted too: the proposal must reach the deck *after*
+    /// the board it answers, or the scrollback shows an answer above its
+    /// question. A green board proposes nothing, which is the other half.
+    #[tokio::test]
+    async fn a_failing_gate_board_proposes_a_plan_revision_after_the_board() {
+        use stella_protocol::{GateBoard, GateRow, GateState};
+
+        let gate = |name: &str, state: GateState| GateRow {
+            name: name.into(),
+            state,
+            deterministic: true,
+        };
+        let board = |gates: Vec<GateRow>| GateBoard {
+            patch: Some("patch-7".into()),
+            gates,
+        };
+
+        let root = tempfile::tempdir().expect("root");
+        let registry = stella_tools::ToolRegistry::new(root.path().to_path_buf());
+        let (in_tx, mut in_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let forwarder = spawn_forwarder(
+            rx,
+            None,
+            InsightScope {
+                provider_id: "anthropic".into(),
+                cache_ttl: stella_model::CacheTtl::default(),
+                opens_execute_stage: false,
+            },
+            in_tx,
+            "lead".to_string(),
+            Some(registry.task_board()),
+        );
+        tx.send(AgentEvent::GateBoard {
+            board: board(vec![gate("fmt", GateState::Green)]),
+        })
+        .unwrap();
+        tx.send(AgentEvent::GateBoard {
+            board: board(vec![gate(
+                "tests",
+                GateState::Failed {
+                    case: "a_short_cycle_is_detected".into(),
+                    log: "assertion `left == right` failed".into(),
+                },
+            )]),
+        })
+        .unwrap();
+        close_turn_stream(&registry, tx, forwarder).await;
+
+        let mut seen: Vec<&'static str> = Vec::new();
+        let mut proposal = None;
+        while let Ok(inbound) = in_rx.try_recv() {
+            match inbound {
+                Inbound::Event {
+                    event: AgentEvent::GateBoard { .. },
+                    ..
+                } => seen.push("board"),
+                Inbound::RevisionProposed { proposal: p, .. } => {
+                    seen.push("proposal");
+                    proposal = Some(*p);
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(
+            seen,
+            vec!["board", "board", "proposal"],
+            "the green board proposes nothing, and the proposal follows the board it answers"
+        );
+        let proposal = proposal.expect("the failing board put a revision up");
+        assert_eq!(proposal.gate, "tests");
+        assert_eq!(proposal.subject, "repair a_short_cycle_is_detected");
+        assert_eq!(proposal.revision.to_string(), "r2");
     }
 }

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::subsession::SupervisorMsg;
 
-mod plan_gate;
+pub(crate) mod plan_gate;
 
 pub(crate) use plan_gate::PlanSetup;
 

--- a/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
+++ b/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
@@ -396,7 +396,7 @@ impl PlanGate {
 /// stay on the board forever (a cancelled task keeps its row as an audit
 /// trail, and ids are never reused), so a plan only ever grows, and a change
 /// to it is an insertion somebody made.
-fn plan_tasks(board: &[TaskItem]) -> Vec<TaskNode> {
+pub(crate) fn plan_tasks(board: &[TaskItem]) -> Vec<TaskNode> {
     board
         .iter()
         .map(|item| TaskNode::new(item.id.clone(), item.subject.clone()))

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -79,7 +79,7 @@ pub use goal::{GoalAssessError, GoalConfig, GoalOutcome, GoalVerifierVerdict};
 pub use hooks::{HookEvent, HookPayload, HookRunOutcome, HookRunner, Hooks, run_hooks};
 pub use loop_detect::{CallRecord, LoopDetectionConfig, LoopIdentity, LoopVerdict, detect_loop};
 pub use mcp_usage::{McpUsageLedger, McpUsageRecord, drain_usage, push_usage};
-pub use plan_graph::{PlanGraph, PlanGraphError};
+pub use plan_graph::{PlanGraph, PlanGraphError, RevisionError, RevisionGate};
 pub use ports::{Clock, LiveService, ToolExecutor};
 pub use repair::{RepairCost, RepairHeadroom, RepairPlan, RepairRefusal, plan_repair};
 pub use retry::{RetryOutcome, RetryPolicy, retry_with_backoff};

--- a/crates/stella-core/src/plan_graph.rs
+++ b/crates/stella-core/src/plan_graph.rs
@@ -56,6 +56,9 @@
 
 use std::collections::HashSet;
 
+pub mod revision;
+pub use revision::{RevisionError, RevisionGate};
+
 use stella_protocol::plan_graph::{
     Divergence, DivergenceCause, DivergenceKind, PlanEdge, PlanEdgeKind, PlanEdgeSource, PlanNode,
     PlanRevision, TaskNode,

--- a/crates/stella-core/src/plan_graph/revision.rs
+++ b/crates/stella-core/src/plan_graph/revision.rs
@@ -244,10 +244,19 @@ fn cause_line(text: &str) -> String {
 /// itself named is one the reader can go and open, and a link from anywhere
 /// else would be this function guessing which issue a failure belongs to.
 /// `None` where the evidence named none, which renders as no cell at all.
+///
+/// Every `#` is tried, not just the first. Rust evidence is full of hashes
+/// that are not issue numbers — `#[test]`, `#![cfg(unix)]` — and stopping at
+/// the first one would drop the link in `#[test] a_case … see #151` while
+/// finding it in `see #151 … #[test] a_case`.
 fn linked_issue(text: &str) -> Option<String> {
-    let rest = text.split_once('#')?.1;
-    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
-    (!digits.is_empty()).then(|| format!("#{digits}"))
+    text.match_indices('#').find_map(|(at, _)| {
+        let digits: String = text[at + 1..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        (!digits.is_empty()).then(|| format!("#{digits}"))
+    })
 }
 
 /// The id the next task in `planned` would take, on the task board's own

--- a/crates/stella-core/src/plan_graph/revision.rs
+++ b/crates/stella-core/src/plan_graph/revision.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The revision gate: a failing gate puts a plan revision up, and nothing runs
+//! until somebody approves it (`design/tui-v2/SPEC.md` §8.1 item 3).
+//!
+//! # The withholding is the point
+//!
+//! [`RevisionGate::admits`] answers `false` for as long as a proposal stands,
+//! and that is the whole mechanism — a caller asks before it runs anything, so
+//! "nothing runs until approval" is a question with one answer rather than a
+//! convention every call site re-implements. There is a second, structural
+//! half underneath it: an approval is the only thing that puts the proposed
+//! task into the plan, and [`PlanGraph::ran`] refuses a task the current
+//! revision does not contain. So even a caller that never asked cannot record
+//! the inserted task as having run.
+//!
+//! `nothing_runs_while_a_proposal_stands` and
+//! `the_proposed_task_cannot_run_until_the_revision_is_approved` are the two
+//! halves of that claim.
+//!
+//! # A proposal answers evidence; it does not gather any
+//!
+//! [`RevisionGate::observe`] reads a [`GateBoard`] — the host's evaluation of
+//! what an installed verification plugin reported (AGENTS.md's opening). It
+//! re-runs no gate and re-checks no evidence; it turns a failure somebody else
+//! observed into a question for the person driving. The cause it carries is
+//! the gate's own words, cut to one line, so a reader can tell what the
+//! proposal is answering without opening the log.
+//!
+//! # Why the first failed gate
+//!
+//! One proposal per board, authored from the first failure in the rule's own
+//! order — the same choice `stella_tui::deck_ui::row_keys`'s
+//! `selected_failed_board` documents for the `r` key, and for the same reason:
+//! two surfaces that picked differently would disagree about which failure the
+//! reader is looking at. A board with several failures loses the rest, and
+//! that is a real limitation rather than a hidden one — the next board after
+//! this repair carries whatever is still red.
+//!
+//! # Pure
+//!
+//! Owned data and no I/O (AGENTS.md #2), which is what lets the acceptance
+//! criterion be witnessed with no terminal, no engine and no plugin.
+
+use stella_protocol::plan_graph::{DivergenceCause, PlanRevision, RevisionProposal, TaskNode};
+use stella_protocol::{GateBoard, GateState};
+
+use super::{PlanGraph, PlanGraphError};
+
+/// How much of a gate's log becomes the cause of the revision it provokes.
+///
+/// One line, cut, matching `stella-cli`'s plan gate: a cause rides a
+/// breadcrumb and a proposal row, never a log pane, and the full text is
+/// already under the failing gate's own row.
+const CAUSE_CHARS: usize = 120;
+
+/// Why a revision-gate call was refused. Named errors, never a bare string
+/// (AGENTS.md #5): "nobody proposed anything" and "the plan moved under the
+/// proposal you are approving" are different repairs, and a caller that had to
+/// read prose to tell them apart would guess.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RevisionError {
+    #[error(
+        "no plan revision is pending; there is nothing to approve, edit or dismiss until a gate \
+         fails and one is put up"
+    )]
+    NothingPending,
+    #[error(
+        "a proposed task needs a subject; a revision that inserts an unnamed task tells the next \
+         reader that the plan grew and not what it grew by"
+    )]
+    BlankSubject,
+    #[error(
+        "the plan moved to r{current} while r{proposed} was standing, so approving would author \
+         something other than what was put up; the proposal is stale and belongs back in front of \
+         whoever is driving"
+    )]
+    PlanMoved { proposed: u32, current: u32 },
+    #[error("the revision could not be written: {0}")]
+    Graph(#[from] PlanGraphError),
+}
+
+/// One session's standing plan-revision proposal, and the withholding it
+/// implies.
+///
+/// At most one proposal at a time, and [`Self::observe`] will not replace one
+/// that is already standing: a second board must not retitle the thing the
+/// reader is looking at while they decide about it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RevisionGate {
+    pending: Option<RevisionProposal>,
+}
+
+impl RevisionGate {
+    /// Put a revision up if `board` carries a failure the plan does not
+    /// already answer, and return it.
+    ///
+    /// `revision` is the number the revision *would* be — `graph.revision()
+    /// .next()` — and `planned` is the plan as it stands.
+    ///
+    /// `None` in four cases, each of which is a reason not to ask rather than
+    /// a failure: a board with no determinate failure (an undecided gate
+    /// blames the instrument, not the worker — see [`GateBoard::has_failure`]);
+    /// a proposal already standing; a plan that already contains a task with
+    /// this subject, so the repair the board is asking for is one somebody
+    /// already planned; and a failure whose evidence says nothing at all,
+    /// which cannot carry a [`DivergenceCause`].
+    pub fn observe(
+        &mut self,
+        revision: PlanRevision,
+        planned: &[TaskNode],
+        board: &GateBoard,
+    ) -> Option<&RevisionProposal> {
+        if self.pending.is_some() {
+            return None;
+        }
+        let gate = board.gates.iter().find(|gate| gate.failed())?;
+        let GateState::Failed { case, log } = &gate.state else {
+            return None;
+        };
+        let cause =
+            DivergenceCause::new(cause_line(if case.trim().is_empty() { log } else { case }))?;
+        let subject = repair_subject(&gate.name, case);
+        if planned.iter().any(|task| task.subject == subject) {
+            return None;
+        }
+        self.pending = Some(RevisionProposal {
+            revision,
+            subject,
+            gate: gate.name.clone(),
+            cause,
+            issue: linked_issue(case).or_else(|| linked_issue(log)),
+        });
+        self.pending.as_ref()
+    }
+
+    /// The proposal on the table, if there is one.
+    #[must_use]
+    pub fn pending(&self) -> Option<&RevisionProposal> {
+        self.pending.as_ref()
+    }
+
+    /// Whether work may proceed — `false` for as long as a proposal stands.
+    ///
+    /// SPEC 8.1's "nothing runs until approval", as one question with one
+    /// answer. See the module docs for the structural half underneath it.
+    #[must_use]
+    pub fn admits(&self) -> bool {
+        self.pending.is_none()
+    }
+
+    /// SPEC 8.1's `e edit`: keep the proposal, change what it would insert.
+    ///
+    /// The gate, the cause and the revision number are not editable, and that
+    /// is the point of a separate verb: they are what the evidence said, and a
+    /// proposal whose cause a reader could rewrite would be a record of the
+    /// reader's opinion rather than of the failure.
+    pub fn edit(&mut self, subject: impl Into<String>) -> Result<(), RevisionError> {
+        let subject = subject.into();
+        if subject.trim().is_empty() {
+            return Err(RevisionError::BlankSubject);
+        }
+        let pending = self.pending.as_mut().ok_or(RevisionError::NothingPending)?;
+        pending.subject = subject;
+        Ok(())
+    }
+
+    /// SPEC 8.1's `x dismiss`: the reader does not want this task.
+    ///
+    /// Returns what was standing, so a caller can say what it dropped. The
+    /// plan is untouched — a dismissed proposal authored no revision, which is
+    /// the difference between declining a change and reverting one — and the
+    /// gate admits again.
+    pub fn dismiss(&mut self) -> Option<RevisionProposal> {
+        self.pending.take()
+    }
+
+    /// SPEC 8.1's `a approve r4`: write the revision the proposal describes.
+    ///
+    /// The insertion goes to the end of the current plan and through
+    /// [`PlanGraph::revise`], so the `[:NEXT]` chain, the retained predecessor
+    /// and the [`Divergence`] carrying the gate's cause all fall out of the
+    /// existing machinery rather than a second code path that could disagree
+    /// with it.
+    ///
+    /// Refused when the plan has moved since the proposal was put up: the
+    /// reader agreed to `r4: add task "<title>"`, and authoring `r5` instead
+    /// would be a different change wearing the answer to this one.
+    ///
+    /// [`Divergence`]: stella_protocol::Divergence
+    pub fn approve(&mut self, graph: &mut PlanGraph) -> Result<PlanRevision, RevisionError> {
+        let proposal = self.pending.as_ref().ok_or(RevisionError::NothingPending)?;
+        let current = graph.revision().next();
+        if current != proposal.revision {
+            return Err(RevisionError::PlanMoved {
+                proposed: proposal.revision.get(),
+                current: current.get(),
+            });
+        }
+        let mut tasks = graph.planned(graph.revision());
+        tasks.push(TaskNode::new(
+            next_task_id(&tasks),
+            proposal.subject.clone(),
+        ));
+        let revision = graph.revise(tasks, proposal.cause.clone())?;
+        self.pending = None;
+        Ok(revision)
+    }
+}
+
+/// SPEC 8.1's `<title>`: what the inserted task is, in the gate's own words.
+///
+/// The failing case when the gate named one, because that is the thing a
+/// repair step has to make pass; the gate's name otherwise. Nothing is
+/// invented — a subject stella made up would be the one line of a proposal a
+/// reader cannot check against the board above it.
+fn repair_subject(gate: &str, case: &str) -> String {
+    let case = case.trim();
+    if case.is_empty() {
+        format!("repair the failing {gate} gate")
+    } else {
+        format!("repair {case}")
+    }
+}
+
+/// The first line of `text`, cut to [`CAUSE_CHARS`] characters.
+///
+/// Characters rather than bytes, so a cut never lands inside a multi-byte
+/// character and produces text no terminal can draw.
+fn cause_line(text: &str) -> String {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("")
+        .chars()
+        .take(CAUSE_CHARS)
+        .collect()
+}
+
+/// The first `#1234` in `text`, as SPEC 8.1's "any linked issue".
+///
+/// Read out of the evidence rather than supplied beside it: an issue the gate
+/// itself named is one the reader can go and open, and a link from anywhere
+/// else would be this function guessing which issue a failure belongs to.
+/// `None` where the evidence named none, which renders as no cell at all.
+fn linked_issue(text: &str) -> Option<String> {
+    let rest = text.split_once('#')?.1;
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    (!digits.is_empty()).then(|| format!("#{digits}"))
+}
+
+/// The id the next task in `planned` would take, on the task board's own
+/// scheme: per-session ordinals, counting up, never reused
+/// (`crate::tasks::TaskBoard::create`).
+///
+/// Derived from the plan rather than minted here, so an approved insertion
+/// lands on the id the board would give it and the two id spaces stay one.
+fn next_task_id(planned: &[TaskNode]) -> String {
+    let highest = planned
+        .iter()
+        .filter_map(|task| task.id.parse::<u32>().ok())
+        .max()
+        .unwrap_or(0);
+    (highest.saturating_add(1)).to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-core/src/plan_graph/revision/tests.rs
+++ b/crates/stella-core/src/plan_graph/revision/tests.rs
@@ -306,6 +306,24 @@ fn the_linked_issue_comes_from_the_evidence_or_not_at_all() {
         None,
         "no issue in the evidence renders as no cell, never as a guess"
     );
+
+    // Rust evidence is full of hashes that are not issue numbers, and the
+    // link must survive one standing in front of it.
+    let mut attributes = RevisionGate::default();
+    assert_eq!(
+        attributes
+            .observe(
+                graph.revision().next(),
+                &graph.planned(graph.revision()),
+                &board(vec![failed(
+                    "tests",
+                    "#[test] a_short_cycle_is_detected",
+                    "the seen-set is rebuilt per run — see #151",
+                )]),
+            )
+            .and_then(|p| p.issue.clone()),
+        Some("#151".to_owned())
+    );
 }
 
 /// A failure whose evidence says nothing cannot carry a cause, and this module

--- a/crates/stella-core/src/plan_graph/revision/tests.rs
+++ b/crates/stella-core/src/plan_graph/revision/tests.rs
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What the revision gate promises, and the two halves of "nothing runs until
+//! approval".
+
+use super::*;
+use stella_protocol::GateRow;
+
+fn plan() -> PlanGraph {
+    PlanGraph::approve(vec![
+        TaskNode::new("1", "read the routes"),
+        TaskNode::new("2", "persist the digest set"),
+        TaskNode::new("3", "verify"),
+    ])
+    .expect("a plan of three tasks")
+}
+
+fn green(name: &str) -> GateRow {
+    GateRow {
+        name: name.into(),
+        state: GateState::Green,
+        deterministic: true,
+    }
+}
+
+fn failed(name: &str, case: &str, log: &str) -> GateRow {
+    GateRow {
+        name: name.into(),
+        state: GateState::Failed {
+            case: case.into(),
+            log: log.into(),
+        },
+        deterministic: true,
+    }
+}
+
+fn board(gates: Vec<GateRow>) -> GateBoard {
+    GateBoard {
+        patch: Some("patch-7".into()),
+        gates,
+    }
+}
+
+/// One failing gate, one proposal, at the number the reader will be shown.
+fn one_failure() -> GateBoard {
+    board(vec![
+        green("fmt"),
+        failed(
+            "tests",
+            "stella_core::loop_detect::a_short_cycle_is_detected",
+            "assertion `left == right` failed\n  left: 3\n right: 2\n",
+        ),
+    ])
+}
+
+// ── the acceptance criterion: nothing runs until approval ──────────────────
+
+/// SPEC 8.1 item 3's last sentence, as one question with one answer. A fresh
+/// gate admits; a gate with a proposal standing does not; approving releases
+/// it, and so does dismissing it.
+#[test]
+fn nothing_runs_while_a_proposal_stands() {
+    let mut graph = plan();
+    let mut gate = RevisionGate::default();
+    assert!(gate.admits(), "a gate with nothing pending must admit");
+
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("a failing board puts a revision up");
+    assert!(
+        !gate.admits(),
+        "a standing proposal withholds — this is the whole of \"nothing runs until approval\""
+    );
+
+    gate.approve(&mut graph)
+        .expect("approve the standing proposal");
+    assert!(gate.admits(), "approval releases the withholding");
+}
+
+/// The other half, and the one a caller cannot route around: the proposed task
+/// is not in the plan until the revision is written, and [`PlanGraph::ran`]
+/// refuses a task the current revision does not contain. So a call site that
+/// never consulted [`RevisionGate::admits`] still cannot record the inserted
+/// task as having run.
+#[test]
+fn the_proposed_task_cannot_run_until_the_revision_is_approved() {
+    let mut graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("a failing board puts a revision up");
+
+    // The id the approval will assign, derived the way the board would.
+    let proposed_id = next_task_id(&graph.planned(graph.revision()));
+    assert_eq!(proposed_id, "4");
+    assert_eq!(
+        graph.ran(&proposed_id),
+        Err(PlanGraphError::UnplannedTask {
+            id: proposed_id.clone(),
+            revision: 1,
+        }),
+        "the proposed task must not be runnable before the revision exists"
+    );
+
+    gate.approve(&mut graph).expect("approve");
+    graph
+        .ran(&proposed_id)
+        .expect("the approved task runs under the revision that inserted it");
+}
+
+/// Approval goes through [`PlanGraph::revise`], so the `[:NEXT]` edge, the
+/// retained predecessor and the divergence carrying the gate's cause are the
+/// existing machinery's rather than a second code path's.
+#[test]
+fn approval_writes_the_next_edge_and_records_the_gates_cause_as_the_drift() {
+    let mut graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("proposal");
+
+    let revision = gate.approve(&mut graph).expect("approve");
+    assert_eq!(revision.to_string(), "r2");
+
+    let planned = graph.planned(revision);
+    assert_eq!(
+        planned.last().map(|task| task.subject.as_str()),
+        Some("repair stella_core::loop_detect::a_short_cycle_is_detected"),
+        "the insertion lands at the end of the plan: {planned:?}"
+    );
+
+    // `r1` is still readable, which is what keeps SPEC 7.3's `planned 3`
+    // computable after the plan grew.
+    assert_eq!(graph.planned_count(), 3);
+
+    let drift = graph.divergences();
+    assert_eq!(drift.len(), 1, "{drift:?}");
+    assert_eq!(drift[0].revision, revision);
+    assert_eq!(
+        drift[0].cause.as_str(),
+        "stella_core::loop_detect::a_short_cycle_is_detected",
+        "the drift carries the gate's own words, not the gate's name"
+    );
+}
+
+// ── what a board is allowed to provoke ─────────────────────────────────────
+
+/// A green board asks nothing. Neither does an undecided one: an abstention
+/// blames the instrument rather than the worker, and proposing a repair for a
+/// gate nobody could decide would put the reader's name on a guess.
+#[test]
+fn a_board_with_no_determinate_failure_proposes_nothing() {
+    let graph = plan();
+    for gates in [
+        vec![green("fmt"), green("tests")],
+        vec![
+            green("fmt"),
+            GateRow {
+                name: "tests".into(),
+                state: GateState::Undecided {
+                    reason: "the plugin reported no evidence for this gate".into(),
+                },
+                deterministic: true,
+            },
+        ],
+        vec![],
+    ] {
+        let mut gate = RevisionGate::default();
+        assert!(
+            gate.observe(
+                graph.revision().next(),
+                &graph.planned(graph.revision()),
+                &board(gates.clone())
+            )
+            .is_none(),
+            "{gates:?} must not put a revision up"
+        );
+        assert!(gate.admits(), "and must not withhold anything");
+    }
+}
+
+/// A second board must not retitle the thing the reader is deciding about.
+#[test]
+fn a_second_board_does_not_replace_a_standing_proposal() {
+    let graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("proposal");
+    let standing = gate.pending().cloned().expect("standing");
+
+    assert!(
+        gate.observe(
+            graph.revision().next(),
+            &graph.planned(graph.revision()),
+            &board(vec![failed(
+                "clippy",
+                "unused import",
+                "warning: unused import"
+            )]),
+        )
+        .is_none(),
+        "a later board must not replace a standing proposal"
+    );
+    assert_eq!(gate.pending(), Some(&standing));
+}
+
+/// The board asking for a repair somebody already planned is not a change of
+/// plan, so nothing is put up and nothing is withheld.
+#[test]
+fn a_repair_the_plan_already_contains_is_not_proposed_again() {
+    let mut graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("proposal");
+    gate.approve(&mut graph).expect("approve");
+
+    let mut second = RevisionGate::default();
+    assert!(
+        second
+            .observe(
+                graph.revision().next(),
+                &graph.planned(graph.revision()),
+                &one_failure()
+            )
+            .is_none(),
+        "the same failure against a plan that now answers it proposes nothing"
+    );
+}
+
+/// The proposal names what the reader can check against the board above it:
+/// the failing case where the gate named one, the gate itself where it did not.
+#[test]
+fn the_subject_is_the_gates_own_words() {
+    let graph = plan();
+    let mut named = RevisionGate::default();
+    assert_eq!(
+        named
+            .observe(
+                graph.revision().next(),
+                &graph.planned(graph.revision()),
+                &one_failure()
+            )
+            .map(|p| p.subject.clone()),
+        Some("repair stella_core::loop_detect::a_short_cycle_is_detected".to_owned())
+    );
+
+    let mut unnamed = RevisionGate::default();
+    assert_eq!(
+        unnamed
+            .observe(
+                graph.revision().next(),
+                &graph.planned(graph.revision()),
+                &board(vec![failed("tests", "  ", "thread 'main' panicked")]),
+            )
+            .map(|p| p.subject.clone()),
+        Some("repair the failing tests gate".to_owned())
+    );
+}
+
+/// SPEC 8.1's "any linked issue": read out of the gate's own evidence, absent
+/// where the evidence named none.
+#[test]
+fn the_linked_issue_comes_from_the_evidence_or_not_at_all() {
+    let graph = plan();
+    let mut gate = RevisionGate::default();
+    assert_eq!(
+        gate.observe(
+            graph.revision().next(),
+            &graph.planned(graph.revision()),
+            &board(vec![failed(
+                "tests",
+                "dedup digest is not stable",
+                "see #151 — the seen-set is rebuilt per run",
+            )]),
+        )
+        .and_then(|p| p.issue.clone()),
+        Some("#151".to_owned())
+    );
+
+    let mut none = RevisionGate::default();
+    assert_eq!(
+        none.observe(
+            graph.revision().next(),
+            &graph.planned(graph.revision()),
+            &one_failure()
+        )
+        .and_then(|p| p.issue.clone()),
+        None,
+        "no issue in the evidence renders as no cell, never as a guess"
+    );
+}
+
+/// A failure whose evidence says nothing cannot carry a cause, and this module
+/// would rather ask nothing than put up a proposal with a blank reason on it.
+#[test]
+fn a_failure_with_no_evidence_at_all_proposes_nothing() {
+    let graph = plan();
+    let mut gate = RevisionGate::default();
+    assert!(
+        gate.observe(
+            graph.revision().next(),
+            &graph.planned(graph.revision()),
+            &board(vec![failed("tests", "   ", "  \n\t\n")]),
+        )
+        .is_none()
+    );
+    assert!(gate.admits());
+}
+
+// ── the three verbs ────────────────────────────────────────────────────────
+
+/// `e edit` changes what would be inserted and nothing else: the gate, the
+/// cause and the number are what the evidence said.
+#[test]
+fn edit_changes_the_subject_and_leaves_the_evidence_alone() {
+    let graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("proposal");
+    let before = gate.pending().cloned().expect("standing");
+
+    gate.edit("rebuild the seen-set on every run")
+        .expect("edit the subject");
+    let after = gate.pending().expect("still standing");
+    assert_eq!(after.subject, "rebuild the seen-set on every run");
+    assert_eq!(after.cause, before.cause);
+    assert_eq!(after.gate, before.gate);
+    assert_eq!(after.revision, before.revision);
+    assert!(!gate.admits(), "editing is not approving");
+
+    assert_eq!(gate.edit("   "), Err(RevisionError::BlankSubject));
+}
+
+/// `x dismiss` declines the change without reverting anything: no revision was
+/// authored, so there is nothing in the plan to take back out.
+#[test]
+fn dismiss_releases_the_withholding_and_writes_no_revision() {
+    let graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("proposal");
+
+    let dropped = gate.dismiss().expect("what was standing");
+    assert_eq!(dropped.gate, "tests");
+    assert!(gate.admits());
+    assert_eq!(graph.revision(), PlanRevision::FIRST);
+    assert!(graph.divergences().is_empty(), "a dismissal is not drift");
+    assert_eq!(gate.dismiss(), None);
+}
+
+/// The three verbs refuse when nobody proposed anything, rather than inventing
+/// something to act on.
+#[test]
+fn the_verbs_refuse_when_nothing_is_pending() {
+    let mut graph = plan();
+    let mut gate = RevisionGate::default();
+    assert_eq!(gate.edit("anything"), Err(RevisionError::NothingPending));
+    assert_eq!(gate.approve(&mut graph), Err(RevisionError::NothingPending));
+    assert_eq!(gate.dismiss(), None);
+}
+
+/// A proposal the reader was shown as `r2` must not silently author `r3`
+/// because the plan moved underneath it.
+#[test]
+fn approving_a_stale_proposal_is_refused_rather_than_renumbered() {
+    let mut graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("proposal");
+
+    graph
+        .revise(
+            graph.planned(graph.revision()),
+            DivergenceCause::new("the plan was put to the person driving again").expect("a cause"),
+        )
+        .expect("an unrelated revision lands first");
+
+    assert_eq!(
+        gate.approve(&mut graph),
+        Err(RevisionError::PlanMoved {
+            proposed: 2,
+            current: 3,
+        })
+    );
+    assert!(
+        !gate.admits(),
+        "a stale proposal still withholds — it goes back in front of the driver"
+    );
+}
+
+// ── the helpers ────────────────────────────────────────────────────────────
+
+/// The insertion takes the id the board would give it, so an approved revision
+/// and the task board never open two id spaces over one plan.
+#[test]
+fn the_next_id_counts_up_from_the_highest_the_plan_holds() {
+    assert_eq!(next_task_id(&[]), "1");
+    assert_eq!(
+        next_task_id(&[TaskNode::new("1", "a"), TaskNode::new("7", "b")]),
+        "8",
+        "ids are never reused, so the next one is past the highest and not past the count"
+    );
+}
+
+/// A cut cause is cut by characters, so it never lands inside one.
+#[test]
+fn a_cause_is_cut_by_characters_and_takes_the_first_line_that_says_anything() {
+    assert_eq!(cause_line("\n\n  first line  \nsecond"), "first line");
+    let wide = "é".repeat(200);
+    assert_eq!(cause_line(&wide).chars().count(), CAUSE_CHARS);
+}

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -130,7 +130,7 @@ pub use stage::StageName;
 // constantly and none of them should have to spell the module path.
 pub use plan_graph::{
     Divergence, DivergenceCause, DivergenceKind, PlanEdge, PlanEdgeKind, PlanEdgeSource, PlanNode,
-    PlanRevision, TaskNode,
+    PlanRevision, RevisionProposal, TaskNode,
 };
 pub use task_contract::{
     Check, CheckKind, CheckMechanism, CheckOutcome, Closure, DefinitionOfDone, Judge, TaskContract,

--- a/crates/stella-protocol/src/plan_graph.rs
+++ b/crates/stella-protocol/src/plan_graph.rs
@@ -340,6 +340,55 @@ pub struct Divergence {
     pub cause: DivergenceCause,
 }
 
+/// A plan revision stella has **proposed** and not made — SPEC 8.1's
+/// `⌥ propose r4: add task "<title>"`.
+///
+/// A proposal is a different thing from a revision all the way to the surface.
+/// [`PlanNode`] is a revision that happened; this is one somebody has been
+/// asked about, and until they answer there is no node, no `[:NEXT]` edge and
+/// nothing that may run. A revision carrying an `approved: bool` instead would
+/// make "nothing runs until it is approved" a flag every producer can set
+/// rather than a shape the graph cannot express.
+///
+/// # What a proposal is allowed to claim
+///
+/// [`Self::gate`] names a gate an installed verification plugin reported on,
+/// and [`Self::cause`] is what that gate's evidence said. Stella re-ran
+/// nothing and re-checked nothing (AGENTS.md's opening), so a proposal
+/// answers reported evidence and is never a measurement of its own.
+///
+/// # Why the subject and not a task id
+///
+/// The proposal names the work in words. Board ids belong to the task board
+/// (`stella_core::tasks::TaskBoard::create` never reuses one), so a proposal
+/// that minted its own would open a second id space beside it. The id is the
+/// board's to assign when the insertion is actually made.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RevisionProposal {
+    /// The revision this would author if it were approved — `r{n+1}` against
+    /// the plan as it stands. A number that has not happened yet, which is why
+    /// it rides here rather than being read off a [`PlanNode`] that does not
+    /// exist.
+    pub revision: PlanRevision,
+    /// The task the revision would insert, in one line: SPEC 8.1's `<title>`.
+    pub subject: String,
+    /// The gate whose failure provoked this — the `[requirements]` key the
+    /// verification plugin's manifest wrote, as [`crate::GateRow::name`]
+    /// spells it.
+    pub gate: String,
+    /// What that gate's evidence said, as the linked cause the revision would
+    /// carry. Non-blank by construction, like every other cause here.
+    pub cause: DivergenceCause,
+    /// The issue this repair belongs to, where the evidence named one.
+    ///
+    /// `None` renders as no cell rather than a blank one, on
+    /// [`crate::GateBoard::patch`]'s rule: an invented link points the reader
+    /// at something they cannot go and look at.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -423,6 +472,36 @@ mod tests {
         let back: Divergence = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(divergence, back);
         assert_eq!(json, serde_json::to_string(&back).expect("re-serialize"));
+    }
+
+    #[test]
+    fn a_revision_proposal_round_trips() {
+        let proposal = RevisionProposal {
+            revision: PlanRevision::FIRST.next(),
+            subject: "repair the unresolved import".into(),
+            gate: "tests".into(),
+            cause: cause("E0432: unresolved import `stella_core::plan_graph`"),
+            issue: Some("#5043".into()),
+        };
+        let json = serde_json::to_string(&proposal).expect("serialize");
+        let back: RevisionProposal = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(proposal, back);
+        assert_eq!(json, serde_json::to_string(&back).expect("re-serialize"));
+    }
+
+    /// A proposal that named no issue writes no `issue` key, so a surface
+    /// cannot render an empty link cell for a link nobody supplied.
+    #[test]
+    fn a_proposal_with_no_issue_writes_no_issue_key() {
+        let json = serde_json::to_string(&RevisionProposal {
+            revision: PlanRevision::FIRST.next(),
+            subject: "repair the unresolved import".into(),
+            gate: "tests".into(),
+            cause: cause("E0432"),
+            issue: None,
+        })
+        .expect("serialize");
+        assert!(!json.contains("issue"), "{json}");
     }
 
     // ── the rules that are the type ────────────────────────────────────────

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -428,6 +428,15 @@ async fn main() -> std::io::Result<()> {
                         "rerun gate \"{gate}\": the demo has no verification plugin bound"
                     )));
                 }
+                // `a` on a revision proposal. The demo keeps no task board, so
+                // it answers with the sentence the real driver sends once the
+                // insertion is written (`service_approve_revision`).
+                WorkspaceInput::ApproveRevision { proposal, .. } => {
+                    let _ = react_tx.send(Inbound::Notice(format!(
+                        "{} approved — added task \"{}\"",
+                        proposal.revision, proposal.subject
+                    )));
+                }
                 WorkspaceInput::Quit => break,
             }
         }

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -842,6 +842,12 @@ impl WorkspaceModel {
             | Inbound::EntityHits { .. }
             | Inbound::RecordedCalls(_)
             | Inbound::InspectedCall(_)
+            // The proposal's scrollback row is written by
+            // `deck_ui::ingest_inner`, which holds the `DeckUi` the
+            // withholding lives on — the row and the hold go in together
+            // (`SessionModel::propose_revision`) rather than one here and one
+            // there.
+            | Inbound::RevisionProposed { .. }
             | Inbound::ShowHelp
             // A parked question is a tool call waiting, not speech. Nothing
             // has been said until the driver answers, and folding the

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -643,6 +643,20 @@ pub struct DeckUi {
     /// Out-of-band view state, never folded: it is a fact about the machine,
     /// not about the session. It gates one thing — see `gates::index_hold`.
     pub index_readiness: IndexReadiness,
+    /// Plan revisions a failing gate has put up and nobody has answered, by
+    /// lane ([`Inbound::RevisionProposed`], SPEC 8.1 item 3).
+    ///
+    /// Out-of-band view state like [`Self::index_readiness`], and here rather
+    /// than on `SessionModel` because a key press clears it: the model is an
+    /// event fold with one mutator, and the answer to a proposal arrives from
+    /// the keyboard.
+    ///
+    /// It gates one thing: `gates::revision_hold` withholds every submission
+    /// while any entry stands, which is the deck's half of SPEC 8.1's
+    /// "nothing runs until approval". Keyed
+    /// by lane and ordered, so two lanes proposing at once hold in a fixed
+    /// order rather than whichever the map happened to yield.
+    pub pending_revisions: std::collections::BTreeMap<AgentId, stella_protocol::RevisionProposal>,
     pub help_open: bool,
     /// Vertical scroll for the help overlay (↑/↓, PageUp/Down, Home/End). Kept
     /// separate from the transcript scroll since the overlay is a different
@@ -897,6 +911,7 @@ impl Default for DeckUi {
             splash: SplashState::new(),
             notice: NoticeState::new(),
             index_readiness: IndexReadiness::unknown(),
+            pending_revisions: std::collections::BTreeMap::new(),
             help_open: false,
             // A sheet, not a log: it opens at its top, never at its tail.
             help_scroll: ScrollState {
@@ -1194,6 +1209,19 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
     }
     if let Inbound::IndexReadiness(readiness) = inbound {
         ui.index_readiness = *readiness;
+        return;
+    }
+    // A plan revision a failing gate put up: the scrollback row and the
+    // withholding are written together, because a transcript showing a
+    // question the deck has stopped waiting on is worse than either alone.
+    // Ignored for a lane the deck does not have: unlike `Inbound::Event`, and
+    // like every other envelope carrying an agent id, this never registers one.
+    if let Inbound::RevisionProposed { agent, proposal } = inbound {
+        if let Some(lane) = model.index_of(agent).and_then(|i| model.agents.get_mut(i)) {
+            lane.model.propose_revision((**proposal).clone());
+            ui.pending_revisions
+                .insert(agent.clone(), (**proposal).clone());
+        }
         return;
     }
     if crate::panel_deck::ingest(&mut ui.panels, inbound) {
@@ -3524,6 +3552,12 @@ fn dispatch_submission(ui: &mut DeckUi, model: &WorkspaceModel) -> DeckAction {
     // (#4043). Checked here rather than inside `submit_prompt` precisely so
     // the text is still in the composer when the hold fires.
     if let Some(held) = gates::index_hold(ui) {
+        return held;
+    }
+    // And a lane with a plan revision standing runs nothing at all until it is
+    // answered (SPEC 8.1 item 3). Same placement, same reason: the composer
+    // still holds the text when the hold fires.
+    if let Some(held) = gates::revision_hold(ui) {
         return held;
     }
     // The deck queue is text-shaped: attachments enter deck prompts as

--- a/crates/stella-tui/src/deck_ui/gates.rs
+++ b/crates/stella-tui/src/deck_ui/gates.rs
@@ -44,6 +44,38 @@ pub(super) fn index_hold(ui: &mut DeckUi) -> Option<DeckAction> {
     Some(DeckAction::Handled)
 }
 
+/// Hold a submission while a plan revision a failing gate put up is still
+/// unanswered — SPEC 8.1 item 3's "nothing runs until approval".
+///
+/// The deck's half of the withholding
+/// `stella_core::plan_graph::RevisionGate::admits` states engine-side. Both
+/// halves are needed and neither implies the other: the engine gate withholds
+/// the *tool calls* of a turn already in flight, and this withholds the
+/// *prompts* the deck would start, which never pass through it.
+///
+/// Workspace-wide rather than per-lane, on [`index_hold`]'s shape and for a
+/// blunter reason: a prompt does not choose its lane — the dispatcher does —
+/// so a hold scoped to the lane the reader happens to be looking at would let
+/// the very next prompt start work on the lane that is waiting for an answer.
+///
+/// `Some` means the keystroke is spent and the composer is untouched, so the
+/// user's text survives. It can never lock anybody out: `a`, `e` and `x` each
+/// clear the entry, and so does the lane going away.
+pub(super) fn revision_hold(ui: &mut DeckUi) -> Option<DeckAction> {
+    let (agent, proposal) = ui.pending_revisions.first_key_value()?;
+    let message = format!(
+        "{agent} is waiting on {}: {} — a approve · e edit · x dismiss on the proposal row",
+        proposal.revision, proposal.subject
+    );
+    // `demand`, not `push`, for `index_hold`'s reason: a dismissed notice
+    // dialog must not swallow the one explanation for a keystroke that was
+    // spent and did nothing.
+    ui.notice.demand(message.clone());
+    ui.scrollback
+        .announce(format!("{}{message}", crate::accessible::NOTICE_MARKER));
+    Some(DeckAction::Handled)
+}
+
 /// A reviewer's in-progress marks on one hunk-review card.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HunkMarks {

--- a/crates/stella-tui/src/deck_ui/row_keys.rs
+++ b/crates/stella-tui/src/deck_ui/row_keys.rs
@@ -3,14 +3,28 @@
 
 //! The bare letters a highlighted transcript row lends the keyboard.
 //!
-//! Four of them today: `u` on a delete event (SPEC 6.3's `· git-backed ·
-//! u undo`, SPEC 11), `l` / `r` on a gate board carrying a failure (SPEC
-//! 8.1's `^N jump · l full log · r rerun gate`), and `x` on a logged memory
-//! (SPEC 6.3's `· x reject`). One module rather than four arms in
-//! `deck_ui.rs`, which is a god file closed to growth — and one *shape*,
-//! because all four answer the same two questions: does this keystroke belong
-//! to the keyboard or to the composer, and does the highlight actually offer
-//! this verb?
+//! `u` on a delete event (SPEC 6.3's `· git-backed · u undo`, SPEC 11),
+//! `l` / `r` on a gate board carrying a failure (SPEC 8.1's `^N jump ·
+//! l full log · r rerun gate`), `x` on a logged memory (SPEC 6.3's
+//! `· x reject`), and `a` / `e` / `x` on a standing plan-revision proposal
+//! (SPEC 8.1's `a approve r4 · e edit · x dismiss`). One module rather than an
+//! arm each in `deck_ui.rs`, which is a god file closed to growth — and one
+//! *shape*, because every one of them answers the same two questions: does
+//! this keystroke belong to the keyboard or to the composer, and does the
+//! highlight actually offer this verb?
+//!
+//! # Why the proposal's keys are here and not on a card
+//!
+//! SPEC 8.1 asks for bare `a` / `e` / `x`, and [`crate::views::approval`]
+//! refuses bare letters. Both are right, because they guard
+//! different things. An approval card *arrives unbidden* over a composer
+//! somebody may be mid-sentence in, so a keystroke already in flight must not
+//! decide a call that runs their `rm -rf`. A transcript row is the opposite:
+//! [`is_bare_row_key`] admits a letter only when the composer is blank **and**
+//! the reader has moved the highlight onto the row, which is why destructive
+//! `u` is already admitted here. `a` on a proposal changes what is *planned*,
+//! and every task it admits still passes the tool-approval gate
+//! `views::approval` guards.
 //!
 //! # The rule every letter here follows
 //!
@@ -37,7 +51,7 @@ use crate::model::TranscriptEntry;
 /// them keeps this half cheap enough to run on every letter typed into the
 /// composer.
 pub(super) fn is_bare_row_key(c: char, key: KeyEvent, ui: &DeckUi) -> bool {
-    matches!(c, 'u' | 'l' | 'r' | 'x')
+    matches!(c, 'a' | 'e' | 'u' | 'l' | 'r' | 'x')
         && !key.modifiers.intersects(
             KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META | KeyModifiers::ALT,
         )
@@ -68,12 +82,49 @@ pub(super) fn act(c: char, model: &WorkspaceModel, ui: &mut DeckUi) -> Option<De
             let gate = selected_failed_board(model, ui)?.1;
             Some(DeckAction::Send(WorkspaceInput::RerunGate { gate }))
         }
-        // The text travels with the id because the rejection is a tombstone
-        // and an id alone would not hold it: the reflection loop re-mines
+        // `a approve r4` — SPEC 8.1's first action. The whole proposal travels
+        // to the driver, which re-checks its revision number against the plan
+        // before writing (`RevisionGate::approve`); the withholding is
+        // released here, because the reader has answered.
+        'a' => {
+            let (agent, proposal) = take_selected_proposal(model, ui)?;
+            Some(DeckAction::Send(WorkspaceInput::ApproveRevision {
+                agent,
+                proposal: Box::new(proposal),
+            }))
+        }
+        // `e edit`. A transcript row holds no text buffer and the deck's one
+        // buffer is the composer, which `is_bare_row_key` requires to be
+        // blank — so `e` hands the proposed subject to the composer and stands
+        // the proposal down: "I will write this one myself". Editing the task
+        // in place, and approving the edited version without retyping it, is
+        // #5289.
+        'e' => {
+            let (_, proposal) = take_selected_proposal(model, ui)?;
+            ui.composer.paste(&proposal.subject);
+            Some(DeckAction::Handled)
+        }
+        // `x reject` on a memory row. The text travels with the id because the
+        // rejection is a tombstone and an id alone would not hold it: the
+        // reflection loop re-mines
         // paraphrases, so the same lesson returns tomorrow under a fresh
         // `nod_…`. `stella-store`'s `forget` compares candidates against the
         // content it copied in, which is what catches the restatement.
+        //
+        // `x` on a standing proposal is `x dismiss` instead (SPEC 8.1). One
+        // letter, two rows, and no ambiguity: the two verbs are selected by
+        // what the highlight is on, and a row is one or the other.
         'x' => {
+            if let Some((agent, proposal)) = take_selected_proposal(model, ui) {
+                let message = format!(
+                    "{} dismissed on {agent}: {}",
+                    proposal.revision, proposal.subject
+                );
+                ui.notice.push(message.clone());
+                ui.scrollback
+                    .announce(format!("{}{message}", crate::accessible::NOTICE_MARKER));
+                return Some(DeckAction::Handled);
+            }
             let (memory_id, text) = super::memory::selected_memory(model, ui)?;
             Some(DeckAction::Send(WorkspaceInput::RejectMemory {
                 memory_id,
@@ -82,6 +133,32 @@ pub(super) fn act(c: char, model: &WorkspaceModel, ui: &mut DeckUi) -> Option<De
         }
         _ => None,
     }
+}
+
+/// The standing proposal under the transcript highlight, removed from the
+/// pending set — so the withholding is released by exactly the key press that
+/// answers it.
+///
+/// `None` for any other selection, and for a proposal row that has already
+/// been answered: the row stays in the scrollback after `a`, `e` or `x` (it is
+/// what the reader saw), and a second press on it must fall through to the
+/// composer rather than re-answering a question that is settled.
+fn take_selected_proposal(
+    model: &WorkspaceModel,
+    ui: &mut DeckUi,
+) -> Option<(String, stella_protocol::RevisionProposal)> {
+    let idx = ui.session_selected?;
+    let agent = model.agents.get(ui.focused)?;
+    let TranscriptEntry::RevisionProposal { proposal } = agent.model.transcript.get(idx)? else {
+        return None;
+    };
+    let id = agent.meta.id.clone();
+    let standing = ui.pending_revisions.get(&id)?;
+    if standing != proposal {
+        return None;
+    }
+    let proposal = ui.pending_revisions.remove(&id)?;
+    Some((id, proposal))
 }
 
 /// Flip entry `idx`'s expanded state for the focused agent — what `ctrl+o`

--- a/crates/stella-tui/src/deck_ui/tests.rs
+++ b/crates/stella-tui/src/deck_ui/tests.rs
@@ -26,6 +26,7 @@ mod issues;
 mod list_vocabulary;
 mod mcp;
 mod queue;
+mod revision;
 mod routing_card;
 mod selection;
 mod sessions;

--- a/crates/stella-tui/src/deck_ui/tests/revision.rs
+++ b/crates/stella-tui/src/deck_ui/tests/revision.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The deck's half of SPEC 8.1 item 3: the proposal a failing gate puts up,
+//! the three keys that answer it, and the submissions withheld until one of
+//! them is pressed.
+
+use super::*;
+use stella_protocol::{DivergenceCause, RevisionProposal, plan_graph::PlanRevision};
+
+fn proposal() -> RevisionProposal {
+    RevisionProposal {
+        revision: PlanRevision::new(2).expect("r2"),
+        subject: "repair a_short_cycle_is_detected".into(),
+        gate: "tests".into(),
+        cause: DivergenceCause::new("assertion `left == right` failed").expect("a cause"),
+        issue: None,
+    }
+}
+
+/// A lane with one ordinary row and then a standing proposal, highlighted.
+///
+/// The row above matters: it is what the "letters fall through elsewhere" test
+/// moves the highlight onto, and a transcript whose only entry is the proposal
+/// cannot express "the highlight is somewhere else".
+fn proposed(model: &mut WorkspaceModel, ui: &mut DeckUi) {
+    model.apply_inbound(&Inbound::Event {
+        agent: "lead".into(),
+        event: AgentEvent::Text {
+            text: "the tests gate went red".into(),
+        },
+    });
+    ingest_inbound(
+        &Inbound::RevisionProposed {
+            agent: "lead".into(),
+            proposal: Box::new(proposal()),
+        },
+        model,
+        ui,
+    );
+    handle_deck_key(key(KeyCode::Up), model, ui);
+}
+
+/// **The acceptance criterion.** With a proposal standing, a submitted prompt
+/// does not dispatch — no `Send`, nothing enqueued — and the composer keeps
+/// the text so nobody loses what they typed. Pressing `a` releases it, and the
+/// same prompt then dispatches.
+///
+/// The withholding is what this pins. A test that only checked the proposal
+/// renders would witness a picture and call it a gate.
+#[test]
+fn nothing_dispatches_until_the_proposal_is_answered() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    proposed(&mut model, &mut ui);
+
+    for c in "fix it".chars() {
+        handle_deck_key(key(KeyCode::Char(c)), &model, &mut ui);
+    }
+    let held = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(
+        held,
+        DeckAction::Handled,
+        "the submission must be withheld, not dispatched"
+    );
+    assert_eq!(
+        ui.composer.buffer(),
+        "fix it",
+        "a held prompt keeps its text — holding a prompt is not eating one"
+    );
+
+    // Answer it. Typing moved no highlight, so `a` lands on the proposal row
+    // the setup left it on.
+    ui.composer.clear();
+    let approved = handle_deck_key(key(KeyCode::Char('a')), &model, &mut ui);
+    assert_eq!(
+        approved,
+        DeckAction::Send(WorkspaceInput::ApproveRevision {
+            agent: "lead".into(),
+            proposal: Box::new(proposal()),
+        }),
+        "a sends the approval, carrying the proposal the driver re-checks"
+    );
+    assert!(
+        ui.pending_revisions.is_empty(),
+        "and releases the withholding"
+    );
+
+    // The hold's own notice is still on screen; clearing it is the reader
+    // pressing Esc, and is not part of what this test is about.
+    ui.notice.dismiss();
+    for c in "fix it".chars() {
+        handle_deck_key(key(KeyCode::Char(c)), &model, &mut ui);
+    }
+    let sent = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert!(
+        matches!(
+            sent,
+            DeckAction::Send(
+                WorkspaceInput::Enqueue { .. }
+                    | WorkspaceInput::EnqueueNext { .. }
+                    | WorkspaceInput::ToAgent { .. }
+            )
+        ),
+        "once answered, the same prompt dispatches: {sent:?}"
+    );
+}
+
+/// `x dismiss`: the proposal goes, the withholding goes with it, and nothing
+/// is sent — a dismissal writes no revision, so there is nothing for a driver
+/// to do about it.
+#[test]
+fn x_dismisses_the_proposal_and_sends_nothing() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    proposed(&mut model, &mut ui);
+
+    let action = handle_deck_key(key(KeyCode::Char('x')), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled, "x claimed the keystroke");
+    assert!(ui.pending_revisions.is_empty());
+    assert!(
+        ui.notice.entries().iter().any(|n| n.contains("r2")),
+        "the dismissal says what it dropped"
+    );
+}
+
+/// `e edit` hands the proposed subject to the composer and stands the proposal
+/// down — see `row_keys`'s `'e'` arm and #5289 for why in-place editing is not
+/// this key yet.
+#[test]
+fn e_hands_the_subject_to_the_composer() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    proposed(&mut model, &mut ui);
+
+    assert_eq!(
+        handle_deck_key(key(KeyCode::Char('e')), &model, &mut ui),
+        DeckAction::Handled
+    );
+    assert_eq!(ui.composer.buffer(), "repair a_short_cycle_is_detected");
+    assert!(ui.pending_revisions.is_empty());
+}
+
+/// The three letters belong to the row, not to the keyboard: with the
+/// highlight anywhere else they type, which is what keeps a prompt containing
+/// the word `already` from losing its `a`.
+#[test]
+fn the_letters_type_when_the_highlight_is_not_a_proposal() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    proposed(&mut model, &mut ui);
+    // Off the proposal row and onto the one above it.
+    ui.session_selected = Some(0);
+
+    for c in "aex".chars() {
+        handle_deck_key(key(KeyCode::Char(c)), &model, &mut ui);
+    }
+    assert_eq!(ui.composer.buffer(), "aex");
+    assert_eq!(
+        ui.pending_revisions.len(),
+        1,
+        "and the proposal is still standing"
+    );
+}
+
+/// A second press on an already-answered row types rather than re-answering:
+/// the row stays in the scrollback because it is what the reader saw, and it
+/// is no longer a question.
+#[test]
+fn an_answered_proposal_row_lends_no_more_letters() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    proposed(&mut model, &mut ui);
+    handle_deck_key(key(KeyCode::Char('x')), &model, &mut ui);
+
+    handle_deck_key(key(KeyCode::Char('a')), &model, &mut ui);
+    assert_eq!(ui.composer.buffer(), "a");
+}
+
+/// The row is in the scrollback and reads as SPEC 8.1 writes it.
+#[test]
+fn the_proposal_lands_in_the_transcript() {
+    let mut model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    proposed(&mut model, &mut ui);
+
+    let lane = model.agents.first().expect("the lead lane");
+    assert!(
+        lane.model.transcript.iter().any(|entry| matches!(
+            entry,
+            crate::model::TranscriptEntry::RevisionProposal { proposal } if proposal.gate == "tests"
+        )),
+        "the proposal is filed where the reader is looking"
+    );
+}

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -604,6 +604,21 @@ pub enum Inbound {
     /// prompts, far larger than any other `Inbound` payload, and this variant
     /// would otherwise set the size of every channel send.
     InspectedCall(Box<InspectView>),
+    /// A failing gate has put a plan revision up for `agent` — SPEC 8.1 item 3.
+    ///
+    /// Out-of-band view-and-model state like [`Inbound::GraphSnapshot`], not
+    /// an [`Inbound::Event`]: `stella_core::plan_graph::RevisionGate` authors
+    /// it host-side from a `GateBoard` the host already evaluated, so the
+    /// journal keeps the board and the proposal is the host's reading of it.
+    /// Routing it as an event would put a host-side decision into the durable
+    /// stream, where a second producer could then write one.
+    ///
+    /// Folded by `SessionModel::propose_revision`, which files the scrollback
+    /// row and starts withholding the composer in one step.
+    RevisionProposed {
+        agent: AgentId,
+        proposal: Box<stella_protocol::RevisionProposal>,
+    },
 }
 
 /// One row of the ISSUES tab's browse list — tracker-agnostic: the driver
@@ -1301,6 +1316,23 @@ pub enum WorkspaceInput {
     RerunGate {
         /// The gate's name, as its row states it.
         gate: String,
+    },
+    /// `a` on a highlighted revision proposal: make the plan revision the
+    /// failing gate put up — SPEC 8.1's `a approve r4`.
+    ///
+    /// The whole proposal travels rather than its subject alone, because the
+    /// driver re-checks it before writing: `RevisionGate::approve` refuses a
+    /// proposal whose revision number the plan has moved past, and a subject
+    /// on its own carries no number to check.
+    ///
+    /// `e edit` and `x dismiss` are absent from this enum on purpose. Both are
+    /// answered entirely inside the deck — `e` hands the subject to the
+    /// composer and stands the proposal down, `x` drops it — and neither
+    /// writes anything, so a round trip to the driver would be a message whose
+    /// only effect is latency.
+    ApproveRevision {
+        agent: AgentId,
+        proposal: Box<stella_protocol::RevisionProposal>,
     },
     /// Plan card (`/plan`), post-approval `e`: ask the driver to open a
     /// scope-change proposal for `agent`'s locked scope. The deck never edits

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -33,6 +33,7 @@ mod inline_diff;
 mod memory;
 pub mod recall;
 mod reset;
+mod revision;
 mod summarize;
 mod turn;
 

--- a/crates/stella-tui/src/model/entry.rs
+++ b/crates/stella-tui/src/model/entry.rs
@@ -19,8 +19,8 @@
 //! determinism extends through the renderer precisely because these are inert).
 
 use stella_protocol::{
-    BudgetMode, CiStatus, GateBoard, MediaJobState, MediaKind, MemoryClass, PrStatus, StageName,
-    SubAgentStatus, Withholder,
+    BudgetMode, CiStatus, GateBoard, MediaJobState, MediaKind, MemoryClass, PrStatus,
+    RevisionProposal, StageName, SubAgentStatus, Withholder,
 };
 
 use super::recall::{RecallBudget, RecalledFrameRow};
@@ -386,6 +386,19 @@ pub enum TranscriptEntry {
     /// is carried unchanged — every field on it is already content with no
     /// styling, which is what an entry is (module docs).
     GateBoard { board: GateBoard },
+    /// The plan revision a failing gate put up, and has not had answered —
+    /// SPEC 8.1 item 3.
+    ///
+    /// A transcript row rather than an overlay, which is what lends it the
+    /// bare `a` / `e` / `x` keys: `deck_ui::row_keys` admits a letter only
+    /// when the composer is blank and the reader has highlighted the row,
+    /// where `views::approval`'s card arrives unbidden over a composer
+    /// somebody may be typing into and refuses bare letters for that reason.
+    ///
+    /// The proposal is carried whole. Every field on it is content the
+    /// producer settled — `stella_core::plan_graph::RevisionGate` authors it
+    /// from a board the host evaluated — and nothing here re-derives any of it.
+    RevisionProposal { proposal: RevisionProposal },
     /// A goal-check verdict from the verifier loop (`AgentEvent::GoalVerdict`) —
     /// the symmetric scrollback row to [`Self::Verdict`]. `met` is the
     /// pass/fail; `round` is the verifier iteration it settled on.

--- a/crates/stella-tui/src/model/revision.rs
+++ b/crates/stella-tui/src/model/revision.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The scrollback record of a plan revision a failing gate put up (SPEC 8.1
+//! item 3).
+//!
+//! Not part of [`SessionModel::apply`]'s fold, because a proposal is not an
+//! `AgentEvent`: `stella_core::plan_graph::RevisionGate` authors it
+//! host-side from a `GateBoard` the host already evaluated, and it reaches the
+//! deck on `Inbound::RevisionProposed`. A replayed event log therefore shows
+//! the gate board that provoked the proposal rather than the proposal — the
+//! same shape `Inbound::GraphSnapshot` and the rest of the out-of-band
+//! envelopes have. Routing it as an event would put a host-side reading into the
+//! session's durable journal, where a second producer could then write one.
+//!
+//! The *withholding* the proposal implies is `DeckUi::pending_revisions`', not
+//! this row's. State a key press clears belongs to the interaction layer
+//! (`model`'s own module doc draws that line), and this is the record of what
+//! was asked.
+
+use stella_protocol::RevisionProposal;
+
+use super::{SessionModel, TranscriptEntry};
+
+impl SessionModel {
+    /// File the proposal in the scrollback.
+    ///
+    /// A superseded proposal's row stays where it is: it is what the reader
+    /// was looking at, and deleting it would leave an action row they had
+    /// half-answered with no trace of what it asked.
+    pub fn propose_revision(&mut self, proposal: RevisionProposal) {
+        self.transcript
+            .push(TranscriptEntry::RevisionProposal { proposal });
+        self.evict_transcript_overflow();
+    }
+}

--- a/crates/stella-tui/src/render/entry.rs
+++ b/crates/stella-tui/src/render/entry.rs
@@ -321,6 +321,13 @@ fn projected_rows(
             out.extend(crate::views::gate_board::board_rows(board, expanded, width));
             true
         }
+        // The block the failing board above provoked. Fixed height — there is
+        // no log to open, so it is not expandable and `l` stays the gate
+        // board's.
+        TranscriptEntry::RevisionProposal { proposal } => {
+            out.extend(crate::views::revision_proposal::proposal_rows(proposal));
+            true
+        }
         TranscriptEntry::Complete {
             cost_usd,
             turn,
@@ -609,7 +616,7 @@ fn entry_body(
         // once, in `views::gate_board`. The arm exists because this match is
         // exhaustive by design, and it delegates rather than drawing a second
         // board here for the reason the two above delegate.
-        TranscriptEntry::GateBoard { .. } => {
+        TranscriptEntry::GateBoard { .. } | TranscriptEntry::RevisionProposal { .. } => {
             projected_rows(entry, view, expanded, width, out);
         }
         TranscriptEntry::BudgetTick {

--- a/crates/stella-tui/src/transcript_nav.rs
+++ b/crates/stella-tui/src/transcript_nav.rs
@@ -157,6 +157,14 @@ pub fn entry_fields(entry: &TranscriptEntry) -> Vec<&str> {
                 })
             })
             .collect(),
+        // "which failure did that repair task come from?" is a find-box
+        // question, and the cause is where the answer lives — the gate's own
+        // words, on the row that proposed the work.
+        E::RevisionProposal { proposal } => vec![
+            proposal.subject.as_str(),
+            proposal.gate.as_str(),
+            proposal.cause.as_str(),
+        ],
         E::GoalVerdict { reasoning, .. } => vec![reasoning],
         // The child's id and task are the searchable part; its summary never
         // reaches the transcript, by design.

--- a/crates/stella-tui/src/views.rs
+++ b/crates/stella-tui/src/views.rs
@@ -35,6 +35,7 @@ pub mod pulse;
 pub mod question;
 pub mod queue;
 pub(crate) mod record;
+pub mod revision_proposal;
 pub mod seats;
 pub mod session;
 pub mod sessions;

--- a/crates/stella-tui/src/views/revision_proposal.rs
+++ b/crates/stella-tui/src/views/revision_proposal.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The plan revision a failing gate puts up — SPEC 8.1 items 3 and 4.
+//!
+//! ```text
+//!  │ ⌥ propose r4: add task "repair a_short_cycle_is_detected"
+//!  │     cause  tests · assertion `left == right` failed
+//!  │     issue  #151
+//!  │     a approve r4 · e edit · x dismiss
+//!  │     merge blocked · unblocks on green
+//! ```
+//!
+//! ## Gold, because it is drift and not an alarm
+//!
+//! The headline takes [`glyph::DRIFT`] in [`token::GOLD_BRIGHT`], the same
+//! metal `plan_card::step_style` gives an inserted step — a proposal and the
+//! drift row it becomes are one fact seen twice, and painting them differently
+//! would make the reader work out that they are the same thing. Red is spent
+//! on the failing gate row above (SPEC 2's scarcity rule, and
+//! [`super::gate_board`]'s module docs); a proposal is what stella is doing
+//! about that failure, not a second alarm about it.
+//!
+//! ## Nothing here runs anything
+//!
+//! A projection of owned data onto `Line<'static>`, like every other view in
+//! this module. The keys named in the action row are
+//! `deck_ui::row_keys`'s, and the withholding they release is
+//! `stella_core::plan_graph::RevisionGate::admits`'s — this file draws the
+//! sentence and holds none of the state behind it.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use stella_protocol::RevisionProposal;
+use stella_tui_theme::{glyph, token};
+
+use super::transcript::rail_span;
+
+/// SPEC 8.1 item 4's banner. Stated as the proposal's closing line because
+/// that is where the reader is looking when they decide: the merge is blocked
+/// by the gate that failed, and a green board is what lifts it — never this
+/// approval, which changes the plan and settles nothing.
+const MERGE_BLOCKED: &str = "merge blocked · unblocks on green";
+
+/// Cells the proposal's detail lines are indented under its headline.
+const DETAIL_INDENT: &str = "     ";
+
+/// Every row the proposal owns.
+#[must_use]
+pub fn proposal_rows(proposal: &RevisionProposal) -> Vec<Line<'static>> {
+    let mut rows = vec![headline(proposal), field("cause", &cause_text(proposal))];
+    if let Some(issue) = &proposal.issue {
+        rows.push(field("issue", issue));
+    }
+    rows.push(detail(
+        &format!("a approve {} · e edit · x dismiss", proposal.revision),
+        token::GOLD,
+    ));
+    rows.push(detail(MERGE_BLOCKED, token::MUTED));
+    rows
+}
+
+/// `⌥ propose r4: add task "<title>"`.
+///
+/// The subject is quoted because it is the task's own words and can contain
+/// the separators around it — an unquoted title with a `·` in it would read as
+/// two cells.
+fn headline(proposal: &RevisionProposal) -> Line<'static> {
+    let gold = Style::new().fg(token::GOLD_BRIGHT);
+    Line::from(vec![
+        rail_span(token::GOLD_BRIGHT),
+        Span::styled(format!(" {} ", glyph::DRIFT), gold),
+        Span::styled(
+            format!("propose {}", proposal.revision),
+            gold.add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(": add task \"{}\"", proposal.subject),
+            Style::new().fg(token::TEXT),
+        ),
+    ])
+}
+
+/// `cause  tests · assertion …` — the gate that failed and what its evidence
+/// said, joined so the reader never has to look up which gate a cause belongs
+/// to.
+fn cause_text(proposal: &RevisionProposal) -> String {
+    format!("{} · {}", proposal.gate, proposal.cause.as_str())
+}
+
+/// One labelled detail line: a dim label, then the value in plain text.
+fn field(label: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        rail_span(token::GOLD_BRIGHT),
+        Span::styled(
+            format!("{DETAIL_INDENT}{label}  "),
+            Style::new().fg(token::DIM),
+        ),
+        Span::styled(value.to_owned(), Style::new().fg(token::TEXT)),
+    ])
+}
+
+/// One unlabelled detail line in `color`.
+fn detail(text: &str, color: ratatui::style::Color) -> Line<'static> {
+    Line::from(vec![
+        rail_span(token::GOLD_BRIGHT),
+        Span::styled(format!("{DETAIL_INDENT}{text}"), Style::new().fg(color)),
+    ])
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-tui/src/views/revision_proposal/tests.rs
+++ b/crates/stella-tui/src/views/revision_proposal/tests.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What the proposal block says, and in which metal.
+
+use super::*;
+use stella_protocol::DivergenceCause;
+use stella_protocol::plan_graph::PlanRevision;
+
+fn proposal(issue: Option<&str>) -> RevisionProposal {
+    RevisionProposal {
+        revision: PlanRevision::new(4).expect("r4"),
+        subject: "repair a_short_cycle_is_detected".into(),
+        gate: "tests".into(),
+        cause: DivergenceCause::new("assertion `left == right` failed").expect("a cause"),
+        issue: issue.map(str::to_owned),
+    }
+}
+
+fn text(rows: &[Line<'static>]) -> Vec<String> {
+    rows.iter()
+        .map(|row| {
+            row.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+/// SPEC 8.1 item 3, written out: the drift glyph, the revision the approval
+/// would author, the task in the gate's own words, the cause, and the action
+/// row naming all three keys.
+#[test]
+fn the_block_states_the_revision_the_cause_and_the_three_keys() {
+    let rows = text(&proposal_rows(&proposal(Some("#151"))));
+    assert_eq!(
+        rows,
+        vec![
+            " │ ⌥ propose r4: add task \"repair a_short_cycle_is_detected\"".to_owned(),
+            " │     cause  tests · assertion `left == right` failed".to_owned(),
+            " │     issue  #151".to_owned(),
+            " │     a approve r4 · e edit · x dismiss".to_owned(),
+            " │     merge blocked · unblocks on green".to_owned(),
+        ]
+    );
+}
+
+/// A proposal whose evidence named no issue draws no issue row, rather than a
+/// labelled blank one.
+#[test]
+fn no_linked_issue_draws_no_issue_row() {
+    let rows = text(&proposal_rows(&proposal(None)));
+    assert!(!rows.iter().any(|row| row.contains("issue")), "{rows:#?}");
+    assert_eq!(rows.len(), 4);
+}
+
+/// The glyph is the gate-enforced [`glyph::DRIFT`] and not the `⑂` both
+/// issues wrote: `stella_tui_theme::glyph::ALL` is checked, so a second drift
+/// mark would be a mark no other surface draws.
+#[test]
+fn the_marker_is_the_theme_drift_glyph() {
+    let rows = text(&proposal_rows(&proposal(None)));
+    assert!(rows[0].contains(glyph::DRIFT), "{}", rows[0]);
+    assert!(!rows[0].contains('⑂'), "{}", rows[0]);
+}
+
+/// Drift metal, never the alarm: the proposal answers a red gate row and must
+/// not become a second one (SPEC 2's scarcity rule).
+#[test]
+fn the_proposal_spends_gold_and_never_red() {
+    let rows = proposal_rows(&proposal(Some("#151")));
+    let colors: Vec<_> = rows
+        .iter()
+        .flat_map(|row| row.spans.iter())
+        .filter_map(|span| span.style.fg)
+        .collect();
+    assert!(
+        colors.contains(&token::GOLD_BRIGHT),
+        "the headline takes drift gold: {colors:?}"
+    );
+    assert!(
+        !colors.contains(&token::RED),
+        "a proposal is not an alarm: {colors:?}"
+    );
+    assert!(
+        !colors.contains(&token::GREEN),
+        "and it settles nothing: {colors:?}"
+    );
+}

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -93,6 +93,11 @@ mod task_zoom;
 #[path = "deck_render_snapshots/gate_board.rs"]
 mod gate_board;
 
+/// SPEC 8.1's plan-revision proposal, the block the board above provokes. See
+/// [`graph`]'s doc for why this is `#[path]` rather than a plain `mod`.
+#[path = "deck_render_snapshots/revision_proposal.rs"]
+mod revision_proposal;
+
 /// See [`graph`]'s doc for why this is `#[path]` rather than a plain `mod`.
 #[path = "deck_render_snapshots/start_work.rs"]
 mod start_work;

--- a/crates/stella-tui/tests/deck_render_snapshots/revision_proposal.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots/revision_proposal.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! SPEC 8.1 items 3 and 4: the failing board, and the plan revision it puts up.
+//!
+//! Both entries in one frame on purpose. The proposal is a *response* to the
+//! board — its cause is the gate's own words — and a golden of the block alone
+//! could not show that the two read as one exchange, which is the thing SPEC
+//! 8.1 is actually asking for.
+//!
+//! A submodule for the reason [`super::gate_board`] is one: the parent reached
+//! its ceiling. Every helper comes from the parent, and one command blesses
+//! them all:
+//! `BLESS=1 cargo test -p stella-tui --test deck_render_snapshots`.
+//!
+//! Colour is stripped by `render_frame`, so the gold/`GOLD_BRIGHT` claims stay
+//! where they can be asserted on spans:
+//! `views::revision_proposal::tests::the_proposal_spends_gold_and_never_red`.
+
+use super::*;
+
+use stella_protocol::{
+    DivergenceCause, GateBoard, GateRow, GateState, RevisionProposal, plan_graph::PlanRevision,
+};
+use stella_tui::deck_ui::ingest_inbound;
+
+/// The `09-gate-failure` exchange: `✗ tests failed`, then
+/// `⌥ propose r2: add task "…"` with its cause, its linked issue, the action
+/// row and the merge banner.
+#[test]
+fn deck_render_snapshots_pin_a_gate_failure_and_the_revision_it_proposes() {
+    let mut model = fixture_model();
+    model.apply_inbound(&Inbound::Event {
+        agent: "lead".into(),
+        event: AgentEvent::GateBoard {
+            board: GateBoard {
+                patch: Some("patch-7".into()),
+                gates: vec![
+                    GateRow {
+                        name: "fmt".into(),
+                        state: GateState::Green,
+                        deterministic: true,
+                    },
+                    GateRow {
+                        name: "tests".into(),
+                        state: GateState::Failed {
+                            case: "stella_core::loop_detect::a_short_cycle_is_detected".into(),
+                            log: "assertion `left == right` failed\n  left: 3\n  right: 2".into(),
+                        },
+                        deterministic: true,
+                    },
+                ],
+            },
+        },
+    });
+
+    let mut ui = ui_for(DeckTab::Session);
+    ingest_inbound(
+        &Inbound::RevisionProposed {
+            agent: "lead".into(),
+            proposal: Box::new(RevisionProposal {
+                revision: PlanRevision::new(2).expect("r2"),
+                subject: "repair stella_core::loop_detect::a_short_cycle_is_detected".into(),
+                gate: "tests".into(),
+                cause: DivergenceCause::new("assertion `left == right` failed").expect("a cause"),
+                issue: Some("#151".into()),
+            }),
+        },
+        &mut model,
+        &mut ui,
+    );
+
+    let frame = render_frame(&model, &mut ui, W, H);
+    // SPEC 8.1 writes `⌥`, `stella_tui_theme::glyph::DRIFT` is `⌥`, and
+    // `glyph::ALL` is gate-enforced — so the `⑂` both issues wrote would be a
+    // drift mark no other surface draws. An absence assertion, because a
+    // blessed golden cannot be relied on to notice a glyph swap.
+    assert!(frame.contains('⌥'), "{frame}");
+    assert!(!frame.contains('⑂'), "{frame}");
+    assert_golden(
+        "session_revision_proposal",
+        "SPEC 8.1: a failing gate board and the plan revision it proposes",
+        W,
+        H,
+        &frame,
+    );
+}

--- a/crates/stella-tui/tests/snapshots/deck/session_revision_proposal.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_revision_proposal.txt
@@ -1,0 +1,45 @@
+# deck golden · session_revision_proposal
+# SPEC 8.1: a failing gate board and the plan revision it proposes
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
+
+── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
+ │ ⎿ 312 lines                                                                                                                               42ms
+
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
+ │ ⎿                                                                                                                                 +4 −1 · 18ms
+ │     10 -  const items = []
+ │     10 +  const items = useAutomations()
+ │     11 +  const [q, setQ] = useState("")
+ │     12 +  const filtered = filter(items, q)
+ │     13 +  const onNew = () => open()
+
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
+
+☰  plan  5/7  ·  Workflows canvas
+
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
+
+ │ ◇ gate board · patch-7 · 1/2 green · $0.00
+ │   ✓ fmt · green · $0.00 · det
+ │   ✗ tests failed
+ │       stella_core::loop_detect::a_short_cycle_is_detected
+ │       assertion `left == right` failed
+ │         left: 3
+ │       ^N jump · l full log · r rerun gate
+
+ │ ⌥ propose r2: add task "repair stella_core::loop_detect::a_short_cycle_is_detected"
+ │     cause  tests · assertion `left == right` failed
+ │     issue  #151
+ │     a approve r2 · e edit · x dismiss
+ │     merge blocked · unblocks on green
+
+
+>>>
+ ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/session_revision_proposal.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_revision_proposal.txt
@@ -39,7 +39,7 @@
  │     a approve r2 · e edit · x dismiss
  │     merge blocked · unblocks on green
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help


### PR DESCRIPTION
## What & why

SPEC 8.1 item 3: on a gate failure stella responds with a **proposed plan revision**, never a silent fix — `⌥ propose r4: add task "<title>"` with the linked cause and any linked issue, action row `a approve r4 · e edit · x dismiss`, and **nothing runs until approval**. Item 4's receipt line, `merge blocked · unblocks on green`, closes the block.

Nothing authored one before this. `ScopeProposal::revision` was displayed but never generated, the plan-review dialog left with the staged pipeline (#3861/#3865), and no approve/edit/dismiss vocabulary existed.

Closes #5043

### What ships

**`stella-protocol` — `RevisionProposal`** (`src/plan_graph.rs`). A proposal is a different type from a revision all the way to the surface: `PlanNode` is a revision that happened, this is one somebody has been asked about, and until they answer there is no node, no `[:NEXT]` edge and nothing that may run. A revision carrying an `approved: bool` would make "nothing runs until approval" a flag every producer can set rather than a shape the graph cannot express. Round-trips byte-for-byte (invariant #4).

**`stella-core` — `RevisionGate`** (new `src/plan_graph/revision.rs`). Pure, no I/O (invariant #2), which is what lets the acceptance criterion be witnessed with no terminal, no engine and no plugin.

- `observe(revision, planned, board)` authors from the **first determinate failure** on a `GateBoard` — the same choice `row_keys::selected_failed_board` documents for `r`, so the two keys never disagree about which failure they mean. It returns `None` for a green board, an *undecided* one (an abstention blames the instrument, not the worker), a proposal already standing, a repair the plan already contains, and a failure whose evidence says nothing.
- **`admits()` is the withholding** — `false` while a proposal stands.
- **`approve(&mut PlanGraph)` goes through `PlanGraph::revise`**, so the `[:NEXT]` edge, the retained predecessor and the `Divergence` carrying the gate's cause all come from #5037's machinery rather than a second code path that could disagree with it.

**`stella-tui`** — `TranscriptEntry::RevisionProposal`, `views/revision_proposal.rs`, routed through `render/entry.rs`; `DeckUi::pending_revisions`; `gates::revision_hold` beside `index_hold`; `a` / `e` / `x` in `deck_ui/row_keys.rs`.

**`stella-cli`** — `forwarder.rs` authors on a failing `GateBoard` (it is the one place a gate board and the lane's plan are both in view) and sends `Inbound::RevisionProposed` **after** the board it answers; `driver_support::service_approve_revision` puts the approved task on the session's board, which *is* the plan on this path (`task_tap/plan_gate.rs`'s module doc), so the next step's `PlanGate::review` authors the revision through the machinery that already writes every other one.

No new `AgentEvent`, no consumers-ledger row, no `docs/wire/` regeneration: the forwarder already holds both the `TaskBoardHandle` and the `ScopeReview` revision latch, and a proposal is this host's *reading* of evidence a plugin reported — it does not belong in the durable journal beside the board it read.

### Stella re-ran nothing

A proposal answers a `GateBoard`, which is the host's evaluation of what an installed verification plugin reported (AGENTS.md's opening). `RevisionGate` re-runs no gate and re-checks no evidence. Approving one **changes the plan and settles nothing** — which is exactly why the block closes on `merge blocked · unblocks on green` and why `service_approve_revision`'s doc says so out loud.

### Three judgement calls, stated so they can be overruled

1. **The drift glyph is `⌥`, not `⑂`.** The issue writes `⑂`; SPEC 7.2, 7.3 and 8.1 all write `⌥`, `stella_tui_theme::glyph::DRIFT` is `'⌥'`, and `glyph::ALL` is gate-enforced — so `⑂` would fail the glyph test. Built `⌥`, and the golden carries `assert!(!frame.contains('⑂'))` so a blessed snapshot cannot quietly swap it back.

2. **`add task "<title>"`, not `add task 3b "<title>"`.** `TaskBoard::create` commits in its own doc to ordinal ids that are never reused, and `plan_gate::plan_tasks` reads those straight into the plan graph — so a `3b` needs a second id space beside the board's. Every insertion also lands at the end (the board only grows), so the position `3b` encodes is always the same. **This is a maintainer's call**: if the `3b` spelling matters, the change is `repair_subject` plus a board-side id scheme, and I would rather be told than invent the second id space.

3. **`e edit` hands the subject to the composer** rather than editing in place. A transcript row holds no text buffer and the deck's one buffer is the composer, which `is_bare_row_key` requires to be blank. `RevisionGate::edit` is written and tested for the in-place version; the deck side is #5289.

### The exemplar

`RevisionGate` follows `stella_core::plan_graph::PlanGraph`'s own shape (#5037) — one owned struct, all mutation through methods, every rule stated on the type — and `gates::revision_hold` is `index_hold` with a different question. `service_approve_revision` is `service_rerun_gate`'s shape one verb over.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

Each verified by hand: break the named line, watch the named test fail, restore.

| Test | Crate | What it witnesses | Reverting this makes it fail |
|---|---|---|---|
| `nothing_runs_while_a_proposal_stands` | stella-core | **The acceptance criterion.** A standing proposal withholds; approving releases it | `RevisionGate::admits` → `true` (also fails 2 siblings) |
| `the_proposed_task_cannot_run_until_the_revision_is_approved` | stella-core | The structural half: `PlanGraph::ran` refuses the proposed task before approval, admits it after — so a caller that never asked still cannot run it | `RevisionGate::approve` |
| `approval_writes_the_next_edge_and_records_the_gates_cause_as_the_drift` | stella-core | `r2`'s `[:NEXT]` chain, `r1` still readable, one `Divergence` carrying the gate's own words | `RevisionGate::approve` |
| `nothing_dispatches_until_the_proposal_is_answered` | stella-tui | **The deck's half.** A submitted prompt is withheld and keeps its text; `a` sends the approval and releases it; the same prompt then dispatches | the `gates::revision_hold(ui)` call in `dispatch_submission` |
| `x_dismisses_the_proposal_and_sends_nothing` / `e_hands_the_subject_to_the_composer` | stella-tui | The other two verbs | `row_keys::act`'s `'x'` / `'e'` arms |
| `the_letters_type_when_the_highlight_is_not_a_proposal` / `an_answered_proposal_row_lends_no_more_letters` | stella-tui | `a` / `e` / `x` stay the composer's everywhere else, and a settled row is not a question | `take_selected_proposal`'s two `None` paths |
| `a_failing_gate_board_proposes_a_plan_revision_after_the_board` | stella-cli | The producer, and its ordering: a green board proposes nothing; the proposal follows the board it answers | the forwarder's `revisions.observe(...)` |
| `approving_a_revision_puts_the_task_on_the_board_and_names_the_cause` / `..._twice_adds_one_task` | stella-cli | The approval writes one board row and names the failure it repairs | `service_approve_revision` |
| `the_block_states_the_revision_the_cause_and_the_three_keys` + 3 siblings | stella-tui | The rendering, span-level: `⌥` not `⑂`, gold not red, no issue row when the evidence named none | `views::revision_proposal` |
| `deck_render_snapshots_pin_a_gate_failure_and_the_revision_it_proposes` | stella-tui | The board and the block in one rendered deck | any of the above |
| `a_revision_proposal_round_trips` / `..._writes_no_issue_key` | stella-protocol | Invariant #4 | the serde attributes |

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-core -p stella-protocol -p stella-tui -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test` for those four crates (per CLAUDE.md, no workspace build on this machine — **CI is this PR's evidence**)
- [x] `make guards-fast`, `make prose`, `make wire-schema`, `make invariants`, `make doc-links`, `./scripts/check-file-size.sh`, `./scripts/check-consumer-sites.sh`, `make diag-reference` (no change)
- [x] Docs: every new item carries a doc comment; SPEC 8.1 is cited where it is implemented
- [x] `Closes #5043` above **and** as a commit trailer

## Nothing left behind

- [x] Filed: **#5289** (`e edit` cannot edit the task in place), **#5296** (a standing revision does not withhold the tool calls of a turn already in flight — the engine-side `PlanGate` half)

Designed around, not fixed: **#5261** (nothing selects `gate_board` yet), **#5266** (`r rerun gate` answers in words and runs nothing, deliberately), **#5267** (`judge` collapses abstentions). The deck binds no wrapper today, so no deck lane emits a `GateBoard` yet — this PR makes the path right for when one does, which is what #5261/#5266 track.

## Ground-rule check

- [x] No I/O added to `stella-core` — `RevisionGate` is owned data and pure functions
- [x] No new dependencies
- [x] No new outbound network calls
- [x] `RevisionProposal` round-trips through serde (test included)
- [x] File-size: `deck_ui.rs` (a god file) grew by 4 lines of call site plus the field; `model.rs` was left where it was by putting the fold in `model/revision.rs`

## Anything reviewers should know?

The two id spaces are the thing to look at. `RevisionGate::next_task_id` derives the next id from the plan the way `TaskBoard::create` derives it from the board; they agree by construction today. `service_approve_revision` deliberately does **not** reconstruct a `PlanGraph` to call `approve` — a graph rebuilt from the board between turns restarts at `r1`, so every number it produced would contradict the `r{n}` the reader just approved. The engine-side path where a live `PlanGraph` exists is #5296.

## Summary by Sourcery

Require explicit approval of proposed plan revisions before work resumes after a determinate gate failure.

New Features:
- Add proposed plan revisions that require explicit approval before new work can run after a determinate gate failure.
- Expose approve, edit, and dismiss actions for revision proposals in the terminal interface.
- Render revision proposals with their cause, optional issue, available actions, and merge-blocked status.

Bug Fixes:
- Prevent failing gate results from being silently repaired or from allowing work to proceed against an unapproved plan.
- Preserve gate failure ordering and evidence when creating and displaying a proposed revision.

Enhancements:
- Centralize revision proposal lifecycle management in a pure core revision gate with stale-plan protection and plan-graph integration.
- Route gate failures and revision approvals through the CLI and TUI while keeping proposals out of the durable event journal.
- Record approved repair tasks and their failure causes on the task board without duplicating tasks on repeated approval.
- Add searchable transcript support and deck-level submission withholding for pending proposals.

Tests:
- Add protocol serialization round-trip coverage for revision proposals.
- Add core coverage for withholding, approval, dismissal, editing, stale proposals, plan graph updates, and failure filtering.
- Add CLI coverage for proposal ordering and idempotent approval.
- Add TUI interaction, rendering, and snapshot coverage for proposal actions and presentation.