### PR TITLE
test(stella-cli): cover the arm that turns a manifest event into a receipt

### DIFF
--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -1065,6 +1065,10 @@ mod pipeline_variant_tests;
 #[cfg(test)]
 mod usage_recovery_tests;
 
+// The receipt plane's write path — the arm below had no test of its own.
+#[cfg(test)]
+mod receipt_write_tests;
+
 #[cfg(test)]
 mod run_terminator_tests {
     use super::*;

--- a/crates/stella-cli/src/agent/persistence/receipt_write_tests.rs
+++ b/crates/stella-cli/src/agent/persistence/receipt_write_tests.rs
@@ -1,0 +1,70 @@
+//! The receipt plane's write path, covered end to end.
+//!
+//! `record_step_manifest` had tests; the arm of `persist_event_detailed` that
+//! calls it had none, so nothing anywhere asserted that a `StepManifest` event
+//! turns into the two rows a prompt reconstruction is rebuilt from. That gap is
+//! where #5255 was hunted, and it is worth closing whatever that turns out to
+//! have been: this is the only test that fails if the arm is deleted, renamed
+//! or given a row it cannot write.
+
+use super::*;
+
+fn manifest_event() -> AgentEvent {
+    AgentEvent::StepManifest {
+        turn_instance: 0,
+        step: 1,
+        call_seq: 0,
+        role: stella_protocol::ModelCallRole::Worker,
+        provider: "openrouter".into(),
+        upstream_provider: None,
+        model: "moonshotai/kimi-k3".into(),
+        blocks: vec![stella_protocol::ManifestEntry {
+            block_id: "blk_1dfbdb3ce2c541220dfa27b7".into(),
+            cache_zone: stella_protocol::CacheZone::StablePrefix,
+            token_cost: 2033,
+            resident_since_step: 1,
+            message_index: 0,
+            call_id: None,
+        }],
+        effective_budget_tokens: 153_159,
+        calibration_factor: 1.0,
+        estimated_input_tokens: 2_194,
+        stall_seconds_requested: None,
+        compiled_frame: None,
+    }
+}
+
+/// One manifest event, both rows.
+///
+/// The values are the ones a real turn recorded (execution 321 of this
+/// repository's own store), so the test exercises the shape the engine emits
+/// rather than a shape invented to pass.
+#[test]
+fn a_manifest_event_lands_its_receipt_and_entries() {
+    let store = stella_store::Store::in_memory().expect("store");
+    let execution_id = store
+        .begin_execution("deck", "prompt", "openrouter", "moonshotai/kimi-k3")
+        .expect("begin");
+
+    let outcome = persist_event_detailed(&store, execution_id, 0, &manifest_event(), "openrouter");
+    assert!(
+        outcome.is_complete(),
+        "persisting a manifest reported {outcome:?}"
+    );
+
+    let entries = store
+        .step_manifest(execution_id, 0, 1, 0)
+        .expect("read the manifest back");
+    assert_eq!(
+        entries.len(),
+        1,
+        "the event's one block should be one manifest row"
+    );
+    assert_eq!(entries[0].block_id, "blk_1dfbdb3ce2c541220dfa27b7");
+    // The header carries the call's identity, which is what the reconstruction
+    // addresses a receipt by.
+    let calls = store
+        .recorded_calls(execution_id)
+        .expect("read the receipt header back");
+    assert_eq!(calls.len(), 1, "one call, one receipt header");
+}


### PR DESCRIPTION
Refs #5255

## What this adds

One test, covering the arm of `persist_event_detailed` that turns an
`AgentEvent::StepManifest` into a `step_receipt` header and its `step_manifest`
entries. `record_step_manifest` has tests; this arm had none.

The values are the ones execution 321 of this repository's own store actually
recorded, so it exercises the shape the engine emits rather than one invented
to pass.

## Why it is worth a PR on its own

That untested seam is where #5255 lived. This workspace's store holds 1,258
`step_manifest` events with zero rows in either receipt table, and the
investigation was slow precisely because the store write was covered and the
event path was not — so there was no way to tell which side to suspect without
writing this.

Writing it answered the question: **the arm works.** It writes both rows,
against an in-memory store and against a file-backed copy of the live
database. That, plus the probes recorded on #5255, excludes the store, the
schema, the SQL, the row conversion, a stale binary, prune, migration data
loss, a dead code path, and brief lock contention.

## No witness, and why

The arm works on `main`, so there is no fail-to-pass flip to show — this is
coverage, in the class `CONTRIBUTING.md` exempts. What it buys is that the arm
cannot be deleted, renamed, or handed a row it cannot write without something
going red.

## What is still open

#5255 stays open: the cause of the historical loss is unidentified, and I have
said so on the issue rather than offering a third theory. One theory I raised
there is now falsified in writing — a brief write-lock collision does *not*
cost the receipt, because the store's `busy_timeout` is honoured.

Two follow-ups are recorded on the issue: a non-fatal signal when a receipt
write fails (today it is `let _ =`, which is deliberate policy about not
failing the turn, but silence is a separate choice from that), and #5382, which
would let the Observatory rebuild the call index from the journal — where all
1,258 manifests still are — so the prompt inspector works whatever the write
bug turns out to be.

## Checks

`cargo test -p stella-cli --bin stella receipt_write` passes,
`cargo clippy -p stella-cli --all-targets` is clean, `cargo fmt --check` is
clean, and `make guards-fast` passes.

## Summary by Sourcery

Cover the StepManifest receipt persistence path to prevent regressions in recording receipt headers and manifest entries.

Enhancements:
- Add end-to-end coverage ensuring StepManifest events produce both receipt headers and manifest entries.

Tests:
- Add an in-memory persistence test covering the receipt-writing path for a manifest event.