### PR TITLE
feat(stella-context): episodes mint observed_in edges to the files they touched (#5338)

### DIFF
--- a/crates/stella-cli/src/memory/anchor_scan.rs
+++ b/crates/stella-cli/src/memory/anchor_scan.rs
@@ -1,4 +1,9 @@
-//! The staleness scan: which memory anchors stopped holding, and recording it.
+//! The staleness scan: which anchors stopped holding, and recording it.
+//!
+//! Covers memory anchors (the files a lesson is about) and episode anchors
+//! (the files a turn touched, #5338) on the same terms — the question it asks
+//! is whether the file is still there, which does not depend on which kind of
+//! record pointed at it.
 //!
 //! This is the *policy* half of #775. `stella-context` owns the semantics —
 //! ending world validity is not supersession, and never deletes — while the
@@ -18,7 +23,9 @@ use stella_context::{Clock, ContextStore, SystemClock};
 struct StaleAnchor {
     edge_id: i64,
     path: String,
-    memory: String,
+    /// The anchoring record's text — a memory's content or an episode's
+    /// summary — so the report can name what goes stale.
+    source: String,
 }
 
 /// Walk the open `observed_in` anchors and report — or end — the ones whose
@@ -57,15 +64,12 @@ pub(crate) fn scan_stale_anchors(
         .map(|a| StaleAnchor {
             edge_id: a.edge_id,
             path: a.path,
-            memory: a.memory,
+            source: a.source,
         })
         .collect();
 
     if stale.is_empty() {
-        println!(
-            "\n  {} every memory anchor still points at a file",
-            "✓".green()
-        );
+        println!("\n  {} every anchor still points at a file", "✓".green());
         return Ok(());
     }
 
@@ -78,7 +82,7 @@ pub(crate) fn scan_stale_anchors(
         println!(
             "    {} — {}",
             a.path.yellow(),
-            a.memory.chars().take(60).collect::<String>().dimmed()
+            a.source.chars().take(60).collect::<String>().dimmed()
         );
     }
 

--- a/crates/stella-context/src/retrieval/recall_tests.rs
+++ b/crates/stella-context/src/retrieval/recall_tests.rs
@@ -867,3 +867,71 @@ async fn ending_an_anchor_stops_live_recall_traversing_it() {
         "the anchor is still BELIEVED; only the present stops seeing it"
     );
 }
+
+/// **The traversal witness (#5338).** Recall seeded at a file reaches the
+/// episodes that touched it.
+///
+/// This is the question the issue names — "what happened to this file" — and
+/// before the episode anchor loop it had no answer: recall expands from an
+/// anchor seed through `neighbors_valid_at`, and an episode's file list lived
+/// in a JSON column with no edge for that expansion to follow.
+///
+/// The corpus is large enough that the frame budget binds, for
+/// the same reason `an_anchor_to_a_deleted_file_stops_feeding_recall` builds
+/// one: with a handful of records, recency alone would seat the episode and
+/// its presence would prove nothing about the edge.
+#[tokio::test]
+async fn recall_seeded_at_a_file_reaches_the_episode_that_touched_it() {
+    let clock = FixedClock::shared(1_000);
+    let dir = TempDir::new().unwrap();
+    let store = ContextStore::open_with(
+        dir.path().join("context.db"),
+        Arc::new(HashEmbedder::default()),
+        clock.clone(),
+    )
+    .unwrap();
+
+    store
+        .upsert(
+            crate::writeback::ContextDelta::new().with_episode(
+                crate::writeback::EpisodeInput::new(
+                    "zzz quokka marmalade tessellation",
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:05:00Z",
+                )
+                .with_files(["src/registry.rs"]),
+            ),
+        )
+        .await
+        .unwrap();
+
+    for i in 0..40 {
+        clock.advance(100);
+        store
+            .upsert(crate::writeback::ContextDelta::new().with_memory(
+                crate::writeback::MemoryInput::reflection(
+                    format!("unrelated later note number {i} about deployment rollout"),
+                    Vec::<String>::new(),
+                ),
+            ))
+            .await
+            .unwrap();
+    }
+
+    let mut q = base_query("what happened here", "deployment note");
+    // The uri spelling must match what the write side minted.
+    q.anchors = vec!["file://src/registry.rs".into()];
+    q.max_frames = 3;
+
+    let got = store.recall(&q).await.unwrap();
+    assert!(
+        got.frames
+            .iter()
+            .any(|f| f.content.as_deref().unwrap_or_default().contains("quokka")),
+        "the file anchor must pull in the episode that touched it: {:?}",
+        got.frames
+            .iter()
+            .map(|f| f.content.clone())
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/stella-context/src/store/edge.rs
+++ b/crates/stella-context/src/store/edge.rs
@@ -236,8 +236,9 @@ pub(crate) struct OpenAnchor {
     pub edge_id: i64,
     /// The anchored node's `uri`, e.g. `file://stella-cli/src/agent.rs`.
     pub uri: String,
-    /// The anchoring memory's content, for reporting which memory goes stale.
-    pub memory: String,
+    /// The anchoring record's content — a memory's text or an episode's
+    /// summary — for reporting which record goes stale.
+    pub source: String,
 }
 
 /// Every `rel` anchor still believed *and* still holding in the world.
@@ -265,7 +266,7 @@ pub(crate) fn open_anchors(conn: &Connection, rel: &str) -> Result<Vec<OpenAncho
         Ok(OpenAnchor {
             edge_id: r.get(0)?,
             uri: r.get(1)?,
-            memory: r.get::<_, Option<String>>(2)?.unwrap_or_default(),
+            source: r.get::<_, Option<String>>(2)?.unwrap_or_default(),
         })
     })?;
     let mut out = Vec::new();

--- a/crates/stella-context/src/writeback.rs
+++ b/crates/stella-context/src/writeback.rs
@@ -22,7 +22,9 @@ use crate::store::{
 };
 use crate::warm;
 
-/// `edge.rel` for a memory-to-file anchor: *this memory is about that file*.
+/// `edge.rel` for a record-to-file anchor: *this record is about that file*.
+/// Minted from memories (the files a lesson is about) and from episodes (the
+/// files a turn touched, #5338).
 ///
 /// One string, exported, because three planes have to agree on it — the write
 /// side in [`ContextStore::upsert`], the staleness scan that ends its world
@@ -78,8 +80,15 @@ pub struct EpisodeInput {
     /// content and (truncated) its citation label, so this is the text recall
     /// actually embeds and surfaces.
     pub summary: String,
-    /// Workspace-relative paths the episode touched, stored as a JSON array on
-    /// the `episode` row.
+    /// Workspace-relative paths the episode touched.
+    ///
+    /// Stored two ways, because they answer two questions. The JSON array on
+    /// the `episode` row is the record of what this turn did. The
+    /// [`ANCHOR_REL`] edges minted from the mirror node are what a *traversal*
+    /// follows, so "what happened to this file" reaches the turns that touched
+    /// it — a JSON column cannot be walked, and until #5338 that was the only
+    /// place these lived, which left the graph channel reaching memories and
+    /// stopping there.
     pub files_touched: Vec<String>,
     /// How the episode ended.
     pub outcome: EpisodeOutcome,
@@ -123,6 +132,17 @@ impl EpisodeInput {
         S: Into<String>,
     {
         self.domains = domains.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Record the files this episode touched. See [`Self::files_touched`].
+    #[must_use]
+    pub fn with_files<I, S>(mut self, files: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.files_touched = files.into_iter().map(Into::into).collect();
         self
     }
 
@@ -548,7 +568,8 @@ pub struct UpsertReceipt {
     pub embeddings_reused: usize,
     /// New domain-tag associations written across all records this batch.
     pub domain_tags_added: usize,
-    /// `observed_in` anchor edges inserted from a memory to a file it is about.
+    /// `observed_in` anchor edges inserted from a memory or an episode to a
+    /// file it is about.
     /// Re-asserting an anchor that is already open on both time axes inserts
     /// nothing and is not counted; an anchor whose world validity was ended by
     /// the staleness scan *is* re-opened, because a file that came back is a
@@ -556,7 +577,9 @@ pub struct UpsertReceipt {
     pub anchors_written: usize,
 }
 
-/// An open memory→file anchor, as the staleness scan sees it.
+/// An open record→file anchor, as the staleness scan sees it. The source is a
+/// memory or an episode; the scan treats both the same, because the question
+/// it asks — is this file still here — does not depend on which.
 #[derive(Debug, Clone)]
 pub struct AnchorView {
     /// Edge rowid — pass to [`ContextStore::end_anchor_validity`].
@@ -567,8 +590,9 @@ pub struct AnchorView {
     /// to test for existence. Anchors are written relative (matching
     /// `record_taxonomy`), so this joins onto the workspace root directly.
     pub path: String,
-    /// The anchoring memory's text, so a report can name what goes stale.
-    pub memory: String,
+    /// The anchoring record's text — a memory's content or an episode's
+    /// summary — so a report can name what goes stale.
+    pub source: String,
 }
 
 /// A fact resolved to human labels for point-in-time queries (`L-C4`: cite by
@@ -717,6 +741,9 @@ impl ContextStore {
             receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, &now)?;
             receipt.nodes_upserted += 1;
             receipt.episodes_written += 1;
+            // The files this turn touched, as edges rather than only as the
+            // JSON column written above (#5338).
+            anchor_to_files(&tx, id, &ep.files_touched, &ep.domains, &now, &mut receipt)?;
         }
 
         for memory in &delta.memories {
@@ -741,38 +768,14 @@ impl ContextStore {
             // node's identity is minted in this loop — a caller would have to
             // reconstruct `memory://{lineage}` by hand and would silently
             // anchor to nothing the day that spelling changed.
-            for path in &memory.anchors {
-                let file = NodeInput::new(NodeKind::File, path.as_str())
-                    .with_uri(format!("file://{path}"))
-                    .with_domains(memory.domains.clone());
-                let dst = upsert_node(&tx, &file, &now)?;
-                receipt.domain_tags_added += tag_node_domains(&tx, dst, &file.domains, &now)?;
-                receipt.nodes_upserted += 1;
-                // Open on BOTH axes, not merely un-superseded: an anchor whose
-                // file was deleted has `valid_to` set and `superseded_at` null,
-                // and re-learning the same lesson after the file comes back
-                // must open a new interval rather than be swallowed as a
-                // duplicate. `live_triple_exists` checks belief only, which is
-                // right for `apply_fact` and wrong here.
-                if !open_anchor_exists(&tx, id, ANCHOR_REL, dst)? {
-                    insert_edge(
-                        &tx,
-                        ANCHOR_REL,
-                        id,
-                        dst,
-                        1.0,
-                        &serde_json::json!({}),
-                        // No `valid_from`: we know the memory is about this
-                        // file now, not when that started being true. NULL is
-                        // "unbounded in the past", which is the honest claim.
-                        None,
-                        None,
-                        &now,
-                        None,
-                    )?;
-                    receipt.anchors_written += 1;
-                }
-            }
+            anchor_to_files(
+                &tx,
+                id,
+                &memory.anchors,
+                &memory.domains,
+                &now,
+                &mut receipt,
+            )?;
         }
 
         for fact in &delta.facts {
@@ -792,7 +795,7 @@ impl ContextStore {
         Ok(receipt)
     }
 
-    /// Every memory→file anchor still believed and still holding in the world.
+    /// Every record→file anchor still believed and still holding in the world.
     ///
     /// This is a *reader*, not a scan. The store knows which
     /// anchors are open; it does not know which files exist, and it must not
@@ -807,7 +810,7 @@ impl ContextStore {
                 edge_id: a.edge_id,
                 path: a.uri.strip_prefix("file://").unwrap_or(&a.uri).to_string(),
                 uri: a.uri,
-                memory: a.memory,
+                source: a.source,
             })
             .collect())
     }
@@ -986,6 +989,57 @@ fn live_triple_exists(
         |r| r.get(0),
     )?;
     Ok(n > 0)
+}
+
+/// Mint an [`ANCHOR_REL`] edge from `src` to every path in `paths`, upserting
+/// the file node each one needs.
+///
+/// One helper for both record kinds rather than a copy in each loop. A memory
+/// and an episode make the *same* claim about a file — this record is about
+/// that file — and the discipline it has to keep is the subtle half: the
+/// bi-temporal duplicate check below, and `valid_from: None`. Two copies of
+/// that would be two chances to get it wrong, and the divergence would be
+/// invisible until a scan reported one kind of anchor and not the other.
+fn anchor_to_files(
+    tx: &rusqlite::Transaction<'_>,
+    src: i64,
+    paths: &[String],
+    domains: &[String],
+    now: &str,
+    receipt: &mut UpsertReceipt,
+) -> Result<(), ContextError> {
+    for path in paths {
+        let file = NodeInput::new(NodeKind::File, path.as_str())
+            .with_uri(format!("file://{path}"))
+            .with_domains(domains.to_vec());
+        let dst = upsert_node(tx, &file, now)?;
+        receipt.domain_tags_added += tag_node_domains(tx, dst, &file.domains, now)?;
+        receipt.nodes_upserted += 1;
+        // Open on BOTH axes, not merely un-superseded: an anchor whose file
+        // was deleted has `valid_to` set and `superseded_at` null, and
+        // re-asserting it after the file comes back must open a new interval
+        // rather than be swallowed as a duplicate. `live_triple_exists` checks
+        // belief only, which is right for `apply_fact` and wrong here.
+        if !open_anchor_exists(tx, src, ANCHOR_REL, dst)? {
+            insert_edge(
+                tx,
+                ANCHOR_REL,
+                src,
+                dst,
+                1.0,
+                &serde_json::json!({}),
+                // No `valid_from`: we know the record is about this file now,
+                // not when that started being true. NULL is "unbounded in the
+                // past", which is the honest claim.
+                None,
+                None,
+                now,
+                None,
+            )?;
+            receipt.anchors_written += 1;
+        }
+    }
+    Ok(())
 }
 
 /// Does an anchor exist that is open on **both** time axes?

--- a/crates/stella-context/src/writeback/tests.rs
+++ b/crates/stella-context/src/writeback/tests.rs
@@ -270,9 +270,130 @@ async fn a_memory_anchors_to_the_files_it_is_about() {
     paths.sort();
     assert_eq!(paths, vec!["src/main.rs", "src/registry.rs"]);
     assert!(
-        open.iter().all(|a| a.memory.contains("registry.rs")),
+        open.iter().all(|a| a.source.contains("registry.rs")),
         "each anchor names the memory it came from, so a scan can report it"
     );
+}
+
+/// **The witness (#5338).** An episode's `files_touched` become `observed_in`
+/// edges, so "what happened to this file" reaches the turns that touched it.
+///
+/// The paths were stored as a JSON array on the `episode` row and nowhere
+/// else, which is a column a traversal cannot follow: the graph channel the
+/// anchors design exists for reached memories and stopped there.
+#[tokio::test]
+async fn an_episode_anchors_to_every_file_it_touched() {
+    let clock = FixedClock::shared(1_000);
+    let (_dir, store) = store_at(clock.clone());
+
+    let receipt = store
+        .upsert(
+            ContextDelta::new().with_episode(
+                EpisodeInput::new(
+                    "split the registry",
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:05:00Z",
+                )
+                .with_files(["src/registry.rs", "src/main.rs"])
+                .with_domains(["core"]),
+            ),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(receipt.anchors_written, 2);
+    let open = store.open_anchors().unwrap();
+    let mut paths: Vec<String> = open.iter().map(|a| a.path.clone()).collect();
+    paths.sort();
+    assert_eq!(paths, vec!["src/main.rs", "src/registry.rs"]);
+    assert!(
+        open.iter().all(|a| a.source.contains("split the registry")),
+        "each anchor names the record it came from, so a scan can report it"
+    );
+}
+
+/// The same de-duplication memories get. A session that re-writes an episode
+/// over the same window updates one row, and must not grow one edge per pass.
+#[tokio::test]
+async fn re_anchoring_an_episodes_files_writes_nothing_new() {
+    let clock = FixedClock::shared(1_000);
+    let (_dir, store) = store_at(clock.clone());
+
+    let delta = || {
+        ContextDelta::new().with_episode(
+            EpisodeInput::new(
+                "split the registry",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:05:00Z",
+            )
+            .with_files(["src/registry.rs"]),
+        )
+    };
+    let first = store.upsert(delta()).await.unwrap();
+    clock.advance(1_000);
+    let second = store.upsert(delta()).await.unwrap();
+
+    assert_eq!(first.anchors_written, 1);
+    assert_eq!(second.anchors_written, 0, "the anchor already held");
+    assert_eq!(store.open_anchors().unwrap().len(), 1);
+}
+
+/// The staleness scan sees episode anchors on the same terms as memory ones:
+/// a deleted file ends world validity, and belief is untouched. Anything else
+/// would leave episode anchors pointing at files that are gone forever, since
+/// the scan is the only thing that ends them.
+#[tokio::test]
+async fn an_episode_anchor_ends_world_validity_like_a_memory_anchor() {
+    let clock = FixedClock::shared(1_000);
+    let (_dir, store) = store_at(clock.clone());
+    store
+        .upsert(
+            ContextDelta::new().with_episode(
+                EpisodeInput::new(
+                    "split the registry",
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:05:00Z",
+                )
+                .with_files(["src/registry.rs"]),
+            ),
+        )
+        .await
+        .unwrap();
+
+    let anchor = store.open_anchors().unwrap().remove(0);
+    clock.advance(1_000);
+    let gone_at = store.clock().now_rfc3339();
+    assert!(store.end_anchor_validity(anchor.edge_id, &gone_at).unwrap());
+    assert!(
+        store.open_anchors().unwrap().is_empty(),
+        "the anchor stopped holding in the world"
+    );
+    assert!(
+        store
+            .facts_as_of(None)
+            .unwrap()
+            .iter()
+            .any(|f| f.predicate == crate::writeback::ANCHOR_REL),
+        "the anchor is still BELIEVED; only the present stops seeing it"
+    );
+}
+
+/// An episode that touched nothing writes no edges and no file nodes — the
+/// common case for a summary with no `files_touched`.
+#[tokio::test]
+async fn an_episode_touching_no_files_anchors_nothing() {
+    let clock = FixedClock::shared(1_000);
+    let (_dir, store) = store_at(clock.clone());
+    let receipt = store
+        .upsert(ContextDelta::new().with_episode(EpisodeInput::new(
+            "thought about it",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:05:00Z",
+        )))
+        .await
+        .unwrap();
+    assert_eq!(receipt.anchors_written, 0);
+    assert!(store.open_anchors().unwrap().is_empty());
 }
 
 /// Re-learning the same lesson must not grow the graph. The reflection loop


### PR DESCRIPTION
## What & why

An episode's `files_touched` were stored as a JSON array on the `episode` row and nowhere else. A JSON column cannot be walked, so a question like "what happened to this file" traversed to memories and stopped there — the graph channel the anchors design exists for reached half of what it was built to reach.

Episodes now mint `observed_in` edges to file anchor nodes at writeback, following the memory-anchor pattern already in the crate and keeping the same validity-interval discipline:

- The duplicate check is open on **both** time axes, so re-writing an episode over the same window adds nothing, while a file that comes back opens a new interval rather than being swallowed as a duplicate.
- `valid_from` stays NULL — the honest claim is that we know the record is about this file *now*, not when that started being true.
- The staleness scan ends episode anchors exactly as it ends memory ones, and `end_anchor_validity` leaves belief untouched.

Closes #5338

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`recall_seeded_at_a_file_reaches_the_episode_that_touched_it` — the traversal the issue asks for: write an episode touching a file, recall seeded at that file, the episode comes back.

**I verified the fail→pass flip by ablation rather than assuming it.** With the one `anchor_to_files` call in the episode loop replaced by a no-op and everything else identical, all three episode witnesses fail:

```
---- writeback::tests::an_episode_anchors_to_every_file_it_touched
assertion `left == right` failed
  left: 0
 right: 2
---- retrieval::recall_tests::recall_seeded_at_a_file_reaches_the_episode_that_touched_it
---- writeback::tests::an_episode_anchor_ends_world_validity_like_a_memory_anchor
test result: FAILED. 0 passed; 3 failed
```

Restored: `177 passed; 0 failed`.

The traversal test builds a 40-record corpus so the frame budget genuinely binds — the same construction `an_anchor_to_a_deleted_file_stops_feeding_recall` uses, and for the same reason: with a handful of records recency alone would seat the episode and its presence would prove nothing about the edge. The episode's text shares no vocabulary with the query, so the graph edge is the only thing that can put it in the result.

Also: `re_anchoring_an_episodes_files_writes_nothing_new` (the reflection loop re-writes constantly; an anchor that duplicated per pass would make one file accumulate hundreds of identical edges), `an_episode_anchor_ends_world_validity_like_a_memory_anchor` (belief survives — the whole reason this is `end_world_validity` and not `close_edge`), and `an_episode_touching_no_files_anchors_nothing`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-context -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-context` (177 passed), `cargo test -p stella-cli` — green
- [x] `make guards-fast` — 13 passed, 0 failed
- [x] `Closes #5338` in this description **and** as a commit trailer

Per CLAUDE.md ("CI builds and tests; this laptop does not") the workspace build and full suite are CI's.

## Reviewers should know

**One helper, not two loops.** The memory loop's anchor body moved into `anchor_to_files` and the episode loop calls the same function. A memory and an episode make the same claim about a file, and the discipline above is the subtle half — two copies would be two chances to get it wrong, and the divergence would stay invisible until a scan reported one kind of anchor and not the other. The memory path's behaviour is unchanged, which its existing tests still assert.

**A field rename: `AnchorView::memory` → `source`** (and `OpenAnchor::memory` likewise). The field now carries an episode summary as well as a memory's text; the SQL that fills it already read `src.content` without caring which, so the query is untouched. Leaving the name would be exactly the stale name this repo treats as a bug. The only consumers are this crate's tests and `stella-cli`'s `anchor_scan`, both updated, along with the prose in three places that said every anchor came from a memory.

**What I checked before widening the rel.** Episode anchors now flow through `open_anchors` and therefore through `stella memory validate`, which is intended — a deleted file should end an episode anchor too. Forgetting is `supersede_node`, a per-node tombstone, so it does not sweep by rel and a forgotten memory cannot take an episode's anchors with it.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR.

## Ground-rule check

- [x] No new dependencies, no new network calls
- [x] No I/O added to `stella-core` (untouched); the store keeps its "does this file exist" ignorance — that question stays in `stella-cli`'s scan, which is what lets the store be tested without a real tree
