### PR TITLE
fix(stella-context): lineage steal refused, episode lineage repaired, and backdated corrections cannot invert an interval

### DIFF
--- a/crates/stella-context/src/store/edge.rs
+++ b/crates/stella-context/src/store/edge.rs
@@ -181,6 +181,13 @@ pub(crate) fn insert_edge(
 /// Close an edge's intervals: set `superseded_at` (transaction time) and, if
 /// not already ended, `valid_to` (world time). **Never deletes** (`L-C3`) — the
 /// row survives so "what did we believe at T1" still answers.
+///
+/// The world interval may not invert (#5325): a correction backdated to
+/// before this edge's own `valid_from` clamps to it, so the edge ends the
+/// instant it began rather than before — `valid_to < valid_from` would match
+/// `neighbors_valid_at`'s half-open test at *no* instant, retroactively
+/// erasing the old belief from every world-time query while belief-time
+/// queries still show it.
 pub(crate) fn close_edge(
     conn: &Connection,
     edge_id: i64,
@@ -188,7 +195,9 @@ pub(crate) fn close_edge(
     valid_to: &str,
 ) -> Result<(), ContextError> {
     conn.execute(
-        "UPDATE edge SET superseded_at = ?2, valid_to = COALESCE(valid_to, ?3) WHERE id = ?1",
+        "UPDATE edge SET superseded_at = ?2,
+             valid_to = COALESCE(valid_to, MAX(COALESCE(valid_from, ?3), ?3))
+         WHERE id = ?1",
         params![edge_id, superseded_at, valid_to],
     )?;
     Ok(())

--- a/crates/stella-context/src/store/record.rs
+++ b/crates/stella-context/src/store/record.rs
@@ -26,7 +26,7 @@ pub(crate) fn insert_episode(
 ) -> Result<i64, ContextError> {
     let files = serde_json::to_string(files_touched)?;
     // `lineage_id = public_id`: an episode is its own lineage's first (and so
-    // far only) revision, the invariant migrate_v8's backfill established.
+    // far only) revision, the rule migrate_v8's backfill established.
     // The insert has to keep establishing it — rows written without the
     // column carried NULL from the moment v8 landed, which is what
     // migrate_v12 repairs.

--- a/crates/stella-context/src/store/record.rs
+++ b/crates/stella-context/src/store/record.rs
@@ -25,9 +25,14 @@ pub(crate) fn insert_episode(
     now: &str,
 ) -> Result<i64, ContextError> {
     let files = serde_json::to_string(files_touched)?;
+    // `lineage_id = public_id`: an episode is its own lineage's first (and so
+    // far only) revision, the invariant migrate_v8's backfill established.
+    // The insert has to keep establishing it — rows written without the
+    // column carried NULL from the moment v8 landed, which is what
+    // migrate_v12 repairs.
     let id: i64 = conn.query_row(
-        "INSERT INTO episode (public_id, summary, files_touched, outcome, salience, started_at, ended_at, recorded_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        "INSERT INTO episode (public_id, lineage_id, summary, files_touched, outcome, salience, started_at, ended_at, recorded_at)
+         VALUES (?1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
          ON CONFLICT(public_id) DO UPDATE SET
              summary = excluded.summary,
              files_touched = excluded.files_touched,
@@ -58,6 +63,31 @@ pub(crate) fn insert_memory(
     salience: f64,
     now: &str,
 ) -> Result<i64, ContextError> {
+    // Two lineages cannot share one revision id. `public_id` is a hash of
+    // kind + content, so revising lineage B onto text an existing memory of
+    // lineage A already carries conflicts on A's row — and the upsert below
+    // would re-parent that row into B, leaving lineage A with zero revisions
+    // and a live mirror node, with no error anywhere (#5322). That is a
+    // merge of two memories, which is not something a revision may do
+    // silently; refuse it the way the ledger refuses two records claiming
+    // one id.
+    let held_by: Option<String> = conn
+        .query_row(
+            "SELECT lineage_id FROM memory WHERE public_id = ?1",
+            params![public_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    if let Some(existing) = held_by
+        && existing != lineage_id
+    {
+        return Err(ContextError::InvalidInput(format!(
+            "memory revision `{public_id}` already belongs to lineage `{existing}` — \
+             revising lineage `{lineage_id}` onto the same text would merge two \
+             memories and erase one's history; edit or retire the existing memory \
+             instead"
+        )));
+    }
     conn.execute(
         "UPDATE memory SET superseded_at = ?3
          WHERE lineage_id = ?1 AND public_id <> ?2 AND superseded_at IS NULL",

--- a/crates/stella-context/src/store/schema.rs
+++ b/crates/stella-context/src/store/schema.rs
@@ -14,7 +14,7 @@ use crate::embed::EmbedderFingerprint;
 use crate::error::ContextError;
 
 /// The current on-disk schema version, tracked in `PRAGMA user_version`.
-pub(crate) const SCHEMA_VERSION: i64 = 11;
+pub(crate) const SCHEMA_VERSION: i64 = 12;
 
 /// The v1 schema. Applied once, inside the migration transaction. Bi-temporal
 /// columns (`valid_from`/`valid_to`/`recorded_at`/`superseded_at`) exist on both
@@ -515,6 +515,19 @@ CREATE TABLE IF NOT EXISTS ab_control_counter (
 );
 ";
 
+/// V12 — **repair the episode rows v8's backfill could not see** (#5324).
+///
+/// `migrate_v8` added `episode.lineage_id` and backfilled
+/// `lineage_id = public_id`, but `insert_episode` kept inserting without the
+/// column — so every episode written after v8 landed carried NULL, and the
+/// one-shot backfill (which only runs when `user_version < 8`) could never
+/// repair them. The insert now writes the column; this step repairs the rows
+/// written in between. Statement-level idempotent: after the first run no row
+/// is NULL.
+pub(crate) const MIGRATION_V12: &str = "\
+UPDATE episode SET lineage_id = public_id WHERE lineage_id IS NULL;
+";
+
 /// Open a connection with the plane's fixed pragmas: WAL for concurrent
 /// reader/writer, `NORMAL` sync (durable enough with WAL, far cheaper than
 /// `FULL`), foreign keys on, and a busy timeout so a warm-task write never
@@ -639,6 +652,9 @@ pub(crate) fn migrate(conn: &Connection) -> Result<(), ContextError> {
     if version < 11 {
         tx.execute_batch(MIGRATION_V11)?;
     }
+    if version < 12 {
+        tx.execute_batch(MIGRATION_V12)?;
+    }
     // ── APPEND POINT — RESERVED SLOT ────────────────────────────────────
     // This is an ordered `if version < N` ladder and `SCHEMA_VERSION` is its
     // high-water mark. Two branches that each add "the next step" merge
@@ -658,7 +674,9 @@ pub(crate) fn migrate(conn: &Connection) -> Result<(), ContextError> {
     //   v11: the A/B recall control's durable turn counter (#1221) — TAKEN,
     //        see `MIGRATION_V11`.
     //
-    // The next free step is v12: take it and add your own line here.
+    //   v12: episode lineage repair (#5324) — TAKEN, see `MIGRATION_V12`.
+    //
+    // The next free step is v13: take it and add your own line here.
     tx.pragma_update(None, "user_version", SCHEMA_VERSION)?;
     tx.commit()?;
     Ok(())

--- a/crates/stella-context/src/store/tests.rs
+++ b/crates/stella-context/src/store/tests.rs
@@ -770,6 +770,123 @@ fn as_of_reconstructs_half_open_transaction_interval() {
     assert_eq!(neighbor_ids(&conn, a, Some(T3)), Vec::<i64>::new());
 }
 
+/// A correction backdated to before the closed edge's own `valid_from` must
+/// not write `valid_to < valid_from` (#5325): the inverted interval matches
+/// the half-open world-time test at NO instant, so the old belief would be
+/// retroactively erased from every world-time query while belief-time queries
+/// still showed it. The close clamps to `valid_from` — a well-formed empty
+/// interval, which is what "wrong from the start" honestly is.
+#[test]
+fn a_backdated_close_cannot_invert_the_world_interval() {
+    let (_dir, store) = tmp_store();
+    let conn = store.conn();
+    let (a, b) = (concept(&conn, "a"), concept(&conn, "b"));
+    let props = serde_json::json!({});
+    // World-valid from T2; corrected at T3 with a valid_to backdated to T1.
+    let e = insert_edge(
+        &conn,
+        "relates_to",
+        a,
+        b,
+        1.0,
+        &props,
+        Some(T2),
+        None,
+        T2,
+        None,
+    )
+    .unwrap();
+    close_edge(&conn, e, T3, T1).unwrap();
+
+    let (from, to): (String, String) = conn
+        .query_row(
+            "SELECT valid_from, valid_to FROM edge WHERE id = ?1",
+            params![e],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(from, T2);
+    assert_eq!(
+        to, T2,
+        "the close clamps to valid_from instead of inverting"
+    );
+
+    // A close after the start is untouched by the clamp.
+    let e2 = insert_edge(
+        &conn,
+        "relates_to",
+        a,
+        b,
+        1.0,
+        &props,
+        Some(T1),
+        None,
+        T1,
+        None,
+    )
+    .unwrap();
+    close_edge(&conn, e2, T3, T2).unwrap();
+    let to2: String = conn
+        .query_row(
+            "SELECT valid_to FROM edge WHERE id = ?1",
+            params![e2],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(to2, T2);
+}
+
+/// An episode row carries its lineage from birth (#5324): `migrate_v8`'s
+/// backfill established `lineage_id = public_id` and only runs once, so the
+/// insert has to keep the column populated or every later row decays to NULL.
+#[test]
+fn an_episode_is_born_with_its_own_lineage() {
+    let (_dir, store) = tmp_store();
+    let conn = store.conn();
+    insert_episode(
+        &conn,
+        "epi_test",
+        "a summary",
+        &serde_json::json!([]),
+        "success",
+        0.5,
+        T1,
+        T1,
+        T1,
+    )
+    .unwrap();
+    let lineage: Option<String> = conn
+        .query_row(
+            "SELECT lineage_id FROM episode WHERE public_id = 'epi_test'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(lineage.as_deref(), Some("epi_test"));
+}
+
+/// Two lineages cannot share one revision id (#5322). Revising lineage B onto
+/// text lineage A already carries used to conflict on A's row and re-parent
+/// it into B — lineage A kept its live mirror node and lost every revision,
+/// with no error anywhere. The insert now refuses, and A's history survives.
+#[test]
+fn a_revision_cannot_steal_another_lineages_row() {
+    let (_dir, store) = tmp_store();
+    let conn = store.conn();
+    insert_memory(&conn, "mem_a", "mem_a", "reflection", "the text", 0.5, T1).unwrap();
+
+    let err = insert_memory(&conn, "mem_a", "mem_b", "reflection", "the text", 0.5, T2)
+        .expect_err("a cross-lineage identity collision must refuse");
+    assert!(
+        err.to_string().contains("already belongs to lineage"),
+        "the refusal names the collision: {err}"
+    );
+
+    let history = memory_revisions(&conn, "mem_a").unwrap();
+    assert_eq!(history.len(), 1, "lineage A keeps its revision");
+    assert!(history[0].is_current());
+}
+
 #[test]
 fn as_of_ignores_world_validity_valid_from_valid_to() {
     // THE DISCRIMINATOR. An edge whose world-validity window closed in the

--- a/crates/stella-context/src/store/tests.rs
+++ b/crates/stella-context/src/store/tests.rs
@@ -775,7 +775,7 @@ fn as_of_reconstructs_half_open_transaction_interval() {
 /// the half-open world-time test at NO instant, so the old belief would be
 /// retroactively erased from every world-time query while belief-time queries
 /// still showed it. The close clamps to `valid_from` — a well-formed empty
-/// interval, which is what "wrong from the start" honestly is.
+/// interval, which is what "wrong from the start" is.
 #[test]
 fn a_backdated_close_cannot_invert_the_world_interval() {
     let (_dir, store) = tmp_store();


### PR DESCRIPTION
## What this is

The second cycle of the self-improvement correctness sweep: the three confirmed `stella-context` record-layer defects filed by the first cycle's review, each fixed with a witness verified red on the old code and green on the new.

## The defects

1. **A revision could steal another lineage's row** (#5322). A revision's `public_id` is `hash(kind, content)` — global, not lineage-scoped — so revising lineage B onto text an existing memory of lineage A already carries conflicted on A's row, and `insert_memory`'s `ON CONFLICT ... SET lineage_id = excluded.lineage_id` re-parented it: lineage A kept its live mirror node and lost every revision, silently. The insert now refuses a conflict whose existing row belongs to a different lineage — a typed `InvalidInput` naming both lineages, the same rule the ledger applies to two records claiming one id. The ordinary paths are untouched: a same-lineage re-write still upserts (`stella-cli`'s 325 memory tests pass unchanged).
   Witness: `a_revision_cannot_steal_another_lineages_row`.

2. **Episodes were born with NULL lineage** (#5324). `migrate_v8` added `episode.lineage_id` and backfilled `lineage_id = public_id`, but `insert_episode` kept inserting without the column — so every episode written after v8 carried NULL, unrepairable by a backfill that only runs below v8. The insert now writes the column, and `MIGRATION_V12` (schema 11 → 12, taking the ladder's reserved slot) repairs the rows written in between.
   Witness: `an_episode_is_born_with_its_own_lineage`.

3. **A backdated correction wrote an inverted world interval** (#5325). `close_edge` set `valid_to = COALESCE(valid_to, <correction's valid_from>)`, so a correction backdated to before the closed edge's own `valid_from` produced `valid_to < valid_from` — an interval the half-open world-time test matches at no instant, retroactively erasing the old belief from world-time queries while belief-time queries still showed it. The close now clamps to `valid_from`: a well-formed empty interval, which is what "wrong from the start" honestly is.
   Witness: `a_backdated_close_cannot_invert_the_world_interval` (the after-the-start close is pinned untouched).

## Witness verification (the artisanal way)

With the three behavior changes reverted on top of this branch:

```
cargo test -p stella-context a_revision_cannot_steal  -> red (no refusal; row re-parented)
cargo test -p stella-context an_episode_is_born       -> red (lineage NULL)
cargo test -p stella-context a_backdated_close        -> red (interval inverted)
```

Restored: `cargo test -p stella-context` — 172 passed, 0 failed; `cargo test -p stella-cli memory` — 325 passed; `cargo clippy -p stella-context --all-targets -- -D warnings` green.

Closes #5322, Closes #5324, Closes #5325

## Summary by Sourcery

Preserve record-layer lineage and temporal consistency by rejecting cross-lineage memory collisions, repairing episode lineage data, and preventing inverted edge intervals.

Bug Fixes:
- Prevent memory revisions from reassigning rows owned by another lineage by rejecting cross-lineage identity collisions.
- Ensure newly inserted episodes retain their lineage and repair existing episodes with missing lineage values.
- Clamp backdated edge closures to the edge start time to prevent invalid world-time intervals.

Tests:
- Add regression coverage for cross-lineage memory conflicts, episode lineage initialization, and backdated edge closure behavior.