### PR TITLE
feat(ci): notice when a commit on main has no completed CI run

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -209,6 +209,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-core-reachability.sh
 
+      - name: the unverified-main detector, and that it fails open
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-main-verified.sh
+
       - name: the session-scratch boundary
         if: ${{ !cancelled() }}
         run: ./scripts/test-no-scratch.sh

--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -88,3 +88,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/main-canary.sh --announce
+
+      # The other half of the same question, and the one nothing asked: is
+      # there a commit on `main` that nothing VERIFIED — as distinct from one
+      # a check said no about (#5027)?
+      #
+      # This canary only files when its own job runs and fails, so a
+      # `startup_failure`, a cancellation, or a run that was never created
+      # produces no issue at all. On 2026-08-26 four commits landed during a
+      # runner outage and `main` sat unchecked for 85 minutes with every
+      # surface reading green.
+      #
+      # `!cancelled()` so it still reports when the reconciliation above
+      # failed: a red `main` that ALSO carries unverified commits is worse
+      # than either, and the reader should see both. It fails open at every
+      # unknown, so it cannot itself become the thing blocking a repair.
+      - name: Every recent commit on main has a completed ci run
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/check-main-verified.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,20 @@ silent failure costs here). `make main-canary` runs the same check locally
 without filing anything; `scripts/main-canary.sh`'s header carries the full
 argument, including why it deliberately does not open a fix PR (#3332).
 
+It answers "is `main` **known broken**". A second step in the same workflow —
+`scripts/check-main-verified.sh` (`make main-verified`) — answers the question
+nothing else here asks: is there a commit on `main` that nothing **verified**?
+Those are different states, and every other mechanism reads the second as
+green. The canary files only when its own job runs and fails, so a
+`startup_failure`, a cancellation, or a run that was never created produces no
+issue; `main-red-hold.yml` passes when no issue is open; and `gh run list`
+shows no row at all for a run that never existed. On 2026-08-26 an Actions
+outage landed four commits with no completed `ci` run between them and `main`
+sat unchecked for 85 minutes with every surface reading green (#5027). A
+failing run is a **verified** commit and stays the canary's business; this
+reports only the absence of an answer, and fails open at every unknown so it
+can never be the thing blocking a repair.
+
 A seventh, `main-red-hold.yml`, is the canary's other half: the canary *detects*,
 and this is what consumes the detection at the point a merge is still a
 decision. It runs on `pull_request`, asks the tracker whether a `main-red`

--- a/Makefile
+++ b/Makefile
@@ -815,6 +815,14 @@ deleted-tests-test: ## Test the deleted-test guard's live-vs-stale PR body handl
 # the point a merge is still a decision (#3917). Not a gate step for the same
 # reason the canary is not — it asks the issue tracker a question, and `gate`
 # is hermetic and offline by contract.
+.PHONY: main-verified
+main-verified: ## Ask whether every recent commit on main has a completed ci run (#5027)
+	@./scripts/check-main-verified.sh
+
+.PHONY: main-verified-test
+main-verified-test: ## Test the unverified-main detector (hermetic; not part of `gate`)
+	./scripts/test-main-verified.sh
+
 .PHONY: main-red-hold
 main-red-hold: ## Ask whether an open `main-red` issue should hold a PR (reads the tracker)
 	@./scripts/check-main-red-hold.sh

--- a/scripts/check-main-verified.sh
+++ b/scripts/check-main-verified.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+#
+# Has every recent commit on `main` actually been verified? (#5027)
+#
+#   scripts/check-main-verified.sh [--limit N] [--stuck-minutes M]
+#
+# ── The gap this closes ──────────────────────────────────────────────────────
+#
+# Every existing mechanism here answers "is main KNOWN BROKEN". None answers
+# "is main UNVERIFIED", and those are different states:
+#
+#   main-canary.yml   files only when its job RUNS and FAILS. A
+#                     `startup_failure`, a cancellation, or a run that is never
+#                     created produces no issue at all.
+#   main-red-hold.yml asks the tracker whether a `main-red` issue is open. With
+#                     none filed it passes, so merges keep flowing onto a tree
+#                     nothing has checked.
+#   gh run list       reads GREEN to a human skimming it, because a run that
+#                     was never created leaves no row.
+#
+# On 2026-08-26 between 15:25 and 15:31 UTC, Actions stopped allocating
+# runners. Four commits landed on `main` in that window and none got a
+# completed `ci` run: one still `queued` with no runner ever assigned, one
+# marked `failure` with all three jobs `queued` and zero steps executed, and
+# two with no run created at all. `main` sat unverified for about 85 minutes
+# and nothing said so. It happened to be fine — which is luck, not a signal.
+# The same window would have looked identical if one of those merges had
+# broken the tree.
+#
+# ── What counts as verified ──────────────────────────────────────────────────
+#
+# A `ci` run for that exact commit that reached a terminal conclusion of its
+# own accord: `success`, `failure`, `cancelled`, `timed_out`. A FAILING run is
+# verified — the canary and the hold deal with that, and it is not this
+# script's business. What is reported is the absence of an answer:
+#
+#   missing          no `ci` run exists for the commit
+#   queued too long  a run past --stuck-minutes with no runner
+#   startup_failure  the workflow never began, so no check ran
+#
+# ── It fails OPEN, at every unknown ──────────────────────────────────────────
+#
+# No `gh`, an unreachable API, an unparseable answer: report and exit 0. This
+# is a monitor, and a monitor that can itself block a merge is worse than the
+# gap it watches — the same argument `main-red-claim.sh`'s header makes about
+# a claim check. Every unknown is loud, never silent.
+
+set -uo pipefail
+
+# A decided verdict must survive a reader that closes the pipe early (#1815).
+trap '' PIPE
+
+limit=10
+stuck_minutes=45
+fixture_runs=""
+fixture_commits=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --limit)
+    limit="${2:-}"
+    shift 2
+    ;;
+  --stuck-minutes)
+    stuck_minutes="${2:-}"
+    shift 2
+    ;;
+  # Test-only, and paired: a fixture that supplied runs but took real commits
+  # would compare two different worlds and report nonsense.
+  --fixture-runs)
+    fixture_runs="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-commits)
+    fixture_commits="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  -h | --help)
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    echo "check-main-verified: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+case "$limit" in '' | *[!0-9]*)
+  echo "check-main-verified: --limit takes a whole number" >&2
+  exit 2
+  ;;
+esac
+case "$stuck_minutes" in '' | *[!0-9]*)
+  echo "check-main-verified: --stuck-minutes takes a whole number" >&2
+  exit 2
+  ;;
+esac
+
+if [ "$use_fixture" -eq 1 ] && { [ -z "$fixture_runs" ] && [ -z "$fixture_commits" ]; }; then
+  echo "check-main-verified: --fixture-runs and --fixture-commits go together" >&2
+  exit 2
+fi
+
+# `unknown` is the only exit this script takes when it cannot answer, so it is
+# one function rather than a repeated pair of lines that could drift apart.
+unknown() {
+  echo "check-main-verified: UNKNOWN — $1"
+  echo "  Exiting 0: a monitor that can block a merge is worse than the gap it"
+  echo "  watches. This run established nothing; it did not establish green."
+  exit 0
+}
+
+if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  unknown "gh is not installed, so no run could be looked up"
+fi
+
+# ── The two reads ────────────────────────────────────────────────────────────
+#
+# Commits first: the question is about commits that landed, and a run list with
+# no commits to match it against cannot answer anything.
+
+if [ "$use_fixture" -eq 1 ]; then
+  commits="$fixture_commits"
+elif ! commits="$(git log --format='%H %h %s' -n "$limit" origin/main 2>/dev/null)"; then
+  unknown "could not read origin/main — fetch it first"
+fi
+if [ -z "$commits" ]; then
+  unknown "origin/main has no commits to check"
+fi
+
+# `<sha> <status> <conclusion> <created_at>` per line, which is the shape the
+# fixture supplies too so the two paths cannot diverge.
+if [ "$use_fixture" -eq 1 ]; then
+  runs="$fixture_runs"
+elif ! runs="$(gh run list --workflow ci.yml --branch main --limit 60 \
+  --json headSha,status,conclusion,createdAt \
+  --jq '.[] | "\(.headSha) \(.status) \(.conclusion // "none") \(.createdAt)"' 2>/dev/null)"; then
+  unknown "could not reach the Actions API"
+fi
+
+now_epoch="$(date -u +%s 2>/dev/null || echo 0)"
+
+# Seconds since an RFC-3339 timestamp, or 0 when this platform's `date` will
+# not parse it — BSD and GNU take different flags, which is what
+# `stat-portability` is about. Zero reads as "just created" and so never
+# reports stuck: an unparseable timestamp must not become a finding.
+age_seconds() {
+  local ts="$1" at
+  at="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" +%s 2>/dev/null ||
+    date -u -d "$ts" +%s 2>/dev/null || echo 0)"
+  [ "$at" -eq 0 ] && echo 0 && return
+  echo $((now_epoch - at))
+}
+
+unverified=""
+count=0
+
+while IFS= read -r commit; do
+  [ -z "$commit" ] && continue
+  sha="${commit%% *}"
+  rest="${commit#* }"
+  short="${rest%% *}"
+  subject="${rest#* }"
+  count=$((count + 1))
+
+  verdict="missing"
+  while IFS= read -r run; do
+    [ -z "$run" ] && continue
+    run_sha="${run%% *}"
+    [ "$run_sha" = "$sha" ] || continue
+    run_rest="${run#* }"
+    status="${run_rest%% *}"
+    run_rest="${run_rest#* }"
+    conclusion="${run_rest%% *}"
+    created="${run_rest##* }"
+
+    case "$conclusion" in
+    success | failure | cancelled | timed_out)
+      # A FAILING run is a verified commit: the canary and the hold own that
+      # state, and reporting it here would be a second voice saying the same
+      # thing in different words.
+      verdict="verified"
+      break
+      ;;
+    startup_failure)
+      verdict="startup_failure — the workflow never began, so no check ran"
+      ;;
+    *)
+      if [ "$status" = "completed" ]; then
+        verdict="completed as '$conclusion', which is not a verdict this build recognises"
+      else
+        age="$(age_seconds "$created")"
+        if [ "$age" -gt $((stuck_minutes * 60)) ]; then
+          verdict="$status for $((age / 60))m — past the ${stuck_minutes}m threshold, so no runner is coming"
+        else
+          verdict="verified"
+        fi
+      fi
+      ;;
+    esac
+  done <<EOF
+$runs
+EOF
+
+  if [ "$verdict" != "verified" ]; then
+    unverified="${unverified}  $short  $verdict
+      $subject
+"
+  fi
+done <<EOF
+$commits
+EOF
+
+if [ -z "$unverified" ]; then
+  echo "check-main-verified: OK — each of the last $count commit(s) on main has a completed ci run."
+  exit 0
+fi
+
+echo "check-main-verified: FAILED — main carries commits nothing verified."
+echo
+echo "$unverified"
+cat <<'TXT'
+This is NOT "main is red". A failing run is a verified commit and the canary
+owns that. These commits have no answer at all, which every other mechanism
+here reads as green: the canary files only when its job runs and fails, the
+red-main hold passes when no issue is open, and `gh run list` shows no row for
+a run that was never created.
+
+Re-dispatch the missing runs and let them finish before merging onto this tree:
+
+  gh workflow run ci.yml --ref main
+
+An Actions incident is the usual cause (#5027). If that is what this is, the
+runs will start on their own once capacity returns — but nothing was checking,
+which is the part this exists to fix.
+TXT
+exit 1

--- a/scripts/test-main-verified.sh
+++ b/scripts/test-main-verified.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Tests for check-main-verified.sh (#5027).
+#
+#   ./scripts/test-main-verified.sh
+#
+# Hermetic: every case drives the script through its paired fixtures, so
+# nothing here needs `gh`, a network, or the repository's real run history. A
+# monitor whose subject is an Actions outage is precisely the script you
+# cannot test by waiting for one.
+#
+# ── The four shapes, from the run that motivated it ──────────────────────────
+#
+# On 2026-08-26 four commits landed during a runner outage and produced four
+# different non-answers. Each is a case here, because a guard that catches
+# three of them still lets the fourth through as green:
+#
+#   002b9624  created, still `queued`, no runner ever assigned
+#   258f1a8c  marked `failure` with all three jobs queued and zero steps
+#   f1f36660  no run created for the push at all
+#   68020ccd  no run until 85 minutes later
+#
+# The second is the one worth pausing on: it reads as a VERIFIED failure to
+# every other mechanism, and this script agrees — a `failure` conclusion is an
+# answer, and the canary owns it. The gap is the other three.
+#
+# ── The direction that matters most ──────────────────────────────────────────
+#
+# A monitor that fabricates blocks merges during an incident, which is exactly
+# when the repair needs to land. Every unknown must exit 0 and say so, and the
+# `U` cases pin that.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-main-verified.sh"
+
+pass=0
+fail=0
+
+# A commit line as `git log --format='%H %h %s'` prints one.
+commit() { printf '%s %s %s\n' "$1" "${1:0:8}" "$2"; }
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+long_ago() {
+  date -u -v-3H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -d '3 hours ago' +%Y-%m-%dT%H:%M:%SZ
+}
+
+# want <name> <expect-pass|expect-fail> <commits> <runs> [substring]
+want() {
+  local name="$1" expect="$2" commits="$3" runs="$4" sub="${5:-}" out rc
+  out="$("$SCRIPT" --fixture-commits "$commits" --fixture-runs "$runs" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -eq 0 ]; then
+      pass=$((pass + 1)); echo "ok   $name"
+    else
+      fail=$((fail + 1)); echo "FAIL $name — expected exit 0, got $rc:"; echo "$out"
+      return
+    fi
+  else
+    if [ "$rc" -eq 0 ]; then
+      fail=$((fail + 1)); echo "FAIL $name — the guard passed an unverified commit:"; echo "$out"
+      return
+    fi
+    pass=$((pass + 1)); echo "ok   $name"
+  fi
+  if [ -n "$sub" ]; then
+    case "$out" in
+      *"$sub"*) ;;
+      *)
+        fail=$((fail + 1)); echo "FAIL $name — output did not say '$sub':"; echo "$out" ;;
+    esac
+  fi
+}
+
+A=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+B=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+# ── V: a verified commit is silent ───────────────────────────────────────────
+want "a commit with a successful run passes" expect-pass \
+  "$(commit $A 'a good merge')" \
+  "$A completed success $(now_iso)"
+
+# A FAILING run is still an ANSWER. The canary and the red-main hold own that
+# state; a second voice reporting it here would be noise, and would fire on
+# every red main forever.
+want "a commit with a FAILING run is verified, not reported" expect-pass \
+  "$(commit $A 'a merge that broke the tree')" \
+  "$A completed failure $(now_iso)"
+
+want "and so is a cancelled or timed-out one" expect-pass \
+  "$(commit $A 'a merge whose run was cancelled')" \
+  "$A completed cancelled $(now_iso)"
+
+# ── M: no run at all — f1f36660's shape ──────────────────────────────────────
+# The one `gh run list` shows as nothing, which reads green to a human.
+want "a commit with NO run is reported" expect-fail \
+  "$(commit $A 'a merge nothing ran for')" \
+  "$B completed success $(now_iso)" \
+  "missing"
+
+# ── Q: queued past the threshold — 002b9624's shape ──────────────────────────
+want "a run queued for hours with no runner is reported" expect-fail \
+  "$(commit $A 'a merge during the outage')" \
+  "$A queued none $(long_ago)" \
+  "no runner is coming"
+
+# ...and a run queued for a moment is NOT. Without this the guard fires on
+# every merge in the ninety seconds before a runner picks it up, which is how a
+# monitor earns a mute filter.
+want "a run queued a moment ago is not reported" expect-pass \
+  "$(commit $A 'a merge just now')" \
+  "$A in_progress none $(now_iso)"
+
+# ── S: startup_failure — the canary's own blind spot ─────────────────────────
+want "a startup_failure is reported" expect-fail \
+  "$(commit $A 'a merge whose workflow never began')" \
+  "$A completed startup_failure $(now_iso)" \
+  "never began"
+
+# ── W: a conclusion this build has never seen ────────────────────────────────
+# GitHub adds spellings. An unrecognised one must not read as verified — the
+# same three-state discipline the self-driving watch sentinel needed.
+want "an unrecognised conclusion is not read as verified" expect-fail \
+  "$(commit $A 'a merge with a novel conclusion')" \
+  "$A completed moon_phase $(now_iso)" \
+  "not a verdict this build recognises"
+
+# ── U: every unknown exits 0 ─────────────────────────────────────────────────
+# The direction that matters most: this runs during an Actions incident, which
+# is exactly when the repair must be able to land.
+if out="$("$SCRIPT" --fixture-commits "" --fixture-runs "$A completed success $(now_iso)" 2>&1)" &&
+  [ -z "${out##*UNKNOWN*}" ]; then
+  pass=$((pass + 1)); echo "ok   no commits to check is UNKNOWN, not a failure"
+else
+  fail=$((fail + 1)); echo "FAIL an empty commit list did not exit 0 as unknown:"; echo "$out"
+fi
+
+# An unknown says so rather than passing quietly — a silent exit 0 here would
+# be indistinguishable from green, which is the whole defect.
+case "$out" in
+  *"did not establish green"*) pass=$((pass + 1)); echo "ok   and says it established nothing" ;;
+  *) fail=$((fail + 1)); echo "FAIL an unknown exited 0 without saying so:"; echo "$out" ;;
+esac
+
+# ── N: several commits, one bad ──────────────────────────────────────────────
+# The reported window is a run of merges, not one; a guard that stopped at the
+# first verified commit would have missed three of the four that day.
+multi="$(commit $A 'verified')
+$(commit $B 'unverified')"
+want "one unverified commit among several is found" expect-fail \
+  "$multi" \
+  "$A completed success $(now_iso)" \
+  "${B:0:8}"
+
+# ── the real repository ──────────────────────────────────────────────────────
+# It must not fabricate against real history. Skipped without `gh`, because
+# there the script correctly reports UNKNOWN and the case would prove nothing.
+if command -v gh >/dev/null 2>&1 && git rev-parse origin/main >/dev/null 2>&1; then
+  out="$("$SCRIPT" --limit 3 2>&1)"
+  rc=$?
+  case "$out" in
+    *UNKNOWN*) pass=$((pass + 1)); echo "ok   the real repo answered UNKNOWN (no API access here)" ;;
+    *)
+      if [ "$rc" -eq 0 ]; then
+        pass=$((pass + 1)); echo "ok   the real repo's recent commits are verified"
+      else
+        # Not a test failure: main really may carry an unverified commit, which
+        # is the thing this script exists to say. Reported so the reader sees
+        # it rather than reading a red suite as a broken guard.
+        pass=$((pass + 1)); echo "ok   the real repo reported unverified commits (that is a finding, not a bug):"
+        printf '       %s\n' "$out"
+      fi
+      ;;
+  esac
+else
+  echo "skip the real repository — no gh or no origin/main"
+fi
+
+echo
+echo "main-verified: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

Every mechanism here answers **"is `main` known broken"**. None answered **"is `main` unverified"** — and every surface reads the second as green:

| mechanism | why it misses this |
|---|---|
| `main-canary.yml` | files only when its own job **runs and fails**. A `startup_failure`, a cancellation, or a run that is never created produces no issue at all |
| `main-red-hold.yml` | asks whether a `main-red` issue is open, and passes when none is — so merges keep flowing onto a tree nothing has checked |
| `gh run list` | shows **no row** for a run that never existed, which reads green to a human skimming it |

On 2026-08-26 an Actions outage landed four commits on `main` with no completed `ci` run between them. It sat unverified for 85 minutes and nothing said so. It happened to be fine — that is luck, not a signal; the same window would have looked identical if one of those merges had broken the tree.

## What it does

`scripts/check-main-verified.sh` walks the last N commits on `main` and asks whether each has a `ci` run that reached a terminal conclusion. **Sketch 1** of the three the issue lists, chosen because it closes the reported gap on its own.

**A failing run is a verified commit.** The canary and the hold own that state; a second voice reporting it here would fire on every red `main` forever. What is reported is the absence of an answer:

- no run exists for the commit
- a run queued past `--stuck-minutes` with no runner ever assigned
- `startup_failure` — the workflow never began
- a conclusion this build does not recognise (GitHub adds spellings; an unknown word must not read as verified)

Runs as a second step in `main-canary.yml` under `!cancelled()`, so a red `main` that **also** carries unverified commits reports both.

### It fails open, loudly

No `gh`, an unreachable API, an unparseable timestamp → report `UNKNOWN` and exit 0. This runs during an Actions incident, which is exactly when a repair must be able to land: a monitor that can itself block a merge is worse than the gap it watches, the same argument `main-red-claim.sh`'s header makes. An unknown **says** it established nothing rather than exiting quietly — a silent 0 would be indistinguishable from green, which is the whole defect.

### The issue's other two sketches, answered rather than left silent

**2 — "treat *the canary could not run* as its own reportable state."** This subsumes it. A `startup_failure` on `ci` is reported directly; a `startup_failure` on the canary itself means this step did not run either, and the next scheduled run catches the commit because the check is over *commits*, not over runs of itself.

**3 — "should `main-red-hold.yml` hold on unverified, not only known-red?"** **No, and not in this PR.** During an Actions incident every commit is unverified, so holding on unknown would block every merge including the repair — the exact failure mode #3917 describes, arrived at from the other side. `unblocks-main` would have to cover it, and that is a maintainer's call about branch protection rather than a script change. This reports; it does not hold.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-main-verified.sh` — 12 hermetic cases through paired fixtures, so nothing needs `gh`, a network, or real run history. A monitor whose subject is an Actions outage is precisely the script you cannot test by waiting for one.

One case per shape from the incident, plus the anti-vacuity direction:

```
ok   a commit with a successful run passes
ok   a commit with a FAILING run is verified, not reported
ok   and so is a cancelled or timed-out one
ok   a commit with NO run is reported
ok   a run queued for hours with no runner is reported
ok   a run queued a moment ago is not reported
ok   a startup_failure is reported
ok   an unrecognised conclusion is not read as verified
ok   no commits to check is UNKNOWN, not a failure
ok   and says it established nothing
ok   one unverified commit among several is found
ok   the real repo's recent commits are verified

main-verified: 12 passed, 0 failed
```

`a run queued a moment ago is not reported` is the one that keeps this usable: without it the guard fires on every merge in the ninety seconds before a runner picks it up, which is how a monitor earns a mute filter.

## The gate

- [x] `make guards-fast` green (compiles nothing)
- [x] `make gate-parity` — OK, 52 gate steps
- [x] `shellcheck` clean; `check-prose` OK
- [x] Docs updated — AGENTS.md's canary section now names both questions and which mechanism answers each
- [x] `Closes #5027` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed or answered above.

Sketch 3 is deliberately not done and the reasoning is in this PR rather than a new issue, because it is a decision for you rather than a task for anyone — say the word and I will file it as one.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls beyond the `gh` read the canary already makes

## Anything reviewers should know?

This is **not** a required check and does not gate merges — it reports into the workflow a person already reads when `main` moves. Making it a hold is sketch 3 above, and I have argued against it.

The `--stuck-minutes` default is 45. That is a judgement, not a measurement: long enough that an ordinary queue wait never fires, short enough that an outage is noticed within one canary run. Say if you would rather it were tighter.

Closes #5027
Refs #4804

## Summary by Sourcery

Detect and report recent `main` commits that lack a completed CI verification while keeping the monitor fail-open during Actions incidents.

New Features:
- Add a detector that identifies recent `main` commits without a completed, recognised CI run and reports missing, stuck, startup-failed, or unknown verification states.
- Run the unverified-main detector alongside the existing main canary without making it a merge-blocking check.

Bug Fixes:
- Close the gap where absent or non-starting CI runs on `main` were interpreted as healthy.

Enhancements:
- Make the detector fail open with an explicit UNKNOWN result when verification cannot be determined.
- Expose local commands for checking and testing main verification status.

CI:
- Add hermetic coverage for the detector to guard self-tests, including successful, failing, cancelled, missing, stuck, startup-failure, unknown-conclusion, and fail-open scenarios.

Documentation:
- Document the distinction between known-broken and unverified `main` states and the responsibilities of each monitoring mechanism.

Tests:
- Add fixture-based tests covering verification status across recent commits and ensuring unknown conditions do not fail the workflow.