### PR TITLE
feat(ci): ask whether somebody is already implementing an issue

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -193,6 +193,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-main-red-claim.sh
 
+      - name: the issue-claim pre-flight, standing-down branch included
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-issue-claim.sh
+
       - name: the retired-hex ban in every notation, and the citation check
         if: ${{ !cancelled() }}
         run: ./scripts/test-tokens.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,31 @@ a claim check that can block a repair is worse than the duplication it
 prevents. `make main-red-claim` asks by hand; `make main-red-claim-test`
 covers it, standing-down branch included.
 
+**The same collision happens over an issue, and `scripts/issue-claim.sh` is
+the same mechanic pointed at one.** Two sessions implemented #5045 in
+parallel and one merge kept one tree, dropping the other implementation with
+no conflict to report; #4336 and #5054 are the same shape, three in one
+afternoon (#5224). Every signal said that branch was abandoned — it existed
+only locally, in a stale worktree, clean, with no remote branch and no PR.
+
+```bash
+./scripts/issue-claim.sh check 5045   # exit 0 proceed, 1 stand down
+./scripts/issue-claim.sh claim 5045   # check, then post the claim
+```
+
+It asks the **pull requests first**, because that is the stronger signal and
+the one the issue itself never shows: a sweep PR can close forty issues at
+once while each of them still reads unassigned, unlabelled and open. Then the
+claim comments, on the red-`main` rules — the tracker is the table so a peer
+in another worktree can see it, a comment carries its author and timestamp, a
+claim lapses so a crashed session cannot hold an issue shut, and every unknown
+proceeds loudly. `make issue-claim N=5045` asks by hand; `make
+issue-claim-test` covers it, both blocking branches included.
+
+Run it **before writing code and again before opening the PR**. The gap
+between those two is enough: a peer's PR can merge inside one issue's worth of
+work, and then the check that was clean at the start is stale at the end.
+
 An eighth, `windows-check.yml`, is the only compiler in this project that
 looks at a `#[cfg(windows)]` arm: `ci.yml` runs on `ubuntu-latest` and
 `release.yml`'s matrix is two Apple targets and two Linux ones, so every

--- a/Makefile
+++ b/Makefile
@@ -835,6 +835,14 @@ main-red-claim: ## Ask whether somebody is already repairing a red `main` (reads
 main-red-claim-test: ## Test the red-main claim pre-flight, standing-down branch included (hermetic; not part of `gate`)
 	./scripts/test-main-red-claim.sh
 
+.PHONY: issue-claim
+issue-claim: ## Ask whether somebody is already implementing an issue: make issue-claim N=5045
+	@./scripts/issue-claim.sh check $(N)
+
+.PHONY: issue-claim-test
+issue-claim-test: ## Test the issue-claim pre-flight, standing-down branch included (hermetic; not part of `gate`)
+	./scripts/test-issue-claim.sh
+
 .PHONY: check
 check: $(GATE_GUARDS) $(GATE_NO_BUILD) lint ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy, no rustdoc and no tests
 	@./scripts/check-hooks-installed.sh

--- a/scripts/issue-claim.sh
+++ b/scripts/issue-claim.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# Is somebody already implementing issue #N? (#5224)
+#
+#   scripts/issue-claim.sh check <n>    # exit 0 proceed, 1 stand down
+#   scripts/issue-claim.sh claim <n>    # check, then post the claim
+#
+# ── Why this exists ──────────────────────────────────────────────────────────
+#
+# Two sessions implemented #5045 in parallel, on the same branch name, and one
+# merge resolved "keeping this tree" — silently dropping the other
+# implementation. The same shape hit #4336 and #5054. Three collisions in one
+# afternoon, each costing a full implementation.
+#
+# Every signal said the branch was abandoned: it existed only locally, in a
+# stale worktree at an old `main`, clean tree, no remote branch, no open PR.
+# There was nothing to see, because nothing was writing anything down.
+#
+# `main-red-claim.sh` solves exactly this shape for a red-`main` repair, and
+# this is that mechanic pointed at an issue. The rules are its rules:
+#
+#   the tracker is the table   a local claim is invisible to the peer session
+#                              that needs it — the sessions are in different
+#                              worktrees, often on different machines.
+#   a comment is the claim     so it carries an author and a timestamp without
+#                              any new storage.
+#   it lapses                  an assignee never lapses, and a crashed session
+#                              would then hold an issue shut forever.
+#   every unknown proceeds     loudly. A claim check that can BLOCK work is
+#                              worse than the duplication it prevents.
+#
+# ── What it cannot see ───────────────────────────────────────────────────────
+#
+# A claim is a signal somebody chose to leave. It does not see a session that
+# never ran this, and it is not a lock: two sessions that both check within a
+# second of each other both proceed. It converts the common case — a peer who
+# started ten minutes ago — from invisible into obvious, and that is all it
+# claims to do.
+#
+# It also does not replace reading the open PRs. A merged or open PR closing
+# the issue is a stronger signal than any claim, and this prints one when it
+# finds it — that is the check that would have saved this session twice.
+
+set -uo pipefail
+
+# A decided verdict must survive a reader that closes the pipe early (#1815).
+trap '' PIPE
+
+marker="<!-- issue-claim -->"
+window_minutes=90
+
+mode=""
+issue=""
+fixture_login=""
+fixture_claims=""
+fixture_prs=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  check | claim)
+    mode="$1"
+    shift
+    ;;
+  --window-minutes)
+    window_minutes="${2:-}"
+    shift 2
+    ;;
+  # Test-only, and paired: a fixture that supplied claims but read the real
+  # tracker would compare two different worlds. The same trap
+  # `main-red-claim.sh`'s paired fixtures avoid.
+  --fixture-login)
+    fixture_login="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-claims)
+    fixture_claims="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-prs)
+    fixture_prs="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  -h | --help)
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    if [ -z "$issue" ]; then
+      issue="$1"
+      shift
+    else
+      echo "issue-claim: unknown argument '$1'" >&2
+      exit 2
+    fi
+    ;;
+  esac
+done
+
+if [ -z "$mode" ] || [ -z "$issue" ]; then
+  echo "issue-claim: usage: issue-claim.sh check|claim <issue-number>" >&2
+  exit 2
+fi
+case "$issue" in '' | *[!0-9]*)
+  echo "issue-claim: '<issue>' takes a whole number" >&2
+  exit 2
+  ;;
+esac
+case "$window_minutes" in '' | *[!0-9]*)
+  echo "issue-claim: --window-minutes takes a whole number of minutes" >&2
+  exit 2
+  ;;
+esac
+window_seconds=$((window_minutes * 60))
+
+# `proceed` is the only exit this script takes when it is unsure, so it is one
+# function rather than a repeated pair of lines that could drift apart.
+proceed() {
+  echo "$1" || true
+  exit 0
+}
+
+if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  echo "note: gh is not installed, so this run could not ask whether #$issue is" >&2
+  echo "      already being worked. Proceeding: a claim check that can block" >&2
+  echo "      work is worse than the duplication it prevents." >&2
+  proceed "ok  proceed (could not ask)"
+fi
+
+# ── The stronger signal first ────────────────────────────────────────────────
+#
+# A PR that closes the issue beats any claim, and it is the check that would
+# have caught the collisions this script was filed for: #5246 closed 44 issues
+# in one sweep, and none of them showed a thing on the issue itself.
+
+if [ "$use_fixture" -eq 1 ]; then
+  prs="$fixture_prs"
+elif ! prs="$(gh pr list --state all --limit 100 --json number,state,body \
+  --jq ".[] | select(.body | test(\"Closes #$issue\\\\b\")) | \"\(.number) \(.state)\"" 2>/dev/null)"; then
+  echo "note: could not list pull requests. Proceeding (fail-open); the claim" >&2
+  echo "      check below still runs." >&2
+  prs=""
+fi
+
+if [ -n "$prs" ]; then
+  echo "STAND DOWN  #$issue is already claimed by a pull request." >&2
+  echo "" >&2
+  printf '     %s\n' "$prs" >&2
+  echo "" >&2
+  echo "     A MERGED one means the work is done and the issue is stale." >&2
+  echo "     An OPEN one means somebody is on it right now." >&2
+  echo "" >&2
+  echo "     Read its diff before writing anything. Sometimes yours covers" >&2
+  echo "     something theirs missed and belongs on top of \`main\`; more often" >&2
+  echo "     it is the same work twice. A sweep PR can close forty issues at" >&2
+  echo "     once and show nothing on any of them, which is why this asks the" >&2
+  echo "     PRs rather than the issue." >&2
+  exit 1
+fi
+
+if [ "$use_fixture" -eq 1 ]; then
+  me="$fixture_login"
+elif ! me="$(gh api user --jq .login 2>/dev/null)"; then
+  me=""
+fi
+if [ -z "$me" ]; then
+  echo "note: could not read this session's login, so a claim on #$issue cannot" >&2
+  echo "      be told from one of its own. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (identity unknown)"
+fi
+
+# Every claim comment, as `<login> <age-in-seconds>`. The arithmetic is jq's:
+# `date` spells the same conversion two incompatible ways across macOS and
+# Linux, and this script is run from a clone on both.
+if [ "$use_fixture" -eq 1 ]; then
+  claims="$fixture_claims"
+elif ! claims="$(gh issue view "$issue" --json comments --jq "
+    .comments[]
+    | select(.body | startswith(\"$marker\"))
+    | \"\(.author.login) \((now - (.createdAt | fromdateiso8601)) | floor)\"
+  " 2>/dev/null)"; then
+  echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (comments unreadable)"
+fi
+
+# The freshest claim by anybody else. A claim of this session's own is not a
+# reason to stand it down: re-running the pre-flight is what a session does
+# when it comes back to work it already started.
+held_by=""
+held_age=""
+while read -r who age; do
+  [ -n "$who" ] || continue
+  [ "$who" = "$me" ] && continue
+  case "$age" in
+  '' | *[!0-9]*) continue ;;
+  esac
+  [ "$age" -lt "$window_seconds" ] || continue
+  if [ -z "$held_age" ] || [ "$age" -lt "$held_age" ]; then
+    held_by="$who"
+    held_age="$age"
+  fi
+done <<EOF
+$claims
+EOF
+
+if [ -n "$held_by" ]; then
+  minutes=$((held_age / 60))
+  echo "STAND DOWN  #$issue is already being implemented." >&2
+  echo "" >&2
+  echo "     claimed by @$held_by, ${minutes}m ago (window: ${window_minutes}m)" >&2
+  echo "" >&2
+  echo "     Two sessions implemented #5045 in parallel and one merge kept one" >&2
+  echo "     tree, dropping the other implementation without a conflict to" >&2
+  echo "     report. Every signal said that branch was abandoned (#5224)." >&2
+  echo "" >&2
+  echo "     What to do:" >&2
+  echo "       - Pick something else. The claim lapses by itself after" >&2
+  echo "         ${window_minutes}m, so a session that died cannot hold this shut." >&2
+  echo "       - Working it anyway (the claim looks stale, or you are doing a" >&2
+  echo "         different part)? Say so on #$issue, so the next session reads" >&2
+  echo "         a reason rather than a collision." >&2
+  exit 1
+fi
+
+if [ "$mode" = "check" ]; then
+  proceed "ok  #$issue is unclaimed — no PR closes it and no live claim holds it."
+fi
+
+body="$marker $me
+Implementing this. The claim lapses after ${window_minutes} minutes, so it
+cannot hold the issue shut if this session dies
+(\`scripts/issue-claim.sh\`, #5224)."
+
+if [ "$use_fixture" -eq 1 ]; then
+  proceed "ok  claimed #$issue as @$me (fixture: nothing was posted)"
+fi
+
+if ! gh issue comment "$issue" --body "$body" >/dev/null 2>&1; then
+  echo "note: could not post the claim on #$issue. Proceeding anyway: the claim" >&2
+  echo "      is an optimisation, and the work is not." >&2
+  proceed "ok  proceed (claim not posted)"
+fi
+
+echo "ok  claimed #$issue as @$me" || true

--- a/scripts/test-issue-claim.sh
+++ b/scripts/test-issue-claim.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Hermetic tests for scripts/issue-claim.sh (#5224).
+#
+#   ./scripts/test-issue-claim.sh    (or: make issue-claim-test)
+#
+# No network and no `gh`: every case drives the fixture seams, so the suite is
+# the same on a bare runner as on a dev box with a live tracker.
+#
+# The cases that matter most are the two controls, one on each side:
+#
+#   - the **positive** controls — a fresh claim by somebody else, and a PR
+#     that closes the issue, must each actually stand a session down. A
+#     pre-flight that cannot be shown to block is a comment, not a guard, and
+#     this one spends its life proceeding because most issues are unclaimed.
+#   - the **negative** controls — every unknown must proceed. That is the whole
+#     safety argument (a claim check that can block work is worse than the
+#     duplication it prevents), and it is one branch per unknown, so it is one
+#     case per branch.
+#
+# Not a `make gate` step, matching `main-red-claim-test`: the subject asks the
+# issue tracker a question, and the gate is hermetic and offline by contract.
+#
+# bash 3.2 compatible.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/issue-claim.sh"
+
+pass=0
+fail=0
+
+ok() { printf '  \033[32m✓\033[0m %s\n' "$*"; pass=$((pass + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=$((fail + 1)); }
+
+# One assertion shape: run with every seam pinned and compare the exit code.
+# An expected block must also name its reason, because "exit 1" is satisfied by
+# a typo in the script just as well as by the case's own subject.
+want() { # want <name> <expect-proceed|expect-block> <want-substring> <mode> <login> <claims> <prs>
+  local name="$1" expect="$2" want_text="$3" mode="$4" login="$5" claims="$6" prs="$7"
+  local out rc
+  out="$("$SCRIPT" "$mode" 5045 \
+    --fixture-login "$login" \
+    --fixture-claims "$claims" \
+    --fixture-prs "$prs" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-proceed" ] && [ "$rc" -ne 0 ]; then
+    bad "$name — expected proceed, got exit $rc: $out"
+    return
+  fi
+  if [ "$expect" = "expect-block" ] && [ "$rc" -eq 0 ]; then
+    bad "$name — expected a stand-down, got exit 0: $out"
+    return
+  fi
+  case "$out" in
+    *"$want_text"*) ok "$name" ;;
+    *) bad "$name — right exit, wrong reason (wanted '$want_text'): $out" ;;
+  esac
+}
+
+echo "issue-claim"
+
+# ── the positive controls: the two things that must actually block ───────────
+
+# A live peer. Without this case the script is a comment.
+want "a fresh claim by somebody else stands this session down" \
+  expect-block "claimed by @grace" check "ada" "grace 300" ""
+
+# A PR that closes the issue — the signal that would have caught the
+# collisions this script was filed for, and the one the issue itself never
+# shows. #5246 closed forty-four issues in one sweep with nothing on any of
+# them.
+want "an OPEN pull request closing the issue stands this session down" \
+  expect-block "5246 OPEN" check "ada" "" "5246 OPEN"
+
+want "and so does a MERGED one — the work is already done" \
+  expect-block "5246 MERGED" check "ada" "" "5246 MERGED"
+
+# The PR check runs FIRST and on its own: a claim-free issue with a live PR
+# must still block, or the stronger signal would be reachable only when the
+# weaker one happened to be absent too.
+want "a PR blocks even with no claim comments at all" \
+  expect-block "already claimed by a pull request" check "ada" "" "5246 OPEN"
+
+# ── the negative controls: every unknown proceeds ────────────────────────────
+
+want "an unclaimed issue proceeds" \
+  expect-proceed "is unclaimed" check "ada" "" ""
+
+# A session's own claim is not a reason to stand it down — re-running the
+# pre-flight is what a session does when it comes back to work it started.
+want "a claim of this session's own does not stand it down" \
+  expect-proceed "is unclaimed" check "ada" "ada 300" ""
+
+# A lapsed claim is not a claim. Without this a crashed session holds an issue
+# shut forever, which is why this is a comment rather than an assignee.
+want "a claim past the window has lapsed" \
+  expect-proceed "is unclaimed" check "ada" "grace 999999" ""
+
+# An unreadable identity cannot tell a claim of its own from a peer's, so it
+# proceeds rather than guessing.
+want "an unknown identity proceeds" \
+  expect-proceed "identity unknown" check "" "grace 300" ""
+
+# A malformed age is not a claim. The alternative is a parse failure standing a
+# session down on a comment nobody can date.
+want "a claim with an unreadable age is ignored" \
+  expect-proceed "is unclaimed" check "ada" "grace notanumber" ""
+
+# ── claim mode ───────────────────────────────────────────────────────────────
+
+want "claim posts when the issue is free" \
+  expect-proceed "claimed #5045 as @ada" claim "ada" "" ""
+
+# ...and refuses to post over somebody else's live claim, which is the whole
+# point: `claim` is `check` plus a write, never a write that skips the check.
+want "claim stands down rather than posting over a peer" \
+  expect-block "claimed by @grace" claim "ada" "grace 300" ""
+
+# ── argument handling ────────────────────────────────────────────────────────
+
+out="$("$SCRIPT" check 2>&1)"
+if [ $? -eq 2 ] && [ -z "${out##*usage*}" ]; then
+  ok "a missing issue number is a usage error, not a silent proceed"
+else
+  bad "a missing issue number did not error: $out"
+fi
+
+out="$("$SCRIPT" check abc 2>&1)"
+if [ $? -eq 2 ]; then
+  ok "a non-numeric issue is refused"
+else
+  bad "a non-numeric issue was accepted: $out"
+fi
+
+# The window is configurable, and the case proves the flag reaches the
+# comparison rather than being parsed and dropped.
+if out="$("$SCRIPT" check 5045 --window-minutes 1 \
+  --fixture-login ada --fixture-claims "grace 300" --fixture-prs "" 2>&1)"; then
+  ok "--window-minutes narrows the window (a 5m claim lapses under 1m)"
+else
+  bad "--window-minutes did not reach the comparison: $out"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  printf 'issue-claim: %d passed\n' "$pass"
+else
+  printf 'issue-claim: %d passed, %d FAILED\n' "$pass" "$fail"
+fi
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

Two sessions implemented #5045 in parallel, on the same branch name, and one merge resolved *"keeping this tree"* — dropping the other implementation with **no conflict to report**. #4336 and #5054 are the same shape: three collisions in one afternoon, each costing a full implementation.

Every signal said the branch was abandoned: local only, in a stale worktree at an old `main`, clean tree, no remote branch, no open PR. There was nothing to see, because nothing was writing anything down.

`scripts/issue-claim.sh` is `main-red-claim.sh`'s mechanic pointed at an issue, on its rules:

| rule | why |
|---|---|
| the tracker is the table | a local claim is invisible to the peer session that needs it — different worktrees, often different machines |
| a comment is the claim | it carries an author and a timestamp with no new storage |
| it lapses (90m) | an assignee never lapses, and a crashed session would hold an issue shut forever |
| every unknown proceeds, loudly | a claim check that can **block** work is worse than the duplication it prevents |

## It asks the pull requests first

The issue names `dispatch_claims` as the shipped mechanism; this adds the half that actually catches the reported case. **A sweep PR can close forty issues at once while every one of them still reads unassigned, unlabelled and open** — #5246 closed 44 that way.

Verified against live data on this repository:

```
$ ./scripts/issue-claim.sh check 5357
STAND DOWN  #5357 is already claimed by a pull request.
     5246 MERGED

$ ./scripts/issue-claim.sh check 4153
ok  #4153 is unclaimed — no PR closes it and no live claim holds it.
```

**Full disclosure on where this comes from:** #5357 is one of nine issues *this session* implemented with witness tests before discovering #5246 already contained all nine. The whole batch was thrown away. Later the same session lost two more branches to a peer PR that merged mid-flight. This script is the check that would have caught both, which is why the AGENTS.md text says to run it **before writing code and again before opening the PR** — the gap between those two is enough for a peer's PR to land.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-issue-claim.sh` — 14 hermetic cases through paired fixtures, so the suite is the same on a bare runner as on a dev box with a live tracker.

**Two positive controls**, because a pre-flight that cannot be shown to block is a comment, not a guard — and this one spends its life proceeding:

- a fresh claim by somebody else stands the session down
- a PR closing the issue stands the session down (open **and** merged, and with no claim comments at all, so the stronger signal is not reachable only when the weaker one is absent)

**One negative control per unknown**, which is the whole safety argument: unknown identity, unreadable age, lapsed claim, own claim, no claim. Each is one branch, so each is one case.

```
issue-claim: 14 passed
```

## The gate

- [x] `make guards-fast` green (compiles nothing)
- [x] `make gate-parity` — OK, 52 gate steps
- [x] `shellcheck` clean; `check-prose` OK
- [x] Docs updated — AGENTS.md documents it beside the red-`main` claim it mirrors
- [x] `Closes #5224` appears both here and as a commit trailer

Not a gate step, matching `main-red-claim-test`: the subject asks the issue tracker a question, and the gate is hermetic and offline by contract. `make issue-claim N=5045` asks by hand.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls beyond the `gh` reads the sibling claim already makes

## Anything reviewers should know?

**It is not a lock, and the header says so.** Two sessions that check within a second of each other both proceed. It converts the common case — a peer who started ten minutes ago, or a PR that landed an hour ago — from invisible into obvious, and that is all it claims.

The 90-minute window is longer than the red-`main` claim's 20. That is deliberate and the reason is the subject: a `main` repair is minutes and a stale claim there blocks something urgent, while implementing an issue is often an hour or more and a 20-minute window would lapse mid-work. Say if you would rather they matched.

Closes #5224

## Summary by Sourcery

Add a fail-open issue-claim guard that surfaces existing implementations and active peer work before duplicate effort begins.

New Features:
- Add an issue-claim pre-flight that checks for closing pull requests and active claims before work begins or a pull request is opened.
- Support claiming an issue through a timestamped, automatically expiring tracker comment with fail-open behavior for unknown states.

Bug Fixes:
- Prevent duplicate implementations from going unnoticed when existing open or merged pull requests already close an issue.

Enhancements:
- Document the issue-claim workflow and provide Makefile commands for checking and testing it.

CI:
- Run the hermetic issue-claim self-tests in the guard workflow.

Documentation:
- Document issue claiming, expiration, usage, and recommended pre-flight timing in AGENTS.md.

Tests:
- Add 14 hermetic tests covering pull-request and claim stand-down cases, fail-open conditions, claim mode, and argument handling.