### PR TITLE
ci(guard-self-tests): run the canary's hermetic self-tests in CI

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -35,13 +35,14 @@ name: guard-self-tests
 # **`canary-self-tests`** — one suite, in its own job because it is the one that
 # compiles: scripts/main-canary.sh's `compile` row runs `cargo check`, and under
 # `--manifest-dir` that is a throwaway one-function crate rather than this
-# workspace. It is also the slow one — measured at 5m07s on 2026-08-28, of which
-# the fixture compiles are a small part: `--manifest-dir` redirects only the
-# `lockfile-sync` and `compile` rows, so every one of the suite's ~38 canary
-# invocations still runs `check-prose.py` and `check-file-size.sh` over the live
-# tree (4.7s and 3.7s each). #5417 is where that is being decided; neither
-# property belongs in the `self-tests` job above, which is toolchain-free and
-# seconds (#5356).
+# workspace. It is also the slow one: 8m16s on this runner and 5m07s on an M-series
+# laptop, both measured 2026-08-28. The fixture compiles are a small part of that.
+# `--manifest-dir` redirects only the `lockfile-sync` and `compile` rows, so every
+# one of the suite's ~38 canary invocations still runs `check-prose.py` and
+# `check-file-size.sh` over the live tree — 4.7s and 3.7s each on the laptop, which
+# accounts for essentially all of its 5m07s. #5417 is where that is being decided;
+# neither property belongs in the `self-tests` job above, which is toolchain-free
+# and seconds (#5356).
 #
 # No `paths:` filter, deliberately, and for a different reason than
 # wire-schema.yml and docs-guards.yml have one. Those two narrow to escape a

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -32,11 +32,22 @@ name: guard-self-tests
 # each builds throwaway git repositories and the gate is what a contributor
 # runs before every push.
 #
+# **`canary-self-tests`** — one suite, in its own job because it is the one that
+# compiles: scripts/main-canary.sh's `compile` row runs `cargo check`, and under
+# `--manifest-dir` that is a throwaway one-function crate rather than this
+# workspace. It is also the slow one — measured at 5m07s on 2026-08-28, of which
+# the fixture compiles are a small part: `--manifest-dir` redirects only the
+# `lockfile-sync` and `compile` rows, so every one of the suite's ~38 canary
+# invocations still runs `check-prose.py` and `check-file-size.sh` over the live
+# tree (4.7s and 3.7s each). #5417 is where that is being decided; neither
+# property belongs in the `self-tests` job above, which is toolchain-free and
+# seconds (#5356).
+#
 # No `paths:` filter, deliberately, and for a different reason than
 # wire-schema.yml and docs-guards.yml have one. Those two narrow to escape a
-# cost — a toolchain, a browser — that this workflow does not pay: every step
-# below is shell or Python over the tree and the whole run is a couple of
-# minutes. Several suites also assert something about the *live* tree
+# cost — a workspace build, a browser — that this workflow does not pay: the two
+# jobs above are shell and Python over the tree, and the third compiles a
+# fixture crate. Several suites also assert something about the *live* tree
 # (`test-module-reachability.sh`'s R1 is "this repository is clean"), so a
 # filter would make them blind in exactly the direction they exist to watch.
 # file-size.yml made the same call for the same reason.
@@ -95,9 +106,11 @@ jobs:
       # `--workspace` for everything, which is its documented fall-back, and 13
       # of its 25 cases went red in this job before it moved.
       #
-      # The three DELIBERATELY unhosted ones are named in the Makefile's
+      # The deliberately unhosted ones are named in the Makefile's
       # `UNHOSTED_SELF_TESTS`, with the reason each is excluded;
       # scripts/check-gate-parity.sh fails when a suite is in neither place.
+      # test-main-canary.sh is not among them any more — it wants a toolchain,
+      # so it has the job below rather than a step here (#5356).
       - name: action-pins guard covers composite actions
         if: ${{ !cancelled() }}
         run: ./scripts/test-action-pins.sh
@@ -167,8 +180,8 @@ jobs:
       # setup-dev-env.sh's own workspace-shape check requires
       # `crates/stella-core/`. Needs the runner's preinstalled rustfmt for the
       # formatting-hook cases (H6/H6b); ubuntu-latest ships one, so this adds
-      # no toolchain-install step the way test-main-canary.sh/
-      # test-guard-sigpipe.sh's `cargo check`/`cargo build` exclusion would.
+      # no toolchain-install step the way test-guard-sigpipe.sh's
+      # `cargo build` would — that is what keeps this job toolchain-free.
       - name: dev-env setup script and its fmt-file hook
         if: ${{ !cancelled() }}
         run: ./scripts/test-dev-env.sh
@@ -268,3 +281,28 @@ jobs:
       - name: wire-path guard failure directions
         if: ${{ !cancelled() }}
         run: ./scripts/test-wire-paths.sh
+
+  canary-self-tests:
+    name: post-merge canary self-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # rust-toolchain.toml pins the repo to 1.97.0 and rustup honours it for
+      # every cargo invocation inside the checkout, so this step exists to put
+      # *a* rustup on PATH; the pin is installed by the first cargo call. The
+      # canary runs from the repo root even when checking a fixture, which is
+      # what brings the pin into it.
+      - name: Install Rust (rustup; the pin comes from rust-toolchain.toml)
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      # Not cached: the fixture workspaces are built in $TMPDIR and thrown away,
+      # so there is no `target/` for Swatinem/rust-cache to carry between runs,
+      # and no dependency to fetch — the fixture crate has none.
+      #
+      # scripts/test-main-canary-live.sh is NOT run here, and that is the whole
+      # point of the split: its cases expect a green verdict, so it reports what
+      # `main` is red on rather than what the canary can do. It is named in the
+      # Makefile's `UNHOSTED_SELF_TESTS` with that reason (#5356).
+      - name: the canary opens, refreshes and explains a main-red issue
+        run: ./scripts/test-main-canary.sh

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,16 @@ GATE_STEPS := $(GATE_GUARDS) $(GATE_NO_BUILD) doc-warnings doc-warnings-schema \
 # They stay out of `make gate` for the separate reason that they build
 # throwaway git repositories; that exclusion is not what this variable records.
 #
-#   test-main-canary.sh   — its cases run the canary against the LIVE tree and
-#                           expect it green, so it reports whatever `main` is
+#   test-main-canary-live.sh
+#                         — its cases expect the canary to report GREEN, which
+#                           it can only do when the LIVE tree is green: the
+#                           `file-size` and `prose` rows take no
+#                           `--manifest-dir`. So it reports whatever `main` is
 #                           red on rather than the canary's own capability —
 #                           which is main-canary.yml's job, after the merge.
-#                           It also pays a `cargo check --workspace`.
+#                           The canary's other cases are decided by a fixture
+#                           tree, hold whatever `main` is red on, and run in
+#                           guard-self-tests.yml as test-main-canary.sh (#5356).
 #   test-guard-sigpipe.sh — same shape: every case asserts a real guard exits 0
 #                           on this tree with its reader gone, so a genuinely
 #                           red guard fails it for the wrong reason, and
@@ -90,7 +95,7 @@ GATE_STEPS := $(GATE_GUARDS) $(GATE_NO_BUILD) doc-warnings doc-warnings-schema \
 # workspace-shape check requires `crates/stella-core/`, a mismatch dating to
 # this workspace's move under `crates/` long after the fixture was written.
 # Fixed by reshaping the fixture to match; it now runs in guard-self-tests.yml.
-UNHOSTED_SELF_TESTS := test-main-canary.sh test-guard-sigpipe.sh
+UNHOSTED_SELF_TESTS := test-main-canary-live.sh test-guard-sigpipe.sh
 
 .PHONY: help
 help: ## Show this help
@@ -804,8 +809,9 @@ main-canary: ## Ask whether main still composes green (check only; no issue is f
 	@./scripts/main-canary.sh
 
 .PHONY: main-canary-test
-main-canary-test: ## Test the post-merge canary, announcements included (hermetic; not part of `gate`)
+main-canary-test: ## Test the post-merge canary, announcements included (both suites; not part of `gate`)
 	./scripts/test-main-canary.sh
+	./scripts/test-main-canary-live.sh
 
 .PHONY: deleted-tests-test
 deleted-tests-test: ## Test the deleted-test guard's live-vs-stale PR body handling (hermetic; not part of `gate`; #4495)

--- a/scripts/lib/main-canary-harness.sh
+++ b/scripts/lib/main-canary-harness.sh
@@ -1,0 +1,141 @@
+# shellcheck shell=bash
+#
+# Sourced helper: the fixtures and assertion vocabulary both main-canary test
+# suites drive scripts/main-canary.sh with (#5356).
+#
+# The suites are split by what a case NEEDS, not by what it tests:
+#
+#   scripts/test-main-canary.sh       every case whose verdict is a fact about
+#                                     the canary. A fixture tree under
+#                                     `--manifest-dir` decides it, so it holds
+#                                     whatever `main` is red on, and CI runs it
+#                                     (.github/workflows/guard-self-tests.yml).
+#   scripts/test-main-canary-live.sh  the cases that expect the canary to report
+#                                     GREEN. It can only do that when the live
+#                                     tree is green — the `file-size` and
+#                                     `prose` rows read the repository itself
+#                                     and take no `--manifest-dir` — so those
+#                                     cases report what `main` is doing rather
+#                                     than what the canary can do, which is
+#                                     main-canary.yml's job after the merge.
+#
+# Everything both suites need lives here, so the split costs no second copy of
+# the fixture builder or the assertion vocabulary. Source it before any `cd`,
+# so `$0` still resolves:
+#
+#   # shellcheck source=scripts/lib/main-canary-harness.sh
+#   . "$(dirname "$0")/lib/main-canary-harness.sh"
+
+canary="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/main-canary.sh"
+
+pass=0
+fail=0
+
+# Both suites build cargo workspaces and the canary's `compile` row runs
+# `cargo check`, so a toolchain-free machine can only report a false green.
+# Skipping says so; it does not pass silently.
+require_cargo() {
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "skip $1 — no cargo toolchain on PATH"
+    exit 0
+  fi
+}
+
+# Set `$tmp` to a throwaway directory, removed when the suite exits. It assigns
+# rather than prints because a `$(...)` reader would run the `trap` in a
+# subshell, leaving the real one uncleaned.
+canary_scratch() {
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+}
+
+# A minimal, network-free workspace at $1 whose lock matches its manifests.
+make_workspace() {
+  local dir="$1"
+  mkdir -p "$dir/crates/demo/src"
+  cat >"$dir/Cargo.toml" <<'TOML'
+[workspace]
+members = ["crates/demo"]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+TOML
+  cat >"$dir/crates/demo/Cargo.toml" <<'TOML'
+[package]
+name = "demo"
+version.workspace = true
+edition.workspace = true
+TOML
+  echo 'pub fn demo() {}' >"$dir/crates/demo/src/lib.rs"
+  (cd "$dir" && cargo generate-lockfile --offline >/dev/null 2>&1)
+}
+
+expect() {
+  local name="$1" want_code="$2" needle="$3"
+  shift 3
+  local out code
+  set +e
+  out="$("$canary" "$@" 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -ne "$want_code" ]; then
+    echo "FAIL  $name — exit $code, wanted $want_code"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+  fi
+  case "$out" in
+  *"$needle"*) ;;
+  *)
+    echo "FAIL  $name — output did not contain: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+    ;;
+  esac
+  echo "ok    $name"
+  pass=$((pass + 1))
+}
+
+refute() {
+  local name="$1" needle="$2"
+  shift 2
+  local out code
+  set +e
+  out="$("$canary" "$@" 2>&1)"
+  code=$?
+  set -e
+  # An absent needle proves nothing if the canary never ran: a refute against a
+  # script that could not start passes for free, which is how a broken harness
+  # reports green. The canary decides every run with 0, 1 or 2 — anything else
+  # is the shell answering instead of it.
+  case "$code" in
+  0 | 1 | 2) ;;
+  *)
+    echo "FAIL  $name — the canary did not run (exit $code)"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+    ;;
+  esac
+  case "$out" in
+  *"$needle"*)
+    echo "FAIL  $name — output should NOT have contained: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    ;;
+  *)
+    echo "ok    $name"
+    pass=$((pass + 1))
+    ;;
+  esac
+}
+
+# The tally, and the suite's exit status.
+canary_tally() {
+  echo
+  echo "$1: $pass passed, $fail failed"
+  [ "$fail" -eq 0 ]
+}

--- a/scripts/test-main-canary-live.sh
+++ b/scripts/test-main-canary-live.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# The live-tree tests for scripts/main-canary.sh (#3332, split out at #5356).
+#
+# Every case here expects the canary to report GREEN, and it can only do that
+# when this repository is green: the `file-size` and `prose` rows take no
+# `--manifest-dir` and read the live tree whatever the fixture says. So a
+# failure in this suite means `main` is red, not that the canary lost a
+# capability — which is main-canary.yml's job to report, after the merge, and
+# is why the Makefile's `UNHOSTED_SELF_TESTS` keeps this file out of CI.
+#
+# It is still worth running by hand, and `make main-canary-test` runs it: the
+# recovery branch is here, and a canary that only ever opens issues becomes a
+# stale-issue generator, gets muted, and is then worth less than nothing.
+#
+# The rest — every case a fixture decides on its own — is
+# scripts/test-main-canary.sh, which CI runs.
+#
+# Run: ./scripts/test-main-canary-live.sh   (or `make main-canary-test`, which
+# runs both suites)
+set -euo pipefail
+
+# shellcheck source=scripts/lib/main-canary-harness.sh
+. "$(dirname "$0")/lib/main-canary-harness.sh"
+
+require_cargo test-main-canary-live
+canary_scratch
+
+# ── green ─────────────────────────────────────────────────────────────────
+make_workspace "$tmp/clean"
+expect "a composing tree passes" 0 "OK — main composes green" --manifest-dir "$tmp/clean"
+
+# A green run must not file anything. This is the case that keeps the canary
+# worth reading: a monitor that comments on healthy days gets muted.
+refute "a green run announces nothing" "gh issue create" \
+  --announce --dry-run --manifest-dir "$tmp/clean"
+
+# The prose row RUNS, rather than merely being present in the checks array
+# (#4828). It cannot be exercised the way `compile` and `lockfile-sync` are:
+# those two take `--manifest-dir` and can be pointed at a broken fixture,
+# while `check-prose` reads the live tree and has no such switch — the same
+# reason `file-size` has no red fixture case here either. So the assertion
+# available is that the row reports its verdict at all, which is exactly what
+# was missing when the canary called a prose-red `main` green.
+expect "the prose row runs and reports" 0 "ok   prose" --manifest-dir "$tmp/clean"
+
+# ── one DoD box per FAILING check, and none for the rest (#5173) ──────────
+# The other three boxes-in-the-issue cases are hermetic and live in the CI
+# suite. This one is not: `prose` is named as the check that must NOT get a
+# box, so a prose-red tree fails it for a reason that has nothing to do with
+# the canary.
+make_workspace "$tmp/nocompile"
+echo 'pub fn demo() { let x: u32 = "not a u32"; }' >"$tmp/nocompile/crates/demo/src/lib.rs"
+refute "and offers no box for a check that passed" \
+  "- [ ] \`prose\` passes on a fresh" \
+  --announce --dry-run --manifest-dir "$tmp/nocompile"
+
+# ── recovery: the branch that keeps this worth reading ────────────────────
+# A canary that only ever opens issues becomes a stale-issue generator and gets
+# muted, at which point it is worse than nothing. Recovery only runs when an
+# issue is already open, hence --fixture-open-issue.
+expect "main going green closes the open issue" 0 "gh issue close 42" \
+  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/clean"
+expect "and says so on the way out" 0 "main recovered — closed #42" \
+  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/clean"
+
+canary_tally test-main-canary-live

--- a/scripts/test-main-canary.sh
+++ b/scripts/test-main-canary.sh
@@ -1,122 +1,36 @@
 #!/usr/bin/env bash
 #
-# Tests for scripts/main-canary.sh (#3332).
+# The hermetic tests for scripts/main-canary.sh (#3332, split at #5356).
 #
-# Hermetic: the red cases drive the canary at a throwaway workspace via
-# --manifest-dir, and every announcing case runs under --dry-run, so nothing
-# here needs a network, a GH_TOKEN, or the repository's real issues. A monitor
-# that files issues is precisely the kind of script you cannot test by running
-# it for real.
+# Every case here is decided by a fixture tree under `--manifest-dir`, and every
+# announcing case runs under `--dry-run`, so nothing needs a network, a
+# GH_TOKEN, or the repository's real issues. A monitor that files issues is
+# precisely the kind of script you cannot test by running it for real.
+#
+# Hermetic in the sense that matters for CI: each case asserts something about
+# what the CANARY does, so it holds whatever `main` is red on. The canary's
+# `file-size` and `prose` rows still read the live tree — they take no
+# `--manifest-dir` — but a fixture that is already red stays red whatever those
+# two report, and a needle asserted about the fixture's own failure is there
+# either way. The cases that expect a GREEN verdict cannot say that, and live in
+# scripts/test-main-canary-live.sh.
 #
 # The cases that matter are the announcing branches. A canary that cannot be
-# shown to open an issue when main is red, and to CLOSE it when main recovers,
-# is indistinguishable from one that always says "green" — and a monitor
-# trusted on that basis is worse than no monitor, because it is also an excuse
-# not to look.
+# shown to open an issue when main is red is indistinguishable from one that
+# always says "green" — and a monitor trusted on that basis is worse than no
+# monitor, because it is also an excuse not to look. The recovery half of that
+# argument — closing the issue when main comes back — needs a green verdict, so
+# it is the live suite's.
+#
+# Run: ./scripts/test-main-canary.sh   (or `make main-canary-test`, which runs
+# both suites)
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-canary="$repo_root/scripts/main-canary.sh"
+# shellcheck source=scripts/lib/main-canary-harness.sh
+. "$(dirname "$0")/lib/main-canary-harness.sh"
 
-if ! command -v cargo >/dev/null 2>&1; then
-  echo "skip test-main-canary — no cargo toolchain on PATH"
-  exit 0
-fi
-
-tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
-
-pass=0
-fail=0
-
-# A minimal, network-free workspace at $1 whose lock matches its manifests.
-make_workspace() {
-  dir="$1"
-  mkdir -p "$dir/crates/demo/src"
-  cat >"$dir/Cargo.toml" <<'TOML'
-[workspace]
-members = ["crates/demo"]
-resolver = "2"
-
-[workspace.package]
-version = "0.1.0"
-edition = "2021"
-TOML
-  cat >"$dir/crates/demo/Cargo.toml" <<'TOML'
-[package]
-name = "demo"
-version.workspace = true
-edition.workspace = true
-TOML
-  echo 'pub fn demo() {}' >"$dir/crates/demo/src/lib.rs"
-  (cd "$dir" && cargo generate-lockfile --offline >/dev/null 2>&1)
-}
-
-expect() {
-  name="$1"
-  want_code="$2"
-  needle="$3"
-  shift 3
-  set +e
-  out="$("$canary" "$@" 2>&1)"
-  code=$?
-  set -e
-  if [ "$code" -ne "$want_code" ]; then
-    echo "FAIL  $name — exit $code, wanted $want_code"
-    printf '      %s\n' "$out"
-    fail=$((fail + 1))
-    return
-  fi
-  case "$out" in
-  *"$needle"*) ;;
-  *)
-    echo "FAIL  $name — output did not contain: $needle"
-    printf '      %s\n' "$out"
-    fail=$((fail + 1))
-    return
-    ;;
-  esac
-  echo "ok    $name"
-  pass=$((pass + 1))
-}
-
-refute() {
-  name="$1"
-  needle="$2"
-  shift 2
-  set +e
-  out="$("$canary" "$@" 2>&1)"
-  set -e
-  case "$out" in
-  *"$needle"*)
-    echo "FAIL  $name — output should NOT have contained: $needle"
-    printf '      %s\n' "$out"
-    fail=$((fail + 1))
-    ;;
-  *)
-    echo "ok    $name"
-    pass=$((pass + 1))
-    ;;
-  esac
-}
-
-# ── green ─────────────────────────────────────────────────────────────────
-make_workspace "$tmp/clean"
-expect "a composing tree passes" 0 "OK — main composes green" --manifest-dir "$tmp/clean"
-
-# A green run must not file anything. This is the case that keeps the canary
-# worth reading: a monitor that comments on healthy days gets muted.
-refute "a green run announces nothing" "gh issue create" \
-  --announce --dry-run --manifest-dir "$tmp/clean"
-
-# The prose row RUNS, rather than merely being present in the checks array
-# (#4828). It cannot be exercised the way `compile` and `lockfile-sync` are:
-# those two take `--manifest-dir` and can be pointed at a broken fixture,
-# while `check-prose` reads the live tree and has no such switch — the same
-# reason `file-size` has no red fixture case here either. So the assertion
-# available is that the row reports its verdict at all, which is exactly what
-# was missing when the canary called a prose-red `main` green.
-expect "the prose row runs and reports" 0 "ok   prose" --manifest-dir "$tmp/clean"
+require_cargo test-main-canary
+canary_scratch
 
 # ── red: the 2026-08-16 incident ──────────────────────────────────────────
 # The shared-cell shape: the version moved and the lock did not. Both PRs that
@@ -205,6 +119,10 @@ refute "and never claims the break started there" "canary found \`main\` broken 
 # reds every other PR, so the repair is what they are all waiting on — and it
 # used to arrive without one. #5171 could not pass its own checks against
 # #5166 until the section was appended by hand.
+#
+# These four are why this suite had to leave the live-tree file (#5356): they
+# guard against reintroducing that deadlock, they are decided entirely by the
+# fixture, and until the split no workflow ran them.
 expect "the issue carries a Definition of done" 1 "### Definition of done" \
   --announce --dry-run --manifest-dir "$tmp/red"
 # One box per FAILING check, named. A generic box would not tell the repair
@@ -215,9 +133,6 @@ expect "with a box naming the check that failed" 1 \
   --announce --dry-run --manifest-dir "$tmp/red"
 expect "the compile failure names compile, not the lockfile" 1 \
   "- [ ] \`compile\` passes on a fresh" \
-  --announce --dry-run --manifest-dir "$tmp/nocompile"
-refute "and offers no box for a check that passed" \
-  "- [ ] \`prose\` passes on a fresh" \
   --announce --dry-run --manifest-dir "$tmp/nocompile"
 # Every box must be tickable BEFORE the merge, or the deadlock is traded for a
 # PR that can never satisfy its own DoD: the gate reads the boxes on the PR,
@@ -235,15 +150,6 @@ expect "the section still says who closes the issue" 1 \
 expect "the label is provisioned before the issue" 1 "gh label create main-red" \
   --announce --dry-run --manifest-dir "$tmp/red"
 
-# ── recovery: the branch that keeps this worth reading ────────────────────
-# A canary that only ever opens issues becomes a stale-issue generator and gets
-# muted, at which point it is worse than nothing. Recovery only runs when an
-# issue is already open, hence --fixture-open-issue.
-expect "main going green closes the open issue" 0 "gh issue close 42" \
-  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/clean"
-expect "and says so on the way out" 0 "main recovered — closed #42" \
-  --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/clean"
-
 # ── a red main that stays red is ONE issue, not one per merge ─────────────
 # Ten merges against a broken tree must produce ten comments on one issue. The
 # opposite — an issue per run — is how a monitor earns a mute filter.
@@ -253,9 +159,10 @@ refute "and does not open a second issue" "gh issue create" \
   --announce --dry-run --fixture-open-issue 42 --manifest-dir "$tmp/red"
 
 # ── argument handling ─────────────────────────────────────────────────────
+# These three are decided before any check runs, so no fixture is needed at all.
 # --dry-run alone reads as a configured monitor while reporting to nobody.
 expect "--dry-run without --announce is refused" 2 "only means something with --announce" \
-  --dry-run --manifest-dir "$tmp/clean"
+  --dry-run --manifest-dir "$tmp/red"
 expect "an unknown argument exits 2" 2 "unknown argument" --nope
 expect "--label with no value exits 2" 2 "--label needs a value" --label
 
@@ -282,6 +189,4 @@ else
   fail=$((fail + 1))
 fi
 
-echo
-echo "test-main-canary: $pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+canary_tally test-main-canary


### PR DESCRIPTION
## What & why

`scripts/test-main-canary.sh` held all 34 cases and ran in **no workflow**. Most
are hermetic — decided by a fixture tree under `--dry-run --manifest-dir` — and
could have run server-side. They did not, because they shared a file with a
handful that expect the canary to report GREEN, which it can only do when the
live tree is green: the `file-size` and `prose` rows take no `--manifest-dir`.

The DoD-section cases added for #5173/#5268 were in the hermetic group. They are
what proves a canary-filed `main-red` issue arrives closable — the fix for the
deadlock where one red `main` stalled the whole PR queue until a human hand-edited
an issue body. A regression in the canary's issue body would have reintroduced
that deadlock with no CI run to notice.

Split by what a case **needs**, not by what it tests:

| File | Cases | Runs |
| --- | --- | --- |
| `scripts/test-main-canary.sh` | 28, every one decided by the fixture | `guard-self-tests.yml`'s new `canary-self-tests` job |
| `scripts/test-main-canary-live.sh` | 6, each expecting a green verdict | by hand / `make main-canary-test`; named in `UNHOSTED_SELF_TESTS` with the reason |
| `scripts/lib/main-canary-harness.sh` | — | sourced by both: the fixture builder and `expect`/`refute`, so the split costs no second copy |

`make main-canary-test` runs both, so a contributor's one command is unchanged.
The `canary-self-tests` job is its own job rather than a step in `self-tests`
because it is the one suite that compiles, and that job is toolchain-free by
design.

One defect fixed along the way: `refute` now fails when the canary exits with
anything but its own `0`/`1`/`2`. An absent needle proves nothing if the script
never started — a refute against a broken invocation passes for free, which is
how a broken harness reports green. The split's first run hit exactly that (a
path bug in the new lib), and four `refute` cases reported `ok` while every
`expect` around them reported exit 127.

Closes #5356

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The witness is the workflow wiring, so it is demonstrated rather than asserted —
the issue's own DoD asks for this. Breaking the canary's DoD emission
(`### Definition of done` → `### What done looks like` in `scripts/main-canary.sh`)
and running the suite CI now runs:

```
ok    and warns the cause may be older
ok    and never claims the break started there
FAIL  the issue carries a Definition of done — output did not contain: ### Definition of done
ok    with a box naming the check that failed
...
test-main-canary: 27 passed, 1 failed
$ echo $?
1
```

On `main` that same break is caught by nothing: `rg -n 'test-main-canary' .github/workflows/`
finds no `run:` step. The canary was then restored (`git checkout -- scripts/main-canary.sh`).

Both suites pass unbroken:

```
test-main-canary: 28 passed, 0 failed        (5m07s)
test-main-canary-live: 6 passed, 0 failed    (1m01s)
```

28 + 6 = 34, the count the file had before the split.

`gate-parity` accounts for both, and the accounting is live rather than vacuous —
deleting the new workflow step and re-running it:

```
check-gate-parity: FAIL — no workflow runs the guard self-test 'scripts/test-main-canary.sh'.
check-gate-parity:      Add it to a workflow, or name it in UNHOSTED_SELF_TESTS in
check-gate-parity:      the Makefile with the reason it is excluded.
```

## The gate

Per CLAUDE.md ("CI builds and tests; this laptop does not") the workspace build
and test suite are CI's; this diff compiles no Rust. Run here:

- [x] `make guards-fast` — green, `cargo fmt --check` included
- [x] `./scripts/check-gate-parity.sh`, `./scripts/test-gate-parity.sh` (14/14),
      `./scripts/check-action-pins.sh`, `./scripts/check-left-behind.sh`,
      `make shellcheck`, `check-prose`, `check-line-citations`
- [x] Docs updated where behavior changed — the `Makefile`'s `UNHOSTED_SELF_TESTS`
      block, `main-canary-test`'s help line, and `guard-self-tests.yml`'s header
- [x] `Closes #5356` appears both above and as a commit trailer

No test was deleted: every case in the old file is present in one of the two new
ones, and `check-deleted-tests.sh` reads Rust `#[test]`s rather than these.

## Nothing left behind

- [x] Filed: #5417, #5418

**#5417** is the finding underneath this one. `--manifest-dir` is documented as
"check a fixture tree" but redirects only two of the four rows, so a fixture run
still judges the live tree. That is *why* six cases cannot be hermetic, and it is
also the entire runtime of the CI suite: measured here, `check-prose.py` is 4.7s
and `check-file-size.sh --absolute` is 3.7s, and the suite makes ~38 canary
invocations — 8.4s × 38 ≈ 5m20s against a measured 5m07s total, so the fixture
compiles are noise. Not fixed here because the obvious remedy (skip those rows
under `--manifest-dir`) breaks the case that exists to prove the `prose` row RUNS
(#4828), and that needs a design decision rather than a patch. The issue writes
one shape down to argue with.

**#5418** is unrelated drift I walked into: AGENTS.md and CONTRIBUTING.md both say
`guard-self-tests.yml` runs three steps and name `prose`, `hue-separation`,
`transcript-surfaces`. It runs four — `line-citations` is in neither list, and is
also missing from AGENTS.md's list of what ci.yml does *not* run, so the document
says ci.yml runs a step no workflow mentions. Under-reporting is #1437's direction.
Left out of this PR to keep it one logical change.

## Anything reviewers should know?

**The cost is real and is stated rather than smoothed.** The new job adds ~5m of
runner time per PR plus the pinned toolchain's install. It is not on the critical
path — `ci.yml`'s Rust job is far longer and runs in parallel — and #5417 is the
issue that removes it. The measurement is recorded in the job's header comment
with the date, so the next reader can tell whether it still holds.

**Why `--manifest-dir` cases are safe to call hermetic even though two rows read
the live tree.** A fixture that is already red stays red whatever those two
report, and every needle asserted is about the fixture's own failure. The one
exception is `and offers no box for a check that passed`, which names `prose` as
the check that must NOT get a DoD box — a prose-red tree fails it for a reason
that has nothing to do with the canary. That case is in the live suite, and the
issue's own list of the four DoD cases to rescue does not include it.

**`refute`'s new exit-code check is a behavior change to the shared harness.** It
can only turn a vacuous pass into a failure, never the reverse, and all 34 cases
pass with it.

## Summary by Sourcery

Run the canary's hermetic self-tests in CI while separating checks that depend on the live repository tree.

New Features:
- Run the hermetic canary self-tests as a dedicated CI job with the required Rust toolchain.

Bug Fixes:
- Prevent refutation tests from passing when the canary fails to start by validating its exit status.

Enhancements:
- Split canary tests into fixture-based hermetic cases and live-tree cases while sharing their harness.
- Keep live-tree canary checks available through `make main-canary-test` while documenting them as intentionally unhosted in CI.

CI:
- Add the canary self-test suite to `guard-self-tests.yml` and update gate-parity accounting.

Documentation:
- Update workflow and Makefile guidance to describe the canary test split and CI coverage.

Tests:
- Retain all 34 canary cases across the two suites and add CI coverage for the 28 hermetic cases.