### PR TITLE
fix(bench): the frozen replay analyzer supplies its own posture schema

### DIFF
--- a/bench/harbor_adapter/stella_harbor/secure_launcher.py
+++ b/bench/harbor_adapter/stella_harbor/secure_launcher.py
@@ -110,6 +110,28 @@ _FIXED_LEDGER_PATH = "bench/evidence/stella-tb21-run-ledger.json"
 _FIXED_MANIFEST_PATH = "bench/evidence/stella-tb21-study-manifest.json"
 _FIXED_ANALYZER_PATH = "bench/terminal_bench_analysis/tb21_analysis.py"
 _FIXED_PUBLIC_TIMING_PATH = "bench/terminal_bench_analysis/github_public_timing.py"
+# The analyzer's sibling, split out of it by #2549 as "a size boundary, not a
+# new address" — `tb21_analysis` imports it at module scope and re-exports its
+# names. It joins the frozen set for the same reason the analyzer is in it: its
+# bytes decide what the replay computes.
+#
+# Without this the loader execed the analyzer with nothing supplying
+# `tb21_posture_schema`, so the import at the top of that file resolved only
+# when some earlier importer had already put the analyzer's directory on
+# `sys.path`. Running the launcher's own test file alone did not, and the two
+# refusal tests there got "replay analyzer could not be loaded" instead of the
+# specific refusal they assert — a launcher whose refusal reason depends on
+# import-order luck (#5108).
+_FIXED_POSTURE_SCHEMA_PATH = "bench/terminal_bench_analysis/tb21_posture_schema.py"
+# Pinned here rather than derived, because a hash the loader computes from the
+# file it is about to run proves nothing. This literal lives in a file that is
+# itself in `_FIXED_ADAPTER_SOURCE_PATHS`, so it is covered by `adapter_sha256`
+# and byte-compared against the published commit — the same chain that already
+# authorises the analyzer. `test_posture_schema_pin_matches_the_frozen_file`
+# fails the moment the two drift.
+_FIXED_POSTURE_SCHEMA_SHA256 = (
+    "be6c8ac5bd142aece32b73f4565b422db73eb7fc366c66482ca61de5091f08d3"
+)
 _FIXED_PROTOCOL_PATH = "bench/terminal-bench-2.1-protocol.md"
 # Every Python source in the adapter package, enumerated rather than globbed:
 # the public-tree check compares this exact set against the published commit,
@@ -154,6 +176,21 @@ _FIXED_READINESS_SOURCE_PATHS = (
     "bench/readiness/synthetic-adapter-sentinel/instruction.md",
     "bench/readiness/synthetic-adapter-sentinel/task.toml",
     "bench/readiness/synthetic-adapter-sentinel/tests/test.sh",
+)
+# The frozen sources outside the adapter package: byte-compared against the
+# published commit like the adapter's own, but not folded into `adapter_sha256`.
+#
+# A name rather than a tuple built at the one call site, so the tests can drive
+# the check against the same list it enforces. The fake published tree in
+# `test_secure_launcher.py` used to re-list these by hand, and adding
+# `_FIXED_POSTURE_SCHEMA_PATH` reddened thirty tests that were each correct
+# about a list that no longer matched.
+_FIXED_NON_ADAPTER_SOURCE_PATHS = (
+    _FIXED_ANALYZER_PATH,
+    _FIXED_PUBLIC_TIMING_PATH,
+    _FIXED_POSTURE_SCHEMA_PATH,
+    _FIXED_PROTOCOL_PATH,
+    *_FIXED_READINESS_SOURCE_PATHS,
 )
 _RUN_LEDGER_SCHEMA = "stella-tb21-run-ledger-v2"
 _GITHUB_ATTESTATION_SCHEMA = "stella-tb21-github-attestation-v2"
@@ -1619,13 +1656,27 @@ def _validate_confirmatory_manifest(
 
 
 def _load_frozen_replay_analyzer(runtime_identity: Mapping[str, Any]) -> ModuleType:
-    """Execute the exact source-bound analyzer bytes without consulting ``.pyc``."""
+    """Execute the exact source-bound analyzer bytes without consulting ``.pyc``.
+
+    Three modules, not two. ``tb21_analysis`` imports ``tb21_posture_schema`` at
+    module scope, so the analyzer cannot execute without it — and nothing here
+    supplied it, nor put its directory on ``sys.path``. The import therefore
+    resolved on whatever some earlier importer happened to have done, which made
+    the launcher's refusal reason depend on import order (#5108).
+
+    The schema is supplied the same way the timing verifier is, rather than by
+    widening ``sys.path``: an entry on the path would let *any* importable
+    ``tb21_posture_schema`` execute here, and executing unverified bytes is the
+    one thing this function exists to prevent.
+    """
     repository_root = Path(__file__).resolve().parents[3]
     analyzer_path = repository_root / _FIXED_ANALYZER_PATH
     timing_path = repository_root / _FIXED_PUBLIC_TIMING_PATH
+    schema_path = repository_root / _FIXED_POSTURE_SCHEMA_PATH
     try:
         analyzer_raw = analyzer_path.read_bytes()
         timing_raw = timing_path.read_bytes()
+        schema_raw = schema_path.read_bytes()
     except OSError as exc:
         raise RuntimeError(
             "prior-stage replay cannot read the frozen analyzer"
@@ -1636,19 +1687,34 @@ def _load_frozen_replay_analyzer(runtime_identity: Mapping[str, Any]) -> ModuleT
         "analysis_sha256"
     ) or timing_sha256 != runtime_identity.get("public_timing_sha256"):
         raise RuntimeError("prior-stage replay analyzer bytes drifted")
+    # Against the pin above rather than against `runtime_identity`, which has no
+    # field for it: the study manifest is preregistered at a fixed version, and
+    # adding a field would refuse every manifest already recorded. The pin is in
+    # this file, which `adapter_sha256` covers and the public-tree check
+    # byte-compares, so the chain of authority is unbroken.
+    if hashlib.sha256(schema_raw).hexdigest() != _FIXED_POSTURE_SCHEMA_SHA256:
+        raise RuntimeError("prior-stage replay posture schema bytes drifted")
 
     timing_module = ModuleType("github_public_timing")
     timing_module.__file__ = str(timing_path)
     timing_module.__package__ = ""
+    schema_module = ModuleType("tb21_posture_schema")
+    schema_module.__file__ = str(schema_path)
+    schema_module.__package__ = ""
     analyzer_module = ModuleType("_stella_tb21_paid_stage_replay")
     analyzer_module.__file__ = str(analyzer_path)
     analyzer_module.__package__ = ""
     previous_timing = sys.modules.get("github_public_timing")
+    previous_schema = sys.modules.get("tb21_posture_schema")
     previous_analyzer = sys.modules.get(analyzer_module.__name__)
     try:
         sys.modules["github_public_timing"] = timing_module
         exec(  # noqa: S102 - exact verified source bytes are the replay authority
             compile(timing_raw, str(timing_path), "exec"), timing_module.__dict__
+        )
+        sys.modules["tb21_posture_schema"] = schema_module
+        exec(  # noqa: S102 - exact verified source bytes are the replay authority
+            compile(schema_raw, str(schema_path), "exec"), schema_module.__dict__
         )
         sys.modules[analyzer_module.__name__] = analyzer_module
         exec(  # noqa: S102 - exact verified source bytes are the replay authority
@@ -1662,6 +1728,10 @@ def _load_frozen_replay_analyzer(runtime_identity: Mapping[str, Any]) -> ModuleT
             sys.modules.pop("github_public_timing", None)
         else:
             sys.modules["github_public_timing"] = previous_timing
+        if previous_schema is None:
+            sys.modules.pop("tb21_posture_schema", None)
+        else:
+            sys.modules["tb21_posture_schema"] = previous_schema
         if previous_analyzer is None:
             sys.modules.pop(analyzer_module.__name__, None)
         else:
@@ -2407,12 +2477,7 @@ def _verify_public_runtime_sources(
     adapter_prefix = "bench/harbor_adapter/stella_harbor/"
     expected_adapter_paths = set(_FIXED_ADAPTER_SOURCE_PATHS)
     expected_readiness_paths = set(_FIXED_READINESS_SOURCE_PATHS)
-    fixed_paths = (
-        _FIXED_ANALYZER_PATH,
-        _FIXED_PUBLIC_TIMING_PATH,
-        _FIXED_PROTOCOL_PATH,
-        *_FIXED_READINESS_SOURCE_PATHS,
-    )
+    fixed_paths = _FIXED_NON_ADAPTER_SOURCE_PATHS
     local_bytes: dict[str, bytes] = {}
     for relative in (*_FIXED_ADAPTER_SOURCE_PATHS, *fixed_paths):
         path = repository_root / relative

--- a/bench/harbor_adapter/tests/test_frozen_replay_analyzer.py
+++ b/bench/harbor_adapter/tests/test_frozen_replay_analyzer.py
@@ -1,0 +1,114 @@
+"""The frozen replay analyzer's own load path (#5108).
+
+Its own file rather than more of `test_secure_launcher.py`, which is
+grandfathered at its size ceiling: `scripts/check-file-size.sh` refuses growth
+there, and raising the ceiling to fit three tests is the expedient CLAUDE.md
+forbids.
+
+Every test here runs standalone by construction, which is the property under
+test — the defect was a loader whose success depended on what some earlier
+importer had put on `sys.path`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the package")
+
+import stella_harbor.secure_launcher as launcher_module  # noqa: E402
+
+
+def _repository_root() -> Path:
+    return Path(launcher_module.__file__).resolve().parents[3]
+
+
+def _identity_for_the_frozen_files() -> dict[str, str]:
+    """The runtime identity a manifest would carry for the tree as it stands."""
+    root = _repository_root()
+    return {
+        "analysis_sha256": hashlib.sha256(
+            (root / launcher_module._FIXED_ANALYZER_PATH).read_bytes()
+        ).hexdigest(),
+        "public_timing_sha256": hashlib.sha256(
+            (root / launcher_module._FIXED_PUBLIC_TIMING_PATH).read_bytes()
+        ).hexdigest(),
+    }
+
+
+def test_posture_schema_pin_matches_the_frozen_file() -> None:
+    """The pin the loader verifies against is the schema module actually on disk.
+
+    The pin is a literal on purpose — a hash the loader computes from the file it
+    is about to run proves nothing. That makes drift possible, so this is what
+    catches it: edit `tb21_posture_schema.py` without updating
+    `_FIXED_POSTURE_SCHEMA_SHA256` and the paid-stage replay would refuse at run
+    time, hours into a benchmark, instead of here.
+    """
+    schema_path = _repository_root() / launcher_module._FIXED_POSTURE_SCHEMA_PATH
+
+    assert schema_path.is_file()
+    assert (
+        hashlib.sha256(schema_path.read_bytes()).hexdigest()
+        == launcher_module._FIXED_POSTURE_SCHEMA_SHA256
+    )
+
+
+def test_frozen_replay_analyzer_loads_without_a_prepared_sys_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The analyzer loads on its own, with no help from whoever imported first.
+
+    The witness. `tb21_analysis` imports `tb21_posture_schema` at module scope,
+    and the loader supplied neither the module nor a `sys.path` entry that would
+    find it — so it loaded only when some earlier importer had already put the
+    analyzer's directory on the path. Running the whole suite did; running
+    `test_secure_launcher.py` alone did not, and its two refusal tests got
+    "prior-stage replay analyzer could not be loaded" in place of the specific
+    refusal they assert.
+
+    Both the path entry and any cached copies of the sibling modules are removed
+    here, so the load has nothing to inherit.
+    """
+    analysis_dir = str(
+        (_repository_root() / launcher_module._FIXED_POSTURE_SCHEMA_PATH).parent
+    )
+    monkeypatch.setattr(
+        "sys.path", [entry for entry in sys.path if entry != analysis_dir]
+    )
+    for cached in ("tb21_posture_schema", "tb21_analysis", "github_public_timing"):
+        monkeypatch.delitem(sys.modules, cached, raising=False)
+
+    analyzer = launcher_module._load_frozen_replay_analyzer(
+        _identity_for_the_frozen_files()
+    )
+
+    # A name the schema module supplies, reached through the analyzer — so this
+    # fails if the import resolved to nothing, not merely if the exec raised.
+    assert analyzer.STUDY_MANIFEST_ENGINE_POSTURE_FIELDS
+    assert callable(analyzer.ingest_job)
+
+    # And the load leaves no trace: a launcher that permanently installed its own
+    # `tb21_posture_schema` would change what every later import resolves to.
+    assert "tb21_posture_schema" not in sys.modules
+
+
+def test_a_drifted_posture_schema_refuses_by_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schema whose bytes are not the pinned ones is refused, and says which.
+
+    The refusal has to name the schema rather than the analyzer: reporting
+    "analyzer bytes drifted" for a schema edit is the same misdirection this
+    issue was filed about, one layer down.
+    """
+    monkeypatch.setattr(
+        launcher_module, "_FIXED_POSTURE_SCHEMA_SHA256", "00" * 32, raising=True
+    )
+
+    with pytest.raises(RuntimeError, match="posture schema bytes drifted"):
+        launcher_module._load_frozen_replay_analyzer(_identity_for_the_frozen_files())

--- a/bench/harbor_adapter/tests/test_secure_launcher.py
+++ b/bench/harbor_adapter/tests/test_secure_launcher.py
@@ -1002,12 +1002,12 @@ class _FakePublicIntentReader:
 
     def get_tree(self, commit_sha: str) -> dict[str, object]:
         assert isinstance(commit_sha, str) and len(commit_sha) == 40
+        # Read off the launcher rather than re-listed: a hand-copied second list
+        # here goes stale the moment a source joins the frozen set, and reds
+        # every test in this file for a reason that is about the copy (#5108).
         paths = (
             *launcher_module._FIXED_ADAPTER_SOURCE_PATHS,
-            launcher_module._FIXED_ANALYZER_PATH,
-            launcher_module._FIXED_PUBLIC_TIMING_PATH,
-            launcher_module._FIXED_PROTOCOL_PATH,
-            *launcher_module._FIXED_READINESS_SOURCE_PATHS,
+            *launcher_module._FIXED_NON_ADAPTER_SOURCE_PATHS,
         )
         return {
             "truncated": False,


### PR DESCRIPTION
## What & why

`_load_frozen_replay_analyzer` execs `tb21_analysis.py` from verified source bytes, and that file imports `tb21_posture_schema` at module scope. Nothing here supplied that module or put its directory on `sys.path`, so the import resolved only when some earlier importer happened to have done it.

Running the whole `harbor_adapter` suite did. Running `tests/test_secure_launcher.py` alone did not, and its two refusal tests got a generic `prior-stage replay analyzer could not be loaded` in place of the specific refusal they assert:

```
$ cd bench/harbor_adapter && uv run pytest tests/test_secure_launcher.py -q
FAILED tests/test_secure_launcher.py::test_missing_prior_readiness_job_never_reserves_or_execs
FAILED tests/test_secure_launcher.py::test_forged_prior_readiness_artifacts_never_reserve_or_exec
2 failed, 145 passed
```

A launcher whose refusal reason depends on import order cannot be reasoned about, and CLAUDE.md names this exact shape — a proof that came off a `ModuleNotFoundError`.

### Why not `sys.path`

The issue offers either remedy. This takes the second: the schema is supplied the way `github_public_timing` already is. A `sys.path` entry would let *any* importable `tb21_posture_schema` execute here, and executing unverified bytes is what this function exists to prevent.

### Where the pin lives, and why not the manifest

The schema's identity is pinned in `secure_launcher.py` rather than added to `runtime_identity`. The study manifest is preregistered at a fixed version (`stella-tb21-study-manifest-v6`), so a new required field would refuse every manifest already recorded — it would break replay of the runs this machinery exists to replay. `secure_launcher.py` is in `_FIXED_ADAPTER_SOURCE_PATHS`, so the pin is already covered by `adapter_sha256` and byte-compared against the published commit: the same chain that authorises the analyzer. The schema path also joins the frozen set, so the public-tree check compares its bytes too.

### One thing this cleaned up on the way

The fake published tree in `test_secure_launcher.py` re-listed the frozen non-adapter paths by hand. Adding one path reddened 30 tests that were each correct about a list that no longer matched, so that list is now read off the launcher (`_FIXED_NON_ADAPTER_SOURCE_PATHS`) instead of copied.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Each of these fails with the schema exec backed out; the first two also fail on `origin/main` when the file is run alone:

- `test_missing_prior_readiness_job_never_reserves_or_execs` *(pre-existing)*
- `test_forged_prior_readiness_artifacts_never_reserve_or_exec` *(pre-existing)*
- `test_frozen_replay_analyzer_loads_without_a_prepared_sys_path`
- `test_posture_schema_pin_matches_the_frozen_file`
- `test_a_drifted_posture_schema_refuses_by_name`

```
$ cd bench/harbor_adapter && uv run pytest tests/test_secure_launcher.py -q
147 passed
$ uv run pytest tests/test_frozen_replay_analyzer.py -q
3 passed
$ uv run pytest -q
766 passed, 2 skipped
```

The new tests are in their own file because `test_secure_launcher.py` is grandfathered at its size ceiling — `make file-size` caught them pushing it +99 over, and raising a baseline to fit three tests is the expedient CLAUDE.md forbids. The launcher file is back to exactly its recorded 3368.

## The gate

- [x] `make guards-fast` green (this diff compiles no Rust; `file-size`, `no-secrets`, `shellcheck`, `lockfile-sync`, `fmt --check` and the rest pass)
- [ ] `cargo` steps — not reached by this diff; CI runs them
- [x] Docs updated where behavior changed — the constants and the loader carry their own reasoning
- [x] `Closes #5108` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing new: everything I noticed here is fixed in this PR.

One observation that is **not** mine and not new: `bench/terminal_bench_analysis`'s own pytest suite fails collection locally with `ModuleNotFoundError: No module named 'tb21_analysis'` on all 7 test files. That is unchanged by this PR — it touches no file in that directory — and CI runs that suite behind `uv sync --locked` in `bench.yml`, which this local invocation did not do. Flagging it rather than filing, since I could not establish it is a defect rather than my invocation.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The pin is a literal, which means it can drift from the file. `test_posture_schema_pin_matches_the_frozen_file` is what catches that — without it, a schema edit would fail at replay time, hours into a benchmark, instead of in CI. That is the cost of pinning rather than deriving, and deriving is not an option: a hash the loader computes from the file it is about to run proves nothing.

Closes #5108

## Summary by Sourcery

Supply and verify the frozen posture schema when loading the replay analyzer to make secure replay deterministic and self-contained.

Bug Fixes:
- Load the frozen posture schema from verified source bytes so replay analyzer behavior and refusal reasons no longer depend on import order or a prepared `sys.path`.
- Reject drifted posture schema bytes with a schema-specific error before replay execution.

Enhancements:
- Centralize the frozen non-adapter source path list and reuse it in public-tree verification and test fixtures.

Tests:
- Add standalone coverage for schema pin integrity, isolated analyzer loading, and schema drift refusal.