### PR TITLE
feat(stella-tui): behind --mouse, a tab-row click switches tabs and the wheel scrolls

### DIFF
--- a/crates/stella-cli/src/cli.rs
+++ b/crates/stella-cli/src/cli.rs
@@ -259,6 +259,15 @@ pub(crate) struct GlobalArgs {
     #[arg(long, global = true, hide_short_help = true)]
     pub(crate) no_anim: bool,
 
+    /// Capture the mouse in interactive mode
+    ///
+    /// A click on the tab row switches tabs and the wheel scrolls the
+    /// transcript, at the price of the terminal's own text selection (use
+    /// shift+drag to select while captured). Off by default for that reason;
+    /// forced off by --accessible. Env: STELLA_MOUSE=1.
+    #[arg(long, global = true, hide_short_help = true)]
+    pub(crate) mouse: bool,
+
     /// Diagnostics: -v info, -vv debug, -vvv trace
     ///
     /// Turns on the diagnostic plane — the stream that explains why stella

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -405,6 +405,7 @@ pub async fn run_deck_session(
     let crate::term_policy::DeckPresentation {
         no_anim,
         accessible,
+        mouse,
     } = presentation;
     crate::enterprise_telemetry::authorize_execution_surface(
         crate::enterprise_telemetry::ExecutionSurface::Deck,
@@ -799,9 +800,9 @@ pub async fn run_deck_session(
         recent_path: Some(palette_recent_path(&cfg.workspace_root)),
         no_anim,
         accessible,
+        mouse_capture: mouse,
         mid_turn_prompt: steer::mid_turn_prompt_policy(cfg),
         voice_enabled: voice::enabled(cfg),
-        ..Default::default()
     };
     // The deck owns its channel ends and runs on its own task so rendering
     // never waits on the driver (and vice versa).

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -612,6 +612,7 @@ fn deck_presentation(globals: &cli::GlobalArgs) -> term_policy::DeckPresentation
     term_policy::DeckPresentation {
         no_anim: term_policy::animation_disabled(globals.no_anim),
         accessible: term_policy::accessible_mode(globals.accessible),
+        mouse: term_policy::mouse_requested(globals.mouse),
     }
 }
 

--- a/crates/stella-cli/src/term_policy.rs
+++ b/crates/stella-cli/src/term_policy.rs
@@ -99,6 +99,12 @@ pub(crate) struct DeckPresentation {
     /// the user's own screen with settled messages moving into scrollback.
     /// See `stella_tui::DeckOptions::accessible`.
     pub(crate) accessible: bool,
+    /// Mouse capture requested ([`mouse_requested`]): tab-row clicks and
+    /// wheel scroll, at the price of native text selection. Forced off
+    /// downstream when [`Self::accessible`] is set
+    /// (`stella_tui::accessible::mouse_capture_enabled`), so this is the
+    /// request, never the last word.
+    pub(crate) mouse: bool,
 }
 
 /// Whether the Command Deck runs in accessible mode: the `--accessible` flag
@@ -114,12 +120,22 @@ pub(crate) struct DeckPresentation {
 /// once, in their shell profile, rather than remember a flag on every
 /// invocation — the flag is the exception, not the habit.
 pub(crate) fn accessible_mode(accessible_flag: bool) -> bool {
-    accessible_flag || accessible_env(std::env::var_os("STELLA_ACCESSIBLE").as_deref())
+    accessible_flag || truthy_env(std::env::var_os("STELLA_ACCESSIBLE").as_deref())
 }
 
-/// The env half of [`accessible_mode`], kept pure so the convention is
-/// testable without touching the process environment.
-pub(crate) fn accessible_env(value: Option<&std::ffi::OsStr>) -> bool {
+/// Whether the deck captures the mouse: the `--mouse` flag or its
+/// `STELLA_MOUSE` env synonym, for a user who wants it in every session.
+/// Accessible mode still forces capture off downstream
+/// (`stella_tui::accessible::mouse_capture_enabled`) — a captured mouse takes
+/// the selection away from the assistive technology that needs it.
+pub(crate) fn mouse_requested(mouse_flag: bool) -> bool {
+    mouse_flag || truthy_env(std::env::var_os("STELLA_MOUSE").as_deref())
+}
+
+/// The env half of [`accessible_mode`] and [`mouse_requested`] — the house
+/// boolean convention (set and not `0`), kept pure so it is testable without
+/// touching the process environment.
+pub(crate) fn truthy_env(value: Option<&std::ffi::OsStr>) -> bool {
     value.is_some_and(|v| !v.is_empty() && v != "0")
 }
 

--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -16,7 +16,7 @@ use super::build_info::{
     BUILD_VERSION_IDENTITY, long_version_static, version_static, version_string,
 };
 use super::term_policy::{
-    PlainReason, accessible_env, animation_disabled, deck_decision, dumb_terminal,
+    PlainReason, animation_disabled, deck_decision, dumb_terminal, truthy_env,
 };
 use super::{
     AuthCmd, Cli, Command, OutputFormat, TelemetryCmd, error_summary_json, fleet_verbs,
@@ -247,21 +247,22 @@ fn a_dumb_terminal_disables_colour_unless_the_user_forces_it() {
     assert!(!dumb_terminal(None, None));
 }
 
-/// `--accessible` has an env synonym so a screen-reader user can set it once,
-/// in their shell profile, instead of remembering a flag on every invocation
-/// (#1258). It follows this CLI's house convention for boolean env vars, where
-/// an explicit `0` means off — the same rule `STELLA_PLAIN` and
-/// `STELLA_NO_ENV_FILE` follow, so there is one convention to learn.
+/// `--accessible` and `--mouse` have env synonyms (`STELLA_ACCESSIBLE`,
+/// `STELLA_MOUSE`) so a user can set either once, in their shell profile,
+/// instead of remembering a flag on every invocation (#1258). Both read the
+/// CLI's house convention for boolean env vars, where an explicit `0` means
+/// off — the same rule `STELLA_PLAIN` and `STELLA_NO_ENV_FILE` follow, so
+/// there is one convention to learn.
 #[test]
-fn the_accessible_env_var_follows_the_house_boolean_convention() {
+fn the_flag_env_synonyms_follow_the_house_boolean_convention() {
     use std::ffi::OsStr;
     let v = |s: &str| Some(OsStr::new(s)).map(|o| o.to_owned());
 
-    assert!(accessible_env(v("1").as_deref()));
-    assert!(accessible_env(v("yes").as_deref()));
-    assert!(!accessible_env(v("0").as_deref()));
-    assert!(!accessible_env(v("").as_deref()));
-    assert!(!accessible_env(None));
+    assert!(truthy_env(v("1").as_deref()));
+    assert!(truthy_env(v("yes").as_deref()));
+    assert!(!truthy_env(v("0").as_deref()));
+    assert!(!truthy_env(v("").as_deref()));
+    assert!(!truthy_env(None));
 }
 
 /// Accessible mode is a mode ON the deck, not a third surface beside it — so

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -178,7 +178,6 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     let slash = ui
         .composer
         .slash_menu(&ui.slash_commands, &palette_state(model, ui));
-    let slash_open = slash.as_ref().is_some_and(|m| !m.is_empty());
     if let Some(menu) = slash.filter(|m| !m.is_empty()) {
         let selected = ui.slash_selected.min(menu.matches.len().saturating_sub(1));
         let popup = slash_popup_area(area, bands[3], crate::render::display_rows(&menu).len());
@@ -319,12 +318,34 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
     // Position the hardware cursor at the composer caret so the terminal (and
     // anything anchored to it — CJK/IME candidate windows, screen readers,
     // cursor-following tmux panes) has something to track. Suppressed under
-    // any overlay that owns the keyboard ahead of the composer — matching the
-    // precedence `handle_key` already applies — so the caret doesn't sit in
-    // the composer while the user is typing into a dialog. The startup
-    // notice is deliberately excluded: it is non-modal, and a key still
-    // reaches the composer while it's showing (see `handle_key`).
-    let overlay_owns_keyboard = ui.help_open
+    // any overlay that owns the keyboard ahead of the composer — so the caret
+    // doesn't sit in the composer while the user is typing into a dialog. The
+    // startup notice is deliberately excluded: it is non-modal, and a key
+    // still reaches the composer while it's showing (see `handle_key`).
+    if !overlay_owns_keyboard(model, ui)
+        && let Some(pos) = composer_cursor
+    {
+        frame.set_cursor_position(pos);
+    }
+}
+
+/// Whether an overlay owns the keyboard ahead of the composer — the
+/// precedence `handle_key_inner` applies, read from state rather than from
+/// the key chain, so the cursor suppression above and the mouse dispatch
+/// (`crate::mouse`) share one answer instead of each keeping a list that
+/// drifts.
+pub(crate) fn overlay_owns_keyboard(model: &WorkspaceModel, ui: &DeckUi) -> bool {
+    let slash_open = ui
+        .composer
+        .slash_menu(&ui.slash_commands, &palette_state(model, ui))
+        .is_some_and(|m| !m.is_empty());
+    let arg_open = !crate::composer::args::arg_matches(
+        &ui.composer,
+        "/model",
+        &crate::views::picker::typeahead_candidates(model, ui),
+    )
+    .is_empty();
+    ui.help_open
         // Both parked asks are claimed ahead of everything else in
         // `handle_key_inner`, so either owns the keyboard while it is up.
         || parked::owns_keyboard(ui)
@@ -357,10 +378,7 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         // The SETTINGS tab's ENGINE / TOOLS config editors own the keyboard
         // (inline edit buffers, model/picker filters) while focused.
         || (ui.tab == DeckTab::Settings && ui.engine.focused)
-        || (ui.tab == DeckTab::Settings && ui.tools.focused);
-    if !overlay_owns_keyboard && let Some(pos) = composer_cursor {
-        frame.set_cursor_position(pos);
-    }
+        || (ui.tab == DeckTab::Settings && ui.tools.focused)
 }
 
 /// The slash popup's live description overrides, read from the model at

--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -60,9 +60,10 @@ const SHELL_OUTPUT_CAP: usize = 4000;
 #[derive(Debug, Clone, Default)]
 pub struct DeckOptions {
     /// Enable mouse capture. Off by default so native terminal selection
-    /// keeps working (L-T2). NOTE: no mouse events are handled yet — the
-    /// event loop discards them — so turning this on currently only costs
-    /// selection; it exists as the seam for click/scroll/reorder to land.
+    /// keeps working (L-T2). Opted in, events dispatch through
+    /// [`crate::mouse::handle_deck_mouse`] — a tab-row click switches tabs,
+    /// the wheel scrolls the Session transcript — at the price of the
+    /// terminal's own text selection.
     pub mouse_capture: bool,
     /// Structured debug log path (`STELLA_DEBUG=1`), or `None` for a no-op sink.
     pub debug_log_path: Option<PathBuf>,
@@ -858,16 +859,20 @@ pub async fn run_deck(
                         ui.voice.interrupt();
                     }
                     // Any mouse event dismisses the startup notice, exactly as
-                    // any key does.
-                    //
-                    // NOTE: mouse capture is OFF by default (L-T2 — enabling
-                    // it takes the terminal's own text selection away), so
-                    // this arm only fires for sessions that opted in via
-                    // `DeckOptions::mouse_capture`. On a default session the
-                    // keypress and the dwell timer are the dismissal paths,
-                    // and no click ever reaches the process to be handled.
-                    Some(Event::Mouse(_)) => {
+                    // any key does, then dispatches (tab-row clicks, wheel
+                    // scroll — `crate::mouse`). This arm only fires for
+                    // sessions that opted in via `DeckOptions::mouse_capture`
+                    // (L-T2 — capture takes the terminal's own text selection
+                    // away); on a default session the keypress and the dwell
+                    // timer are the notice's dismissal paths, and no click
+                    // ever reaches the process. The dispatch returns only
+                    // Handled/Ignored by contract (`handle_deck_mouse`), so
+                    // this arm carries none of the key arm's queue or quit
+                    // plumbing.
+                    Some(Event::Mouse(mouse)) => {
                         ui.notice.dismiss();
+                        let width = terminal.size()?.width;
+                        crate::mouse::handle_deck_mouse(mouse, width, &model, &mut ui);
                     }
                     // Resize / focus change: the next draw picks them up.
                     Some(_) => {}

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -2515,7 +2515,7 @@ fn handle_pick_version_key(key: KeyEvent, ui: &mut DeckUi) -> DeckAction {
 /// same first-visit affordance as the INSTALLED AGENTS pane. Rides
 /// [`DeckUi::pending_inputs`] because the tab switch itself already is the
 /// key's returned action.
-fn queue_issues_first_load(ui: &mut DeckUi) {
+pub(crate) fn queue_issues_first_load(ui: &mut DeckUi) {
     if ui.tab == DeckTab::Issues && !ui.issues.loaded && !ui.issues.busy {
         let seq = ui.issues.bump_seq();
         ui.issues.list_wait = seq;

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -75,6 +75,7 @@ pub mod envelope;
 pub mod fleet_dashboard;
 pub mod graph;
 pub mod markdown;
+pub mod mouse;
 pub mod notice;
 pub mod palette;
 pub mod panel_deck;

--- a/crates/stella-tui/src/mouse.rs
+++ b/crates/stella-tui/src/mouse.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Mouse dispatch for the deck: a click on the tab row switches tabs, the
+//! wheel scrolls the Session transcript, and a click while the splash is up
+//! skips it — each routed to the state change its key equivalent makes.
+//! Capture is opt-in ([`crate::deck_shell::DeckOptions::mouse_capture`],
+//! L-T2), so a default session never reaches this module and keeps the
+//! terminal's own text selection.
+
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+use crate::WorkspaceModel;
+use crate::deck::DeckTab;
+use crate::deck_ui::{DeckAction, DeckUi, queue_issues_first_load};
+
+/// Transcript lines one wheel notch moves. Three is the terminal-emulator
+/// convention (xterm and its descendants), so the deck scrolls at the speed
+/// the rest of the user's terminal does.
+const WHEEL_LINES: usize = 3;
+
+/// Route one mouse event to the deck.
+///
+/// `width` is the frame's, from the same terminal the last draw measured —
+/// the tab hit test needs it because the tab row narrows with the frame
+/// (`views::frame::tab_row_hit`).
+///
+/// Returns [`DeckAction::Handled`] or [`DeckAction::Ignored`] and nothing
+/// else, by construction: no mouse verb submits, quits, or runs a shell
+/// command, which is what lets `deck_shell`'s mouse arm stay free of the key
+/// arm's queue and quit plumbing. A future verb that sends must grow that
+/// arm to match the key arm's dispatch.
+///
+/// Not wrapped in `accessible::announce`: accessible mode forces mouse
+/// capture off (`accessible::mouse_capture_enabled`), so no event reaches
+/// here on a session with a reader to announce to.
+pub fn handle_deck_mouse(
+    ev: MouseEvent,
+    width: u16,
+    model: &WorkspaceModel,
+    ui: &mut DeckUi,
+) -> DeckAction {
+    // While the splash is up, a click dismisses it — the same impatience rule
+    // as "any key, Esc included, dismisses it" (`handle_key_inner`).
+    if !ui.splash.is_done() {
+        if matches!(ev.kind, MouseEventKind::Down(_)) {
+            ui.splash.skip();
+            return DeckAction::Handled;
+        }
+        return DeckAction::Ignored;
+    }
+    // A modal dialog owns the mouse on the terms it owns the keyboard: a
+    // click or a wheel notch must not reach the surface behind it. The
+    // AGENTS page replaces the bands outright, so the tab row a click would
+    // hit is not even drawn.
+    if ui.agents_page.open || crate::deck_render::overlay_owns_keyboard(model, ui) {
+        return DeckAction::Ignored;
+    }
+    match ev.kind {
+        // The tab row is the frame's top row (`deck_render`'s first band).
+        MouseEventKind::Down(MouseButton::Left) if ev.row == 0 => {
+            match crate::views::frame::tab_row_hit(model, ui, width, ev.column) {
+                Some(tab) => {
+                    ui.set_tab(tab);
+                    // The same follow-up the Tab key runs: landing on ISSUES
+                    // for the first time starts its load.
+                    queue_issues_first_load(ui);
+                    DeckAction::Handled
+                }
+                None => DeckAction::Ignored,
+            }
+        }
+        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown if ui.tab == DeckTab::Session => {
+            let (total, height) = (ui.metrics.session_total, ui.metrics.session_height);
+            if ev.kind == MouseEventKind::ScrollUp {
+                ui.session_scroll.scroll_up(WHEEL_LINES, total, height);
+            } else {
+                ui.session_scroll.scroll_down(WHEEL_LINES, total, height);
+            }
+            DeckAction::Handled
+        }
+        _ => DeckAction::Ignored,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{AgentMeta, Inbound};
+
+    fn down(column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    fn wheel(kind: MouseEventKind) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: 10,
+            row: 10,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    /// A model with one registered agent and a `DeckUi` past the splash — the
+    /// state a deck is in when a mouse event can first mean anything.
+    fn fixture() -> (WorkspaceModel, DeckUi) {
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        let mut ui = DeckUi::default();
+        ui.splash.skip();
+        (model, ui)
+    }
+
+    /// The column a title occupies on the rendered tab row, so the click the
+    /// test sends is the click a user aims at what they see.
+    fn column_of(model: &WorkspaceModel, ui: &DeckUi, title: &str, width: u16) -> u16 {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        let area = Rect::new(0, 0, width, 1);
+        let mut buf = Buffer::empty(area);
+        crate::views::frame::render_tab_row(model, ui, area, &mut buf);
+        let row: String = (0..width)
+            .map(|x| {
+                buf.cell((x, 0))
+                    .map(|c| c.symbol().to_string())
+                    .unwrap_or_default()
+            })
+            .collect();
+        row.find(title).expect("title on the rendered row") as u16
+    }
+
+    /// The witness for clickable tabs: a left click on a tab's title on the
+    /// top row moves the deck to that tab, exactly as Tab-cycling to it would.
+    #[test]
+    fn a_click_on_a_tab_title_switches_to_that_tab() {
+        let (model, mut ui) = fixture();
+        assert_eq!(ui.tab, DeckTab::Session);
+        let col = column_of(&model, &ui, DeckTab::Graph.title(), 100);
+        let action = handle_deck_mouse(down(col, 0), 100, &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled);
+        assert_eq!(ui.tab, DeckTab::Graph);
+    }
+
+    /// A click on the ISSUES title runs the Tab key's first-load follow-up,
+    /// so the tab a click opens is never emptier than the tab a key opens.
+    #[test]
+    fn a_click_on_issues_queues_its_first_load() {
+        let (model, mut ui) = fixture();
+        let col = column_of(&model, &ui, DeckTab::Issues.title(), 100);
+        handle_deck_mouse(down(col, 0), 100, &model, &mut ui);
+        assert_eq!(ui.tab, DeckTab::Issues);
+        assert!(ui.issues.busy, "first load queued");
+    }
+
+    /// A click below the tab row, or on the air between titles, changes
+    /// nothing.
+    #[test]
+    fn a_click_off_the_titles_is_ignored() {
+        let (model, mut ui) = fixture();
+        let col = column_of(&model, &ui, DeckTab::Graph.title(), 100);
+        assert_eq!(
+            handle_deck_mouse(down(col, 5), 100, &model, &mut ui),
+            DeckAction::Ignored,
+            "below the tab row"
+        );
+        assert_eq!(
+            handle_deck_mouse(down(0, 0), 100, &model, &mut ui),
+            DeckAction::Ignored,
+            "the leading column of air"
+        );
+        assert_eq!(ui.tab, DeckTab::Session);
+    }
+
+    /// While an overlay owns the keyboard it owns the mouse: a click on a tab
+    /// title under the help overlay must not switch the surface behind it.
+    #[test]
+    fn a_modal_overlay_claims_the_click() {
+        let (model, mut ui) = fixture();
+        ui.help_open = true;
+        let col = column_of(&model, &ui, DeckTab::Graph.title(), 100);
+        assert_eq!(
+            handle_deck_mouse(down(col, 0), 100, &model, &mut ui),
+            DeckAction::Ignored
+        );
+        assert_eq!(ui.tab, DeckTab::Session);
+    }
+
+    /// The wheel scrolls the Session transcript by [`WHEEL_LINES`], against
+    /// the totals the last draw recorded — the same route the arrow keys take.
+    #[test]
+    fn the_wheel_scrolls_the_session_transcript() {
+        let (model, mut ui) = fixture();
+        ui.metrics.session_total = 100;
+        ui.metrics.session_height = 10;
+        handle_deck_mouse(wheel(MouseEventKind::ScrollUp), 100, &model, &mut ui);
+        assert!(!ui.session_scroll.follow, "scrolled out of follow");
+        assert_eq!(ui.session_scroll.top, 100 - 10 - WHEEL_LINES);
+        handle_deck_mouse(wheel(MouseEventKind::ScrollDown), 100, &model, &mut ui);
+        assert_eq!(ui.session_scroll.top, 100 - 10, "one notch back down");
+    }
+
+    /// A click while the splash is up skips it, exactly as any key does.
+    #[test]
+    fn a_click_skips_the_splash() {
+        let mut model = WorkspaceModel::new();
+        model.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        let mut ui = DeckUi::default();
+        assert!(!ui.splash.is_done());
+        let action = handle_deck_mouse(down(0, 0), 100, &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled);
+        assert!(ui.splash.is_done());
+    }
+}

--- a/crates/stella-tui/src/views/frame.rs
+++ b/crates/stella-tui/src/views/frame.rs
@@ -103,8 +103,10 @@ pub fn render_chrome_row(
     Paragraph::new(Line::from(spans)).render(row, buf);
 }
 
-/// Draw the tab row into the top row of `area`.
-pub fn render_tab_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+/// The tab row's trailing hint (the plan-card chord, Session only) — shared
+/// by [`render_tab_row`] and [`tab_row_hit`] so the budget both compute from
+/// it is one number.
+fn tab_row_trailing(model: &WorkspaceModel, ui: &DeckUi) -> Vec<Span<'static>> {
     let mut trailing: Vec<Span<'static>> = Vec::new();
     if ui.tab == DeckTab::Session && plan_of(model, ui).is_some_and(|p| !p.is_empty()) {
         // The chord comes from the keymap, never from a literal here: this
@@ -116,7 +118,31 @@ pub fn render_tab_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut
         ));
         trailing.push(Span::raw("   "));
     }
+    trailing
+}
 
+/// The tab a click on `column` of the tab row selects, or `None`: on the
+/// Session breadcrumb (which names plan steps, not tabs), on the air between
+/// titles, or past the list. `width` is the frame's — the same rectangle
+/// [`render_tab_row`] drew into — so the budget, the rung, and therefore
+/// every title's column match what is on screen.
+pub fn tab_row_hit(
+    model: &WorkspaceModel,
+    ui: &DeckUi,
+    width: u16,
+    column: u16,
+) -> Option<DeckTab> {
+    if ui.tab == DeckTab::Session && breadcrumb_spans(model, ui).is_some() {
+        return None;
+    }
+    let trailing = tab_row_trailing(model, ui);
+    let budget = (width as usize).saturating_sub(right_edge_reserve(&trailing));
+    tab_list::hit(ui.tab, budget, column as usize)
+}
+
+/// Draw the tab row into the top row of `area`.
+pub fn render_tab_row(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer) {
+    let trailing = tab_row_trailing(model, ui);
     let budget = (area.width as usize).saturating_sub(right_edge_reserve(&trailing));
     let left = match ui.tab {
         DeckTab::Session => {

--- a/crates/stella-tui/src/views/frame/tab_list.rs
+++ b/crates/stella-tui/src/views/frame/tab_list.rs
@@ -42,11 +42,34 @@ const RUNGS: [Rung; 3] = [Rung::Full, Rung::Short, Rung::Solo];
 /// `budget` is what [`super::right_edge_reserve`] leaves — never the whole
 /// row, which is what makes the mark survive every width.
 pub(super) fn spans(active: DeckTab, budget: usize) -> Vec<Span<'static>> {
+    rung_spans(active, chosen_rung(active, budget))
+}
+
+/// The rung [`spans`] renders into `budget`: the widest that fits, or
+/// [`Rung::Solo`] when nothing does.
+fn chosen_rung(active: DeckTab, budget: usize) -> Rung {
     RUNGS
         .iter()
-        .map(|rung| rung_spans(active, *rung))
-        .find(|spans| width(spans) <= budget)
-        .unwrap_or_else(|| rung_spans(active, Rung::Solo))
+        .copied()
+        .find(|rung| width(&rung_spans(active, *rung)) <= budget)
+        .unwrap_or(Rung::Solo)
+}
+
+/// The tab under `column` of the row [`spans`] renders into `budget`, or
+/// `None` for a column on the air between titles or past the list — the hit
+/// test for a click on the tab row. Derived from the same cells and the same
+/// rung choice as [`spans`], so the two cannot disagree about where a title
+/// sits.
+pub(super) fn hit(active: DeckTab, budget: usize, column: usize) -> Option<DeckTab> {
+    let mut x = 0;
+    for (tab, span) in rung_cells(active, chosen_rung(active, budget)) {
+        let w = span.width();
+        if (x..x + w).contains(&column) {
+            return tab;
+        }
+        x += w;
+    }
+    None
 }
 
 /// The columns a rendering occupies.
@@ -56,31 +79,54 @@ fn width(spans: &[Span<'static>]) -> usize {
 
 /// The active tab in gold with a cell of air either side, the rest muted.
 fn rung_spans(active: DeckTab, rung: Rung) -> Vec<Span<'static>> {
+    rung_cells(active, rung)
+        .into_iter()
+        .map(|(_, span)| span)
+        .collect()
+}
+
+/// One rendering as cells: each span with the tab a click on it lands on —
+/// `None` for the air between titles and for [`Rung::Solo`]'s `4/9` note.
+/// [`rung_spans`] and [`hit`] both derive from this, which is what keeps the
+/// pixels drawn and the columns hit-tested the same list.
+fn rung_cells(active: DeckTab, rung: Rung) -> Vec<(Option<DeckTab>, Span<'static>)> {
     let muted = Style::new().fg(token::MUTED);
     let dim = Style::new().fg(token::DIM);
     let lit = Style::new().fg(token::GOLD).add_modifier(Modifier::BOLD);
-    let mut spans = vec![Span::raw(" ")];
+    let mut cells = vec![(None, Span::raw(" "))];
     if rung == Rung::Solo {
-        spans.push(Span::styled(format!("  {}  ", active.title()), lit));
-        spans.push(Span::styled(
-            format!("{}/{}", active.index() + 1, DeckTab::ALL.len()),
-            dim,
+        cells.push((
+            Some(active),
+            Span::styled(format!("  {}  ", active.title()), lit),
         ));
-        return spans;
+        cells.push((
+            None,
+            Span::styled(
+                format!("{}/{}", active.index() + 1, DeckTab::ALL.len()),
+                dim,
+            ),
+        ));
+        return cells;
     }
     for (i, tab) in DeckTab::ALL.iter().enumerate() {
         if i > 0 {
-            spans.push(Span::raw(" "));
+            cells.push((None, Span::raw(" ")));
         }
         if *tab == active {
-            spans.push(Span::styled(format!("  {}  ", tab.title()), lit));
+            cells.push((
+                Some(*tab),
+                Span::styled(format!("  {}  ", tab.title()), lit),
+            ));
         } else if rung == Rung::Short {
-            spans.push(Span::styled(short_title(*tab).to_string(), muted));
+            cells.push((
+                Some(*tab),
+                Span::styled(short_title(*tab).to_string(), muted),
+            ));
         } else {
-            spans.push(Span::styled(tab.title(), muted));
+            cells.push((Some(*tab), Span::styled(tab.title(), muted)));
         }
     }
-    spans
+    cells
 }
 
 /// A tab's three-letter form: the first three letters of [`DeckTab::title`].
@@ -204,6 +250,51 @@ mod tests {
             assert!(row.contains(tab.title()), "{row}");
             assert!(row.contains(&format!("/{}", DeckTab::ALL.len())), "{row}");
         }
+    }
+
+    /// A click on a full title lands on that tab, and the air between titles
+    /// lands on nothing. The expected column comes from the rendered text, so
+    /// this holds [`hit`] to what a reader actually sees, not to the cells it
+    /// shares with the renderer.
+    #[test]
+    fn a_click_on_a_full_title_lands_on_its_tab() {
+        for active in DeckTab::ALL {
+            let row = text(active, 65);
+            for tab in DeckTab::ALL {
+                let col = row.find(tab.title()).expect("title on the row");
+                assert_eq!(hit(active, 65, col), Some(tab), "{tab:?} in {row}");
+            }
+        }
+        // The leading column of air, and any column past the list.
+        assert_eq!(hit(DeckTab::Session, 65, 0), None);
+        assert_eq!(hit(DeckTab::Session, 65, 200), None);
+    }
+
+    /// The abbreviated rung is clickable on the same terms: a three-letter
+    /// form selects its tab.
+    #[test]
+    fn a_click_on_a_short_title_lands_on_its_tab() {
+        let row = text(DeckTab::Graph, 50);
+        for tab in DeckTab::ALL {
+            let needle = if tab == DeckTab::Graph {
+                tab.title()
+            } else {
+                short_title(tab)
+            };
+            let col = row.find(needle).expect("form on the row");
+            assert_eq!(hit(DeckTab::Graph, 50, col), Some(tab), "{tab:?} in {row}");
+        }
+    }
+
+    /// [`Rung::Solo`] names one tab, so a click selects the tab already
+    /// selected — and the `4/9` position note selects nothing.
+    #[test]
+    fn the_solo_rung_hits_only_the_active_tab() {
+        let row = text(DeckTab::Settings, 17);
+        let title = row.find("SETTINGS").expect("title on the row");
+        assert_eq!(hit(DeckTab::Settings, 17, title), Some(DeckTab::Settings));
+        let note = row.find("9/9").expect("note on the row");
+        assert_eq!(hit(DeckTab::Settings, 17, note), None);
     }
 
     /// The abbreviated rung still names all nine tabs, and the active one in

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -230,6 +230,11 @@ The cards below are in `stella --help`'s own order, for the same reason the subc
     Freeze all deck animation to a static frame, for CI and asciinema-style recordings.
     Env `STELLA_NO_ANIM` / `NO_COLOR`.
   </OptionCard>
+  <OptionCard name="--mouse" defaultValue="off">
+    Capture the mouse in interactive mode: click a tab to switch to it, wheel-scroll the
+    transcript. Costs the terminal's own text selection (shift+drag still selects), which
+    is why it is off by default. Env `STELLA_MOUSE=1`.
+  </OptionCard>
   <OptionCard name="-v / --verbose" defaultValue="warn">
     Diagnostics: `-v` info, `-vv` debug, `-vvv` trace. See
     [below](#diagnostics--v---log-level---log-file).


### PR DESCRIPTION
## What & why

Gives `DeckOptions::mouse_capture` — the seam L-T2 left for exactly this — its first consumer. Behind an opt-in `--mouse` flag (`STELLA_MOUSE=1` synonym), a left click on a tab title switches to that tab on every width rung of the tab list, the wheel scrolls the Session transcript three lines a notch, and a click skips the splash as any key does. Capture stays off by default because it takes the terminal's own text selection, and accessible mode still forces it off.

Two structural choices, both aimed at "cannot drift":

- **The hit test derives from the render.** `tab_list::rung_cells` now tags each span with the tab a click on it selects; `spans` (what draws) and `hit` (what a click consults) both project from it, so the pixels and the hit columns are one list. The exemplar is this crate's own metrics pattern (`ui.metrics.session_total`, recorded by the draw and consulted by the keys) — render records, input consults.
- **Modality is one predicate.** `deck_render`'s inline cursor-suppression expression — already the render-side copy of the key chain's overlay precedence — is extracted as `overlay_owns_keyboard`, and the mouse dispatch reads the same function, so a click cannot reach the surface behind a dialog and a future overlay joins both gates by editing one place.

`handle_deck_mouse` returns only Handled/Ignored by contract, so `deck_shell`'s mouse arm carries none of the key arm's queue or quit plumbing.

Closes #5392

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`mouse::tests` — a click on a tab title switches to it (probing the column on the *rendered* row, not the shared cells), a modal overlay claims the click, off-title clicks are ignored, the wheel scrolls against the recorded metrics, a click skips the splash, and a click on ISSUES runs the Tab key's first-load follow-up. `tab_list::tests` adds hit tests for all three width rungs. None of these compile on `main` — the surface is absent there. The tab-row refactor is held byte-identical by the existing golden deck frames, which pass unregenerated.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, green)
- [x] `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings` — the workspace run is CI's (per CLAUDE.md this laptop does not build the workspace)
- [x] `cargo test -p stella-tui` (1389 lib + suites) and `cargo test -p stella-cli` (2434) — the workspace run is CI's
- [x] Docs updated: `--mouse` card in `website/content/docs/commands/index.mdx`, flag help in `cli.rs`, `DeckOptions::mouse_capture` doc rewritten from "nothing handles mouse events yet" to what now does
- [x] CLA signed
- [x] `Closes #5392` above and as a commit trailer

**Renamed test** (for the deleted-tests guard): `the_accessible_env_var_follows_the_house_boolean_convention` → `the_flag_env_synonyms_follow_the_house_boolean_convention` in `crates/stella-cli/src/tests.rs`, following `accessible_env` → `truthy_env` now two flags read the same env convention. Nothing is deleted; the assertions are unchanged.

## Nothing left behind

- [x] Filed: #5394 (the wheel scrolls only the Session tab; overlay bodies deliberately ignore it in this slice), #5395 (OSC 8 hyperlinks for transcript file paths — clickable with no capture cost), #5396 (a stella-cli subsession test failed once under the full parallel run during verification, passes alone; unrelated to this diff)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Wheel-over-a-modal doing nothing (rather than scrolling the overlay body) is the deliberate conservative edge of this slice — #5394 is the handoff. `deck_ui.rs` sits 4 lines under its size ceiling, which is why the dispatcher is a new `mouse.rs` at the crate root and the only `deck_ui.rs` edit is a zero-line visibility change (`queue_issues_first_load` → `pub(crate)`).

## Summary by Sourcery

Enable opt-in mouse interaction for deck tab navigation and Session transcript scrolling while preserving default terminal selection and accessibility behavior.

New Features:
- Add opt-in mouse capture for interactive deck sessions via `--mouse` or `STELLA_MOUSE=1`, enabling tab switching, Session transcript wheel scrolling, and splash dismissal by click.

Enhancements:
- Route mouse input through shared overlay ownership and render-derived tab hit testing so modal interactions and clickable tab positions remain consistent with the UI.
- Keep mouse capture disabled in accessible mode and preserve native terminal text selection by default.

Documentation:
- Document the new `--mouse` option, environment variable, selection tradeoff, and accessible-mode behavior in CLI help and user documentation.

Tests:
- Add coverage for tab clicks across tab-row layouts, modal interception, splash dismissal, Session scrolling, and Issues first-load behavior.