### PR TITLE
Carry a prose baseline entry across a rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,11 @@
     it has its own door: `make prose-adopt PATTERN=<name>` records that
     pattern's pre-existing hits, once, and refuses to touch any other
     pattern's numbers. A backticked span or a fenced block is exempt: naming
-    a banned construction in order to ban it is a citation.
+    a banned construction in order to ban it is a citation. A file that
+    **moves** takes its entry with it: `--update` asks git what was renamed
+    and carries each one to the new path before applying the same `min`, so a
+    move can still only lower a count. Stage the move (`git mv`) or git
+    reports a delete beside an untracked file and there is nothing to follow.
   - **The same command holds density**, over
     `scripts/prose-density-baseline.txt`: the mean length of every crate's
     leading `//!` blocks, ratcheted down only. A count of banned phrases

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -32,6 +32,16 @@ add a pair, so the only way past a failure is to delete the prose. Per
 pattern rather than per file so a file cannot pay for new prose of one kind
 by deleting prose of another.
 
+Keyed by path, which means a file that MOVES takes its debt with it or the
+same sentences are read as newly written the moment they land somewhere else.
+`--update` therefore asks git what was renamed and carries each entry to the
+file's new path first (`renamed_paths`). The ratchet is unchanged by this: a
+carried entry still goes through the same `min`, so a move can lower a count
+and never raise one, and a genuinely new file still starts at zero. Without
+it, splitting a module means rewording prose nobody was editing — #5420 hit
+this and had to hand-edit the baseline, which is the one thing this file is
+supposed to make unnecessary.
+
 Adding a pattern is the one case a count legitimately goes up, and
 `--adopt=<name>` is the only door: it records that pattern's pre-existing
 hits and refuses to touch any other pattern's numbers, or to run twice for
@@ -229,6 +239,46 @@ DENSITY_HEADER = """\
 # many sentences. A file can be entirely within the first and three times
 # longer than it needs to be.
 """
+
+
+def renamed_paths(root: Path) -> dict[str, str]:
+    """Old path -> new path, for every file git sees as renamed against HEAD.
+
+    Only `--update` consults this. The plain check judges the tree as it
+    stands, so a move fails until someone runs `--update` — the same workflow
+    the file-size ratchet has.
+
+    Fails open at every unknown (no git, no HEAD, an unreadable tree): an
+    empty map means no entry is carried, which is the behaviour this had
+    before, so a broken git can never turn a red gate green.
+
+    Detection is git's, not ours, which is why the move must be staged —
+    `git mv`, or `git add` after a plain `mv`. An unstaged move looks like a
+    delete plus an untracked file, and nothing can honestly pair those.
+
+    It is also why a move that rewrites most of the file carries nothing: git
+    reports a delete beside an add once similarity drops far enough, and there
+    is no rename to follow. That is the right answer rather than a gap — a
+    file rewritten in transit is new prose, and it should be read as new.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "-M", "--name-status", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if proc.returncode != 0:
+        return {}
+    moved: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) == 3 and fields[0].startswith("R"):
+            moved[fields[1]] = fields[2]
+    return moved
 
 
 def tracked_files(root: Path) -> list[str]:
@@ -538,6 +588,23 @@ def main() -> int:
         return 0
 
     if "--update" in flagset:
+        # A moved file's debt follows it, so the same sentences in a new home
+        # are not read as newly written. Applied before anything else looks at
+        # `baseline`, so the carried entry goes through the identical `min`
+        # below and a move can still only lower a count.
+        moved = renamed_paths(root)
+        if moved:
+            baseline = {
+                (moved.get(path, path), pattern): n
+                for (path, pattern), n in baseline.items()
+            }
+            carried = sorted(
+                (old, new)
+                for old, new in moved.items()
+                if any(path == new for path, _ in baseline)
+            )
+            for old, new in carried:
+                print(f"check-prose: carried {old} -> {new}")
         # A pair absent from the baseline is held to zero, so `.get(pair, 0)`
         # is what makes --update refuse to grandfather a first-time offender.
         merged = {p: min(n, baseline.get(p, 0)) for p, n in per_pair.items()}
@@ -555,7 +622,11 @@ def main() -> int:
                 print(f"  {path} [{pattern}]: {was} -> {now}", file=sys.stderr)
             print(
                 "\nDelete the constructions instead. "
-                "`./scripts/check-prose.py --report` names every line.",
+                "`./scripts/check-prose.py --report` names every line.\n"
+                "If one of these files was MOVED rather than written, stage "
+                "the move (`git mv`, or `git add` after `mv`) and re-run: an "
+                "unstaged move reads as a delete plus a new file, so its "
+                "entry cannot be carried.",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -444,5 +444,123 @@ else
   ok "D9 a missing density baseline refuses"
 fi
 
+# ── R: a moved file takes its debt with it ───────────────────────────────────
+#
+# The baseline is keyed by path, so before this a rename read as prose someone
+# had just written: the entry stayed stranded at the old path and the same
+# sentences were judged at zero allowance in their new home. Splitting a module
+# then meant rewording comments nobody was editing, and #5420 hand-edited the
+# baseline instead — the one move this file exists to make unnecessary.
+#
+# R1 is the witness: it fails before `--update` learned to ask git what moved.
+# R3 and R4 are the direction that must NOT change — carrying a debt forward is
+# not forgiving one.
+
+# $1 = root. Commit, so HEAD exists and git can answer what was renamed.
+commit_all() {
+  (cd "$1" &&
+    git config user.email test@example.com &&
+    git config user.name "Test" &&
+    git add -A &&
+    git commit -qm fixture) >/dev/null 2>&1
+}
+
+# $1 = root, $2 = old path, $3 = new path. Staged, which is what git needs to
+# report a rename rather than a delete beside an untracked file.
+move() {
+  (cd "$1" && git mv "$2" "$3") >/dev/null 2>&1
+}
+
+# $1 = case name, $2 = root. `--update` must succeed.
+expect_update_ok() {
+  if python3 "$SCRIPT" --update "$2" >/dev/null 2>&1; then
+    ok "$1"
+  else
+    no "$1" "--update exited non-zero"
+  fi
+}
+
+r="$(new_root r1)"
+doc "$r" docs/old.md <<'EOF'
+The cost is deliberate: the retention it buys is not worth the residue.
+EOF
+baseline "$r" docs/old.md filler-adverb 1
+commit_all "$r"
+move "$r" docs/old.md docs/new.md
+expect_fail "R1 a moved file fails the plain check until the tree is updated" "$r"
+expect_update_ok "R1 --update accepts the move" "$r"
+expect_line "R1 the entry lands at the new path" "$r" "docs/new.md filler-adverb 1"
+expect_absent "R1 the old path is gone" "$r" "docs/old.md"
+expect_pass "R1 the tree passes once the entry moved" "$r"
+
+# R2: the count carried is the file's own, not a fresh grant. Rewording during
+# the move must lower it, and the lower number is what gets written.
+#
+# The body is long and only one line changes, because the carry rides on git's
+# similarity detection: rewrite most of a short file and git reports a delete
+# beside an add, no rename to follow, and the entry is correctly not carried.
+# That is the honest limit, and it is why a real split — which moves text
+# verbatim — carries cleanly while a rewrite does not.
+r="$(new_root r2)"
+doc "$r" docs/old.md <<'EOF'
+The store keys every child table off `executions.id`.
+The hub replicates above a durable per-project cursor.
+The cost is deliberate, and this clause is deliberately redundant.
+Retention is opt-in, and dropping an execution cascades.
+Reads never touch a project store.
+The canary re-asks the composition questions after the merge.
+EOF
+baseline "$r" docs/old.md filler-adverb 2
+commit_all "$r"
+move "$r" docs/old.md docs/new.md
+doc "$r" docs/new.md <<'EOF'
+The store keys every child table off `executions.id`.
+The hub replicates above a durable per-project cursor.
+The cost is deliberate, and this clause repeats it.
+Retention is opt-in, and dropping an execution cascades.
+Reads never touch a project store.
+The canary re-asks the composition questions after the merge.
+EOF
+expect_update_ok "R2 --update accepts a move that also reworded" "$r"
+expect_line "R2 the carried count is the lower one" "$r" "docs/new.md filler-adverb 1"
+
+# R3: a move is not an amnesty. Prose ADDED while the file moved is still new
+# prose, and `--update` must refuse it exactly as it would in place.
+r="$(new_root r3)"
+doc "$r" docs/old.md <<'EOF'
+The cost is deliberate: the retention it buys is not worth the residue.
+EOF
+baseline "$r" docs/old.md filler-adverb 1
+commit_all "$r"
+move "$r" docs/old.md docs/new.md
+doc "$r" docs/new.md <<'EOF'
+The cost is deliberate, and the second clause is deliberately redundant.
+EOF
+expect_update_refused "R3 --update refuses prose added while moving" "$r"
+
+# R4: carrying one file's debt must not forgive another file's. A rename
+# alongside a first-time offender is still refused, on the offender.
+r="$(new_root r4)"
+doc "$r" docs/old.md <<'EOF'
+The cost is deliberate: the retention it buys is not worth the residue.
+EOF
+baseline "$r" docs/old.md filler-adverb 1
+commit_all "$r"
+move "$r" docs/old.md docs/new.md
+doc "$r" docs/fresh.md <<'EOF'
+Two things follow from that, and the second is the hard one.
+EOF
+expect_update_refused "R4 a rename does not grandfather an unrelated file" "$r"
+
+# R5: no HEAD to diff against — a fresh repository with nothing committed.
+# The rename map fails open, so the guard behaves exactly as it did before it
+# could ask: a broken or absent git never turns a red gate green.
+r="$(new_root r5)"
+doc "$r" docs/a.md <<'EOF'
+Two things follow from that, and the second is the hard one.
+EOF
+baseline "$r"
+expect_update_refused "R5 an unaskable git still refuses a first-time offender" "$r"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

`scripts/prose-baseline.txt` is keyed by (file, pattern), so a file that **moves**
leaves its entry stranded at the old path and the identical sentences are judged
at zero allowance in their new home. A pure rename reads to the guard as prose
somebody just wrote.

`make prose-update` could not repair that either — it refuses to add a pair, by
design — so the author of a module split chose between rewording comments nobody
was editing and hand-editing the baseline, which CLAUDE.md calls the expedient it
forbids.

#5420 is where this cost real work: eleven moved test files surfaced seventeen
pre-existing constructions in their new homes. Fifteen were reworded, correctly.
Two were `door.variant` field accesses — the field the test exists to pin,
unreducible without renaming production code — and that PR hand-edited the
baseline to carry the entry across at a lower count. This removes the need for
that hand-edit, which matters now because the god-file and crate-structure work
queued behind it moves far more than eleven files.

## How

`--update` asks git what was renamed and carries each entry to the new path
**before** the existing `min` runs, so the ratchet is untouched: a carried entry
goes through the same comparison, a move can lower a count and never raise one,
and a genuinely new file still starts at zero. It prints each carry, so the
baseline diff stays reviewable.

Two limits, documented in the docstring, in the `--update` refusal message, and
in CLAUDE.md's prose block — where an author meets them rather than discovers
them:

- Detection is git's, so the move must be **staged**. An unstaged move is a
  delete beside an untracked file, and nothing can honestly pair those.
- A move that rewrites most of the file carries nothing, because git stops
  calling it a rename once similarity drops far enough. That is the right
  answer, not a gap: a file rewritten in transit is new prose.

Every unknown — no git, no HEAD, an unreadable tree — fails open to an empty
rename map, which reproduces the previous behaviour exactly. A broken git can
never turn a red gate green.

## The witness

- [x] `scripts/test-prose-guard.sh` R1: a staged rename is carried by `--update`,
      the entry lands at the new path, the old path is gone, and the tree then
      passes. Fails before this change (the entry stays stranded and `--update`
      refuses), passes after.

Four more cases pin the directions that must **not** change:

- **R2** — a move that also reworded carries the *lower* count, not a fresh grant.
- **R3** — prose added while moving is still refused. A move is not an amnesty.
- **R4** — carrying one file's entry does not grandfather an unrelated new file.
- **R5** — a repository with no HEAD still refuses a first-time offender.

`./scripts/test-prose-guard.sh` reports **42 passed, 0 failed** (37 pre-existing
plus these 5).

## The gate

- [x] `./scripts/test-prose-guard.sh` — 42 passed, 0 failed
- [x] `make prose` green on this tree
- [x] `make guards-fast` green
- [x] `cargo fmt --check` (no Rust touched)
- [x] Docs updated: the script docstring, the `--update` refusal message, and
      CLAUDE.md's prose block

Compiles nothing, so there is no clippy or test tier to report beyond CI's.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

`scripts/file-size-baseline.txt` has the identical shape and the identical
problem — a renamed grandfathered file loses its ceiling, and
`check-file-size.sh --update` refuses to add an entry for a file it does not
already know. Deliberately left out so this change stays one mechanism; called
out in #5434's "Not in scope" and worth its own issue.

Closes #5434

## Summary by Sourcery

Preserve prose baseline allowances across staged file renames without weakening the existing prose ratchet.

New Features:
- Carry prose-baseline entries to new paths when staged Git renames are detected during updates.

Bug Fixes:
- Prevent renamed files from being treated as entirely new prose while preserving refusal of newly added prose and unrelated files.

Enhancements:
- Keep the existing ratchet behavior by applying the normal minimum-count comparison after carrying entries, with graceful fallback when rename detection is unavailable.
- Document staged-rename requirements and rename similarity limits.

Documentation:
- Update prose-guard guidance and command messages to explain baseline handling for moved files.

Tests:
- Add coverage for staged renames, reworded moves, added prose during moves, unrelated new files, and repositories without HEAD.