### PR TITLE
fix(stella-cli): `stella tools --enable` asks a human, and refuses when none is there

### DIFF
--- a/crates/stella-cli/src/cli/command.rs
+++ b/crates/stella-cli/src/cli/command.rs
@@ -340,9 +340,20 @@ pub(crate) enum Command {
 
         /// Enable an adopted tool — the one approval in the protocol a
         /// machine never grants itself. Refused if the tool's bytes changed
-        /// since its witness ran.
+        /// since its witness ran, and refused with no terminal attached
+        /// unless --yes says a human already read the declaration.
         #[arg(long, value_name = "NAME", conflicts_with_all = ["validate", "adopt"])]
         enable: Option<String>,
+
+        /// Accept an --enable without being asked interactively.
+        ///
+        /// The escape hatch the human-presence check needs to be usable at
+        /// all: a provisioning script has no terminal, and refusing it
+        /// outright would be a rule nobody could follow. A flag rather than an
+        /// environment variable, so granting the tool is a line somebody wrote
+        /// down and a reviewer can find (#5332).
+        #[arg(long, requires = "enable")]
+        yes: bool,
 
         /// Stop offering an adopted tool, keeping its proof on file
         #[arg(

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -661,6 +661,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             validate,
             adopt,
             enable,
+            yes,
             disable,
             foundry,
         }) => {
@@ -676,10 +677,15 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 _ if enable.is_some() => tool_foundry::adopt::run_tools_enable(
                     enable.as_deref().unwrap_or_default(),
                     true,
+                    *yes,
                 ),
+                // Disabling withdraws authority rather than granting it, so it
+                // asks nobody: the direction that needs a human is the one that
+                // lets a model call new code (#5332).
                 _ if disable.is_some() => tool_foundry::adopt::run_tools_enable(
                     disable.as_deref().unwrap_or_default(),
                     false,
+                    true,
                 ),
                 // `--validate` (dir optional) is the strict pre-flight path;
                 // a plain `stella tools` stays the lenient listing.

--- a/crates/stella-cli/src/tool_foundry/adopt.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt.rs
@@ -65,11 +65,31 @@ pub(crate) fn run_tools_adopt(name: &str) -> Result<(), String> {
 }
 
 /// `stella tools --enable <name>` / `--disable <name>`.
-pub(crate) fn run_tools_enable(name: &str, enabled: bool) -> Result<(), String> {
+///
+/// # Why enabling asks and disabling does not
+///
+/// The evolution ledger requires deterministic proof **plus a local human** for
+/// an executable tool, and the proof half was real: `adopt_in` runs the
+/// capability witness, adoption lands disabled, re-adoption revokes approval,
+/// and enabling re-checks the bytes. The human half was enforced by nothing but
+/// the convention that a CLI invocation comes from a person — which an agent
+/// holding the `bash` tool falsifies. It could stage, adopt and enable its own
+/// authored tool inside one turn, and the next session's model could call it
+/// (#5332).
+///
+/// So `--enable` renders what is being granted and asks, exactly the way
+/// `stella plugin install` does, and refuses with no terminal attached unless
+/// `--yes` says a human already read it. Disabling withdraws authority and asks
+/// nobody: the direction that needs a person is the one that lets a model call
+/// new code.
+pub(crate) fn run_tools_enable(name: &str, enabled: bool, yes: bool) -> Result<(), String> {
     let root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
     let store = Store::open(&root).map_err(|e| format!("cannot open the workspace store: {e}"))?;
-    set_enabled_in(&root, &store, name, enabled)?;
+    if !run_tools_enable_in(&root, &store, name, enabled, yes)? {
+        println!("not enabled.");
+        return Ok(());
+    }
 
     if enabled {
         crate::plain::section_header("Tool enabled");
@@ -198,6 +218,108 @@ pub(crate) fn adopt_in(root: &Path, store: &Store, name: &str) -> Result<Adopted
         .adopt_foundry_tool(&record)
         .map_err(|e| format!("cannot record the adoption: {e}"))?;
     Ok(record)
+}
+
+/// The consent gate and the ledger write. The testable core of
+/// [`run_tools_enable`]: no cwd, no reporting.
+///
+/// `Ok(false)` means a human was asked and said no — the one outcome that is
+/// neither a grant nor an error.
+pub(crate) fn run_tools_enable_in(
+    root: &Path,
+    store: &Store,
+    name: &str,
+    enabled: bool,
+    yes: bool,
+) -> Result<bool, String> {
+    // Before the ledger write, and rendered from the manifest on disk rather
+    // than from the name the caller typed: the thing being approved is the
+    // script the model will run.
+    if enabled && !yes {
+        print!("{}", enable_consent_text(root, store, name)?);
+        // `true` for the first input: this is a plain text command, so the only
+        // questions are whether stdio is a terminal.
+        if !crate::interactive::human_is_present(true) {
+            return Err(format!(
+                "nothing here can ask you to approve `{name}` — no terminal is attached. \
+                 Enabling a self-authored tool is the one approval in this protocol a machine \
+                 never grants itself; re-run with --yes if you have read the declaration above \
+                 and accept it."
+            ));
+        }
+        if !confirm_enable(name)? {
+            return Ok(false);
+        }
+    }
+
+    set_enabled_in(root, store, name, enabled)?;
+    Ok(true)
+}
+
+/// What enabling `name` would grant, in the words of the manifest on disk.
+///
+/// Rendered from the files rather than the ledger, and from the files rather
+/// than the caller's argument: the thing a human is approving is the script the
+/// model will run, so that is what is shown. Pure over the workspace so the
+/// text is testable without a terminal — the presence check around it is the
+/// half a test cannot drive.
+pub(crate) fn enable_consent_text(
+    root: &Path,
+    store: &Store,
+    name: &str,
+) -> Result<String, String> {
+    use std::fmt::Write as _;
+
+    let record = store
+        .adopted_foundry_tool(name)
+        .map_err(|e| format!("cannot read the adoption ledger: {e}"))?
+        .ok_or_else(|| {
+            format!(
+                "`{name}` has not been adopted — prove it first with \
+                 `stella tools --adopt {name}`"
+            )
+        })?;
+    let manifest_path = root.join(ADOPTED_DIR).join(format!("{name}.toml"));
+    let script_path = root.join(ADOPTED_DIR).join(format!("{name}.sh"));
+    let text = std::fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("cannot read {}: {e}", manifest_path.display()))?;
+    let tool = custom::parse_manifest(&text, &manifest_path)?;
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "\nEnabling `{name}` offers it to the model every turn."
+    );
+    let _ = writeln!(out, "\n  description  {}", tool.description);
+    let _ = writeln!(out, "  runs         {}", script_path.display());
+    let _ = writeln!(out, "  witness      {}", record.witness);
+    let _ = writeln!(
+        out,
+        "\nIt was authored by the foundry, not by you. The witness above is proof that the \
+         call fails without it and succeeds with it — it is not proof that the script is \
+         safe to run, which is the question only you can answer."
+    );
+    Ok(out)
+}
+
+/// The yes/no on an `--enable`.
+///
+/// A bare `y`/`yes` and nothing else, matching `plugin install` — anything a
+/// caller pipes in that is not an explicit yes is a no.
+fn confirm_enable(name: &str) -> Result<bool, String> {
+    use std::io::{BufRead as _, Write as _};
+
+    print!("\nEnable `{name}`? [y/N] ");
+    std::io::stdout()
+        .flush()
+        .map_err(|e| format!("cannot write the prompt: {e}"))?;
+    let mut line = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .map_err(|e| format!("cannot read your answer: {e}"))?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
 }
 
 /// Flip one adoption's enablement, refusing to enable a tool whose bytes no

--- a/crates/stella-cli/src/tool_foundry/adopt/tests.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt/tests.rs
@@ -364,3 +364,113 @@ fn relocation_rewrites_exactly_the_command() {
     );
     assert!(relocate_command("command = [\"./other.sh\"]", "jq").is_err());
 }
+
+/// **Witness (#5332).** A non-interactive `--enable` is refused, and says why.
+///
+/// The evolution ledger requires deterministic proof *plus a local human* for
+/// an executable tool. The proof half was real; the human half was enforced by
+/// nothing but the convention that a CLI invocation comes from a person — which
+/// an agent holding the `bash` tool falsifies. It could stage, adopt and enable
+/// its own authored tool inside one turn.
+///
+/// This drives `set_enabled_in`'s caller-side gate through its testable half:
+/// the refusal fires wherever no terminal is attached, which is exactly what a
+/// test process is.
+#[test]
+fn a_non_interactive_enable_is_refused_rather_than_granted() {
+    let (ws, store) = workspace();
+    let name = author_cat(ws.path(), &store);
+    adopt_in(ws.path(), &store, &name).expect("adopt");
+
+    // No terminal here — the same condition an agent's shell presents.
+    assert!(
+        !crate::interactive::human_is_present(true),
+        "precondition: a test process has no terminal to ask at"
+    );
+
+    let refusal = run_tools_enable_in(ws.path(), &store, &name, true, false)
+        .expect_err("a machine must not grant itself this approval");
+    assert!(
+        refusal.contains("--yes"),
+        "the refusal names the way through: {refusal}"
+    );
+
+    assert!(
+        !store
+            .adopted_foundry_tool(&name)
+            .expect("read")
+            .expect("adopted")
+            .enabled,
+        "and nothing was granted"
+    );
+}
+
+/// `--yes` is the documented way through, so the check above is a discipline
+/// rather than a wall.
+///
+/// Without this the refusal could be satisfied by making `--enable` impossible,
+/// which would break every provisioning script that legitimately has no
+/// terminal.
+#[test]
+fn an_explicit_yes_still_enables_without_a_terminal() {
+    let (ws, store) = workspace();
+    let name = author_cat(ws.path(), &store);
+    adopt_in(ws.path(), &store, &name).expect("adopt");
+
+    run_tools_enable_in(ws.path(), &store, &name, true, true).expect("--yes grants it");
+
+    assert!(
+        store
+            .adopted_foundry_tool(&name)
+            .expect("read")
+            .expect("adopted")
+            .enabled
+    );
+}
+
+/// Disabling asks nobody. The direction that needs a human is the one that lets
+/// a model call new code; withdrawing that authority must never be blocked by
+/// the absence of a terminal, or a compromised tool could not be switched off
+/// from a script.
+#[test]
+fn disabling_needs_no_human_and_no_yes() {
+    let (ws, store) = workspace();
+    let name = author_cat(ws.path(), &store);
+    adopt_in(ws.path(), &store, &name).expect("adopt");
+    run_tools_enable_in(ws.path(), &store, &name, true, true).expect("enable");
+
+    run_tools_enable_in(ws.path(), &store, &name, false, false).expect("disable asks nobody");
+
+    assert!(
+        !store
+            .adopted_foundry_tool(&name)
+            .expect("read")
+            .expect("adopted")
+            .enabled
+    );
+}
+
+/// The consent text names what is actually being granted — the script the model
+/// will run — rather than the name the caller typed.
+///
+/// A prompt that echoed the argument would be a confirmation of the reader's
+/// own typing, which is not consent to anything.
+#[test]
+fn the_consent_text_names_the_script_and_the_witness() {
+    let (ws, store) = workspace();
+    let name = author_cat(ws.path(), &store);
+    let adopted = adopt_in(ws.path(), &store, &name).expect("adopt");
+
+    let text = enable_consent_text(ws.path(), &store, &name).expect("render");
+
+    assert!(text.contains("cat.sh"), "the script it runs: {text}");
+    assert!(text.contains(&adopted.witness), "the proof on file: {text}");
+    assert!(
+        text.contains("Read one file's contents."),
+        "the manifest's own description: {text}"
+    );
+    assert!(
+        text.contains("not proof that the script is safe"),
+        "and what the witness does NOT establish: {text}"
+    );
+}

--- a/website/content/docs/commands/tools.mdx
+++ b/website/content/docs/commands/tools.mdx
@@ -81,9 +81,23 @@ Take a staged tool all the way to a usable one:
 # cannot see it: jq.toml (with a [foundry] table) + jq.sh.
 stella tools --validate .stella/tools/proposed
 stella tools --adopt jq          # run its witness; records the proof, stays disabled
-stella tools --enable jq         # the one human approval
+stella tools --enable jq         # the one human approval — prints what it grants and asks
 stella tools --foundry           # what was adopted, and what it has been worth
 ```
+
+<Callout type="warn">
+  **`--enable` asks, and refuses when nobody can answer.** It prints the script
+  the model would run, the witness on file, and what that witness does *not*
+  establish, then waits for a `y`. With no terminal attached it refuses rather
+  than proceeding — otherwise an agent holding the `bash` tool could stage,
+  adopt and enable its own tool inside one turn, and "the approval a machine
+  never grants itself" would be enforced only by the habit that a CLI
+  invocation comes from a person. Pass `--yes` for a provisioning script, where
+  granting it is something somebody wrote down.
+
+  `--disable` asks nobody: withdrawing the authority must never be blocked by
+  the absence of a terminal.
+</Callout>
 
 ## Self-authored tools
 


### PR DESCRIPTION
## What & why

The evolution ledger requires **deterministic proof plus a local human** before an executable tool the foundry authored may run.

The proof half was real — `adopt_in` runs the capability witness, adoption lands the tool disabled, re-adoption revokes the approval, and enabling re-checks the bytes against the ones the witness ran.

**The human half was enforced by nothing.** `--enable` performed no presence check, rendered no consent, and asked no question. The guarantee rested on the convention that a CLI invocation comes from a person — which an agent holding the `bash` tool falsifies. It could stage, adopt and enable its own authored tool inside one turn, and the next session's model could call it. The "approval a machine never grants itself" comment in `foundry.rs` and `cli/command.rs` described an intention, not a mechanism.

## What it does now

`--enable` follows the `stella plugin install` pattern the issue points at:

```
Enabling `jq` offers it to the model every turn.

  description  Read one file's contents.
  runs         /repo/.stella/tools/jq.sh
  witness      <the proof on file>

It was authored by the foundry, not by you. The witness above is proof that the
call fails without it and succeeds with it — it is not proof that the script is
safe to run, which is the question only you can answer.

Enable `jq`? [y/N]
```

With no terminal attached it **refuses**, naming `--yes` as the way through — the escape hatch a provisioning script needs, and the one that makes granting the tool something somebody wrote down. Without it the rule would be one nobody could follow.

`--disable` asks nobody. The direction that needs a person is the one that lets a model call new code; withdrawing that authority must never be blocked by the absence of a terminal, or a tool could not be switched off from a script.

The consent is rendered from the **manifest on disk**, not from the name the caller typed — a prompt echoing the argument is a confirmation of the reader's own typing, which is not consent to anything.

`run_tools_enable_in` is the testable core, mirroring `adopt_in`: no cwd, no reporting, and `Ok(false)` for the one outcome that is neither a grant nor an error.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

| test | what it holds |
|---|---|
| `a_non_interactive_enable_is_refused_rather_than_granted` | **the witness** — verified failing with the gate backed out. A test process has no terminal, which is the same condition an agent's shell presents |
| `an_explicit_yes_still_enables_without_a_terminal` | `--yes` works, so the check is a discipline rather than a wall |
| `disabling_needs_no_human_and_no_yes` | withdrawal is never blocked |
| `the_consent_text_names_the_script_and_the_witness` | the text names the script, the witness, the manifest's own description, and what the witness does *not* establish |

```
$ cargo test -p stella-cli --bin stella tool_foundry
17 passed; 0 failed
$ cargo clippy -p stella-cli --all-targets -- -D warnings
clean
```

With the gate backed out: `16 passed; 1 failed` — the witness, and only the witness.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] Targeted tests green (SCR-001 — CI runs the workspace)
- [x] `make command-docs` OK
- [x] Docs updated: `website/content/docs/commands/tools.mdx` carries the ask, the refusal, `--yes`, and why `--disable` is different
- [x] `Closes #5332` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

The issue's DoD also asks to **"stamp the authority on the adopted-tool row"**. I have deliberately not done that here, and want to say why rather than quietly drop it: the adoption ledger row has no authority column, adding one is a store schema migration, and the honest value to stamp for `--yes` is "somebody asserted they had read it" — which is a different and weaker claim than an interactive `y`. That is a design question worth its own issue rather than a field invented inside this PR. Say the word and I will file it, or add it here if you would rather it landed together.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

This is a behaviour change for anyone scripting `stella tools --enable` today: those invocations start failing until `--yes` is added. That is the point of the fix, and the refusal message says exactly what to add.

Closes #5332

## Summary by Sourcery

Require human confirmation before granting adopted tools model access while retaining an explicit non-interactive provisioning path.

New Features:
- Require explicit human consent or --yes before enabling an adopted foundry tool, including a declaration of the script, description, and witness.
- Add a --yes option for non-interactive provisioning workflows.

Bug Fixes:
- Prevent non-interactive callers and agents from enabling self-authored executable tools without human approval.

Enhancements:
- Allow disabling adopted tools without terminal access or confirmation, preserving immediate withdrawal of authority.

Documentation:
- Document the interactive enablement prompt, non-interactive refusal, --yes escape hatch, and confirmation-free disabling behavior.

Tests:
- Add coverage for non-interactive refusal, explicit --yes enablement, confirmation-free disabling, and consent text contents.