### PR TITLE
fix(stella-cli): the promotion ledger survives a trimmed newline, and the evolution ledger's prose tells the truth

### DIFF
--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -161,16 +161,24 @@ pub(crate) fn append_promotion(
             .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
     }
     let mut appended = text;
+    // A ledger that lost only its trailing newline still verifies, so
+    // without this the new line glues onto the old tail — one unparseable
+    // line, durably written. Normalize first, and verify BEFORE the write,
+    // so a bad concatenation is an error returned and not a corrupt
+    // governance file already on disk.
+    if !appended.is_empty() && !appended.ends_with('\n') {
+        appended.push('\n');
+    }
     appended.push_str(&line);
     appended.push('\n');
+    let events = stella_core::records::promotion::parse_and_verify(&appended)
+        .map_err(|violation| format!("ledger invalid after append: {}", violation.reason))?;
     stella_store::durable::write_atomic_preserving_mode(
         &path,
         appended.as_bytes(),
         stella_store::durable::MODE_SHARED,
     )
     .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
-    let events = stella_core::records::promotion::parse_and_verify(&appended)
-        .map_err(|violation| format!("ledger invalid after append: {}", violation.reason))?;
     Ok(stella_core::records::promotion::policy_version(&events))
 }
 

--- a/crates/stella-cli/src/context_records/tests.rs
+++ b/crates/stella-cli/src/context_records/tests.rs
@@ -427,6 +427,24 @@ fn appending_a_promotion_extends_the_chain_and_leaves_the_reviewed_dir_clean() {
     );
 }
 
+/// A ledger that lost only its trailing newline still verifies — so the next
+/// append used to glue its line onto the old tail and durably write one
+/// unparseable line, discovering the damage only after it was on disk.
+#[test]
+fn appending_to_a_newline_trimmed_ledger_does_not_glue_lines() {
+    let root = tempfile::tempdir().unwrap();
+    append_promotion(root.path(), grant("ctx.acme.web.a", "first grant")).unwrap();
+
+    // Trim the trailing newline, as an editor or a filter pipeline would.
+    let (path, text) = promotion_ledger_text(root.path());
+    std::fs::write(&path, text.trim_end_matches('\n')).unwrap();
+    read_promotions(root.path()).expect("the trimmed ledger still verifies");
+
+    append_promotion(root.path(), grant("ctx.acme.web.b", "second grant")).unwrap();
+    let events = read_promotions(root.path()).expect("the appended ledger verifies");
+    assert_eq!(events.len(), 2, "both grants survive as separate lines");
+}
+
 /// A record set file, as a plugin package or a repository ships one.
 fn record_set(set_id: &str, lineage: &str) -> String {
     format!(

--- a/crates/stella-core/src/context_record/lifecycle.rs
+++ b/crates/stella-core/src/context_record/lifecycle.rs
@@ -198,9 +198,11 @@ pub struct ProposalRecord {
     ///
     /// The proposal has to store it because it keeps only the observations'
     /// `record_id`s and so cannot re-derive the grade later. `None` means a
-    /// record written before provenance was carried: absent, not weak, and
-    /// refused by [`stella_protocol::provenance::authorises`] rather than
-    /// rounded down to a grade it never earned.
+    /// record written before provenance was carried: absent, not weak — and
+    /// meant to be refused by [`stella_protocol::provenance::authorises`]
+    /// rather than rounded down to a grade it never earned, once that gate
+    /// is wired into the publication paths (today nothing calls it on any of
+    /// them; #4865 tracks the wiring).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<ProvenanceGrade>,
     pub score: ProposalScore,

--- a/crates/stella-parity/README.md
+++ b/crates/stella-parity/README.md
@@ -50,11 +50,17 @@ everywhere at once. The embedding story the matrix serves is
 
 ## Boundary — does this change belong here?
 
-One file, one job: `src/lib.rs` holds the posture types, the matrix rows, and
-the tests (inline `mod tests`) that keep the rows true. A change belongs
-here when it is a matrix decision — a new row, a posture change, a witness
-name, a composition-seam entry, lowering `UNWITNESSED_BASELINE` after writing
-a missing witness. The capability *itself* never lives here: its engine home
+Two ledgers, one discipline. `src/lib.rs` holds the CLI-vs-API capability
+matrix: the posture types, the matrix rows, and the tests (inline `mod
+tests`) that keep the rows true. `src/evolution.rs` holds the evolution
+ledger (AGENTS.md invariant #11): one row per surface Stella changes itself
+through — framework, memory, skill, tool, workflow, model — each declaring a
+posture, timing, impact class, rollback artifact, and, for a live posture,
+the witness test proving the surface can be changed; its rows and the
+`EvolutionSurface` enum come from one macro table, so a surface without a
+row does not compile. A change belongs here when it is a ledger decision — a
+new row, a posture change, a witness name, a composition-seam entry,
+lowering `UNWITNESSED_BASELINE` after writing a missing witness. The capability *itself* never lives here: its engine home
 is `stella-core`, its surfaces are `stella-cli` and `stella-serve`, and this
 crate only records how they relate.
 

--- a/crates/stella-parity/README.md
+++ b/crates/stella-parity/README.md
@@ -53,7 +53,7 @@ everywhere at once. The embedding story the matrix serves is
 Two ledgers, one discipline. `src/lib.rs` holds the CLI-vs-API capability
 matrix: the posture types, the matrix rows, and the tests (inline `mod
 tests`) that keep the rows true. `src/evolution.rs` holds the evolution
-ledger (AGENTS.md invariant #11): one row per surface Stella changes itself
+ledger (AGENTS.md rule 11): one row per surface Stella changes itself
 through — framework, memory, skill, tool, workflow, model — each declaring a
 posture, timing, impact class, rollback artifact, and, for a live posture,
 the witness test proving the surface can be changed; its rows and the

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -315,7 +315,7 @@ evolution_surfaces! {
         EvolutionPosture::Shipped {
             mechanism: "mined candidates clear the distinct-task floor and are written as \
                         SKILL.md. The measured-lift gate exists and is off by default \
-                        (`SkillMineConfig::require_measured_lift` is `false`), so the shipped \
+                        (`AutoCreateConfig::require_measured_lift` is `false`), so the shipped \
                         default promotes on mining eligibility — which is why this row's \
                         impact is an advisory record and not a steering one",
             witness: "a_skill_that_helps_is_promoted_with_its_lift_recorded",

--- a/crates/stella-parity/src/evolution/tests.rs
+++ b/crates/stella-parity/src/evolution/tests.rs
@@ -106,7 +106,9 @@ fn every_parked_row_cites_an_issue() {
             _ => continue,
         };
         assert!(
-            cited.starts_with('#') && cited[1..].chars().all(|c| c.is_ascii_digit()),
+            cited.len() > 1
+                && cited.starts_with('#')
+                && cited[1..].chars().all(|c| c.is_ascii_digit()),
             "the {} row cites `{cited}`, which is not a `#NNNN` issue reference",
             row.surface.as_str()
         );


### PR DESCRIPTION
## What this is

Small, contained hardening of the steering-governance surface, from a full review of the context-record ledger and the evolution ledger. One behavior fix with a witness; three prose/test corrections whose subject is exactly the "a doc claim is a claim" rule.

## The changes

1. **`append_promotion` glued lines onto a newline-trimmed ledger** (`stella-cli/src/context_records.rs`). A `promotions.jsonl` missing only its trailing newline still passes `parse_and_verify` — so the next append concatenated its event onto the old tail, producing one unparseable line, and the durable write landed *before* the post-append verification, leaving a corrupt governance artifact on disk with the error arriving after the damage. The append now normalizes the trailing newline and verifies the whole chain before writing.
   Witness: `appending_to_a_newline_trimmed_ledger_does_not_glue_lines` — verified red on the old code (the artisanal way: behavior lines reverted on top of this branch, test fails; restored, `cargo test -p stella-cli context_records` green).

2. **The evolution ledger's Skill row named a field on the wrong type** (`stella-parity/src/evolution.rs`): `SkillMineConfig::require_measured_lift` — the field lives on `AutoCreateConfig` (`stella-core/src/skills.rs`), and the witness sweep cannot catch prose type names.

3. **`every_parked_row_cites_an_issue` accepted a bare `#`** (`stella-parity/src/evolution/tests.rs`): the all-digits check is vacuously true over an empty iterator. It now requires at least one digit.

4. **Two stale doc claims corrected**: `stella-parity/README.md`'s Boundary section said "One file, one job: `src/lib.rs`" while the crate also carries the evolution ledger (`src/evolution.rs`, invariant #11) — now described beside the capability matrix. And `ProposalRecord::provenance` (`stella-core/src/context_record/lifecycle.rs`) claimed a `None` grade is "refused by `stella_protocol::provenance::authorises`" — nothing calls `authorises` on any publication path, so the comment now states the truth and cites #4865, which tracks the wiring.

## Verification

`cargo test -p stella-parity` (23 passed), `cargo test -p stella-cli context_records` (14 passed), `cargo clippy -p stella-core -p stella-parity -p stella-cli --all-targets -- -D warnings` green. Items 2–4 are prose corrections; per the witness contract, no witness applies — the evidence is the named field/function existing where the new text says it does (`AutoCreateConfig` in `skills.rs`; `authorises`'s call sites being tests only).

Refs #4865

## Summary by Sourcery

Harden promotion ledger appends and correct evolution-ledger validation and documentation claims.

Bug Fixes:
- Prevent promotion ledger entries from being concatenated when the existing ledger lacks a trailing newline.
- Validate the complete promotion ledger before persisting an appended entry.

Enhancements:
- Correct the evolution ledger's documented configuration type and require non-empty issue references in parked-row validation.
- Align parity and provenance documentation with the ledger structure and current publication behavior.

Documentation:
- Update parity and provenance documentation to accurately describe ledger ownership and currently unwired authorization behavior.

Tests:
- Add coverage confirming appends to newline-trimmed promotion ledgers remain valid and preserve separate events.

Closes #5345
