### PR TITLE
fix(stella-observatory): the selection-health panel folds under the tuned policy

### DIFF
--- a/crates/stella-observatory/src/context_db.rs
+++ b/crates/stella-observatory/src/context_db.rs
@@ -87,7 +87,9 @@ pub(crate) fn self_improvement(root: &Path) -> Result<Value, DbError> {
     let unreadable = unreadable_reflections(root)?;
     let db = root.join(".stella").join("private").join("context.db");
     let Some(conn) = open_read_only(&db) else {
-        let mut payload = empty_payload(false);
+        // Reported even here: "no context.db" and "context.db under tuned
+        // thresholds" are different states, and the panel says which.
+        let mut payload = empty_payload(false, &crate::fsview::selection_health_policy(root));
         crate::db::merge(
             &mut payload,
             json!({ "unreadable_reflections": unreadable }),
@@ -110,8 +112,12 @@ pub(crate) fn self_improvement(root: &Path) -> Result<Value, DbError> {
     let proposals = proposal_rows(&conn)?;
     let events = event_rows(&conn)?;
     let episodes = episode_rows(&conn)?;
-    let health = health_rows(&conn)?;
-    let policy = SelectionHealthPolicy::default();
+    // The thresholds this workspace actually applies, not the shipped ones.
+    // The fold below and the `health_policy` echo must be the same policy: a
+    // panel that folded under one and reported another would be worse than the
+    // default it replaces, which at least said which numbers it used (#1944).
+    let policy = crate::fsview::selection_health_policy(root);
+    let health = health_rows(&conn, policy)?;
 
     Ok(json!({
         "present": true,
@@ -126,10 +132,9 @@ pub(crate) fn self_improvement(root: &Path) -> Result<Value, DbError> {
         // simply never learned anything. They rendered identically until this
         // existed (#2175).
         "unreadable_reflections": unreadable,
-        // The thresholds the fold above ran with. The CLI reads tuned values
-        // out of the settings scope chain; the dashboard runs the shipped
-        // defaults and says so, rather than silently presenting a verdict
-        // computed under thresholds the reader cannot see.
+        // The thresholds the fold above ran with — kept in the payload now
+        // that they are the tuned ones, because a reader still cannot tell a
+        // tuned verdict from a default one without seeing the numbers.
         "health_policy": {
             "min_attributable_uses": policy.min_attributable_uses,
             "not_helpful_ratio_threshold": policy.not_helpful_ratio_threshold,
@@ -141,8 +146,7 @@ pub(crate) fn self_improvement(root: &Path) -> Result<Value, DbError> {
 /// The payload shape with nothing in it. Same key set as the populated branch
 /// so a client indexing a section never finds the key missing — the lesson
 /// `Observatory::cursor` already carries.
-fn empty_payload(present: bool) -> Value {
-    let policy = SelectionHealthPolicy::default();
+fn empty_payload(present: bool, policy: &SelectionHealthPolicy) -> Value {
     json!({
         "present": present,
         "counts": [],
@@ -375,7 +379,7 @@ fn episode_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
 
 /// Selection health, folded from the ledger's use/feedback records through the
 /// same pure fold the CLI runs, worst standing first.
-fn health_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
+fn health_rows(conn: &Connection, policy: SelectionHealthPolicy) -> Result<Vec<Value>, DbError> {
     let uses: Vec<(String, ContextUse)> = kind_rows(conn, "context_use", USE_READ_LIMIT)?
         .into_iter()
         .filter_map(|(record_id, body)| {
@@ -389,7 +393,7 @@ fn health_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
             .into_iter()
             .filter_map(|(_, body)| serde_json::from_str::<ContextUseFeedback>(&body).ok())
             .collect();
-    let mut health = fold_selection_health(&uses, &feedback, SelectionHealthPolicy::default());
+    let mut health = fold_selection_health(&uses, &feedback, policy);
     health.sort_by(|a, b| {
         b.failing
             .cmp(&a.failing)

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use serde_json::{Value, json};
+use stella_core::context_record::SelectionHealthPolicy;
 
 pub use contributions::{ContributedDir, NoContributions, PluginContributions, PluginTier};
 
@@ -823,6 +824,68 @@ fn settings_scope(scope: &str, path: PathBuf) -> Value {
         "parse_error": parse_error,
         "settings": body,
     })
+}
+
+/// The selection-health thresholds this workspace actually applies.
+///
+/// The dashboard used to fold every record under
+/// `SelectionHealthPolicy::default()` while the loop read tuned values out of
+/// the settings scope chain, so a workspace with a tuned `context.efficacy`
+/// could see a different failing/earning verdict on the panel than the thing
+/// it is a panel *of* (#1944).
+///
+/// Read through [`settings_scope`] rather than a second parser, per the
+/// observatory's read-only contract: the same three files `config` reports,
+/// merged in the same order the CLI's `Settings::load` merges them — user,
+/// then org-managed, then project — **per field**, so a project that tunes one
+/// threshold does not silently reset the other two to their defaults. Redaction
+/// cannot reach these: it replaces strings under a credential key, and every
+/// threshold here is a number.
+///
+/// A scope that is absent, unreadable, or carries no `context.efficacy`
+/// contributes nothing, so a workspace that has tuned nothing lands exactly on
+/// the shipped defaults.
+#[must_use]
+pub fn selection_health_policy(workspace_root: &Path) -> SelectionHealthPolicy {
+    let user = user_config_dir()
+        .map(|d| d.join("settings.json"))
+        .unwrap_or_else(|| PathBuf::from("settings.json"));
+    let mut policy = SelectionHealthPolicy::default();
+    // Later wins, which is the CLI's order: project overrides managed
+    // overrides user.
+    for path in [
+        user,
+        managed_settings_path(),
+        workspace_root.join(".stella").join("settings.json"),
+    ] {
+        let scope = settings_scope("", path);
+        let Some(efficacy) = scope
+            .get("settings")
+            .and_then(|s| s.get("context"))
+            .and_then(|c| c.get("efficacy"))
+        else {
+            continue;
+        };
+        if let Some(v) = efficacy
+            .get("min_attributable_uses")
+            .and_then(Value::as_u64)
+        {
+            policy.min_attributable_uses = v as u32;
+        }
+        if let Some(v) = efficacy
+            .get("not_helpful_ratio_threshold")
+            .and_then(Value::as_f64)
+        {
+            policy.not_helpful_ratio_threshold = v;
+        }
+        if let Some(v) = efficacy
+            .get("min_attribution_confidence")
+            .and_then(Value::as_u64)
+        {
+            policy.min_attribution_confidence = v as u8;
+        }
+    }
+    policy
 }
 
 /// The full configuration picture: the settings scope chain (ascending

--- a/crates/stella-observatory/src/tests.rs
+++ b/crates/stella-observatory/src/tests.rs
@@ -14,6 +14,9 @@ mod execution_routes;
 /// The raw HTTP surface tests -- a child module for the same reason.
 mod http_surface;
 
+/// The selection-health panel's policy (#1944).
+mod selection_health;
+
 #[test]
 fn host_header_gates_dns_rebinding() {
     let local = [

--- a/crates/stella-observatory/src/tests/selection_health.rs
+++ b/crates/stella-observatory/src/tests/selection_health.rs
@@ -1,0 +1,139 @@
+//! The selection-health panel's policy: it folds under the thresholds the
+//! workspace tuned, not the shipped defaults (#1944). Split out of the parent
+//! module, which sits at the 1500-line ratchet with no baseline entry.
+
+use super::*;
+
+/// Seed a `context.db` whose one record has three assessed not-helpful uses.
+///
+/// Chosen so the **verdict** turns on `min_attributable_uses` alone: three
+/// assessed uses is below the shipped floor of 5 (not attributable, so not
+/// failing) and at or above a tuned 2 (attributable, ratio 1.0 over any
+/// threshold, so failing). Nothing else in the fixture moves.
+fn seed_three_not_helpful_uses(ws: &Path) {
+    let private = ws.join(".stella/private");
+    std::fs::create_dir_all(&private).unwrap();
+    let conn = Connection::open(private.join("context.db")).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE context_records (
+           record_id TEXT PRIMARY KEY,
+           lineage_id TEXT,
+           record_kind TEXT NOT NULL,
+           record_hash TEXT,
+           schema_version TEXT,
+           body TEXT NOT NULL,
+           observed_at TEXT,
+           recorded_at TEXT,
+           supersedes TEXT);",
+    )
+    .unwrap();
+    for n in 0..3 {
+        let use_body = serde_json::json!({
+            "use_kind": "cited",
+            "context_record_id": "ctx.acme.web.a",
+            "use_trace_id": format!("trace-{n}"),
+            "task_id": format!("task-{n}"),
+            "influence_stage": "execution",
+            "observed_at": "2026-08-04T09:00:00Z",
+        })
+        .to_string();
+        let feedback_body = serde_json::json!({
+            "context_use_id": format!("use-{n}"),
+            "use_trace_id": format!("trace-{n}"),
+            "task_id": format!("task-{n}"),
+            "evaluation": "not_helpful",
+            "had_opportunity": true,
+            "influence_stage": "execution",
+            "outcome_relation": "unrelated",
+            "observable_effect_refs": ["diff:1"],
+            "evaluation_method": "deterministic_validation",
+            "attribution_confidence": 90,
+            "observed_at": "2026-08-04T09:00:00Z",
+        })
+        .to_string();
+        conn.execute(
+            "INSERT INTO context_records (record_id, record_kind, body)
+             VALUES (?1, 'context_use', ?2)",
+            rusqlite::params![format!("use-{n}"), use_body],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO context_records (record_id, record_kind, body)
+             VALUES (?1, 'context_use_feedback', ?2)",
+            rusqlite::params![format!("fb-{n}"), feedback_body],
+        )
+        .unwrap();
+    }
+}
+
+/// **Witness (#1944).** The selection-health panel folds under the thresholds
+/// this workspace tuned, not the shipped defaults.
+///
+/// Fails on main, where `health_rows` always passed
+/// `SelectionHealthPolicy::default()` while the CLI read tuned values out of
+/// the settings scope chain — so a workspace with a tuned `context.efficacy`
+/// read a different failing/earning verdict on the dashboard than the loop it
+/// is a dashboard *of* actually applied.
+///
+/// The assertion is the **verdict**, not the echoed numbers: a payload that
+/// reported tuned thresholds beside a default-folded verdict would be worse
+/// than the default it replaces, which at least named the numbers it used.
+#[test]
+fn the_selection_health_panel_folds_under_the_tuned_policy() {
+    let ws = TempDir::new().unwrap();
+    seed_three_not_helpful_uses(ws.path());
+    std::fs::write(
+        ws.path().join(".stella/settings.json"),
+        r#"{"context":{"efficacy":{"min_attributable_uses":2,
+                                   "not_helpful_ratio_threshold":0.5}}}"#,
+    )
+    .unwrap();
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&respond(ws.path(), "/api/context-lifecycle").body).unwrap();
+
+    let row = &body["selection_health"][0];
+    assert_eq!(row["assessed_uses"], 3);
+    assert_eq!(
+        row["attributable"], true,
+        "three assessed uses clears the tuned floor of 2"
+    );
+    assert_eq!(
+        row["failing"], true,
+        "and a not-helpful ratio of 1.0 is over the tuned 0.5 — the verdict \
+         the loop itself reaches"
+    );
+
+    let policy = &body["health_policy"];
+    assert_eq!(policy["min_attributable_uses"], 2);
+    assert_eq!(policy["not_helpful_ratio_threshold"], 0.5);
+    // Per-field: tuning two values must not reset the third.
+    assert_eq!(policy["min_attribution_confidence"], 80);
+}
+
+/// The same fixture under no settings at all reaches the OPPOSITE verdict.
+///
+/// This is what makes the test above a witness rather than a restatement: the
+/// data is identical and only the policy differs, so a fold that ignored the
+/// tuned policy would produce this row in both tests.
+#[test]
+fn the_same_uses_are_not_failing_under_the_shipped_policy() {
+    let ws = TempDir::new().unwrap();
+    seed_three_not_helpful_uses(ws.path());
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&respond(ws.path(), "/api/context-lifecycle").body).unwrap();
+
+    let row = &body["selection_health"][0];
+    assert_eq!(row["assessed_uses"], 3);
+    assert_eq!(
+        row["attributable"], false,
+        "three assessed uses is below the shipped floor of 5"
+    );
+    assert_eq!(row["failing"], false);
+
+    let policy = &body["health_policy"];
+    assert_eq!(policy["min_attributable_uses"], 5);
+    assert_eq!(policy["not_helpful_ratio_threshold"], 0.8);
+    assert_eq!(policy["min_attribution_confidence"], 80);
+}


### PR DESCRIPTION
## What & why

The Self-improve tab folded every record through `fold_selection_health` under `SelectionHealthPolicy::default()` — 5 assessed uses / 0.8 ratio / confidence 80 — while the CLI reads tuned values out of the settings scope chain (`memory::tuning::selection_health_policy`, used at `memory/learning.rs`).

So a workspace with a tuned `context.efficacy` could read a **different failing/earning verdict on the dashboard than the loop it is a dashboard of actually applies**. The payload was honest about which numbers it used, which is why this was a wrong answer rather than a silent one — but a panel whose verdicts disagree with the thing they describe is still the wrong answer.

## How

`fsview::selection_health_policy` reads the same three files `config` already reports — user, then org-managed, then project — through the existing `settings_scope`, not a second parser, per the observatory's read-only contract.

Merged **per field**, matching `Settings::load`, so a project that tunes one threshold does not silently reset the other two to their defaults. Redaction cannot reach these: it replaces strings under a credential key, and every threshold here is a number.

The `health_policy` echo stays in the payload — worth more now, not less. A reader still cannot tell a tuned verdict from a default one without seeing the numbers, and the fold and the echo now come from one value, so they cannot disagree.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Both tests share one fixture — three assessed not-helpful uses at confidence 90 — chosen so the **verdict** turns on `min_attributable_uses` alone and nothing else moves:

| test | settings | `attributable` | `failing` |
|---|---|---|---|
| `the_selection_health_panel_folds_under_the_tuned_policy` | floor 2, ratio 0.5 | `true` | **`true`** |
| `the_same_uses_are_not_failing_under_the_shipped_policy` | none | `false` | `false` |

The second is what makes the first a witness rather than a restatement: identical data, only the policy differs, so a fold that ignored the tuned policy would produce the same row in both.

Verified by reverting the fold to `SelectionHealthPolicy::default()`:

```
test tests::the_same_uses_are_not_failing_under_the_shipped_policy ... ok
test tests::the_selection_health_panel_folds_under_the_tuned_policy ... FAILED
  assertion failed: three assessed uses clears the tuned floor of 2
  left: Bool(false)   right: true
```

My first attempt at this test asserted only the echoed `health_policy` numbers and **passed with the fix backed out** — the workspace had no `context.db`, so it exercised the empty-payload branch and never reached the fold. That is why this one seeds a real database and asserts the verdict.

```
$ cargo test -p stella-observatory
152 passed; 0 failed
$ cargo clippy -p stella-observatory --all-targets -- -D warnings
clean
$ python3 ./scripts/check-prose.py
OK
```

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-observatory --all-targets -- -D warnings`
- [x] Targeted tests green (SCR-001 — CI runs the workspace)
- [x] `Closes #1944` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — `stella-observatory` already depends on `stella-core`
- [x] No new outbound network calls; the observatory stays read-only
- [x] The settings read goes through the existing redaction-aware `settings_scope`, as the issue's constraint requires

## Anything reviewers should know?

The empty-payload branch also reports the tuned policy now. "No `context.db`" and "a `context.db` read under tuned thresholds" are different states, and the panel should say which even when it has no rows to show.

Closes #1944

## Summary by Sourcery

Align the observatory’s selection-health verdicts and reported thresholds with the workspace policy used by the learning loop.

Bug Fixes:
- Make the selection-health panel use the workspace’s tuned policy so its verdicts match the thresholds applied by the learning loop.
- Report the effective selection-health policy consistently even when no context database is present.

Enhancements:
- Load selection-health thresholds from the existing user, managed, and project settings scopes with per-field precedence.

Tests:
- Add witness coverage proving tuned and default policies produce different selection-health verdicts for identical records.