### PR TITLE
docs(bench): reconcile the two Arm A spend figures — $78.25 is canonical

### DIFF
--- a/bench/evidence/tb21-hh10-20260731/README.md
+++ b/bench/evidence/tb21-hh10-20260731/README.md
@@ -119,3 +119,66 @@ python bench/evidence/score_dev_baseline.py score \
 
 Both intervals are deterministic given the committed rows: the bootstrap is
 seeded (`20260729`, 50,000 draws) and Clopper–Pearson needs no seed.
+
+## The two spend figures, reconciled ($75.83 vs $78.25) — #2372
+
+Two committed extractions over this one run published different Arm A totals.
+Both are correct about what they measure, and **$78.25 is the canonical spend**.
+
+| extraction | figure | per solved task |
+| --- | --- | --- |
+| `score.json` → `descriptive.usd_total`, summing `trials.jsonl`'s `usd` | $75.8325 | $1.31 |
+| `docs/benchmarks/terminal-bench-2-1-glm-5-2.json`, summing the trajectories | $78.2467 | $1.35 |
+
+### What the difference is
+
+It is not spread across the run. Split the 89 trials by `accounting_state`:
+
+| trials | delta (trajectory − trial row) |
+| --- | --- |
+| 54 with `accounting_state: complete` | **−$0.0001** total; largest single task 4.9e-5 |
+| 35 with `accounting_state: incomplete` | **+$2.4143** total — the entire discrepancy |
+
+Every one of those 35 carries `exception_type: AgentTimeoutError`, and every
+one of them is higher in the trajectory extraction. The complete-accounting
+trials agree to within the fourth decimal the JSON stores, which is rounding.
+
+### The ruling, and why
+
+`trials.jsonl`'s `usd` is **the agent's own reported accounting**, and a run the
+harness kills on its timeout never reports the call that was in flight. The
+model was still billed for it. The trajectory extraction sums the calls that
+actually happened, so it captures that last one.
+
+So the trial rows **undercount by exactly the money spent on the calls 35
+timed-out trials were making when they were stopped**. $78.25 is what the run
+cost; $75.83 is what the agent got to report before it was killed.
+
+That is the unflattering direction, and it is the true one. It also means the
+already-published figure needs no correction: `docs/benchmarks/` and
+`website/public/presentations/BENCHMARK_METHODOLOGY.md` quote $78.25 / $1.35.
+
+### What was NOT changed
+
+`trials.jsonl` and `score.json` are preregistered history and are untouched.
+`descriptive.usd_total` still reads $75.8325, and that number is still the
+right answer to the question it asks — "what did the agents report spending" —
+which is a different question from "what did this run cost". Rewriting it would
+destroy the evidence that the two differ, which is the finding.
+
+Reproduce:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+d = json.loads(pathlib.Path("docs/benchmarks/terminal-bench-2-1-glm-5-2.json").read_text())
+docs = {r["task"]: r["stella"]["cost_usd"] for r in d["rows"]}
+tr = [json.loads(l) for l in
+      pathlib.Path("bench/evidence/tb21-hh10-20260731/trials.jsonl").read_text().splitlines() if l.strip()]
+trials = {t["task_name"].split("/", 1)[-1]: t for t in tr}
+for state in ("complete", "incomplete"):
+    d_ = sum(docs[k] - trials[k]["usd"] for k in docs
+             if (trials[k]["accounting_state"] == "incomplete") == (state == "incomplete"))
+    print(f"{state:11s} {d_:+.4f}")
+PY
+```

--- a/website/public/presentations/BENCHMARK_METHODOLOGY.md
+++ b/website/public/presentations/BENCHMARK_METHODOLOGY.md
@@ -67,9 +67,17 @@ what preregistration exists to prevent.
   ran a model we trained.
 - **stella:** $78.25 total → **$1.35 per solved task** (78.25 / 58). The
   committed score table (`score.json`) extracts $75.83 → $1.31 from the trial
-  rows; the published results page extracts $78.25 from the trajectories. The
-  difference is the extraction layer, not the run. **The deck quotes the
-  higher figure.**
+  rows; the published results page extracts $78.25 from the trajectories.
+  **$78.25 is the canonical figure, and the deck quotes it.**
+
+  The $2.41 gap is now reconciled rather than merely disclosed (#2372, and
+  `bench/evidence/tb21-hh10-20260731/README.md` carries the working). It is
+  not spread across the run: the 54 trials whose accounting completed agree to
+  −$0.0001, and the whole difference sits on the 35 that hit
+  `AgentTimeoutError`. A trial row's `usd` is what the *agent reported*, and an
+  agent the harness kills mid-call never reports that call — the model was
+  billed for it anyway. So the trial rows undercount by exactly what those 35
+  timed-out trials were spending when they were stopped.
 - **The arms' costs are not comparable**, for three independent reasons, any
   one of which is enough: (1) the arms bill through different providers, so a
   dollar difference is at least as likely route pricing as agent behavior;


### PR DESCRIPTION
## What & why

The one preregistered TB 2.1 head-to-head published **two** totals for Arm A:

| extraction | figure | per solved task |
|---|---|---|
| `score.json` → `descriptive.usd_total`, summing `trials.jsonl`'s `usd` | $75.8325 | $1.31 |
| `docs/benchmarks/terminal-bench-2-1-glm-5-2.json`, summing trajectories | $78.2467 | $1.35 |

`BENCHMARK_METHODOLOGY.md` disclosed both and said *"the difference is the extraction layer, not the run"* — true, and incomplete. A published benchmark with two costs is exactly the reputation this project exists to build, so it is worth knowing **which** and **why**.

## The finding

The difference is not spread across the run. Split the 89 trials by `accounting_state`:

| trials | delta (trajectory − trial row) |
|---|---|
| **54** with `accounting_state: complete` | **−$0.0001** total; largest single task 4.9e-5 |
| **35** with `accounting_state: incomplete` | **+$2.4143** — the entire discrepancy |

Every one of those 35 carries `exception_type: AgentTimeoutError`, and every one is higher in the trajectory extraction. The complete-accounting trials agree to within the fourth decimal the JSON stores, which is rounding.

## The ruling

`trials.jsonl`'s `usd` is **the agent's own reported accounting**, and an agent the harness kills mid-call never reports that call. The model was billed for it anyway. The trajectory extraction sums the calls that actually happened.

**So the trial rows undercount by exactly the money 35 timed-out trials were spending when they were stopped.** $78.25 is what the run cost; $75.83 is what the agents got to report before being killed.

That is the unflattering direction, and it is the true one — CLAUDE.md's "measure honestly, especially when it costs us". It also means **the published figure needs no correction**: `docs/benchmarks/` and the deck already quote $78.25 / $1.35.

## What was deliberately NOT changed

`trials.jsonl` and `score.json` are preregistered history and are untouched, per the issue's own constraint. `descriptive.usd_total` still reads $75.8325 — and it is still the right answer to the question it asks, *"what did the agents report spending"*, which is a different question from *"what did this run cost"*. Rewriting it would destroy the evidence that the two differ, which is the finding.

## The witness

- [ ] No witness test needed — this is a docs/evidence change with no behaviour to flip.

The claim is reproducible instead, and the command is committed in the evidence README so a reader can re-derive the ruling rather than take it:

```
$ python3 …   # the snippet in bench/evidence/tb21-hh10-20260731/README.md
complete    -0.0001
incomplete  +2.4143
```

## The gate

- [x] `make guards-fast` green (compiles nothing)
- [x] `python3 ./scripts/check-prose.py` OK
- [x] `Closes #2372` appears both here and as a commit trailer

## Nothing left behind

- [x] There is nothing new.

One thing I want to name rather than file, because it is a judgement for you: **the `usd` field's meaning is not documented anywhere near it.** A future reader summing `trials.jsonl` will make the same undercount, and nothing in the schema says the field is the agent's report rather than the run's cost. Renaming it (`usd_reported`?) would be the durable fix and would touch the preregistered rows, which the constraint here forbids. Say the word and I will file it as its own issue with that trade-off written out.

## Ground-rule check

- [x] No code changed; no new deps; no network

Closes #2372
Refs #1013

## Summary by Sourcery

Establish the canonical Arm A benchmark cost and document why trajectory-based accounting exceeds agent-reported trial totals.

Enhancements:
- Reconcile the two published Arm A spend figures by establishing $78.25 as the canonical run cost and explaining the $2.41 discrepancy from timed-out trials.

Documentation:
- Document the spend reconciliation, supporting evidence, and reproducible analysis in the benchmark evidence README and methodology presentation.