### PR TITLE
feat(stella-tui): tap-to-talk dictation and a /voice command to switch it on (#5347)

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -112,6 +112,7 @@ mod steering;
 mod task_tap;
 mod theme_cmd;
 mod voice;
+mod voice_cmd;
 mod whistle;
 mod worker_control;
 use driver_support::{
@@ -803,6 +804,7 @@ pub async fn run_deck_session(
         mouse_capture: mouse,
         mid_turn_prompt: steer::mid_turn_prompt_policy(cfg),
         voice_enabled: voice::enabled(cfg),
+        voice_mode: voice::mode(cfg),
     };
     // The deck owns its channel ends and runs on its own task so rendering
     // never waits on the driver (and vice versa).

--- a/crates/stella-cli/src/command_deck/command_side.rs
+++ b/crates/stella-cli/src/command_deck/command_side.rs
@@ -19,6 +19,7 @@ use super::*;
 // `/models` parsing moved next to the rest of the slash vocabulary in #4775;
 // this module is the queue-free half of the same vocabulary and still asks it.
 use super::slash_commands::{ModelsCommand, parse_models_command};
+use super::voice_cmd::{VoiceCommand, parse_voice_command};
 
 /// Try `trimmed` as a queue-free command. `true` = recognized and handled
 /// (possibly by spawning a task that reports later); `false` = not one —
@@ -46,6 +47,7 @@ pub(super) fn run(
         }
         "/info" | "/models" => say(Config::available_models_plain(None)),
         "/theme" => say(theme_cmd::current_summary(cfg)),
+        "/voice" => say(voice_cmd::current_summary(cfg)),
         // Export THIS session's telemetry to a timestamped ZIP of raw JSON
         // dumps + a self-contained HTML dashboard, in the background: the
         // in-flight turn is not paused, not queued behind, not interrupted.
@@ -72,6 +74,31 @@ pub(super) fn run(
                         Ok(msg) | Err(msg) => say(msg),
                     },
                     theme_cmd::ThemeCommand::Usage(arg) => say(theme_cmd::usage(&arg)),
+                }
+                return true;
+            }
+            // `/voice hold|tap|off` — persist, then tell the deck, which
+            // holds the gesture on its own `VoiceUi`. The live update rides
+            // only on a successful write, so a session never ends up
+            // dictating in a mode that was not saved.
+            if let Some(command) = parse_voice_command(trimmed) {
+                let written = match command {
+                    VoiceCommand::On(mode) => {
+                        voice_cmd::set_mode(mode).map(|msg| (msg, true, mode))
+                    }
+                    VoiceCommand::Off => voice_cmd::set_off()
+                        .map(|msg| (msg, false, voice_cmd::persisted(&cfg.workspace_root).1)),
+                    VoiceCommand::Usage(arg) => {
+                        say(voice_cmd::usage(&arg));
+                        return true;
+                    }
+                };
+                match written {
+                    Ok((msg, enabled, mode)) => {
+                        let _ = in_tx.send(Inbound::VoiceConfig { enabled, mode });
+                        say(msg);
+                    }
+                    Err(msg) => say(msg),
                 }
                 return true;
             }

--- a/crates/stella-cli/src/command_deck/skills.rs
+++ b/crates/stella-cli/src/command_deck/skills.rs
@@ -64,6 +64,11 @@ pub(super) const DECK_BUILTINS: &[(&str, &str, SlashDomain)] = &[
         SlashDomain::Config,
     ),
     (
+        "/voice",
+        "dictation on/off and which spacebar gesture (hold · tap; persists)",
+        SlashDomain::Config,
+    ),
+    (
         "/init",
         "index the workspace: domains + code graph",
         SlashDomain::Code,
@@ -184,7 +189,7 @@ pub(super) const SIDEBAND: &[&str] = &[
     // `/info`'s pre-rename name, still routed (#4617) — a queue-free
     // command must not become queued just because the reader typed the
     // name they learned.
-    "/models", "/theme", "/export", "/donate",
+    "/models", "/theme", "/voice", "/export", "/donate",
 ];
 
 /// Whether `head` (the first `/`-token of a submission) is queue-free.

--- a/crates/stella-cli/src/command_deck/voice.rs
+++ b/crates/stella-cli/src/command_deck/voice.rs
@@ -52,6 +52,21 @@ pub(super) fn enabled(cfg: &Config) -> bool {
         .unwrap_or(false)
 }
 
+/// Which spacebar gesture dictates (`voice.mode`), threaded into
+/// `DeckOptions` beside [`enabled`].
+///
+/// Validated here rather than stored typed, the house convention for a slug
+/// in settings: an unreadable value falls back to the default gesture, so a
+/// typo costs the mode a person asked for and never dictation itself.
+pub(super) fn mode(cfg: &Config) -> stella_tui::voice::VoiceMode {
+    Settings::load(&cfg.workspace_root)
+        .ok()
+        .and_then(|s| s.voice.as_ref().and_then(|v| v.mode.clone()))
+        .as_deref()
+        .and_then(stella_tui::voice::VoiceMode::parse)
+        .unwrap_or_default()
+}
+
 /// One in-flight capture, or nothing. Held by `run_deck_session` across the
 /// whole session; transcription tasks are spawned and own their own halves.
 #[derive(Default)]
@@ -591,6 +606,9 @@ mod tests {
     fn a_declared_provider_entry_overrides_endpoint_and_env() {
         let voice = VoiceSettings {
             enabled: Some(true),
+            // Transcription is mode-agnostic: which gesture opened the
+            // capture is the deck's business, not the endpoint's.
+            mode: None,
             provider: Some("groq".to_string()),
             model: Some("whisper-large-v3".to_string()),
             language: Some("en".to_string()),

--- a/crates/stella-cli/src/command_deck/voice_cmd.rs
+++ b/crates/stella-cli/src/command_deck/voice_cmd.rs
@@ -1,0 +1,219 @@
+//! The `/voice` slash command — switch dictation on, off, or between
+//! gestures, and persist the choice.
+//!
+//! Dictation shipped switched off, reachable only by hand-editing
+//! `voice.enabled` in a settings file (ADR 0020), so the feature was out of
+//! reach for anyone who had not read the ADR. This is the one command that
+//! turns it on: `/voice tap`, `/voice hold`, `/voice off`.
+//!
+//! Kept out of the `command_deck` dispatcher for the reason
+//! [`super::theme_cmd`] is — the parser, the settings write and the reply
+//! text live together, and the dispatcher only wires them to `say`.
+//!
+//! Unlike `/theme`, the live half is not a global this module can flip: the
+//! gesture lives on the deck's own `stella_tui::voice::VoiceUi`, on the other
+//! side of the envelope. So the caller follows a successful write with an
+//! `Inbound::VoiceConfig`. Persisting alone would make `/voice tap` a command
+//! that reports success and changes nothing until the next session.
+
+use stella_tui::voice::VoiceMode;
+
+use crate::settings::{Settings, VoiceSettings};
+
+/// `/voice …` — the dictation switch.
+pub enum VoiceCommand {
+    /// `/voice hold` or `/voice tap` — switch on, in that gesture.
+    On(VoiceMode),
+    /// `/voice off` — switch dictation off, leaving the provider settings
+    /// (`voice.provider`, `voice.model`, `voice.language`) in place so
+    /// switching back on does not ask for them again.
+    Off,
+    /// Anything else after `/voice`.
+    Usage(String),
+}
+
+/// Parse `trimmed` as a [`VoiceCommand`]; `None` leaves it on the normal
+/// path. A bare `/voice` (no argument) never reaches here — it has no
+/// whitespace to split on and is handled by the exact-match arm, exactly as
+/// `/theme` is.
+pub fn parse_voice_command(trimmed: &str) -> Option<VoiceCommand> {
+    let (head, rest) = trimmed.split_once(char::is_whitespace)?;
+    if head != "/voice" {
+        return None;
+    }
+    let arg = rest.trim();
+    if arg.eq_ignore_ascii_case("off") {
+        return Some(VoiceCommand::Off);
+    }
+    match VoiceMode::parse(arg) {
+        Some(mode) => Some(VoiceCommand::On(mode)),
+        None => Some(VoiceCommand::Usage(arg.to_string())),
+    }
+}
+
+/// What each gesture is, in one line — the text `/voice` prints.
+fn blurb(mode: VoiceMode) -> &'static str {
+    match mode {
+        VoiceMode::Hold => "hold space through the warmup, release to stop",
+        VoiceMode::Tap => "tap space on an empty prompt to start, tap again to stop",
+    }
+}
+
+/// The persisted state, resolved the way the deck resolves it at startup:
+/// `(enabled, mode)`, so the summary and the writer agree on what
+/// "currently" means rather than each reading settings its own way.
+pub fn persisted(workspace_root: &std::path::Path) -> (bool, VoiceMode) {
+    let voice = Settings::load(workspace_root).ok().and_then(|s| s.voice);
+    let enabled = voice.as_ref().and_then(|v| v.enabled).unwrap_or(false);
+    let mode = voice
+        .as_ref()
+        .and_then(|v| v.mode.as_deref())
+        .and_then(VoiceMode::parse)
+        .unwrap_or_default();
+    (enabled, mode)
+}
+
+/// The mode list, one per line, marking the active one.
+fn mode_menu(active: VoiceMode, enabled: bool) -> String {
+    VoiceMode::ALL
+        .iter()
+        .map(|m| {
+            let mark = if enabled && *m == active {
+                "●"
+            } else {
+                "○"
+            };
+            format!("  {mark} {:<5} {}", m.slug(), blurb(*m))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The bare-`/voice` summary: whether dictation is on, which gesture it is
+/// bound to, and how to change either.
+pub fn current_summary(cfg: &crate::config::Config) -> String {
+    let (enabled, mode) = persisted(&cfg.workspace_root);
+    let state = if enabled {
+        format!("on ({})", mode.slug())
+    } else {
+        "off".to_string()
+    };
+    format!(
+        "dictation: {state}\n\n{}\n\n\
+         `/voice tap` or `/voice hold` switches on; `/voice off` switches off.\n\
+         Tap mode is the one that works when your terminal reports no key\n\
+         releases and OS key repeat is off — there a hold cannot be told from\n\
+         a tap, and hold mode never starts.",
+        mode_menu(mode, enabled),
+    )
+}
+
+/// Switch dictation on in `mode` and persist it (`voice.enabled`,
+/// `voice.mode`) to user-scope settings.
+pub fn set_mode(mode: VoiceMode) -> Result<String, String> {
+    write_section(Some(true), Some(mode), || {
+        format!(
+            "dictation → on, {} mode ({}). Saved — new sessions start here too.",
+            mode.slug(),
+            blurb(mode)
+        )
+    })
+}
+
+/// Switch dictation off and persist it, leaving the gesture and the provider
+/// settings recorded so `/voice` can switch back on without asking again.
+pub fn set_off() -> Result<String, String> {
+    write_section(Some(false), None, || {
+        "dictation → off. Saved — `/voice tap` or `/voice hold` switches it back on.".to_string()
+    })
+}
+
+/// The shared write: load the user-scope `[voice]` section, apply the fields
+/// this command owns, save it back, and render `ok` on success.
+///
+/// Read-modify-write on the section, not the file: `[voice]` also carries
+/// `provider`, `model` and `language`, and a fresh struct here would erase a
+/// configured local Whisper endpoint.
+///
+/// A failure names what did *not* happen. Unlike `/theme`, nothing has taken
+/// effect at this point — the caller sends the live update only on `Ok` — so
+/// a failed write leaves the session exactly as it was, and the message says
+/// that rather than `/theme`'s "it worked for now but was not saved".
+fn write_section(
+    enabled: Option<bool>,
+    mode: Option<VoiceMode>,
+    ok: impl Fn() -> String,
+) -> Result<String, String> {
+    let mut voice: VoiceSettings = Settings::load_user_scope(&mut Vec::new())
+        .ok()
+        .and_then(|s| s.voice)
+        .unwrap_or_default();
+    if let Some(enabled) = enabled {
+        voice.enabled = Some(enabled);
+    }
+    if let Some(mode) = mode {
+        voice.mode = Some(mode.slug().to_string());
+    }
+    let Some(path) = crate::settings::user_config_path() else {
+        return Err(
+            "dictation was not changed: the user settings path is unavailable (is $HOME set?)"
+                .to_string(),
+        );
+    };
+    voice
+        .save_to(&path)
+        .map_err(|e| format!("dictation was not changed: {e}"))?;
+    Ok(ok())
+}
+
+/// The reply to `/voice <unknown>`: name the valid set rather than silently
+/// no-op'ing on a typo.
+pub fn usage(arg: &str) -> String {
+    format!(
+        "unknown voice mode `{arg}` — try `/voice hold`, `/voice tap`, or `/voice off`:\n\n{}",
+        mode_menu(VoiceMode::default(), false)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_voice_command_reads_each_mode_and_flags_junk() {
+        assert!(matches!(
+            parse_voice_command("/voice tap"),
+            Some(VoiceCommand::On(VoiceMode::Tap))
+        ));
+        assert!(matches!(
+            parse_voice_command("/voice hold"),
+            Some(VoiceCommand::On(VoiceMode::Hold))
+        ));
+        // Case-insensitive, like every other slug argument in the deck.
+        assert!(matches!(
+            parse_voice_command("/voice TAP"),
+            Some(VoiceCommand::On(VoiceMode::Tap))
+        ));
+        assert!(matches!(
+            parse_voice_command("/voice Off"),
+            Some(VoiceCommand::Off)
+        ));
+        // An unknown argument is a named error, never a silent no-op.
+        assert!(matches!(
+            parse_voice_command("/voice push"),
+            Some(VoiceCommand::Usage(s)) if s == "push"
+        ));
+        // Bare `/voice` has no whitespace to split — the exact-match arm owns it.
+        assert!(parse_voice_command("/voice").is_none());
+        // `/voice` must not swallow an unrelated head.
+        assert!(parse_voice_command("/voices list").is_none());
+    }
+
+    #[test]
+    fn the_usage_and_menu_name_every_shipped_mode() {
+        let text = usage("push");
+        for mode in VoiceMode::ALL {
+            assert!(text.contains(mode.slug()), "usage omits {}", mode.slug());
+        }
+    }
+}

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -880,6 +880,17 @@ pub struct VoiceSettings {
     /// selected by name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+    /// Which gesture on the spacebar dictates: `"hold"` (the default — hold
+    /// through a warmup, release to stop) or `"tap"` (tap on an empty
+    /// composer to start, tap again to stop).
+    ///
+    /// Unset or unrecognised means `hold`, validated at the read site
+    /// ([`stella_tui::voice::VoiceMode::parse`]) like every other slug in
+    /// this file. `tap` is what makes dictation reachable at all on a
+    /// terminal that reports no key releases with OS key-repeat disabled,
+    /// where a hold cannot be told from a tap (#5347).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
     /// The provider id whose OpenAI-compatible `audio/transcriptions`
     /// endpoint transcribes. Unset falls back to `openai`; any provider
     /// whose settings declare a compatible `base_url` (a local Whisper
@@ -893,6 +904,58 @@ pub struct VoiceSettings {
     /// Unset sends no hint and the model auto-detects.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+}
+
+impl VoiceSettings {
+    /// Whether every field is unset — the section would serialize to `{}`,
+    /// and the writers drop the key instead.
+    pub fn is_empty(&self) -> bool {
+        self.enabled.is_none()
+            && self.mode.is_none()
+            && self.provider.is_none()
+            && self.model.is_none()
+            && self.language.is_none()
+    }
+
+    /// Persist THIS section as the `"voice"` key of the settings file at
+    /// `path`, preserving every other key byte-for-byte at the value level —
+    /// the same read-modify-write contract as [`UiSettings::save_to`],
+    /// [`ToolsSettings::save_to`] and [`AgentEngineConfig::save_to`].
+    ///
+    /// That contract is the whole reason this exists rather than a serialize
+    /// of a fresh struct: `[voice]` also carries `provider`, `model` and
+    /// `language`, and `/voice tap` writing only what it knows about would
+    /// silently drop a configured local Whisper endpoint. An empty section
+    /// removes the key rather than writing `{}`.
+    pub fn save_to(&self, path: &Path) -> Result<(), String> {
+        if toml_config::path_is_toml(path) {
+            let user_private = user_config_path().as_deref() == Some(path);
+            let value = (!self.is_empty()).then_some(self);
+            return toml_io::save_section(path, "voice", value, user_private);
+        }
+        private::reject_symlink(path)?;
+        let mut root: serde_json::Value = match std::fs::read_to_string(path) {
+            Ok(contents) => serde_json::from_str(&contents)
+                .map_err(|e| format!("invalid settings file {}: {e}", path.display()))?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => serde_json::json!({}),
+            Err(e) => return Err(format!("cannot read {}: {e}", path.display())),
+        };
+        let object = root
+            .as_object_mut()
+            .ok_or_else(|| format!("settings file {} is not a JSON object", path.display()))?;
+        if self.is_empty() {
+            object.remove("voice");
+        } else {
+            let value =
+                serde_json::to_value(self).map_err(|e| format!("cannot serialize voice: {e}"))?;
+            object.insert("voice".to_string(), value);
+        }
+        let mut rendered = serde_json::to_string_pretty(&root)
+            .map_err(|e| format!("cannot render settings: {e}"))?;
+        rendered.push('\n');
+        let user_private = user_settings_path().as_deref() == Some(path);
+        private::write_settings(path, rendered.as_bytes(), user_private)
+    }
 }
 
 impl UiSettings {

--- a/crates/stella-cli/src/settings/tests.rs
+++ b/crates/stella-cli/src/settings/tests.rs
@@ -10,6 +10,7 @@ mod auto_trust_project;
 mod private_state;
 mod toml;
 mod trust;
+mod voice;
 
 use super::*;
 

--- a/crates/stella-cli/src/settings/tests/voice.rs
+++ b/crates/stella-cli/src/settings/tests/voice.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The `[voice]` section's writer: what `/voice` persists, and what it must
+//! not destroy on the way (#5347).
+//!
+//! A sibling file rather than more lines in `settings/tests.rs`, which sits at
+//! the 1500-line ratchet.
+
+use super::*;
+// The gesture slug these tests round-trip is parsed where it is read, the
+// house convention for a slug in settings (`VoiceSettings::mode`).
+use stella_tui::voice::VoiceMode;
+
+/// **Witness (#5347).** `/voice tap` persists both fields and the next
+/// session reads them back — the whole point of the command, since dictation
+/// was previously reachable only by hand-editing this file.
+///
+/// The section write is the part that can silently go wrong: `[voice]` also
+/// carries the transcription endpoint, so a writer that serialized a fresh
+/// struct would switch dictation on and drop the provider it dictates
+/// through. That is asserted here rather than argued.
+#[test]
+fn voice_mode_save_preserves_the_transcription_endpoint_and_roundtrips() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write(
+        dir.path(),
+        "settings.json",
+        r#"{"providers": {"zai": {"default_model": "glm-5.2"}},
+            "voice": {"provider": "groq", "model": "whisper-large-v3"},
+            "future_key": {"anything": true}}"#,
+    );
+
+    // What `/voice tap` writes: read-modify-write on the loaded section.
+    let mut voice = Settings::load_from(std::slice::from_ref(&path))
+        .unwrap()
+        .voice
+        .unwrap_or_default();
+    voice.enabled = Some(true);
+    voice.mode = Some("tap".to_string());
+    voice.save_to(&path).unwrap();
+
+    let raw: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(raw["voice"]["enabled"], true);
+    assert_eq!(raw["voice"]["mode"], "tap");
+    // The endpoint the user configured is still there…
+    assert_eq!(raw["voice"]["provider"], "groq");
+    assert_eq!(raw["voice"]["model"], "whisper-large-v3");
+    // …as is every sibling key, at the value level.
+    assert_eq!(raw["providers"]["zai"]["default_model"], "glm-5.2");
+    assert_eq!(raw["future_key"]["anything"], true);
+
+    // The next session reads it back through the normal load path and
+    // resolves the gesture the deck will bind to Space.
+    let merged = Settings::load_from(std::slice::from_ref(&path)).unwrap();
+    let loaded = merged.voice.as_ref().unwrap();
+    assert_eq!(loaded.enabled, Some(true));
+    assert_eq!(
+        loaded.mode.as_deref().and_then(VoiceMode::parse),
+        Some(VoiceMode::Tap)
+    );
+
+    // `/voice off` leaves the gesture and the endpoint recorded, so switching
+    // back on does not ask for either again.
+    let mut off = loaded.clone();
+    off.enabled = Some(false);
+    off.save_to(&path).unwrap();
+    let raw: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(raw["voice"]["enabled"], false);
+    assert_eq!(raw["voice"]["mode"], "tap");
+    assert_eq!(raw["voice"]["provider"], "groq");
+
+    // An empty section is dropped rather than written as `{}`.
+    VoiceSettings::default().save_to(&path).unwrap();
+    let raw: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert!(raw.as_object().unwrap().get("voice").is_none());
+    assert_eq!(raw["providers"]["zai"]["default_model"], "glm-5.2");
+}
+
+/// An absent or unreadable `voice.mode` resolves to the gesture that shipped
+/// first, so an existing `voice.enabled` behaves exactly as it did before
+/// this field existed — a typo costs the mode, never dictation itself.
+#[test]
+fn an_absent_or_junk_voice_mode_falls_back_to_hold() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write(
+        dir.path(),
+        "settings.json",
+        r#"{"voice": {"enabled": true}}"#,
+    );
+    let merged = Settings::load_from(std::slice::from_ref(&path)).unwrap();
+    let voice = merged.voice.as_ref().unwrap();
+    assert_eq!(voice.enabled, Some(true));
+    assert_eq!(voice.mode, None);
+    assert_eq!(
+        voice
+            .mode
+            .as_deref()
+            .and_then(VoiceMode::parse)
+            .unwrap_or_default(),
+        VoiceMode::Hold
+    );
+
+    let path = write(
+        dir.path(),
+        "junk.json",
+        r#"{"voice": {"enabled": true, "mode": "push"}}"#,
+    );
+    let merged = Settings::load_from(std::slice::from_ref(&path)).unwrap();
+    let voice = merged.voice.as_ref().unwrap();
+    assert_eq!(
+        voice
+            .mode
+            .as_deref()
+            .and_then(VoiceMode::parse)
+            .unwrap_or_default(),
+        VoiceMode::Hold,
+        "an unrecognised mode must not disable dictation"
+    );
+}

--- a/crates/stella-tui/src/deck.rs
+++ b/crates/stella-tui/src/deck.rs
@@ -875,7 +875,10 @@ impl WorkspaceModel {
             // A dictation's text is keyboard input by another route — it
             // lands in the composer (`ingest_inbound`), never the record.
             | Inbound::VoiceTranscript { .. }
-            | Inbound::VoiceFailed { .. } => {}
+            | Inbound::VoiceFailed { .. }
+            // Switching the dictation gesture is settings, not speech; the
+            // `/voice` reply itself is the transcript row a person reads.
+            | Inbound::VoiceConfig { .. } => {}
         }
     }
 

--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -113,6 +113,40 @@ pub struct DeckOptions {
     /// off by default — ADR 0020). The caller reads settings for the reason
     /// it resolves [`Self::mid_turn_prompt`]: this crate does not read config.
     pub voice_enabled: bool,
+    /// Which dictation gesture is bound to Space (`voice.mode` in settings,
+    /// `hold` by default). Read by the caller for the same reason as
+    /// [`Self::voice_enabled`]; `/voice` re-sends it mid-session as
+    /// [`Inbound::VoiceConfig`].
+    pub voice_mode: crate::voice::VoiceMode,
+}
+
+/// Carry out a [`crate::voice::VoiceCmd`]: the composer edit it asks for, and
+/// the input it sends the driver.
+///
+/// Three arms fold voice events — a reported release, a swallowed space, and
+/// the tick clock — and every one of them can now open or close a capture, so
+/// the retraction and the send live here rather than being written out three
+/// times and drifting apart.
+fn apply_voice_cmd(
+    cmd: crate::voice::VoiceCmd,
+    ui: &mut DeckUi,
+    submissions: &UnboundedSender<WorkspaceInput>,
+) {
+    match cmd {
+        crate::voice::VoiceCmd::Start { retract } => {
+            for _ in 0..retract {
+                ui.composer.backspace();
+            }
+            let _ = submissions.send(WorkspaceInput::VoiceStart);
+        }
+        crate::voice::VoiceCmd::Stop => {
+            let _ = submissions.send(WorkspaceInput::VoiceStop);
+        }
+        crate::voice::VoiceCmd::Cancel => {
+            let _ = submissions.send(WorkspaceInput::VoiceCancel);
+        }
+        crate::voice::VoiceCmd::None => {}
+    }
 }
 
 fn now_ms() -> u64 {
@@ -608,6 +642,7 @@ pub async fn run_deck(
     // Push-to-talk: enablement is the caller's (settings), release reporting
     // is the terminal's (the same push as the Enter semantics above).
     ui.voice.enabled = opts.voice_enabled;
+    ui.voice.mode = opts.voice_mode;
     ui.voice.release_events = guard.kitty();
     let mut resources = ResourceMonitor::new();
 
@@ -738,16 +773,19 @@ pub async fn run_deck(
                     // fires and the repeat-gap fallback in the tick arm ends
                     // the hold instead (`crate::voice`).
                     Some(Event::Key(key)) if key.kind == KeyEventKind::Release => {
-                        if is_plain_space(key)
-                            && ui.voice.space_release(model.now_ms) == crate::voice::VoiceCmd::Stop
-                        {
-                            let _ = submissions.send(WorkspaceInput::VoiceStop);
+                        if is_plain_space(key) {
+                            let cmd = ui.voice.space_release(model.now_ms);
+                            apply_voice_cmd(cmd, &mut ui, &submissions);
                         }
                     }
-                    // While recording, the held space's repeats are "still
-                    // held", never characters — and Esc abandons the capture.
+                    // While recording, a space is never a character. In hold
+                    // mode it is a repeat saying the key is still down; in
+                    // tap mode it is the second tap, which ends the capture
+                    // (`crate::voice::VoiceUi::swallowed_space`). Esc
+                    // abandons the capture in both.
                     Some(Event::Key(key)) if ui.voice.swallows_space() && is_plain_space(key) => {
-                        ui.voice.space_repeat(model.now_ms);
+                        let cmd = ui.voice.swallowed_space(model.now_ms);
+                        apply_voice_cmd(cmd, &mut ui, &submissions);
                     }
                     Some(Event::Key(key))
                         if ui.voice.esc_cancels()
@@ -842,7 +880,13 @@ pub async fn run_deck(
                         if space
                             && space_landed_in_composer(&ui.composer, before_len, before_cursor)
                         {
-                            ui.voice.typed_space(model.now_ms);
+                            // Whether that space met an *empty* composer is
+                            // what arms tap mode, and only dispatch knows it
+                            // — hence the snapshot above rather than a guess
+                            // inside the machine.
+                            let cmd =
+                                ui.voice.typed_space(model.now_ms, before_len == 0);
+                            apply_voice_cmd(cmd, &mut ui, &submissions);
                         } else if !space {
                             ui.voice.interrupt();
                         }
@@ -922,18 +966,8 @@ pub async fn run_deck(
                 // here — retracting exactly the spaces the arming run typed —
                 // and, without release reporting, a quiet repeat stream ends
                 // the recording here too.
-                match ui.voice.tick(model.now_ms) {
-                    crate::voice::VoiceCmd::Start { retract } => {
-                        for _ in 0..retract {
-                            ui.composer.backspace();
-                        }
-                        let _ = submissions.send(WorkspaceInput::VoiceStart);
-                    }
-                    crate::voice::VoiceCmd::Stop => {
-                        let _ = submissions.send(WorkspaceInput::VoiceStop);
-                    }
-                    crate::voice::VoiceCmd::Cancel | crate::voice::VoiceCmd::None => {}
-                }
+                let cmd = ui.voice.tick(model.now_ms);
+                apply_voice_cmd(cmd, &mut ui, &submissions);
             }
         }
     }

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -1219,16 +1219,9 @@ fn ingest_inner(inbound: &Inbound, model: &mut WorkspaceModel, ui: &mut DeckUi) 
         ui.index_readiness = *readiness;
         return;
     }
-    // A dictation's answer is keyboard input by another route: paste the
-    // text at the cursor, or say why there is none (`crate::voice`).
-    if let Inbound::VoiceTranscript { text } = inbound {
-        ui.voice.settled();
-        ui.paste(text);
-        return;
-    }
-    if let Inbound::VoiceFailed { reason } = inbound {
-        ui.voice.settled();
-        ui.notice.push(reason.clone());
+    // The dictation envelopes — transcript, failure, and the gesture
+    // `/voice` just persisted (`voice_inbound`).
+    if voice_inbound::ingest(inbound, ui) {
         return;
     }
     // A plan revision a failing gate put up: the scrollback row and the
@@ -3682,6 +3675,7 @@ mod skills_keys;
 
 /// ISSUES-tab browse keys and the multiselect they drive.
 mod issues_keys;
+mod voice_inbound;
 use issues_keys::{handle_issues_browse_key, issues_page_request};
 
 #[cfg(test)]

--- a/crates/stella-tui/src/deck_ui/voice_inbound.rs
+++ b/crates/stella-tui/src/deck_ui/voice_inbound.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The three dictation envelopes, folded into the deck's UI state.
+//!
+//! `crate::voice` is the pure decision half and stays that way — it never
+//! learns what a composer or a notice is. This is the other side of that
+//! line: the driver's answers arrive as [`Inbound`] and have to *do*
+//! something to a [`DeckUi`], so the doing lives here.
+//!
+//! A sibling file rather than more arms in `deck_ui.rs`, which is a
+//! grandfathered god file closed to growth (AGENTS.md § "God files").
+
+use crate::deck_ui::DeckUi;
+use crate::envelope::Inbound;
+
+/// Fold a dictation envelope. `true` means it was one and the caller is done
+/// with it — the same "recognized and handled" contract the rest of
+/// `ingest_inbound`'s chain uses.
+pub(super) fn ingest(inbound: &Inbound, ui: &mut DeckUi) -> bool {
+    match inbound {
+        // A dictation's answer is keyboard input by another route: it lands
+        // in the composer at the cursor, never in the record.
+        Inbound::VoiceTranscript { text } => {
+            ui.voice.settled();
+            ui.paste(text);
+            true
+        }
+        // No text to paste — say why instead, as a transient notice.
+        Inbound::VoiceFailed { reason } => {
+            ui.voice.settled();
+            ui.notice.push(reason.clone());
+            true
+        }
+        // `/voice` switched dictation on, off, or between gestures and has
+        // already persisted it. Any gesture in flight is returned to rest
+        // first: the new mode reads the spacebar differently, and a capture
+        // folded half under one set of rules and half under the other has no
+        // key left that ends it.
+        Inbound::VoiceConfig { enabled, mode } => {
+            ui.voice.settled();
+            ui.voice.enabled = *enabled;
+            ui.voice.mode = *mode;
+            true
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::voice::{VoiceCmd, VoiceMode};
+
+    /// **Witness (#5347).** `/voice tap` takes effect in the session that ran
+    /// it, not only in the next one.
+    ///
+    /// Without the envelope the deck keeps the enablement and mode it read at
+    /// startup, so the command reports success and the spacebar keeps doing
+    /// the old thing — which is the opposite of "first use is one command".
+    #[test]
+    fn a_voice_config_envelope_rebinds_the_gesture_in_this_session() {
+        let mut ui = DeckUi::default();
+        assert!(!ui.voice.enabled, "dictation ships off");
+        assert_eq!(ui.voice.mode, VoiceMode::Hold);
+
+        assert!(ingest(
+            &Inbound::VoiceConfig {
+                enabled: true,
+                mode: VoiceMode::Tap,
+            },
+            &mut ui,
+        ));
+        assert!(ui.voice.enabled);
+        assert_eq!(ui.voice.mode, VoiceMode::Tap);
+
+        // And the machine is live in the new mode straight away: one space on
+        // an empty composer opens a capture.
+        assert_eq!(
+            ui.voice.typed_space(0, true),
+            VoiceCmd::Start { retract: 1 }
+        );
+    }
+
+    /// Switching mode mid-gesture returns the machine to rest. A capture
+    /// started under hold-mode rules has no stop key once tap mode is bound,
+    /// so leaving it running would wedge dictation for the session.
+    #[test]
+    fn switching_mode_mid_capture_returns_the_machine_to_rest() {
+        let mut ui = DeckUi::default();
+        ui.voice.enabled = true;
+        ui.voice.mode = VoiceMode::Tap;
+        ui.voice.typed_space(0, true);
+        assert!(ui.voice.recording());
+
+        ingest(
+            &Inbound::VoiceConfig {
+                enabled: true,
+                mode: VoiceMode::Hold,
+            },
+            &mut ui,
+        );
+        assert!(!ui.voice.recording());
+        assert_eq!(ui.voice.mode, VoiceMode::Hold);
+    }
+
+    #[test]
+    fn a_non_voice_envelope_is_handed_back() {
+        let mut ui = DeckUi::default();
+        assert!(!ingest(&Inbound::ShowHelp, &mut ui));
+    }
+}

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -647,6 +647,21 @@ pub enum Inbound {
     /// refused transcription request). Ingest returns the voice state to
     /// rest and raises `reason` as a transient notice.
     VoiceFailed { reason: String },
+    /// Dictation was switched on, off, or between modes by `/voice`, which
+    /// runs on the driver side and has just persisted the same values to
+    /// settings.
+    ///
+    /// Without this the deck would keep the enablement and mode it read at
+    /// startup, so `/voice tap` would report success and change nothing until
+    /// the next session — and "first use is one command" is the whole point
+    /// of the command (#5347). Any gesture in flight is returned to rest:
+    /// the keys mean something different the instant the mode changes, and a
+    /// half-finished hold folded by tap-mode rules is a capture nobody can
+    /// stop.
+    VoiceConfig {
+        enabled: bool,
+        mode: crate::voice::VoiceMode,
+    },
 }
 
 // The ISSUES tab's read models. Re-exported rather than moved behind a

--- a/crates/stella-tui/src/keymap.rs
+++ b/crates/stella-tui/src/keymap.rs
@@ -573,15 +573,18 @@ pub const BINDINGS: &[Binding] = &[
     ),
     // Wherever a bare space types, that is (`voice`'s observation fold); a
     // tab where space pages or toggles never arms. Off until `voice.enabled`
-    // (ADR 0020).
+    // (ADR 0020). Which gesture the key carries is `voice.mode`, so the row
+    // names both: a reader in tap mode holding the key would conclude the
+    // sheet is lying about their deck.
     row(
-        "space (hold)",
-        "dictate — keep holding until listening, release to insert the transcript",
+        "space",
+        "dictate — hold until listening, or tap to start and stop (`/voice`)",
         Everywhere,
         &[
             "a_bare_space_is_the_push_to_talk_key_and_a_modified_space_is_not",
             "the_voice_observation_requires_a_space_that_actually_landed",
             "a_hold_crosses_the_warmup_and_retracts_exactly_what_it_typed",
+            "tap_mode_records_with_no_key_repeat_and_no_release_events",
             "esc_cancels_a_recording_without_transcribing",
         ],
     ),

--- a/crates/stella-tui/src/voice.rs
+++ b/crates/stella-tui/src/voice.rs
@@ -1,7 +1,11 @@
-//! Push-to-talk dictation: the pure hold-spacebar state machine.
+//! Push-to-talk dictation: the pure spacebar state machine.
 //!
 //! Hold Space in the composer and, after a warmup, the deck records the
-//! microphone and pastes the transcript at the cursor (ADR 0020). This module
+//! microphone and pastes the transcript at the cursor (ADR 0020); or, in
+//! [`VoiceMode::Tap`], tap Space on an empty composer to start and tap again
+//! to stop. Both modes enter the same [`VoicePhase::Listening`] and leave it
+//! the same way, so everything downstream of the gesture — the caret colour,
+//! the status line, Esc, the transcript paste — is written once. This module
 //! is only the *decision* half: a fold over observed key events and the deck's
 //! ~30fps tick clock, held on [`crate::deck_ui::DeckUi`] like every other
 //! interaction state. Capture and transcription live on the driver side of
@@ -28,10 +32,23 @@
 //! the release event itself. Every other terminal ends it when the OS
 //! key-repeat stream goes quiet: while a key is held the OS delivers repeats
 //! every few tens of milliseconds, so a gap longer than [`LISTENING_GAP_MS`]
-//! means the key is up. That fallback requires OS key-repeat to be enabled;
-//! with repeat disabled and no release reporting, the hold can never be told
-//! from a tap and dictation stays dormant (#5347 tracks tap-to-toggle as the
-//! remedy).
+//! means the key is up. That fallback requires OS key-repeat to be enabled.
+//!
+//! ## Why tap mode exists
+//!
+//! With repeat disabled *and* no release reporting, a hold cannot be told
+//! from a tap by any signal this machine receives, so hold mode can never
+//! arm and dictation is unreachable. [`VoiceMode::Tap`] is the way in that
+//! depends on neither: one observed space starts the capture and the next
+//! one ends it, which every terminal can deliver. It is chosen by name
+//! (`/voice tap`, persisted as `voice.mode`), never inferred — the two modes
+//! read the same key, so guessing wrong would make Space do the other thing
+//! at the moment a person is trying to type.
+//!
+//! Tap mode arms only from an **empty composer**. A space is a word gap far
+//! more often than it is a gesture, and an empty composer is what separates
+//! "I am starting to dictate" from "I am typing" with no warmup to wait
+//! through.
 
 /// How long Space must be held before recording starts. Long enough that
 /// every ordinary use of the key — a word gap, a quick run of indentation —
@@ -84,6 +101,66 @@ const DRIVER_HTTP_TIMEOUT_MS: u64 = 60_000;
 /// tuning either number without reading the other is the whole hazard.
 const _: () = assert!(TRANSCRIBE_WAIT_MS > DRIVER_HTTP_TIMEOUT_MS);
 
+/// The shortest a [`VoiceMode::Tap`] capture can be, and the window in which
+/// a space cannot end the capture it just started.
+///
+/// Tap mode reads one key event as "start" and the next as "stop", which is
+/// exactly what a *held* space looks like once OS key-repeat delivers its
+/// first repeat. There is no signal that separates the two — that is the
+/// premise tap mode exists under — so the floor is a clock instead: it is set
+/// at [`ARMING_GAP_MS`], which is already this module's measure of the
+/// slowest initial key-repeat delay a terminal will hand us. A space held in
+/// tap mode therefore records for this long and stops, rather than opening
+/// and closing a capture on one keypress and posting silence to a
+/// transcription provider.
+///
+/// The cost is that a double-tap faster than this does not stop the capture.
+/// Nobody dictates for under three quarters of a second, and the status line
+/// says the recording is live throughout.
+pub const TAP_MIN_MS: u64 = ARMING_GAP_MS;
+
+/// Which gesture starts a dictation. Both modes record the same way and end
+/// in the same [`VoicePhase`]s; they differ only in what begins and ends the
+/// capture.
+///
+/// Chosen by name and persisted (`voice.mode`, `/voice hold` / `/voice tap`),
+/// never inferred from terminal capabilities: both modes read Space, so a
+/// wrong guess makes the spacebar do the other thing without being asked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VoiceMode {
+    /// Hold Space through the warmup to record; release to stop. Needs
+    /// either release reporting or OS key-repeat (see the module docs).
+    #[default]
+    Hold,
+    /// Tap Space on an empty composer to record; tap again to stop. Needs
+    /// neither, which is the point.
+    Tap,
+}
+
+impl VoiceMode {
+    /// Every mode, in the order `/voice` lists them.
+    pub const ALL: &'static [VoiceMode] = &[VoiceMode::Hold, VoiceMode::Tap];
+
+    /// The persisted spelling (`voice.mode`) and the `/voice` argument.
+    pub fn slug(self) -> &'static str {
+        match self {
+            VoiceMode::Hold => "hold",
+            VoiceMode::Tap => "tap",
+        }
+    }
+
+    /// Parse a persisted or typed mode. Case-insensitive and space-trimmed;
+    /// `None` for anything else, so an unreadable `voice.mode` falls back to
+    /// the default rather than disabling dictation.
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "hold" => Some(VoiceMode::Hold),
+            "tap" => Some(VoiceMode::Tap),
+            _ => None,
+        }
+    }
+}
+
 /// Where the dictation gesture currently stands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VoicePhase {
@@ -134,8 +211,12 @@ pub struct VoiceUi {
     pub enabled: bool,
     /// Whether the terminal reports key release (the kitty keyboard protocol
     /// was pushed — `TerminalGuard::kitty`). With it, release ends the hold
-    /// on the event; without it, the repeat-gap fallback does.
+    /// on the event; without it, the repeat-gap fallback does. Inert in
+    /// [`VoiceMode::Tap`], which ends a capture on the next space instead.
     pub release_events: bool,
+    /// `voice.mode` from settings, threaded in via `DeckOptions` and
+    /// switchable mid-session by `/voice` ([`crate::envelope::Inbound::VoiceConfig`]).
+    pub mode: VoiceMode,
     phase: VoicePhase,
 }
 
@@ -163,11 +244,31 @@ impl VoiceUi {
     }
 
     /// A plain space was dispatched normally and the composer really grew by
-    /// one space at the cursor. Starts or extends the arming run; the warmup
-    /// itself completes on [`Self::tick`], so this never returns a command.
-    pub fn typed_space(&mut self, now_ms: u64) {
+    /// one space at the cursor. `composer_was_empty` reports whether that
+    /// space landed into an empty composer — the shell knows, and only the
+    /// shell can know, because dispatch is what decides where a key goes.
+    ///
+    /// In [`VoiceMode::Hold`] this starts or extends the arming run and the
+    /// warmup completes on [`Self::tick`], so it returns nothing. In
+    /// [`VoiceMode::Tap`] it *is* the start: there is no warmup to wait
+    /// through, so the capture opens here and the one space it typed is
+    /// retracted immediately.
+    pub fn typed_space(&mut self, now_ms: u64, composer_was_empty: bool) -> VoiceCmd {
         if !self.enabled {
-            return;
+            return VoiceCmd::None;
+        }
+        if self.mode == VoiceMode::Tap {
+            // Only from rest and only from an empty composer: mid-sentence a
+            // space is a word gap, and a gesture that fires there would make
+            // the spacebar unusable for typing.
+            if self.phase == VoicePhase::Idle && composer_was_empty {
+                self.phase = VoicePhase::Listening {
+                    since_ms: now_ms,
+                    last_ms: now_ms,
+                };
+                return VoiceCmd::Start { retract: 1 };
+            }
+            return VoiceCmd::None;
         }
         self.phase = match self.phase {
             VoicePhase::Idle => VoicePhase::Arming {
@@ -184,22 +285,46 @@ impl VoiceUi {
             },
             other => other,
         };
+        VoiceCmd::None
     }
 
-    /// A plain space arrived while recording (swallowed by the shell): the
-    /// key is still held.
-    pub fn space_repeat(&mut self, now_ms: u64) {
-        if let VoicePhase::Listening { since_ms, .. } = self.phase {
-            self.phase = VoicePhase::Listening {
-                since_ms,
-                last_ms: now_ms,
-            };
+    /// A plain space arrived while recording, so the shell swallowed it
+    /// rather than typing it ([`Self::swallows_space`]).
+    ///
+    /// The two modes read the same event as opposite things, which is why
+    /// this is named for what was *observed* rather than for either reading:
+    /// under [`VoiceMode::Hold`] it is a key-repeat saying the key is still
+    /// down, and under [`VoiceMode::Tap`] it is the second tap, ending the
+    /// capture once [`TAP_MIN_MS`] has passed.
+    pub fn swallowed_space(&mut self, now_ms: u64) -> VoiceCmd {
+        let VoicePhase::Listening { since_ms, .. } = self.phase else {
+            return VoiceCmd::None;
+        };
+        if self.mode == VoiceMode::Tap {
+            if now_ms.saturating_sub(since_ms) >= TAP_MIN_MS {
+                self.phase = VoicePhase::Transcribing { since_ms: now_ms };
+                return VoiceCmd::Stop;
+            }
+            return VoiceCmd::None;
         }
+        self.phase = VoicePhase::Listening {
+            since_ms,
+            last_ms: now_ms,
+        };
+        VoiceCmd::None
     }
 
     /// The terminal reported Space released (only ever arrives when
     /// [`Self::release_events`]).
+    ///
+    /// Inert in [`VoiceMode::Tap`]: the release being reported there is the
+    /// release of the tap that *started* the capture, and ending on it would
+    /// collapse tap mode back into hold mode on exactly the terminals that
+    /// can report releases.
     pub fn space_release(&mut self, now_ms: u64) -> VoiceCmd {
+        if self.mode == VoiceMode::Tap {
+            return VoiceCmd::None;
+        }
         match self.phase {
             // Released inside the warmup: it was a tap (or a short hold);
             // the spaces it typed stay typed.
@@ -257,8 +382,12 @@ impl VoiceUi {
                 }
             }
             VoicePhase::Listening { since_ms, last_ms } => {
-                let released =
-                    !self.release_events && now_ms.saturating_sub(last_ms) > LISTENING_GAP_MS;
+                // Hold mode only. A tap-mode capture has no repeat stream to
+                // go quiet — nothing is being held — so this rule would end
+                // every tap recording a third of a second after it started.
+                let released = self.mode == VoiceMode::Hold
+                    && !self.release_events
+                    && now_ms.saturating_sub(last_ms) > LISTENING_GAP_MS;
                 if released || now_ms.saturating_sub(since_ms) >= MAX_HOLD_MS {
                     self.phase = VoicePhase::Transcribing { since_ms: now_ms };
                     VoiceCmd::Stop
@@ -289,15 +418,19 @@ impl VoiceUi {
     }
 
     /// The pulse-row line for an in-progress gesture, or `None` at rest.
-    /// Deterministic over `(phase, now_ms)` — the goldens render it.
+    /// Deterministic over `(mode, phase, now_ms)` — the goldens render it.
     pub fn status_line(&self, now_ms: u64) -> Option<String> {
         match self.phase {
             VoicePhase::Idle => None,
             VoicePhase::Arming { .. } => Some("◌ keep holding to dictate…".to_string()),
             VoicePhase::Listening { since_ms, .. } => {
                 let s = now_ms.saturating_sub(since_ms) / 1000;
+                let stop = match self.mode {
+                    VoiceMode::Hold => "release to stop",
+                    VoiceMode::Tap => "tap space to stop",
+                };
                 Some(format!(
-                    "● listening {}:{:02} · release to stop · esc cancels",
+                    "● listening {}:{:02} · {stop} · esc cancels",
                     s / 60,
                     s % 60
                 ))
@@ -345,14 +478,14 @@ mod tests {
         assert_eq!(v.status_line(waiting_since + TRANSCRIBE_WAIT_MS), None);
 
         // And a new gesture can start, which is the whole point.
-        v.typed_space(waiting_since + TRANSCRIBE_WAIT_MS);
+        v.typed_space(waiting_since + TRANSCRIBE_WAIT_MS, true);
         assert!(matches!(v.phase(), VoicePhase::Arming { .. }));
     }
 
     use super::*;
 
     fn armed(v: &mut VoiceUi, start_ms: u64) {
-        v.typed_space(start_ms);
+        v.typed_space(start_ms, true);
         assert!(matches!(v.phase(), VoicePhase::Arming { .. }));
     }
 
@@ -363,7 +496,9 @@ mod tests {
         let mut t = 0;
         while t < WARMUP_MS {
             t += 50;
-            v.typed_space(t);
+            // Only the first space of the run met an empty composer; hold
+            // mode ignores the flag either way.
+            v.typed_space(t, false);
             typed += 1;
             let cmd = v.tick(t);
             if let VoiceCmd::Start { retract } = cmd {
@@ -384,7 +519,7 @@ mod tests {
     #[test]
     fn disabled_never_arms() {
         let mut v = VoiceUi::default();
-        v.typed_space(0);
+        assert_eq!(v.typed_space(0, true), VoiceCmd::None);
         assert_eq!(v.phase(), VoicePhase::Idle);
     }
 
@@ -401,7 +536,7 @@ mod tests {
     fn typing_a_word_after_spaces_aborts_the_arming() {
         let mut v = enabled();
         armed(&mut v, 0);
-        v.typed_space(100);
+        v.typed_space(100, false);
         v.interrupt(); // any other key
         assert_eq!(v.phase(), VoicePhase::Idle);
     }
@@ -426,11 +561,11 @@ mod tests {
             matches!(v.phase(), VoicePhase::Arming { .. }),
             "700ms without a repeat is inside ARMING_GAP_MS"
         );
-        v.typed_space(700);
+        v.typed_space(700, false);
         let mut t = 700;
         loop {
             t += 50;
-            v.typed_space(t);
+            v.typed_space(t, false);
             if let VoiceCmd::Start { .. } = v.tick(t) {
                 break;
             }
@@ -499,7 +634,7 @@ mod tests {
         let mut t = since_ms;
         while t < since_ms + MAX_HOLD_MS {
             t += 100;
-            v.space_repeat(t);
+            v.swallowed_space(t);
         }
         assert_eq!(v.tick(t), VoiceCmd::Stop);
     }
@@ -512,6 +647,170 @@ mod tests {
         // is still listening.
         v.settled();
         assert_eq!(v.phase(), VoicePhase::Idle);
+    }
+
+    fn tapping() -> VoiceUi {
+        VoiceUi {
+            enabled: true,
+            mode: VoiceMode::Tap,
+            ..VoiceUi::default()
+        }
+    }
+
+    /// **The witness.** Tap mode starts and stops a recording on a terminal
+    /// that reports no key releases and whose OS delivers no key-repeat —
+    /// the configuration in which hold mode can never arm, and the reason
+    /// #5347 exists.
+    ///
+    /// Every signal hold mode relies on is withheld here: `release_events`
+    /// is false, and not one repeat is delivered between the two taps. Under
+    /// `VoiceMode::Hold` the same script records nothing at all, which
+    /// `the_same_script_records_nothing_in_hold_mode` below asserts directly.
+    #[test]
+    fn tap_mode_records_with_no_key_repeat_and_no_release_events() {
+        let mut v = tapping();
+        assert!(!v.release_events, "the terminal reports no releases");
+
+        // One tap on an empty composer opens the capture immediately — no
+        // warmup — and retracts the single space it typed.
+        assert_eq!(v.typed_space(0, true), VoiceCmd::Start { retract: 1 });
+        assert!(v.recording());
+        assert!(v.swallows_space());
+
+        // The tick clock runs on with no repeats arriving. Hold mode would
+        // have called that a release long ago; tap mode keeps recording.
+        let mut t = 0;
+        while t < 10 * LISTENING_GAP_MS {
+            t += 50;
+            assert_eq!(v.tick(t), VoiceCmd::None);
+        }
+        assert!(
+            v.recording(),
+            "a silent repeat stream must not end a tap capture"
+        );
+
+        // The second tap ends it.
+        assert_eq!(v.swallowed_space(t), VoiceCmd::Stop);
+        assert!(matches!(v.phase(), VoicePhase::Transcribing { .. }));
+    }
+
+    /// The control for the witness above: the identical script under
+    /// `VoiceMode::Hold` never reaches a recording, so the test proves tap
+    /// mode rather than proving the harness.
+    #[test]
+    fn the_same_script_records_nothing_in_hold_mode() {
+        let mut v = enabled();
+        assert_eq!(v.typed_space(0, true), VoiceCmd::None);
+        let mut t = 0;
+        while t < 10 * LISTENING_GAP_MS {
+            t += 50;
+            v.tick(t);
+        }
+        assert!(!v.recording());
+        assert_eq!(
+            v.phase(),
+            VoicePhase::Idle,
+            "the arming gap dismissed it as a tap"
+        );
+    }
+
+    #[test]
+    fn tap_mode_ignores_a_space_typed_into_a_non_empty_composer() {
+        let mut v = tapping();
+        // Mid-sentence, a space is a word gap and must stay one.
+        assert_eq!(v.typed_space(0, false), VoiceCmd::None);
+        assert_eq!(v.phase(), VoicePhase::Idle);
+        // The empty composer is what arms it.
+        assert_eq!(v.typed_space(10, true), VoiceCmd::Start { retract: 1 });
+    }
+
+    #[test]
+    fn tap_mode_never_arms_while_disabled() {
+        let mut v = VoiceUi {
+            mode: VoiceMode::Tap,
+            ..VoiceUi::default()
+        };
+        assert_eq!(v.typed_space(0, true), VoiceCmd::None);
+        assert_eq!(v.phase(), VoicePhase::Idle);
+    }
+
+    /// A space held in tap mode delivers repeats that are indistinguishable
+    /// from a second tap. `TAP_MIN_MS` is what stops the first of them ending
+    /// the capture it started — the capture survives to the floor and then
+    /// ends, rather than posting silence to a provider.
+    #[test]
+    fn a_held_space_in_tap_mode_cannot_stop_the_capture_it_started() {
+        let mut v = tapping();
+        assert_eq!(v.typed_space(0, true), VoiceCmd::Start { retract: 1 });
+        // Every repeat arriving strictly inside the floor is refused.
+        let mut t = 50;
+        while t < TAP_MIN_MS {
+            assert_eq!(v.swallowed_space(t), VoiceCmd::None, "at {t}ms");
+            assert!(v.recording());
+            t += 50;
+        }
+        // At the floor, the next one ends the capture.
+        assert_eq!(v.swallowed_space(TAP_MIN_MS), VoiceCmd::Stop);
+    }
+
+    /// The release of the *starting* tap must not end the capture: a terminal
+    /// that reports releases would otherwise collapse tap mode into hold
+    /// mode, which is the mode the user explicitly did not pick.
+    #[test]
+    fn a_reported_release_does_not_end_a_tap_capture() {
+        let mut v = tapping();
+        v.release_events = true;
+        assert_eq!(v.typed_space(0, true), VoiceCmd::Start { retract: 1 });
+        assert_eq!(v.space_release(20), VoiceCmd::None);
+        assert!(v.recording(), "the tap's own release is not the stop");
+        assert_eq!(v.swallowed_space(TAP_MIN_MS), VoiceCmd::Stop);
+    }
+
+    #[test]
+    fn esc_cancels_a_tap_recording_and_the_cap_still_binds() {
+        let mut v = tapping();
+        v.typed_space(0, true);
+        assert!(v.esc_cancels());
+        assert_eq!(v.cancel(), VoiceCmd::Cancel);
+        assert_eq!(v.phase(), VoicePhase::Idle);
+
+        // And the hard cap ends a tap capture nobody stops.
+        let mut v = tapping();
+        v.typed_space(0, true);
+        assert_eq!(v.tick(MAX_HOLD_MS), VoiceCmd::Stop);
+    }
+
+    #[test]
+    fn the_tap_status_line_names_the_key_that_stops_it() {
+        let mut v = tapping();
+        v.typed_space(0, true);
+        let line = v.status_line(65_000).unwrap();
+        assert!(line.contains("listening 1:05"), "{line}");
+        assert!(line.contains("tap space to stop"), "{line}");
+        // Hold mode still says what it always said — the goldens render it.
+        let mut h = enabled();
+        hold_through_warmup(&mut h);
+        let VoicePhase::Listening { since_ms, .. } = h.phase() else {
+            panic!("recording");
+        };
+        assert!(
+            h.status_line(since_ms).unwrap().contains("release to stop"),
+            "hold mode's wording is unchanged"
+        );
+    }
+
+    #[test]
+    fn every_mode_round_trips_through_its_slug() {
+        for mode in VoiceMode::ALL {
+            assert_eq!(VoiceMode::parse(mode.slug()), Some(*mode));
+        }
+        // Case and surrounding space are forgiven; junk is not.
+        assert_eq!(VoiceMode::parse(" TAP "), Some(VoiceMode::Tap));
+        assert_eq!(VoiceMode::parse("hold"), Some(VoiceMode::Hold));
+        assert_eq!(VoiceMode::parse("push"), None);
+        // The default is the mode that shipped first, so an existing
+        // `voice.enabled` with no `voice.mode` behaves exactly as before.
+        assert_eq!(VoiceMode::default(), VoiceMode::Hold);
     }
 
     #[test]

--- a/crates/stella-tui/tests/deck_render_snapshots/voice.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots/voice.rs
@@ -15,7 +15,7 @@
 //! `the_caret_recolours_while_the_microphone_is_live` holds that half.
 
 use stella_tui::deck::DeckTab;
-use stella_tui::voice::VoiceCmd;
+use stella_tui::voice::{VoiceCmd, VoiceMode};
 
 use super::{H, W, assert_golden, fixture_model, render_frame, ui_for};
 
@@ -30,17 +30,18 @@ fn deck_render_snapshots_pin_the_voice_recording_row() {
     // warmup completes mid-run, and the frame renders at `model.now_ms`, so
     // the elapsed time it shows is fixture data.
     let start = model.now_ms - 2_000;
-    ui.voice.typed_space(start);
+    ui.voice.typed_space(start, true);
     let mut t = start;
     let mut started = false;
     while t < model.now_ms {
         t += 50;
         // The same routing the shell applies: once recording, a space event
-        // is "still held" rather than a character.
+        // is swallowed rather than typed — in hold mode that reads as "still
+        // held".
         if ui.voice.swallows_space() {
-            ui.voice.space_repeat(t);
+            ui.voice.swallowed_space(t);
         } else {
-            ui.voice.typed_space(t);
+            ui.voice.typed_space(t, false);
         }
         if matches!(ui.voice.tick(t), VoiceCmd::Start { .. }) {
             started = true;
@@ -53,6 +54,44 @@ fn deck_render_snapshots_pin_the_voice_recording_row() {
     assert_golden(
         "session_voice_recording",
         "the SESSION tab while push-to-talk is listening",
+        W,
+        H,
+        &frame,
+    );
+}
+
+/// The same row in tap mode, which has to say a different thing: nothing is
+/// being held, so "release to stop" would be advice a person cannot follow.
+///
+/// A second golden rather than an assertion on the string, for the reason the
+/// parent's module docs give — a `contains` check cannot see a row that moved
+/// or a column that shifted.
+#[test]
+fn deck_render_snapshots_pin_the_tap_mode_recording_row() {
+    let model = fixture_model();
+    let mut ui = ui_for(DeckTab::Session);
+    ui.voice.enabled = true;
+    ui.voice.mode = VoiceMode::Tap;
+    // One tap on an empty composer, 2s before the fixture clock's "now": the
+    // capture opens on the space itself, with no warmup to run through.
+    let start = model.now_ms - 2_000;
+    assert!(matches!(
+        ui.voice.typed_space(start, true),
+        VoiceCmd::Start { retract: 1 }
+    ));
+    // The tick clock runs on with no repeats arriving: hold mode would have
+    // called that a release, and tap mode keeps recording.
+    let mut t = start;
+    while t < model.now_ms {
+        t += 50;
+        assert_eq!(ui.voice.tick(t), VoiceCmd::None);
+    }
+    assert!(ui.voice.recording(), "the frame is of a live recording");
+
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "session_voice_recording_tap",
+        "the SESSION tab while tap-mode dictation is listening",
         W,
         H,
         &frame,

--- a/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
@@ -14,7 +14,7 @@
 │ │  e               edit the selected skill                                       !cmd            run a shell command NOW (skips the queue)                 │ │
 │ │  p               pin / unpin                                                   /               slash commands — ↑↓ pick · tab completes · ⏎ runs         │ │
 │ │  n               new skill — drafted by the LLM                                ctrl-v          paste — a copied image is attached to the prompt          │ │
-│ │  ctrl-o          preview                                                       space (hold)    dictate — keep holding until listening, release to inser… │ │
+│ │  ctrl-o          preview                                                       space           dictate — hold until listening, or tap to start and stop… │ │
 │ │  ctrl-x ×2       delete (press twice to confirm)                               ctrl-a          SUB-AGENTS — o open · n nudge · f flag · x stop · xx del… │ │
 │ │  type            search skills                                                 ctrl-t          the queue editor                                          │ │
 │ │                                                                                ctrl-e          SESSIONS — every session on this machine                  │ │

--- a/crates/stella-tui/tests/snapshots/deck/session_voice_recording_tap.txt
+++ b/crates/stella-tui/tests/snapshots/deck/session_voice_recording_tap.txt
@@ -1,0 +1,45 @@
+# deck golden · session_voice_recording_tap
+# the SESSION tab while tap-mode dictation is listening
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
+
+◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
+    symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
+    memory  event-log REPL                                                                                                                90 tok
+    ⋯ ctrl+o for provenance and budget
+
+── PLAN ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  Planning the automations cluster: list, editor, triggers, workflows.
+
+☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
+── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
+ │ ⎿ 312 lines                                                                                                                               42ms
+
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
+ │ ⎿                                                                                                                                 +4 −1 · 18ms
+ │     10 -  const items = []
+ │     10 +  const items = useAutomations()
+ │     11 +  const [q, setQ] = useState("")
+ │     12 +  const filtered = filter(items, q)
+ │     13 +  const onNew = () => open()
+
+ │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
+ │   irreducible generation
+
+☰  plan  5/7  ·  Workflows canvas
+
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
+
+ ● listening 0:02 · tap space to stop · esc cancels
+>>>
+ ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help

--- a/docs/adr/0020-voice-dictation-push-to-talk.md
+++ b/docs/adr/0020-voice-dictation-push-to-talk.md
@@ -82,8 +82,11 @@ enable it.
 - A terminal with `REPORT_EVENT_TYPES` gets crisp release detection; every
   other terminal inherits the repeat-gap heuristic, which requires OS
   key-repeat to be enabled. A user with key-repeat disabled and no kitty
-  protocol cannot hold-to-talk; the tap-to-toggle mode Claude Code also
-  ships is the remedy and is tracked as a follow-up issue.
+  protocol cannot hold-to-talk. `voice.mode = "tap"` (#5347) is the way in
+  for them: one space on an empty composer starts the capture and the next
+  ends it, which needs neither signal. It is chosen by name rather than
+  inferred from terminal capabilities — both modes read the spacebar, so a
+  wrong guess makes Space do the other thing without being asked.
 - Recording is bounded (a hard cap, and the elapsed time is drawn from the
   deck's tick clock), and audio is written to a temporary file that is
   removed after transcription — nothing about a dictation persists except

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -477,6 +477,13 @@ theme = "stella-dark"
 
 [voice]
 enabled = false
+# mode = "hold"              # hold | tap. `hold` holds Space through a warmup
+#                            # and stops on release; `tap` taps Space on an
+#                            # empty prompt to start and taps again to stop.
+#                            # Pick tap when holding Space never starts a
+#                            # recording: hold needs either key-release
+#                            # reporting or OS key repeat, and tap needs
+#                            # neither. `/voice tap` writes this for you.
 # provider = "openai"        # or "groq", or any [providers] entry with a
 #                            # compatible base_url (a local Whisper server)
 # model = "whisper-1"

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -248,6 +248,14 @@ Open a tab or run an action:
     Switch and persist the colour theme (`stella-dark`, `stella-light`). With no
     argument, show the current theme.
   </OptionCard>
+  <OptionCard name="/voice">
+    Turn dictation on and pick the spacebar gesture: `/voice hold` (hold Space
+    through a warmup, release to stop), `/voice tap` (tap Space on an empty
+    prompt to start, tap again to stop), `/voice off`. Persists, and takes
+    effect in this session. With no argument, show what is set. Pick `tap` if
+    holding Space never starts a recording — hold needs either a terminal that
+    reports key releases or OS key repeat, and tap needs neither.
+  </OptionCard>
   <OptionCard name="/init">
     Index the workspace: domain taxonomy plus the code graph.
   </OptionCard>

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -478,17 +478,27 @@ the theme removes the `ui` key rather than leaving an empty `{}` behind.
 
 ## The `voice` section
 
-Push-to-talk dictation: hold Space in the composer, speak, release, and the transcript
-lands at the cursor. Off by default — recording streams microphone audio to the provider
-named below, an egress you opt into by name. The provider id resolves through
-`providers` (or the built-in table) for its endpoint and API key, so this section holds
-no credential of its own; any provider with an OpenAI-compatible `audio/transcriptions`
-endpoint works, a local Whisper server included.
+Dictation from the composer: speak, and the transcript lands at the cursor. Off by
+default — recording streams microphone audio to the provider named below, an egress you
+opt into by name. The provider id resolves through `providers` (or the built-in table)
+for its endpoint and API key, so this section holds no credential of its own; any
+provider with an OpenAI-compatible `audio/transcriptions` endpoint works, a local
+Whisper server included.
+
+`/voice tap`, `/voice hold` and `/voice off` write both fields below and take effect in
+the session that runs them, so nothing here has to be edited by hand.
 
 <CardGrid size="md">
   <OptionCard name="enabled" defaultValue="false">
-    Whether holding Space records at all. Until this is `true`, a held spacebar just
-    types spaces.
+    Whether Space records at all. Until this is `true`, the spacebar just types spaces.
+  </OptionCard>
+  <OptionCard name="mode" defaultValue="hold">
+    Which gesture dictates. `hold` holds Space through a short warmup and stops on
+    release; `tap` taps Space on an empty prompt to start and taps again to stop.
+
+    Pick `tap` if holding Space never starts a recording: hold mode needs either a
+    terminal that reports key releases or OS key repeat, and with neither one a hold
+    cannot be told from a tap. Tap mode needs neither.
   </OptionCard>
   <OptionCard name="provider" defaultValue="openai">
     The provider id whose `audio/transcriptions` endpoint transcribes. Any `providers`
@@ -504,7 +514,7 @@ endpoint works, a local Whisper server included.
 
 ```json title="<workspace>/.stella/settings.json"
 {
-  "voice": { "enabled": true, "provider": "openai", "model": "whisper-1" }
+  "voice": { "enabled": true, "mode": "tap", "provider": "openai", "model": "whisper-1" }
 }
 ```
 

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -377,8 +377,12 @@ mid_turn_prompt = "queue"   # queue | ask | spawn
 
 ### `[voice]`
 
-Push-to-talk dictation: hold Space in the composer, speak, release, and the transcript
-lands at the cursor. Whole-block last-wins, like `[ui]`. Off by default — recording
+Dictation from the composer: speak, and the transcript lands at the cursor. Hold Space
+through a warmup and release, or set `mode = "tap"` to tap Space on an empty prompt to
+start and tap again to stop — the mode to pick when holding Space never starts anything,
+because your terminal reports no key releases and OS key repeat is off. `/voice tap`,
+`/voice hold` and `/voice off` write these fields for you. Whole-block last-wins, like
+`[ui]`. Off by default — recording
 streams microphone audio to the provider named below, an egress you opt into by name.
 The provider id resolves through `[providers]` (or the built-in table) for its endpoint
 and API key, so this section holds no credential of its own; any provider with an
@@ -387,6 +391,7 @@ OpenAI-compatible `audio/transcriptions` endpoint works, a local Whisper server 
 ```toml title="stella.toml"
 [voice]
 enabled = true
+mode = "hold"                # hold | tap
 provider = "openai"          # any [providers] entry with a compatible base_url
 model = "whisper-1"
 language = "en"              # BCP 47 hint; omit to auto-detect


### PR DESCRIPTION
## What & why

Push-to-talk (#5346, ADR 0020) shipped hold mode only, and hold mode needs either kitty-protocol release events or OS key-repeat to tell a hold from a tap. A user with key-repeat disabled in a terminal that reports no releases could never start a dictation — `stella_tui::voice`'s own module docs named this issue as the remedy. Dictation was also reachable only by hand-editing `voice.enabled` in a settings file.

**Tap mode** (`voice.mode = "tap"`): one space observed into an *empty* composer opens the capture, and the next one ends it. Neither signal hold mode depends on is required. It is a second entry path into the same `Listening`/`Transcribing` phases, so the caret recolour, the status line, Esc and the transcript paste are written once and unchanged.

The mode is chosen by name, never inferred from terminal capabilities: both modes read the spacebar, so guessing wrong makes Space do the other thing at the moment someone is trying to type.

`TAP_MIN_MS` is the floor a capture cannot be stopped inside. A space *held* in tap mode delivers key-repeats that are indistinguishable from a second tap — there is no signal separating them, which is the premise tap mode exists under — so without a floor the first repeat closes the capture it just opened and posts silence to a transcription provider. It is set at `ARMING_GAP_MS`, already this module's measure of the slowest initial key-repeat delay.

**`/voice hold|tap|off`** persists both fields and takes effect in the session that runs it. `VoiceSettings::save_to` follows `UiSettings::save_to`'s read-modify-write contract, so switching dictation on cannot drop a configured local Whisper endpoint (asserted, not argued). The live half rides a new `Inbound::VoiceConfig`, sent only on a successful write — persisting alone would make `/voice tap` report success and change nothing until the next session, which is the opposite of "first use is one command".

Closes #5347

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`voice::tests::tap_mode_records_with_no_key_repeat_and_no_release_events` — a capture starts and stops with `release_events` false and not one repeat delivered. It does not merely fail on `main`; it does not compile there, since `VoiceMode` does not exist.

Because "it fails on main" is weak evidence when the harness itself is new, two controls sit beside it:

- `the_same_script_records_nothing_in_hold_mode` runs the **identical** script under `VoiceMode::Hold` and asserts no recording ever starts — so the witness proves tap mode rather than proving the fixture.
- `a_held_space_in_tap_mode_cannot_stop_the_capture_it_started` pins the `TAP_MIN_MS` floor at its boundary.

Others: `a_reported_release_does_not_end_a_tap_capture` (a release-reporting terminal must not collapse tap mode into hold mode), `tap_mode_ignores_a_space_typed_into_a_non_empty_composer`, `voice_mode_save_preserves_the_transcription_endpoint_and_roundtrips` (the `/voice tap` persistence witness the issue asks for, including that `[voice]`'s provider survives), `an_absent_or_junk_voice_mode_falls_back_to_hold`, and `a_voice_config_envelope_rebinds_the_gesture_in_this_session`.

Rendering is pinned by a second golden frame, `session_voice_recording_tap` — the tap row reads `● listening 0:02 · tap space to stop · esc cancels`, and hold mode's wording is unchanged (its golden did not move). The help-sheet golden moved by exactly the one keymap row.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-tui`, `cargo test -p stella-cli` — both green
- [x] `make guards-fast` — 13 passed, 0 failed
- [x] Docs updated: `settings.mdx`, `stella-toml.mdx`, `stella.example.toml`, `chat.mdx`'s slash list, and ADR 0020's consequence (tap is no longer "tracked as a follow-up")
- [x] `Closes #5347` in this description **and** as a commit trailer

Per CLAUDE.md ("CI builds and tests; this laptop does not") the workspace build and full suite are CI's — this PR's evidence is its CI run, plus the targeted runs above.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

Two size ceilings were hit and **split rather than raised** — no baseline entry was added:

- `deck_ui.rs` is a grandfathered god file closed to growth, so the three voice envelopes moved to `deck_ui/voice_inbound.rs`. This leaves it *below* its recorded ceiling rather than at it. `voice.rs` stays a pure fold — it never learns what a composer or a notice is — which is why the fold went under `deck_ui/` and not into the state machine.
- The settings witnesses went to `settings/tests/voice.rs` rather than push `settings/tests.rs` past 1500.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls (the transcription request is unchanged)
- [x] Exemplar followed: `theme_cmd.rs` for the command's shape (parser / persist / reply in one module, dispatcher only wires them to `say`), and `UiSettings::save_to` for the section writer.

## Anything reviewers should know?

**One rename.** `VoiceUi::space_repeat` → `swallowed_space`. The two modes read that event as opposite things — a key-repeat in hold mode, the stop tap in tap mode — so it is now named for what the shell *observed* rather than for either reading. No test was deleted; the two moved settings tests are new in this PR.

**The `TAP_MIN_MS` trade, stated plainly.** A deliberate double-tap faster than 750ms will not stop the capture. That is a real cost, accepted because nobody dictates for under three quarters of a second and the status line shows the recording is live throughout. The alternative — no floor — makes a held space in tap mode record nothing at all.

**What is not covered.** Whether a given terminal actually withholds both release reporting and key-repeat is a fact about a user's machine, not something a unit test can assert; the witness withholds both signals at the machine's boundary, which is the closest this crate can get without a terminal in the loop.
