### PR TITLE
fix(stella-cli): close the three doors around governance-mode enforcement

### DIFF
--- a/crates/stella-cli/src/context_cmd.rs
+++ b/crates/stella-cli/src/context_cmd.rs
@@ -43,7 +43,11 @@ use stella_core::ingest::record::{ContextFile, Proposal};
 
 mod amend;
 mod explain;
-mod govern;
+// `pub(crate)` rather than private: the separation gate is one rule with three
+// callers, and two of them (`proposals retract`, `ingest --refresh`) live
+// outside this module. A second copy of the check is exactly what #5328 was
+// filed about.
+pub(crate) mod govern;
 mod propose;
 mod review;
 // `pub(crate)` for one reason: the retirement handshake spans two commands, so its

--- a/crates/stella-cli/src/context_cmd.rs
+++ b/crates/stella-cli/src/context_cmd.rs
@@ -196,9 +196,14 @@ pub enum ContextCmd {
         /// New mode; omit to show current governance, policy version, and
         /// every ledger enforcement grant.
         mode: Option<String>,
-        /// Enable proposer/approver separation (regulated mode).
-        #[arg(long)]
-        separation: bool,
+        /// Enable proposer/approver separation (regulated mode). `--separation
+        /// false` turns it off; omitting it leaves it as it is.
+        ///
+        /// `Option<bool>` rather than a flag, because absent and `false` must
+        /// not be the same request: as a bare flag, `stella context govern
+        /// regulated` silently turned an existing separation OFF (#5328).
+        #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+        separation: Option<bool>,
         /// Confirm a mode change without asking interactively.
         #[arg(long)]
         yes: bool,

--- a/crates/stella-cli/src/context_cmd/govern.rs
+++ b/crates/stella-cli/src/context_cmd/govern.rs
@@ -28,18 +28,28 @@ use super::review::actor;
 pub(crate) fn run_govern(
     root: &Path,
     mode: Option<&str>,
-    separation: bool,
+    separation: Option<bool>,
     yes: bool,
 ) -> Result<(), String> {
-    let current = read_governance(root);
-    let Some(mode) = mode else {
+    let current = read_governance(root)?;
+    // Nothing to change: show. `--separation` alone IS something to change, and
+    // used to be discarded by an early return here (#5328).
+    if mode.is_none() && separation.is_none() {
         return show_governance(root, &current);
-    };
-    let target = parse_mode(mode)?;
+    }
+    // Merged with the document rather than rebuilt from the flags. Every field
+    // the caller did not speak about keeps the value the repository recorded —
+    // `govern regulated` with no `--separation` used to silently turn an
+    // existing separation off, which is a governance change nobody asked for
+    // and nobody was told about (#5328).
     let next = Governance {
-        mode: target,
-        separation,
+        mode: match mode {
+            Some(mode) => parse_mode(mode)?,
+            None => current.mode,
+        },
+        separation: separation.unwrap_or(current.separation),
     };
+    let target = next.mode;
     if next == current {
         println!(
             "governance already {} (separation {})",
@@ -63,10 +73,15 @@ pub(crate) fn run_govern(
              records and their enforcement are unchanged until promoted under the new mode. [y/N]",
             current.mode.as_str(),
             target.as_str(),
-            if separation {
-                ", with proposer/approver separation"
-            } else {
-                ""
+            // What the change actually does to separation, read off the merged
+            // document — a prompt that echoed the flag would say nothing about
+            // separation whenever the flag was absent, which is exactly when
+            // the caller most needs to be told it is unchanged.
+            match (current.separation, next.separation) {
+                (false, true) => ", turning proposer/approver separation on",
+                (true, false) => ", turning proposer/approver separation OFF",
+                (true, true) => ", with proposer/approver separation still on",
+                (false, false) => "",
             }
         );
         let mut answer = String::new();
@@ -87,6 +102,51 @@ pub(crate) fn run_govern(
         GOVERNANCE_FILE
     );
     Ok(())
+}
+
+/// The record's author, or a refusal when separation bars this actor from
+/// writing the ledger event they are about to write.
+///
+/// Shared by `promote` and by `keep`'s supersession path. The check lived only
+/// inside `promote`, so a supersession — which the fold reads as revoking any
+/// blocking grant the lineage held — went to the ledger with `proposer: None`
+/// and no separation check at all: one door checked, the other open (#5328).
+///
+/// The author comes from the local decision ledger's publish events. Absent
+/// means "could not be established", and under separation that fails **closed**
+/// — an unattributable record is exactly the case separation exists to refuse.
+///
+/// `bars` and `instead` name the act in the caller's own words, so the refusal
+/// tells a human what to do about *this* command rather than a generic one.
+pub(crate) fn separation_cleared(
+    root: &Path,
+    governance: &Governance,
+    lineage: &str,
+    handle: &str,
+    approver: &str,
+    bars: &str,
+    instead: &str,
+) -> Result<Option<String>, String> {
+    let proposer = read_decisions(root)
+        .iter()
+        .filter(|event| event.lineage_id == lineage && event.decision.publishes())
+        .map(|event| event.actor.clone())
+        .next_back();
+    if governance.mode != GovernanceMode::Regulated || !governance.separation {
+        return Ok(proposer);
+    }
+    match &proposer {
+        None => Err(format!(
+            "proposer/approver separation is on, and ^{handle}'s author could not be \
+             established from the decision ledger — record the authorship first, or have \
+             the author's machine publish the record through `stella context keep`"
+        )),
+        Some(author) if *author == approver => Err(format!(
+            "proposer/approver separation is on: {author} authored ^{handle} and cannot \
+             {bars} — a different identity must {instead}"
+        )),
+        Some(_) => Ok(proposer),
+    }
 }
 
 fn show_governance(root: &Path, governance: &Governance) -> Result<(), String> {
@@ -175,7 +235,7 @@ pub(crate) fn run_promote(
         ));
     }
 
-    let governance = read_governance(root);
+    let governance = read_governance(root)?;
     let events = read_promotions(root)?;
     let current = blocking_grants(&events)
         .get(&lineage)
@@ -194,32 +254,15 @@ pub(crate) fn run_promote(
     // The record's author, for separation: the publish actor from the local
     // decision ledger when this machine published it. Absent means "could
     // not be established" — and under separation that fails CLOSED.
-    let proposer = read_decisions(root)
-        .iter()
-        .filter(|event| event.lineage_id == lineage && event.decision.publishes())
-        .map(|event| event.actor.clone())
-        .next_back();
-    if governance.mode == GovernanceMode::Regulated && governance.separation {
-        match &proposer {
-            None => {
-                return Err(format!(
-                    "proposer/approver separation is on, and ^{}'s author could not be \
-                     established from the decision ledger — record the authorship first, or \
-                     have the author's machine publish the record through `stella context keep`",
-                    entry.record.handle
-                ));
-            }
-            Some(author) if *author == approver => {
-                return Err(format!(
-                    "proposer/approver separation is on: {author} authored ^{} and cannot \
-                     approve its own enforcement — a different identity must run this \
-                     promotion (or pass --approver)",
-                    entry.record.handle
-                ));
-            }
-            Some(_) => {}
-        }
-    }
+    let proposer = separation_cleared(
+        root,
+        &governance,
+        &lineage,
+        &entry.record.handle,
+        &approver,
+        "approve its own enforcement",
+        "run this promotion (or pass --approver)",
+    )?;
 
     let version = append_promotion(
         root,
@@ -275,4 +318,80 @@ fn git_identity() -> Option<String> {
     }
     let email = String::from_utf8_lossy(&output.stdout).trim().to_string();
     (!email.is_empty()).then_some(email)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context_records::{GOVERNANCE_FILE, read_governance};
+
+    /// Seed a repository whose recorded policy is regulated with separation on.
+    fn regulated_with_separation() -> tempfile::TempDir {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(root.path().join(".stella/rules")).expect("rules dir");
+        std::fs::write(
+            root.path().join(GOVERNANCE_FILE),
+            "mode = \"regulated\"\nseparation = true\n",
+        )
+        .expect("seed policy");
+        root
+    }
+
+    /// **Witness (#5328, door 3).** Changing the mode does not silently turn an
+    /// existing separation off.
+    ///
+    /// Fails on the base, where `run_govern` rebuilt `Governance` from the
+    /// flags — `separation` was a bare `bool`, so a caller who said nothing
+    /// about separation was indistinguishable from one who asked for it off,
+    /// and `stella context govern regulated` revoked it without a word.
+    #[test]
+    fn changing_the_mode_leaves_separation_as_the_repository_recorded_it() {
+        let root = regulated_with_separation();
+
+        run_govern(root.path(), Some("team"), None, true).expect("mode change");
+
+        let after = read_governance(root.path()).expect("policy still parses");
+        assert_eq!(after.mode, GovernanceMode::Team, "the mode moved");
+        assert!(
+            after.separation,
+            "and separation stayed on — nobody asked for it to change"
+        );
+    }
+
+    /// **Witness (#5328, door 3).** `--separation` with no mode is an update,
+    /// not a no-op.
+    ///
+    /// Fails on the base, where a `None` mode returned early through
+    /// `show_governance` and the flag was discarded — the command printed the
+    /// current policy and exited 0, so it looked like it had worked.
+    #[test]
+    fn separation_alone_changes_separation_and_leaves_the_mode() {
+        let root = regulated_with_separation();
+
+        run_govern(root.path(), None, Some(false), true).expect("separation change");
+
+        let after = read_governance(root.path()).expect("policy still parses");
+        assert!(!after.separation, "separation was turned off as asked");
+        assert_eq!(
+            after.mode,
+            GovernanceMode::Regulated,
+            "and the mode is untouched"
+        );
+    }
+
+    /// Neither argument still shows rather than writes, so the two above cannot
+    /// be satisfied by making every invocation a write.
+    #[test]
+    fn neither_argument_leaves_the_policy_exactly_as_it_was() {
+        let root = regulated_with_separation();
+        let before = std::fs::read_to_string(root.path().join(GOVERNANCE_FILE)).expect("read");
+
+        run_govern(root.path(), None, None, true).expect("show");
+
+        assert_eq!(
+            std::fs::read_to_string(root.path().join(GOVERNANCE_FILE)).expect("read"),
+            before,
+            "showing the policy must not rewrite it"
+        );
+    }
 }

--- a/crates/stella-cli/src/context_cmd/govern.rs
+++ b/crates/stella-cli/src/context_cmd/govern.rs
@@ -149,6 +149,34 @@ pub(crate) fn separation_cleared(
     }
 }
 
+/// [`separation_cleared`], but only where the lineage actually holds a blocking
+/// grant.
+///
+/// The gate every **lifecycle** event goes through: `keep`'s supersession,
+/// `proposals retract`, and `ingest --refresh`'s retirement all append events
+/// whose latest-event fold drops any blocking grant the lineage held. That is
+/// enforcement being revoked, which is the act separation governs — and all
+/// three used to write it with `proposer: None` and no check at all (#5328).
+///
+/// Scoped rather than universal, because these three are also how an ordinary
+/// advisory record is edited or retired. `promote` guards the transition INTO
+/// blocking and needs no scoping; these guard the ones that silently undo it,
+/// and must not make routine editing in a regulated repository need a second
+/// identity.
+pub(crate) fn separation_cleared_if_enforced(
+    root: &Path,
+    governance: &Governance,
+    lineage: &str,
+    approver: &str,
+    bars: &str,
+    instead: &str,
+) -> Result<Option<String>, String> {
+    if !blocking_grants(&read_promotions(root)?).contains_key(lineage) {
+        return Ok(None);
+    }
+    separation_cleared(root, governance, lineage, lineage, approver, bars, instead)
+}
+
 fn show_governance(root: &Path, governance: &Governance) -> Result<(), String> {
     let events = read_promotions(root)?;
     println!(
@@ -392,6 +420,110 @@ mod tests {
             std::fs::read_to_string(root.path().join(GOVERNANCE_FILE)).expect("read"),
             before,
             "showing the policy must not rewrite it"
+        );
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_gate_tests {
+    use super::*;
+    use crate::context_records::{RULES_DIR, append_promotion};
+
+    fn regulated() -> Governance {
+        Governance {
+            mode: GovernanceMode::Regulated,
+            separation: true,
+        }
+    }
+
+    fn grant(root: &Path, lineage: &str) {
+        std::fs::create_dir_all(root.join(RULES_DIR)).expect("rules dir");
+        append_promotion(
+            root,
+            PromotionEvent {
+                seq: 0,
+                prev: String::new(),
+                at: "2026-08-04T09:00:00Z".into(),
+                lineage_id: lineage.into(),
+                from: "advisory".into(),
+                to: "blocking".into(),
+                approver: "lead".into(),
+                proposer: None,
+                reason: "measured over 30 days".into(),
+                mode: "regulated".into(),
+                action: stella_core::records::promotion::LedgerAction::Grant,
+            },
+        )
+        .expect("grant");
+    }
+
+    /// **Witness (#5328).** An armed record's author cannot clear its own
+    /// grant through a lifecycle event.
+    ///
+    /// Fails on the base, where the separation check lived only in
+    /// `run_promote`. The three lifecycle writers — `keep`'s supersession,
+    /// `proposals retract`, `ingest --refresh`'s retirement — each appended an
+    /// event whose latest-event fold drops the grant, with `proposer: None`
+    /// and no check. One door was guarded and three were open.
+    #[test]
+    fn clearing_a_grant_is_refused_when_the_author_could_not_be_established() {
+        let root = tempfile::tempdir().expect("tempdir");
+        grant(root.path(), "ctx.acme.web.a");
+
+        let refusal = separation_cleared_if_enforced(
+            root.path(),
+            &regulated(),
+            "ctx.acme.web.a",
+            "someone",
+            "retire its own enforced record",
+            "make this change",
+        )
+        .expect_err("separation fails closed on an unattributable record");
+
+        assert!(refusal.contains("could not be established"), "{refusal}");
+    }
+
+    /// A lineage holding no grant is untouched, so routine editing and
+    /// retirement of an advisory record still work in a regulated repository.
+    ///
+    /// Without this the fix would make every `keep`, `retract` and
+    /// `ingest --refresh` in a regulated repo need a second identity — a much
+    /// larger behaviour change than the issue asks for.
+    #[test]
+    fn an_advisory_lineage_passes_the_lifecycle_gate_untouched() {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(root.path().join(RULES_DIR)).expect("rules dir");
+
+        assert_eq!(
+            separation_cleared_if_enforced(
+                root.path(),
+                &regulated(),
+                "ctx.acme.web.never-promoted",
+                "someone",
+                "retire its own enforced record",
+                "make this change",
+            ),
+            Ok(None)
+        );
+    }
+
+    /// Separation off — the shipped default — clears everything, so the gate
+    /// cannot break a solo or team repository.
+    #[test]
+    fn the_gate_is_inert_where_separation_is_not_in_force() {
+        let root = tempfile::tempdir().expect("tempdir");
+        grant(root.path(), "ctx.acme.web.a");
+
+        assert!(
+            separation_cleared_if_enforced(
+                root.path(),
+                &Governance::default(),
+                "ctx.acme.web.a",
+                "someone",
+                "retire its own enforced record",
+                "make this change",
+            )
+            .is_ok()
         );
     }
 }

--- a/crates/stella-cli/src/context_cmd/review.rs
+++ b/crates/stella-cli/src/context_cmd/review.rs
@@ -431,7 +431,38 @@ pub fn run_keep(
             // The accountable supersession event (spec §4, #2728) — file
             // first, ledger second, and a ledger failure is loud: an
             // unrecorded supersession is what the ledger exists to prevent.
-            let governance = crate::context_records::read_governance(root);
+            let governance = crate::context_records::read_governance(root)?;
+            let approver = actor();
+            // The same separation check `promote` runs, and for the same
+            // reason: the latest-event fold drops any blocking grant the
+            // lineage held, so superseding an armed record revokes enforcement.
+            // That is the act separation governs, and this path used to perform
+            // it with `proposer: None` and no check at all (#5328).
+            //
+            // Scoped to a lineage that actually holds a grant, which is what
+            // keeps ordinary editing of an advisory record possible in a
+            // regulated repository. `promote` guards the transition INTO
+            // blocking; this guards the one that silently undoes it.
+            let holds_a_grant = stella_core::records::promotion::blocking_grants(
+                &crate::context_records::read_promotions(root)?,
+            )
+            .contains_key(&record.lineage_id);
+            let proposer = if holds_a_grant {
+                crate::context_cmd::govern::separation_cleared(
+                    root,
+                    &governance,
+                    &record.lineage_id,
+                    // The lineage id, because this `Record` carries no handle —
+                    // it is also what the ledger event is keyed by, so a human
+                    // reading the refusal can find the event it prevented.
+                    &record.lineage_id,
+                    &approver,
+                    "supersede its own enforced record",
+                    "make this change — it revokes a live blocking grant",
+                )?
+            } else {
+                None
+            };
             crate::context_records::append_promotion(
                 root,
                 stella_core::records::promotion::PromotionEvent {
@@ -441,8 +472,8 @@ pub fn run_keep(
                     lineage_id: record.lineage_id.clone(),
                     from: "active".to_string(),
                     to: "superseded".to_string(),
-                    approver: actor(),
-                    proposer: None,
+                    approver,
+                    proposer,
                     reason: format!(
                         "{old_id} superseded by {} via `stella context keep`",
                         record.record_id.as_deref().unwrap_or("<unstamped>")

--- a/crates/stella-cli/src/context_cmd/review.rs
+++ b/crates/stella-cli/src/context_cmd/review.rs
@@ -443,26 +443,14 @@ pub fn run_keep(
             // keeps ordinary editing of an advisory record possible in a
             // regulated repository. `promote` guards the transition INTO
             // blocking; this guards the one that silently undoes it.
-            let holds_a_grant = stella_core::records::promotion::blocking_grants(
-                &crate::context_records::read_promotions(root)?,
-            )
-            .contains_key(&record.lineage_id);
-            let proposer = if holds_a_grant {
-                crate::context_cmd::govern::separation_cleared(
-                    root,
-                    &governance,
-                    &record.lineage_id,
-                    // The lineage id, because this `Record` carries no handle —
-                    // it is also what the ledger event is keyed by, so a human
-                    // reading the refusal can find the event it prevented.
-                    &record.lineage_id,
-                    &approver,
-                    "supersede its own enforced record",
-                    "make this change — it revokes a live blocking grant",
-                )?
-            } else {
-                None
-            };
+            let proposer = crate::context_cmd::govern::separation_cleared_if_enforced(
+                root,
+                &governance,
+                &record.lineage_id,
+                &approver,
+                "supersede its own enforced record",
+                "make this change — it revokes a live blocking grant",
+            )?;
             crate::context_records::append_promotion(
                 root,
                 stella_core::records::promotion::PromotionEvent {

--- a/crates/stella-cli/src/context_cmd/validate.rs
+++ b/crates/stella-cli/src/context_cmd/validate.rs
@@ -117,7 +117,7 @@ pub fn run_validate(root: &Path, format: QueryFormat) -> Result<(), String> {
     // records themselves say — an edited grant is worse than a missing one.
     let promotions = crate::context_records::read_promotions(root)
         .map_err(|violation| format!("promotion ledger failed verification: {violation}"))?;
-    let governance = crate::context_records::read_governance(root);
+    let governance = crate::context_records::read_governance(root)?;
 
     let files = rule_files(root, true, true);
     let now = now_rfc3339();

--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -76,12 +76,42 @@ pub(crate) const GOVERNANCE_FILE: &str = ".stella/rules/governance.toml";
 const PROMOTION_LOCK: &str = ".stella/private/promotions.lock";
 
 /// Read the governance settings; absent file = solo defaults (§5.1).
-pub(crate) fn read_governance(root: &Path) -> stella_core::records::promotion::Governance {
+///
+/// **Absent is a default; unreadable is an error.** These two used to be the
+/// same answer, and the answer was `Solo` — the least governed tier — so one
+/// corrupt character in `governance.toml` silently switched off `validate`'s
+/// regulated check and `promote`'s separation check. The strictest-tier
+/// selector was the least defended artifact in the directory, while a broken
+/// `promotions.jsonl` beside it failed loudly (#5328).
+///
+/// A file that exists says the repository has an opinion about its own
+/// governance. Failing to parse it is a failure to read that opinion, and
+/// substituting the weakest one is the direction that cannot be recovered
+/// from: nothing downstream can tell it from a repository that chose `Solo`.
+pub(crate) fn read_governance(
+    root: &Path,
+) -> Result<stella_core::records::promotion::Governance, String> {
     let path = root.join(GOVERNANCE_FILE);
-    std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|text| toml::from_str(&text).ok())
-        .unwrap_or_default()
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        // Only "it is not there" is the default. A permission error or an I/O
+        // failure is a file this process could not read, not one that is
+        // absent.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(stella_core::records::promotion::Governance::default());
+        }
+        Err(error) => {
+            return Err(format!("cannot read {}: {error}", path.display()));
+        }
+    };
+    toml::from_str(&text).map_err(|error| {
+        format!(
+            "{} is not readable governance policy: {error}\n\
+             Governance decides who may grant enforcement, so this is refused \
+             rather than defaulted — repair the file, or delete it to mean solo.",
+            path.display()
+        )
+    })
 }
 
 /// Write the governance settings. Callers ask the user first (§5.4) — this

--- a/crates/stella-cli/src/context_records/tests.rs
+++ b/crates/stella-cli/src/context_records/tests.rs
@@ -553,3 +553,65 @@ fn a_promotion_grant_does_not_arm_a_record_a_plugin_shipped() {
         "the same grant must still arm the repository's own record"
     );
 }
+
+/// **Witness (#5328, door 1).** A `governance.toml` this build cannot parse is
+/// an error, not a silent demotion to solo.
+///
+/// Fails on the base, where the read was `.ok().and_then(parse).unwrap_or_default()`
+/// — so one corrupt character switched off `validate`'s regulated check and
+/// `promote`'s separation check, and nothing downstream could tell the result
+/// from a repository that had chosen `Solo`. The strictest-tier selector was
+/// the least defended artifact in the directory, while a broken
+/// `promotions.jsonl` beside it failed loudly.
+#[test]
+fn an_unparseable_governance_file_is_refused_rather_than_read_as_solo() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(root.path().join(RULES_DIR)).unwrap();
+    std::fs::write(
+        root.path().join(GOVERNANCE_FILE),
+        "mode = \"regulated\"\nseparation = tru",
+    )
+    .unwrap();
+
+    let read = read_governance(root.path());
+    let message = read.expect_err("a corrupt policy file must not read as a policy");
+    assert!(
+        message.contains("governance"),
+        "the refusal names what it could not read: {message}"
+    );
+}
+
+/// Absent still means solo — the default the spec gives (§5.1), and the half
+/// that must survive door 1's fix.
+///
+/// Without this, "fail closed" could be satisfied by refusing every repository
+/// that has never run `stella context govern`, which is nearly all of them.
+#[test]
+fn an_absent_governance_file_is_still_the_solo_default() {
+    let root = tempfile::tempdir().unwrap();
+
+    assert_eq!(
+        read_governance(root.path()).expect("absent is a default, not a failure"),
+        stella_core::records::promotion::Governance::default()
+    );
+}
+
+/// A file that parses is read as written, so the refusal above cannot be
+/// satisfied by refusing everything.
+#[test]
+fn a_well_formed_governance_file_is_read_as_written() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(root.path().join(RULES_DIR)).unwrap();
+    std::fs::write(
+        root.path().join(GOVERNANCE_FILE),
+        "mode = \"regulated\"\nseparation = true\n",
+    )
+    .unwrap();
+
+    let governance = read_governance(root.path()).expect("well-formed policy reads");
+    assert_eq!(
+        governance.mode,
+        stella_core::records::promotion::GovernanceMode::Regulated
+    );
+    assert!(governance.separation);
+}

--- a/crates/stella-cli/src/ingest_cmd/refresh.rs
+++ b/crates/stella-cli/src/ingest_cmd/refresh.rs
@@ -202,6 +202,19 @@ fn published_from_source(root: &Path, rel: &str) -> Vec<PublishedFile> {
 /// record must not keep the authority to deny tool calls.
 fn record_retirement(root: &Path, rel: &str, claim: &PublishedClaim) -> Result<(), String> {
     let governance = crate::context_records::read_governance(root)?;
+    let approver = crate::context_cmd::actor();
+    // The same separation gate the other two lifecycle writers run. The fold
+    // this event feeds drops any blocking grant the lineage held — the doc
+    // above says so — so retiring an armed record revokes enforcement, and
+    // that is what separation governs (#5328).
+    let proposer = crate::context_cmd::govern::separation_cleared_if_enforced(
+        root,
+        &governance,
+        &claim.lineage_id,
+        &approver,
+        "retire its own enforced record",
+        "make this change — it revokes a live blocking grant",
+    )?;
     crate::context_records::append_promotion(
         root,
         stella_core::records::promotion::PromotionEvent {
@@ -211,8 +224,8 @@ fn record_retirement(root: &Path, rel: &str, claim: &PublishedClaim) -> Result<(
             lineage_id: claim.lineage_id.clone(),
             from: "active".to_string(),
             to: "archived".to_string(),
-            approver: crate::context_cmd::actor(),
-            proposer: None,
+            approver,
+            proposer,
             reason: format!(
                 "retired by `stella ingest --refresh {rel}`: the source no longer asserts \
                  {} (was {})",

--- a/crates/stella-cli/src/ingest_cmd/refresh.rs
+++ b/crates/stella-cli/src/ingest_cmd/refresh.rs
@@ -201,7 +201,7 @@ fn published_from_source(root: &Path, rel: &str) -> Vec<PublishedFile> {
 /// revokes any blocking grant the lineage held, which is correct: a retired
 /// record must not keep the authority to deny tool calls.
 fn record_retirement(root: &Path, rel: &str, claim: &PublishedClaim) -> Result<(), String> {
-    let governance = crate::context_records::read_governance(root);
+    let governance = crate::context_records::read_governance(root)?;
     crate::context_records::append_promotion(
         root,
         stella_core::records::promotion::PromotionEvent {

--- a/crates/stella-cli/src/proposals_cmd/retract.rs
+++ b/crates/stella-cli/src/proposals_cmd/retract.rs
@@ -209,7 +209,7 @@ fn retract_in_place(published: &mut Published) -> Result<(), String> {
 /// asserting a claim, and the same fold that drops any blocking grant the
 /// lineage held.
 fn record_retraction(workspace_root: &Path, lineage_id: &str, reason: &str) -> Result<(), String> {
-    let governance = crate::context_records::read_governance(workspace_root);
+    let governance = crate::context_records::read_governance(workspace_root)?;
     crate::context_records::append_promotion(
         workspace_root,
         stella_core::records::promotion::PromotionEvent {

--- a/crates/stella-cli/src/proposals_cmd/retract.rs
+++ b/crates/stella-cli/src/proposals_cmd/retract.rs
@@ -210,6 +210,20 @@ fn retract_in_place(published: &mut Published) -> Result<(), String> {
 /// lineage held.
 fn record_retraction(workspace_root: &Path, lineage_id: &str, reason: &str) -> Result<(), String> {
     let governance = crate::context_records::read_governance(workspace_root)?;
+    let approver = crate::context_cmd::actor();
+    // The same separation gate `promote` and `keep` run, for the same reason:
+    // this event's fold drops any blocking grant the lineage held, so retracting
+    // an armed record revokes enforcement. Scoped to a lineage that actually
+    // holds one, so retracting an advisory record stays an ordinary act
+    // (#5328).
+    let proposer = crate::context_cmd::govern::separation_cleared_if_enforced(
+        workspace_root,
+        &governance,
+        lineage_id,
+        &approver,
+        "retract its own enforced record",
+        "make this change — it revokes a live blocking grant",
+    )?;
     crate::context_records::append_promotion(
         workspace_root,
         stella_core::records::promotion::PromotionEvent {
@@ -219,8 +233,8 @@ fn record_retraction(workspace_root: &Path, lineage_id: &str, reason: &str) -> R
             lineage_id: lineage_id.to_string(),
             from: RecordStatus::Active.as_str().to_string(),
             to: RecordStatus::Retracted.as_str().to_string(),
-            approver: crate::context_cmd::actor(),
-            proposer: None,
+            approver,
+            proposer,
             reason: format!("retracted by `stella proposals retract`: {}", reason.trim()),
             mode: governance.mode.as_str().to_string(),
             action: stella_core::records::promotion::LedgerAction::Retired,

--- a/website/content/docs/commands/context.mdx
+++ b/website/content/docs/commands/context.mdx
@@ -241,10 +241,16 @@ non-interactively); personal records stay private across the transition.
 
 Each argument changes only what it names. `govern team` moves the mode and
 leaves separation as the repository recorded it; `--separation false` turns
-separation off and leaves the mode. In regulated mode with separation on, the
-identity that authored a record cannot approve its own enforcement grant, nor
-supersede that record while the grant is live — and an author that cannot be
-established fails closed.
+separation off and leaves the mode.
+
+In regulated mode with separation on, the identity that authored a record
+cannot approve its own enforcement grant — and, while that grant is live,
+cannot clear it either. That covers every event whose ledger fold drops the
+grant: `context keep`'s supersession, `proposals retract`, and
+`ingest --refresh`'s retirement, alongside `context promote` itself. A record
+holding **no** grant is untouched by any of it, so editing and retiring
+advisory records stays ordinary. An author that cannot be established fails
+closed.
 
 `.stella/rules/governance.toml` decides who may grant enforcement, so a file
 that exists and does not parse is an error rather than a fall back to `solo`.

--- a/website/content/docs/commands/context.mdx
+++ b/website/content/docs/commands/context.mdx
@@ -232,15 +232,23 @@ a natural-language statement never silently becomes blocking behavior. An
 edited, dropped, or reordered ledger line breaks the chain, `stella context
 validate` fails on it, and a broken ledger grants nothing.
 
-### `stella context govern [solo|team|regulated] [--separation] [--yes]`
+### `stella context govern [solo|team|regulated] [--separation[=true|false]] [--yes]`
 
-Show or change the governance mode. With no argument it prints the mode, the
-current policy version, and every ledger enforcement grant with its approver
-and reason. A mode change always asks first (`--yes` confirms
-non-interactively); personal records stay private across the transition. In
-regulated mode with `--separation`, the identity that authored a record
-cannot approve its own enforcement grant — and an author that cannot be
+Show or change the governance mode. With **no arguments** it prints the mode,
+the current policy version, and every ledger enforcement grant with its
+approver and reason. Any change asks first (`--yes` confirms
+non-interactively); personal records stay private across the transition.
+
+Each argument changes only what it names. `govern team` moves the mode and
+leaves separation as the repository recorded it; `--separation false` turns
+separation off and leaves the mode. In regulated mode with separation on, the
+identity that authored a record cannot approve its own enforcement grant, nor
+supersede that record while the grant is live — and an author that cannot be
 established fails closed.
+
+`.stella/rules/governance.toml` decides who may grant enforcement, so a file
+that exists and does not parse is an error rather than a fall back to `solo`.
+Delete it to mean solo.
 
 ## Two proposal substrates, separate
 


### PR DESCRIPTION
## What & why

Governance decides who may grant enforcement. Three separate paths went around that decision.

### 1. `read_governance` failed open

```rust
std::fs::read_to_string(&path).ok().and_then(|t| toml::from_str(&t).ok()).unwrap_or_default()
```

An unparseable `governance.toml` became `Solo` — the least governed tier — so **one corrupt character switched off `validate`'s regulated check and `promote`'s separation check**, and nothing downstream could tell the result from a repository that had chosen solo. The strictest-tier selector was the least defended artifact in the directory, while a broken `promotions.jsonl` beside it failed loudly.

It now returns `Result`. **Absent is still the solo default** (§5.1); *unreadable* is an error. The five call sites all return `Result<(), String>` already, so they propagate with `?`.

### 2. `keep`'s supersession path had no separation check

It wrote a ledger event with `proposer: None` and ran no check, while the same check sat inside `run_promote`. The latest-event fold **drops any blocking grant the lineage held**, so superseding an armed record revokes enforcement — which is the act separation governs.

The check is now `govern::separation_cleared`, shared by both callers. Applied here only when the lineage actually holds a grant: `promote` guards the transition *into* blocking, this guards the one that silently undoes it, and ordinary editing of an advisory record stays possible in a regulated repository.

### 3. `run_govern` rebuilt the document from the flags

`separation` was a bare `bool`, so "not passed" and "passed false" were the same request:

- `stella context govern regulated` silently turned an existing separation **off**.
- `--separation` with no mode was discarded by the `let Some(mode) = mode else { return show }` early return — the command printed the current policy and exited 0, so it looked like it had worked.

Now `Option<bool>`, merged with the recorded document rather than rebuilt. Each argument changes only what it names. The confirmation prompt reports what the change does to separation rather than echoing the flag — a prompt that echoed the flag said nothing about separation exactly when the caller most needed to be told it was unchanged.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Each was verified failing with its own fix backed out:

| test | door |
|---|---|
| `an_unparseable_governance_file_is_refused_rather_than_read_as_solo` | 1 |
| `an_absent_governance_file_is_still_the_solo_default` | 1 — so "fail closed" cannot be satisfied by refusing every repository that never ran `govern` |
| `a_well_formed_governance_file_is_read_as_written` | 1 — nor by refusing everything |
| `changing_the_mode_leaves_separation_as_the_repository_recorded_it` | 3 |
| `separation_alone_changes_separation_and_leaves_the_mode` | 3 |
| `neither_argument_leaves_the_policy_exactly_as_it_was` | 3 — so the two above cannot be satisfied by making every invocation a write |

```
$ cargo test -p stella-cli --bin stella context_
79 passed; 0 failed
$ cargo clippy -p stella-cli --all-targets -- -D warnings
clean
```

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] Targeted tests green (SCR-001 — CI runs the workspace)
- [x] Docs updated: `website/content/docs/commands/context.mdx`'s `govern` section carries the new flag shape, the merge semantics, and the unreadable-policy refusal
- [x] `Closes #5328` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing: all three doors are closed in this PR.

**One thing I want a reviewer's eye on rather than a filed issue:** door 2 is scoped to a lineage that *currently holds a blocking grant*. The alternative reading of the issue — run the check on every supersession — would make editing any published record in a regulated repo require a second identity, which I judged to be a bigger behavioural change than the issue asks for and not obviously wanted. Say the word and I will widen it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Door 1 is a behaviour change with a blast radius: a repository whose `governance.toml` is currently unparseable has been running as `solo` without knowing it, and after this it gets an error from `context validate`, `promote`, `keep`, `retract` and `ingest --refresh` until the file is repaired or deleted. That is the point — but it will look like a new failure rather than a disclosed old one, so the message says which file, why it is refused, and that deleting it means solo.

Closes #5328

## Summary by Sourcery

Close governance enforcement bypasses by failing safely on unreadable policies, applying separation checks to grant-clearing lifecycle actions, and merging only explicitly requested policy changes.

Bug Fixes:
- Reject unreadable governance policies instead of silently treating them as the least governed mode while preserving the solo default for absent policies.
- Enforce proposer/approver separation across promotion, supersession, retraction, and refresh retirement when a lineage holds a blocking grant.
- Preserve unspecified governance settings when updating policy and allow separation to be changed independently of the governance mode.

Enhancements:
- Centralize governance separation checks and improve refusal and confirmation messaging.

Documentation:
- Document governance update merge semantics, separation flag values, lifecycle enforcement checks, and refusal of unreadable governance policies.

Tests:
- Add witness coverage for unreadable, absent, and valid governance policies, independent governance updates, and lifecycle separation enforcement.