### PR TITLE
fix(stella-cli,stella-tui): /reload reseats the panel deck, and a stale request starts nothing

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -173,6 +173,50 @@ pub(crate) fn chrome_note(text: String) -> Inbound {
     }
 }
 
+/// Tell the session what one panel reseat decided: the refused slash names,
+/// SPEC 12.4's handshakes, and the seats themselves.
+///
+/// One function because boot and `/reload` owe the operator the same three
+/// things in the same order, and #5253 is what happens when the two paths are
+/// written separately — the second one was never written at all.
+///
+/// The handshakes go in the **transcript**, which is where SPEC 12.4 asks for
+/// them and where a consent document belongs: it has to be scrollable and still
+/// there after the transient boot dialog is gone.
+///
+/// On `deck_tx`, so they are not journaled — [`chrome_note`]'s own contract,
+/// and sharper here than at boot: this runs again at every `/reload`, so a
+/// journaled copy would stack one handshake per reload on top of every resumed
+/// transcript. It costs the audit nothing, because what a person answered is
+/// durable in the grant file beside the package with the moment they answered
+/// it; these blocks are the reminder, not the record.
+///
+/// `chrome_note` folds the lead to `Running`, so the idle status this file
+/// asserts at startup is re-asserted after them rather than left contradicted.
+fn announce_panels(
+    reseated: plugin_panels::Reseated,
+    deck_tx: &UnboundedSender<Inbound>,
+    in_tx: &UnboundedSender<Inbound>,
+) {
+    for refusal in reseated.refusals {
+        let _ = deck_tx.send(system_notice(refusal));
+    }
+    let spoke = !reseated.handshakes.is_empty();
+    for handshake in reseated.handshakes {
+        let _ = deck_tx.send(chrome_note(handshake));
+    }
+    if spoke {
+        let _ = in_tx.send(Inbound::Status {
+            agent: LEAD.to_string(),
+            status: AgentStatus::WaitingInput,
+        });
+    }
+    let _ = in_tx.send(Inbound::PanelsSeated {
+        generation: reseated.generation,
+        seats: reseated.seats,
+    });
+}
+
 /// A **session-startup system notification**: the deck talking about the
 /// session itself — a resumable predecessor, what the code-graph pass
 /// indexed, an `mcp.toml` that went untrusted. Shown in a transient dialog
@@ -727,49 +771,14 @@ pub async fn run_deck_session(
         None,
     ));
 
-    // Seat the plugin panels (SPEC 12.2). The roster is the install grant:
-    // `PluginRoster::load` drops every package whose consent receipt no longer
-    // matches, and `panel_routes` emits nothing for a plugin that is not in
-    // it — so a panel that was never granted is never leased a rectangle and
-    // never asked for a frame. A slash name colliding with one of the deck's
-    // own is refused here, out loud, and only that popup is lost.
-    // Through `PluginRoster::load` and nowhere else — that is where the #3509
-    // project-tier trust gate lives (`plugin_hooks`'s
-    // `no_other_production_site_reads_the_plugins_tier`).
-    let panel_settings = crate::settings::Settings::load(&cfg.workspace_root).unwrap_or_default();
-    let (panel_roster, _) =
-        crate::plugin_cmd::roster::PluginRoster::load(&cfg.workspace_root, &panel_settings);
-    let panel_routes = panel_roster.panel_routes();
-    let seating = plugin_panels::seat(&panel_routes);
-    for refusal in seating.refusals {
-        let _ = deck_tx.send(system_notice(refusal));
-    }
-    // SPEC 12.4's handshake, before anything is seated (#5056). In the
-    // **transcript**, which is what the spec asks for and where a consent
-    // document belongs: it has to be scrollable and still there after the boot
-    // dialog is gone, which the transient notice above is not.
-    //
-    // Through `deck_tx`, so it is not journaled. That is `chrome_note`'s own
-    // contract — boot narration that re-runs every launch must not replay and
-    // pile up on a resumed transcript — and it costs the audit nothing here:
-    // what a person answered is durable in the grant file beside the package,
-    // with the moment they answered it, and this block is the reminder rather
-    // than the record.
-    //
-    // `chrome_note` folds the lead to `Running`, so the idle assert this file
-    // already makes at startup is repeated below rather than left contradicted.
-    let handshakes = plugin_panels::handshakes(&panel_roster);
-    let spoke = !handshakes.is_empty();
-    for handshake in handshakes {
-        let _ = deck_tx.send(chrome_note(handshake));
-    }
-    if spoke {
-        let _ = in_tx.send(Inbound::Status {
-            agent: LEAD.to_string(),
-            status: AgentStatus::WaitingInput,
-        });
-    }
-    let _ = in_tx.send(Inbound::PanelsSeated(seating.seats));
+    // Seat the plugin panels (SPEC 12.2), and keep the plane so `/reload` can
+    // seat them again from a freshly composed roster (#5253). The roster is the
+    // grant: `PluginRoster::load` drops every package whose consent receipt no
+    // longer matches, `panel_routes` emits nothing for a plugin whose panel
+    // handshake was not answered `allow`, and a slash name colliding with one
+    // of the deck's own is refused out loud with only that popup lost.
+    let mut panels = plugin_panels::PanelPlane::default();
+    announce_panels(panels.reseat(&cfg.workspace_root), &deck_tx, &in_tx);
 
     // Honour the persisted colour theme (`ui.theme`) before the deck spawns its
     // render task, so the very first frame — the launch cinematic — is already
@@ -1176,12 +1185,15 @@ pub async fn run_deck_session(
                     // spawned rather than awaited so the driver's own loop is
                     // no more blocked on a plugin's process than the draw is.
                     Some(WorkspaceInput::PanelFrameWanted {
+                        generation,
                         slot,
                         tick,
                         cols,
                         rows,
                     }) => {
-                        plugin_panels::spawn_tick(&panel_routes, slot, tick, cols, rows, &in_tx);
+                        plugin_panels::spawn_tick(
+                            &panels, generation, slot, tick, cols, rows, &in_tx,
+                        );
                         continue 'session;
                     }
                     // SKILLS-tab ops work whether or not a turn is running — handled
@@ -1617,7 +1629,10 @@ pub async fn run_deck_session(
         };
         if matches!(
             command,
-            DeckCommand::Handled | DeckCommand::InitCompleted | DeckCommand::SessionModel(_)
+            DeckCommand::Handled
+                | DeckCommand::InitCompleted
+                | DeckCommand::Reloaded
+                | DeckCommand::SessionModel(_)
         ) {
             // A handled command emits its answer as `Text`, which flips the
             // lead to `Running` in the deck's fold — but no turn is in flight.
@@ -1657,6 +1672,22 @@ pub async fn run_deck_session(
                     &mut lead_meta,
                     &in_tx,
                 );
+                continue 'session;
+            }
+            DeckCommand::Reloaded => {
+                // `/reload`'s whole job is "refresh your stella
+                // configurations", and the panel seats were the one
+                // configuration it did not reach (#5253): a plugin installed,
+                // removed, or retracted with `plugins.<name> = "off"` kept
+                // whatever seats the session opened with until it restarted —
+                // and a retraction that does not take effect until restart is
+                // a grant that outlived the decision to revoke it.
+                //
+                // Wholesale, which is why the plane carries a generation: the
+                // route list `spawn_tick` indexes is replaced here, so a
+                // request the deck raised against the old seats names a
+                // seating that no longer exists and starts nothing.
+                announce_panels(panels.reseat(&cfg.workspace_root), &deck_tx, &in_tx);
                 continue 'session;
             }
             DeckCommand::InitCompleted => {
@@ -1906,18 +1937,14 @@ pub async fn run_deck_session(
                         }
                         // A panel's next frame, mid-turn — see the idle arm.
                         Some(WorkspaceInput::PanelFrameWanted {
+                            generation,
                             slot,
                             tick,
                             cols,
                             rows,
                         }) => {
                             plugin_panels::spawn_tick(
-                                &panel_routes,
-                                slot,
-                                tick,
-                                cols,
-                                rows,
-                                &in_tx,
+                                &panels, generation, slot, tick, cols, rows, &in_tx,
                             );
                         }
                         // A queue-free command runs beside the turn — the

--- a/crates/stella-cli/src/command_deck/plugin_panels.rs
+++ b/crates/stella-cli/src/command_deck/plugin_panels.rs
@@ -50,6 +50,90 @@ pub(super) struct Seating {
     pub(super) refusals: Vec<String>,
 }
 
+/// The panel routes this session is driving, and which composition of the
+/// roster they came from.
+///
+/// # Why the driver holds a generation at all (#5253)
+///
+/// The panels are seated from the roster, and the roster changes under a live
+/// session: a plugin is installed, removed, or retracted with
+/// `plugins.<name> = "off"`, and `/reload` is the command whose whole job is to
+/// pick that up. Reseating is wholesale — `PanelDeck::reseat` replaces every
+/// slot — so a slot index means one plugin before a reseat and another after
+/// it.
+///
+/// That is survivable on the **answer** leg, which `PanelSlot::settle` already
+/// handles by checking the surface and the tick a frame carries. It is not
+/// survivable on the **request** leg: a `PanelFrameWanted` raised before a
+/// reseat and handled after one names a slot that still resolves, and starting
+/// the program it now resolves to is a third party's code running against a
+/// lease nobody granted it. So the seating rides on the request, the driver
+/// refuses a mismatch, and the two lists cannot be read against each other at
+/// all.
+#[derive(Default)]
+pub(super) struct PanelPlane {
+    /// Which composition these routes came from. Counted up by
+    /// [`PanelPlane::reseat`] and never reused, so a wrapped or repeated value
+    /// cannot make a stale request look current.
+    generation: u64,
+    /// Every panel a host may ask for a frame, in the order the deck seats
+    /// them.
+    routes: Vec<PluginPanelRoute>,
+}
+
+/// Everything one reseat owes the session: the seats, the refusals, the
+/// handshakes, and which seating they belong to.
+pub(super) struct Reseated {
+    pub(super) generation: u64,
+    pub(super) seats: Vec<PanelSeat>,
+    pub(super) refusals: Vec<String>,
+    pub(super) handshakes: Vec<String>,
+}
+
+impl PanelPlane {
+    /// Recompose the roster from disk and replace the plane with what it
+    /// admits.
+    ///
+    /// The whole panel half of a session's boot, and of every `/reload`, in one
+    /// call — so the two paths cannot come to differ, which is the shape #5253
+    /// found: the seating existed in exactly one place, and `/reload` had no
+    /// way to reach it.
+    ///
+    /// Through `PluginRoster::load` and nowhere else: that is where the #3509
+    /// project-tier trust gate lives (`plugin_hooks`'s
+    /// `no_other_production_site_reads_the_plugins_tier`), and a second reader
+    /// would be a second place it can be forgotten.
+    pub(super) fn reseat(&mut self, workspace_root: &std::path::Path) -> Reseated {
+        let settings = crate::settings::Settings::load(workspace_root).unwrap_or_default();
+        let (roster, _) = crate::plugin_cmd::roster::PluginRoster::load(workspace_root, &settings);
+        let routes = roster.panel_routes();
+        let seating = seat(&routes);
+        let handshakes = handshakes(&roster);
+        self.generation = self.generation.saturating_add(1);
+        self.routes = routes;
+        Reseated {
+            generation: self.generation,
+            seats: seating.seats,
+            refusals: seating.refusals,
+            handshakes,
+        }
+    }
+}
+
+#[cfg(test)]
+impl PanelPlane {
+    /// A plane over routes a test composed, at a stated seating.
+    ///
+    /// `#[cfg(test)]` rather than a `pub(super)` constructor: production has
+    /// exactly one way to build a plane, and that is
+    /// [`PanelPlane::reseat`] reading the roster off disk. A second door in the
+    /// shipping binary would be a second place the trust gate can be bypassed
+    /// (CLAUDE.md, "`#[cfg(test)]` is the better answer").
+    fn at(generation: u64, routes: Vec<PluginPanelRoute>) -> Self {
+        Self { generation, routes }
+    }
+}
+
 /// Decide which of `routes` may draw, and refuse every slash name that
 /// collides with one of the deck's own commands.
 ///
@@ -201,15 +285,27 @@ pub(super) fn handshakes(roster: &crate::plugin_cmd::roster::PluginRoster) -> Ve
 /// the route list are built from the same `panel_routes()` in the same order,
 /// so an index outside it is a message from a deck that has been reseated and
 /// there is no plugin it could mean.
+///
+/// **A `generation` naming an earlier seating is the same refusal, for the case
+/// the index check cannot see** (#5253). A request minted before a reseat and
+/// answered after one carries a slot index that still resolves — to a
+/// *different plugin's* route — so an index-only check would start somebody
+/// else's program against a lease the operator never granted it. The deck
+/// stamps the seating on the request and this drops any that is not the one
+/// in force.
 pub(super) fn spawn_tick(
-    routes: &[PluginPanelRoute],
+    plane: &PanelPlane,
+    generation: u64,
     slot: usize,
     tick: u64,
     cols: u16,
     rows: u16,
     tx: &tokio::sync::mpsc::UnboundedSender<stella_tui::envelope::Inbound>,
 ) {
-    let Some(route) = routes.get(slot) else {
+    if generation != plane.generation {
+        return;
+    }
+    let Some(route) = plane.routes.get(slot) else {
         return;
     };
     let lease = PanelLease::new(
@@ -506,7 +602,7 @@ mod tests {
         // produced is exactly what a stale deck sends — and the driver starts
         // nothing.
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        spawn_tick(&routes, 0, 1, 40, 8, &tx);
+        spawn_tick(&PanelPlane::at(1, routes.clone()), 1, 0, 1, 40, 8, &tx);
         drop(tx);
         assert!(rx.recv().await.is_none(), "nothing was even answered");
 
@@ -529,7 +625,7 @@ mod tests {
         let routes = panel_routes_of(&tier);
         assert_eq!(routes.len(), 1, "a granted plugin's panel routes");
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        spawn_tick(&routes, 0, 1, 40, 8, &tx);
+        spawn_tick(&PanelPlane::at(1, routes.clone()), 1, 0, 1, 40, 8, &tx);
         // The fixture draws no frame, so the answer is whichever of the two
         // no-frame envelopes the exchange earned. **Both are correct here and
         // pinning one is a race**: the fixture starts a real process, and a
@@ -596,7 +692,7 @@ mod tests {
         // roster never produced is exactly what a stale deck sends.
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         for slot in [0, 1] {
-            spawn_tick(&routes, slot, 1, 40, 8, &tx);
+            spawn_tick(&PanelPlane::at(1, routes.clone()), 1, slot, 1, 40, 8, &tx);
         }
         drop(tx);
         // Drained before anything is asserted, and that is the synchronisation
@@ -631,7 +727,7 @@ mod tests {
         assert_eq!(routes.len(), 1, "only the allowed panel is routed");
         assert_eq!(routes[0].plugin, "allowed");
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        spawn_tick(&routes, 0, 1, 40, 8, &tx);
+        spawn_tick(&PanelPlane::at(1, routes.clone()), 1, 0, 1, 40, 8, &tx);
         // Either no-frame envelope, on the sibling witness's measured reason:
         // the fixture starts a real process and a loaded machine overruns the
         // 33ms budget often enough that pinning one of them is a race.
@@ -647,6 +743,157 @@ mod tests {
             "a frameless tick still rearms the seat: {got:?}"
         );
         assert!(marker.exists(), "the allowed plugin's process did run");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **The `/reload` witness (#5253).** A reseat composes the roster again
+    /// from disk, so a plugin retracted since the last one loses its seat and
+    /// its route — and the seating moves, which is what tells the two apart.
+    ///
+    /// Driven through [`PanelPlane::reseat`] rather than through the driver
+    /// loop, because that function is the whole of what `/reload` now does to
+    /// the panels: `DeckCommand::Reloaded` calls it and hands what it returns
+    /// to `announce_panels`. What is under test is that composing twice gives
+    /// two different answers, which is the thing that used to be impossible —
+    /// the seating happened once, at session open, and nothing could reach it
+    /// again.
+    #[cfg(unix)]
+    #[test]
+    fn a_reseat_drops_a_plugin_retracted_since_the_last_one() {
+        use crate::plugin_cmd::panel_grant::PanelVerdict;
+
+        let root = std::env::temp_dir().join(format!("stella-panel-live-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let workspace = root.join("ws");
+        std::fs::create_dir_all(&workspace).expect("temp workspace");
+        // The user tier, moved wholesale by `test_user_home` — which takes the
+        // process-wide env lock, so nothing here reads the developer's own
+        // `~/.stella/plugins` and nothing concurrent sees a half-moved home.
+        // The project tier would need `STELLA_TRUST_PROJECT` as well, and a
+        // retraction that could be confused with that gate is a worse witness.
+        let _home = crate::paths::test_user_home(root.join("home"));
+        let tier = stella_home::resolve_user_plugins_dir(crate::paths::user_extension_root())
+            .expect("the redirected home resolves its plugins tier");
+        std::fs::create_dir_all(&tier).expect("user tier");
+        let marker = root.join("unused");
+        plant_panel(&tier, "alpha", &marker, true, Some(PanelVerdict::Allow));
+
+        let mut plane = PanelPlane::default();
+        let first = plane.reseat(&workspace);
+        assert_eq!(first.generation, 1);
+        let seated: Vec<&str> = first
+            .seats
+            .iter()
+            .map(|seat| seat.plugin.as_str())
+            .collect();
+        assert_eq!(seated, vec!["alpha"], "the installed panel is seated");
+
+        // The retraction an operator writes by hand, and the whole reason
+        // `/reload` exists: withdraw the panel without deleting anything.
+        std::fs::create_dir_all(workspace.join(".stella")).expect("settings dir");
+        std::fs::write(
+            workspace.join(".stella").join("settings.json"),
+            "{\"plugins\": {\"alpha\": \"off\"}}",
+        )
+        .expect("settings");
+
+        let second = plane.reseat(&workspace);
+        assert!(
+            second.seats.is_empty(),
+            "the retracted plugin lost its seat: {:?}",
+            second.seats
+        );
+        assert_eq!(
+            second.generation, 2,
+            "and the seating moved, so a request raised against the first one is \
+             refusable rather than merely out of range"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **The reseat witness (#5253).** A frame request minted before a reseat
+    /// starts nothing after one — asserted on the *process*, because that is
+    /// what the seating generation exists to stop.
+    ///
+    /// `PanelSlot::settle` already refuses a stale *frame*
+    /// (`a_frame_in_flight_across_a_reseat_lands_nowhere`), and that is a
+    /// different property one leg later: by the time there is a frame to
+    /// refuse, the plugin that now holds the slot index has already been
+    /// started, with its environment resolved and its argv run. A slot index is
+    /// all a request carries otherwise, and after a reseat slot 0 is somebody
+    /// else — so an index-only check cannot tell "the panel you asked for" from
+    /// "the panel that inherited its number".
+    ///
+    /// Two plugins with **separate markers**, so a green run says which program
+    /// ran rather than that something did.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_frame_request_from_a_previous_seating_starts_nothing() {
+        use crate::plugin_cmd::panel_grant::PanelVerdict;
+
+        let _env = crate::test_env::lock();
+        let root = std::env::temp_dir().join(format!("stella-panel-reseat-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp root");
+        let tier = stella_home::resolve_user_plugins_dir(Some(root.join(".stella")))
+            .expect("an explicit stella root resolves its plugins tier");
+        let alpha_ran = root.join("alpha-ran");
+        let beta_ran = root.join("beta-ran");
+
+        plant_panel(&tier, "alpha", &alpha_ran, true, Some(PanelVerdict::Allow));
+        plant_panel(&tier, "beta", &beta_ran, true, Some(PanelVerdict::Allow));
+
+        // Seating 1 holds both, in name order, so `alpha` is slot 0.
+        let both = panel_routes_of(&tier);
+        assert_eq!(both.len(), 2, "{both:?}");
+        assert_eq!(both[0].plugin, "alpha");
+
+        // `alpha` is retracted and the driver reseats: seating 2 holds `beta`
+        // alone, which makes `beta` slot 0.
+        let plane = PanelPlane::at(2, vec![both[1].clone()]);
+        assert_eq!(plane.routes[0].plugin, "beta");
+
+        // The request the deck raised under seating 1, arriving now.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        spawn_tick(&plane, 1, 0, 1, 40, 8, &tx);
+        drop(tx);
+        let answered = rx.recv().await;
+
+        assert!(
+            !beta_ran.exists(),
+            "a stale request started the plugin that inherited its slot: {}",
+            beta_ran.display()
+        );
+        assert!(
+            !alpha_ran.exists(),
+            "and it did not resurrect the retracted one either: {}",
+            alpha_ran.display()
+        );
+        assert!(
+            answered.is_none(),
+            "a request naming a seating that is gone is answered by nobody, because \
+             there is no seat left to rearm: {answered:?}"
+        );
+
+        // Anti-vacuity: the same slot, under the seating that is in force, does
+        // start `beta` and only `beta`.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        spawn_tick(&plane, 2, 0, 1, 40, 8, &tx);
+        let got = rx.recv().await;
+        assert!(
+            matches!(
+                got,
+                Some(
+                    stella_tui::envelope::Inbound::PanelSilent { slot: 0 }
+                        | stella_tui::envelope::Inbound::PanelThrottled { slot: 0, .. }
+                )
+            ),
+            "a frameless tick still rearms the seat: {got:?}"
+        );
+        assert!(beta_ran.exists(), "beta drew under its own seating");
+        assert!(!alpha_ran.exists(), "and alpha stayed retracted");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/stella-cli/src/command_deck/slash_commands.rs
+++ b/crates/stella-cli/src/command_deck/slash_commands.rs
@@ -32,6 +32,19 @@ pub(super) enum DeckCommand {
     /// derived state (memory domains, Graph tab, custom extensions) which the
     /// new taxonomy/index changed.
     InitCompleted,
+    /// `/reload` re-read the settings chain; skip the turn AND reseat the
+    /// panel deck from a freshly composed roster (#5253).
+    ///
+    /// Carried back to the driver loop rather than done in `reload_command`
+    /// for `SessionModel`'s reason: reseating moves state only the loop owns
+    /// — the route list `spawn_tick` indexes and the seating generation that
+    /// tells a request minted before the reseat from one minted after it —
+    /// and neither is reachable from here.
+    ///
+    /// Its own answer rather than folded into `Handled`, because the two mean
+    /// different things to the loop: `Handled` is "this command is finished",
+    /// and this is "it is finished and it changed something you hold".
+    Reloaded,
     /// `/model <provider/slug>` typed in full: skip the turn and apply the
     /// session-only model switch. Carried back to the driver loop rather
     /// than applied in `run_deck_command`, because the switch moves state
@@ -218,7 +231,10 @@ pub(super) async fn run_deck_command(
                 Err(e) => say(format!("init failed: {e}")),
             }
         }
-        "/reload" => say(settings_io::reload_command(cfg, in_tx)),
+        "/reload" => {
+            say(settings_io::reload_command(cfg, in_tx));
+            return DeckCommand::Reloaded;
+        }
         // Deck-local commands (tab switches, `/agents` opening the Agents
         // tab, the transcript-page overlays) are normally consumed in
         // interactive mode, but a queued one reaches here — accept it as handled (a no-op)

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -862,7 +862,7 @@ impl WorkspaceModel {
             // state rather than a record: the frame on screen is the last one
             // its plugin drew, and a transcript row per tick would fill the
             // conversation with somebody else's repaints.
-            | Inbound::PanelsSeated(_)
+            | Inbound::PanelsSeated { .. }
             | Inbound::PanelFrame { .. }
             | Inbound::PanelSilent { .. }
             | Inbound::PanelThrottled { .. } => {}

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -458,7 +458,8 @@ pub enum Inbound {
     /// touches the transcript, so nothing here can be mistaken for the model
     /// speaking.
     Notice(String),
-    /// The plugin panels this session may draw, seated once at session open.
+    /// The plugin panels this session may draw, as of one composition of the
+    /// roster.
     ///
     /// **A seat is the install grant crossing into the deck.** The driver
     /// composes the roster, drops every package whose grant is not in force,
@@ -467,9 +468,27 @@ pub enum Inbound {
     /// So an ungranted plugin is never leased a rectangle — not because the
     /// renderer declines to draw one, but because no slot for it exists.
     ///
+    /// Sent at session open **and again whenever the roster could have
+    /// changed** (`/reload`), replacing every seat wholesale — a seat is the
+    /// grant's shadow, so a plugin retracted between two of these has to lose
+    /// its rectangle, and merging would leave it drawing from a slot nobody
+    /// renewed (#5253).
+    ///
     /// Out-of-band view state, applied to `DeckUi::panels` and ignored by the
     /// model fold, like [`Inbound::Notice`] above.
-    PanelsSeated(Vec<PanelSeat>),
+    PanelsSeated {
+        /// Which composition these seats came from, counted up by the driver.
+        ///
+        /// Stamped onto every [`WorkspaceInput::PanelFrameWanted`] the deck
+        /// raises against them, so a request still in flight when the next
+        /// reseat lands names a seating that no longer exists and starts no
+        /// process. Without it a stale request reaches the driver as a bare
+        /// slot index, and an index means whatever the *route* list says it
+        /// means when it arrives — which is a different plugin's program.
+        generation: u64,
+        /// The panels that may draw, in seating order.
+        seats: Vec<PanelSeat>,
+    },
     /// One frame a plugin drew inside its budget, for the seat at `slot`.
     ///
     /// The tick that produced it ran as a task off the draw path
@@ -1167,6 +1186,16 @@ pub enum WorkspaceInput {
     /// state: a plugin addresses cells inside a rectangle the host measured,
     /// and the driver has never seen the terminal.
     PanelFrameWanted {
+        /// The seating this request belongs to, echoed from
+        /// [`Inbound::PanelsSeated`].
+        ///
+        /// The driver refuses a request naming any other, which is what stops
+        /// a request minted before a reseat from starting the plugin that now
+        /// holds its slot. `PanelSlot::settle` is the same rule on the return
+        /// leg and does not subsume this one: that one keeps a stale *frame*
+        /// off the screen, and by the time a frame exists somebody's program
+        /// has already run.
+        generation: u64,
         /// Which seat, as an index into [`Inbound::PanelsSeated`].
         slot: usize,
         /// The host's counter for this frame, echoed on the frame that

--- a/crates/stella-tui/src/panel_deck.rs
+++ b/crates/stella-tui/src/panel_deck.rs
@@ -25,10 +25,17 @@
 //! # A slot exists because a grant did
 //!
 //! Nothing here constructs a slot from a manifest. The host composes the
-//! roster, drops every package whose install grant is not in force, and hands
-//! what is left to [`PanelDeck::seat`] — so "no frame before the grant" is a
-//! property of the route table rather than of the renderer, and the renderer
-//! cannot be the place it is undone.
+//! roster, drops every package whose install grant is not in force and every
+//! panel the operator has not allowed, and hands what is left to
+//! [`PanelDeck::reseat`] — so "no frame before the grant" is a property of the
+//! route table rather than of the renderer, and the renderer cannot be the
+//! place it is undone.
+//!
+//! It hands them over **again** whenever the roster could have changed, which
+//! is what makes a retraction take effect inside a live session: a seat is the
+//! grant's shadow, so the list is replaced whole and the seating it belongs to
+//! is counted, and a frame request raised against an older one names a seating
+//! that no longer exists (#5253).
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -208,25 +215,44 @@ pub struct PanelDeck {
     slots: Vec<PanelSlot>,
     /// Which command panel's popup is open, as an index into `slots`.
     open_popup: Option<usize>,
+    /// Which composition of the roster these seats came from, echoed onto
+    /// every request raised against them (#5253).
+    generation: u64,
 }
 
 impl PanelDeck {
-    /// Seat one admitted panel. The host calls this once per route.
-    pub fn seat(&mut self, slot: PanelSlot) {
-        self.slots.push(slot);
-    }
-
-    /// Replace every seat with the ones the driver admitted.
+    /// Replace every seat with the ones the driver admitted, as of
+    /// `generation`.
+    ///
+    /// **The only way seats are made**, which is what the seating generation
+    /// needs to be true. A `seat(one)` that pushed a single slot lived here
+    /// with no caller; it is gone rather than left, because it would add a slot
+    /// the deck then stamps with a generation that slot was never part of, and
+    /// a request raised against it would name a seating the driver's route list
+    /// does not agree with. Deletion rather than a comment, on CLAUDE.md's
+    /// reasoning about an unused item that asserts something the code does not.
     ///
     /// Wholesale rather than per-seat, because the seat list is the grant's
     /// shadow: a plugin retracted between two of these must lose its rectangle,
     /// and merging would leave it drawing from a slot nobody renewed.
-    pub fn reseat(&mut self, seats: &[crate::envelope::PanelSeat]) {
+    ///
+    /// The open popup closes with them. It is an index into a list that has
+    /// just been replaced, so keeping it would leave whichever plugin now
+    /// holds that index open on the screen without anybody having typed its
+    /// name.
+    pub fn reseat(&mut self, generation: u64, seats: &[crate::envelope::PanelSeat]) {
         self.open_popup = None;
+        self.generation = generation;
         self.slots = seats
             .iter()
             .map(|seat| PanelSlot::new(&seat.plugin, seat.surface, seat.command.clone()))
             .collect();
+    }
+
+    /// Which composition these seats came from.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
     }
 
     /// Every seated panel, in seating order.
@@ -280,6 +306,7 @@ impl PanelDeck {
             panel.awaiting = true;
             panel.asked_at = Some(now);
             out.push(crate::envelope::WorkspaceInput::PanelFrameWanted {
+                generation: self.generation,
                 slot,
                 tick: panel.tick,
                 cols,
@@ -350,7 +377,7 @@ const REFRESH: std::time::Duration = std::time::Duration::from_millis(1000);
 pub fn ingest(deck: &mut PanelDeck, inbound: &crate::envelope::Inbound) -> bool {
     use crate::envelope::Inbound;
     match inbound {
-        Inbound::PanelsSeated(seats) => deck.reseat(seats),
+        Inbound::PanelsSeated { generation, seats } => deck.reseat(*generation, seats),
         Inbound::PanelFrame { slot, frame } => {
             if let Some(slot) = deck.slot_mut(*slot) {
                 // Refused frames are dropped rather than reported: a frame for
@@ -557,17 +584,24 @@ mod tests {
     #[test]
     fn a_frame_in_flight_across_a_reseat_lands_nowhere() {
         let mut deck = PanelDeck::default();
-        deck.reseat(&[
-            seat("alpha", PanelSurface::Settings),
-            seat("beta", PanelSurface::Overlay),
-        ]);
+        deck.reseat(
+            1,
+            &[
+                seat("alpha", PanelSurface::Settings),
+                seat("beta", PanelSurface::Overlay),
+            ],
+        );
         let (slot, tick) = drawn_then_asked(&mut deck)
             .into_iter()
             .find(|(slot, _)| *slot == 0)
             .expect("alpha asked for a frame");
 
         // alpha is uninstalled while its frame is in flight, so slot 0 is beta.
-        deck.reseat(&[seat("beta", PanelSurface::Overlay)]);
+        // A second seating, numbered as the driver numbers it — which the frame
+        // does not carry and `settle` never reads. That is the point: this rule
+        // holds on the frame's own surface and tick alone, so it is still the
+        // last line of defence for a host that got the seating wrong.
+        deck.reseat(2, &[seat("beta", PanelSurface::Overlay)]);
         assert_eq!(deck.slots()[0].plugin(), "beta", "slot 0 changed hands");
 
         let landed = deck.slot_mut(slot).expect("a seat").settle(frame(
@@ -595,7 +629,7 @@ mod tests {
     #[test]
     fn a_frame_answering_its_own_lease_is_drawn() {
         let mut deck = PanelDeck::default();
-        deck.reseat(&[seat("alpha", PanelSurface::Settings)]);
+        deck.reseat(1, &[seat("alpha", PanelSurface::Settings)]);
         let (slot, tick) = drawn_then_asked(&mut deck)[0];
 
         assert!(
@@ -616,7 +650,7 @@ mod tests {
     #[test]
     fn a_frame_answering_another_surface_is_refused() {
         let mut deck = PanelDeck::default();
-        deck.reseat(&[seat("alpha", PanelSurface::Settings)]);
+        deck.reseat(1, &[seat("alpha", PanelSurface::Settings)]);
         let (slot, tick) = drawn_then_asked(&mut deck)[0];
 
         assert!(
@@ -634,7 +668,7 @@ mod tests {
     #[test]
     fn a_frame_carrying_a_stale_tick_is_refused() {
         let mut deck = PanelDeck::default();
-        deck.reseat(&[seat("alpha", PanelSurface::Settings)]);
+        deck.reseat(1, &[seat("alpha", PanelSurface::Settings)]);
         let (slot, tick) = drawn_then_asked(&mut deck)[0];
 
         assert!(
@@ -652,7 +686,7 @@ mod tests {
     #[test]
     fn a_seat_that_asked_for_nothing_accepts_nothing() {
         let mut deck = PanelDeck::default();
-        deck.reseat(&[seat("alpha", PanelSurface::Settings)]);
+        deck.reseat(1, &[seat("alpha", PanelSurface::Settings)]);
         assert!(
             !deck
                 .slot_mut(0)
@@ -669,7 +703,10 @@ mod tests {
         let mut deck = PanelDeck::default();
         assert!(ingest(
             &mut deck,
-            &Inbound::PanelsSeated(vec![seat("alpha", PanelSurface::Settings)])
+            &Inbound::PanelsSeated {
+                generation: 1,
+                seats: vec![seat("alpha", PanelSurface::Settings)],
+            }
         ));
         assert!(ingest(&mut deck, &Inbound::PanelSilent { slot: 0 }));
         assert!(ingest(

--- a/crates/stella-tui/tests/plugin_panel_placements.rs
+++ b/crates/stella-tui/tests/plugin_panel_placements.rs
@@ -82,8 +82,29 @@ fn seat_hello(ui: &mut DeckUi, manifest: &PluginManifest) {
             command: Some("hello".to_string()),
         },
     ];
+    reseat(ui, 1, seats);
+}
+
+/// Replace the deck's seats, the way the driver does at session open and
+/// again at every `/reload`.
+fn reseat(ui: &mut DeckUi, generation: u64, seats: Vec<PanelSeat>) {
     let mut model = WorkspaceModel::new();
-    stella_tui::deck_ui::ingest_inbound(&Inbound::PanelsSeated(seats), &mut model, ui);
+    stella_tui::deck_ui::ingest_inbound(
+        &Inbound::PanelsSeated { generation, seats },
+        &mut model,
+        ui,
+    );
+}
+
+/// One overlay seat for `plugin`, which is all the reseat witnesses need: the
+/// SESSION tab draws every overlay panel, so a seat there is on screen without
+/// a tab switch or a popup.
+fn overlay_seat(plugin: &str) -> PanelSeat {
+    PanelSeat {
+        plugin: plugin.to_string(),
+        surface: PanelSurface::Overlay,
+        command: None,
+    }
 }
 
 /// Run one full loop turn for `slot`: draw once so the deck measures the lease,
@@ -104,6 +125,7 @@ async fn pump(ui: &mut DeckUi, slot: usize, process: &Runtime, mut draw: impl Fn
                 tick,
                 cols,
                 rows,
+                ..
             } if asked == slot => Some((tick, cols, rows)),
             _ => None,
         })
@@ -361,6 +383,114 @@ fn slots_asked(ui: &mut DeckUi, now: std::time::Instant) -> Vec<usize> {
         .collect();
     asked.sort_unstable();
     asked
+}
+
+/// Every request the deck raised at `now`, as `(generation, slot)`.
+fn requests_at(ui: &mut DeckUi, now: std::time::Instant) -> Vec<(u64, usize)> {
+    ui.panels
+        .requests_at(now)
+        .into_iter()
+        .filter_map(|input| match input {
+            WorkspaceInput::PanelFrameWanted {
+                generation, slot, ..
+            } => Some((generation, slot)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// **The retraction witness (#5253).** A plugin dropped by a reseat is asked
+/// for no further frames — asserted on `requests_at`, not on the rendering,
+/// because a rectangle that has stopped being painted and one that is still
+/// starting somebody's process every second look identical on screen.
+#[test]
+fn a_plugin_dropped_by_a_reseat_is_asked_for_no_further_frames() {
+    let mut ui = ready_ui();
+    let model = lead_workspace();
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("a test terminal");
+    let mut draw = |ui: &mut DeckUi| {
+        terminal
+            .draw(|f| stella_tui::deck_render::render_deck(&model, ui, f))
+            .expect("the deck draws");
+    };
+
+    reseat(
+        &mut ui,
+        1,
+        vec![overlay_seat("alpha"), overlay_seat("beta")],
+    );
+    draw(&mut ui);
+    let opened = std::time::Instant::now();
+    assert_eq!(
+        slots_asked(&mut ui, opened),
+        vec![0, 1],
+        "both overlays are on screen"
+    );
+
+    // `alpha` is retracted — `plugins.alpha = "off"`, or removed outright —
+    // and the driver reseats with what is left.
+    reseat(&mut ui, 2, vec![overlay_seat("beta")]);
+    let plugins: Vec<&str> = ui.panels.slots().iter().map(|slot| slot.plugin()).collect();
+    assert_eq!(plugins, vec!["beta"], "alpha lost its seat");
+
+    // A clear refresh interval later, so the interval is not what answers.
+    draw(&mut ui);
+    let later = opened + std::time::Duration::from_secs(5);
+    let asked = requests_at(&mut ui, later);
+    assert_eq!(
+        asked,
+        vec![(2, 0)],
+        "one seat, and it names the seating it belongs to"
+    );
+    assert_eq!(
+        ui.panels.slots()[0].plugin(),
+        "beta",
+        "and the seat that was asked is beta's"
+    );
+}
+
+/// **The in-flight witness (#5253).** A request minted before a reseat carries
+/// the seating it was minted under, so the driver can tell it from one raised
+/// against the seats that exist now.
+///
+/// `PanelSlot::settle` already keeps a stale *frame* off the screen
+/// (`a_frame_in_flight_across_a_reseat_lands_nowhere`), and that is not this:
+/// by the time a frame exists, the plugin that now holds the slot index has
+/// already been started. The generation is what the driver refuses on, before
+/// anything runs.
+#[test]
+fn a_request_minted_before_a_reseat_names_the_seating_it_was_minted_under() {
+    let mut ui = ready_ui();
+    let model = lead_workspace();
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("a test terminal");
+    let mut draw = |ui: &mut DeckUi| {
+        terminal
+            .draw(|f| stella_tui::deck_render::render_deck(&model, ui, f))
+            .expect("the deck draws");
+    };
+
+    reseat(&mut ui, 7, vec![overlay_seat("alpha")]);
+    draw(&mut ui);
+    let opened = std::time::Instant::now();
+    let in_flight = requests_at(&mut ui, opened);
+    assert_eq!(in_flight, vec![(7, 0)]);
+
+    // Slot 0 changes hands while that request is still travelling.
+    reseat(&mut ui, 8, vec![overlay_seat("beta")]);
+    draw(&mut ui);
+    let after = requests_at(&mut ui, opened + std::time::Duration::from_secs(5));
+    assert_eq!(
+        after,
+        vec![(8, 0)],
+        "the new seating raises its own request"
+    );
+
+    assert_ne!(
+        in_flight[0].0, after[0].0,
+        "and the two name the same slot under different seatings, which is the \
+         whole of what the driver has to tell apart"
+    );
+    assert_eq!(ui.panels.generation(), 8);
 }
 
 /// The namespaced alias is derived and always available, whatever the manifest


### PR DESCRIPTION
> Stacked on #5295 (`feat/5056-panel-handshake-grant`) — the two share the seating path, and the panel grant is one of the things that has to reseat. **Base this on #5295, or rebase onto `main` once it lands.**

## What & why

Panels were seated once, at session open, and nothing seated them again. `/reload` — the command whose whole job is to re-read your stella configuration — rebuilt the settings chain and left the seats alone, so a plugin installed, removed, or retracted with `plugins.<name> = "off"` kept whatever panels the session opened with until it restarted.

The retraction is the one that matters: it is how an operator withdraws a grant without deleting files, and a withdrawal that waits for a restart is a grant that outlived the decision to revoke it. The retracted plugin's rectangle kept drawing, and its process kept being started once a second.

`PanelDeck::reseat` was already wholesale, so the mechanism existed; nothing called it a second time. It is now called from `PanelPlane::reseat`, which is the whole panel half of a boot *and* of a `/reload` in one function — the two paths cannot come to differ, which is the shape this bug had.

**The hazard the issue's "Watch out for" names is real, and it is fixed at the request leg.** `spawn_tick` indexes the driver's route list by the slot number the deck sent, and reseating changes what a slot means — so a `PanelFrameWanted` raised before a reseat and handled after one would start whichever plugin inherited its index. That is *not* a rendering bug: the environment is resolved and the argv is run before any frame exists to be refused. So the seating rides on the request: the deck stamps `PanelsSeated`'s generation onto every `PanelFrameWanted`, and the driver drops any that names another.

`PanelSlot::settle` is the same rule one leg later and keeps its own witness (`a_frame_in_flight_across_a_reseat_lands_nowhere`): it stops a stale *frame* reaching the screen. Neither subsumes the other, and the two doc comments now say which leg each covers.

Closes #5253

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Each verified by hand — revert the named change, watch the named test fail, restore.

| Test | Fails without |
| --- | --- |
| `a_frame_request_from_a_previous_seating_starts_nothing` (`plugin_panels.rs`) | the generation check in `spawn_tick`. **Two plugins with separate marker files**, so a green run says *which* program ran rather than that something did. Reverted, it panics `a stale request started the plugin that inherited its slot: …/beta-ran` — the process, not the route list. |
| `a_plugin_dropped_by_a_reseat_is_asked_for_no_further_frames` (`plugin_panel_placements.rs`) | the reseat reaching the deck. Asserted on `requests_at`, not on the rendering: a rectangle that has stopped being painted and one that is still starting a process every second look identical on screen. |
| `a_request_minted_before_a_reseat_names_the_seating_it_was_minted_under` | the generation on `WorkspaceInput::PanelFrameWanted` |
| `a_reseat_drops_a_plugin_retracted_since_the_last_one` | `PanelPlane::reseat` (compile-level on `main` — the function does not exist). It composes the roster twice across a `plugins.<name> = "off"` written between them, and asserts both that the seat is gone and that the generation moved. |

## What is verified by hand rather than by a test, and why

Typing `/reload` now returns `DeckCommand::Reloaded` instead of `Handled`, and the driver's arm for it calls `panels.reseat(…)`. The *reseat* is witnessed and the *refusal* is witnessed; the link between them is carried by the compiler — `command_deck.rs`'s match over `DeckCommand` has no wildcard, so a missing arm is a build error — plus hand-verification, not by a test.

That is because **no test in this crate calls `run_deck_command` at all**: it takes a `&dyn Provider`, a `&ToolRegistry`, a `&mut Config`, a `&CustomExtensions` and a `&dyn AskUserIo`, and there is no fixture that assembles them. Building one is worth doing and is bigger than this change, so it is filed as **#5298** rather than smuggled in — and the gap is stated here rather than left for a reviewer to find.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-tui --all-targets -- -D warnings`
- [x] `make guards-fast` green (`prose`, `file-size`, `consumer-sites`, `tokens`, …)
- [x] `cargo test -p stella-cli --bin stella plugin` (162), `cargo test -p stella-tui --lib` (1330), `--test plugin_panel_placements` (8), `--test hello_panel_demo`, `--test deck_render_snapshots` (31), `--test deck_snapshot` (9)
- [ ] `cargo test --workspace` — CI's, per CLAUDE.md
- [x] `Closes #5253` in this description **and** as a commit trailer

## Nothing left behind

- [x] Filed: #5298 (no test calls the deck's slash dispatcher, so what a command answers the driver loop is only ever reviewed)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] No new `AgentEvent` variant — `Inbound` and `WorkspaceInput` are `stella-tui`'s own deck envelopes, so no consumers-ledger row and no `docs/wire/` regeneration. Both changed variants are struct-shaped now; every arm and pattern was updated, and `deck.rs`'s exhaustive model fold is what would have caught a miss.

## Anything reviewers should know?

- **The issue's description of `/reload` is slightly off, and it does not change the fix.** It says `/reload` "rebuilds the slash vocabulary"; on `main` that rebuild (`Inbound::SlashCommands(deck_slash_commands(&custom))`) is in the `/init` arm, and `reload_command` only re-reads the settings chain and refreshes the ENGINE panel. The panel seats were untouched by both, which is the bug either way. Reseating does refresh the panel *slash names*, since `PanelsSeated` carries them and `PanelDeck::command_index` reads them.
- `DeckCommand::Reloaded` joins the `matches!` that re-asserts the lead's idle status after a handled command, so `/reload` still leaves the dashboard on `WaitingInput`.
- `reseat` clearing the open popup is now stated in its doc comment rather than left as a line of code: the popup is an index into a list that has just been replaced, so keeping it would leave whichever plugin inherited that index open on screen without anybody having typed its name.
- #5185 (a frame's cell count is chars rather than display width) is untouched.

## Summary by Sourcery

Reseat plugin panels during `/reload` and reject requests from obsolete panel seatings.

Bug Fixes:
- Make `/reload` recompose plugin panel seats so installed, removed, or retracted plugins take effect without restarting the session.
- Prevent frame requests created under an earlier panel seating from starting the plugin that later inherits their slot.

Enhancements:
- Unify panel seating for session startup and `/reload`, including refreshed handshakes, refusals, seat replacement, and popup reset.
- Track panel seating generations through the TUI and driver to reject stale requests while preserving stale-frame protection.

Tests:
- Add coverage for panel reseating, plugin retraction, seating-generation propagation, and stale requests starting no processes.