### PR TITLE
fix(cli): summarize memory budget drops as one line with the remedy

### DIFF
--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -778,36 +778,8 @@ impl SessionMemory {
         let latency_ms = u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
         // Phase 2 (#713): the host's cross-provider merge is a second budget
         // pass and reported nothing at all, so anything it cut vanished
-        // without a trace — a silent truncation `L-C5` bans. The report is a
-        // single summary line rather than one line per frame: five evicted
-        // memories are one fact (the budget is too small for this turn), said
-        // once, with the remedy and the budget the turn actually ran with.
-        // A required item it could not honor is the loudest case and is named
-        // first: the caller pointed at that file, and being told it did not
-        // fit is the whole difference between a budget and a lie.
-        let required_over = recalled
-            .dropped
-            .iter()
-            .filter(|d| d.reason == stella_context::DropReason::RequiredOverBudget)
-            .count();
-        if required_over > 0 {
-            report(format!(
-                "recall could not fit {required_over} anchored frame(s) — each exceeds the \
-                 {max_tokens}-token budget on its own; raise context.retrieval.max_tokens in \
-                 stella.toml to include them"
-            ));
-        }
-        let budget_drops = recalled
-            .dropped
-            .iter()
-            .filter(|d| d.reason == stella_context::DropReason::TokenBudget)
-            .count();
-        if budget_drops > 0 {
-            report(format!(
-                "{budget_drops} memories did not fit this turn's {max_tokens}-token retrieval \
-                 budget — raise context.retrieval.max_tokens in stella.toml to include them"
-            ));
-        }
+        // without a trace — a silent truncation `L-C5` bans.
+        report_budget_drops(&recalled.dropped, max_tokens, &mut report);
         // ...and the same report goes to the ledger, which is the half that
         // used to end here (#3358): the stderr line above is a warning a human
         // sees once, on one of the several surfaces that recall, while
@@ -830,6 +802,41 @@ impl SessionMemory {
             },
             dropped,
         }
+    }
+}
+
+/// The host-merge drop report: a single summary line per class rather than
+/// one line per frame. Five evicted memories are one fact — the budget is too
+/// small for this turn — said once, with the remedy and the budget the turn
+/// actually ran with, and without the internal handle a user cannot act on.
+/// A required item the merge could not honor is the loudest case and is named
+/// first: the caller pointed at that file, and being told it did not fit is
+/// the whole difference between a budget and a lie.
+pub(super) fn report_budget_drops(
+    dropped: &[crate::contextgraph::HostDroppedFrame],
+    max_tokens: u32,
+    report: &mut impl FnMut(String),
+) {
+    let required_over = dropped
+        .iter()
+        .filter(|d| d.reason == stella_context::DropReason::RequiredOverBudget)
+        .count();
+    if required_over > 0 {
+        report(format!(
+            "recall could not fit {required_over} anchored frame(s) — each exceeds the \
+             {max_tokens}-token budget on its own; raise context.retrieval.max_tokens in \
+             stella.toml to include them"
+        ));
+    }
+    let budget_drops = dropped
+        .iter()
+        .filter(|d| d.reason == stella_context::DropReason::TokenBudget)
+        .count();
+    if budget_drops > 0 {
+        report(format!(
+            "{budget_drops} memories did not fit this turn's {max_tokens}-token retrieval \
+             budget — raise context.retrieval.max_tokens in stella.toml to include them"
+        ));
     }
 }
 

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -331,7 +331,9 @@ impl SessionMemory {
             &selected,
             record.as_ref(),
         );
-        report_steering_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
+        report_steering_drops(&set, self.retrieval.max_tokens, |message| {
+            eprintln!("  {} {message}", "!".yellow())
+        });
 
         let frames = kept_frames(&recall.frames, &set);
         let kept = kept_skills(&selected.selected, &set);
@@ -463,7 +465,9 @@ impl SessionMemory {
             &selected,
             record.as_ref(),
         );
-        report_steering_drops(&set, |message| eprintln!("  {} {message}", "!".yellow()));
+        report_steering_drops(&set, self.retrieval.max_tokens, |message| {
+            eprintln!("  {} {message}", "!".yellow())
+        });
 
         // The per-frame cut this block exists to make. It runs AFTER the plane
         // has packed, not before the query: the drop is about what the model
@@ -652,7 +656,8 @@ impl SessionMemory {
 
     async fn recalled_frames(&self, goal: &str) -> RecalledFrames {
         let anchors = goal_path_anchors(goal, &self.workspace_root);
-        self.recalled_frames_anchored(goal, anchors, |message| {
+        let max_tokens = self.retrieval.max_tokens;
+        self.recalled_frames_anchored_reporting(goal, anchors, max_tokens, |message| {
             eprintln!("  {} {message}", "!".yellow())
         })
         .await
@@ -669,7 +674,8 @@ impl SessionMemory {
         report: impl FnMut(String),
     ) -> Recall {
         let anchors = goal_path_anchors(goal, &self.workspace_root);
-        self.recalled_frames_anchored(goal, anchors, report)
+        let max_tokens = self.retrieval.max_tokens;
+        self.recalled_frames_anchored_reporting(goal, anchors, max_tokens, report)
             .await
             .recall
     }
@@ -682,6 +688,22 @@ impl SessionMemory {
         &self,
         goal: &str,
         anchors: Vec<String>,
+        report: impl FnMut(String),
+    ) -> RecalledFrames {
+        let max_tokens = self.retrieval.max_tokens;
+        self.recalled_frames_anchored_reporting(goal, anchors, max_tokens, report)
+            .await
+    }
+
+    /// The one frame-query body every recall path funnels through, with the
+    /// turn's retrieval budget explicit: the budget-pressure summary the
+    /// query emits names this number, so it is a parameter rather than a
+    /// second read of `self.retrieval` the caller could disagree with.
+    async fn recalled_frames_anchored_reporting(
+        &self,
+        goal: &str,
+        anchors: Vec<String>,
+        max_tokens: u32,
         mut report: impl FnMut(String),
     ) -> RecalledFrames {
         // Both withholding switches live HERE, at the frame query the rendered
@@ -756,18 +778,35 @@ impl SessionMemory {
         let latency_ms = u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
         // Phase 2 (#713): the host's cross-provider merge is a second budget
         // pass and reported nothing at all, so anything it cut vanished
-        // without a trace — a silent truncation `L-C5` bans. A required item
-        // it could not honor is the loudest case and is named first: the
-        // caller pointed at that file, and being told it did not fit is the
-        // whole difference between a budget and a lie.
-        for drop in &recalled.dropped {
-            if drop.reason == stella_context::DropReason::RequiredOverBudget {
-                report(format!(
-                    "recall could not fit an anchored frame: {} ({} tokens) exceeds the \
-                     {}-token budget — raise context.retrieval.max_tokens to include it",
-                    drop.citation_label, drop.token_cost, query.max_tokens
-                ));
-            }
+        // without a trace — a silent truncation `L-C5` bans. The report is a
+        // single summary line rather than one line per frame: five evicted
+        // memories are one fact (the budget is too small for this turn), said
+        // once, with the remedy and the budget the turn actually ran with.
+        // A required item it could not honor is the loudest case and is named
+        // first: the caller pointed at that file, and being told it did not
+        // fit is the whole difference between a budget and a lie.
+        let required_over = recalled
+            .dropped
+            .iter()
+            .filter(|d| d.reason == stella_context::DropReason::RequiredOverBudget)
+            .count();
+        if required_over > 0 {
+            report(format!(
+                "recall could not fit {required_over} anchored frame(s) — each exceeds the \
+                 {max_tokens}-token budget on its own; raise context.retrieval.max_tokens in \
+                 stella.toml to include them"
+            ));
+        }
+        let budget_drops = recalled
+            .dropped
+            .iter()
+            .filter(|d| d.reason == stella_context::DropReason::TokenBudget)
+            .count();
+        if budget_drops > 0 {
+            report(format!(
+                "{budget_drops} memories did not fit this turn's {max_tokens}-token retrieval \
+                 budget — raise context.retrieval.max_tokens in stella.toml to include them"
+            ));
         }
         // ...and the same report goes to the ledger, which is the half that
         // used to end here (#3358): the stderr line above is a warning a human
@@ -1064,6 +1103,11 @@ fn record_section_text(rendered: RenderedChannel) -> Option<String> {
 /// because `SKILLS_SECTION_TOKEN_BUDGET` is a constant and nothing
 /// configurable widens it until #3243 Phase 4 collapses the two budgets.
 ///
+/// Memory drops return `None`: the frame query already reported them as ONE
+/// summary line naming the budget and the remedy, and repeating the same
+/// advice once per evicted memory — with an internal id a user cannot act on
+/// — is the noise that line exists to replace.
+///
 /// `None` for a source this path never produces — a tool schema or a
 /// plugin-contributed candidate. Silence there is the absence of a producer,
 /// not a withheld report.
@@ -1079,10 +1123,7 @@ fn drop_message(
              record budget: ^{handle} — raise its precedence, or trim the records that \
              outrank it"
         )),
-        SteeringSource::Memory => Some(format!(
-            "a memory recalled for this turn did not fit the retrieval budget: {handle} \
-             — raise `context.retrieval.max_tokens`"
-        )),
+        SteeringSource::Memory => None,
         SteeringSource::Skill if still_selected => Some(format!(
             "a skill matching this turn did not fit the skills section's token budget: \
              {handle} — nothing configurable widens that budget yet (#3243)"
@@ -1103,6 +1144,12 @@ fn drop_message(
 /// to the person watching the run — the #2709 observability gap in its other
 /// half.
 ///
+/// Memory drops are summarized, not enumerated: `memory_budget` is the
+/// `context.retrieval.max_tokens` the turn ran with, and the report is one
+/// line — how many memories missed the budget, the budget itself, and the
+/// knob that widens it — instead of one line per memory repeating the same
+/// remedy under an internal id.
+///
 /// Two recall-side filters are deliberately **not** reported here, and that is
 /// a decision rather than an omission. `project_recalled_frame` drops a frame
 /// the citation-label rule cannot name, and `is_suppressed_local_frame` drops
@@ -1115,8 +1162,20 @@ fn drop_message(
 /// already accounted for by the usage report captured above the filters.
 pub(super) fn report_steering_drops(
     set: &stella_core::steering::SteeringSet,
+    memory_budget: u32,
     mut report: impl FnMut(String),
 ) {
+    let memory_drops = set
+        .dropped
+        .iter()
+        .filter(|d| d.source == stella_core::steering::SteeringSource::Memory)
+        .count();
+    if memory_drops > 0 {
+        report(format!(
+            "{memory_drops} memories did not fit this turn's {memory_budget}-token retrieval \
+             budget — raise context.retrieval.max_tokens in stella.toml to include them"
+        ));
+    }
     for drop in &set.dropped {
         let still_selected = set
             .selected

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -786,3 +786,67 @@ fn every_dropped_source_gets_a_line_with_its_own_remedy() {
         "no source invents a line it has no producer for: {joined}"
     );
 }
+
+/// **Witness (#5444, frame-query half).** The host merge's drop report is one
+/// summary line per class — never one line per evicted frame repeating the
+/// same remedy under a citation label.
+///
+/// Fails on base, where the `RequiredOverBudget` loop in
+/// `recalled_frames_anchored` formatted one line per dropped frame
+/// ("recall could not fit an anchored frame: {label} ({cost} tokens) …") and
+/// ordinary budget evictions said nothing at all. The merge's own drop
+/// *shapes* are exercised where they are produced (the CGP composition
+/// conformance run in `contextgraph::tests`); what is pinned here is the
+/// report's shape, which is this module's own contract.
+#[test]
+fn the_merge_drop_report_is_one_summary_line_per_class() {
+    use crate::contextgraph::HostDroppedFrame;
+
+    fn evicted(id: &str, reason: stella_context::DropReason) -> HostDroppedFrame {
+        HostDroppedFrame {
+            provider: "local".into(),
+            id: id.into(),
+            citation_label: format!("[{id}]"),
+            token_cost: 120,
+            reason,
+        }
+    }
+
+    let dropped = vec![
+        evicted("nod_a", stella_context::DropReason::TokenBudget),
+        evicted("nod_b", stella_context::DropReason::TokenBudget),
+        evicted("nod_c", stella_context::DropReason::TokenBudget),
+        evicted("nod_d", stella_context::DropReason::TokenBudget),
+        evicted("nod_e", stella_context::DropReason::TokenBudget),
+        evicted("anchored", stella_context::DropReason::RequiredOverBudget),
+        // A count-limit eviction is not budget pressure: advising a bigger
+        // token budget for it would be a remedy that cannot help.
+        evicted("over_count", stella_context::DropReason::FrameCount),
+    ];
+
+    let mut lines = Vec::new();
+    crate::memory::recall::report_budget_drops(&dropped, 1200, &mut |m| lines.push(m));
+
+    assert_eq!(
+        lines.len(),
+        2,
+        "one line per budget class, not one per frame: {lines:?}"
+    );
+    assert!(
+        lines[0].contains("1 anchored frame(s)") && lines[0].contains("1200-token budget"),
+        "the required-over-budget class is named first, with the budget: {lines:?}"
+    );
+    assert_eq!(
+        lines[1],
+        "5 memories did not fit this turn's 1200-token retrieval budget — raise \
+         context.retrieval.max_tokens in stella.toml to include them",
+        "the exact line a user reads: count, budget, remedy, no internal id"
+    );
+    let joined = lines.join("\n");
+    for id in ["nod_a", "nod_b", "nod_c", "nod_d", "nod_e", "over_count"] {
+        assert!(
+            !joined.contains(id),
+            "no per-frame handle leaks into the summary: {joined}"
+        );
+    }
+}

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -696,8 +696,10 @@ fn a_touched_path_that_is_not_a_file_is_not_an_anchor() {
     );
 }
 
-/// **Witness (#3437).** One drop line per evicted candidate, whatever its
-/// source, each carrying the remedy its own channel answers to.
+/// **Witness (#3437).** Every dropped source reaches the person watching the
+/// run with the remedy its own channel answers to — and memory drops reach
+/// them as ONE summary line, not one line per evicted memory repeating the
+/// same remedy under an internal id.
 ///
 /// Fails on base, where `report_record_drops` filtered `SteeringSet::dropped`
 /// to `SteeringSource::Record` and emitted through a single producer that hard-
@@ -743,17 +745,30 @@ fn every_dropped_source_gets_a_line_with_its_own_remedy() {
     };
 
     let mut lines = Vec::new();
-    crate::memory::recall::report_steering_drops(&set, |message| lines.push(message));
+    crate::memory::recall::report_steering_drops(&set, 1200, |message| lines.push(message));
 
-    assert_eq!(lines.len(), 4, "one line per reportable source: {lines:?}");
+    assert_eq!(
+        lines.len(),
+        4,
+        "one summary for the memory drops, then one line per remaining \
+         reportable source: {lines:?}"
+    );
     let joined = lines.join("\n");
     assert!(
-        lines[0].contains("^deploy-policy") && lines[0].contains("raise its precedence"),
-        "the record channel's own sentence is unchanged: {joined}"
+        lines[0].contains("1 memories did not fit")
+            && lines[0].contains("1200-token retrieval budget")
+            && lines[0].contains("context.retrieval.max_tokens in stella.toml"),
+        "memory drops are one summary line naming the count, the budget the \
+         turn ran with, and the remedy — not one line per memory under an \
+         internal id: {joined}"
     );
     assert!(
-        lines[1].contains("nod_evicted") && lines[1].contains("`context.retrieval.max_tokens`"),
-        "a frame the merge evicted names the retrieval budget: {joined}"
+        !joined.contains("nod_evicted"),
+        "the summary does not leak the internal handle a user cannot act on: {joined}"
+    );
+    assert!(
+        lines[1].contains("^deploy-policy") && lines[1].contains("raise its precedence"),
+        "the record channel's own sentence is unchanged: {joined}"
     );
     assert!(
         lines[2].contains("seat-loser") && lines[2].contains("`skills.max_skills`"),


### PR DESCRIPTION
## Problem

Closes #5444.

A turn whose recall evicted N memories printed N near-identical warnings, each naming an internal handle (`nod_…`, `code-graph:sym:…`) a user cannot act on — and none of them stating the budget the turn actually ran with or where the knob lives:

```
! a memory recalled for this turn did not fit the retrieval budget: code-graph:sym:crates/stella-cli/src/context_records.rs:241:read — raise context.retrieval.max_tokens
! a memory recalled for this turn did not fit the retrieval budget: nod_8c00d4136d5691b9921591fd — raise context.retrieval.max_tokens
! a memory recalled for this turn did not fit the retrieval budget: nod_3d50a81cd7e9b4edcb5ec07f — raise context.retrieval.max_tokens
! … (once per evicted memory)
```

## Fix

One summary line per turn, stating the count, the budget, and the remedy:

```
! 5 memories did not fit this turn's 1200-token retrieval budget — raise context.retrieval.max_tokens in stella.toml to include them
```

- `report_steering_drops` now takes the turn's retrieval budget and summarizes `SteeringSource::Memory` drops into a single line; `drop_message` returns `None` for `Memory` so the per-candidate path no longer duplicates it. Record and skill drops keep their per-candidate lines — those name distinct, actionable remedies per item.
- `recalled_frames_anchored` threads the budget through a new `recalled_frames_anchored_reporting` body, so the host-merge report (which also covered required-over-budget anchored frames, one line each) emits the same summary shape; required frames get their own one-line summary since their remedy differs (each exceeds the budget on its own).
- The #3437 witness test now pins the summary shape: count, budget, remedy, and no internal handle in the output.

## Verification

- `cargo test -p stella-cli memory::` — 304 passed, 0 failed
- `cargo clippy -p stella-cli` — clean
- Witness: `every_dropped_source_gets_a_line_with_its_own_remedy` updated to assert the summary line and the absence of the internal id; fails against the old per-memory format.

## Summary by Sourcery

Summarize retrieval budget drops once per turn with actionable budget details instead of repeating warnings for each evicted memory.

Bug Fixes:
- Consolidate memory retrieval budget warnings into a single per-turn summary that reports the number of omitted memories, the active token budget, and the configuration remedy.
- Extend budget-drop reporting to anchored frame merges, including a separate summary for required frames that exceed the budget individually.
- Prevent internal memory handles and duplicate per-candidate warnings from appearing in user-facing retrieval diagnostics.

Enhancements:
- Preserve individual actionable warnings for record and skill drops while centralizing memory and anchored-frame budget reporting.

Tests:
- Update the steering-drop witness to verify the consolidated memory warning and absence of internal handles.
- Add coverage for one-line-per-class reporting of host-merge budget drops and required-over-budget frames.