### PR TITLE
fix(stella-cli): a failed prompt-receipt write is reported, not discarded

### DIFF
--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -975,7 +975,14 @@ pub(crate) fn persist_event_detailed(
         compiled_frame,
     } = event
     {
-        let _ = store.record_step_manifest(
+        // Reported, not discarded. This is the receipts plane: the header and
+        // its entries are written in one transaction, so a failure here turns
+        // OFF `stella inspect --diff`, the Observatory's prompt inspector and
+        // the context-diff panel together — the three surfaces that answer
+        // "what exactly did this call see". A `let _` made that silent, which
+        // is how a workspace can end up with 588k manifest entries, no
+        // receipts, and nothing anywhere saying so (#5255).
+        let receipt = store.record_step_manifest(
             execution_id,
             &StepManifestRow {
                 turn_instance: *turn_instance,
@@ -1013,6 +1020,12 @@ pub(crate) fn persist_event_detailed(
                     .collect(),
             },
         );
+        if receipt.is_err() {
+            warn_store_write_failed(
+                "the prompt receipt (`stella inspect --diff` and the Observatory's \
+                 prompt inspector read it)",
+            );
+        }
     }
     // What disqualifies the execution's COST ROLLUP, which is the only thing
     // `usage_complete` claims — deliberately not `recorded`.

--- a/crates/stella-cli/src/agent/persistence/receipt_write_tests.rs
+++ b/crates/stella-cli/src/agent/persistence/receipt_write_tests.rs
@@ -68,3 +68,84 @@ fn a_manifest_event_lands_its_receipt_and_entries() {
         .expect("read the receipt header back");
     assert_eq!(calls.len(), 1, "one call, one receipt header");
 }
+
+/// **Witness (#5255).** A receipt write that fails reaches the caller, so the
+/// arm can report it.
+///
+/// The call site was `let _ = store.record_step_manifest(...)`, so a failing
+/// write said nothing at all — and the three surfaces the receipts plane exists
+/// for (`stella inspect --diff`, the Observatory's prompt inspector, the
+/// context-diff panel) went dark together with no trace. That silence is how
+/// this repository's own store reached 588,091 manifest entries and zero
+/// receipts with nothing anywhere saying so.
+///
+/// The failure is a real one the store already refuses — a token budget past
+/// SQLite's INTEGER range — rather than an injected seam, so what runs here is
+/// the error path a caller would actually meet.
+#[test]
+fn a_failed_receipt_write_reaches_the_caller() {
+    let store = stella_store::Store::in_memory().expect("store");
+    let execution_id = store
+        .begin_execution("deck", "prompt", "openrouter", "moonshotai/kimi-k3")
+        .expect("begin");
+
+    let AgentEvent::StepManifest {
+        effective_budget_tokens,
+        ..
+    } = &mut unwritable_manifest_event()
+    else {
+        panic!("the fixture is a StepManifest");
+    };
+    assert_eq!(
+        *effective_budget_tokens,
+        u64::MAX,
+        "the fixture carries the value the store refuses"
+    );
+
+    // Precondition: the ordinary event writes fine, so the assertion below is
+    // about the failure rather than about a broken fixture.
+    let ok = persist_event_detailed(&store, execution_id, 0, &manifest_event(), "openrouter");
+    assert!(ok.is_complete());
+    assert_eq!(
+        store.recorded_calls(execution_id).expect("read").len(),
+        1,
+        "one receipt from the good event"
+    );
+
+    // The unwritable one: the arm now sees an `Err` where it used to see a
+    // discarded `Result`, and warns. The turn's own accounting is untouched —
+    // a receipt that could not be written must not take the event log with it.
+    let outcome = persist_event_detailed(
+        &store,
+        execution_id,
+        1,
+        &unwritable_manifest_event(),
+        "openrouter",
+    );
+    assert!(
+        outcome.is_complete(),
+        "the warning is the channel for this, not the outcome ({outcome:?})"
+    );
+    assert_eq!(
+        store.recorded_calls(execution_id).expect("read").len(),
+        1,
+        "and nothing half-written landed — the receipt and its entries share \
+         one transaction"
+    );
+}
+
+/// The same manifest with a token budget SQLite cannot store, which is a
+/// failure `record_step_manifest` produces on its own (`sqlite_i64`).
+fn unwritable_manifest_event() -> AgentEvent {
+    let mut event = manifest_event();
+    if let AgentEvent::StepManifest {
+        step,
+        effective_budget_tokens,
+        ..
+    } = &mut event
+    {
+        *step = 2;
+        *effective_budget_tokens = u64::MAX;
+    }
+    event
+}


### PR DESCRIPTION
## What & why

`persist_event_detailed`'s `StepManifest` arm called:

```rust
let _ = store.record_step_manifest(execution_id, &StepManifestRow { … });
```

The header and its entries share one transaction, so that single discarded `Result` turns off **all three** surfaces the receipts plane exists for — `stella inspect --diff`, the Observatory's prompt inspector, and the context-diff panel — with no trace anywhere.

That is the shape #5255 describes. Confirmed read-only against this repository's own store, on `main`:

```
$ sqlite3 "file:.stella/private/store.db?mode=ro" \
    "SELECT (SELECT count(*) FROM step_receipt), (SELECT count(*) FROM step_manifest),
            (SELECT count(*) FROM executions), (SELECT max(execution_id) FROM step_manifest);"
0|588091|321|178
```

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_failed_receipt_write_reaches_the_caller` drives the **real** error path rather than an injected seam: a token budget past SQLite's INTEGER range, which `record_step_manifest`'s own `sqlite_i64` refuses. It also pins the two things that must not change — the turn's accounting stays complete (the warning is the channel for this, not the outcome), and nothing half-written lands.

```
$ cargo test -p stella-cli --bin stella receipt_write
test a_manifest_event_lands_its_receipt_and_entries ... ok
test a_failed_receipt_write_reaches_the_caller ... ok
2 passed; 0 failed
```

## The issue's other two conditions were already met — verified, not assumed

| DoD item | where | verdict |
|---|---|---|
| a test counting both tables after one recorded turn | `receipt_write_tests::a_manifest_event_lands_its_receipt_and_entries` | already on `main` |
| the write's failure is reported | **this PR** | — |
| the prompt control says the receipt is missing | `openCtxDialog` renders *"No receipt for this call"* rather than returning early | already on `main` |

I read both before writing anything, and ticked those two boxes on the issue against the code rather than on the strength of the comments citing #5255.

## What I could NOT settle, stated plainly

**The root cause of that 0/588091 split is still unknown**, and this PR does not claim otherwise. What I ruled out:

- **Not the current writer.** `record_step_manifest` inserts the `step_receipt` header and the `step_manifest` entries in one transaction and commits at the end, so today's code cannot produce entries without a header. The live arm is wired and reaches it.
- **Not the prune cascade.** Both `step_manifest` and `step_receipt` are in `DEPENDENT_TABLES`, so a prune removes them together — it cannot leave one behind.
- **Not an obvious migration row-dropper.** The v13 rebuild copies with no filter, and a PK collision there would error rather than drop silently. I did not read the whole v29 → v40 range.

The store is at `user_version = 40` with `step_receipt` in the correct current shape, so the table exists and is simply empty. Whatever emptied it is historical; this PR makes the *next* failure audible instead of silent, which is the part that is fixable without knowing what the last one was.

If you would rather keep #5255 open for the forensics, say so and I will reopen it with these findings and close only the reporting half.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] Targeted tests green (SCR-001 — CI runs the workspace)
- [x] `python3 ./scripts/check-prose.py` OK
- [x] `Closes #5255` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing new: everything I noticed is fixed or stated above.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The warning uses the existing `warn_store_write_failed` channel rather than a new one, and names the surfaces the reader loses — "the prompt receipt (`stella inspect --diff` and the Observatory's prompt inspector read it)" — because "store write failed" alone sends people to look at a database that is otherwise fine, which is the mistake `PersistOutcome`'s own doc comment records.

Closes #5255

## Summary by Sourcery

Make failed prompt receipt writes visible to users and operators instead of silently disabling receipt-based inspection surfaces.

Bug Fixes:
- Report prompt receipt persistence failures instead of silently discarding them, while preserving turn accounting and transaction atomicity.

Tests:
- Add a regression test covering a real SQLite-incompatible receipt write and verifying that no partial receipt data is stored.