### PR TITLE
feat(ci): a stella-core module must be reachable from the engine's step path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,14 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: python3 ./scripts/check-module-reachability.py
 
+      # Reachability from the crate root is not reachability from the engine:
+      # `search.rs`, `records/` and the rest are all reachable from `lib.rs`,
+      # which is how a 15k-LOC subsystem lands in stella-core behind a
+      # `pub mod` line. This walks the step path instead, down-only (#5115).
+      - name: a stella-core module is reachable from the step path
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-core-reachability.py
+
       # Also toolchain-free. AGENTS.md requires that anything noticed and not
       # fixed becomes an issue written as a handoff; nothing checked it, and an
       # unenforced standard reads as one the codebase is meeting. The decidable

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -205,6 +205,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-module-reachability.sh
 
+      - name: the core-reachability walker and its ratchet direction
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-core-reachability.sh
+
       - name: the session-scratch boundary
         if: ${{ !cancelled() }}
         run: ./scripts/test-no-scratch.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + god-files
                          #   + gate-parity + left-behind + role-names
                          #   + stat-portability + module-reachability
+                         #   + core-reachability (a stella-core module is
+                         #     reachable from the engine's step path; down-only)
                          #   + typed-errors
                          #   + tool-error-class (#3167 unclassified-ToolOutput::error ratchet)
                          #   + dead-code-allows
@@ -680,6 +682,28 @@ Append; do not renumber. `scripts/check-invariants.sh` enforces both halves.
    wiring `authorises` into each publication path is tracked separately, and
    the rows say plainly where today's evidence falls short of what they
    require.
+12. **`stella-core` holds the step path.** A module that lives there is one the
+   engine reaches — from `driver`, `step` or `ports`, transitively, through
+   paths it actually names. Anything else is in the crate because somebody put
+   it there, and belongs in its own.
+
+   Reachability from the **crate root** is not this: `search.rs`, `records/`
+   and `skills/` are all reachable from `lib.rs`, which is why
+   `module-reachability` passes on every one of them, and how a 15k-LOC
+   subsystem lands here behind a `pub mod` line. That is how the record plane
+   arrived (#5113).
+
+   A `#[cfg(test)]` reference does **not** count. A subsystem the engine
+   touches only from its own tests is a subsystem the engine does not need —
+   `driver/restore.rs`'s test module names `crate::skills`, and reading that
+   as reachability would make the whole skill plane look like engine code.
+
+   Enforced by `scripts/check-core-reachability.py` (`make core-reachability`),
+   a **down-only ratchet** over `scripts/core-reachability-baseline.txt`. The
+   baseline records the residents that predate the guard, so it lands green;
+   `--update` refuses to add an entry, so a red run is cleared by moving the
+   module or by making the engine genuinely use it, never by recording it. It
+   is meant to reach empty, and each eviction under #5113 deletes a line.
 ---
 
 ## The definition of done: witness tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ python3 ./scripts/check-adr-numbering.py
 ./scripts/check-role-names.sh
 ./scripts/check-stat-portability.sh
 python3 ./scripts/check-module-reachability.py
+python3 ./scripts/check-core-reachability.py
 python3 ./scripts/check-typed-errors.py
 python3 ./scripts/check-tool-error-class.py
 python3 ./scripts/check-dead-code-allows.py

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
                     adr-numbering \
                     command-docs website-inputs brand-case file-size god-files gate-parity left-behind \
-                    role-names stat-portability module-reachability typed-errors \
+                    role-names stat-portability module-reachability core-reachability \
+                    typed-errors \
                     tool-error-class \
                     dead-code-allows measured-constants diagnostic-codes consumer-sites \
                     bench-suites wire-paths \
@@ -758,6 +759,18 @@ module-reachability: ## Assert every .rs under a crate's src/ is reachable from 
 .PHONY: module-reachability-test
 module-reachability-test: ## Test the module-reachability walker (hermetic; not part of `gate`)
 	./scripts/test-module-reachability.sh
+
+.PHONY: core-reachability
+core-reachability: ## Assert a stella-core module is reachable from the engine's step path (#5115)
+	@python3 ./scripts/check-core-reachability.py
+
+.PHONY: core-reachability-update
+core-reachability-update: ## Shrink the core-reachability baseline after an eviction (refuses to grow)
+	@python3 ./scripts/check-core-reachability.py --update
+
+.PHONY: core-reachability-test
+core-reachability-test: ## Test the core-reachability walker (hermetic; not part of `gate`)
+	./scripts/test-core-reachability.sh
 
 .PHONY: god-files
 god-files: ## Assert AGENTS.md and the crate READMEs name the baselined god files (#1435)

--- a/scripts/check-core-reachability.py
+++ b/scripts/check-core-reachability.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Guard: a `stella-core` module is reachable from the engine's step path.
+
+See #5115 (child of #5113).
+
+`check-module-reachability.py` proves every `.rs` file is reachable from its
+**crate root**, and passes on all of today's residents — `search.rs`,
+`records/`, `skills/` and the rest *are* reachable from `lib.rs`. Reachability
+from the crate root is not reachability from the engine, and nothing stopped
+the next 15k-LOC subsystem from moving into `stella-core` behind a `pub mod`
+line. That is exactly how the record plane got there.
+
+So this walks a different graph: from the step path — `driver`, `step`,
+`ports` — outward through the crate-internal paths those modules actually
+*name*, and reports every module the engine never reaches. A module outside
+that closure is in `stella-core` because somebody put it there, not because
+the engine needs it.
+
+## The baseline is a down-only ratchet
+
+`scripts/core-reachability-baseline.txt` records the modules that are outside
+the closure **today**, so this lands green and each eviction PR shrinks a list
+the guard already enforces. It may never gain an entry: `--update` refuses to
+add one, exactly as the typed-errors ratchet does, and the only way past a red
+run is to move the module out or to make the engine genuinely use it. It is
+meant to reach empty.
+
+## A test-only reference is not reachability
+
+`#[cfg(test)]` blocks are stripped before any path is read. The doc's v0.9.40
+sweep found this false positive first: `driver/restore.rs`'s test module names
+`crate::skills`, which would otherwise have made the whole skill plane look
+like engine code. A subsystem the engine only touches from its tests is a
+subsystem the engine does not need.
+
+This is a fact about the repository rather than about a crate, so it is never
+scoped by CARGO_SCOPE (AGENTS.md § "The gate"), and a text-level walk keeps it
+in the toolchain-free `guards-fast` rung.
+
+Usage:
+    ./scripts/check-core-reachability.py [ROOT]
+    ./scripts/check-core-reachability.py --update [ROOT]   # shrink the baseline
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+CRATE = "crates/stella-core"
+BASELINE = "scripts/core-reachability-baseline.txt"
+
+# The engine. Everything else in the crate has to earn its place by being named
+# from here, transitively.
+STEP_PATH_ROOTS = ("driver.rs", "driver", "step.rs", "step", "ports.rs", "ports")
+
+# `crate::foo`, `use crate::{foo, bar}`, `super::foo` — the crate-internal
+# references that make a module engine code. Only the FIRST segment matters:
+# reaching `crate::records::promotion::x` reaches the `records` module, and the
+# walk continues from that module's own file.
+CRATE_PATH = re.compile(r"\bcrate\s*::\s*([A-Za-z_][A-Za-z0-9_]*)")
+USE_GROUP = re.compile(r"\buse\s+crate\s*::\s*\{([^}]*)\}", re.S)
+GROUP_HEAD = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)")
+
+# `mod foo;`, matching the sibling guard's rule so the two agree about what a
+# module declaration is.
+MOD_DECL = re.compile(
+    r"(?:^|[;{}\]\s])(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
+
+CFG_TEST = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+
+
+def strip_comments(src: str) -> str:
+    """Blank out comments and string literals, keeping newlines.
+
+    Same shape as the sibling guard's, and needed for the same reason: a
+    `crate::records` written inside a doc comment describing this very rule
+    must not count as a reference.
+    """
+    out: list[str] = []
+    i, n = 0, len(src)
+    while i < n:
+        two = src[i : i + 2]
+        if two == "//":
+            while i < n and src[i] != "\n":
+                out.append(" ")
+                i += 1
+        elif two == "/*":
+            depth = 1
+            out.append("  ")
+            i += 2
+            while i < n and depth:
+                two = src[i : i + 2]
+                if two == "/*":
+                    depth += 1
+                    out.append("  ")
+                    i += 2
+                elif two == "*/":
+                    depth -= 1
+                    out.append("  ")
+                    i += 2
+                else:
+                    out.append("\n" if src[i] == "\n" else " ")
+                    i += 1
+        elif src[i] == '"':
+            out.append(" ")
+            i += 1
+            while i < n and src[i] != '"':
+                if src[i] == "\\":
+                    out.append(" ")
+                    i += 1
+                    if i < n:
+                        out.append("\n" if src[i] == "\n" else " ")
+                        i += 1
+                    continue
+                out.append("\n" if src[i] == "\n" else " ")
+                i += 1
+            if i < n:
+                out.append(" ")
+                i += 1
+        else:
+            out.append(src[i])
+            i += 1
+    return "".join(out)
+
+
+def strip_cfg_test(text: str) -> str:
+    """Blank out every `#[cfg(test)]` item, braces balanced.
+
+    A subsystem the engine reaches only from its own tests is not engine code —
+    the false positive the issue names, where `driver/restore.rs`'s test module
+    references `crate::skills`.
+
+    A `#[cfg(test)] mod tests;` declaration (no block) is blanked to its
+    semicolon, so the sibling file is not walked either.
+    """
+    out = list(text)
+    for match in CFG_TEST.finditer(text):
+        i = match.end()
+        while i < len(text) and text[i] not in "{;":
+            i += 1
+        if i >= len(text):
+            break
+        start = match.start()
+        if text[i] == ";":
+            end = i + 1
+        else:
+            depth, j = 0, i
+            while j < len(text):
+                if text[j] == "{":
+                    depth += 1
+                elif text[j] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            end = min(j + 1, len(text))
+        for k in range(start, end):
+            if out[k] != "\n":
+                out[k] = " "
+    return "".join(out)
+
+
+def child_dir(file: Path) -> Path:
+    """Where `mod foo;` inside `file` looks for `foo` — the sibling's rule."""
+    if file.stem in {"lib", "main", "mod"}:
+        return file.parent
+    return file.parent / file.stem
+
+
+def module_file(src: Path, name: str) -> Path | None:
+    """`crate::<name>` as a file under `src/`, either spelling."""
+    for candidate in (src / f"{name}.rs", src / name / "mod.rs"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def referenced_modules(text: str) -> set[str]:
+    """Every top-level crate module this text names."""
+    names = set(CRATE_PATH.findall(text))
+    for group in USE_GROUP.findall(text):
+        # `use crate::{a, b::c, d as e}` — each entry's head is a module.
+        for entry in group.split(","):
+            head = GROUP_HEAD.search(entry)
+            if head:
+                names.add(head.group(1))
+    return names
+
+
+def walk(src: Path) -> set[Path]:
+    """Every file the engine reaches, from the step path outward."""
+    queue: list[Path] = []
+    for entry in STEP_PATH_ROOTS:
+        target = src / entry
+        if target.is_file():
+            queue.append(target)
+        elif target.is_dir():
+            queue.extend(sorted(target.rglob("*.rs")))
+
+    seen: set[Path] = set()
+    while queue:
+        file = queue.pop()
+        if file in seen or not file.is_file():
+            continue
+        seen.add(file)
+        text = strip_cfg_test(strip_comments(file.read_text(encoding="utf-8", errors="replace")))
+
+        # Submodules of this file are part of it.
+        base = child_dir(file)
+        for name in MOD_DECL.findall(text):
+            for candidate in (base / f"{name}.rs", base / name / "mod.rs"):
+                if candidate.is_file():
+                    queue.append(candidate)
+                    break
+
+        # And every crate-level module it names, with that module's whole
+        # subtree: reaching `crate::records` reaches the record plane, which is
+        # the claim this guard is about.
+        for name in referenced_modules(text):
+            target = module_file(src, name)
+            if target is None:
+                continue
+            queue.append(target)
+            subtree = src / name
+            if subtree.is_dir():
+                queue.extend(sorted(subtree.rglob("*.rs")))
+    return seen
+
+
+def crate_sources(src: Path) -> list[Path]:
+    return sorted(p for p in src.rglob("*.rs") if p.is_file())
+
+
+def top_level_name(src: Path, file: Path) -> str:
+    """The crate-level module a file belongs to — what the baseline records.
+
+    A directory rather than a file, so evicting `records/` shrinks the baseline
+    by one line rather than by thirty.
+    """
+    rel = file.relative_to(src)
+    return rel.parts[0][:-3] if len(rel.parts) == 1 else rel.parts[0]
+
+
+def read_baseline(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+    return {
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+
+BASELINE_HEADER = """\
+# Modules in `stella-core` that the engine's step path does not reach.
+#
+# A DOWN-ONLY ratchet (#5115). This records the debt that predates the guard;
+# it may never gain an entry, and `--update` refuses to add one. Each eviction
+# under #5113 deletes a line here. It is meant to reach empty.
+#
+# Regenerate after an eviction:  ./scripts/check-core-reachability.py --update
+"""
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if a != "--update"]
+    update = "--update" in sys.argv[1:]
+    root = Path(args[0] if args else ".").resolve()
+    src = root / CRATE / "src"
+    baseline_path = root / BASELINE
+
+    if not src.is_dir():
+        print(f"check-core-reachability: no {CRATE}/src at {root} — nothing to check")
+        return 0
+
+    reached = walk(src)
+    unreached = sorted(
+        {
+            top_level_name(src, f)
+            for f in crate_sources(src)
+            if f not in reached and f.name != "lib.rs"
+        }
+    )
+    baseline = read_baseline(baseline_path)
+
+    if update:
+        added = sorted(set(unreached) - baseline)
+        if added:
+            print("check-core-reachability: REFUSING to grow the baseline.\n")
+            print("These modules are new debt, not recorded debt:")
+            for name in added:
+                print(f"  {name}")
+            print(
+                "\nThe ratchet only goes down. Move the module out of stella-core,"
+                "\nor make the engine actually use it — do not record it here."
+            )
+            return 1
+        kept = sorted(baseline & set(unreached))
+        baseline_path.write_text(
+            BASELINE_HEADER + "\n".join(kept) + ("\n" if kept else ""), encoding="utf-8"
+        )
+        retired = sorted(baseline - set(unreached))
+        for name in retired:
+            print(f"check-core-reachability: retired {name} — the engine reaches it now")
+        print(f"check-core-reachability: baseline holds {len(kept)} module(s)")
+        return 0
+
+    new_debt = sorted(set(unreached) - baseline)
+    reachable_now = sorted(baseline - set(unreached))
+
+    if new_debt:
+        print("check-core-reachability: FAILED\n")
+        print(
+            "These stella-core modules are not reachable from the engine's step\n"
+            "path (driver / step / ports) and are not in the baseline:\n"
+        )
+        for name in new_debt:
+            print(f"  {name}")
+        print(
+            "\nstella-core holds the step path (AGENTS.md rule 12). A subsystem\n"
+            "that lands here behind a `pub mod` line is how the record plane got in.\n"
+            "Move it to its own crate, or make the engine genuinely use it.\n"
+            "Do NOT add a baseline entry — the ratchet only goes down."
+        )
+        return 1
+
+    if reachable_now:
+        print("check-core-reachability: baseline is STALE\n")
+        print("The engine now reaches these, so their baseline entries are dead:\n")
+        for name in reachable_now:
+            print(f"  {name}")
+        print("\nRun ./scripts/check-core-reachability.py --update and commit the diff.")
+        return 1
+
+    print(
+        f"check-core-reachability: OK — {len(baseline)} module(s) outside the step "
+        f"path, all recorded; none added."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -155,6 +155,7 @@ step_command() {
   adr-numbering) echo 'check-adr-numbering' ;;
   doc-links) echo 'check-doc-links' ;;
   module-reachability) echo 'check-module-reachability' ;;
+  core-reachability) echo 'check-core-reachability' ;;
   typed-errors) echo 'check-typed-errors' ;;
   tool-error-class) echo 'check-tool-error-class' ;;
   dead-code-allows) echo 'check-dead-code-allows' ;;

--- a/scripts/core-reachability-baseline.txt
+++ b/scripts/core-reachability-baseline.txt
@@ -1,0 +1,21 @@
+# Modules in `stella-core` that the engine's step path does not reach.
+#
+# A DOWN-ONLY ratchet (#5115). This records the debt that predates the guard;
+# it may never gain an entry, and `--update` refuses to add one. Each eviction
+# under #5113 deletes a line here. It is meant to reach empty.
+#
+# Regenerate after an eviction:  ./scripts/check-core-reachability.py --update
+event_stream
+extensions
+goal
+ingest
+mcp_usage
+plan_graph
+redact
+repair
+scoreboard
+search
+subagent
+tool_foundry
+turn_slots
+workspace_scope

--- a/scripts/test-core-reachability.sh
+++ b/scripts/test-core-reachability.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Tests for check-core-reachability.py (#5115).
+#
+#   ./scripts/test-core-reachability.sh
+#
+# Run it after touching that script. Not part of `make gate`: it builds
+# throwaway crate fixtures, the same posture as `module-reachability-test`.
+#
+# ── Why a fixture instead of the real tree ───────────────────────────────────
+#
+# Asserting against `crates/stella-core` alone would only prove the baseline
+# matches today's residents, which is what a green run says anyway. What needs
+# proving is the three directions the guard can be wrong in:
+#
+#   misses      a module the engine never reaches passes unrecorded — the
+#               #5113 defect, a subsystem landing behind a `pub mod` line.
+#   fabricates  a module the engine DOES reach is reported unreachable. Worse
+#               in practice: it reddens a healthy tree and the reader's only
+#               recourse is to distrust the guard.
+#   drifts      a baseline entry outlives the module it recorded, so the
+#               ratchet stops meaning anything.
+#
+# The test-only case is its own kind of fabrication and has its own case: a
+# `#[cfg(test)]` reference must NOT count, or the guard would call every module
+# a driver test touches "engine code".
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-core-reachability.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# A throwaway tree shaped like the real one: `crates/stella-core/src` with a
+# step path, so the guard's roots resolve.
+new_core() { # <case>
+  local dir="$TMP/$1/crates/stella-core/src"
+  mkdir -p "$dir"
+  printf 'pub mod driver;\npub mod step;\npub mod ports;\n' >"$dir/lib.rs"
+  printf 'pub fn drive() {}\n' >"$dir/driver.rs"
+  printf 'pub fn step() {}\n' >"$dir/step.rs"
+  printf 'pub trait Port {}\n' >"$dir/ports.rs"
+  echo "$dir"
+}
+
+seed_baseline() { # <case> <entries…>
+  local case="$1"
+  shift
+  mkdir -p "$TMP/$case/scripts"
+  : >"$TMP/$case/scripts/core-reachability-baseline.txt"
+  for name in "$@"; do
+    echo "$name" >>"$TMP/$case/scripts/core-reachability-baseline.txt"
+  done
+}
+
+# want <name> <expect-pass|expect-fail> <case> [substring]
+want() {
+  local name="$1" expect="$2" case="$3" sub="${4:-}" out rc
+  out="$(python3 "$SCRIPT" "$TMP/$case" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -eq 0 ]; then
+      pass=$((pass + 1)); echo "ok   $name"
+    else
+      fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+    fi
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1)); echo "FAIL $name — the guard passed it:"; echo "$out"
+    return
+  fi
+  case "$out" in
+    *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+    *) fail=$((fail + 1)); echo "FAIL $name — failed for the wrong reason (wanted '$sub'):"; echo "$out" ;;
+  esac
+}
+
+# ── U: the defect — a subsystem the engine never reaches ─────────────────────
+# Reachable from `lib.rs`, which is exactly what `module-reachability` checks
+# and passes. This guard exists because that is not the same question.
+src="$(new_core unreached)"
+printf 'pub mod records;\n' >>"$src/lib.rs"
+mkdir -p "$src/records"
+printf 'pub fn promote() {}\n' >"$src/records/mod.rs"
+seed_baseline unreached
+want "a module the engine never reaches is reported" expect-fail unreached "records"
+
+# ...and is silent once recorded, which is what lets this land green.
+seed_baseline unreached records
+want "and is silent once the baseline records it" expect-pass unreached
+
+# ── R: a module the engine DOES reach is never reported ──────────────────────
+src="$(new_core reached)"
+printf 'pub mod budget;\n' >>"$src/lib.rs"
+printf 'pub fn spend() {}\n' >"$src/budget.rs"
+printf 'pub fn drive() { crate::budget::spend(); }\n' >"$src/driver.rs"
+seed_baseline reached
+want "a module the step path uses is not reported" expect-pass reached
+
+# The grouped form resolves too, so `use crate::{a, b}` is not a blind spot.
+src="$(new_core grouped)"
+printf 'pub mod budget;\npub mod loopdetect;\n' >>"$src/lib.rs"
+printf 'pub fn spend() {}\n' >"$src/budget.rs"
+printf 'pub fn detect() {}\n' >"$src/loopdetect.rs"
+printf 'use crate::{budget, loopdetect};\npub fn drive() { budget::spend(); loopdetect::detect(); }\n' >"$src/driver.rs"
+seed_baseline grouped
+want "a grouped use reaches every module it names" expect-pass grouped
+
+# ── T: a test-only reference is not reachability ─────────────────────────────
+# The false positive #5115 names: `driver/restore.rs`'s test module references
+# `crate::skills`, which would otherwise make the whole skill plane look like
+# engine code.
+src="$(new_core testonly)"
+printf 'pub mod skills;\n' >>"$src/lib.rs"
+printf 'pub fn select() {}\n' >"$src/skills.rs"
+cat >"$src/driver.rs" <<'RS'
+pub fn drive() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn t() {
+        crate::skills::select();
+    }
+}
+RS
+seed_baseline testonly
+want "a #[cfg(test)] reference does not make a module engine code" expect-fail testonly "skills"
+
+# ── C: a comment is not a reference ──────────────────────────────────────────
+# The sibling guard's own history: prose describing the rule must not satisfy
+# it.
+src="$(new_core commented)"
+printf 'pub mod skills;\n' >>"$src/lib.rs"
+printf 'pub fn select() {}\n' >"$src/skills.rs"
+printf '// The engine does not call crate::skills — that is the point.\npub fn drive() {}\n' >"$src/driver.rs"
+seed_baseline commented
+want "a module named only in a comment is still unreached" expect-fail commented "skills"
+
+# ── S: a stale baseline entry is reported ────────────────────────────────────
+# Without this the ratchet rots: an entry outliving its module records debt
+# that no longer exists, and the count stops meaning anything.
+src="$(new_core stale)"
+seed_baseline stale records
+want "a baseline entry whose module is gone is reported" expect-fail stale "STALE"
+
+# ── G: --update refuses to grow ──────────────────────────────────────────────
+# The whole ratchet contract. Without this the remedy for a red run is one
+# command, and the guard governs nothing.
+src="$(new_core grow)"
+printf 'pub mod records;\n' >>"$src/lib.rs"
+printf 'pub fn promote() {}\n' >"$src/records.rs"
+seed_baseline grow
+out="$(python3 "$SCRIPT" --update "$TMP/grow" 2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && [ -z "${out##*REFUSING*}" ]; then
+  pass=$((pass + 1)); echo "ok   --update refuses to record new debt"
+else
+  fail=$((fail + 1)); echo "FAIL --update recorded new debt (rc=$rc):"; echo "$out"
+fi
+case "$(cat "$TMP/grow/scripts/core-reachability-baseline.txt")" in
+  *records*) fail=$((fail + 1)); echo "FAIL --update wrote the entry anyway" ;;
+  *) pass=$((pass + 1)); echo "ok   and left the baseline untouched" ;;
+esac
+
+# ── D: --update shrinks ──────────────────────────────────────────────────────
+src="$(new_core shrink)"
+seed_baseline shrink records goal
+python3 "$SCRIPT" --update "$TMP/shrink" >/dev/null 2>&1
+if [ ! -s "$TMP/shrink/scripts/core-reachability-baseline.txt" ] ||
+   [ -z "$(grep -v '^#' "$TMP/shrink/scripts/core-reachability-baseline.txt" | tr -d '[:space:]')" ]; then
+  pass=$((pass + 1)); echo "ok   --update retires entries whose modules are gone"
+else
+  fail=$((fail + 1)); echo "FAIL --update kept dead entries:"
+  cat "$TMP/shrink/scripts/core-reachability-baseline.txt"
+fi
+
+# ── the real tree ────────────────────────────────────────────────────────────
+# It must pass with its seeded baseline; a guard that cannot run green on the
+# repository it ships in is not adoptable.
+if out="$(python3 "$SCRIPT" "$repo_root" 2>&1)"; then
+  pass=$((pass + 1)); echo "ok   the real stella-core passes with its seeded baseline"
+else
+  fail=$((fail + 1)); echo "FAIL the real tree is red:"; echo "$out"
+fi
+
+echo
+echo "core-reachability: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

`check-module-reachability.py` proves every `.rs` file is reachable from its **crate root** — and passes on all of today's residents, because `search.rs`, `records/` and `skills/` *are* reachable from `lib.rs`.

Reachability from the crate root is not reachability from the engine. Nothing stopped the next 15k-LOC subsystem from landing in `stella-core` behind a `pub mod` line, which is exactly how the record plane got there (#5113).

`check-core-reachability.py` walks the other graph: from `driver`, `step` and `ports` outward, through the crate-internal paths those modules actually *name*. **Fourteen** modules in `stella-core` are outside that closure today:

```
event_stream  extensions  goal      ingest    mcp_usage  plan_graph  redact
repair        scoreboard  search    subagent  tool_foundry  turn_slots  workspace_scope
```

### A `#[cfg(test)]` reference does not count

The false positive this issue names: `driver/restore.rs`'s test module references `crate::skills`, and reading that as reachability would make the whole skill plane look like engine code. A subsystem the engine touches only from its own tests is one the engine does not need.

### Down-only, seeded

`scripts/core-reachability-baseline.txt` records those fourteen, so this lands **green on `main` immediately** and each eviction under #5113 shrinks a list the guard already enforces.

`--update` **refuses to add an entry** — the only way past a red run is to move the module out or to make the engine genuinely use it, never to record it. It also reports a *stale* entry, so the count cannot rot into meaning nothing.

**No module moves in this PR.** The issue's non-goal is explicit: the ratchet lands first.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-core-reachability.sh` — 11 cases over throwaway crate fixtures, covering the three ways this guard can be wrong: **missing** an unreached module, **fabricating** one the engine does reach, and letting the baseline **drift**.

```
ok   a module the engine never reaches is reported
ok   and is silent once the baseline records it
ok   a module the step path uses is not reported
ok   a grouped use reaches every module it names
ok   a #[cfg(test)] reference does not make a module engine code
ok   a module named only in a comment is still unreached
ok   a baseline entry whose module is gone is reported
ok   --update refuses to record new debt
ok   and left the baseline untouched
ok   --update retires entries whose modules are gone
ok   the real stella-core passes with its seeded baseline

core-reachability: 11 passed, 0 failed
```

The issue's three conditions, each demonstrated rather than asserted:

| condition | evidence |
|---|---|
| a fixture with an unreached module fails | case `U` above |
| the real tree passes with the seeded baseline | last case, and `make core-reachability` |
| deleting one baseline entry without deleting the module fails | run against the **real** tree with `search` removed from the baseline → `FAILED … search`, exit 1 |

## The gate

- [x] `make guards-fast` green (compiles nothing)
- [x] `make core-reachability` — OK, 14 recorded, none added
- [x] `make gate-parity` — OK, 52 gate steps, named in AGENTS.md and CONTRIBUTING.md, each run by a workflow
- [x] `make invariants` — OK, 12 rules, 429 citations resolve
- [x] `shellcheck` clean; `check-prose` OK
- [x] `Closes #5115` appears both here and as a commit trailer

Wired into `GATE_STEPS`, `ci.yml`, `guard-self-tests.yml`, AGENTS.md's gate block and CONTRIBUTING.md's list — `gate-parity` caught two of those four when I had only done the other two, which is what that guard is for.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

The baseline's fourteen entries are the eviction work #5113 tracks, and each of its children shrinks this list — that is the point of landing the ratchet first rather than a gap I am leaving.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — a text-level walk, so this stays in the toolchain-free `guards-fast` rung
- [x] No new outbound network calls

## Anything reviewers should know?

**The walk is textual, and deliberately over-approximates in the safe direction.** Reaching `crate::records::promotion::x` marks the *whole* `records` subtree reached, so the guard under-reports rather than fabricating — a module it calls unreachable really is unnamed by the engine, while one it calls reachable may only be partly used. Fabrication is the worse failure for a gate (it reddens a healthy tree and the reader's recourse is to distrust the guard), so the bias is chosen, not incidental.

`#[path]` is not modelled. The sibling guard fails loudly on it; there are none in this tree, and adding the same refusal here would be dead code today — say the word if you would rather have it.

Closes #5115
Refs #5113

## Summary by Sourcery

Enforce that stella-core modules remain justified by reachability from the engine’s step path through a down-only CI ratchet.

New Features:
- Add a guard that verifies stella-core modules are reachable from the engine’s driver, step, or ports path.

Enhancements:
- Introduce a down-only reachability baseline that reports new unreachable modules and stale debt without allowing the baseline to grow.
- Exclude test-only references and comments from reachability analysis while supporting transitive crate-internal module usage.

Build:
- Add Makefile targets for checking, updating, and testing core reachability.

CI:
- Run the core-reachability guard in CI and add its self-tests to the guard workflow.
- Include the new guard in gate parity validation.

Documentation:
- Document the engine step-path reachability rule and its down-only ratchet in AGENTS.md and CONTRIBUTING.md.

Tests:
- Add hermetic fixture tests covering unreachable modules, reachable modules, grouped imports, test-only references, comments, stale baselines, and ratchet update behavior.

Chores:
- Seed the reachability baseline with existing stella-core modules that are currently outside the engine step-path closure.