### PR TITLE
fix(stella-cli): the governance doors close, and the reflection cursor stops losing lessons

### DIFF
--- a/crates/stella-cli/src/context_cmd.rs
+++ b/crates/stella-cli/src/context_cmd.rs
@@ -196,9 +196,10 @@ pub enum ContextCmd {
         /// New mode; omit to show current governance, policy version, and
         /// every ledger enforcement grant.
         mode: Option<String>,
-        /// Enable proposer/approver separation (regulated mode).
-        #[arg(long)]
-        separation: bool,
+        /// Turn proposer/approver separation on (`--separation false`
+        /// turns it off; omitted, the current setting is kept).
+        #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+        separation: Option<bool>,
         /// Confirm a mode change without asking interactively.
         #[arg(long)]
         yes: bool,

--- a/crates/stella-cli/src/context_cmd/govern.rs
+++ b/crates/stella-cli/src/context_cmd/govern.rs
@@ -28,17 +28,25 @@ use super::review::actor;
 pub(crate) fn run_govern(
     root: &Path,
     mode: Option<&str>,
-    separation: bool,
+    separation: Option<bool>,
     yes: bool,
 ) -> Result<(), String> {
-    let current = read_governance(root);
-    let Some(mode) = mode else {
-        return show_governance(root, &current);
+    let current = read_governance(root)?;
+    let target = match mode {
+        Some(mode) => parse_mode(mode)?,
+        // `--separation` with no mode is an update to the current mode, not
+        // a discarded flag (#5328) — it used to fall into the show path and
+        // silently do nothing.
+        None if separation.is_some() => current.mode,
+        None => return show_governance(root, &current),
     };
-    let target = parse_mode(mode)?;
+    // Merge with the document rather than rebuilding it from the flags:
+    // `govern regulated` without `--separation` used to silently turn an
+    // existing separation OFF (#5328). Absent means "keep what is set";
+    // `--separation false` turns it off on the record.
     let next = Governance {
         mode: target,
-        separation,
+        separation: separation.unwrap_or(current.separation),
     };
     if next == current {
         println!(
@@ -63,7 +71,7 @@ pub(crate) fn run_govern(
              records and their enforcement are unchanged until promoted under the new mode. [y/N]",
             current.mode.as_str(),
             target.as_str(),
-            if separation {
+            if next.separation {
                 ", with proposer/approver separation"
             } else {
                 ""
@@ -175,7 +183,7 @@ pub(crate) fn run_promote(
         ));
     }
 
-    let governance = read_governance(root);
+    let governance = read_governance(root)?;
     let events = read_promotions(root)?;
     let current = blocking_grants(&events)
         .get(&lineage)

--- a/crates/stella-cli/src/context_cmd/review.rs
+++ b/crates/stella-cli/src/context_cmd/review.rs
@@ -431,7 +431,17 @@ pub fn run_keep(
             // The accountable supersession event (spec §4, #2728) — file
             // first, ledger second, and a ledger failure is loud: an
             // unrecorded supersession is what the ledger exists to prevent.
-            let governance = crate::context_records::read_governance(root);
+            // The separation gate runs first (#5328): a supersession clears
+            // any blocking grant the lineage holds, so under separation the
+            // author cannot disarm their own enforced record alone.
+            let governance = crate::context_records::read_governance(root)?;
+            let approver = actor();
+            let proposer = crate::context_records::separation_checked_proposer(
+                root,
+                &record.lineage_id,
+                &approver,
+                "superseding it via `stella context keep`",
+            )?;
             crate::context_records::append_promotion(
                 root,
                 stella_core::records::promotion::PromotionEvent {
@@ -441,8 +451,8 @@ pub fn run_keep(
                     lineage_id: record.lineage_id.clone(),
                     from: "active".to_string(),
                     to: "superseded".to_string(),
-                    approver: actor(),
-                    proposer: None,
+                    approver,
+                    proposer,
                     reason: format!(
                         "{old_id} superseded by {} via `stella context keep`",
                         record.record_id.as_deref().unwrap_or("<unstamped>")

--- a/crates/stella-cli/src/context_cmd/tests.rs
+++ b/crates/stella-cli/src/context_cmd/tests.rs
@@ -950,6 +950,134 @@ fn separation_refuses_the_authors_own_grant() {
     );
 }
 
+/// #5328 door 1: a governance file that is PRESENT but broken fails closed.
+/// It used to parse-or-default, so a one-character corruption silently
+/// switched a regulated repository to solo — turning off validate's
+/// regulated check and promote's separation gate. An absent file is still
+/// the solo default.
+#[test]
+fn a_corrupt_governance_file_fails_closed_and_an_absent_one_stays_solo() {
+    let root = tempfile::tempdir().unwrap();
+
+    let absent = crate::context_records::read_governance(root.path()).unwrap();
+    assert_eq!(
+        absent.mode,
+        stella_core::records::promotion::GovernanceMode::Solo
+    );
+
+    std::fs::create_dir_all(root.path().join(RULES_DIR)).unwrap();
+    std::fs::write(
+        root.path().join(".stella/rules/governance.toml"),
+        "mode = ]]not toml",
+    )
+    .unwrap();
+    let err = crate::context_records::read_governance(root.path()).unwrap_err();
+    assert!(err.contains("does not parse"), "got: {err}");
+}
+
+/// #5328 door 2: the ledger's latest-event fold clears a lineage's blocking
+/// grant on a supersession or retraction, so disarming is an enforcement
+/// change — under separation, the record's author cannot do it alone, and
+/// an unestablishable author fails closed. A lineage holding no blocking
+/// grant passes untouched: superseding your own advisory record is
+/// authoring, not enforcement.
+#[test]
+fn separation_refuses_the_authors_own_disarm_of_a_blocking_grant() {
+    let root = tempfile::tempdir().unwrap();
+    let lineage = "ctx.acme.web.no-force-push";
+    write_guarded_project_record(root.path(), lineage);
+    let event = stella_core::records::decision::DecisionEvent::keep(
+        "no-force-push-1234abcd",
+        lineage,
+        "author@example.test",
+        "2026-08-01T00:00:00Z",
+        format!("{RULES_DIR}/{lineage}.toml"),
+    );
+    crate::context_records::append_decision(root.path(), &event).unwrap();
+    crate::context_records::write_governance(
+        root.path(),
+        &stella_core::records::promotion::Governance {
+            mode: stella_core::records::promotion::GovernanceMode::Regulated,
+            separation: true,
+        },
+    )
+    .unwrap();
+
+    // No blocking grant yet: the author may retire their own advisory record.
+    crate::context_records::separation_checked_proposer(
+        root.path(),
+        lineage,
+        "author@example.test",
+        "superseding it",
+    )
+    .expect("an advisory record's author may supersede it");
+
+    govern::run_promote(
+        root.path(),
+        lineage,
+        "blocking",
+        "reviewed by a second pair of eyes",
+        Some("lead@example.test"),
+    )
+    .unwrap();
+
+    let refused = crate::context_records::separation_checked_proposer(
+        root.path(),
+        lineage,
+        "author@example.test",
+        "superseding it",
+    )
+    .unwrap_err();
+    assert!(refused.contains("cannot do that alone"), "got: {refused}");
+
+    let proposer = crate::context_records::separation_checked_proposer(
+        root.path(),
+        lineage,
+        "second@example.test",
+        "superseding it",
+    )
+    .unwrap();
+    assert_eq!(
+        proposer.as_deref(),
+        Some("author@example.test"),
+        "the event carries the author it protected"
+    );
+}
+
+/// #5328 door 3: `govern <mode>` merges with the document instead of
+/// rebuilding it from the flags — an omitted `--separation` keeps the
+/// current setting, `--separation false` turns it off on the record, and
+/// `--separation` with no mode updates the current mode instead of being
+/// silently discarded.
+#[test]
+fn govern_keeps_separation_unless_told_otherwise() {
+    let root = tempfile::tempdir().unwrap();
+    crate::context_records::write_governance(
+        root.path(),
+        &stella_core::records::promotion::Governance {
+            mode: stella_core::records::promotion::GovernanceMode::Regulated,
+            separation: true,
+        },
+    )
+    .unwrap();
+
+    govern::run_govern(root.path(), Some("team"), None, true).unwrap();
+    let g = crate::context_records::read_governance(root.path()).unwrap();
+    assert_eq!(
+        g.mode,
+        stella_core::records::promotion::GovernanceMode::Team
+    );
+    assert!(g.separation, "an omitted flag keeps separation on");
+
+    govern::run_govern(root.path(), None, Some(false), true).unwrap();
+    let g = crate::context_records::read_governance(root.path()).unwrap();
+    assert_eq!(
+        g.mode,
+        stella_core::records::promotion::GovernanceMode::Team
+    );
+    assert!(!g.separation, "an explicit false turns it off");
+}
+
 /// #994 acceptance (c): validate fails on a hash mismatch — an edited grant
 /// is a governance failure regardless of what the records say.
 #[test]

--- a/crates/stella-cli/src/context_cmd/validate.rs
+++ b/crates/stella-cli/src/context_cmd/validate.rs
@@ -117,7 +117,7 @@ pub fn run_validate(root: &Path, format: QueryFormat) -> Result<(), String> {
     // records themselves say — an edited grant is worse than a missing one.
     let promotions = crate::context_records::read_promotions(root)
         .map_err(|violation| format!("promotion ledger failed verification: {violation}"))?;
-    let governance = crate::context_records::read_governance(root);
+    let governance = crate::context_records::read_governance(root)?;
 
     let files = rule_files(root, true, true);
     let now = now_rfc3339();

--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -76,12 +76,83 @@ pub(crate) const GOVERNANCE_FILE: &str = ".stella/rules/governance.toml";
 const PROMOTION_LOCK: &str = ".stella/private/promotions.lock";
 
 /// Read the governance settings; absent file = solo defaults (§5.1).
-pub(crate) fn read_governance(root: &Path) -> stella_core::records::promotion::Governance {
+///
+/// A file that is PRESENT but unreadable or unparseable fails closed
+/// (#5328): governance selects the enforcement tier, so a one-character
+/// corruption must not silently switch a regulated repository back to solo
+/// defaults — turning off validate's regulated check and promote's
+/// separation gate with nothing on screen. The broken ledger beside it
+/// already fails loudly; the file that decides how strictly the ledger is
+/// held must not be softer than the ledger.
+pub(crate) fn read_governance(
+    root: &Path,
+) -> Result<stella_core::records::promotion::Governance, String> {
     let path = root.join(GOVERNANCE_FILE);
-    std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|text| toml::from_str(&text).ok())
-        .unwrap_or_default()
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(stella_core::records::promotion::Governance::default());
+        }
+        Err(e) => return Err(format!("cannot read {}: {e}", path.display())),
+    };
+    toml::from_str(&text).map_err(|e| {
+        format!(
+            "{} does not parse: {e} — this file selects the governance tier, so it \
+             must be repaired (or deleted to return to solo defaults) rather than \
+             silently ignored",
+            path.display()
+        )
+    })
+}
+
+/// The separation gate for a lifecycle event that would DISARM enforcement,
+/// returning the record's author (as the event's `proposer`) once it holds.
+///
+/// The ledger's latest-event fold retains only grant events, so a
+/// `Superseded`/`Retired` event on a lineage clears its blocking grant — a
+/// supersession or retraction is an enforcement change exactly as much as the
+/// grant was, and it used to run with no separation check while `stella
+/// context promote` failed closed (#5328). Under regulated mode with
+/// separation on, a lineage holding a live blocking grant cannot be disarmed
+/// by its own author acting alone, and an author the decision ledger cannot
+/// establish fails closed the way `run_promote` already does. Lineages with
+/// no live blocking grant pass untouched: superseding your own advisory
+/// record is authoring, not enforcement.
+pub(crate) fn separation_checked_proposer(
+    root: &Path,
+    lineage_id: &str,
+    approver: &str,
+    act: &str,
+) -> Result<Option<String>, String> {
+    let governance = read_governance(root)?;
+    let proposer = read_decisions(root)
+        .iter()
+        .filter(|event| event.lineage_id == lineage_id && event.decision.publishes())
+        .map(|event| event.actor.clone())
+        .next_back();
+    if !(governance.mode == stella_core::records::promotion::GovernanceMode::Regulated
+        && governance.separation)
+    {
+        return Ok(proposer);
+    }
+    let events = read_promotions(root)?;
+    if !stella_core::records::promotion::blocking_grants(&events).contains_key(lineage_id) {
+        return Ok(proposer);
+    }
+    match &proposer {
+        None => Err(format!(
+            "proposer/approver separation is on, and {lineage_id} holds a live blocking \
+             grant whose author could not be established from the decision ledger — {act} \
+             would disarm that grant; record the authorship first, or have a different \
+             identity run this"
+        )),
+        Some(author) if author == approver => Err(format!(
+            "proposer/approver separation is on: {author} authored {lineage_id}, which \
+             holds a live blocking grant — {act} would disarm it, and its author cannot \
+             do that alone; a different identity must run this"
+        )),
+        Some(_) => Ok(proposer),
+    }
 }
 
 /// Write the governance settings. Callers ask the user first (§5.4) — this

--- a/crates/stella-cli/src/ingest_cmd/refresh.rs
+++ b/crates/stella-cli/src/ingest_cmd/refresh.rs
@@ -201,7 +201,17 @@ fn published_from_source(root: &Path, rel: &str) -> Vec<PublishedFile> {
 /// revokes any blocking grant the lineage held, which is correct: a retired
 /// record must not keep the authority to deny tool calls.
 fn record_retirement(root: &Path, rel: &str, claim: &PublishedClaim) -> Result<(), String> {
-    let governance = crate::context_records::read_governance(root);
+    let governance = crate::context_records::read_governance(root)?;
+    // Retirement clears any blocking grant the lineage holds, so the
+    // separation gate runs first (#5328) — same rule as `context keep`'s
+    // supersession path.
+    let approver = crate::context_cmd::actor();
+    let proposer = crate::context_records::separation_checked_proposer(
+        root,
+        &claim.lineage_id,
+        &approver,
+        "retiring it via `stella ingest --refresh`",
+    )?;
     crate::context_records::append_promotion(
         root,
         stella_core::records::promotion::PromotionEvent {
@@ -211,8 +221,8 @@ fn record_retirement(root: &Path, rel: &str, claim: &PublishedClaim) -> Result<(
             lineage_id: claim.lineage_id.clone(),
             from: "active".to_string(),
             to: "archived".to_string(),
-            approver: crate::context_cmd::actor(),
-            proposer: None,
+            approver,
+            proposer,
             reason: format!(
                 "retired by `stella ingest --refresh {rel}`: the source no longer asserts \
                  {} (was {})",

--- a/crates/stella-cli/src/memory/observations.rs
+++ b/crates/stella-cli/src/memory/observations.rs
@@ -105,8 +105,49 @@ pub(crate) fn extract_reflection_observations(store: &ContextStore, log_path: &P
     // the new content that now sits under the old offset.
     let start = if consumed > lines.len() { 0 } else { consumed };
 
+    let (appended, consumed_to) =
+        consume(&lines, start, |lesson| append_observation(store, lesson));
+
+    // Advanced last and best-effort. If this write fails the next turn re-scans
+    // and re-derives the same ids, which the ledger absorbs as replays.
+    let _ = store.set_extraction_cursor(REFLECTION_SOURCE, &consumed_to.to_string());
+    appended
+}
+
+/// What consuming one log line concluded, as the cursor cares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineOutcome {
+    /// A genuinely new record landed.
+    Appended,
+    /// Consumed with nothing to add: a replay, or a record the
+    /// redaction/typing stage refused. Deterministic either way — re-reading
+    /// the line can never change the answer — so the cursor may move past it.
+    Consumed,
+    /// The ledger write itself failed: SQLITE_BUSY from a concurrent process
+    /// past the busy timeout, a full disk. Transient by nature — the same
+    /// line can succeed on the next scan — so the cursor must not move past
+    /// it.
+    StoreFailed,
+}
+
+/// Consume `lines[start..]`, returning `(newly appended, cursor position)`.
+///
+/// The cursor advances to the first line whose ledger write FAILED, and never
+/// past it (#5323). It used to advance to `lines.len()` unconditionally,
+/// which put every failed line below the cursor forever — the module header's
+/// "a crash costs one re-scan, never a duplicate" held for crashes and not
+/// for failures, and the lexical path (which re-reads the whole log) did not
+/// share the loss, so the two paths diverged exactly here. Later lines are
+/// still consumed in the same pass; their successes replay as no-ops on the
+/// re-scan, which content-derived ids make free.
+fn consume(
+    lines: &[&str],
+    start: usize,
+    mut append: impl FnMut(&ReflectionLesson) -> LineOutcome,
+) -> (usize, usize) {
     let mut appended = 0usize;
-    for line in &lines[start..] {
+    let mut stop: Option<usize> = None;
+    for (offset, line) in lines[start..].iter().enumerate() {
         let Ok(lesson) = serde_json::from_str::<ReflectionLesson>(line) else {
             continue;
         };
@@ -116,25 +157,25 @@ pub(crate) fn extract_reflection_observations(store: &ContextStore, log_path: &P
         // Only a genuinely NEW record counts. A replay reports `AlreadyPresent`
         // and must not inflate the number, or "how many observations did this
         // turn produce" becomes "how many lines did it re-read".
-        if append_observation(store, &lesson) == Some(AppendOutcome::Appended) {
-            appended += 1;
+        match append(&lesson) {
+            LineOutcome::Appended => appended += 1,
+            LineOutcome::Consumed => {}
+            LineOutcome::StoreFailed => {
+                stop.get_or_insert(start + offset);
+            }
         }
     }
-
-    // Advanced last and best-effort. If this write fails the next turn re-scans
-    // and re-derives the same ids, which the ledger absorbs as replays.
-    let _ = store.set_extraction_cursor(REFLECTION_SOURCE, &lines.len().to_string());
-    appended
+    (appended, stop.unwrap_or(lines.len()))
 }
 
-/// Redact, type, and append one lesson. `None` on any failure.
-fn append_observation(store: &ContextStore, lesson: &ReflectionLesson) -> Option<AppendOutcome> {
+/// Redact, type, and append one lesson.
+fn append_observation(store: &ContextStore, lesson: &ReflectionLesson) -> LineOutcome {
     // Redaction happens BEFORE the record is constructed, so no unredacted
     // typed record ever exists — not even transiently in memory as something a
     // later refactor could persist by accident.
     let redaction = redact_secrets(&lesson.lesson);
 
-    let record = ObservationRecord::new(
+    let Ok(record) = ObservationRecord::new(
         ObservationSource::ReflectionLesson,
         format!("reflection:{}", lesson.occurred_at),
         task_id_for(lesson),
@@ -142,23 +183,27 @@ fn append_observation(store: &ContextStore, lesson: &ReflectionLesson) -> Option
         lesson.domains.clone(),
         redaction.redacted,
         rfc3339(lesson.occurred_at),
-    )
-    .ok()?;
+    ) else {
+        return LineOutcome::Consumed;
+    };
 
-    let body = serde_json::to_string(&record).ok()?;
-    let outcome = store
-        .append_record(LedgerAppend {
-            record_id: &record.record_id,
-            lineage_id: &record.lineage_id,
-            record_kind: stella_core::context_record::ContextRecordKind::Observation.as_str(),
-            record_hash: &record.record_hash,
-            schema_version: LIFECYCLE_SCHEMA_VERSION,
-            body: &body,
-            observed_at: &record.observed_at,
-            supersedes: None,
-        })
-        .ok()?;
-    Some(outcome)
+    let Ok(body) = serde_json::to_string(&record) else {
+        return LineOutcome::Consumed;
+    };
+    match store.append_record(LedgerAppend {
+        record_id: &record.record_id,
+        lineage_id: &record.lineage_id,
+        record_kind: stella_core::context_record::ContextRecordKind::Observation.as_str(),
+        record_hash: &record.record_hash,
+        schema_version: LIFECYCLE_SCHEMA_VERSION,
+        body: &body,
+        observed_at: &record.observed_at,
+        supersedes: None,
+    }) {
+        Ok(AppendOutcome::Appended) => LineOutcome::Appended,
+        Ok(_) => LineOutcome::Consumed,
+        Err(_) => LineOutcome::StoreFailed,
+    }
 }
 
 /// Every observation in the ledger, oldest first — what the miner consumes.

--- a/crates/stella-cli/src/memory/observations/tests.rs
+++ b/crates/stella-cli/src/memory/observations/tests.rs
@@ -102,6 +102,61 @@ fn a_shrunken_log_restarts_from_the_beginning() {
     assert_eq!(all_observations(&store, 100).len(), 4);
 }
 
+/// #5323's witness. A transient ledger failure (SQLITE_BUSY past the busy
+/// timeout, a full disk) used to be swallowed while the cursor advanced to
+/// `lines.len()` — the failed lessons sat below the cursor forever, lost with
+/// no trace. The cursor now stops at the first failed line; the lines after
+/// it are still consumed in the same pass, and re-scanning them is a no-op
+/// replay.
+#[test]
+fn a_failed_append_holds_the_cursor_at_the_failed_line() {
+    let mk = |text: &str, at: u64| {
+        serde_json::to_string(&ReflectionLesson {
+            lesson: text.to_string(),
+            domains: vec!["testing".into()],
+            occurred_at: at,
+            task_id: String::new(),
+            trigger: String::new(),
+            saves: String::new(),
+            kind: crate::memory::LessonKind::Process,
+        })
+        .expect("serialize")
+    };
+    let owned = [mk("A.", 100), mk("B.", 200), mk("C.", 300)];
+    let lines: Vec<&str> = owned.iter().map(String::as_str).collect();
+
+    // The middle line's write fails; both its neighbors land.
+    let (appended, cursor) = consume(&lines, 0, |lesson| {
+        if lesson.occurred_at == 200 {
+            LineOutcome::StoreFailed
+        } else {
+            LineOutcome::Appended
+        }
+    });
+    assert_eq!(
+        appended, 2,
+        "the lines after the failure are still consumed"
+    );
+    assert_eq!(
+        cursor, 1,
+        "the cursor stops at the failed line, not past it"
+    );
+
+    // With every write landing, the cursor consumes the whole log.
+    let (appended, cursor) = consume(&lines, 0, |_| LineOutcome::Appended);
+    assert_eq!((appended, cursor), (3, 3));
+
+    // A deterministic refusal (redaction/typing) is consumed, never wedges.
+    let (appended, cursor) = consume(&lines, 0, |lesson| {
+        if lesson.occurred_at == 200 {
+            LineOutcome::Consumed
+        } else {
+            LineOutcome::Appended
+        }
+    });
+    assert_eq!((appended, cursor), (2, 3));
+}
+
 #[test]
 fn only_new_lines_are_extracted_after_a_cursor_advance() {
     let (dir, store) = store();

--- a/crates/stella-cli/src/proposals_cmd/retract.rs
+++ b/crates/stella-cli/src/proposals_cmd/retract.rs
@@ -209,7 +209,17 @@ fn retract_in_place(published: &mut Published) -> Result<(), String> {
 /// asserting a claim, and the same fold that drops any blocking grant the
 /// lineage held.
 fn record_retraction(workspace_root: &Path, lineage_id: &str, reason: &str) -> Result<(), String> {
-    let governance = crate::context_records::read_governance(workspace_root);
+    let governance = crate::context_records::read_governance(workspace_root)?;
+    // Retirement clears any blocking grant the lineage holds, so the
+    // separation gate runs first (#5328) — same rule as `context keep`'s
+    // supersession path.
+    let approver = crate::context_cmd::actor();
+    let proposer = crate::context_records::separation_checked_proposer(
+        workspace_root,
+        lineage_id,
+        &approver,
+        "retracting it via `stella proposals retract`",
+    )?;
     crate::context_records::append_promotion(
         workspace_root,
         stella_core::records::promotion::PromotionEvent {
@@ -219,8 +229,8 @@ fn record_retraction(workspace_root: &Path, lineage_id: &str, reason: &str) -> R
             lineage_id: lineage_id.to_string(),
             from: RecordStatus::Active.as_str().to_string(),
             to: RecordStatus::Retracted.as_str().to_string(),
-            approver: crate::context_cmd::actor(),
-            proposer: None,
+            approver,
+            proposer,
             reason: format!("retracted by `stella proposals retract`: {}", reason.trim()),
             mode: governance.mode.as_str().to_string(),
             action: stella_core::records::promotion::LedgerAction::Retired,


### PR DESCRIPTION
## What this is

The second cycle of the self-improvement correctness sweep, `stella-cli` half: the reflection-extraction cursor loss (#5323) and the three governance doors (#5328), each fixed with witnesses verified red on the old code and green on the new.

## The defects

1. **A transient ledger failure permanently lost reflection lessons** (#5323). The typed extraction loop swallowed `append_observation` failures (SQLITE_BUSY past the busy timeout, a full disk) and advanced the cursor to `lines.len()` unconditionally — the failed lessons sat below the cursor forever, while the lexical path (which re-reads the whole log) did not share the loss. The per-line outcome is now typed (`LineOutcome`): a replay or a *deterministic* refusal is consumed — so a permanently malformed lesson can never wedge the cursor — and only a transient store failure holds it, at the first failed line. Later lines are still consumed in the same pass; the re-scan replays them as no-ops, which content-derived ids make free.
   Witness: `a_failed_append_holds_the_cursor_at_the_failed_line`, driven through the loop's injectable append seam (the failure a real store produces here is SQLITE_BUSY under concurrent load, which a test cannot force deterministically without a five-second busy-timeout stall per line; the seam is the same code path with only the store call injected).

2. **Governance-mode enforcement had three doors around it** (#5328):
   - `read_governance` failed OPEN — a one-character corruption of `governance.toml` silently became solo defaults, switching off validate's regulated check and promote's separation gate. It now fails closed with the repair named; an absent file stays solo.
   - The ledger's latest-event fold clears a lineage's blocking grant on a `Superseded`/`Retired` event — so `context keep`'s supersession, `proposals retract`, and `ingest --refresh` each *disarmed enforcement* with no separation check and `proposer: None`. All three now run one shared gate (`separation_checked_proposer`): under regulated+separation, a lineage holding a live blocking grant cannot be disarmed by its own author alone, an unestablishable author fails closed (the `run_promote` rule), and the event records the author it protected. Advisory records pass untouched — superseding your own advisory record is authoring, not enforcement.
   - `govern` rebuilt `Governance` from the flags: `govern regulated` without `--separation` silently turned an existing separation OFF, and `--separation` with no mode was discarded by the show path. The flag is now `Option<bool>` (absent keeps the current setting; `--separation false` turns it off on the record) and a bare `--separation` updates the current mode.
   Witnesses: `a_corrupt_governance_file_fails_closed_and_an_absent_one_stays_solo`, `separation_refuses_the_authors_own_disarm_of_a_blocking_grant`, `govern_keeps_separation_unless_told_otherwise`.

## Witness verification (the artisanal way)

With the four behavior changes reverted on top of this branch (cursor stop removed, parse-or-default restored, gate neutralized, flag-rebuild restored): all four witnesses red. Restored: `cargo test -p stella-cli context` (119 passed), `observations` (14 passed); `cargo clippy -p stella-cli --all-targets -- -D warnings`, `make prose`, and `make command-docs` green.

Closes #5323, Closes #5328

## Summary by Sourcery

Close governance enforcement bypasses and make reflection extraction recover safely from transient ledger failures.

Bug Fixes:
- Preserve reflection lessons after transient ledger write failures by keeping the extraction cursor at the first failed line while consuming later lines safely.
- Fail closed on unreadable or malformed governance configuration instead of silently reverting to solo defaults.
- Enforce proposer/approver separation when superseding, retracting, or retiring records that hold live blocking grants.
- Prevent governance commands from unintentionally changing or discarding the existing separation setting.

Enhancements:
- Centralize governance checks for lifecycle actions that can disarm enforcement and record the protected author in resulting events.

Tests:
- Add regression coverage for reflection cursor recovery, corrupt governance files, enforcement disarm protection, and governance flag merging.