### PR TITLE
fix(stella-core): mined skills describe themselves in words selection can match (#5335)

### DIFF
--- a/crates/stella-cli/src/skill_manager/learned.rs
+++ b/crates/stella-cli/src/skill_manager/learned.rs
@@ -370,7 +370,11 @@ mod tests {
     fn write_learned_skill(dir: &Path, name: &str, lesson: &str, traces: &[u64]) {
         let candidate = stella_core::skills::SkillCandidate {
             name: name.to_string(),
-            description: format!("Learned from {} observations.", traces.len()),
+            // What `mine_skill_candidates` now writes: the lesson's own
+            // words, not the occurrence count (#5335). The count moved into
+            // the rendered `## Evidence` section, and this fixture claims to
+            // be the bytes the learner puts on disk — so it has to follow.
+            description: lesson.to_string(),
             domains: vec!["testing".into()],
             body: lesson.to_string(),
             occurrences: traces.len(),

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -879,6 +879,66 @@ pub struct SkillRejection {
 /// against. Those three must agree byte-for-byte or a rejection silently
 /// misses — and `migration_contract::candidate_identity_is_pinned_to_a_literal`
 /// is the literal all three are pinned to.
+/// The longest a mined description may be. Descriptions are one-liners —
+/// rendered into a single frontmatter field, listed in a fixed-width column,
+/// and read by the scorer as a bag of words, where every extra term the
+/// prompt does not share lowers `coverage`'s ratio. A lesson longer than this
+/// is cut at a word boundary.
+const DESCRIPTION_MAX_CHARS: usize = 200;
+
+/// The shortest a first sentence may be before a `.`/`!`/`?` is believed to
+/// end it. Without this, a lesson opening `e.g. ` or `cf. ` describes itself
+/// in four characters. Any real sentence clears it, so the guard costs
+/// nothing it was not meant to catch.
+const SENTENCE_MIN_CHARS: usize = 24;
+
+/// The one-line description a mined candidate is **found** by.
+///
+/// [`select_skills_reporting`] scores `name + description` and nothing else,
+/// so this string is half of a learned skill's entire searchable vocabulary —
+/// and the other half, [`candidate_id`], is a slug `slugify` truncates at 40
+/// characters. This used to be `"Learned from N observations."`: two words
+/// that match no prompt anyone will ever write, occupying the one field that
+/// decides whether the skill is reachable at all. A skill was therefore
+/// findable only through whatever fragment of its lesson survived those 40
+/// characters — the mechanism that mints skills and the mechanism that
+/// surfaces them tuned against each other (#5335).
+///
+/// So the lesson describes itself: its first sentence, whitespace collapsed
+/// (the frontmatter writer emits `description:` on one line, and a lesson
+/// mined from a multi-line note would otherwise produce a `SKILL.md` that
+/// parses back as something else), capped at [`DESCRIPTION_MAX_CHARS`].
+///
+/// The provenance it replaced is not lost — [`render_skill_markdown`] writes
+/// it into the file, which is where a person reading the skill looks for it
+/// and where no scorer is charged for it.
+fn candidate_description(text: &str) -> String {
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut end = flat.len();
+    let mut taken = 0usize;
+    for (i, ch) in flat.char_indices() {
+        taken += 1;
+        if matches!(ch, '.' | '!' | '?') && taken >= SENTENCE_MIN_CHARS {
+            let rest = &flat[i + ch.len_utf8()..];
+            if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+                end = i;
+                break;
+            }
+        }
+    }
+    let sentence = flat[..end].trim_end_matches(['.', '!', '?', ' ']);
+    if sentence.chars().count() <= DESCRIPTION_MAX_CHARS {
+        return sentence.to_string();
+    }
+    // Cut at a word boundary rather than mid-word: a half word is neither
+    // readable nor a term the scorer can match.
+    let capped: String = sentence.chars().take(DESCRIPTION_MAX_CHARS).collect();
+    match capped.rsplit_once(char::is_whitespace) {
+        Some((head, _)) if !head.is_empty() => format!("{head}…"),
+        _ => capped,
+    }
+}
+
 pub fn candidate_id(text: &str) -> String {
     format!(
         "{}-{}",
@@ -971,15 +1031,13 @@ pub fn mine_skill_candidates(
             })
             .collect();
 
-        let plural = if occurrences == 1 { "" } else { "s" };
-        let salience_note = if salient {
-            " (includes a salient signal)"
-        } else {
-            ""
-        };
         candidates.push(SkillCandidate {
             name: candidate_id(&text),
-            description: format!("Learned from {occurrences} observation{plural}{salience_note}."),
+            // The lesson's own words, so the skill is reachable by its
+            // subject matter (#5335). The occurrence count that used to sit
+            // here is written into the file instead — see
+            // `candidate_description` and `render_skill_markdown`.
+            description: candidate_description(&text),
             domains,
             occurrences,
             salient,
@@ -1001,7 +1059,8 @@ pub fn mine_skill_candidates(
 /// Render the exact `SKILL.md` content for `candidate` — the same frontmatter
 /// shape [`skill_from_file`] parses back, including the `origin: auto` marker
 /// so a reload tags it [`SkillOrigin::AutoCreated`], plus an `## Evidence`
-/// section listing the backing occurrences. Writing this to disk is the I/O
+/// section opening with the provenance line and listing the backing
+/// occurrences. Writing this to disk is the I/O
 /// half `stella-cli` owns; this half is pure and round-trips through the
 /// parser above.
 pub fn render_skill_markdown(candidate: &SkillCandidate) -> String {
@@ -1014,7 +1073,20 @@ pub fn render_skill_markdown(candidate: &SkillCandidate) -> String {
     out.push_str("origin: auto\n");
     out.push_str("---\n\n");
     out.push_str(&candidate.body);
-    out.push_str("\n\n## Evidence\n\n");
+    // The provenance line, which the `description` field used to carry until
+    // #5335 gave that field to the lesson's own vocabulary. Here it costs the
+    // scorer nothing and sits where a person reading the skill looks for it,
+    // directly above the occurrences it counts.
+    let plural = if candidate.occurrences == 1 { "" } else { "s" };
+    let salience_note = if candidate.salient {
+        " (includes a salient signal)"
+    } else {
+        ""
+    };
+    out.push_str(&format!(
+        "\n\n## Evidence\n\nLearned from {} observation{plural}{salience_note}.\n\n",
+        candidate.occurrences
+    ));
     for e in &candidate.evidence {
         out.push_str(&format!(
             "- `{}` (observed at {}): {}\n",

--- a/crates/stella-core/src/skills/migration_contract.rs
+++ b/crates/stella-core/src/skills/migration_contract.rs
@@ -19,7 +19,12 @@
 //! * **byte-identical skill files** — the exact `SKILL.md` bytes for a fixed
 //!   candidate. This is the gate criterion "existing skill files are
 //!   byte-identical after migration", reduced to the one function that decides
-//!   it.
+//!   it. The literal moved once, in #5335, and the reason is on the test: a
+//!   provenance line joined the `## Evidence` section when the `description`
+//!   field was given to the lesson's own vocabulary. Identity did not move
+//!   with it — `candidate_id` hashes the lesson text, not the description —
+//!   so no file on disk was orphaned or duplicated, which is the failure this
+//!   contract exists to catch.
 //! * **the per-session cap** and **never clobbering a hand-edited file**,
 //!   including the order they are checked in.
 //!
@@ -76,11 +81,27 @@ fn candidate_identity_is_pinned_to_a_literal() {
 /// literal. Frontmatter key order, the `origin: auto` marker, the blank-line
 /// placement, and the `## Evidence` line format are all required: the
 /// parser round-trips them, and a user's `git diff` sees every one.
+///
+/// **This literal moved once (#5335)**: the provenance
+/// sentence left the `description` field — where it was the only thing the
+/// selection scorer could read, and matched no prompt — and became the first
+/// line of `## Evidence`. What that costs is bounded and was checked rather
+/// than assumed. Nothing re-renders a `SKILL.md` that already exists (the
+/// miner's `already_captured` guard and the no-clobber check below), so no
+/// file on disk was rewritten; and `candidate_id` hashes the lesson text
+/// rather than the description, so `candidate_identity_is_pinned_to_a_literal`
+/// is untouched and no skill was orphaned or duplicated. Only skills minted
+/// from here on carry the new shape.
+///
+/// The `description` below is what `candidate_description` now yields for
+/// `PINNED_LESSON`, so these bytes are the bytes a real mining pass writes
+/// today rather than a shape only this test produces.
 #[test]
 fn rendered_skill_bytes_are_pinned() {
     let candidate = SkillCandidate {
         name: "prefer-updating-witness-test-assertions-e2010443".into(),
-        description: "Learned from 2 observations.".into(),
+        description: "Prefer updating witness-test assertions to match the live renderer output"
+            .into(),
         domains: vec!["testing".into(), "cli".into()],
         body: PINNED_LESSON.into(),
         occurrences: 2,
@@ -103,7 +124,7 @@ fn rendered_skill_bytes_are_pinned() {
         render_skill_markdown(&candidate),
         "---\n\
          name: prefer-updating-witness-test-assertions-e2010443\n\
-         description: Learned from 2 observations.\n\
+         description: Prefer updating witness-test assertions to match the live renderer output\n\
          domains: [testing, cli]\n\
          origin: auto\n\
          ---\n\
@@ -111,6 +132,8 @@ fn rendered_skill_bytes_are_pinned() {
          Prefer updating witness-test assertions to match the live renderer output.\n\
          \n\
          ## Evidence\n\
+         \n\
+         Learned from 2 observations.\n\
          \n\
          - `reflection:101` (observed at 101): Prefer updating witness-test assertions to match the live renderer output.\n\
          - `reflection:100` (observed at 100): Prefer updating witness-test assertions to match the live renderer output.\n"

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -1101,3 +1101,114 @@ proptest::proptest! {
         proptest::prop_assert_eq!(parsed.origin, SkillOrigin::AutoCreated);
     }
 }
+
+// ---- #5335: a mined skill's description is vocabulary selection can match ----
+
+/// The lesson the witness below mines. Its discriminating words — `sqlx`,
+/// `directory` — sit past the 40 characters `slugify` keeps, so the candidate
+/// name cannot carry them and the description is the only place they can
+/// reach the scorer.
+const SQLX_LESSON: &str = "Always add a down migration to every schema change \
+                           that touches the sqlx migrations directory";
+
+/// **The witness (#5335).** A mined skill whose lesson is about sqlx
+/// migrations is selected for a prompt about sqlx migrations.
+///
+/// It was not, and the reason was structural rather than a tuning miss. The
+/// miner wrote `description: "Learned from N observations."` while
+/// `select_skills_reporting` scores `name + description` and nothing else, so
+/// a learned skill's entire searchable vocabulary was its 40-character slug
+/// plus two words that match no prompt ever written. The mechanism that mints
+/// skills and the mechanism that surfaces them were tuned against each other.
+#[test]
+fn a_mined_skill_is_selected_for_a_prompt_about_its_own_lesson() {
+    let obs: Vec<SkillObservation> = (1..=3).map(|i| observation(SQLX_LESSON, i)).collect();
+    let candidates = mine_skill_candidates(obs, &[], &[], &SkillMineConfig::default());
+    assert_eq!(candidates.len(), 1);
+    let candidate = &candidates[0];
+
+    // The words the prompt will share are genuinely absent from the name, so
+    // this test cannot pass by accident through the slug.
+    assert!(
+        !candidate.name.contains("sqlx"),
+        "the slug truncates before `sqlx`, which is the whole premise: {}",
+        candidate.name
+    );
+
+    let skill = Skill {
+        name: candidate.name.clone(),
+        description: candidate.description.clone(),
+        domains: candidate.domains.clone(),
+        body: candidate.body.clone(),
+        origin: SkillOrigin::AutoCreated,
+        source_path: format!(".stella/skills/{}/SKILL.md", candidate.name),
+        contributed_by: None,
+    };
+
+    let selection = select_skills_reporting(
+        std::slice::from_ref(&skill),
+        "how should I write the sqlx migrations for this schema change",
+        &[],
+        &SelectionConfig::default(),
+    );
+    assert_eq!(
+        selection.selected.len(),
+        1,
+        "the mined skill must be reachable by its own subject matter; \
+         description was {:?}",
+        skill.description
+    );
+    assert!(
+        selection.selected[0]
+            .matched_terms
+            .contains(&"sqlx".to_string()),
+        "matched on {:?}",
+        selection.selected[0].matched_terms
+    );
+}
+
+/// The frontmatter writer emits `description:` on one line
+/// ([`render_skill_markdown`]), so a description carrying a newline would
+/// produce a `SKILL.md` that parses back as something else. The boilerplate it
+/// replaces was single-line by construction; a lesson's own words are not.
+#[test]
+fn a_mined_description_is_one_line_and_round_trips_through_the_file() {
+    let lesson = "Prefer `ripgrep` over grep.\nIt is faster\r\nand respects .gitignore.";
+    let obs: Vec<SkillObservation> = (1..=3).map(|i| observation(lesson, i)).collect();
+    let candidates = mine_skill_candidates(obs, &[], &[], &SkillMineConfig::default());
+    assert_eq!(candidates.len(), 1);
+    let candidate = &candidates[0];
+    assert!(
+        !candidate.description.contains('\n') && !candidate.description.contains('\r'),
+        "a multi-line description corrupts the frontmatter: {:?}",
+        candidate.description
+    );
+
+    let rendered = render_skill_markdown(candidate);
+    let parsed = skill_from_file(".stella/skills/x/SKILL.md", &rendered).unwrap();
+    assert_eq!(parsed.description, candidate.description);
+    assert_eq!(parsed.origin, SkillOrigin::AutoCreated);
+}
+
+/// The provenance the description used to carry is not lost — it moves into
+/// the written file, where a person reading the skill can still see how many
+/// observations minted it and whether one was salient.
+#[test]
+fn the_written_skill_still_records_how_many_observations_minted_it() {
+    let obs: Vec<SkillObservation> = (1..=3).map(|i| observation(SQLX_LESSON, i)).collect();
+    let candidates = mine_skill_candidates(obs, &[], &[], &SkillMineConfig::default());
+    let rendered = render_skill_markdown(&candidates[0]);
+    assert!(
+        rendered.contains("3 observation"),
+        "the occurrence count must survive somewhere a reader can find it:\n{rendered}"
+    );
+}
+
+/// A one-word lesson has no sentence to cut and must still describe itself
+/// rather than falling back to prose no prompt matches.
+#[test]
+fn a_short_lesson_becomes_its_own_description() {
+    let obs: Vec<SkillObservation> = (1..=3).map(|i| observation("use pnpm", i)).collect();
+    let candidates = mine_skill_candidates(obs, &[], &[], &SkillMineConfig::default());
+    assert_eq!(candidates[0].description, "use pnpm");
+}

--- a/crates/stella-tui/src/views/skills.rs
+++ b/crates/stella-tui/src/views/skills.rs
@@ -231,13 +231,17 @@ fn render_installed(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
             + meta.chars().count();
         let desc_room = width.saturating_sub(used + 3);
         // A learned row spends its last column on **provenance** rather than
-        // on a description (SPEC 9.2). Nothing is lost: the description a
-        // mined skill carries is `Learned from N observations.`, which is the
-        // trace count already — said less precisely, and without the turn or
-        // the identity `r rename` has to keep. The real prose is in the body,
-        // one `ctrl+o` away. *This* column and not a right-aligned one: the
-        // right edge of an installed row is where per-skill economics land
-        // (#4337).
+        // on a description (SPEC 9.2), because provenance carries the turn and
+        // the identity `r rename` has to keep, and the description does not.
+        //
+        // That trade used to be free: the description a mined skill carried
+        // was `Learned from N observations.`, the trace count said less
+        // precisely. Since #5335 it is the lesson's own first sentence, so
+        // there is now a real thing on the other side of the choice — #5425
+        // is where whether this column should prefer it gets decided. The
+        // full prose is in the body either way, one `ctrl+o` away. *This*
+        // column and not a right-aligned one: the right edge of an installed
+        // row is where per-skill economics land (#4337).
         let tail = provenance(row).unwrap_or_else(|| row.description.clone());
         let desc = if desc_room >= 6 && !tail.is_empty() {
             format!("  {}", truncate(&tail, desc_room))


### PR DESCRIPTION
## What & why

`select_skills_reporting` scores `name + description` and nothing else. `mine_skill_candidates` wrote `description: "Learned from N observations."` — two words that match no prompt anyone will ever write, occupying the one field that decides whether a learned skill is reachable at all. The other half of that vocabulary, `candidate_id`, is a slug `slugify` truncates at 40 characters, so a mined skill was findable only through whatever fragment of its lesson survived the cut. The mechanism that mints skills and the mechanism that surfaces them were tuned against each other, and auto-created skills were self-handicapped in exactly the surface built to surface them.

The lesson now describes itself. `candidate_description` takes the representative text's first sentence, collapses whitespace, and caps it at 200 characters on a word boundary. Two constraints are enforced rather than hoped for:

- **Single line.** `render_skill_markdown` emits `description:` on one line, so a lesson mined from a multi-line note would otherwise produce a `SKILL.md` that parses back as something else. The boilerplate it replaces was single-line by construction; a lesson's own words are not.
- **A sentence terminator counts only after 24 characters**, so a lesson opening `e.g. ` does not describe itself in four.

The provenance is not lost — it opens the `## Evidence` section, directly above the occurrences it counts, where a reader looks for it and where no scorer is charged for it.

Closes #5335

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`skills::tests::a_mined_skill_is_selected_for_a_prompt_about_its_own_lesson`. I ran it against unmodified code before writing the fix; it fails there with `left: 0, right: 1` and the message `description was "Learned from 3 observations."` — the exact defect the issue names.

The fixture is built so it cannot pass by accident: the lesson's discriminating words (`sqlx`, `directory`) sit past the 40 characters `slugify` keeps, and the test **asserts** `!candidate.name.contains("sqlx")` before selecting, so the slug cannot be what carries it. It then asserts `sqlx` is in `matched_terms`, not merely that something was selected.

`a_short_lesson_becomes_its_own_description` also fails on old code (`left: "Learned from 3 observations."`).

Two more are guards rather than witnesses, and I am labelling them honestly — both **pass on old code**, because the old boilerplate was single-line and did contain the count. They exist to stop the new behaviour regressing: `a_mined_description_is_one_line_and_round_trips_through_the_file` (a `\n` in a description corrupts the frontmatter — the new failure mode this change introduces) and `the_written_skill_still_records_how_many_observations_minted_it` (the provenance survives the move).

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-core -p stella-cli -p stella-tui --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-core` (86 skills tests), `-p stella-cli`, `-p stella-tui` — all green
- [x] `make guards-fast` — 13 passed, 0 failed
- [x] `Closes #5335` in this description **and** as a commit trailer

Per CLAUDE.md ("CI builds and tests; this laptop does not") the workspace build and full suite are CI's.

## Reviewers should know: a pinned contract moved

`skills::migration_contract::rendered_skill_bytes_are_pinned` is a byte-literal contract, and this PR moves it. That is argued on the test rather than re-blessed, because the thing it protects deserves the check:

- **Identity does not move.** `candidate_id` hashes the lesson *text*, not the description, so `candidate_identity_is_pinned_to_a_literal` passes untouched. That is the dangerous half — a drifted id renames every skill file a user has and the next pass writes a duplicate beside it.
- **No file on disk is rewritten.** Nothing re-renders an existing `SKILL.md` (the miner's `already_captured` guard, plus the no-clobber check pinned in the same module). Only skills minted from here on carry the new shape.
- The fixture's `description` is now what `candidate_description` actually yields for the pinned lesson, so those bytes are the bytes a real mining pass writes rather than a shape only that test produces.

**On the scoring direction.** `coverage` is asymmetric — it divides by the *skill's* vocabulary — so adding terms to a description can in principle lower the ratio. It cannot here: the terms removed (`learned`, `observations`) match no prompt, so they were pure denominator. Replacing them with the lesson's own words strictly improves both the ratio and the `matched_terms.len() >= 2` corroboration gate.

## Nothing left behind

- [x] Filed: #5425

Two comments this change invalidates are corrected in the same PR rather than filed:

- `views/skills.rs` justified spending a learned row's last column on provenance with "nothing is lost: the description is the trace count anyway". That is no longer true. The comment now states the real trade and names **#5425**, where whether the column should now prefer the description gets decided — a display judgement I did not want to make silently inside a scoring fix.
- `skill_manager/learned.rs`'s fixture claims to be "exactly as `render_skill_markdown` writes it", so it follows the renderer.

## Ground-rule check

- [x] No I/O added to `stella-core` — `candidate_description` is a pure function over a borrowed string
- [x] No new dependencies, no new network calls
