### PR TITLE
fix(bench): ingest.py truncates large event fields, not the JSON document

### DIFF
--- a/bench/telemetry_store/ingest.py
+++ b/bench/telemetry_store/ingest.py
@@ -104,6 +104,38 @@ COST_NORM_NO_RUN_DATE = "no_run_date"
 COST_NORM_UNMIGRATED = "unmigrated"
 
 
+# The event members large enough to blow the old whole-document cap:
+# `file_change`'s diff, `tool_result`'s output, and a handful of other
+# event types' free-text `text`. Every other member is already small
+# (paths, ids, timestamps).
+PAYLOAD_TRUNCATABLE_FIELDS = ("diff", "output", "text")
+PAYLOAD_FIELD_CHAR_CAP = 20_000
+
+
+def bounded_payload_json(event: dict) -> str:
+    """Serialize an event for `events.payload_json`, always valid JSON.
+
+    `json.dumps(event)[:20000]` sliced the *document*, not a field, so an
+    oversized event was stored as a truncated prefix that `json.loads`
+    rejects outright. This caps the members that are actually large —
+    `diff`, `output`, `text` — before serializing, so the stored cell always
+    parses, and marks which members it shortened under `_truncated` so a
+    reader can tell a genuinely short diff from a cut one.
+    """
+    truncated = []
+    capped = event
+    for field in PAYLOAD_TRUNCATABLE_FIELDS:
+        value = event.get(field)
+        if isinstance(value, str) and len(value) > PAYLOAD_FIELD_CHAR_CAP:
+            if capped is event:
+                capped = dict(event)
+            capped[field] = value[:PAYLOAD_FIELD_CHAR_CAP]
+            truncated.append(field)
+    if truncated:
+        capped["_truncated"] = truncated
+    return json.dumps(capped)
+
+
 def now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -286,7 +318,7 @@ def ingest_trial(conn, run_id, arm, agent, tdir, model=None):
                 conn.execute(
                     "INSERT OR REPLACE INTO events (event_id,trial_id,seq,type,payload_json)"
                     " VALUES (?,?,?,?,?)",
-                    (f"{trial_id}:{seq}", trial_id, seq, t, json.dumps(e)[:20000]),
+                    (f"{trial_id}:{seq}", trial_id, seq, t, bounded_payload_json(e)),
                 )
                 n_ev += 1
                 if t in ("tool_start", "tool_call"):

--- a/bench/telemetry_store/tests/test_ingest.py
+++ b/bench/telemetry_store/tests/test_ingest.py
@@ -14,6 +14,7 @@ from ingest import (
     COST_NORM_PRICED,
     COST_NORM_UNMIGRATED,
     COST_NORM_UNPRICED_MODEL,
+    bounded_payload_json,
     connect,
     elapsed_seconds,
     ingest_trial,
@@ -154,6 +155,62 @@ def test_ingest_records_why_a_trial_is_unpriced(tmp_path):
     ).fetchone()
     assert cost is None
     assert status == COST_NORM_NO_MODEL
+
+
+def test_an_oversized_event_payload_still_parses():
+    """`json.dumps(e)[:20000]` sliced the *document*, so an oversized event
+    was stored as a truncated prefix `json.loads` rejects outright — a
+    `file_change` with a 30,000-char diff reproduces it directly."""
+    diff = "+" + ("x" * 30_000)
+    raw = bounded_payload_json({"type": "file_change", "path": "a.rs", "diff": diff})
+    payload = json.loads(raw)
+    assert payload["_truncated"] == ["diff"]
+    assert len(payload["diff"]) == 20_000
+
+
+def test_an_oversized_tool_output_still_parses():
+    output = "x" * 30_000
+    raw = bounded_payload_json({"type": "tool_result", "call_id": "c1", "output": output})
+    payload = json.loads(raw)
+    assert payload["_truncated"] == ["output"]
+    assert len(payload["output"]) == 20_000
+
+
+def test_a_normal_sized_event_is_unmarked_and_untouched():
+    """A short diff must not gain a `_truncated` key — a reader has to be
+    able to tell a genuinely short payload from a cut one."""
+    event = {"type": "file_change", "path": "a.rs", "diff": "@@\n+let x = 1;"}
+    payload = json.loads(bounded_payload_json(event))
+    assert "_truncated" not in payload
+    assert payload == event
+
+
+def test_ingest_trial_writes_only_parseable_event_payloads(tmp_path):
+    """Exercised through `ingest_trial` itself rather than the helper alone:
+    every `events.payload_json` cell round-trips through `json.loads`, for a
+    trial whose event stream holds an oversized `file_change` and an
+    oversized `tool_result`."""
+    conn = connect(str(tmp_path / "bench.db"))
+    _seed_run(conn)
+    tdir = _write_trial(tmp_path, _result())
+    agent_dir = os.path.join(tdir, "agent")
+    os.makedirs(agent_dir, exist_ok=True)
+    events = [
+        {"type": "file_change", "path": "a.rs", "kind": "modified", "diff": "+" + "x" * 30_000},
+        {"type": "tool_result", "call_id": "c1", "output": "y" * 30_000, "duration_ms": 5},
+    ]
+    with open(os.path.join(agent_dir, "stella-events.jsonl"), "w") as fh:
+        for event in events:
+            fh.write(json.dumps(event) + "\n")
+
+    ingest_trial(conn, "tag", "stella", "stella", tdir)
+
+    rows = conn.execute("SELECT type, payload_json FROM events ORDER BY seq").fetchall()
+    assert len(rows) == 2
+    for kind, raw in rows:
+        payload = json.loads(raw)  # must not raise
+        field = "diff" if kind == "file_change" else "output"
+        assert payload["_truncated"] == [field]
 
 
 def test_migration_is_idempotent_and_marks_pre_existing_rows(tmp_path):


### PR DESCRIPTION
## What & why

`bench/telemetry_store/ingest.py` wrote every event payload as
`json.dumps(e)[:20000]` — a character slice of a **JSON document**, not a
field. Any event whose serialized form exceeded 20,000 characters was stored
as a truncated prefix that `json.loads` rejects outright, with no marker on
the row saying so.

This mattered because the two event types with the largest payloads —
`file_change` (a `diff`) and `tool_result` (the tool's whole output) — are
exactly what `grade.py`'s diff-convergence and tool-exit rules read. The
grader already counts unreadable payloads rather than treating them as absent
facts (`_payload`, `TRUNCATION_GAP = "#5088"`), but counting is a workaround,
not a fix.

Picked **option 1** from the issue: truncate the large string members, not
the document. `bounded_payload_json` caps `diff`/`output`/`text` to 20,000
characters each before serializing, so the stored cell is always valid JSON,
and marks which members it shortened under a `_truncated` key so a reader can
tell a genuinely short payload from a cut one. `ingest.py`'s call site now
calls this instead of slicing the dumped string.

`grade.py`'s `_payload`/`TRUNCATION_GAP` workaround is left in place —
freshly ingested trials will simply never trigger it, and it stays as a
defence for any database already holding pre-fix rows.

**A database already ingested keeps its broken cells.** This changes what a
future ingest writes; it does not rewrite existing rows, and no re-ingest is
being run as part of this PR.

Closes #5088

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`bench/telemetry_store/tests/test_ingest.py`:
`test_an_oversized_event_payload_still_parses`,
`test_an_oversized_tool_output_still_parses`,
`test_a_normal_sized_event_is_unmarked_and_untouched`, and
`test_ingest_trial_writes_only_parseable_event_payloads` (the integration
case through `ingest_trial` itself, per the issue's exact ask: a fixture
trial with an oversized `file_change` and an oversized `tool_result`).

Checked the artisanal way: with the call site reverted to
`json.dumps(e)[:20000]` and the tests kept, the integration test fails with
`json.decoder.JSONDecodeError: Unterminated string starting at: line 1
column 69` — reproducing the issue's own repro exactly. Restored, all 53
tests in `bench/telemetry_store/tests/` pass.

## The gate

- [x] `python3 -m pytest bench/telemetry_store/tests/` — 53 passed, 0 failed
- [x] `make guards-fast` — green, including prose and file-size
- [x] `cargo fmt --check` — n/a (Python-only change), ran anyway, clean

## Nothing left behind

- [ ] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Preserve parseable telemetry payloads by bounding oversized event fields during ingestion.

Bug Fixes:
- Ensure oversized event payloads remain valid JSON by truncating only large string fields instead of the serialized document.
- Record truncated payload fields so consumers can distinguish shortened values from complete payloads.

Tests:
- Add unit and integration coverage for oversized diffs, tool outputs, normal payloads, and parseable ingested event records.