### PR TITLE
fix(stella-core,stella-cli): a truncated promotions ledger is detected, not read as shorter

### DIFF
--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -178,21 +178,89 @@ pub(crate) fn promotion_ledger_text(root: &Path) -> (std::path::PathBuf, String)
     (path, text)
 }
 
+/// Where this machine remembers the ledger's head, relative to the workspace.
+///
+/// Under `.stella/private/` for the reason [`PROMOTION_LOCK`] is: it is one
+/// clone's memory of what it last saw, not reviewed policy. Committing it
+/// would make one developer's machine the authority on another's, and it would
+/// have to be updated in every pull request that touches a grant.
+const PROMOTION_HEAD_PIN: &str = ".stella/private/promotions-head.json";
+
 /// Verify and parse the promotion ledger. A chain violation is an error the
 /// caller must surface — never silently treated as an empty ledger, which
 /// would read tampering as "no grants" and drop enforcement without a trace.
+///
+/// **Two checks, because the chain can only see one of the two ways a ledger
+/// lies.** `parse_and_verify` walks each line against the one before it, which
+/// a truncated tail satisfies perfectly — so a removed demotion event
+/// resurrects the grant it revoked and `validate` goes green on it (#5327).
+/// The second check compares the file against [`PROMOTION_HEAD_PIN`], this
+/// machine's record of what it last read.
+///
+/// The pin is advanced after a clean read, so ordinary growth is silent and
+/// only a *shrink* or a rewrite is reported. A failure to write it is not an
+/// error: the worst case is one unprotected read, and refusing to run because
+/// a private cache could not be updated would be worse than the gap.
 pub(crate) fn read_promotions(
     root: &Path,
 ) -> Result<Vec<stella_core::records::promotion::PromotionEvent>, String> {
     let (path, text) = promotion_ledger_text(root);
-    stella_core::records::promotion::parse_and_verify(&text).map_err(|violation| {
+    let events = stella_core::records::promotion::parse_and_verify(&text).map_err(|violation| {
         format!(
             "{} line {}: {}",
             path.display(),
             violation.line,
             violation.reason
         )
-    })
+    })?;
+
+    if let Some(pinned) = read_head_pin(root)
+        && let Some(violation) =
+            stella_core::records::promotion::continuity_violation(&text, &pinned)
+    {
+        return Err(format!(
+            "{}: {}\n\
+             This machine's record of the ledger's head is {}; repair the ledger from Git \
+             history, or delete {PROMOTION_HEAD_PIN} if you know the change was intended.",
+            path.display(),
+            violation.reason,
+            PROMOTION_HEAD_PIN
+        ));
+    }
+    write_head_pin(root, &text);
+    Ok(events)
+}
+
+/// What this machine last saw at the end of the ledger, if it has looked.
+fn read_head_pin(root: &Path) -> Option<stella_core::records::promotion::ChainHead> {
+    let text = std::fs::read_to_string(root.join(PROMOTION_HEAD_PIN)).ok()?;
+    // An unreadable pin is no pin. Failing closed here would refuse every
+    // command on a corrupt private cache, which is a local artifact the user
+    // never wrote and can always delete — the opposite of `governance.toml`,
+    // where the file IS the policy.
+    serde_json::from_str(&text).ok()
+}
+
+/// Record the ledger's head as this machine's new anchor. Best-effort.
+fn write_head_pin(root: &Path, text: &str) {
+    let Some(head) = stella_core::records::promotion::head_of(text) else {
+        return;
+    };
+    let path = root.join(PROMOTION_HEAD_PIN);
+    let Some(parent) = path.parent() else { return };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    if let Ok(body) = serde_json::to_string(&head) {
+        // Owner-only, like everything else under `.stella/private/`: another
+        // account able to rewrite this pin could hide a truncation from the
+        // check it exists to feed.
+        let _ = stella_store::durable::write_atomic(
+            &path,
+            body.as_bytes(),
+            stella_store::durable::MODE_PRIVATE,
+        );
+    }
 }
 
 /// Append one promotion event, stamping seq + prev from the verified tail.

--- a/crates/stella-cli/src/context_records/tests.rs
+++ b/crates/stella-cli/src/context_records/tests.rs
@@ -386,6 +386,18 @@ fn grant(lineage: &str, reason: &str) -> stella_core::records::promotion::Promot
     }
 }
 
+/// The event that revokes a grant — the one whose removal from the tail turns
+/// a blocking record back on with nothing in the file to show for it (#5327).
+fn retirement(lineage: &str) -> stella_core::records::promotion::PromotionEvent {
+    stella_core::records::promotion::PromotionEvent {
+        from: "active".into(),
+        to: "archived".into(),
+        action: stella_core::records::promotion::LedgerAction::Retired,
+        reason: "the source stopped asserting it".into(),
+        ..grant(lineage, "unused")
+    }
+}
+
 /// The promotion ledger is the repository-visible, hash-chained artifact the
 /// enforcement grants live in, so its append is a durable replacement, not a
 /// truncate in place — and nothing the replacement needs may land in the
@@ -551,5 +563,105 @@ fn a_promotion_grant_does_not_arm_a_record_a_plugin_shipped() {
             .expect("the workspace's own record loads")
             .is_enforced(),
         "the same grant must still arm the repository's own record"
+    );
+}
+
+/// **Witness (#5327).** A ledger truncated after this machine read it is
+/// refused, where the hash chain sees nothing wrong.
+///
+/// Fails on the base, where `read_promotions` ran `parse_and_verify` and
+/// nothing else. Removing the last line satisfies every rule that function has
+/// — the result is a shorter, internally consistent ledger — so a truncated
+/// demotion resurrected the grant it revoked, and `stella context validate`,
+/// whose regulated check keys on `is_enforced()` downstream of that grant,
+/// exited green on it.
+#[test]
+fn a_ledger_truncated_after_it_was_read_is_refused() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(root.path().join(RULES_DIR)).unwrap();
+    let ledger = root.path().join(PROMOTION_LEDGER);
+
+    // Two events: a grant, then the retirement that revokes it.
+    append_promotion(
+        root.path(),
+        grant("ctx.acme.web.a", "measured over 30 days"),
+    )
+    .expect("grant");
+    append_promotion(root.path(), retirement("ctx.acme.web.a")).expect("retire");
+
+    // The read that establishes this machine's anchor.
+    let seen = read_promotions(root.path()).expect("a healthy ledger reads");
+    assert_eq!(seen.len(), 2);
+
+    // Truncate the retirement away.
+    let text = std::fs::read_to_string(&ledger).unwrap();
+    let kept: String = text.lines().take(1).map(|l| format!("{l}\n")).collect();
+    std::fs::write(&ledger, &kept).unwrap();
+
+    // The chain alone still says it is fine — that is the defect.
+    assert!(
+        stella_core::records::promotion::parse_and_verify(&kept).is_ok(),
+        "precondition: the hash chain cannot see a truncated tail"
+    );
+
+    let refusal = read_promotions(root.path()).expect_err("the anchor must catch it");
+    assert!(
+        refusal.contains("removed from the end"),
+        "and say what happened: {refusal}"
+    );
+}
+
+/// Appending is silent, which is what keeps the anchor usable on an
+/// append-only ledger.
+///
+/// Without this the fix could be satisfied by refusing every ledger that ever
+/// changed, which would refuse every promotion this repository makes.
+#[test]
+fn a_ledger_that_grew_since_the_last_read_is_not_refused() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(root.path().join(RULES_DIR)).unwrap();
+
+    append_promotion(
+        root.path(),
+        grant("ctx.acme.web.a", "measured over 30 days"),
+    )
+    .expect("grant");
+    read_promotions(root.path()).expect("first read anchors");
+
+    append_promotion(root.path(), retirement("ctx.acme.web.a")).expect("retire");
+    let after = read_promotions(root.path()).expect("growth is not a violation");
+
+    assert_eq!(after.len(), 2);
+}
+
+/// The anchor lives under `.stella/private/` and is never a reviewed artifact.
+///
+/// It is one machine's memory of what it last saw. Committing it would make
+/// one developer's clone the authority on another's, and every pull request
+/// touching a grant would have to update it.
+#[test]
+fn the_head_anchor_is_private_and_not_beside_the_ledger() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(root.path().join(RULES_DIR)).unwrap();
+    append_promotion(
+        root.path(),
+        grant("ctx.acme.web.a", "measured over 30 days"),
+    )
+    .expect("grant");
+    read_promotions(root.path()).expect("read");
+
+    assert!(
+        root.path()
+            .join(".stella/private/promotions-head.json")
+            .is_file(),
+        "the anchor is written where private local state lives"
+    );
+    assert!(
+        !root
+            .path()
+            .join(RULES_DIR)
+            .join("promotions-head.json")
+            .exists(),
+        "and never beside the reviewed ledger"
     );
 }

--- a/crates/stella-core/src/records/promotion.rs
+++ b/crates/stella-core/src/records/promotion.rs
@@ -16,8 +16,33 @@
 //! the chain makes them *self-evident* — a validator needs only the file
 //! itself to prove no line was edited, dropped, or reordered. "Immutable"
 //! here is tamper-EVIDENT, not tamper-proof: nothing stops a hostile rewrite
-//! of file plus history, but no such rewrite can survive
-//! [`parse_and_verify`] against a previously seen head digest.
+//! of file plus history.
+//!
+//! # What the chain cannot see, and what does
+//!
+//! [`parse_and_verify`] checks each line against the one before it and the
+//! sequence from 1, so **deleting the last N lines satisfies both**. What is
+//! left is a shorter ledger that verifies perfectly. That is not a corner
+//! case: truncating a demotion event resurrects a revoked blocking grant,
+//! truncating a grant disarms a record — and `stella context validate`'s
+//! regulated check keys on `is_enforced()`, itself downstream of the grant, so
+//! the ungoverned list comes back empty and validate exits **green** on the
+//! truncated ledger. Deleting the file entirely reads as a ledger with no
+//! events at all (#5327).
+//!
+//! Detecting it needs one fact the file cannot carry: what the head was last
+//! time. [`ChainHead`] is that fact and [`continuity_violation`] is the check.
+//! The module doc used to claim a rewrite "cannot survive `parse_and_verify`
+//! against a previously seen head digest" — true of the function, and empty in
+//! practice, because nothing recorded a head digest to compare against.
+//!
+//! The pin is a **local** artifact and belongs under `.stella/private/`: it is
+//! one machine's memory of what it last saw, not reviewed policy, and
+//! committing it would make one developer's clone the authority on another's.
+//! Its cost is that a fresh clone has nothing to compare against until its
+//! first read — the anchor detects a truncation that happens *after* it has
+//! seen the ledger once, which is the case that matters, and cannot speak to
+//! what arrived before it.
 //!
 //! Per ADR 0007 the enforcement vocabulary is exactly two-valued
 //! (`advisory` | `blocking`); the four review-ladder labels are UI over it
@@ -165,10 +190,84 @@ pub struct ChainViolation {
     pub reason: String,
 }
 
+/// What a reader last saw at the end of a ledger — the anchor a truncation
+/// cannot forge.
+///
+/// Both fields are needed and neither is sufficient. The count alone would be
+/// satisfied by a ledger rewritten to the same length; the digest alone has no
+/// position to be checked at, since a truncated ledger's own last line is a
+/// perfectly good line that hashes to itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainHead {
+    /// How many events the ledger held.
+    pub seq: u64,
+    /// SHA-256 of the last line's exact bytes, by [`line_digest`].
+    pub digest: String,
+}
+
+/// The head of `text`, or `None` for a ledger with no events.
+///
+/// Computed off the raw lines rather than off re-serialized events: the chain
+/// is over exact bytes, and a round trip through `serde` is not guaranteed to
+/// reproduce them.
+#[must_use]
+pub fn head_of(text: &str) -> Option<ChainHead> {
+    let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    let last = lines.last()?;
+    Some(ChainHead {
+        seq: lines.len() as u64,
+        digest: line_digest(last),
+    })
+}
+
+/// Has this ledger lost or rewritten history it is known to have held?
+///
+/// The question [`parse_and_verify`] structurally cannot ask. It walks each
+/// line against the one before it and the sequence from 1, so a ledger with its
+/// last N lines removed passes every check it makes — it is a shorter ledger,
+/// internally consistent, and there is nothing inside the file that says
+/// otherwise. `pinned` is the outside fact: what a reader on this machine saw
+/// the last time it looked.
+///
+/// Growth is fine and is the normal case. What is refused is a ledger that is
+/// now *shorter* than the anchor, or one whose line at the anchor's position no
+/// longer hashes to what it did — the two shapes of "history was rewritten".
+#[must_use]
+pub fn continuity_violation(text: &str, pinned: &ChainHead) -> Option<ChainViolation> {
+    let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    let anchored = lines.get(pinned.seq as usize - 1);
+    match anchored {
+        None => Some(ChainViolation {
+            line: lines.len() + 1,
+            reason: format!(
+                "the ledger has {} event(s) but this machine last read {} — {} event(s) were \
+                 removed from the end. The hash chain cannot see this: a truncated ledger \
+                 verifies perfectly, and a removed demotion resurrects the grant it revoked",
+                lines.len(),
+                pinned.seq,
+                pinned.seq as usize - lines.len()
+            ),
+        }),
+        Some(line) if line_digest(line) != pinned.digest => Some(ChainViolation {
+            line: pinned.seq as usize,
+            reason: format!(
+                "event {} is not the one this machine last read — the line's digest changed, \
+                 so history was rewritten rather than appended to",
+                pinned.seq
+            ),
+        }),
+        Some(_) => None,
+    }
+}
+
 /// Parse a promotions ledger and verify its hash chain: every line must
 /// parse, `seq` must be contiguous from 1, and each event's `prev` must equal
 /// the SHA-256 of the previous line's exact bytes. An edited, dropped, or
 /// reordered line breaks the chain at the first divergence.
+///
+/// **This cannot see a truncated tail.** Removing the last N lines leaves a
+/// ledger that satisfies every rule here; [`continuity_violation`] is what
+/// catches that, and it needs an anchor from outside the file (#5327).
 pub fn parse_and_verify(text: &str) -> Result<Vec<PromotionEvent>, ChainViolation> {
     let mut events = Vec::new();
     let mut prev_line: Option<&str> = None;
@@ -396,5 +495,95 @@ mod tests {
         ]);
         let events = parse_and_verify(&text).unwrap();
         assert!(blocking_grants(&events).is_empty());
+    }
+
+    /// **Witness (#5327).** A truncated tail passes the hash chain, and the
+    /// anchor is what catches it.
+    ///
+    /// The first assertion is the defect: `parse_and_verify` walks each line
+    /// against the one before it and the sequence from 1, so removing the last
+    /// line leaves a ledger that satisfies both. The module doc claimed a
+    /// rewrite "cannot survive `parse_and_verify` against a previously seen
+    /// head digest" — true of the function, and empty in practice, because
+    /// nothing recorded one.
+    #[test]
+    fn a_truncated_tail_verifies_and_is_caught_only_by_the_anchor() {
+        let full = ledger(&[
+            event("^a", "blocking", "lead@example.test"),
+            retirement("^a"),
+        ]);
+        let seen = head_of(&full).expect("a ledger with events has a head");
+
+        // Drop the retirement — the event whose removal resurrects the grant.
+        let truncated: String = full.lines().take(1).map(|l| format!("{l}\n")).collect();
+
+        let events = parse_and_verify(&truncated)
+            .expect("the chain sees nothing wrong with a shorter ledger");
+        assert_eq!(
+            blocking_grants(&events).len(),
+            1,
+            "and the revoked grant is live again"
+        );
+
+        let violation = continuity_violation(&truncated, &seen)
+            .expect("the anchor is what notices the ledger shrank");
+        assert!(
+            violation.reason.contains("removed from the end"),
+            "and says what happened: {}",
+            violation.reason
+        );
+    }
+
+    /// Appending is not a violation, which is what keeps the check usable.
+    ///
+    /// Without this the anchor could be satisfied by refusing every ledger that
+    /// ever changed, and the ledger is append-only by design — growth is the
+    /// normal case and must be silent.
+    #[test]
+    fn a_ledger_that_only_grew_is_not_a_violation() {
+        let first = ledger(&[event("^a", "blocking", "lead@example.test")]);
+        let seen = head_of(&first).expect("head");
+        let grown = ledger(&[
+            event("^a", "blocking", "lead@example.test"),
+            retirement("^a"),
+        ]);
+
+        assert_eq!(continuity_violation(&grown, &seen), None);
+        assert_eq!(
+            continuity_violation(&first, &seen),
+            None,
+            "and so is no change"
+        );
+    }
+
+    /// A ledger rewritten to the same length is caught too.
+    ///
+    /// The count alone would miss this, which is why the anchor carries a
+    /// digest as well: a hostile rewrite that preserves the event count is the
+    /// obvious way around a length check.
+    #[test]
+    fn a_rewritten_event_at_the_same_position_is_a_violation() {
+        let original = ledger(&[event("^a", "blocking", "lead@example.test")]);
+        let seen = head_of(&original).expect("head");
+        let rewritten = ledger(&[event("^a", "blocking", "someone-else@example.test")]);
+
+        let violation = continuity_violation(&rewritten, &seen).expect("caught");
+        assert!(
+            violation.reason.contains("rewritten rather than appended"),
+            "{}",
+            violation.reason
+        );
+    }
+
+    /// Deleting the whole file reads as an empty ledger, and the anchor is the
+    /// only thing that can tell that from a repository that never promoted
+    /// anything.
+    #[test]
+    fn an_emptied_ledger_is_a_violation_against_a_head_that_saw_events() {
+        let original = ledger(&[event("^a", "blocking", "lead@example.test")]);
+        let seen = head_of(&original).expect("head");
+
+        assert!(continuity_violation("", &seen).is_some());
+        assert_eq!(head_of(""), None, "and an empty ledger anchors nothing");
     }
 }


### PR DESCRIPTION
## What & why

`parse_and_verify` checks every line against the one before it and the sequence from 1. **Deleting the last N lines satisfies both** — what is left is a shorter ledger that verifies perfectly, and there is nothing inside the file that says otherwise.

The module doc claimed a rewrite *"cannot survive `parse_and_verify` against a previously seen head digest"*. True of the function; empty in practice, because **nothing anywhere recorded a head digest**. `line_digest`'s only call sites were inside `promotion.rs`, and the ledger's sole I/O owner had no continuity concept at all.

What that cost:

| truncate | result |
|---|---|
| a demotion or retirement event | the revoked blocking grant is **live again** |
| a grant | the record disarms — and `stella context validate`'s regulated check keys on `is_enforced()`, itself downstream of that grant, so the ungoverned list is empty and **validate exits green on the truncated ledger** |
| the whole file | reads as a ledger that never had any events |

## The fix

One fact the file cannot carry: what the head was last time.

- **`ChainHead` + `continuity_violation`** in `stella-core` — pure, no I/O (invariant 2). Both a **count and a digest**, because either alone is forgeable: a rewrite to the same length passes a length check, and a digest alone has no position to be checked at.
- **The pin** in `.stella/private/promotions-head.json`, for the reason `PROMOTION_LOCK` lives there: it is one machine's memory of what it last saw, not reviewed policy. Committing it would make one developer's clone the authority on another's, and force every grant-touching PR to update it.

Advanced after a clean read, so ordinary growth on an append-only ledger is silent and only a **shrink or a rewrite** is reported. A failure to write the pin costs one unprotected read and is not an error; an unreadable pin is no pin — the opposite of `governance.toml`, where the file *is* the policy.

**Its limit, stated rather than glossed:** a fresh clone has nothing to compare against until its first read. The anchor catches a truncation that happens *after* this machine has seen the ledger — the case that matters — and cannot speak to what arrived before it. The module doc says so.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_truncated_tail_verifies_and_is_caught_only_by_the_anchor` asserts **the defect first** — `parse_and_verify` returns `Ok` on the truncated ledger and `blocking_grants` reports the revoked grant as live — and only then that the anchor catches it. A test that just asserted the new function works would not have shown why it is needed.

| test | holds |
|---|---|
| `a_truncated_tail_verifies_and_is_caught_only_by_the_anchor` | the chain passes; the grant resurrects; the anchor fires |
| `a_ledger_that_only_grew_is_not_a_violation` | append-only growth stays silent — the fix cannot be "refuse every change" |
| `a_rewritten_event_at_the_same_position_is_a_violation` | why the anchor carries a digest and not just a count |
| `an_emptied_ledger_is_a_violation_against_a_head_that_saw_events` | a deleted file is not "no promotions" |
| `a_ledger_truncated_after_it_was_read_is_refused` | the same through `read_promotions`, asserting the chain still sees nothing wrong |
| `a_ledger_that_grew_since_the_last_read_is_not_refused` | end-to-end anti-vacuity |
| `the_head_anchor_is_private_and_not_beside_the_ledger` | the pin never becomes a reviewed artifact |

```
$ cargo test -p stella-core promotion
all green
$ cargo test -p stella-cli --bin stella context_records
17 passed; 0 failed
$ cargo clippy -p stella-cli -p stella-core --all-targets -- -D warnings
clean
$ python3 ./scripts/check-prose.py
OK
```

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` on both touched crates
- [x] Targeted tests green (SCR-001 — CI runs the workspace)
- [x] Docs updated: the module header's claim about an anchor that did not exist is replaced by what the chain can and cannot see, and where the anchor lives
- [x] `Closes #5327` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

The issue also floats a second mode — "a validate mode comparing against a git base ref, requiring that ref's ledger to be a verified prefix of the working tree's". That is a genuinely different check (it protects a *fresh clone*, which the local pin structurally cannot) and it needs a decision about which ref, so it is not folded in here. Say the word and I will file it; I have not, because the issue's own DoD is satisfied by the local pin and I would rather not file a ticket for a design nobody has asked for yet.

## Ground-rule check

- [x] No I/O added to `stella-core` — `ChainHead` and `continuity_violation` are pure functions over borrowed text; the file reads live in `stella-cli`
- [x] No new deps
- [x] New cross-boundary type round-trips through serde (`ChainHead` derives both)

## Anything reviewers should know?

This can fire on a **legitimate** history rewrite — a bad merge repaired by hand, a rebase that touched the ledger. That is the intended behaviour: those are exactly the cases a human should look at. The error names the pin file and says deleting it means "I know the change was intended", so the way through is one `rm` and not a code change.

Closes #5327

## Summary by Sourcery

Detect promotion-ledger truncation and history rewrites without rejecting legitimate append-only growth.

New Features:
- Add local promotion-ledger continuity tracking that detects truncation and same-position history rewrites after a machine has read the ledger.

Bug Fixes:
- Prevent truncated promotion history from silently resurrecting revoked grants or making validation pass as though enforcement had never existed.

Enhancements:
- Introduce pure promotion-ledger head and continuity validation in stella-core.
- Store the last-seen ledger head as private, best-effort local state under `.stella/private/` while allowing normal append-only growth.

Documentation:
- Document the limits of hash-chain verification, the local continuity anchor, and its fresh-clone behavior.

Tests:
- Add witness and regression coverage for truncation, ledger growth, same-length rewrites, emptied ledgers, and private anchor placement.