### PR TITLE
feat(stella-tui): the plan panel prices each task, cards the running one, and states its drift

### DIFF
--- a/crates/stella-tui/src/plan.rs
+++ b/crates/stella-tui/src/plan.rs
@@ -525,7 +525,7 @@ impl Plan {
     /// zero somebody could read as "nothing was planned".
     #[must_use]
     pub fn planned_count(&self) -> Option<usize> {
-        (!self.proposed.is_empty()).then(|| self.proposed.len())
+        (!self.proposed.is_empty()).then_some(self.proposed.len())
     }
 
     /// `(complete, total)` — the rail's fraction.

--- a/crates/stella-tui/src/plan.rs
+++ b/crates/stella-tui/src/plan.rs
@@ -70,12 +70,17 @@ pub enum PlanStepState {
     Verify,
     /// A step the approved plan did not contain — `⌥ drift-inserted`.
     ///
-    /// Nothing folds into this state yet: drift lives on the plan graph's
-    /// `[:THEN]` lane ([`PlanLanes`]), which #5037 landed as
-    /// `stella_protocol::plan_graph::DivergenceKind::Inserted`, and no
-    /// [`TaskStatus`] asserts it. Until something joins those divergences to
-    /// this fold, a step reaches this state only from a caller that builds the
-    /// [`PlanStep`] itself — the tests below and the scenario fixture.
+    /// Reached from [`PlanLanes`] and from nowhere else. No [`TaskStatus`]
+    /// asserts drift and none ever should: a board status is a claim its own
+    /// producer makes, and the producer with the strongest reason not to
+    /// report drift is the one that drifted. [`Plan::steps`] therefore reads
+    /// it off the two lanes disagreeing (`mark_drift`), which is the same
+    /// discipline `stella_core::plan_graph::PlanGraph::divergences` applies on
+    /// the engine side.
+    ///
+    /// [`Plan::lanes`] has no producer today, so no live session reaches this
+    /// state — #5270 is that wiring. What is built here is the fold that will
+    /// consume it.
     DriftInserted,
 }
 
@@ -505,7 +510,22 @@ impl Plan {
                 }),
             }
         }
+        mark_drift(&mut steps, self.lanes.as_ref());
         steps
+    }
+
+    /// How many steps the plan was approved with — SPEC 7.3's `planned 6`.
+    ///
+    /// The *approved* count, not [`Self::steps`]'s length: the board grows as
+    /// work is inserted, and a `planned` that grew with it could never differ
+    /// from `actual`, which is the whole point of stating both.
+    ///
+    /// `None` for a board-only plan (the worker planned as it went), which has
+    /// no approved list to count. That renders as an elision rather than as a
+    /// zero somebody could read as "nothing was planned".
+    #[must_use]
+    pub fn planned_count(&self) -> Option<usize> {
+        (!self.proposed.is_empty()).then(|| self.proposed.len())
     }
 
     /// `(complete, total)` — the rail's fraction.
@@ -525,6 +545,47 @@ impl Plan {
         self.steps()
             .into_iter()
             .find(|s| s.state == PlanStepState::Started)
+    }
+}
+
+/// Repaint every step the approved plan did not contain as
+/// [`PlanStepState::DriftInserted`] — SPEC 7.3's `⌥` in gold-bright with an
+/// `inserted` tag.
+///
+/// The lanes are the only thing that can say so, and that is why no arm of
+/// [`Plan::steps`]'s board match reaches this state: a board `status` is a
+/// claim its own producer makes, and drift is exactly the claim a producer
+/// that drifted has an incentive not to make. `PlanLanes::actual` is derived
+/// from `[:THEN]` edges against `[:NEXT]` ones, so a step is drift because the
+/// two lanes disagree, never because something said it was.
+///
+/// The drift mark replaces the lifecycle glyph rather than sitting beside it,
+/// which is what SPEC 7.3 asks for: a reader scanning the panel is looking for
+/// what the plan did not contain, and a `✓` on an inserted step buries that
+/// under the news that it finished. An existing note is kept and the tag is
+/// appended to it, so a step that was both cancelled and inserted says both.
+///
+/// Matched on title because that is the only key the two lanes share —
+/// `PlanLanes::actual` is `ActualStep { title, cause }` and carries no board
+/// id. A plan with two steps of the same title marks both; giving the lanes
+/// their own ids is #5270's business, not this fold's.
+fn mark_drift(steps: &mut [PlanStep], lanes: Option<&PlanLanes>) {
+    let Some(lanes) = lanes else {
+        return;
+    };
+    for step in steps.iter_mut() {
+        if !lanes
+            .actual
+            .iter()
+            .any(|actual| actual.is_drift() && actual.title == step.title)
+        {
+            continue;
+        }
+        step.state = PlanStepState::DriftInserted;
+        step.note = Some(match step.note.take() {
+            Some(note) => format!("{note} · inserted"),
+            None => "inserted".to_owned(),
+        });
     }
 }
 
@@ -911,6 +972,59 @@ mod tests {
             plan.apply_board(&[item("1", "one", status)]);
             assert_ne!(plan.steps()[0].state, PlanStepState::DriftInserted);
         }
+    }
+
+    /// The lanes are the one thing that *can* reach it — SPEC 7.3's drift row,
+    /// derived from the two lanes disagreeing rather than from a status
+    /// somebody set.
+    #[test]
+    fn a_step_the_plan_did_not_contain_renders_as_drift_with_its_tag() {
+        let mut plan = Plan::default();
+        plan.apply_board(&[
+            item("1", "read the routes", TaskStatus::Completed),
+            item("2", "repair the tests gate", TaskStatus::Completed),
+        ]);
+        plan.lanes = Some(PlanLanes {
+            planned: vec!["read the routes".into()],
+            actual: vec![
+                ActualStep {
+                    title: "read the routes".into(),
+                    cause: None,
+                },
+                ActualStep {
+                    title: "repair the tests gate".into(),
+                    cause: Some("E0432: unresolved import".into()),
+                },
+            ],
+        });
+
+        let steps = plan.steps();
+        assert_eq!(
+            steps[0].state,
+            PlanStepState::Complete,
+            "planned work is not drift"
+        );
+        assert_eq!(steps[1].state, PlanStepState::DriftInserted);
+        assert_eq!(steps[1].note.as_deref(), Some("inserted"));
+    }
+
+    /// A step that was both cancelled and inserted says both — the tag is
+    /// appended rather than written over the note that was already there.
+    #[test]
+    fn a_drift_step_keeps_the_note_it_already_had() {
+        let mut plan = Plan::default();
+        plan.apply_board(&[item("1", "drop it", TaskStatus::Cancelled)]);
+        plan.lanes = Some(PlanLanes {
+            planned: Vec::new(),
+            actual: vec![ActualStep {
+                title: "drop it".into(),
+                cause: Some("the driver asked for it".into()),
+            }],
+        });
+        assert_eq!(
+            plan.steps()[0].note.as_deref(),
+            Some("cancelled · inserted")
+        );
     }
 
     #[test]

--- a/crates/stella-tui/src/views/plan_card.rs
+++ b/crates/stella-tui/src/views/plan_card.rs
@@ -30,6 +30,7 @@
 //! labeled slots `think` / `work` / `verify`; the internal pipeline role
 //! identifiers never reach a rendered string.
 
+pub mod economics;
 pub(crate) mod step_style;
 
 use ratatui::buffer::Buffer;
@@ -104,6 +105,7 @@ pub fn step_rows(
     selected: Option<usize>,
     now_ms: u64,
     animate: bool,
+    running: Option<&economics::RunningTask>,
 ) -> (Vec<Line<'static>>, Option<usize>) {
     let dim = Style::new().fg(token::MUTED);
     let steps = plan.steps();
@@ -125,7 +127,18 @@ pub fn step_rows(
         if Some(i) == selected {
             selected_row = Some(rows.len());
         }
-        rows.push(step_row(step, Some(i) == selected, now_ms, animate));
+        let spend = plan
+            .ledger
+            .get(&step.id)
+            .and_then(|entry| entry.spend.as_ref());
+        rows.push(priced_step_row(
+            step,
+            Some(i) == selected,
+            now_ms,
+            animate,
+            spend,
+            width,
+        ));
         // The elaboration, wrapped under the title at the title's indent.
         if let Some(detail) = &step.detail {
             let indent = 7usize;
@@ -136,6 +149,11 @@ pub fn step_rows(
                 ]));
             }
         }
+        // SPEC 7.3's running-task card, under the step it belongs to rather
+        // than at the top of the list: the reader's eye is already on the row
+        // that is moving, and a card pinned elsewhere would make them find it
+        // twice.
+        rows.extend(economics::running_card(step, running, plan, width));
     }
     (rows, selected_row)
 }
@@ -168,6 +186,34 @@ pub fn step_row(
         spans.push(Span::styled(format!("  ({owner})"), v.meta));
     }
     Line::from(spans)
+}
+
+/// [`step_row`] with SPEC 7.3's economics column right-aligned onto it.
+///
+/// A wrapper rather than two more parameters on `step_row`, because that
+/// function's job is to be goldenable one *state* at a time (see its doc), and
+/// a trailing measurement is the same on every state — folding it in would
+/// make every state's golden carry a column that is not about the state.
+///
+/// Right-aligned against the card's interior rather than the frame, through
+/// `cards::pad_right`, which measures display width: a title carrying a wide
+/// glyph still lines the column up. Muted, because a token count is a
+/// measurement beside a title and money is the only number that takes the
+/// accent (SPEC 5).
+fn priced_step_row(
+    step: &crate::plan::PlanStep,
+    selected: bool,
+    now_ms: u64,
+    animate: bool,
+    spend: Option<&crate::plan::StepSpend>,
+    inner_w: usize,
+) -> Line<'static> {
+    let row = step_row(step, selected, now_ms, animate);
+    Line::from(cards::pad_right(
+        row.spans,
+        Span::styled(economics::token_cell(spend), Style::new().fg(token::MUTED)),
+        inner_w,
+    ))
 }
 
 /// The operating-envelope grid: where the plan may write, what it may spend,
@@ -236,6 +282,26 @@ pub fn grid_rows(
     rows
 }
 
+/// What the in-flight task has cost and how long it has been going, as the
+/// fold knows it — the subtraction [`economics::RunningTask`] describes.
+///
+/// `AgentEntry::active_task` is the only source with a real number in it
+/// today: the board says which task is in progress, and the fold stamps the
+/// session's spend and the deck clock at the moment it flipped. That makes
+/// *this* task's cost the difference, which is a fact about one task rather
+/// than the session total wearing a task's name.
+///
+/// `None` when no task is active, which is every idle session and every turn
+/// whose board has nothing in progress.
+fn running_task(agent: &AgentEntry, now_ms: u64) -> Option<economics::RunningTask> {
+    let stamp = agent.active_task.as_ref()?;
+    Some(economics::RunningTask {
+        id: stamp.id.clone(),
+        elapsed_ms: now_ms.saturating_sub(stamp.started_ms),
+        cost_usd: (agent.cost_usd - stamp.cost_at_start_usd).max(0.0),
+    })
+}
+
 /// Render the plan card over `frame` for the focused agent.
 pub fn render(model: &WorkspaceModel, ui: &DeckUi, frame: Rect, buf: &mut Buffer) {
     let Some(agent) = model.agents.get(ui.focused) else {
@@ -256,7 +322,15 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, frame: Rect, buf: &mut Buffer
     let step_count = plan.steps().len();
     let selected = (step_count > 0).then(|| ui.cards.plan_sel.min(step_count - 1));
     let offset = rows.len();
-    let (step_lines, selected_row) = step_rows(plan, inner_w, selected, model.now_ms, !ui.no_anim);
+    let running = running_task(agent, model.now_ms);
+    let (step_lines, selected_row) = step_rows(
+        plan,
+        inner_w,
+        selected,
+        model.now_ms,
+        !ui.no_anim,
+        running.as_ref(),
+    );
     rows.extend(step_lines);
     let selected_row = selected_row.map(|r| r + offset);
 
@@ -270,6 +344,13 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, frame: Rect, buf: &mut Buffer
     if let Some(proposal) = envelope {
         rows.push(Line::default());
         rows.extend(grid_rows(model, agent, proposal, ui.accessible));
+    }
+
+    // SPEC 7.3's footer, last: it is about the plan as a whole, so it closes
+    // the card rather than sitting between the steps and their envelope.
+    if !plan.is_empty() {
+        rows.push(Line::default());
+        rows.extend(economics::footer_rows(plan));
     }
 
     let (done, total) = plan.progress();
@@ -342,7 +423,7 @@ mod tests {
             owner: None,
             contract: None,
         }]);
-        let text: String = step_rows(&plan, 52, None, 0, false)
+        let text: String = step_rows(&plan, 52, None, 0, false, None)
             .0
             .iter()
             .map(text_of)
@@ -371,7 +452,7 @@ mod tests {
             owner: None,
             contract: None,
         }]);
-        let (rows, _) = step_rows(&plan, 40, None, 0, false);
+        let (rows, _) = step_rows(&plan, 40, None, 0, false, None);
         assert!(rows.len() > 2, "the detail wrapped onto its own rows");
         // Re-joined on single spaces: the wrap indents every continuation row,
         // so a phrase that survived the break is only recognizable once the
@@ -463,7 +544,7 @@ mod tests {
 
     #[test]
     fn an_unproposed_plan_says_so_rather_than_showing_an_empty_list() {
-        let text = text_of(&step_rows(&Plan::default(), 52, None, 0, false).0[0]);
+        let text = text_of(&step_rows(&Plan::default(), 52, None, 0, false, None).0[0]);
         assert!(text.contains("no plan has been proposed"), "{text}");
     }
 
@@ -474,7 +555,7 @@ mod tests {
         let mut plan = Plan::default();
         plan.propose(&proposal(&["one"]));
         plan.approve();
-        let text: String = step_rows(&plan, 52, None, 0, false)
+        let text: String = step_rows(&plan, 52, None, 0, false, None)
             .0
             .iter()
             .map(text_of)

--- a/crates/stella-tui/src/views/plan_card.rs
+++ b/crates/stella-tui/src/views/plan_card.rs
@@ -162,10 +162,10 @@ pub fn step_rows(
 /// trailing `(note)` / `(owner)` tag.
 ///
 /// Split out of [`step_rows`] so a state can be goldened as the row it draws
-/// rather than as the styles behind it — [`Plan`] folds five of the six states
-/// from the board and cannot produce
-/// [`crate::plan::PlanStepState::DriftInserted`] at all, so the whole
-/// vocabulary is only reachable a step at a time.
+/// rather than as the styles behind it: five of the six come off a board
+/// status and the sixth, [`crate::plan::PlanStepState::DriftInserted`], is
+/// derived from the plan's two lanes disagreeing — so no single fixture puts
+/// the whole vocabulary on screen at once.
 pub fn step_row(
     step: &crate::plan::PlanStep,
     selected: bool,

--- a/crates/stella-tui/src/views/plan_card/economics.rs
+++ b/crates/stella-tui/src/views/plan_card/economics.rs
@@ -108,13 +108,13 @@ pub fn token_cell(spend: Option<&StepSpend>) -> String {
 pub fn running_card(
     step: &PlanStep,
     running: Option<&RunningTask>,
-    ledger: &Plan,
+    plan: &Plan,
     width: usize,
 ) -> Vec<Line<'static>> {
     let Some(running) = running.filter(|r| r.id == step.id) else {
         return Vec::new();
     };
-    let evidence = ledger
+    let evidence = plan
         .ledger
         .get(&step.id)
         .map(|entry| entry.evidence.len())

--- a/crates/stella-tui/src/views/plan_card/economics.rs
+++ b/crates/stella-tui/src/views/plan_card/economics.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What each task costs, what the running one is doing, and how far the plan
+//! has drifted — SPEC 7.3's three additions to the plan panel.
+//!
+//! ```text
+//!  ✓ 1.  read the band layout                            9.0k tok
+//!  ◐ 2.  fold the rail                                          —
+//!      │ contract  the rail renders at one height · unit · det
+//!      │ evidence  —
+//!      │ cost      $0.12 · 3:04
+//!  ⌥ 4.  repair the tests gate  (inserted)                      —
+//!
+//!  planned 3 · actual — · ⌥ — drift
+//!  drift is recorded, not hidden. it trains your model.
+//! ```
+//!
+//! # An em dash is an answer
+//!
+//! Two of the three producers do not exist yet. `Plan::ledger` has a reader
+//! and no writer — its own doc says why the session's untagged edits and runs
+//! must not be borrowed to fill it — and `Plan::lanes` is in the same state
+//! (`Plan::propose` sets it to `None` and nothing else writes it; #5286 and
+//! #5270 are where that wiring is tracked). So the economics column, the actual count
+//! and the drift count each render `—`.
+//!
+//! That is the point rather than a placeholder. A `0 tok` would be a
+//! measurement nobody took, and `⌥ 0 drift` would say the plan held when
+//! nothing checked. The shape is here so the producers land into a surface
+//! that already reads them, and the dash says exactly which half is missing.
+//!
+//! # No `det` ratio, anywhere
+//!
+//! SPEC 5 forbids one and this issue drops it from the economics line by name.
+//! A check either reaches a model or it does not — the running card's contract
+//! line carries that as the `det` word, off `CheckMechanism::judge`, never as
+//! a percentage.
+//!
+//! # Pure
+//!
+//! Projections onto `Line<'static>` over owned data, like every other view.
+//! The running card's cost is a subtraction the *caller* performs against
+//! `AgentEntry::active_task` (see [`RunningTask`]), so nothing here reads a
+//! clock or a session.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use stella_protocol::TaskContract;
+use stella_tui_theme::{glyph, token};
+
+use crate::plan::{Plan, PlanStep, StepSpend};
+use crate::views::cards;
+
+/// What a cell renders when its producer does not exist yet — see the module
+/// docs. One spelling, so no surface invents a second way to say "unmeasured".
+pub const ELIDED: &str = "—";
+
+/// SPEC 7.3's closing sentence, under the counts.
+const DRIFT_CLOSER: &str = "drift is recorded, not hidden. it trains your model.";
+
+/// Cells the running card's sub-lines are indented, matching the detail rows
+/// [`super::step_rows`] already draws under a step title.
+const SUB_INDENT: &str = "     ";
+
+/// The in-flight task's live numbers, as the caller measured them.
+///
+/// The cost is a *subtraction* — `AgentEntry::cost_usd` now, less
+/// `ActiveTaskStamp::cost_at_start_usd` when the board flipped this task
+/// active — and the elapsed likewise. Both belong to the deck fold, which owns
+/// the clock and the stamp; this module renders what it is handed and measures
+/// nothing, which is what keeps the plan card a pure projection.
+///
+/// It is not read out of [`Plan::ledger`]: that map is the *attributed*
+/// per-step spend and has no producer, while this is one number about one task
+/// that the fold genuinely knows.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunningTask {
+    /// The `PlanStep::id` the board has in progress.
+    pub id: String,
+    /// How long it has been running, from the deck clock.
+    pub elapsed_ms: u64,
+    /// What the session has spent since it went active.
+    pub cost_usd: f64,
+}
+
+/// SPEC 7.3's right-aligned economics cell for one step — `9.0k tok`, or
+/// [`ELIDED`] where nothing has attributed spend to it.
+#[must_use]
+pub fn token_cell(spend: Option<&StepSpend>) -> String {
+    spend.map_or_else(
+        || ELIDED.to_owned(),
+        |spend| format!("{} tok", crate::textline::fmt_tokens(spend.tokens)),
+    )
+}
+
+/// The running task's card: its contract, its evidence, and what it has cost.
+///
+/// Three sub-lines under the step's own row rather than a second framed box,
+/// because the plan card is already a frame and a box inside a box costs two
+/// columns of rail for no extra meaning. What marks it as a card is the gold
+/// rail on each line — the same device the transcript uses to bind a block to
+/// the row above it.
+///
+/// Empty when `step` is not the running task, so a caller can hand every step
+/// the same `running` and get the card exactly once.
+#[must_use]
+pub fn running_card(
+    step: &PlanStep,
+    running: Option<&RunningTask>,
+    ledger: &Plan,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let Some(running) = running.filter(|r| r.id == step.id) else {
+        return Vec::new();
+    };
+    let evidence = ledger
+        .ledger
+        .get(&step.id)
+        .map(|entry| entry.evidence.len())
+        .filter(|rows| *rows > 0)
+        .map_or_else(
+            || ELIDED.to_owned(),
+            |rows| format!("{rows} recorded this task"),
+        );
+    let cost = format!(
+        "${:.2} · {}",
+        running.cost_usd,
+        cards::fmt_mss(running.elapsed_ms)
+    );
+    let budget = width.saturating_sub(GUTTER_W).max(MIN_VALUE_COLS);
+    [
+        ("contract", contract_line(step.contract.as_ref(), budget)),
+        ("evidence", evidence),
+        ("cost", cost),
+    ]
+    .into_iter()
+    .map(|(label, value)| sub_line(label, &value, budget))
+    .collect()
+}
+
+/// The contract in one line, inside `budget` columns: what done means, and the
+/// mechanism that settles it with its `det` tag.
+///
+/// The first check only. SPEC 7.3 asks the running card for *a* contract line,
+/// and a task with four checks belongs in the task zoom (SPEC 7.5), which
+/// renders every one of them — a card that grew a row per check would push the
+/// plan off the screen exactly when the reader wants to see it.
+///
+/// **The statement is what gets cut, never the tail.** The mechanism and the
+/// `det` word say whether a model gets to decide, and a naive truncation drops
+/// exactly them because they come last. So the tail is measured first and the
+/// author's sentence is fitted into what remains.
+fn contract_line(contract: Option<&TaskContract>, budget: usize) -> String {
+    let Some(contract) = contract else {
+        return format!("{ELIDED} · the board stated no contract");
+    };
+    if matches!(contract, TaskContract::ReadOnly) {
+        return "read only · no contract".to_owned();
+    }
+    let Some(check) = contract.checks().next() else {
+        return format!("{ELIDED} · the contract carries no checks");
+    };
+    let judge = if check.mechanism.judge().is_deterministic() {
+        "det"
+    } else {
+        "model"
+    };
+    let more = contract.checks().count().saturating_sub(1);
+    let mut tail = format!(" · {} · {judge}", check.mechanism.as_str());
+    if more > 0 {
+        tail.push_str(&format!(" · +{more} more"));
+    }
+    let room = budget.saturating_sub(unicode_width::UnicodeWidthStr::width(tail.as_str()));
+    format!("{}{tail}", cards::truncate_cols(&check.statement, room))
+}
+
+/// Columns the rail, the gap and the label column take before a value starts.
+const GUTTER_W: usize = SUB_INDENT.len() + 2 + LABEL_W;
+
+/// The label column's width — `contract` is the longest of the three.
+const LABEL_W: usize = 10;
+
+/// The narrowest value column worth rendering, so a hostile terminal width
+/// leaves a cut sentence rather than nothing at all.
+const MIN_VALUE_COLS: usize = 8;
+
+/// One `label  value` sub-line on the card's gold rail.
+fn sub_line(label: &str, value: &str, budget: usize) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{SUB_INDENT}│ "),
+            Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(format!("{label:<LABEL_W$}"), Style::new().fg(token::MUTED)),
+        Span::styled(
+            cards::truncate_cols(value, budget),
+            Style::new().fg(token::TEXT),
+        ),
+    ])
+}
+
+/// SPEC 7.3's footer: `planned 6 · actual 7 · ⌥ 1 drift`, then the closing
+/// sentence.
+///
+/// `planned` is the approved plan's own step count, which the fold has.
+/// `actual` and the drift count come from [`Plan::lanes`] and elide to
+/// [`ELIDED`] while nothing writes it (module docs, #5270).
+///
+/// The counts row is muted and the `⌥` takes drift gold, so the one cell that
+/// is a *finding* is the one that is not grey. The closing sentence is dimmer
+/// still: it is the card's argument, and it should not compete with the
+/// numbers it is about.
+#[must_use]
+pub fn footer_rows(plan: &Plan) -> Vec<Line<'static>> {
+    let muted = Style::new().fg(token::MUTED);
+    let (actual, drift) = plan.lanes.as_ref().map_or_else(
+        || (ELIDED.to_owned(), ELIDED.to_owned()),
+        |lanes| {
+            (
+                lanes.actual.len().to_string(),
+                lanes.divergences().to_string(),
+            )
+        },
+    );
+    let planned = plan
+        .planned_count()
+        .map_or_else(|| ELIDED.to_owned(), |n| n.to_string());
+    vec![
+        Line::from(vec![
+            Span::styled(format!("planned {planned} · actual {actual} · "), muted),
+            Span::styled(
+                format!("{} {drift} drift", glyph::DRIFT),
+                Style::new().fg(token::GOLD_BRIGHT),
+            ),
+        ]),
+        Line::from(Span::styled(DRIFT_CLOSER, Style::new().fg(token::DIM))),
+    ]
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-tui/src/views/plan_card/economics.rs
+++ b/crates/stella-tui/src/views/plan_card/economics.rs
@@ -121,7 +121,13 @@ pub fn running_card(
         .filter(|rows| *rows > 0)
         .map_or_else(
             || ELIDED.to_owned(),
-            |rows| format!("{rows} recorded this task"),
+            |rows| {
+                if rows == 1 {
+                    "1 row".to_owned()
+                } else {
+                    format!("{rows} rows")
+                }
+            },
         );
     let cost = format!(
         "${:.2} · {}",

--- a/crates/stella-tui/src/views/plan_card/economics/tests.rs
+++ b/crates/stella-tui/src/views/plan_card/economics/tests.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What the economics column, the running card and the drift footer say — and
+//! what they say when nothing has measured them.
+
+use super::*;
+use crate::plan::{EvidenceKind, EvidenceRow, PlanStepState, StepLedger};
+use stella_protocol::{
+    Check, CheckMechanism, DefinitionOfDone, Judge, ScopeProposal, TaskItem, TaskStatus,
+};
+
+fn text(line: &Line<'static>) -> String {
+    line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+fn rows_text(rows: &[Line<'static>]) -> Vec<String> {
+    rows.iter().map(text).collect()
+}
+
+fn step(id: &str, title: &str) -> PlanStep {
+    PlanStep {
+        id: id.into(),
+        title: title.into(),
+        detail: None,
+        state: PlanStepState::Started,
+        owner: None,
+        note: None,
+        contract: None,
+    }
+}
+
+fn spend(tokens: u64) -> StepSpend {
+    StepSpend {
+        usd: 0.12,
+        tokens,
+        cache_read_pct: 40,
+        model_calls: 3,
+        est_remaining_usd: None,
+    }
+}
+
+fn running(id: &str) -> RunningTask {
+    RunningTask {
+        id: id.into(),
+        elapsed_ms: 184_000,
+        cost_usd: 0.12,
+    }
+}
+
+fn contract(statement: &str, mechanism: &str, judge: Judge) -> TaskContract {
+    TaskContract::DefinitionOfDone(
+        DefinitionOfDone::from_vec(vec![Check::new(
+            statement,
+            CheckMechanism::new(mechanism, judge),
+        )])
+        .expect("one check is a definition of done"),
+    )
+}
+
+// ── the economics column ───────────────────────────────────────────────────
+
+/// SPEC 7.3's `9k tok`, from the ledger — and the em dash where nothing has
+/// attributed spend to the step.
+#[test]
+fn the_token_cell_states_a_measurement_or_says_there_is_none() {
+    assert_eq!(token_cell(Some(&spend(9_100))), "9.1k tok");
+    assert_eq!(token_cell(Some(&spend(420))), "420 tok");
+    assert_eq!(token_cell(None), ELIDED);
+}
+
+/// **The elision is the claim.** `Plan::ledger` has no producer, so a real
+/// plan's every row reads `—` — never `0 tok`, which would be a measurement
+/// nobody took.
+#[test]
+fn a_plan_with_no_ledger_prices_every_step_at_the_elision() {
+    let mut plan = Plan::default();
+    plan.propose(&ScopeProposal {
+        summary: "collapse the rail surfaces".into(),
+        steps: vec!["read the band layout".into(), "fold the rail".into()],
+        ..Default::default()
+    });
+    plan.approve();
+
+    let (rows, _) = crate::views::plan_card::step_rows(&plan, 52, None, 0, false, None);
+    let text = rows_text(&rows).join("\n");
+    assert_eq!(
+        text.matches(ELIDED).count(),
+        2,
+        "one elided cell per step:\n{text}"
+    );
+    assert!(!text.contains("0 tok"), "{text}");
+}
+
+// ── the running card ───────────────────────────────────────────────────────
+
+/// SPEC 7.3's three sub-lines, on the one task the board has in progress.
+#[test]
+fn the_running_card_states_the_contract_the_evidence_and_the_cost() {
+    let mut step = step("2", "fold the rail");
+    step.contract = Some(contract(
+        "the rail renders once",
+        "unit",
+        Judge::Deterministic,
+    ));
+    let plan = Plan::default();
+
+    let rows = rows_text(&running_card(&step, Some(&running("2")), &plan, 52));
+    assert_eq!(rows.len(), 3);
+    assert!(
+        rows[0].contains("contract") && rows[0].contains("the rail renders once"),
+        "{rows:#?}"
+    );
+    assert!(
+        rows[0].contains("unit") && rows[0].contains("det"),
+        "{rows:#?}"
+    );
+    assert!(
+        rows[1].contains("evidence") && rows[1].ends_with(ELIDED),
+        "{rows:#?}"
+    );
+    assert!(
+        rows[2].contains("$0.12") && rows[2].contains("3:04"),
+        "{rows:#?}"
+    );
+}
+
+/// The card belongs to the running task and nothing else, so a caller can hand
+/// every step the same `running` and get it exactly once.
+#[test]
+fn only_the_running_task_draws_a_card() {
+    let plan = Plan::default();
+    assert!(running_card(&step("3", "verify"), Some(&running("2")), &plan, 52).is_empty());
+    assert!(running_card(&step("2", "fold the rail"), None, &plan, 52).is_empty());
+}
+
+/// A model-judged check says `model`, never a ratio: SPEC 5 forbids a `det`
+/// percentage anywhere, and a check either reaches a model or it does not.
+#[test]
+fn the_contract_line_names_the_judge_as_a_word_and_never_as_a_ratio() {
+    let mut step = step("2", "fold the rail");
+    step.contract = Some(contract(
+        "the panel reads as one surface",
+        "review",
+        Judge::Model,
+    ));
+    let plan = Plan::default();
+    let rows = rows_text(&running_card(&step, Some(&running("2")), &plan, 52));
+    assert!(rows[0].contains("model"), "{rows:#?}");
+    assert!(!rows[0].contains('%'), "{rows:#?}");
+
+    // A read-only task produces no diff, so nothing can settle it and it says
+    // so rather than showing a check it does not have.
+    let mut read_only = step.clone();
+    read_only.contract = Some(TaskContract::ReadOnly);
+    let rows = rows_text(&running_card(&read_only, Some(&running("2")), &plan, 52));
+    assert!(rows[0].contains("read only · no contract"), "{rows:#?}");
+
+    // And a task the board gave no contract at all names the gap.
+    let mut bare = step;
+    bare.contract = None;
+    let rows = rows_text(&running_card(&bare, Some(&running("2")), &plan, 52));
+    assert!(rows[0].contains(ELIDED), "{rows:#?}");
+}
+
+/// A contract too wide for the card loses the *sentence*, never the mechanism
+/// and its judge — those are what say whether a model gets to decide, and a
+/// naive cut drops exactly them because they come last.
+#[test]
+fn a_wide_contract_line_cuts_the_statement_and_keeps_the_judge() {
+    let mut step = step("2", "fold the rail");
+    step.contract = Some(contract(
+        "every panel in the deck renders at the height the layout gave it and no other",
+        "unit",
+        Judge::Deterministic,
+    ));
+    let plan = Plan::default();
+
+    let rows = rows_text(&running_card(&step, Some(&running("2")), &plan, 52));
+    assert!(rows[0].ends_with("· unit · det"), "{rows:#?}");
+    assert!(rows[0].contains('…'), "the statement was cut: {rows:#?}");
+    assert!(
+        rows[0].chars().count() <= 52,
+        "and the row still fits the card: {rows:#?}"
+    );
+}
+
+/// The evidence line counts this task's own rows once a ledger holds them.
+#[test]
+fn the_evidence_line_counts_the_rows_the_ledger_holds_for_this_task() {
+    let mut plan = Plan::default();
+    plan.ledger.insert(
+        "2".into(),
+        StepLedger {
+            evidence: vec![EvidenceRow {
+                kind: EvidenceKind::Edit,
+                subject: "crates/stella-tui/src/views/frame.rs".into(),
+                outcome: "+41 -6".into(),
+            }],
+            spend: None,
+        },
+    );
+    let rows = rows_text(&running_card(
+        &step("2", "fold the rail"),
+        Some(&running("2")),
+        &plan,
+        52,
+    ));
+    assert!(rows[1].contains('1'), "{rows:#?}");
+    assert!(!rows[1].contains(ELIDED), "{rows:#?}");
+}
+
+// ── the drift footer ───────────────────────────────────────────────────────
+
+/// SPEC 7.3's footer, with lanes: `planned n · actual m · ⌥ k drift`, then the
+/// closing sentence.
+#[test]
+fn the_footer_counts_both_lanes_and_the_drift_between_them() {
+    use crate::plan::{ActualStep, PlanLanes};
+
+    let mut plan = Plan::default();
+    plan.propose(&ScopeProposal {
+        summary: "collapse the rail surfaces".into(),
+        steps: vec!["a".into(), "b".into(), "c".into()],
+        ..Default::default()
+    });
+    plan.approve();
+    plan.lanes = Some(PlanLanes {
+        planned: vec!["a".into(), "b".into(), "c".into()],
+        actual: vec![
+            ActualStep {
+                title: "a".into(),
+                cause: None,
+            },
+            ActualStep {
+                title: "b".into(),
+                cause: None,
+            },
+            ActualStep {
+                title: "c".into(),
+                cause: None,
+            },
+            ActualStep {
+                title: "repair the tests gate".into(),
+                cause: Some("E0432".into()),
+            },
+        ],
+    });
+
+    let rows = rows_text(&footer_rows(&plan));
+    assert_eq!(rows[0], "planned 3 · actual 4 · ⌥ 1 drift");
+    assert_eq!(
+        rows[1],
+        "drift is recorded, not hidden. it trains your model."
+    );
+    assert!(!rows[0].contains('⑂'), "the drift mark is the theme's ⌥");
+}
+
+/// **The elision, again.** `Plan::lanes` has no producer, so the two counts it
+/// owns read `—`. `planned` is the approved plan's own step count and is
+/// stated, because the fold genuinely has it.
+#[test]
+fn the_footer_elides_the_counts_that_have_no_producer() {
+    let mut plan = Plan::default();
+    plan.propose(&ScopeProposal {
+        summary: "collapse the rail surfaces".into(),
+        steps: vec!["a".into(), "b".into(), "c".into()],
+        ..Default::default()
+    });
+    plan.approve();
+    assert_eq!(plan.lanes, None, "nothing writes lanes today (#5270)");
+
+    let rows = rows_text(&footer_rows(&plan));
+    assert_eq!(rows[0], "planned 3 · actual — · ⌥ — drift");
+    assert!(!rows[0].contains(" 0 drift"), "{rows:#?}");
+}
+
+/// A board-only plan was never approved as a list, so `planned` has nothing to
+/// count and says so rather than reporting the board's growing length.
+#[test]
+fn a_board_only_plan_elides_the_planned_count_too() {
+    let mut plan = Plan::default();
+    plan.apply_board(&[TaskItem {
+        id: "1".into(),
+        subject: "read the routes".into(),
+        description: None,
+        status: TaskStatus::InProgress,
+        owner: None,
+        contract: None,
+    }]);
+    assert_eq!(plan.planned_count(), None);
+    assert_eq!(
+        rows_text(&footer_rows(&plan))[0],
+        "planned — · actual — · ⌥ — drift"
+    );
+}

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -93,11 +93,6 @@ mod task_zoom;
 #[path = "deck_render_snapshots/gate_board.rs"]
 mod gate_board;
 
-/// SPEC 7.3's plan-panel economics. See [`graph`]'s doc for why this is
-/// `#[path]` rather than a plain `mod`.
-#[path = "deck_render_snapshots/plan_economics.rs"]
-mod plan_economics;
-
 /// See [`graph`]'s doc for why this is `#[path]` rather than a plain `mod`.
 #[path = "deck_render_snapshots/start_work.rs"]
 mod start_work;
@@ -106,6 +101,15 @@ mod start_work;
 /// `#[path]` rather than a plain `mod`.
 #[path = "deck_render_snapshots/mcp.rs"]
 mod mcp;
+
+/// SPEC 7.3's plan-panel economics. See [`graph`]'s doc for why this is
+/// `#[path]` rather than a plain `mod`.
+///
+/// Declared last rather than in the list's order, so this and #5043's
+/// `revision_proposal` module do not both land on the line above
+/// [`start_work`] and collide when the two branches meet.
+#[path = "deck_render_snapshots/plan_economics.rs"]
+mod plan_economics;
 
 /// The command used to regenerate every golden in this file. Quoted verbatim in
 /// each snapshot header and in every failure message, so nobody has to go

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -93,6 +93,11 @@ mod task_zoom;
 #[path = "deck_render_snapshots/gate_board.rs"]
 mod gate_board;
 
+/// SPEC 7.3's plan-panel economics. See [`graph`]'s doc for why this is
+/// `#[path]` rather than a plain `mod`.
+#[path = "deck_render_snapshots/plan_economics.rs"]
+mod plan_economics;
+
 /// See [`graph`]'s doc for why this is `#[path]` rather than a plain `mod`.
 #[path = "deck_render_snapshots/start_work.rs"]
 mod start_work;

--- a/crates/stella-tui/tests/deck_render_snapshots/plan_economics.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots/plan_economics.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! SPEC 7.3's expanded plan panel, with every producer supplied — the
+//! economics column, the running-task card, a drift row, and the drift footer.
+//!
+//! The card the workspace fixture draws (`card_plan`) is the *live* state:
+//! nothing writes `Plan::ledger` or `Plan::lanes` yet (#5286, #5270), so every
+//! economics cell there reads `—` and the footer's two lane counts do too.
+//! That golden is what a user sees today, and it stays.
+//!
+//! This one is the other half: the same card with the producers standing in,
+//! so the layout those issues will land into is pinned now rather than
+//! discovered later.
+//!
+//! A submodule for the reason [`super::gate_board`] is one: the parent is
+//! within twenty lines of its ceiling. Every helper comes from the parent, and
+//! one command blesses them all:
+//! `BLESS=1 cargo test -p stella-tui --test deck_render_snapshots`.
+//!
+//! Colour is stripped by `render_frame`, so the gold/`GOLD_BRIGHT` claims stay
+//! where they can be asserted on spans — `views::plan_card::step_style`'s own
+//! tests for the drift row's metal, and
+//! `views::plan_card::economics::tests` for the rest.
+
+use super::*;
+
+use stella_protocol::{TaskItem, TaskStatus};
+use stella_tui::deck::ActiveTaskStamp;
+use stella_tui::deck_ui::cards::Card;
+use stella_tui::plan::{ActualStep, EvidenceKind, EvidenceRow, PlanLanes, StepLedger, StepSpend};
+
+fn task(id: &str, subject: &str, status: TaskStatus) -> TaskItem {
+    TaskItem {
+        id: id.into(),
+        subject: subject.into(),
+        description: None,
+        status,
+        owner: None,
+        contract: None,
+    }
+}
+
+fn spend(usd: f64, tokens: u64) -> StepSpend {
+    StepSpend {
+        usd,
+        tokens,
+        cache_read_pct: 62,
+        model_calls: 3,
+        est_remaining_usd: None,
+    }
+}
+
+/// The plan panel with every SPEC 7.3 element on screen at once.
+#[test]
+fn deck_render_snapshots_pin_the_plan_panel_economics() {
+    let mut model = fixture_model();
+    let agent = model.agents.first_mut().expect("the lead lane");
+
+    // A plan of three approved steps, plus one the plan did not contain.
+    agent.model.plan.apply_board(&[
+        task("1", "extract types", TaskStatus::Completed),
+        task("2", "move hooks", TaskStatus::InProgress),
+        task("3", "update 9 imports", TaskStatus::Pending),
+        task("4", "repair the failing tests gate", TaskStatus::Pending),
+    ]);
+    // What each step spent — SPEC 7.3's right-aligned `9k tok`.
+    for (id, usd, tokens) in [("1", 0.31, 9_100u64), ("2", 0.12, 4_200)] {
+        agent.model.plan.ledger.insert(
+            id.into(),
+            StepLedger {
+                evidence: vec![EvidenceRow {
+                    kind: EvidenceKind::Edit,
+                    subject: "packages/automations/src/types.ts".into(),
+                    outcome: "+41 -6".into(),
+                }],
+                spend: Some(spend(usd, tokens)),
+            },
+        );
+    }
+    // The two lanes, disagreeing by one step — which is what makes task 4 a
+    // drift row rather than an ordinary one.
+    agent.model.plan.lanes = Some(PlanLanes {
+        planned: vec![
+            "extract types".into(),
+            "move hooks".into(),
+            "update 9 imports".into(),
+        ],
+        actual: vec![
+            ActualStep {
+                title: "extract types".into(),
+                cause: None,
+            },
+            ActualStep {
+                title: "move hooks".into(),
+                cause: None,
+            },
+            ActualStep {
+                title: "repair the failing tests gate".into(),
+                cause: Some("E0432: unresolved import".into()),
+            },
+        ],
+    });
+    // The board's in-progress task, with the anchors the running card's cost
+    // and clock are measured against.
+    agent.active_task = Some(ActiveTaskStamp {
+        id: "2".into(),
+        started_ms: model.now_ms.saturating_sub(184_000),
+        cost_at_start_usd: agent.cost_usd - 0.12,
+    });
+
+    let mut ui = ui_for(DeckTab::Session);
+    ui.cards.raise(Card::Plan);
+    let frame = render_frame(&model, &mut ui, W, H);
+
+    // SPEC 7.2, 7.3 and 8.1 all write `⌥`, `stella_tui_theme::glyph::DRIFT` is
+    // `⌥`, and `glyph::ALL` is gate-enforced — so the `⑂` this issue wrote
+    // would be a drift mark no other surface draws. An absence assertion,
+    // because a blessed golden cannot be relied on to notice a glyph swap.
+    assert!(frame.contains('⌥'), "{frame}");
+    assert!(!frame.contains('⑂'), "{frame}");
+    // SPEC 5 forbids a `det` ratio anywhere, and this issue drops it from the
+    // economics line by name.
+    assert!(!frame.contains("det est"), "{frame}");
+    assert!(!frame.contains("det %"), "{frame}");
+
+    assert_golden(
+        "card_plan_economics",
+        "SPEC 7.3: per-task economics, the running-task card, a drift row, the drift footer",
+        W,
+        H,
+        &frame,
+    );
+}

--- a/crates/stella-tui/tests/snapshots/deck/card_plan_economics.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan_economics.txt
@@ -22,7 +22,7 @@
 ── EXECUTE ─────────────────────────────────────────│▸ ✓ 1. extract types                        9.1k tok  │────────────────────────────────────────────────────
                                                     │  ◐ 2. move hooks                           4.2k tok  │
  │ ⊙ apps/app/automations/page.tsx                  │     │ contract  — · the board stated no contract     │                                              ⚡ 42ms
- │ ⎿ 312 lines                                      │     │ evidence  1 recorded this task                 │                                 42ms
+ │ ⎿ 312 lines                                      │     │ evidence  1 row                                │                                 42ms
                                                     │     │ cost      $0.12 · 3:04                         │
  │ ● edit apps/app/automations/page.tsx +4 -1       │  ○ 3. update 9 imports                            —  │                                              ⚡ 18ms
  │ ⎿                                                │  ⌥ 4. repair the failing tests gate  (inserted)   —  │                         +4 −1 · 18ms

--- a/crates/stella-tui/tests/snapshots/deck/card_plan_economics.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan_economics.txt
@@ -39,7 +39,7 @@
                                                     ╰───────────────────────── e edit · locked · esc close ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
-
+ ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
 zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/crates/stella-tui/tests/snapshots/deck/card_plan_economics.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_plan_economics.txt
@@ -1,9 +1,9 @@
-# deck golden · card_plan
-# the /plan card over SESSION — every step, then the envelope
+# deck golden · card_plan_economics
+# SPEC 7.3: per-task economics, the running-task card, a drift row, the drift footer
 # viewport 160×40 · rendered through render_deck, styling stripped
 # regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
 
- SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
+ SESSION  ▸ plan · task 2 move hooks · 1/4                                                                                                    ⌃S plan   stella*
 
 ◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
     symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
@@ -16,16 +16,16 @@
 
 ☰  plan  4/7  ·  Wire the triggers API
 
- │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
- │   irreducible generation
-
-── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                    ╭ plan  pending approval · 3 steps ────────────────────╮
- │ ⊙ apps/app/automations/page.tsx                  │Refactor the automations store into a shared worksp…  │                                              ⚡ 42ms
- │ ⎿ 312 lines                                      │                                                      │                                 42ms
-                                                    │▸ ○ 1. extract types                               —  │
- │ ● edit apps/app/automations/page.tsx +4 -1       │  ○ 2. move hooks                                  —  │                                              ⚡ 18ms
- │ ⎿                                                │  ○ 3. update 9 imports                            —  │                         +4 −1 · 18ms
+ │ ◐ model worker · 349 tok/s                       ╭ plan  working 1/4 ───────────────────────────────────╮                                            ⚡ 1830ms
+ │   irreducible generation                         │Refactor the automations store into a shared worksp…  │
+                                                    │                                                      │
+── EXECUTE ─────────────────────────────────────────│▸ ✓ 1. extract types                        9.1k tok  │────────────────────────────────────────────────────
+                                                    │  ◐ 2. move hooks                           4.2k tok  │
+ │ ⊙ apps/app/automations/page.tsx                  │     │ contract  — · the board stated no contract     │                                              ⚡ 42ms
+ │ ⎿ 312 lines                                      │     │ evidence  1 recorded this task                 │                                 42ms
+                                                    │     │ cost      $0.12 · 3:04                         │
+ │ ● edit apps/app/automations/page.tsx +4 -1       │  ○ 3. update 9 imports                            —  │                                              ⚡ 18ms
+ │ ⎿                                                │  ⌥ 4. repair the failing tests gate  (inserted)   —  │                         +4 −1 · 18ms
  │     10 -  const items = []                       │                                                      │
  │     10 +  const items = useAutomations()         │repo      macanderson/web-app ⎇ feat/automations-store│
  │     11 +  const [q, setQ] = useState("")         │write     packages/automations/** · apps/app/automatio│
@@ -34,9 +34,9 @@
                                                     │models    think — · work glm-5.2-air · verify —       │
  │ ◐ model worker · 428 tok/s                       │shell     allowlisted                                 │                                            ⚡ 2100ms
  │   irreducible generation                         │                                                      │
-                                                    │planned 3 · actual — · ⌥ — drift                      │
+                                                    │planned 3 · actual 3 · ⌥ 1 drift                      │
 ☰  plan  5/7  ·  Workflows canvas                   │drift is recorded, not hidden. it trains your model.  │
-                                                    ╰────────────────────────────────── x skip · esc close ╯
+                                                    ╰───────────────────────── e edit · locked · esc close ╯
 ⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
 
 


### PR DESCRIPTION
## What & why

SPEC 7.3's expanded plan panel asks for four things the card did not render:

1. **Per-task right-aligned economics** (`9k tok`), with `det%` dropped by name.
2. **The running task as a card** showing its contract line, evidence line and cost line.
3. **Drift rows** marked `⌥` in gold_bright with an `inserted` tag.
4. **The footer** `planned 6 · actual 7 · ⌥ 1 drift`, then `drift is recorded, not hidden. it trains your model.`

`plan_card::step_rows` drew marker, number, title and note; the footer read `{state} {done}/{total}{revision}`.

Closes #5040

### What ships

**`crates/stella-tui/src/views/plan_card/economics.rs`** (new) — `token_cell`, `running_card`, `footer_rows`, and the `RunningTask` the caller measures. A submodule rather than more lines in `plan_card.rs`, which was at 488 and would have gone past 700.

**`priced_step_row`** wraps `step_row` and right-aligns the economics cell through `cards::pad_right` (unicode-width aware, measured against the card's 52-cell interior). A wrapper rather than two more parameters, because `step_row`'s documented job is to be goldenable one *state* at a time and a trailing measurement is the same on every state.

**`Plan::steps` grows one derivation** (`mark_drift`): a step the two lanes disagree about becomes `PlanStepState::DriftInserted` — which `step_style` has painted `⌥` in `GOLD_BRIGHT` since it landed and which nothing could reach. Read off `PlanLanes` and never off a `TaskStatus`, because a board status is a claim its own producer makes and the producer with the strongest reason not to report drift is the one that drifted. That is the same discipline `PlanGraph::divergences` applies engine-side, and `no_board_snapshot_can_fold_a_step_into_drift_inserted` still passes unchanged.

**`Plan::planned_count`** — the *approved* step count, not `steps().len()`: the board grows as work is inserted, so a `planned` that grew with it could never differ from `actual`, which is the whole point of stating both.

### The elisions, and why they are the point

The handover on this issue checked and then **retracted** a claim that `Plan::lanes` was populated. I re-verified both fields on this branch's base:

- `Plan::ledger` — one production reader (`task_zoom.rs`), one `insert`, in `plan.rs`'s own test. **#5286.**
- `Plan::lanes` — the only production write is `self.lanes = None` in `Plan::propose`; the single `Some(...)` is a test. **#5270.**

So the economics column, the `actual` count and the drift count render `—`. That is the answer rather than a placeholder: `0 tok` would be a measurement nobody took, and `⌥ 0 drift` would say the plan held when nothing checked. Two cells *are* real and are stated — `planned`, which is the approved list's own length, and the running task's cost, which is a genuine subtraction against `AgentEntry::active_task`'s stamp.

### Two goldens, deliberately

| Golden | What it pins |
|---|---|
| `card_plan` (updated) | The **live** card: every economics cell `—`, `planned 3 · actual — · ⌥ — drift`. What a user sees today. |
| `card_plan_economics` (new) | The same card with the missing producers supplied, so the layout #5286 and #5270 will land into is pinned now rather than discovered later. |

```
│▸ ✓ 1. extract types                        9.1k tok  │
│  ◐ 2. move hooks                           4.2k tok  │
│     │ contract  — · the board stated no contract     │
│     │ evidence  1 recorded this task                 │
│     │ cost      $0.12 · 3:04                         │
│  ○ 3. update 9 imports                            —  │
│  ⌥ 4. repair the failing tests gate  (inserted)   —  │
│                                                      │
│planned 3 · actual 3 · ⌥ 1 drift                      │
│drift is recorded, not hidden. it trains your model.  │
```

### Three judgement calls, stated so they can be overruled

1. **The drift glyph is `⌥`, not `⑂`.** The issue writes `⑂`; SPEC 7.2, 7.3 and 8.1 all write `⌥`, `stella_tui_theme::glyph::DRIFT` is `'⌥'`, and `glyph::ALL` is gate-enforced. The golden carries `assert!(!frame.contains('⑂'))` so a blessed snapshot cannot swap it back.

2. **The running card is three rail-marked sub-lines, not a nested box.** The plan card is already a frame, and a box inside a box costs two columns of rail for no extra meaning. The gold `│` is the device the transcript already uses to bind a block to the row above it.

3. **A wide contract line cuts the author's sentence and keeps the mechanism and its judge.** Those say whether a model gets to decide, and a naive truncation drops exactly them because they come last — `a_wide_contract_line_cuts_the_statement_and_keeps_the_judge` is the test.

**Out of scope:** the green-meter fold-in this issue also carries. Both sites are `token::GOLD` today, from `a2f021cec` (#5064) — confirmed against the code, not the commit message.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here)

Each verified by hand: break the named line, watch the named test fail, restore.

| Test | What it witnesses | Reverting this makes it fail |
|---|---|---|
| `a_step_the_plan_did_not_contain_renders_as_drift_with_its_tag` | A step the lanes disagree about renders `DriftInserted` with an `inserted` tag; a planned one does not | the `mark_drift(...)` call in `Plan::steps` |
| `a_drift_step_keeps_the_note_it_already_had` | A cancelled *and* inserted step says both | the same |
| `a_plan_with_no_ledger_prices_every_step_at_the_elision` | **The elision.** Every step of a real plan reads `—`, never `0 tok` | `economics::token_cell` in `priced_step_row` |
| `the_token_cell_states_a_measurement_or_says_there_is_none` | `9.1k tok` / `420 tok` / `—` | `economics::token_cell` |
| `the_running_card_states_the_contract_the_evidence_and_the_cost` | SPEC 7.3's three sub-lines | `economics::running_card` |
| `only_the_running_task_draws_a_card` | The card belongs to the in-flight task and nothing else | `running.filter(...)` |
| `the_contract_line_names_the_judge_as_a_word_and_never_as_a_ratio` | `det` / `model` as a word, no `%`; read-only and contract-less both name their gap | `economics::contract_line` |
| `a_wide_contract_line_cuts_the_statement_and_keeps_the_judge` | The cut lands on the sentence, not on the tag | `contract_line`'s tail-first measurement |
| `the_evidence_line_counts_the_rows_the_ledger_holds_for_this_task` | The evidence line stops eliding once a ledger holds rows | `running_card`'s ledger lookup |
| `the_footer_counts_both_lanes_and_the_drift_between_them` | `planned 3 · actual 4 · ⌥ 1 drift` + the closing sentence, `⌥` not `⑂` | `economics::footer_rows` |
| `the_footer_elides_the_counts_that_have_no_producer` | **The elision, again.** `planned 3 · actual — · ⌥ — drift`, never ` 0 drift` | `footer_rows`' `map_or_else` |
| `a_board_only_plan_elides_the_planned_count_too` | A plan nobody approved as a list counts nothing | `Plan::planned_count` |
| `deck_render_snapshots_pin_the_plan_panel_economics` | All four elements in one rendered deck, plus the `⑂` and `det %` absence assertions | the `running_card` call in `step_rows` (and anything else above) |
| `card_plan` (updated golden) | The live card's elisions and footer inside the real frame | any of the above |

`step_style`'s own `a_drift_inserted_step_is_gold_bright_glyph_and_tag` covers the metal, which the style-stripped goldens cannot see. `no_board_snapshot_can_fold_a_step_into_drift_inserted` still passes: the new path is the lanes, not the board.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui --all-targets -- -D warnings`
- [x] `cargo test -p stella-tui` (scoped per SCR-001 — `plan`, `views::plan_card`, `deck`, `render`, and the whole `deck_render_snapshots` target). **CI is this PR's evidence.**
- [x] `make guards-fast`, `make prose`, `./scripts/check-file-size.sh`, `cargo doc -p stella-tui` (no warnings)
- [x] Goldens regenerated with `BLESS=1 …` and **the diff read** — `card_plan`'s 14 changed lines are the economics column, the footer and the reflow they cause; nothing else moved
- [x] `Closes #5040` above **and** as a commit trailer

## Nothing left behind

- [x] There is nothing new: the two gaps this PR renders around were already filed — **#5286** (`Plan::ledger` has a reader and no producer) and **#5270** (the same for `Plan::lanes`). Both are cited from the code that elides because of them, and #5286 already notes the two may want one fold.

## Ground-rule check

- [x] No I/O added anywhere; `economics` is a pure projection onto `Line<'static>`
- [x] No new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types — `RunningTask` is `stella-tui`'s own and crosses no crate boundary

## Anything reviewers should know?

`mark_drift` matches on **title**, because `PlanLanes::actual` is `ActualStep { title, cause }` and carries no board id — a plan with two steps of the same title marks both. Giving the lanes their own ids is #5270's business; the function says so.

`card_plan`'s golden changed by 14 lines. Reading them: the two new rows at the bottom are the footer, the `—` at the end of each step row is the economics column, and everything else is the reflow those cause inside a card whose height grew by three. No step text, glyph or envelope row changed.

## Summary by Sourcery

Expand the Stella TUI plan panel with task economics, running-task details, and explicit drift reporting.

New Features:
- Render per-step token economics and an expanded card for the currently running task with contract, evidence, and cost details.
- Display plan drift rows and a footer summarizing planned, actual, and drift counts.

Enhancements:
- Derive inserted drift steps from disagreements between plan lanes while preserving existing step notes.
- Distinguish approved plan size from the current board step count and explicitly elide unavailable measurements rather than showing misleading zeroes.

Tests:
- Add unit and snapshot coverage for economics elisions, running-task details, contract truncation, drift rendering, and lane count summaries.