### PR TITLE
fix(stella-cli): `stella migrate config` no longer drops the [reward] block

### DIFF
--- a/crates/stella-cli/src/settings/migrate.rs
+++ b/crates/stella-cli/src/settings/migrate.rs
@@ -95,6 +95,19 @@ pub fn render(settings: &Settings, scope: ConfigScope) -> Result<String, String>
     {
         doc["ui"] = toml_io::item_for(ui, "ui")?;
     }
+    // The reward weights. Omitted here until #2629, while the header told the
+    // reader the document was "serialized from the settings.json beside it, not
+    // transcribed, so nothing here can disagree with what stella read" and then
+    // instructed them to delete the JSON — so a migration silently reset a
+    // tuned `[reward]` block to the defaults.
+    //
+    // `settings.enterprise_telemetry` is NOT migrated, and that is not the
+    // same omission: it is a private field, managed-scope only, and a
+    // user-scope `stella.toml` carrying it would be a document claiming
+    // authority its scope does not have.
+    if let Some(reward) = &settings.reward {
+        doc["reward"] = toml_io::item_for(reward, "reward")?;
+    }
     if let Some(authority) = &settings.managed_authority {
         doc["authority"] = toml_io::item_for(authority, "authority")?;
     }

--- a/crates/stella-cli/src/settings/tests/toml.rs
+++ b/crates/stella-cli/src/settings/tests/toml.rs
@@ -814,6 +814,7 @@ const RICH_SETTINGS: &str = r#"{
   "ui": {"theme": "stella-dark"},
   "mcp": {"registry_url": "https://registry.example"},
   "context": {"retrieval": {"rrf_k": 60.0, "mmr_lambda": 0.7, "ann_probes": 12}},
+  "reward": {"deterministic_weight": 0.25, "per_usd": 0.75},
   "hooks": {"PreToolUse": [
     {"matcher": "bash", "hooks": [{"type": "command", "command": "./audit.sh", "timeoutMs": 5000}]}
   ]}
@@ -843,6 +844,19 @@ fn migrating_a_settings_file_preserves_every_value_it_configured() {
     assert_eq!(before.mcp, after.mcp, "mcp");
     assert_eq!(before.context, after.context, "context");
     assert_eq!(before.hooks, after.hooks, "hooks");
+    // **Witness (#2629).** `render` wrote no `[reward]` section, so a user with
+    // tuned weights ran `migrate config`, was told the file was "serialized
+    // from the settings.json beside it, not transcribed", deleted the JSON as
+    // the header instructs, and silently lost their weights to the defaults.
+    //
+    // This test's own name claimed it covered everything, which is what let
+    // the gap survive: `RICH_SETTINGS` simply had no `[reward]` block to lose.
+    assert_eq!(before.reward, after.reward, "reward");
+    assert_eq!(
+        after.reward_policy().unwrap().outcome.deterministic,
+        0.25,
+        "and the migrated weight resolves into the policy, not just the struct"
+    );
 }
 
 /// A retired key does not survive the migration into a freshly-generated file


### PR DESCRIPTION
## What & why

`settings::migrate::render` wrote a section for `run`, `providers`, the engine block, `tools`, `hooks`, `mcp`, `context`, `context_providers`, `ui` and `authority` — and **nothing for `settings.reward`**.

A user with tuned reward weights ran `stella migrate config`, read a header telling them the file was *"serialized from the settings.json beside it, not transcribed, so nothing here can disagree with what stella read"*, deleted the JSON as that header instructs, and silently lost their weights to the defaults. The header's claim is what makes this worse than an ordinary omission: it tells the reader the file is complete.

## `enterprise_telemetry` is not the same gap

The issue asked to confirm before fixing it, so I did rather than assuming. It is a **private** field (`settings.rs`, no `pub`), managed-scope only, and a user-scope `stella.toml` carrying it would be a document claiming authority its scope does not have. Left out, with the reason stated in the code beside the fix so the next reader does not re-derive it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The contract test's own name — `migrating_a_settings_file_preserves_every_value_it_configured` — claimed it covered everything, and **that is what let the gap survive**: `RICH_SETTINGS` simply had no `[reward]` block to lose. It has one now.

With the section backed out:

```
test settings::tests::toml::migrating_a_settings_file_preserves_every_value_it_configured ... FAILED
assertion `left == right` failed: reward
  left: Some(RewardSettings { deterministic_weight: Some(0.25), per_step: None, per_usd: Some(0.75), … })
 right: None
```

The assertion also checks the migrated weight **resolves into the policy** (`reward_policy().outcome.deterministic == 0.25`), not just that the struct round-trips — a value that survives serde but never reaches the policy would be the same loss one layer down.

```
$ cargo test -p stella-cli --bin stella settings::
141 passed; 0 failed
$ cargo clippy -p stella-cli --all-targets -- -D warnings
clean
```

## Its sibling #2630 is already fixed — closed with evidence, not in this PR

While here I checked #2630 (five `[agents]` keys reported as unrecognized) and closed it as completed. Three of the five were forgotten and are now listed; the other two (`approval_wait_secs`, `responsibilities`) are no longer `AgentsSection` fields, so listing them would be the *opposite* defect — a stale entry silencing a real typo. `approval_wait_secs` is in `RETIRED` and gets a sentence explaining what it used to bound.

And it cannot recur: `settings::completeness::the_toml_agents_vocabulary_matches_the_section` destructures `AgentsSection` by name, so a new field is a compile error until listed, and asserts the list in both directions. That closes the root cause #2630 identified — two legitimately-different vocabularies with nothing distinguishing "renamed on purpose" from "forgotten".

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] Targeted tests green (SCR-001 — CI runs the workspace)
- [x] `python3 ./scripts/check-prose.py` OK
- [x] `Closes #2629` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed here or closed with evidence on #2630.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

Closes #2629
Refs #2616

## Summary by Sourcery

Preserve reward configuration during settings migration so tuned weights are not silently reset to defaults.

Bug Fixes:
- Preserve configured reward weights when migrating settings.json to stella.toml.

Enhancements:
- Clarify why managed-only enterprise telemetry is excluded from user-scope configuration migration.

Tests:
- Extend migration coverage to include reward settings and verify migrated weights resolve into the effective reward policy.