### PR TITLE
fix(stella-store,stella-observatory): usage stats no longer count a system call as a resolved door

### DIFF
--- a/crates/stella-observatory/src/db.rs
+++ b/crates/stella-observatory/src/db.rs
@@ -633,6 +633,14 @@ impl Observatory {
 
     /// Per-(provider, model) usage — the same rows `stella stats` prints,
     /// same semantics (`resolved` = outcome `completed`, `off-grid` = local).
+    ///
+    /// `WHERE e.kind != 'system'` excludes standalone system calls
+    /// (reflection, skill authorship) from both `runs` and `resolved` — they
+    /// are not doors, and counting them here is the same measurement
+    /// artifact `stella-store`'s `usage_stats_scoped` was fixed for.
+    /// This crate reads the store file directly rather than through
+    /// `stella-store`'s API, so the literal is duplicated rather than shared
+    /// via a constant.
     pub fn models(&self) -> Result<Value, DbError> {
         let Some(conn) = self.store() else {
             return Ok(json!([]));
@@ -656,6 +664,7 @@ impl Observatory {
                                sum(duration_ms)        AS duration_ms
                         FROM telemetry GROUP BY execution_id) t
                ON t.execution_id = e.id
+             WHERE e.kind != 'system'
              GROUP BY e.provider, e.model
              ORDER BY total_cost_usd DESC, e.provider ASC, e.model ASC",
             |r| {

--- a/crates/stella-store/src/export.rs
+++ b/crates/stella-store/src/export.rs
@@ -32,6 +32,7 @@ use base64::Engine as _;
 use rusqlite::ToSql;
 use serde::Serialize;
 
+use crate::migrations::SYSTEM_NON_DOOR;
 use crate::{Result, Store, UsageStatsRow};
 
 /// Which executions an analytics read covers.
@@ -229,11 +230,26 @@ impl Store {
 
     /// One SQL body, both scopes. See [`ExportScope`] for why this is not two
     /// functions.
+    ///
+    /// A standalone system call (`kind = 'system'` — reflection, skill
+    /// authorship) is excluded from both `runs` and `resolved`: it is not a
+    /// door, `EXECUTIONS_DDL`'s doc states the rule, and counting it here
+    /// pulls `resolve_rate` toward 1 and `cost_per_resolved_usd` down every
+    /// time a workspace does more reflection. This predicate is
+    /// local to the usage aggregate rather than folded into
+    /// [`ExportScope::executions_where`], which the raw `/export` dump also
+    /// uses and must keep every row, system included.
     fn usage_stats_scoped(&self, scope: ExportScope<'_>) -> Result<Vec<UsageStatsRow>> {
         let conn = self.lock();
         // The inner aggregate stays unfiltered on purpose: it is joined by
         // `execution_id` to an already-scoped `executions`, so a telemetry row
         // from another session has no surviving row to attach to.
+        let scope_where = scope.executions_where("e.");
+        let doors_where = if scope_where.is_empty() {
+            format!("WHERE e.kind != '{SYSTEM_NON_DOOR}'")
+        } else {
+            format!("{scope_where} AND e.kind != '{SYSTEM_NON_DOOR}'")
+        };
         let sql = format!(
             "SELECT e.provider,
                     e.model,
@@ -256,10 +272,9 @@ impl Store {
                FROM telemetry
                GROUP BY execution_id
              ) t ON t.execution_id = e.id
-             {}
+             {doors_where}
              GROUP BY e.provider, e.model
-             ORDER BY total_cost_usd DESC, e.provider ASC, e.model ASC",
-            scope.executions_where("e.")
+             ORDER BY total_cost_usd DESC, e.provider ASC, e.model ASC"
         );
         let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(scope.bindings().as_slice(), |row| {
@@ -650,6 +665,43 @@ mod tests {
 
         let workspace = store.usage_stats().expect("workspace");
         assert_eq!(workspace.len(), 3, "all three executions: {workspace:?}");
+    }
+
+    /// A standalone system call (reflection, skill
+    /// authorship) is not a door — `EXECUTIONS_DDL`'s doc states the rule —
+    /// so it must not be counted as a run or, worse, a resolved task: doing
+    /// so pulls `resolve_rate` toward 1 and `cost_per_resolved_usd` down
+    /// every time a workspace does more reflection, which is a measurement
+    /// artifact in the flattering direction.
+    ///
+    /// Fails on the pre-fix code with `runs = 2, resolved = 2`: the `system`
+    /// execution below closes `completed` exactly like the `deck` one, and
+    /// nothing distinguished them.
+    #[test]
+    fn a_completed_system_call_is_not_counted_as_a_resolved_door() {
+        let store = Store::in_memory().expect("store");
+
+        let door = store
+            .begin_execution("deck", "make it faster", "anthropic", "m")
+            .expect("door execution");
+        store
+            .finish_execution(door, "completed", 1.0)
+            .expect("close door");
+
+        let system = store
+            .begin_execution("system", "reflect on the last turn", "anthropic", "m")
+            .expect("system execution");
+        store
+            .finish_execution(system, "completed", 0.01)
+            .expect("close system call");
+
+        let stats = store.usage_stats().expect("stats");
+        assert_eq!(stats.len(), 1, "one (provider, model) pair: {stats:?}");
+        assert_eq!(stats[0].runs, 1, "the system call must not count as a run");
+        assert_eq!(
+            stats[0].resolved, 1,
+            "the system call must not count as resolved"
+        );
     }
 
     /// A session with no executions of its own must export nothing — not fall


### PR DESCRIPTION
## What & why

`Store::usage_stats_scoped` (`crates/stella-store/src/export.rs`) — the query
behind `stella stats` — counted every execution row with no `kind` predicate,
so a standalone system call (reflection, skill authorship) counted as a `run`,
and one that closed `completed` counted as `resolved`. `EXECUTIONS_DDL`'s doc
already states the rule in bold: **a query over doors must exclude
`kind = 'system'`** — this query didn't.

**This changes published numbers, in the honest direction, and the drop is the
point.** `resolve_rate` and `cost_per_resolved_usd` were both computed from an
inflated `runs`/`resolved` pair, and the inflation grows with how much
reflection a workspace has done — the more reflection, the better `stella
stats` looked. Any cost-per-task or resolve-rate figure quoted from `stella
stats` before this PR was quoting a flattered number.

The fix adds `e.kind != 'system'` to `usage_stats_scoped`'s own `WHERE`
clause, reusing the existing `SYSTEM_NON_DOOR` constant
(`crates/stella-store/src/migrations/execution_role.rs`) rather than
hardcoding the literal twice. It is **not** folded into
`ExportScope::executions_where`, the helper the raw `/export` archive dump
also uses — that dump is meant to keep every row, system included, for audit
fidelity, so widening the shared helper would have silently changed the
archive's contents as a side effect of fixing the aggregate.

Per the issue's instruction to check the sibling rather than assume:
`stella-observatory`'s `Db::models()` (`crates/stella-observatory/src/db.rs`)
runs the same query independently — it reads the store file directly rather
than through `stella-store`'s API, so it has no dependency on `stella-store`
to share the fix through. It carried the identical defect and gets the same
`WHERE e.kind != 'system'` predicate, as a literal (consistent with this
file's existing style — `if provider == "local"` a few lines below).

`crates/stella-cli/src/stats.rs`'s `to_stats_rows` and
`crates/stella-cli/src/accounted_call.rs`'s `complete_standalone` were both
named in the issue as relevant context, not as call sites needing a change:
the renderer passes through whatever `runs`/`resolved` it's given, and the
system-call completion path is correct as written — a successful system call
should close `completed`; the bug was in what counted it, not in what wrote
it.

Closes #5107

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-store/src/export.rs`'s
`a_completed_system_call_is_not_counted_as_a_resolved_door`: a store holding
one `deck` execution closed `completed` and one `system` execution closed
`completed`. Checked the artisanal way — with the SQL predicate reverted and
the test kept, it fails with `runs = 2, resolved = 2` (exactly what the issue
predicted); with the predicate restored, `runs = 1, resolved = 1`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-store -p stella-observatory --all-targets -- -D warnings`
- [x] `cargo test -p stella-store` — 463 passed, 0 failed
- [x] `cargo test -p stella-observatory` — 153 passed, 0 failed
- [ ] `cargo test --workspace` — not run locally; this repo's rule is CI builds
      and tests, not this machine (AGENTS.md, "CI builds and tests; this laptop
      does not"). The pushed branch's CI run is the evidence.
- [x] `Closes #5107` appears both above and as a commit trailer

## Nothing left behind

- [ ] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Exclude standalone system calls from usage statistics to ensure resolve rates and cost-per-resolved figures reflect doors בלבד.

Bug Fixes:
- Exclude standalone system calls from usage statistics so they are not counted as door runs or resolved doors.
- Apply the same system-call exclusion to observatory per-model usage statistics.

Enhancements:
- Keep system executions included in raw export archives while filtering them only from usage aggregates.

Tests:
- Add a regression test confirming completed system calls do not affect run or resolved counts.