### PR TITLE
fix(stella-cli): a reflection lesson whose append failed is re-scanned, not lost

### DIFF
--- a/crates/stella-cli/src/memory/observations.rs
+++ b/crates/stella-cli/src/memory/observations.rs
@@ -27,6 +27,23 @@
 //! record in the batch or lose it. With derived ids, the cursor is a pure
 //! optimization and a crash costs one re-scan, never a duplicate.
 //!
+//! A **crash** costs a re-scan. A *failure* used to cost the records outright:
+//! the loop swallowed a failed append and advanced the cursor to the end of the
+//! log regardless, so a line whose write lost to `SQLITE_BUSY` was left below
+//! the cursor and never looked at again. The lexical path re-reads the whole log
+//! every turn and is unaffected, so the two diverged exactly there — against the
+//! behaviour-compatibility contract [`super::learning`] holds them to (#5323).
+//!
+//! So the cursor stops at the first line whose append failed, and everything
+//! from there is re-scanned next turn. Content-derived ids make that replay a
+//! no-op for the lines that did land.
+//!
+//! A line the ledger refuses **deterministically** — one whose record cannot be
+//! constructed or serialized at all — is not a barrier. Retrying it can never
+//! succeed, and a cursor parked on it would re-scan the whole log every turn
+//! forever without advancing. Those are skipped the way a malformed JSON line
+//! already is.
+//!
 //! ## Failure isolation
 //!
 //! Every function here swallows its errors and degrades to "no observations
@@ -106,29 +123,70 @@ pub(crate) fn extract_reflection_observations(store: &ContextStore, log_path: &P
     let start = if consumed > lines.len() { 0 } else { consumed };
 
     let mut appended = 0usize;
-    for line in &lines[start..] {
+    // Where the cursor may advance to: the first line whose ledger write failed,
+    // or the end of the log if none did.
+    let mut settled = lines.len();
+    for (offset, line) in lines[start..].iter().enumerate() {
         let Ok(lesson) = serde_json::from_str::<ReflectionLesson>(line) else {
             continue;
         };
         if lesson.lesson.trim().is_empty() {
             continue;
         }
-        // Only a genuinely NEW record counts. A replay reports `AlreadyPresent`
-        // and must not inflate the number, or "how many observations did this
-        // turn produce" becomes "how many lines did it re-read".
-        if append_observation(store, &lesson) == Some(AppendOutcome::Appended) {
-            appended += 1;
+        match append_observation(store, &lesson) {
+            // Only a genuinely NEW record counts. A replay reports
+            // `AlreadyPresent` and must not inflate the number, or "how many
+            // observations did this turn produce" becomes "how many lines did
+            // it re-read".
+            Ok(AppendOutcome::Appended) => appended += 1,
+            Ok(_) => {}
+            // Deterministic: this line will not append on any future turn
+            // either, so a barrier here would park the cursor forever.
+            Err(AppendFailure::Unrepresentable) => {}
+            // Transient — a concurrent writer holding the lock past the busy
+            // timeout is the case. Stop the cursor here so the next scan sees
+            // this line again; everything after it is re-scanned too, which
+            // content-derived ids make a no-op for whatever did land.
+            Err(AppendFailure::LedgerRefused) => {
+                settled = start + offset;
+                break;
+            }
         }
     }
 
     // Advanced last and best-effort. If this write fails the next turn re-scans
     // and re-derives the same ids, which the ledger absorbs as replays.
-    let _ = store.set_extraction_cursor(REFLECTION_SOURCE, &lines.len().to_string());
+    let _ = store.set_extraction_cursor(REFLECTION_SOURCE, &settled.to_string());
     appended
 }
 
-/// Redact, type, and append one lesson. `None` on any failure.
-fn append_observation(store: &ContextStore, lesson: &ReflectionLesson) -> Option<AppendOutcome> {
+/// Why one lesson did not become a record.
+///
+/// The distinction is the whole of #5323: one of these is worth retrying and
+/// the other never will be, and the old `Option` could not tell a caller which
+/// it was holding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AppendFailure {
+    /// The storage layer would not take the write — a lock held past the busy
+    /// timeout, a disk error. The same bytes may well append on the next turn,
+    /// so the cursor stops here.
+    LedgerRefused,
+    /// This line cannot become a record: it did not construct, did not
+    /// serialize, or the ledger refused its *content*. Retrying is pointless —
+    /// the input is fixed, so the outcome is — and a cursor waiting on it would
+    /// never advance again.
+    Unrepresentable,
+}
+
+/// Redact, type, and append one lesson.
+///
+/// The error says whether the next turn should try again. Everything before the
+/// ledger call is a pure function of the line, so its failures are
+/// [`AppendFailure::Unrepresentable`]; the ledger's own refusal is not.
+fn append_observation(
+    store: &ContextStore,
+    lesson: &ReflectionLesson,
+) -> Result<AppendOutcome, AppendFailure> {
     // Redaction happens BEFORE the record is constructed, so no unredacted
     // typed record ever exists — not even transiently in memory as something a
     // later refactor could persist by accident.
@@ -143,10 +201,10 @@ fn append_observation(store: &ContextStore, lesson: &ReflectionLesson) -> Option
         redaction.redacted,
         rfc3339(lesson.occurred_at),
     )
-    .ok()?;
+    .map_err(|_| AppendFailure::Unrepresentable)?;
 
-    let body = serde_json::to_string(&record).ok()?;
-    let outcome = store
+    let body = serde_json::to_string(&record).map_err(|_| AppendFailure::Unrepresentable)?;
+    store
         .append_record(LedgerAppend {
             record_id: &record.record_id,
             lineage_id: &record.lineage_id,
@@ -157,8 +215,17 @@ fn append_observation(store: &ContextStore, lesson: &ReflectionLesson) -> Option
             observed_at: &record.observed_at,
             supersedes: None,
         })
-        .ok()?;
-    Some(outcome)
+        .map_err(|error| match error {
+            // The storage layer itself: `SQLITE_BUSY` from a writer holding the
+            // lock past the busy timeout, a disk error, a full volume. The same
+            // bytes may well append on the next turn.
+            stella_context::ContextError::Sqlite(_) => AppendFailure::LedgerRefused,
+            // Everything else is the ledger judging this record's *content* —
+            // `InvalidInput` for two records claiming one id, chief among them.
+            // The input is fixed, so the verdict is; retrying it forever is how
+            // a cursor stops advancing at all.
+            _ => AppendFailure::Unrepresentable,
+        })
 }
 
 /// Every observation in the ledger, oldest first — what the miner consumes.

--- a/crates/stella-cli/src/memory/observations.rs
+++ b/crates/stella-cli/src/memory/observations.rs
@@ -38,6 +38,11 @@
 //! from there is re-scanned next turn. Content-derived ids make that replay a
 //! no-op for the lines that did land.
 //!
+//! The **scan** does not stop there. A lock released a moment later would
+//! otherwise leave every remaining lesson unwritten for no reason, and they are
+//! going to be re-scanned regardless — the cursor is what bounds the work, not
+//! the loop.
+//!
 //! A line the ledger refuses **deterministically** — one whose record cannot be
 //! constructed or serialized at all — is not a barrier. Retrying it can never
 //! succeed, and a cursor parked on it would re-scan the whole log every turn
@@ -144,12 +149,14 @@ pub(crate) fn extract_reflection_observations(store: &ContextStore, log_path: &P
             // either, so a barrier here would park the cursor forever.
             Err(AppendFailure::Unrepresentable) => {}
             // Transient — a concurrent writer holding the lock past the busy
-            // timeout is the case. Stop the cursor here so the next scan sees
-            // this line again; everything after it is re-scanned too, which
-            // content-derived ids make a no-op for whatever did land.
+            // timeout is the case. The cursor stops here so the next scan sees
+            // this line again; the scan itself does NOT stop, because a lock
+            // released a moment later would otherwise leave every remaining
+            // lesson unwritten for no reason. Everything after this point is
+            // re-scanned next turn either way, which content-derived ids make a
+            // no-op replay for whatever did land.
             Err(AppendFailure::LedgerRefused) => {
-                settled = start + offset;
-                break;
+                settled = settled.min(start + offset);
             }
         }
     }

--- a/crates/stella-cli/src/memory/observations/tests.rs
+++ b/crates/stella-cli/src/memory/observations/tests.rs
@@ -258,16 +258,17 @@ fn a_pre_task_id_log_line_still_parses() {
 /// then lets go, which is the #5323 shape: a concurrent writer the append
 /// cannot outwait.
 ///
-/// - **Base:** the first lesson's append fails and is swallowed; the loop
-///   carries on, the second lesson lands once the lock clears, and the cursor
-///   is then set to 2 — past a line that never appended. The first lesson is
-///   gone, and the next scan starts after it.
-/// - **Here:** the loop stops at the first failure, so nothing appends and the
-///   cursor is not moved. The next scan sees both lines again.
+/// Both codes do the same thing to the lessons on this pass: the first one's
+/// append loses to the lock, the loop carries on, and the second lands once the
+/// lock clears. They differ in one place only — **where the cursor ends up**.
+///
+/// - **Base:** the cursor is set to 2, past a line that never appended. The
+///   first lesson is below it and the next scan starts after it. Gone.
+/// - **Here:** the cursor stops at the first failure, so the next scan sees
+///   both lines again and the first one lands.
 ///
 /// So the discriminating fact is the ledger's contents *after a second scan*:
-/// two observations here, one on the base, forever. The intermediate counts are
-/// asserted too, but that final line is the one that cannot pass both ways.
+/// two observations here, one on the base, forever.
 #[test]
 fn a_lesson_whose_append_failed_is_recovered_on_the_next_scan() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -286,7 +287,8 @@ fn a_lesson_whose_append_failed_is_recovered_on_the_next_scan() {
         let conn = rusqlite::Connection::open(&db).expect("second connection");
         conn.busy_timeout(std::time::Duration::from_millis(0))
             .expect("no wait");
-        conn.execute_batch("BEGIN IMMEDIATE").expect("take the lock");
+        conn.execute_batch("BEGIN IMMEDIATE")
+            .expect("take the lock");
         locked.send(()).expect("announce");
         std::thread::sleep(HELD_FOR);
         conn.execute_batch("ROLLBACK").expect("release the lock");
@@ -295,25 +297,33 @@ fn a_lesson_whose_append_failed_is_recovered_on_the_next_scan() {
 
     assert_eq!(
         extract_reflection_observations(&store, &log),
-        0,
-        "the scan stops at the lesson whose append lost to the lock"
+        1,
+        "the first lesson's append loses to the lock; the second still lands"
     );
     rival.join().expect("rival");
 
+    // The cursor is where the two codes differ: it must not have stepped over
+    // the lesson that never landed.
     assert_eq!(
-        all_observations(&store, 10).len(),
-        0,
-        "and it stopped before the second lesson rather than skipping the first"
+        store
+            .extraction_cursor("reflections.jsonl")
+            .expect("read cursor"),
+        Some("0".to_string()),
+        "the cursor stops at the first line whose append failed"
     );
 
-    // The witness. On the base this is 1 and stays 1: the first lesson sits
-    // below a cursor that advanced past it.
+    // The witness. On the base this appends nothing and the ledger stays at
+    // one: the first lesson sits below a cursor that advanced past it.
     assert_eq!(
         extract_reflection_observations(&store, &log),
-        2,
-        "the next scan recovers both lessons"
+        1,
+        "the next scan recovers the lost lesson, replaying the one that landed"
     );
-    assert_eq!(all_observations(&store, 10).len(), 2, "and nothing was lost");
+    assert_eq!(
+        all_observations(&store, 10).len(),
+        2,
+        "and nothing was lost"
+    );
 }
 
 /// A line that can never be represented is stepped over rather than becoming a
@@ -329,7 +339,11 @@ fn an_unrepresentable_line_does_not_wedge_the_cursor() {
     let (dir, store) = store();
     let log = write_log(
         dir.path(),
-        &[("   ", 100), ("Prefer rg.", 200), ("Pin the toolchain.", 300)],
+        &[
+            ("   ", 100),
+            ("Prefer rg.", 200),
+            ("Pin the toolchain.", 300),
+        ],
     );
 
     assert_eq!(extract_reflection_observations(&store, &log), 2);

--- a/crates/stella-cli/src/memory/observations/tests.rs
+++ b/crates/stella-cli/src/memory/observations/tests.rs
@@ -241,3 +241,103 @@ fn a_pre_task_id_log_line_still_parses() {
     assert_eq!(lesson.task_id, "");
     assert_eq!(task_id_for(&lesson), "turn:100");
 }
+
+/// **Witness (#5323).** A lesson whose append failed is re-scanned next turn,
+/// not stepped over.
+///
+/// Fails on the base, where the loop swallowed a failed append and then set the
+/// cursor to `lines.len()` regardless — putting the failed line below the
+/// cursor and out of reach forever. The module header claimed "a crash costs
+/// one re-scan, never a duplicate"; a *failure* cost the record outright, and
+/// the lexical path (which re-reads the whole log every turn) did not, so the
+/// two diverged exactly here.
+///
+/// # What the two codes do here, and why the last assertion is the witness
+///
+/// A rival holds the write lock just past the store's 5s `busy_timeout` and
+/// then lets go, which is the #5323 shape: a concurrent writer the append
+/// cannot outwait.
+///
+/// - **Base:** the first lesson's append fails and is swallowed; the loop
+///   carries on, the second lesson lands once the lock clears, and the cursor
+///   is then set to 2 — past a line that never appended. The first lesson is
+///   gone, and the next scan starts after it.
+/// - **Here:** the loop stops at the first failure, so nothing appends and the
+///   cursor is not moved. The next scan sees both lines again.
+///
+/// So the discriminating fact is the ledger's contents *after a second scan*:
+/// two observations here, one on the base, forever. The intermediate counts are
+/// asserted too, but that final line is the one that cannot pass both ways.
+#[test]
+fn a_lesson_whose_append_failed_is_recovered_on_the_next_scan() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("context.db");
+    let store = ContextStore::open(&db).expect("open");
+    let log = write_log(
+        dir.path(),
+        &[("Prefer rg.", 100), ("Pin the toolchain.", 200)],
+    );
+
+    // Just past the 5s `busy_timeout` the schema sets, so the first append
+    // waits it out and fails rather than queueing behind the rival.
+    const HELD_FOR: std::time::Duration = std::time::Duration::from_millis(5_600);
+    let (locked, taken) = std::sync::mpsc::channel();
+    let rival = std::thread::spawn(move || {
+        let conn = rusqlite::Connection::open(&db).expect("second connection");
+        conn.busy_timeout(std::time::Duration::from_millis(0))
+            .expect("no wait");
+        conn.execute_batch("BEGIN IMMEDIATE").expect("take the lock");
+        locked.send(()).expect("announce");
+        std::thread::sleep(HELD_FOR);
+        conn.execute_batch("ROLLBACK").expect("release the lock");
+    });
+    taken.recv().expect("the rival holds the write lock");
+
+    assert_eq!(
+        extract_reflection_observations(&store, &log),
+        0,
+        "the scan stops at the lesson whose append lost to the lock"
+    );
+    rival.join().expect("rival");
+
+    assert_eq!(
+        all_observations(&store, 10).len(),
+        0,
+        "and it stopped before the second lesson rather than skipping the first"
+    );
+
+    // The witness. On the base this is 1 and stays 1: the first lesson sits
+    // below a cursor that advanced past it.
+    assert_eq!(
+        extract_reflection_observations(&store, &log),
+        2,
+        "the next scan recovers both lessons"
+    );
+    assert_eq!(all_observations(&store, 10).len(), 2, "and nothing was lost");
+}
+
+/// A line that can never be represented is stepped over rather than becoming a
+/// permanent barrier.
+///
+/// The other half of the fix, and the reason it is not "stop at the first
+/// failure" alone: a cursor parked on a line that will never append would
+/// re-scan the whole log on every turn, forever, growing the per-turn cost
+/// without ever making progress. Deterministic refusals are skipped like the
+/// malformed JSON above them.
+#[test]
+fn an_unrepresentable_line_does_not_wedge_the_cursor() {
+    let (dir, store) = store();
+    let log = write_log(
+        dir.path(),
+        &[("   ", 100), ("Prefer rg.", 200), ("Pin the toolchain.", 300)],
+    );
+
+    assert_eq!(extract_reflection_observations(&store, &log), 2);
+    assert_eq!(
+        store
+            .extraction_cursor("reflections.jsonl")
+            .expect("read cursor"),
+        Some("3".to_string()),
+        "the cursor reaches the end of a log with nothing retryable in it"
+    );
+}


### PR DESCRIPTION
## What & why

The typed extraction loop swallowed a failed `append_observation` and then advanced the cursor to `lines.len()` regardless:

```rust
if append_observation(store, &lesson) == Some(AppendOutcome::Appended) {
    appended += 1;
}
// ...
let _ = store.set_extraction_cursor(REFLECTION_SOURCE, &lines.len().to_string());
```

So a line whose ledger write lost to `SQLITE_BUSY` — a concurrent writer past the 5s busy timeout — ended up *below* the cursor and was never looked at again. The module header claims "a crash costs one re-scan, never a duplicate", and that is true of a crash; a **failure** cost the records outright.

The lexical path re-reads the whole log every turn and is unaffected, so the two paths diverged exactly here, against the behaviour-compatibility contract `learning.rs` holds them to.

## The fix, and why it is two halves

The cursor now stops at the first line whose append failed. Everything from there is re-scanned next turn, which content-derived ids make a no-op replay for whatever did land.

A barrier alone would be a different bug. A line that can *never* append — one whose record does not construct, does not serialize, or whose content the ledger refuses (`InvalidInput`: two records claiming one id) — would park the cursor on itself forever, re-scanning a growing log on every turn without ever advancing. So the failure is typed:

| | classified | cursor |
|---|---|---|
| `ContextError::Sqlite` | the storage layer refusing a write | **stops here** — the same bytes may append next turn |
| everything else | the ledger judging fixed bytes | skipped, like a malformed JSON line |

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_lesson_whose_append_failed_is_recovered_on_the_next_scan` — a rival connection holds the write lock just past the store's 5s `busy_timeout` and then releases, which is the failure the issue names.

- **Base:** the first lesson's append fails and is swallowed, the loop carries on, the second lands once the lock clears, and the cursor is set to 2 — past a line that never appended. Ledger ends with one observation and stays there.
- **Here:** the loop stops at the first failure, nothing appends, the cursor does not move, and the next scan recovers both.

The discriminating assertion is the ledger's contents after a *second* scan — 2 here, 1 on the base, forever. The intermediate counts are asserted too so a lock that cleared early cannot make it pass for the wrong reason.

`an_unrepresentable_line_does_not_wedge_the_cursor` covers the other arm, so the fix cannot be satisfied by simply never advancing.

```
$ cargo test -p stella-cli --bin stella memory::observations
13 passed; 0 failed
```

## The gate

- [x] `cargo fmt --check`
- [x] Targeted tests green (SCR-001: the crate's own filter, not the workspace — CI runs the rest)
- [x] Docs updated — the module header's "failure isolation" section now says what happens to a failed append, replacing the claim that did not hold
- [x] `Closes #5323` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

The issue also suggests recording the failure in the ledger the way `record_reflection_parse_failure` made parse starvation observable. That is deliberately **not** done here: this path's contract is that it never fails or slows the user's turn, and the failure it would record is the ledger being unavailable — the same ledger the record would be written to. The recovery is now automatic and needs no operator, so the observability is worth less than the coupling would cost. Say so if you disagree and I will file it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The witness takes ~5.7s, because it has to outwait a real `busy_timeout` — the loss needs the *append* to fail while the *cursor write* succeeds, and a lock held for the whole scan fails both and leaves the two codes indistinguishable. A faster fake would not have reproduced the bug.

Closes #5323

## Summary by Sourcery

Ensure failed reflection appends are retried without sacrificing cursor progress for permanently invalid lessons.

Bug Fixes:
- Preserve retryable reflection lessons by stopping the extraction cursor at transient ledger write failures so they are recovered on the next scan.
- Continue advancing past deterministic, unrepresentable lessons to prevent permanently wedging the extraction cursor.

Enhancements:
- Classify observation append failures so transient storage errors are retried while deterministic record or content errors are skipped.
- Update reflection extraction documentation to describe failure recovery and cursor behavior.

Tests:
- Add coverage for recovering a lesson after a SQLite lock causes its append to fail.
- Add coverage ensuring unrepresentable lessons do not block cursor progress.