### PR TITLE
fix(stella-core): four correctness defects in the learning and steering decision modules

### DIFF
--- a/crates/stella-cli/src/memory/skill_files.rs
+++ b/crates/stella-cli/src/memory/skill_files.rs
@@ -21,8 +21,9 @@ impl SkillSource for FsSkillSource {
                 // same-name entries in one root (flat `foo.md` beside
                 // `foo/SKILL.md`, or a frontmatter `name:` colliding with a
                 // sibling's slug) picked their winner per machine. The
-                // rendered prompt bytes must not depend on that (invariant
-                // #7); root order still decides cross-root precedence.
+                // rendered prompt bytes must not depend on that (AGENTS.md
+                // rule 7, byte-stable prompts); root order still decides
+                // cross-root precedence.
                 let mut paths: Vec<std::path::PathBuf> =
                     entries.flatten().map(|entry| entry.path()).collect();
                 paths.sort();

--- a/crates/stella-cli/src/memory/skill_files.rs
+++ b/crates/stella-cli/src/memory/skill_files.rs
@@ -16,8 +16,17 @@ impl SkillSource for FsSkillSource {
         for root in roots {
             // Flat layout: <root>/<slug>.md
             if let Ok(entries) = std::fs::read_dir(root) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
+                // Sorted per root: `read_dir` order is filesystem enumeration
+                // order, and the loader's merge is last-writer-wins — so two
+                // same-name entries in one root (flat `foo.md` beside
+                // `foo/SKILL.md`, or a frontmatter `name:` colliding with a
+                // sibling's slug) picked their winner per machine. The
+                // rendered prompt bytes must not depend on that (invariant
+                // #7); root order still decides cross-root precedence.
+                let mut paths: Vec<std::path::PathBuf> =
+                    entries.flatten().map(|entry| entry.path()).collect();
+                paths.sort();
+                for path in paths {
                     if path.extension().is_some_and(|e| e == "md") {
                         if let Ok(content) = std::fs::read_to_string(&path) {
                             files.push(skills::SkillFile {

--- a/crates/stella-core/src/ingest/gate.rs
+++ b/crates/stella-core/src/ingest/gate.rs
@@ -284,8 +284,8 @@ mod tests {
     /// tokenizes to `[twenty, one, rust, crates]`, so from `twenty` the noun
     /// sits three tokens out — a window of `CARDINAL_LOOKAHEAD` alone stopped
     /// one short, and the spelled-compound count claim kept its `path_exists`
-    /// probe (#4262's false green). Digit forms and the deliberate `one`
-    /// exemption pin the boundary from the other side.
+    /// probe (#4262's false green). Digit forms and the `one` exemption pin
+    /// the boundary from the other side.
     #[test]
     fn a_spelled_compound_cardinal_loses_its_path_probe() {
         assert!(!probe_can_discriminate(

--- a/crates/stella-core/src/ingest/gate.rs
+++ b/crates/stella-core/src/ingest/gate.rs
@@ -129,9 +129,14 @@ fn states_a_cardinality(statement: &str) -> bool {
         if !is_cardinal {
             continue;
         }
+        // The window is the intervening tokens PLUS the noun itself: with a
+        // lookahead of 2, the noun may sit at most three tokens out — which
+        // is exactly `twenty[-one Rust] crates`. `take(CARDINAL_LOOKAHEAD)`
+        // stopped one short and missed the doc's own example (#4262's shape:
+        // the count claim kept its probe and went green on every run).
         if tokens[i + 1..]
             .iter()
-            .take(CARDINAL_LOOKAHEAD)
+            .take(CARDINAL_LOOKAHEAD + 1)
             .any(|next| is_plural_noun(next))
         {
             return true;
@@ -273,6 +278,35 @@ mod tests {
         }
         // A decree could honor a gated probe; ingest never produces one.
         assert!(probe_honored(Origin::User, ProbeKind::CommandSucceeds));
+    }
+
+    /// The lookahead's own documented example: `twenty-one Rust crates`
+    /// tokenizes to `[twenty, one, rust, crates]`, so from `twenty` the noun
+    /// sits three tokens out — a window of `CARDINAL_LOOKAHEAD` alone stopped
+    /// one short, and the spelled-compound count claim kept its `path_exists`
+    /// probe (#4262's false green). Digit forms and the deliberate `one`
+    /// exemption pin the boundary from the other side.
+    #[test]
+    fn a_spelled_compound_cardinal_loses_its_path_probe() {
+        assert!(!probe_can_discriminate(
+            ProbeKind::PathExists,
+            "All twenty-one Rust crates live under crates/."
+        ));
+        assert!(!probe_can_discriminate(
+            ProbeKind::PathExists,
+            "There are 21 Rust crates under crates/."
+        ));
+        // `one` is not a cardinal here: "one job" claims existence, which is
+        // exactly what a path probe can refute.
+        assert!(probe_can_discriminate(
+            ProbeKind::PathExists,
+            "A tool does exactly one job, declared in one place."
+        ));
+        // A cardinal with no plural noun in reach quantifies nothing.
+        assert!(probe_can_discriminate(
+            ProbeKind::PathExists,
+            "The two of them agree."
+        ));
     }
 
     #[test]

--- a/crates/stella-core/src/self_tuning.rs
+++ b/crates/stella-core/src/self_tuning.rs
@@ -286,14 +286,20 @@ pub fn select_winner(arms: &[ArmSamples], baseline_id: &str, config: &SelectionC
         }
     }
 
-    // Winner = highest mean. `partial_cmp` guards against NaN (treated equal),
-    // so a NaN mean can never win by accident.
+    // Winner = highest mean, with a NaN mean ordered below every finite one.
+    // Treating NaN as merely Equal was not enough: `max_by` keeps the later
+    // element on Equal, so a NaN in the middle of three arms handed the scan
+    // to whatever came after it — a 0.9 arm could lose to a 0.5 arm.
     let Some(winner) = stats
         .iter()
-        .max_by(|a, b| {
-            a.mean
+        .max_by(|a, b| match (a.mean.is_nan(), b.mean.is_nan()) {
+            (true, true) => std::cmp::Ordering::Equal,
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            (false, false) => a
+                .mean
                 .partial_cmp(&b.mean)
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .unwrap_or(std::cmp::Ordering::Equal),
         })
         .cloned()
     else {
@@ -456,6 +462,29 @@ mod tests {
             ..outcome
         };
         assert!(reward(&unsolved, &w) < reward(&outcome, &w));
+    }
+
+    /// Three arms with a NaN mean in the middle: `max_by` keeps the later
+    /// element on Equal, so a NaN treated as Equal handed the scan to
+    /// whatever followed it — here the 0.5 arm "beat" the 0.9 baseline, and
+    /// the decision read `BelowMinEffect` on a negative lift instead of
+    /// `BaselineIsBest`. The NaN arm itself must still never win.
+    #[test]
+    fn a_nan_mean_cannot_corrupt_the_winner_scan() {
+        let config = SelectionConfig {
+            min_samples_per_arm: 3,
+            ..SelectionConfig::default()
+        };
+        let arms = vec![
+            arm("baseline", "medium", &[0.9, 0.9, 0.9]),
+            arm("noise", "broken", &[f64::NAN, 0.5, 0.5]),
+            arm("worse", "low", &[0.5, 0.5, 0.5]),
+        ];
+        let decision = select_winner(&arms, "baseline", &config);
+        assert!(
+            matches!(decision, Decision::Keep(KeepReason::BaselineIsBest { .. })),
+            "the highest finite mean must win the scan, got {decision:?}"
+        );
     }
 
     #[test]

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -551,7 +551,12 @@ pub fn select_skills_reporting(
         // least two shared terms unless a domain tag corroborates.
         let corroborated = !matched_domains.is_empty() || matched_terms.len() >= 2;
 
-        if corroborated && score >= config.min_score {
+        // The floor reads the evidence-bearing half only. The AutoCreated
+        // bonus is a tie-break on ordering, and its own doc promises it is
+        // "never large enough to select a skill that is otherwise below
+        // min_score" — letting it into the threshold gave freshly-mined
+        // skills a LOWER selection floor than hand-authored ones.
+        if corroborated && lexical + domain_score >= config.min_score {
             selected.push(SelectedSkill {
                 skill: skill.clone(),
                 score,

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -544,6 +544,46 @@ fn auto_created_skill_wins_the_tie_break() {
     assert!(selected[0].score > selected[1].score);
 }
 
+/// The bonus's own contract: "never large enough to select a skill that is
+/// otherwise below `min_score`". Identical wording under two origins, with
+/// lexical coverage just under the floor — if the bonus reaches the
+/// threshold, the freshly-mined (least-vetted) skill gets a LOWER selection
+/// floor than the hand-authored one, the opposite of a tie-break.
+#[test]
+fn the_auto_created_bonus_cannot_lift_a_skill_over_the_floor() {
+    let config = SelectionConfig {
+        max_skills: 5,
+        min_score: 0.6,
+        domain_boost: 0.5,
+        auto_created_bonus: 0.2,
+    };
+    // Names reuse description terms so both skills score over the same
+    // four-term vocabulary: coverage = 2/4 = 0.5, below the 0.6 floor.
+    let skills = vec![
+        skill(
+            "quaxle-marlow",
+            "quaxle fenwick marlow jubilant",
+            &[],
+            SkillOrigin::Workspace,
+        ),
+        skill(
+            "quaxle-jubilant",
+            "quaxle fenwick marlow jubilant",
+            &[],
+            SkillOrigin::AutoCreated,
+        ),
+    ];
+    let selected = select_skills(&skills, "quaxle fenwick", &[], &config);
+    assert!(
+        selected.is_empty(),
+        "the bonus lifted a below-floor skill into selection: {:?}",
+        selected
+            .iter()
+            .map(|s| (&s.skill.name, s.score))
+            .collect::<Vec<_>>()
+    );
+}
+
 // ---- rendering ----
 
 #[test]


### PR DESCRIPTION
## What this is

Four confirmed correctness defects in the learning/steering decision modules — skill selection, self-tuning winner selection, the reflection-ingest cardinality gate, and skill-file discovery — found by a full read of those modules. Each behavior change carries a witness test verified red on the old code and green on the new.

## The defects

1. **The cardinality gate missed its own documented example** (`stella-core/src/ingest/gate.rs`, `states_a_cardinality`). The lookahead counts *intervening* tokens, but the window was `take(CARDINAL_LOOKAHEAD)` — one short of where the noun may sit. From `twenty` in "twenty-one Rust crates" the window was `[one, rust]` and `crates` was never reached, so the spelled-compound count claim kept its `path_exists` probe and went green on every run — #4262's false-green shape, which this gate exists to stop. Digit forms were unaffected.
   Witness: `a_spelled_compound_cardinal_loses_its_path_probe` (also pins the digit form, the deliberate `one` exemption, and a cardinal with no plural noun in reach).

2. **The auto-created bonus breached the selection floor** (`stella-core/src/skills.rs`, `select_skills_reporting`). `auto_created_bonus` documents itself as a tie-break "never large enough to select a skill that is otherwise below `min_score`" — but the threshold compared the full score including the bonus, giving freshly-mined (least-vetted) skills a *lower* selection floor than hand-authored ones with identical wording. The floor now reads the evidence-bearing half (lexical + domain); the bonus still orders survivors.
   Witness: `the_auto_created_bonus_cannot_lift_a_skill_over_the_floor`.

3. **A NaN mean corrupted the winner scan** (`stella-core/src/self_tuning.rs`, `select_winner`). NaN was treated as `Equal`, and `max_by` keeps the later element on `Equal` — so means `[0.9, NaN, 0.5]` walked to the 0.5 arm as "winner". Downstream guards kept a promotion from firing, but the decision named the wrong reason, and the doc's "a NaN mean can never win by accident" held only for the NaN arm itself. NaN now loses to every finite mean. All live call sites pass two arms today; the third-arm shape is where this bit.
   Witness: `a_nan_mean_cannot_corrupt_the_winner_scan`.

4. **Skill files loaded in filesystem enumeration order** (`stella-cli/src/memory/skill_files.rs`, `FsSkillSource`). The loader's same-name merge is last-writer-wins, so two colliding entries in one root (flat `foo.md` beside `foo/SKILL.md`, or a frontmatter `name:` matching a sibling's slug) picked their winner per machine — and the rendered prompt bytes depended on it, against the byte-stable-prompts invariant (#7). Entries now sort per root; root order still decides cross-root precedence.
   No practical witness: the defect is `read_dir`'s platform-dependent enumeration order, which a test cannot force on a filesystem that happens to enumerate sorted. Verified by inspection that the sort is the only change and the merge semantics are untouched; the loader's existing precedence tests still pass.

## Witness verification (the artisanal way)

With the three behavior lines reverted on top of this branch:

```
cargo test -p stella-core a_spelled_compound            -> red
cargo test -p stella-core the_auto_created_bonus_cannot -> red
cargo test -p stella-core a_nan_mean_cannot             -> red
```

Restored: `cargo test -p stella-core skills` (82 passed), `self_tuning` (16 passed), `ingest` (68 passed); `cargo clippy -p stella-core -p stella-cli --all-targets -- -D warnings` green.

## Not in this PR

The same review surfaced items needing design decisions or their own PRs — the `'/'` path-string contract skill discovery leans on, the Welch-z calibration claim at the sample floor, and description minting for learned skills. Filed as issues from this review session.

## Summary by Sourcery

Fix four correctness defects in learning, steering, and skill-file decision behavior.

Bug Fixes:
- Correct cardinality-gate lookahead so spelled compound counts can no longer retain inappropriate path probes.
- Prevent auto-created skill bonuses from selecting skills below the evidence threshold.
- Ensure NaN means cannot corrupt self-tuning winner selection.
- Make skill-file loading deterministic within each root to stabilize same-name merge results.

Tests:
- Add regression coverage for cardinality boundaries, skill-selection floors, and NaN winner handling.

Closes #5344
