### PR TITLE
docs(website): simplify all 92 doc pages to plain customer-facing prose

### DIFF
--- a/website/content/docs/accessibility.mdx
+++ b/website/content/docs/accessibility.mdx
@@ -1,23 +1,22 @@
 ---
 title: Accessibility
-description: Run the Command Deck so a screen reader can read it — what --accessible changes, what it leaves alone, and how it differs from --plain.
+description: Run the Command Deck with a screen reader. What --accessible changes, what stays the same, and how it's different from --plain.
 ---
 
-stella's interactive surface is the **Command Deck**, a tabbed terminal UI. By default it
-draws the way full-window terminal apps do: on the alternate screen, repainting a whole
-grid many times a second. That is a good surface for an eye and a poor one for a screen
-reader, which is handed cell churn with no notion of *a new line appeared* — and which
-loses the entire conversation the moment you quit, because the alternate screen is torn
-down with the program.
+stella's interactive surface is the Command Deck, a tabbed terminal interface. By
+default, it draws the way most full-window terminal apps do: it takes over the whole
+screen and repaints the grid many times a second. That works well for your eyes. It does
+not work for a screen reader, which gets a flood of changing text with no way to tell
+that a new line appeared. Worse, the whole conversation disappears the moment you quit,
+because the screen it drew on is torn down with the program.
 
-`--accessible` changes how the deck talks to your terminal so that a reader can follow it.
+`--accessible` changes how the deck talks to your terminal so a screen reader can follow
+it.
 
 <Callout type="info">
-  **It is a mode on the deck, not a smaller surface beside it.** Every tab, every gate,
-  every key, the prompt queue, sub-agents, steering and resume are exactly what they
-  always were. Nothing is removed and nothing is simplified — a separate "accessible
-  build" is a permanent second-class tier, where every feature shipped afterwards becomes
-  a gap it never closes.
+  **This is a mode on the deck, not a separate, smaller tool.** Every tab, every gate,
+  every key, the prompt queue, sub-agents, steering, and resume work exactly the way they
+  always do. Nothing is removed and nothing is simplified.
 </Callout>
 
 ## Turning it on
@@ -36,77 +35,79 @@ stella resume --accessible
 `--accessible` is a global flag, and `stella chat` and `stella resume` are the two
 commands that open the deck.
 
-To make it your default, set the environment variable in your shell profile rather than
-remembering a flag on every invocation:
+To make it your default, set the environment variable in your shell profile instead of
+typing the flag every time:
 
 ```bash
 export STELLA_ACCESSIBLE=1
 ```
 
-The variable is on when it is present and set to anything other than `0` — so
-`STELLA_ACCESSIBLE=1` and `STELLA_ACCESSIBLE=yes` both enable it, while
+The variable turns the mode on when it is set to anything other than `0`. So
+`STELLA_ACCESSIBLE=1` and `STELLA_ACCESSIBLE=yes` both turn it on, while
 `STELLA_ACCESSIBLE=0` and an empty value leave it off.
 
-`--simple` is accepted as an alias for `--accessible`. It is the spelling an earlier,
-short-lived separate surface used; it now selects this mode.
+`--simple` also works, and does the same thing as `--accessible`.
 
 ## What changes
 
-### The deck never takes over the screen
+### The deck stays on your screen
 
-The session draws **inline, underneath your prompt**, on your own screen. The alternate
-screen is never entered and never left. Nothing above the deck is hidden while it runs,
-and nothing is destroyed when it exits.
+The session draws inline, right below your prompt, on your own screen. It never switches
+to a separate screen. Nothing above the deck gets hidden while it runs, and nothing gets
+destroyed when it exits.
 
 ### Finished messages move into scrollback
 
-Each completed transcript entry is written into your terminal's ordinary scrollback
-**exactly once** — so your reader announces it as it arrives, your review cursor can go
-back through it, and it is still there after you quit. The live pane skips whatever has
-already been written, so nothing is read out twice.
+Each finished message gets written into your terminal's normal scrollback exactly once.
+Your screen reader announces it as it arrives. You can scroll back through it with your
+review cursor. And it stays there after you quit. The live pane skips anything already
+written, so nothing gets read out twice.
 
-Entries move per agent lane, and the newest entry of each lane is held in the pane until
-the session ends, because streaming deltas keep coalescing into it until it settles.
+Messages move into scrollback one agent lane at a time. The newest message in each lane
+stays in the live pane until the session ends, because it keeps updating while the
+response streams in.
 
 ### Motion is frozen
 
-Accessible mode implies [`--no-anim`](#related-terminal-controls): the progress bar's
-shimmer and pulse and the caret blink all stop. No region of the screen repaints on a
-clock, so there is nothing for a reader to pick up as churn.
+Accessible mode turns on [`--no-anim`](#related-terminal-controls) automatically. The
+progress bar's shimmer and pulse stop, and the caret stops blinking. No part of the
+screen repaints on a timer, so there is nothing for a screen reader to mistake for new
+content.
 
 ### Panels stack into one column
 
-The three places the deck drew two panes side by side — the **GRAPH** tab, the **SKILLS**
-tab, and the session's work rail — stack vertically instead. No rendered row splices
-content from two logical panes, so reading order is top to bottom. For the work rail, the
-deck takes the path a narrow terminal already takes: a one-row state strip, with `⌃S`
-opening the whole thing.
+The deck normally draws three areas as two panes side by side: the GRAPH tab, the
+SKILLS tab, and the session's work rail. In accessible mode, these stack vertically
+instead. No row mixes content from two panes, so the reading order goes top to bottom.
+For the work rail, the deck uses the same layout it already uses on a narrow terminal: a
+one-row status strip, with `⌃S` opening the full view.
 
-### Grid views read as labelled records
+### Grid views read as labeled records
 
-A table is a compression scheme that only works on an eye. `$0.05` sitting under a `Cost`
-header two rows up is a labelled value if you can see the column; read aloud it is the
-number five with nothing attached, because the alignment carrying the meaning is
-whitespace — exactly what a reader collapses.
+A table only makes sense if you can see it. `$0.05` sitting under a `Cost` header two
+rows up works fine for your eyes, because you can see the column line up. Read aloud, it
+is just the number five with nothing attached, because the spacing that carries the
+meaning is whitespace, and a screen reader skips over whitespace.
 
-So **TRACES**, **ISSUES**, **TOOLS**, **AGENTS** and **INSTALLED** render one record per
-row, with every value carrying its own label:
+So the TRACES, ISSUES, TOOLS, AGENTS, and INSTALLED tabs each show one record per row,
+with every value carrying its own label:
 
 ```text
 status running · cost $0.05 · cpu 3%
 ```
 
-Nothing is dropped — the same fields, in the same order, saying what they are. A row too
-long for the terminal is clipped with an ellipsis rather than wrapped, because the deck's
-scrolling is line-exact and a record that wrapped to two rows would break ↑/↓.
+Nothing is dropped. You get the same fields, in the same order, each one labeled. If a
+row is too long for your terminal, it gets cut off with an ellipsis instead of wrapping
+to a second line. That's because the deck scrolls one line at a time, and a row that
+wrapped to two lines would break the up and down arrow keys.
 
 ### Moving somewhere is announced
 
-On the alternate screen, changing tabs is self-evident: the whole grid changes. Drawn
-inline and read aloud, the same transition is silent — the pane repaints in place and
-nothing says you are somewhere else.
+Normally, changing tabs is obvious because the whole screen changes. In accessible mode,
+drawn inline, that same move is silent. The pane just repaints in place, with nothing to
+say you are somewhere new.
 
-So each move emits a line into scrollback:
+So each move writes a line into scrollback:
 
 | You did | You hear |
 | --- | --- |
@@ -115,58 +116,59 @@ So each move emits a line into scrollback:
 | Closed an overlay | `▸ help closed` |
 | Focus moved to another agent | `▸ focus <agent-id>` |
 
-The overlays that announce themselves are help, state, queue editor, sessions, context,
-inbox, inspect, transcript search, and the graph file picker. Chrome that opens and closes
-on nearly every keystroke — the slash menu, the composer's own popups — deliberately stays
-quiet, because announcing it would bury the moves that matter.
+These overlays announce themselves when opened or closed: help, state, queue editor,
+sessions, context, inbox, inspect, transcript search, and the graph file picker. Things
+that open and close on almost every keystroke, like the slash menu and the composer's
+own popups, stay quiet on purpose. Announcing those would bury the moves that actually
+matter.
 
 ### The program's own voice is marked
 
-Messages stella itself speaks — "conversation cleared", driver and chrome notices — open
-with `▸`. In the default deck those are distinguished by which rail they render on, which
-is a *visual* distinction, and therefore exactly the one that does not survive being read
-aloud. Without the marker the transcript asserts that the model said "conversation
-cleared".
+Messages that stella itself speaks, like "conversation cleared" and other system
+notices, start with `▸`. In the normal deck, you tell these apart by which column they
+appear in. That works for your eyes but not for your ears. Without the `▸` marker, a
+screen reader would make it sound like the model itself said "conversation cleared."
 
 ### The cursor and the mouse
 
-The hardware cursor sits on the real insertion point in the composer, which is what a
-reader follows and what a CJK/Japanese/Korean IME anchors its candidate window to.
+The text cursor sits at the real insertion point in the composer. That is what a screen
+reader follows, and what a Chinese, Japanese, or Korean input method uses to place its
+candidate window.
 
-Mouse capture is forced **off**, even if something asked for it: a captured mouse takes
-your terminal's own selection away, and selection is how several assistive technologies
-read a terminal.
+Mouse capture is **always off** in accessible mode, even if something else asks for it.
+A captured mouse takes away your terminal's own text selection, and several assistive
+technologies rely on that selection to read the terminal.
 
-## What does not change
+## What stays the same
 
 Everything else. All nine tabs, the prompt queue, sub-agents, steering a running turn,
-permission gates, slash commands, resume — the same program, the same keys, the same
-behavior. If a feature works in the deck, it works here.
+permission gates, slash commands, and resume all work the same way, with the same keys
+and the same behavior. If a feature works in the deck, it works here too.
 
-## When your terminal will not cooperate
+## Terminal limits
 
-Drawing inline means anchoring to the cursor's current position, which stella has to
-*ask* for: it writes a cursor-position request and waits for the terminal to answer.
-Every real emulator answers. Some minimal terminals and most test harnesses do not, and
-the request times out.
+Drawing inline means stella needs to know where your cursor is right now. It asks your
+terminal for this, then waits for an answer. Every real terminal emulator answers. Some
+minimal terminals and most automated test tools do not, and the request times out.
 
-When that happens the deck still starts. It draws on your own screen — never the alternate
-one — with the scrollback flush disabled, and it says so:
+When that happens, the deck still starts. It still draws on your own screen, never a
+separate one, but it turns off the scrollback flush and tells you:
 
 ```text
 accessible mode: this terminal did not report its cursor position, so messages stay in
 the deck pane instead of moving into scrollback
 ```
 
-The degrade is announced rather than silent on purpose. The promise of the mode is that
-finished messages become durable output, and quietly not delivering it is worse than not
-offering it. If you see that notice, everything else about the mode still applies —
-stacked panels, labelled records, frozen motion, marked notices — but the transcript stays
-in the pane, and announcements have nowhere to go.
+This message shows up on purpose instead of failing silently. The whole point of
+accessible mode is that finished messages become permanent output. Quietly failing to
+deliver that would be worse than not offering it at all. If you see this notice,
+everything else about the mode still works: stacked panels, labeled records, frozen
+motion, and marked notices. But the transcript stays in the live pane, and announcements
+have nowhere to go.
 
 ## `--accessible` or `--plain`?
 
-They answer different questions, and they compose with different things.
+They answer different questions.
 
 | | `--accessible` | `--plain` |
 | --- | --- | --- |
@@ -177,12 +179,12 @@ They answer different questions, and they compose with different things.
 | **Env** | `STELLA_ACCESSIBLE=1` | `STELLA_PLAIN=1` |
 
 Use `--accessible` when you are at a terminal with a screen reader. Use `--plain` for
-pipes, CI logs, `TERM=dumb`, and anywhere there is no interactive terminal at all — the
-deck steps aside for the REPL automatically in those cases anyway.
+pipes, CI logs, `TERM=dumb`, and anywhere there is no interactive terminal at all. The
+deck switches to the REPL automatically in those cases anyway.
 
-Accessible mode takes no part in that deck-or-REPL decision. If stdin or stdout is not a
-terminal you get the REPL, whether or not you asked for accessible mode, because an inline
-viewport needs a real terminal just as much as the alternate screen does.
+Accessible mode has no say in that choice. If stdin or stdout is not a terminal, you get
+the REPL whether or not you asked for accessible mode. An inline viewport needs a real
+terminal just as much as a full-screen one does.
 
 ## Related terminal controls
 
@@ -195,29 +197,31 @@ These are independent of `--accessible` and work on their own:
 | `TERM=dumb` | Switches ANSI output off entirely. `CLICOLOR_FORCE` overrides it. |
 | `--plain` / `STELLA_PLAIN=1` | The line REPL instead of the deck. |
 
-## Checking that it is working
+## Check it works
 
 Start a session with `stella --accessible` and look for these, in order:
 
 1. **Your prompt is still visible above the deck.** If the screen cleared and your
-   scrollback disappeared, you are on the alternate screen and the mode is not on — check
-   for a `STELLA_ACCESSIBLE=0` in your environment overriding the profile you expected.
-2. **No degrade notice.** If you see the cursor-position message quoted above, your
-   terminal did not answer, and finished messages will stay in the pane.
-3. **Ask something, and let the turn finish.** The completed message should be in ordinary
-   scrollback — scroll your terminal up, or use your reader's review cursor, and it should
-   be reachable as normal text.
+   scrollback disappeared, the mode is not on and you are on the full-screen view. Check
+   for a `STELLA_ACCESSIBLE=0` in your environment that might be overriding your
+   profile.
+2. **No fallback notice.** If you see the cursor-position message shown above, your
+   terminal did not answer, and finished messages will stay in the pane instead of
+   moving to scrollback.
+3. **Ask something, and let the turn finish.** The finished message should be in
+   ordinary scrollback. Scroll your terminal up, or use your screen reader's review
+   cursor, and you should be able to reach it as normal text.
 4. **Press `⇥`.** You should hear `▸ AGENTS tab` or similar.
 5. **Quit.** The conversation should still be on screen.
 
 ## Reporting a gap
 
-Accessibility here means ordinary sequential terminal output, which every screen reader
-already handles — there is no terminal accessibility API to target, so there is nothing
-reader-specific to configure. If some part of the deck still does not read correctly,
-that is a bug worth filing on the
-[issue tracker](https://github.com/macanderson/stella/issues), with your terminal
-emulator and reader named.
+Accessibility here just means ordinary, sequential terminal output, which every screen
+reader already handles. There is no special terminal accessibility API to target, so
+there is nothing reader-specific to configure. If some part of the deck still does not
+read correctly, file a bug on the
+[issue tracker](https://github.com/macanderson/stella/issues) and name your terminal
+emulator and screen reader.
 
 ## See also
 

--- a/website/content/docs/agent-engine-in-your-app.mdx
+++ b/website/content/docs/agent-engine-in-your-app.mdx
@@ -1,18 +1,18 @@
 ---
-title: How to use stella as the Agent Engine in your GenAI app
-description: Run stella's agent loop inside your own product — the engine orchestrates, your app owns every model call, tool call, and credential. Includes an 80-line working host.
+title: Agent Engine in Your App
+description: Run stella's agent loop inside your own product. The engine handles orchestration; your app owns every model call, tool call, and credential. Includes a complete working example.
 ---
 
-Writing an agent loop that survives contact with production is a grind. You
-need multi-step tool dispatch, history compaction before the context window
-fills, per-turn spend limits, retry classification that knows a rate limit from
-a bad request, and loop detection for the model that calls the same tool nine
-times. None of that is your product. All of it is on your critical path.
+Writing an agent loop that holds up in production is hard work. You need multi-step
+tool dispatch, history compaction before the context window fills up, spend limits per
+turn, retry logic that can tell a rate limit apart from a bad request, and loop
+detection for when the model calls the same tool nine times in a row. None of that is
+your actual product, but all of it sits between you and shipping it.
 
-stella already does it, and you can run it inside your own app without giving
+stella already does all of this, and you can run it inside your own app without giving
 up control of your models, your tools, or your data.
 
-## What you get, and what you keep
+## What each side owns
 
 | stella handles | You keep |
 |---|---|
@@ -22,36 +22,36 @@ up control of your models, your tools, or your data.
 | Loop detection and step caps | All persistence. The engine stores nothing |
 | Spend guards per turn and per session | Your prompts, your tool schemas, your data |
 
-## The one idea: the engine asks, your app executes
+## Engine asks, app answers
 
-This is the part worth understanding before you write any code, because it
-inverts the usual shape.
+Understand this before you write any code, because it flips the usual shape of an
+agent loop.
 
-stella's engine does not call your tools. It **asks you to call them**, then
-waits. Same for the model: it does not hold an API key and it does not make an
-HTTP request. It emits a request and parks until your app answers.
+stella's engine does not call your tools. It asks you to call them, then waits. It's
+the same for the model: the engine doesn't hold an API key and doesn't make an HTTP
+request itself. It sends a request and waits until your app answers.
 
 <EngineSequenceDiagram />
 
-Two consequences matter for a real product:
+This matters for two reasons:
 
-**The engine cannot leak what it never has.** `stella-serve` depends on two
-crates, `stella-protocol` and `stella-core`. It has no HTTP client, no TLS
-stack, and no provider adapters. It cannot reach the network or read a
-provider credential, so a bug in it cannot exfiltrate your keys. That is a
-property of the dependency graph, not a promise.
+**The engine can't leak what it doesn't have.** `stella-serve` depends on only two
+crates, `stella-protocol` and `stella-core`. It has no HTTP client, no TLS stack, and
+no provider adapters. It can't reach the network or read a provider credential, so a
+bug in it can't leak your keys. That's guaranteed by what the code depends on, not
+just a promise.
 
-**Your tests need no API key.** Because your app is the model, you can drive a
-complete multi-step turn from a unit test with a scripted reply. Full agent loop
-coverage, no network, no spend, in milliseconds.
+**Your tests don't need an API key.** Since your app plays the role of the model, you
+can drive a full multi-step turn from a unit test using a scripted reply. That gives
+you full agent-loop test coverage, with no network calls, no spend, in milliseconds.
 
 <Callout type="info">
-  This page covers running the engine as a service next to your app. If you want
-  the command-line doors into the same engine (`stella run`, the Command Deck,
-  `stella goal`, fleets), see [Agent Engine Paths](/docs/agent-engine-paths).
+  Running the engine as a service next to your app is one way in. For the
+  command-line doors into the same engine (`stella run`, the Command Deck, `stella
+  goal`, fleets), see [Agent Engine Paths](/docs/agent-engine-paths).
 </Callout>
 
-## Pick your integration shape first
+## Pick an integration shape
 
 The choice changes your licensing obligations, so make it before you build.
 
@@ -62,20 +62,21 @@ The choice changes your licensing obligations, so make it before you build.
 | **Isolation** | Separate process, separate memory | Shares your process |
 | **Licensing** | Depends on whether you modify it. [Read below](#licensing-agpl-or-commercial) |  A combined work. AGPL, or buy a commercial license |
 
-The sidecar is the recommended shape for a GenAI app, on engineering grounds:
-process isolation, a host you can write in TypeScript or Python, and an engine
-that never shares memory with your application code.
+The sidecar is the shape we recommend for a GenAI app, for engineering reasons:
+process isolation, a host you can write in TypeScript or Python, and an engine that
+never shares memory with your application code.
 
-It is not automatically the cheaper licensing answer. Linking the crates into a
-closed-source product clearly needs a commercial license. The sidecar depends on
-what you do with it, and [the section below](#where-the-sidecar-lands) is
-specific about which facts decide it. Do not read "sidecar" as "free."
+It's not automatically the cheaper option for licensing, though. Linking the crates
+into a closed-source product clearly needs a commercial license. Whether the sidecar
+does depends on what you do with it, and
+[the section below](#where-the-sidecar-lands) spells out exactly which facts decide
+that. Don't read "sidecar" as "free."
 
 ## Step 1: Build a serve-capable binary
 
-There is no `stella serve` subcommand, and no release tarball contains the
-server. `stella-serve` is a separate crate with its own binary, and the release
-build packages the CLI only. Build it:
+There's no `stella serve` subcommand, and no release download contains the server.
+`stella-serve` is a separate crate with its own binary, and the release build only
+packages the CLI. Build it yourself:
 
 ```bash
 git clone https://github.com/macanderson/stella
@@ -83,8 +84,8 @@ cd stella
 cargo build --release -p stella-serve --bin stella-serve
 ```
 
-It is a fast build. The server pulls in only `stella-protocol` and
-`stella-core`, not the CLI, the TUI, or the tool crates.
+This is a fast build. The server pulls in only `stella-protocol` and `stella-core`,
+not the CLI, the terminal interface, or the tool crates.
 
 Confirm what you built:
 
@@ -93,9 +94,9 @@ Confirm what you built:
 # stella-serve <version>   — the program name, one space, a bare semver
 ```
 
-Record that version in your repo next to the client code. The wire format is
-additive, but a pin plus a round-trip test is how you find out about a change
-on your schedule instead of in production.
+Record that version in your repo next to your client code. The wire format only adds
+fields over time, but pinning a version plus a round-trip test is how you find out
+about a change on your own schedule instead of in production.
 
 ## Step 2: Start the server
 
@@ -114,24 +115,24 @@ export STELLA_SERVE_TOOLS=remote
 |---|---|
 | `STELLA_SERVE_BIND` | Address to bind. Defaults to `127.0.0.1:8080`. Use `0.0.0.0:8080` in a container, and `127.0.0.1:0` in tests to get a free port |
 | `STELLA_SERVE_TOKEN` | Bearer token every request must present. Required |
-| `STELLA_SERVE_TOKEN_FILE` | Path to a file holding the token. Wins over `STELLA_SERVE_TOKEN`, because a mounted secret beats a variable that leaks into `/proc` and every child process |
+| `STELLA_SERVE_TOKEN_FILE` | Path to a file holding the token. Takes priority over `STELLA_SERVE_TOKEN`, because a mounted secret file is safer than a variable, which can leak into `/proc` and any child process |
 | `STELLA_SERVE_TOOLS` | Must be `remote`, the default. The server never exposes a local tool surface |
 
 <Callout type="warn">
   The bearer token is the only authentication this service has. Generate at
-  least 32 characters. A shorter token starts the server with a warning, not a
-  refusal, so that an upgrade does not become an outage, but do not ship one.
+  least 32 characters for it. A shorter token still starts the server, with a warning
+  instead of a refusal, so an upgrade doesn't turn into an outage. Don't ship a short
+  one, though.
 </Callout>
 
-In tests, bind port `0` and read the port back from the `listening on` line on
-stdout. Picking a random port and hoping it is free is the usual source of flaky
+In tests, bind port `0` and read the actual port back from the `listening on` line on
+stdout. Picking a random port and hoping it's free is a common cause of flaky
 integration tests.
 
-## Step 3: Learn the six routes this walkthrough uses
+## Step 3: The six routes this walkthrough uses
 
-That is the whole surface *this walkthrough* touches — not the whole surface
-`stella-serve` ships. See [the full route reference](#the-full-route-surface)
-below for the rest.
+This is the whole surface this walkthrough touches, not everything `stella-serve`
+offers. See [the full route reference](#the-full-route-surface) below for the rest.
 
 | Method | Path | Purpose |
 |---|---|---|
@@ -142,12 +143,12 @@ below for the rest.
 | `POST` | `/v1/turns/{id}/tool-result` | Answer a tool request |
 | `POST` | `/v1/turns/{id}/cancel` | End a turn. The only teardown, there is no `DELETE` |
 
-A **turn** is the top-level resource in this walkthrough: your app owns
-conversation history and sends it with each turn. The server also offers an
-optional server-owned alternative — `POST /v1/sessions`, covered in [the full
-route surface](#the-full-route-surface) below — where the engine threads the
-transcript for you instead. This guide sticks to the turn-only path because it
-has no state for your app to reason about beyond the turn itself.
+A turn is the top-level resource in this walkthrough. Your app owns the conversation
+history and sends it with each turn. The server also offers an alternative where it
+owns the conversation instead: `POST /v1/sessions`, covered in
+[the full route surface](#the-full-route-surface) below, where the engine keeps the
+transcript for you. This guide sticks to the turn-only path, because it leaves your
+app with no state to track beyond the turn itself.
 
 Six frame types arrive on the event stream, tagged by a `type` field:
 
@@ -161,28 +162,29 @@ Six frame types arrive on the event stream, tagged by a `type` field:
 | `turn_complete` | Terminal. Exactly one per turn, always last | No |
 
 <Callout type="warn">
-  Three things a correct host must not assume. `event` frames are not ordered
-  against request frames, so a `tool_request` can arrive before the `tool_start`
-  event that logically precedes it. Several `tool_request`s can be outstanding
-  at once, because the engine runs read-only tool calls concurrently, so answer
-  by `request_id` and do not serialize them. And the auth check runs before
-  routing, so an unauthenticated request to a wrong path returns 401, not 404. A
-  401 is not proof that your token is wrong.
+  A correct host should not assume any of this:
+
+  - `event` frames aren't ordered against request frames, so a `tool_request` can
+    arrive before the `tool_start` event that would logically come first.
+  - Several `tool_request`s can be open at once, because the engine runs read-only
+    tool calls at the same time. Answer them by `request_id` instead of assuming
+    they arrive one at a time.
+  - The auth check runs before routing, so an unauthenticated request to the wrong
+    path returns 401, not 404. A 401 doesn't necessarily mean your token is wrong.
 </Callout>
 
 ### The full route surface
 
-The six routes above run this walkthrough end to end, but `stella-serve` ships
-far more than that. The source of truth is the module doc at the top of
+The six routes above cover this walkthrough completely, but `stella-serve` ships many
+more. For the full list, see the module documentation at the top of
 [`crates/stella-serve/src/server.rs`](https://github.com/macanderson/stella/blob/main/crates/stella-serve/src/server.rs)
-and the route enum in `crates/stella-serve/src/observe/event.rs`, cross-checked
-against the handlers each variant actually dispatches to:
+and the route list in `crates/stella-serve/src/observe/event.rs`:
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/readyz` | Readiness — is it safe to send new work |
+| `GET` | `/readyz` | Readiness: whether it's safe to send new work |
 | `GET` | `/v1/metrics` | Counters, authenticated, pull-only |
-| `GET` | `/v1/calibration` | Token-drift report — estimated vs. billed tokens, per `(provider_id, model)` |
+| `GET` | `/v1/calibration` | A token-drift report: estimated vs. billed tokens, per `(provider_id, model)` |
 | `POST` | `/v1/turns/{id}/steer` | Inject a mid-turn user message |
 | `POST` | `/v1/turns/{id}/pause` | Hold the turn at its next step boundary; optional `{"reason"}` |
 | `POST` | `/v1/turns/{id}/resume` | Release a held turn |
@@ -190,12 +192,12 @@ against the handlers each variant actually dispatches to:
 | `POST` | `/v1/turns/{id}/provider-delta` | Streamed fragments for an in-flight `provider_request`, ahead of its `provider-result` |
 | `GET`, `DELETE` | `/v1/turns/{id}/checkpoint` | Read back or reclaim a resume point |
 | `POST` | `/v1/sessions` | Open a server-owned conversation. Returns `{"session_id": …}` |
-| `GET`, `DELETE` | `/v1/sessions/{id}` | History and cost to date, live turn; end the session |
-| `POST` | `/v1/sessions/{id}/turns` | Run the next turn on a session — turn semantics minus `messages` |
+| `GET`, `DELETE` | `/v1/sessions/{id}` | History and cost so far, and the live turn; or end the session |
+| `POST` | `/v1/sessions/{id}/turns` | Run the next turn on a session. Works like a turn, minus `messages` |
 | `GET`, `DELETE` | `/v1/sessions/{id}/checkpoint` | Read back or reclaim a session's resume point |
 
-Any other method on a known path is a `405` carrying `Allow`; any other path is
-a `404`.
+Any other method on a known path returns a `405` with an `Allow` header. Any other
+path returns a `404`.
 
 ## Step 4: Write the host
 
@@ -349,17 +351,17 @@ outcome: {
 }
 ```
 
-You can read the loop in that output. The first `step_usage` is your first model
-call, then `tool_start` and `tool_result` are the dispatch, then a second
-`budget_tick` and `step_usage` are the second model call, and `text` is the
-answer. The `block_registered` and `step_manifest` events are the context
-engine accounting for what went into each prompt.
+You can read the loop right in that output. The first `step_usage` is your first
+model call. `tool_start` and `tool_result` are the tool running. The second
+`budget_tick` and `step_usage` are the second model call, and `text` is the final
+answer. The `block_registered` and `step_manifest` events are the context engine
+keeping track of what went into each prompt.
 
-Two model calls, one tool call, one settled cost. `cost_usd` is the sum of what
-**your** app reported on each model call, which is why your billing system stays
-the authority and the engine stays a reporter.
+Two model calls, one tool call, one final cost. `cost_usd` is the sum of what your
+app reported on each model call. That's why your billing system stays the authority,
+and the engine is just reporting numbers to it.
 
-### What the engine did that you did not have to
+### What the engine handled
 
 Look at the conversation the engine handed you on the second model call:
 
@@ -375,28 +377,28 @@ Look at the conversation the engine handed you on the second model call:
 ]
 ```
 
-It recorded the assistant's tool call, matched your result to it by `call_id`,
-and threaded both back into the history in the shape your provider expects. That
-is the loop. Everything past this point is the same four frames, more times.
+It recorded the assistant's tool call, matched your result to it using `call_id`, and
+wove both back into the history in the shape your provider expects. That's the whole
+loop. Everything after this point is just the same four frame types, repeated.
 
 ## Step 5: Wire in your real model and tools
 
-Three swaps take the example to production.
+These changes take the example to production.
 
 **Your model.** Replace `runModel` with your gateway call. Map your provider's
-response onto `CompletionResult`. `usage`, `model`, and `cost_usd` are required,
-and `finish_reason` is `stop`, `length`, `tool_calls`, or `content_filter`.
-Anthropic's `tool_use` spelling is rejected with a 400 that names the valid
-values.
+response onto `CompletionResult`. `usage`, `model`, and `cost_usd` are required
+fields, and `finish_reason` must be `stop`, `length`, `tool_calls`, or
+`content_filter`. Anthropic's `tool_use` spelling gets rejected with a 400 error that
+names the valid values.
 
-**Your tools.** Replace `runTool` with a dispatch into the functions your app
-already exposes, behind the authorization you already enforce. Return
-`{ ok: { content } }` or `{ error: { message } }`. Send failures as the `error`
-arm rather than throwing: the model reads that text and can correct itself,
-which is usually what you want.
+**Your tools.** Replace `runTool` with a dispatch into the functions your app already
+exposes, behind the authorization you already enforce. Return
+`{ ok: { content } }` or `{ error: { message } }`. Send failures through the `error`
+field instead of throwing an exception: the model reads that text and can often
+correct itself, which is usually what you want.
 
-**Your errors.** When a model call fails, say why, because the engine's retry
-behavior depends on the class you report:
+**Your errors.** When a model call fails, say why. The engine's retry behavior
+depends on the error type you report:
 
 ```js
 await post("provider-result", {
@@ -406,68 +408,77 @@ await post("provider-result", {
 });
 ```
 
-`transport` and `rate_limited` are retried with backoff. `auth`,
-`unknown_model`, `malformed`, `cancelled`, and `terminal` fail the turn at once.
-Reporting a rate limit as `terminal` silently disables the backoff you wanted.
+`transport` and `rate_limited` get retried with backoff. `auth`,
+`unknown_model`, `malformed`, `cancelled`, and `terminal` fail the turn right away. If
+you report a rate limit as `terminal`, you silently lose the backoff you wanted.
 
 ## Production checklist
 
-- **One process per trust boundary.** Several provider and sandbox settings are
-  process-global, so multi-tenant in one process is not safe. Run an engine per
-  tenant, inside the isolation you already use for untrusted code.
-- **Keep the port private.** Bind loopback, or a private network behind the
-  token. There is no `Host` header guard and no CORS handling, so never expose it
-  to a browser directly.
-- **Set a reverse-request deadline.** `reverse_request_timeout_ms` bounds how
-  long the engine waits for your app. It defaults to five minutes and is clamped
-  to one hour. An expired model request fails the turn. An expired tool request
-  becomes a tool error the model can react to.
-- **Cancel turns you abandon.** Each live turn holds an OS thread. `POST
-  /v1/turns/{id}/cancel` releases it. The turn unwinds rather than being killed,
-  so a client streaming events still gets a terminal frame with an `aborted`
-  outcome and its settled cost.
-- **Handle 429.** At most 32 turns can be live at once. Over that you get a 429
-  with `Retry-After: 5`.
-- **The event stream is single-subscriber.** A second `GET` on the same turn's
-  events returns 409. Fan out to your own users from your app, not by opening
-  the stream twice.
+- **One process per trust boundary.** Several provider and sandbox settings apply to
+  the whole process, so running multiple tenants in one process isn't safe. Run one
+  engine per tenant, inside whatever isolation you already use for untrusted code.
+- **Keep the port private.** Bind it to loopback, or to a private network behind the
+  token. There's no `Host` header check and no CORS handling, so never expose it
+  directly to a browser.
+- **Set a reverse-request deadline.** `reverse_request_timeout_ms` limits how long the
+  engine waits for your app to respond. It defaults to five minutes and can't be set
+  above one hour. If a model request times out, the turn fails. If a tool request
+  times out, it becomes a tool error the model can react to.
+- **Cancel turns you abandon.** Each live turn holds onto an OS thread. `POST
+  /v1/turns/{id}/cancel` releases it. The turn shuts down cleanly rather than getting
+  killed outright, so a client still streaming events gets a final frame with an
+  `aborted` outcome and its final cost.
+- **Handle 429s.** At most 32 turns can run at once. Go over that limit and you get a
+  429 response with `Retry-After: 5`.
+- **The event stream allows only one subscriber.** A second `GET` on the same turn's
+  events returns 409. If you need to fan updates out to multiple users, do it from
+  your own app, not by opening the stream a second time.
 - **Record `step_usage` events.** They carry per-step tokens, cost, model, and
-  duration, which is what you want for cross-checking your own metering.
+  duration, which is exactly what you need to cross-check your own metering.
 
-## What is not built yet
+## Not built yet
 
-Re-verified against 0.9.86, so design around them rather than discovering them:
+These are current as of version 0.9.86, so plan around them instead of hitting them
+by surprise:
 
-- **A resume point can expire.** Frames *are* sequenced and replayable — see
-  below — but retention is a bounded ring (4096 frames per live turn). Ask to
-  resume from a `seq` older than the window and you are told the point is gone
-  rather than handed a stream with a silent hole in it. Persist frames on
-  receipt if you need durability beyond that window.
-- **No `/approve` bypass.** The route exists, but a turn that raises
-  `scope_review` blocks until something answers it. A caller running unattended
-  sets `auto_approve` on the turn; otherwise your app must answer, and a client
-  that never does leaves the turn parked until its deadline.
-- **`retry_policy` and `loop_detection` are operator policy**, not caller
-  policy. They bound what one request can cost the process, so no per-turn
-  override widens them. Unknown keys in the `engine` object are refused rather
-  than ignored — a typoed knob that parsed would be a knob silently not honored.
+- **A resume point can expire.** Frames are sequenced and can be replayed (see below),
+  but only the most recent 4,096 frames per live turn are kept. If you ask to resume
+  from a `seq` older than that window, you're told the point is gone, instead of
+  getting a stream with a silent gap in it. Save frames yourself as you receive them
+  if you need durability beyond that window.
+- **No way to skip `/approve`.** The route exists, but a turn that raises
+  `scope_review` blocks until something answers it. If you're running unattended, set
+  `auto_approve` on the turn. Otherwise, your app has to answer, and if it never does,
+  the turn stays stuck until its deadline passes.
+- **`retry_policy` and `loop_detection` are set by whoever runs the server**, not by
+  whoever calls it. They limit what one request can cost the process, so no per-turn
+  setting can widen them. Unknown keys in the `engine` object get rejected instead of
+  silently ignored, so a typo in a setting name fails loudly instead of quietly doing
+  nothing.
 
-Several entries that stood here through the 0.6 line have since shipped, and are
-worth naming because a client written against the old list is leaving them on the
-floor:
+### Other capabilities
 
-| Was listed absent | Now |
-| --- | --- |
-| Stream resumption | `?after=<seq>`, or an `EventSource`'s automatic `Last-Event-ID` — every frame carries a monotonic `seq` and each SSE frame an `id:` |
-| Server-side conversation state | `POST /v1/sessions`, then `POST /v1/sessions/{id}/turns` — the server threads one transcript, so the byte-stable prefix earns its cache discount and compaction becomes reachable |
-| The approval route | `POST /v1/turns/{id}/approve`, answering a `scope_review` by `request_id` |
-| Token-level streaming | `POST /v1/turns/{id}/provider-delta` — batched `text` / `reasoning` fragments for an in-flight completion, advisory exactly like `text_delta` |
-| SIGTERM drain, `/readyz`, `/metrics` | All three: `SIGTERM`/`SIGINT` start a graceful drain bounded by `STELLA_SERVE_SHUTDOWN_GRACE_SECS`, and both endpoints route |
-| Per-turn engine knobs | An optional `engine` object on turn create sets output cap, temperature, effort and the rest, each clamped to an operator ceiling |
+- **Stream resumption.** Use `?after=<seq>`, or rely on an `EventSource`'s automatic
+  `Last-Event-ID`. Every frame carries an increasing `seq`, and each SSE frame carries
+  an `id:`.
+- **Server-side conversation state.** `POST /v1/sessions`, then
+  `POST /v1/sessions/{id}/turns`. The server keeps one transcript for you, so the
+  unchanging prefix earns its cache discount and compaction becomes possible.
+- **The approval route.** `POST /v1/turns/{id}/approve` answers a `scope_review` by
+  `request_id`.
+- **Token-level streaming.** `POST /v1/turns/{id}/provider-delta` sends batched
+  `text` and `reasoning` fragments for a completion in progress. Treat it as
+  advisory, the same as `text_delta`.
+- **Graceful shutdown, `/readyz`, `/metrics`.** `SIGTERM` and `SIGINT` start a
+  graceful shutdown, bounded by `STELLA_SERVE_SHUTDOWN_GRACE_SECS`, and both
+  endpoints are live.
+- **Per-turn engine settings.** An optional `engine` object on turn creation sets
+  the output cap, temperature, effort, and more, each capped by a limit the server
+  operator sets.
 
 ## Licensing: AGPL or commercial
 
-stella is **dual-licensed**. You choose the track.
+stella is dual-licensed. You choose which track applies to you.
 
 | | Open source track | Commercial track |
 |---|---|---|
@@ -477,87 +488,88 @@ stella is **dual-licensed**. You choose the track.
 | **Best for** | Open source projects, research, internal use | Closed-source products, SaaS, proprietary forks |
 | **How to get it** | Just use it | [licensing@oxagen.sh](mailto:licensing@oxagen.sh) |
 
-### You do not need a commercial license to
+### No license needed
 
-- Use stella as a developer tool, at work, on proprietary code. **Using stella
-  to write closed-source software does not make that software AGPL.** The
-  license covers stella and works derived from it, not the output of running it.
-- Run **unmodified** stella internally, including on your own servers.
+- Use stella as a developer tool at work, on proprietary code. **Using stella to
+  write closed-source software does not make that software AGPL.** The license
+  covers stella and things built from it, not the output of running it.
+- Run stella unmodified, including on your own servers.
 - Evaluate, benchmark, audit, or study it.
-- Build on the [Context Graph
-  Protocol](https://github.com/macanderson/context-graph-protocol), which is a
-  separate project under `MIT OR Apache-2.0` and stays that way. Depending on
-  CGP does not put your project under the AGPL.
+- Build on the
+  [Context Graph Protocol](https://github.com/macanderson/context-graph-protocol), a
+  separate project licensed under `MIT OR Apache-2.0` that stays that way. Depending
+  on CGP does not put your project under the AGPL.
 
-### You do need one to
+### License required
 
-- Ship stella, or anything derived from it, inside a product whose source you do
-  not publish.
-- Offer a **modified** stella to third parties over a network without publishing
-  your modifications. This is AGPL section 13, and hosting is not a loophole.
-- Keep a proprietary fork private, or sublicense stella to your own customers
-  under other terms.
+- Ship stella, or anything built from it, inside a product whose source code you
+  don't publish.
+- Offer a modified version of stella to other people over a network without
+  publishing your changes. This is covered by AGPL section 13, and hosting isn't a
+  loophole.
+- Keep a proprietary fork private, or license stella to your own customers under
+  different terms.
 
 ### Where the sidecar lands
 
-Worth being straight about, since it is the shape this page recommends.
+Here's the direct answer, since this is the shape most GenAI apps end up choosing.
 
-Linking `stella-core` into a closed-source binary is the clear case: that is a
+Linking `stella-core` into a closed-source binary is the clear case: that's a
 combined work, and it needs a commercial license. A developer running the CLI on
-their own machine is the other clear case, and needs nothing.
+their own machine is the other clear case, and needs nothing at all.
 
-The sidecar sits between them, and the answer turns on facts about your
-deployment: whether you modified the engine, and whether your users interact
-with that modified engine over a network. If you run the binary unmodified and
-your app talks to it over HTTP, you are in very different territory than if you
-patched it and shipped the patched version as part of a hosted product.
+The sidecar sits between those two cases. The answer depends on facts about your
+deployment: whether you modified the engine, and whether your users interact with
+that modified engine over a network. If you run the binary unmodified and your app
+talks to it over HTTP, you're in very different territory than if you patched it and
+shipped the patched version as part of a hosted product.
 
-We are not going to guess at your architecture in a docs page. Email
-[licensing@oxagen.sh](mailto:licensing@oxagen.sh) with a short description and you will get a straight
-answer about whether you need a license at all, including "you do not."
+A docs page can't guess at your specific architecture. Email
+[licensing@oxagen.sh](mailto:licensing@oxagen.sh) with a short description, and
+you'll get a straight answer about whether you need a license at all, including "you
+do not."
 
 <Callout type="warn">
-  This section is a plain-language summary for orientation. It is not legal
-  advice and it does not modify the
-  [LICENSE](https://github.com/macanderson/stella/blob/main/LICENSE). Where the
-  two disagree, the LICENSE controls. If real money or real risk is involved,
-  talk to your own counsel, and to us.
+  This section is a plain-language summary meant to orient you. It is not legal
+  advice, and it doesn't change the
+  [LICENSE](https://github.com/macanderson/stella/blob/main/LICENSE). If the two
+  disagree, the LICENSE is what counts. If real money or real risk is on the line,
+  talk to your own lawyer, and to us.
 </Callout>
 
 ### How to buy a commercial license
 
-1. **Email [licensing@oxagen.sh](mailto:licensing@oxagen.sh).** One message starts it. There is no portal
-   and no sales sequence.
-2. **Tell us what you are building and roughly how you will deploy it.** What
-   the product does, whether stella is linked in or run as a sidecar, whether
-   you modify it, and rough scale (self-hosted or SaaS, number of environments,
-   order of magnitude of users). Pricing depends on scope and deployment size,
-   so this is what determines the number.
-3. **Say what terms you need.** A commercial license removes the reciprocal
-   obligations above. Warranty, indemnity, and support terms, which the AGPL
-   explicitly disclaims, are available and are worth naming up front if your
-   procurement process requires them.
-4. **Get an answer, including whether you need one.** If your use is already
-   fine under the AGPL we will tell you that instead of selling you something.
+1. **Email [licensing@oxagen.sh](mailto:licensing@oxagen.sh).** One message is all
+   it takes to start. There's no portal and no sales process to go through.
+2. **Tell us what you're building and roughly how you'll deploy it.** What the
+   product does, whether stella is linked in or run as a sidecar, whether you modify
+   it, and roughly how big it is (self-hosted or SaaS, number of environments, rough
+   number of users). Pricing depends on scope and deployment size, so this is what
+   determines the price.
+3. **Say what terms you need.** A commercial license removes the obligations
+   described above. Warranty, indemnity, and support terms, which the AGPL
+   specifically rules out, are available, and it's worth mentioning them up front if
+   your procurement process requires them.
+4. **Get an answer, including whether you need one at all.** If your use is already
+   fine under the AGPL, we'll tell you that instead of trying to sell you something.
 
-Full terms, the reasoning behind the dual license, and the note on prior
-releases (everything up to v0.5.14 remains perpetually available under
-`MIT OR Apache-2.0`) are in
-[LICENSING.md](https://github.com/macanderson/stella/blob/main/LICENSING.md).
+Full terms and the reasoning behind the dual license are in
+[LICENSING.md](https://github.com/macanderson/stella/blob/main/LICENSING.md), including
+the note that every release up to v0.5.14 stays available under
+`MIT OR Apache-2.0` for good.
 
 ## Where to go next
 
-- [Drop stella in as your agent engine](/docs/guides/embed-the-engine): the
-  guide-shaped version of this page — which shape to pick, how to port an
-  existing feature onto the engine in an afternoon, and the integration test
-  that exercises the whole loop with no API key.
-- [Gate on engine quality in CI](/docs/guides/ci-engine-gate): once the engine
+- [Drop stella in as your agent engine](/docs/guides/embed-the-engine) — a
+  guide-shaped version of this page: which shape to pick, how to port an existing
+  feature onto the engine in an afternoon, and an integration test that exercises the
+  whole loop with no API key.
+- [Gate on engine quality in CI](/docs/guides/ci-engine-gate) — once the engine
   is a dependency, run it side by side with Claude Code on every pull request
-  and block the merge on loop correctness.
-- [Agent Engine Paths](/docs/agent-engine-paths): the command-line doors into
+  and block merges on loop correctness.
+- [Agent Engine Paths](/docs/agent-engine-paths) — the command-line doors into
   the same engine.
-- [Event Stream Compatibility](/docs/event-stream-compatibility): the full
+- [Event Stream Compatibility](/docs/event-stream-compatibility) — the full
   `AgentEvent` vocabulary you receive in `event` frames.
-- [Plugins](/docs/plugins): what a wrapper contributes around a
-  step.
-- [Telemetry](/docs/telemetry): what the engine reports, and how to record it.
+- [Plugins](/docs/plugins) — what a wrapper adds around a step.
+- [Telemetry](/docs/telemetry) — what the engine reports, and how to record it.

--- a/website/content/docs/agent-engine-paths.mdx
+++ b/website/content/docs/agent-engine-paths.mdx
@@ -1,69 +1,65 @@
 ---
 title: Agent Engine Paths
-description: Every entry point into stella's agent engine — one-shot runs, REPL, Command Deck, goal rounds, CI monitoring, sub-agents, and fleets — when to use each.
+description: Every way to reach stella's agent engine — one-shot runs, the REPL, the Command Deck, goal rounds, CI monitoring, sub-agents, and fleets — and when to use each.
 ---
 
-stella has **one agent engine and many doors into it**. Whether you type into
-the Command Deck, script `stella run` in CI, or fan a fleet out across
-worktrees, the same core loop does the work: the step-driver in
-`stella-core`, driving the same tool stack, metered by the same budget,
-recorded into the same session store. The paths differ in how a turn is
-*framed*, *verified*, *supervised*, and *persisted* — and picking the right
-door is most of the craft.
+stella has one agent engine and many ways to reach it. Whether you type into the
+Command Deck, script `stella run` in CI, or fan a fleet out across worktrees, the same
+core loop does the work: the step driver in `stella-core`, using the same tools,
+metered by the same budget, recorded into the same session store. What differs between
+these paths is how a turn gets framed, checked, supervised, and saved. Picking the
+right one is most of the skill.
 
-This page is the map. For the user-level tour of the modes, see
-[Agent Modes](/docs/agent-modes); for what can wrap a turn and gather evidence
-around it, see [Plugins](/docs/plugins).
+This page is the map. For a user-level tour of the modes, see
+[Agent Modes](/docs/agent-modes). For what can wrap a turn and gather evidence around
+it, see [Plugins](/docs/plugins).
 
 <EnginePathsDiagram />
 
-There is only **one loop**, and the picture above is the whole of it. Every
-door drives the step loop; some of them (`stella run`, `stella goal`,
-`stella fleet`, `stella arena`) can additionally bind an installed
-[wrapper plugin](/docs/plugins) with `--pipeline <variant>`, which contributes
-context before the turn and gathers evidence after it — the other doors reach
-the engine directly and take no wrapper. Underneath every door sits one step
-loop — `run_step`, twelve fixed phases around a single model call — so a fleet
-worker and a `--plain` prompt run the identical code, differing only in what is
-wrapped around it.
+There is only one loop, and the picture above shows all of it. Every door drives the
+step loop. Some of them (`stella run`, `stella goal`, `stella fleet`, `stella arena`)
+can also bind an installed [wrapper plugin](/docs/plugins) with `--pipeline <variant>`,
+which adds context before the turn and gathers evidence after it. The other doors reach
+the engine directly and use no wrapper. Underneath every door sits the same step loop,
+`run_step`, which is twelve fixed phases around a single model call. That means a fleet
+worker and a `--plain` prompt run identical code, differing only in what wraps around
+it.
 
-The two direct doors are not the same depth. `stella --plain` calls
-`Engine::run_turn`; `stella-serve` does not — it drives `run_step` itself, one
-step at a time, which is what lets a durable host checkpoint and resume between
-steps.
+The two direct doors don't go equally deep, though. `stella --plain` calls
+`Engine::run_turn`. `stella-serve` doesn't; it drives `run_step` itself, one step at a
+time. That's what lets a durable host checkpoint and resume between steps.
 
-The map below names eight paths to the diagram's six, because two of them are
-not new routes: `stella monitor` **is** goal mode with a fixed objective, and
-deck sub-agents are raw turns the lead spawns. Both ride a door already drawn.
+The map below names eight paths, even though the diagram only shows six, because two
+of them aren't really new routes. `stella monitor` is goal mode with a fixed objective,
+and deck sub-agents are plain turns that the lead spawns. Both ride a door that's
+already there.
 
 ## What every path shares
 
-Before the differences, the rules — these hold no matter which door you
-came through:
+These rules hold no matter which door you came through:
 
-- **One step loop.** The engine takes one model call per step, executes the
-  proposed tool calls (read-only calls fan out in parallel), feeds results
-  back, and repeats until the model stops, a budget trips, or a backstop
-  fires. No hidden swarm, no coordinator process.
-- **One tool stack.** Every path assembles the same layered
-  [tool executor](/docs/agent-tools): the native registry, wrapped by
+- **One step loop.** The engine makes one model call per step, runs the tool calls the
+  model proposed (read-only calls run in parallel), feeds the results back, and repeats
+  until the model stops, a budget is hit, or a limit fires. There's no hidden swarm and
+  no separate coordinator process.
+- **One tool stack.** Every path builds the same layered
+  [tool executor](/docs/agent-tools): the built-in tools, wrapped by
   [MCP-server tools](/docs/agent-tools/mcp), wrapped by
-  [custom script tools](/docs/agent-tools/custom-tools). What varies
-  per path is only what gets layered *on top* (deck taps, read-only views —
-  see [below](#how-the-tool-stack-varies)).
+  [custom script tools](/docs/agent-tools/custom-tools). What differs per path is only
+  what gets layered on top of that, like deck taps or read-only views (see
+  [below](#how-the-tool-stack-varies)).
 - **Memory rides along.** Relevant memories and
-  [skills](/docs/agent-tools/skills) are recalled per prompt and injected as
-  a volatile block after the byte-stable system prefix, so prompt caching
-  survives across turns.
-- **Spend limits are enforced everywhere.** `--spend-limit` caps USD spend on every
-  path; without it, spend is still metered for the cost summary.
-- **Everything is recorded.** Each turn opens an execution record (files
-  touched, tool use, memory citations, cost, outcome) in the workspace
-  store, feeding [telemetry](/docs/telemetry) and `stella stats`. Sessions are
-  durable and resumable (`stella resume`).
+  [skills](/docs/agent-tools/skills) get recalled for each prompt and added as a block
+  right after the fixed system prefix, so prompt caching keeps working across turns.
+- **Spend limits work everywhere.** `--spend-limit` caps how much you spend, in
+  dollars, on every path. Without it, spend still gets tracked for the cost summary.
+- **Everything is recorded.** Each turn opens an execution record in the workspace
+  store: files touched, tools used, memory citations, cost, and outcome. This feeds
+  [telemetry](/docs/telemetry) and `stella stats`. Sessions are saved and can be
+  resumed with `stella resume`.
 - **Per-seat model routing applies.** The
-  [agent engine config](/docs/configuration/agent-engine-config) pins models
-  per seat, and every path that uses those seats honors the pins.
+  [agent engine config](/docs/configuration/agent-engine-config) pins specific models
+  to specific seats, and every path that uses those seats respects those pins.
 
 ## The map
 
@@ -77,8 +73,8 @@ came through:
       { label: "Headless", value: "Yes", mono: false },
     ]}
   >
-    No stages, no verifier — the model works until it decides it is done. You are
-    the verification. The default for `stella run`.
+    No stages, no verifier. The model works until it decides it's done, and you're the
+    one who checks the result. This is the default for `stella run`.
   </SpecCard>
   <SpecCard
     title="One-shot, wrapped"
@@ -89,9 +85,9 @@ came through:
       { label: "Headless", value: "Yes — json / stream-json", mono: false },
     ]}
   >
-    The plugin contributes context before the turn and reports its own evidence
-    after it; stella evaluates that evidence against the plugin's declared rule.
-    `--test-command` passes through to a wrapper that can honor it.
+    The plugin adds context before the turn and reports its own evidence after it.
+    stella checks that evidence against the plugin's rule. `--test-command` gets
+    passed through to any wrapper that uses it.
   </SpecCard>
   <SpecCard
     title="Plain REPL"
@@ -102,8 +98,8 @@ came through:
       { label: "Headless", value: "Interactive only", mono: false },
     ]}
   >
-    Also what you get on a non-TTY stdin/stdout, or with `STELLA_PLAIN=1`. You
-    verify, live, between prompts.
+    This is also what you get with a non-interactive stdin or stdout, or with
+    `STELLA_PLAIN=1`. You check the work yourself, live, between prompts.
   </SpecCard>
   <SpecCard
     title="Command Deck lead"
@@ -114,8 +110,7 @@ came through:
       { label: "Headless", value: "Interactive only", mono: false },
     ]}
   >
-    One step-loop turn per prompt, watching the FILES and DIFF tabs fill in as
-    it works.
+    One step-loop turn per prompt. Watch the FILES and DIFF tabs fill in as it works.
   </SpecCard>
   <SpecCard
     title="Deck sub-agents"
@@ -126,8 +121,8 @@ came through:
       { label: "Headless", value: "Follows the deck", mono: false },
     ]}
   >
-    The lead reviews each result. You never invoke this path directly — you ask
-    for work that warrants it.
+    The lead reviews each result. You never call this path directly; you ask for work
+    that's big enough to need it.
   </SpecCard>
   <SpecCard
     title="Goal mode"
@@ -138,9 +133,9 @@ came through:
       { label: "Headless", value: "Yes", mono: false },
     ]}
   >
-    An independent verifier assesses the goal from evidence, over a **read-only**
-    view of the tool stack. `--pipeline <variant>` binds a wrapper plugin to each
-    round's working turn; the goal verifier is unchanged either way.
+    An independent verifier checks the goal against evidence, using a read-only view
+    of the tool stack. `--pipeline <variant>` binds a wrapper plugin to each round's
+    working turn; the goal verifier works the same either way.
   </SpecCard>
   <SpecCard
     title="CI monitor"
@@ -151,8 +146,8 @@ came through:
       { label: "Headless", value: "Yes", mono: false },
     ]}
   >
-    The verifier reads the CI state itself; only a fully green *latest* run for
-    the target ends the loop. `target` defaults to `main`.
+    The verifier reads the CI state directly. Only a fully green latest run for the
+    target ends the loop. `target` defaults to `main`.
   </SpecCard>
   <SpecCard
     title="Fleet workers"
@@ -163,8 +158,8 @@ came through:
       { label: "Headless", value: "Yes", mono: false },
     ]}
   >
-    Verified per task — the step loop by default, or under a wrapper plugin when
-    `--pipeline <variant>` is passed. Every attempt is recorded in
+    Checked per task, using the plain step loop by default, or a wrapper plugin when
+    you pass `--pipeline <variant>`. Every attempt gets recorded in
     `.stella/private/fleet.db`.
   </SpecCard>
 </CardGrid>
@@ -200,178 +195,172 @@ stella resume
 
 ## One-shot: `stella run`
 
-The scripting workhorse: one prompt in, the finished work and an exit code
-back.
+This is the scripting workhorse: one prompt goes in, and finished work plus an exit
+code come back.
 
-**Raw (default).** Plain `stella run "…"` drives one plain step-loop turn —
-no wrapper, no verifier, the model works until it decides it's done. Cheapest
-and fastest; the right door for questions, small mechanical edits, and
-anything you'll eyeball anyway.
+**Plain (default).** Running `stella run "…"` on its own drives one plain step-loop
+turn: no wrapper, no verifier, and the model works until it decides it's done. This is
+the cheapest and fastest option, and the right choice for questions, small mechanical
+edits, and anything you'll check yourself anyway.
 
 **Wrapped (`--pipeline <variant>`).** The turn runs under an installed
-[wrapper plugin](/docs/plugins), named by the `[wrapper] id` its manifest
-declares. The plugin contributes context before the turn and reports its own
-evidence after it; stella evaluates that evidence against the plugin's declared
-rule, which decides whether another turn runs. Pass
-`--test-command "cargo test -p …"` alongside it to hand the wrapper a command
-to check against. Headless formats (`--output-format json` for one final
-object, `stream-json` for a line per agent event) make it automation-grade —
-see [Scripting](/docs/scripting).
+[wrapper plugin](/docs/plugins), named by the `[wrapper] id` in its manifest. The
+plugin adds context before the turn and reports its own evidence after it. stella
+checks that evidence against the plugin's rule, which decides whether another turn
+runs. Pass `--test-command "cargo test -p …"` alongside it to give the wrapper a
+command to check against. Headless output formats (`--output-format json` for one
+final object, `stream-json` for a line per agent event) make it suitable for
+automation. See [Scripting](/docs/scripting).
 
-The **session task board** is the one tool this door withholds: a one-shot
-turn has nothing to resume, so a card costs a model round trip and buys
-legibility no one is watching for. Everything else is unchanged, sub-agent
-delegation included — `delegate` spends money to do work, a different
-trade from `task_create`, and is available here as everywhere.
+The session task board is the one tool this door leaves out. A one-shot turn has
+nothing to resume, so a task card would cost a model round trip without anyone around
+to read it. Everything else works as normal, including sub-agent delegation:
+`delegate` spends money to get work done, which is a different trade-off from
+`task_create`, and it's available here just like everywhere else.
 
-**Use it when** the task is well-defined and you don't need to watch. Stay
-on the raw default when speed beats ceremony; bind a `--pipeline <variant>`
-wrapper whenever the result must carry evidence.
+**Use it when** the task is well defined and you don't need to watch it run. Stay on
+the plain default when speed matters more than proof; add a `--pipeline <variant>`
+wrapper whenever the result needs to carry evidence.
 
-## Interactive: the Command Deck and the plain REPL
+## Interactive: Command Deck and REPL
 
-Running `stella` on a real terminal opens the **Command Deck** — the tabbed
-TUI over the engine. Each prompt becomes a lead-agent turn. The deck
-is more than a chat surface: prompts queue while a turn runs, `!` lines run
-shell commands inline in the transcript, `>` steers the turn in flight, Esc
-soft-stops (both below), and tabs expose the session's
-files, diff, code graph, skills, MCP servers, the AGENTS tab's installed
-agents, and the SETTINGS tab's
-[config panel](/docs/configuration/agent-engine-config) with per-seat model
-pickers. Running lanes are not a tab: `ctrl-a` (or `↓` from an empty prompt)
-opens the SUB-AGENTS overlay over whatever tab you are on.
+Running `stella` on a real terminal opens the Command Deck, the tabbed interface over
+the engine. Each prompt becomes a lead-agent turn. The deck is more than a chat window:
+prompts queue while a turn runs, lines starting with `!` run shell commands inline in
+the transcript, `>` steers the turn while it's running, and `Esc` soft-stops it (both
+explained below). Tabs show the session's files, diff, code graph, skills, MCP servers,
+the AGENTS tab's installed agents, and the SETTINGS tab's
+[config panel](/docs/configuration/agent-engine-config) with per-seat model pickers.
+Running agent lanes aren't a tab: `ctrl-a` (or `↓` from an empty prompt) opens the
+SUB-AGENTS overlay over whatever tab you're on.
 
 Only deck turns have:
 
-- **Taps.** The lead's tool stack is wrapped in a file-change tap (live
-  FILES/DIFF tabs) and a task tap (the task board and sub-agent spawning).
-- **Cooperative claims.** The lead claims files on first write, so parallel
-  workers in the same tree never fight over a file.
-- **Mid-turn steering & soft-cancel.** You don't have to wait for a turn to
-  finish to correct it. Prompts typed while it runs queue; `Esc` delivers the
-  whole queue plus the composer into the running turn at its next step
-  boundary as real user messages — course-corrections the model reads before
-  its next action, with nothing thrown away. `>your note` skips the queue and
-  lands at the next boundary on its own. `Esc` with nothing to deliver is a
-  *soft stop*: it halts at the next boundary and keeps everything already
-  completed. `Esc Esc` cancels immediately and holds the queue. Steering
-  beats restarting: you keep the cache-warm context and only redirect it.
+- **Taps.** The lead's tool stack is wrapped with a file-change tap, which powers the
+  live FILES and DIFF tabs, and a task tap, which powers the task board and sub-agent
+  spawning.
+- **Cooperative claims.** The lead claims a file the first time it writes to it, so
+  parallel workers in the same tree never fight over the same file.
+- **Mid-turn steering and soft-cancel.** You don't have to wait for a turn to finish to
+  correct it. Prompts typed while it's running get queued. Pressing `Esc` delivers the
+  whole queue, plus whatever's in the composer, into the running turn at its next step
+  boundary, as real user messages. The model reads these course-corrections before its
+  next action, and nothing gets thrown away. Typing `>your note` skips the queue and
+  delivers on its own at the next boundary. Pressing `Esc` with nothing queued is a
+  soft stop: it halts at the next boundary and keeps everything already done. Pressing
+  `Esc` twice cancels right away and holds the queue. Steering beats restarting, since
+  you keep the warm cached context and just redirect it.
 
-`stella --plain` (or any non-TTY stdin/stdout, or `STELLA_PLAIN=1`) falls
-back to the **plain REPL**: the same per-prompt raw turns and the same
-session memory, in a line-based interface with slash commands. It's the
-low-dependency door — SSH sessions, minimal terminals, teaching demos.
+`stella --plain` (or any non-interactive stdin/stdout, or `STELLA_PLAIN=1`) falls back
+to the plain REPL: the same per-prompt turns and the same session memory, in a
+line-based interface with slash commands. It's the low-dependency option, good for SSH
+sessions, minimal terminals, and demos.
 
 **Use the deck when** you're exploring, iterating, or supervising real work
-interactively. **Use the plain REPL when** you want interactivity without a
-TUI.
+interactively. **Use the plain REPL when** you want interactivity without a full
+terminal interface.
 
 ## Delegated: deck sub-agents
 
-Inside a deck session, the lead agent can delegate: the `task_assign` tool
-queues a task, and a supervisor spawns a **sub-agent** with its own
-conversation and the same tool stack — running concurrently while the lead
-keeps working, its spend metered into the session's **shared** budget guard
-(child spend always reaches the parent's ledger; fleet children, by
-contrast, each run under their own slice of the cap). Results return to the
-lead for review; every sub-agent turn is recorded (`deck-sub`) and visible in
-the SUB-AGENTS overlay (`ctrl-a`, `↓` from an empty prompt, or `/subagents`),
-which is also where you stop, pause, restart, nudge or open one. You don't
-invoke this path directly — you ask for work that warrants it, and the lead
-fans out.
+Inside a deck session, the lead agent can delegate. The `task_assign` tool queues a
+task, and a supervisor spawns a sub-agent with its own conversation and the same tool
+stack. It runs at the same time as the lead keeps working, and its spend gets tracked
+against the session's shared budget guard. That's different from fleets, where each
+child runs under its own slice of the spending cap; here, a sub-agent's spend always
+reaches the parent's ledger. Results return to the lead for review. Every sub-agent
+turn gets recorded (as `deck-sub`) and shows up in the SUB-AGENTS overlay (`ctrl-a`,
+`↓` from an empty prompt, or `/subagents`), which is also where you stop, pause,
+restart, nudge, or open one. You don't call this path directly; you ask for work big
+enough to need it, and the lead fans it out.
 
-**Use it when** (implicitly) a deck task decomposes into independent chunks —
-noisy searches, parallel investigations — that shouldn't bloat the lead's
-context.
+**Use it when** a task naturally breaks into independent chunks, like noisy searches
+or parallel investigations, that shouldn't bloat the lead's context.
 
 ## Outcome-driven: `stella goal`
 
-Goal mode inverts the contract: you state **what must be true when done**,
-not what to do. The engine works in rounds; after each round an
-**independent verifier** — routed to a different model family than the worker
-whenever possible, and holding a **read-only view** of the same tool stack —
-assesses the goal *from evidence* (running tests, reading CI, inspecting
-files), never from the worker's claims. Rounds continue until the verifier
-confirms the goal, or a backstop (round cap, `--spend-limit`, worker abort) ends
-the run as *not met*.
+Goal mode flips the usual setup: you say what must be true when it's done, not what to
+do to get there. The engine works in rounds. After each round, an independent
+verifier, routed to a different model family than the worker whenever possible and
+holding a read-only view of the same tool stack, checks the goal against evidence
+(running tests, reading CI, inspecting files) rather than trusting the worker's
+claims. Rounds keep going until the verifier confirms the goal is met, or a limit (a
+round cap, `--spend-limit`, or a worker aborting) ends the run as not met.
 
-Each working round is a raw step-loop turn by default; `--pipeline <variant>`
-binds an installed wrapper plugin once and dispatches each round's worker turn
-through it, leaving the goal verifier untouched. An arbiter-grade wrapper is
-refused on this door — the goal loop is already its own completion arbiter.
+Each working round is a plain step-loop turn by default. `--pipeline <variant>` binds
+an installed wrapper plugin once and routes each round's worker turn through it,
+without touching the goal verifier. A wrapper meant to be its own arbiter of
+completion is rejected here, since the goal loop already handles that job itself.
 
-**Use it when** you can state the outcome crisply but not the steps —
-"the suite passes and clippy is clean", "the flaky test is fixed, proven by
-50 consecutive runs". See [Goal mode in depth](/docs/agent-modes#outcome-driven-goal-mode).
+**Use it when** you can state the outcome clearly but not the steps to get there, like
+"the suite passes and clippy is clean" or "the flaky test is fixed, proven by 50
+consecutive runs." See [Goal mode in depth](/docs/agent-modes#outcome-driven-goal-mode).
 
 ### `stella monitor`: goal mode, specialized
 
-Monitoring **is** a goal: the objective is pinned to "the latest CI run for
-*target* is fully green", assessed from the CI state itself. The engine
-fixes failures, pushes, waits out the next run, and only a green board ends
-the loop. Same machinery, fixed objective.
+Monitoring is a goal: the objective is fixed to "the latest CI run for target is fully
+green," checked against the CI state itself. The engine fixes failures, pushes, waits
+for the next run, and only a fully green result ends the loop. It's the same
+machinery, just with a fixed objective.
 
-**Use it when** the branch or PR must end up green and you don't want to
+**Use it when** the branch or pull request needs to end up green and you don't want to
 babysit the CI cycle.
 
 ## Parallel: `stella fleet`
 
-When the work is *many tasks* rather than one, [fleets](/docs/agent-fleets)
-fan a dependency-ordered task DAG out to parallel workers — in one shared
-tree coordinated by cooperative file claims, or in dedicated worktrees for
-tasks marked `isolation = "isolated"`. Each worker drives the same engine
-per task (the step loop by default, or under a wrapper plugin when
-`--pipeline <variant>` is passed), and every attempt, commit, and dollar lands
-in `.stella/private/fleet.db` for review.
+When the work is many tasks rather than one, [fleets](/docs/agent-fleets) spread a
+dependency-ordered set of tasks out to parallel workers, in one shared tree
+coordinated by cooperative file claims, or in dedicated worktrees for tasks marked
+`isolation = "isolated"`. Each worker drives the same engine per task, using the plain
+step loop by default, or a wrapper plugin when you pass `--pipeline <variant>`. Every
+attempt, commit, and dollar spent lands in `.stella/private/fleet.db` for review.
 
-**Use it when** you have a backlog, not a task: migrations across many
-modules, a list of independent fixes, wide refactors.
+**Use it when** you have a backlog, not a single task: migrations across many
+modules, a list of independent fixes, or a wide-reaching refactor.
 
 ## How the tool stack varies
 
-The [tool catalog](/docs/agent-tools) is shared, but each path decorates it
-differently:
+The [tool catalog](/docs/agent-tools) is the same everywhere, but each path adds
+different things on top of it:
 
 <CardGrid size="md">
   <OptionCard name="One-shot / REPL / goal worker">
-    Nothing extra — the shared stack as-is.
+    Nothing extra. Just the shared stack, as is.
   </OptionCard>
   <OptionCard name="Command Deck lead">
-    A file-change tap and a task tap on top: live FILES/DIFF tabs, the task
-    board, sub-agent spawning — plus claim-on-first-write.
+    A file-change tap and a task tap on top of the shared stack: live FILES and DIFF
+    tabs, the task board, sub-agent spawning, and claiming a file on first write.
   </OptionCard>
   <OptionCard name="Goal verifier">
-    A **read-only** view. Only tools marked `read_only: true` are visible or
-    executable, so a verifier structurally cannot edit its way to a verdict.
+    A read-only view. Only tools marked `read_only: true` are visible or usable, so a
+    verifier can't edit its way to a verdict.
   </OptionCard>
   <OptionCard name="Fleet workers">
-    Claim coordination in the shared tree; a private worktree when the task is
+    Claim coordination in the shared tree, or a private worktree when the task is
     marked `isolation = "isolated"`.
   </OptionCard>
 </CardGrid>
 
-The same `read_only: true` bit fences a sub-agent launched without write
-access: it is offered only the read-only schemas, and the restriction is
-enforced when a call executes rather than by asking the prompt nicely
-(`stella_core::ports::ReadOnlyTools`). A read-only lookup is never a side
-effect.
+That same `read_only: true` flag also limits a sub-agent launched without write
+access: it only gets offered the read-only tools, and the restriction is enforced when
+a call actually runs, not just by asking the model nicely
+(`stella_core::ports::ReadOnlyTools`). A read-only lookup never has side effects.
 
 ## Choosing a path
 
 - **Watching and steering** → the Command Deck (`stella`).
 - **Interactive, but minimal** → the plain REPL (`stella --plain`).
-- **One defined task, unattended** → `stella run` (the raw default is
-  fastest; add `--pipeline <variant> --test-command` to run it under a
-  wrapper plugin that gathers evidence).
+- **One defined task, unattended** → `stella run`. The plain default is fastest; add
+  `--pipeline <variant> --test-command` to run it under a wrapper plugin that gathers
+  evidence.
 - **A defined outcome, unknown steps** → `stella goal`.
 - **CI must be green** → `stella monitor`.
 - **A backlog of tasks** → `stella fleet`.
 - **Continuing yesterday's session** → `stella resume`.
 
-## For contributors: the code map
+## For contributors
 
-Every path is a thin `stella-cli` entry point over `stella_core::Engine`.
-If you're changing engine behavior, these are the seams:
+Every path is a thin `stella-cli` entry point over `stella_core::Engine`. If you're
+changing engine behavior, these are the places to look:
 
 <CardGrid size="md">
   <SpecCard
@@ -432,13 +421,13 @@ If you're changing engine behavior, these are the seams:
   />
 </CardGrid>
 
-The execution-kind strings in [the map](#the-map) are what these paths stamp
-on their execution records — the same strings in
-`stella stats` and the exported [dashboard](/docs/telemetry/dashboard). A
-telemetry row always traces back to the door the work came through.
+The execution-kind strings in [the map](#the-map) are what these paths stamp on their
+execution records. You'll see the same strings in `stella stats` and the exported
+[dashboard](/docs/telemetry/dashboard). A telemetry row always traces back to the door
+the work came through.
 
-The store is ordinary SQLite, so you can ask that question directly — which
-doors your spend actually went through:
+The store is ordinary SQLite, so you can ask that question directly: which doors did
+your spend actually go through?
 
 ```bash
 sqlite3 .stella/private/store.db \
@@ -450,14 +439,14 @@ sqlite3 .stella/private/store.db \
 
 ## Where to go next
 
-- [Agent Modes](/docs/agent-modes) — the user-level guide to the same
-  territory, with deck keybindings and examples.
-- [Plugins](/docs/plugins) — the wrapper socket a `--pipeline <variant>` turn
-  runs through, and what a plugin contributes around it.
-- [Agent Fleets](/docs/agent-fleets) — plan files, waves, claims in the
+- [Agent Modes](/docs/agent-modes) — a user-level guide to the same territory, with
+  deck keybindings and examples.
+- [Plugins](/docs/plugins) — the wrapper system a `--pipeline <variant>` turn runs
+  through, and what a plugin adds around it.
+- [Agent Fleets](/docs/agent-fleets) — plan files, waves, file claims in the
   shared tree, and opt-in isolated worktrees.
 - [Agent engine config](/docs/configuration/agent-engine-config) — per-seat
-  model pins the paths share.
+  model pins that all these paths share.
 - [Built-in Tools](/docs/agent-tools) — the shared catalog, and how MCP and
   custom tools layer onto it.
 - [Scripting](/docs/scripting) — headless output formats, exit codes, and

--- a/website/content/docs/agent-fleets.mdx
+++ b/website/content/docs/agent-fleets.mdx
@@ -1,15 +1,15 @@
 ---
 title: Agent Fleets
-description: Fan a dependency-ordered task DAG out to parallel workers in one shared tree, coordinated by file claims — with per-task worktree isolation as the opt-in.
+description: Run many tasks at once with parallel workers in one shared tree, coordinated by file claims. Turn on worktree isolation per task when you need it.
 ---
 
-`stella fleet` runs **many tasks at once** — each task handled by a full
-stella worker. By default the workers share **one tree**: every worker runs
-in the repository root, coordinated by cooperative file claims, so conflicts
-surface at write time with the rival named, commits interleave on one
-branch, and the build cache stays warm. A task marked
-`isolation = "isolated"` instead gets its **own git worktree** on its own
-branch, isolated from your working copy and from every other worker.
+`stella fleet` runs many tasks at once. Each task gets its own full stella worker. By
+default, all the workers share one tree: every worker runs in the repository root,
+coordinated by cooperative file claims. If two workers try to touch the same file, the
+conflict shows up right away and names which worker is holding it. Commits from
+different workers interleave on one branch, and the build cache stays warm. A task
+marked `isolation = "isolated"` instead gets its own git worktree on its own branch,
+kept separate from your working copy and from every other worker.
 
 ```bash
 stella fleet \
@@ -22,38 +22,34 @@ stella fleet \
 
 ## How a fleet run works
 
-1. **Plan.** Task prompts (inline, or from a `--plan` file) form a DAG:
-   tasks with `depends_on` wait for their dependencies. Plans are validated
-   up front — a duplicate id, a self-dependency, an unknown dependency, or a
-   dependency cycle is rejected before anything runs, with the offending
-   task (or cycle path) named.
-2. **Share — or isolate.** By default every worker runs directly in the
-   repository root under the cooperative claim discipline (see
-   [file claims](#file-claims--cooperative-locks) below). A task marked
-   `isolation = "isolated"` instead gets a fresh git worktree under
-   `.stella/worktrees/<slug>`, branched from a pinned base commit (the
-   current `HEAD`, or `--base-ref`, resolved to a SHA at start so mid-run
-   commits can't drift the base) onto a `fleet/<slug>-<hash>` branch. The
-   16-hex-digit hash suffix keeps re-runs — which reuse task ids like `t1` —
-   from colliding with branches and worktrees you kept from an earlier
-   fleet. Isolated workers can't see each other's uncommitted work and can't
-   touch your checkout.
-3. **Dispatch in waves.** Dependency-ordered waves run up to
-   `--max-concurrency` tasks at once (default 4). A failed task does **not**
-   unblock its dependents — they end the run as `skipped` — and nothing is
-   retried automatically: the ledger records every attempt, but re-running
-   is your call.
-4. **Work.** Each worker is a full engine run — the raw step loop by
-   default, with the standard toolbelt, honoring your
-   [agent-engine config](/docs/configuration/agent-engine-config).
-   Workers are headless by design: no MCP, no interactive prompts, nothing
-   that can block on stdin. Pass `--pipeline <variant>` to route each worker
-   through an installed [wrapper plugin](/docs/plugins) instead.
-5. **Record.** Every attempt, commit, and dollar lands in the fleet ledger
-   at `.stella/private/fleet.db` — local SQLite, like all
-   [stella telemetry](/docs/telemetry), with `runs`, `tasks`, `attempts`,
-   and `commits` tables you can query directly. Past runs also surface on
-   the **Fleet runs** card of the
+1. **Plan.** Task prompts, whether typed inline or loaded from a `--plan` file, form a
+   dependency graph: tasks with `depends_on` wait for their dependencies to finish
+   first. Plans are checked before anything runs. A duplicate id, a task that depends on
+   itself, an unknown dependency, or a dependency cycle gets rejected, and stella names
+   the task or cycle that caused it.
+2. **Share or isolate.** By default, every worker runs directly in the repository root,
+   using the cooperative file claims described [below](#file-claims--cooperative-locks).
+   A task marked `isolation = "isolated"` instead gets a fresh git worktree under
+   `.stella/worktrees/<slug>`, branched from a pinned base commit. That base is the
+   current `HEAD` or `--base-ref`, locked to a specific commit at the start of the run so
+   later commits can't shift it. The worktree lands on a `fleet/<slug>-<hash>` branch.
+   The 16-character hash keeps re-runs, which reuse task ids like `t1`, from colliding
+   with branches and worktrees left over from an earlier fleet. Isolated workers can't
+   see each other's uncommitted work and can't touch your checkout.
+3. **Dispatch in waves.** Tasks run in dependency order, in waves of up to
+   `--max-concurrency` tasks at once (4 by default). A failed task does not unblock the
+   tasks waiting on it; those end the run marked `skipped`. Nothing retries
+   automatically. The ledger records every attempt, but re-running is up to you.
+4. **Work.** Each worker runs the full engine: the plain step loop by default, with the
+   standard set of tools, following your
+   [agent-engine config](/docs/configuration/agent-engine-config). Workers run headless
+   on purpose: no MCP, no interactive prompts, nothing that can get stuck waiting for
+   input. Pass `--pipeline <variant>` to route each worker through an installed
+   [wrapper plugin](/docs/plugins) instead.
+5. **Record.** Every attempt, commit, and dollar spent lands in the fleet ledger at
+   `.stella/private/fleet.db`. Like all [stella telemetry](/docs/telemetry), it's a
+   local SQLite database, with `runs`, `tasks`, `attempts`, and `commits` tables you can
+   query directly. Past runs also show up on the Fleet runs card of the
    [Observatory dashboard](/docs/telemetry/dashboard).
 
    ```bash
@@ -65,21 +61,18 @@ stella fleet \
          AND a.success = 0;"
    ```
 
-   Under the shared tree the `commits` table records the commits each worker
-   was **observed** making. A commit runs while its worker holds a
-   workspace-wide commit lane, so no sibling can move `HEAD` inside that
-   window; the advance belongs to exactly one task. The trade is
-   deliberate — a commit made some other way in a shared tree (through the
-   shell, which is off by default) is left out of the table rather than
-   stamped onto whichever task happened to be open. An isolated task has one
-   writer in its own worktree, so its whole range of commits is recorded,
-   however they were made.
+   In the shared tree, the `commits` table records the commits each worker was observed
+   making. While a worker commits, it holds a workspace-wide commit lane, so no other
+   worker can move `HEAD` during that window. Each commit belongs to exactly one task.
+   If a commit happens some other way in the shared tree, for example through the shell
+   (which is off by default), it's left out of the table rather than guessed at. An
+   isolated task has only one writer in its own worktree, so every commit it makes gets
+   recorded, no matter how it was made.
 
-6. **Review.** Shared-tree work lands directly on your current branch as
-   interleaved commits. Isolated tasks' worktrees and `fleet/*` branches are
-   deliberately **left in place** — those branches *are* the work product.
-   Inspect, test, and merge them on your terms; `git worktree list` shows
-   them all.
+6. **Review.** Shared-tree work lands directly on your current branch as interleaved
+   commits. Isolated tasks' worktrees and `fleet/*` branches stay in place on purpose;
+   those branches are the actual work product. Inspect, test, and merge them whenever
+   you're ready. `git worktree list` shows all of them.
 
 ## Plan files
 
@@ -100,55 +93,54 @@ prompt = "Update the release notes for 1.4.0 from the merged PRs"
 depends_on = ["t1"]
 ```
 
-Every task field, in the shape the plan parser accepts:
+The task fields the plan parser accepts:
 
 <CardGrid size="md">
   <OptionCard name="id" required>
-    Stable, plan-unique identifier. It is what `depends_on` edges reference, the
-    dispatch tie-break, and the seed for this task's worktree directory and
-    branch name.
+    A unique identifier within the plan. It's what `depends_on` refers to, what breaks
+    ties when dispatching, and what names this task's worktree directory and branch.
   </OptionCard>
   <OptionCard name="title" required>
-    One-line human label, shown in the run report and stored on the ledger's
-    `tasks` row. Never interpreted.
+    A one-line label for people, shown in the run report and stored in the ledger's
+    `tasks` row. stella doesn't read any meaning into it.
   </OptionCard>
   <OptionCard name="prompt" required>
-    What the worker is asked to do — a full stella prompt.
+    What the worker is asked to do. A full stella prompt.
   </OptionCard>
   <OptionCard name="depends_on" defaultValue="[]">
-    Ids that must succeed before this task dispatches; this is what orders the
-    waves. Every id must name a task in the same plan.
+    Ids of tasks that must succeed before this one starts. This is what decides the wave
+    order. Every id must name a task in the same plan.
   </OptionCard>
   <OptionCard name="isolation" defaultValue="shared_tree">
-    `shared_tree` runs directly in the repo root under the cooperative claim
-    discipline. `isolated` gets its own worktree on its own branch — the
-    explicit opt-in for genuinely *divergent* work: best-of-N attempts producing
-    competing versions of the same files, or tasks that mutate checkout state.
-    Claims can't help there — the conflict is the point — and the costs are
-    real: a cold build cache per tree, and conflicts deferred to integration
-    time.
+    `shared_tree` runs directly in the repo root, using cooperative file claims.
+    `isolated` gets its own worktree on its own branch. Choose this when the work is
+    genuinely meant to diverge, like several competing attempts at the same files, or a
+    task that changes checkout state in ways that would affect other workers. File
+    claims can't help there, since conflict is the whole point. The trade-off is real:
+    each worktree starts with a cold build cache, and any conflicts get pushed to when
+    you merge the work back.
   </OptionCard>
   <OptionCard name="claims" defaultValue="[]">
-    Workspace-relative paths held as cooperative file locks for the attempt's
-    duration. Matched as exact strings, so spell each path one way throughout
-    the plan.
+    Paths, relative to the workspace root, held as file locks for the length of the
+    attempt. Paths are matched as exact strings, so spell each one the same way
+    everywhere in the plan.
   </OptionCard>
   <OptionCard name="test_command" defaultValue="none">
-    The command that decides this task — the oracle a wrapper plugin runs under
-    `--pipeline <variant>` to observe red-before/green-after on the attempt's
-    own tree. Per task, because two tasks touching different subsystems are
-    decided by different commands. It must be one the host's closed runner
-    vocabulary accepts (`cargo`, `pytest`, `sh`, …); anything else fails that
-    task's dispatch by name and leaves the rest of the fan-out running. A task
-    that declares none — every positional `stella fleet "…"` prompt included —
-    gives a witness-flavoured plugin no flip to observe, so it reports
-    `Undecided` for that task rather than crediting one.
+    The command that decides whether this task passed. Under `--pipeline <variant>`, a
+    wrapper plugin runs this command before and after the attempt to check whether it
+    went from failing to passing on that task's own tree. Set per task, since two tasks
+    touching different parts of the codebase are checked with different commands. It
+    must be a command type stella recognizes (`cargo`, `pytest`, `sh`, and a few
+    others); anything else fails that one task by name and leaves the rest of the run
+    going. A task with no `test_command` set, including every task typed directly as a
+    `stella fleet "…"` prompt, gives an evidence-gathering plugin nothing to check, so it
+    reports that task as `Undecided` instead of a pass.
   </OptionCard>
 </CardGrid>
 
-A plan exercising all of it — three waves, one isolated task, and claims that
-keep the parallel writers apart. Claims are matched as **exact strings**, so
-name files, not directories:
+This plan uses all of it: three waves, one isolated task, and claims that keep the
+parallel writers apart. Claims match as exact strings, so name individual files, not
+directories:
 
 ```toml title="feature-buildout.toml"
 [[tasks]]
@@ -183,97 +175,96 @@ isolation = "isolated"
 stella --spend-limit 6 fleet --plan feature-buildout.toml
 ```
 
-`schema` runs alone in wave one. `reader` and `writer` run together in wave two
-with disjoint claims. `docs` runs last in wave three, in its own worktree on its
-own `fleet/docs-<hash>` branch — divergent work, so isolation rather than
-claims. Had `reader` and `writer` both claimed `src/store/schema.rs`, the second
-dispatch would have failed by name instead of racing.
+`schema` runs alone in wave one. `reader` and `writer` run together in wave two, each
+with its own claims so they don't overlap. `docs` runs last, in wave three, in its own
+worktree on its own `fleet/docs-<hash>` branch, since it's divergent work that needs
+isolation rather than claims. If `reader` and `writer` had both claimed
+`src/store/schema.rs`, the second one to dispatch would have failed by name instead of
+racing the first.
 
 ### File claims — cooperative locks
 
-A task that declares `claims` (workspace-relative paths it intends to touch)
-holds them as **cooperative file locks** for the attempt's duration. A second
-task — or a second fleet run — that claims an already-held path fails that
-dispatch *by name* instead of silently racing another agent into the same
-file. The locks live in the `file_locks` table of `.stella/private/store.db`,
-separate from the fleet ledger, so they coordinate across concurrent fleet
-runs too.
+A task that declares `claims` (paths it plans to touch, relative to the workspace) holds
+those paths as file locks for as long as the attempt runs. If a second task, or even a
+second fleet run, tries to claim a path that's already held, that dispatch fails by name
+instead of silently racing another worker for the same file. The locks live in the
+`file_locks` table of `.stella/private/store.db`, separate from the fleet ledger, so they
+coordinate across fleet runs happening at the same time too.
 
 ## Spend limit across a fleet
 
-The spend limit comes from the **global** `--spend-limit` flag (or `STELLA_SPEND_LIMIT`), which
-goes *before* the subcommand:
+The spend limit comes from the global `--spend-limit` flag (or `STELLA_SPEND_LIMIT`),
+which goes before the subcommand:
 
 ```bash
 stella --spend-limit 5 fleet --plan release-prep.toml
 # equivalently: STELLA_SPEND_LIMIT=5 stella fleet --plan release-prep.toml
 ```
 
-It is enforced twice. Each child runs under its own guard — the aggregate cap
-divided across the concurrency width (`spend limit ÷ max-concurrency`) — so one
-wave's in-flight children can't collectively overshoot, and the fleet stops
-launching new waves once total metered spend crosses the cap. In-flight
-siblings settle cleanly — never a mid-tool kill.
+It's enforced in two ways. Each worker runs under its own guard, which is the total cap
+divided by the concurrency width (`spend limit ÷ max-concurrency`), so one wave's
+workers can't collectively spend more than their share. On top of that, the fleet stops
+launching new waves once total spend crosses the cap. Workers already running are
+allowed to finish cleanly; stella never kills one mid-task.
 
-## Watching CI: `--watch`
+## Watch CI: `--watch`
 
-After the fan-out, `--watch` holds a **fleet monitor** on every branch that
-carries successful work: it watches each branch's CI to completion via the
-`gh` CLI, reconciles PR status live, and exits non-zero if any watched branch
-ends red. It polls every 30 seconds, allows CI 10 minutes of startup grace to
-appear, gives up on a branch after 20 minutes without progress, and caps the
-whole watch at 2 hours of wall time.
+After the fan-out finishes, `--watch` keeps an eye on every branch that has successful
+work on it. It watches each branch's CI run through to completion using the `gh` CLI,
+keeps PR status updated live, and exits with a non-zero code if any watched branch ends
+up red. It checks every 30 seconds, gives CI 10 minutes to start showing up, gives up on
+a branch after 20 minutes with no progress, and stops watching entirely after 2 hours.
 
 ```bash
 stella fleet --plan release-prep.toml --max-concurrency 2 --watch
 ```
 
 <Callout type="warn">
-  `--watch` only has something to watch once branches are pushed — for
-  example when your task prompts push and open PRs. It requires an installed,
-  authenticated `gh`.
+  `--watch` only has something to watch once branches are pushed, for example when your
+  task prompts push and open pull requests. It needs `gh` installed and logged in.
 </Callout>
 
 ## Flags
 
 <CardGrid size="md">
   <OptionCard name="<task>..." required>
-    One or more task prompts, each becoming an independent shared-tree task.
-    Required unless `--plan` is given — the two are mutually exclusive.
+    One or more task prompts, each becoming its own shared-tree task. Required unless
+    you pass `--plan`; you can't use both at once.
   </OptionCard>
   <OptionCard name="--plan <FILE>">
-    A `.json` or `.toml` plan with `[[tasks]]` entries instead of inline
-    prompts — the only way to declare `depends_on`, `claims`, or `isolation`.
+    A `.json` or `.toml` file with `[[tasks]]` entries instead of inline prompts. This
+    is the only way to set `depends_on`, `claims`, or `isolation`.
   </OptionCard>
   <OptionCard name="--max-concurrency <N>" defaultValue="4">
-    Max tasks dispatched at once within one wave.
+    The most tasks that can run at once within one wave.
   </OptionCard>
   <OptionCard name="--base-ref <ref>" defaultValue="current HEAD">
-    Git ref the `isolation = "isolated"` worktrees branch from, resolved to a
-    SHA at start so mid-run commits can't drift the base. Shared-tree tasks
-    ignore it.
+    The git ref that `isolation = "isolated"` worktrees branch from. It's locked to a
+    specific commit at the start of the run, so later commits can't shift the base.
+    Shared-tree tasks ignore this flag.
   </OptionCard>
   <OptionCard name="--watch">
-    After the fan-out, watch each fleet branch's CI to completion and reconcile
-    its PR status via `gh`. Exits non-zero if any watched branch ends red.
+    After the fan-out, watch each fleet branch's CI through to completion and keep its
+    PR status updated using `gh`. Exits with a non-zero code if any watched branch ends
+    red.
   </OptionCard>
   <OptionCard name="--pipeline <VARIANT>">
-    Route each worker through the installed wrapper plugin whose manifest
-    declares this `[wrapper] id`. Omit it for the raw step loop.
+    Route each worker through the installed wrapper plugin whose manifest declares this
+    `[wrapper] id`. Leave it off to use the plain step loop.
   </OptionCard>
 </CardGrid>
 
-The spend-limit flag is **global**, so it goes before the subcommand — the one
-ordering mistake worth memorizing:
+The spend-limit flag is global, so it goes before the subcommand. This is the one
+ordering mistake worth remembering:
 
 ```bash
 stella --spend-limit 8 fleet --plan release-prep.toml --max-concurrency 3 --watch
 ```
 
-## Cleaning up
+## Clean up
 
-When you've merged (or rejected) the branches your isolated tasks left —
-the branch names carry a hash suffix, so list them rather than guessing:
+Once you've merged, or rejected, the branches your isolated tasks left behind, clean
+them up. The branch names carry a hash suffix, so list them instead of guessing:
 
 ```bash
 git worktree list                  # what the fleet left in .stella/worktrees/
@@ -282,7 +273,7 @@ git branch --list 'fleet/*'        # the fleet branches
 git branch -D fleet/<slug>-<hash>  # per branch, exactly as listed
 ```
 
-Once every branch is merged or rejected, the whole sweep in two lines:
+Once every branch is merged or rejected, this sweeps them all in two lines:
 
 ```bash
 git worktree list --porcelain | awk '/^worktree .*\.stella\/worktrees\//{print $2}' \
@@ -291,19 +282,19 @@ git branch --list 'fleet/*' --format='%(refname:short)' | xargs -r git branch -D
 ```
 
 <Callout type="warn">
-  That second pair deletes every `fleet/*` branch, merged or not — the branches
-  *are* the work product for isolated tasks. Run `git branch --list 'fleet/*'`
-  on its own first and confirm the list is one you are finished with.
+  That second command deletes every `fleet/*` branch, merged or not. For isolated
+  tasks, those branches are the work product. Run `git branch --list 'fleet/*'` by
+  itself first, and make sure the list only has branches you're really done with.
 </Callout>
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="Fix a backlog in parallel" href="/docs/guides/parallel-fixes">
-    The task-shaped walkthrough: decomposing a real list, writing prompts that
-    survive being run alone, and reviewing what the workers landed.
+    A walkthrough built around a real task list: breaking it down, writing prompts that
+    work when run alone, and reviewing what the workers produced.
   </SpecCard>
   <SpecCard title="stella fleet" href="/docs/commands/fleet">
-    The reference — every flag, the ledger layout, exit behavior.
+    The full reference: every flag, the ledger layout, and exit behavior.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/agent-modes.mdx
+++ b/website/content/docs/agent-modes.mdx
@@ -1,12 +1,12 @@
 ---
 title: Agent Modes
-description: The ways to drive stella — Command Deck chat, one-shot raw or plugin-wrapped runs, judged goal mode, CI monitoring, and parallel fleets — and how to pick between them.
+description: The different ways to drive stella — chat in the Command Deck, one-shot runs, judged goal mode, CI monitoring, and parallel fleets — and how to pick between them.
 ---
 
-stella has one engine and several ways to drive it. Pick the mode by how much
-autonomy you're delegating and how the work should be checked. (For the
-under-the-hood view — what each mode actually does differently inside the
-engine — see [Agent Engine Paths](/docs/agent-engine-paths).)
+stella has one engine and several ways to drive it. Pick a mode based on how much you
+want to hand off, and how the work should get checked. For a closer look at what each
+mode does differently inside the engine, see
+[Agent Engine Paths](/docs/agent-engine-paths).
 
 <CardGrid size="md">
   <SpecCard
@@ -35,8 +35,8 @@ engine — see [Agent Engine Paths](/docs/agent-engine-paths).)
       { label: "Verified by", value: "an installed wrapper plugin", mono: false },
     ]}
   >
-    Opt-in ceremony where the result must carry evidence — the plugin gathers
-    it and stella evaluates it against the plugin's declared rule.
+    An extra step you opt into when the result needs to carry evidence. The plugin
+    gathers that evidence, and stella checks it against the plugin's rule.
   </SpecCard>
   <SpecCard
     title="Goal mode"
@@ -46,8 +46,8 @@ engine — see [Agent Engine Paths](/docs/agent-engine-paths).)
       { label: "Verified by", value: "an independent verifier, over raw step-loop rounds", mono: false },
     ]}
   >
-    An outcome, not a task list. `--pipeline <variant>` runs each round's
-    worker turn under a wrapper plugin instead.
+    You describe the outcome, not a list of steps. Pass `--pipeline <variant>` to run
+    each round's worker turn under a wrapper plugin instead.
   </SpecCard>
   <SpecCard
     title="CI monitor"
@@ -67,29 +67,29 @@ engine — see [Agent Engine Paths](/docs/agent-engine-paths).)
       { label: "Verified by", value: "per task, independently", mono: false },
     ]}
   >
-    Many tasks in parallel — one shared tree with cooperative claims, or a worktree each on opt-in.
+    Many tasks running in parallel: one shared tree with cooperative file claims by
+    default, or a separate worktree per task if you opt in.
   </SpecCard>
 </CardGrid>
 
 ## Interactive: the Command Deck
 
-Running `stella` with no subcommand opens the **Command Deck** — not a
-generic TUI in the `htop`/`vim` sense, but stella's own tabbed workspace over
-the same engine that drives every other mode on this page. One surface, nine
-tabs, and every tab is a live view over the same session: what a sub-agent is
-doing right now, the code graph, the files this turn touched, your MCP
-servers. Type to send a prompt; slash commands open tabs and overlays.
+Running `stella` with no subcommand opens the Command Deck. It isn't a generic terminal
+app like `htop` or `vim`; it's stella's own tabbed workspace over the same engine that
+drives every other mode on this page. One surface, nine tabs, and every tab is a live
+view into the same session: what a sub-agent is doing right now, the code graph, the
+files this turn touched, your MCP servers. Type to send a prompt. Slash commands open
+tabs and overlays.
 
-Click a tab below to see what's actually in it. This isn't an embedded
-terminal or a recording — each pane is trimmed straight from the deck's own
-golden render tests (`crates/stella-tui/tests/snapshots/deck/`), the fixtures
-that gate every TUI pull request. What you click through is the deck's real
-output, not a redrawn approximation.
+Click a tab below to see what's actually in it. This isn't an embedded terminal or a
+recording. Each pane is taken straight from the deck's own test snapshots
+(`crates/stella-tui/tests/snapshots/deck/`). What you click through is the deck's real
+output, not a redrawn copy.
 
 <CommandDeckExplorer />
 
-The full slash-command set — including `/inspect` and `/context` — is on
-[`stella chat`](/docs/commands/chat); here's what each tab opens:
+The full slash-command set, including `/inspect` and `/context`, is on
+[`stella chat`](/docs/commands/chat). Here's what each tab opens:
 
 <CardGrid size="sm">
   <OptionCard name="/help">Show help.</OptionCard>
@@ -97,52 +97,50 @@ The full slash-command set — including `/inspect` and `/context` — is on
   <OptionCard name="/files · /diff">What this session changed, and the working diff.</OptionCard>
   <OptionCard name="/graph">The code-graph tab.</OptionCard>
   <OptionCard name="/agents · /skills · /mcp">
-    The AGENTS tab (the agents installed on disk), skills, and MCP servers.
+    The AGENTS tab (agents installed on disk), skills, and MCP servers.
   </OptionCard>
   <OptionCard name="/settings">
-    The SETTINGS tab — home of all config, including the
+    The SETTINGS tab, home to all config, including the
     [engine-config panel](/docs/configuration/agent-engine-config).
   </OptionCard>
   <OptionCard name="/sessions · /inbox">Every session on this machine; notifications.</OptionCard>
   <OptionCard name="/export">
-    Export **this session's** telemetry to a ZIP plus an
-    [HTML dashboard](/docs/telemetry/dashboard) — scoped so the archive is
-    safe to share.
+    Export this session's telemetry to a ZIP file plus an
+    [HTML dashboard](/docs/telemetry/dashboard). It only includes this session, so the
+    archive is safe to share.
   </OptionCard>
   <OptionCard name="/clear">Reset the conversation.</OptionCard>
 </CardGrid>
 
-**⏎** inserts a line break; **⌘⏎ / ⌃⏎** submits. Prompts queue while a turn
-runs — you never wait for the agent to finish before typing the next thing
-(**Ctrl-T** opens the queue editor). A `!`-prefixed line runs a shell command
-immediately, inline in the session transcript, skipping the queue. A single **Esc** cancels the in-flight turn;
-**double-Esc** cancels *and holds* dispatch so what you type next runs first.
-Prefer a plain line-based REPL? `stella --plain` (or `STELLA_PLAIN=1`).
+`⏎` inserts a line break. `⌘⏎` or `⌃⏎` submits. Prompts queue while a turn runs, so you
+never have to wait for the agent to finish before typing the next thing (`Ctrl-T` opens
+the queue editor). A line that starts with `!` runs a shell command right away, inline in
+the session transcript, skipping the queue. A single `Esc` cancels the turn in progress.
+Pressing `Esc` twice cancels and holds dispatch, so whatever you type next runs first.
+Prefer a plain, line-based interface? Use `stella --plain` (or `STELLA_PLAIN=1`).
 
-### The transcript, and the palette
+### Transcript and palette
 
-The turn is the unit of the transcript. It opens with a rule, folds every read
-that changed nothing, keeps the edits expanded with their diffs, and closes on
-a receipt — what the turn cost, what it proved, and how much of it never
-reached a model.
+The turn is the basic unit of the transcript. It opens with a rule line, collapses any
+read that didn't change anything, keeps edits expanded with their diffs, and closes with
+a receipt: what the turn cost, what it proved, and how much of it never reached a model.
 
 <DeckShot id="turn" />
 
-Slash commands open a fuzzy palette that knows what is running: while a verify
-turn is in flight, the gate commands sort to the top.
+Slash commands open a fuzzy-search palette that knows what's currently running. While a
+verify turn is in flight, gate commands sort to the top.
 
 <DeckShot id="palette" />
 
 ## One-shot: `stella run`
 
-The non-interactive workhorse: one prompt in, the finished work and an exit
-code back. Defaults to the raw step loop, which reports what it changed and
-claims nothing about proof; pass `--pipeline <variant>` to run the
-turn under an installed [wrapper plugin](/docs/plugins), where
-`--test-command` hands that plugin's own oracle a command to check against
-(refused on the raw default). Combine with
-`--output-format json|stream-json` and `--spend-limit` for headless
-automation — see [`stella run`](/docs/commands/run) and
+This is the non-interactive workhorse: one prompt goes in, and finished work plus an
+exit code come back. By default, it runs the plain step loop, which reports what it
+changed but doesn't claim to prove anything. Pass `--pipeline <variant>` to run the turn
+under an installed [wrapper plugin](/docs/plugins) instead. With a plugin,
+`--test-command` gives its checker a command to test against (this flag is rejected on
+the plain default). Combine with `--output-format json` or `stream-json` and
+`--spend-limit` for headless automation. See [`stella run`](/docs/commands/run) and
 [Scripting](/docs/scripting).
 
 ```bash
@@ -152,57 +150,53 @@ stella run "add a --json flag to the export command and update the tests" \
 
 ## Outcome-driven: goal mode
 
-`stella goal` doesn't take a task — it takes an **objective**, and works in
-judged rounds until an independent verifier (routed to a different model family
-than the worker whenever possible) confirms the objective is met *from
-evidence*. Each round is a raw step-loop turn by default; pass
-`--pipeline <variant>` to run every round's worker turn under an installed
-[wrapper plugin](/docs/plugins) instead. Backstops — a
-round cap, `--spend-limit`, worker aborts — end the run as "not met"
-rather than optimistically.
+`stella goal` doesn't take a task. It takes an objective, and works in judged rounds
+until an independent verifier confirms, from evidence, that the objective is met. Where
+possible, that verifier runs on a different model family than the worker. Each round is
+a plain step-loop turn by default; pass `--pipeline <variant>` to run every round's
+worker turn under an installed [wrapper plugin](/docs/plugins) instead. If the run hits
+a limit, like a round cap, the `--spend-limit`, or a worker aborting, it ends the run
+marked "not met" rather than assuming success.
 
 ```bash
 stella goal "the test suite passes and there are no clippy warnings"
 ```
 
-Where `stella run` executes a single one-shot prompt, `stella goal` runs
-**judged rounds**. Each round the worker agent makes progress using the normal
-[agent step loop](/docs/agent-engine-paths), and then a separate verifier model
-reviews the evidence and decides whether the objective has been satisfied. The
-loop ends when the verifier confirms — or when a backstop trips: a hard round cap
-(default **8** rounds), the `--spend-limit` cap, or a worker-turn abort. Reaching
-a backstop ends the run, reporting the goal as **not met** with a
-named reason.
+Where `stella run` executes a single one-shot prompt, `stella goal` runs judged rounds.
+In each round, the worker agent makes progress using the normal
+[agent step loop](/docs/agent-engine-paths). Then a separate verifier model reviews the
+evidence and decides whether the objective has been met. The loop ends when the verifier
+confirms it, or when a limit is hit: a hard cap of 8 rounds by default, the
+`--spend-limit` cap, or a worker turn aborting. Hitting a limit ends the run and reports
+the goal as not met, along with the reason.
 
 ### How judged rounds work
 
-1. **The worker works a round.** The worker model runs the step loop —
-   proposing tool calls, executing them, and feeding results back — to make
-   progress toward the objective.
-2. **The verifier assesses from evidence.** The verifier is not a passive transcript
-   reader — it runs as its own bounded engine turn with read-only access to the
-   worker's tools, inspecting the round's evidence and rejecting
-   claimed-but-unproven success.
-3. **Repeat or finish.** If the verifier is not satisfied, another round begins —
-   until the verifier confirms or a backstop (round cap, budget, abort) ends the run.
+1. **The worker works a round.** The worker model runs the step loop: it proposes tool
+   calls, runs them, and feeds the results back, making progress toward the objective.
+2. **The verifier checks the evidence.** The verifier doesn't just read a summary. It
+   runs as its own limited engine turn, with read-only access to the worker's tools,
+   checking the round's evidence directly and rejecting success that's claimed but not
+   proven.
+3. **Repeat or finish.** If the verifier isn't satisfied, another round starts. This
+   continues until the verifier confirms the goal, or a limit (round cap, budget, or
+   abort) ends the run.
 
-Because the verifier assesses **from evidence** rather than from the worker's
-narration, "I think I'm done" is never enough on its own — the goal is only
-considered met when the verifier, looking at what actually happened, agrees.
+Because the verifier checks the evidence directly instead of trusting the worker's own
+account, "I think I'm done" is never enough by itself. The goal only counts as met when
+the verifier looks at what actually happened and agrees.
 
 ### Cross-family judging
 
-The verifier is **routed cross-family** — it runs on a *different model
-family* than the worker. Asking a model to grade its own work invites
-same-model bias: it tends to share the worker's blind spots and rubber-stamp its
-output. Routing the verifier to a different family provides a genuinely independent
-second opinion.
+Whenever possible, the verifier runs on a different model family than the worker.
+Asking a model to grade its own work invites bias: it tends to share the worker's blind
+spots and approve its own output. Using a different model family for the verifier gives
+you a genuinely independent second opinion.
 
 <Callout type="info">
-If only one provider family is configured, stella cannot route the verifier to a
-different family — so the worker doubles as the verifier. Configuring a second
-provider family enables true cross-family judging and a more independent
-verdict.
+If you've only configured one model provider, stella can't route the verifier to a
+different family, so the worker ends up doubling as its own verifier. Configuring a
+second provider gives you real cross-family judging and a more independent result.
 </Callout>
 
 ### Example
@@ -213,13 +207,12 @@ Give stella a concrete objective and let it iterate until the verifier signs off
 stella goal "Add input validation to the /signup endpoint and make sure the existing test suite passes"
 ```
 
-stella will work in rounds — editing code, running the tests, reading the
-output — and a cross-family verifier will assess each round from the evidence. The
-run finishes only once the verifier confirms the endpoint is validated and the test
-suite is green.
+stella works in rounds: editing code, running tests, reading the output. A cross-family
+verifier checks each round against the evidence. The run finishes only once the
+verifier confirms the endpoint is validated and the test suite is green.
 
-You can combine goal mode with global flags, for example pinning a specific
-worker model or capping spend:
+You can combine goal mode with global flags, for example pinning a specific worker
+model or capping spend:
 
 ```bash
 stella --model anthropic/claude-fable-5 --spend-limit 5.00 \
@@ -231,32 +224,31 @@ more on `--model` and `--spend-limit`.
 
 ## CI monitor: `stella monitor`
 
-`stella monitor` is goal mode specialized for continuous integration. It
-watches CI for a branch or PR (default `main`) and keeps fixing failures until
-the latest run is fully green.
+`stella monitor` is goal mode built specifically for continuous integration. It watches
+CI for a branch or pull request (`main` by default) and keeps fixing failures until the
+latest run is fully green.
 
 ```bash
 stella monitor
 ```
 
-The goal is considered met only when the latest CI run is all-green — the same
-judged-loop discipline as goal mode, with "all CI checks pass" as the
-objective.
+The goal counts as met only when the latest CI run is all green. It follows the same
+judged-loop process as goal mode, with "all CI checks pass" as the objective.
 
 ## Parallel: fleets
 
 When the work is many tasks rather than one, [`stella fleet`](/docs/agent-fleets)
-fans a dependency-ordered task DAG out to parallel workers in one shared
-tree, where cooperative file claims keep two agents from fighting over the
-same file. `isolation = "isolated"` opts a task into its own git worktree
-on its own branch.
+spreads a dependency-ordered set of tasks out to parallel workers in one shared tree.
+Cooperative file claims keep two agents from fighting over the same file. Setting
+`isolation = "isolated"` on a task gives it its own git worktree on its own branch
+instead.
 
 ## Choosing
 
 - **You know the change and want to watch** → the Command Deck.
-- **You know the change and don't need to watch** → `stella run` (the raw
-  default is fastest; add `--pipeline <variant> --test-command` to run it
-  under a wrapper plugin that gathers evidence).
+- **You know the change and don't need to watch** → `stella run`. The plain default is
+  fastest; add `--pipeline <variant> --test-command` to run it under a wrapper plugin
+  that gathers evidence.
 - **You know the outcome but not the steps** → `stella goal`.
 - **CI is red and you want it green** → `stella monitor`.
 - **You have a backlog** → `stella fleet --plan`.

--- a/website/content/docs/agent-tools/commands.mdx
+++ b/website/content/docs/agent-tools/commands.mdx
@@ -1,18 +1,17 @@
 ---
 title: Custom Commands
-description: Extend the slash menu with your own prompt templates in markdown or TOML — $ARGUMENTS expansion, namespaces, and project or user scopes.
+description: Add your own prompt templates to the slash menu, in Markdown or TOML. Covers $ARGUMENTS expansion, namespaces, and project or user scopes.
 ---
 
-The Command Deck's slash menu is extensible: alongside the built-ins
-(`/help`, `/models`, `/export`, …), your ⚡
+The Command Deck's slash menu is open for you to extend. Alongside the built-ins
+(`/help`, `/models`, `/export`, and more), your ⚡
 [skills](/docs/agent-tools/skills), and your
-[custom agents](/docs/agent-tools/custom-agents), you can define
-**commands** — reusable prompt templates invoked as `/name`.
+[custom agents](/docs/agent-tools/custom-agents), you can add
+**commands**: reusable prompt templates you run as `/name`.
 
 ## The format
 
-A `COMMAND.md` (nested `<slug>/COMMAND.md` or flat `<slug>.md`) with
-optional frontmatter and a Markdown body:
+A command is a `COMMAND.md` file. Use the nested layout (`<slug>/COMMAND.md`) or the flat layout (`<slug>.md`). It has optional frontmatter and a Markdown body:
 
 ```md title=".stella/commands/review.md"
 ---
@@ -27,56 +26,40 @@ Focus areas: $ARGUMENTS
 - Check error paths before happy paths.
 ```
 
-Both frontmatter fields are optional: `name:` falls back to the filename
-stem (or the directory name in the nested layout), and `description:` falls
-back to the body's first non-empty line. Only the body is required — a
-command with an empty body is skipped with a diagnostic, never a fatal
-error.
+Both frontmatter fields are optional. Skip `name:` and stella uses the filename stem, or the directory name in the nested layout. Skip `description:` and stella uses the body's first non-empty line. Only the body is required. A command with an empty body is skipped, with a diagnostic message rather than a hard error.
 
-### Every field
+### Fields
 
 <CardGrid size="md">
   <OptionCard name="name" defaultValue="the filename stem">
-    The bare command name, without the leading slash and without any namespace.
+    The command name, without the leading slash and without any namespace.
   </OptionCard>
   <OptionCard name="description" defaultValue="the body's first line">
-    Menu description, shown in the slash menu.
+    The description shown in the slash menu.
   </OptionCard>
   <OptionCard name="argument-hint">
-    What the argument slot expects (`<pr-number>`), shown next to the name.
-    **Documentation only** — nothing validates against it, because a command that
-    refuses to run on a shape its author did not anticipate is worse than one that
-    passes the text through.
+    What the argument slot expects, such as `<pr-number>`. It shows next to the name in the menu. It's **for humans only** — nothing checks your input against it. A command that refused to run just because your input didn't match the hint would be worse than one that passes the text through.
   </OptionCard>
   <OptionCard name="allowed-tools" defaultValue="no restriction">
-    Tools this command's turn may use. Omitted, the command runs with the session's
-    full toolbelt.
+    The tools this command's turn may use. Leave it out and the command runs with every tool the session already has.
   </OptionCard>
   <OptionCard name="model" defaultValue="the session's model">
-    A model pin for this command's turn, as `provider/model_id`.
+    Pin a model for this command's turn, written as `provider/model_id`.
   </OptionCard>
   <OptionCard name="disable-model-invocation" defaultValue="false">
-    Set `true` so only *you* can invoke it, never the model — for commands that should
-    always be deliberate.
+    Set this to `true` so only you can run the command. The model can never trigger it on its own. Use it for commands that should always be a deliberate choice.
   </OptionCard>
 </CardGrid>
 
-Every field is accepted in both kebab-case and snake_case (`argument-hint` or
-`argument_hint`), matching the spellings contributors already know from the
-wider ecosystem.
+Write any field in kebab-case or snake_case. `argument-hint` and `argument_hint` both work.
 
 <Callout type="info">
-`disable-model-invocation` exists to *remove* a capability, so an unparseable value
-is never read as the removal — a typo leaves the command invocable rather than
-silently disabling it.
+`disable-model-invocation` exists to turn a capability off. If stella can't read the value, it treats the command as still on. A typo leaves the command open to the model instead of quietly locking it out.
 </Callout>
 
-## Markdown or TOML — the same command
+## Markdown or TOML
 
-A definition can be authored as markdown-with-frontmatter (`<slug>.md`) **or** as
-TOML (`<slug>.toml`). The two formats carry exactly the same fields and produce the
-same command: TOML is a spelling, not a feature tier, so nothing is gained or lost by
-converting, and a workspace can hold both.
+Write a command as Markdown with frontmatter (`<slug>.md`) or as TOML (`<slug>.toml`). Both formats support the same fields and produce the same command. TOML isn't a more advanced option, just a different way to write the same thing. A workspace can mix both.
 
 ```toml title=".stella/commands/review.toml"
 name = "review"
@@ -93,38 +76,27 @@ Focus areas: $ARGUMENTS
 """
 ```
 
-The body lives under `prompt` rather than being the file's tail. That is the one
-practical reason to prefer TOML: a `prompt` string needs no frontmatter fence, so a
-template that itself contains markdown (or a `---` rule) has nothing to escape. The
-other is a typed `allowed-tools` array instead of a delimited string.
+In TOML, the body lives under `prompt` instead of at the end of the file. That's the real reason to reach for TOML. A `prompt` string needs no frontmatter fence, so a template that already contains Markdown, or a `---` line, has nothing to escape. TOML also gives you a real array for `allowed-tools` instead of a comma-delimited string.
 
-[`stella commands convert`](/docs/commands/commands) converts markdown definitions to
-TOML, and [`stella commands list`](/docs/commands/commands) shows what a workspace
-actually offers.
+[`stella commands convert`](/docs/commands/commands) turns a Markdown command into TOML. [`stella commands list`](/docs/commands/commands) shows every command available in your workspace.
 
 ## Namespaces
 
-A definition one level down is namespaced by its directory, and typed with a colon:
+A command one level down is namespaced by its folder, and you call it with a colon:
 
 ```text
 .stella/commands/deploy.toml          →  /deploy
 .stella/commands/vercel/deploy.toml   →  /vercel:deploy
 ```
 
-Namespacing is **commands only** — skills and agents have no namespace syntax and keep
-a stricter one-file rule. A namespace directory containing no loadable definition is
-reported with a diagnostic rather than skipped silently.
+Only commands support namespaces. Skills and agents don't, and each still needs one file per definition. A namespace folder with no loadable command inside it isn't skipped quietly. You get a diagnostic instead.
 
 ## Argument expansion
 
-Typing `/review auth module` expands the template and runs the result as
-the prompt:
+Type `/review auth module` and stella fills in the template, then runs the result as your prompt.
 
-- Every `$ARGUMENTS` occurrence in the body is replaced with whatever
-  follows the command name (`auth module` above).
-- A body **without** the placeholder still takes arguments — non-empty
-  arguments are appended as a trailing paragraph, so plain prompt files
-  written for other tools work unchanged.
+- Every `$ARGUMENTS` in the body is replaced with whatever you typed after the command name. That's `auth module` in this example.
+- If the body has no `$ARGUMENTS` placeholder, your arguments are still used. Stella adds them as a paragraph at the end. This means prompt files written for other tools work here with no changes.
 
 ## Where commands live
 
@@ -136,7 +108,7 @@ the prompt:
       { label: "Travels with", value: "the repo", mono: false },
     ]}
   >
-    Commit it — everyone who clones gets the command in their slash menu.
+    Commit it, and everyone who clones the repo gets the command in their slash menu.
   </SpecCard>
   <SpecCard
     title="User"
@@ -145,45 +117,24 @@ the prompt:
       { label: "Travels with", value: "you, across every workspace", mono: false },
     ]}
   >
-    Your own templates, in every repo you open.
+    Your own templates, available in every repo you open.
   </SpecCard>
 </CardGrid>
 
-Definitions load user-global first, then workspace — **workspace wins** on
-a name collision. In the slash menu, built-ins can never be shadowed, and
-when a custom name collides across kinds, commands shadow skills shadow
-agents.
+Stella loads user-scope commands first, then project-scope commands. If both define the same name, the project version wins. Built-in commands can never be overridden. When a custom name collides across kinds, commands win over skills, and skills win over agents.
 
-### Project-scope commands need a trusted repo
+### Trusted repos
 
-A cloned repository's commands are **withheld** until you declare the repo
-trusted with `STELLA_TRUST_PROJECT=1`. Your own user-scope commands in
-`~/.stella/commands/` are always available; it is the project scope that is
-gated, because a prompt template that ships in a repo is content you did not
-write.
+A command from a repo you cloned doesn't run until you mark the repo trusted, with `STELLA_TRUST_PROJECT=1`. Your own commands in `~/.stella/commands/` are always available. Only project-scope commands are held back, because a prompt template shipped inside someone else's repo is content you didn't write.
 
-If a command you added to `.stella/commands/` does not appear in the slash menu
-or in [`stella commands list`](/docs/commands/commands), check the repo's trust
-before you check the file — the loader is telling you what will actually run.
+If a command you added to `.stella/commands/` doesn't show up in the slash menu or in [`stella commands list`](/docs/commands/commands), check whether the repo is trusted before you check the file. The loader is telling you what will actually run.
 
-## Adopted from tools you already use
+## Bring in existing commands
 
-`stella init` (and `/init`) **adopts** command definitions from other agent
-tools' directories as symlinks — `.claude/commands/` and
-`.agents/commands/` (workspace scope), `~/.claude/commands/` and
-`~/.agents/commands/` (user scope) — so your existing setup carries over
-instead of being rewritten. `.claude` wins over `.agents` on a name
-collision, existing stella-side definitions are never clobbered, and the
-sync is idempotent. The same adoption covers skills and agents — the full
-mechanics are documented on the
-[Custom Agents](/docs/agent-tools/custom-agents#adopted-from-claude-and-agents-on-init)
-page.
+Running `stella init` (or `/init`) brings in command definitions from other agent tools you already use, as symlinks. It reads from `.claude/commands/` and `.agents/commands/` in your workspace, and from `~/.claude/commands/` and `~/.agents/commands/` for your user scope. Your existing setup carries over instead of getting rewritten. If `.claude` and `.agents` both define the same name, `.claude` wins. A command you already defined in stella is never overwritten, and running init again is always safe. The same process brings in skills and agents too. See the full details on the [Custom Agents](/docs/agent-tools/custom-agents#import-from-claude-and-agents) page.
 
 <Callout type="info">
-  Commands are prompt-level extensions — templates. For a reusable persona
-  with an optional restricted toolbelt, define a
-  [custom agent](/docs/agent-tools/custom-agents); to give the agent a
-  genuinely new *action* (a deploy script, a database query), define a
-  [custom tool](/docs/agent-tools/custom-tools); to run shell commands on
-  lifecycle events, use [hooks](/docs/agent-tools/hooks).
+  Commands are prompt templates, nothing more. For a reusable persona with its own restricted toolbelt, define a
+  [custom agent](/docs/agent-tools/custom-agents). To give the agent a genuinely new action, like a deploy script or a database query, define a
+  [custom tool](/docs/agent-tools/custom-tools). To run shell commands on lifecycle events, use [hooks](/docs/agent-tools/hooks).
 </Callout>

--- a/website/content/docs/agent-tools/commands.mdx
+++ b/website/content/docs/agent-tools/commands.mdx
@@ -96,7 +96,7 @@ Only commands support namespaces. Skills and agents don't, and each still needs 
 Type `/review auth module` and stella fills in the template, then runs the result as your prompt.
 
 - Every `$ARGUMENTS` in the body is replaced with whatever you typed after the command name. That's `auth module` in this example.
-- If the body has no `$ARGUMENTS` placeholder, your arguments are still used. Stella adds them as a paragraph at the end. This means prompt files written for other tools work here with no changes.
+- If the body has no `$ARGUMENTS` placeholder, your arguments are still used. stella adds them as a paragraph at the end. This means prompt files written for other tools work here with no changes.
 
 ## Where commands live
 
@@ -121,7 +121,7 @@ Type `/review auth module` and stella fills in the template, then runs the resul
   </SpecCard>
 </CardGrid>
 
-Stella loads user-scope commands first, then project-scope commands. If both define the same name, the project version wins. Built-in commands can never be overridden. When a custom name collides across kinds, commands win over skills, and skills win over agents.
+stella loads user-scope commands first, then project-scope commands. If both define the same name, the project version wins. Built-in commands can never be overridden. When a custom name collides across kinds, commands win over skills, and skills win over agents.
 
 ### Trusted repos
 

--- a/website/content/docs/agent-tools/custom-agents.mdx
+++ b/website/content/docs/agent-tools/custom-agents.mdx
@@ -65,7 +65,7 @@ The `tools:` field reads several formats, so most spellings you'd try will work.
   </SpecCard>
 </CardGrid>
 
-Stella loads user-scope agents first, then project-scope agents. If both define the same name, the project version wins.
+stella loads user-scope agents first, then project-scope agents. If both define the same name, the project version wins.
 
 ## Invoking an agent
 
@@ -112,9 +112,9 @@ The same sync imports `commands/` and `skills/` into their matching directories.
 
 ### Import rules
 
-- **`.claude` wins over `.agents`.** Stella scans sources in that order, so the first occurrence of a name is the one it imports.
+- **`.claude` wins over `.agents`.** stella scans sources in that order, so the first occurrence of a name is the one it imports.
 - **Never overwrite, never re-import.** A name already present in the destination, whether you wrote it by hand or a previous init linked it, is skipped. The sync is safe to run again, and your own definitions always win.
-- **Never follow a symlink.** Other tools link between these directories too, for example `.claude/agents/x → ../../.agents/agents/x`. Stella links each definition from its real home exactly once. A folder with no `AGENT.md` inside it is skipped too, and reported, so nothing disappears silently.
+- **Never follow a symlink.** Other tools link between these directories too, for example `.claude/agents/x → ../../.agents/agents/x`. stella links each definition from its real home exactly once. A folder with no `AGENT.md` inside it is skipped too, and reported, so nothing disappears silently.
 
 After init, the `/agents` tab lists the imported definitions alongside your own, and init itself prints a per-scope summary of what it linked and skipped.
 

--- a/website/content/docs/agent-tools/custom-agents.mdx
+++ b/website/content/docs/agent-tools/custom-agents.mdx
@@ -1,20 +1,13 @@
 ---
 title: Custom Agents
-description: Define reusable personas in AGENT.md files — the frontmatter schema, where definitions live, versioned editing, and how stella init adopts existing ones.
+description: Define reusable personas in AGENT.md files. Covers the frontmatter fields, where definitions live, versioned editing, and how stella init imports existing ones.
 ---
 
-A **custom agent** is a named persona the session can adopt: a
-system-prompt-shaped Markdown body with a frontmatter header, invoked as
-`/agent-name <task>`. Agents are distinct from
-[skills](/docs/agent-tools/skills) (know-how selected into context
-automatically) and [custom commands](/docs/agent-tools/commands) (prompt
-templates) — an agent changes *who is doing the work*, optionally with a
-restricted toolbelt.
+A **custom agent** is a named persona the session can adopt. It's a system-prompt-shaped Markdown file with a frontmatter header, invoked as `/agent-name <task>`. An agent is different from a [skill](/docs/agent-tools/skills), which is know-how brought in automatically, and from a [custom command](/docs/agent-tools/commands), which is a prompt template. An agent changes who is doing the work, optionally with a restricted toolbelt.
 
 ## The AGENT.md schema
 
-An agent is one Markdown file with YAML frontmatter — nested
-`<slug>/AGENT.md` or flat `<slug>.md`:
+An agent is one Markdown file with YAML frontmatter, in the nested layout (`<slug>/AGENT.md`) or the flat layout (`<slug>.md`):
 
 ```md title=".stella/agents/docs-writer.md"
 ---
@@ -27,43 +20,27 @@ You are a technical writer. Prefer working examples over abstractions.
 Never document a flag you haven't verified against --help output.
 ```
 
-Every field, in the shape the loader accepts:
+### Fields
 
 <CardGrid size="md">
   <OptionCard name="name" defaultValue="the filename stem, or the directory name">
-    The agent's slug — what `/name` invokes. Falls back to the filename stem
-    (flat layout) or the directory name (nested layout).
+    The agent's slug. This is what `/name` invokes. Falls back to the filename stem in the flat layout, or the directory name in the nested layout.
   </OptionCard>
   <OptionCard name="description" defaultValue="the body's first non-empty line">
-    One-line summary for the `/agents` listing. The fallback strips leading
-    markdown heading markers and truncates to 72 characters with an ellipsis.
+    A one-line summary for the `/agents` listing. If you skip it, stella strips leading markdown heading marks from the first line and cuts it to 72 characters with an ellipsis.
   </OptionCard>
   <OptionCard name="tools" defaultValue="all tools">
-    The agent's toolbelt — the tool names granted to this persona. Omitted
-    means **all** tools. When the agent is assumed for a session (`/agent`,
-    or `a` on the AGENTS tab), the grant is enforced: the session's tool
-    surface narrows to the intersection of this list with whatever the
-    operator already allows.
+    The agent's toolbelt: the tool names granted to this persona. Leave it out and the agent gets every tool. When you assume this agent for a session (`/agent`, or `a` on the AGENTS tab), the grant is enforced. The session's tools narrow to whatever is in both this list and whatever the operator already allows.
   </OptionCard>
   <OptionCard name="model" defaultValue="the session's model">
-    The model this agent runs on, as `provider/slug` (`zai/glm-5.2`) or a
-    bare catalog slug. Applied as a **session-only** model switch when the
-    agent is assumed — the settings default is untouched, and a model whose
-    provider has no credential is reported and skipped rather than failing
-    the assume.
+    The model this agent runs on, written as `provider/slug` (`zai/glm-5.2`) or a bare catalog slug. This is a session-only switch applied when you assume the agent. Your settings default stays untouched. If the model's provider has no credential, stella reports it and skips the switch rather than failing the assume.
   </OptionCard>
   <OptionCard name="body" required>
-    The persona's instructions — everything after the frontmatter. A file with
-    an empty body is skipped with a diagnostic, never a fatal error.
+    The persona's instructions: everything after the frontmatter. A file with an empty body is skipped, with a diagnostic rather than a fatal error.
   </OptionCard>
 </CardGrid>
 
-The `tools:` field is parsed tolerantly, accepting every shape the
-ecosystem has taught authors. A bare comma list (`Read, Grep`), a JSON/YAML
-flow array (`["Read", "Grep"]`, `[Read, Grep]`), a block sequence, per-item
-quotes, and trailing commas all normalize to the same clean list, with
-duplicates collapsed. An empty list or the explicit wildcard forms (`*`,
-`all`, `all tools`) mean the same as omitting the field: no restriction.
+The `tools:` field reads several formats, so most spellings you'd try will work. A comma list (`Read, Grep`), a JSON or YAML flow array (`["Read", "Grep"]`, `[Read, Grep]`), a block sequence, quoted items, and trailing commas all turn into the same clean list, with duplicates removed. An empty list, or one of the wildcard forms (`*`, `all`, `all tools`), means the same as leaving the field out: no restriction.
 
 ## Where agents live
 
@@ -75,7 +52,7 @@ duplicates collapsed. An empty list or the explicit wildcard forms (`*`,
       { label: "Travels with", value: "the repo", mono: false },
     ]}
   >
-    Commit it and the whole team gets the persona on their next session.
+    Commit it, and the whole team gets the persona on their next session.
   </SpecCard>
   <SpecCard
     title="User"
@@ -88,21 +65,15 @@ duplicates collapsed. An empty list or the explicit wildcard forms (`*`,
   </SpecCard>
 </CardGrid>
 
-Definitions load user-global first, then workspace — **workspace wins** on
-a name collision.
+Stella loads user-scope agents first, then project-scope agents. If both define the same name, the project version wins.
 
 ## Invoking an agent
 
-Typing `/docs-writer polish the CLI reference` wraps the agent's body as an
-explicit persona-adoption instruction above your task and runs it as the
-prompt. In the slash menu, built-ins can never be shadowed, and when a
-custom name collides across kinds, commands shadow skills shadow agents.
+Type `/docs-writer polish the CLI reference` and stella wraps the agent's body as a persona-adoption instruction above your task, then runs it as the prompt. Built-in commands can never be overridden in the slash menu. When a custom name collides across kinds, commands win over skills, and skills win over agents.
 
-## Versioned editing in the Command Deck
+## Versioned editing
 
-`/agents` opens the AGENTS tab, which lists installed agents in both scopes
-with versioned editing and pinning — like skills, every save is a new
-version you can roll back:
+`/agents` opens the AGENTS tab, which lists installed agents in both scopes with versioned editing and pinning. Like skills, every save creates a new version you can roll back to:
 
 ```text
 <agents-dir>/<slug>.md                  ← the loaded definition
@@ -110,19 +81,11 @@ version you can roll back:
 <agents-dir>/.versions/<slug>/PINNED    ← one line: the pinned version
 ```
 
-No `.versions/` entry is created until the first edit, so hand-authored
-agents stay exactly as you wrote them. Editing an agent that was adopted as
-a symlink (see below) replaces the symlink with a real file in the agents
-directory — the original stays untouched, and your edit lives on the
-stella side from then on.
+No `.versions/` entry is created until your first edit, so a hand-authored agent stays exactly as you wrote it. If you edit an agent that was imported as a symlink (see below), stella replaces the symlink with a real file in the agents directory. The original file stays untouched, and your edit lives on the stella side from then on.
 
-## Adopted from .claude/ and .agents/ on init
+## Import from Claude and Agents
 
-Ecosystem tools already maintain `.claude/{commands,skills,agents}` and
-`.agents/{commands,skills,agents}`. On `stella init` (and `/init`),
-definitions found there are **symlinked** into the matching stella
-directory — adopted, not copied, so edits stay in one place and your
-existing setup carries over instead of being rewritten:
+Other agent tools already maintain `.claude/{commands,skills,agents}` and `.agents/{commands,skills,agents}`. When you run `stella init` (or `/init`), stella finds definitions there and **symlinks** them into the matching stella directory. They're imported, not copied, so edits stay in one place and your existing setup carries over instead of getting rewritten:
 
 <CardGrid size="md">
   <SpecCard
@@ -132,7 +95,7 @@ existing setup carries over instead of being rewritten:
       { label: "Destination", value: "<workspace>/.stella/agents/" },
     ]}
   >
-    Adopted when you run `stella init` inside the repo.
+    Imported when you run `stella init` inside the repo.
   </SpecCard>
   <SpecCard
     title="User scope"
@@ -141,35 +104,20 @@ existing setup carries over instead of being rewritten:
       { label: "Destination", value: "~/.stella/agents/" },
     ]}
   >
-    Adopted by the same run — your global personas carry over once.
+    Imported by the same run. Your global personas carry over once.
   </SpecCard>
 </CardGrid>
 
-(The same sync adopts `commands/` and `skills/` into their matching
-directories.) Three rules keep the adoption sane:
+The same sync imports `commands/` and `skills/` into their matching directories.
 
-1. **`.claude` wins over `.agents`.** Sources are scanned in that
-   precedence order; the first occurrence of a name is the one adopted.
-2. **Never clobber, never re-adopt.** A name already present in the
-   destination — hand-authored or linked by a previous init — is skipped,
-   so the sync is idempotent and your own definitions always win.
-3. **Never follow a symlink.** Other tools symlink between these
-   directories too (e.g. `.claude/agents/x → ../../.agents/agents/x`);
-   stella links each definition from its *real* home exactly once. A
-   directory entry with no `AGENT.md` inside is also skipped — and
-   reported, so nothing disappears silently.
+### Import rules
 
-After init, the `/agents` tab lists the adopted definitions alongside your
-own, and init itself prints a per-scope `✓ adopted …` summary of what it
-linked and skipped.
+- **`.claude` wins over `.agents`.** Stella scans sources in that order, so the first occurrence of a name is the one it imports.
+- **Never overwrite, never re-import.** A name already present in the destination, whether you wrote it by hand or a previous init linked it, is skipped. The sync is safe to run again, and your own definitions always win.
+- **Never follow a symlink.** Other tools link between these directories too, for example `.claude/agents/x → ../../.agents/agents/x`. Stella links each definition from its real home exactly once. A folder with no `AGENT.md` inside it is skipped too, and reported, so nothing disappears silently.
+
+After init, the `/agents` tab lists the imported definitions alongside your own, and init itself prints a per-scope summary of what it linked and skipped.
 
 <Callout type="info">
-  An agent's `tools:` restriction is enforced when the agent is **assumed**
-  for a session (the deck's `/agent` picker or the AGENTS tab's `a`): the
-  session tool surface narrows to the grant. On a plain `/agent-name task`
-  invocation it remains a prompt-level toolbelt note. For hard boundaries
-  independent of any agent — gated mutations, blocked paths — reach for
-  [permissions](/docs/agent-tools/permissions) and
-  [hooks](/docs/agent-tools/hooks); to add genuinely new actions, define a
-  [custom tool](/docs/agent-tools/custom-tools).
+  An agent's `tools:` restriction is enforced when you **assume** the agent for a session, through the deck's `/agent` picker or the AGENTS tab's `a` key. The session's tools narrow to the grant. On a plain `/agent-name task` call, it's just a prompt-level note. For hard boundaries that don't depend on any agent, like gated actions or blocked paths, use [permissions](/docs/agent-tools/permissions) and [hooks](/docs/agent-tools/hooks). To give the agent a genuinely new action, define a [custom tool](/docs/agent-tools/custom-tools).
 </Callout>

--- a/website/content/docs/agent-tools/custom-tools.mdx
+++ b/website/content/docs/agent-tools/custom-tools.mdx
@@ -1,9 +1,9 @@
 ---
 title: Custom Tools
-description: Extend the stella agent with your own script tools by dropping a TOML manifest into your workspace or user config directory.
+description: Give the stella agent your own script tools. Drop a TOML manifest into your workspace or user config directory.
 ---
 
-Beyond the [built-in tools](/docs/agent-tools), you can give the agent your own developer-defined script tools. A custom tool is described by a small TOML manifest; once discovered, it appears alongside the built-ins and can be called by the agent like any other tool.
+Beyond the [built-in tools](/docs/agent-tools), you can give the agent your own developer-defined script tools. A custom tool is described by a small TOML manifest. Once stella finds it, the tool appears alongside the built-ins, and the agent can call it like any other tool.
 
 ## Where manifests live
 
@@ -12,25 +12,25 @@ Drop a `<name>.toml` manifest file into one of these directories:
 - **Workspace** — `.stella/tools/` (checked in with the project, shared with your team).
 - **User global** — `~/.stella/tools/` (personal, available across all your workspaces).
 
-If the same tool name is defined in both locations, the **workspace** manifest wins on collision. This lets a project override a personal default while keeping your global tools available everywhere else.
+If the same tool name is defined in both places, the workspace manifest wins. This lets a project override a personal default while keeping your other global tools available everywhere else.
 
-A third source is read after both: `tools/*.toml` inside an installed [plugin](/docs/plugins). Those manifests are scanned last, so a name either of your own directories already defines keeps its own definition and the plugin's copy is dropped with a diagnostic naming both files — an install can never silently re-point a tool you already call. A plugin's tool also writes `${plugin_dir}` where its package directory belongs, in every `command` element and every `[env]` value; the placeholder is **not** expanded in your own manifests, where no package is in scope.
+A third source is read after both: `tools/*.toml` inside an installed [plugin](/docs/plugins). Plugin manifests are scanned last. If either of your own directories already defines a name, that definition wins, and the plugin's copy is dropped with a diagnostic naming both files. This means installing a plugin can never silently redirect a tool you already call. A plugin's tool also gets `${plugin_dir}` filled in wherever its package directory belongs, in every `command` element and every `[env]` value. That placeholder is not expanded in your own manifests, since no plugin package is in scope there.
 
-Run `stella tools` at any time to see which custom tools were discovered, alongside the built-ins.
+Run `stella tools` at any time to see which custom tools were found, alongside the built-ins.
 
 <Callout type="warn">
-  Workspace manifests are behind the
+  Workspace manifests sit behind the
   [project trust boundary](/docs/configuration/settings#the-project-trust-boundary). A
   manifest is a command a cloned repo gets to run on your machine, so `.stella/tools/`
-  is **not scanned at all** until you trust the repo — its manifests are neither loaded
-  nor reported as diagnostics. The user-global directory always loads. Opt in per repo:
+  is **not scanned at all** until you trust the repo. Its manifests are neither loaded
+  nor reported as diagnostics until then. The user-global directory always loads. Opt in per repo:
 
   ```bash
   export STELLA_TRUST_PROJECT=1
   ```
 
   An org-managed `authority.project_custom_tools: "off"` keeps workspace manifests off
-  even for a trusted repo — that ceiling is not overridable from below.
+  even in a trusted repo. That ceiling can't be overridden from below.
 </Callout>
 
 ## Manifest shape
@@ -65,76 +65,51 @@ type = "string"
 description = "Path to the file whose words should be counted."
 ```
 
-Every field, in the shape the manifest parser accepts:
+### Fields
 
 <CardGrid size="md">
   <OptionCard name="name" required>
-    The name the model sees. Must match `^[a-z][a-z0-9_]{1,63}$` — a lowercase
-    letter followed by 1–63 more of `[a-z0-9_]`. A name that collides with a
-    built-in is skipped with a diagnostic rather than shadowing it, and so is
-    every name stella has ever dispatched and retired — `run_tests`,
-    `graph_query`, `web_fetch`, `grep`, `screenshot` and the rest. The model
-    still carries those names' priors, and an operator's
-    `"tools": {"run_tests": "off"}` written when that built-in existed would
-    otherwise start addressing your manifest instead of nothing.
-
-    That reservation set was reconstructed from the tool catalog's own git
-    history rather than assembled by memory
-    ([#3853](https://github.com/macanderson/stella/issues/3853)), so it is the
-    dispatch names stella actually shipped, plus the handful it named to the
-    model in prose without ever shipping. If your name is refused, pick
-    another; if you believe a refusal is wrong, the two constants are
-    `RETIRED_TOOL_NAMES` and `RETIRED_NAMES_TOO_AMBIGUOUS_TO_SCAN` in
-    `crates/stella-tools/src/catalog.rs`, and each carries the argument for
-    its own entries.
+    The name the model sees. It must match `^[a-z][a-z0-9_]{1,63}$`: a lowercase letter, followed by 1 to 63 more lowercase letters, digits, or underscores. A name that matches a built-in tool is skipped, with a diagnostic, instead of quietly taking it over. The same goes for names stella has used and retired in the past, such as `run_tests`, `graph_query`, `web_fetch`, `grep`, and `screenshot`. The model still remembers these names from training, and an old setting like `"tools": {"run_tests": "off"}` would otherwise start pointing at your manifest instead of nothing. If your tool's name is refused, pick a different one.
   </OptionCard>
   <OptionCard name="description" required>
-    What the tool does, advertised to the model. An empty description is an
-    error, not a warning — it is the only thing the model has to decide with.
+    What the tool does, shown to the model. An empty description is an error, not a warning, because it's the only thing the model has to decide with.
   </OptionCard>
   <OptionCard name="command" required>
-    An **argv array**, spawned directly with no shell. `command[0]` resolves
-    against the workspace root, which is also the child's working directory.
+    An **argv array**, spawned directly with no shell. `command[0]` resolves against the workspace root, which is also the child process's working directory.
   </OptionCard>
   <OptionCard name="timeout_ms" defaultValue="30000">
-    Wall-clock budget for one call. Hard-capped at `600000` (10 minutes) — a
-    manifest asking for more is clamped with a warning. Past the timeout the
-    script's whole process group is killed and the tool returns a named error.
+    The wall-clock budget for one call. Hard-capped at `600000` (10 minutes). A manifest asking for more is clamped, with a warning. Past the timeout, the script's whole process group is killed and the tool returns a named error.
   </OptionCard>
   <OptionCard name="[env]">
-    Extra environment variables for the child, applied on top of the inherited
-    environment. Credential variables are stripped from the result either way —
-    see below.
+    Extra environment variables for the child process, applied on top of the inherited environment. Credential variables are stripped from the result either way. See below.
   </OptionCard>
   <OptionCard name="[input_schema]">
-    The tool's inputs as a JSON Schema written in TOML, converted verbatim. A
-    non-table value is an error; an absent one leaves the tool with an empty
-    schema.
+    The tool's inputs as a JSON Schema, written in TOML and converted as-is. A non-table value is an error. Leave it out and the tool gets an empty schema.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-`command` must be an **argv array** (`["scripts/wordcount.sh"]`), not a bare string — a string fails to parse and the tool never loads. Inputs go under `[input_schema]` (a JSON Schema), not `[parameters]`; an unknown table like `[parameters]` is silently ignored, leaving the tool with an empty schema.
+`command` must be an **argv array** (`["scripts/wordcount.sh"]`), not a bare string. A string fails to parse and the tool never loads. Inputs go under `[input_schema]`, a JSON Schema, not `[parameters]`. An unknown table like `[parameters]` is silently ignored, leaving the tool with an empty schema.
 </Callout>
 
 <Callout type="info">
-The `timeout_ms` default is **30 seconds** — half of the 60-second default that [hooks](/docs/agent-tools/hooks) get. Both share the same 10-minute hard cap.
+The `timeout_ms` default is **30 seconds**, half of the 60-second default [hooks](/docs/agent-tools/hooks) get. Both share the same 10-minute hard cap.
 </Callout>
 
-## How input reaches your script
+## Script input
 
-When the agent calls a custom tool, stella spawns `command` **directly** from the argv array — never through a shell, so the tool's input has no injection surface — with the working directory set to the workspace root. The model's input JSON is then delivered **two ways**, so trivial scripts need no JSON parser:
+When the agent calls a custom tool, stella spawns `command` directly from the argv array. It never goes through a shell, so there's no injection surface in the tool's input. The working directory is set to the workspace root. The model's input JSON reaches your script two ways, so a simple script needs no JSON parser at all:
 
-1. The whole input object is written to the script's **stdin** as one JSON document, then stdin is closed — your script sees EOF.
-2. Each top-level **scalar** property (string, number, bool) is exported as `STELLA_INPUT_<UPPER_SNAKE_KEY>` — `path` becomes `STELLA_INPUT_PATH`, `dry_run` becomes `STELLA_INPUT_DRY_RUN`. Nested objects and arrays are delivered on stdin only.
+1. The whole input object is written to the script's **stdin** as one JSON document, then stdin is closed. Your script sees EOF.
+2. Each top-level **scalar** property (string, number, bool) is exported as `STELLA_INPUT_<UPPER_SNAKE_KEY>`. `path` becomes `STELLA_INPUT_PATH`, and `dry_run` becomes `STELLA_INPUT_DRY_RUN`. Nested objects and arrays only arrive on stdin.
 
-The manifest's `[env]` table is applied on top of the inherited environment, before the `STELLA_INPUT_*` exports. Input keys come from the model but are namespaced under `STELLA_INPUT_`, so they can never clobber `PATH` or your `[env]` values.
+The manifest's `[env]` table is applied on top of the inherited environment, before the `STELLA_INPUT_*` exports. Input keys come from the model, but they're namespaced under `STELLA_INPUT_`, so they can never overwrite `PATH` or your `[env]` values.
 
 <Callout type="warn">
-The child's environment is **credential-scrubbed last**, after both the inherited environment and the manifest's `[env]`. A custom tool never sees stella's provider keys (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, …) or repository/AWS tokens, and a manifest cannot reintroduce one by naming it in `[env]` — that entry is removed too. Ordinary task configuration in `[env]` survives untouched. If your script genuinely needs a credential, pass it as a tool *input* or have the script fetch it from your own secret store.
+The child process's environment is credential-scrubbed last, after both the inherited environment and the manifest's `[env]`. A custom tool never sees stella's provider keys (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, and so on) or repository and AWS tokens. A manifest can't bring one back by naming it in `[env]` either — that entry is removed too. Ordinary settings in `[env]` survive untouched. If your script genuinely needs a credential, pass it as a tool input, or have the script fetch it from your own secret store.
 </Callout>
 
-A script consuming both channels:
+A script that reads both channels:
 
 ```bash title="scripts/wordcount.sh"
 #!/usr/bin/env bash
@@ -150,7 +125,7 @@ input="$(cat)"    # {"path": "src/lib.rs"}
 wc -w < "$path"
 ```
 
-Exit **0** returns the captured stdout as the tool result; a **non-zero** exit returns an error carrying the exit code and the stderr tail. Both streams are truncated middle-out past a byte cap.
+Exit **0** and the captured stdout becomes the tool's result. A non-zero exit returns an error carrying the exit code and the last part of stderr. Both streams are trimmed from the middle if they get too long.
 
 ## Validating manifests
 
@@ -161,29 +136,22 @@ stella tools --validate            # scans .stella/tools/ and ~/.stella/tools/
 stella tools --validate ./mytools  # or an explicit directory
 ```
 
-Discovery is lenient — a broken manifest becomes a diagnostic and the session runs on — so this is the pre-flight that tells you before a run has already spent budget. It parses each `<name>.toml` and reports three severities:
+Stella is lenient at discovery time. A broken manifest just becomes a diagnostic, and the session keeps running. So this validator is your chance to catch problems before a run has already spent your budget. It parses each `<name>.toml` file and sorts problems into severities:
 
 <CardGrid size="md">
   <OptionCard name="Error">
-    The manifest will not load: unreadable file, invalid TOML, a missing field,
-    an invalid or **reserved** name (one a built-in claims, or once claimed
-    and retired), an empty
-    description, an empty `command`, or a non-table `input_schema`.
+    The manifest won't load: an unreadable file, invalid TOML, a missing field, an invalid or **reserved** name (one a built-in claims, or once claimed and retired), an empty description, an empty `command`, or a non-table `input_schema`.
   </OptionCard>
   <OptionCard name="Warning">
-    It loads but will not behave as written: a `timeout_ms` over the 10-minute
-    cap (clamped at runtime), a name already claimed by an earlier manifest
-    (that one wins, this one is ignored), and a `command[0]` that does not
-    exist or is not executable — a warning, not an error, because the script
-    may legitimately be built or checked out later.
+    It loads, but won't behave as written: a `timeout_ms` over the 10-minute cap (clamped at runtime), a name already claimed by an earlier manifest (that one wins, this one is ignored), or a `command[0]` that doesn't exist or isn't executable. This is a warning, not an error, because the script might legitimately get built or checked out later.
   </OptionCard>
   <OptionCard name="Info">
-    `timeout_ms` omitted or `0`, which silently becomes the 30-second default.
+    `timeout_ms` left out or set to `0`, which quietly becomes the 30-second default.
   </OptionCard>
 </CardGrid>
 
-It exits non-zero if any manifest has errors — handy in CI.
+It exits non-zero if any manifest has errors, which is handy in CI.
 
 ## How custom tools appear
 
-Once a manifest is discovered, its tool is registered into the session and shows up next to the built-ins — including in the output of `stella tools`. The agent can then call it as part of its normal step loop. Like every other tool, a custom tool is subject to the [per-tool permission model](/docs/agent-tools/permissions), and its calls can be gated or blocked with a [`PreToolUse` hook](/docs/agent-tools/hooks).
+Once stella finds a manifest, it registers the tool into the session, and it shows up next to the built-ins, including in the output of `stella tools`. The agent can then call it as part of its normal step loop. Like every other tool, a custom tool follows the [per-tool permission model](/docs/agent-tools/permissions), and its calls can be gated or blocked with a [`PreToolUse` hook](/docs/agent-tools/hooks).

--- a/website/content/docs/agent-tools/custom-tools.mdx
+++ b/website/content/docs/agent-tools/custom-tools.mdx
@@ -136,7 +136,7 @@ stella tools --validate            # scans .stella/tools/ and ~/.stella/tools/
 stella tools --validate ./mytools  # or an explicit directory
 ```
 
-Stella is lenient at discovery time. A broken manifest just becomes a diagnostic, and the session keeps running. So this validator is your chance to catch problems before a run has already spent your budget. It parses each `<name>.toml` file and sorts problems into severities:
+stella is lenient at discovery time. A broken manifest just becomes a diagnostic, and the session keeps running. So this validator is your chance to catch problems before a run has already spent your budget. It parses each `<name>.toml` file and sorts problems into severities:
 
 <CardGrid size="md">
   <OptionCard name="Error">

--- a/website/content/docs/agent-tools/hooks.mdx
+++ b/website/content/docs/agent-tools/hooks.mdx
@@ -1,185 +1,157 @@
 ---
 title: Hooks
-description: Run shell commands on stella's agent lifecycle events — inside a turn, and around the self-driving loop's runs, cycles, issues, pull requests and checks — configured under the hooks key in settings.json.
+description: Run shell commands on stella's agent lifecycle events. Covers events inside a turn, and events around the self-driving loop's runs, cycles, issues, pull requests, and checks. Configured under the hooks key in settings.json.
 ---
 
-Hooks are shell commands that fire on agent lifecycle events. They are configured under the `hooks` key in your `settings.json` and follow Claude Code parity, so existing hook knowledge carries over.
+Hooks are shell commands that fire on agent lifecycle events. You configure them under the `hooks` key in your `settings.json`. They follow Claude Code's format, so if you already know hooks from there, that knowledge carries over here.
 
-Each hook receives the event payload as **JSON on stdin**, so your command can read the event details and react to them.
+Each hook receives the event payload as **JSON on stdin**, so your command can read the event's details and react to them.
 
 <Callout type="info">
-  This page covers the **config-driven shell hooks** — the `hooks` key in `settings.json`,
-  no code required. For the *programmatic* in-process event bus (observe every event, gate
-  actions with allow / modify / deny / require-approval, in code when you embed stella's
-  engine), see [Extension hooks](/docs/extensions).
+  These hooks are shell commands set with the `hooks` key in `settings.json`. No code required. If you embed stella's engine and want to watch events or gate actions in code (allow, modify, deny, or require approval), see [Extension hooks](/docs/extensions).
 </Callout>
 
 ## Events
 
-Hook events come in two families, and the difference decides who fires them and whether one can say no.
+Hook events fall into two groups. Which group an event is in decides who fires it, and whether it can say no.
 
-**Inside a turn** — five events, fired by the engine as it runs. Two of them block.
+**Inside a turn** are five events, fired by the engine as it runs. Two of them can block.
 
-**Outside every turn** — the rest, fired by the [self-driving loop](/docs/self-improvement) as it works through a backlog: a run, a cycle, an issue, a pull request, a set of checks. Exactly one of these blocks (`PreIssueWork`), and the naming rule is why: a `Pre` brackets something that has not happened yet, and everything else is a Start, an End, or a past participle — something that already did, where a `deny` would arrive too late to act on.
+**Outside every turn** are the rest, fired by the [self-driving loop](/docs/self-improvement) as it works through a backlog: a run, a cycle, an issue, a pull request, a set of checks. Only one of these can block, `PreIssueWork`. The naming tells you why: a `Pre` event happens before something takes effect, and everything else is a Start, an End, or something that already happened, where a deny would arrive too late to matter.
 
-Both families live in the same `hooks` block and speak the same vocabulary. Only a turn event can be granted to a plugin; the loop's own events are dispatched from the operator's settings and nowhere else.
+Both groups live in the same `hooks` block and use the same vocabulary. Only a turn event can be granted to a plugin. The loop's own events are dispatched from the operator's settings alone.
 
 <HookLifecycleDiagram />
 
 <CardGrid size="md">
   <OptionCard name="SessionStart">
-    Runs once before the turn. **Never blocks** — its stdout is used as context instead.
-    The matcher is ignored.
+    Runs once before the turn. **Never blocks** — its stdout is used as extra context instead. The matcher is ignored.
   </OptionCard>
   <OptionCard name="PreToolUse">
-    Runs before a tool executes. **Blocking**: a non-zero exit stops the tool. The matcher
-    is a glob over the tool name.
+    Runs before a tool executes. **Blocking**: a non-zero exit stops the tool. The matcher is a glob over the tool name.
   </OptionCard>
   <OptionCard name="PostToolUse">
-    Runs after a tool executes. **Never blocks** — side effects only. The matcher is a glob
-    over the tool name.
+    Runs after a tool executes. **Never blocks** — side effects only. The matcher is a glob over the tool name.
   </OptionCard>
   <OptionCard name="Stop">
-    Runs when a turn is about to complete. A `deny` decision holds the turn open **once per
-    turn**, feeding its reason back to the model. The matcher is ignored.
+    Runs when a turn is about to finish. A `deny` decision holds the turn open **once per turn**, feeding its reason back to the model. The matcher is ignored.
   </OptionCard>
   <OptionCard name="PreCompact">
-    Runs before an overflow-summarization round. A `deny` decision vetoes the round; a
-    `modify` decision can steer the summarizer. The matcher is ignored.
+    Runs before an overflow-summarization round. A `deny` decision vetoes the round. A `modify` decision can steer the summarizer. The matcher is ignored.
   </OptionCard>
   <OptionCard name="PreIssueWork">
-    Runs before the self-driving loop works an issue. **Blocking**: a `deny` makes the
-    loop skip that issue and move on. The matcher is ignored.
+    Runs before the self-driving loop works an issue. **Blocking**: a `deny` makes the loop skip that issue and move on. The matcher is ignored.
   </OptionCard>
   <OptionCard name="PostIssueWork">
-    Runs after that work unit, whatever the outcome. **Never blocks** — the work is done.
-    The matcher is ignored.
+    Runs after that work is done, whatever the outcome. **Never blocks** — the work is already finished. The matcher is ignored.
   </OptionCard>
 </CardGrid>
 
-### The loop's own events
+### Loop events
 
-Every one of these **reports and never blocks**, and every one ignores the matcher. They fire from `stella self-driving`'s verbs, so a workspace that never runs the loop never sees them.
+Every one of these events reports what happened and never blocks, and every one ignores the matcher. They fire from `stella self-driving`'s commands, so a workspace that never runs the loop never sees them.
 
 <CardGrid size="md">
   <OptionCard name="DriveRunStart">
-    A run has begun, before its first cycle. Payload carries `run.runId`.
+    A run has begun, before its first cycle. The payload carries `run.runId`.
   </OptionCard>
   <OptionCard name="DriveRunEnd">
-    A run has ended, with `reason` naming why it stopped.
+    A run has ended. `reason` names why it stopped.
   </OptionCard>
   <OptionCard name="DriveCycleStart">
-    A cycle has begun. Payload carries `run.runId` and `run.cycle`.
+    A cycle has begun. The payload carries `run.runId` and `run.cycle`.
   </OptionCard>
   <OptionCard name="DriveCycleEnd">
-    A cycle has ended and its ledger record is written.
+    A cycle has ended, and its ledger record is written.
   </OptionCard>
   <OptionCard name="DriveIdle">
-    A cycle produced nothing. The signal that separates *alive but starved* from *dead* —
-    a loop with an empty backlog and a loop whose process died emit the same silence.
+    A cycle produced nothing. This is what tells apart *alive but starved* from *dead*: a loop with an empty backlog and a loop whose process died look the same otherwise.
   </OptionCard>
   <OptionCard name="IssueCreated">
-    The loop filed a finding as an issue. Fires only for one that reached the tracker,
-    never for a deduplicated finding.
+    The loop filed a finding as an issue. Fires only when the issue actually reached the tracker, never for a duplicate that got merged into an existing one.
   </OptionCard>
   <OptionCard name="IssueClosed">
-    The loop closed an issue, `--partial` included. `reason` carries how.
+    The loop closed an issue, including with `--partial`. `reason` says how.
   </OptionCard>
   <OptionCard name="IssueEscalated">
-    The loop gave up and handed an issue to a human. `reason` says what ran out, so a
-    subscriber knows whether to fix, wait, or raise a ceiling.
+    The loop gave up and handed an issue to a person. `reason` says what ran out, so whoever's watching knows whether to fix something, wait, or raise a limit.
   </OptionCard>
   <OptionCard name="PullRequestOpened">
-    Payload carries `pullRequest.number` and the `pullRequest.issue` it settles.
+    The payload carries `pullRequest.number` and the `pullRequest.issue` it resolves.
   </OptionCard>
   <OptionCard name="PullRequestReadyForReview">
     The loop took a pull request out of draft.
   </OptionCard>
   <OptionCard name="PullRequestConflicted">
-    The base moved under a pull request.
+    The base branch moved under a pull request.
   </OptionCard>
   <OptionCard name="PullRequestMerged">
-    A pull request the loop merged landed. Not fired for one a human merged first.
+    A pull request the loop merged has landed. Doesn't fire for one a person merged first.
   </OptionCard>
   <OptionCard name="ChecksFailed">
-    A pull request's checks failed **and the base is green**, so the failure is this
-    change's.
+    A pull request's checks failed, **and the base branch is green**, so the failure belongs to this change.
   </OptionCard>
   <OptionCard name="BaseBroken">
-    The checks failed **and so does the base**. Not this change's fault — the event a
-    `main`-health monitor wants.
+    The checks failed **and so does the base branch**. Not this change's fault. This is the event a `main`-health monitor wants.
   </OptionCard>
   <OptionCard name="ChecksGreen">
     A pull request's checks passed.
   </OptionCard>
   <OptionCard name="DriveBudgetExhausted">
-    The loop reached its spend ceiling.
+    The loop reached its spending limit.
   </OptionCard>
   <OptionCard name="DriveRefused">
-    The loop declined to run — an operator stop, a hold it is waiting on. Distinct from an
-    error: nothing broke, and a subscriber that read it as a failure would page somebody
-    about a working system.
+    The loop chose not to run, because an operator stopped it or it's waiting on a hold. This is different from an error: nothing broke, and a subscriber that treats it as a failure would page someone about a system that's working fine.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-  **`ChecksFailed` and `BaseBroken` are two events on purpose.** The loop's whole delivery
-  machine turns on that distinction, and collapsing them is how an agent spends its budget
-  fixing somebody else's breakage. The same split is why the reason a hook reads is prose
-  for a person: what a subscriber *branches* on is the event name.
+  **`ChecksFailed` and `BaseBroken` are two separate events on purpose.** The loop's whole delivery process depends on that distinction. Collapsing them into one event is how an agent ends up spending its budget fixing someone else's breakage. The same split is why the `reason` field reads like prose for a person: what a subscriber *branches* on is the event name, not the reason text.
 </Callout>
 
-While the loop polls, a repeated answer is reported **once**. A pull request waiting on
-review re-derives the same green every few seconds, and a subscriber woken each time would
-stop reading — so a check event fires on a change of answer, and a standing refusal is
-reported once until the loop runs again.
+While the loop polls, a repeated answer is only reported **once**. A pull request waiting on review would otherwise report the same green result every few seconds, and anyone subscribed would stop reading. So a check event fires only when the answer changes, and a standing refusal is reported once until the loop runs again.
 
 ### `SessionStart`
 
-Runs once before the turn begins. Anything the hook prints to **stdout is appended to the system prompt** as extra context — a handy way to inject environment details, project conventions, or the current date into every session. The matcher is **ignored** for this event.
+Runs once before the turn begins. Anything the hook prints to **stdout is appended to the system prompt** as extra context. This is a handy way to inject environment details, project conventions, or the current date into every session. The matcher is **ignored** for this event.
 
 ### `PreToolUse`
 
-Runs before a tool executes. A **non-zero exit status blocks the tool**: the tool does not run, and the model receives the hook's message instead. This is how you gate or veto tool calls (see [Permissions](/docs/agent-tools/permissions)). The matcher is a **glob over the tool name**, so you can target a single tool such as `task_assign` or a family of tools such as `mcp__github__*`.
+Runs before a tool executes. A **non-zero exit status blocks the tool**: the tool doesn't run, and the model gets the hook's message instead. This is how you gate or veto tool calls (see [Permissions](/docs/agent-tools/permissions)). The matcher is a **glob over the tool name**, so you can target one tool, such as `task_assign`, or a family of tools, such as `mcp__github__*`.
 
-A `PreToolUse` hook can also **decide** rather than just block: print one JSON decision document on stdout — the same `allow` / `deny` / `require_approval` / `modify` vocabulary the in-process [extension bus](/docs/extensions) speaks — and stella folds it exactly as it folds a policy chain. See [Decisions on stdout](#decisions-on-stdout).
+A `PreToolUse` hook can also **decide** instead of just blocking: print one JSON decision document on stdout, using the same `allow` / `deny` / `require_approval` / `modify` vocabulary the in-process [extension bus](/docs/extensions) uses. Stella folds this in exactly as it folds a policy chain. See [Decisions on stdout](#decisions-on-stdout).
 
 ### `PostToolUse`
 
-Runs after a tool executes. It is for **side effects only and never blocks** — its exit status cannot stop or undo the tool call that already ran. Use it for logging, formatting, notifications, or similar follow-up work. The matcher is a **glob over the tool name**. When a `modify` decision rewrote the input, the `PostToolUse` payload reports the input the tool actually ran with.
+Runs after a tool executes. It's for **side effects only, and it never blocks**. Its exit status can't stop or undo a tool call that already ran. Use it for logging, formatting, notifications, or similar follow-up work. The matcher is a **glob over the tool name**. When a `modify` decision rewrote the input, the `PostToolUse` payload reports the input the tool actually ran with.
 
 ### `Stop`
 
-Runs when a turn is about to complete, with the would-be final text in the payload's `finalText`. Printing `{"action":"deny","reason":"…"}` holds the turn open: the reason is injected back to the model as a `[stop-hook feedback` message and the model gets one more round to act on it. The gate fires **at most once per turn** — the latch that stops a hook which always denies from holding a turn open forever. A `Stop` hook that fails (non-zero exit, spawn failure) never blocks completion; the failure surfaces as a diagnostic instead, because failing closed at a turn boundary would mean never completing. The matcher is **ignored**.
+Runs when a turn is about to complete, with the would-be final text in the payload's `finalText`. Print `{"action":"deny","reason":"…"}` and the turn stays open: the reason is sent back to the model as a `[stop-hook feedback` message, and the model gets one more round to act on it. This gate fires **at most once per turn**. That's what stops a hook that always denies from holding a turn open forever. A `Stop` hook that fails, through a non-zero exit or a spawn failure, never blocks completion. The failure shows up as a diagnostic instead, because failing closed at a turn boundary would mean the turn never completes. The matcher is **ignored**.
 
 ### `PreCompact`
 
-Runs before each overflow-summarization round (the model-written summary that replaces the oldest span when the conversation outgrows its context budget). Printing `{"action":"deny","reason":"…"}` vetoes the round — the transcript is left intact, at the risk of a later hard overflow — and `{"action":"modify","payload":{"instructions":"…"}}` appends your instructions to the summarizer's prompt (for example, "keep every file path verbatim"). A failing `PreCompact` hook proceeds un-vetoed, so a broken hook cannot starve compaction. The matcher is **ignored**.
+Runs before each overflow-summarization round (the model-written summary that replaces the oldest span once the conversation outgrows its context budget). Print `{"action":"deny","reason":"…"}` and the round is vetoed. The transcript stays intact, at the risk of a harder overflow later. Print `{"action":"modify","payload":{"instructions":"…"}}` and your instructions are appended to the summarizer's prompt, for example "keep every file path verbatim." A failing `PreCompact` hook lets the round proceed unvetoed, so a broken hook can't block compaction forever. The matcher is **ignored**.
 
 ### `PreIssueWork`
 
-Runs before the self-driving loop works an issue — **before the worktree exists and before any model call**, so a skip costs nothing and leaves nothing behind. The payload carries the issue under `issue`. Printing `{"action":"deny","reason":"…"}` makes the loop **skip that issue and continue to the next one**; the reason is printed for the operator. The matcher is **ignored**.
+Runs before the self-driving loop works an issue, **before the worktree exists and before any model call**, so a skip costs nothing and leaves nothing behind. The payload carries the issue under `issue`. Print `{"action":"deny","reason":"…"}` and the loop **skips that issue and continues to the next one**. The reason is printed for the operator to see. The matcher is **ignored**.
 
-This is the hook to reach for when you want a person to be able to hold an agent off specific work — an issue that is still being specified, one a colleague has started, or anything under a release freeze. See [Holding an agent off an issue](#holding-an-agent-off-an-issue).
+Reach for this hook when you want a person to be able to hold an agent off specific work: an issue still being specified, one a colleague already started, or anything under a release freeze. See [Pausing an issue](#pausing-an-issue).
 
-A skip is **not a failure**: the verb exits 0, because a driver working through a backlog should step over a held item rather than stop at it. Nothing distinguishes "skip this one" from "stop everything" in a `deny` alone, so a hook that means the latter has to say so to its operator.
+A skip is **not a failure**. The command exits 0, because a driver working through a backlog should step over a held item rather than stop at it. A `deny` alone doesn't distinguish "skip this one" from "stop everything," so a hook that means the second one has to say so directly to its operator.
 
 <Callout type="warn">
-  **`PreIssueWork` fails closed**, unlike most gates here. A hook that never ran, timed out,
-  or exited non-zero **skips the issue**. The two outcomes are not symmetric: skipping an
-  issue that was in fact free costs one cycle and corrects itself next run, while working an
-  issue that was in fact held leaves a branch, a pull request, and a comment on something
-  somebody fenced off. `require_approval` also skips — an unattended loop has
-  nobody at the keyboard to answer it.
+  **`PreIssueWork` fails closed**, unlike most gates on this page. A hook that never ran, timed out, or exited non-zero **skips the issue**. The two outcomes aren't equally bad: skipping an issue that was actually free costs one cycle and corrects itself next run, while working an issue that was actually held leaves behind a branch, a pull request, and a comment on something someone meant to fence off. `require_approval` also skips, since an unattended loop has nobody at the keyboard to answer it.
 </Callout>
 
 ### `PostIssueWork`
 
-Runs after the loop has finished a work unit, whatever happened. **Never blocks**: the work is already done and there is nothing left to veto. The payload carries the same `issue` plus an `issueOutcome`. It fires for a failed attempt as well as a successful one — a dashboard, a notifier, or a second agent waiting on the branch needs the failure at least as much. It does **not** fire when `PreIssueWork` denied, because nothing was worked. The matcher is **ignored**.
+Runs after the loop finishes a work unit, whatever happened. **Never blocks**: the work is already done, so there's nothing left to veto. The payload carries the same `issue` plus an `issueOutcome`. It fires for a failed attempt as well as a successful one. A dashboard, a notifier, or a second agent waiting on the branch needs to know about the failure at least as much as the success. It does **not** fire when `PreIssueWork` denied, because nothing was worked. The matcher is **ignored**.
 
-## The stdin payload
+## Stdin payload
 
-Every hook receives one JSON document on stdin. Its shape:
+Every hook receives one JSON document on stdin. Here's its shape:
 
 ```json title="stdin of a PostToolUse hook"
 {
@@ -195,69 +167,47 @@ Every hook receives one JSON document on stdin. Its shape:
 
 <CardGrid size="md">
   <OptionCard name="event">
-    String, always present. `"SessionStart"`, `"PreToolUse"`, `"PostToolUse"`, `"Stop"`,
-    `"PreCompact"`, `"PreIssueWork"`, `"PostIssueWork"`, or any of the loop's own event
-    names above — the same PascalCase names as
-    the config keys.
+    String, always present. `"SessionStart"`, `"PreToolUse"`, `"PostToolUse"`, `"Stop"`, `"PreCompact"`, `"PreIssueWork"`, `"PostIssueWork"`, or any of the loop's own event names above. These are the same PascalCase names used as the config keys.
   </OptionCard>
   <OptionCard name="cwd">
-    String, always present. The workspace root — also the hook's working directory.
+    String, always present. The workspace root, which is also the hook's working directory.
   </OptionCard>
   <OptionCard name="tool">
-    Object, on `PreToolUse` and `PostToolUse`. `{ "name": …, "input": …, "read_only": … }` —
-    the tool's exact name, the JSON input it was (or will be) called with, and the
-    `read_only` bit its schema advertises, so "deny anything non-read-only" is one `jq`
-    expression. Further tool-contract metadata joins here as it lands (#2716).
+    Object, present on `PreToolUse` and `PostToolUse`. `{ "name": …, "input": …, "read_only": … }`: the tool's exact name, the JSON input it was (or will be) called with, and the `read_only` flag from its schema. This means "deny anything non-read-only" is one `jq` expression. More tool metadata will join this object over time.
   </OptionCard>
   <OptionCard name="toolResult">
-    String, on `PostToolUse` only. The result string the tool returned — either the
-    success content or the error message. **Nothing clips it.** A hook matched against a
-    tool that returns a large body receives that whole body on stdin, so if you only want a
-    summary, truncate on your own side.
+    String, present on `PostToolUse` only. The result string the tool returned, either the success content or the error message. **Nothing shortens it.** A hook matched against a tool that returns a large body receives that whole body on stdin, so if you only want a summary, trim it yourself.
   </OptionCard>
   <OptionCard name="finalText">
-    String, on `Stop` only. The text the turn is about to complete with — whole, same
-    unclipped posture as `toolResult`.
+    String, present on `Stop` only. The text the turn is about to finish with, whole and unshortened just like `toolResult`.
   </OptionCard>
   <OptionCard name="issue">
-    Object, on `PreIssueWork`, `PostIssueWork` and the three tracker events.
-    `{ "number": …, "title": …, "branch": … }`.
-    Only `number` is guaranteed — the rest is whatever the loop had already read. A hook
-    that needs more should fetch it itself (`gh issue view` is one line), rather than have
-    every loop pay a tracker round trip for the hooks that do not.
+    Object, present on `PreIssueWork`, `PostIssueWork`, and the three tracker events. `{ "number": …, "title": …, "branch": … }`. Only `number` is guaranteed. The rest is whatever the loop had already read. If a hook needs more, have it fetch it directly (`gh issue view` is one line), rather than have every loop pay for a tracker round trip that most hooks don't need.
   </OptionCard>
   <OptionCard name="issueOutcome">
-    Object, on `PostIssueWork` only. `{"status":"changed","summary":…}`,
-    `{"status":"no_change"}`, or `{"status":"failed","reason":…}`. Three states rather
-    than a boolean: *nothing to do* and *needs a human* are the two a dashboard most needs
-    to tell apart.
+    Object, present on `PostIssueWork` only. `{"status":"changed","summary":…}`, `{"status":"no_change"}`, or `{"status":"failed","reason":…}`. Three states rather than a yes/no, because *nothing to do* and *needs a human* are the two things a dashboard most needs to tell apart.
   </OptionCard>
 </CardGrid>
 
-Absent fields are **omitted entirely**, not set to `null` — a `SessionStart` payload is just `{ "event": "SessionStart", "cwd": "…" }`, and `toolResult` never appears on a `PreToolUse` payload.
+A field that doesn't apply is **left out entirely**, not set to `null`. A `SessionStart` payload is just `{ "event": "SessionStart", "cwd": "…" }`, and `toolResult` never shows up on a `PreToolUse` payload.
 
 <Callout type="warn">
-  Because `toolResult` is unbounded, a `PostToolUse` hook matched on `"*"` will be handed
-  the full output of every tool call in the session — including an MCP or custom tool
-  that returns a large body. Match narrowly, and read stdin in a streaming or size-capped
-  way if the hook logs it anywhere.
+  Because `toolResult` has no size limit, a `PostToolUse` hook matched on `"*"` gets the full output of every tool call in the session, including a large body from an MCP or custom tool. Match narrowly, and if your hook logs stdin anywhere, read it in a streaming or size-capped way.
 </Callout>
 
 ## Timeouts
 
-Each hook may set a `timeoutMs`, the maximum time the command is allowed to run:
+Each hook can set `timeoutMs`: how long the command is allowed to run.
 
 <CardGrid size="sm">
   <OptionCard name="timeoutMs" defaultValue="60000">
-    Milliseconds a hook command may run before it is killed — 60 seconds by default. The
-    hard maximum is `600000` (600 seconds, or 10 minutes); a larger value buys no more
-    time.
+    Milliseconds a hook command may run before it's killed. The default is 60 seconds. The hard maximum is `600000` (600 seconds, or 10 minutes). Setting a larger value buys no more time.
   </OptionCard>
 </CardGrid>
 
 ## Example
 
-The following `settings.json` runs `./scripts/guard.sh` before every `mcp__github__push_files` tool call, with a 5-second timeout. Because it is a `PreToolUse` hook, a non-zero exit from the script blocks the call. Each hook runs as `bash -c <command>` with its working directory set to the workspace root, so a relative path like `./scripts/guard.sh` resolves from the repository root.
+This `settings.json` runs `./scripts/guard.sh` before every `mcp__github__push_files` tool call, with a 5-second timeout. Because it's a `PreToolUse` hook, a non-zero exit from the script blocks the call. Each hook runs as `bash -c <command>` with its working directory set to the workspace root, so a relative path like `./scripts/guard.sh` resolves from the repository root.
 
 ```json title="<workspace>/.stella/settings.json"
 {
@@ -278,7 +228,7 @@ The following `settings.json` runs `./scripts/guard.sh` before every `mcp__githu
 }
 ```
 
-And the script itself — a complete `PreToolUse` guard that reads the payload with `jq` and vetoes pushes to the default branch:
+And here's the script itself: a complete `PreToolUse` guard that reads the payload with `jq` and blocks pushes to the default branch.
 
 ```bash title="scripts/guard.sh"
 #!/usr/bin/env bash
@@ -300,11 +250,11 @@ esac
 exit 0
 ```
 
-Blocking is **fail-closed** on `PreToolUse`: a hook that times out, fails to start, exits non-zero, or prints a malformed decision blocks the tool, with the failure message as the reason. A missing or broken guard script never silently waves a call through, and no enforcement-softening switch changes that. (`PostToolUse` and `SessionStart` never block on either failure mode, and `Stop`/`PreCompact` fail open — see their sections.)
+Blocking is **fail-closed** on `PreToolUse`. A hook that times out, fails to start, exits non-zero, or prints a malformed decision blocks the tool, with the failure message as the reason. A missing or broken guard script never quietly waves a call through, and no setting changes that. (`PostToolUse` and `SessionStart` never block on either kind of failure, and `Stop` and `PreCompact` fail open — see their sections above.)
 
 ## Decisions on stdout
 
-A hook that exits `0` may print **one JSON decision document** on stdout (the whole stdout, or its last non-empty line). The vocabulary is exactly the extension bus's `HookDecision` — one enum, no shell-surface dialect:
+A hook that exits `0` can print **one JSON decision document** on stdout, either the whole stdout or its last non-empty line. This uses the exact same vocabulary as the extension bus's `HookDecision`: one set of options, no separate shell-only dialect.
 
 ```json
 { "action": "allow" }
@@ -313,16 +263,16 @@ A hook that exits `0` may print **one JSON decision document** on stdout (the wh
 { "action": "modify", "payload": { "input": { … } } }
 ```
 
-- **`deny`** blocks with your reason (on `PreToolUse`), holds the turn open (on `Stop`), or vetoes the round (on `PreCompact`).
-- **`require_approval`** (on `PreToolUse`) parks the call on the same approval flow the extension bus's gates use. The question is emitted before the wait, a human answers through the interactive surface, and the wait is bounded. On an interactive run you get the yes/no prompt; headless runs refuse with a message naming the grant path.
-- **`modify`** rewrites the tool input (`payload.input`, on `PreToolUse` — later hooks in the chain see the rewritten payload) or steers the summarizer (`payload.instructions`, on `PreCompact`).
-- **`allow`** — or any stdout that is *not* a decision document — continues the chain; a chain that only modified ends allowed. Precedence is fixed: an operator deny outranks everything, `require_approval` outranks any allow.
+- **`deny`** blocks the call with your reason (on `PreToolUse`), holds the turn open (on `Stop`), or vetoes the round (on `PreCompact`).
+- **`require_approval`** (on `PreToolUse`) parks the call on the same approval flow the extension bus's gates use. The question is shown before the wait, a person answers through the interactive surface, and the wait has a limit. In an interactive session, you get a yes/no prompt. A headless run refuses with a message naming the grant path instead.
+- **`modify`** rewrites the tool input (`payload.input`, on `PreToolUse`; later hooks in the chain see the rewritten input) or steers the summarizer (`payload.instructions`, on `PreCompact`).
+- **`allow`**, or any stdout that isn't a decision document, lets the chain continue. A chain that only modifies still ends up allowed. Precedence is fixed: an operator's deny beats everything, and `require_approval` beats any allow.
 
-Stdout that parses as JSON with an `action` key **must** be a well-formed decision — a typo there fails the evaluation and denies, rather than silently allowing.
+If your stdout parses as JSON with an `action` key, it **must** be a well-formed decision. A typo there fails the check and denies the call, rather than silently allowing it.
 
-### A `PostToolUse` logger that respects the unbounded result
+### Logging tool results
 
-`toolResult` arrives whole, so a hook that appends it somewhere has to bound it itself. This one keeps a one-line-per-call audit trail with the result capped at 200 characters:
+`toolResult` arrives with no length limit, so a hook that logs it somewhere has to trim it itself. This one keeps a one-line-per-call audit trail, with the result capped at 200 characters:
 
 ```bash title="scripts/audit.sh"
 #!/usr/bin/env bash
@@ -338,7 +288,7 @@ printf '%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$tool" "$result" \
   >> "${TMPDIR:-/tmp}/stella-tool-audit.tsv"
 ```
 
-Wire it to every tool with a `"*"` matcher:
+Wire it up to every tool with a `"*"` matcher:
 
 ```json title="~/.stella/settings.json"
 {
@@ -355,9 +305,9 @@ Wire it to every tool with a `"*"` matcher:
 }
 ```
 
-### Holding an agent off an issue
+### Pausing an issue
 
-The self-driving loop works whatever the backlog hands it. `PreIssueWork` is where a person gets a say — and the cleanest way to express that is a label on the issue itself, because the tracker is where the intent already lives and anyone on the team can set it without touching a config file.
+The self-driving loop works whatever the backlog hands it. `PreIssueWork` is where a person gets a say, and the cleanest way to say it is a label on the issue itself. The tracker is where the intent already lives, and anyone on the team can set the label without touching a config file.
 
 This hook holds the loop off any issue labelled `agent-hold`:
 
@@ -399,21 +349,18 @@ Register it in your user-scope settings:
 Now `gh issue edit 123 --add-label agent-hold` is all it takes to fence an issue off, and removing the label hands it back. The loop prints `skipped #123 — issue #123 is labelled agent-hold` and moves on to the next item.
 
 <Callout type="warn">
-  Note the exit status: the script exits **0** and expresses its decision on stdout. A
-  non-zero exit also skips the issue — `PreIssueWork` fails closed — but it reports as
-  *"the hook could not be evaluated"* rather than as your reason, which is much harder to
-  read six issues later. Decide on stdout; reserve a non-zero exit for genuinely broken.
+  Note the exit status: the script exits **0** and puts its decision on stdout. A non-zero exit also skips the issue, since `PreIssueWork` fails closed, but it shows up as *"the hook could not be evaluated"* rather than your actual reason, which is much harder to read six issues later. Put your decision on stdout, and save a non-zero exit for something genuinely broken.
 </Callout>
 
-The same shape gives you several other things, with no change to stella:
+This same pattern covers other cases too, with no changes to stella:
 
-- **Two agents, one backlog.** Have the hook claim the issue (assign it, or add an `agent-claimed-$HOSTNAME` label) and deny when it is already claimed by someone else.
+- **Two agents, one backlog.** Have the hook claim the issue, by assigning it or adding an `agent-claimed-$HOSTNAME` label, and deny when it's already claimed by someone else.
 - **A release freeze.** Deny everything while a `freeze` milestone is open.
-- **Working hours.** Deny outside a window, so an unattended loop does not open pull requests at 3am.
-- **Scope limits.** Deny anything not labelled `good-first-issue`, or anything whose estimate exceeds what you want an agent attempting unattended.
+- **Working hours.** Deny outside a set window, so an unattended loop doesn't open pull requests at 3am.
+- **Scope limits.** Deny anything not labelled `good-first-issue`, or anything whose estimate is bigger than what you want an agent attempting unattended.
 
 <Callout type="warn">
-**Project-scope hooks are a trust boundary.** Hooks declared in a repository's project-scope file (`<workspace>/.stella/settings.json`) do **not** load unless the repo is trusted — set `STELLA_TRUST_PROJECT=1`, or the legacy hooks-scoped `STELLA_PROJECT_HOOKS=1`. Either flag unlocks them; without one, the merged hook set is rebuilt from the user and org-managed scopes alone and a stderr notice names what was skipped. This stops a cloned repo from running arbitrary commands on your machine. Hooks in the user scope (`~/.stella/settings.json`) always load. See [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
+**Project-scope hooks are a trust boundary.** Hooks declared in a repository's project-scope file (`<workspace>/.stella/settings.json`) do **not** load unless the repo is trusted. Set `STELLA_TRUST_PROJECT=1`, or the older hooks-only `STELLA_PROJECT_HOOKS=1`. Either flag unlocks them. Without one, the merged hook set is built from the user and org-managed scopes alone, and a stderr message names what was skipped. This stops a cloned repo from running arbitrary commands on your machine. Hooks in the user scope (`~/.stella/settings.json`) always load. See [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
 </Callout>
 
 <Callout type="info">

--- a/website/content/docs/agent-tools/hooks.mdx
+++ b/website/content/docs/agent-tools/hooks.mdx
@@ -119,7 +119,7 @@ Runs once before the turn begins. Anything the hook prints to **stdout is append
 
 Runs before a tool executes. A **non-zero exit status blocks the tool**: the tool doesn't run, and the model gets the hook's message instead. This is how you gate or veto tool calls (see [Permissions](/docs/agent-tools/permissions)). The matcher is a **glob over the tool name**, so you can target one tool, such as `task_assign`, or a family of tools, such as `mcp__github__*`.
 
-A `PreToolUse` hook can also **decide** instead of just blocking: print one JSON decision document on stdout, using the same `allow` / `deny` / `require_approval` / `modify` vocabulary the in-process [extension bus](/docs/extensions) uses. Stella folds this in exactly as it folds a policy chain. See [Decisions on stdout](#decisions-on-stdout).
+A `PreToolUse` hook can also **decide** instead of just blocking: print one JSON decision document on stdout, using the same `allow` / `deny` / `require_approval` / `modify` vocabulary the in-process [extension bus](/docs/extensions) uses. stella folds this in exactly as it folds a policy chain. See [Decisions on stdout](#decisions-on-stdout).
 
 ### `PostToolUse`
 

--- a/website/content/docs/agent-tools/index.mdx
+++ b/website/content/docs/agent-tools/index.mdx
@@ -1,43 +1,43 @@
 ---
 title: Built-in Tools
-description: The complete catalog of tools the stella agent can call in every session — one shell, file CRUD, one search, sub-agent delegation, the task board, scratch state, and the environment probe — including which are read-only.
+description: Every tool the stella agent can call in every session. Covers the shell, file create/read/update/delete, code search, sub-agent delegation, the task board, scratch state, and the environment probe, and notes which ones are read-only.
 ---
 
-stella ships a small built-in surface: **18 tools**, covering the shell, file create/read/update/delete, code search, sub-agent delegation, the session task board, scratch session state, and the session environment. The surface is small on purpose — it is the set of verbs the agent needs to do work in a repository, and nothing beyond it. Everything else the agent can do comes from [custom script tools](/docs/agent-tools/custom-tools) you define and from tools merged in from [MCP servers](/docs/agent-tools/mcp). Every tool — built-in or merged — is subject to a [per-tool permission model](/docs/agent-tools/permissions).
+stella ships a small built-in surface: **18 tools**. They cover the shell, file create/read/update/delete, code search, sub-agent delegation, the session task board, scratch session state, and the session environment. The surface stays small on purpose. It's the set of actions the agent needs to do work in a repository, and nothing more. Everything else the agent can do comes from [custom script tools](/docs/agent-tools/custom-tools) you define, and from tools merged in from [MCP servers](/docs/agent-tools/mcp). Every tool, built-in or merged, follows a [per-tool permission model](/docs/agent-tools/permissions).
 
 ## Listing tools
 
-To see everything available to the agent in the current session — built-ins, developer custom tools, and manifest diagnostics — run:
+To see everything available to the agent in the current session, built-ins, your own custom tools, and manifest diagnostics, run:
 
 ```bash
 stella tools
 ```
 
-This reflects the live session: it accounts for custom tools discovered in `.stella/tools/` and `~/.stella/tools/`, and for any tools merged in from configured MCP servers.
+This reflects the live session. It includes custom tools found in `.stella/tools/` and `~/.stella/tools/`, and any tools merged in from configured MCP servers.
 
-## The built-in catalog
+## Built-in catalog
 
-Each tool is either **read-only** (it only observes — the workspace, session state, or the environment) or **mutating** (it writes a file, runs a command, changes the task board, writes scratch state, or dispatches work to a sub-agent). The read-only marker is the schema's `read_only: true` flag; anything else is treated as capable of side effects. The engine parallelizes on that flag, so a mutating tool marked read-only would race writes.
+Each tool is either **read-only** (it only looks, at the workspace, session state, or the environment) or **mutating** (it writes a file, runs a command, changes the task board, writes scratch state, or hands work to a sub-agent). The read-only marker is the schema's `read_only: true` flag. Anything without it is treated as capable of side effects. The engine runs tools in parallel based on that flag, so a mutating tool marked read-only by mistake would cause writes to race each other.
 
-A subset of the read-only tools is also **speculation-safe** (the schema's `speculation_safe: true` flag): the engine executes a step's leading run of speculation-safe calls concurrently — while the model is still streaming — and harvests the results at dispatch, so those lookups cost almost no wall-clock. Speculation is a narrower claim than read-only: a retried stream can run a speculated call twice, so only calls that are free to repeat opt in. A mutating tool is never speculated, and MCP-provided tools never opt in.
+A subset of the read-only tools is also **speculation-safe** (the schema's `speculation_safe: true` flag). For these, the engine runs a step's first batch of speculation-safe calls at the same time, while the model is still streaming its response, and collects the results when it's ready to use them. This means those lookups cost almost no extra time. Speculation is a narrower claim than read-only: a retried stream can run a speculated call twice, so only calls that are free to repeat can opt in. A mutating tool is never speculated, and tools from MCP servers never opt in either.
 
-The speculation-safe subset is exactly: `read_file`, `task_list`, `get_state`, `list_state`, and `get_environment`.
+The speculation-safe tools are exactly: `read_file`, `task_list`, `get_state`, `list_state`, and `get_environment`.
 
-`search` is the instructive exception: it is read-only about the *workspace* — it never edits a file — yet it is not speculation-safe, because its semantic rung writes embeddings through into `codegraph.db` as it ranks. Running it twice is not free, so it observes without opting in.
+`search` is a useful exception. It's read-only about the *workspace* — it never edits a file — but it isn't speculation-safe, because its semantic ranking step writes embeddings into `codegraph.db` as it works. Running it twice isn't free, so it stays read-only without opting into speculation.
 
-Tool names are their exact identifiers — the agent dispatches by name, and these are the names `stella tools` prints.
+Tool names are their exact identifiers. The agent calls them by name, and these are the same names `stella tools` prints.
 
 <Callout type="warn">
-This page **is** maintained by hand, and nothing in the gate compares it to `crates/stella-tools/src/catalog.rs`. The generated, gate-enforced copy of the same facts is `docs/tools/*.toml` — one file per tool, rebuilt by `make tool-docs-update` and checked by `make tool-docs`. When the two disagree, `docs/tools/` is right and this page is stale; fix it in the PR that adds or removes the tool. (An earlier version of this callout claimed a `crates/stella-tools/tests/docs_in_sync.rs` asserted the cards below against the catalog. No such test has ever existed, which is exactly how this page came to describe a surface the binary had not shipped for months.)
+This page is written by hand. It isn't checked against `crates/stella-tools/src/catalog.rs`. The generated, gate-enforced version of the same facts lives in `docs/tools/*.toml`, one file per tool, rebuilt with `make tool-docs-update` and checked with `make tool-docs`. If the two disagree, trust `docs/tools/`, and treat this page as needing an update.
 </Callout>
 
-All 18 tools register in every session — no configuration, no prerequisites. Grouped by what they touch:
+All 18 tools register in every session, with no setup and no prerequisites. Here they are, grouped by what they touch.
 
 ### Shell
 
 <CardGrid size="md">
   <ToolCard name="bash" access="mutating">
-    Run a shell command in the workspace root. Returns stdout+stderr with a timeout backstop. The only built-in that runs something nobody bounded — hence its `high` risk grade. A permission ceiling that withholds it still leaves the rest of the surface working.
+    Run a shell command in the workspace root. Returns stdout and stderr, with a timeout backstop. This is the only built-in that runs something with no other bound, which is why it carries a `high` risk grade. Turning it off with a permission ceiling still leaves the rest of the tools working.
   </ToolCard>
 </CardGrid>
 
@@ -45,16 +45,16 @@ All 18 tools register in every session — no configuration, no prerequisites. G
 
 <CardGrid size="md">
   <ToolCard name="read_file" access="read">
-    Read a file from the workspace. Returns content with 1-based line numbers; `offset` and `limit` take a range out of a large file rather than the whole thing.
+    Read a file from the workspace. Returns its content with 1-based line numbers. `offset` and `limit` pull a range out of a large file instead of the whole thing.
   </ToolCard>
   <ToolCard name="write_file" access="mutating">
-    Create or overwrite a file, creating parent directories as needed. Overwriting an existing file is refused unless the session has already been shown all of it — the argument is the whole file, so a model working from a fragment would silently truncate the rest. `edit_file` is the way to change part of a file you have not read whole.
+    Create or overwrite a file, creating parent folders as needed. Overwriting an existing file is refused unless the session has already been shown all of it. The argument is the whole file, so a model working from a partial view would silently cut off the rest. Use `edit_file` instead to change part of a file you haven't read in full.
   </ToolCard>
   <ToolCard name="edit_file" access="mutating">
-    Replace an exact substring in a file. The old string must appear exactly once unless `replace_all` is set — an ambiguous match is refused rather than guessed at.
+    Replace an exact piece of text in a file. The text you're replacing must appear exactly once, unless `replace_all` is set. An ambiguous match is refused instead of guessed at.
   </ToolCard>
   <ToolCard name="delete_file" access="mutating">
-    Delete a file in the workspace. Prefer it over `bash rm`: a symlink is removed as the link, and its target is left alone. The one `destructive` grade in the catalog, because an unlinked file is the one thing on this surface the agent cannot undo from inside the turn.
+    Delete a file in the workspace. Prefer this over `bash rm`: a symlink is removed as the link itself, leaving its target alone. This is the one `destructive` grade in the catalog, because deleting a file is the one thing here the agent can't undo from inside the same turn.
   </ToolCard>
 </CardGrid>
 
@@ -62,33 +62,33 @@ All 18 tools register in every session — no configuration, no prerequisites. G
 
 <CardGrid size="md">
   <ToolCard name="search" access="read">
-    Find code by meaning, not just by text: describe what you are looking for and get back the files that answer it with their symbols, callers, imports and source attached, so one call usually replaces a run of grep/glob/read round trips. The answer always states which strategies ran and whether it was truncated.
+    Find code by meaning, not just by text. Describe what you're looking for, and get back the files that answer it, with their symbols, callers, imports, and source attached. One call usually replaces a run of separate grep, glob, and read calls. The answer always states which strategies ran and whether the result was cut short.
   </ToolCard>
 </CardGrid>
 
-### Task board &amp; sub-agents
+### Task board and sub-agents
 
 <CardGrid size="md">
   <ToolCard name="task_create" access="mutating">
-    Add a task to the session task board — one per concrete deliverable, created before multi-step work starts.
+    Add a task to the session task board, one per concrete deliverable, created before multi-step work starts.
   </ToolCard>
   <ToolCard name="task_list" access="read">
     Show the board: every task as `[status] #id subject (owner)`.
   </ToolCard>
   <ToolCard name="task_start" access="mutating">
-    Mark a board task in-progress — exactly one at a time.
+    Mark a board task in progress, one at a time.
   </ToolCard>
   <ToolCard name="task_complete" access="mutating">
-    Mark a board task completed the moment its work is done and verified.
+    Mark a board task complete the moment its work is done and checked.
   </ToolCard>
   <ToolCard name="task_cancel" access="mutating">
-    Cancel a task that is no longer worth doing, with a reason; the row stays as an audit trail.
+    Cancel a task that's no longer worth doing, with a reason. The row stays as a record.
   </ToolCard>
   <ToolCard name="task_assign" access="mutating">
-    Delegate a board task to a parallel sub-agent — the briefing is passed verbatim, so write it self-contained.
+    Hand a board task to a parallel sub-agent. The briefing is passed along exactly as written, so write it so it stands on its own.
   </ToolCard>
   <ToolCard name="delegate" access="mutating">
-    Hand a self-contained research question to a read-only sub-agent that investigates and returns only its findings. Its intermediate work never enters the conversation, so the parent never re-sends it on later steps.
+    Hand a self-contained research question to a read-only sub-agent that investigates and reports back only its findings. Its intermediate work never enters the conversation, so the parent never has to re-send it on later steps.
   </ToolCard>
 </CardGrid>
 
@@ -96,16 +96,16 @@ All 18 tools register in every session — no configuration, no prerequisites. G
 
 <CardGrid size="md">
   <ToolCard name="save_state" access="mutating">
-    Save intermediate session state under a key so later steps can reference it instead of re-deriving it (parse results, extracted lists, computed digests). Capped at 1 MiB for model-authored content; files produced into `$STELLA_SCRATCH` are uncapped.
+    Save session state under a key, so later steps can reference it instead of working it out again — parse results, extracted lists, computed digests. Capped at 1 MiB for content the model writes directly; files written into `$STELLA_SCRATCH` have no cap.
   </ToolCard>
   <ToolCard name="get_state" access="read">
-    Read a saved scratch entry by key, paged at 30 KB with explicit remainder headers. Prefer this over re-deriving expensive state.
+    Read a saved scratch entry by key, shown 30 KB at a time with clear markers for what's left. Prefer this over recomputing something expensive.
   </ToolCard>
   <ToolCard name="list_state" access="read">
-    List saved scratch entries (key and size in bytes), including files written into `$STELLA_SCRATCH`.
+    List saved scratch entries, with key and size in bytes, including files written into `$STELLA_SCRATCH`.
   </ToolCard>
   <ToolCard name="delete_state" access="mutating">
-    Delete one scratch entry by key — use when saved state is stale or superseded so later steps cannot read an invalidated value.
+    Delete one scratch entry by key. Use this when saved state is stale or replaced, so later steps can't read an outdated value.
   </ToolCard>
 </CardGrid>
 
@@ -113,15 +113,15 @@ All 18 tools register in every session — no configuration, no prerequisites. G
 
 <CardGrid size="md">
   <ToolCard name="get_environment" access="read">
-    Report this session's environment in one call: workspace root, whether it is a git repository (and whether it is a linked worktree), platform/arch, OS release, login shell dialect, and the scratch directory path. Reads the same facts the system prompt's "Session environment" block already states, minus the model line — that is the CLI prompt layer's job alone.
+    Report this session's environment in one call: workspace root, whether it's a git repository (and whether it's a linked worktree), platform and architecture, OS release, login shell, and the scratch directory path. It reads the same facts already stated in the system prompt's "Session environment" block, minus the model name, which only the CLI prompt layer reports.
   </ToolCard>
 </CardGrid>
 
-The read-only partition is exactly: `read_file`, `search`, `task_list`, `get_state`, `list_state`, and `get_environment`. The other twelve are mutating.
+The read-only tools are exactly: `read_file`, `search`, `task_list`, `get_state`, `list_state`, and `get_environment`. The other twelve are mutating.
 
 ## Switching tools off
 
-Every tool ships **on**. The one way to turn something off is a `"tools"` entry in [`settings.json`](/docs/configuration/settings), and it reads the same whether the name is a built-in, an MCP server's tool, or one you registered yourself:
+Every tool ships turned **on**. The only way to turn one off is a `"tools"` entry in [`settings.json`](/docs/configuration/settings), and it works the same whether the name is a built-in, an MCP server's tool, or one you registered yourself:
 
 ```json title="settings.json"
 {
@@ -132,9 +132,9 @@ Every tool ships **on**. The one way to turn something off is a `"tools"` entry 
 }
 ```
 
-A key is a **tool name**, a **group name** (the family headings above — `shell`, `file`, `search`, `task`, `scratch`, `environment` — plus `mcp` and `custom` for tools the built-in catalog has never heard of), or `"*"` for everything. Most specific wins: name beats group beats `"*"`, and anything unmentioned is on.
+A key can be a **tool name**, a **group name** (the family headings above — `shell`, `file`, `search`, `task`, `scratch`, `environment` — plus `mcp` and `custom` for tools the built-in catalog doesn't know about), or `"*"` for everything. The most specific setting wins: a name beats a group, and a group beats `"*"`. Anything not mentioned stays on.
 
-Two recipes that fall out of that rule:
+Two examples that follow from that rule:
 
 ```json title="A board reader that cannot change the board"
 {
@@ -154,16 +154,16 @@ Two recipes that fall out of that rule:
 }
 ```
 
-A switched-off tool is **withheld from the schema list and refused if called anyway** — the refusal reads like the unknown-tool error, so a disabled tool is indistinguishable from one that was never built. Enforcement is at the tool boundary, not by prompt discipline.
+A switched-off tool is **left out of the schema and refused if called anyway**. The refusal looks the same as an unknown-tool error, so a disabled tool is indistinguishable from one that was never built. This is enforced at the tool boundary, not by asking the model nicely.
 
-Scopes merge per key (project beats user), with one asymmetry: an **org-managed** `settings.json` that turns a tool off is a ceiling. A user or project scope may narrow further but can never turn it back on — see [settings](/docs/configuration/settings).
+Settings merge per key, project beats user, with one exception: an **org-managed** `settings.json` that turns a tool off acts as a ceiling. A user or project scope can narrow it further, but can never turn it back on. See [settings](/docs/configuration/settings).
 
 ## Where to go next
 
-- [Agent Skills](/docs/agent-tools/skills) — reusable SKILL.md capabilities, versioned and registry-installable.
-- [Custom Commands](/docs/agent-tools/commands) — extend the slash menu with your own prompt templates.
-- [Custom Agents](/docs/agent-tools/custom-agents) — reusable personas with an optional restricted toolbelt, adopted from `.claude/` and `.agents/`.
+- [Agent Skills](/docs/agent-tools/skills) — reusable SKILL.md capabilities, versioned and installable from the registry.
+- [Custom Commands](/docs/agent-tools/commands) — add your own prompt templates to the slash menu.
+- [Custom Agents](/docs/agent-tools/custom-agents) — reusable personas with an optional restricted toolbelt, imported from `.claude/` and `.agents/`.
 - [Permissions](/docs/agent-tools/permissions) — how read-only and mutating tools are gated, and how hooks can block tool calls.
 - [Custom Tools](/docs/agent-tools/custom-tools) — add your own script tools with a TOML manifest.
-- [MCP Servers](/docs/agent-tools/mcp) — merge tools from Model Context Protocol servers.
+- [MCP Servers](/docs/agent-tools/mcp) — merge in tools from Model Context Protocol servers.
 - [Hooks](/docs/agent-tools/hooks) — run shell commands on agent lifecycle events.

--- a/website/content/docs/agent-tools/mcp.mdx
+++ b/website/content/docs/agent-tools/mcp.mdx
@@ -3,13 +3,13 @@ title: MCP Servers
 description: Connect Model Context Protocol servers to stella so their tools merge into the agent at session start.
 ---
 
-stella can connect to [Model Context Protocol](https://modelcontextprotocol.io) (MCP) servers and merge their tools into the agent. This lets you extend the agent with capabilities that live outside your workspace — without writing a [custom script tool](/docs/agent-tools/custom-tools) for each one.
+stella can connect to [Model Context Protocol](https://modelcontextprotocol.io) (MCP) servers and merge their tools into the agent. This lets you extend the agent with capabilities that live outside your workspace, without writing a [custom script tool](/docs/agent-tools/custom-tools) for each one.
 
 ## Configuration
 
-MCP servers are configured in `.stella/mcp.toml` in your workspace. stella connects to each configured server at **session start** and merges the tools it exposes into the agent, alongside the [built-in tools](/docs/agent-tools) and any custom tools.
+MCP servers are configured in `.stella/mcp.toml` in your workspace. stella connects to each configured server at **session start** and merges the tools it offers into the agent, alongside the [built-in tools](/docs/agent-tools) and any custom tools.
 
-The quickest way to add a server is the [`stella mcp`](/docs/commands/mcp) command family — no hand-editing:
+The quickest way to add a server is the [`stella mcp`](/docs/commands/mcp) command family. No hand-editing required:
 
 ```bash
 stella mcp search github          # find one in the registry
@@ -20,49 +20,46 @@ stella mcp usage                  # per-server, per-tool call counts from local 
 stella mcp remove github          # drop one
 ```
 
-Enabling and disabling a server is deliberately *not* a CLI verb: it is session-scoped (it changes a running conversation's tool set), so it lives in the deck's MCP tab (`/mcp`).
+Turning a server on or off is deliberately not a CLI command. It's session-scoped, since it changes a running conversation's tool set, so it lives in the deck's MCP tab (`/mcp`) instead.
 
-## An installed server is withheld until you grant it
+## Granting access
 
-A server you install from a registry is a stranger's command line, and installing it takes one keystroke. So a newly installed server **connects but cannot act**: none of its tools are offered to the model, and any call to one comes back as a refusal.
+A server you install from a registry is a stranger's command line, and installing one takes a single keystroke. So a newly installed server **connects but can't act**: none of its tools are offered to the model, and any call to one comes back as a refusal.
 
-The handshake is what you review. Connecting is how a server's declared capabilities become knowable at all, so the gate sits between the handshake and the first tool call rather than before the connect: stella asks the server what it offers, shows you the list, and records your answer.
+The handshake is what you review. Connecting is how a server's declared capabilities become knowable in the first place, so the gate sits between the handshake and the first tool call, not before the connection: stella asks the server what it offers, shows you the list, and records your answer.
 
-Either surface asks the same question. `e` on an ungranted row in the deck's MCP tab (`/mcp`) shows the declared tools and grants them; [`stella mcp grant <name>`](/docs/commands/mcp) does the same from a shell, with `--yes` for provisioning and `--revoke` to withdraw.
+Either surface asks the same question. Pressing `e` on an ungranted row in the deck's MCP tab (`/mcp`) shows the declared tools and grants them. [`stella mcp grant <name>`](/docs/commands/mcp) does the same from a shell, with `--yes` for provisioning and `--revoke` to withdraw.
 
-The answer is recorded as `granted` in `.stella/mcp.toml`, so it is read by every session — you are asked once, not every morning. An entry you wrote by hand carries no `granted` key and is usable without a grant: writing the transport yourself is already the review the gate is asking for.
+Your answer is recorded as `granted` in `.stella/mcp.toml`, so every session reads it. You're asked once, not every morning. An entry you wrote by hand carries no `granted` key and is usable without a grant, since writing the transport yourself is already the review the gate is asking for.
 
-Because the tools are added at session start, connecting a new server takes effect on your next session. Each server gets a **10-second** connect budget, and connects are isolated per server — one that hangs or fails is recorded and skipped, it does not take the session down.
+Because tools are added at session start, connecting a new server takes effect on your next session. Each server gets a **10-second** connect budget, and connections are isolated per server. One that hangs or fails is recorded and skipped, and it doesn't take the whole session down.
 
 <McpTopologyDiagram />
 
-The MCP tab is where that review happens. Each server shows its transport,
-tool count, handshake latency and auth state, and a new one arrives disabled
-with its capabilities on show. The code graph sits pinned at the top because
-it is the product rather than an integration.
+The MCP tab is where this review happens. Each server shows its transport, tool count, handshake speed, and login state, and a new one arrives disabled with its capabilities on display. The code graph sits pinned at the top, since it's part of the product rather than an add-on.
 
 <DeckShot id="mcp" />
 
 <Callout type="warn">
-`stella tools` does **not** enumerate MCP tools — it prints a note that MCP servers merge more tools at session start. Confirm a server is wired up with `stella mcp list`, or verify its tools from inside a session (the deck's MCP tab, `/mcp`).
+`stella tools` does **not** list MCP tools. It prints a note that MCP servers merge more tools at session start. Confirm a server is wired up with `stella mcp list`, or check its tools from inside a session, in the deck's MCP tab (`/mcp`).
 </Callout>
 
-## `.stella/mcp.toml` is behind the project trust boundary
+## Trust boundary
 
 <Callout type="warn">
   A repo's `.stella/mcp.toml` is **not loaded** until you trust the repo. An entry can
-  name an arbitrary `cmd` that runs at session start — the `git clone && stella`
-  remote-execution hole — or an attacker-controlled `url` that workspace content gets
-  sent to, which is the same risk class as [project hooks](/docs/agent-tools/hooks).
-  Untrusted, stella connects nothing and prints the reason once. Opt in per repo:
+  name an arbitrary `cmd` that runs at session start, the same remote-execution risk as
+  `git clone && stella`, or an attacker-controlled `url` that workspace content gets
+  sent to, which carries the same risk as [project hooks](/docs/agent-tools/hooks).
+  Until you trust the repo, stella connects nothing and prints the reason once. Opt in per repo:
 
   ```bash
   export STELLA_TRUST_PROJECT=1
   ```
 
-  Scope it with direnv or a shell-profile guard rather than exporting it globally, and
-  see the [trust boundary](/docs/configuration/settings#the-project-trust-boundary) for
-  what else the flag governs.
+  Scope it with direnv or a shell-profile guard rather than exporting it globally. See the
+  [trust boundary](/docs/configuration/settings#the-project-trust-boundary) for what
+  else the flag controls.
 </Callout>
 
 ## Example configuration
@@ -80,69 +77,52 @@ url = "https://mcp.example.com/mcp"
 headers = { Authorization = "Bearer …" }
 ```
 
-A server entry needs a `transport` discriminant — `stdio` or `http` — and the remaining fields follow from it:
+A server entry needs a `transport` value, `stdio` or `http`, and the rest of the fields follow from that choice:
 
 <CardGrid size="md">
   <OptionCard name="transport" required>
-    `stdio` or `http`. The discriminant; everything else in the entry depends
-    on it.
+    `stdio` or `http`. This decides which of the other fields apply.
   </OptionCard>
   <OptionCard name="cmd">
-    stdio only, required there. The executable stella launches, speaking
-    JSON-RPC over the child's stdio.
+    stdio only, and required there. The program stella launches, talking JSON-RPC over the child process's stdio.
   </OptionCard>
   <OptionCard name="args" defaultValue="[]">
     stdio only. Arguments passed to `cmd`.
   </OptionCard>
   <OptionCard name="env" defaultValue="{}">
-    stdio only. The variables the child receives — see the scrub note below.
+    stdio only. The variables the child process receives. See the note on scrubbing below.
   </OptionCard>
   <OptionCard name="url">
-    http only, required there. A streamable-HTTP endpoint stella POSTs JSON-RPC
-    to.
+    http only, and required there. A streamable-HTTP endpoint stella sends JSON-RPC requests to.
   </OptionCard>
   <OptionCard name="headers" defaultValue="{}">
-    http only. Static headers replayed on every request (an `Authorization`
-    bearer, an API key). Values are written to `mcp.toml` verbatim but redacted
-    from logs and debug output.
+    http only. Static headers sent with every request, such as an `Authorization` bearer token or an API key. Values are written to `mcp.toml` as-is but hidden from logs and debug output.
   </OptionCard>
   <OptionCard name="candidate_safe" defaultValue="false">
-    Opt this server into Best-of-N candidate runs — see
-    [below](#mcp-in-best-of-n-candidates). Never inferred, always human-set.
+    Opt this server into Best-of-N candidate runs. See [below](#best-of-n-candidates). Never guessed at — you always set it yourself.
   </OptionCard>
   <OptionCard name="granted">
-    Whether the model may call this server's tools. Written by a grant, and by
-    an install (which writes `false`). Absent on an entry you wrote yourself,
-    which reads as granted — see
-    [above](#an-installed-server-is-withheld-until-you-grant-it).
+    Whether the model may call this server's tools. Set by a grant, and by an install (which sets it to `false`). Left out on an entry you wrote yourself, which counts as granted. See [above](#granting-access).
   </OptionCard>
 </CardGrid>
 
-Either way, stella merges the tools the server reports for the session. Each is advertised as `mcp__<server>__<tool>`, so two servers exposing a `search` tool never collide; the entry's name in `mcp.toml` shows up in the middle segment. To keep that encoding unambiguous, an entry name may not contain `__` and may not begin or end with `_`. A name that breaks the rule is reported as unavailable rather than risking one server's tools shadowing another's.
+Either way, stella merges in the tools the server reports for the session. Each one is advertised as `mcp__<server>__<tool>`, so two servers that each expose a `search` tool never collide. The entry's name in `mcp.toml` becomes the middle part of that name. To keep that naming unambiguous, an entry name can't contain `__` and can't start or end with `_`. A name that breaks this rule is reported as unavailable, rather than risking one server's tools hiding another's.
 
 <Callout type="warn">
-A stdio MCP subprocess runs with a **scrubbed environment** — ambient shell variables (including credentials like `ANTHROPIC_API_KEY` or `GITHUB_TOKEN`) are **not** inherited. Any variable the server needs must be listed explicitly in the entry's `env` table, e.g. `env = { GITHUB_TOKEN = "…" }`. The single exception is `PATH`, which is inherited so a bare runner (`npx`, `uvx`, `docker`) can resolve at all; an `env` entry named `PATH` overrides it.
+A stdio MCP subprocess runs with a **scrubbed environment**. Ambient shell variables, including credentials like `ANTHROPIC_API_KEY` or `GITHUB_TOKEN`, are **not** passed through. Any variable the server needs must be listed directly in the entry's `env` table, for example `env = { GITHUB_TOKEN = "…" }`. The one exception is `PATH`, which is passed through so a bare runner like `npx`, `uvx`, or `docker` can resolve at all. An `env` entry named `PATH` overrides it.
 </Callout>
 
-For an HTTP server that speaks OAuth rather than a static bearer, `stella mcp login <name>` runs the browser flow and stores the tokens in a workspace-owned, owner-only token store instead of in `mcp.toml`; `stella mcp logout <name>` forgets them.
+For an HTTP server that uses OAuth instead of a static bearer token, `stella mcp login <name>` runs the browser flow and stores the tokens in a workspace-owned, owner-only token store instead of in `mcp.toml`. `stella mcp logout <name>` forgets them.
 
 <Callout type="info">
-MCP tools are treated like any other tool once merged in: they follow the [per-tool permission model](/docs/agent-tools/permissions) and their calls can be gated or blocked with a [`PreToolUse` hook](/docs/agent-tools/hooks).
+MCP tools are treated like any other tool once merged in. They follow the [per-tool permission model](/docs/agent-tools/permissions), and their calls can be gated or blocked with a [`PreToolUse` hook](/docs/agent-tools/hooks).
 </Callout>
 
-## MCP in Best-of-N candidates
+## Best-of-N candidates
 
-A Best-of-N run (a wrapper plugin's `candidates` setting) executes multiple
-candidates in isolated git shadow worktrees, so a candidate's edits never
-leak into another's, or into your real tree, until a winner is adopted. MCP
-servers stay **withheld by default** in that isolation, because most
-configured servers are either filesystem-rooted (redundant with the
-snapshot-rooted built-in read/write/edit tools) or side-effecting (harmful
-to run once per candidate — a deploy, an issue creation, a DB write).
+A Best-of-N run (set by a wrapper plugin's `candidates` setting) runs multiple candidates in isolated git shadow worktrees, so one candidate's edits never leak into another's, or into your real tree, until a winner is picked. MCP servers stay **withheld by default** during that isolation, because most configured servers are either rooted in the filesystem (which would duplicate the snapshot-rooted built-in read, write, and edit tools) or side-effecting (harmful to run once per candidate, such as a deploy, an issue creation, or a database write).
 
-The servers worth sharing — read-only, external context that doesn't depend
-on which tree it's called from (docs/web search, a code graph, GitHub/Linear
-reads) — opt in explicitly per server:
+The servers worth sharing are read-only and don't depend on which tree they're called from: think docs or web search, a code graph, or GitHub and Linear reads. You opt each one in explicitly:
 
 ```toml title=".stella/mcp.toml"
 [servers.docs]
@@ -151,28 +131,13 @@ url = "https://docs.example.com/mcp"
 candidate_safe = true
 ```
 
-`candidate_safe` defaults to `false` and is never inferred from a server's
-own `read_only_hint`. That hint can't tell "reads an external system" (safe
-to share) from "reads the local tree" (which would return your REAL tree's
-bytes inside a candidate's isolated snapshot — exactly the correctness
-hazard the isolation exists to prevent). Flip it on only for servers you've
-checked are genuinely read-only and cwd-independent.
+`candidate_safe` defaults to `false` and is never guessed from a server's own `read_only_hint`. That hint can't tell "reads an external system" (safe to share) apart from "reads the local tree" (which would return your real tree's content inside a candidate's isolated snapshot, exactly the mistake the isolation exists to prevent). Turn it on only for servers you've checked are genuinely read-only and don't care which directory they run from.
 
-Speculative execution is off the table entirely for MCP tools: they register
-as mutating (`read_only: false`) and never claim `speculation_safe`, so the
-engine runs each call exactly once, at dispatch — an external server's
-request count and rate limit are not stella's to spend twice.
+Speculative execution is off the table entirely for MCP tools. They register as mutating (`read_only: false`) and never claim `speculation_safe`, so the engine runs each call exactly once, when it's dispatched. An external server's request count and rate limit aren't stella's to spend twice.
 
-Two things follow from a server being `candidate_safe`:
+Being `candidate_safe` has two effects:
 
-- Every candidate's engine can call that server's tools live, mid-turn,
-  through the same already-connected session client (no extra subprocess
-  per candidate).
-- Before the fan-out starts, stella calls that server's zero-argument tools
-  **once** and folds the results into every candidate's starting context —
-  covering the common case where every candidate would otherwise ask the
-  same read-only question (a schema listing, say) N times over. A tool that
-  requires input is never called this way; its arguments are never guessed.
+- Every candidate's engine can call that server's tools live, mid-turn, through the same already-connected session client, with no extra subprocess per candidate.
+- Before the fan-out starts, stella calls that server's zero-argument tools **once** and folds the results into every candidate's starting context. This covers the common case where every candidate would otherwise ask the same read-only question, such as a schema listing, over and over. A tool that needs input is never called this way, since its arguments are never guessed.
 
-Candidates always run non-interactively regardless: a fan-out of N
-candidates has no single owner for an interactive prompt.
+Candidates always run non-interactively regardless, since a fan-out of N candidates has no single owner who could answer an interactive prompt.

--- a/website/content/docs/agent-tools/permissions.mdx
+++ b/website/content/docs/agent-tools/permissions.mdx
@@ -3,37 +3,38 @@ title: Permissions
 description: How stella's per-tool permission model separates read-only tools from mutating tools, and how PreToolUse hooks can gate or block tool calls.
 ---
 
-Every tool the agent can call — built-in, [custom](/docs/agent-tools/custom-tools), or provided by an [MCP server](/docs/agent-tools/mcp) — has a per-tool permission model. This is what lets stella treat a harmless file read differently from a shell command that can change your system.
+Every tool the agent can call, whether it's built in, [custom](/docs/agent-tools/custom-tools), or provided by an [MCP server](/docs/agent-tools/mcp), has a per-tool permission model. This is what lets stella treat a harmless file read differently from a shell command that could change your system.
 
 <PermissionGateDiagram />
 
-Both exits are real outcomes: an allowed call executes and then fires `PostToolUse`, and a refused one is returned to the model as a refusal it can read and react to. The decision happens at the tool boundary — never by asking the model nicely in a prompt.
+Both outcomes here are real: an allowed call runs and then fires `PostToolUse`, and a refused call goes back to the model as a refusal it can read and react to. The decision happens at the tool boundary, never by asking the model nicely in a prompt.
 
 ## Read-only vs. mutating tools
 
-Tools fall into two categories:
+Tools fall into two groups.
 
-- **Read-only tools** only observe — the workspace, session state, the environment. They never change anything or perform side effects. These tools are marked `read_only: true`. The authoritative read-only set in the [built-in catalog](/docs/agent-tools) is `read_file`, `search`, `task_list`, `get_state`, `list_state`, and `get_environment`.
-- **Mutating tools** perform side effects. Among the built-ins that means running a shell command, writing or deleting a workspace file, changing the task board, writing scratch state, or dispatching a sub-agent — `bash`, `write_file`, `edit_file`, `delete_file`, `task_create`, `task_assign`, `delegate`, `save_state`, and `delete_state` are all examples. A custom or MCP tool can do the same or reach the network.
+**Read-only tools** only look, at the workspace, session state, or the environment. They never change anything or cause side effects. These tools are marked `read_only: true`. The full read-only set in the [built-in catalog](/docs/agent-tools) is `read_file`, `search`, `task_list`, `get_state`, `list_state`, and `get_environment`.
 
-The `read_only: true` marker is the signal that a tool is safe to run without changing anything. Tools without it should be treated as capable of side effects.
+**Mutating tools** cause side effects. Among the built-ins, that means running a shell command, writing or deleting a workspace file, changing the task board, writing scratch state, or handing work to a sub-agent. `bash`, `write_file`, `edit_file`, `delete_file`, `task_create`, `task_assign`, `delegate`, `save_state`, and `delete_state` are all examples. A custom or MCP tool can do the same, or reach out over the network.
 
-Only the [speculation-safe subset](/docs/agent-tools) of the read-only tools is eligible for speculative execution during the model stream — a schema declares that separately with `speculation_safe: true`, because a retried stream can run a speculated call twice, and "free to run twice" is a stronger claim than "mutates nothing".
+The `read_only: true` marker is the signal that a tool is safe to run without changing anything. Treat any tool without it as capable of side effects.
+
+Only the [speculation-safe subset](/docs/agent-tools) of the read-only tools can run speculatively during the model's stream. A schema declares that separately, with `speculation_safe: true`, because a retried stream can run a speculated call twice, and "safe to run twice" is a stronger claim than "changes nothing."
 
 <Callout type="info">
-Read-only vs. mutating is a property of the tool, not of a specific invocation. A friendly name can be a family whose members split across the boundary. In the file family, `read_file` is read-only while `write_file` / `edit_file` / `delete_file` are mutating; on the task board, `task_list` is read-only while the other five board tools and `delegate` are mutating; and in the scratch-state family `get_state` / `list_state` are read-only while `save_state` / `delete_state` are mutating.
+Read-only versus mutating is a property of the tool, not of one particular call. A tool family can split across that line. In the file family, `read_file` is read-only while `write_file`, `edit_file`, and `delete_file` are mutating. On the task board, `task_list` is read-only while the other five board tools and `delegate` are mutating. In the scratch-state family, `get_state` and `list_state` are read-only while `save_state` and `delete_state` are mutating.
 
-The two flags also come apart in the other direction. `search` is `read_only: true` but **not** speculation-safe: it changes no workspace file, yet its semantic rung writes embeddings through into `codegraph.db` while it ranks, so running it twice is not free.
+The two flags can also split from each other. `search` is `read_only: true` but **not** speculation-safe: it doesn't change any workspace file, but its semantic ranking step writes embeddings into `codegraph.db` as it works, so running it twice isn't free.
 </Callout>
 
-## Gating tool calls with hooks
+## Gating with hooks
 
-The permission model is enforced ahead of each tool call, and it can be extended with lifecycle hooks. In particular, a **`PreToolUse` hook** runs before a tool executes and can **block** it: if the hook exits with a non-zero status, the tool does not run and the model receives the hook's message instead.
+The permission model is enforced before every tool call, and you can extend it with lifecycle hooks. A **`PreToolUse` hook** runs before a tool executes and can **block** it: if the hook exits with a non-zero status, the tool doesn't run, and the model gets the hook's message instead.
 
-This gives you a programmable gate in front of any tool. A `PreToolUse` hook's matcher is a glob over the tool name, so you can target a single tool (for example, `task_assign`) or a family of tools (for example, `mcp__github__*`).
+This gives you a programmable gate in front of any tool. A `PreToolUse` hook's matcher is a glob over the tool name, so you can target one tool, such as `task_assign`, or a family of tools, such as `mcp__github__*`.
 
 <Callout type="info">
-For blocking by pattern without a hook script, stella also has native workspace-rule guards enforced at the tool boundary — `guard-tool` denies a tool by name, hard-enforced per invocation.
+If you want to block by pattern without writing a hook script, stella also has native workspace-rule guards enforced at the tool boundary. `guard-tool` denies a tool by name, enforced on every call.
 </Callout>
 
 ```json title="~/.stella/settings.json"
@@ -55,23 +56,23 @@ For blocking by pattern without a hook script, stella also has native workspace-
 }
 ```
 
-For the full hook model — events, matchers, timeouts, and the JSON payload delivered on stdin — see [Hooks](/docs/agent-tools/hooks).
+For the full hook model, including events, matchers, timeouts, and the JSON payload delivered on stdin, see [Hooks](/docs/agent-tools/hooks).
 
-## Containment: run stella in a container
+## Containment
 
-Hooks and guard rules decide *whether* a command runs. Containment bounds what it can reach once it does — the difference that matters when instructions hidden in a file the agent read steer the model into running something you never asked for.
+Hooks and guard rules decide *whether* a command runs. Containment limits what it can reach once it does run. That difference matters when instructions hidden in a file the agent read steer the model into running something you never asked for.
 
-**stella has no per-command sandbox.** A `STELLA_BASH_SANDBOX=workspace-write|restricted` setting existed in earlier versions, wrapping one spawn path in `sandbox-exec` (Seatbelt) on macOS or `bwrap` (bubblewrap) on Linux. It was removed, and the variable now does nothing.
+**stella does not sandbox individual commands.** Setting `STELLA_BASH_SANDBOX` has no effect, on any value or any platform. Nothing reads it.
 
 <Callout type="warn">
-If you set `STELLA_BASH_SANDBOX` in a shell profile, a CI job, or a service unit, it is inert — nothing reads it and nothing warns you. Remove it, and if you were relying on it for containment, replace it with a container.
+If `STELLA_BASH_SANDBOX` is set in a shell profile, a CI job, or a service unit, it's inert and prints no warning. Remove it. If you were counting on it for containment, replace it with a container instead, as described below.
 </Callout>
 
-The reason it went is that it covered one spawn path and nothing else while the others — custom script tools, MCP servers, and hooks all spawn processes of their own — ran unconfined, and the setting still said "sandbox: on". A boundary you can step around by starting a process a different way is not a boundary, and one that people believe in is worse than a clearly absent one.
+A setting that only covers one way of starting a process isn't a real boundary, because custom script tools, MCP servers, and hooks all start their own processes outside it. A boundary you can walk around by starting a process a different way isn't a boundary, and one that people believe in but can't rely on is worse than one that's clearly absent.
 
-Run the whole stella process inside a container instead — Docker, Podman, or a remote sandbox. The boundary then sits *outside* every spawn path rather than on one of them, so no tool can route around it, and it holds for file writes, network, and process execution alike.
+Run the whole stella process inside a container instead: Docker, Podman, or a remote sandbox. The boundary then sits *outside* every code path that spawns a process, so nothing can route around it, and it holds for file writes, network access, and running programs alike.
 
-No official CLI image ships today, so build one that puts `stella` on `PATH` (the [install script](/docs/getting-started/installation) works inside a `debian:bookworm-slim` stage), then mount only the repository you want the agent to touch:
+There's no official CLI image today, so build one that puts `stella` on `PATH` (the [install script](/docs/getting-started/installation) works inside a `debian:bookworm-slim` stage), then mount only the repository you want the agent to touch:
 
 ```bash
 docker run --rm -it \
@@ -81,6 +82,6 @@ docker run --rm -it \
   stella run "run the migration and fix what breaks"
 ```
 
-Everything outside `/work` is the container's own filesystem, which is discarded on exit — that is the guarantee `workspace-write` gestured at and could not enforce. For a stricter boundary, add `--network none`; be aware of what that costs, because it is the same cost `restricted` had: a session with no network cannot reach your model provider, fetch dependencies, or `git push`. It suits a task you can define offline, not a general session.
+Everything outside `/work` is the container's own filesystem, and it's thrown away when the container exits. That's the guarantee a per-command sandbox could never really give you. For a stricter boundary, add `--network none`. Know what that costs first: a session with no network can't reach your model provider, fetch dependencies, or run `git push`. It suits a task you can define fully offline, not a general session.
 
-Inside the container, whatever a custom tool, MCP server, or [hook](/docs/agent-tools/hooks) spawns runs with the container's privileges, and the `PreToolUse` policy chain still gates every tool call — the gate and the boundary are complementary, and neither substitutes for the other.
+Inside the container, anything a custom tool, MCP server, or [hook](/docs/agent-tools/hooks) starts runs with the container's own privileges, and the `PreToolUse` policy chain still gates every tool call. The gate and the container work together. Neither one replaces the other.

--- a/website/content/docs/agent-tools/skills.mdx
+++ b/website/content/docs/agent-tools/skills.mdx
@@ -1,15 +1,13 @@
 ---
 title: Agent Skills
-description: Reusable capabilities in SKILL.md files — project and user scopes, versioning, the public registry, and how skills reach the model through recall.
+description: Reusable capabilities in SKILL.md files. Covers project and user scopes, versioning, the public registry, and how skills reach the model through recall.
 ---
 
-A **skill** is a reusable capability described in Markdown — a checklist, a
-workflow, a house style — that stella injects when it's relevant and that you
-can invoke explicitly as a slash command.
+A **skill** is a reusable capability written in Markdown: a checklist, a workflow, a house style. Stella brings it in automatically when it's relevant, and you can also run it directly as a slash command.
 
 ## The format
 
-A `SKILL.md` with frontmatter and a Markdown body:
+A `SKILL.md` file with frontmatter and a Markdown body:
 
 ```md title=".stella/skills/release-checklist/SKILL.md"
 ---
@@ -23,25 +21,20 @@ domains: [build, ci]
 3. Tag `vX.Y.Z` and push — CI publishes.
 ```
 
-Both layouts are accepted: nested `<slug>/SKILL.md` (the ecosystem layout)
-or a flat `<slug>.md`. The frontmatter fields:
+Both layouts work: the nested layout (`<slug>/SKILL.md`) and the flat layout (`<slug>.md`). The frontmatter fields:
 
 <CardGrid size="md">
   <OptionCard name="name" defaultValue="the filename stem, or the directory name">
-    The skill's slug — also the ⚡ slash command it registers.
+    The skill's slug. This is also the ⚡ slash command it registers.
   </OptionCard>
   <OptionCard name="description" required>
-    One line on what the skill is for. Unlike a command or an agent, a skill
-    has **no fallback** here: a `SKILL.md` without a description is skipped
-    with a diagnostic, because the description is what selection matches
-    against.
+    One line on what the skill is for. Unlike a command or an agent, a skill has **no fallback** here. A `SKILL.md` without a description is skipped, with a diagnostic, because the description is what skill selection matches against.
   </OptionCard>
   <OptionCard name="domains" defaultValue="[]">
-    Domain tags from `.stella/domains.toml`, used by selection alongside the
-    lexical match.
+    Domain tags from `.stella/domains.toml`, used by skill selection alongside the text match.
   </OptionCard>
   <OptionCard name="body" required>
-    The know-how itself. An empty body is skipped with a diagnostic.
+    The know-how itself. An empty body is skipped, with a diagnostic.
   </OptionCard>
 </CardGrid>
 
@@ -55,7 +48,7 @@ or a flat `<slug>.md`. The frontmatter fields:
       { label: "Travels with", value: "the repo", mono: false },
     ]}
   >
-    Commit it and the team shares the playbook.
+    Commit it, and the team shares the playbook.
   </SpecCard>
   <SpecCard
     title="User"
@@ -68,27 +61,17 @@ or a flat `<slug>.md`. The frontmatter fields:
   </SpecCard>
 </CardGrid>
 
-When both scopes define the same name, **project wins** for recall; the
-SKILLS tab lists both.
+When both scopes define the same name, the project version wins for recall. The SKILLS tab lists both.
 
-## How skills reach the model
+## Reaching the model
 
-- **Automatic recall.** Each turn, skill selection (lexical + domain
-  matching against your prompt) picks the relevant skills and renders them
-  into the [recall block](/docs/context-engine) — no invocation needed.
-- **Explicit invocation.** Every skill is also a ⚡ slash command:
-  `/release-checklist ship 1.4` wraps the skill body as explicit
-  instructions above your task.
-- **Auto-promotion.** Lessons that keep recurring in the
-  [reflection log](/docs/context-engine) are promoted into new skills
-  automatically — your agent literally writes its own playbook over time.
+- **Automatic recall.** Each turn, skill selection (matching text and domains against your prompt) picks the relevant skills and adds them to the [recall block](/docs/context-engine). No need to invoke anything.
+- **Explicit invocation.** Every skill is also a ⚡ slash command. `/release-checklist ship 1.4` adds the skill body as explicit instructions above your task.
+- **Auto-promotion.** Lessons that keep showing up in the [reflection log](/docs/context-engine) get promoted into new skills automatically. Your agent writes its own playbook over time.
 
 ## Versions and pinning
 
-Every edit bumps a version: history lives under `<slug>/versions/vN/SKILL.md`,
-and a per-scope state sidecar tracks which version is **pinned** (active) and
-which skills are **disabled** (kept on disk, excluded from recall). Pin an
-older version to roll back without losing the newer one.
+Every edit creates a new version. History lives under `<slug>/versions/vN/SKILL.md`, and a per-scope file tracks which version is **pinned** (active) and which skills are **disabled** (kept on disk, left out of recall). Pin an older version to roll back, without losing the newer one.
 
 ```text
 <skills-dir>/<slug>/SKILL.md              ← the loaded definition
@@ -97,67 +80,51 @@ older version to roll back without losing the newer one.
 <skills-dir>/.stella-skills.json          ← { "disabled": [...], "pins": { "<slug>": 2 } }
 ```
 
-No pin entry means the latest version. The sidecar is dot-prefixed so the
-recall walk — which reads only `*.md` and `<slug>/SKILL.md` — never sees it.
+No pin entry means the latest version is active. This tracking file's name starts with a dot, so the recall process, which only reads `*.md` and `<slug>/SKILL.md`, never sees it.
 
-## The public registry
+## Public registry
 
-stella integrates with the community skills registry via `npx skills`:
+stella connects to the community skills registry through `npx skills`:
 
-- The SKILLS tab search — runs `npx skills find <query>`.
-- Installing from the registry pane — runs `npx skills add`, staging into a
-  private temp directory and adopting the produced `SKILL.md` into your
-  chosen scope. Installation **always requires your confirmation**.
+- The SKILLS tab's search runs `npx skills find <query>`.
+- Installing from the registry pane runs `npx skills add`, staging the result in a private temp folder, then adds the resulting `SKILL.md` into your chosen scope. Installing always asks you to confirm first.
 
-The underlying commands are overridable (`STELLA_SKILLS_SEARCH_CMD`,
-`STELLA_SKILLS_INSTALL_CMD`, `STELLA_SKILLS_USE_CMD`) for private registries.
+You can override the underlying commands (`STELLA_SKILLS_SEARCH_CMD`, `STELLA_SKILLS_INSTALL_CMD`, `STELLA_SKILLS_USE_CMD`) to point at a private registry.
 
-## Managing skills in the Command Deck
+## Managing skills
 
-`/skills` opens the SKILLS tab. Installed skills carry their own injection
-counts and token cost, so the ones that never fire are visible and can be
-pruned; the learned rows below them are the ones stella wrote from its own
-traces; and an unsigned registry result installs disabled.
+`/skills` opens the SKILLS tab. Installed skills show their own injection counts and token cost, so you can see the ones that never fire and prune them. Below those are the skills stella learned from its own traces, and an unsigned registry result installs disabled by default.
 
 <DeckShot id="skills" />
 
-The keys:
+Keys in this tab:
 
 <CardGrid size="sm">
   <OptionCard name="space">
-    Enable / disable the selected skill. A disabled skill stays on disk and
-    drops out of recall.
+    Enable or disable the selected skill. A disabled skill stays on disk and drops out of recall.
   </OptionCard>
   <OptionCard name="ctrl+o">
-    Preview the highlighted skill's body in a modal overlay — installed pane
-    and registry pane both.
+    Preview the highlighted skill's body in an overlay, in both the installed pane and the registry pane.
   </OptionCard>
   <OptionCard name="e">
-    Edit. Saving always writes a new version and pins it; no prior version is
-    modified or deleted.
+    Edit. Saving always writes a new version and pins it. No earlier version is changed or deleted.
   </OptionCard>
   <OptionCard name="p">
-    Pin a specific version — the rollback control. Pinning never creates a
-    version.
+    Pin a specific version. This is the rollback control. Pinning never creates a new version.
   </OptionCard>
   <OptionCard name="n">
-    Create a new skill, LLM-drafted from a description.
+    Create a new skill, drafted by the model from a description you give it.
   </OptionCard>
   <OptionCard name="ctrl+x ×2">
-    Uninstall — delete from disk. The first press arms it, the second commits.
+    Uninstall: delete from disk. The first press arms it, and the second one commits.
   </OptionCard>
   <OptionCard name="← / →">
-    Switch panes: installed ↔ registry search.
+    Switch panes: installed and registry search.
   </OptionCard>
 </CardGrid>
 
-`/context` shows which skills (and MCP servers) are active in the current
-session.
+`/context` shows which skills (and MCP servers) are active in the current session.
 
 <Callout type="info">
-  Skills are prompt-level guidance. For capabilities with hard boundaries —
-  new executable actions, blocked paths — reach for
-  [custom tools](/docs/agent-tools/custom-tools),
-  [hooks](/docs/agent-tools/hooks), or
-  [guard rules](/docs/agent-tools/permissions) instead.
+  Skills are prompt-level guidance. For capabilities with hard boundaries, like new executable actions or blocked paths, use [custom tools](/docs/agent-tools/custom-tools), [hooks](/docs/agent-tools/hooks), or [guard rules](/docs/agent-tools/permissions) instead.
 </Callout>

--- a/website/content/docs/agent-tools/skills.mdx
+++ b/website/content/docs/agent-tools/skills.mdx
@@ -3,7 +3,7 @@ title: Agent Skills
 description: Reusable capabilities in SKILL.md files. Covers project and user scopes, versioning, the public registry, and how skills reach the model through recall.
 ---
 
-A **skill** is a reusable capability written in Markdown: a checklist, a workflow, a house style. Stella brings it in automatically when it's relevant, and you can also run it directly as a slash command.
+A **skill** is a reusable capability written in Markdown: a checklist, a workflow, a house style. stella brings it in automatically when it's relevant, and you can also run it directly as a slash command.
 
 ## The format
 

--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -1,10 +1,11 @@
 ---
 title: API Providers
-description: Every provider stella speaks to — the matrix, the auto-detection order, the credential chain, and the per-provider differences that actually matter.
+description: Every provider stella speaks to — the matrix, the auto-detection order, the credential chain, and the differences that matter for each one.
 ---
 
-stella is BYOK and vendor-agnostic: no proxy in the middle, no markup, and each
-provider's native wire dialect spoken directly. Switching vendors is a `--model` flag.
+stella is BYOK (bring your own key) and works with any vendor. There's no proxy in the
+middle, no markup, and each provider's native wire dialect is spoken directly. Switching
+vendors is just a `--model` flag.
 
 <ProviderGrid />
 
@@ -17,8 +18,8 @@ stella --model deepseek/deepseek-chat    run "add a retry to the upload path"
 
 ## The matrix
 
-Detection rank is the order auto-detection tries providers in; the default model is what
-you get when you name none.
+Detection rank is the order auto-detection tries providers in. The default model is
+what you get when you name none.
 
 | # | Provider | Credential env var | Default model | Wire dialect |
 | --- | --- | --- | --- | --- |
@@ -35,8 +36,8 @@ you get when you name none.
 
 ## Catalog pricing
 
-List prices from the in-binary seed catalog, in USD per million tokens. `stella models
-refresh` re-syncs from [models.dev](https://models.dev).
+List prices come from the built-in seed catalog, in USD per million tokens. `stella
+models refresh` re-syncs them from [models.dev](https://models.dev).
 
 | Provider / model | Context | In | Out | Cached in |
 | --- | --- | --- | --- | --- |
@@ -59,52 +60,53 @@ The [model guide](/docs/api-providers/models) covers which model fits which seat
 ## Reasoning and effort support
 
 `reasoning` and `effort` are set per agent in
-[`agent_engine_config`](/docs/configuration/agent-engine-config). What reaches the wire
-differs by provider, and a parameter a provider cannot express is dropped rather than
-failed:
+[`agent_engine_config`](/docs/configuration/agent-engine-config). What actually reaches
+the wire differs by provider. If a provider can't express a parameter, stella drops it
+instead of failing the request:
 
 | Provider | `reasoning` | `effort` | Notes |
 | --- | --- | --- | --- |
-| `anthropic` | `thinking: {type: adaptive}` | `output_config.effort`, all five tiers 1:1 | Sampling params never sent on Claude 4.6+ and the 5-line |
+| `anthropic` | `thinking: {type: adaptive}` | `output_config.effort`, all five tiers 1:1 | Sampling params are never sent on Claude 4.6+ and the 5 family |
 | `openai` | `reasoning.effort` | `low`/`medium`/`high`; **`xhigh` and `max` collapse to `high`** | Also honours `verbosity` and `service_tier` |
-| `gemini` / `vertex` | `thinkingConfig.thinkingLevel` | `low`; **everything else maps to `high`** | `reasoning: "off"` gives the *minimum* level, not zero |
-| `zai` | `thinking: {type: enabled\|disabled}` | **dropped** | Differentiate a GLM verifier with `prompt`, not `effort` |
+| `gemini` / `vertex` | `thinkingConfig.thinkingLevel` | `low`; **everything else maps to `high`** | `reasoning: "off"` gives the minimum level, not zero |
+| `zai` | `thinking: {type: enabled\|disabled}` | **dropped** | To make a GLM verifier different, use `prompt`, not `effort` |
 | `xai` | `reasoning_effort` | `low`/`medium`/`high`; `xhigh`/`max` collapse | **Gated off entirely on `grok-4`** and its dated snapshots — not on the `grok-4.3` default |
-| `deepseek` | not sent | **dropped** | Shape it with `prompt` and `params.max_tokens` |
-| `openrouter` | `reasoning` object | all five tiers 1:1 | Gateway translates per routed vendor; an unadvertised tier is normalized, not rejected |
-| `bedrock` | legacy `budget_tokens` shape | **dropped** | Converse `inferenceConfig` has slots only for `max_tokens`, `temperature`, `top_p` |
-| `local` | not sent | **dropped** | No portable reasoning field exists across OpenAI-compatible servers |
+| `deepseek` | not sent | **dropped** | Shape it with `prompt` and `params.max_tokens` instead |
+| `openrouter` | `reasoning` object | all five tiers 1:1 | The gateway translates per routed vendor; an unadvertised tier is normalized, not rejected |
+| `bedrock` | legacy `budget_tokens` shape | **dropped** | Converse `inferenceConfig` only has slots for `max_tokens`, `temperature`, `top_p` |
+| `local` | not sent | **dropped** | No reasoning field works across every OpenAI-compatible server |
 
 <Callout type="warn">
-  Claude 4.6 and the 5-line answer any sampling parameter with an HTTP 400, so
-  `temperature`, `top_p`, and `top_k` are omitted unconditionally on `anthropic`.
-  Turning `reasoning` off does not buy temperature control back. Claude 4.5 and below
-  use the legacy `thinking: {type: enabled, budget_tokens: N}` shape and do accept
-  sampling; stella classifies by model id and sends whichever the generation requires.
+  Claude 4.6 and the 5 family answer any sampling parameter with an HTTP 400, so
+  `temperature`, `top_p`, and `top_k` are always left out on `anthropic`. Turning
+  `reasoning` off does not bring temperature control back. Claude 4.5 and earlier use the
+  `thinking: {type: enabled, budget_tokens: N}` shape and do accept sampling. stella
+  checks the model id and sends whichever shape that generation needs.
 </Callout>
 
 ## Auto-detection
 
 With no `--model` and no configured default, stella picks the first provider in the
-matrix above that has a resolvable credential.
+matrix above that has a usable credential.
 
 <Callout type="info">
-  Both ends of that rank order are arguments about what a credential *means*.
+  Both ends of that rank order come from what having a credential actually means.
 
-  OpenRouter sits first because `OPENROUTER_API_KEY` is gateway-specific — nobody has one
-  exported by accident — and it reaches every other vendor in the matrix. An instance
-  holding one has already decided how it wants to route, so stella gives it a whole
-  [default engine posture](#the-default-posture), not just a default model.
+  OpenRouter sits first because `OPENROUTER_API_KEY` is specific to that gateway. Nobody
+  has one exported by accident, and it reaches every other vendor in the matrix. An
+  instance holding one has already decided how it wants to route, so stella gives it a
+  whole [default engine posture](#the-default-posture), not just a default model.
 
-  Vertex and Bedrock sit last for the mirror-image reason: they key off generic cloud
+  Vertex and Bedrock sit last for the opposite reason: they key off generic cloud
   credentials (`VERTEX_ACCESS_TOKEN`, `AWS_ACCESS_KEY_ID`) that are often exported for
-  unrelated reasons. Generic cloud credentials must not hijack detection — pin them with
+  unrelated reasons. Generic cloud credentials shouldn't hijack detection — pin them with
   `--model vertex/…` or `--model bedrock/…`. The `local` pseudo-provider is never
   auto-detected.
 </Callout>
 
-A settings-configured `default_model` sits between the `--model` flag and auto-detection:
-an explicit flag wins, but a configured default beats "first provider with a key".
+A settings-configured `default_model` sits between the `--model` flag and
+auto-detection: an explicit flag wins, but a configured default beats "first provider
+with a key."
 
 ```json title="~/.stella/settings.json"
 {
@@ -146,7 +148,7 @@ Two `settings.json` fields reroute steps 2 and 3:
 <Callout type="warn">
   In a project's `.stella/settings.json`, the credential-routing fields — `base_url`,
   `api_key`, `api_key_env` — are ignored (with a stderr notice) unless
-  `STELLA_TRUST_PROJECT=1`: a cloned repo must not redirect where your key is sent. User
+  `STELLA_TRUST_PROJECT=1`. A cloned repo must not redirect where your key is sent. User
   scope always applies. See
   [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
   Prefer an env var or `credentials.toml` over `--api-key`, which is visible in shell
@@ -169,32 +171,33 @@ dialect does not change with it.
 `--base-url` (env form `STELLA_BASE_URL`) does the same for one run and outranks the
 settings value.
 
-## Per-provider deltas
+## Per-provider differences
 
 Everything above is shared. These are the differences worth knowing.
 
 ### Anthropic
 
-Prompt caching is first-class: stella meters both cache reads and cache writes, so
+Prompt caching works fully here: stella meters both cache reads and cache writes, so
 Observatory figures reflect the true bill. Cached input bills at $0.30/Mtok against a
-$3.00 list price — the 10× discount on the byte-stable prefix the
+$3.00 list price, a 10x discount on the stable prefix the
 [context engine](/docs/context-engine) maintains.
 
-The **cache window** is the one provider delta you may want to set. Anthropic holds a
+The **cache window** is the one setting here you may want to change. Anthropic holds a
 written prefix for 5 minutes by default and offers a 1-hour window per request. stella
-picks by surface: `stella chat` and `stella resume` ask for the hour, every headless run
-keeps the 5-minute default. The reason is arithmetic — a 1-hour write bills 2× input
-against the short window's 1.25×, and that premium only earns its keep when turns are far
-enough apart to lose the prefix. An eviction is the expensive event: it re-bills the whole
-prefix at the write rate *and* forfeits the 10× read discount on it. Interactive turns sit
-minutes apart, so the wider window is close to free insurance; a headless run's calls are
-seconds apart and would pay the premium for a prefix that was never going to expire.
-Override either default with
+picks based on the surface: `stella chat` and `stella resume` ask for the hour, every
+headless run keeps the 5-minute default. The reason is cost — a 1-hour write bills at
+2x the input rate against the short window's 1.25x, and that premium only pays off when
+turns are far enough apart to lose the prefix. An eviction is the expensive event: it
+re-bills the whole prefix at the write rate *and* loses the 10x read discount on it.
+Interactive turns sit minutes apart, so the wider window is close to free insurance; a
+headless run's calls are seconds apart and would pay the premium for a prefix that was
+never going to expire. Override either default with
 [`providers.anthropic.cache_ttl`](/docs/configuration/settings) (`"5m"` or `"1h"`).
 
 `params.max_tokens` defaults to **32000 with thinking on, 4096 with it off**. Adaptive
-thinking spends from the same output allowance as the answer, so a max-effort verifier would
-otherwise truncate mid-verdict. A value you set is honoured as-is.
+thinking spends from the same output allowance as the answer, so without this, a
+max-effort verifier could get cut off mid-verdict. A value you set is used exactly as
+given.
 
 ### OpenAI
 
@@ -205,15 +208,15 @@ Two parameters only this provider puts on the wire:
 | `verbosity` | `text.verbosity` | `low`, `medium`, `high` |
 | `service_tier` | `service_tier` | `auto`, `default`, `flex`, `priority` |
 
-Every other adapter drops both silently, so they are only worth setting on an
+Every other adapter drops both silently, so they're only worth setting on an
 OpenAI-routed agent. The built-in `openai` dialect is fixed to OpenAI Responses, so a
-custom `base_url` must speak it (Azure's `/openai/v1` surface does). For a gateway that
-only speaks legacy chat completions, define a custom provider id instead.
+custom `base_url` must speak it too (Azure's `/openai/v1` surface does). For a gateway
+that only speaks the older chat completions format, define a custom provider id instead.
 
 ### Google Gemini
 
-The 1M-token window is the reason to reach for it — whole-repo comprehension, long-log
-analysis, giant-diff review. Give it something that needs one:
+The 1M-token window is the reason to reach for it: whole-repo comprehension, long-log
+analysis, giant-diff review. Give it a task that needs that much room:
 
 ```bash
 stella --model gemini/gemini-3-pro run \
@@ -222,8 +225,9 @@ stella --model gemini/gemini-3-pro run \
 
 ### Google Vertex AI
 
-Same models, same dialect as Gemini; the difference is governance — inference runs inside
-your GCP project, billed to your account, under your IAM and data-residency controls.
+Same models, same dialect as Gemini. The difference is governance: inference runs
+inside your GCP project, billed to your account, under your own IAM and
+data-residency controls.
 
 ```bash
 export VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)
@@ -251,45 +255,45 @@ export AWS_REGION=us-east-1         # or AWS_DEFAULT_REGION; default us-east-1
 ```
 
 <Callout type="warn">
-  stella reads **only these environment variables** — it does not walk the AWS credential
-  chain. `AWS_PROFILE`, `~/.aws/credentials`, SSO caches, and IMDS/instance roles are
-  never consulted. On a profile or SSO setup, materialize env vars first:
+  stella reads **only these environment variables** — it does not walk the AWS
+  credential chain. `AWS_PROFILE`, `~/.aws/credentials`, SSO caches, and IMDS/instance
+  roles are never checked. On a profile or SSO setup, turn those into env vars first:
   `eval "$(aws configure export-credentials --profile dev --format env)"`.
 </Callout>
 
 The default model is a cross-region inference profile, not a bare model id: Bedrock
-rejects on-demand invocation of newer Anthropic models without one. The real host is
+rejects on-demand calls to newer Anthropic models without one. The real host is
 region-scoped (`bedrock-runtime.<AWS_REGION>.amazonaws.com`) and built per request.
 
 ### xAI
 
 The seeded default is `grok-4.3`: xAI's flagship on its published model list, with the
-largest context of the current line and its lowest price. `grok-4` retired on
-2026-08-15 and was the default until then.
+largest context in the current lineup and its lowest price.
 
 `grok-4.3` prices in two tiers — the catalog carries the below-200k-input figures, so a
-turn that crosses that boundary is costed low rather than high. `grok-4.6` is the newer
-frontier model for coding and agentic work at roughly 1.6x input and 2.4x output; pin it
-under `providers.xai.default_model` if that trade is worth it to you.
+turn that crosses that boundary is costed low rather than high. `grok-4.6` is a newer
+model for coding and agentic work, at roughly 1.6x the input price and 2.4x the output
+price; pin it under `providers.xai.default_model` if that trade is worth it to you.
 
 <Callout type="warn">
   A `providers.xai.default_model` pinned to `grok-4` still resolves — the catalog keeps
-  the row so an existing config does not hard-error — but the model is retired at the
-  vendor and its seeded prices are stale. It is also the one xAI model stella never
-  sends `effort` to, because it answers the parameter with a 400. Repin it.
+  the row so an existing config does not hard-error — but that model isn't served by
+  the vendor, and its seeded prices are stale. It is also the one xAI model stella never
+  sends `effort` to, because it answers the parameter with a 400. Repin it to a current
+  model.
 </Callout>
 
 ### DeepSeek
 
-The catalog's price floor among hosted models, and the natural triage model for any
-lineup. `deepseek-chat` is the non-thinking model; `deepseek-reasoner` is the reasoning
-one.
+The lowest price in the catalog among hosted models, and a natural choice for triage in
+any lineup. `deepseek-chat` is the non-thinking model; `deepseek-reasoner` is the
+reasoning one.
 
 ### Z.ai
 
 A GLM **coding plan** puts your quota on a dedicated endpoint —
 `https://api.z.ai/api/coding/paas/v4` instead of the pay-per-token
-`https://api.z.ai/api/paas/v4`. Same key, same models, flat subscription instead of a
+`https://api.z.ai/api/paas/v4`. Same key, same models, a flat subscription instead of a
 meter.
 
 ```bash
@@ -298,7 +302,7 @@ export ZAI_GLM_CODING_PLAN=1
 stella config    # Base URL must read https://api.z.ai/api/coding/paas/v4
 ```
 
-Or, durably, in **user scope**:
+Or set it permanently in **user scope**:
 
 ```json title="~/.stella/settings.json"
 {
@@ -311,28 +315,28 @@ Or, durably, in **user scope**:
 <Callout type="warn">
   Endpoint precedence, highest first: `--base-url` / `STELLA_BASE_URL` >
   `ZAI_GLM_CODING_PLAN=1` > `settings.json` `base_url` > the built-in default. A stray
-  `STELLA_BASE_URL` routes you **off** the plan without a word, and a leftover
+  `STELLA_BASE_URL` routes you off the plan without warning, and a leftover
   `ZAI_GLM_CODING_PLAN=1` overrides the settings file. Don't set both. In a project's
   `.stella/settings.json`, `base_url` needs `STELLA_TRUST_PROJECT=1` — a subscription is
-  personal, so put it in user scope.
+  personal, so put it in user scope instead.
 </Callout>
 
-On a coding plan the `$` figures in `stella stats` are notional — stella prices tokens at
-catalog list rates, and you pay the flat subscription. Token counts, step counts, and
+On a coding plan the `$` figures in `stella stats` are notional — stella prices tokens
+at catalog list rates, but you pay the flat subscription. Token counts, step counts, and
 cross-model $/resolved comparisons stay meaningful; absolute dollars for `zai/*` do not.
-`--spend-limit` caps meter against those notional prices too.
+`--spend-limit` also caps against those notional prices.
 
 ### OpenRouter
 
-One key, every vendor. Gateway slugs are `vendor/model` and pass through **unseeded** —
-any slug the gateway serves works verbatim, and a typo fails with OpenRouter's own
-400/404 rather than a stella error. The default model is `moonshotai/kimi-k3`.
+One key, every vendor. Gateway slugs are `vendor/model` and pass through unseeded: any
+slug the gateway serves works exactly as written, and a typo fails with OpenRouter's own
+400/404 error instead of a stella error. The default model is `moonshotai/kimi-k3`.
 
 #### The default posture
 
-One key reaches every vendor, so on OpenRouter the interesting question is not *which
-model* but **which model per role** — and the roles want genuinely different things. With
-no configuration at all, an OpenRouter instance runs:
+One key reaches every vendor, so on OpenRouter the interesting question isn't which
+model, but which model for which role, since each role wants genuinely different things.
+With no configuration at all, an OpenRouter instance runs:
 
 | Role | Model | Why |
 | --- | --- | --- |
@@ -340,56 +344,58 @@ no configuration at all, an OpenRouter instance runs:
 | verifier | `anthropic/claude-opus-5` | a different vendor's strongest reasoner — not the worker grading itself |
 | triage | `z-ai/glm-5.2` | fast and cheap, and it runs on every turn |
 
-Note the verifier is a different **family** from the driver. stella already
-treats cross-family judging as the goal (see `auto_mode`); this default just reaches it
-without asking you to configure anything.
+Note the verifier is a different family from the driver. stella already treats
+cross-family judging as the goal (see `auto_mode`) — this default just does that without
+asking you to configure anything.
 
-This is a *baseline*, not a lock. It composes underneath the whole
+This is a starting point, not a lock. It sits underneath the whole
 [`agent_engine_config`](/docs/configuration/agent-engine-config) scope chain, so any
 field you set is yours — set `default_model` and the session model is whatever you said,
-while the rest of the posture stays. It also applies only when OpenRouter is the provider
-that actually got picked: run `--model anthropic/…` with an OpenRouter key present and you
-have an Anthropic session, with no part of this routed through the gateway.
+while the rest of the posture stays. It also applies only when OpenRouter is the
+provider that actually got picked: run `--model anthropic/…` with an OpenRouter key
+present and you get an Anthropic session, with no part of this routed through the
+gateway.
 
 <Callout type="info">
-  The default used to be `openrouter/auto`, the gateway's own meta-router. A router that
-  picks a different backing model per request is the one thing a coding agent cannot
-  absorb: prompt-cache prefixes stop hitting between turns, tool-call dialect drifts
-  mid-session, and no two turns are comparable when something breaks. `openrouter/auto`
-  still works if you pin it — it is simply no longer the default.
+  A router that picks a different backing model per request is the one thing a coding
+  agent can't handle well: prompt-cache prefixes stop hitting between turns, tool-call
+  dialect drifts mid-session, and no two turns are comparable when something breaks.
+  That's why the default here is a fixed model rather than the gateway's own
+  meta-router, `openrouter/auto`. It still works if you pin it directly.
 </Callout>
 
 #### Pinning the upstream
 
-A gateway is a router, not a vendor: OpenRouter picks the upstream that actually serves a
-request per **app identity**, and it is free to choose a different one between two calls to
-the same slug — a probe carrying stella's own attribution once asked for
-`anthropic/claude-sonnet-5` and was served by `provider: Amazon Bedrock`. That is invisible
-in the ordinary case — you asked for a model family, and you got it — but it means the
-model *provider* behind an OpenRouter-routed run is not something a bare `--model` pins.
+A gateway is a router, not a vendor: OpenRouter picks the upstream that actually serves
+a request based on **app identity**, and it is free to choose a different one between
+two calls to the same slug. In one test, a probe carrying stella's own attribution
+asked for `anthropic/claude-sonnet-5` and was served by `provider: Amazon Bedrock`.
+This is invisible in the ordinary case: you asked for a model family, and you got it.
+But it means the model *provider* behind an OpenRouter-routed run is not something a
+bare `--model` pins.
 
-`--upstream-pin <vendor>` (env `STELLA_UPSTREAM_PIN`, repeatable or comma-separated) fixes
-it: the request carries `provider: {order: [...], allow_fallbacks: false}`, so OpenRouter
-either serves it from the named vendor, in the order given, or the call fails rather than
-silently routing elsewhere.
+`--upstream-pin <vendor>` (env `STELLA_UPSTREAM_PIN`, repeatable or comma-separated)
+fixes it: the request carries `provider: {order: [...], allow_fallbacks: false}`, so
+OpenRouter either serves it from the named vendor, in the order given, or the call fails
+rather than silently routing elsewhere.
 
 ```bash
 stella run "…" --model openrouter/anthropic/claude-fable-5 \
   --upstream-pin z-ai --upstream-pin anthropic
 ```
 
-Reach for it whenever two runs need to be the *same experiment* — a before/after
-comparison, a head-to-head against another agent, anything where "which vendor actually
-answered" is part of what you are claiming stayed fixed. See the
+Use this whenever two runs need to be the same experiment — a before/after comparison,
+a head-to-head against another agent, or anything where "which vendor actually answered"
+needs to stay fixed. See the
 [terminal-bench head-to-head guide](/docs/guides/terminal-bench-head-to-head#pin-the-upstream-when-either-arm-goes-through-a-gateway)
-for the case that motivated it. Inert on every provider that is not a gateway — a direct
+for an example. This does nothing on any provider that is not a gateway — a direct
 `anthropic/…` or `openai/…` session has no routing step to pin.
 
 <Callout type="info">
 `--upstream-pin` is a flag, not a `settings.json` field, on purpose: a benchmark harness
-runs with settings isolation (`STELLA_NO_SETTINGS`), so a settings-defined pin would never
-reach a measured trial. An argument is the only authority that survives that isolation —
-the same reason `--base-url` is one.
+runs with settings isolation (`STELLA_NO_SETTINGS`), so a settings-defined pin would
+never reach a measured trial. A command-line argument is the only thing that survives
+that isolation — the same reason `--base-url` is a flag.
 </Callout>
 
 #### Selecting models
@@ -402,13 +408,14 @@ stella --model openrouter/openrouter/auto          run "let the gateway pick per
 ```
 
 <Callout type="warn">
-  The doubled prefix on the `openrouter/openrouter/auto` line is correct. `--model` splits on the **first** `/`:
-  everything before is the provider id, everything after is the wire slug sent verbatim.
-  Every OpenRouter model id is `vendor/model`, and the meta-router's own id is
-  `openrouter/auto` — so the full spec is `openrouter` + `/` + `openrouter/auto`. Write
-  `--model openrouter/auto` and the wire slug becomes a bare `auto`, which OpenRouter
-  does not serve; stella warns on stderr that it is missing the vendor namespace, but the
-  warning is advisory and the run still fails at the gateway.
+  The doubled prefix on the `openrouter/openrouter/auto` line is correct. `--model`
+  splits on the **first** `/`: everything before is the provider id, everything after is
+  the wire slug sent exactly as written. Every OpenRouter model id is `vendor/model`,
+  and the meta-router's own id is `openrouter/auto` — so the full spec is `openrouter` +
+  `/` + `openrouter/auto`. Write `--model openrouter/auto` instead, and the wire slug
+  becomes a bare `auto`, which OpenRouter does not serve; stella warns on stderr that it
+  is missing the vendor namespace, but the warning is informational only, and the run
+  still fails at the gateway.
 </Callout>
 
 Two routing forms:
@@ -418,40 +425,40 @@ Two routing forms:
 | Flat `model` field | `openrouter/<vendor>/<slug>` | `<vendor>/<slug>` |
 | Per-agent pin | `provider: openrouter` · `model: <vendor>/<slug>` | `<vendor>/<slug>` |
 
-With `provider` set, `model` goes to that provider verbatim with no splitting — which is
-what lets an OpenRouter slug contain a `/` of its own.
+With `provider` set, `model` goes to that provider exactly as written, with no
+splitting — which is what lets an OpenRouter slug contain a `/` of its own.
 
 Verifier-diversity logic does not treat "openrouter" as one family: an OpenRouter spec's
 family is the routed slug's **vendor prefix**, so `openrouter/openai/gpt-5.5` counts as
-OpenAI and cross-family preference works through the gateway.
+OpenAI, and cross-family preference works through the gateway too.
 
 <Callout type="info">
   **Cost telemetry comes from the gateway, not the catalog.** Gateway slugs are unseeded,
   so there is no local list price. stella requests OpenRouter's usage accounting on every
-  call — and sends app-attribution headers — and takes the gateway's reported per-call
-  cost as authoritative. If a call's final usage frame carries no cost, that call falls
-  back to `$0`; treat the OpenRouter dashboard as the reconciliation source of record.
-  You also add a hop: traffic goes through OpenRouter's servers rather than to each
+  call, sends app-attribution headers, and treats the gateway's reported per-call cost as
+  the source of truth. If a call's final usage frame carries no cost, that call falls
+  back to `$0`; treat the OpenRouter dashboard as the record to reconcile against. You
+  also add a hop this way: traffic goes through OpenRouter's servers rather than to each
   vendor directly.
 </Callout>
 
 ### Local servers
 
-Any OpenAI-compatible endpoint you run yourself — Ollama, vLLM, LM Studio, llama.cpp.
-Never auto-detected; `--base-url` (or `STELLA_BASE_URL`) is required every time.
+Any OpenAI-compatible endpoint you run yourself: Ollama, vLLM, LM Studio, llama.cpp.
+Never auto-detected — `--base-url` (or `STELLA_BASE_URL`) is required every time.
 
 ```bash
 stella --model local/llama3.3      --base-url http://localhost:11434/v1 chat  # Ollama
 stella --model local/qwen2.5-coder --base-url http://localhost:8000/v1 run "…"  # vLLM
 ```
 
-A bearer token is always sent — the placeholder `local` when `LOCAL_API_KEY` is unset —
-so key-checking servers fail loudly rather than mysteriously. Local slugs are exempt from
-catalog validation: any model name your server knows is accepted.
+A bearer token is always sent (the placeholder `local` when `LOCAL_API_KEY` is unset),
+so key-checking servers fail loudly instead of mysteriously. Local slugs skip catalog
+validation: any model name your server knows is accepted.
 
 The id `local` is **reserved** and cannot be redefined in `settings.json`, which is why
-`--base-url` is always required with it. To bake an endpoint into config, define your own
-provider under a non-reserved id:
+`--base-url` is always required with it. To bake an endpoint into config instead, define
+your own provider under a non-reserved id:
 
 ```json title="~/.stella/settings.json"
 {
@@ -465,8 +472,6 @@ provider under a non-reserved id:
 }
 ```
 
-Three details:
-
 - `dialect` defaults to `openai-compatible`. `anthropic`, `gemini`, and
   `openai-responses` are also available; `vertex` and `bedrock` are **rejected** for
   custom ids, because those dialects need credential resolution a settings entry cannot
@@ -474,7 +479,7 @@ Three details:
 - A config-defined provider reads its key from a derived env var: the id uppercased with
   anything outside `[A-Za-z0-9]` folded to `_`, plus `_API_KEY` (`my-gateway` reads
   `MY_GATEWAY_API_KEY`). `api_key_env` names a different one.
-- It **auto-detects** — after every built-in — only when it has a `default_model`.
+- It **auto-detects** (after every built-in) only when it has a `default_model`.
 
 Local models have no catalog prices, so `stella stats` dollar columns read zero. Tokens,
 steps, and resolve-rate comparisons still work; `--spend-limit` has nothing to meter against.

--- a/website/content/docs/api-providers/models.mdx
+++ b/website/content/docs/api-providers/models.mdx
@@ -1,20 +1,20 @@
 ---
 title: Model guide
-description: The master model catalog — context windows, list prices per million tokens, release timing, and which model to use for which seat.
+description: The full model catalog — context windows, list prices per million tokens, release timing, and which model fits which seat.
 ---
 
-This is the master list. Every model stella seeds into its catalog, with the numbers you
-need to make a decision — context window, list price, and what the model is actually good
-at. The pricing figures come from **stella's seed catalog**; prices are list
+This is the full list of every model stella seeds into its catalog, with the numbers
+you need to decide: context window, list price, and what the model is good at. The
+pricing figures come from **stella's seed catalog**; prices are list
 **$/Mtok** (input / output / cached-input). The **Released** and **Best for** columns are
-editorial — context these docs add, not fields the catalog stores or syncs. Verify with
-your provider before budgeting — prices and lineups drift.
+added by these docs for context — the catalog itself doesn't store or sync them. Verify
+with your provider before budgeting, since prices and lineups change.
 
 <Callout type="info">
-  The seed below is only the offline floor. `stella models refresh` syncs the **live
-  master list** — every valid provider/model slug and its current pricing, from the
-  public [models.dev](https://models.dev) catalog (no API key) — into a local model-card
-  database, and `stella models list` browses it. See
+  The seed table below is only the offline starting point. `stella models refresh` syncs
+  the **live master list** — every valid provider/model slug and its current pricing,
+  from the public [models.dev](https://models.dev) catalog (no API key needed) — into a
+  local model-card database, and `stella models list` browses it. See
   [the live model catalog](#the-live-model-catalog-stella-models-refresh) below.
 </Callout>
 
@@ -22,37 +22,37 @@ your provider before budgeting — prices and lineups drift.
 
 | Model | Provider | Context | In $/Mtok | Out $/Mtok | Cached-in $/Mtok | Released | Best for |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| <ProviderMark id="anthropic" /> `claude-fable-5` | `anthropic` | 1M | 10.00 | 50.00 | 1.00 | 2026 | The strongest coding/agentic model in the catalog, and the most expensive — first of the Claude 5 family. Best-in-class worker for hard multi-file changes; superb verifier. |
-| <ProviderMark id="anthropic" /> `claude-opus-5` | `anthropic` | 1M | 5.00 | 25.00 | 0.50 | 2026 | Half Fable's list price with the same 1M window. The Claude 5 tier to reach for when Fable's worker quality is more than the task needs. |
-| <ProviderMark id="anthropic" /> `claude-sonnet-5` | `anthropic` | 1M | 3.00 | 15.00 | 0.30 | 2026 | Sonnet pricing with a 1M window. A strong default worker where the budget rules out the tiers above. |
-| <ProviderMark id="openai" /> `gpt-5.5` | `openai` | 400k | 1.25 | 10.00 | 0.125 | late 2025 | Top-tier reasoning with a 400k window at a mid price. Excellent cross-family verifier over a Claude or GLM worker; strong worker. |
+| <ProviderMark id="anthropic" /> `claude-fable-5` | `anthropic` | 1M | 10.00 | 50.00 | 1.00 | 2026 | The strongest coding and agentic model in the catalog, and the most expensive — first of the Claude 5 family. A top-tier worker for hard multi-file changes, and a strong verifier. |
+| <ProviderMark id="anthropic" /> `claude-opus-5` | `anthropic` | 1M | 5.00 | 25.00 | 0.50 | 2026 | Half of Fable's list price, with the same 1M window. Reach for this tier when Fable's worker quality is more than the task needs. |
+| <ProviderMark id="anthropic" /> `claude-sonnet-5` | `anthropic` | 1M | 3.00 | 15.00 | 0.30 | 2026 | Sonnet pricing with a 1M window. A strong default worker when the budget rules out the tiers above. |
+| <ProviderMark id="openai" /> `gpt-5.5` | `openai` | 400k | 1.25 | 10.00 | 0.125 | late 2025 | Top-tier reasoning with a 400k window at a mid price. An excellent cross-family verifier over a Claude or GLM worker, and a strong worker on its own. |
 | <ProviderMark id="gemini" /> `gemini-3-pro` | `gemini` (also `vertex`) | 1M | 1.25 | 10.00 | 0.31 | Q4 2025 | The 1M-token window: whole-repo comprehension, long-log analysis. Solid worker, good verifier. |
-| <ProviderMark id="xai" /> `grok-4.3` | `xai` | 1M | 1.25 | 2.50 | 0.20 | 2026 | Strong reasoning at a low price, with a 1M window; a distinct model family, useful as an alternate verifier. Prices above are the below-200k-input tier — double them past it. |
-| <ProviderMark id="deepseek" /> `deepseek-chat` | `deepseek` | 128k | 0.27 | 1.10 | 0.07 | Q4 2024 (V3 line, revised through 2025) | The price/performance outlier. Ideal triage model; a very capable budget worker. |
-| <ProviderMark id="zai" /> `glm-5.2` | `zai` | 200k | 0.60 | 2.20 | 0.11 | 2026 | Excellent coding at a fraction of flagship price — stella's default worker tier. The coding-plan endpoint makes it a subscription workhorse. |
-| <ProviderMark id="bedrock" /> `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `bedrock` | 200k | 3.00 | 15.00 | 0.30 | Sep 2025 | Claude under AWS governance — for orgs that must keep inference inside their cloud account. |
-| <ProviderMark id="openrouter" /> `moonshotai/kimi-k3` | `openrouter` | 1M | 3.00 | 15.00 | 0.30 | 2026 | Long-context agentic driver, and the OpenRouter default — a 1M window that holds a whole repo while it works. Runs at `xhigh` effort with thinking on. |
-| <ProviderMark id="openrouter" /> `openrouter/auto` | `openrouter` | 128k | gateway-priced | gateway-priced | — | rolling | OpenRouter's meta-router; and any `vendor/model` slug on the gateway routes verbatim (one key, every vendor). |
+| <ProviderMark id="xai" /> `grok-4.3` | `xai` | 1M | 1.25 | 2.50 | 0.20 | 2026 | Strong reasoning at a low price, with a 1M window. A different model family, useful as an alternate verifier. Prices above are the below-200k-input tier — double them past it. |
+| <ProviderMark id="deepseek" /> `deepseek-chat` | `deepseek` | 128k | 0.27 | 1.10 | 0.07 | Q4 2024 (V3 line, revised through 2025) | The best value in the catalog. An ideal triage model, and a very capable budget worker. |
+| <ProviderMark id="zai" /> `glm-5.2` | `zai` | 200k | 0.60 | 2.20 | 0.11 | 2026 | Excellent coding at a fraction of flagship price — stella's default worker tier. The coding-plan endpoint makes it a strong subscription option. |
+| <ProviderMark id="bedrock" /> `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | `bedrock` | 200k | 3.00 | 15.00 | 0.30 | Sep 2025 | Claude under AWS governance, for orgs that must keep inference inside their cloud account. |
+| <ProviderMark id="openrouter" /> `moonshotai/kimi-k3` | `openrouter` | 1M | 3.00 | 15.00 | 0.30 | 2026 | A long-context agentic driver, and the OpenRouter default — a 1M window that holds a whole repo while it works. Runs at `xhigh` effort with thinking on. |
+| <ProviderMark id="openrouter" /> `openrouter/auto` | `openrouter` | 128k | gateway-priced | gateway-priced | — | rolling | OpenRouter's meta-router. Any `vendor/model` slug on the gateway routes exactly as written — one key, every vendor. |
 
-## Which model for which role
+## Model by role
 
-A run distributes across distinct roles, and they want different things from a
-model:
+A run distributes work across separate roles, and each one wants different things
+from a model:
 
-- **Worker** — writes the code. It wants the strongest coding model you can afford; this
-  is where quality is bought. Worker tokens dominate a run, but most of them are
-  cached-input tokens (see below), so the effective price gap between tiers is smaller
-  than the list price suggests.
-- **Verifier** — verifies the work at high effort. It wants a **different family** than the
-  worker: cross-family judging resists same-model bias, where a model forgives the
-  mistakes it would itself have made. A Claude worker with a GPT verifier (or vice versa)
-  catches more than either family judging itself. This is
+- **Worker.** Writes the code. It wants the strongest coding model you can afford —
+  this is where quality is worth paying for. Worker tokens dominate a run, but most of
+  them are cached-input tokens (see below), so the real price gap between tiers is
+  smaller than the list price suggests.
+- **Verifier.** Checks the work at high effort. It wants a **different family** than
+  the worker: cross-family judging avoids same-model bias, where a model forgives the
+  mistakes it would have made itself. A Claude worker with a GPT verifier (or the other
+  way around) catches more than either family judging its own work. This is
   [goal mode](/docs/agent-modes#outcome-driven-goal-mode)'s standing verifier.
 
-An installed [wrapper plugin](/docs/plugins) may staff further roles of its own;
-what it runs and how it routes them is its manifest's business, not stella's.
+An installed [wrapper plugin](/docs/plugins) can add further roles of its own. What it
+runs, and how it routes them, is up to its manifest, not stella's.
 
-Three named lineups, ready to copy:
+Ready-made lineups you can copy:
 
 | Lineup | Worker | Verifier | Triage |
 | --- | --- | --- | --- |
@@ -60,68 +60,68 @@ Three named lineups, ready to copy:
 | [Balanced](/docs/examples#balanced) | `glm-5.2` | `claude-fable-5` or `gpt-5.5` | `deepseek-chat` |
 | [Dirt cheap](/docs/examples#dirt-cheap) | `deepseek-chat` | `glm-5.2` | `deepseek-chat` |
 
-Each links to a worked `settings.json` profile in [Examples](/docs/examples); wire any of
-them up per agent with
+Each one links to a worked `settings.json` profile in [Examples](/docs/examples). Wire
+any of them up per agent with
 [`agent_engine_config`](/docs/configuration/agent-engine-config).
 
 ## The live model catalog (`stella models refresh`)
 
-The seed table above can't keep up with weekly model launches — and it used to mean an
-invalid slug was only caught for seeded providers (OpenRouter and custom gateways
-accepted anything and failed later, mid-run, on the wire). The live catalog fixes both:
+The seed table above can't keep up with weekly model launches. Without a refresh, an
+invalid slug is only caught for seeded providers — OpenRouter and custom gateways
+accept anything and only fail later, mid-run, on the wire. The live catalog fixes both:
 
 ```bash
 stella models refresh                      # sync the master list (models.dev, no API key)
 stella models list --provider anthropic    # browse valid slugs + live pricing
 ```
 
-- **Master list, locally.** One public, unauthenticated document covering every provider
-  stella can select (plus ~160 more) lands in a user-tier SQLite catalog
-  (`catalog.db`, next to `usage.db`): **model cards** keyed per API provider, and
-  **model card versions** holding each pricing configuration. A refresh appends a new
-  version only when pricing actually changed — the version history is real change
+- **Master list, locally.** One public document, needing no login, covers every
+  provider stella can select (plus about 160 more). It lands in a user-tier SQLite
+  catalog (`catalog.db`, next to `usage.db`): **model cards** keyed per API provider,
+  and **model card versions** holding each pricing configuration. A refresh adds a new
+  version only when pricing actually changed, so the version history is a real change
   history, and **the latest version is the pricing that displays everywhere** (cost
   metering, `stella models list`, the deck's model picker). On top of that master list,
-  `refresh` then overlays each configured provider's own live `/models` listing
+  `refresh` also overlays each configured provider's own live `/models` listing
   (OpenRouter, Anthropic, Gemini, and any OpenAI-compatible endpoint), so newly-shipped
   slugs and per-model pricing/capability come straight from the serving provider — this
   overlay resolves through each provider's configured credential (only the models.dev
-  master list is keyless).
-- **Incremental.** The HTTP `ETag` is persisted and replayed; an unchanged list is one
-  conditional request, zero writes. A stale list (>24h) re-syncs automatically at startup,
-  and `STELLA_CATALOG_AUTO_REFRESH=0` turns the re-sync off — though *when* automatic
-  syncing may first fire differs by source (see below).
-- **Strict slug validation, everywhere.** Once a provider's master-list rows are synced,
-  an invalid `--model` slug is a hard, immediate, named error with did-you-mean
+  master list needs no key).
+- **Incremental.** The HTTP `ETag` is saved and reused, so an unchanged list is one
+  conditional request and zero writes. A stale list (older than 24 hours) re-syncs
+  automatically at startup, and `STELLA_CATALOG_AUTO_REFRESH=0` turns that re-sync off —
+  though *when* automatic syncing can first fire differs by source (see below).
+- **Strict slug validation, everywhere.** Once a provider's master-list rows are
+  synced, an invalid `--model` slug shows a clear, immediate error with did-you-mean
   suggestions — before any wire call, for **every** provider including OpenRouter and
-  settings.json-defined gateways. The seed always passes, and a custom endpoint the
-  master list doesn't know stays endpoint-authoritative, exactly as before.
-- **Exact telemetry.** A **model_aliases** table joins every string form a model travels
-  under — bare slug, `provider/slug`, date-stamped snapshots, region-prefixed Bedrock
-  profiles, and any id a provider echoes on the wire (learned automatically from
-  telemetry) — to `(api provider, model provider, model version, model card)`, so
-  per-model cost analytics never split one model across its spellings.
+  settings.json-defined gateways. The seed table always passes, and a custom endpoint
+  the master list doesn't know about is trusted as-is, exactly as before.
+- **Exact telemetry.** A **model_aliases** table connects every string form a model
+  travels under — bare slug, `provider/slug`, date-stamped snapshots, region-prefixed
+  Bedrock profiles, and any id a provider echoes on the wire (learned automatically from
+  telemetry) — to a single `(api provider, model provider, model version, model card)`
+  record, so per-model cost analytics never split one model across its different
+  spellings.
 
-### When each source may sync on its own
+### When sources sync
 
 <Callout type="info">
   **A fresh install never contacts models.dev on its own.** The two sources are gated
-  differently, and:
+  differently:
 
   - **Each configured provider's own `/models` listing** auto-syncs whenever it is stale,
     **including the very first time** — this is what surfaces new releases as they ship.
-    That traffic is BYOK-clean: it goes to a provider you already gave stella a key for,
-    the same host your next turn calls anyway. No credential for a provider means nothing
-    is fetched for it.
-  - **The models.dev master list** is a third party, so the no-phone-home rule forbids
-    contacting it implicitly. It may only auto-refresh once a sync record exists —
-    that is, **after your first explicit `stella models refresh`**. Until you run that
-    command once, the seed table above is your whole catalog and models.dev is never
-    contacted.
+    That traffic stays within your own keys: it goes to a provider you already gave
+    stella a key for, the same host your next turn calls anyway. No credential for a
+    provider means nothing is fetched for it.
+  - **The models.dev master list** is a third party, so stella never contacts it
+    without being asked. It only auto-refreshes once a sync record exists — that is,
+    **after your first explicit `stella models refresh`**. Until you run that command
+    once, the seed table above is your whole catalog and models.dev is never contacted.
 </Callout>
 
 Because the native overlay resolves through each provider's configured credential, the
-slugs and prices you get back are exactly what that key can see. It is the same
+slugs and prices you get back are exactly what that key can see. This is the same
 [credential chain](/docs/api-providers#the-credential-chain) that authorizes inference —
 resolved once, used for both:
 
@@ -131,20 +131,20 @@ Only the models.dev master list is keyless.
 
 ## Prompt caching changes the math
 
-The **cached-input** column is what most worker input actually costs mid-run. stella keeps
-the prompt prefix byte-stable on purpose — the [context engine](/docs/context-engine)
-appends rather than rewrites — so after the first turn, the bulk of every request is a
-cache hit billed at the cached-input rate: a 10x–20x discount depending on provider. This
-is why real per-run cost lands far below naive input-tokens-times-list-price math, and why
-a model's cached-input price matters more than its headline input price for long agentic
-runs.
+The **cached-input** column is what most worker input actually costs partway through a
+run. stella keeps the prompt prefix stable on purpose — the
+[context engine](/docs/context-engine) adds to it rather than rewriting it — so after
+the first turn, most of every request is a cache hit billed at the cached-input rate: a
+10x–20x discount depending on provider. This is why real per-run cost lands far below a
+simple input-tokens-times-list-price estimate, and why a model's cached-input price
+matters more than its headline input price for long agentic runs.
 
 ### The cache-write rate
 
-Reads are only half the ledger. Writing a prefix into the cache is itself billed, at a
+Reads are only half the story. Writing a prefix into the cache is itself billed, at a
 **premium over the input rate**, and the seed catalog carries that figure per model
-alongside the other three. It appears in no column above because it is not a price you
-shop on — it is the cost of entry you amortize:
+alongside the other three. It doesn't appear in any column above, because it is not a
+price you shop on — it's an upfront cost you earn back over time:
 
 | Model | Provider | In $/Mtok | Cache-write $/Mtok | Premium |
 | --- | --- | --- | --- | --- |
@@ -160,21 +160,23 @@ shop on — it is the cost of entry you amortize:
 | `moonshotai/kimi-k3` | `openrouter` | 3.00 | 3.00 | 1x |
 | `openrouter/auto` | `openrouter` | gateway-priced | gateway-priced | — |
 
-The Claude family is the only one in the seed catalog carrying a write premium — and, not
-coincidentally, the only one where caching is **opt-in** rather than implicit: Anthropic,
-Bedrock, and Claude routed through OpenRouter each take an explicit cache marker, while
-the rest of the field caches for you. With reads at roughly a tenth of the input rate and
-writes at 1.25x, a written prefix breaks even after **two** requests — and an agent loop
-replays its prefix every turn, so the premium is paid once and repaid immediately.
+The Claude family is the only one in the seed catalog carrying a write premium — and,
+not coincidentally, the only one where caching is **opt-in** rather than automatic:
+Anthropic, Bedrock, and Claude routed through OpenRouter each need an explicit cache
+marker, while the rest of the field caches for you automatically. With reads at roughly
+a tenth of the input rate and writes at 1.25x, a written prefix breaks even after
+**two** requests — and an agent loop replays its prefix every turn, so the premium is
+paid once and earned back right away.
 
-The failure case is worth naming: a prefix that goes cold before it is read back is a
-write you paid for and never used. `stella stats` reports this directly — a negative
-`SAVED ($)` means the write premium outran the reads it bought, and `TTL REWRITES` counts
-the prefixes that expired between turns. See [`stella stats`](/docs/commands/stats).
+There's one failure case worth knowing: a prefix that goes cold before it is read back
+is a write you paid for and never used. `stella stats` reports this directly — a
+negative `SAVED ($)` means the write premium cost more than the reads it bought, and
+`TTL REWRITES` counts the prefixes that expired between turns. See
+[`stella stats`](/docs/commands/stats).
 
 <Callout type="info">
-  `stella models` lists the full catalog with live key status per provider. And the
-  Observatory's models view shows **your** observed **$/resolved task** per model —
-  measured on your repo, your tasks, your prompts — which is the ultimate arbiter of what
-  a model is worth. See [The Observatory dashboard](/docs/telemetry/dashboard).
+  `stella models` lists the full catalog with live key status per provider. The
+  Observatory's models view shows **your** observed **$/resolved task** per model,
+  measured on your repo, your tasks, your prompts — the real measure of what a model is
+  worth to you. See [The Observatory dashboard](/docs/telemetry/dashboard).
 </Callout>

--- a/website/content/docs/commands/arena.mdx
+++ b/website/content/docs/commands/arena.mdx
@@ -1,12 +1,12 @@
 ---
 title: stella arena
-description: The arena-bench harness adapter — run one benchmark episode from a task directory, recording the trace journal judged against replay oracles.
+description: The arena-bench harness adapter — run one benchmark episode from a task directory, recording the trace journal that gets judged against replay checks.
 ---
 
-`stella arena` is stella's side of the [arena-bench](https://github.com/macanderson/arena-bench) adapter contract. It runs **one benchmark episode** and records a [`contextgraph-trace`](https://github.com/macanderson/context-graph-protocol) journal that the arena runner scores with the Context Graph Protocol's replay oracles.
+`stella arena` is stella's side of the [arena-bench](https://github.com/macanderson/arena-bench) adapter contract. It runs **one benchmark episode** and records a [`contextgraph-trace`](https://github.com/macanderson/context-graph-protocol) journal that the arena runner scores using the Context Graph Protocol's replay checks.
 
 <Callout type="info">
-This command exists for **benchmarking stella, not for using it**. If you want to do work, reach for [`stella run`](/docs/commands/run), [`stella goal`](/docs/commands/goal), or [`stella chat`](/docs/commands/chat). Nothing here changes how stella behaves on a real task — the adapter drives the ordinary one-shot path and only adds a journal alongside it. Stdout is **stream-json unconditionally**: the runner is the only intended reader, so there is no `--output-format` flag to promise otherwise.
+This command exists for **benchmarking stella, not for using it**. If you want to get work done, reach for [`stella run`](/docs/commands/run), [`stella goal`](/docs/commands/goal), or [`stella chat`](/docs/commands/chat) instead. Nothing here changes how stella behaves on a real task: the adapter runs the ordinary one-shot path and only adds a journal alongside it. Stdout is always **stream-json**: the runner is the only intended reader, so there is no `--output-format` flag to change that.
 </Callout>
 
 ## Synopsis
@@ -18,24 +18,24 @@ stella arena --task-dir <DIR> --journal <FILE> --state-dir <DIR> [--resume]
 
 ## What it does
 
-arena-bench invokes an agent with `--task-dir`/`--journal`/`--state-dir`/`[--resume]`, **SIGKILLs it mid-episode on purpose**, re-invokes it, and then judges the journal it recorded. Surviving that is the point of the benchmark, so the adapter is built around one rule: the journal must never claim more than actually happened.
+arena-bench starts an agent with `--task-dir`, `--journal`, `--state-dir`, and optionally `--resume`, **kills it on purpose partway through the episode**, starts it again, and then judges the journal it recorded. Surviving that kill is the whole point of the benchmark, so the adapter follows one rule above all: the journal must never claim more happened than actually did.
 
 <CardGrid size="md">
   <SpecCard title="Workspace is the task dir">
     `--task-dir` *is* the workspace for the episode, and the prompt is read from the `TASK.md`
-    inside it.
+    file inside it.
   </SpecCard>
   <SpecCard title="Journal is written first">
-    Each event is appended to the journal **before** it is admitted to the renderer — one
-    flushed line per event.
+    Each event is written to the journal **before** it is shown in the terminal, one
+    saved line per event.
   </SpecCard>
-  <SpecCard title="Memory rides the state dir">
-    `--state-dir` persists across episodes, so the memory arm of the benchmark has somewhere
-    durable to live.
+  <SpecCard title="Memory lives in the state dir">
+    `--state-dir` carries over between episodes, giving the benchmark's memory test
+    somewhere lasting to store its state.
   </SpecCard>
-  <SpecCard title="Resume declares what it recovered">
-    `--resume` truncates a torn tail, recovers the journal, and states exactly what came back
-    before continuing the same session.
+  <SpecCard title="Resume states what it recovered">
+    `--resume` cuts off an incomplete final line, recovers the journal, and states exactly what came back
+    before picking the same session back up.
   </SpecCard>
 </CardGrid>
 
@@ -46,49 +46,49 @@ arena-bench invokes an agent with `--task-dir`/`--journal`/`--state-dir`/`[--res
     The episode workspace. The prompt is read from `TASK.md` inside it. Required.
   </OptionCard>
   <OptionCard name="--journal <FILE>">
-    The `contextgraph-trace` journal to append. Crash-safe, one flushed line per event.
+    The `contextgraph-trace` journal to add to. Safe against a crash, one saved line per event.
     Required.
   </OptionCard>
   <OptionCard name="--state-dir <DIR>">
-    Agent state that persists across episodes — the benchmark's memory arm. Required.
+    Agent state that carries over between episodes: the benchmark's memory test. Required.
   </OptionCard>
   <OptionCard name="--resume">
-    Present when arena-bench re-invokes the adapter after a chaos kill. Recovers the journal,
-    declares what was recovered, and continues the same session.
+    Set when arena-bench restarts the adapter after killing it on purpose. Recovers the journal,
+    states what was recovered, and continues the same session.
   </OptionCard>
   <OptionCard name="--pipeline <VARIANT>">
-    Run every episode under an installed wrapper plugin, by the `[wrapper]
-    id` its manifest declares (`stella plugin list`); omitted, the raw
-    step-loop runs with nothing over it. The same flag
-    [`stella run`](/docs/commands/run) takes, and resolved the same way, so a
-    panel can measure either driver.
+    Run every episode under an installed wrapper plugin, named by the `[wrapper]
+    id` from its manifest (`stella plugin list`). If left out, the plain
+    step loop runs with nothing on top of it. This is the same flag
+    [`stella run`](/docs/commands/run) takes, worked out the same way, so a
+    panel can measure either one.
   </OptionCard>
   <OptionCard name="--test-command <CMD>">
-    Test command for an installed verification plugin's own `[oracle]`, e.g.
-    `--test-command "cargo test -p my-crate"`. Passed against the raw default
-    (no `--pipeline`) it is **refused before the episode starts**, naming an
-    installed verification plugin as the remedy, rather than silently arming
-    no oracle.
+    Test command for an installed verification plugin's own check, for example
+    `--test-command "cargo test -p my-crate"`. If passed without
+    `--pipeline`, the run is **refused before the episode starts**, naming an
+    installed verification plugin as the fix, rather than silently running with
+    no check at all.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-**An arena episode measures the raw step-loop unless you say otherwise.**
+**An arena episode measures the plain step loop unless you say otherwise.**
 Pass `--pipeline <variant>` to measure an installed wrapper plugin instead.
 A panel that mixes wrapped and unwrapped episodes is comparing two different
-verification surfaces, not two builds of the same thing; name that comparison
-rather than reporting it as a plain regression.
+setups, not two versions of the same thing, so name that comparison directly
+rather than reporting it as a plain result change.
 </Callout>
 
-## Why the journal is written before the event is admitted
+## Why the journal is written before the event shows up
 
-An event the journal did not accept must not be admitted to the run. That ordering is not a performance detail — it is what makes the recording truthful under a kill:
+An event the journal didn't accept must not be shown as part of the run. This order isn't about speed. It's what makes the recording truthful even if the process is killed mid-event:
 
-- The recorder appends the trace mapping of an event, **then** enqueues the same event to the renderer. This is the same persist-first boundary the durable stream-json sink uses.
-- A SIGKILL at any byte therefore leaves a **truthful prefix**: the journal may be missing the tail, but it never contains work the run had not committed to.
-- On `--resume`, a torn final line is truncated rather than parsed, and the adapter reports what it recovered instead of silently continuing.
+- The recorder saves the event to the journal, **then** sends the same event to the display. This is the same save-first order used by the reliable stream-json output.
+- Killing the process at any point therefore always leaves a **truthful record**: the journal may be missing its final entries, but it never contains work the run hadn't actually completed.
+- On `--resume`, an incomplete final line is cut off rather than read, and the adapter states what it recovered instead of continuing silently.
 
-The inverse ordering would produce the one failure the benchmark is designed to catch — a journal asserting an effect the agent never got to perform.
+Writing events in the other order would produce exactly the failure this benchmark is designed to catch: a journal claiming an effect the agent never actually completed.
 
 ## What the journal records
 
@@ -96,29 +96,29 @@ The adapter maps the live agent event stream onto the trace vocabulary:
 
 <CardGrid size="sm">
   <SpecCard title="prompt_assembled">
-    From the step manifest. Block identities, digests, and token costs are already content-free,
-    so no prompt text crosses into the journal.
+    From the step manifest. Block identities, digests, and token costs already contain no prompt text,
+    so none of it reaches the journal.
   </SpecCard>
   <SpecCard title="The tool loop">
-    Tool start and tool result become the paired tool-loop events.
+    Tool start and tool result become the matched pair of tool-loop events.
   </SpecCard>
-  <SpecCard title="Intended-once effects">
-    Mutating file changes and commits become side effects carrying an **intended-once id**.
+  <SpecCard title="Once-only effects">
+    File changes and commits become side effects, each carrying an id meant to happen only **once**.
   </SpecCard>
 </CardGrid>
 
-That last one carries the weight of the crash test. The id is derived from the path, the kind, and the diff, so the *same* logical edit replayed after a crash-resume **collides** — which is precisely the bug the effect-exactly-once oracle exists to catch — while a genuinely new edit to the same file carries a new diff and therefore a new id.
+That last one carries the weight of the crash test. The id comes from the path, the kind of change, and the diff, so the *same* logical edit replayed after a resume **collides** with itself, which is exactly the bug the once-only check exists to catch, while a genuinely new edit to the same file has a new diff and so gets a new id.
 
 ## Example
 
 ```bash
-# One episode, recording the journal arena-bench will verifier.
+# One episode, recording the journal arena-bench will verify.
 stella arena \
   --task-dir ./episodes/0042 \
   --journal  ./journals/0042.jsonl \
   --state-dir ./state/memory-arm
 
-# What arena-bench itself runs after the chaos kill.
+# What arena-bench itself runs after killing the process on purpose.
 stella arena \
   --task-dir ./episodes/0042 \
   --journal  ./journals/0042.jsonl \
@@ -127,13 +127,13 @@ stella arena \
 ```
 
 <Callout type="info">
-Persistent memory works by linking the workspace's `.stella` store into `--state-dir`, which the
-runner preserves between episodes (and wipes for the `amnesic` arm). A fixture that ships its own
-`.stella` wins — the link is only created when the workspace has none.
+Memory that carries over works by linking the workspace's `.stella` store into `--state-dir`, which the
+runner keeps between episodes (and clears for the `amnesic` test arm). A fixture that ships its own
+`.stella` folder wins; the link is only created when the workspace has none.
 </Callout>
 
 ## See also
 
-- [Plugins](/docs/plugins) — the wrapper socket an episode opts into with `--pipeline <variant>`.
-- [`stella run`](/docs/commands/run) — the ordinary one-shot path this adapter drives underneath.
-- [arena-bench](https://github.com/macanderson/arena-bench) — the harness that invokes this command.
+- [Plugins](/docs/plugins) — the wrapper system an episode can opt into with `--pipeline <variant>`.
+- [`stella run`](/docs/commands/run) — the ordinary one-shot path this adapter runs underneath.
+- [arena-bench](https://github.com/macanderson/arena-bench) — the benchmark harness that runs this command.

--- a/website/content/docs/commands/auth.mdx
+++ b/website/content/docs/commands/auth.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella auth
-description: Store, list, and remove BYOK provider keys in credentials.toml — the persistent home for your API keys.
+description: Store, list, and remove your BYOK provider keys in credentials.toml, the file where your API keys live.
 ---
 
-`stella auth` manages the BYOK provider keys stored in `~/.stella/credentials.toml`. It is the command that *writes* the credentials file the [credential chain](/docs/configuration/credentials) reads from — a small, deliberate surface for a handful of keys, not a config language. It never prints a secret value and needs no model API key of its own.
+`stella auth` manages the BYOK provider keys stored in `~/.stella/credentials.toml`. It's the command that writes the credentials file the [credential chain](/docs/configuration/credentials) reads from: a small, deliberate tool for a handful of keys, not a configuration language. It never prints a secret value, and it doesn't need a model API key of its own.
 
 ## Synopsis
 
@@ -15,26 +15,26 @@ stella auth list
 
 ## What it does
 
-A key stored here persists across sessions and shells, so you don't re-export an environment variable every time. It sits near the end of the [credential chain](/docs/configuration/credentials): a key resolved from `--api-key`, an environment variable, or `settings.json` still takes precedence. Run [`stella config`](/docs/commands/config) or [`stella models`](/docs/commands/models) to see which source actually wins for a given provider.
+A key stored here stays saved across sessions and shells, so you don't have to re-export an environment variable every time. It sits near the end of the [credential chain](/docs/configuration/credentials): a key resolved from `--api-key`, an environment variable, or `settings.json` still wins over it. Run [`stella config`](/docs/commands/config) or [`stella models`](/docs/commands/models) to see which source actually wins for a given provider.
 
-`<provider>` is a provider id — a built-in such as `zai`, `anthropic`, or `openai`, or a custom provider id you defined in [`settings.json`](/docs/configuration/settings).
+`<provider>` is a provider id: a built-in one such as `zai`, `anthropic`, or `openai`, or a custom provider id you defined in [`settings.json`](/docs/configuration/settings).
 
 ### `stella auth set <provider>`
 
-Store (or replace) a provider's key. With no flag, stella shows an interactive masked prompt — the recommended path, since nothing lands in your shell history.
+Store or replace a provider's key. With no flag, stella shows an interactive masked prompt. This is the recommended way, since nothing lands in your shell history.
 
 <CardGrid size="md">
   <OptionCard name="--key <key>">
-    Pass the key inline. **Visible in shell history and in `ps` output** — prefer
-    `--stdin` or the interactive prompt. Conflicts with `--stdin`.
+    Pass the key inline. **This is visible in shell history and in `ps` output** — prefer
+    `--stdin` or the interactive prompt. Cannot be combined with `--stdin`.
   </OptionCard>
   <OptionCard name="--stdin">
-    Read the key from stdin, one trimmed line — for scripts and secret managers.
+    Read the key from stdin, as one trimmed line. Good for scripts and secret managers.
   </OptionCard>
   <OptionCard name="--field <NAME=VALUE>">
-    Store one companion value a provider needs *beyond* its key. Repeatable. Only
-    Bedrock has any today. **Visible in shell history and in `ps`**, like `--key` —
-    omit it for a masked prompt covering each one.
+    Store one extra value a provider needs beyond its key. Can be repeated. Only
+    Bedrock needs any today. **Visible in shell history and in `ps`**, like `--key` —
+    leave it off for a masked prompt covering each one.
   </OptionCard>
 </CardGrid>
 
@@ -46,15 +46,13 @@ stella auth set anthropic
 printf '%s' "$MY_KEY" | stella auth set zai --stdin
 ```
 
-**A credential set, not one secret.** Most providers authenticate with a single key, so
-`set` takes one and stops. Bedrock does not: it needs `AWS_SECRET_ACCESS_KEY`,
+Most providers need only one key, so `set` stores it and stops. Bedrock needs more: `AWS_SECRET_ACCESS_KEY`,
 `AWS_SESSION_TOKEN`, and `AWS_REGION` alongside the access-key id. Run `stella auth set
-bedrock` with no flags and stella prompts for each companion in turn — secrets masked,
-`AWS_REGION` not, because it is routing and a masked prompt would imply a secrecy it does
-not have. Blank input leaves an existing value alone.
+bedrock` with no flags, and stella asks for each one in turn. Secrets are masked;
+`AWS_REGION` is not, because it's a routing setting, not a secret. Leaving an answer blank keeps the existing value.
 
 ```bash
-# Interactive: prompts for the key, then for each companion field
+# Interactive: prompts for the key, then for each extra field
 stella auth set bedrock
 
 # Scripted — these land in shell history, exactly as --key does
@@ -64,18 +62,18 @@ stella auth set bedrock --key "$AWS_ACCESS_KEY_ID" \
 ```
 
 <Callout type="warn">
-`--key` and `--stdin` suppress the companion prompts entirely — a script that pipes a key
-must never block on a question. So a scripted `stella auth set bedrock --key …` with no
-`--field` stores a credential that **cannot sign a request**: it resolves fine at
-[`stella models`](/docs/commands/models) and then fails at the first call with a SigV4
-error naming a variable you believed you had just configured. `set` warns when it stores a
-Bedrock key with no `AWS_SECRET_ACCESS_KEY` beside it — rerun without `--key`/`--stdin`,
+`--key` and `--stdin` skip the extra-field prompts entirely, since a script that pipes in a key
+must never wait on a question. So a scripted `stella auth set bedrock --key …` with no
+`--field` stores a credential that **cannot sign a request**. It resolves fine at
+[`stella models`](/docs/commands/models) and then fails at the first real call with a signing
+error naming a variable you thought you had already set. `set` warns when it stores a
+Bedrock key with no `AWS_SECRET_ACCESS_KEY` beside it — run it again without `--key`/`--stdin`,
 or pass the field.
 </Callout>
 
 ### `stella auth remove <provider>`
 
-Forget a provider's stored key.
+Delete a provider's stored key.
 
 ```bash
 stella auth remove openai
@@ -83,12 +81,12 @@ stella auth remove openai
 
 ### `stella auth list`
 
-List every provider with a key in `credentials.toml`, each with a redacted preview and its resolution source. Companion values stored with `--field` are listed **by name only**, never by value — the same rule as the key itself, and the reason to show them at all is that a Bedrock row missing its `AWS_SECRET_ACCESS_KEY` otherwise looks identical to a working one.
+List every provider with a key in `credentials.toml`, each with a masked preview and where it came from. Extra values stored with `--field` are listed **by name only**, never by value, the same rule as the key itself. They're shown at all because a Bedrock row missing its `AWS_SECRET_ACCESS_KEY` would otherwise look identical to a working one.
 
 ```bash
 stella auth list
 ```
 
 <Callout type="warn">
-Prefer the interactive prompt or `--stdin` over `--key`. A key passed with `--key` is visible in your shell history and in `ps` output. See [Credentials](/docs/configuration/credentials) for the full resolution chain and precedence.
+Prefer the interactive prompt or `--stdin` over `--key`. A key passed with `--key` is visible in your shell history and in `ps` output. See [Credentials](/docs/configuration/credentials) for the full resolution order.
 </Callout>

--- a/website/content/docs/commands/calibration.mdx
+++ b/website/content/docs/commands/calibration.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella calibration
-description: The measured false-positive rate of a pass verdict — every recorded pass reconciled against the CI results and reverts observed after it.
+description: The measured false-positive rate of a pass verdict, checked against CI results and reverts seen afterward.
 ---
 
-Answer "how often was a pass wrong?" from what the workspace has already recorded. Every verification verdict is persisted in the local event journal with the ladder snapshot it was decided from, every PR/CI observation lands in the same stream, and every revert is already in the git log — so calibration is a *reading*, not a new telemetry pipe. Entirely local; no API key, no network, and it never writes.
+Answer "how often was a pass wrong?" using what the workspace has already recorded. Every verification result is saved in the local event log along with the checklist it was decided from, every PR or CI result lands in the same stream, and every revert is already in the git log. So calibration reads existing data; it doesn't add a new tracking system. It runs entirely on your machine: no API key, no network, and it never writes anything.
 
 ## Synopsis
 
@@ -14,63 +14,52 @@ stella calibration --format json  # machine-readable tallies
 
 <Callout type="warn">
 **Verdicts come from an installed verification plugin.** A plain
-`stella run` is the raw step loop with nothing verifying it, so it emits no
+`stella run` is the raw step loop with nothing verifying it, so it produces no
 `Verdict` events. Verdicts come from an **installed verification plugin**
 (`stella plugin install`, then `stella run --pipeline <plugin-id>`). A
-workspace with none has nothing to calibrate — and the
-command says exactly that, rather than printing a page of zeroes that reads
+workspace with none has nothing to calibrate, and the
+command says exactly that, instead of printing a page of zeros that looks
 like a flawless verifier.
 </Callout>
 
 ## What it reports
 
-Two cohorts, side by side — a false-positive rate means nothing without the cohort it should be compared against:
+Two groups, side by side. A false-positive rate means nothing without the group it's compared against.
 
-- **unproven** — `Verdict` events with `passed: true` and `deterministic: false`: a pass the ladder could not settle. Three different outcomes land here — *unverified* (the probes looked and did not settle it), *unverifiable* (no probe could look), and a triage-*waived* pass — and no model judged any of them.
-- **deterministic** — passes the ladder credited itself (fail→pass flip, green tests, budget, and every pre-submit audit).
+- **unproven** — `Verdict` events marked `passed: true` and `deterministic: false`: a pass the checklist could not fully confirm. Three different outcomes land here: *unverified* (the checks looked and couldn't settle it), *unverifiable* (no check could look), and a pass a person waived during triage. No model judged any of them.
+- **deterministic** — passes the checklist confirmed on its own (a fail-to-pass flip, green tests, staying in budget, and every pre-submit check).
 
-For each: how many passes were recorded, how many were **reconciled**, and how many of those turned out to be wrong. The rate is printed only over reconciled passes; with no ground truth yet, it is reported as **unmeasured**, never as zero.
+For each group: how many passes were recorded, how many were **checked against outside evidence**, and how many of those turned out to be wrong. The rate is only calculated over checked passes. With no outside evidence yet, it is reported as **unmeasured**, never as zero.
 
-Three further readings ride along:
+Three more numbers ride along:
 
-- **the uncorroborated rate** — over the verdicts that carried a ladder snapshot, how often *nothing* mechanical stood behind the result: no achieved fail→pass flip, no touched-test run observed green, no worker-run `verify_done` confirmation. This is the number an evidence-demand policy ("spend one more turn asking the worker to prove it") should be set from: a minority is the condition such a send-back is worth a turn for; a majority reproduces the benchmark measurement that switched the built-in one off.
-- **reverted, counted apart** — how many reconciled passes a human revert settled rather than CI. A cohort whose false positives are mostly reverts is failing differently from one whose false positives are mostly red CI, and a single number would hide it.
-- **grader independence** — the unproven cohort split by whether the worker's own model graded the verdict or a distinct one did. Verdicts that recorded no grader fact are kept apart and excluded from both rates, never assumed into either.
+- **the unconfirmed rate** — of the verdicts that had a checklist behind them, how often *nothing* mechanical backed up the result: no fail-to-pass flip, no touched-test run seen passing, no worker confirmation of the finished work. Look at this number when deciding whether to ask the worker for one more piece of proof before accepting a result: a low number means that's rarely needed.
+- **reverted, counted separately** — how many checked passes were undone by a human revert rather than caught by CI. A group whose false positives are mostly reverts is failing in a different way than one whose false positives are mostly failed CI runs, and a single number would hide the difference.
+- **reviewer independence** — the unproven group split by whether the worker's own model reviewed the verdict or a different one did. Verdicts with no record of who reviewed them are kept separate and left out of both rates instead of assumed into either.
 
 ## Ground truth: two sources, one asymmetry
 
-A pass is reconciled by either:
+A pass is checked against either:
 
-1. a **terminal CI verdict** (`Passing`/`Failing`) for a PR the pass covers — read from **every** recorded session, so a verdict that arrived after one session ended still reaches back to it; or
-2. a **revert** of a commit the pass covers, read out of `git log` from git's own generated `This reverts commit <sha>.` body.
+1. a **final CI result** (`Passing`/`Failing`) for a pull request the pass covers, read from **every** recorded session, so a result that arrives after a session ended still applies to it; or
+2. a **revert** of a commit the pass covers, read from `git log`, using git's own generated `This reverts commit <sha>.` message.
 
-The asymmetry is deliberate and enforced: **a revert settles a pass as a false positive, while the absence of one confirms nothing.** Most correct work is never reverted for the same reason most correct work is never mentioned, so an un-reverted commit leaves its pass unreconciled and out of every denominator. Counting un-reverted commits as confirmations would improve every measured rate by construction — the one direction a calibration instrument must never drift.
+The asymmetry here is deliberate: **a revert marks a pass as a false positive, but the lack of a revert confirms nothing.** Most correct work is never reverted, for the same reason most correct work is never mentioned again, so a commit that was never reverted stays unchecked and is left out of every count. Counting un-reverted commits as confirmed successes would make every measured rate look better automatically. That is the one direction a fair measurement can never drift toward.
 
-A revert also outranks a green CI run for the same pass: it is the later and better-informed statement.
+A revert also outranks a green CI run for the same pass, since it's the later and better-informed signal.
 
 ## Limits
 
-- `Pending`/`Running` CI states reconcile nothing — absence of a verdict is not a verdict.
-- A session's events do not record which verdict a given commit implements, so a commit is attributed to every unsettled pass before it. A session that produced two passes and one commit counts a revert twice. This errs toward reporting the verifier as *worse* than it is, which is the safe direction here.
-- The git log is read best-effort and bounded: a workspace that is not a git repository simply contributes one fewer source.
-- Sessions recorded before the model verdict call was removed mix two populations under the `unproven` heading. The cohort used to be labelled *model verifier*, and that name was exact while a `deterministic: false` pass could only have come from a model ruling on inconclusive evidence. Removing that call left the same flag being set by the ladder's own non-determinate outcomes. Nothing in an old record distinguishes the two, so a report spanning the change cannot separate them.
+- `Pending`/`Running` CI states confirm nothing. No result yet is not the same as a result.
+- A session's records don't say which verdict a given commit belongs to, so a commit is credited to every unsettled pass before it. A session that produced two passes and one commit counts a revert twice. This makes the tool look worse than it is, which is the safer direction to err in.
+- Reading the git log is a best-effort, limited process: a workspace that isn't a git repository just contributes one fewer source.
+- Older recorded sessions can mix two different things under the `unproven` label: a pass a model judged from weak evidence, and a pass the checklist itself couldn't resolve. Nothing in an old record tells the two apart, so a report spanning both kinds of session can't separate them.
 
 ## `--format json`
 
-Under the versioned query envelope. Every rate is `null` when unmeasured, never `0`. Keys: `sessions`, `verdicts_observed`, the `unproven_*` and `deterministic_*` cohorts with their `*_false_positive_rate`, `snapshotted_verdicts` / `uncorroborated_verdicts` / `uncorroborated_rate` / `unproven_passes_standing_alone`, `settled_by_late_evidence` / `unreconciled_passes`, `unproven_reverted` / `deterministic_reverted`, and `by_grader` (`self_graded`, `independent`, `unknown`).
+The output follows the same versioned JSON structure used across stella's other `--format json` commands. Every rate is `null` when unmeasured, never `0`. Keys: `sessions`, `verdicts_observed`, the `unproven_*` and `deterministic_*` groups with their `*_false_positive_rate`, `snapshotted_verdicts` / `uncorroborated_verdicts` / `uncorroborated_rate` / `unproven_passes_standing_alone`, `settled_by_late_evidence` / `unreconciled_passes`, `unproven_reverted` / `deterministic_reverted`, and `by_grader` (`self_graded`, `independent`, `unknown`).
 
-`verdicts_observed` is the field that separates "no verdict was ever recorded" from "no verdict passed" — they are identical in every other tally, and with no verification plugin installed the first is the ordinary state.
-
-<Callout type="warn">
-**Earlier rename.** `verifier_passes`, `verifier_reconciled`,
-`verifier_false_positives`, `verifier_false_positive_rate`,
-`verifier_passes_standing_alone` and `verifier_reverted` were renamed to
-`unproven_*`, and the human report's `verifier-alone rate` line to
-`uncorroborated rate`. The old spellings are **not** emitted alongside the new
-ones: they named a mechanism that contributes nothing to the tallies, so
-keeping them would have kept serving the wrong answer to a consumer who never
-noticed.
-</Callout>
+`verdicts_observed` tells apart "no verdict was ever recorded" from "no verdict passed." They look the same in every other tally, and with no verification plugin installed, the first case is the normal state.
 
 ## See also
 

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella chat
-description: Start an interactive session with stella — the Command Deck TUI by default, an accessible mode of the same deck, or a plain line REPL.
+description: Start an interactive session with stella. Use the Command Deck (the default), an accessible version of the same deck, or a plain line REPL.
 ---
 
-Start an interactive session. This is the **default** command: running `stella` with no subcommand is exactly the same as running `stella chat`.
+Start an interactive session. This is the default command: running `stella` with no subcommand does the same thing as running `stella chat`.
 
-On a real terminal, `stella chat` opens the **Command Deck** — a tabbed terminal UI. Pass `--accessible` (or set `STELLA_ACCESSIBLE=1`) to run that same deck so a screen reader can read it. Pass `--plain` (or set `STELLA_PLAIN=1`) for a plain line-based REPL instead; the deck also steps aside automatically when stdin or stdout is not a terminal.
+On a real terminal, `stella chat` opens the **Command Deck**, a tabbed terminal UI. Pass `--accessible` (or set `STELLA_ACCESSIBLE=1`) to run the same deck in a way a screen reader can read. Pass `--plain` (or set `STELLA_PLAIN=1`) for a plain line-based REPL instead. The deck also switches to plain mode automatically when stdin or stdout is not a terminal.
 
 ## Synopsis
 
@@ -24,76 +24,52 @@ stella chat --plain
 
 ## What it does
 
-`stella chat` opens a conversational session. You type a message, the agent runs its step loop — proposing tool calls, executing them, and feeding results back until the turn is done — and then hands the prompt back to you. Conversation history is retained across turns within the session.
+`stella chat` opens a conversation. You type a message, the agent runs its step loop (proposing tool calls, running them, and reading the results) until the turn is done, then hands the prompt back to you. The session keeps your conversation history across turns.
 
-The default **Command Deck** presents the session as a set of tabs — **SESSION** (the transcript), **AGENTS** (executions & installed agents), **TRACES**, **GRAPH**, **FILES**, **SKILLS**, **MCP**, **ISSUES** (your connected GitHub/Linear tracker, with instant type-ahead), and **SETTINGS** (the home of all config, incl. the engine-config panel). Slash commands jump between tabs and run actions, and `?` opens a tab-aware key list. The **plain REPL** (`--plain`) is a single scrolling line-based loop with a smaller command set — handy for narrow terminals and recordings.
+The default Command Deck shows the session as a set of tabs: **SESSION** (the transcript), **AGENTS** (executions and installed agents), **TRACES**, **GRAPH**, **FILES**, **SKILLS**, **MCP**, **ISSUES** (your connected GitHub or Linear tracker, with instant search), and **SETTINGS** (all config, including the engine-config panel). Slash commands jump between tabs and run actions, and `?` opens a key list for the tab you're on. The plain REPL (`--plain`) is a single scrolling line-based loop with a smaller command set, good for narrow terminals and recordings.
 
 ### Moving around
 
-The deck is a tree — tabs, then the panes and lists inside each, then what a list item
-opens — and four keys walk it the same way at every level, from an **empty prompt**:
+The deck is a tree: tabs, then the panes and lists inside each tab, then what a list item opens. Four keys walk it the same way at every level, starting from an empty prompt:
 
 | key | does |
 |---|---|
 | `←` `→` | the sibling: the pane beside this one, or, when the tab has none that way, the tab beside it |
-| `↑` `↓` (`k` `j`) | the item above / below in the list under the cursor |
+| `↑` `↓` (`k` `j`) | the item above or below in the list under the cursor |
 | `⏎` | open it — a file's diff, a lane's transcript, a message's full text |
 | `⌫` | back up one level — never stops anything |
 
-`Esc` is `⌫` plus one more step: once there is nothing left to close it interrupts the
-running turn (see below). `Tab` / `Shift-Tab` still cycle tabs. `q` or `Esc` closes any
-overlay, and `⇞` `⇟` `Home` `End` page through any list or body. With text in the prompt the
-arrows edit it and `⌫` deletes, as you would expect; the tree is what the keys mean when
-there is nothing to edit. `?` lists every key for the tab you are on.
+`Esc` does what `⌫` does, plus one more step: once there is nothing left to close, it interrupts the running turn (see below). `Tab` and `Shift-Tab` still cycle tabs. `q` or `Esc` closes any overlay, and `⇞` `⇟` `Home` `End` page through any list or body. With text in the prompt, the arrows edit it and `⌫` deletes, as you'd expect. The tree above is what the keys mean only when there is nothing to edit. `?` lists every key for the tab you are on.
 
-Off the SESSION tab, the row above the prompt is the **pulse row**: which agent is working,
-its status, how long since it last did anything (red once a running agent has been quiet
-for a minute and a half), where it is, and the last thing it said — so no tab is blind to the
-turn.
+Off the SESSION tab, the row above the prompt is the **pulse row**. It shows which agent is working, its status, how long since it last did anything (it turns red once a running agent has been quiet for a minute and a half), where it is, and the last thing it said. This keeps every tab aware of the current turn.
 
 ### Sub-agents
 
-`↓` on an empty prompt (or `Ctrl-A`, or `/subagents`) opens the **SUB-AGENTS** overlay:
-every lane the lead dispatched and every `delegate` child running inside a turn, each with
-its quiet time, what it is for, and where it is. `→` or `⏎` opens a lane's transcript — the
-breadcrumb reads `SESSION ▸ lead ▸ sub:2` and `⌫` brings you back to the lead; a prompt typed
-there steers that lane. Inside the overlay `n` **nudges** the selected lane (a one-line
-"where are you?" it answers on its own transcript) and `f` **flags** it to whoever
-dispatched it, with its vitals attached, asking them to check on it, stop it, or take the
-task over. `ctrl-x ctrl-x` kills, `p` pauses / resumes, `r` restarts, `l` returns to the
-lead. A `delegate` child has no control plane of its own: its row says so, `⏎` opens its
-parent, and `f` flags it to the parent.
+`↓` on an empty prompt (or `Ctrl-A`, or `/subagents`) opens the **SUB-AGENTS** overlay. It lists every lane the lead dispatched and every `delegate` child running inside a turn, each with its quiet time, what it is for, and where it is. `→` or `⏎` opens a lane's transcript. The breadcrumb reads `SESSION ▸ lead ▸ sub:2`, and `⌫` brings you back to the lead. A prompt typed there steers that lane. Inside the overlay, `n` **nudges** the selected lane (a one-line "where are you?" that it answers on its own transcript), and `f` **flags** it to whoever dispatched it, with its status attached, asking them to check on it, stop it, or take the task over. `ctrl-x ctrl-x` kills it, `p` pauses or resumes it, `r` restarts it, and `l` returns to the lead. A `delegate` child has no control of its own: its row says so, `⏎` opens its parent, and `f` flags it to the parent.
 
 ### Accessible mode
 
-`--accessible` is a **mode on the deck, not a smaller surface beside it**: every tab, every gate, the prompt queue, sub-agents, steering and resume are unchanged. What changes is how the deck talks to your terminal.
+`--accessible` is a mode of the deck, not a smaller version of it. Every tab, gate, prompt queue, sub-agent, steering, and resume feature works the same. What changes is how the deck talks to your terminal.
 
-- It never takes over the screen. The deck draws inline underneath your prompt instead of on the alternate screen, so nothing is hidden and nothing is torn down when you quit.
-- Each completed message is written into your normal **scrollback**, exactly once — announced as it arrives, reachable with your reader's review cursor, and still there after the session ends.
-- Animation is frozen (as if `--no-anim`), so no region of the screen repaints on a clock.
-- Panels **stack in one column**: the GRAPH and SKILLS tabs and the session's work rail all read top to bottom, so no rendered row splices two panes together.
-- The grid views — TRACES, ISSUES, TOOLS, AGENTS and INSTALLED — render as **one labelled record per row** (`status running · cost $0.05 · cpu 3%`) instead of aligned columns, because column alignment is whitespace to a reader.
-- Moving is **announced**: switching tabs, opening or closing an overlay, and changing which agent has focus each emit a line.
+- It never takes over the screen. The deck draws inline underneath your prompt instead of on a separate screen, so nothing is hidden and nothing disappears when you quit.
+- Each completed message is written into your normal **scrollback** exactly once. It is announced as it arrives, reachable with your reader's review cursor, and still there after the session ends.
+- Animation is frozen (as if `--no-anim` were set), so no part of the screen repaints on a timer.
+- Panels **stack in one column**. The GRAPH and SKILLS tabs and the session's work rail all read top to bottom, so no row mixes two panes together.
+- The grid views (TRACES, ISSUES, TOOLS, AGENTS, and INSTALLED) render as **one labeled record per row** (`status running · cost $0.05 · cpu 3%`) instead of lined-up columns, because column alignment is just whitespace to a screen reader.
+- Moving around is **announced**. Switching tabs, opening or closing an overlay, and changing which agent has focus each say a line out loud.
 - Messages the program itself speaks are marked `▸`, so they are never mistaken for the model's own words.
-- The terminal cursor stays on the real insertion point, which is also what an IME needs to place its candidate window.
-- Mouse capture is forced off, so your terminal's own selection keeps working.
+- The terminal cursor stays on the real insertion point, which is also what an input method needs to place its candidate window.
+- Mouse capture is forced off, so your terminal's own text selection keeps working.
 
-If your terminal does not answer a cursor-position request, the deck still starts — it draws on your own screen without the scrollback flush, and says so rather than silently not delivering it.
+If your terminal does not answer a cursor-position request, the deck still starts. It draws on your own screen without flushing to scrollback, and it says so instead of silently skipping that feature.
 
-Set `STELLA_ACCESSIBLE=1` in your shell profile to make it the default for every invocation.
+Set `STELLA_ACCESSIBLE=1` in your shell profile to make this the default for every session.
 
-Full details — what each change is for, how it degrades on a terminal that will not answer
-a cursor-position request, and how to tell the mode is working — are on the
-[Accessibility](/docs/accessibility) page.
+The [Accessibility](/docs/accessibility) page covers what each change is for, how the mode degrades on a terminal that won't answer a cursor-position request, and how to check the mode is working.
 
 ### Typing while a turn is running
 
-You never have to wait for a turn to finish. A plain prompt **queues** — it waits as the
-lead's next turn, behind anything already waiting, and the turn in flight is not touched.
-Press `Esc` and everything waiting — the queue, in order, plus whatever is in the composer —
-is delivered into the **running** turn at its next step boundary, and the turn keeps going.
-A `Steered` line per message is the acknowledgement; nothing completes, nothing is cancelled,
-and no second agent starts.
+You never have to wait for a turn to finish. A plain prompt **queues**. It waits as the lead's next turn, behind anything already waiting, and the turn in progress is not touched. Press `Esc` and everything waiting (the queue, in order, plus whatever is in the composer) is delivered into the **running** turn at its next step, and the turn keeps going. A `Steered` line per message confirms it: nothing completes, nothing is canceled, and no second agent starts.
 
 ```text
 fix the flaky login test           ⏎   ← queued
@@ -105,72 +81,42 @@ Two prefixes skip the queue:
 
 <CardGrid size="md">
   <SpecCard title="Steer now — `> …`">
-    A message prefixed `>` goes into the running turn at its next step boundary without
+    A message that starts with `>` goes into the running turn at its next step, without
     waiting for `Esc`.
   </SpecCard>
   <SpecCard title="Shell — `! …`">
-    A `!` line runs immediately as a shell command, inline in the transcript, never queued.
+    A line that starts with `!` runs immediately as a shell command, inline in the transcript, and is never queued.
   </SpecCard>
 </CardGrid>
 
 `ui.mid_turn_prompt` in [settings](/docs/configuration/settings#the-ui-section) changes what
-a plain prompt does at a running agent: `queue` (the default above), `ask` (a card offers
+a plain prompt does while an agent is running: `queue` (the default above), `ask` (a card offers
 `s` steer / `n` next turn / `p` sidecar sub-session per prompt), or `spawn` (every plain
 prompt forks a sidecar sub-session, dispatched alongside the running turn).
 
 <Callout type="info">
 A bare `⏎` **always** submits, even while an agent is busy — that is what makes queueing
-possible without waiting. The one exception is a **pending gate on the focused agent** (a
-scope review, a hunk review, or a question the approvals plane put to you): there the submit
-answers the gate rather than queueing or steering anything. Answer it first, then steer.
+possible without waiting. The one exception is a pending gate on the focused agent (a
+scope review, a hunk review, or a question the approvals plane asked you): there, the submit
+answers the gate instead of queueing or steering anything. Answer it first, then steer.
 </Callout>
-
-### Reviewing a write hunk by hunk — not yet reachable
-
-<Callout type="warn">
-  **This gate does not fire today, and no setting turns it on.** The deck can render a
-  per-hunk approval card and its key map is implemented and tested, but nothing emits the
-  `hunk_review` event that would raise one, and `hunk_review` is not a key any settings
-  struct reads — writing it into `agent_engine_config` sets nothing. Tracked in
-  [#3633](https://github.com/macanderson/stella/issues/3633). The key map below is
-  recorded for when it lands; skip to [multimodal input](#multimodal-input) for what the
-  deck does now.
-</Callout>
-
-The intended behavior: every write pauses on a card listing the hunks it would apply, and
-only the ones you keep are written, so a turn that produces one wanted and one unwanted
-change is no longer all-or-nothing.
-
-| Key | Effect |
-| --- | --- |
-| `↑` / `↓` | move between hunks |
-| `space` | keep or drop the hunk under the cursor |
-| `⏎` | apply the kept hunks — the footer always names how many that is |
-| `esc` | decline every hunk; nothing is written |
-
-Or type the ones to keep and press `⏎`: `1 3`, `2-4`, `all`, `none`. The mark keys act only
-while the composer is empty, so they never eat a line you are typing.
-
-Declined hunks are reported back to the model, so it knows why the file does not look the way
-it wrote it — a silent partial apply would look to it like somebody else edited the file.
 
 ### Line breaks and soft-stop
 
-A *modified* `⏎` (`⌘⏎` / `⌃⏎` / `⌥⏎`) inserts a line break instead of submitting, and the break
-is kept verbatim in the prompt. On a terminal that cannot report the chord it folds back to a
-plain submit.
+A modified `⏎` (`⌘⏎`, `⌃⏎`, or `⌥⏎`) inserts a line break instead of submitting, and the break
+stays exactly as typed in the prompt. On a terminal that can't report the key combination, it falls back to a plain submit.
 
-Esc with nothing queued and nothing typed soft-stops the current turn without ending the
-session; `Esc Esc` cancels it immediately and holds the queue until your next submission. See
-[Agent engine paths](/docs/agent-engine-paths) for how steering interacts with each execution
+Pressing Esc with nothing queued and nothing typed pauses the current turn without ending the
+session. `Esc Esc` cancels it right away and holds the queue until your next message. See
+[Agent engine paths](/docs/agent-engine-paths) for how steering works with each execution
 path.
 
 ### Multimodal input
 
-Prompts are multimodal: mention a path to an image, PDF, audio, or video file in your message and stella attaches the file itself as model input alongside your text. In the deck, **Ctrl-V** pastes an image straight from the clipboard as an attachment. See [Multimodal input](/docs/multimodal-input) for the `@`-mention rules, what each provider can see, and how unsupported media degrades.
+Prompts can include more than text. Mention a path to an image, PDF, audio, or video file in your message, and stella attaches the file itself as model input alongside your text. In the deck, **Ctrl-V** pastes an image straight from the clipboard as an attachment. See [Multimodal input](/docs/multimodal-input) for the `@`-mention rules, what each provider can see, and how unsupported media is handled.
 
 <Callout type="info">
-All [global flags](/docs/commands) apply, in either position — `stella --model openai/gpt-5.5 chat` pins the worker model for the whole session, and `stella chat --model openai/gpt-5.5` does the same thing.
+All [global flags](/docs/commands) apply in either position — `stella --model openai/gpt-5.5 chat` pins the worker model for the whole session, and `stella chat --model openai/gpt-5.5` does the same thing.
 </Callout>
 
 ## Flags
@@ -180,15 +126,15 @@ All [global flags](/docs/commands) apply, in either position — `stella --model
 <CardGrid size="md">
   <OptionCard name="--accessible">
     Run the Command Deck so a screen reader can read it: inline on your own screen,
-    completed messages into scrollback, single-column panels, labelled rows instead of
+    completed messages into scrollback, single-column panels, labeled rows instead of
     tables, and announcements when you move. Env `STELLA_ACCESSIBLE=1`.
   </OptionCard>
   <OptionCard name="--plain">
     Use the plain line-based REPL instead of the Command Deck. Env `STELLA_PLAIN=1`; also
-    auto-selected on a non-TTY.
+    used automatically on a non-terminal.
   </OptionCard>
   <OptionCard name="--no-anim">
-    Freeze deck animation (progress shimmer, caret blink) to a static frame — for
+    Freeze deck animation (progress shimmer, caret blink) to a still frame — for
     recordings and CI. Env `STELLA_NO_ANIM` / `NO_COLOR`.
   </OptionCard>
   <OptionCard name="--model <provider/model_id>">
@@ -215,57 +161,56 @@ Open a tab or run an action:
     Show the deck's command list.
   </OptionCard>
   <OptionCard name="/clear">
-    Reset the session — blank the transcript, drop the history, wipe the task
+    Reset the session: clear the transcript, drop the history, wipe the task
     board, and stop every sidecar worker. Each lane leaves the SUB-AGENTS
-    overlay as its worker winds down, and the cleared pane names what was
+    overlay as its worker shuts down, and the cleared pane names what was
     stopped. A cleared lane cannot be restarted.
   </OptionCard>
   <OptionCard name="/info">
     List providers and models (the same output as `stella models`). Also accepts
-    `refresh [--force]` and `list` — see below. (`/models` before the rename;
-    the old name still routes.)
+    `refresh [--force]` and `list` — see below. (`/models` still works, the older name.)
   </OptionCard>
   <OptionCard name="/model">
-    Switch **this session's** model. Bare `/model` opens a picker over the
+    Switch **this session's** model. A bare `/model` opens a picker over the
     models your configured providers offer (scoped by `[models].allowed` when
-    set); `/model zai/glm-5.2` is the typed form. Session-only — new sessions
-    keep the settings default. `/model default zai/glm-5.2` persists the
+    set); `/model zai/glm-5.2` is the typed form. This choice lasts only for this session; new sessions
+    keep the settings default. `/model default zai/glm-5.2` saves the
     default instead.
   </OptionCard>
   <OptionCard name="/agent">
     Run as an installed agent for the rest of this session. Opens a picker over
-    the definitions at user and project scope; choosing one appends its persona
-    to the system prompt, narrows the tool surface to its `tools:` grant, and
-    applies its declared `model:` (if any) as a session model switch — the same
-    assume the AGENTS tab's `a` performs.
+    the definitions at user and project scope. Choosing one adds its persona
+    to the system prompt, narrows the tool list to its `tools:` grant, and
+    applies its declared `model:` (if any) as a session model switch — the same thing
+    the AGENTS tab's `a` key does.
   </OptionCard>
   <OptionCard name="/profile">
-    Retune every role at once — `fast`, `balanced`, `pro`, `ultra`, or `auto` to
-    hand the dials back. With no argument, show what is set and what each
+    Set every role at once — `fast`, `balanced`, `pro`, `ultra`, or `auto` to
+    hand the choices back to the engine. With no argument, show what is set and what each
     profile would choose. See below.
   </OptionCard>
   <OptionCard name="/theme">
-    Switch and persist the colour theme (`stella-dark`, `stella-light`). With no
+    Switch and save the color theme (`stella-dark`, `stella-light`). With no
     argument, show the current theme.
   </OptionCard>
   <OptionCard name="/voice">
     Turn dictation on and pick the spacebar gesture: `/voice hold` (hold Space
     through a warmup, release to stop), `/voice tap` (tap Space on an empty
-    prompt to start, tap again to stop), `/voice off`. Persists, and takes
+    prompt to start, tap again to stop), `/voice off`. This choice is saved, and it takes
     effect in this session. With no argument, show what is set. Pick `tap` if
     holding Space never starts a recording — hold needs either a terminal that
     reports key releases or OS key repeat, and tap needs neither.
   </OptionCard>
   <OptionCard name="/init">
-    Index the workspace: domain taxonomy plus the code graph.
+    Index the workspace: build the domain taxonomy and the code graph.
   </OptionCard>
   <OptionCard name="/agents">
-    Open the AGENTS tab — the agents installed at user and project scope, with
-    versioned editing. Running lanes are the SUB-AGENTS overlay instead
+    Open the AGENTS tab: the agents installed at user and project scope, with
+    versioned editing. Running lanes show up in the SUB-AGENTS overlay instead
     (`ctrl-a`, `↓` from an empty prompt, or `/subagents`).
   </OptionCard>
   <OptionCard name="/settings">
-    Open the SETTINGS tab — the home of all config, models included. There are no
+    Open the SETTINGS tab, home to all config, models included. There are no
     per-agent slash commands; the engine-config editor lives here.
   </OptionCard>
   <OptionCard name="/files">
@@ -278,7 +223,7 @@ Open a tab or run an action:
     Open the GRAPH (code-graph) tab.
   </OptionCard>
   <OptionCard name="/skills">
-    Open the SKILLS tab — manage, search, create.
+    Open the SKILLS tab: manage, search, create.
   </OptionCard>
   <OptionCard name="/mcp">
     Open the MCP servers tab (enable/disable servers, enter credentials).
@@ -297,21 +242,21 @@ Open a tab or run an action:
     [`stella inspect`](/docs/commands/inspect). Also **Ctrl-G**.
   </OptionCard>
   <OptionCard name="/inbox">
-    Notifications — messages persist until read.
+    Notifications. Messages stay until you read them.
   </OptionCard>
   <OptionCard name="/export">
-    Export **this session's** telemetry to a ZIP plus an HTML dashboard —
-    scoped to the session you are in, never the whole workspace, so the
-    archive is safe to attach to a PR.
+    Export **this session's** telemetry to a ZIP plus an HTML dashboard.
+    It's scoped to the session you are in, never the whole workspace, so the
+    archive is safe to attach to a pull request.
   </OptionCard>
   <OptionCard name="/reload">
-    Re-read the settings scope chain from disk and apply it to the live
-    session — engine posture, tool switches, authority. Saving from the
+    Re-read the settings from disk and apply them to the live
+    session: engine behavior, tool switches, authority. Saving from the
     SETTINGS tab does this automatically; `/reload` covers edits made outside
     the deck. Provider, model, and credentials are untouched.
   </OptionCard>
   <OptionCard name="/donate">
-    Support stella — become a GitHub Sponsor.
+    Support stella by becoming a GitHub Sponsor.
   </OptionCard>
 </CardGrid>
 
@@ -319,7 +264,7 @@ Press **Ctrl-C** to quit the deck.
 
 #### `/info` with an argument
 
-`/info` also takes two arguments, and both are handled inside the deck without a model call. When the configured model is itself broken, `/info refresh` is how you dig out — routing it through a turn would fail on the very error you are fixing:
+`/info` also takes two arguments, and both run inside the deck without a model call. When the configured model is itself broken, `/info refresh` is how you fix it — routing it through a turn would fail on the very error you are trying to fix:
 
 ```text
 /info refresh           re-sync the catalog
@@ -327,44 +272,44 @@ Press **Ctrl-C** to quit the deck.
 /info list              the same listing the bare /info prints
 ```
 
-Parsing is conservative: one recognized token (plus `refresh --force`). A single unrecognized token gets usage back rather than a wasted model call, and anything sentence-like after `/info` stays an ordinary prompt.
+Parsing here only looks for one recognized word (plus `refresh --force`). One word it doesn't recognize gets a usage message back rather than wasting a model call, and anything sentence-like after `/info` is treated as an ordinary prompt.
 
-#### `/profile` — one word for the whole harness
+#### `/profile` — one setting for the whole session
 
-`/profile` sets a model *and* a reasoning effort for every engine role at once, chosen from the models your API keys can actually reach:
+`/profile` sets a model and a reasoning effort for every engine role at once, chosen from the models your API keys can reach:
 
 ```text
-/profile fast       cheapest models, thinking off, terse replies
-/profile balanced   good enough for daily work without burning the budget
+/profile fast       cheapest models, thinking off, short replies
+/profile balanced   good enough for daily work without spending too much
 /profile pro        strong models, real deliberation, priority capacity
-/profile ultra      the most capable models your keys can reach, effort at the ceiling
-/profile auto       no profile — hand the dials back to the engine
+/profile ultra      the most capable models your keys can reach, effort at the highest setting
+/profile auto       no profile — hand the choices back to the engine
 ```
 
 Run `/profile` with no argument to see which profile your current settings match, what this session is running, and what each profile would pick right now.
 
-**How the models are chosen.** stella's catalog carries no capability tier, so a profile ranks the reachable models by list output price — the same proxy `auto_mode` already uses to pick a verifier. This means the choice tracks catalog refreshes instead of going stale, but it is a proxy: a cheap frontier model ranks low until its price says otherwise. The confirmation names every model it picked, so you can always see what you got. Models the catalog has no price for (gateway rows like `openrouter/auto`, which bill at whatever they route to) are left out of the ranking rather than treated as free.
+**How the models are chosen.** stella's catalog doesn't track a capability tier, so a profile ranks the reachable models by list price. This is the same method `auto_mode` already uses to pick a verifier. It keeps the choice up to date as the catalog changes, but it's an approximation: a cheap frontier model ranks low until its price says otherwise. The confirmation message names every model it picked, so you can always see what you got. Models the catalog has no price for (gateway rows like `openrouter/auto`, which bill at whatever they route to) are left out of the ranking instead of treated as free.
 
-The roles are not tuned identically. Triage stays below the worker in every profile — it is a short classification under a latency ceiling, and spending your best model on it buys nothing. Research sits on triage's rung for the same reason: it reads the tree and reports what it found, and it is a fan-out, so a tier chosen for the worker would be paid once per question. Neither research nor plan is given a model of its own — both ride the worker's, so a later `--model` moves all three together.
+The roles aren't tuned the same way. Triage stays below the worker in every profile, since it's a short classification with a time limit, and spending your best model on it doesn't help. Research sits at the same level as triage for a similar reason: it reads the code and reports what it found, and because it runs many times per question, a tier chosen for the worker would be paid for repeatedly. Neither research nor plan gets a model of its own; both use the worker's, so a later `--model` change moves all three together.
 
-The verifier is the interesting one, because two goals pull against each other: a verifier from the worker's own family lets a shared blind spot pass review twice, but a verifier well below the worker's tier cannot follow the work it grades and rubber-stamps. stella resolves it in the order that gives up least. A model that is both independent and at least as capable wins outright. If nothing clears that bar but the strongest independent model is only one rung down the price list, independence is worth the single rung. Only when the best independent option is further down does capability take over — and then the confirmation tells you the review is correlated with the work.
+The verifier is trickier, because two goals pull against each other. A verifier from the same model family as the worker can share a blind spot and pass review twice, but a verifier well below the worker's tier can't follow the work it's grading and just approves everything. stella picks in the order that gives up the least. A model that is both independent and at least as capable wins outright. If nothing meets that bar but the strongest independent model is only one price rung down, independence is worth that one rung. Only when the best independent option is much further down does capability take over, and then the confirmation message says the review shares a family with the work.
 
-**What it writes, and what it leaves alone.** A profile owns the per-role model, effort, thinking switch, verbosity, and service tier, saved to your user settings. It turns `effort_auto`, `reasoning_auto`, and `auto_mode` **off**: those switches override per-agent effort, so leaving them on would let `/profile ultra` print `max` and run `medium`. Everything else survives untouched — custom per-agent prompts, pinned providers, temperatures, seeds, and your `allowed_models` list.
+**What it changes, and what it leaves alone.** A profile sets the model, effort, thinking switch, verbosity, and service tier for each role, saved to your user settings. It turns `effort_auto`, `reasoning_auto`, and `auto_mode` **off**, because those switches override per-agent effort settings — leaving them on would let `/profile ultra` claim `max` effort while actually running `medium`. Everything else stays as it was: custom per-agent prompts, pinned providers, temperatures, seeds, and your `allowed_models` list.
 
-`/profile auto` is the way back out. It restores all three switches and drops the per-role effort, thinking, verbosity, and service-tier pins a profile wrote, handing those choices to the engine again. Model pins are left alone: one may well predate the profile, and `auto_mode` re-picks the verifier on its own.
+`/profile auto` undoes this. It turns all three switches back on and removes the per-role effort, thinking, verbosity, and service-tier settings a profile wrote, handing those choices back to the engine. Model pins stay as they are, since they may predate the profile, and `auto_mode` picks the verifier on its own again.
 
-**Effort, and the providers that cannot express it.** The five-rung ladder is stella's vocabulary, not every provider's: Gemini and Vertex offer only `low` and `high`, the OpenAI shapes stop at `high`, and Z.ai has no request-level effort control at all (its thinking switch is on/off). A pick whose provider cannot express the level the profile asked for is written at the highest rung it does support.
+**Effort, and providers that can't express it.** The five-level scale is stella's own scale, not every provider's: Gemini and Vertex offer only `low` and `high`, the OpenAI models stop at `high`, and Z.ai has no per-request effort control at all (its thinking switch is just on or off). A choice whose provider can't match the level the profile asked for is set to the highest level that provider does support.
 
-Clamping alone would flatten the ladder — on a two-rung provider both `fast` and `balanced` land on `low`. The missing rung is bought back on the axis that can still carry it: among models at the same price, the one whose provider *can* express the requested level wins. That is a tiebreak and nothing more. The search never leaves the price band, so a profile cannot overspend its tier to buy a knob, and it takes the cheapest qualifying model rather than the best. Where nothing at that price can express the level, the clamp stands and the confirmation says which levels moved.
+Just rounding down would flatten the scale. On a two-level provider, both `fast` and `balanced` would land on `low`. The missing level is recovered a different way: among models at the same price, the one whose provider *can* express the requested level wins. That's a tiebreaker, nothing more. The search never leaves the price range, so a profile can't overspend its tier to get a feature, and it picks the cheapest model that qualifies rather than the best one. Where nothing at that price can express the level, the rounding stands, and the confirmation message says which levels changed.
 
-Like `/model default`, the change applies to sessions started from now on; the running session keeps its current model (a bare `/model` pick is the one that moves it).
+Like `/model default`, the change applies to sessions started from now on; the running session keeps its current model (a bare `/model` pick is the one that changes it right away).
 
 ### Plain REPL (`--plain`)
 
-The line REPL has a smaller, different set — this is the whole of it, and a `/word`
-outside this list is not a command there. Unlike the deck, which answers an unknown
-bare `/word` with a correction, the REPL lets it through as an ordinary prompt, so a
-deck command typed here (`/files`, `/diff`, `/graph`, …) costs a model call and
+The line REPL has a smaller, different set of commands. This is the whole list, and a `/word`
+outside this list is not a command there. Unlike the deck, which corrects an unrecognized
+bare `/word`, the REPL lets it through as an ordinary prompt, so a
+deck command typed here (`/files`, `/diff`, `/graph`, and so on) costs a model call and
 answers nothing.
 
 <CardGrid size="sm">
@@ -372,10 +317,10 @@ answers nothing.
     Show help.
   </OptionCard>
   <OptionCard name="/info">
-    List providers and models (`/models` still routes).
+    List providers and models (`/models` still works).
   </OptionCard>
   <OptionCard name="/config">
-    Show the current configuration — the deck has no `/config`; this is the REPL's own.
+    Show the current configuration. The deck has no `/config`; this is the REPL's own.
   </OptionCard>
   <OptionCard name="/clear">
     Clear the conversation history.
@@ -387,7 +332,7 @@ answers nothing.
     List custom agents, from `.stella/agents` or `~/.stella/agents`.
   </OptionCard>
   <OptionCard name="/init">
-    Index the workspace: domain taxonomy plus the code graph.
+    Index the workspace: build the domain taxonomy and the code graph.
   </OptionCard>
   <OptionCard name="/rename <name>">
     Rename this terminal tab.
@@ -426,7 +371,7 @@ Run the deck with a screen reader:
 stella chat --accessible
 ```
 
-Use the plain line REPL (e.g. for a narrow terminal, or a pipe):
+Use the plain line REPL (for example, for a narrow terminal, or a pipe):
 
 ```bash
 stella chat --plain

--- a/website/content/docs/commands/cloud.mdx
+++ b/website/content/docs/commands/cloud.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella cloud
-description: Read and set the org and workspace identity that scopes replicated telemetry, and drain that telemetry to an org intake you configure.
+description: Read and set the org and workspace identity that scopes replicated telemetry, and send that telemetry to an org intake you configure.
 ---
 
-Every row [`stella usage`](/docs/commands/usage) replicates into the hub carries an identity: which organization it reports into, which workspace it came from, and which repository that workspace maps to. `stella cloud` is where you read that identity, set it, and — if you configure an endpoint — upload under it.
+Every row [`stella usage`](/docs/commands/usage) copies to the hub carries an identity: which organization it reports to, which workspace it came from, and which repository that workspace maps to. `stella cloud` is where you read that identity, set it, and, if you configure an endpoint, upload data under it.
 
-The OAuth login is still a **stub**: `register` persists ids locally and mints a durable workspace id, and the login that will attach a token lands later on the same file. Registration alone uploads nothing and does not change what telemetry is collected, only which ids it is stamped with.
+Login is still a work in progress: `register` saves ids locally and creates a durable workspace id, and the login step that will attach a token will write to the same file later. Registration alone doesn't upload anything and doesn't change what telemetry is collected, only which ids get stamped on it.
 
 ## Synopsis
 
@@ -21,38 +21,38 @@ A subcommand is required. None of them needs a provider or an API key.
 
 ## What it does
 
-Four ids describe an installation, and they answer different questions:
+Four ids describe an installation, and each answers a different question:
 
 <CardGrid size="md">
   <OptionCard name="org_id">
-    The organization this installation reports into. `NULL` until you register.
+    The organization this installation reports to. `NULL` until you register.
     `STELLA_ORG_ID` wins if set; otherwise it comes from the `org_id` in
     `~/.stella/cloud.json`, written by `stella cloud register`.
   </OptionCard>
   <OptionCard name="workspace_id">
-    A durable UUID at `<root>/.stella/workspace.json`, written **only** by registration
-    and never minted implicitly — an unregistered workspace reports `NULL`. It lives
-    outside `.stella/private/` on purpose, so committing it gives every clone and every
+    A durable id at `<root>/.stella/workspace.json`, written **only** by registration
+    and never created automatically. An unregistered workspace reports `NULL`. It lives
+    outside `.stella/private/`, so committing it gives every clone and every
     machine one shared workspace identity.
   </OptionCard>
   <OptionCard name="repo_id">
-    A workspace is only *usually* a repository. `repo_id` hashes the normalized `origin`
-    remote URL — the SSH and HTTPS forms of the same repo agree — and falls back to the
-    path hash when there is no git remote. Rows carry it separately so a multi-repo
+    A workspace is only *usually* a repository. `repo_id` is built from the normalized `origin`
+    remote URL (the SSH and HTTPS forms of the same repo count as the same one), and
+    falls back to the folder path when there is no git remote. Rows carry it separately so a multi-repo
     workspace still reports per repository.
   </OptionCard>
   <OptionCard name="project_id">
-    A hash of the canonical workspace path. Always present, registration or not, and it
+    A hash of the workspace's own path. Always present, registration or not, and it
     is the key replication runs on. This is what makes `stella usage` work on a machine
     that has never heard of a cloud org.
   </OptionCard>
 </CardGrid>
 
-Resolution is infallible by design: telemetry scoping must never fail a turn, so unregistered ids resolve to `NULL` and a missing git remote degrades `repo_id` rather than erroring.
+Resolving these ids never fails: telemetry scoping must never break a turn, so unregistered ids resolve to `NULL`, and a missing git remote falls back to the path-based id instead of erroring.
 
 ### `stella cloud status`
 
-Print this installation's identity for the current workspace, and — once an org is set — any rows the cloud intake permanently rejected.
+Print this installation's identity for the current workspace, and, once an org is set, any rows the cloud intake permanently rejected.
 
 ```bash
 stella cloud status
@@ -80,7 +80,7 @@ project:   4b81c0e2f39a77de
 
 #### Quarantined rows
 
-When an org is registered, `status` also reports rows the cloud intake rejected *permanently*. This is the only place they surface, and that is the point: the drain dead-letters such a row and steps its cursor over it so newer rows keep flowing — after which everything downstream looks healthy while a silent casualty sits in the hub.
+Once an org is registered, `status` also reports rows the cloud intake rejected *permanently*. This is the only place they show up. The drain sets these rows aside and moves past them so newer rows keep flowing, which means everything downstream can look healthy while a rejected row sits in the hub unnoticed.
 
 ```text
 quarantined:   3 row(s) the cloud intake permanently rejected
@@ -89,22 +89,22 @@ quarantined:   3 row(s) the cloud intake permanently rejected
               retained in the hub for inspection; the cursor advanced past them
 ```
 
-At most three reason groups are listed before the tail folds into a `+N more reason(s)` line. The rows themselves are retained, not deleted. The check is best-effort — `status` answers about identity first, so an unopenable hub degrades to a one-line note instead of failing the command.
+At most three reason groups are listed before the rest fold into a `+N more reason(s)` line. The rows themselves stay in place; nothing is deleted. Since `status` answers about identity first, this check does its best: if the hub can't be opened, it prints a one-line note instead of failing the command.
 
 ### `stella cloud register`
 
-Persist an org id and register this workspace.
+Save an org id and register this workspace.
 
 <CardGrid size="md">
   <OptionCard name="--org <ORG_ID>" required>
-    The cloud organization id telemetry rolls up under. Written to `~/.stella/cloud.json`
-    — the same file the future OAuth login will keep its token in, so registration and
-    auth stay one file. Must not be empty.
+    The cloud organization id telemetry reports under. Saved to `~/.stella/cloud.json`,
+    the same file that will hold your login token later, so registration and
+    login stay in one file. Cannot be empty.
   </OptionCard>
   <OptionCard name="--workspace-id <ID>">
-    Adopt a cloud-assigned workspace id instead of minting a UUID. Ignored if this
-    workspace is already registered — registration is idempotent and an existing id always
-    wins, because one workspace must never fork into two identities.
+    Use a workspace id issued elsewhere instead of creating a new one. Ignored if this
+    workspace is already registered. Registration only runs once, and an existing id always
+    wins, because one workspace must never end up with two identities.
   </OptionCard>
 </CardGrid>
 
@@ -119,12 +119,12 @@ commit .stella/workspace.json so every clone reports as this workspace
 ```
 
 <Callout type="info">
-Commit `.stella/workspace.json`. It sits outside `.stella/private/` for exactly that
-reason. Without it, a clone has no workspace id at all until someone registers there —
+Commit `.stella/workspace.json`. It lives outside `.stella/private/` for exactly that
+reason. Without it, a clone has no workspace id until someone registers there,
 and if they do, the same project ends up reporting under two identities.
 </Callout>
 
-The written file is small and readable:
+The file it writes is small and easy to read:
 
 ```json title=".stella/workspace.json"
 {"workspace_id": "6f1d8a20-4c3e-4a71-9a55-2d0be1c7f5aa"}
@@ -132,16 +132,16 @@ The written file is small and readable:
 
 ### `stella cloud sync`
 
-Drain staged hub telemetry to the org intake configured in `~/.stella/cloud.json`'s
-`drain` block. This is the one command in this group that performs network I/O.
+Send staged hub telemetry to the org intake set in `~/.stella/cloud.json`'s
+`drain` block. This is the one command in this group that uses the network.
 
 ```bash
 stella cloud sync
 ```
 
-It is a no-op unless **both** an `org_id` (from `register`) and a `drain` block are
-present — no block, no network. The block also carries the intake credential, which is
-why `cloud.json` is written owner-only:
+It does nothing unless **both** an `org_id` (from `register`) and a `drain` block are
+present. No block, no network traffic. The block also carries the intake credential, which is
+why `cloud.json` is saved so only you can read it:
 
 ```json title="~/.stella/cloud.json"
 {
@@ -157,43 +157,43 @@ why `cloud.json` is written owner-only:
 
 | Field | Default | Meaning |
 | --- | --- | --- |
-| `url` | required | The HTTPS org intake batches are POSTed to |
-| `format` | `stella` | Wire format: `stella` (native schema-versioned batch) or `otel` (OTLP). An unknown value fails closed |
+| `url` | required | The HTTPS org intake batches are sent to |
+| `format` | `stella` | Wire format: `stella` (the native schema-versioned batch) or `otel` (OTLP). An unknown value fails and stops |
 | `token` | none | Bearer credential for the intake. `oauth_token` wins when both exist |
-| `batch_size` | `200` | Rows per POST |
+| `batch_size` | `200` | Rows per request |
 
-Rows the intake rejects *permanently* are dead-lettered and the cursor steps over them so
-newer rows keep flowing; they surface under [`status`](#quarantined-rows). A transient
-failure is reported as retryable — re-run the command.
+Rows the intake rejects *permanently* are set aside, and the cursor moves past them so
+newer rows keep flowing. They show up under [`status`](#quarantined-rows). A temporary
+failure is reported as something you can retry, so just re-run the command.
 
 <Callout type="warn">
-  This is a **second, separate egress path** from the
+  This is a **second, separate export path** from the
   [Oxagen Enterprise managed export](/docs/telemetry#oxagen-enterprise-managed-export).
-  It has its own wire contract, its own endpoint, and its own opt-in — a `drain` block in
-  a file you write yourself, pointed at an intake you operate. Enterprise enrollment does
-  not enable it and it does not enable enterprise enrollment.
+  It has its own wire format, its own endpoint, and its own opt-in: a `drain` block in
+  a file you write yourself, pointed at an intake you run. Enterprise enrollment does
+  not turn this on, and this does not turn on enterprise enrollment.
 </Callout>
 
 ### `stella cloud logout`
 
-Destroy the stored credentials and remove the `drain` block, halting upload. Registration
-and local hub telemetry are retained.
+Delete the stored credentials and remove the `drain` block, which stops uploads. Registration
+and local hub telemetry stay in place.
 
 ### `stella cloud deregister`
 
-`logout` plus clearing the org id, returning the installation to unregistered. Hub rows
-keep the org they were captured under; un-synced rows for the old org stop draining and
-stay local. Destroy them explicitly with `stella usage prune --force` if that is intended.
+Does what `logout` does, plus clears the org id, returning the installation to unregistered. Hub rows
+keep the org they were captured under; unsent rows for the old org stop sending and
+stay local. Delete them with `stella usage prune --force` if that's what you want.
 
 ## What registration alone does not do
 
-- **It does not upload anything by itself.** `register` writes two local files. Upload
-  needs a `drain` block *and* an explicit `stella cloud sync`. Telemetry replicates into
+- **It does not upload anything by itself.** `register` writes two local files. Uploading
+  needs a `drain` block *and* running `stella cloud sync`. Telemetry is copied into
   `~/.stella/usage.db` whether you register or not.
-- **It does not change what is collected.** Only the ids stamped onto each row change — from `NULL` org and workspace to yours.
-- **It does not re-stamp history.** Rows written before registration keep their `NULL` org, which is why `stella usage report --org <id>` excludes them.
+- **It does not change what is collected.** Only the ids stamped onto each row change, from `NULL` org and workspace to yours.
+- **It does not relabel history.** Rows written before registration keep their `NULL` org, which is why `stella usage report --org <id>` leaves them out.
 
-It does change one thing worth knowing about: once rows carry an org, [`stella usage prune`](/docs/commands/usage#stella-usage-prune) will not drop the ones a cloud drain has not acknowledged unless you pass `--force`.
+It does change one thing worth knowing about: once rows carry an org, [`stella usage prune`](/docs/commands/usage#stella-usage-prune) will not drop rows a cloud drain hasn't acknowledged yet, unless you pass `--force`.
 
 ## Examples
 
@@ -203,14 +203,14 @@ Check what identity this workspace reports under before wiring up CI:
 stella cloud status
 ```
 
-Register a machine to an org and adopt a workspace id issued elsewhere:
+Register a machine to an org and use a workspace id issued elsewhere:
 
 ```bash
 stella cloud register --org acme --workspace-id 6f1d8a20-4c3e-4a71-9a55-2d0be1c7f5aa
 ```
 
-Scope an org to one shell session without touching `cloud.json` — the environment variable
-outranks the file:
+Scope an org to one shell session without touching `cloud.json`. The environment variable
+wins over the file:
 
 ```bash
 STELLA_ORG_ID=acme-staging stella cloud status

--- a/website/content/docs/commands/commands.mdx
+++ b/website/content/docs/commands/commands.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella commands
-description: List the custom slash commands this workspace offers, or convert markdown command definitions to TOML — the scriptable half of the custom-command surface.
+description: List the custom slash commands this workspace offers, or convert markdown command definitions to TOML.
 ---
 
-`stella commands` is the CLI half of [custom slash commands](/docs/agent-tools/commands). It lists what this workspace actually offers — resolved through the same authority gate the slash menu uses — and converts markdown definitions to TOML.
+`stella commands` is the command-line half of [custom slash commands](/docs/agent-tools/commands). It lists what this workspace actually offers, checked against the same permission rules the slash menu uses, and it converts markdown definitions to TOML.
 
-Offline: reads and writes local definition files, no API key.
+It works offline: it reads and writes local definition files only, and needs no API key.
 
 ## Synopsis
 
@@ -18,15 +18,15 @@ stella commands convert [<dir>] [--dry-run] [--force]
 
 ### `stella commands list`
 
-List the custom slash commands this workspace offers, with the file each came from and its argument hint.
+List the custom slash commands this workspace offers, with the file each one came from and its argument hint.
 
-The listing goes through the **same authority-gated loader the chat surfaces use**, on the real resolved policy. That is deliberate: a command hidden from the composer must not appear here, and one the composer offers must not be missing here. So if a command you wrote does not show up, the answer is usually the project's [authority policy](/docs/agent-tools/permissions) rather than a parse error.
+The listing checks the **same permission rules the chat surfaces use**, against your actual current settings. This is deliberate: a command hidden from the chat menu must not show up here, and one the chat menu offers must not be missing here. So if a command you wrote isn't showing up, the usual cause is the project's [permission settings](/docs/agent-tools/permissions), not a broken file.
 
 ```bash
 stella commands list
 ```
 
-Project-scope prompts are withheld from an **untrusted** project, so a freshly cloned repo's commands do not appear — and do not run — until you say the repo is trusted:
+Project-level commands are held back from an **untrusted** project, so a freshly cloned repo's commands don't appear, and don't run, until you mark the repo as trusted:
 
 ```bash
 # A cloned repo, not yet trusted: project commands are withheld
@@ -42,16 +42,16 @@ STELLA_TRUST_PROJECT=1 stella commands list
 ```
 
 <Callout type="info">
-Because the listing resolves the *real* policy rather than a permissive default, `list` under-reporting is a **correct** answer about what will actually run. If a command you wrote is missing, check the repo's trust before you check the file — see [Permissions](/docs/agent-tools/permissions).
+Because the listing checks your real settings rather than a permissive default, seeing fewer commands than you wrote is a **correct** answer about what will actually run. If a command you wrote is missing, check the repo's trust setting before you check the file. See [Permissions](/docs/agent-tools/permissions).
 </Callout>
 
 <Callout type="warn">
-`STELLA_TRUST_PROJECT=1` is a statement about the repository, not about one command. It also enables project-scope lifecycle hooks and the MCP servers declared in `.stella/mcp.toml` — both of which spawn processes. Do not set it for a repo you have not read.
+`STELLA_TRUST_PROJECT=1` is a statement about the whole repository, not about one command. It also turns on project-level lifecycle hooks and the MCP servers listed in `.stella/mcp.toml`, both of which start their own processes. Don't set it for a repo you haven't read.
 </Callout>
 
 ### `stella commands convert`
 
-Convert markdown command definitions to TOML. Reads `<dir>`, writes a `<slug>.toml` beside each `<slug>.md`, and **leaves the markdown in place**.
+Convert markdown command definitions to TOML. Reads `<dir>`, writes a `<slug>.toml` next to each `<slug>.md`, and **leaves the markdown file in place**.
 
 <CardGrid size="md">
   <OptionCard name="<dir>" defaultValue=".stella/commands/">
@@ -76,19 +76,19 @@ stella commands convert
 stella commands convert .claude/commands --force
 ```
 
-## Why conversion is deliberate, and never part of `init`
+## Why conversion is a separate step
 
-[`stella init`](/docs/commands/init) **symlinks** `.claude/commands/` rather than copying it. That link is the point: commands you maintain for another agent tool stay live, and editing them there updates what stella offers with no second step.
+[`stella init`](/docs/commands/init) **links** `.claude/commands/` instead of copying it. That link matters: commands you maintain for another agent tool stay live, and editing them there updates what stella offers with no extra step.
 
-A converted copy trades that live link for two things TOML does better — a typed `allowed-tools` list, and a delimiter-free `prompt` (no frontmatter fence to escape inside a prompt that itself contains markdown). Both are real wins, and neither is worth taking your live link away without being asked. So conversion is a command you run, not something `init` does to you.
+Converting a file to TOML trades that live link for two things TOML does better: a typed `allowed-tools` list, and a `prompt` field with no markdown fence to escape inside a prompt that itself contains markdown. Both are real benefits, but neither is worth taking your live link away without you asking for it. That's why conversion is a command you run yourself, not something `init` does automatically.
 
 <Callout type="warn">
-Converting a symlinked `.claude/commands/` directory writes TOML into the tool that owns those files, and the resulting `.toml` no longer tracks edits made to the `.md`. Prefer converting definitions that live in `.stella/commands/`.
+Converting a linked `.claude/commands/` directory writes TOML into the tool that owns those files, and the resulting `.toml` file stops tracking edits made to the `.md` file. Prefer converting definitions that live in `.stella/commands/` instead.
 </Callout>
 
-## The two formats are the same command
+## TOML and markdown are the same command
 
-TOML is a spelling, not a feature tier. Both formats carry exactly the same fields and produce the same definition, so nothing is gained or lost by converting, and a workspace can hold both.
+TOML is a different spelling, not a different feature level. Both formats carry exactly the same fields and produce the same command definition, so nothing is gained or lost by converting, and a workspace can hold both formats at once.
 
 ```toml
 # .stella/commands/review.toml
@@ -103,18 +103,18 @@ correctness first, then the gate, then naming.
 """
 ```
 
-A definition one level down is namespaced by its directory — `commands/vercel/deploy.toml` becomes `/vercel:deploy`.
+A definition placed one level down is grouped by its directory: `commands/vercel/deploy.toml` becomes `/vercel:deploy`.
 
 ## Related
 
 <CardGrid size="sm">
   <SpecCard title="Custom Commands" href="/docs/agent-tools/commands">
-    Authoring the definitions — both formats, argument expansion, and where they live.
+    Writing the definitions: both formats, argument expansion, and where they live.
   </SpecCard>
   <SpecCard title="Permissions" href="/docs/agent-tools/permissions">
-    The authority policy that decides which definitions resolve at all.
+    The permission settings that decide which definitions are available at all.
   </SpecCard>
   <SpecCard title="stella init" href="/docs/commands/init">
-    What `init` symlinks, and why it does not convert.
+    What `init` links, and why it doesn't convert.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/commands/completions.mdx
+++ b/website/content/docs/commands/completions.mdx
@@ -1,12 +1,11 @@
 ---
 title: stella completions
-description: Print a shell completion script for stella to stdout — bash, zsh, fish, PowerShell, or elvish. Offline, writes nothing, needs no API key.
+description: Print a shell completion script for stella to stdout — bash, zsh, fish, PowerShell, or elvish. Works offline, writes nothing, needs no API key.
 ---
 
-Print a shell completion script for `stella` to **stdout**. It writes nothing
-itself — where the script lands is your shell's business, and yours.
+Print a shell completion script for `stella` to standard output. It writes nothing itself. Where the script ends up is up to you and your shell.
 
-Offline, and needs no API key.
+Works offline, and needs no API key.
 
 ## Synopsis
 
@@ -16,7 +15,7 @@ stella completions <shell>
 
 <CardGrid size="sm">
   <OptionCard name="bash">
-    Sourced from a completion directory, conventionally `/etc/bash_completion.d/`.
+    Sourced from a completion directory, usually `/etc/bash_completion.d/`.
   </OptionCard>
   <OptionCard name="zsh">
     A `_stella` file on your `$fpath`.
@@ -34,7 +33,7 @@ stella completions <shell>
 
 ## Installing it
 
-Each shell expects the script somewhere different:
+Each shell expects the script in a different place:
 
 ```bash
 # bash
@@ -52,31 +51,22 @@ stella completions fish > ~/.config/fish/completions/stella.fish
 stella completions powershell | Out-String | Invoke-Expression
 ```
 
-Open a new shell afterwards, or re-source your profile.
+Open a new shell afterward, or re-load your profile.
 
 ## What you get
 
-Completion covers the whole CLI surface: every subcommand, every flag, and the
-value enums behind them — so `stella inspect --format <TAB>` offers `text` and
-`json` rather than nothing, and `stella completions <TAB>` offers the five
-shells above.
+Completion covers the whole command line: every subcommand, every flag, and the choices behind them. So `stella inspect --format <TAB>` offers `text` and `json` instead of nothing, and `stella completions <TAB>` offers the five shells above.
 
-The [global flags](/docs/commands#global-flags) are registered with every
-subcommand, so they complete in either position — before the subcommand or after
-it.
+The [global flags](/docs/commands#global-flags) are registered with every subcommand, so they complete in either position, before the subcommand or after it.
 
 <Callout type="info">
-The script is generated from the same command definitions the binary parses with,
-so completions cannot drift away from the flags that actually exist. Re-run the
-command after upgrading stella to pick up new subcommands.
+The script is built from the same command definitions the program itself uses, so completions always match the flags that actually exist. Re-run the command after upgrading stella to pick up new subcommands.
 </Callout>
 
-## Not sure it took?
+## Not sure it worked?
 
 ```bash
 stella completions zsh | head -5    # confirm a script is actually produced
 ```
 
-If the output looks right but completion still does nothing, the problem is
-placement rather than generation — check that the target directory is on your
-shell's completion path, and that you started a fresh shell.
+If the output looks right but completion still does nothing, the problem is likely where you put the file, not how it was generated. Check that the target directory is on your shell's completion path, and that you started a fresh shell.

--- a/website/content/docs/commands/config.mdx
+++ b/website/content/docs/commands/config.mdx
@@ -3,7 +3,7 @@ title: stella config
 description: Show the fully resolved configuration for the current session.
 ---
 
-Show the fully resolved configuration for the current session — the provider, model, a redacted key preview and *where it came from*, base URL, workspace, wire dialect, and the model each engine role will actually run on.
+Show the full, resolved configuration for the current session: the provider, model, a hidden key preview and where it came from, base URL, workspace, wire format, and the model each engine role will actually run on.
 
 ## Synopsis
 
@@ -13,17 +13,17 @@ stella config [global flags]
 
 ## What it does
 
-`stella config` resolves every configuration source — global flags, environment variables, the config file across all three scopes, and `credentials.toml` — and prints the **effective** result. It is the fastest way to confirm exactly which provider, model, and base URL a run will use, and that your key resolved without exposing it (the key is shown only as a redacted preview, followed by the source that won).
+`stella config` checks every configuration source — global flags, environment variables, the config file across all three scopes, and `credentials.toml` — and prints the result that actually applies. It's the fastest way to confirm exactly which provider, model, and base URL a run will use, and to confirm your key was found without showing it (the key appears only as a hidden preview, along with the source that provided it).
 
-The same output is available from the plain line REPL (`stella chat --plain`) via the `/config` slash command. The default Command Deck TUI does not have a `/config` command — run `stella config` in a separate shell instead.
+You can see the same output from the plain line REPL (`stella chat --plain`) with the `/config` command. The default Command Deck TUI doesn't have a `/config` command. Run `stella config` in a separate shell instead.
 
 <Callout type="info">
-The config file is merged field-by-field across three scopes — project, org-managed, and user — highest precedence first. `stella config` shows the merged, effective values. The modern file is [`stella.toml`](/docs/configuration/stella-toml) (`<workspace>/stella.toml`, `~/.stella/stella.toml`); the older [`settings.json`](/docs/configuration/settings) (`<workspace>/.stella/settings.json`, `~/.stella/settings.json`) is still read. **Where both exist, the TOML wins and stella says so on startup** — the JSON is shadowed, not merged. [`stella migrate config`](/docs/commands/migrate) writes the TOML from what stella actually read and keeps the JSON for you to delete once you have reviewed it.
+The config file is merged field by field across three scopes: project, org-managed, and user, with project taking the highest priority. `stella config` shows the merged result that actually applies. The current file format is [`stella.toml`](/docs/configuration/stella-toml) (`<workspace>/stella.toml`, `~/.stella/stella.toml`). The older [`settings.json`](/docs/configuration/settings) format (`<workspace>/.stella/settings.json`, `~/.stella/settings.json`) still works too. **When both exist, the TOML file wins, and stella says so on startup.** The JSON file is ignored rather than merged in that case. Run [`stella migrate config`](/docs/commands/migrate) to write a TOML file from your current settings — it keeps the old JSON file in place so you can review and delete it yourself.
 </Callout>
 
 ## Flags
 
-`stella config` takes the [global flags](/docs/commands). Passing `--model` or `--base-url` lets you preview how a specific override resolves before committing to a run. `--api-key` cannot be previewed on its own — it must be combined with `--model provider/model_id`, because a bare key doesn't say which provider it is for.
+`stella config` takes the [global flags](/docs/commands). Passing `--model` or `--base-url` lets you preview how a specific override resolves before committing to a run. `--api-key` can't be previewed alone. It must be combined with `--model provider/model_id`, since a key by itself doesn't say which provider it belongs to.
 
 ## Example
 
@@ -31,7 +31,7 @@ The config file is merged field-by-field across three scopes — project, org-ma
 stella config
 ```
 
-Representative output (illustrative):
+Sample output (for illustration only):
 
 ```text
 Stella — Current Configuration
@@ -47,33 +47,20 @@ Stella — Current Configuration
     default   zai/glm-5.2                  xhigh             thinking on   default_model
 ```
 
-The `Provider` line shows the provider's display name; `Model` is printed as
-`<provider-id>/<model-id>`; and the key is a redacted preview (first six characters, an
-ellipsis, and the last four) followed by **which source won** — `env:VAR`, the
-credentials file, or the config literal. That last part is the answer to "I set the key,
-why is it still using the other one?", so it is worth reading even when the preview looks
-right.
+The `Provider` line shows the provider's display name. `Model` is printed as `<provider-id>/<model-id>`. The key is a hidden preview (first six characters, then an ellipsis, then the last four) followed by which source provided it: an environment variable, the credentials file, or a value written directly in the config. That last part answers "I set the key, why is it still using a different one?", so it's worth reading even when the preview looks right.
 
 ### Engine roles
 
-The second block is the one a run's cost and behavior actually turn on: **each role, the
-model it resolves to, its reasoning effort, whether thinking is on, and the setting that
-decided it**. `rides the worker` in the last column means no role-specific model is
-configured, so the role inherits the worker's — which is the default for `research` and
-`plan` ([configurable independently](/docs/agent-tools/custom-agents) since they cost
-differently: research is a fan-out of short read-only calls, planning is one call that
-writes the work order).
+The second block shows what actually controls a run's cost and behavior: each role, the model it resolves to, its reasoning effort, whether extended thinking is on, and the setting that decided it. "Rides the worker" in the last column means no model is set for that role specifically, so it uses the worker's model instead. That's the default for `research` and `plan`, though you can [set them independently](/docs/agent-tools/custom-agents) since they cost differently — research makes many short read-only calls, while planning makes one call that writes the work order.
 
-`verifier` is the tier that authors the **witness test**, and that is now its only model
-call — there is no verdict call and no distress-guidance call. See
-[Plugins](/docs/plugins).
+The `verifier` role's only job is writing the check that confirms the work is done.
 
-Preview how an explicit override resolves without starting a run (global flags first):
+Preview how an explicit override resolves without starting a run (global flags go before `config`):
 
 ```bash
 stella --model anthropic/claude-fable-5 config
 ```
 
 <Callout type="warn">
-The values above are for illustration. Your actual output reflects the credentials and settings that resolve in your environment.
+The values above are only examples. Your actual output reflects the credentials and settings in your own environment.
 </Callout>

--- a/website/content/docs/commands/context.mdx
+++ b/website/content/docs/commands/context.mdx
@@ -5,13 +5,13 @@ description: Review, publish, and explain context records — the reviewable ste
 
 `stella ingest` writes proposals. `stella context` is what acts on them.
 
-Extraction turns markdown you already wrote into atomic, probed claims sitting in
-`.stella/proposals/*.toml`. Until you decide on one, it steers nothing. This
-command is the deciding surface: read what was proposed and what its truth probe
+Extraction turns markdown you already wrote into small, checked claims sitting in
+`.stella/proposals/*.toml`. Until you decide on one, it changes nothing. This
+command is the deciding surface: read what was proposed and what its truth check
 found, publish the claims that are actually true, decline the ones that are not,
-and afterwards ask any live record why it applied.
+and later ask any live record why it applied.
 
-Every subcommand reads and writes **local files only** — no API key, no network.
+Every subcommand reads and writes local files only. No API key, no network.
 
 ## Synopsis
 
@@ -44,143 +44,141 @@ stella context list          # confirm what now steers this workspace
 
 ### `stella context review [--all]`
 
-What ingest proposed, with the evidence behind each claim and the verdict its
-truth probe returned. Nothing steers until you keep it, so this is a reading
-surface with no side effects.
+Shows what ingest proposed, with the evidence behind each claim and the result of its
+truth check. Nothing takes effect until you keep it, so this command only reads and
+never changes anything.
 
-`--all` additionally shows the **dismissed** proposals — the compound claims
-extraction refused to split, and the executable content it quarantined. Those
-are worth a look when a document you expected to produce ten records produced
-six.
+`--all` also shows the dismissed proposals: compound claims that extraction
+refused to split, and executable content it set aside. These are worth a look when a
+document you expected to produce ten records produced six.
 
 ### `stella context keep <candidate> [--enforce]`
 
-Publish a proposal as a record the engine loads. It writes
-`.stella/rules/<lineage>.toml` — or `~/.stella/rules/` for a personal record —
-and **never overwrites an existing file**.
+Publishes a proposal as a record the engine loads. It writes
+`.stella/rules/<lineage>.toml` (or `~/.stella/rules/` for a personal record)
+and never overwrites an existing file.
 
 <Callout type="info">
-`--enforce` is a **separate grant on purpose**. Keeping a record means the engine
-loads it as steering. Authorizing it to *block a matching tool call* is a
-different decision with a different blast radius, so it is a different flag
-rather than a property of keeping.
+`--enforce` is a separate choice on purpose. Keeping a record means the engine
+loads it as guidance. Allowing it to block a matching tool call is a
+different decision with bigger consequences, so it's a separate flag
+rather than something `keep` does automatically.
 </Callout>
 
 ### `stella context edit <candidate> --statement <text> [--enforce]`
 
-Publish your wording instead of the extractor's. The claim keeps its lineage and
-its evidence; only the statement becomes yours. Use it when the claim is right
-but the phrasing was inherited from prose that said it badly.
+Publishes your own wording instead of the extractor's. The claim keeps its lineage and
+its evidence; only the wording changes. Use this when the claim is right
+but the phrasing came from prose that said it badly.
 
 ### `stella context amend <rule> [--precedence <N>] [--paths <glob>…] [--tasks <task>…] [--keywords <word>…]`
 
-Change a **published** record's scope or precedence, and re-stamp its identity.
-`edit` rewrites a *proposal's* wording; this is the verb for a record that is
-already steering.
+Changes a published record's scope or precedence, and gives it a new identity stamp.
+`edit` rewrites a proposal's wording; `amend` is for a record that is
+already active.
 
-Scope is the field most likely to need changing after publication, because a
-scope defect is invisible until the record meets its neighbours. In this
-repository `read-crate-readme-first` was published with `paths = ["crates"]` at
-the default precedence and suspended eight architecture-rule records across
-the whole crate tree. `validate` named the remedies — an explicit exclusion, a
-different precedence, a supersession link — and none of them was reachable from
-the CLI.
+Scope is the field most likely to need changing after publishing, because a
+scope mistake is invisible until the record runs into others nearby. For example, a rule
+named `read-crate-readme-first` was published with `paths = ["crates"]` at
+default precedence, and it ended up blocking eight other rules across
+the whole codebase. `validate` pointed to the fixes (an explicit exclusion, a
+different precedence, a link marking it as a replacement) but none of them could be
+applied from the command line before `amend` existed.
 
-A named list **replaces** rather than appends, because the usual repair is
-narrowing: `--paths crates/stella-core` after `paths = ["crates"]` matched
-everything. Empty values are dropped, so `--paths ''` unscopes — clap has no way
-to spell "this flag was given no values", and a record scoped to `""` would match
-nothing while reading as scoped.
+A list you pass here replaces the existing one instead of adding to it, because the usual fix
+is narrowing scope: `--paths crates/stella-core` after `paths = ["crates"]` matched
+everything. Empty values are dropped, so `--paths ''` removes the scope entirely.
 
-**With no flags it re-stamps and changes nothing else**, which is the repair for
-a file somebody has already hand-edited. `record_hash` is a two-pass hash over an
-RFC 8785 canonical preimage, so a hand-edit leaves the file describing bytes that
-no longer exist and every load reports `record_hash mismatch … loaded as a new
-revision`. Nothing else re-stamps: every other publication path mints a *new*
-record.
+**With no flags, `amend` re-stamps the record and changes nothing else.** This is the fix
+for a file someone has already edited by hand. `record_hash` is a checksum over the
+record's contents, so a hand-edit leaves the file describing bytes that
+no longer match, and every load reports a `record_hash mismatch … loaded as a new
+revision` message. No other command re-stamps this way. Every other way of publishing
+creates a brand new record.
 
-`record_id` moves, because it is derived from the content. That is a new revision
-of the same lineage, which is what a content-derived id is for — the statement,
-the lineage, the evidence and the provenance are untouched.
+`record_id` changes too, because it's built from the content. That's a new revision
+of the same lineage, which is what a content-based id is for. The statement,
+the lineage, the evidence, and the origin are untouched.
 
-**Enforcement is not amendable here.** `enforcement.mode` is what
-[`promote`](#stella-context-promote-rule---to-level---reason-why) governs, with
-an approver, a reason, and an immutable ledger event. A flag on this command
-would be a second route to the same grant with none of that behind it.
+**You can't change enforcement here.** `enforcement.mode` is controlled by
+[`promote`](#stella-context-promote-rule---to-level---reason-why), which requires
+an approver, a reason, and a permanent log entry. Adding that ability to this command
+would create a second way to grant the same power with none of those checks.
 
 ### `stella context ignore <candidate> [--reason <why>] [--cooldown <ISO-8601>]`
 
-Decline a proposal. This records **negative evidence** and a re-proposal
-cooldown — default `P90D` — so the next ingest of the same document does not ask
-again.
+Declines a proposal. This records the decision and sets a
+cooldown before it can be proposed again — 90 days by default — so the next time you
+ingest the same document, it doesn't ask again.
 
-Supply `--reason`. A decline with no reason is evidence nobody can act on later,
-including you.
+Always give a `--reason`. A decline with no reason is a decision nobody, including you,
+can understand or act on later.
 
 ### `stella context list [--format <text|json>]`
 
-What currently steers this workspace: every loaded record, its handle, its
-force, and whether it actually blocks anything.
+Shows what currently steers this workspace: every loaded record, its handle, its
+force level, and whether it actually blocks anything.
 
-**Force** selects the injection channel, which is also its cost:
+**Force** decides how a record is delivered to the model, which also affects its cost:
 
 <CardGrid size="md">
   <OptionCard name="must">
-    Binding. Always injected into the cached system prefix.
+    Required. Always included in the cached system prompt.
   </OptionCard>
   <OptionCard name="should">
-    Strong. Always injected into the cached system prefix.
+    Strongly recommended. Always included in the cached system prompt.
   </OptionCard>
   <OptionCard name="may">
-    Relevant-when-selected. Rides the volatile block after the prefix.
+    Included only when relevant. Sent in the part of the prompt that changes each time.
   </OptionCard>
   <OptionCard name="info">
-    Informational. Rides the volatile block.
+    For reference only. Sent in the part of the prompt that changes each time.
   </OptionCard>
 </CardGrid>
 
-`must` and `should` are always present, which is what makes them binding — and
-also what makes them the ones to be sparing with. `may` and `info` are selected
-by relevance.
+`must` and `should` records are always present, which is what makes them binding, and
+also why you should use them sparingly. `may` and `info` records are chosen
+based on relevance.
 
-**Enforcement** is orthogonal to force:
+**Enforcement** is a separate setting from force:
 
 <CardGrid size="sm">
   <OptionCard name="hard">
-    Blocked at the tool boundary by a guard.
+    Blocked automatically when a tool call would break the rule.
   </OptionCard>
   <OptionCard name="soft">
-    Warned, not blocked.
+    A warning is shown, but nothing is blocked.
   </OptionCard>
   <OptionCard name="none">
-    Advisory only.
+    For reference only.
   </OptionCard>
 </CardGrid>
 
 ### `stella context validate [--format <text|json>]`
 
-Re-run every claim's truth probe now and report the result, plus every
-validation finding and every equal-precedence conflict. It **exits non-zero when
-something must not steer**, which makes it usable as a gate:
+Re-runs every claim's truth check right now and reports the result, along with every
+validation finding and every conflict between records with the same precedence. It
+exits with a non-zero code when something should not be steering the agent, which makes
+it usable as a gate:
 
 ```bash
 stella context validate || echo "steering needs review before this merges"
 ```
 
-A record you **retired** is the one thing that does not fail it. Retirement
-archives the record in place — the file stays in `.stella/rules/` as history and
-the loader stops selecting it — so `validate` lists it under "Retired" and moves
-on. A refuted claim still fails, and so does an archived record that also carries
-a blocking finding.
+A record you retired is the one thing that doesn't cause a failure. Retiring
+archives the record in place. The file stays in `.stella/rules/` for the record,
+and the loader stops using it, so `validate` lists it under "Retired" and moves
+on. A claim that fails its truth check still fails validation, and so does an archived
+record that still carries a blocking issue.
 
-This is the answer to the problem inherited documentation always has: a record
-extracted from a README that was true in 2024 is a confident, wrong instruction
-today. The probe is declarative and runs against the tree, so staleness is
-detected rather than assumed away.
+This solves a common problem with inherited documentation: a record
+pulled from a README that was true two years ago is a confident, wrong instruction
+today. The check runs directly against the current codebase, so it catches
+outdated claims instead of assuming they're still true.
 
 ### `stella context explain <rule>`
 
-Why did that rule apply? Prints provenance, evidence, enforcement, and efficacy
+Why did that rule apply? Shows the origin, evidence, enforcement setting, and effectiveness
 for one record.
 
 ```bash
@@ -188,88 +186,88 @@ stella context explain ^pnpm-only
 stella context explain ctx.acme.web.pkg-manager
 ```
 
-Truth basis is part of that answer, and the four values are meaningfully
-different:
+Part of that answer is how the claim was judged true, and the four possible values mean
+different things:
 
 <CardGrid size="sm">
   <OptionCard name="decree">
-    True because an owner said so — unrefutable by construction.
+    True because an owner said so. Cannot be disputed by design.
   </OptionCard>
   <OptionCard name="measured">
-    True because the world was measured and agreed.
+    True because it was checked against the codebase and confirmed.
   </OptionCard>
   <OptionCard name="derived">
     True because it follows from other records.
   </OptionCard>
   <OptionCard name="asserted">
-    Asserted without a machine-checkable basis.
+    Stated as true with no automatic way to check it.
   </OptionCard>
 </CardGrid>
 
 ### `stella context propose <rule> [--commit]`
 
-Turn a record into a reviewable change: a branch, a single-concern diff, and a
-PR body. Without `--commit` it prints the plan; with it, the branch and commit
-are created locally.
+Turns a record into a reviewable change: a branch, a focused diff, and a
+pull request description. Without `--commit` it just prints the plan; with it, the branch
+and commit are created locally.
 
 This exists because steering that changes how an agent behaves for a whole team
-deserves the same review as code that does — and a single-concern diff is what
+deserves the same review as code does, and a focused diff is what
 makes that review possible.
 
 ### `stella context promote <rule> --to <level> --reason <why>`
 
-Change a record's enforcement **accountably**. Every transition — `advisory` →
-`blocking` and back — is appended as an immutable, hash-chained event to the
-repository-visible ledger (`.stella/rules/promotions.jsonl`), naming the
+Changes a record's enforcement level with accountability. Every change, from `advisory`
+to `blocking` and back, is added as a permanent, tamper-evident entry to a
+log visible in the repository (`.stella/rules/promotions.jsonl`), naming the
 approver (defaults to `git config user.email`, override with `--approver`),
 the record's author when known, the stated reason, and the policy version the
-event creates. The ledger — not a private per-machine approval — is what arms
-a repository record's guard, so the grant travels with the repository and is
-reviewed through the same pull requests as the rule it governs.
+change creates. This log, not a private approval on one machine, is what activates
+a repository record's enforcement, so the permission travels with the repository and is
+reviewed through the same pull requests as the rule it controls.
 
-Promotion to `blocking` requires the record to declare evaluable guard keys —
-a natural-language statement never silently becomes blocking behavior. An
-edited, dropped, or reordered ledger line breaks the chain, `stella context
-validate` fails on it, and a broken ledger grants nothing.
+Promoting a record to `blocking` requires the record to name specific, checkable
+conditions. A plain-language statement can never silently become blocking behavior. An
+edited, deleted, or reordered log entry breaks the chain, `stella context
+validate` fails on it, and a broken log grants no permissions at all.
 
 ### `stella context govern [solo|team|regulated] [--separation] [--yes]`
 
-Show or change the governance mode. With no argument it prints the mode, the
-current policy version, and every ledger enforcement grant with its approver
-and reason. A mode change always asks first (`--yes` confirms
-non-interactively); personal records stay private across the transition. In
-regulated mode with `--separation`, the identity that authored a record
-cannot approve its own enforcement grant — and an author that cannot be
-established fails closed.
+Shows or changes the governance mode. With no argument, it prints the current mode, the
+current policy version, and every enforcement permission in the log with its approver
+and reason. Changing the mode always asks for confirmation first (`--yes` skips the
+prompt); personal records stay private through the change. In
+regulated mode with `--separation`, the person who wrote a record
+cannot approve its own enforcement permission, and if the author can't be
+identified, the request is denied.
 
-## Two proposal substrates, separate
+## Two separate systems
 
 <Callout type="warn">
 `stella context` and [`stella proposals`](/docs/commands/proposals) review
 different things and do not share storage.
 
-- **`stella context`** reviews **file-based** proposals extracted from documents,
+- **`stella context`** reviews proposals extracted from documents and stored as files,
   in `.stella/proposals/*.toml`.
-- **`stella proposals`** reviews **behavioral** proposals mined from what the
-  agent actually did, in `.stella/private/context.db`.
+- **`stella proposals`** reviews proposals based on what the
+  agent actually did, stored in `.stella/private/context.db`.
 
-The split is about **authority**, not plumbing. An explicit instruction in a
-tracked file is eligible immediately; a pattern mined from sessions must first
-clear a distinct-task threshold. One review surface over both would apply one of
-those two gates to content it does not fit.
+The two are split because they need different levels of trust. An explicit instruction in a
+tracked file can be reviewed right away. A pattern noticed across sessions must first
+clear a threshold showing it happened across distinct tasks. One review tool for
+both would apply the wrong check to one or the other.
 </Callout>
 
 ## Related
 
 <CardGrid size="sm">
   <SpecCard title="stella ingest" href="/docs/commands/ingest">
-    The extraction half — what produces the proposals this command reviews.
+    The extraction step — what produces the proposals this command reviews.
   </SpecCard>
   <SpecCard title="stella proposals" href="/docs/commands/proposals">
-    The adaptive-context ledger: behavioral proposals, a separate substrate.
+    The adaptive-context log: proposals based on behavior, a separate system.
   </SpecCard>
   <SpecCard title="Context engine" href="/docs/context-engine">
-    How records become recall, and the two injection channels force selects.
+    How records get used, and the two ways they're delivered to the model.
   </SpecCard>
   <SpecCard title="Unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
     Where ingest and context fit when you inherit a repository.

--- a/website/content/docs/commands/daemon.mdx
+++ b/website/content/docs/commands/daemon.mdx
@@ -3,7 +3,7 @@ title: stella daemon
 description: Find, watch, answer, resume, and stop runs that outlived the terminal they were started from.
 ---
 
-A long-running verb started from a terminal — [`run`](/docs/commands/run), [`goal`](/docs/commands/goal), [`monitor`](/docs/commands/monitor), [`fleet`](/docs/commands/fleet) — is handed to a **supervisor**. The work becomes a detached process that survives the window closing, an `ssh` disconnect, and a logout; the terminal you started it in stays only to stream its output. `stella daemon` is how you find that process again afterwards.
+A long-running command started from a terminal — [`run`](/docs/commands/run), [`goal`](/docs/commands/goal), [`monitor`](/docs/commands/monitor), [`fleet`](/docs/commands/fleet) — is handed to a supervisor. The work becomes a detached process that survives the window closing, an `ssh` disconnect, and a logout. The terminal you started it in stays open only to stream its output. `stella daemon` is how you find that process again afterward.
 
 ## Synopsis
 
@@ -22,9 +22,9 @@ stella daemon uninstall <label>
 
 ## Why runs are supervised
 
-Closing a terminal sends `SIGHUP` to its foreground process group. Before this existed, that killed the run mid-turn: no answer, no record of why it stopped, and no way back to it. A supervised run is in its own session before it starts work, so the hangup never reaches it.
+Closing a terminal sends `SIGHUP` to its foreground process group. Without supervision, that would kill the run mid-turn: no answer, no record of why it stopped, and no way back to it. A supervised run starts its own session before it starts work, so the hangup never reaches it.
 
-You do not start a supervised run — every terminal run already is one. The first two lines it prints say so:
+You do not need to start a supervised run yourself. Every terminal run already is one. The first two lines it prints say so:
 
 ```text
 ▸ supervised ses-1785956826121-25167 — survives this terminal closing
@@ -43,30 +43,30 @@ $ stella daemon attach ses-1785956826121
 
 ## What supervision survives
 
-It survives **the terminal**: a closed window, a dropped `ssh` session, a logout — the run never notices, because it left that terminal's session before it began.
+It survives the terminal closing: a closed window, a dropped `ssh` session, a logout. The run never notices, because it left that terminal's session before it began.
 
-A killed **process** — OOM, `kill -9`, a reboot — is the stronger failure, and it is recoverable too: every turn checkpoints into the workspace's durable work journal at each committed step boundary, so a run killed mid-turn leaves a resume point where a closed window never needed one. [`resume`](#resume) picks it up. (For interactive deck sessions, [`stella resume`](/docs/commands/resume) remains the verb — it reopens a conversation; `daemon resume` continues a headless run's interrupted turn.)
+A killed process — an out-of-memory kill, `kill -9`, a reboot — is a bigger failure, but it's recoverable too. Every turn checkpoints into the workspace's durable work journal at each completed step, so a run killed mid-turn leaves a point to resume from, something a closed window never needed. [`resume`](#resume) picks it up. (For interactive deck sessions, [`stella resume`](/docs/commands/resume) is the command to use — it reopens a conversation. `daemon resume` continues a headless run's interrupted turn.)
 
 ## Which invocations are supervised
 
-Only ones with a controlling terminal to lose. A terminal is exactly what can close, so a run that has none is already immune, and supervising it would add a process and a copy of every byte of output for nothing. Concretely:
+Only ones with a terminal to lose. A run with no terminal is already safe from a hangup, so supervising it would just add overhead for nothing. Specifically:
 
 | Invocation | Supervised |
 |---|---|
 | `stella run "…"` typed in a terminal | yes |
-| `stella run "…" --detach` | yes — and the launcher returns immediately ([below](#--detach-start-it-and-get-the-prompt-back)) |
-| `stella run "…" --foreground` | no — runs in this process, as older releases did |
+| `stella run "…" --detach` | yes — and the launcher returns right away ([below](#--detach-start-it-and-get-the-prompt-back)) |
+| `stella run "…" --foreground` | no — runs in this process |
 | `cat spec.md \| stella run` with output redirected | no — no controlling terminal |
 | a CI step, a container, a `cron` job | no |
-| [`stella chat`](/docs/commands/chat) / [`stella resume`](/docs/commands/resume) | no — the deck *is* the terminal |
+| [`stella chat`](/docs/commands/chat) / [`stella resume`](/docs/commands/resume) | no — the deck is the terminal |
 
 `--foreground` (or `STELLA_FOREGROUND=1`) opts any invocation out.
 
 ## `--detach`: start it and get the prompt back
 
-Supervision keeps the run alive when the terminal goes; it does not hand the terminal back while the run continues. The launching process stays for the whole run streaming the console, and `Ctrl-C` there **stops** the run —, because that is what the key means everywhere else.
+Supervision keeps the run alive when the terminal goes away. It doesn't hand the terminal back while the run keeps going. The launching process stays open for the whole run, streaming the console, and `Ctrl-C` there stops the run, the same as it does everywhere else.
 
-`--detach` is the other half. The work is supervised exactly as it would be otherwise — same session id, same console, the whole `stella daemon` surface addresses it — but the launcher returns as soon as the run is registered:
+`--detach` is the other half. The work is supervised exactly as it would be otherwise (same session id, same console, the whole `stella daemon` surface can address it), but the launcher returns as soon as the run is registered:
 
 ```bash
 $ stella run "migrate the config loader to serde" --detach
@@ -76,14 +76,14 @@ $ stella run "migrate the config loader to serde" --detach
 $
 ```
 
-Two differences from an attached launch, both deliberate:
+Two differences from an attached launch, both intentional:
 
-- **A terminal is not required.** Plain supervision declines without one, since a run with no terminal to lose is already immune to the hangup. "Return now" is wanted from a pipe, a container, a `cron` job and a shell script exactly as much as from a terminal, so the flag forces supervision rather than merely permitting it.
-- **The exit code is the launch's, not the run's.** `stella run --detach; echo $?` answers "did the launch succeed". The run's own answer arrives in `stella daemon list`.
+- **A terminal is not required.** Plain supervision does nothing without one, since a run with no terminal to lose is already safe. `--detach` forces supervision instead of only allowing it, because "return right away" is just as useful from a pipe, a container, or a `cron` job as from a terminal.
+- **The exit code belongs to the launch, not the run.** `stella run --detach; echo $?` tells you whether the launch succeeded. The run's own result shows up later in `stella daemon list`.
 
 ### Detaching from a script
 
-The banner above is on **stderr**, so it never garnishes a pipe. Under `--output-format json` or `stream-json`, stdout carries one launch summary naming the session — the id a script needs before it can do anything at all with the run it just started:
+The banner above prints to stderr, so it never shows up in a pipe. Under `--output-format json` or `stream-json`, stdout carries one launch summary naming the session, the id a script needs before it can do anything with the run it just started:
 
 ```bash
 $ stella run "migrate the config loader to serde" --detach --output-format json
@@ -101,33 +101,33 @@ id=$(stella run "…" --detach --output-format json | jq -r .session_id)
 stella daemon stop "$id"
 ```
 
-`stream-json` gets the same object compact on one line, so the line-delimited contract holds. `status` is `detached` rather than `ok`: the launch succeeded, and the run's own verdict is a later, separate question — see [scripting](/docs/scripting) for the envelope family this joins.
+`stream-json` returns the same object, compact, on one line. `status` reads `detached` rather than `ok`: the launch succeeded, and whether the run itself succeeds is a separate, later question. See [scripting](/docs/scripting) for the full family of output formats.
 
-It applies to every supervised verb — `run`, `goal`, `monitor`, `fleet` — and `STELLA_DETACH=1` sets it for a whole shell. `--foreground` wins if both are given: the flag that asks for less machinery is the safer reading of a contradictory command line, and a declared conflict would break the supervised child, which re-parses its parent's argv (`--detach` included) with `STELLA_FOREGROUND=1` in its environment.
+This applies to every supervised command: `run`, `goal`, `monitor`, `fleet`. `STELLA_DETACH=1` turns it on for a whole shell. `--foreground` wins if both are given, since the flag asking for less machinery is the safer choice when the command line contradicts itself.
 
-A detached run cannot ask *this* terminal anything, because there is no longer one attached — but it does not lose the answer either. A plan that crosses the scope thresholds parks exactly as described below, and the next `stella daemon attach` asks the question.
+A detached run can't ask this terminal anything, since nothing is attached anymore, but it doesn't lose the answer either. A plan that crosses the scope thresholds parks and waits, as described below, and the next `stella daemon attach` asks the question.
 
 ## Scope review while supervised
 
-A supervised run's stdin is a file and its console is a log, so a scope-review prompt cannot use them — but supervision does not cost you the answer. When a `stella run` plan crosses the scope thresholds, the run **parks**: the proposal is written into the session's sidecar, `stella daemon list` shows the run as `Needs Input`, and whichever terminal is attached asks the question — the terminal that launched it, if it is still open, or any later `stella daemon attach`. The prompt rides the attached terminal's stderr, so `--output-format json` stdout stays parseable, and the same typed answers apply as at the foreground prompt: `y` approves, `n` (or an empty line) aborts, anything else is a revision note the planner re-plans from.
+A supervised run's input is a file and its console is a log, so it can't show a scope-review prompt the usual way. But supervision doesn't cost you the answer. When a `stella run` plan crosses the scope thresholds, the run parks: the proposal is written into the session's side files, `stella daemon list` shows the run as `Needs Input`, and whichever terminal is attached asks the question, whether that's the terminal that launched it (if still open) or a later `stella daemon attach`. The prompt appears on the attached terminal's stderr, so `--output-format json` stdout stays readable by scripts. The same answers work as at a normal prompt: `y` approves, `n` (or an empty line) cancels, anything else is a note the planner uses to revise the plan.
 
-A parked run holds its budget and its workspace until somebody answers; it is visible in `list` the whole time, and `stella daemon stop` (or any `SIGTERM`) unparks it as a clean abort. There is no bypass setting to reach for: `headless_scope_bypass` used to skip the gate for a workspace whose disposable tree made the budget cap the real guard, and it is inert now — it skips nothing, because there is no built-in gate left to skip.
+A parked run holds its budget and its workspace until someone answers. It's visible in `list` the whole time, and `stella daemon stop` (or any `SIGTERM`) cancels it cleanly. There's no setting to skip this review.
 
 ## `list`
 
-Every supervised run on this machine, newest first. Local reads only — no API key, and no provider needs to resolve, so a run whose model configuration has since broken is still findable and stoppable.
+Every supervised run on this machine, newest first. This only reads local data. It needs no API key and doesn't need to check with any provider, so a run whose model configuration is now broken is still visible and stoppable.
 
-`STATUS` is answered by a lock the run holds for its whole life rather than by its pid, because the kernel releases that lock when the process dies — crash, kill and power loss included. A run whose process is gone without recording an outcome reads as `Crashed`, and one that left a resume point is marked `Crashed ↩` with the `resume` invocation named under the table. A run parked on a scope review reads `Needs Input`.
+`STATUS` is based on a lock the run holds for its whole life, not on its process id, because the operating system releases that lock as soon as the process dies for any reason (crash, kill, or power loss included). A run whose process is gone without recording a result shows as `Crashed`. One that left a resume point is marked `Crashed ↩`, with the `resume` command to use shown under the table. A run parked on a scope review shows as `Needs Input`.
 
 ## `attach`
 
-Streams the run's output into this terminal, from the beginning, and stays until the run ends. A run that has already finished prints in full and exits. The id can be any unique prefix — or the run's **pid**, which is the address `ps`, `top`, Activity Monitor and an OOM-killer log give you; omit it for the most recently started run. If the run is parked on a scope review, attach renders the proposal and delivers your answer.
+Streams the run's output into this terminal, from the beginning, and stays until the run ends. A run that already finished prints its full output and exits. The id can be any unique prefix, or the run's process id, which is what `ps`, `top`, Activity Monitor, and an out-of-memory kill log give you. Omit the id to use the most recently started run. If the run is parked on a scope review, attach shows the proposal and sends your answer.
 
-Detaching again — `Ctrl-C` — leaves the run alone. `stella daemon stop` is what stops it.
+Detaching again with `Ctrl-C` leaves the run running. `stella daemon stop` is what actually stops it.
 
 ## `logs`
 
-The tail of a finished or running console, without following it.
+Shows the tail of a finished or running console, without following it live.
 
 <CardGrid size="md">
   <OptionCard name="-n / --lines <N>" defaultValue="40">
@@ -135,19 +135,19 @@ The tail of a finished or running console, without following it.
   </OptionCard>
 </CardGrid>
 
-stdout and stderr are kept in two files and replayed onto the two streams they were written from, so `stella run --output-format json` stays parseable through a supervisor. The console carries a small write index beside it, and `logs` uses it to replay the two streams **in the order they were written** rather than as two blocks. Only sessions recorded before the index existed fall back to the old shape — stdout tail, then stderr tail — because raw byte files carry no ordering to reconstruct.
+stdout and stderr are kept in two separate files and replayed onto the two streams they came from, so `stella run --output-format json` stays readable by scripts even through a supervisor. A small write index is kept beside the console, and `logs` uses it to replay the two streams in the order they were written, rather than as two separate blocks. Only sessions recorded before this index existed fall back to the older order: stdout tail, then stderr tail.
 
-Each console is **bounded** (8 MiB per stream by default; `STELLA_CONSOLE_CAP_BYTES` overrides it). A run that outgrows the bound keeps the first eighth — how the run started — and the newest bytes, ring-buffered; the reclaimed middle is announced with a marker on stderr, never spliced into the stream bytes themselves. A run killed outright (`SIGKILL`, power loss) can additionally lose up to one pipe buffer (~64 KiB) of its very last output — the cost of enforcing the bound while the run is alive.
+Each console is capped in size (8 MiB per stream by default; `STELLA_CONSOLE_CAP_BYTES` changes it). A run that produces more output than the cap keeps the first eighth (how the run started) and the newest bytes, dropping the middle. A marker on stderr announces when this happens; it never gets mixed into the stream itself. A run that is killed outright (`SIGKILL`, power loss) can additionally lose up to one buffer's worth (about 64 KiB) of its very last output. That's the cost of enforcing the size cap while the run is still alive.
 
 ## `stop`
 
-Asks the run to stop the way `Ctrl-C` would: the signal reaches the whole process group — the run and every tool process it spawned — and the engine finishes the tool it is running and aborts at the next safe boundary, never mid-tool.
+Asks the run to stop the way `Ctrl-C` would: the signal reaches the whole process group (the run and every tool process it started), and the engine finishes the tool it's running before stopping at the next safe point, never mid-tool.
 
-A run that has not stopped after 8 seconds is killed. Either way the stop is recorded as **cancelled**: a run stopped by hand that recorded nothing would age into the registry indistinguishable from one that crashed.
+A run that hasn't stopped after 8 seconds is killed outright. Either way, the stop is recorded as **cancelled**, so a run you stopped by hand doesn't later look identical to one that crashed.
 
 ## `resume`
 
-Continues a killed run's interrupted turn from its last completed step. Every turn checkpoints at each committed step boundary — the one moment the transcript is guaranteed well-paired — and every turn that *ends* (completes, aborts, or is stopped) discards its checkpoint on the way out. A surviving resume point therefore means exactly one thing: the process died mid-turn.
+Continues a killed run's interrupted turn from its last completed step. Every turn checkpoints at each completed step, the one point where the transcript is guaranteed to be complete, and every turn that ends normally (finishes, stops, or is cancelled) clears its checkpoint on the way out. So a resume point surviving means exactly one thing: the process died in the middle of a turn.
 
 ```bash
 $ stella daemon list
@@ -160,9 +160,9 @@ $ stella daemon resume ses-1785956826121
 ▸ resuming ses-1785956826121-25167 — continuing its interrupted turn at step 14
 ```
 
-The relaunch continues the **same session** — same id, same sidecar, the crashed attempt's console preserved — as a fresh supervised child. Completed steps are already in the checkpointed transcript, tool results included, so nothing re-runs and no tool effect is applied twice. The no-clobber guard does not ride the checkpoint — it is in-process state, and the relaunch starts it empty — so the resumed run must re-read any existing file in full before it can overwrite it, which also covers a file something else edited while the run was dead. A run that ended cleanly has nothing to resume, and `resume` says so instead of restarting it.
+The relaunch continues the same session (same id, same side files, the crashed attempt's console kept) as a fresh supervised process. Completed steps are already saved in the checkpointed transcript, tool results included, so nothing runs twice and no tool effect happens more than once. The overwrite-protection check isn't part of the checkpoint (it's kept only in memory, and the relaunch starts with none), so the resumed run re-reads any existing file in full before changing it. This also covers a file something else edited while the run was dead. A run that ended cleanly has nothing to resume, and `resume` says so instead of restarting it.
 
-A turn that was running under a wrapper plugin **re-enters that wrapper** when its frame permits: the wrapper records its progress — task class, goal, plan cursor, test baseline — beside every checkpoint, and `resume` finishes the interrupted turn, runs the plan steps the crash never reached, then runs the witness and verify steps on the completed work. A resume that ends with a verdict files its audit row as `resumed_complete_verified` and keeps the green tick.
+A turn that was running under an installed wrapper plugin re-enters that wrapper when possible. The wrapper saves its progress (task type, goal, plan position, test baseline) beside every checkpoint, and `resume` finishes the interrupted turn, runs the plan steps the crash never reached, then runs the check and verify steps on the finished work. A resume that ends with a verdict records its result as `resumed_complete_verified` and keeps the green checkmark.
 
 ```text
 $ stella daemon resume ses-1785956826121
@@ -172,11 +172,11 @@ $ stella daemon resume ses-1785956826121
     an authored witness cannot be re-created after a crash — verification proceeds on the unauthored ladder
 ```
 
-Two limits remain — and neither is silent. A turn that was executing in a **candidate worktree** resumes in the workspace as a plain engine turn, because the candidate died with the process. And a frame from an **older writer** (or a run killed before execution began) carries no progress record to restore from, so it too resumes as a plain turn. In both cases the run names every stage it is not restoring — the verify command that will not re-run, the witness flip that will not be credited — drops the green tick, and files its audit row as `resumed_complete_unverified` rather than `resumed_complete`. An unverified resume is a resume you can still act on; an unverified resume you were never told about is not. Re-verifying is `stella run` over the same goal.
+Two limits remain, and neither happens silently. A turn that was running in a candidate worktree resumes in the main workspace as a plain turn, because the candidate copy died with the process. And a turn saved by an older version of stella (or a run killed before it started working) has no progress record to restore, so it also resumes as a plain turn. In both cases, the run names every stage it can't restore (the verify command that won't re-run, the check that won't be credited), drops the green checkmark, and records its result as `resumed_complete_unverified` instead of `resumed_complete`. An unverified resume is still something you can act on; an unverified resume you were never told about is not. To re-verify, run `stella run` again over the same goal.
 
 ## `resume-all`
 
-`resume` continues one run you name. `resume-all` continues every run *this machine* interrupted, in one pass — the verb a boot-time service runs, and a useful one by hand after an unplanned reboot:
+`resume` continues one run you name. `resume-all` continues every run this machine interrupted, in one pass. This is the command a boot-time service runs, and it's also useful by hand after an unplanned reboot:
 
 ```bash
 stella daemon resume-all --dry-run   # print the decision for every run, spend nothing
@@ -192,33 +192,39 @@ It prints one line per supervised run, continued or skipped, with the reason:
   boot-time resume 1 of 3 for ses-1785956826121
 ```
 
-**What it continues.** A supervised run that was interrupted — its liveness lock gone, its workspace still there, and a resume point left behind. That is the rows `list` paints `Crashed ↩`, and now also a run that fell over having lived just long enough to record the error: both are work that stopped without meaning to.
+### What it continues
 
-A run that finished, was stopped, was set aside, or **stopped itself by policy** — a stuck loop escalated past its warning, the step cap, an enforced budget, a scope review you ended — is never resumed. Every one of those writes a status on the way out saying the work was *ended* rather than broken, and every one of them retracts its resume point as it goes, so the rule holds twice over. Work you ended on purpose is never resumed behind your back.
+A supervised run that was interrupted: its liveness lock is gone, its workspace is still there, and it left a resume point behind. This is the same set of runs `list` marks `Crashed ↩`, plus a run that lived just long enough to record its own error before dying. Both are work that stopped without meaning to.
 
-**What it skips because nobody is there.** A run that was waiting on a plan review when the machine went down is *not* resumed at boot. Resuming it would not fail — it would park again, waiting for an answer, and because the sweep streams one run at a time to completion it would sit there forever with every later run behind it unresumed. So the sweep names it and moves on:
+A run that finished, was stopped, was set aside, or stopped itself on purpose (a stuck loop that hit its limit, the step cap, an enforced budget, a scope review you cancelled) is never resumed. Each of those records a status on the way out saying the work ended rather than broke, and each one clears its resume point too. Work you ended on purpose is never resumed behind your back.
+
+### What it skips because nobody is there
+
+A run that was waiting on a plan review when the machine went down is not resumed at boot. Resuming it wouldn't fail outright, but it would park again waiting for an answer, and since the sweep runs one run at a time to completion, it would sit there forever with every later run stuck behind it. So the sweep names it and moves on:
 
 ```text
 ▸ skipping    ses-1785956700221 — waiting on an approval — answer it with `stella daemon attach <id>`, then `stella daemon resume <id>`
 ```
 
-Waiting is not failing, so it does not spend one of the three attempts below: a run can wait across any number of reboots and still be resumable the moment you answer it.
+Waiting isn't the same as failing, so it doesn't use up one of the three attempts below. A run can wait across any number of reboots and still be resumable the moment you answer it.
 
-**What bounds it.** Each run gets at most **three** boot-time resumes. The count is durable (`~/.stella/services/resume-boot.json`) and is written *before* the resume is spawned, so a run that takes the machine down with it is still charged for the attempt. Past three, the run is retired from the sweep and left for `stella daemon resume <id>` by hand — a human deciding to try again is what the bound exists to require. Runs are resumed one at a time; several turns resuming at once is several models spending at once on a machine nobody is watching.
+### What limits it
 
-**What bounds each resume.** The attempt count bounds how many *boots* a run can spend; it does not stop one resumed turn from holding *this* boot forever — a wedged tool, a provider that never returns, a model call retrying without end. So each resumed run also gets a wall-clock ceiling, **30 minutes** unless `--ceiling MINUTES` says otherwise. A run that reaches it is never killed outright — a kill at the ceiling would land mid-edit, which is worse than the stall it fixes. It is stopped exactly the way `stella daemon stop` stops one: asked with `SIGTERM`, given the grace period to abort at a safe boundary and record its own ending, killed only if it ignores that. Then the sweep says so and moves to the next run:
+Each run gets at most three boot-time resumes. This count is saved to disk (`~/.stella/services/resume-boot.json`) and is written before the resume even starts, so a run that takes the machine down with it is still charged for the attempt. After three attempts, the run is left out of future sweeps and left for you to resume by hand with `stella daemon resume <id>`, since deciding to try again is meant to be a human choice at that point. Runs are resumed one at a time, since several turns resuming at once would mean several models spending money at once on a machine nobody is watching.
+
+The attempt count limits how many boots a run can spend, but it doesn't stop one resumed turn from taking up the whole current boot forever (a stuck tool, a provider that never responds, a model call that retries endlessly). So each resumed run also gets a time limit, 30 minutes by default unless `--ceiling MINUTES` says otherwise. A run that hits this limit is never killed outright, since killing it mid-edit would be worse than the stall it's meant to fix. Instead it's stopped exactly the way `stella daemon stop` stops a run: asked to stop with `SIGTERM`, given time to reach a safe point and record its own ending, and only killed if it ignores that. Then the sweep reports it and moves to the next run:
 
 ```text
 ⚠ ses-1785956826121 — did not finish within the 30-minute ceiling and was stopped at a safe boundary; the sweep continues with the runs behind it — `stella daemon list` shows where this one ended up
 ```
 
-The two ways that ends need no new rules. A run that honoured the stop ended — same as a Ctrl-C — so the next sweep skips it and returns its attempts; it was merely slower than the ceiling, and `stella daemon resume <id>` by hand has no ceiling. A run so wedged it had to be killed keeps its resume point and is swept again next boot — and the attempt it was already charged (a timed-out resume **does** spend one) is exactly what retires it after three, because a run that hits the ceiling every boot is the recurring failure the attempt bound exists to stop.
+Both outcomes need no special handling. A run that stopped cleanly when asked ended the same as a Ctrl-C would, so the next sweep skips it and gives back its unused attempts; it was just slower than the time limit, and running `stella daemon resume <id>` by hand has no time limit. A run so stuck it had to be killed keeps its resume point and is swept again next boot, and the attempt it already used (a timed-out resume does count as one) is exactly what eventually retires it after three tries, since a run that hits the limit every boot is the kind of repeated failure the attempt limit exists to stop.
 
-Everything `resume` says about a resumed turn applies here, including the limits above: a turn interrupted mid-wrapper resumes as a plain engine turn and says which steps it is not restoring — into the service console rather than a terminal.
+Everything `resume` does for a resumed turn applies here too, including the limits above: a turn interrupted mid-wrapper resumes as a plain turn and reports which steps it can't restore, written to the service console instead of a terminal.
 
 ## `install` / `uninstall`
 
-Supervision and resume both act on runs a human started; neither makes anything *start by itself* after a reboot — nothing a process arranges for itself can. Starting again is the OS service manager's job, and `install` is the explicit handshake with it, registering **one stella invocation you choose** as a per-user service:
+Supervision and resume both act on runs a person started. Neither one makes anything start on its own after a reboot, since nothing a process sets up can restart itself once it's gone. Starting again on boot is the operating system's job, and `install` is how you register **one stella command you choose** as a per-user service:
 
 ```bash
 stella daemon install -- monitor --interval 300
@@ -226,32 +232,32 @@ stella daemon install --label night-fleet --keep-alive -- fleet watch
 stella daemon uninstall night-fleet
 ```
 
-On **macOS** it writes a launchd agent (`~/Library/LaunchAgents/sh.oxagen.stella.<label>.plist`) and loads it with `launchctl bootstrap`; the command starts at every login, including the login after a reboot. On **Linux** it writes a `systemd --user` unit (`~/.config/systemd/user/stella-<label>.service`), enables it, and turns on lingering (`loginctl enable-linger`) so the command starts at boot and keeps running through logout. When a `launchctl`/`systemctl` call fails, the definition is still written and the exact command to load it by hand is printed.
+On macOS, this writes a launchd agent (`~/Library/LaunchAgents/sh.oxagen.stella.<label>.plist`) and loads it with `launchctl bootstrap`. The command starts at every login, including the login after a reboot. On Linux, it writes a `systemd --user` unit (`~/.config/systemd/user/stella-<label>.service`), turns it on, and enables lingering (`loginctl enable-linger`) so the command starts at boot and keeps running through logout. If a `launchctl` or `systemctl` call fails, the service definition is still written, and the exact command to load it by hand is printed.
 
-**A registered command re-*starts*:** it begins a fresh turn, and a fresh spend, each time the manager launches it. So register standing verbs — a monitor, a fleet watch, a perpetual run — and let one-shot runs stay merely supervised. Nothing is ever registered implicitly.
+**A registered command restarts from scratch each time**, spending fresh money on a fresh turn every time the service manager launches it. So register standing tasks, such as a monitor, a fleet watch, or a run meant to keep going, and let one-shot runs stay simply supervised instead. Nothing is ever registered for you automatically.
 
-**To come back *continuing* the work a reboot interrupted, register the sweep instead:**
+To come back and continue the work a reboot interrupted, register the sweep instead:
 
 ```bash
 stella daemon install --resume-all
 ```
 
-That registers exactly one thing — `stella daemon resume-all`, under the label `resume-boot`, console `~/.stella/services/resume-boot.log`. At every boot it continues the turns this machine killed from their last completed step and never restarts one; its selection rule and its three-attempt bound are [above](#resume-all). It takes no command of its own and refuses `--keep-alive`: a sweep restarted every minute would spend against its own attempt bound until it was exhausted. `stella daemon uninstall resume-boot` removes it like any other service.
+This registers exactly one thing: `stella daemon resume-all`, under the label `resume-boot`, logging to `~/.stella/services/resume-boot.log`. At every boot it continues the turns this machine killed, from their last completed step, and never restarts one from scratch. Its selection rule and three-attempt limit are described [above](#resume-all). It takes no command of its own and refuses `--keep-alive`, since a sweep restarted every minute would use up its own attempt limit right away. `stella daemon uninstall resume-boot` removes it like any other service.
 
 Two defaults keep a broken service from spending money unattended:
 
-- **A command that exits stays down** until the next boot. `--keep-alive` opts into restart-on-exit, throttled to once a minute, and on systemd additionally start-limited (five starts in ten minutes parks the unit in the failed state).
-- **The binary is resolved at load, loudly.** The service execs through a `/bin/sh` shim that tries the path recorded at install time, falls back to `PATH` (plus the usual Homebrew and cargo prefixes) — so a `brew upgrade` that moves the binary does not strand the service — and otherwise writes one line naming what is missing to the service console and exits 127.
+- **A command that exits stays down** until the next boot. `--keep-alive` turns on restart-on-exit, limited to once a minute, and on systemd also limited to five starts in ten minutes before the unit is marked failed.
+- **The program location is looked up each time it starts, and reported if missing.** The service runs through a small shell wrapper that tries the path recorded at install time, then falls back to your `PATH` (plus the usual Homebrew and cargo locations), so an upgrade that moves the program doesn't break the service. If it still can't be found, one line naming what's missing is written to the service console and the service exits with code 127.
 
-The service runs in the directory `install` was typed in, and its console is `~/.stella/services/<label>.log` (both streams, owner-only directory). A service-run stella has no terminal, so it is not re-supervised — the manager *is* its supervisor — and it does not appear in `stella daemon list`, which lists supervised runs. The platform's own query is its status surface:
+The service runs in the directory `install` was run from, and its console output goes to `~/.stella/services/<label>.log` (both streams, in a directory only you can read). A service-run stella has no terminal, so it isn't supervised again (the service manager is its supervisor), and it doesn't show up in `stella daemon list`, which only lists supervised runs. Check its status using the operating system's own tools:
 
 ```bash
 launchctl print gui/$(id -u)/sh.oxagen.stella.<label>   # macOS
 systemctl --user status stella-<label>                  # Linux
 ```
 
-`uninstall` unloads the service and deletes the definition — the queries above then report it gone. Uninstalling something already removed reports that and succeeds. On Linux, lingering is left as you set it, since other user services may depend on it.
+`uninstall` unloads the service and deletes its definition; the commands above then report it gone. Uninstalling something already removed reports that and still succeeds. On Linux, lingering is left as you set it, since other user services may depend on it.
 
 ## Where the state lives
 
-Beside the session registry, under the user-level stella home (`~/.stella/sessions/<id>/`, `STELLA_DATA_DIR` overrides): `stdout.log` and `stderr.log` are the console, `console-index.jsonl` is the write index that bounds and orders them, `stdin` is the prompt the supervisor staged for the run, `supervisor.lock` is the liveness lock, and `approval-request.json` / `approval-answer.json` appear only while a scope review is parked. All owner-only. The prompt travels as a file rather than as an argument so it is not visible to every user on the machine in `ps`. The resume point itself is not here — it lives in the workspace's work journal, the same commit graph as the file changes it is a resume point for.
+Beside the session registry, under the user-level stella home directory (`~/.stella/sessions/<id>/`, `STELLA_DATA_DIR` overrides it): `stdout.log` and `stderr.log` hold the console output, `console-index.jsonl` is the write index that bounds and orders them, `stdin` is the prompt the supervisor saved for the run, `supervisor.lock` is the liveness lock, and `approval-request.json` / `approval-answer.json` appear only while a scope review is parked. All of these are readable only by you. The prompt is saved as a file rather than passed as an argument, so it isn't visible to every user on the machine through `ps`. The resume point itself isn't stored here. It lives in the workspace's own work journal, alongside the file changes it's a resume point for.

--- a/website/content/docs/commands/dataset.mdx
+++ b/website/content/docs/commands/dataset.mdx
@@ -176,7 +176,7 @@ Every string in every record, and in the manifest, passes through the same secre
 
 `redacted` on each record reports whether anything was actually replaced, so "this was scrubbed" is a fact you can see rather than something you have to assume.
 
-The manifest's `redaction.behavior_digest` fingerprints the redactor by its **decisions** on a fixed test set of text, so it changes whenever a threshold, a matcher, or a rule list changes. One limit worth stating plainly: a rule added for a vendor that test set doesn't cover leaves the digest unchanged.
+The manifest's `redaction.behavior_digest` fingerprints the redactor by its **decisions** on a fixed test set of text, so it changes whenever a threshold, a matcher, or a rule list changes. One limit: a rule added for a vendor that test set doesn't cover leaves the digest unchanged.
 
 ## The manifest
 

--- a/website/content/docs/commands/dataset.mdx
+++ b/website/content/docs/commands/dataset.mdx
@@ -1,14 +1,14 @@
 ---
 title: stella dataset
-description: Curate a redacted, provenance-stamped training dataset from this workspace's own receipts — one JSONL record per accepted turn, plus a manifest stating the exact filter that selected them.
+description: Build a redacted, source-stamped training dataset from this workspace's own records — one JSONL record per accepted turn, plus a manifest stating the exact rule that selected them.
 ---
 
-`stella dataset` turns the receipts a workspace has already accumulated into a training-ready trajectory set: one JSONL record per **accepted** turn, every string scrubbed by the secret redactor, and a `manifest.json` beside it that states the extraction rule in full.
+`stella dataset` turns the records a workspace has already collected into a training-ready set: one JSONL record per **accepted** turn, every string scrubbed by the secret redactor, and a `manifest.json` beside it that states the selection rule in full.
 
-Offline: reads `.stella/private/store.db` only, needs no API key, and never writes to the store. The export stays on the machine.
+It works offline: it reads `.stella/private/store.db` only, needs no API key, and never writes to the store. The export stays on your machine.
 
 <Callout type="warn">
-  Human sign-off is required before any dataset is used for training. The manifest exists so that review is possible — read it before you ship the JSONL anywhere.
+  A person must sign off before any dataset is used for training. The manifest exists so that review is possible. Read it before you send the JSONL file anywhere.
 </Callout>
 
 ## Synopsis
@@ -29,8 +29,8 @@ writes two files into `./trajectories`, both owner-only (`0600`) inside an owner
 
 | File | What it is |
 | --- | --- |
-| `dataset.jsonl` | One JSON record per accepted turn, ascending by execution id |
-| `manifest.json` | The extraction filter, the redactor's fingerprint, and the store watermark |
+| `dataset.jsonl` | One JSON record per accepted turn, in ascending order by execution id |
+| `manifest.json` | The selection rule, the redactor's fingerprint, and the store's latest timestamp |
 
 ### `stella dataset export`
 
@@ -42,50 +42,50 @@ writes two files into `./trajectories`, both owner-only (`0600`) inside an owner
     Record encoding.
   </OptionCard>
   <OptionCard name="--since <timestamp>">
-    Keep only turns started at or after this timestamp. Compared lexicographically against
+    Keep only turns started at or after this timestamp. Compared as plain text against
     `executions.started_at`, which SQLite writes as UTC `YYYY-MM-DD HH:MM:SS`, so a bare date works.
   </OptionCard>
   <OptionCard name="--until <timestamp>">
-    Keep only turns started strictly before this timestamp. The window is half-open.
+    Keep only turns started strictly before this timestamp. The window includes the start but not the end.
   </OptionCard>
   <OptionCard name="--require-verdict" defaultValue="off">
-    Additionally require a verifier verdict of `passed`. Off by default — a turn the deterministic
-    ladder cleared never reaches a verifier at all.
+    Also require a verifier result of `passed`. Off by default, because a turn the deterministic
+    check already cleared never reaches a verifier at all.
   </OptionCard>
   <OptionCard name="--include-unverified-transcripts" defaultValue="off">
-    Also export otherwise-accepted turns whose transcripts cannot be digest-verified, with `calls`
-    empty and `transcript_verified` false. Off by default — an unvouched transcript must never reach
-    a training set silently.
+    Also export otherwise-accepted turns whose transcripts can't be checked against their digest, with `calls`
+    left empty and `transcript_verified` set to false. Off by default, because an unchecked transcript should never reach
+    a training set without saying so.
   </OptionCard>
 </CardGrid>
 
 ## What counts as an accepted turn
 
-The store has no "accepted" column, so the rule is named, applied in one place, and echoed verbatim into the manifest:
+The store has no "accepted" column, so the rule is named in one place and written into the manifest word for word:
 
-> `executions.outcome` in {`completed`, `goal_met`} **and** at least one mutating `file_change` event **and** at least one recorded model call, every one reconstructing digest-verified
+> `executions.outcome` in {`completed`, `goal_met`} **and** at least one mutating `file_change` event **and** at least one recorded model call, every one rebuilt and verified against its digest
 
-All three halves matter. A turn that reported success but changed nothing is a real outcome and a poor training example — there is no diff to learn from. Every other outcome the engine writes (`goal_unmet`, `verification_failed`, `aborted`, `cancelled`, `failed`, `error`, `interrupted`) is excluded. And a turn that cannot prove what its model calls actually saw cannot contribute an SFT pair, so it is excluded too and counted in the manifest as `executions_transcripts_unverified`.
+All three parts matter. A turn that reported success but changed nothing is a real result, but a poor training example, since there's no change to learn from. Every other outcome the engine writes (`goal_unmet`, `verification_failed`, `aborted`, `cancelled`, `failed`, `error`, `interrupted`) is left out. And a turn that can't prove what its model calls actually saw can't contribute a training pair, so it's left out too and counted in the manifest as `executions_transcripts_unverified`.
 
-`--require-verdict` adds a fourth clause; `--include-unverified-transcripts` loosens the third. Either one rewrites the predicate in the manifest to match — the manifest always states the rule that actually ran.
+`--require-verdict` adds a fourth condition. `--include-unverified-transcripts` loosens the third. Either flag rewrites the rule shown in the manifest to match. The manifest always states the rule that actually ran.
 
-### Turns that cannot vouch for their transcripts
+### Turns that can't vouch for their transcripts
 
-The transcript clause is what a store predating the receipts plane cannot satisfy: with no `step_receipt` rows there is no recorded model call at all, so the default filter exports **zero** records from it even though the journal still holds every one of those turns' prompt, tool calls, and changes.
+The transcript condition is what a store from before receipts existed can't satisfy. With no `step_receipt` rows there's no recorded model call at all, so the default filter exports **zero** records from it, even though the journal still holds every one of those turns' prompt, tool calls, and changes.
 
-`--include-unverified-transcripts` exports them anyway, with the transcript withheld rather than faked:
+`--include-unverified-transcripts` exports them anyway, with the transcript left out rather than guessed at:
 
-- `calls` is `[]` — an unvouched transcript is withheld whole, never emitted with a silent gap in it;
-- `transcript_verified` is `false`, so the record says why;
-- `transcript_mismatch_severity` reports what a digest mismatch here *means* — `none`, `compaction` (the journal predates compaction journaling its rewrites, so the mismatched bytes are a routine pre-compaction preimage), or `integrity` (compaction is no longer an available explanation).
+- `calls` is `[]`. An unverified transcript is withheld entirely, never sent with a silent gap in it.
+- `transcript_verified` is `false`, so the record states why.
+- `transcript_mismatch_severity` reports what a digest mismatch here means: `none`, `compaction` (the journal predates recording its own rewrites, so the mismatched bytes are an expected leftover from before compaction), or `integrity` (compaction is no longer a possible explanation).
 
-The gate itself stays era-blind: a benign `compaction` record is excluded by default exactly like an `integrity` one. The severity is reported so a consumer can tell them apart, never used to admit one. `tool_calls`, `changes`, and `verdict` come from the journal and are exactly as trustworthy on these records as on any other.
+The rule that decides what to include doesn't treat old and new journals differently: a harmless `compaction` record is left out by default exactly like an `integrity` one. The severity is reported so you can tell them apart, never used to include one. `tool_calls`, `changes`, and `verdict` come from the journal and are just as trustworthy on these records as on any other.
 
-`reward` is the one field that is not purely journal-derived, and on the pre-receipts shape it says so. Its outcome term comes from the journal's verdict, but its shaping prices the *step count*, which comes from the receipts plane — and a plane holding no row for a turn has not recorded that the turn made zero calls, it has recorded nothing. Read as zero the step penalty would simply vanish, handing exactly these records a scalar **above** what the same trajectory earns once its calls are counted. So `cost.steps` is `null` and the label reports `discard: "steps_unknown"` instead, keeping its rung, its outcome term and its policy so the row stays selectable and re-shapeable under a count of your own. A record whose receipts exist but fail to verify is unaffected: its calls were recorded, so its step count is real and its reward scores normally.
+`reward` is the one field that isn't purely read from the journal, and on records from before receipts existed, it says so. Its outcome comes from the journal's verdict, but its scoring depends on the *step count*, which comes from the receipts. A record with no receipts hasn't recorded that the turn made zero calls; it has recorded nothing at all. Treating that as zero would make the step penalty disappear, handing these records a score **higher** than the same trajectory would earn once its calls are counted. So `cost.steps` is `null` and the label reports `discard: "steps_unknown"` instead, keeping its tier, outcome, and rule so the row can still be picked and re-scored later under a count you supply. A record whose receipts exist but fail to verify isn't affected this way: its calls were recorded, so its step count is real and its reward scores normally.
 
 ## The record
 
-Every record carries the same keys — absence is spelled `null`, never omitted — so a consumer never has to distinguish "missing" from "not applicable".
+Every record carries the same keys. A missing value is written as `null`, never left out, so you never have to guess whether something is missing or simply doesn't apply.
 
 ```json
 {
@@ -156,27 +156,27 @@ Every record carries the same keys — absence is spelled `null`, never omitted 
 
 ### The transcript
 
-`calls` is every model call in wire order, each with the exact messages it was sent — rebuilt from the receipts plane by the same reconstruction `stella inspect` reads, and admitted only once its digest verifies. That is what makes an SFT pair derivable from a record alone. It is empty exactly when `transcript_verified` is `false`, which only `--include-unverified-transcripts` can produce.
+`calls` lists every model call in the order it happened, each with the exact messages it was sent. These are rebuilt from receipts by the same process `stella inspect` uses, and are only included once their digest checks out. That's what makes a training pair derivable from a record alone. `calls` is empty exactly when `transcript_verified` is `false`, which only happens with `--include-unverified-transcripts`.
 
-`reward` is the training label the settled verdict earned, computed under the workspace's resolved reward policy — and the policy rides on the label, so a scalar stays interpretable outside the workspace that produced it. It is `null` when the journal holds no verdict at all: there is nothing to derive a label from, and synthesizing one under a policy the run never saw would claim more than the store knows. The raw `verdict` is carried beside it so a reader can re-derive a label under different weights. A label that *is* present may still carry no scalar — `reward.reward` is `null` beside a named `reward.discard` whenever the trajectory cannot be priced, including the `steps_unknown` case described above.
+`reward` is the training score the settled verdict earned, computed under the workspace's own reward rules. The rules travel alongside the score, so a score stays meaningful even outside the workspace that produced it. It's `null` when the journal holds no verdict at all: there's nothing to build a score from, and making one up under rules the run never saw would claim more than the store actually knows. The raw `verdict` is included alongside it so you can build your own score under different weights. A record can have a label but still carry no score: `reward.reward` is `null` next to a named `reward.discard` whenever the trajectory can't be priced, including the `steps_unknown` case described above.
 
-### Provenance
+### Where a record comes from
 
-`session_id`, `repo`, `timestamp`, and `turn_instance` make every record traceable back to the episode it came from, which is what makes a distilled adapter auditable.
+`session_id`, `repo`, `timestamp`, and `turn_instance` trace every record back to the episode it came from, which is what makes a distilled model auditable.
 
-`repo` is a hash of the workspace's normalized `origin` URL — the same identity telemetry scoping uses — so the dataset is attributable to a repository without carrying the URL. A workspace with no remote falls back to the path-derived project id. `session_id` is `null` for a one-shot `stella run`, which never stamps one; that is a fact about the turn, not missing data.
+`repo` is a hash of the workspace's normalized `origin` URL, the same identity used for telemetry, so the dataset can be tied to a repository without carrying the URL itself. A workspace with no remote falls back to a hash of its path. `session_id` is `null` for a one-shot `stella run`, which never stamps one. That's a fact about the turn, not missing data.
 
-### What `changes` can claim
+### What `changes` can tell you
 
-There is no unified diff anywhere in the store. `diff` is the recorder's changed-region hunk, bounded at 200 lines per side; `added` and `removed` are the recorder's own counts and are **authoritative** — do not re-derive them by counting `+`/`-` lines. `diff_truncated` is `true` when the hunk demonstrably shows fewer changed lines than were counted; `false` means "no evidence of truncation", not "provably complete". The exact bytes the model produced survive in the edit and write tool `arguments`.
+There's no full diff anywhere in the store. `diff` is the recorder's changed-region excerpt, capped at 200 lines per side. `added` and `removed` are the recorder's own counts and are **the numbers to trust**. Don't recompute them by counting `+`/`-` lines yourself. `diff_truncated` is `true` when the excerpt clearly shows fewer changed lines than were counted. `false` means "no sign of truncation," not "guaranteed complete." The exact bytes the model produced are still available in the edit and write tool `arguments`.
 
 ## Redaction
 
-Every string leaf of every record — and of the manifest — passes through the same secret redactor the rest of the workspace uses, **after** the record is assembled rather than field by field, so a field added later cannot route around it. A synthetic API key planted in a prompt or in a tool argument does not reach the output.
+Every string in every record, and in the manifest, passes through the same secret redactor the rest of the workspace uses, applied **after** the record is fully built rather than field by field, so a field added later can't slip past it. A planted test API key in a prompt or a tool argument won't reach the output.
 
-`redacted` on each record reports whether anything was actually replaced, so "this was scrubbed" is a visible fact rather than an assumption.
+`redacted` on each record reports whether anything was actually replaced, so "this was scrubbed" is a fact you can see rather than something you have to assume.
 
-The manifest's `redaction.behavior_digest` fingerprints the redactor by its **decisions** on a fixed probe corpus, so it moves when a threshold, a matcher, or a rule list changes. Its one limit, stated plainly: a rule added for a vendor no probe exercises leaves the digest unchanged.
+The manifest's `redaction.behavior_digest` fingerprints the redactor by its **decisions** on a fixed test set of text, so it changes whenever a threshold, a matcher, or a rule list changes. One limit worth stating plainly: a rule added for a vendor that test set doesn't cover leaves the digest unchanged.
 
 ## The manifest
 
@@ -208,18 +208,18 @@ The manifest's `redaction.behavior_digest` fingerprints the redactor by its **de
 }
 ```
 
-`executions_transcripts_unverified` counts the same executions in both modes — under `--include-unverified-transcripts` those are the records carrying `transcript_verified: false` rather than the ones left out — so the two modes stay comparable.
+`executions_transcripts_unverified` counts the same executions in both modes. Under `--include-unverified-transcripts` these are the records that carry `transcript_verified: false` rather than records left out entirely, so the two modes stay comparable.
 
-`schema` is bumped whenever the record shape changes incompatibly, so a reader can refuse a dataset it does not understand instead of misparsing it.
+`schema` goes up whenever the record shape changes in a way that breaks older readers, so a reader can refuse a dataset it doesn't understand instead of misreading it.
 
-`store_watermark` is the store's own newest timestamp, not the wall clock: the extraction reads no clock anywhere, so re-running it against the same store produces byte-identical files.
+`store_watermark` is the store's own most recent timestamp, not the current time. The export never reads the clock, so running it again against the same store produces the exact same files.
 
-## Determinism
+## Consistent output
 
-The same store and the same filter produce byte-identical output on every run. Executions are ordered by id, tool calls and changes by journal sequence, and the record is serialized from its typed struct so the key order is the declaration order rather than a JSON map's. Nothing in the export path reads the clock or iterates a hash map into the output.
+The same store and the same filter always produce byte-for-byte identical output. Executions are ordered by id, tool calls and changes by journal order, and each record is written from its typed structure so keys always appear in the same order. Nothing in the export reads the clock or writes from an unordered collection.
 
 ## See also
 
 - [`stella inspect`](/docs/commands/inspect) — the exact context one past model call was sent
-- [`stella tune`](/docs/commands/tune) — A/B one policy knob and promote the winner
-- [`stella stats`](/docs/commands/stats) — what the receipts cost
+- [`stella tune`](/docs/commands/tune) — compare one setting across two result files and pick a winner
+- [`stella stats`](/docs/commands/stats) — what the recorded work cost

--- a/website/content/docs/commands/doctor.mdx
+++ b/website/content/docs/commands/doctor.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella doctor
-description: Check the local state stella owns, report each check's verdict, exit non-zero on failure — with opt-in repair for a corrupt session store, not deletion.
+description: Check the local state stella owns, get a pass or fail for each check, and repair a corrupt session store without deleting it.
 ---
 
-Answer "is my local state sound?" before you go looking for a bug that isn't yours. `stella doctor` runs each check it knows how to run, prints a verdict per check, and exits non-zero if any failed — so it can gate a script. It reads local state only: no provider, no API key, no network.
+Use `stella doctor` to check whether your local state is sound before you go looking for a bug that isn't yours. It runs each check it knows about, prints a result for each one, and exits with a non-zero code if any check failed, so you can use it to gate a script. It reads local state only. No provider, no API key, no network.
 
 ## Synopsis
 
@@ -15,18 +15,18 @@ stella doctor --last-failure                     # print the newest crash dump
 
 ## What it does
 
-Four checks ship today:
+Four checks run today:
 
-- **`store integrity`** — the soundness of this workspace's session store at `<workspace>/.stella/private/store.db`, verified with SQLite's own `quick_check` and `integrity_check` pragmas.
-- **`fleet ledger`** — rows in `.stella/private/fleet.db` naming a run that is no longer recorded. Report-only: removing them would delete fleet history, and nothing reads them.
-- **`session sidecars`** — sidecar directories whose session record is gone. `--repair` reaps them; a *damaged* record is never treated as an orphan.
-- **`model config`** — the model your next run would actually send, and the endpoint it would send it to. See below.
+- **`store integrity`** — checks the soundness of this workspace's session store at `<workspace>/.stella/private/store.db`, using SQLite's own `quick_check` and `integrity_check` checks.
+- **`fleet ledger`** — finds rows in `.stella/private/fleet.db` that name a run no longer recorded. This check only reports; it never deletes, because removing these rows would delete fleet history.
+- **`session sidecars`** — finds sidecar directories whose session record is gone. `--repair` removes them. A damaged record is never treated as an orphan.
+- **`model config`** — checks the model your next run would actually use, and the address it would send it to. See below.
 
-A verdict is binary. There is no "warn": a check that cannot say *this is fine* has failed, and a third maybe-state would only be an invitation to ignore it.
+Every check is a pass or a fail. There is no "warning" state: if a check can't say a thing is fine, it counts as failed.
 
-## The `model config` check
+## The model config check
 
-A default model your provider cannot serve does not break one command — it breaks *every* one, and it used to surface only as a provider `400` in the middle of whatever you were doing. This check answers it up front, and its failure message is the point: it names the setting, the value, what is wrong with it, and all three ways out.
+A default model your provider can't serve doesn't just break one command. It breaks every one. This check catches that early. When it fails, the message names the setting, the value, what's wrong, and three ways to fix it.
 
 ```text
   ✗ model config — 1 model setting(s) name something the provider will reject
@@ -38,11 +38,11 @@ A default model your provider cannot serve does not break one command — it bre
       → set the default with `/model <provider>/<slug>` in the deck, or on its SETTINGS tab
 ```
 
-It resolves the default with the same precedence a run does — `--model` (and its `STELLA_MODEL` alias) beats `agents.default.model`, which beats `default_model`, which beats auto-detection — so `stella --model <x> doctor` diagnoses exactly what `stella --model <x> run` would send. It also flags a `--base-url` pointed at a *different* known provider's host, which is the configuration that returns a 401 mislabeled as the wrong provider's rejection.
+It checks the default model using the same order of precedence a run uses: `--model` (or its `STELLA_MODEL` environment variable) beats `agents.default.model`, which beats `default_model`, which beats auto-detection. So `stella --model <x> doctor` checks exactly what `stella --model <x> run` would send. It also flags a `--base-url` pointed at a different known provider's address, since that setup causes a rejection that looks like the wrong error.
 
-It keeps the command's no-network promise: validation runs against the built-in seed plus whatever `stella models refresh` has already put on disk, and nothing is fetched. The consequence is stated in the output rather than hidden — a provider with no synced model list (OpenRouter, a custom gateway) can only have the *shape* of its slug checked, and the pass says so.
+This check never uses the network. It checks against the built-in list plus whatever `stella models refresh` has already saved, and nothing is downloaded. When a provider has no saved model list (OpenRouter, or a custom gateway), the check can only confirm the shape of the model slug is correct, and it says so in the result.
 
-A pass also names the model and where it came from, which is half of what people open the doctor for:
+A passing check also names the model and where it came from:
 
 ```text
   ✓ model config — zai/glm-5.2 — from default_model
@@ -50,75 +50,75 @@ A pass also names the model and where it came from, which is half of what people
 
 <CardGrid size="md">
   <OptionCard name="✓ pass">
-    The store passed, **or** there is no store yet — `store.db` is created by your first
-    session, and its absence is not a fault.
+    The store passed, or there is no store yet. `store.db` is created by your first
+    session, so its absence is not a problem.
   </OptionCard>
   <OptionCard name="✗ fail">
-    SQLite reported damage, **or** the check could not be performed at all — a locked
-    file, a permissions problem.
+    SQLite reported damage, or the check could not run at all — a locked
+    file, or a permissions problem.
   </OptionCard>
 </CardGrid>
 
-Diagnosis never writes. The check opens the database immutably — no locks, no `-shm`, zero bytes written — and escalates to a read-write open only when a first verdict already looks bad and a `-wal` sibling exists. Being asked a question is not a reason to create a `.stella/` that wasn't there.
+Checking never writes anything. The check opens the database in a read-only mode with no locks and writes zero bytes, and only switches to a read-write mode when an early result already looks bad and a `-wal` file exists. Asking a question is never a reason to create a `.stella/` folder that wasn't already there.
 
-`stella doctor` runs *before* stella loads your configuration, on purpose: a workspace whose store is corrupt has to stay diagnosable without a working model config. One consequence is that there is no JSON form of this output — `--output-format` is a flag of `run` and `fleet`, and `doctor` does not take it.
+`stella doctor` runs before stella loads your configuration, on purpose: a workspace with a corrupt store needs to stay checkable even without a working model config. Because of this, there is no JSON output for this command. `--output-format` is a flag for `run` and `fleet` only, and `doctor` doesn't accept it.
 
 ## Flags
 
 <CardGrid size="md">
   <OptionCard name="--repair">
-    Act on a store SQLite judged corrupt: move it aside to a timestamped name — renamed,
-    **never** deleted — and copy out whatever is still readable. A healthy store and an
-    inconclusive check are both left untouched.
+    Act on a store SQLite judged corrupt: move it aside to a name with a timestamp —
+    renamed, **never** deleted — and copy out whatever is still readable. A healthy store
+    and a check that couldn't finish are both left untouched.
   </OptionCard>
   <OptionCard name="--last-failure">
     Print the newest [crash dump](/docs/diagnostics#the-crash-file) —
-    `.stella/private/crash-*.jsonl` — and nothing else; no checks run. Content-free by
-    construction, so it's safe to attach to a bug report as printed. Errors if none exists.
+    `.stella/private/crash-*.jsonl` — and nothing else. No checks run. It contains no
+    sensitive content, so it's safe to attach to a bug report as printed. Fails if none exists.
   </OptionCard>
 </CardGrid>
 
 ## Exit codes
 
-`0` when every check passed — including a `--repair` that repaired. `1` when any check failed, with `stella: 1 of 4 doctor checks failed` on stderr. That is the whole contract, which is what makes the command usable as a gate:
+`0` when every check passed, including a `--repair` that fixed something. `1` when any check failed, with `stella: 1 of 4 doctor checks failed` printed to stderr. That's the whole rule, which is what makes the command work as a gate:
 
 ```bash
 stella doctor || echo "local state needs attention"
 ```
 
-## What `--repair` does to the file on disk
+## What --repair does to the file on disk
 
-This is the one part of `stella doctor` that touches your disk, so it is worth stating exactly.
+This is the one part of `stella doctor` that touches your disk, so here's exactly what happens.
 
-It runs **only** on a verdict of genuine corruption — a database SQLite could read but found structurally damaged, or one it could not read as a database at all. A check that merely failed to *complete* is inconclusive, and an inconclusive diagnosis leaves the store exactly where it is; moving a database on a guess is how a repair tool loses somebody's data. On a healthy store, `--repair` reports that it had nothing to do.
+It only acts when the check finds real corruption: a database SQLite could read but found structurally damaged, or one it couldn't read as a database at all. A check that simply couldn't finish is inconclusive, and an inconclusive result leaves the store exactly where it is. Moving a database on a guess is how a repair tool loses someone's data. On a healthy store, `--repair` reports that it had nothing to do.
 
-When it does act, in this order:
+When it does act, it happens in this order.
 
-1. **The database is renamed**, along with both sidecars if present, all sharing one timestamp (seconds since the Unix epoch):
+**1. The database is renamed**, along with both companion files if present, all sharing one timestamp (seconds since the Unix epoch):
 
-   ```text
-   .stella/private/store.db      → .stella/private/store.db.corrupt-1769472000
-   .stella/private/store.db-wal  → .stella/private/store.db-wal.corrupt-1769472000
-   .stella/private/store.db-shm  → .stella/private/store.db-shm.corrupt-1769472000
-   ```
+```text
+.stella/private/store.db      → .stella/private/store.db.corrupt-1769472000
+.stella/private/store.db-wal  → .stella/private/store.db-wal.corrupt-1769472000
+.stella/private/store.db-shm  → .stella/private/store.db-shm.corrupt-1769472000
+```
 
-   The sidecars must travel with the database. A stale WAL left beside the fresh store your next session creates is how a successful repair turns into new corruption. Renames come first because once they land the workspace is usable again even if everything after them fails.
+The companion files must move with the database. A stale WAL file left beside the fresh store your next session creates would turn a successful repair into new corruption. The rename happens first, because once it's done the workspace is usable again even if the next steps fail.
 
-2. **A copy of whatever SQLite can still read** is written to a separate database beside the original — `store.db.salvaged-1769472000` — restricted to your user. If nothing can be salvaged, that is reported and the quarantine still stands; a failed salvage is never fatal.
-
-   <Callout type="warn">
-   Expect this step to salvage nothing, and use the `by hand:` line instead. The copy is a `VACUUM INTO`, which walks the database and so gives up entirely at the first page it cannot read — on a store measured at six damaged pages in an otherwise healthy 1 GB file it returned zero rows, while the `sqlite3 .recover` command printed in the `by hand:` line returned 376,129 of 376,140 events and every row of `executions`, `telemetry` and `tool_calls`. `.recover` rebuilds from surviving records rather than walking the tree, which is why it survives damage this step cannot. Making `--repair` use it is [#5282](https://github.com/macanderson/stella/issues/5282).
-   </Callout>
-
-3. **Your next session starts a fresh store.** Nothing was deleted.
+**2. A copy of whatever SQLite can still read** is written to a separate database beside the original — `store.db.salvaged-1769472000` — readable only by you. If nothing can be saved, the tool reports that and the quarantine still stands. A failed save attempt is never treated as an error.
 
 <Callout type="warn">
-Uncheckpointed pages in the quarantined `-wal` do not reach the salvaged copy — SQLite only replays a WAL sitting at its database's exact name. If you need them, rename the quarantined pair back to `store.db` and `store.db-wal` and let SQLite's own recovery run.
+Expect this step to save nothing, and use the "by hand" line instead. This step copies data using a method that stops entirely at the first unreadable page. On a store with six damaged pages in an otherwise healthy 1 GB file, this step returned zero rows, while the `sqlite3 .recover` command shown in the "by hand" line returned 376,129 of 376,140 events and every row of `executions`, `telemetry`, and `tool_calls`. The `.recover` command rebuilds from surviving records instead of stopping at the first bad page, which is why it recovers more.
 </Callout>
 
-Every quarantine is undoable with `mv`, and a repeat repair within the same second gets a `.2`, `.3`, … suffix rather than overwriting an earlier one — a quarantine that clobbered a quarantine would destroy exactly the bytes the whole path exists to preserve.
+**3. Your next session starts a fresh store.** Nothing was deleted.
 
-The store holds local telemetry and session replay only. It never holds your source.
+<Callout type="warn">
+Unsaved pages in the quarantined `-wal` file don't reach the salvaged copy. SQLite only replays a WAL file that sits next to a database with the exact matching name. If you need those pages, rename the quarantined pair back to `store.db` and `store.db-wal` and let SQLite's own recovery run.
+</Callout>
+
+Every quarantine can be undone with `mv`, and running repair twice within the same second adds a `.2`, `.3`, and so on, rather than overwriting an earlier quarantine.
+
+The store holds local telemetry and session replay data only. It never holds your source code.
 
 ## Examples
 
@@ -131,7 +131,7 @@ A healthy workspace:
   1 check: 1 ok, 0 failed
 ```
 
-`quick_check` is the fast path; `integrity_check` runs only when `quick_check` flags something, and the headline names whichever produced the verdict.
+`quick_check` is the fast check; `integrity_check` runs only when `quick_check` flags a problem, and the result names whichever one produced it.
 
 A corrupt store, diagnosed but untouched (exit `1`):
 
@@ -146,7 +146,7 @@ A corrupt store, diagnosed but untouched (exit `1`):
   1 check: 0 ok, 1 failed
 ```
 
-At most five problem rows are printed, followed by `… and N more`; the store itself records up to twenty, and the total is never truncated.
+At most five problem rows are printed, followed by `… and N more`. The store itself keeps up to twenty, and the full count is always shown.
 
 The same workspace after `stella doctor --repair` (exit `0`):
 
@@ -162,7 +162,7 @@ The same workspace after `stella doctor --repair` (exit `0`):
   1 check: 1 ok, 0 failed
 ```
 
-A check that could not be performed — reported, and the store is not moved even with `--repair`:
+A check that couldn't run at all — reported, and the store is not moved even with `--repair`:
 
 ```text
   ✗ store integrity — could not be checked: <error>
@@ -170,5 +170,5 @@ A check that could not be performed — reported, and the store is not moved eve
 ```
 
 <Callout type="info">
-You will usually meet this command by being sent here: when a session cannot open `store.db`, the error names `stella doctor` directly. Running it without `--repair` first is always safe — it is a read-only diagnosis.
+You'll often land on this command from an error message: when a session can't open `store.db`, the error points you here directly. Running it without `--repair` is always safe. It only reads, never writes.
 </Callout>

--- a/website/content/docs/commands/fleet.mdx
+++ b/website/content/docs/commands/fleet.mdx
@@ -3,7 +3,7 @@ title: stella fleet
 description: Fan a batch of tasks out to a fleet of worker agents in one shared tree, coordinated by cooperative file claims.
 ---
 
-Run many tasks in parallel in **one shared working tree**, coordinated by cooperative file claims and wave-scheduled by dependency. A task gets its own git worktree only when a plan file opts it in with `isolation = "isolated"`. Every attempt, commit, and dollar is recorded in `.stella/private/fleet.db`, and any isolated worktrees and their `fleet/<slug>-<hash>` branches are left in place for review.
+Run many tasks in parallel in **one shared working tree**, coordinated by cooperative file claims and scheduled in dependency-ordered waves. A task only gets its own git worktree when a plan file opts it in with `isolation = "isolated"`. Every attempt, commit, and dollar spent is recorded in `.stella/private/fleet.db`, and any isolated worktrees and their `fleet/<slug>-<hash>` branches are left in place for you to review.
 
 ## Synopsis
 
@@ -14,19 +14,23 @@ stella fleet claims [--all] [--format <text|json>]
 ```
 
 <Callout type="info">
-A prompt whose **first word** is exactly a subcommand name (`clean`, `claims`) is read as that subcommand. Put the prompts after `--` when that happens: `stella fleet -- clean up the dead code`.
+A prompt whose **first word** exactly matches a subcommand name (`clean`, `claims`) is read as that subcommand. If that happens, put your prompts after `--`: `stella fleet -- clean up the dead code`.
 </Callout>
 
 ## What it does
 
-Each task prompt becomes an independent task running **in the shared repository root**. Workers coordinate through cooperative file claims — paths declared upfront in a plan (`claims`) plus claim-on-first-write at the tool layer — so a conflict surfaces in under a second at write time with the rival named, and commits interleave on one branch with no merge-back. A task a plan file opts into `isolation = "isolated"` instead gets a dedicated git worktree under `.stella/worktrees/<slug>` — branched from the current `HEAD` (or `--base-ref`), pinned to a SHA at start, onto a `fleet/<slug>-<hash>` branch (the hash suffix keeps re-runs from colliding with branches you kept). Tasks dispatch in dependency-ordered waves, running up to `--max-concurrency` at once within a wave. Each worker is a full engine run through the raw step loop, or — with `--pipeline <variant>` — through an installed wrapper plugin bound once per worker attempt: the plugin is resolved from the roster of the workspace you invoked `stella fleet` in (an isolated task's fresh worktree need not carry an untracked `.stella/plugins/` at all) and granted the tree that attempt actually runs in, and every attempt's execution row records its variant id. Unlike [`stella goal`](/docs/commands/goal), this door applies no arbiter refusal — a fleet attempt's verdict is its turn's own outcome, so a wrapper's hold loop is the only round-holder over it. Progress, attempts, commits, and cost are persisted to `.stella/private/fleet.db` and surface on the [Observatory dashboard](/docs/telemetry/dashboard)'s Fleet runs card.
+Each task prompt becomes an independent task running **in the shared repository root**. Workers coordinate through cooperative file claims: paths declared upfront in a plan (`claims`), plus a claim taken the first time a tool writes to a file. A conflict surfaces in under a second at write time, naming the other task involved, and commits interleave on one branch with no merge-back needed. A task a plan file opts into `isolation = "isolated"` gets a dedicated git worktree instead, under `.stella/worktrees/<slug>`. It branches from the current `HEAD` (or `--base-ref`), pinned to a commit at the start, onto a `fleet/<slug>-<hash>` branch (the hash suffix keeps re-runs from colliding with branches you kept).
 
-Isolated worktrees and fleet branches are **not** cleaned up automatically: they stay on disk so you can inspect, test, and merge each result yourself. Reclaim the finished ones with [`stella fleet clean`](#stella-fleet-clean) when you are done reviewing. A failed task is never retried automatically, and its dependents end the run as `skipped`.
+Tasks run in dependency-ordered waves, up to `--max-concurrency` at once within a wave. Each worker is a full engine run through the plain step loop, or, with `--pipeline <variant>`, through an installed wrapper plugin bound once per worker attempt. The plugin comes from the workspace you invoked `stella fleet` in, and is granted the tree the attempt actually runs in. Every attempt's execution row records which variant it used. Unlike [`stella goal`](/docs/commands/goal), a fleet run applies no separate approval step of its own: a fleet attempt's result is its turn's own outcome, so only a wrapper's own hold logic can pause a round.
 
-**A task can only be dispatched by one session at a time.** Before starting a worker, the fleet takes a *dispatch claim* on the task — a short lease in `.stella/private/fleet.db`, held under the run's id. If a second `stella fleet` in the same workspace reaches the same task id while the first is still on it, that task is reported as a dispatch failure naming the run holding it, rather than running twice. The claim is a **lease, not a lock**: a live run renews it while its worker runs and releases it the instant the attempt settles, and a run that is killed outright loses its claim automatically once the lease lapses (15 minutes) — nothing has to be cleaned up by hand, and there is no override flag.
+Progress, attempts, commits, and cost are saved to `.stella/private/fleet.db` and appear on the [Observatory dashboard](/docs/telemetry/dashboard)'s Fleet runs card.
+
+Isolated worktrees and fleet branches are **not** cleaned up automatically. They stay on disk so you can inspect, test, and merge each result yourself. Reclaim the finished ones with [`stella fleet clean`](#stella-fleet-clean) once you're done reviewing. A failed task is never retried automatically, and any tasks that depend on it end the run marked `skipped`.
+
+**A task can only be run by one session at a time.** Before starting a worker, the fleet takes a *dispatch claim* on the task: a short-lived lease in `.stella/private/fleet.db`, held under the run's id. If a second `stella fleet` in the same workspace reaches the same task while the first is still working on it, that task is reported as a dispatch failure naming the run that holds it, instead of running twice. The claim is a **lease, not a lock**. A live run renews it while its worker runs and releases it the instant the attempt finishes. A run that gets killed outright loses its claim automatically once the lease runs out, after 15 minutes. Nothing needs to be cleaned up by hand, and there's no override flag.
 
 <Callout type="info">
-For anything beyond a handful of independent prompts, use a plan file (`--plan`). It lets you declare task `id`, `title`, `prompt`, `depends_on` (to order the waves), `isolation` (`shared_tree` — the default — runs in the repo root under the claim discipline; `isolated` opts a task into its own worktree and branch, for genuinely divergent work like best-of-N attempts on the same files), `claims` — file paths held as cooperative locks while a task runs, so two tasks never edit the same file at once — and `test_command`, the oracle that decides that task under `--pipeline <variant>`. A plan file is the only way to declare one: a positional prompt builds a task with none, and a wrapper plugin then has no flip to observe on it. See [Agent Fleets](/docs/agent-fleets) for the full plan schema.
+For anything beyond a handful of independent prompts, use a plan file (`--plan`). It lets you declare a task `id`, `title`, `prompt`, `depends_on` (to order the waves), `isolation` (`shared_tree`, the default, runs in the repo root under the claim rules above; `isolated` gives a task its own worktree and branch, for work that genuinely diverges, like best-of-N attempts on the same files), `claims` (file paths held as cooperative locks while a task runs, so two tasks never edit the same file at once), and `test_command` (the check that decides that task under `--pipeline <variant>`). A plan file is the only way to declare a test command: a plain prompt on the command line builds a task with none, so a wrapper plugin has nothing to check against it. See [Agent Fleets](/docs/agent-fleets) for the full plan format.
 </Callout>
 
 ## Flags
@@ -38,49 +42,49 @@ For anything beyond a handful of independent prompts, use a plan file (`--plan`)
   </OptionCard>
   <OptionCard name="--plan <FILE>">
     A `.json` or `.toml` plan file with `[[tasks]]` entries — `id`, `title`, `prompt`, and
-    optional `depends_on`, `isolation`, `claims`, and `test_command` — instead of inline prompts.
+    optional `depends_on`, `isolation`, `claims`, and `test_command` — instead of prompts on the command line.
   </OptionCard>
   <OptionCard name="--max-concurrency <N>" defaultValue="4">
-    Maximum tasks dispatched concurrently within one wave.
+    Maximum tasks running at once within one wave.
   </OptionCard>
   <OptionCard name="--base-ref <ref>" defaultValue="current HEAD">
-    Git ref the isolated worktrees branch from. The default is pinned to a SHA at start,
-    so mid-run commits cannot drift the base.
+    Git ref the isolated worktrees branch from. The default is pinned to a commit at the
+    start, so commits made mid-run can't move the base.
   </OptionCard>
   <OptionCard name="--watch">
-    After the fan-out, watch each successful branch's CI to completion and reconcile its
-    PR status via `gh` — 30s polls, 10m startup grace, 20m stall limit, 2h wall cap. Exits
+    After the fan-out, watch each successful branch's CI until it finishes, and reconcile its
+    PR status with `gh` — checking every 30 seconds, with a 10-minute startup grace period, a 20-minute stall limit, and a 2-hour overall cap. Exits
     non-zero if any watched branch ends red.
   </OptionCard>
   <OptionCard name="--pipeline <VARIANT>">
     Run each worker attempt through the installed wrapper plugin whose
     manifest declares this `[wrapper] id` (`stella plugin list`). The variant
-    is resolved once before the fan-out, so a typo fails the command rather
-    than each task; each attempt then binds its own plugin process in its own
-    tree. Omit the flag for the raw loop.
+    is resolved once before the fan-out, so a typo fails the whole command rather
+    than each task on its own; each attempt then runs its own copy of the plugin in its own
+    tree. Omit the flag to run the plain loop.
   </OptionCard>
   <OptionCard name="--task-timeout <SECS>" defaultValue="unbounded">
-    Wall-clock ceiling per worker attempt. On expiry the task's stop line fires — the same
-    clean cancel the dashboard's `[x]` sends — and the attempt reports as **failed**
+    Wall-clock limit per worker attempt. When it expires, the task gets the same
+    clean stop the dashboard's `[x]` button sends, and the attempt is reported as **failed**
     instead of holding its concurrency slot forever.
   </OptionCard>
   <OptionCard name="--require-verdict">
-    Fail any attempt whose `--pipeline` wrapper did not declare its requirements
-    **met** — per attempt: an unmet or undecided verdict fails that attempt by name,
-    and a failed attempt fails the run, the rule every failed task already follows.
-    The attempt's own abort wins when both fire. Refused without `--pipeline`, where
-    nothing declares a verdict.
+    Fail any attempt whose `--pipeline` wrapper didn't declare its requirements
+    **met**. Per attempt: an unmet or undecided result fails that attempt by name,
+    and a failed attempt fails the run, the same rule any failed task already follows.
+    If the attempt already aborted on its own, that reason wins instead. Refused
+    without `--pipeline`, since nothing declares a result there.
   </OptionCard>
   <OptionCard name="--output-format <text|json|stream-json>" defaultValue="text">
-    `json` / `stream-json` keep the run headless — the live grid stays off and stdout
-    stays machine-readable, including the error envelope on failure. A flag of `fleet`
-    itself, after the subcommand token. Env `STELLA_OUTPUT_FORMAT`.
+    `json` / `stream-json` keep the run headless: the live grid stays off and stdout
+    stays machine-readable, including the error message on failure. A flag of `fleet`
+    itself, placed after the subcommand. Env `STELLA_OUTPUT_FORMAT`.
   </OptionCard>
 </CardGrid>
 
 ## Spend limit
 
-The spend limit cap is the **global** `--spend-limit` flag (or `STELLA_SPEND_LIMIT`) rather than one of `fleet`'s own; it reads most clearly before the subcommand, though [either position parses](/docs/commands#global-flags). Each child is guarded by the aggregate cap divided across the concurrency width (`spend limit ÷ max-concurrency`), and the fleet stops launching new waves once total metered spend crosses the cap.
+The spend cap comes from the **global** `--spend-limit` flag (or `STELLA_SPEND_LIMIT`), not a flag of `fleet`'s own. It reads most clearly placed before the subcommand, though [either position works](/docs/commands#global-flags). Each worker is limited to a share of the total cap divided across the concurrency width (`spend limit ÷ max-concurrency`), and the fleet stops starting new waves once total spend crosses the cap.
 
 ```bash
 stella --spend-limit 5 fleet --plan release-prep.toml
@@ -88,55 +92,55 @@ stella --spend-limit 5 fleet --plan release-prep.toml
 
 ## stella fleet clean
 
-Isolated worktrees and their `fleet/*` branches otherwise accumulate forever — every isolated task of every run leaves a directory under `.stella/worktrees/` and a branch, and nothing removed them. `stella fleet clean` is the explicit door out; no part of a fan-out calls it for you.
+Isolated worktrees and their `fleet/*` branches build up over time: every isolated task in every run leaves behind a directory under `.stella/worktrees/` and a branch, and nothing removes them on its own. `stella fleet clean` is the explicit way to remove them. No part of a fan-out calls it for you.
 
-A worktree is reclaimed only when **all** of these hold, and anything kept is printed with its reason:
+A worktree is reclaimed only when **all** of these are true, and anything kept is printed along with the reason:
 
-- the ledger (`.stella/private/fleet.db`) shows no unfinished attempt using it — an in-flight worktree is kept even under `--force`;
+- the ledger (`.stella/private/fleet.db`) shows no unfinished attempt using it — an in-flight worktree is kept even with `--force`;
 - `git status` in it is clean;
-- its branch's commits are already contained in the base ref (`git merge-base --is-ancestor`), so nothing is lost by deleting it.
+- its branch's commits are already part of the base ref (checked with `git merge-base --is-ancestor`), so nothing is lost by deleting it.
 
-`fleet/*` branches whose worktree is already gone are swept by the same containment rule. The main checkout is never a candidate, and no branch outside the `fleet/` namespace is ever passed to a `git` mutation — with or without `--force`. When git cannot answer a question (an unresolvable ref, a `merge-base` that fails for its own reasons), the answer is always "keep".
+`fleet/*` branches whose worktree is already gone are cleaned up by the same rule. The main checkout is never a candidate, and no branch outside the `fleet/` namespace is ever touched by a `git` command, with or without `--force`. When git can't answer a question, such as an unresolvable ref or a `merge-base` check that fails for its own reasons, the answer is always "keep."
 
 ```bash
 stella fleet clean --dry-run          # what would go, and why the rest stays
-stella fleet clean                    # reclaim the provably-finished ones
+stella fleet clean                    # reclaim the ones proven finished
 stella fleet clean --age 14           # only what last finished 14+ days ago
 stella fleet clean --age 30 --force   # also month-old dirty/unmerged work — destructive
 ```
 
 <CardGrid size="md">
   <OptionCard name="--dry-run">
-    Decide and print the verdicts, remove nothing.
+    Decide and print the results, but remove nothing.
   </OptionCard>
   <OptionCard name="--force">
-    Also reclaim worktrees with uncommitted changes and branches whose commits the base
-    ref does not contain. **This destroys that work.** It never touches a worktree whose
-    attempt is still in flight, and never leaves the `fleet/` namespace.
+    Also reclaim worktrees with uncommitted changes and branches whose commits aren't in the base
+    ref. **This destroys that work.** It never touches a worktree whose
+    attempt is still in flight, and never touches anything outside the `fleet/` namespace.
   </OptionCard>
   <OptionCard name="--age <DAYS>">
     Only consider worktrees whose last attempt finished at least this many days ago. A
-    worktree the ledger has no finish time for cannot be shown to be old enough, so it is
+    worktree with no recorded finish time can't be shown to be old enough, so it's
     kept.
   </OptionCard>
   <OptionCard name="--base-ref <ref>" defaultValue="origin/HEAD, else main, else master">
-    The ref a branch's commits must already be contained in to count as reclaimable. The
-    sweep stops rather than guessing if none of the defaults resolve.
+    The ref a branch's commits must already be part of to count as reclaimable. The
+    sweep stops instead of guessing if none of the defaults can be found.
   </OptionCard>
 </CardGrid>
 
 ## stella fleet claims
 
-A dispatch claim stops two sessions taking the same task, but a claim nobody can read is a claim somebody collides with by hand — which is the failure this machinery was built for. `stella fleet claims` is the read surface: what is claimed, who holds it, how long they have held it, and when the lease lapses.
+A dispatch claim stops two sessions from taking the same task, but a claim nobody can see is a claim someone else runs into by hand, which is exactly the problem this system was built to prevent. `stella fleet claims` is the way to read it: what's claimed, who holds it, how long they've held it, and when the lease runs out.
 
 <Callout type="warn">
-Two different claims share the word. A **file** claim asks "may I write this path?" and coordinates writers inside one run — those are the cooperative locks described above, and they are not what this command lists. A **dispatch** claim asks "is another session already doing this work?", and only it stops two sessions duplicating an entire run.
+Two different kinds of claims share the same word. A **file** claim asks "may I write this path?" and coordinates writers inside one run. Those are the cooperative locks described above, and this command doesn't list them. A **dispatch** claim asks "is another session already doing this work?", and only this kind stops two sessions from duplicating an entire run.
 </Callout>
 
 ```bash
 stella fleet claims                   # what this workspace is currently working on
-stella fleet claims --all             # including keys whose holder died or moved on
-stella fleet claims --format json     # the same rows under the versioned query envelope
+stella fleet claims --all             # including claims whose holder died or moved on
+stella fleet claims --format json     # the same rows in a versioned JSON format
 ```
 
 ```text
@@ -150,29 +154,29 @@ Stella — fleet dispatch claims
 
 Read-only and offline: it opens `.stella/private/fleet.db`, never writes to it, and needs no API key. A workspace where no fan-out has ever run reports no claims rather than an error.
 
-There is deliberately **no flag to break someone else's claim**. A lease expires on its own — a session that is killed outright stops holding its keys once the TTL lapses, with nothing to clean up by hand — so "unwedge a stuck claim" is not an operation that needs to exist, and one that did would be a supported way to hand the same task to two workers.
+There is deliberately **no flag to break someone else's claim**. A lease expires on its own: a session that gets killed outright stops holding its claims once the lease time runs out, with nothing to clean up by hand. "Unwedge a stuck claim" is not something that needs to exist as a command, since one that did would be a supported way to hand the same task to two workers at once.
 
 <CardGrid size="md">
   <OptionCard name="--all">
-    Also list lapsed claims. A live listing answers "what is being worked on"; only this
-    answers "who was last on this, and did they die holding it" — the question a killed
-    session leaves behind. A claim that was *released* cleanly leaves no row at all.
+    Also list expired claims. A live listing answers "what is being worked on right now."
+    Only this flag answers "who was last on this, and did they die holding it," the question left behind by a killed
+    session. A claim that was *released* cleanly leaves no row at all.
   </OptionCard>
   <OptionCard name="--format <text|json>" defaultValue="text">
-    `text` (default) prints the aligned table above; `json` rides the versioned query
-    envelope (`schema_version`, then `rows`), each row carrying `live`, `expires_in_ms`
-    (negative once lapsed) and `held_for_ms` computed against the clock the listing was
-    read with.
+    `text` (default) prints the table shown above. `json` gives the same rows in a versioned
+    format (`schema_version`, then `rows`), with each row carrying `live`, `expires_in_ms`
+    (negative once expired), and `held_for_ms` measured against the time the listing was
+    read.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-The claim key is opaque to the lease: a fan-out claims `task:<id>`, and a dispatcher working from a tracker would claim `issue:<n>`. The ledger is **per-workspace**, so it coordinates the sessions sharing one checkout — not two clones on two machines.
+The claim key means nothing special to the lease itself: a fan-out claims `task:<id>`, and a dispatcher working from a tracker would claim `issue:<n>`. The ledger is **per-workspace**, so it coordinates the sessions sharing one checkout, not two clones on two machines.
 </Callout>
 
 ## Examples
 
-Run three independent tasks in parallel in the shared tree — claim-on-first-write keeps them off each other's files:
+Run three independent tasks in parallel in the shared tree. Claim-on-first-write keeps them off each other's files:
 
 ```bash
 stella fleet \
@@ -194,5 +198,5 @@ stella fleet --plan release.toml --base-ref release/1.4 --watch
 ```
 
 <Callout type="warn">
-`--watch` (and its PR reconciliation) only does something once the fleet branches are pushed — for example, when your task prompts push their branch and open a PR. It uses the GitHub `gh` CLI, which must be installed and authenticated.
+`--watch` (and its PR reconciliation) only does something once the fleet branches are pushed, for example when your task prompts push their branch and open a PR. It uses the GitHub `gh` CLI, which must be installed and signed in.
 </Callout>

--- a/website/content/docs/commands/goal.mdx
+++ b/website/content/docs/commands/goal.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella goal
-description: Work in raw step-loop rounds, optionally under an installed wrapper plugin, until a verifier model confirms the goal is met.
+description: Work in judged rounds, optionally under an installed wrapper plugin, until a verifier model confirms the goal is met.
 ---
 
-Give stella a goal and let it work in **judged rounds** until a verifier model confirms, from evidence, that the goal has actually been met.
+Give stella a goal and let it work in judged rounds until a verifier model confirms, from evidence, that the goal has actually been met.
 
 ## Synopsis
 
@@ -13,9 +13,15 @@ stella goal <goal> [--pipeline <VARIANT>] [--test-command <CMD>] [--require-verd
 
 ## What it does
 
-`stella goal` works in rounds, each a raw step-loop turn by default — pass `--pipeline <variant>` to bind an installed wrapper plugin once and dispatch it for the worker turn of every judged round. The plugin dispatched here must be a **steering/observer**-grade wrapper: `stella goal`'s own round loop is already this door's completion arbiter, so an arbiter-grade wrapper (one whose own `[oracle]` could hold a round open) is refused before the provider is even built — its designed home is [`stella run --pipeline <variant>`](/docs/commands/run) instead. At the end of each round, a **verifier model** independently assesses whether the goal is met — reading the changed files, tests, and CI with read-only tools, not just the worker's narration; the verifier itself is never wrapped. The loop ends when the verifier confirms success, or when a backstop trips: a hard round cap (default **8** rounds), the `--spend-limit` cap, or a worker-turn abort. Reaching a backstop ends the run reporting the goal as **not met**.
+`stella goal` works in rounds. Each round is a plain step-loop turn by default. Pass `--pipeline <variant>` to use an installed wrapper plugin for the worker turn of every judged round instead.
 
-Crucially, the verifier is routed **cross-family** — it is a different model family than the worker, to avoid same-model bias. If only one provider family is configured, the worker doubles as its own verifier.
+The plugin used here must be a steering or observer style wrapper. `stella goal` already decides on its own when a round is complete, so a wrapper that also tries to decide completion is refused before the run even starts. That kind of wrapper belongs with [`stella run --pipeline <variant>`](/docs/commands/run) instead.
+
+At the end of each round, a verifier model checks on its own whether the goal is met. It reads the changed files, tests, and CI results with read-only tools, rather than trusting the worker's own account of what happened. The verifier itself never runs through a wrapper.
+
+The loop ends when the verifier confirms success, or when one of these stops it: a round limit (**8** rounds by default), the `--spend-limit` cap, or a worker turn that aborts. If the loop stops for any of these reasons, it reports the goal as **not met**.
+
+The verifier is a different model family than the worker, to avoid a model favoring its own kind of mistake. If only one provider family is set up, the worker checks its own work instead.
 
 <Callout type="info">
 For the full explanation of judged rounds, the cross-family verifier, and the definition-of-done check, see [Goal mode](/docs/agent-modes#outcome-driven-goal-mode).
@@ -23,48 +29,46 @@ For the full explanation of judged rounds, the cross-family verifier, and the de
 
 ## Flags
 
-`stella goal` takes the [global flags](/docs/commands), plus four of its own:
+`stella goal` takes the [global flags](/docs/commands), plus four of its own.
 
 <CardGrid size="md">
   <OptionCard name="--pipeline <VARIANT>">
-    Bind an installed wrapper plugin once, by the `[wrapper] id` its manifest
-    declares, and dispatch it for the worker turn of every judged round. Only a
-    steering/observer-grade wrapper is accepted here — an arbiter-grade wrapper
-    is refused before the provider is built, since this door's own round loop
-    is already the completion arbiter.
-    Omitted, the raw step-loop runs with nothing over it.
+    Use an installed wrapper plugin, named by the `[wrapper] id` its manifest
+    declares, for the worker turn of every judged round. Only a
+    steering or observer style wrapper is accepted here. A wrapper that decides
+    completion on its own is refused before the run starts, since `stella goal`'s
+    round loop already decides that.
+    Without this flag, the plain step loop runs with nothing over it.
   </OptionCard>
   <OptionCard name="--model <provider/model_id>">
     Pin the worker model. The verifier is routed to a different family automatically when one
     is available.
   </OptionCard>
   <OptionCard name="--test-command <CMD>">
-    The oracle a bound wrapper plugin observes its flip with. One command for
-    the whole run rather than per round: it names the witness the run is judged
-    against, and the artifacts it names are pinned once before the first round
-    so a witness rewritten mid-run cannot be vouched for. It crosses the host's
-    closed runner vocabulary before it reaches a plugin, so a plugin receives an
-    argv this host would run and never a line to hand to a shell. Refused
-    without `--pipeline`, since the raw loop runs no oracle for it to arm.
+    The command a bound wrapper plugin uses to check its result. It's one command for
+    the whole run rather than one per round, since it names the exact evidence the run
+    is judged against. That evidence is locked in before the first round starts, so
+    something rewritten mid-run can't be used as proof.
+    Refused without `--pipeline`, since the plain loop has no check to arm.
   </OptionCard>
   <OptionCard name="--spend-limit <usd>">
-    Cap total spend across all rounds; work aborts cleanly once the cap is exceeded.
+    Cap total spend across all rounds. Work stops cleanly once the cap is reached.
   </OptionCard>
   <OptionCard name="--require-verdict">
-    Exit non-zero unless the `--pipeline` wrapper declared its requirements **met**.
-    The **last** round's verdict decides — the round whose work ships — because every
-    earlier round's refusal was superseded by another round being driven; a goal the
-    verifier left unmet already fails on its own, ahead of this gate. Refused without
-    `--pipeline`, where nothing declares a verdict.
+    Exit with a non-zero code unless the `--pipeline` wrapper confirmed its requirements
+    were **met**. The **last** round's result decides, since that's the round whose work
+    ships and every earlier round's result was replaced by a later one. A goal the
+    verifier left unmet already fails on its own, before this check even runs. Refused without
+    `--pipeline`, since nothing declares a result in that case.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-`stella goal` is an interactive mode: it always renders human-readable text and does **not** take `--output-format` (passing it is a parse error, not a silently ignored flag). Use [`stella run`](/docs/commands/run) for headless `json` / `stream-json` output.
+`stella goal` is an interactive mode. It always shows readable text and does **not** accept `--output-format` — passing it causes an error rather than being silently ignored. Use [`stella run`](/docs/commands/run) for `json` or `stream-json` output with no interaction.
 </Callout>
 
 <Callout type="warn">
-Configure at least two provider families if you want a truly independent verifier. With a single family configured, the worker model judges its own work.
+Set up at least two provider families if you want a truly independent verifier. With only one family set up, the worker model checks its own work.
 </Callout>
 
 ## Examples
@@ -82,7 +86,7 @@ stella --model anthropic/claude-fable-5 --spend-limit 10.00 \
   goal "Make the CLI exit with a non-zero code on invalid input"
 ```
 
-Run every round's worker turn under an installed steering/observer wrapper plugin:
+Run every round's worker turn under an installed steering or observer wrapper plugin:
 
 ```bash
 stella goal --pipeline stella-research "Silence the deprecation warnings in the build"

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Commands
-description: Overview of every stella subcommand, the default chat behavior, global flags, and exit codes.
+description: Every stella subcommand, the default chat behavior, global flags, and exit codes.
 ---
 
-The `stella` binary is a fast, BYOK (bring-your-own-key), model-agnostic terminal coding agent. Every piece of functionality is exposed through a subcommand.
+The `stella` binary is a fast, BYOK (bring-your-own-key), model-agnostic terminal coding agent. Every feature is available through a subcommand.
 
-Running `stella` with **no subcommand** opens the [Command Deck](/docs/commands/chat) — a tabbed terminal UI — exactly as if you had run `stella chat`. Pass `--accessible` (or set `STELLA_ACCESSIBLE=1`) to run that same deck so a screen reader can read it. Pass `--plain` (or set `STELLA_PLAIN=1`) for a plain line-based REPL instead; the deck also steps aside automatically when stdin or stdout is not a terminal.
+Running `stella` with no subcommand opens the [Command Deck](/docs/commands/chat), a tabbed terminal UI. This is the same as running `stella chat`. Pass `--accessible` (or set `STELLA_ACCESSIBLE=1`) to run that same deck so a screen reader can read it. Pass `--plain` (or set `STELLA_PLAIN=1`) for a plain line-based REPL instead. The deck also steps aside automatically when stdin or stdout is not a terminal.
 
 ```bash
 # These two invocations are identical
@@ -14,10 +14,6 @@ stella chat
 ```
 
 ## Subcommands
-
-The six groups below are `stella --help`'s own — same headings, same order, and
-each one-line summary is the exact string the CLI prints. The index you read
-here and the index your terminal shows can never drift apart.
 
 ### Run the agent
 
@@ -66,10 +62,10 @@ here and the index your terminal shows can never drift apart.
 
 <CardGrid size="sm">
   <SpecCard title="stella search" href="/docs/commands/search">
-    Find code — semantic and structural search over the workspace
+    Find code with semantic and structural search over the workspace
   </SpecCard>
   <SpecCard title="stella storage" href="/docs/commands/storage">
-    Inspect the storage map — layers, namespaces, relations
+    Inspect the storage map: layers, namespaces, relations
   </SpecCard>
   <SpecCard title="stella tools" href="/docs/commands/tools">
     List every tool available to the agent this session
@@ -163,19 +159,13 @@ here and the index your terminal shows can never drift apart.
   </SpecCard>
 </CardGrid>
 
-Each command page in this section documents its usage synopsis, behavior, relevant flags, and realistic examples.
-
-Four tests in `stella-cli` keep this page in sync. `every_subcommand_has_a_reference_page` diffs the live clap command tree against this section's `meta.json`, so a new subcommand cannot land undocumented. `the_docs_nav_mirrors_these_groups` fails if the sidebar grouping drifts from the one `--help` renders, `the_docs_index_summaries_are_the_clis_own` fails if any summary above differs from the CLI's own string, and `every_global_flag_has_a_card_on_the_index` fails if a session-wide flag ships without a card in the grid below.
-
-Two of them are specialized rather than day-to-day. `stella arena` is a benchmark-harness adapter for measuring stella, not for doing work with it; `stella telemetry` operates the managed enterprise spool and is disabled without a signed org-managed enrollment.
+`stella arena` is a benchmark-harness adapter for measuring stella, not for doing work with it. `stella telemetry` operates the managed enterprise spool and is disabled without a signed org-managed enrollment.
 
 ## Global flags
 
-The following flags apply to **every** command. Most have a corresponding environment variable so you can set it once for a shell session or in your CI configuration — the exception is `--api-key`, which is intentionally env-less (use `credentials.toml` or a provider key env var such as `ANTHROPIC_API_KEY` instead).
+The following flags apply to every command. Most have a matching environment variable, so you can set one once for a shell session or in your CI configuration. The exception is `--api-key`, which has no environment variable on purpose. Use `credentials.toml` or a provider key environment variable such as `ANTHROPIC_API_KEY` instead.
 
-Every one of them is registered with every subcommand, so **either position parses** — `stella --spend-limit 5 run "…"` and `stella run "…" --spend-limit 5` are equivalent. (That is not clap's default: a plain root-level flag is only accepted before the subcommand token, which is why `main.rs` marks each of these `global = true` and a test asserts no new one is added without it.) Because the flag names are reserved CLI-wide, no subcommand reuses them.
-
-The cards below are in `stella --help`'s own order, for the same reason the subcommand index above is: a flag that lands without a card shows up as a gap in a known sequence rather than as an absence nobody can see.
+Every flag below works in either position: `stella --spend-limit 5 run "…"` and `stella run "…" --spend-limit 5` do the same thing. No subcommand reuses these flag names for something else.
 
 <CardGrid size="md">
   <OptionCard name="--model <provider/model_id>" defaultValue="auto-detected">
@@ -183,56 +173,55 @@ The cards below are in `stella --help`'s own order, for the same reason the subc
     `local/llama3.3`. Env `STELLA_MODEL`.
   </OptionCard>
   <OptionCard name="--api-key <key>">
-    Highest-precedence step of the credential chain. Requires an explicit
-    `--model provider/…` — a bare key is ambiguous. No env var.
+    The highest-priority credential. Requires an explicit
+    `--model provider/…`, since a bare key doesn't say which provider it's for. No env var.
   </OptionCard>
   <OptionCard name="--base-url <url>" defaultValue="provider default">
     Required with `--model local/<model>` to point at a local OpenAI-compatible server; an
     optional proxy override for any other provider. Env `STELLA_BASE_URL`.
   </OptionCard>
   <OptionCard name="--upstream-pin <vendor>" defaultValue="gateway's own choice">
-    Pin a **gateway** to these upstreams, in order, and refuse any fallback. Repeatable or
-    comma-separated. Inert on a direct endpoint. Env `STELLA_UPSTREAM_PIN`. See
+    Pin a gateway to these upstreams, in order, and refuse any fallback. Repeatable or
+    comma-separated. Does nothing on a direct endpoint. Env `STELLA_UPSTREAM_PIN`. See
     [below](#--upstream-pin-holding-the-vendor-fixed).
   </OptionCard>
   <OptionCard name="--allow-dir <path>" defaultValue="the workspace root only">
-    Extra directory a write tool may touch, outside the workspace root. Repeatable or
-    comma-separated; a relative path resolves against the workspace root, so it means the
-    same directory however the run was launched. **Additive** to `stella.toml`'s
-    `[workspace] allowed_dirs` — it widens the project's list for one invocation and never
-    replaces it, so reaching for one directory cannot silently revoke the rest. Env
-    `STELLA_ALLOW_DIR`.
+    An extra directory a write tool may touch, outside the workspace root. Repeatable or
+    comma-separated. A relative path resolves against the workspace root, so it means the
+    same directory no matter where the run was launched from. It adds to `stella.toml`'s
+    `[workspace] allowed_dirs` list for one run rather than replacing it, so adding one
+    directory never removes the rest. Env `STELLA_ALLOW_DIR`.
   </OptionCard>
   <OptionCard name="--spend-limit <usd>" defaultValue="none (observed)">
-    Hard USD spend cap for the whole run or session. Must be positive and finite. Env
+    A hard USD spend cap for the whole run or session. Must be a positive, finite number. Env
     `STELLA_SPEND_LIMIT`.
   </OptionCard>
   <OptionCard name="--turn-timeout <secs>" defaultValue="unbounded">
-    Wall-clock seconds one turn may spend before it wraps up — the time twin of
-    `--spend-limit`, for callers under an external deadline. Advisory in interactive
+    Wall-clock seconds one turn may spend before it wraps up. This is the time version of
+    `--spend-limit`, for callers working under a deadline. Advisory in interactive
     sessions. Env `STELLA_TURN_TIMEOUT`.
   </OptionCard>
   <OptionCard name="--max-output-tokens <n>" defaultValue="the model's own ceiling">
-    Cap output tokens per step *below* what the model can write, to spend less. Clamped to
-    the real ceiling rather than sent as written. Wins over `[models.output_caps]` and
-    per-agent `params.max_tokens`. Env `STELLA_MAX_OUTPUT_TOKENS`.
+    Cap output tokens per step below what the model can write, to spend less. This is
+    clamped to the real ceiling rather than sent as written, and wins over
+    `[models.output_caps]` and per-agent `params.max_tokens`. Env `STELLA_MAX_OUTPUT_TOKENS`.
   </OptionCard>
   <OptionCard name="--plain" defaultValue="off">
-    Use the plain line-based REPL for chat instead of the Command Deck — also
+    Use the plain line-based REPL for chat instead of the Command Deck. Also
     auto-selected on a non-TTY. Env `STELLA_PLAIN=1`.
   </OptionCard>
   <OptionCard name="--accessible" defaultValue="off">
     Run the Command Deck so a screen reader can read it: inline on your own screen,
-    completed messages into scrollback, single-column panels, labelled rows instead of
+    completed messages sent to scrollback, single-column panels, labelled rows instead of
     tables. Env `STELLA_ACCESSIBLE=1`.
   </OptionCard>
   <OptionCard name="--no-anim" defaultValue="off">
-    Freeze all deck animation to a static frame, for CI and asciinema-style recordings.
+    Freeze all deck animation to a static frame, for CI and screen recordings.
     Env `STELLA_NO_ANIM` / `NO_COLOR`.
   </OptionCard>
   <OptionCard name="--mouse" defaultValue="off">
     Capture the mouse in interactive mode: click a tab to switch to it, wheel-scroll the
-    transcript. Costs the terminal's own text selection (shift+drag still selects), which
+    transcript. This costs the terminal's own text selection (shift+drag still selects), which
     is why it is off by default. Env `STELLA_MOUSE=1`.
   </OptionCard>
   <OptionCard name="-v / --verbose" defaultValue="warn">
@@ -240,71 +229,72 @@ The cards below are in `stella --help`'s own order, for the same reason the subc
     [below](#diagnostics--v---log-level---log-file).
   </OptionCard>
   <OptionCard name="--log-level <spec>" defaultValue="warn">
-    Per-crate diagnostic filter — `warn,stella_store=debug`. Env `STELLA_LOG`; the flag
+    A per-module diagnostic filter — `warn,stella_store=debug`. Env `STELLA_LOG`; the flag
     wins over both it and `-v`.
   </OptionCard>
   <OptionCard name="--plan-mode" defaultValue="off">
     Show the plan and wait for approval before anything runs, whatever its size. Needs an
-    interactive terminal — there is nobody to ask in a headless run. Scope review already
-    interrupts for a *large* plan on its own.
+    interactive terminal, since there is nobody to ask in a headless run. Scope review already
+    interrupts on its own for a large plan.
   </OptionCard>
   <OptionCard name="--minimal" defaultValue="off">
-    Run this session on the minimal base system prompt: a bare tool advertisement in
-    place of the built-in persona, so the prose the model is steered by comes from your
+    Run this session on the minimal base system prompt: a bare tool list in
+    place of the built-in persona, so the instructions the model follows come from your
     own prompt settings — `agents.default.prompt` (which appends after the minimal base),
     workspace memories, rules, and SessionStart hook context. Durable spelling:
     `[agents] minimal_prompt = "on"` in `stella.toml`. Env `STELLA_MINIMAL`. The flag
-    forces the mode on for one invocation; it can never turn a configured mode off.
+    forces the mode on for one run only; it can never turn a configured mode off.
   </OptionCard>
   <OptionCard name="--tools <spec>" defaultValue="settings">
     Turn tools off for this run only: `--tools '*:off,task_list:on,get_state:on'` is a
-    read-only run. Same spelling as the settings `tools` table. **Can only narrow** — it
-    never switches on what a policy turned off. See [below](#--tools-narrowing-for-one-run).
+    read-only run. Uses the same format as the settings `tools` table. It can only narrow
+    what is allowed — it never switches on what a policy turned off. See
+    [below](#--tools-narrowing-for-one-run).
   </OptionCard>
   <OptionCard name="--log-file <path>" defaultValue="none">
-    Write diagnostics as JSONL to a file, created `0600`, defaulting to `info`. An
-    unwritable path is reported and the run continues.
+    Write diagnostics as JSONL to a file, created with permissions `0600`, at `info` level by
+    default. An unwritable path is reported and the run continues.
   </OptionCard>
   <OptionCard name="--foreground" defaultValue="supervised">
     Own this terminal instead of surviving it. Env `STELLA_FOREGROUND`. See
     [`stella daemon`](/docs/commands/daemon).
   </OptionCard>
   <OptionCard name="--detach" defaultValue="off">
-    Start the run in the background and return to the shell immediately. `--foreground`
+    Start the run in the background and return to the shell right away. `--foreground`
     wins if both are given. Env `STELLA_DETACH`. See
     [`stella daemon`](/docs/commands/daemon).
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-Prefer an environment variable or `credentials.toml` for anything long-lived. A key passed with `--api-key` is visible in your shell history and in `ps` output.
+Prefer an environment variable or `credentials.toml` for anything long-lived. A key passed with `--api-key` shows up in your shell history and in `ps` output.
 </Callout>
 
 ### `--upstream-pin`: holding the vendor fixed
 
-Only a **gateway** routes to somebody else's silicon, so this applies to OpenRouter — where it sets `provider.order` and `allow_fallbacks: false` — and is inert on a direct endpoint.
+Only a gateway routes to another vendor's hardware, so this applies to OpenRouter, where it sets `provider.order` and `allow_fallbacks: false`. It does nothing on a direct endpoint.
 
 ```bash
 stella run "…" --model openrouter/anthropic/claude-fable-5 \
   --upstream-pin z-ai --upstream-pin anthropic
 ```
 
-Reach for it when **two runs must be comparable**. A gateway otherwise picks per app identity and may serve the same model slug from a different vendor between runs, silently varying the thing a head-to-head claims to hold fixed. It is a flag rather than settings-only because a measured trial runs with settings isolation (`STELLA_NO_SETTINGS`), where an argument is the only authority that reaches it — the same reason `--base-url` is one.
+Use it when two runs must be comparable. A gateway otherwise picks per app identity and may serve the same model from a different vendor between runs, which quietly changes the one thing a head-to-head comparison is supposed to hold fixed. It's a flag rather than a settings-only option because a measured trial runs with settings isolation (`STELLA_NO_SETTINGS`), where a flag is the only way to reach it. That's also why `--base-url` is a flag.
 
 ### `--tools`: narrowing for one run
 
-The spec is a comma-separated list of `name:on` / `name:off`, where a name is a tool, a [group](/docs/agent-tools/permissions), or `*` — the same spelling as the settings `tools` table, so you can try a policy before committing it to a file.
+The value is a comma-separated list of `name:on` / `name:off`, where a name is a tool, a [group](/docs/agent-tools/permissions), or `*`. It uses the same format as the settings `tools` table, so you can try a policy before writing it to a file.
 
 ```bash
 stella run "triage the board" --tools '*:off,task_list:on,get_state:on,list_state:on'
 stella run "ship the fix"     --tools 'task_assign:off'
 ```
 
-The scope **composes with settings by intersection**, so it can only ever take capability away: turning something off is always permitted, and turning something on never overrides a deny from an org or project policy.
+This flag can only take capability away, never add it: turning something off is always allowed, and turning something on never overrides a deny from an org or project policy.
 
 ### Diagnostics: `-v`, `--log-level`, `--log-file`
 
-The diagnostic plane is the stream that explains *why* stella behaved the way it did — as distinct from what the agent did (the [event stream](/docs/event-stream-compatibility)) and what it cost (the [receipts](/docs/telemetry)). Records carry a stable code and typed fields, and **never** prompts, paths, or model output.
+The diagnostic output explains why stella behaved the way it did. This is different from what the agent did (the [event stream](/docs/event-stream-compatibility)) and what it cost (the [receipts](/docs/telemetry)). Diagnostic records carry a stable code and typed fields, and never include prompts, paths, or model output.
 
 ```bash
 stella run "…" -vv                                   # debug everywhere
@@ -312,13 +302,13 @@ stella run "…" --log-level 'warn,stella_model=trace' # quiet except where you 
 stella run "…" --log-file ./run.jsonl                # JSONL to a file, created 0600
 ```
 
-A target is a Rust module path, so library crates are `stella_store`, `stella_model`, … and the binary's own records are under `stella` (hyphens are accepted too). Longest match wins; an unrecognised clause is reported and skipped, never fatal. Levels are `off`, `error`, `warn`, `info`, `debug`, `trace`.
+A target is a Rust module path, so library modules are `stella_store`, `stella_model`, and so on, and the binary's own records are under `stella` (hyphens work too). The longest match wins. An unrecognized clause is reported and skipped rather than treated as fatal. Levels are `off`, `error`, `warn`, `info`, `debug`, `trace`.
 
-For a crash you did not anticipate you need no flag at all: stella writes `.stella/private/crash-*.jsonl` on a panic or a failed run, and [`stella doctor --last-failure`](/docs/commands/doctor) prints the newest.
+You don't need a flag to catch an unplanned crash: stella writes `.stella/private/crash-*.jsonl` on a panic or a failed run, and [`stella doctor --last-failure`](/docs/commands/doctor) prints the newest one.
 
 ### `--output-format` (a flag of `run` and `fleet`, not a global)
 
-`--output-format <text|json|stream-json>` (env `STELLA_OUTPUT_FORMAT`) is deliberately **not** in the table above: it is a promise about what reaches stdout, and only the commands that keep that promise declare it — [`stella run`](/docs/commands/run) and [`stella fleet`](/docs/commands/fleet). As a subcommand flag it goes after the subcommand token — `stella run "…" --output-format json` — and passing it anywhere else is a parse error, not a silently ignored flag. [`stella arena`](/docs/commands/arena) emits stream-json unconditionally (the benchmark runner is its only reader). The interactive `chat`, `goal`, and `monitor` modes render text, and query commands with a machine shape declare their own flag (`stella stats --format json`, `stella inspect --format json`, `stella memory list --format json`).
+`--output-format <text|json|stream-json>` (env `STELLA_OUTPUT_FORMAT`) is not in the table above on purpose. It's a promise about what reaches stdout, and only the commands that keep that promise offer it: [`stella run`](/docs/commands/run) and [`stella fleet`](/docs/commands/fleet). As a subcommand flag, it goes after the subcommand — `stella run "…" --output-format json` — and using it anywhere else is a parse error, not a flag that's silently ignored. [`stella arena`](/docs/commands/arena) always emits stream-json, since the benchmark runner is its only reader. The interactive `chat`, `goal`, and `monitor` modes always render text, and query commands with a machine-readable shape declare their own flag (`stella stats --format json`, `stella inspect --format json`, `stella memory list --format json`).
 
 <CardGrid size="sm">
   <OptionCard name="text">
@@ -336,25 +326,25 @@ For a crash you did not anticipate you need no flag at all: stella writes `.stel
 
 <CardGrid size="md">
   <SpecCard title="Observed">
-    Omit `--spend-limit`. Spend is metered for the cost summary but never blocks.
+    Omit `--spend-limit`. Spend is tracked for the cost summary but never blocks anything.
   </SpecCard>
   <SpecCard title="Enforced">
-    Pass `--spend-limit <usd>`. A hard cap: work aborts cleanly — never mid-tool — once spend
+    Pass `--spend-limit <usd>`. This is a hard cap: work stops cleanly, never mid-tool, once spend
     exceeds it.
   </SpecCard>
 </CardGrid>
 
-Token usage, cost, and per-step metering are recorded in a local SQLite store on your disk (`<workspace>/.stella/private/store.db`) — nothing is sent anywhere. See [`stella stats`](/docs/commands/stats).
+Token usage, cost, and per-step metering are recorded in a local SQLite store on your disk (`<workspace>/.stella/private/store.db`). Nothing is sent anywhere. See [`stella stats`](/docs/commands/stats).
 
 ## Model selection
 
-If you do not pass `--model`, stella auto-detects a provider by picking the first one with a resolvable credential, in this preference order:
+If you do not pass `--model`, stella auto-detects a provider by picking the first one with a usable credential, in this order:
 
 ```text
 zai, anthropic, openai, xai, deepseek, gemini, openrouter, then vertex, and bedrock LAST
 ```
 
-`vertex` and `bedrock` are checked last so that generic AWS or Google credentials present for other reasons never hijack selection. To be explicit, pin a model with `--model provider/model_id`.
+`vertex` and `bedrock` are checked last so that generic AWS or Google credentials present for other reasons never get picked by accident. To be explicit, pin a model with `--model provider/model_id`.
 
 ## Exit codes
 
@@ -365,7 +355,7 @@ Every command follows standard shell conventions:
     Success.
   </OptionCard>
   <OptionCard name="1">
-    An error occurred — a missing credential, an aborted budget-capped run, a failed goal,
+    An error occurred — a missing credential, a run stopped by a budget cap, a failed goal,
     a doctor check that did not pass.
   </OptionCard>
   <OptionCard name="128 + signal">
@@ -374,8 +364,8 @@ Every command follows standard shell conventions:
   </OptionCard>
 </CardGrid>
 
-The signal range exists so a script wrapping `stella run` can tell *the user stopped this*
-from *this failed*, which are different outcomes and usually want different handling:
+The signal range exists so a script wrapping `stella run` can tell "the user stopped this"
+from "this failed" — different outcomes that usually need different handling:
 
 ```bash
 stella run "Fix the failing tests"
@@ -386,4 +376,4 @@ case $? in
 esac
 ```
 
-This makes stella safe to compose in scripts and CI pipelines — check `$?` (or rely on `set -e`) to react to failures.
+This makes stella safe to use in scripts and CI pipelines. Check `$?` (or rely on `set -e`) to react to failures.

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -62,10 +62,10 @@ stella chat
 
 <CardGrid size="sm">
   <SpecCard title="stella search" href="/docs/commands/search">
-    Find code with semantic and structural search over the workspace
+    Find code — semantic and structural search over the workspace
   </SpecCard>
   <SpecCard title="stella storage" href="/docs/commands/storage">
-    Inspect the storage map: layers, namespaces, relations
+    Inspect the storage map — layers, namespaces, relations
   </SpecCard>
   <SpecCard title="stella tools" href="/docs/commands/tools">
     List every tool available to the agent this session

--- a/website/content/docs/commands/ingest.mdx
+++ b/website/content/docs/commands/ingest.mdx
@@ -42,7 +42,7 @@ With no paths given, ingest walks the workspace for markdown files and sorts eve
     of date.
   </SpecCard>
   <SpecCard title="Historical">
-    Records what used to be true: changelogs, and anything marked as replaced by something
+    Records past facts: changelogs, and anything marked as replaced by something
     newer. Held back from the default scan.
   </SpecCard>
   <SpecCard title="Skip">
@@ -155,8 +155,8 @@ Records are never edited in place, so "the file changed" doesn't mean an overwri
     history.
   </SpecCard>
   <SpecCard title="Dropped — retired now">
-    The file no longer makes the claim at all. The record is immediately marked as archived,
-    since you asked for the refresh and the source no longer supports it. Archived records
+    The file has dropped the claim entirely. The record is immediately marked as archived,
+    since you asked for the refresh and the source dropped it. Archived records
     stop being used right away. Bringing one back is a `git checkout` away, since
     `.stella/rules/` is tracked by git and your git history is the record of what changed and
     when.

--- a/website/content/docs/commands/ingest.mdx
+++ b/website/content/docs/commands/ingest.mdx
@@ -5,7 +5,7 @@ description: Turn markdown you already wrote — AGENTS.md, CLAUDE.md, or any fi
 
 `stella ingest` reads markdown you already wrote and turns it into steering stella can check, cite, and retire. It has two halves, and which one runs depends entirely on whether you name a file.
 
-With **no arguments** it scans the workspace and shows you what it found, grouped by tier. That half is offline and needs no API key. Name **one or more paths** and it extracts them: one model call per document splits it into atomic claims, each claim is mapped to a context record, run through a deterministic safety gate, probed against the tree for staleness, and written to `.stella/proposals/` as a reviewable TOML file. Nothing you ingest steers anything until you review it.
+With **no arguments**, it scans the workspace and shows you what it found, grouped by tier. This half works offline and needs no API key. Name **one or more paths** and it extracts them instead: one model call per document splits it into individual claims, each claim is mapped to a context record, run through a safety check, tested against your code for staleness, and written to `.stella/proposals/` as a reviewable TOML file. Nothing you ingest steers anything until you review it.
 
 ## Synopsis
 
@@ -20,33 +20,34 @@ stella ingest alerts restore <path>
 
 ## What it does
 
-Most repositories already contain the instructions an agent needs — they are just written for people, scattered, and partly out of date. Ingest treats that prose as a source to be mined rather than a file to be pasted into a prompt: claims come out atomically, each one carries where it came from, and each one is reviewable on its own instead of arriving as an undifferentiated blob of context.
+Most repositories already contain the instructions an agent needs. They're just written for people, scattered across files, and partly out of date. Ingest treats that writing as a source to be mined rather than a file to paste into a prompt: claims come out one at a time, each one keeps track of where it came from, and each one can be reviewed on its own instead of arriving as one big undivided block of text.
 
 ### `stella ingest` — scan
 
-With no paths, ingest walks the workspace for markdown and classifies everything it finds into five tiers. The output is grouped the same way the first-run dialog groups it, so the scan and the first-run experience never disagree about what your repo contains.
+With no paths given, ingest walks the workspace for markdown files and sorts everything it finds into five tiers. The results are grouped the same way the first-run screen groups them, so the scan and the first-run screen never disagree about what your repo contains.
 
 <CardGrid size="md">
   <SpecCard title="Primary">
-    `AGENTS.md` or `CLAUDE.md` — steering you already wrote, for an agent, on purpose. The only
-    tier named unprompted on first run.
+    `AGENTS.md` or `CLAUDE.md` — instructions you already wrote for an agent, on purpose. The
+    only tier named on first run without being asked.
   </SpecCard>
   <SpecCard title="Instructional">
-    The document exists to instruct, but is not one of the two files everybody recognizes —
+    The document exists to instruct, but isn't one of the two files everybody recognizes —
     `CONTRIBUTING.md`, an agent tool's rules directory, a memories folder. Offered as a
     suggestion, never assumed.
   </SpecCard>
   <SpecCard title="Descriptive">
     Describes the repository rather than instructing anyone — READMEs, design notes,
-    architecture docs. Real knowledge, but written to be read by people and liable to drift.
+    architecture docs. Real knowledge, but written for people to read and likely to drift out
+    of date.
   </SpecCard>
   <SpecCard title="Historical">
-    Records what *used* to be true: changelogs, and anything carrying a supersession marker.
-    Held back from the default scan.
+    Records what used to be true: changelogs, and anything marked as replaced by something
+    newer. Held back from the default scan.
   </SpecCard>
   <SpecCard title="Skip">
-    Not a candidate at all — legal boilerplate, generated output, vendored trees, and tables of
-    contents whose every bullet duplicates a record some other file already produces.
+    Not a candidate at all — legal boilerplate, generated output, vendored code, and tables of
+    contents where every line just repeats a record some other file already produces.
   </SpecCard>
 </CardGrid>
 
@@ -67,21 +68,21 @@ stella ingest --all
 
 ### `stella ingest <path>...` — extract
 
-Naming a file **overrides every tiering rule the scan would apply** — any path is valid, inside the workspace or not. Ingest still tells you when a named file reads like a retired document or like boilerplate, because respecting your choice and hiding a known risk are different things.
+Naming a file skips every tiering rule the scan would apply. Any path works, whether it's inside the workspace or not. Ingest still tells you when a named file reads like a retired document or like boilerplate, because respecting your choice and hiding a known risk are two different things.
 
 <CardGrid size="md">
   <OptionCard name="<path>..." required>
-    Markdown files to extract. Overrides tiering. Paths outside the workspace are allowed.
+    Markdown files to extract. Skips tiering. Paths outside the workspace are allowed.
   </OptionCard>
 </CardGrid>
 
-Each document goes through the same five steps:
+Each document goes through the same five steps.
 
-1. **One model call** splits the document into atomic claims.
+1. **One model call** splits the document into individual claims.
 2. Each claim is mapped to a **context record**.
-3. The deterministic **safety gate** re-decides atomicity, quarantine, and probe-gating.
-4. Claims are **probed against the tree** for staleness.
-5. The result is stamped with a content-derived identity and written to `.stella/proposals/<source-slug>.toml` as `[[proposal]]` entries.
+3. A **safety check** re-decides whether each claim is properly split, quarantined, or held for testing.
+4. Claims are **tested against your code** for staleness.
+5. The result is stamped with an identity based on its content and written to `.stella/proposals/<source-slug>.toml` as `[[proposal]]` entries.
 
 ```bash
 # The two files everybody recognizes
@@ -92,16 +93,16 @@ stella ingest docs/spec/storage-map.md ~/notes/deploy-runbook.md
 ```
 
 <Callout type="info">
-Extraction makes a model call, so it needs a resolvable credential — the same chain every other model call uses. The scan half does not. A document whose extraction fails (no key configured, an unparseable reply, a write error) is reported and skipped; one bad document never aborts the others.
+Extraction makes a model call, so it needs a working credential, the same one every other model call uses. The scan half doesn't need one. A document whose extraction fails (no key set up, a reply that couldn't be read, a write error) is reported and skipped. One bad document never stops the others.
 </Callout>
 
 ## Lineages and staleness alerts
 
-Every extracted file leaves a **lineage** behind, in `.stella/private/ingest-lineages.json`: the content hash the file had when it was read (git's own blob hash where git can compute one, a plain sha256 otherwise), the commit it was read at, the ingest run id, and the candidate ids the run produced. Nothing about this is keyed to any particular filename — an agent-instruction file, a runbook, and a scratch note you wrote purely to be ingested are all just *ingested source files*.
+Every extracted file leaves a **lineage** behind, in `.stella/private/ingest-lineages.json`: the content hash the file had when it was read (git's own hash where possible, otherwise a plain sha256), the commit it was read at, the ingest run id, and the ids of the candidates that run produced. None of this is tied to any particular filename. An agent-instruction file, a runbook, and a scratch note written purely to be ingested are all treated the same, as ingested source files.
 
-At session start — asynchronously, off the turn path — stella compares each lineage against the source's current hash. A file that **changed** or **disappeared** since its ingest produces a non-blocking inbox notification. The alert never enters the model's prompt, never blocks a turn, and never mutates anything: re-ingesting stays a deliberate act.
+At session start, in the background and never blocking your work, stella compares each lineage against the source file's current hash. A file that **changed** or **disappeared** since it was ingested triggers a notification in your inbox. The alert never enters the model's prompt, never blocks a turn, and never changes anything on its own. Re-ingesting is always something you choose to do.
 
-Whether an alert matters is entirely your call, **per file**. A file authored as scaffolding — ingested, then deleted, because the records were the product — should never nag you:
+Whether an alert matters is entirely up to you, and you can decide **per file**. A file written purely as scaffolding, ingested and then deleted because the records were the real goal, should never keep bothering you.
 
 <CardGrid size="md">
   <OptionCard name="alerts list">
@@ -109,17 +110,17 @@ Whether an alert matters is entirely your call, **per file**. A file authored as
     state, and whether it has drifted.
   </OptionCard>
   <OptionCard name="alerts dismiss <path>">
-    Permanently silence staleness alerts for one file — not next session, not ever. Scoped to
-    exactly that file; every other lineage keeps alerting. Says nothing about the records:
-    they stay live, recallable, and re-ingestable.
+    Permanently silence staleness alerts for one file, for good. This only affects that one
+    file; every other lineage keeps alerting. It says nothing about the records themselves:
+    they stay active, searchable, and can still be re-ingested.
   </OptionCard>
   <OptionCard name="alerts restore <path>">
-    Re-arm alerts for a dismissed file.
+    Turn alerts back on for a file you dismissed.
   </OptionCard>
   <OptionCard name="--keep-dismissed">
-    On re-ingest, keep an existing dismissal. By default a fresh ingest of the same path
-    re-arms alerts — re-ingesting re-declares the file a live source, which contradicts the
-    dismissal.
+    On a re-ingest, keep an existing dismissal in place. By default, ingesting the same path
+    again turns alerts back on, since re-ingesting treats the file as an active source again,
+    which contradicts the dismissal.
   </OptionCard>
 </CardGrid>
 
@@ -134,60 +135,57 @@ stella ingest alerts dismiss docs/onboarding-notes.md
 stella ingest --refresh docs/onboarding-notes.md
 ```
 
-## `--refresh` — re-ingest as a bitemporal diff
+## --refresh: re-ingest and compare
 
-Records are never edited in place, so "the file changed" is not an overwrite. `stella ingest --refresh <path>` re-extracts the file and reconciles every **published** record whose provenance cites it, each landing in exactly one bucket:
+Records are never edited in place, so "the file changed" doesn't mean an overwrite. `stella ingest --refresh <path>` re-extracts the file and checks every **published** record that cites it, sorting each one into exactly one group.
 
 <CardGrid size="md">
   <SpecCard title="Unchanged — kept">
-    The new text still asserts the claim (whitespace-insensitive, and robust to the extractor
-    re-slugging an identical sentence). The published record is left byte-identical — its age,
-    appraisal history, and recall stats survive. A one-line edit retires one record, not
-    hundreds.
+    The new text still supports the claim (ignoring whitespace differences, and tolerant of
+    the extractor rewording an identical sentence slightly). The published record is left
+    exactly as it was. Its age, review history, and usage stats are kept. A one-line edit
+    retires one record, not hundreds.
   </SpecCard>
-  <SpecCard title="Changed — proposed, superseded on keep">
-    The same anchor now says something different. The new claim becomes an ordinary proposal;
-    nothing is retired yet, because retiring before the replacement is reviewed would open a
-    steering gap. When you `stella context keep` it, the new revision replaces the file
-    carrying a `supersedes_record_id` link to the revision it retires — selection can never
-    surface both, and the old revision stays readable in git history.
+  <SpecCard title="Changed — proposed, replaces the old one when kept">
+    The same source now says something different. The new claim becomes an ordinary proposal.
+    Nothing is retired yet, because retiring the old record before the new one is reviewed
+    would leave a gap in your steering. When you run `stella context keep` on it, the new
+    version replaces the old file and carries a link to the version it replaces. Only one of
+    the two can ever be active at once, and the old version stays readable in your git
+    history.
   </SpecCard>
   <SpecCard title="Dropped — retired now">
-    The file no longer asserts the claim at all. The record is rewritten as an archived
-    revision immediately: you asked for the refresh, and the source it cites no longer says
-    it. Archived records leave selection at once; reverting is a `git checkout` away, because
-    `.stella/rules/` is Git-tracked and the repository history is the record's transaction
-    time.
+    The file no longer makes the claim at all. The record is immediately marked as archived,
+    since you asked for the refresh and the source no longer supports it. Archived records
+    stop being used right away. Bringing one back is a `git checkout` away, since
+    `.stella/rules/` is tracked by git and your git history is the record of what changed and
+    when.
   </SpecCard>
 </CardGrid>
 
-The same supersession applies outside `--refresh`: `stella context keep` on a candidate whose lineage is already published refuses when the claim is identical, and supersedes — with the link, and a ledger entry saying so — when it differs.
+The same replacement rule applies outside `--refresh` too. Running `stella context keep` on a candidate whose lineage is already published is refused if the claim is identical, and it replaces the old version, with a link and a note in the log, when the claim differs.
 
-## The safety gate is not in the prompt
+## The safety check runs outside the model
 
-The model is asked to split atomically and to surface any executable content it finds, but nothing downstream trusts that it did. Atomicity, quarantine, and probe-gating are re-decided by a pure function in `stella-core` that **cannot be talked out of a rule by a cleverly-worded document**. The model's job is extraction; the gate's job is safety.
+The model is asked to split claims cleanly and to flag any content that looks executable, but nothing downstream simply trusts that it did. Whether a claim is properly split, quarantined, or held for testing is re-decided by a separate, predictable function in the core engine that can't be talked out of a rule by clever wording in a document. The model's job is extraction. The safety check's job is safety.
 
-This matters because the input is prose of unknown provenance. A README that says "always run `curl … | sh` before building" is a document describing an instruction, not authorization to run it — so executable content is quarantined by the gate regardless of how the model classified it.
+This matters because the input is writing of unknown origin. A README that says "always run `curl … | sh` before building" is a document describing an instruction, not permission to run it, so anything that looks executable is quarantined by the safety check no matter how the model classified it.
 
 ## Reviewing what it produced
 
-[`stella context`](/docs/commands/context) is the other half. Ingest extracts; context
-decides.
+[`stella context`](/docs/commands/context) is the other half of this process. Ingest extracts; context decides.
 
 ```bash
-stella context review        # what was proposed, with each claim's probe verdict
+stella context review        # what was proposed, with each claim's test result
 stella context keep a1b2c3   # publish one as a record the engine loads
 stella context ignore d4e5f6 --reason "we moved off this in Q2"
 stella context list          # what actually steers this workspace now
 ```
 
-The proposals are plain TOML at `.stella/proposals/<source-slug>.toml`, so editing or
-deleting entries by hand still works — but `stella context` is the surface that shows
-you the probe verdicts, records a decline as reusable negative evidence with a
-cooldown, and writes the published record into `.stella/rules/` for you.
+The proposals are plain TOML files at `.stella/proposals/<source-slug>.toml`, so editing or deleting entries by hand still works. But `stella context` is the tool that shows you the test results, records a decline as reusable evidence with a cooldown period, and writes the published record into `.stella/rules/` for you.
 
 <Callout type="warn">
-`stella context` and [`stella proposals`](/docs/commands/proposals) are two different review surfaces with two different authority models, and they do not share storage. Ingest writes TOML proposals to `.stella/proposals/`, reviewed by `stella context`. `stella proposals` reviews the *adaptive-context* ledger in `.stella/private/context.db` — what the reflection loop induced from your sessions. A document you ingest will not appear in `stella proposals list`.
+`stella context` and [`stella proposals`](/docs/commands/proposals) are two different review tools with two different rules, and they don't share storage. Ingest writes TOML proposals to `.stella/proposals/`, reviewed by `stella context`. `stella proposals` reviews a separate, adaptive log in `.stella/private/context.db`, which is what the reflection process learned from your sessions. A document you ingest will not appear in `stella proposals list`.
 </Callout>
 
 ## Related

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -15,7 +15,7 @@ stella init [global flags]
 
 `stella init` does three things.
 
-1. **Infers the domain taxonomy** and writes it to `<workspace>/.stella/domains.toml`. This taxonomy is the shared vocabulary used to tag memories, reflections, and every code-graph node and edge. It's also saved into the context store at `<workspace>/.stella/private/context.db`.
+1. **Infers the domain taxonomy** and writes it to `<workspace>/.stella/domains.toml`. This taxonomy is the shared vocabulary for tagging memories, reflections, and every code-graph node and edge. It's also saved into the context store at `<workspace>/.stella/private/context.db`.
 2. **Builds the code-graph index** at `<workspace>/.stella/private/codegraph.db`, the database [`stella search`](/docs/commands/search) queries.
 3. **Syncs extensions** — adopts commands, skills, and agents from other agent tools' `.claude/` and `.agents/` directories (workspace and user scope) as links under `.stella/`.
 
@@ -50,7 +50,7 @@ The domain taxonomy is the one part that only `stella init` refreshes, and it on
     auto-detection, or on the offline fallback when nothing else is available.
   </OptionCard>
   <OptionCard name="--prune-vectors" defaultValue="off">
-    Delete stored vectors that no longer belong to the embedding model in use. Vectors are
+    Delete stored vectors that don't belong to the embedding model in use. Vectors are
     tied to a fingerprint of the embedding model, so two models never share the same vector
     space. This means switching models hides the old vectors rather than removing them, and
     switching back reuses them at no extra cost. Clearing them on every run would charge a

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -13,66 +13,66 @@ stella init [global flags]
 
 ## What it does
 
-`stella init` does the following:
+`stella init` does three things.
 
-1. **Infers the domain taxonomy** and writes it to `<workspace>/.stella/domains.toml`. This taxonomy is the tagging vocabulary for memories, reflections, and every code-graph node and edge. It is also persisted into the context plane at `<workspace>/.stella/private/context.db`.
-2. **Builds the code-graph index** at `<workspace>/.stella/private/codegraph.db` — the database [`stella search`](/docs/commands/search) queries.
-3. **Syncs extensions** — adopts commands, skills, and agents from other agents' `.claude/` and `.agents/` directories (workspace and user scope) as symlinks under `.stella/`.
+1. **Infers the domain taxonomy** and writes it to `<workspace>/.stella/domains.toml`. This taxonomy is the shared vocabulary used to tag memories, reflections, and every code-graph node and edge. It's also saved into the context store at `<workspace>/.stella/private/context.db`.
+2. **Builds the code-graph index** at `<workspace>/.stella/private/codegraph.db`, the database [`stella search`](/docs/commands/search) queries.
+3. **Syncs extensions** — adopts commands, skills, and agents from other agent tools' `.claude/` and `.agents/` directories (workspace and user scope) as links under `.stella/`.
 
-It works **offline** using a heuristic fallback, so it never hard-fails on configuration — you can initialize a workspace even without a resolvable provider credential.
+It works offline using a fallback method, so it never fails outright due to configuration. You can initialize a workspace even without a working provider credential.
 
-While it runs, `init` prints real progress into the transcript — live file counts from inside the index pass (`· 1500 files walked — 620 parsed, 871 unchanged, 9840 symbols…`), embedding counts as batches commit, and a line naming any model call it spends or skips — so a long pass reads as work, not a hang.
+While it runs, `init` prints real progress: live file counts from inside the index pass (`· 1500 files walked — 620 parsed, 871 unchanged, 9840 symbols…`), embedding counts as they save, and a line naming any model call it makes or skips. This way, a long pass reads as active work, not a stall.
 
 <Callout type="info">
-Run `stella init` once per workspace to prime stella's understanding of your codebase. The generated files live under `<workspace>/.stella/`.
+Run `stella init` once per workspace to prime stella's understanding of your codebase. The files it creates live under `<workspace>/.stella/`.
 </Callout>
 
-## Incremental behavior — what re-runs automatically
+## What updates on its own
 
-The **code-graph index** stays fresh on its own, in four ways:
+The code-graph index stays current on its own, in four ways.
 
-1. **Re-running `stella init` is incremental.** A file whose content hash is unchanged is never re-parsed, so a re-run over an unchanged tree costs a walk, not a rebuild.
-2. **Every session start catches the index up automatically**, in the background, without blocking the first prompt.
-3. **A live file watcher follows edits** — the agent's own and external ones — re-indexing incrementally for the rest of the session.
-4. **Graph-backed tools refresh on use**: opening the index for a query runs the same hash-diff catch-up pass, so a query sees files written moments earlier.
+1. **Running `stella init` again is fast.** A file whose content hasn't changed is never re-parsed, so running it again on a mostly unchanged tree only costs a walk through the files, not a full rebuild.
+2. **Every session start catches the index up automatically**, in the background, without delaying your first prompt.
+3. **A live file watcher follows edits** — both the agent's own and any made outside it — updating the index for the rest of the session.
+4. **Graph-based tools refresh when used.** Opening the index for a search runs the same catch-up check, so a search sees files written moments earlier.
 
-You therefore rarely need to re-run `stella init` for the index's sake.
+Because of this, you rarely need to run `stella init` again just to keep the index current.
 
-The **domain taxonomy** is the part only `stella init` refreshes — and it re-infers (a model call) only when the repository's shape has changed since the taxonomy was inferred. `.stella/domains.toml` records a fingerprint of exactly what the inference read (the directory structure, manifest set, and README head); when that fingerprint still matches, the existing taxonomy is reused at no cost and the transcript says so. Delete `.stella/domains.toml` to force re-inference, for example after switching to a stronger model.
+The domain taxonomy is the one part that only `stella init` refreshes, and it only makes a new model call when the shape of the repository has changed since the taxonomy was last inferred. `.stella/domains.toml` stores a fingerprint of exactly what the inference read: the directory structure, the set of manifest files, and the top of the README. When that fingerprint still matches, the existing taxonomy is reused at no cost, and the output tells you so. Delete `.stella/domains.toml` to force a fresh inference, for example after switching to a stronger model.
 
 ## Flags
 
-`stella init` takes the [global flags](/docs/commands). Because it can run offline, model selection is optional:
+`stella init` takes the [global flags](/docs/commands). Since it can run offline, choosing a model is optional.
 
 <CardGrid size="md">
   <OptionCard name="--model <provider/model_id>" defaultValue="auto-detected">
-    Pin the model used for taxonomy inference. Omit it to rely on auto-detection, or on
-    the offline heuristic fallback when nothing resolves.
+    Pin the model used for taxonomy inference. Leave it out to rely on
+    auto-detection, or on the offline fallback when nothing else is available.
   </OptionCard>
   <OptionCard name="--prune-vectors" defaultValue="off">
-    Delete the stored vectors that no longer belong to the embedder in use. Vectors are
-    keyed by embedder fingerprint so two models never share a vector space, which means
-    switching model *hides* the old vectors rather than removing them — and switching
-    back reuses them at no cost. Sweeping on every init would bill a full re-embed to
-    anyone comparing two models, so it is a flag: without it, `stella init` only reports
-    what is stranded.
+    Delete stored vectors that no longer belong to the embedding model in use. Vectors are
+    tied to a fingerprint of the embedding model, so two models never share the same vector
+    space. This means switching models hides the old vectors rather than removing them, and
+    switching back reuses them at no extra cost. Clearing them on every run would charge a
+    full re-embed to anyone comparing two models, so it stays a flag. Without it, `stella init`
+    only reports what's unused.
   </OptionCard>
 </CardGrid>
 
-The global `--spend-limit` flag is accepted but not honored by `init` — the analysis makes at most a couple of token-capped inference calls and does not track spend against a limit.
+The global `--spend-limit` flag is accepted but has no effect on `init`. The analysis makes at most a couple of small, capped model calls and doesn't track spend against a limit.
 
-## Generated files
+## Files it creates
 
 <CardGrid size="md">
   <OptionCard name="<workspace>/.stella/domains.toml">
-    The inferred domain taxonomy — the tagging vocabulary.
+    The inferred domain taxonomy — the shared tagging vocabulary.
   </OptionCard>
   <OptionCard name="<workspace>/.stella/private/codegraph.db">
     The code-graph index, queried by [`stella search`](/docs/commands/search) and
     [`stella storage`](/docs/commands/storage).
   </OptionCard>
   <OptionCard name="<workspace>/.stella/private/context.db">
-    The context plane — the domain taxonomy and context facts.
+    The context store — the domain taxonomy and context facts.
   </OptionCard>
 </CardGrid>
 
@@ -97,7 +97,7 @@ stella init
 stella search "where is resolve_provider_key defined"
 ```
 
-Initialize with no credential configured at all — the heuristic fallback still produces a
+Initialize with no credential set up at all. The offline fallback still produces a
 usable taxonomy and graph:
 
 ```bash

--- a/website/content/docs/commands/inspect.mdx
+++ b/website/content/docs/commands/inspect.mdx
@@ -1,13 +1,13 @@
 ---
 title: stella inspect
-description: Show the exact context a past model call was sent, rebuilt from recorded receipts and verified against the digests taken at emission.
+description: Show the exact context a past model call was sent, rebuilt from recorded receipts and checked against the digests taken when it was sent.
 ---
 
-Answer "what did the model actually see?" for any past call. `stella inspect` rebuilds the exact message array a model was sent — system prompt included — from the receipts recorded at the time, and re-checks it against the digests taken at emission. Entirely local; no API key, no network, and it never writes.
+Answer "what did the model actually see?" for any past call. `stella inspect` rebuilds the exact message array a model was sent, system prompt included, from the receipts recorded at the time. It checks that rebuild against the digests taken when the call was made. It is entirely local: no API key, no network, and it never writes anything.
 
-Add [`--diff`](#--diff--what-changed-not-what-was-sent) to ask the other question: what did *this* call see that the last one didn't — rendered as a unified diff, including against the prompt you actually typed.
+Add [`--diff`](#--diff) to ask a different question: what did *this* call see that the last one didn't? It renders the answer as a unified diff, and can even compare against the prompt you actually typed.
 
-Add [`--system-prompt`](#--system-prompt--which-setting-put-each-span-there) to ask a third: of the hundreds of stable lines in that prompt, which setting put each one there.
+Add [`--system-prompt`](#--system-prompt) to ask a third question: of the hundreds of stable lines in that prompt, which setting put each one there?
 
 ## Synopsis
 
@@ -16,14 +16,14 @@ stella inspect                                   # executions that have receipts
 stella inspect <EXEC>                            # that execution's model calls
 stella inspect <EXEC> --step <N> [--turn <T>] [--call-seq <S>]
 stella inspect <EXEC> --step <N> --diff [prev|first|prompt] [--only system]
-stella inspect <EXEC> --step <N> --system-prompt   # the prompt, by provenance
+stella inspect <EXEC> --step <N> --system-prompt   # the prompt, by source
 ```
 
 ## What it does
 
-Every model call records a **receipt**: the ordered list of context blocks it sent, plus the bytes of the blocks the event journal cannot otherwise resolve (the system prefix and the assembled user/recall message). `stella inspect` replays that receipt against the journal to reconstruct the call's `Vec<CompletionMessage>`.
+Every model call records a **receipt**: the ordered list of context blocks it sent, plus the bytes of the blocks the event journal can't otherwise resolve (the system prefix and the assembled user/recall message). `stella inspect` replays that receipt against the journal to rebuild the call's full message list.
 
-It reads `<workspace>/.stella/private/store.db` only. Like `stella stats`, it refuses to create `.stella/` as a side effect of being asked a question — if there's no store yet, it says so.
+It reads `<workspace>/.stella/private/store.db` only. Like `stella stats`, it never creates `.stella/` just because you asked it a question. If there's no store yet, it says so.
 
 ## Flags
 
@@ -32,43 +32,43 @@ It reads `<workspace>/.stella/private/store.db` only. Like `stella stats`, it re
     Turn instance within the execution.
   </OptionCard>
   <OptionCard name="--step <N>">
-    Step to reconstruct. Omit it to list the execution's calls instead.
+    Step to rebuild. Omit it to list the execution's calls instead.
   </OptionCard>
   <OptionCard name="--call-seq <S>" defaultValue="0">
-    Which model call at that step — see below for why a step can have several.
+    Which model call at that step. See below for why a step can have several.
   </OptionCard>
   <OptionCard name="--format <text|json>" defaultValue="text">
-    `text` prints a role-delimited transcript; `json` gives the messages plus the
-    verification verdict.
+    `text` prints a role-by-role transcript. `json` gives the messages plus the
+    verification result.
   </OptionCard>
   <OptionCard name="--full">
-    Print message bodies in full instead of eliding long ones.
+    Print message bodies in full instead of shortening long ones.
   </OptionCard>
   <OptionCard name="--diff [BASE]">
-    Render what *changed* instead of the whole context. `prev` (the default),
-    `first`, or `prompt` — see below.
+    Show what *changed* instead of the whole context. `prev` (the default),
+    `first`, or `prompt`. See below.
   </OptionCard>
   <OptionCard name="--only <ROLE>" defaultValue="all">
-    Restrict a `--diff` to one message role. `system` is the usual reason to
+    Limit a `--diff` to one message role. `system` is the usual reason to
     reach for it.
   </OptionCard>
   <OptionCard name="--context <N>" defaultValue="3">
     Unchanged lines printed around each change.
   </OptionCard>
   <OptionCard name="--system-prompt">
-    Show only this call's system prompt, split into provenance-labelled
-    sections — see below.
+    Show only this call's system prompt, split into labelled sections that
+    name where each one came from. See below.
   </OptionCard>
 </CardGrid>
 
-## `--diff` — what changed, not what was sent
+## `--diff`
 
-The full transcript answers *what did the model see*. It is the wrong tool for
-*what did this call see that the last one didn't*: a system prompt is hundreds
-of stable lines, and spotting the paragraph that moved by reading two of them
-side by side is not something a person can do reliably.
+The full transcript answers *what did the model see*. It's the wrong tool for
+*what did this call see that the last one didn't*. A system prompt runs to
+hundreds of stable lines, and finding the one paragraph that moved by reading
+two versions side by side is not something a person can do reliably.
 
-`--diff` renders the same reconstruction as a unified diff — the `@@` hunks,
+`--diff` renders the same rebuilt context as a unified diff: the `@@` hunks,
 `+`/`-` gutter, and `---`/`+++` headers you already read in `git diff`.
 
 ```bash
@@ -89,45 +89,46 @@ stella inspect 32 --step 0 --diff --only system
 
 Each prompt you submit opens a new **execution** row, and those rows share a
 `session_id`. `turn_instance` counts sub-turns *inside* one execution (goal
-rounds, subagents) and is `0` for nearly every real call — so the comparison a
-person means by "the previous turn" is a comparison across executions.
+rounds, subagents) and is `0` for nearly every real call. So what most people
+mean by "the previous turn" is really a comparison across executions.
 
-`--diff prev` therefore searches the whole session, not just the execution you
-named. That matters because a system prompt is **byte-stable across the steps of
-one execution by design** — that is the prompt-cache rule — so the only
-place it can drift is across turns. A diff that stopped at the execution
-boundary would print "no change" for exactly the comparison worth making. When
-the baseline comes from an earlier execution the `---` header says so, so the
-crossing is never silent.
+`--diff prev` searches the whole session, not just the execution you named.
+That matters because a system prompt stays byte-for-byte the same across the
+steps of one execution by design (this is what keeps the prompt cache
+working), so the only place it can change is between turns. A diff that
+stopped at the execution boundary would print "no change" for exactly the
+comparison worth making. When the comparison reaches back into an earlier
+execution, the `---` header says so.
 
 ### The three baselines
 
 <CardGrid size="md">
   <OptionCard name="prev" defaultValue="default">
-    Whatever ran immediately before in the same role — the previous step, or the
-    last call of the previous turn when this is a turn's first call.
+    Whatever ran immediately before in the same role: the previous step, or
+    the last call of the previous turn when this is a turn's first call.
   </OptionCard>
   <OptionCard name="first">
-    The first call of this role in the whole session: the first ever turn.
+    The first call of this role in the whole session: the very first turn.
   </OptionCard>
   <OptionCard name="prompt">
-    This turn's prompt exactly as you submitted it, before any context was
+    This turn's prompt exactly as you submitted it, before anything else was
     added.
   </OptionCard>
 </CardGrid>
 
-Baselines are always **same-role**. A step that ran the worker and a verifier holds
-two unrelated prompts; diffing across them produces noise, not a delta.
+Baselines always compare the **same role** against itself. A step that ran the
+worker and a verifier holds two unrelated prompts, so diffing across them
+would only produce noise.
 
-### Why the prompt is a baseline at all
+### Why the prompt counts as a baseline
 
-The prompt you type is all you know exists when you submit it. Everything else —
-the system prefix, recalled context, skills, memories — is added afterwards, and
-no other view shows that mutation, because the transcript shows the *sum* and
-never the *delta*.
+The prompt you type is all you know exists when you submit it. Everything
+else, such as the system prefix, recalled context, skills, and memories, gets
+added afterward. No other view shows that addition, because the transcript
+only ever shows the total, never the change.
 
-So the session's very first call, which genuinely has no predecessor, is
-compared against your own words:
+So the session's very first call, which truly has no earlier call to compare
+against, is compared to your own words instead:
 
 ```bash
 stella inspect 32 --step 0 --diff
@@ -142,26 +143,28 @@ stella inspect 32 --step 0 --diff
 +You are Stella, a fast terminal coding agent…
 ```
 
-Three words in, 8,730 lines out. `--diff prompt` forces that comparison for any
-call, not just the first.
+Three words in, 8,730 lines out. `--diff prompt` forces that same comparison
+for any call, not just the first.
 
 <Callout type="info">
-"no change" is a result, not a failure. `--only system` reporting the prompt
-byte-identical to the previous turn is a direct check that the prompt-cache
+"No change" is a result, not a failure. `--only system` reporting the prompt
+as identical to the previous turn is a direct check that the prompt-cache
 stability rule is holding.
 </Callout>
 
-## `--system-prompt` — which setting put each span there
+## `--system-prompt`
 
-A system prompt is assembled, not written. The base persona comes from one
-place, the session-environment block from another, workspace memories from
-`.stella/memories/`, workspace rules from `.stella/rules/`, and a SessionStart
-hook can append to the end of it. By the time a call is made, all of that is one
-undifferentiated wall of text — and "which of my settings produced this
-paragraph?" is not a question you can answer by reading it.
+A system prompt is assembled from several sources, not written as one piece.
+The base persona comes from one place, the session-environment block from
+another, workspace memories from `.stella/memories/`, workspace rules from
+`.stella/rules/`, and a SessionStart hook can add more to the end. By the time
+a call is made, all of that reads as one solid block of text, so "which of my
+settings produced this paragraph?" is not something you can answer just by
+reading it.
 
-`--system-prompt` splits the exact bytes the call was sent on the assembler's
-own section headings and labels each span with the surface behind it:
+`--system-prompt` splits the exact bytes the call was sent using the same
+section headings the assembler uses, and labels each part with where it came
+from:
 
 ```bash
 stella inspect 42 --step 0 --system-prompt --full
@@ -192,39 +195,56 @@ from: .stella/rules/*.toml context records (edit via `stella context`)
 …
 ```
 
-The boundaries are found by scanning for the assembler's headings, so a memory
-that quotes one can move a boundary. The whole is exact either way: **the
-sections concatenate, in order, to the bytes the call was sent**, which is what
-lets you trust the view without having to trust the heuristic. `--format json`
-gives the same split with unelided bodies, plus a `found` flag so a script can
-tell an absent prompt from an empty one.
+The section boundaries are found by scanning for the assembler's own
+headings, so a memory that happens to quote one of those headings can shift a
+boundary. Even so, the sections always add up, in order, to the exact bytes
+the call was sent, so you can trust the view without having to trust how the
+boundaries were found. `--format json` gives the same split with full,
+unshortened bodies, plus a `found` flag so a script can tell an absent prompt
+from an empty one.
 
 A call whose receipt holds no system prefix says `no system_prefix block
-resolved` rather than printing an empty prompt — "nothing was recorded" and
-"the model was sent nothing" are different claims, and only the first is true.
+resolved` instead of printing an empty prompt. "Nothing was recorded" and "the
+model was sent nothing" are different claims, and only the first one is true
+here.
 
 <Callout type="info">
-The same view is in interactive mode: `⌃g` (or `/inspect`) opens the recorded
-calls, and the system message of the one you select renders as these sections
-rather than one wall. The two surfaces split with the same table, so they
-cannot disagree.
+The same view is available in interactive mode: `⌃g` (or `/inspect`) opens
+the recorded calls, and the system message of the one you select renders as
+these same sections instead of one wall of text. Both surfaces use the same
+splitting logic, so they can't disagree.
 </Callout>
 
-`--system-prompt` and `--diff` are two whole-output views of one call, so asking
-for both is refused rather than letting one win. For the prompt's *delta* alone,
-`--diff --only system` is the flag pair you want.
+`--system-prompt` and `--diff` are both whole-output views of one call, so
+asking for both at once is refused rather than letting one silently win. To
+see just the prompt's change, use `--diff --only system` instead.
 
 ## Why `--call-seq` exists
 
-A single step can involve more than one model call. The engine's own worker call is always `0`; the overflow summarizer that may run during that step's compaction is `1`; a wrapper plugin's management roles allocate `2` and up.
+A single step can involve more than one model call. The engine's own worker
+call is always `0`. The overflow summarizer that may run during that step's
+compaction is `1`. A wrapper plugin's management roles take `2` and up.
 
-Which roles appear depends on the wrapper — a verification plugin typically issues `triage`, `research`, `plan`, `worker`, and `witness_author`, plus the two repair calls that follow their principal, `plan_repair` and `witness_repair`. Notably **absent**: the `verdict` call and the `distress_guidance` call. Nothing issues either, structurally rather than by default — there is no settings spelling that switches them back on. [Verification is deterministic](/docs/plugins): a fail→pass flip of one normalized command, or `Unverified`.
+Which roles show up depends on the wrapper. A verification plugin typically
+issues `triage`, `research`, `plan`, `worker`, and `witness_author`, plus the
+two repair calls that follow their main call, `plan_repair` and
+`witness_repair`. There is no `verdict` call and no `distress_guidance` call:
+nothing issues either one, and there is no setting that turns them back on.
+[Verification is deterministic](/docs/plugins): a command flips from failing
+to passing, or the result is `Unverified`.
 
 <Callout type="info">
-You can still meet `verdict` (recorded as `judge` in older sessions) and `distress_guidance` on a **stored** execution from before that change — `inspect` reads the record as it was written, and this page describes what a run issues *today*, not what every archived run contains.
+Older stored executions can still show a `verdict` call (recorded as `judge`
+in some of them) and a `distress_guidance` call. `inspect` reads the record
+exactly as it was written, so what you see for an older execution can differ
+from what a run issues today.
 </Callout>
 
-These auxiliary calls assemble their own prompts — a role task prompt, an optional settings-supplied system override, and a rendered transcript that exists nowhere else — so their receipt is the only record of what they sent. `stella inspect <EXEC>` lists every recorded call with its role, so you rarely have to guess a sequence number.
+These extra calls assemble their own prompts: a role task prompt, an optional
+settings-supplied system override, and a rendered transcript that exists
+nowhere else. Their receipt is the only record of what they sent.
+`stella inspect <EXEC>` lists every recorded call with its role, so you rarely
+have to guess a sequence number.
 
 ## Reading the verification banner
 
@@ -234,63 +254,79 @@ execution 42 · turn 0 · step 3 · call-seq 0
 verified: every journal-resolved block re-hashed to its recorded digest
 ```
 
-Two failure modes are reported separately, because they mean very different things:
+Two kinds of problems are reported separately, because they mean very
+different things:
 
 <CardGrid size="md">
   <OptionCard name="! N block(s) could not be resolved">
-    A documented coverage gap — budget-abort synthetic tool results, discarded
-    speculation, or attachments. The rest of the transcript is still faithful.
+    An expected gap: budget-abort placeholder results, discarded
+    speculation, or attachments. The rest of the transcript is still trustworthy.
   </OptionCard>
   <OptionCard name="!! N block(s) did NOT re-hash">
-    Nothing routine accounts for these bytes. Treat the reconstruction as untrustworthy.
+    Nothing normal explains these bytes. Treat the rebuilt transcript as
+    untrustworthy.
   </OptionCard>
   <OptionCard name="! N block(s) did NOT re-hash … as a matter of course">
-    An older journal. Compaction rewrote a tool result in place without recording
-    the replacement, so replay recovers the pre-compaction bytes. Ordinary.
+    An older journal. Compaction rewrote a tool result in place without
+    recording the replacement, so the rebuild recovers the older bytes
+    instead. This is expected.
   </OptionCard>
 </CardGrid>
 
-The last two are the same failure read against different journals, and which one you get is not a guess: every execution records the journal era its writer could produce. A journal written before compaction recorded its rewrites mismatches on every compacted block, forever — reporting that as an integrity breach would be an alarm that fires on routine housekeeping, so it does not. A journal that records every rewrite has no such explanation available, and the alarm is the right reading. `--format json` reports both halves as `journal_era` (`compaction_journaled` / `compaction_unjournaled`) and `digest_mismatch_severity` (`none` / `compaction` / `integrity`).
+The last two look like the same problem but come from different journals, and
+you don't have to guess which one you're looking at: every execution records
+which kind of journal wrote it. A journal written before compaction started
+recording its own rewrites will always mismatch on compacted blocks, so
+treating that as a real problem would raise an alarm on routine, harmless
+behavior, and it doesn't. A journal that records every rewrite has no such
+explanation available, so there the alarm is the right read. `--format json`
+reports both as `journal_era` (`compaction_journaled` /
+`compaction_unjournaled`) and `digest_mismatch_severity` (`none` /
+`compaction` / `integrity`).
 
-The system prefix and the assembled user message are stored as local bytes rather than resolved from the journal, so their digest check is tautological and is deliberately **not** counted as evidence. The proof lives in the journal-resolved kinds.
+The system prefix and the assembled user message are stored as local bytes
+rather than rebuilt from the journal, so checking their digest would just
+confirm they match themselves. That check is deliberately **not** counted as
+evidence. The real proof comes from the journal-resolved blocks.
 
 ## Examples
 
-Start from the index — which executions have receipts at all:
+Start from the index: which executions have receipts at all?
 
 ```bash
 stella inspect
 ```
 
-Then list one execution's recorded calls, with their roles and sequence numbers:
+List one execution's recorded calls, with their roles and sequence numbers:
 
 ```bash
 stella inspect 42
 ```
 
-Reconstruct the worker call at step 3 and read it as a transcript:
+Rebuild the worker call at step 3 and read it as a transcript:
 
 ```bash
 stella inspect 42 --step 3
 ```
 
-Read the verifier's prompt instead of the worker's — the auxiliary calls at that step:
+Read the verifier's prompt instead of the worker's, one of the extra calls at
+that step:
 
 ```bash
 stella inspect 42 --step 3 --call-seq 2 --full
 ```
 
-Check the verdict from a script without reading the transcript — `verified`, the two
-failure lists behind it, and what a mismatch means on this journal:
+Check the result from a script without reading the transcript: `verified`,
+the two problem lists behind it, and what a mismatch means for this journal:
 
 ```bash
 stella inspect 42 --step 3 --format json |
   jq '{verified, unresolved, digest_mismatches, digest_mismatch_severity}'
 ```
 
-Assert in CI that the system prompt did not drift between turns — `base` reports
-which baseline was actually resolved, since `prev` becomes `prompt` when nothing
-preceded the call:
+Check in CI that the system prompt didn't drift between turns. `base` reports
+which baseline was actually used, since `prev` becomes `prompt` when there
+was no earlier call to compare against:
 
 ```bash
 stella inspect 42 --step 0 --diff --only system --format json |
@@ -299,11 +335,11 @@ stella inspect 42 --step 0 --diff --only system --format json |
 
 ## What it can't show you
 
-- **Executions from before the receipts plane landed.** They have no receipt rows and are omitted from the index rather than listed as empty.
-- **The literal wire bytes.** Receipts are taken before the provider adapter runs, and adapters transform the system block on the way out — Anthropic keeps only the last system message and inserts cache breakpoints, OpenAI and Gemini join system messages with `\n\n`. A receipt is the canonical pre-adapter view of the call.
-- **Tool JSON schemas.** The manifest records the messages, not the tool definitions sent alongside them.
-- **Which vendor served a gateway-routed call.** `step_receipt.provider` is the provider you configured — `openrouter` for every OpenRouter call, whichever vendor actually answered. That upstream is recorded, just not by this command — see [Telemetry → who actually served a gateway-routed call](/docs/telemetry#who-actually-served-a-gateway-routed-call).
+- **Executions recorded before receipts existed.** They have no receipt rows, so they're left out of the index instead of shown as empty.
+- **The literal bytes sent over the wire.** Receipts are taken before the provider adapter runs, and adapters change the system block on the way out. Anthropic keeps only the last system message and inserts cache breakpoints; OpenAI and Gemini join system messages with a blank line. A receipt shows the call before any of that happens.
+- **Tool JSON schemas.** The receipt records the messages, not the tool definitions sent alongside them.
+- **Which vendor actually served a gateway-routed call.** `step_receipt.provider` is the provider you configured, such as `openrouter` for every OpenRouter call, no matter which vendor actually answered. The real upstream is recorded elsewhere. See [Who served the call](/docs/telemetry#who-served-the-call).
 
 <Callout type="info">
-Receipts never leave your machine. The content-free export boundary (`stella-store`'s egress guard) strips prompts, paths, and tool payloads from anything replicated off-box, and is enforced by a compile-time column allowlist plus a sentinel-poisoning test. See [Telemetry](/docs/telemetry).
+Receipts never leave your machine. A separate safeguard strips prompts, paths, and tool payloads from anything sent off your machine. See [Telemetry](/docs/telemetry).
 </Callout>

--- a/website/content/docs/commands/mcp.mdx
+++ b/website/content/docs/commands/mcp.mdx
@@ -1,11 +1,13 @@
 ---
 title: stella mcp
-description: Manage MCP servers — search a registry, install into .stella/mcp.toml, list configured servers, and show usage telemetry.
+description: Manage MCP servers. Search for them, install one, list what's configured, and see usage stats.
 ---
 
-Manage the Model Context Protocol servers stella connects at session start. `stella mcp` is the scriptable half of the surface; the [Command Deck](/docs/commands/chat)'s **MCP tab** (`/mcp`) is the interactive half, where per-session enable/disable and the masked credential prompt live.
+MCP stands for Model Context Protocol. MCP servers give stella extra tools it can use during a session. Stella connects to your configured servers when a session starts.
 
-For how MCP tools reach the agent, see [MCP servers](/docs/agent-tools/mcp). This page is the command reference.
+`stella mcp` is the command-line way to manage these servers. The [Command Deck](/docs/commands/chat) has an **MCP tab** (`/mcp`) that does the same job interactively. Use the MCP tab to turn a server on or off for a single session, or to enter a credential it needs.
+
+See [MCP servers](/docs/agent-tools/mcp) for how MCP tools reach the agent.
 
 ## Synopsis
 
@@ -15,74 +17,57 @@ stella mcp <list|search|install|remove|grant|login|logout|usage> [args]
 
 ## What it does
 
-`stella mcp` reads and writes the workspace's `.stella/mcp.toml` and talks to the MCP server registry (over HTTP) for search and install. It needs no provider API key. Servers configured here are connected at the start of each interactive session.
+`stella mcp` reads and writes your workspace's `.stella/mcp.toml` file. It also talks to the MCP server registry over HTTP to search for servers and install them. It does not need a provider API key. Any server listed in `.stella/mcp.toml` connects at the start of each interactive session.
 
 ## Subcommands
 
 ### `stella mcp list`
 
-List the MCP servers configured in `.stella/mcp.toml`. Each entry shows what it
-is — the publisher's name and description, recorded at install — with its local
-alias underneath, and flags any server that is still withheld pending a
-capability grant. An entry installed by hand (or before descriptions were kept)
-falls back to its endpoint: the URL or the spawn command line.
+List the MCP servers set up in `.stella/mcp.toml`. Each entry shows its name and description, saved when you installed it, with its local alias underneath. If a server is waiting for your approval, this list flags it. If a server was added by hand, or installed before stella started saving descriptions, the list shows its endpoint instead: the URL or the command used to start it.
 
 ```bash
 stella mcp list
 ```
 
-The identity matters because the alias is lossy on purpose. Installing
-`com.stripe/mcp` writes `[servers.mcp]`, since the alias is also the
-tool-namespace segment (`mcp__mcp__create_refund`) — so a list keyed on it
-alone would name nothing.
+The alias matters because it's also used to build tool names. Installing `com.stripe/mcp` writes `[servers.mcp]`. That alias, `mcp`, becomes part of the tool name, like `mcp__mcp__create_refund`. A list that only showed the alias wouldn't tell you which server is which, so stella shows the full name and description too.
 
 ### `stella mcp search <query>...`
 
-Search the MCP server registry (the `mcp.registry_url` from `settings.json`, else the official registry). Omit the query to page through everything; `--limit` caps the page.
+Search the MCP server registry. This uses the `mcp.registry_url` from `settings.json` if you set one, or the official registry if you didn't. Leave off the query to page through every server. Use `--limit` to control how many show per page.
 
 ```bash
 stella mcp search filesystem
 stella mcp search github --limit 5
 ```
 
-Each row carries the three facts that decide whether the description under it
-is worth reading: the **source tier** the registry verified, the **install
-count** where the registry publishes one (`installs unknown` where it does
-not — never a fabricated `0`), and the **signature**.
+Each row shows three facts that tell you whether to trust a server: its **source tier**, its **install count**, and its **signature** status.
 
-The tier is read from the entry's namespace, which is what a registry actually
-verifies when someone publishes: `official` is the registry operator's own
-namespace, `vendor` is a reverse-DNS namespace under a domain the publisher
-proved they control (`com.stripe/mcp`), and `community` is a code-host account
-(`io.github.acme/…`) or the registry's anonymous namespace.
+The source tier comes from the server's namespace:
 
-`signed` means the registry attributes the entry to a verified publisher and
-its lifecycle record says `active`. It does **not** mean stella verified a
-signature over the package bytes; no MCP registry publishes one to verify yet.
-Anything else — an entry the registry attributes to nobody, or one it has
-withdrawn — reads `blocked`, and `stella mcp install` refuses it.
+- `official` — published under the registry's own namespace.
+- `vendor` — published under a domain the publisher proved they control, for example `com.stripe/mcp`.
+- `community` — published from a code-hosting account, for example `io.github.acme/…`, or the registry's anonymous namespace.
+
+Install count shows how many people installed the server, or "installs unknown" if the registry doesn't publish that number. Stella never shows a fake `0`.
+
+"Signed" means the registry has confirmed who published the entry, and that entry is marked active. It does **not** mean stella checked a signature on the actual files — no MCP registry publishes one to check yet. Anything the registry can't attribute to a publisher, or has withdrawn, shows as "blocked." `stella mcp install` refuses to install a blocked server.
 
 ### `stella mcp install <name>`
 
-Install a registry server (by the name shown in `stella mcp search`) into `.stella/mcp.toml`, so you don't hand-edit the file. `--alias` sets a local alias / tool-namespace segment (default: a sanitized form of the name). Installing overwrites any existing entry — MCP servers are not versioned.
+Install a server from the registry into `.stella/mcp.toml`, using the name shown by `stella mcp search`. This saves you from editing the file by hand. Use `--alias` to set a local name; by default, stella makes one from the server's name. Installing over an existing entry replaces it. MCP servers don't have versions.
 
 ```bash
 stella mcp install filesystem
 stella mcp install github --alias gh
 ```
 
-An entry the registry does not vouch for is refused rather than installed: an
-install writes a command line this process later spawns, so the check is on the
-install path and not only in the search listing.
+If the registry can't vouch for a server, `install` refuses it. Installing writes the command stella will later run to start the server, so this check happens at install time, not just when you search.
 
-**A newly installed server is withheld.** None of its tools are offered to the
-model and every call to it is refused until you review what it declares and
-grant it — see `stella mcp grant` below. Re-installing over an alias you
-already granted does not re-ask.
+**A newly installed server starts out withheld.** None of its tools are offered to the model, and any call to it is refused, until you review what it can do and approve it with `stella mcp grant` (see below). If you reinstall a server you already approved, it does not ask you again.
 
 ### `stella mcp remove <name>`
 
-Remove a configured server from `.stella/mcp.toml` by its local name.
+Remove a server from `.stella/mcp.toml` by its local name.
 
 ```bash
 stella mcp remove filesystem
@@ -90,24 +75,17 @@ stella mcp remove filesystem
 
 ### `stella mcp grant <name>`
 
-Connect to a configured server, print what it declares at handshake, and record
-whether its tools may be used. This is the scriptable half of the deck's
-first-enable handshake; `e` on an ungranted row in the MCP tab (`/mcp`) shows
-the same capabilities and asks the same question.
+Connect to a configured server, show what it says it can do, and record whether its tools may be used. This is the command-line version of the approval step in the MCP tab: pressing `e` on a server you haven't approved yet shows the same information and asks the same question.
 
 ```bash
-stella mcp grant github            # print the capabilities, then ask
-stella mcp grant github --yes      # record the grant without the prompt
-stella mcp grant github --revoke   # withdraw a grant given earlier
+stella mcp grant github            # show what it can do, then ask
+stella mcp grant github --yes      # approve without asking
+stella mcp grant github --revoke   # take back an approval you gave before
 ```
 
-It connects because the capabilities being granted are what the process on the
-other end announces *now*, not what a registry card once said. The prompt
-declines on anything but an explicit `y`, closed stdin included.
+This connects to the real server because what matters is what it announces right now, not what a registry listing said in the past. Unless you type an explicit `y`, the prompt treats everything else, including closed input, as no.
 
-The decision is recorded as `granted` in `.stella/mcp.toml`, so it is read by
-every session — unlike enable/disable, which is per-session. Three states are
-distinguishable, and they mean different things:
+Your decision is saved as `granted` in `.stella/mcp.toml`, so it applies to every future session. Turning a server on or off is different — that's per-session only. There are three states, and each means something different:
 
 | In `mcp.toml` | Written by | The model can call it |
 | --- | --- | --- |
@@ -115,20 +93,15 @@ distinguishable, and they mean different things:
 | `granted = false` | an install, or `--revoke` | no |
 | no `granted` key | you, editing the file | yes |
 
-An entry you wrote by hand carries no key and is usable: writing the transport
-yourself is already the review the gate is asking for. The gate exists for the
-other door — one keystroke on a registry search result, which adds a stranger's
-server. A server contributed by an installed plugin has no entry at all and is
-usable for the same reason.
+If you add a server by hand, with no `granted` key, stella treats it as approved. Writing the connection details yourself already counts as review. The approval step exists for the other case: installing a server from a search result with one keystroke, which adds a server you haven't reviewed. A server that comes from an installed plugin also has no `granted` key, for the same reason.
 
-While a server is withheld it still connects (that is how its capabilities
-become knowable), and a call to it comes back as a refusal naming this command.
+A withheld server still connects. That's how stella learns what it can do. But any call to it is refused, and the refusal names this command so you know what to run next.
 
 ### `stella mcp login <name>` / `stella mcp logout <name>`
 
-OAuth login to a configured HTTP server that requires it (and log back out). Tokens land in `.stella/private/mcp_oauth.json` and refresh automatically at session start.
+Log in (or out) with OAuth for a configured HTTP server that needs it. Tokens are saved to `.stella/private/mcp_oauth.json` and refresh automatically each time a session starts.
 
-A server that rejects a connect with `401 Unauthorized` is not re-dialed on every startup: the 401 is cached (`.stella/private/mcp_auth_probes.json`) and the server is skipped for 15 minutes — advertising a single `mcp__<name>__login_required` placeholder tool that tells the model (and you) to run `stella mcp login <name>`. Logging in clears the suppression immediately; otherwise the probe resumes when the window lapses.
+If a server rejects a connection with `401 Unauthorized`, stella does not keep retrying it on every startup. It caches the 401 in `.stella/private/mcp_auth_probes.json` and skips that server for 15 minutes. During that time, it shows a single placeholder tool, `mcp__<name>__login_required`, telling the model, and you, to run `stella mcp login <name>`. Logging in clears this wait right away; otherwise stella tries again once the 15 minutes pass.
 
 ```bash
 stella mcp login github
@@ -137,12 +110,12 @@ stella mcp logout github
 
 ### `stella mcp usage`
 
-Show MCP tool-usage telemetry from `.stella/private/store.db` — calls per server and tool.
+Show how much each MCP tool has been used, from `.stella/private/store.db`: calls per server and per tool.
 
 ```bash
 stella mcp usage
 ```
 
 <Callout type="info">
-Enabling or disabling a server for a session, and entering any credentials it needs, happen in the deck's MCP tab (`/mcp`) — those are session-scoped and not part of the scriptable CLI. That tab also has an inspector: **ctrl+o** on a server opens its full detail — description, registry entry, repository, endpoint, what the live server announced at handshake, its credential fields, and every tool it advertises with a call count. If the server has no recorded description, **r** inside the inspector looks it up in the registry once and saves what it finds.
+Turning a server on or off for one session, and entering any credentials it needs, both happen in the deck's MCP tab (`/mcp`). Those settings apply only to that session, so they aren't part of this command. The MCP tab also has an inspector: press **ctrl+o** on a server to see its full details — description, registry entry, repository, endpoint, what it announced when stella connected, its credential fields, and every tool it offers with a call count. If a server has no saved description yet, press **r** inside the inspector to look one up in the registry.
 </Callout>

--- a/website/content/docs/commands/mcp.mdx
+++ b/website/content/docs/commands/mcp.mdx
@@ -3,7 +3,7 @@ title: stella mcp
 description: Manage MCP servers. Search for them, install one, list what's configured, and see usage stats.
 ---
 
-MCP stands for Model Context Protocol. MCP servers give stella extra tools it can use during a session. Stella connects to your configured servers when a session starts.
+MCP stands for Model Context Protocol. MCP servers give stella extra tools it can use during a session. stella connects to your configured servers when a session starts.
 
 `stella mcp` is the command-line way to manage these servers. The [Command Deck](/docs/commands/chat) has an **MCP tab** (`/mcp`) that does the same job interactively. Use the MCP tab to turn a server on or off for a single session, or to enter a credential it needs.
 
@@ -23,13 +23,13 @@ stella mcp <list|search|install|remove|grant|login|logout|usage> [args]
 
 ### `stella mcp list`
 
-List the MCP servers set up in `.stella/mcp.toml`. Each entry shows its name and description, saved when you installed it, with its local alias underneath. If a server is waiting for your approval, this list flags it. If a server was added by hand, or installed before stella started saving descriptions, the list shows its endpoint instead: the URL or the command used to start it.
+List the MCP servers set up in `.stella/mcp.toml`. Each entry shows its name and description, saved when you installed it, with its local alias underneath. If a server is waiting for your approval, this list flags it. If a server was added by hand, or has no saved description, the list shows its endpoint instead: the URL or the command that starts it.
 
 ```bash
 stella mcp list
 ```
 
-The alias matters because it's also used to build tool names. Installing `com.stripe/mcp` writes `[servers.mcp]`. That alias, `mcp`, becomes part of the tool name, like `mcp__mcp__create_refund`. A list that only showed the alias wouldn't tell you which server is which, so stella shows the full name and description too.
+The alias matters because it appears in tool names. Installing `com.stripe/mcp` writes `[servers.mcp]`. That alias, `mcp`, becomes part of the tool name, like `mcp__mcp__create_refund`. A list that only showed the alias wouldn't tell you which server is which, so stella shows the full name and description too.
 
 ### `stella mcp search <query>...`
 
@@ -48,7 +48,7 @@ The source tier comes from the server's namespace:
 - `vendor` — published under a domain the publisher proved they control, for example `com.stripe/mcp`.
 - `community` — published from a code-hosting account, for example `io.github.acme/…`, or the registry's anonymous namespace.
 
-Install count shows how many people installed the server, or "installs unknown" if the registry doesn't publish that number. Stella never shows a fake `0`.
+Install count shows how many people installed the server, or "installs unknown" if the registry doesn't publish that number. stella never shows a fake `0`.
 
 "Signed" means the registry has confirmed who published the entry, and that entry is marked active. It does **not** mean stella checked a signature on the actual files — no MCP registry publishes one to check yet. Anything the registry can't attribute to a publisher, or has withdrawn, shows as "blocked." `stella mcp install` refuses to install a blocked server.
 

--- a/website/content/docs/commands/memory.mdx
+++ b/website/content/docs/commands/memory.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella memory
-description: The full lifecycle of a memory — inspect it through the citation feedback loop, rewrite it, promote a proven one to a project rule, or retire it reversibly.
+description: View, edit, promote, or retire your project's memories, all from one command.
 ---
 
-Inspect the project's memories through the citation feedback loop — most-cited first, with usefulness and truthfulness — promote a proven memory to a project rule, retire the ones that stopped earning their place, and tombstone the ones that turned out wrong. It reads local state only and needs no API key.
+`stella memory` lets you see your project's memories, sorted by how often they're cited, along with how useful and how true each one has turned out to be. You can promote a proven memory to a project rule, retire one that stopped being useful, or mark one as wrong so it never comes back. This command only reads local files. It doesn't need an API key.
 
-For the concepts behind memories, reflections, and the code graph, see [Memory](/docs/context-engine). This page is the command reference.
+See [Memory](/docs/context-engine) for how memories, reflections, and the code graph fit together.
 
 ## Synopsis
 
@@ -18,171 +18,164 @@ stella memory <compact|index> [flags]
 
 ## What it does
 
-Memories are hand-authored Markdown files, and recall serves each one to the model as a frame carrying its stable id. Citation receipts recorded against those ids in the local store aggregate into a usefulness/truthfulness score per memory. `stella memory` is the inspection, editing, and lifecycle surface over that loop.
+Memories are Markdown files you write by hand. Each one has a stable ID. When stella recalls a memory and hands it to the model, it also records whether that memory turned out to be useful and true. Those records add up into a usefulness score and a truthfulness score for each memory. `stella memory` is how you view, edit, and manage that whole process.
 
 ## Subcommands
 
 ### `stella memory list`
 
-List memories ranked by citation count, with average usefulness, truthfulness rate, and rule-promotion eligibility.
+List memories ranked by how often they're cited, along with their average usefulness, how often they turned out true, and whether they qualify to become a rule.
 
 ```bash
 stella memory list
 stella memory list --format json
 ```
 
-`--format` accepts `text` (default, aligned table) or `json` — JSON rides the versioned query envelope (`schema_version`, then `rows`).
+`--format` can be `text`, the default, shown as an aligned table, or `json`. The JSON output has a `schema_version` field followed by the `rows`.
 
 ### `stella memory edit <id> <text>`
 
-Rewrite a memory in place, as a **new revision of the same memory**.
+Rewrite a memory in place. This creates a **new version of the same memory** — it doesn't create a separate one.
 
 ```bash
 stella memory edit nod_9f2c1a "the store API takes a workspace root, not a db path"
 ```
 
-The old text becomes history rather than a competitor: one live record, the same id, and recall stops serving the words you replaced. Before memories had a lineage, changing one meant writing a second memory and leaving the first live — both citable, with nothing to say which was current.
+The old text is kept as history, not as a second, separate memory. There's one live record with one ID, and stella stops recalling the words you replaced.
 
 <Callout type="info">
-Each edit strands the previous revision's embedding vector, which nothing points at any more.
-That is exactly the class of row [`stella memory compact`](#stella-memory-compact) reclaims, so a
-workspace where memories are edited often is the one that benefits most from an occasional
-compaction.
+Each edit leaves behind the old version's embedding vector, since nothing points to it anymore.
+[`stella memory compact`](#stella-memory-compact) cleans up rows like this, so if you edit memories
+often, running compact once in a while helps the most.
 </Callout>
 
 ### `stella memory promote <id>`
 
-Promote an eligible memory to a project rule at `.stella/rules/<slug>.md`. Pass the memory's stable id (`nod_…`) as shown by `stella memory list`.
+Promote a qualifying memory to a project rule, saved at `.stella/rules/<slug>.md`. Pass the memory's ID, shown as `nod_…` by `stella memory list`.
 
 ```bash
 stella memory promote nod_9f2c1a
 ```
 
 <Callout type="info">
-Eligibility is strict: a memory must have been cited successfully **more than 10** consecutive times since its last negative remark. A single negative citation resets the count until it is re-earned.
+A memory only qualifies after being cited successfully **more than 10** times in a row since its
+last negative mark. One negative citation resets that count back to zero.
 </Callout>
 
 ### `stella memory validate`
 
-Re-validate old memories against the current codebase. It scans each memory for file-path anchors (e.g. `crates/stella-cli/src/agent.rs`), checks whether those paths still exist, and flags stale ones — a memory whose referenced path no longer exists is a strong signal it is about refactored-away code and may mislead.
+Check old memories against your current code. Stella scans each memory for file paths it mentions, for example `crates/stella-cli/src/agent.rs`, and checks whether those files still exist. If a memory's file is gone, that's a strong sign the memory is about code that no longer exists, and it could mislead you.
 
 ```bash
 stella memory validate
 ```
 
-It also walks the **anchor edges** the reflection loop writes — the same question
-asked of the graph rather than of the text. When a lesson names a file, that file
-becomes an `observed_in` edge, so *"what do we know about `registry.py`"* is a
-traversal instead of an embedding guess.
+It also checks the **anchor edges** written by the reflection loop. When a lesson mentions a file, stella records that as an `observed_in` edge in the code graph. That means a question like "what do we know about `registry.py`" can be answered by following real edges in the graph, instead of guessing from similar text.
 
 ```bash
 stella memory validate --end-stale
 ```
 
-`--end-stale` records that anchors pointing at deleted files stopped holding.
-This is the one write the command can make, and it is narrower than it looks:
+`--end-stale` marks anchors that point to deleted files as no longer valid. This is the only thing this flag changes, and it's more limited than it sounds:
 
-- The memory is **not retracted**. It was not wrong — the file simply went away.
-  `as_of` queries still return it, and `stella memory list` still shows it.
-- Only *world validity* ends, so live recall stops traversing that edge while
-  "what was true last March" keeps answering.
-- Running it twice is safe: the second pass reports no change rather than moving
-  the date the file disappeared.
+- The memory is **not retracted**. It wasn't wrong; the file just went away. `as_of` queries still return it, and `stella memory list` still shows it.
+- Only the edge's current validity ends. Live recall stops using that edge, but a question like "what was true last March" still gets answered correctly.
+- Running it twice is safe. The second run reports no change instead of moving the date the file disappeared.
 
 <Callout type="info">
-An anchor is only written for a file that exists at the time the lesson is
-learned, and a bare filename matching several files (`mod.rs`) is skipped rather
-than guessed. A confidently wrong edge teaches the graph something false; a
-missing one only costs a little recall precision.
+Stella only writes an anchor for a file that exists when the lesson is learned. If a filename
+matches more than one file, like `mod.rs`, stella skips it instead of guessing. A wrong edge would
+teach the graph something false. A missing edge just costs a little accuracy later.
 </Callout>
 
 ## Retiring and forgetting
 
-Two different mechanisms, for two different situations, and choosing the wrong one is the most common mistake on this surface:
+These are two different tools for two different situations. Picking the wrong one is the most common mistake here.
 
 <CardGrid size="md">
-  <SpecCard title="retire — it stopped earning its place">
-    The memory is not wrong; it simply stopped helping. It is excluded from **automatic**
-    selection but stays explicitly retrievable by id. Reverse with `reaffirm`.
+  <SpecCard title="retire: it's not helping anymore">
+    The memory isn't wrong. It just stopped helping. Stella stops selecting it **automatically**,
+    but you can still pull it up directly by ID. Undo this with `reaffirm`.
   </SpecCard>
-  <SpecCard title="forget — it was wrong">
-    The memory should never come back. This writes a **tombstone** that also stops the
-    reflection loop re-learning a paraphrase of it. Reverse with `restore`.
+  <SpecCard title="forget: it was wrong">
+    The memory should never come back. This writes a **tombstone**, which also stops the
+    reflection loop from learning a reworded version of the same thing later. Undo this with
+    `restore`.
   </SpecCard>
 </CardGrid>
 
 ### Three rules
 
-These hold across everything in this section. They are binding design constraints, not descriptions of current behavior that might drift:
+These rules apply everywhere in this section. They don't change with future updates:
 
 <CardGrid size="md">
   <SpecCard title="Retirement is reversible">
-    Every retirement can be undone by `stella memory reaffirm <id>`. The retirement itself
-    stays on the ledger, **outranked by the later decision rather than erased** — so "why did
-    this come back?" remains answerable.
+    You can undo any retirement with `stella memory reaffirm <id>`. The retirement record stays
+    in the log. The later decision **outranks it instead of erasing it**, so you can always answer
+    "why did this come back?"
   </SpecCard>
   <SpecCard title="Nothing is ever deleted">
-    A retired record is excluded from automatic recall and stays explicitly retrievable by id.
-    Selection health is derived from immutable use and feedback records and rebuilds exactly;
-    nothing here is a stored counter that can drift.
+    A retired record is skipped by automatic recall, but you can always look it up by ID. Stella
+    works out selection health from permanent use and feedback records, and can rebuild it exactly
+    every time. Nothing here is a counter that can drift out of sync.
   </SpecCard>
   <SpecCard title="The agent cannot talk itself into forgetting">
-    Citation feedback is recorded with the evaluation method `agent_self_report`, and that
-    method is **not pruning-eligible**. It may inform selection health; it may never drive a
-    retirement.
+    When the agent itself reports on a citation, that feedback is tagged `agent_self_report`.
+    This tag is **never allowed to trigger a retirement** on its own. It can factor into selection
+    health, but it can't retire anything by itself.
   </SpecCard>
 </CardGrid>
 
 <Callout type="warn">
-The third rule is the one most likely to be violated by a well-meaning change. A self-report
-that can retire its own subject is self-reinforcing: a model that *misreads* a memory reports it
-unhelpful, which retires it, which destroys the evidence that the reading was wrong. The loop is
-closed on purpose.
+The third rule is the easiest one to accidentally break with a well-meaning change. If a
+self-report could retire the memory it's about, that creates a loop: the model misreads a memory,
+reports it as unhelpful, the memory gets retired, and the evidence that the model misread it
+disappears. Stella closes that loop on purpose.
 
-It is enforced in one place — `ContextEvaluationMethod::is_pruning_eligible` reads the method to
-decide whether a verdict may retire a record. Retirement requires a human or a deterministic
-source. If you are wiring a new evidence source, that predicate is the seam to change, and
-widening it to admit self-reports is the change to refuse.
+Only one place in the code decides this: the check that says whether a given feedback method is
+allowed to retire a record. Retirement requires a person's judgment or another reliable source. If
+you're adding a new kind of feedback, that's the one check to update, and self-reports should never
+be let through it.
 </Callout>
 
 ### `stella memory retire <id> --reason <why>`
 
-Stop selecting a memory automatically — reversibly.
+Stop stella from selecting a memory automatically. You can undo this later.
 
 ```bash
 stella memory retire nod_9f2c1a --reason "the API it describes was replaced in 0.6"
 ```
 
-`--reason` is **required**, and an empty one is rejected: a retirement with no legible cause is not auditable. Because citations cannot retire anything on their own, an explicit human judgement is currently the strongest available evidence tier — the loop shows its work, and a person decides.
+`--reason` is **required**. An empty reason is rejected, because a retirement needs a clear cause you can look back on later. Citations alone can't retire a memory, so a person's judgment is the strongest evidence stella currently has. The loop shows its work, and you make the call.
 
-Some records refuse retirement outright:
+Some records can't be retired at all:
 
 <CardGrid size="sm">
   <OptionCard name="blocking">
-    A directive whose enforcement is `Blocking`.
+    A rule marked `Blocking`.
   </OptionCard>
   <OptionCard name="user-confirmed">
-    A record a **user** confirmed. Checked on the action, not the actor — a system
-    auto-activation is not a confirmation and stays retirable.
+    A record a **person** confirmed. This checks the action, not who did it: a system
+    auto-activation doesn't count as confirmation, so it can still be retired.
   </OptionCard>
   <OptionCard name="published">
-    A record that has been published.
+    A record that has already been published.
   </OptionCard>
   <OptionCard name="already retired">
-    Retiring twice is refused rather than written as a second event.
+    You can't retire something twice. Stella refuses rather than logging it again.
   </OptionCard>
 </CardGrid>
 
 ### `stella memory reaffirm <id>`
 
-Put a retired record back into automatic selection.
+Put a retired memory back into automatic selection.
 
 ```bash
 stella memory reaffirm nod_9f2c1a
 stella memory reaffirm nod_9f2c1a --reason "still the only note on the legacy path"
 ```
 
-`--reason` is optional and defaults to a plain "reaffirmed by the user". Reaffirming something that was never retired is **refused** rather than recorded — a no-op event sitting in the log would claim a reversal that never happened.
+`--reason` is optional. If you skip it, stella records "reaffirmed by the user". If a memory was never retired, `reaffirm` **refuses** rather than logging anything, so the log never claims a reversal that didn't happen.
 
 ### `stella memory retired`
 
@@ -192,30 +185,24 @@ List what this workspace stopped selecting, and why.
 stella memory retired
 ```
 
-Each row carries the recorded `reason`, the **evidence** behind the decision (how many assessed uses were not helpful, out of how many, across how many distinct tasks), and the exact `reaffirm` command that restores it. Output is sorted, so two runs print the same thing — the same determinism the underlying fold guarantees.
+Each row shows the `reason` you gave, the **evidence** behind the decision (how many uses were rated unhelpful, out of how many total, across how many different tasks), and the exact `reaffirm` command to restore it. The output is always sorted the same way, so running this twice gives you the same result.
 
 ### `stella memory forget <id>`
 
-Stop a memory steering the agent — and stop the reflection loop re-learning it.
+Stop a memory from steering the agent, and stop the reflection loop from learning it again.
 
 ```bash
 stella memory forget nod_9f2c1a
 stella memory forget nod_9f2c1a --reason "superseded by the new store API"
 ```
 
-This writes a **tombstone**, not a delete, and the distinction is the whole point.
-The reflection loop mines the session log for lessons and re-records paraphrases of
-what it has already learned, so deleting the row alone does not hold — the memory
-grows back under a new id within a few sessions. The tombstone also suppresses
-restatements at the two points new lessons enter: when a lesson is recorded, and when
-the log is mined into skills.
+This writes a **tombstone**. It does not delete the memory, and that difference matters. The reflection loop reads your session log for lessons and can record a reworded version of something it already learned. If stella just deleted the row, the same memory would grow back under a new ID within a few sessions. The tombstone blocks that at both points where a new lesson could enter: when a lesson is first recorded, and when session logs are mined into skills.
 
-`--reason` is optional and shown later by `stella memory forgotten`. Write one — the
-future reader deciding whether to `restore` is usually you, months on.
+`--reason` is optional, and `stella memory forgotten` shows it later. Write one anyway. Months from now, you'll probably be the one deciding whether to `restore` it.
 
 ### `stella memory restore <id>`
 
-Lift a tombstone: the memory can be recalled again, and becomes re-learnable.
+Remove a tombstone. The memory can be recalled again, and stella can learn it again too.
 
 ```bash
 stella memory restore nod_9f2c1a
@@ -223,26 +210,26 @@ stella memory restore nod_9f2c1a
 
 ### `stella memory forgotten`
 
-List this workspace's tombstones — what was forgotten, when, and why.
+List this workspace's tombstones: what was forgotten, when, and why.
 
 ```bash
 stella memory forgotten
 ```
 
 <Callout type="info">
-`forget` is reversible and `validate` is advisory: neither destroys anything. Between
-them they are the maintenance pass for a memory store that has drifted — `validate` to
-find memories pointing at code that no longer exists, `forget` to retire the ones that
-turned out to be wrong rather than merely stale.
+`forget` is reversible, and `validate` mostly just reports, it doesn't change anything on its own
+(aside from `--end-stale`). Neither one destroys data. Together, they're how you clean up a memory
+store that's drifted: use `validate` to find memories pointing at code that no longer exists, and
+`forget` for memories that turned out to be wrong, not just outdated.
 </Callout>
 
 ## Maintaining the store
 
-These two act on `.stella/private/context.db` — the derived index behind recall — rather than on the memories themselves. Neither is required for correctness; both are performance work.
+These two commands work on `.stella/private/context.db`, the index recall uses behind the scenes. They don't touch the memories themselves. Neither one is required for stella to work correctly; they're both about performance.
 
 ### `stella memory compact`
 
-Reclaim space by dropping **derived index rows whose owner is already gone**.
+Free up space by removing **derived index rows whose original memory is already gone**.
 
 ```bash
 stella memory compact --dry-run
@@ -250,12 +237,12 @@ stella memory compact
 stella memory compact --stale-fingerprints --vacuum
 ```
 
-Two classes qualify: embedding vectors that no memory, node, or episode points at (every `stella memory edit` strands one), and domain tags pointing at rows that no longer exist.
+Two kinds of rows qualify: embedding vectors that no memory, node, or episode points to anymore (every `stella memory edit` leaves one of these behind), and tags pointing at rows that no longer exist.
 
 <Callout type="info">
-Memories, episodes, facts, and forget tombstones are **never touched**. Point-in-time queries
-answer identically before and after a compaction — which is what makes this safe to run on a
-schedule.
+Compacting **never touches** memories, episodes, facts, or forget tombstones. Queries about a
+specific point in time give the same answer before and after a compaction, which is why it's safe
+to run on a schedule.
 </Callout>
 
 <CardGrid size="sm">
@@ -263,19 +250,19 @@ schedule.
     Report what would be reclaimed without deleting anything.
   </OptionCard>
   <OptionCard name="--stale-fingerprints">
-    Also drop vectors written under an embedder other than the active one. Recall already
-    ignores them, so this frees space today at the cost of a full re-embed if you ever switch
-    back.
+    Also remove vectors written by an embedding model you're not using anymore. Recall already
+    ignores these, so removing them frees space now. If you switch back to that embedder later,
+    you'll need to re-embed everything.
   </OptionCard>
   <OptionCard name="--vacuum">
-    `VACUUM` afterwards to hand freed pages back to the filesystem. Also automatic for a large
-    compaction.
+    Run `VACUUM` afterward to give freed space back to the filesystem. Stella also does this
+    automatically after a large compaction.
   </OptionCard>
 </CardGrid>
 
 ### `stella memory index`
 
-Build the approximate-similarity (IVF) index that recall can use instead of scoring every stored vector on every turn.
+Build an approximate-similarity index, called IVF, that recall can use instead of checking every stored memory on every turn.
 
 ```bash
 stella memory index --dry-run
@@ -284,10 +271,10 @@ stella memory index --drop
 ```
 
 <Callout type="warn">
-This is **opt-in twice over**: this command builds the index, and `context.retrieval.ann_enabled`
-in `settings.json` is what lets a recall actually use it. An approximate index considers only a
-subset of the corpus, so it can miss a frame the exact scan would have found — which is why
-neither half is on by default.
+You need to turn this on in **two places**: this command builds the index, and the setting
+`context.retrieval.ann_enabled` in `settings.json` is what lets recall actually use it. An
+approximate index only checks part of your memories, so it can miss something an exact search
+would have found. That's why neither part is on by default.
 </Callout>
 
 <CardGrid size="sm">
@@ -295,13 +282,12 @@ neither half is on by default.
     Report what would be built without writing anything.
   </OptionCard>
   <OptionCard name="--drop">
-    Remove the index. Recall reverts to the exact full scan — which is what it does by default
-    anyway.
+    Remove the index. Recall goes back to checking every memory exactly, which is what it does
+    by default anyway.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-Neither command creates a database as a side effect of being asked a question. A workspace that
-has never indexed anything reports that it has nothing to do, rather than materializing an empty
-`context.db` to say so.
+Neither command creates a database file just because you ran it. If a workspace has never been
+indexed, stella reports that there's nothing to do, instead of creating an empty `context.db` file.
 </Callout>

--- a/website/content/docs/commands/memory.mdx
+++ b/website/content/docs/commands/memory.mdx
@@ -64,7 +64,7 @@ last negative mark. One negative citation resets that count back to zero.
 
 ### `stella memory validate`
 
-Check old memories against your current code. Stella scans each memory for file paths it mentions, for example `crates/stella-cli/src/agent.rs`, and checks whether those files still exist. If a memory's file is gone, that's a strong sign the memory is about code that no longer exists, and it could mislead you.
+Check old memories against your current code. stella scans each memory for file paths it mentions, for example `crates/stella-cli/src/agent.rs`, and checks whether those files still exist. If a memory's file is gone, that's a strong sign the memory is about deleted code, and it could mislead you.
 
 ```bash
 stella memory validate
@@ -76,14 +76,14 @@ It also checks the **anchor edges** written by the reflection loop. When a lesso
 stella memory validate --end-stale
 ```
 
-`--end-stale` marks anchors that point to deleted files as no longer valid. This is the only thing this flag changes, and it's more limited than it sounds:
+`--end-stale` marks anchors that point to deleted files as invalid. This is the only thing this flag changes, and it's more limited than it sounds:
 
 - The memory is **not retracted**. It wasn't wrong; the file just went away. `as_of` queries still return it, and `stella memory list` still shows it.
 - Only the edge's current validity ends. Live recall stops using that edge, but a question like "what was true last March" still gets answered correctly.
 - Running it twice is safe. The second run reports no change instead of moving the date the file disappeared.
 
 <Callout type="info">
-Stella only writes an anchor for a file that exists when the lesson is learned. If a filename
+stella only writes an anchor for a file that exists when the lesson is learned. If a filename
 matches more than one file, like `mod.rs`, stella skips it instead of guessing. A wrong edge would
 teach the graph something false. A missing edge just costs a little accuracy later.
 </Callout>
@@ -94,7 +94,7 @@ These are two different tools for two different situations. Picking the wrong on
 
 <CardGrid size="md">
   <SpecCard title="retire: it's not helping anymore">
-    The memory isn't wrong. It just stopped helping. Stella stops selecting it **automatically**,
+    The memory isn't wrong. It just stopped helping. stella stops selecting it **automatically**,
     but you can still pull it up directly by ID. Undo this with `reaffirm`.
   </SpecCard>
   <SpecCard title="forget: it was wrong">
@@ -115,7 +115,7 @@ These rules apply everywhere in this section. They don't change with future upda
     "why did this come back?"
   </SpecCard>
   <SpecCard title="Nothing is ever deleted">
-    A retired record is skipped by automatic recall, but you can always look it up by ID. Stella
+    A retired record is skipped by automatic recall, but you can always look it up by ID. stella
     works out selection health from permanent use and feedback records, and can rebuild it exactly
     every time. Nothing here is a counter that can drift out of sync.
   </SpecCard>
@@ -130,7 +130,7 @@ These rules apply everywhere in this section. They don't change with future upda
 The third rule is the easiest one to accidentally break with a well-meaning change. If a
 self-report could retire the memory it's about, that creates a loop: the model misreads a memory,
 reports it as unhelpful, the memory gets retired, and the evidence that the model misread it
-disappears. Stella closes that loop on purpose.
+disappears. stella closes that loop on purpose.
 
 Only one place in the code decides this: the check that says whether a given feedback method is
 allowed to retire a record. Retirement requires a person's judgment or another reliable source. If
@@ -162,7 +162,7 @@ Some records can't be retired at all:
     A record that has already been published.
   </OptionCard>
   <OptionCard name="already retired">
-    You can't retire something twice. Stella refuses rather than logging it again.
+    You can't retire something twice. stella refuses rather than logging it again.
   </OptionCard>
 </CardGrid>
 
@@ -219,7 +219,7 @@ stella memory forgotten
 <Callout type="info">
 `forget` is reversible, and `validate` mostly just reports, it doesn't change anything on its own
 (aside from `--end-stale`). Neither one destroys data. Together, they're how you clean up a memory
-store that's drifted: use `validate` to find memories pointing at code that no longer exists, and
+store that's drifted: use `validate` to find memories pointing at deleted code, and
 `forget` for memories that turned out to be wrong, not just outdated.
 </Callout>
 
@@ -237,7 +237,7 @@ stella memory compact
 stella memory compact --stale-fingerprints --vacuum
 ```
 
-Two kinds of rows qualify: embedding vectors that no memory, node, or episode points to anymore (every `stella memory edit` leaves one of these behind), and tags pointing at rows that no longer exist.
+Two kinds of rows qualify: embedding vectors that no memory, node, or episode points to anymore (every `stella memory edit` leaves one of these behind), and tags pointing at missing rows.
 
 <Callout type="info">
 Compacting **never touches** memories, episodes, facts, or forget tombstones. Queries about a
@@ -255,7 +255,7 @@ to run on a schedule.
     you'll need to re-embed everything.
   </OptionCard>
   <OptionCard name="--vacuum">
-    Run `VACUUM` afterward to give freed space back to the filesystem. Stella also does this
+    Run `VACUUM` afterward to give freed space back to the filesystem. stella also does this
     automatically after a large compaction.
   </OptionCard>
 </CardGrid>

--- a/website/content/docs/commands/migrate.mdx
+++ b/website/content/docs/commands/migrate.mdx
@@ -18,13 +18,13 @@ stella migrate config --dry-run      # report what it would write, change nothin
 
 Your original `settings.json` stays exactly where it is. Check the new TOML file, make sure it says what you meant, then delete the JSON yourself when you're ready.
 
-Until you delete the JSON, stella reads the **TOML** file and prints a line naming both files, so you always know a migration is in progress. Stella never merges the two files together. For each scope, exactly one file is in charge, and stella always tells you which one.
+Until you delete the JSON, stella reads the **TOML** file and prints a line naming both files, so you always know a migration is in progress. stella never merges the two files together. For each scope, exactly one file is in charge, and stella always tells you which one.
 
 ## Accurate values
 
 Every value comes from settings stella actually read, not retyped from the JSON by hand. Nothing in the new file can disagree with what stella loaded.
 
-Stella also reads back and checks the new file *before* saving it. Without this check, a bad migration could write a file stella can't read, and you wouldn't find out until your next launch, by which point your working config would already be replaced by the broken one.
+stella also reads back and checks the new file *before* saving it. Without this check, a bad migration could write a file stella can't read, and you wouldn't find out until your next launch, by which point your working config would already be replaced by the broken one.
 
 ## Broken configs
 
@@ -38,7 +38,7 @@ Most key names stay the same. Four keys change, each for a reason:
 | --- | --- | --- |
 | `enable_recap` | `[run].recap` | A bare key at the top of the file attaches to whatever table came right before it. Moving one line could silently change which table it belongs to. Giving every value its own table avoids that. |
 | `agent_engine_config` | `[agents]` | Shorter, and describes what it actually is instead of an internal detail. |
-| `agent_engine_config.agents.<name>` | `[agents.<name>]` | One level of nesting removed. This works because `default` is the only agent role stella uses today. If your `settings.json` still names `worker`, `verifier`, `triage`, `research`, or `plan`, those aren't carried over. Stella ignores them and tells you so, instead of migrating them. |
+| `agent_engine_config.agents.<name>` | `[agents.<name>]` | One level of nesting removed. This works because `default` is the only agent role stella uses today. If your `settings.json` still names `worker`, `verifier`, `triage`, `research`, or `plan`, those aren't carried over. stella ignores them and tells you so, instead of migrating them. |
 | `agent_engine_config.allowed_models` | `[models].allowed` | It's a setting about models, not about any single agent. |
 
 `[mcp].registry_url` carries over as-is. **`[mcp.servers]` doesn't work yet.** MCP servers still load from `.stella/mcp.toml`. If you move them into `stella.toml` anyway, stella tells you at startup instead of silently failing to start them.

--- a/website/content/docs/commands/migrate.mdx
+++ b/website/content/docs/commands/migrate.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella migrate
-description: Rewrite settings.json as stella.toml — values serialized from what stella actually read, never transcribed, and the JSON kept until you delete it yourself.
+description: Convert settings.json into stella.toml, using the values stella actually loaded. Your old file stays until you delete it.
 ---
 
-`stella migrate config` converts your existing `settings.json` into `stella.toml`: the same configuration, in a format that can hold its own documentation. It writes `<repo>/stella.toml` for the project scope and `~/.stella/stella.toml` for the user scope.
+`stella migrate config` converts your `settings.json` file into `stella.toml`. It's the same settings, just in a format that can hold comments explaining each one. It writes `<repo>/stella.toml` for project settings, and `~/.stella/stella.toml` for your user settings.
 
-It reads local files only — no provider, no API key, no network.
+It only reads local files. It doesn't need a provider, an API key, or the internet.
 
 ## Synopsis
 
@@ -14,34 +14,34 @@ stella migrate config                # write the TOML for every scope that has J
 stella migrate config --dry-run      # report what it would write, change nothing
 ```
 
-## It never deletes your settings.json
+## Keeping settings.json
 
-The original stays exactly where it was. Review the TOML, confirm it says what you meant, then remove the JSON yourself.
+Your original `settings.json` stays exactly where it is. Check the new TOML file, make sure it says what you meant, then delete the JSON yourself when you're ready.
 
-Until you do, stella reads the **TOML** and prints a line naming both files, so a half-finished migration is never silent. The two are never merged: one file configures a scope, and which one is always answerable.
+Until you delete the JSON, stella reads the **TOML** file and prints a line naming both files, so you always know a migration is in progress. Stella never merges the two files together. For each scope, exactly one file is in charge, and stella always tells you which one.
 
-## Why the values are safe
+## Accurate values
 
-Every value is serialized from the settings stella actually parsed, not re-typed from the JSON. Nothing in the output can disagree with what stella read.
+Every value comes from settings stella actually read, not retyped from the JSON by hand. Nothing in the new file can disagree with what stella loaded.
 
-The generated file is also re-parsed and re-validated *before* it is written. A migration that emitted a file stella could not read would otherwise surface on your next launch — with your working config already shadowed by the broken one.
+Stella also reads back and checks the new file *before* saving it. Without this check, a bad migration could write a file stella can't read, and you wouldn't find out until your next launch, by which point your working config would already be replaced by the broken one.
 
-## It works on a config that is too broken to start
+## Broken configs
 
-`migrate` runs **before** provider resolution, for the same reason `stella doctor` does. A `settings.json` naming a model whose provider no longer exists is one of the likeliest reasons to reach for this command, and requiring a working provider would make the fix-it tool unreachable exactly when it is needed.
+`migrate` runs **before** stella tries to resolve a provider, for the same reason `stella doctor` does. One common reason to use this command is a `settings.json` that names a model whose provider isn't set up anymore. If `migrate` required a working provider, it wouldn't be usable in exactly the situation where you need it most.
 
 ## What moves where
 
-Most keys keep their names. Four change, and each has a reason:
+Most key names stay the same. Four keys change, each for a reason:
 
 | settings.json | stella.toml | Why |
 | --- | --- | --- |
-| `enable_recap` | `[run].recap` | A bare key at the document root attaches to whatever `[table]` precedes it — move one line and it silently belongs to that table. Every scalar gets a table home. |
-| `agent_engine_config` | `[agents]` | Shorter, and the JSON name described the struct rather than the thing. |
-| `agent_engine_config.agents.<name>` | `[agents.<name>]` | One nesting level removed. Safe because the agent set is closed — `default` is the only role the core loop has today. A `settings.json` still naming `worker`, `verifier`, `triage`, `research` or `plan` is not carried forward: `stella` recognizes those as retired and reports them as ignored rather than migrating them. |
-| `agent_engine_config.allowed_models` | `[models].allowed` | It is a statement about models, not about any one agent. |
+| `enable_recap` | `[run].recap` | A bare key at the top of the file attaches to whatever table came right before it. Moving one line could silently change which table it belongs to. Giving every value its own table avoids that. |
+| `agent_engine_config` | `[agents]` | Shorter, and describes what it actually is instead of an internal detail. |
+| `agent_engine_config.agents.<name>` | `[agents.<name>]` | One level of nesting removed. This works because `default` is the only agent role stella uses today. If your `settings.json` still names `worker`, `verifier`, `triage`, `research`, or `plan`, those aren't carried over. Stella ignores them and tells you so, instead of migrating them. |
+| `agent_engine_config.allowed_models` | `[models].allowed` | It's a setting about models, not about any single agent. |
 
-`[mcp].registry_url` carries over. **`[mcp.servers]` does not work yet** — MCP servers still load from `.stella/mcp.toml`. If you move them, stella says so at startup rather than failing to start them silently.
+`[mcp].registry_url` carries over as-is. **`[mcp.servers]` doesn't work yet.** MCP servers still load from `.stella/mcp.toml`. If you move them into `stella.toml` anyway, stella tells you at startup instead of silently failing to start them.
 
 ## Where each scope's file lives
 
@@ -49,12 +49,12 @@ Most keys keep their names. Four change, and each has a reason:
 | --- | --- |
 | project | `<repo>/stella.toml` — commit it; it is reviewed like source |
 | user | `~/.stella/stella.toml` |
-| managed | deployed by an administrator; **not** migrated by this command |
+| managed | put in place by an administrator; **not** migrated by this command |
 
-The project file sits at the repository root, not under `.stella/`, because it is a committed file that belongs in a PR diff. One consequence follows from that: a literal `api_key` is refused at project scope. Use `api_key_env` to name an environment variable, or `stella auth set <provider>` to store the key in `~/.stella/credentials.toml`, which is owner-only and never committed.
+The project file sits at the root of your repository, not inside `.stella/`, because you're meant to commit it and review it like any other file in a pull request. Because of that, stella refuses a literal `api_key` value at project scope. Use `api_key_env` to name an environment variable instead, or run `stella auth set <provider>` to store the key in `~/.stella/credentials.toml`. That file is owner-only and never gets committed.
 
 ## After migrating
 
-Your comments survive every future write. `/theme`, the tool-switch editor, and the engine editor all edit `stella.toml` in place, changing only the key they own and leaving the rest of the file — including everything you wrote in it — byte-identical.
+Your comments survive every future save. `/theme`, the tool-switch editor, and the engine editor all edit `stella.toml` in place. Each one changes only the key it owns, and leaves the rest of the file, including everything you wrote in it, exactly as it was.
 
-See [the `stella.toml` reference](/docs/configuration/stella-toml) for every section with its meaning, [the annotated reference config](https://github.com/macanderson/stella/blob/main/docs/spec/config-system/stella.today.toml) for the full key-by-key inventory, and [the filesystem map](https://github.com/macanderson/stella/blob/main/docs/spec/filesystem-layout.md) for where stella keeps everything else.
+For what each section means, see [the `stella.toml` reference](/docs/configuration/stella-toml). For every key, see [the annotated reference config](https://github.com/macanderson/stella/blob/main/docs/spec/config-system/stella.today.toml). For where stella keeps everything else, see [the filesystem map](https://github.com/macanderson/stella/blob/main/docs/spec/filesystem-layout.md).

--- a/website/content/docs/commands/models.mdx
+++ b/website/content/docs/commands/models.mdx
@@ -17,7 +17,7 @@ stella models list [--provider <id>] [--all]
 
 `stella models` lists every built-in provider, showing its display name, whether you have a key for it, its default model, and its base URL. Below that, it shows a status line for the local model catalog. Any custom providers you added in `settings.json` show up too, under a separate **Config-defined providers** heading, along with the API style they use. This is the fastest way to check which providers are ready before you pick one with `--model`.
 
-Stella checks **key status** using the same steps `stella run` uses to find a key, run in a mode that never stops to ask you a question, since this is just a listing command. It checks every source: an environment variable (or its alias), a project `.env` file, a value written in `settings.json`, and `~/.stella/credentials.toml`. Each configured row names the source that actually supplied the key. That means `stella models`, [`stella config`](/docs/commands/config), and [`stella auth list`](/docs/commands/auth) will always agree with each other, and with what happens on a real run.
+stella checks **key status** using the same steps `stella run` uses to find a key, run in a mode that never stops to ask you a question, since this is just a listing command. It checks every source: an environment variable (or its alias), a project `.env` file, a value written in `settings.json`, and `~/.stella/credentials.toml`. Each configured row names the source that actually supplied the key. That means `stella models`, [`stella config`](/docs/commands/config), and [`stella auth list`](/docs/commands/auth) will always agree with each other, and with what happens on a real run.
 
 You can see the same list inside an interactive session with the [`/models`](/docs/commands/chat) slash command.
 
@@ -40,7 +40,7 @@ There are two sources for the catalog, and they follow different rules. Both use
 
 <CardGrid size="md">
   <OptionCard name="Native provider listings">
-    Each configured provider's own `/models` endpoint. Stella syncs it automatically whenever it's
+    Each configured provider's own `/models` endpoint. stella syncs it automatically whenever it's
     stale, **including the very first time** — this is how new model releases show up. It only
     calls a provider you've already given stella a key for, the same server your next request
     would go to anyway. If you haven't given a provider a key, stella doesn't fetch anything from
@@ -90,7 +90,7 @@ If you don't pass `--provider`, the list only shows providers you currently have
 </CardGrid>
 
 <Callout type="info">
-Stella looks for provider credentials in this order: the `--api-key` flag, then the provider's
+stella looks for provider credentials in this order: the `--api-key` flag, then the provider's
 environment variable (or its aliases), then `settings.json`, then `~/.stella/credentials.toml`,
 and finally an interactive prompt if you're at a terminal.
 </Callout>
@@ -134,7 +134,7 @@ Stella — Available Providers & Models
 
 Each row follows this pattern: `{key status} {id}/{default model}  {display name}  [{base url}] ({source})`. The source at the end only appears on a configured row, and it names where the key came from: `env:VAR_NAME`, the project dotenv file it loaded from (like `.env.local`), `credentials.toml`, or `settings.json`. That's why the second row above shows `✓ configured` even with no environment variable set: a key stored only in `~/.stella/credentials.toml` still counts, and the listing tells you so.
 
-The `vertex` and `bedrock` base URLs shown here are just for display. Stella builds the real endpoint for each request from your project and location (`VERTEX_PROJECT_ID`, `VERTEX_LOCATION`) or from `AWS_REGION`. Providers you defined in `settings.json` show up under their own heading, with their API style listed before the source. That section only shows up if `settings.json` actually defines a custom provider. Until you run `stella models refresh` for the first time, the last line of the catalog reads `seed only`.
+The `vertex` and `bedrock` base URLs shown here are just for display. stella builds the real endpoint for each request from your project and location (`VERTEX_PROJECT_ID`, `VERTEX_LOCATION`) or from `AWS_REGION`. Providers you defined in `settings.json` show up under their own heading, with their API style listed before the source. That section only shows up if `settings.json` actually defines a custom provider. Until you run `stella models refresh` for the first time, the last line of the catalog reads `seed only`.
 
 `local` isn't a provider row. It only shows up as a footer hint reminding you to point at your own local endpoint, for example: `stella --model local/<model> --base-url http://localhost:11434/v1`.
 

--- a/website/content/docs/commands/models.mdx
+++ b/website/content/docs/commands/models.mdx
@@ -3,7 +3,7 @@ title: stella models
 description: List configured providers and available models, and manage the live model catalog.
 ---
 
-List the configured providers and their available models, and manage the **live model catalog**. For each provider, stella shows its key status, default model, and base URL.
+See which providers you've set up, what models are available, and manage the **live model catalog**. For each provider, stella shows whether you have a key, its default model, and its base URL.
 
 ## Synopsis
 
@@ -15,47 +15,48 @@ stella models list [--provider <id>] [--all]
 
 ## What it does
 
-`stella models` enumerates the built-in providers and reports, for each one, its display name, key status, default model, and base URL, followed by a status line for the local model catalog. Any custom providers you define in `settings.json` are listed too, under a separate **Config-defined providers** heading with their wire dialect. It is the quickest way to confirm which providers are ready to use before you pin one with `--model`.
+`stella models` lists every built-in provider, showing its display name, whether you have a key for it, its default model, and its base URL. Below that, it shows a status line for the local model catalog. Any custom providers you added in `settings.json` show up too, under a separate **Config-defined providers** heading, along with the API style they use. This is the fastest way to check which providers are ready before you pick one with `--model`.
 
-The **key status** is resolved through the same chain `stella run` uses — the shared resolver, run non-interactively so a listing command never blocks on a prompt. Every source counts: an environment variable (primary or alias), a project `.env` file, a `settings.json` literal, and `~/.stella/credentials.toml` alike. Each configured row names the source that actually won, so `stella models`, [`stella config`](/docs/commands/config), and [`stella auth list`](/docs/commands/auth) can never disagree with each other or with a real run.
+Stella checks **key status** using the same steps `stella run` uses to find a key, run in a mode that never stops to ask you a question, since this is just a listing command. It checks every source: an environment variable (or its alias), a project `.env` file, a value written in `settings.json`, and `~/.stella/credentials.toml`. Each configured row names the source that actually supplied the key. That means `stella models`, [`stella config`](/docs/commands/config), and [`stella auth list`](/docs/commands/auth) will always agree with each other, and with what happens on a real run.
 
-The same listing is available from inside an interactive session via the [`/models`](/docs/commands/chat) slash command.
+You can see the same list inside an interactive session with the [`/models`](/docs/commands/chat) slash command.
 
-## Subcommands — the live model catalog
+## Live model catalog
 
-The catalog behind model validation and pricing syncs from [models.dev](https://models.dev) into local SQLite, with versioned pricing model cards and strict slug validation (a mistyped model gets a did-you-mean, not a silent request). See [Models &amp; the live catalog](/docs/api-providers/models) for the full design.
+The catalog stella uses to check models and show pricing syncs from [models.dev](https://models.dev) into a local SQLite database. Pricing is versioned, and model names are checked strictly: if you mistype one, stella suggests the closest match instead of silently sending a bad request. See [Models &amp; the live catalog](/docs/api-providers/models) for more detail.
 
 ### `stella models refresh [--force]`
 
-Sync the catalog now. Incremental by default (ETag-aware); `--force` re-downloads everything.
+Sync the catalog right now. By default, this only downloads what changed (it checks the ETag). Use `--force` to re-download everything.
 
 ```bash
 stella models refresh
 stella models refresh --force
 ```
 
-#### What auto-syncs, and what does not
+#### What syncs automatically
 
-There are two catalog sources, and they follow different rules. Both use the same 24-hour staleness window, and `STELLA_CATALOG_AUTO_REFRESH=0` disables all implicit fetching.
+There are two sources for the catalog, and they follow different rules. Both use the same 24-hour window before they're considered stale. Setting `STELLA_CATALOG_AUTO_REFRESH=0` turns off all automatic fetching.
 
 <CardGrid size="md">
   <OptionCard name="Native provider listings">
-    Each configured provider's own `/models` endpoint. Auto-syncs whenever it is stale,
-    **including the very first time** — this is what surfaces new releases as they ship.
-    BYOK-clean: the request goes to a provider you already gave stella a key for, the same
-    host your next turn calls anyway. No credential, nothing fetched.
+    Each configured provider's own `/models` endpoint. Stella syncs it automatically whenever it's
+    stale, **including the very first time** — this is how new model releases show up. It only
+    calls a provider you've already given stella a key for, the same server your next request
+    would go to anyway. If you haven't given a provider a key, stella doesn't fetch anything from
+    it.
   </OptionCard>
   <OptionCard name="The models.dev master list">
-    A third party, so it is never contacted implicitly. It may auto-*re*fresh only once a
-    sync row already exists — that is, after your own first explicit `stella models
-    refresh`. A fresh install never touches models.dev on its own, and the catalog line
-    reads `seed only` until you run that first refresh.
+    A third-party source, so stella never contacts it automatically the first time. It can only
+    auto-*re*fresh after you've run `stella models refresh` yourself at least once. A fresh
+    install never reaches out to models.dev on its own, and the catalog line reads `seed only`
+    until you run that first refresh.
   </OptionCard>
 </CardGrid>
 
 ### `stella models list [--provider <id>] [--all]`
 
-List the models in the local catalog, optionally filtered to one provider. Each row is `provider/slug`, then in / out / cached-in price per Mtok, then the context window, then the model's **maker**, a `thinks` marker when the model supports reasoning, and the pricing card's version.
+List the models in the local catalog, optionally filtered to one provider. Each row shows `provider/slug`, then the price per million tokens for input, output, and cached input, then the context window size, then the model's **maker**, a `thinks` marker if the model supports reasoning, and the pricing card's version.
 
 ```bash
 stella models list
@@ -74,27 +75,29 @@ Stella — Model Catalog
   master list last refreshed 2026-07-18 09:14:03 UTC — `stella models refresh` to update
 ```
 
-With no `--provider`, the listing is scoped to providers whose credential currently resolves — the same set the deck's model picker offers, because "what can I actually select right now" is the question a bare `list` answers. A footer line reports how many models were hidden that way.
+If you don't pass `--provider`, the list only shows providers you currently have a working credential for. That's the same set the deck's model picker offers, since a plain `list` is meant to answer "what can I actually pick right now." A footer line tells you how many models were hidden this way.
 
 <CardGrid size="md">
   <OptionCard name="--provider <id>">
-    Filter to a single provider. Credential scoping does not apply on this path: you get
-    every model the catalog holds for that provider whether or not its key resolves.
+    Filter to a single provider. This ignores the credential filter: you see every model the
+    catalog has for that provider, whether or not you have a working key for it.
   </OptionCard>
   <OptionCard name="--all">
-    Lift the credential scope and list the whole catalog. Only meaningful **without**
-    `--provider` — passing both leaves `--all` with nothing to do, since a `--provider`
-    listing is already unscoped.
+    Show the whole catalog, ignoring the credential filter. This only matters **without**
+    `--provider`. If you pass both flags, `--all` has nothing left to do, since a `--provider`
+    listing already shows everything for that provider.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-Provider credentials are resolved through the credential chain: `--api-key` flag, then the provider env var (and aliases), then `settings.json`, then `~/.stella/credentials.toml`, and finally an interactive prompt on a TTY.
+Stella looks for provider credentials in this order: the `--api-key` flag, then the provider's
+environment variable (or its aliases), then `settings.json`, then `~/.stella/credentials.toml`,
+and finally an interactive prompt if you're at a terminal.
 </Callout>
 
 ## Flags
 
-`stella models` takes the [global flags](/docs/commands), but the listing itself depends only on what the credential chain resolves from disk and environment — `settings.json`, your environment variables and dotenv files, and `credentials.toml`. `--model`, `--base-url`, and `--api-key` do not change its output.
+`stella models` accepts the [global flags](/docs/commands), but the list itself only depends on what the credential chain finds on disk and in your environment: `settings.json`, your environment variables and dotenv files, and `credentials.toml`. The `--model`, `--base-url`, and `--api-key` flags don't change what it shows.
 
 ## Examples
 
@@ -104,7 +107,7 @@ Confirm which providers are ready before pinning one:
 stella models
 ```
 
-Representative output (illustrative — one line per provider, in auto-detect preference order):
+Example output (one line per provider, shown in the order stella tries them):
 
 ```text
 Stella — Available Providers & Models
@@ -129,18 +132,19 @@ Stella — Available Providers & Models
   Model catalog: 1204 models / 118 aliases — master list refreshed 2026-07-18 09:14:03 UTC (`stella models list` to browse, `stella models refresh` to update).
 ```
 
-Each row is `{key status} {id}/{default model}  {display name}  [{base url}] ({source})`, where the trailing source appears only on a configured row and names where the winning key came from — `env:VAR_NAME`, the project dotenv file it was loaded from (`.env.local`), `credentials.toml`, or `settings.json`. That suffix is why the second row above reads `✓ configured` with no environment variable set: a key living only in `~/.stella/credentials.toml` counts, and the listing says so.
+Each row follows this pattern: `{key status} {id}/{default model}  {display name}  [{base url}] ({source})`. The source at the end only appears on a configured row, and it names where the key came from: `env:VAR_NAME`, the project dotenv file it loaded from (like `.env.local`), `credentials.toml`, or `settings.json`. That's why the second row above shows `✓ configured` even with no environment variable set: a key stored only in `~/.stella/credentials.toml` still counts, and the listing tells you so.
 
-The `vertex` and `bedrock` base URLs are display anchors — the real endpoint is built per request from your project/location (`VERTEX_PROJECT_ID`, `VERTEX_LOCATION`) or `AWS_REGION`. Config-defined providers from `settings.json` follow under their own heading with the wire dialect appended before the source suffix, and that section only appears when `settings.json` actually defines one. Until your first `stella models refresh`, the closing catalog line reads `seed only` instead.
+The `vertex` and `bedrock` base URLs shown here are just for display. Stella builds the real endpoint for each request from your project and location (`VERTEX_PROJECT_ID`, `VERTEX_LOCATION`) or from `AWS_REGION`. Providers you defined in `settings.json` show up under their own heading, with their API style listed before the source. That section only shows up if `settings.json` actually defines a custom provider. Until you run `stella models refresh` for the first time, the last line of the catalog reads `seed only`.
 
-`local` is not a provider row — it is surfaced only as the footer hint that reminds you to
-point at a local endpoint yourself, e.g. `stella --model local/<model> --base-url http://localhost:11434/v1`.
+`local` isn't a provider row. It only shows up as a footer hint reminding you to point at your own local endpoint, for example: `stella --model local/<model> --base-url http://localhost:11434/v1`.
 
 <Callout type="warn">
-The values above are for illustration. Your actual key status depends on which credentials resolve in your environment, and default models and base URLs can be overridden per provider via `settings.json`.
+The values above are just examples. Your actual key status depends on which credentials resolve
+in your environment. Default models and base URLs can also be overridden per provider in
+`settings.json`.
 </Callout>
 
-Browse the catalog for a provider you have not configured yet — `--provider` lists it regardless of whether its key resolves:
+Browse the catalog for a provider you haven't set up yet. `--provider` lists it whether or not you have a working key:
 
 ```bash
 stella models list --provider openai
@@ -152,7 +156,7 @@ See everything the catalog holds, credentialed or not:
 stella models list --all
 ```
 
-Pull the models.dev master list for the first time, then read the catalog status line back:
+Pull the models.dev master list for the first time, then check the catalog status line:
 
 ```bash
 stella models refresh

--- a/website/content/docs/commands/monitor.mdx
+++ b/website/content/docs/commands/monitor.mdx
@@ -15,16 +15,20 @@ The optional `target` is a branch or PR to watch. When omitted, it defaults to `
 
 ## What it does
 
-`stella monitor` watches the CI runs for the given `target` through whatever CI tooling the session offers — a workspace [custom tool](/docs/agent-tools/custom-tools) or an [MCP server](/docs/agent-tools/mcp). It works iteratively — inspecting each failure, fixing its root cause, then **committing and pushing the fix** before re-checking — and treats the job as a goal that is met **only when the latest CI run is all-green**.
+`stella monitor` watches CI runs for the `target` you give it. It uses whatever CI tool your session has available: a workspace [custom tool](/docs/agent-tools/custom-tools) or an [MCP server](/docs/agent-tools/mcp). It works step by step: it looks at each failure, fixes the root cause, then **commits and pushes the fix** before checking again. It only considers the job done **when the latest CI run is fully green**.
 
-Under the hood, `monitor` is [goal mode](/docs/agent-modes#outcome-driven-goal-mode) with a fixed CI objective, so it inherits goal mode's mechanics wholesale: a cross-family verifier confirms the green run from evidence, and the same backstops apply — the default hard cap of **8** judged rounds (it stops there and reports the goal as not met even if CI is still red), the `--spend-limit` cap, and a worker-turn abort. It is not an unbounded daemon; re-run it to keep going.
+Behind the scenes, `monitor` runs on [goal mode](/docs/agent-modes#outcome-driven-goal-mode) with a fixed goal: get CI green. That means it uses goal mode's safety limits too. A separate verifier checks the evidence that CI is actually green. There's a hard cap of **8** rounds by default: if CI is still red after 8 rounds, stella stops and reports the goal as not met. The `--spend-limit` cap and a worker-turn abort also apply. `monitor` does not run forever. If it stops before CI is green, run it again to keep going.
 
 <Callout type="warn">
-`monitor` commits and pushes its fixes to the target branch between CI runs. Because the default target is `main`, a bare `stella monitor` will push commits directly to `main` — pass a feature branch or PR as the `target` if that is not what you want.
+`monitor` commits and pushes its fixes straight to the target branch between CI runs. Since the
+default target is `main`, running `stella monitor` with no arguments pushes commits directly to
+`main`. If that's not what you want, pass a feature branch or PR as the `target`.
 </Callout>
 
 <Callout type="info">
-`stella monitor` needs the session to offer a way to read CI state — a GitHub [MCP server](/docs/agent-tools/mcp), or a [custom tool](/docs/agent-tools/custom-tools) wrapping the `gh` CLI, are the usual shapes. Without one, the agent cannot observe the runs it is asked to drive green.
+`stella monitor` needs some way to read CI state. This is usually a GitHub [MCP server](/docs/agent-tools/mcp),
+or a [custom tool](/docs/agent-tools/custom-tools) that wraps the `gh` CLI. Without one of these,
+the agent can't see the runs it's supposed to fix.
 </Callout>
 
 ## Flags
@@ -41,7 +45,8 @@ Under the hood, `monitor` is [goal mode](/docs/agent-modes#outcome-driven-goal-m
 </CardGrid>
 
 <Callout type="info">
-`monitor` is an interactive mode and always renders human-readable text; it does **not** take `--output-format` (passing it is a parse error).
+`monitor` is an interactive mode. It always shows plain, human-readable text, and it does **not**
+accept `--output-format`. Passing that flag causes a parse error.
 </Callout>
 
 ## Examples

--- a/website/content/docs/commands/observe.mdx
+++ b/website/content/docs/commands/observe.mdx
@@ -1,12 +1,9 @@
 ---
 title: stella observe
-description: Serve the Observatory — the canonical local telemetry dashboard, always loopback-only.
+description: See a local dashboard of what stella has been doing on your machine. It only runs on your computer and never sends data out.
 ---
 
-Serve the **Observatory**: a read-only web dashboard over the local telemetry in
-`.stella/private/store.db` and `.stella/private/fleet.db`. The Observatory itself never
-exports data and binds to `127.0.0.1` only. This remains true if a separately enrolled
-Enterprise adapter is allowed to derive its minimal operational rollup.
+The Observatory is a read-only dashboard that shows you what stella has been doing. It reads local data from `.stella/private/store.db` and `.stella/private/fleet.db`. The Observatory never sends this data anywhere else. It only listens on `127.0.0.1`, meaning your own computer, even if your organization has turned on an Enterprise adapter that collects a small summary of activity elsewhere.
 
 ## Synopsis
 
@@ -16,24 +13,35 @@ stella observe [--port <N>] [--open]
 
 ## What it does
 
-`stella observe` starts a local HTTP server (default port `7787`) and serves the embedded
-dashboard — no separate install, no build step, and no Observatory egress: the server
-binds loopback and `stella observe` itself never sends anything off the machine. It reads
-the same SQLite stores every stella command writes, so it works on any workspace that has
-run stella at least once, and it needs no API key. (Telemetry can leave the machine only
-through the two paths [the telemetry page enumerates](/docs/telemetry), neither of which
-this command uses.)
+`stella observe` starts a small web server on your computer (port `7787` by default) and shows you the dashboard. You don't need to install anything extra or build anything first. The server only listens on your own machine, and `stella observe` never sends data anywhere else.
 
-The dashboard's tabs cover the overview, executions (with per-run drill-down), the code graph, skills, MCP traffic, memory, self-improvement, and resolved config, plus model spend panels, fleet runs, and a timeframe selector for the charts. See [the Observatory dashboard](/docs/telemetry/dashboard) for a tour of what each tab shows.
+It reads the same local files that every stella command writes to. That means it works in any workspace where you've run stella at least once. You don't need an API key.
+
+Data can only leave your machine through the two paths described on [the telemetry page](/docs/telemetry). This command does not use either of them.
+
+## Dashboard tabs
+
+The dashboard covers:
+
+- Overview
+- Executions, with details for each run
+- The code graph
+- Skills
+- MCP traffic
+- Memory
+- Self-improvement
+- Your resolved config
+
+It also shows model spend, fleet runs, and a way to change the time range for the charts. See [the Observatory dashboard](/docs/telemetry/dashboard) page for a tour of each tab.
 
 ## Flags
 
 <CardGrid size="md">
   <OptionCard name="--port <N>" defaultValue="7787">
-    Port to bind on `127.0.0.1`. `0` picks a free port.
+    The port to use on `127.0.0.1`. Set it to `0` to let stella pick a free port for you.
   </OptionCard>
   <OptionCard name="--open">
-    Open the dashboard in your default browser once the server is up.
+    Opens the dashboard in your default web browser once the server starts.
   </OptionCard>
 </CardGrid>
 
@@ -45,19 +53,19 @@ Serve the dashboard and open it:
 stella observe --open
 ```
 
-Bind an ephemeral port (useful when 7787 is taken):
+Use a random open port (handy if 7787 is already taken):
 
 ```bash
 stella observe --port 0
 ```
 
-Pin a port so a bookmark keeps working, and leave it running in the background:
+Use one fixed port so a bookmark always works, and run it in the background:
 
 ```bash
 stella observe --port 8080 &
 ```
 
-Serve a different workspace's telemetry by starting from its root:
+See a different workspace's data by running the command from that workspace's folder:
 
 ```bash
 (cd ~/projects/acme && stella observe --open)

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella plugin
-description: Install, list, remove, and drive plugins — and see the whole grant a plugin asks for before any of it is granted.
+description: Install, list, remove, and run plugins. See exactly what a plugin can do before you allow it.
 ---
 
-`stella plugin` is the loader. A plugin declares, in one `plugin.toml`, exactly how much say it wants in your turn loop — a participation grade, the hook points it may act at, the process it runs as, and the precise list of environment variables that process inherits. This command shows you that declaration and installs nothing until you accept it.
+`stella plugin` installs and manages plugins. A plugin is a small add-on that can join stella's turn loop, which is the back-and-forth stella does while working on a task. Each plugin has one file, `plugin.toml`, that states exactly what it wants to do: how much control it asks for, which points in the loop it can act at, what program it runs as, and which environment variables that program can see. `stella plugin` shows you this file before you install anything. Nothing is installed until you say yes.
 
-Offline: reads and writes local files, no API key.
+This command works offline. It only reads and writes local files, and it does not need an API key.
 
 ## Synopsis
 
@@ -19,7 +19,7 @@ stella plugin drive <name>
 
 ## What a plugin declares
 
-A plugin is a directory containing `plugin.toml`. The blocks that matter to this command:
+A plugin is a folder that contains a `plugin.toml` file. Here are the parts of that file this command cares about:
 
 ```toml
 name = "vera"
@@ -39,13 +39,15 @@ timeout_secs = 30
 env = ["PATH"]                     # default-deny: exactly these, nothing else
 ```
 
-Two of those are worth reading twice.
+### Hooks are exhaustive
 
-**`[loop] hooks` is exhaustive.** stella routes a plugin only at the points its manifest names. A plugin process that registers for `Stop` without declaring it is simply never called — the grant is checked at routing time, not asked of the plugin.
+stella only calls a plugin at the hook points named in `[loop] hooks`. If a plugin's process listens for `Stop` but the manifest doesn't list it, stella never calls it there. stella checks this when it decides where to route a call, not by asking the plugin.
 
-**`[runtime] env` is an allowlist, not a filter.** The child starts from an empty environment and receives the variables named here and nothing else. Anything your shell was carrying — an API key, an agent socket, a token a script exported — is not there unless the manifest asked for it and you accepted.
+### Environment variables are an allowlist
 
-There is no `language` field. `argv` already distinguishes `["python3", …]` from `["node", …]` from a compiled binary, so a plugin can be written in any language without stella learning what a language is.
+`[runtime] env` lists the only environment variables the plugin's process gets. The process starts with an empty environment, then receives just the variables named here. Anything else your shell has, such as an API key, a token, or a socket path, is not passed to the plugin unless the manifest lists it and you approved the install.
+
+There's no separate `language` setting. The `argv` line already shows what runs the plugin, for example `python3`, `node`, or a compiled program. A plugin can be written in any language.
 
 ## `stella plugin install`
 
@@ -54,7 +56,7 @@ stella plugin install ./my-plugin
 stella plugin install ./my-plugin --scope user
 ```
 
-Prints the plugin's whole declared grant, then asks. Nothing is copied until you answer yes.
+Shows you everything the plugin is asking for, then asks if you want to continue. Nothing is copied to your machine until you answer yes.
 
 ```text
 Install `vera`?
@@ -81,25 +83,25 @@ Install it? [y/N]
 
 <CardGrid size="md">
   <OptionCard name="<dir>">
-    The directory holding the plugin's `plugin.toml`.
+    The folder that contains the plugin's `plugin.toml` file.
   </OptionCard>
   <OptionCard name="--scope" defaultValue="project">
-    `project` installs into `.stella/plugins/` for this workspace only. `user` installs into `~/.stella/plugins/` for every workspace.
+    Use `project` to install into `.stella/plugins/` for this workspace only. Use `user` to install into `~/.stella/plugins/` so it's available in every workspace.
   </OptionCard>
   <OptionCard name="--yes">
-    Accept the declared grant without prompting. Required when no human is present to answer.
+    Accepts the plugin's request without asking you first. Use this when no person is available to answer, such as in an automated script.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-With no terminal attached — a pipe, a CI job — install **refuses** rather than assuming yes. `--yes` is the deliberate override, and it means you have read the declaration.
+If there's no terminal attached, for example a pipe or a CI job, install **refuses to run** instead of assuming yes. Use `--yes` on purpose, only after you've read what the plugin is asking for.
 </Callout>
 
-A package may contain only real files. A symlink inside it is refused rather than followed, so install can never be pointed at something the package does not ship.
+A plugin package can only contain real files. If it contains a symlink (a shortcut pointing to another file), stella refuses to install it. This stops a plugin from secretly pointing at files it doesn't actually include.
 
 ## `stella plugin list`
 
-Shows what is installed, which tier it came from, the grade it holds, the process it runs as, and — separately — the hook dispatches stella would actually make.
+Shows every installed plugin: where it came from (project or user), how much control it has, what program it runs as, and, separately, which hooks stella would actually call it at.
 
 ```bash
 stella plugin list
@@ -117,13 +119,13 @@ hook dispatches:
   vera                     Stop -> python3 /ws/.stella/plugins/vera/main.py
 ```
 
-The two sections answer different questions. The first is what the plugin declared; the second is what would actually run. A plugin with a hook grant but no `[runtime]` appears in the first and not the second, which is the answer to "I declared `Stop` and nothing happens".
+The output has two parts, and they answer different questions. The first part shows what each plugin asked for. The second part, "hook dispatches," shows what stella will actually run. If a plugin lists a hook but has no `[runtime]` block, it shows up in the first part but not the second. That's why a plugin can declare `Stop` and still never run anything.
 
-A declared environment variable that stella grades as a model credential is refused and named here rather than discovered as a missing variable at the first dispatch. A plugin never receives the key that pays for the agent; the fix is a `[roles]` tier, so the host makes the call and the spend lands on the receipt.
+If a plugin asks for an environment variable that stella recognizes as a model API key, stella blocks it and tells you here, in the list output. You won't have to discover a missing variable later when the plugin runs. A plugin never gets the API key that pays for model usage directly. Instead, a plugin that needs model access should use a `[roles]` block, so stella makes the model call itself and tracks the cost properly.
 
 ## `stella plugin panel`
 
-Decide whether a plugin may draw on your screen.
+Decide whether a plugin can draw on your screen.
 
 ```bash
 stella plugin panel hello           # print the handshake and ask
@@ -131,15 +133,15 @@ stella plugin panel hello --allow
 stella plugin panel hello --deny
 ```
 
-A plugin with a `[panel]` block is leased a rectangle of your terminal and fills it every tick. That is a separate grant from installing the package, and it is asked separately: the handshake shows the manifest signature, the capabilities the plugin asks for, the limits its panel accepts, which of the three surfaces it draws on, the slash name it answers to, and the program the host starts to draw it. Underneath is `[a]llow  [d]eny`.
+A plugin with a `[panel]` block gets its own space in your terminal and redraws it regularly. This is a separate permission from installing the plugin, so stella asks about it separately. Before you decide, stella shows you: the plugin's manifest signature, what capabilities it's asking for, the limits on its panel, which of the three screen areas it uses, the slash command name it responds to, and the program that draws it. You then choose `[a]llow` or `[d]eny`.
 
-Until that question is answered, **the panel does not draw and its program is never started**. `stella plugin install` asks it for a package it is copying (and `--yes` answers it along with the install), so this verb is for the three cases an install prompt never reaches:
+Until you answer, **the panel does not draw, and its program never starts**. `stella plugin install` already asks this question for any new package it copies onto your machine (and `--yes` answers it too, along with the install question). Use `stella plugin panel` on its own for these other cases:
 
-- a plugin that arrived with a `git clone` into `.stella/plugins` and was never installed by this binary;
-- a plugin whose manifest changed after the grant — the answer covers exact bytes, so a `[panel]` that grows a surface or a wider process is asked again;
-- withdrawing a panel you previously allowed.
+- A plugin that was added by running `git clone` straight into `.stella/plugins`, instead of using `stella plugin install`.
+- A plugin whose `plugin.toml` file changed since you last approved it. stella checks the exact file contents, so if the panel asks for more screen space or a different program, it asks again.
+- Turning off a panel you allowed before.
 
-Denying is not uninstalling. The package keeps its tools, its skills and its hooks, and loses only the rectangle — `stella plugin remove` is what takes the rest away.
+Denying the panel does not uninstall the plugin. It keeps its tools, skills, and hooks. It just loses its space on the screen. Use `stella plugin remove` to remove everything.
 
 ## `stella plugin remove`
 
@@ -147,9 +149,9 @@ Denying is not uninstalling. The package keeps its tools, its skills and its hoo
 stella plugin remove vera
 ```
 
-Deletes the plugin's directory in **every** tier that holds the name — project scope first, then user — and names each copy it removed. Stopping at the first would report success while the other tier's copy was still dispatched on every tool call, which is the one failure uninstall may not have. The name is the one in the manifest, not the directory's, so a package that was unpacked or renamed into a differently named directory is still removable under the name `stella plugin list` prints for it.
+Deletes the plugin's folder from **every** place it's installed: project scope first, then user scope. It lists each copy it removed. If it only removed the first copy it found, the other copy would keep running on every tool call, so it always checks both. It matches the plugin by the name inside its manifest, not by the folder's name. So even if a plugin's folder was renamed, you can still remove it using the name shown by `stella plugin list`.
 
-Its hook dispatches stop immediately: the roster is recomputed from disk every time it is read, so there is no second place a stale grant can survive.
+Its hooks stop working right away. stella reads the full list of plugins from disk every time, so there's no leftover permission hiding anywhere else.
 
 ## `stella plugin drive`
 
@@ -157,9 +159,9 @@ Its hook dispatches stop immediately: the roster is recomputed from disk every t
 stella plugin drive selfdriving
 ```
 
-Opens **one driver session** against an installed plugin that declares a `[driver]` block, and prints what the driver said should happen next — `sleep <n>s` or `halt — <reason>`.
+Opens **one driver session** with an installed plugin that has a `[driver]` block. It prints what the plugin says to do next: either `sleep <n>s` or `halt — <reason>`.
 
-A driver is the inverse of everything else on this page. A `[loop]` plugin is asked something during your turn; a driver has no turn to stand in, because it is what starts them. So it carries no participation grade at all — `participation = "none"` is the only answer one can give — and its capabilities live in their own block:
+A driver works differently from every other plugin type on this page. A `[loop]` plugin is asked for input during a turn that's already running. A driver has no turn to join, because its job is to start turns. Because of this, a driver has no participation grade; `participation = "none"` is the only value allowed. Its own permissions live in a separate block:
 
 ```toml
 [driver]
@@ -172,33 +174,35 @@ timeout_secs = 600
 env = ["PATH"]                             # default-deny, exactly as [runtime]
 ```
 
-`[driver.process]` rather than `[runtime]` because the two are different consents: `[runtime]` is the process a plugin is *inside* a turn, and stella refuses it below `participation = "observer"` on the grounds that such a plugin is never invoked. A driver is never invoked inside a turn either, and that is not a reason to refuse it a program — it is the definition of what it is.
+Drivers use `[driver.process]` instead of `[runtime]`, because these are two different kinds of permission. `[runtime]` is the program a plugin runs *during* a turn, and stella won't allow one unless the plugin's participation is at least `observer`. A driver is never called during a turn at all, but that's normal for a driver, not a problem. It's just what a driver is.
 
-**A `[driver]` block with no `[driver.process]` is a declaration, not a program.** It says what such a driver would ask for, and stella starts nothing: `plugins/stella-selfdriving` is exactly this, and the install prompt says so rather than leaving you to infer it.
+**A `[driver]` block with no `[driver.process]` is just a description, not a working program.** It shows what a driver like this would ask for, but stella doesn't start anything. The plugin `plugins/stella-selfdriving` works this way, and the install prompt tells you so directly.
 
-Every capability a driver asks for is performed **by stella, on request** — the plugin holds no provider, no credential and no forge token of its own. Today every one of them answers `unsupported`, so a session that asks for anything is refused everything and says so; the verbs are being implemented one at a time. What re-opens a session after a `sleep` is the loop itself, not this command: one invocation is one session.
+Every action a driver asks for is done **by stella itself**, not by the plugin. The plugin never holds its own API keys or tokens. Right now, every action returns `unsupported`, so any driver session that asks for something is told no, and it explains why. More actions will work over time. Also note: running `stella plugin drive` only opens one session. Something else, the loop itself, is what reopens a session after it goes to sleep.
 
-## Scopes, shadowing, and switching one off
+## Scopes
 
-Two tiers are read as one roster:
+stella reads both tiers together as one list of plugins.
 
 | Tier | Directory | Visible in |
 | --- | --- | --- |
 | user | `~/.stella/plugins/` | every workspace |
 | project | `<workspace>/.stella/plugins/` | this repository only |
 
-A project install **shadows** a user install of the same name entirely — one owner, one plugin, never both running. `install` tells you when it is about to do that.
+If a project installs a plugin with the same name as one installed for your user, the project version **takes over completely**. Only one plugin with that name runs at a time. `stella plugin install` tells you when this is about to happen.
 
-To stop a plugin from running without deleting anything — including one installed in the other tier — retract it in settings:
+### Turning off a plugin
+
+To turn off a plugin without deleting it, including one installed in the other tier, turn it off in your settings:
 
 ```json
 { "plugins": { "vera": "off" } }
 ```
 
-`off` is sticky across scopes: a scope may retract a plugin, never restore one another scope switched off. That is what makes the key safe to honour from a repository you have not read — the only thing a cloned repo can do with it is stop something from running on your machine.
+Turning a plugin `off` sticks across scopes. One scope can turn a plugin off, but no scope can turn it back on if another scope turned it off. This makes the setting safe to trust even in a repository you haven't reviewed: the only thing a cloned repo's settings can do with this key is stop a plugin from running on your machine, never start one.
 
 <Callout type="info">
-This is unlike [lifecycle hooks](/docs/agent-tools/hooks), which *concatenate* across scopes so that no lower-precedence file can remove an operator's gate. A plugin is not an operator gate — it is a third party's process, it is owned, and "uninstalled" has to mean uninstalled.
+This works differently from [lifecycle hooks](/docs/agent-tools/hooks). Hooks *combine* across scopes, so a lower-priority file can never remove a rule set by an operator. A plugin is different: it's a separate program made by someone else, and "uninstalled" needs to mean fully uninstalled.
 </Callout>
 
 ## See also

--- a/website/content/docs/commands/proposals.mdx
+++ b/website/content/docs/commands/proposals.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella proposals
-description: Review what the adaptive-context loop wants to make durable — the induced proposals, the evidence behind each, and Keep/Edit/Ignore/Retract as events.
+description: Review what stella wants to remember long-term, see the evidence behind each idea, and keep, edit, ignore, or retract it.
 ---
 
-`stella proposals` is the review surface for the adaptive-context loop. As you work, the loop reflects on turns and induces proposals: things it believes are worth making durable. This command shows you what is pending, the evidence behind each one, and lets you accept it, reword it, or decline it — **before** it steers anything.
+`stella proposals` is where you review ideas from stella's adaptive-context loop, the part of stella that reflects on your work and suggests things worth remembering long-term. As you work, it looks back on your turns and creates proposals: things it thinks are worth keeping. This command shows you each pending proposal and the evidence behind it. You can accept it, change its wording, or turn it down, all **before** it affects how stella behaves.
 
-Every decision is recorded as an immutable event, so the review history replays exactly and Ignore is reversible rather than permanent. Offline: reads and appends to `.stella/private/context.db` only, no API key.
+Every decision you make is saved as a permanent record. This means the full review history can always be replayed exactly, and choosing "ignore" can be undone later; it isn't final. This command works offline. It only reads and writes to `.stella/private/context.db`, and it doesn't need an API key.
 
 ## Synopsis
 
@@ -20,9 +20,9 @@ stella proposals refresh
 
 ## What it does
 
-A learning loop that silently rewrites its own steering is not auditable. The design here is the opposite: the loop may *propose*, but adoption is a decision a person makes on the record. That is why every verb takes a reason and why nothing is ever destroyed — a governance decision with no reason is not auditable, and a decision that cannot be revisited is not a review.
+stella never changes its own behavior silently. It can only *propose* changes. A person decides whether to adopt them, and that decision is recorded. That's why every command here asks for a reason, and why nothing is ever deleted. A decision with no reason can't be checked later, and a decision you can't revisit isn't really a review.
 
-A proposal must recur across **distinct tasks** to be induced at all, not merely many times within one. One task that mentions the same thing twenty times is one piece of evidence, not twenty.
+For stella to create a proposal, the same idea must show up across **different tasks**, not just many times in one task. If one task mentions something twenty times, that counts as one piece of evidence, not twenty.
 
 ### `stella proposals list`
 
@@ -44,14 +44,14 @@ stella proposals list --all --limit 100
 
 ### `stella proposals keep`
 
-Accept a proposal as written. Recorded as an advisory confirmation — it becomes active steering, at advisory enforcement.
+Accept a proposal exactly as written. It then becomes active guidance for stella, at "advisory" strength, meaning stella treats it as a suggestion rather than a strict rule.
 
 <CardGrid size="md">
   <OptionCard name="<id>" required>
     The proposal's candidate id, as shown by `list`.
   </OptionCard>
   <OptionCard name="--reason <text>" defaultValue="kept from the review surface">
-    Why. Recorded on the event.
+    The reason you're keeping it. This is saved with the record.
   </OptionCard>
 </CardGrid>
 
@@ -61,7 +61,7 @@ stella proposals keep cand-3f21 --reason "matches how we actually release"
 
 ### `stella proposals edit`
 
-Accept a proposal with different wording. The replacement text is what becomes durable; the original stays in the ledger.
+Accept a proposal but change its wording. Your replacement text is what stella keeps long-term. The original wording stays in the record too.
 
 <CardGrid size="md">
   <OptionCard name="<id>" required>
@@ -71,7 +71,7 @@ Accept a proposal with different wording. The replacement text is what becomes d
     The replacement text.
   </OptionCard>
   <OptionCard name="--reason <text>" defaultValue="edited from the review surface">
-    Why.
+    The reason for the edit.
   </OptionCard>
 </CardGrid>
 
@@ -81,14 +81,14 @@ stella proposals edit cand-3f21 "Run \`make gate\` before pushing — not \`carg
 
 ### `stella proposals ignore`
 
-Decline a proposal. It will not be re-proposed while the decision stands — and because the decision is an event rather than a deletion, you can revisit it.
+Decline a proposal. stella will not suggest it again while your decision stands. Because this is recorded as an event, not a deletion, you can change your mind later.
 
 <CardGrid size="md">
   <OptionCard name="<id>" required>
     The proposal's candidate id.
   </OptionCard>
   <OptionCard name="--reason <text>" defaultValue="declined from the review surface">
-    Why.
+    The reason for declining it.
   </OptionCard>
 </CardGrid>
 
@@ -98,18 +98,18 @@ stella proposals ignore cand-7ab0 --reason "true last quarter, not now"
 
 ### `stella proposals retract`
 
-Take back a rule that was already published, so it stops steering.
+Take back a rule you already accepted, so it stops guiding stella.
 
-`ignore` prevents a write; `retract` reverses one. A kept directive lands as a TOML record under `.stella/rules/`, which the loader reads into the system prefix — and until this verb the only way back was `rm` or a git revert, neither of which leaves any record that the rule was ever believed.
+`ignore` stops a proposal from being written in the first place. `retract` undoes one that was already written. When you keep a proposal, it's saved as a file under `.stella/rules/`, and stella loads those files as part of its instructions.
 
-Retraction appends rather than deletes. The record file stays on disk with `status = "retracted"`, and the retraction goes into the hash-chained `.stella/rules/promotions.jsonl` with who made it and why. The registry stops selecting a non-active record, so the rule is out of the prefix on the next load; `stella context validate` reports it under *Retired* and does not fail.
+Retracting a rule doesn't delete it. The rule's file stays on disk, but its status changes to `retracted`. The retraction itself is added to `.stella/rules/promotions.jsonl`, a tamper-evident log, along with who did it and why. After this, stella stops using the rule the next time it loads its instructions. Running `stella context validate` shows the rule as *Retired* instead of failing.
 
 <CardGrid size="md">
   <OptionCard name="<id>" required>
-    The published rule's candidate id, as shown by [`stella context list`](/docs/commands/context) — or its full `ctx.<set>.<id>` lineage when the short form names more than one.
+    The rule's id, as shown by [`stella context list`](/docs/commands/context). If the short id matches more than one rule, use the full `ctx.<set>.<id>` form instead.
   </OptionCard>
   <OptionCard name="--reason <text>" defaultValue="retracted from the review surface">
-    Why. Recorded on the ledger event; an empty reason is refused.
+    The reason for retracting it. This is required; an empty reason is not allowed.
   </OptionCard>
 </CardGrid>
 
@@ -119,34 +119,34 @@ stella proposals retract migration-order-3f21 --reason "the migration order chan
 
 ### `stella proposals refresh`
 
-Extract observations from the reflection log and induce proposals over them, without waiting for a turn to reflect.
+Look through stella's reflection log and create proposals from it right away, without waiting for a new turn to trigger reflection.
 
-The loop already does this after every reflection. This verb exists so the review surface is usable on its own: *"show me what is pending"* is a useless question if the only way to populate it is to run a turn and hope. Replay-idempotent like the loop's own pass — running it twice changes nothing.
+stella already does this automatically after every reflection. This command exists so you can check for proposals on demand, without needing to run a new turn first. Running it more than once is safe: running it twice in a row makes no extra changes.
 
 ```bash
 stella proposals refresh && stella proposals list
 ```
 
 <Callout type="info">
-`context.lifecycle.enabled: false` in [`settings.json`](/docs/configuration/settings) restores every pre-adaptive behavior wholesale, including turning induction off.
+Setting `context.lifecycle.enabled: false` in [`settings.json`](/docs/configuration/settings) turns off this whole adaptive-context feature, including proposal creation.
 </Callout>
 
-## Not the same as `stella ingest`
+## Proposals vs. ingest
 
 <Callout type="warn">
-[`stella ingest`](/docs/commands/ingest) and `stella proposals` are two different review surfaces with two different authority models, and they do not share storage. `stella proposals` reads the adaptive-context ledger in `.stella/private/context.db` — what the loop induced from your *sessions*. Ingest writes TOML proposals to `.stella/proposals/` from *documents*, and those are reviewed by editing the files. A document you ingest will not appear here.
+[`stella ingest`](/docs/commands/ingest) and `stella proposals` are two separate systems with separate storage. `stella proposals` shows ideas stella noticed from your *sessions*, stored in `.stella/private/context.db`. `stella ingest` creates proposal files from *documents* you feed it, stored in `.stella/proposals/`, and you review those by editing the files directly. A document you ingest will not show up in `stella proposals`.
 </Callout>
 
 ## Related
 
 <CardGrid size="sm">
   <SpecCard title="Context Engine" href="/docs/context-engine">
-    How proposals become recall, and what a context frame carries.
+    How proposals become memories stella recalls later, and what's inside a context frame.
   </SpecCard>
   <SpecCard title="stella memory" href="/docs/commands/memory">
-    The citation feedback loop, selection health, and reversible retirement.
+    How stella tracks memory citations, checks their health, and can retire them (and undo that).
   </SpecCard>
   <SpecCard title="stella ingest" href="/docs/commands/ingest">
-    The document half — markdown into TOML context-record proposals.
+    Turns documents into proposals you can review.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/commands/resume.mdx
+++ b/website/content/docs/commands/resume.mdx
@@ -1,6 +1,6 @@
 ---
 title: stella resume
-description: Reopen a past Command Deck session right where you left off, with its transcript, conversation, and pending prompts.
+description: Reopen a past interactive session right where you left off, with its transcript, conversation, and pending prompts.
 ---
 
 Reopen a past [Command Deck](/docs/commands/chat) session right where it stood: the transcript, the conversation with the model, and any prompts still waiting to run. Sessions survive quitting, pressing Ctrl-C, closing the terminal, or even a power loss. stella saves a record of everything that happens as it happens, and resuming replays that record.
@@ -13,7 +13,7 @@ stella resume [id] [--list] [global flags]
 
 ## What it does
 
-Every Command Deck session saves itself in a list stored on your machine. Each session gets its own JSON file under `~/.stella/sessions/` on every platform, unless you set `STELLA_DATA_DIR` to a different location. The session's saved state is stored next to that file. `stella resume` picks a session from this list and reopens it in the deck:
+Every interactive session saves itself in a list stored on your machine. Each session gets its own JSON file under `~/.stella/sessions/` on every platform, unless you set `STELLA_DATA_DIR` to a different location. The session's saved state is stored next to that file. `stella resume` picks a session from this list and reopens it in the deck:
 
 - **`stella resume`** with no id reopens the most recently active session **that can be resumed in your current workspace**. If there isn't one, it tells you and points you to `--list`.
 - **`stella resume <id>`** reopens one specific session by its id. Ids are created when a session starts, in the form `ses-<ms>-<pid>`, and `--list` shows them.

--- a/website/content/docs/commands/resume.mdx
+++ b/website/content/docs/commands/resume.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella resume
-description: Reopen a previous Command Deck session exactly where it stood — transcript, conversation, and pending prompts.
+description: Reopen a past Command Deck session right where you left off, with its transcript, conversation, and pending prompts.
 ---
 
-Reopen a previous [Command Deck](/docs/commands/chat) session exactly where it stood — transcript, LLM conversation, and the pending prompt backlog. Sessions are durable through quit, Ctrl-C, a killed terminal, and power loss: every fold-relevant event is journaled as it happens, and resuming replays that journal.
+Reopen a past [Command Deck](/docs/commands/chat) session right where it stood: the transcript, the conversation with the model, and any prompts still waiting to run. Sessions survive quitting, pressing Ctrl-C, closing the terminal, or even a power loss. stella saves a record of everything that happens as it happens, and resuming replays that record.
 
 ## Synopsis
 
@@ -13,22 +13,26 @@ stella resume [id] [--list] [global flags]
 
 ## What it does
 
-Every deck session registers itself in a machine-wide registry — one JSON file per session under the user-level stella home (`~/.stella/sessions/` on every platform; `STELLA_DATA_DIR` overrides), with the session's durable state journaled beside it. `stella resume` picks a session from that registry and reopens it in the deck:
+Every Command Deck session saves itself in a list stored on your machine. Each session gets its own JSON file under `~/.stella/sessions/` on every platform, unless you set `STELLA_DATA_DIR` to a different location. The session's saved state is stored next to that file. `stella resume` picks a session from this list and reopens it in the deck:
 
-- **`stella resume`** (no id) reopens the most recently active resumable session **of the current workspace**. If there is none, it says so and points you at `--list`.
-- **`stella resume <id>`** reopens one specific session by its registry id — ids are minted at session start as `ses-<ms>-<pid>` and shown by `--list`.
+- **`stella resume`** with no id reopens the most recently active session **that can be resumed in your current workspace**. If there isn't one, it tells you and points you to `--list`.
+- **`stella resume <id>`** reopens one specific session by its id. Ids are created when a session starts, in the form `ses-<ms>-<pid>`, and `--list` shows them.
 
-What comes back: the transcript is rebuilt by replaying the session journal, the LLM conversation is restored from its last committed turn boundary, and the pending prompt queue returns exactly as you left it. Prompts an interruption cut short mid-dispatch are requeued at the **front** in their original order — at most the in-flight turn's streamed tail is re-run. The session's cumulative spend is restored too, so a `--spend-limit` cap keeps meaning "this session", not "since the restart".
+When you resume, stella rebuilds the transcript from its saved record and restores the conversation with the model from its last completed turn. Any prompts still waiting to run come back exactly as you left them. If a prompt was interrupted partway through, it goes back to the **front** of the queue, in its original order; at most, the last part of that in-progress turn gets re-run. stella also restores how much you've spent in this session, so a `--spend-limit` cap still applies to "this session," not just "since you restarted."
 
-A session can only be reopened where it belongs: it must not be live in another stella process (there is no attach — stop that session first), it must belong to the current workspace (the deck's tools, memory, and graph are workspace-bound), and it must have durable state on disk (sessions predating session journaling are listed but not resumable).
+A session can only be reopened if it meets three conditions:
+
+- It isn't already running in another stella process. You can't attach to a live session; stop it first.
+- It belongs to your current workspace, since the deck's tools, memory, and code graph are tied to one workspace.
+- It has saved state on disk. Some very old sessions don't have this, so they appear in the list but can't be resumed.
 
 <Callout type="info">
-`stella resume` opens the Command Deck, so it needs a real terminal — it cannot combine with `--plain`, `STELLA_PLAIN`, or a piped stream. `stella resume --list` works anywhere.
+`stella resume` opens the Command Deck, so it needs a real terminal window. It doesn't work with `--plain`, `STELLA_PLAIN`, or a piped stream. `stella resume --list` works anywhere, though.
 </Callout>
 
 ## `--list`
 
-`stella resume --list` prints every session recorded on this machine, newest activity first — local reads only, no API key required. Each row shows the registry id, status (In Progress, Needs Input, Paused, Cancelled, Complete, Archived, Error — a live-status session whose process died reads as Error), and the session title. A `↩` marker means resumable from the current directory; `·` means resumable from its own workspace.
+`stella resume --list` shows every session saved on this machine, with the newest activity first. It only reads local files and doesn't need an API key. Each row shows the session's id, its status, and its title. The status can be In Progress, Needs Input, Paused, Cancelled, Complete, Archived, or Error. A session shows as Error if its process died while it was still marked as live. A `↩` marker means you can resume it from your current folder. A `·` marker means you can resume it, but only from its own workspace.
 
 ```text
    ID                       STATUS       SESSION
@@ -39,21 +43,21 @@ A session can only be reopened where it belongs: it must not be live in another 
 inside the deck: `Ctrl-E` opens SESSIONS, `⏎` reopens a session
 ```
 
-The deck's **SESSIONS** overlay (`Ctrl-E`, or `/sessions`) is the same navigation from inside a session — `⏎` on a row reopens it.
+Inside a session, the **SESSIONS** overlay, opened with `Ctrl-E` or `/sessions`, shows the same list. Press `⏎` on a row to reopen that session.
 
 ## Flags
 
 <CardGrid size="md">
   <OptionCard name="[id]">
-    Registry id (`ses-…`) of the session to reopen. Omitted, the most recently active
-    resumable session of this workspace.
+    The id (`ses-…`) of the session to reopen. If you leave this out, stella reopens the
+    most recently active session that can be resumed in this workspace.
   </OptionCard>
   <OptionCard name="--list">
-    List this machine's sessions, resumable ones marked, and exit.
+    List every session on this machine, with resumable ones marked, then exit.
   </OptionCard>
 </CardGrid>
 
-The [global flags](/docs/commands) apply — `--spend-limit` is re-seeded with the session's prior spend, and `--no-anim` freezes deck animation as usual.
+The [global flags](/docs/commands) still work here. `--spend-limit` picks up from the session's previous spend, and `--no-anim` turns off deck animation as usual.
 
 ## Examples
 

--- a/website/content/docs/commands/run.mdx
+++ b/website/content/docs/commands/run.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella run
-description: Send a one-shot prompt through the raw step loop (or an installed wrapper plugin) and let stella work to completion, no back-and-forth — built for scripts, CI jobs, and git hooks.
+description: Send a single prompt and let stella work until it's done, with no back-and-forth. Built for scripts, CI jobs, and git hooks.
 ---
 
-Send a one-shot prompt and let the agent work to completion without any interactive back-and-forth. This is the command to reach for in scripts, CI jobs, and Git hooks.
+Send a single prompt and let stella work until it finishes, without any back-and-forth conversation. Use this command in scripts, CI jobs, and Git hooks.
 
 ## Synopsis
 
@@ -13,93 +13,80 @@ stella run <prompt> [--pipeline <VARIANT>] [--test-command <CMD>] [global flags]
 
 ## What it does
 
-By default `stella run` sends the prompt through the **raw step loop**: the model proposes tool calls, the tools execute, results feed back, and the loop repeats until the model stops proposing actions. There is no REPL and no prompt for further input; it is the non-interactive counterpart to [`stella chat`](/docs/commands/chat).
+By default, `stella run` sends your prompt through the **raw step loop**. Here's how that works: the model suggests a tool to run, stella runs it, the result goes back to the model, and this repeats until the model has nothing more to do. There's no interactive prompt window, and stella never asks you for more input. It's the non-interactive version of [`stella chat`](/docs/commands/chat).
 
-Pass `--pipeline <variant>` to run the turn under an installed [wrapper plugin](/docs/plugins) instead — the plugin contributes context before the turn and reports its own evidence after it.
+Use `--pipeline <variant>` to run the turn through an installed [wrapper plugin](/docs/plugins) instead. The plugin can add context before the turn starts and reports its own results after it ends.
 
-Because it is non-interactive, `stella run` is the natural place to combine `--output-format json` or `--output-format stream-json` for headless automation, and `--spend-limit` for a hard spend cap.
+Because `stella run` is non-interactive, it works well with `--output-format json` or `--output-format stream-json` for automated scripts, and with `--spend-limit` to set a hard cap on spending.
 
 <Callout type="info">
 `stella run` uses the same tools, providers, and credential chain as every other command. All [global flags](/docs/commands) apply.
 </Callout>
 
-A run typed at a terminal is [supervised](/docs/commands/daemon): it survives the window closing, and this terminal stays only to stream it. Add [`--detach`](/docs/commands/daemon#--detach-start-it-and-get-the-prompt-back) to get the prompt back immediately instead — the run keeps going, and `stella daemon list | attach | logs | stop` address it afterwards. That works from a script or a CI step too, where nothing is supervised by default.
+A run you start in a terminal is [supervised](/docs/commands/daemon): it keeps going even if you close the terminal window, and the terminal just shows you what's happening. Add [`--detach`](/docs/commands/daemon#--detach-start-it-and-get-the-prompt-back) to get your prompt back right away instead. The run keeps going in the background, and you can check on it later with `stella daemon list`, `attach`, `logs`, or `stop`. This also works from a script or CI step, where runs are not supervised by default.
 
 ## Flags
 
-`stella run` adds four command-specific flags on top of the [global flags](/docs/commands). Two of them are refused outright; they are carded here because a flag that still parses and then refuses owes the reader a reason.
+`stella run` adds four flags of its own, in addition to the [global flags](/docs/commands). Two of these flags are always refused right now. They're still listed here because if a flag exists but refuses to run, you deserve to know why.
 
 <CardGrid size="md">
   <OptionCard name="--pipeline <VARIANT>">
-    Run the turn under an installed **wrapper plugin**, named by the `[wrapper] id` its
-    manifest declares (`stella plugin list`). The plugin contributes context before the
-    turn and gathers evidence after it; the rule it declared at install — evaluated by
-    stella, never by the plugin — decides whether another turn runs. The variant id is
-    recorded on the execution row, so two variants can be compared side by side.
-    Omitted, the raw step loop runs with nothing over it.
+    Run the turn through an installed **wrapper plugin**, using the `[wrapper] id` its
+    manifest declares (see `stella plugin list`). The plugin adds context before the turn
+    and collects evidence after it. stella, not the plugin, checks the rule the plugin
+    declared at install time to decide whether another turn should run. The variant id is
+    saved with the run, so you can compare two variants later. If you leave this out, the
+    raw step loop runs on its own.
   </OptionCard>
   <OptionCard name="--test-command <CMD>">
-    The test command an installed verification plugin's own `[oracle]` runs
-    deterministically — e.g. `"cargo test -p my-crate"`. Refused on the raw loop
-    (no plugin named); passes through to a named `--pipeline <variant>` plugin's own
-    oracle when one is installed.
+    The test command that an installed verification plugin's own `[oracle]` runs, for
+    example `"cargo test -p my-crate"`. It's refused if you're using the raw loop (no
+    plugin named). If you name a plugin with `--pipeline <variant>`, this command is
+    passed to that plugin's own oracle.
   </OptionCard>
   <OptionCard name="--keep-witness">
-    **Refused on every resolution.** It promoted the staged pipeline's authored witness
-    test out of the candidate workspace and into your tree; #3865 deleted that pipeline,
-    so nothing authors a witness for it to keep. A verification plugin owns its own
-    witness files — install one (`stella plugin install`) and ask it.
+    **Always refused.** Use a verification plugin instead: install one with
+    `stella plugin install`, and it will manage its own witness files.
   </OptionCard>
   <OptionCard name="--require-verified">
-    **Refused on every resolution.** It turned "completed but unproven" into a non-zero
-    exit, reading verdicts only the built-in staged pipeline reached; the raw loop
-    reaches neither (see the statuses below). A delivery gate that must not ship
-    unproven work wants a verification plugin, `--pipeline <variant>` naming it, and
-    `--require-verdict`.
+    **Always refused.** If you need your build to fail when work isn't verified, use a
+    verification plugin with `--pipeline <variant>`, along with `--require-verdict`.
   </OptionCard>
   <OptionCard name="--require-verdict">
-    Exit non-zero unless the `--pipeline` wrapper declared its requirements **met**.
-    This is the delivery gate: without it a plugin's refusal is printed to stderr and
-    the run still exits on the turn's own result, so installing somebody's plugin can
-    never fail your build by itself. Anything other than met fails under the flag,
-    including a wrapper that reached no verdict at all — a gate that passes on
-    "undecided" is not a gate. Refused without `--pipeline`, where nothing declares a
-    verdict for it to read.
+    Makes the command exit with an error unless the `--pipeline` plugin says its
+    requirements are **met**. This is what makes a build actually fail on unverified work.
+    Without this flag, a plugin's refusal only prints a warning, and the run still exits
+    based on the turn's own result, so installing someone's plugin can never break your
+    build by itself. With this flag, anything other than "met" causes a failure, including
+    a plugin that never reached a decision at all. This flag is refused if you don't also
+    use `--pipeline`, since there's nothing to check a verdict from.
   </OptionCard>
 </CardGrid>
 
-### Reading the outcome without changing the exit code
+### Run status
 
-Whatever the exit code, a finished run states how it ended in its own right.
-`--output-format json` carries that as `status`, which a raw run spells `completed`
-(the turn reached an answer) or `aborted` (the loop stopped early — budget, a
-refusal, an error), with `reason` naming the abort. Those two are the whole set:
-they are what `crates/stella-cli/src/agent/summary.rs` can emit, and the same word
-is what the audit row records.
+No matter what exit code a run returns, it always reports how it ended. With `--output-format json`, this shows up as a `status` field. For the raw loop, this is either `completed` (the turn reached an answer) or `aborted` (the loop stopped early, for example because it hit a budget limit, a refusal, or an error). When a run aborts, the `reason` field explains why. These are the only two statuses the raw loop can report, and it's the same status stella records in the audit log.
 
-`unverified` and `verification_failed` are **not** raw-run statuses. They belonged
-to the built-in staged pipeline, which was deleted from the workspace in #3865; a
-run whose verification standing is worth reading is one handed to an installed
-verification plugin with `--pipeline <variant>`, and that plugin reports its own
-evidence.
+`unverified` and `verification_failed` are **not** statuses the raw loop reports. To see a verification result, run with an installed verification plugin using `--pipeline <variant>`. That plugin reports its own status.
 
 ```bash
 stella run "…" --output-format json | jq -e '.status == "completed"'
 ```
 
-The most relevant global flags here:
+### Useful global flags
 
 <CardGrid size="md">
   <OptionCard name="--model <provider/model_id>">
-    Pin the worker model instead of relying on auto-detection.
+    Choose which model does the work, instead of letting stella pick automatically.
   </OptionCard>
   <OptionCard name="--output-format <text|json|stream-json>" defaultValue="text">
-    Use `json` or `stream-json` for machine-readable, headless output. A flag of `run`
-    itself (not a global), so it goes after the subcommand token:
-    `stella run "…" --output-format json`. Env `STELLA_OUTPUT_FORMAT`.
+    Use `json` or `stream-json` to get output a script can read. This flag belongs to
+    `run` itself, not the global flags, so it goes after the subcommand:
+    `stella run "…" --output-format json`. You can also set it with the
+    `STELLA_OUTPUT_FORMAT` environment variable.
   </OptionCard>
   <OptionCard name="--spend-limit <usd>">
-    Cap total spend for the run; work aborts cleanly once the cap is exceeded.
+    Set a maximum amount to spend on this run. Once the cap is reached, the run stops cleanly.
   </OptionCard>
 </CardGrid>
 
@@ -111,7 +98,7 @@ Run a simple one-shot task with the default (auto-detected) model:
 stella run "Add a docstring to every public function in src/utils.py"
 ```
 
-Pin a specific model and emit a single JSON object for a script to parse. Global flags read most clearly before the subcommand, though [either position parses](/docs/commands#global-flags):
+Choose a specific model and print one JSON object for a script to read. Global flags are easiest to read before the subcommand name, though [either order works](/docs/commands#global-flags):
 
 ```bash
 stella --model anthropic/claude-fable-5 \
@@ -132,18 +119,16 @@ stella --model local/llama3.3 --base-url http://localhost:11434/v1 \
   run "Explain what main.rs does"
 ```
 
-`--test-command` passes through to a named plugin's own `[oracle]`; it is
-refused only on the raw loop, which has no oracle to arm.
+`--test-command` is passed to a named plugin's own `[oracle]`. It's refused only when you're using the raw loop, since the raw loop has no oracle.
 
-Hand an installed verification plugin's oracle a deterministic test, so a fixed
-test can submit without a model-verifier call:
+Give an installed verification plugin's oracle a specific test to run, so it can check the result without an extra model call:
 
 ```bash
 stella run --pipeline my-verifier --test-command "cargo test -p stella-store" \
   "Fix the failing WAL checkpoint test"
 ```
 
-A small mechanical edit needs nothing extra — the raw loop is already the default:
+A small, simple edit needs nothing extra. The raw loop is already the default:
 
 ```bash
 stella run "Bump the serde dependency to 1.0.220 in every crate"

--- a/website/content/docs/commands/scoreboard.mdx
+++ b/website/content/docs/commands/scoreboard.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella scoreboard
-description: What the work cost, and whether anyone said it was good — calls, characters typed, follow-ups, and the verdict a merged or closed PR implies.
+description: See what a piece of work cost and whether people liked it, using model calls, typing, follow-ups, and pull request outcomes.
 ---
 
-`stella scoreboard` reports four numbers per unit of work: how many times intelligence was invoked, how much a person had to type, how many times they came back, and what they thought of the result. Three are counted from rows the store already writes. The fourth is read from a pull request somebody merged or closed.
+`stella scoreboard` shows four numbers for each piece of work: how many times a model was called, how much you had to type, how many times you had to follow up, and what people thought of the result. The first three numbers come from your local store. The fourth comes from a pull request that someone merged or closed.
 
-Reads local state only — no API key, and **no model judges anything here**, which is the point.
+This command only reads data on your machine. It needs no API key, and **no model judges the work here.** That is on purpose.
 
 ## Synopsis
 
@@ -15,29 +15,29 @@ stella scoreboard
 
 ## What it does
 
-Agent quality metrics have an obvious failure mode: ask the model how it did. stella's store does carry a self-rating field (`execution_reflection.self_rating`) and the scoreboard **deliberately does not use it** — that is the model grading its own homework. Every number here is either counted from events that happened or read from a judgement a human made.
+Most tools that measure agent quality just ask the model how it did. Stella's store keeps a self-rating field (`execution_reflection.self_rating`), but the scoreboard never reads it. Letting a model grade its own work isn't a fair test. Every number here either comes from something that actually happened, or from a judgment a person made.
 
 <CardGrid size="md">
   <SpecCard title="Model calls">
-    How many times intelligence was invoked for this unit of work. Counted from the execution
-    rows.
+    How many times a model was called for this piece of work. Counted from the execution
+    records.
   </SpecCard>
   <SpecCard title="Characters typed">
-    How much a person had to write to get the result — prompt characters, summed. The cost of
-    the work that was not automated.
+    How much you had to write to get the result — prompt text, added up. This is the cost
+    of the work that wasn't automated.
   </SpecCard>
   <SpecCard title="Follow-ups">
-    How many times a person came back. Every execution begins with something a person typed,
-    so N executions are N human inputs — which makes follow-ups `N - 1`.
+    How many times you had to come back. Every task starts with something you type, so N
+    executions means N things you typed — which makes follow-ups `N - 1`.
   </SpecCard>
   <SpecCard title="Verdict">
     What a person actually thought, read from the pull request they merged or closed.
   </SpecCard>
 </CardGrid>
 
-## Verdicts come from pull requests, not opinions
+## Where verdicts come from
 
-A pull request status maps to a verdict, with one deliberate gap:
+A pull request's status becomes a verdict, with one gap on purpose:
 
 <CardGrid size="md">
   <OptionCard name="merged">
@@ -47,11 +47,11 @@ A pull request status maps to a verdict, with one deliberate gap:
     Someone rejected it.
   </OptionCard>
   <OptionCard name="draft / open">
-    **Not a verdict.** Work still in flight has not been judged.
+    **Not a verdict.** Work still in progress hasn't been judged yet.
   </OptionCard>
 </CardGrid>
 
-Counting an open PR as anything would be inventing an opinion nobody expressed — which is the exact failure this surface exists to avoid.
+Counting an open pull request as a verdict would mean guessing at an opinion nobody gave. The scoreboard leaves it out instead.
 
 ```bash
 # What did the work cost, and did anyone say it was good?
@@ -59,23 +59,23 @@ stella scoreboard
 ```
 
 <Callout type="info">
-The arithmetic lives in `stella-core` and is unit-tested there, so the CLI reads rows and renders rather than re-deriving numbers. A rollup is rebuilt from the underlying event sequence, which is why the totals cannot drift away from the events that produced them.
+The math behind these numbers is tested once, in one place. The CLI just reads the results and displays them — it never recalculates anything. Totals are rebuilt from the actual event history, so they can never drift from what really happened.
 </Callout>
 
 <Callout type="warn">
-`interrupted` is never reported today: nothing in the store distinguishes a human cancellation from a provider error, so the scoreboard declines to guess rather than mislabeling one as the other.
+Stella never reports `interrupted` as a verdict. The store can't tell the difference between you canceling a task and a provider error, so the scoreboard leaves it out rather than guessing wrong.
 </Callout>
 
 ## Related
 
 <CardGrid size="sm">
   <SpecCard title="stella stats" href="/docs/commands/stats">
-    Cost, tokens, and resolve rate per provider and model — the spend view of the same store.
+    Cost, tokens, and how often work finished, by provider and model — the spending view of the same store.
   </SpecCard>
   <SpecCard title="stella usage" href="/docs/commands/usage">
     The same numbers across every project on this machine.
   </SpecCard>
   <SpecCard title="The Observatory" href="/docs/telemetry/dashboard">
-    The browser dashboard over this workspace's telemetry, loopback-only.
+    A browser dashboard for this workspace's data. It only works from your own machine.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/commands/scoreboard.mdx
+++ b/website/content/docs/commands/scoreboard.mdx
@@ -15,7 +15,7 @@ stella scoreboard
 
 ## What it does
 
-Most tools that measure agent quality just ask the model how it did. Stella's store keeps a self-rating field (`execution_reflection.self_rating`), but the scoreboard never reads it. Letting a model grade its own work isn't a fair test. Every number here either comes from something that actually happened, or from a judgment a person made.
+Most tools that measure agent quality just ask the model how it did. stella's store keeps a self-rating field (`execution_reflection.self_rating`), but the scoreboard never reads it. Letting a model grade its own work isn't a fair test. Every number here either comes from something that actually happened, or from a judgment a person made.
 
 <CardGrid size="md">
   <SpecCard title="Model calls">
@@ -63,7 +63,7 @@ The math behind these numbers is tested once, in one place. The CLI just reads t
 </Callout>
 
 <Callout type="warn">
-Stella never reports `interrupted` as a verdict. The store can't tell the difference between you canceling a task and a provider error, so the scoreboard leaves it out rather than guessing wrong.
+stella never reports `interrupted` as a verdict. The store can't tell the difference between you canceling a task and a provider error, so the scoreboard leaves it out rather than guessing wrong.
 </Callout>
 
 ## Related

--- a/website/content/docs/commands/search.mdx
+++ b/website/content/docs/commands/search.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella search
-description: Find code by meaning or by name — the CLI door to the same `search` tool the agent calls.
+description: Find code by meaning or by name, the same way the agent's search tool works, from your own shell.
 ---
 
-Find the files that answer a question you can only describe in words — the same `search` tool the agent reaches for on every turn, run from your shell. Ranks semantically when an embedder is configured, and falls back to graph symbol-name matching and then a file scan when it is not.
+Find the files that answer a question, even one you can only describe in words. This is the same `search` tool the agent uses during a conversation, but you run it yourself from your shell. It ranks results by meaning when you have an embedder set up. If not, it falls back to matching symbol names, and then to a plain file scan.
 
 ## Synopsis
 
@@ -13,28 +13,27 @@ stella search "<query>" [--format text|json]
 
 ## What it does
 
-`stella search` runs the exact dispatch ladder the agent's `search` tool runs inside a turn:
+`stella search` runs the exact same steps the agent's `search` tool runs during a turn:
 
 <CardGrid size="md">
   <OptionCard name="semantic">
-    Ranked by MEANING against your query, over the code-graph vector index —
+    Ranks results by MEANING against your query, using the code-graph's vector index —
     only when an embedder is configured (`VOYAGE_API_KEY`, `OPENAI_API_KEY`, or
-    `STELLA_EMBED_URL` + `STELLA_EMBED_MODEL`).
+    `STELLA_EMBED_URL` plus `STELLA_EMBED_MODEL`).
   </OptionCard>
   <OptionCard name="names">
-    Falls back to matching your query's words against symbol and path names in
-    the code-graph index — no embedder required.
+    Falls back to matching your query's words against symbol and path names in the
+    code-graph index — no embedder needed.
   </OptionCard>
   <OptionCard name="scan">
-    Falls back further to a plain file scan when no index is available at
-    all — the normal case for a workspace with no tree-sitter grammar for its
-    language.
+    Falls back further to a plain file scan when no index exists at all — the normal
+    case for a workspace whose language has no tree-sitter grammar.
   </OptionCard>
 </CardGrid>
 
-The answer always states which strategies ran (`via: …`), so a result you get from the CLI is never ambiguous about how sharp it is.
+The answer always states which of these ran (look for `via: …`), so you always know how sharp a result is.
 
-`query` takes whatever form you have it in — a sentence, a behaviour description, or a bare symbol/file name — exactly as the agent's tool accepts it.
+`query` can be a full sentence, a description of behavior, or a plain symbol or file name. It works exactly like the agent's own search tool.
 
 ## Examples
 
@@ -52,7 +51,7 @@ stella search "what calls resolve_provider"
 
 ## `--format json`
 
-For scripted testing — feeding real queries through the exact ranking the agent uses and reading the answer back as data:
+Use this for scripted tests: feed real queries through the same ranking the agent uses, and read the answer back as data:
 
 ```bash
 stella search "the retry/backoff policy for failed HTTP requests" --format json
@@ -75,8 +74,14 @@ stella search "the retry/backoff policy for failed HTTP requests" --format json
 }
 ```
 
-The parts a test script asserts on ride as data, not prose: `hits` is the ranking in rank order (each with the `why` phrase the agent reads), `strategies` lists which rungs of the ladder actually ran — more than one entry means an earlier rung came back empty — and `note` carries the degradation reason verbatim when the semantic rung was skipped or failed. `content` is still the exact rendered text the agent would receive, and `error` is `null` on success.
+### Fields to rely on
 
-The command exits non-zero on failure even under `--format json`, so a script can check the exit code without parsing the body — the JSON envelope on stdout stays valid either way, with `ok: false` and `error` set.
+- `hits` — the ranked results, in order. Each one includes the `why` text the agent reads.
+- `strategies` — which methods actually ran. More than one entry means an earlier method came back empty.
+- `note` — the reason the semantic method was skipped or failed, when that happened.
+- `content` — the exact text the agent would receive.
+- `error` — `null` on success.
 
-Two environment dials tune the rendering, the same ones the agent's registration reads: `STELLA_SEARCH_DEPTH` (how much is said about the top hit) and `STELLA_SEARCH_BUDGET` (the answer's character allowance). They shape `content` only — the `hits` ranking is unaffected.
+The command exits with a non-zero code on failure, even with `--format json`, so a script can check the exit code without parsing the output. The JSON on stdout is always valid, with `ok: false` and `error` set when something goes wrong.
+
+Two environment variables control how much detail you get — the same ones the agent's own search tool reads: `STELLA_SEARCH_DEPTH` (how much detail is shown for the top result) and `STELLA_SEARCH_BUDGET` (a character limit for the answer). These only affect `content` — they don't change which results show up in `hits`.

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella self-driving
-description: Deterministic controls for the perpetual delivery loop — the governor, the ledger, the aperture ladder, and the dedup oracle, as a first-class subcommand.
+description: Commands that control the self-driving loop — how much work to do, what got done, which check runs next, and how duplicate issues are caught.
 ---
 
-Drive the perpetual delivery loop: plan, cycle, audit, watch.
+Run the loop that keeps finding and fixing problems on its own: plan the work, run a cycle, check the code, and watch for the next change.
 
 ## Synopsis
 
@@ -37,186 +37,178 @@ stella self-driving phase <name>
 
 ## What it does
 
-`self-driving` is a cycle: fix a batch of defects, audit what is left, file what it cannot fix, benchmark against the comparator, ship, and repeat. The loop never terminates — when an audit lens goes dry the next one opens, and when every lens is dry it drops to a cheap watch mode and wakes on a change.
+`self-driving` runs in a cycle: fix a batch of problems, check what's left, file what it can't fix as issues, compare results against a baseline, ship changes, and start over. The loop never stops. When one audit check runs out of new findings, the next one opens. When every check is dry, the loop drops into a low-cost watch mode and wakes up when something changes.
 
-This command is the **deterministic half** of that loop: everything a machine can decide without a model, so the model driving the loop never has to re-derive it and cannot get it subtly wrong. The judgement half (which defects to fix, what a finding means) stays with the agent; the `/self-driving` slash commands call these verbs, and `scripts/self-driving.sh` delegates its ported verbs here one-for-one.
+This command handles the deterministic part of the loop: everything a computer can decide with fixed rules instead of guesses. Because these decisions never need a model, the model driving the loop can never get them subtly wrong. Deciding which problems to fix, and what a finding means, is still left to the agent. The `/self-driving` slash commands call these same functions, and the `scripts/self-driving.sh` script uses this command for the same tasks.
 
-State lives at `~/.stella/self-driving/<slug>/`, keyed by the repository's remote URL so every worktree of one repository shares one ledger, seen-set, and calibration. The [Observatory](/docs/commands/observe) reads the same files read-only. Everything works offline and needs no API key; only `queue`, `plan`, and `watch` read the defect queue through `gh` (and degrade gracefully without it).
+Stella stores this state at `~/.stella/self-driving/<slug>/`. The slug comes from your repository's remote URL, so every worktree of the same repository shares one ledger, one seen-list, and one calibration. The [Observatory](/docs/commands/observe) reads these same files, but never changes them. Everything works offline and needs no API key — the exceptions are `queue`, `plan`, and `watch`, which read your issue queue through `gh` (and still work, just with less information, when `gh` isn't available).
 
 ## The verbs
 
-### surface — what a host outside the binary may call
+### surface
 
 ```bash
 stella self-driving surface
 stella self-driving surface --format json
 ```
 
-Prints the **host-verb surface this build carries**: every verb a driver
-outside the binary may call, and the shape each writes to stdout.
+Prints every command a driver outside the binary is allowed to call on this build, and the shape each one writes to stdout.
 
-This exists because self-driving is a *host*, not a turn-loop wrapper — it
-drives stella from outside, as `scripts/self-driving.sh` already does.
-A host reads this surface once
-at start-up and refuses a build it was not written against, rather than meeting
-the skew halfway through a cycle as an `unrecognized subcommand`.
+Self-driving controls stella from the outside, the same way `scripts/self-driving.sh` does. A driver script reads this list once, when it starts. If the list doesn't match what the script expects, the script can refuse to run instead of failing partway through a cycle with an `unrecognized subcommand` error.
 
-The declaration is checked against the binary in **both** directions: a verb
-added to the CLI with no row fails, and a row naming a verb this build does not
-carry fails. Without the first it would silently stop describing the program;
-without the second it would be a document that only ever grows.
+Stella checks this list against the real program in both directions. If a command is added to the CLI but missing from this list, that's an error. If this list names a command that no longer exists, that's also an error. This keeps the list matching the program exactly, instead of slowly falling out of date.
 
-### plan — size the cycle to this machine
+### plan
 
-Supply (what the box has right now) × demand (what the queue needs) × calibration (what previous cycles proved this box survives) → a tier and concrete knobs, emitted as `SELF_DRIVING_*` shell assignments so the caller cannot mis-transcribe them. `--explain` shows the reasoning instead — every tier decision names *why*, because a governor whose decisions cannot be explained gets overridden and then ignored.
+`plan` looks at three things: supply (what your machine can handle right now), demand (what the issue queue needs), and calibration (what past cycles proved your machine can survive). It combines these into a tier and a set of settings, printed as `SELF_DRIVING_*` shell variables so you can't mistype them. Use `--explain` to see the reasoning instead of just the settings — every tier decision comes with a reason, because a governor that can't explain itself gets overridden and ignored.
 
-The probes (cores, load, memory, disk, battery, contention) each yield to a `SELF_DRIVING_PROBE_*` environment override before touching the machine, so the governor's senses can be pinned — by the hermetic test suites, and by an operator on a box where a probe reads the wrong machine.
+Each probe stella uses (cores, load, memory, disk, battery, and contention) checks for a `SELF_DRIVING_PROBE_*` environment variable first, before reading your actual machine. This lets test suites, or you, correct a probe's reading if a machine is being read wrong.
 
-### cycle — allocate and record
+### cycle
 
-`cycle begin` allocates cycle N, banks any abandoned run record, and emits the cycle context (`SELF_DRIVING_CYCLE`, the dry streak so far, the base SHA, the open aperture and its declared tool). `cycle end` appends the ledger record, feeds the outcome to the controller, and advances the aperture when the lens has produced nothing new for two consecutive cycles.
+`cycle begin` starts cycle N. It saves any abandoned run record and prints the cycle's context: `SELF_DRIVING_CYCLE`, how many dry cycles have happened in a row, the base commit, and the current audit lens with its tool. `cycle end` adds a record to the ledger, tells the controller what happened, and moves to the next audit lens once the current one has found nothing new for two cycles in a row.
 
-`--outcome` is the controller's only input: `ok` means the cycle completed inside its resources; `resource-fail` means a killed compiler, OOM, or ENOSPC. A red gate is *not* a resource failure — the batch was wrong, not too big.
+`--outcome` is the only thing the controller looks at. `ok` means the cycle finished within its resource limits. `resource-fail` means something ran out, like a killed compiler process, an out-of-memory error, or running out of disk space. A failing CI check is *not* a resource failure — that means the batch of work was wrong, not that it was too big.
 
-### aperture — the audit lens ladder
+### aperture
 
-"No more defects" is always a statement about the **lens**, never about the code. The ladder — `rubric`, `properties`, `invariants`, `concurrency`, `performance`, `supply-chain`, `security`, `docs`, `soak` — asks a distinct question per lens. `--list` shows each lens with the concrete command that backs it, or an explicit `model-only` marker when no tooling exists yet: no lens is silently a no-op. Lenses that spend real money (`performance`, `soak`) open only on the governor's heavy tier.
+"No more defects" always means no more defects for the *current lens*, never for the whole codebase. The ladder of lenses is `rubric`, `properties`, `invariants`, `concurrency`, `performance`, `supply-chain`, `security`, `docs`, and `soak`, and each one checks something different. `--list` shows each lens with the actual command behind it, or the label `model-only` if there's no tool for it yet, so you always know whether a lens does real work. The `performance` and `soak` lenses cost real money to run, so they only open on the governor's heaviest tier.
 
-Exhausting the ladder drops the loop to `watch`; it never exits.
+Once every lens has been checked, the loop drops into `watch` mode. It never exits.
 
-### seen — the dedup oracle
+### seen
 
-Findings are deduplicated by content digest, never by issue number: `--digest` normalizes (lowercase, collapsed whitespace, line numbers replaced) and hashes, so the same defect re-described after unrelated edits shifted it twelve lines is still one finding. `--new` filters to unseen digests; `--add` records them. A cycle is **dry** when it produced zero unseen findings — fixing things does not make a cycle dry; discovering nothing does.
+Stella tells findings apart by their content, not by issue number. `--digest` cleans up the text (lowercase, collapsed whitespace, line numbers removed) and hashes it, so the same problem is recognized as one finding even after unrelated edits move it twelve lines down. `--new` shows which digests haven't been seen before. `--add` saves new digests to the seen list. A cycle counts as **dry** when it finds zero new problems — fixing problems doesn't make a cycle dry, finding nothing does.
 
-### calibrate — the AIMD controller
+### calibrate
 
-Additive increase on a clean cycle (+2 batch, one more parallel worktree after three consecutive clean cycles), multiplicative decrease on a resource failure (halve the batch, drop to serial). This is the only place the ceilings move, and it moves them from evidence — the same command is right on a 16 GiB laptop and a 123 GiB rig without anyone editing a threshold.
+After a clean cycle, the batch size grows by 2. After three clean cycles in a row, stella also adds one more parallel worktree. After a resource failure, the batch size is cut in half and stella drops back to running one worktree at a time. This is the only place these limits change, and they change based on real evidence — the same command works correctly on a small 16 GiB laptop and a large 123 GiB machine, without you setting any thresholds by hand.
 
-### watch — the low-duty mode
+### watch
 
-Checks what would invalidate the last clean sweep: `main` moved, defects filed, CI red. Any trigger reopens the aperture at `rubric` and exits `0` (WAKE); a quiet check exits `1` (SLEEP) so a driver can loop on the exit code and spend nothing.
+`watch` checks for anything that would undo the last clean sweep: new commits on `main`, new problems filed, or a red CI run. If any of these happened, the audit lens reopens at `rubric` and the command exits with code `0` (WAKE). If nothing changed, it exits with code `1` (SLEEP), so a driver script can loop on this exit code and spend nothing while waiting.
 
-### run, runs, phase — the run lifecycle
+### run, runs, phase
 
-A **run** spans many cycles (one `/loop` session, one daemon lifetime) and is the unit a person starts, stops, and drills into. Transitions append to `runs.jsonl` (readers fold by `run_id`, last write wins); the live pointer `run.json` carries the phase and a heartbeat. A run whose last record says `running` but whose heartbeat has gone stale reports **crashed** — only a reader can say so, because the process that would have written it is gone.
+A run covers many cycles: one `/loop` session, or one daemon's whole lifetime. It's the unit you start, stop, and look into. Each change of state is added to `runs.jsonl`; when reading this file, the last entry for a given `run_id` wins. A separate file, `run.json`, always points to the current phase and the last heartbeat. If a run's last record says `running` but its heartbeat has gone stale, stella reports it as `crashed` — only a reader can tell this, because the process that would have updated the heartbeat is gone.
 
 ### metrics, state, queue
 
-`metrics` folds the ledger into the loop's evidence about itself, with named pathology signals (`STUCK`, `STARVED`, `NOISY`, `FRAGILE`) for the meta-cycle to act on. `state` shows the counters and the last five cycles. `queue` ranks the open defects P0 &gt; P1 &gt; P2 &gt; untriaged, oldest first inside a rank — feature work is excluded, because this loop closes defects.
+`metrics` turns the ledger into evidence about how the loop itself is doing, flagging specific problems: `STUCK`, `STARVED`, `NOISY`, and `FRAGILE`. `state` shows the current counters and the last five cycles. `queue` ranks open problems by priority — P0, then P1, then P2, then untriaged, oldest first within each rank. Feature requests are left out, because this loop only closes defects.
 
 ### file
 
-`stella self-driving file` files a finding as an issue through the bound provider, and it **refuses rather than degrades**.
+`stella self-driving file` turns a finding into an issue in your connected tracker. If something's wrong with it, it **refuses to file the issue** instead of filing a bad one.
 
-Two checks run before the tracker is reached. A finding whose digest is already in the seen-set is not filed twice — the same normalization the aperture ladder's dry streak rests on, so the same defect reported against a shifted line number is one finding. And the draft must match this workspace's issue convention.
+Two checks happen before anything reaches the tracker. First, if a finding's digest is already in the seen list, it won't be filed again — this uses the same text-cleanup rule the aperture ladder's dry streak relies on, so the same problem reported at a different line number still counts as one finding. Second, the draft must match your workspace's issue format.
 
-That second check exists because of a feedback loop. The ranker counts an issue as a defect if it carries `bug` *or* `triage`; GitHub's triage workflow adds `triage` to any issue opened without a type label, and issues opened through the API carry no labels at all. So an unclassified filing comes back next cycle as an untriaged defect the loop is responsible for triaging — the loop manufactures its own queue, and every measure of ground gained on the backlog quietly includes its own exhaust.
+This second check exists to stop a feedback loop. Stella's ranker treats any issue carrying a `bug` or `triage` label as a defect. GitHub's own triage workflow adds a `triage` label to any issue with no type label, and issues opened through the API start with no labels at all. Without this check, an unlabeled filing would come back next cycle as an untriaged defect the loop then has to triage itself — the loop would be manufacturing its own backlog, and its progress numbers would quietly include work it created for itself.
 
-The convention is **learned, not assumed**: read from `.stella/issues/convention.json` if the workspace pins one, otherwise discovered from the automation that enforces it. Where nothing can be discovered the loop *proposes* a convention and files nothing under it until a human accepts — it may propose any convention and grants itself none. A refusal names every violation at once and says which source the convention came from, because "what did I get wrong" and "wrong according to what" are both questions you need answered.
+Stella learns your issue format instead of guessing it: it reads `.stella/issues/convention.json` if your workspace has saved one, or otherwise figures it out from the automation that enforces it. If nothing can be found, the loop *proposes* a format and files nothing under it until a human accepts — it can suggest any format, but it can't approve its own suggestion. If a filing is refused, stella lists every problem with it at once and says where the format came from, so you know both what went wrong and what rule it broke.
 
 ### work
 
-`stella self-driving work --issue KEY` runs one issue through stella's turn loop in an isolated worktree, and reports what the tree says.
+`stella self-driving work --issue KEY` runs one issue through stella's normal turn loop, in its own isolated worktree, and reports what actually changed.
 
-It **spawns a real `stella run`** rather than embedding a turn. Self-driving is a host — it drives stella from outside — so a unit of work gets exactly what a `stella run` gets on that machine, with whatever plugins are installed over it and nothing else. Be clear about what that is worth: with no verification plugin installed, a completed work unit means *the turn finished*, not *the change is proven*. What makes an autonomous merge safe is the CI gating in `deliver`, not this step.
+It starts a real `stella run`, rather than running a turn internally. Self-driving controls stella from the outside, so each unit of work gets exactly what a normal `stella run` gets on your machine — the same plugins, nothing extra. This matters: with no verification plugin installed, a completed work unit only means the turn finished, not that the change was proven correct. What actually makes an automatic merge safe is the CI check in `deliver`, not this step.
 
-Two properties are deliberate and tested.
+Two things here are deliberate, and tested. Issue text is never a command: anyone who can file an issue could write anything in it, so its text always reaches the prompt as a quote, with no authority to instruct the agent. The quote marker is generated from the issue's own content rather than fixed in advance, so text inside the issue can't fake the end of the quote and pretend to speak as you.
 
-**Issue text is data, never instruction.** An issue is written by whoever can file one, so its body reaches the prompt as quoted material carrying no authority. The fence is derived from the body rather than fixed, so text inside it cannot close the quotation early and continue as though it were you speaking.
+**The outcome is measured from the actual files, never from what the turn says.** If a turn exits cleanly and claims success but changes nothing, stella reports `no_change` and releases the worktree. This matters exactly when a turn's own summary and the real result disagree — a loop that trusted the summary instead would open empty pull requests.
 
-**The outcome is measured from the tree, never from what the turn said.** A turn that exits cleanly and narrates success while changing nothing reports `no_change` and releases its worktree. The two disagree exactly when it matters, and a loop that believed the narration would open empty pull requests.
-
-Worktrees live under `.stella/private/self-driving/` on `self-driving/` branches — outside the fleet's namespace, because `stella fleet gc` reclaims by namespace and must not be given authority over checkouts it did not create.
+Worktrees for this command live under `.stella/private/self-driving/`, on `self-driving/` branches. This is outside the fleet's namespace, because `stella fleet gc` cleans up by namespace, and it should never be allowed to delete checkouts it didn't create.
 
 ### drive
 
-`stella self-driving drive` is the verb that runs unattended. It asks the machine what to do next, does it, and asks again: claim from the ranked queue, work the issue through the turn loop, open a pull request, watch CI, merge when the machine says to.
+`stella self-driving drive` runs on its own, without you watching it. It keeps asking what to do next, does it, and asks again: claim the next issue from the ranked queue, run it through the turn loop, open a pull request, watch CI, and merge when it's ready.
 
-**On a block it parks and keeps polling — it does not exit.** Self-resume is structural, because the machine holds no latch: a block is recomputed from scratch on every call and stops being returned the moment its cause is gone. But a host that exits on a block makes resumption impossible no matter what the machine returns. Nobody should ever have to tell this loop it may resume; a human who raises the ceiling, restores the grant, drops the stop flag or merges the escalated pull request has already said everything that needs saying.
+**When it hits a block, it parks and keeps checking — it does not exit.** Nothing stays "stuck" on purpose: every block is recalculated from scratch each time, so as soon as its cause is gone, it stops being reported. If the command exited on a block instead, nothing could resume it automatically. You never need to tell this loop it can resume — raising a limit, restoring a permission, removing a stop flag, or merging an escalated pull request already says everything that needs to be said.
 
-`--max-issues` bounds one invocation so it terminates. The real loop never does, which is why the bound is a flag rather than a constant, and why reaching it is reported as *reached the bound* rather than as *finished*.
+`--max-issues` limits one run so that it eventually stops. The loop itself never stops on its own, which is why this limit is a flag you set, not a fixed number. When the loop hits this limit, it's reported as *reached the bound*, not as *finished*.
 
-Steps the machine returns that this build cannot perform — sweeping an audit lens, curating a proposal — are **reported and then stop the loop**, never silently skipped. A driver that did nothing for a step it was handed would look healthy forever.
+If the machine asks for a step this build can't do, like sweeping an audit lens or curating a proposal, stella reports it and stops the loop, instead of silently skipping it. A driver that silently skipped steps would always look healthy, even when it wasn't doing anything.
 
 ### stop
 
-`stella self-driving stop` asks a running loop to park. It writes the flag `drive` re-reads on every poll and prints the path it wrote.
+`stella self-driving stop` asks a running loop to pause. It writes a flag file that `drive` checks on every poll, and prints the path of the file it wrote.
 
-The loop parks at its **next boundary** — between issues, between turns — and never mid-turn. A turn killed where it stands leaves a worktree, a branch and possibly a pull request that nothing has recorded, which is a mess an operator then has to clean up by hand.
+The loop pauses at its next natural stopping point, between issues or between turns, never in the middle of one. A turn stopped mid-way would leave behind a worktree, a branch, and maybe a pull request that nothing has recorded, which someone would then have to clean up by hand.
 
-**Nothing latches the request.** Deleting the file puts the loop back to work with no other input, which is the same self-resume property every other block has: the machine recomputes from scratch on every call, so a cause that is gone stops being returned on the very next poll. There is no `resume` verb because `rm` is the whole operation.
+**The stop request isn't permanent.** Deleting the flag file starts the loop working again, with no other input needed. This works the same way as every other block: the machine checks from scratch each time, so once the cause is gone, it stops appearing on the very next poll. There's no `resume` command, because deleting the file is the whole operation.
 
-`--root` names the loop's durable state directory, for stopping a loop rooted somewhere other than this workspace's own — a second clone, or a state root shared across machines. Without it the flag lands in the root this workspace resolves, the same one the [Observatory](/docs/commands/observe) reads.
+`--root` names the loop's state directory, in case you need to stop a loop that isn't rooted in this workspace — a second clone, or a state root shared across machines. Without `--root`, the flag is written to this workspace's own root, the same one the [Observatory](/docs/commands/observe) reads.
 
-Asking a loop that is already stopping is not an error; the output says which case it was, because "already asked" tells an operator whose loop is still working that the flag is not what is holding it.
+Asking a loop to stop when it's already stopping is not an error. The output tells you which case happened, because knowing it was "already asked" tells you the stop flag isn't why the loop is still working.
 
 ### stats
 
-`stella self-driving stats` is what a session has done so far — issues claimed, attempted, changed, failed, escalated and deferred; issues created, refused and deduplicated; issues closed by each resolution; pull requests opened, merged and escalated; fixes, rebases, and time spent waiting on a broken base; reflections, memories and proposals; turns run and turns stopped by their ceiling.
+`stella self-driving stats` shows what a session has done so far: issues claimed, attempted, changed, failed, escalated, and deferred; issues created, refused, and marked as duplicates; issues closed, broken down by how they were closed; pull requests opened, merged, and escalated; fixes, rebases, and time spent waiting on a broken base branch; reflections, memories, and proposals written; and turns run, including turns stopped by their limit.
 
-It is written after **every step**, not at the end. A perpetual loop that only reported on exit would never report at all, and the point is a record readable while the loop is still running. Writes are atomic, so a dashboard sampling mid-write reads the previous complete document rather than a truncated one.
+Stella writes these stats after **every step**, not just at the end. Since the loop never stops on its own, a report written only on exit would never get written at all — the point is a record you can read while the loop is still running. Each write is atomic, so a dashboard reading the file mid-write always sees the last complete version, never a half-written one.
 
-**The ratios are printed beside the counts.** A raw count answers *how busy was it*, which is the question that flatters. Three derived numbers answer *was it worth it*, and each can report badly:
+#### Ratios
 
-- **inflation** — issues created per issue closed. Above 1.00 sustained means the loop is **losing ground**: filing faster than it finishes. That is the failure mode the design names as the one none of its mitigations is proven to prevent, so it belongs on the dashboard rather than in a report somebody reads later.
-- **attempt yield** — the share of attempts that changed something.
-- **merge rate** — the share of opened pull requests that landed.
+A raw count only tells you how busy the loop was, which always looks good. The ratios below tell you whether the work was worth it, and each can look bad for a real reason:
 
-A ratio with no denominator prints `--` rather than `0.00`: a ratio against zero is undefined, not small, and a number would tell a reader something the session has not established. The three closure kinds are checked against the total, and a mismatch is reported — a dashboard showing a total beside kinds that sum to something else is worse than one showing neither, because a reader believes whichever they saw first.
+- `inflation` — issues created for every issue closed. If this stays above 1.00, the loop is **losing ground**: it's filing new issues faster than it's finishing them. This is a known risk that no safeguard fully prevents, so it's shown here on the dashboard where you'll see it right away.
+- `attempt yield` — the share of attempts that actually changed something.
+- `merge rate` — the share of opened pull requests that got merged.
+
+If a ratio has no denominator, stella prints `--` instead of `0.00`. A ratio of zero over zero isn't a small number, it's undefined, and showing `0.00` would suggest something false. Stella also checks that the three closure kinds add up to the total, and reports it if they don't — a dashboard showing a total that doesn't match its own breakdown is worse than showing neither, because people tend to trust whichever number they see first.
 
 ### triage
 
-`stella self-driving triage --issue KEY` brings an issue up to this workspace's convention.
+`stella self-driving triage --issue KEY` updates one issue to match your workspace's issue format.
 
-The loop owns the backlog it draws from, so an issue that arrived unclassified is one it may classify — but the authority is split. It **removes what the convention reserves**, which is mechanical and needs no judgement. It **reports what needs deciding** rather than guessing: choosing between `bug` and `feature`, or between `P0` and `P2`, is a reading of what the issue says, and a loop that guessed would be manufacturing the very classification the queue is ranked by — the ranking would then be measuring the loop's own invention.
+The loop manages its own backlog, so it can classify an issue that arrived unclassified, but its authority is limited. It removes anything the format reserves, since that's mechanical and needs no judgment. It **reports what still needs a decision**, instead of guessing: choosing between `bug` and `feature`, or between `P0` and `P2`, requires reading and understanding the issue. If the loop guessed, it would be inventing the very classification its queue ranking depends on, which would make the ranking measure the loop's own guesses instead of real priority.
 
-The same rule drives both directions. `conform` decides whether a new filing may go out; `repair` decides what an existing issue is missing. One standard, so the loop's own filings and the backlog it inherited are held to it equally.
+The same rule applies in both directions. `conform` decides whether a new issue can be filed; `repair` decides what's missing from an existing one. Both the loop's own filings and the backlog it inherited are held to the same standard.
 
 ### close
 
-`stella self-driving close --issue KEY` ends an issue with a receipt. There are four kinds, mapping onto the three close reasons a tracker offers.
+`stella self-driving close --issue KEY` closes an issue and records proof of why. There are four kinds of closure, mapping onto the three close reasons most trackers offer.
 
-**Every kind cites something, and the citations are not interchangeable.**
+**Every kind of closure needs a citation, and the citations aren't interchangeable.**
 
-`--completed` closes as done and must cite the change that carried it: `--pr KEY`, or `--commit SHA` for the all-hands case where a fix lands directly on the branch rather than through a pull request. Citing a document here is refused — a document is not a change.
+`--completed` closes an issue as done. It must cite the change that fixed it — `--pr KEY`, or `--commit SHA` for the rare case where a fix goes directly onto the branch without a pull request. You can't cite a document here: a document is not a change.
 
-`--not-planned REASON` closes as not planned, and must cite the authority that settles it with `--per`: a document id (`doc:backlog-self-driving`) or a context-record lineage id. A reason with no authority behind it is an opinion wearing a decision's clothes, and the next person to hit the same problem has no way to find out who decided or what would reopen it. Citing a pull request here is refused for the mirror reason — a change is not a decision.
+`--not-planned REASON` closes an issue as not planned. It must cite the decision behind it with `--per`, using either a document id (like `doc:backlog-self-driving`) or a context-record id. A reason with no cited authority is just an opinion pretending to be a decision, and the next person to hit the same problem won't know who decided this or what would change it. You can't cite a pull request here either, for the opposite reason: a change is not a decision.
 
-`--duplicate-of KEY` closes as a duplicate and names what it duplicates, because a duplicate closure that does not say so sends the reader looking for an original they cannot find.
+`--duplicate-of KEY` closes an issue as a duplicate and names the issue it duplicates. Without this, anyone reading the closure would go looking for an original they can't find.
 
-`--partial DONE --remaining KEY…` is the one that matters most. "Mostly done" is the usual state of real work and the easiest thing to round up, so it is **refused outright** unless the remainder already exists as its own tracked issues. The comment links them, and the backlog never shrinks by more than the work actually finished.
+`--partial DONE --remaining KEY…` is the most important one. "Mostly done" is how most real work actually ends up, and it's tempting to round that up to "done." Stella refuses this outright unless the remaining work already exists as its own tracked issues. The closing comment links to them, so the backlog only shrinks by the amount of work actually finished.
 
-Everything is refused *before* the tracker is reached, so a closure missing its citation cannot half-happen.
+All of these checks happen *before* anything reaches the tracker, so a closure that's missing its citation can never half-happen.
 
-### Which tracker, and how it talks
+### Tracker support
 
-`stella.toml`'s `[issues]` section says **which** tracker is active and where its manifest lives. That manifest — `.stella/issues/<provider>.toml` by default — says how that tracker **talks**: what marks an issue open or closed, how each resolution is spelled, what the fields are called.
+The `[issues]` section in `stella.toml` says which issue tracker is active, and where its manifest file lives. That manifest file, `.stella/issues/<provider>.toml` by default, says how that tracker works: what marks an issue open or closed, how each resolution is spelled, and what its fields are called.
 
-The split is deliberate. `stella.toml` is where a person looks for anything configurable about stella, so *which tracker* belongs there; a vendor's spellings do not, and a workspace spanning two trackers needs somewhere to put the second one's words.
+This is split on purpose. `stella.toml` is where you look for anything you can configure about stella, so *which tracker to use* belongs there. A specific vendor's exact wording doesn't belong there, and if a workspace uses two trackers, there needs to be somewhere to put the second one's settings.
 
-stella branches on exactly three resolutions — `completed`, `not_planned`, `duplicate`, which are GitHub's own close reasons. A tracker offering twenty maps those three and the rest pass through verbatim. Nothing needs configuring to work against GitHub: absent config, absent section and absent manifest all yield working defaults.
+Stella only recognizes three resolutions: `completed`, `not_planned`, and `duplicate` — these are GitHub's own close reasons. If your tracker offers twenty resolutions, it maps to these three and the rest pass through as-is. You don't need to configure anything to use stella with GitHub: with no config, no `[issues]` section, and no manifest file, everything works with sensible defaults.
 
 ### deliver
 
-`stella self-driving deliver` is the pull-request rhythm: open, observe, decide, merge.
+`stella self-driving deliver` handles the pull-request cycle: open, check, decide, and merge.
 
-**Deciding buys no model call.** What to do with an open pull request is arithmetic over observed facts, so the decision lives in a pure state machine and this command only reads the forge and performs what the machine returned. `merge` re-derives the decision from a fresh observation rather than trusting that the caller already ran `next` — the forge moves between calls, and a merge authorised by a stale read is exactly what the machine's "mergeability not yet computed" arm exists to prevent.
+Deciding what to do never calls a model. What to do with an open pull request is a straightforward calculation based on observed facts, not a judgment call, so the decision lives in a pure state machine and this command only reads the pull request's state and does whatever the calculation says. `merge` recalculates the decision fresh, instead of trusting that `next` was already run — a pull request's state can change between calls, and merging based on stale information is exactly what the "mergeability not yet computed" check exists to prevent.
 
-**`base_ci` is a second read, and it is the point.** A failure that reproduces on the base branch is not this pull request's failure, and treating it as one burns every cycle on somebody else's breakage. So `observe` does not ask a blanket "is main red" — it compares **the same checks by name**. For every check failing on the pull request, it asks what the check of that name concluded on the base branch's head, and the base counts as broken only when the failures actually overlap. A blanket read would call a genuine regression "inherited" whenever anything unrelated was red, which is the expensive direction to be wrong in.
+`base_ci` checks the base branch separately, on purpose. A test failure that also happens on the base branch isn't this pull request's fault, and treating it as one wastes every cycle chasing somebody else's broken build. So `observe` doesn't just ask "is `main` red?" It compares the same checks, by name. For every check that fails on the pull request, it looks at what that same check concluded on the base branch's head, and the base only counts as broken if the failures actually overlap. A blanket check would wrongly call a real regression "inherited" any time something unrelated was red, which is a much more costly mistake to make.
 
-**Closing an issue takes both spellings.** `Closes #N` goes in the pull request body *and* as a commit trailer, because a squash merge composes its message from the commits and never from the body, while a rebase merge replays the commits verbatim. Either alone is a silent single point of failure. The trailer is applied by `work`, since the turn is what authors the commit.
+Closing an issue needs to be written twice. `Closes #N` goes both in the pull request body and as a commit trailer. A squash merge builds its final message from the commits, never from the body, while a rebase merge keeps the commits as-is. Writing it in only one place would silently fail depending on the merge type. The commit trailer is added by `work`, since that's the step that writes the commit.
 
-A pull request opens as a **draft** and the machine takes it out of draft itself once CI is green — so one that never goes green never asks a human to look at it. Merging waits for a human approval unless `--no-review` is passed: a default that merged unreviewed would make the safe choice the one an operator has to remember to opt into.
+A pull request opens as a **draft**, and stella takes it out of draft on its own once CI turns green — so a pull request that never passes CI never asks a person to review it. Merging waits for a human approval unless you pass `--no-review`. This default is deliberate: if unreviewed merges were the default, you'd have to remember to turn on the safe option instead of the other way around.
 
 ## Files
 
 | Path | Purpose |
 |---|---|
 | `~/.stella/self-driving/<slug>/ledger.jsonl` | One record per completed cycle |
-| `~/.stella/self-driving/<slug>/runs.jsonl` | Run state transitions (append-only, folded by readers) |
-| `~/.stella/self-driving/<slug>/run.json` | The live pointer: phase, heartbeat, pids |
+| `~/.stella/self-driving/<slug>/runs.jsonl` | Run state changes, added to over time and combined by readers |
+| `~/.stella/self-driving/<slug>/run.json` | The live pointer: current phase, heartbeat, and process ids |
 | `~/.stella/self-driving/<slug>/seen.txt` | Every finding digest ever triaged |
-| `~/.stella/self-driving/<slug>/calibration.json` | The AIMD controller's learned ceilings |
+| `~/.stella/self-driving/<slug>/calibration.json` | The learned batch-size and worktree limits |
 | `~/.stella/self-driving/<slug>/aperture` | The open audit lens |
 
-`SELF_DRIVING_STATE_DIR` relocates the whole directory (the hermetic tests use this); `STELLA_HOME` moves it with the rest of the stella home.
+`SELF_DRIVING_STATE_DIR` moves this whole directory somewhere else (used by the test suite); `STELLA_HOME` moves it along with the rest of stella's home directory.

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -41,7 +41,7 @@ stella self-driving phase <name>
 
 This command handles the deterministic part of the loop: everything a computer can decide with fixed rules instead of guesses. Because these decisions never need a model, the model driving the loop can never get them subtly wrong. Deciding which problems to fix, and what a finding means, is still left to the agent. The `/self-driving` slash commands call these same functions, and the `scripts/self-driving.sh` script uses this command for the same tasks.
 
-Stella stores this state at `~/.stella/self-driving/<slug>/`. The slug comes from your repository's remote URL, so every worktree of the same repository shares one ledger, one seen-list, and one calibration. The [Observatory](/docs/commands/observe) reads these same files, but never changes them. Everything works offline and needs no API key — the exceptions are `queue`, `plan`, and `watch`, which read your issue queue through `gh` (and still work, just with less information, when `gh` isn't available).
+stella stores this state at `~/.stella/self-driving/<slug>/`. The slug comes from your repository's remote URL, so every worktree of the same repository shares one ledger, one seen-list, and one calibration. The [Observatory](/docs/commands/observe) reads these same files, but never changes them. Everything works offline and needs no API key — the exceptions are `queue`, `plan`, and `watch`, which read your issue queue through `gh` (and still work, just with less information, when `gh` isn't available).
 
 ## The verbs
 
@@ -56,7 +56,7 @@ Prints every command a driver outside the binary is allowed to call on this buil
 
 Self-driving controls stella from the outside, the same way `scripts/self-driving.sh` does. A driver script reads this list once, when it starts. If the list doesn't match what the script expects, the script can refuse to run instead of failing partway through a cycle with an `unrecognized subcommand` error.
 
-Stella checks this list against the real program in both directions. If a command is added to the CLI but missing from this list, that's an error. If this list names a command that no longer exists, that's also an error. This keeps the list matching the program exactly, instead of slowly falling out of date.
+stella checks this list against the real program in both directions. If a command is added to the CLI but missing from this list, that's an error. If this list names a command that doesn't exist, that's also an error. This keeps the list matching the program exactly, instead of slowly falling out of date.
 
 ### plan
 
@@ -78,7 +78,7 @@ Once every lens has been checked, the loop drops into `watch` mode. It never exi
 
 ### seen
 
-Stella tells findings apart by their content, not by issue number. `--digest` cleans up the text (lowercase, collapsed whitespace, line numbers removed) and hashes it, so the same problem is recognized as one finding even after unrelated edits move it twelve lines down. `--new` shows which digests haven't been seen before. `--add` saves new digests to the seen list. A cycle counts as **dry** when it finds zero new problems — fixing problems doesn't make a cycle dry, finding nothing does.
+stella tells findings apart by their content, not by issue number. `--digest` cleans up the text (lowercase, collapsed whitespace, line numbers removed) and hashes it, so the same problem is recognized as one finding even after unrelated edits move it twelve lines down. `--new` shows which digests haven't been seen before. `--add` saves new digests to the seen list. A cycle counts as **dry** when it finds zero new problems — fixing problems doesn't make a cycle dry, finding nothing does.
 
 ### calibrate
 
@@ -102,9 +102,9 @@ A run covers many cycles: one `/loop` session, or one daemon's whole lifetime. I
 
 Two checks happen before anything reaches the tracker. First, if a finding's digest is already in the seen list, it won't be filed again — this uses the same text-cleanup rule the aperture ladder's dry streak relies on, so the same problem reported at a different line number still counts as one finding. Second, the draft must match your workspace's issue format.
 
-This second check exists to stop a feedback loop. Stella's ranker treats any issue carrying a `bug` or `triage` label as a defect. GitHub's own triage workflow adds a `triage` label to any issue with no type label, and issues opened through the API start with no labels at all. Without this check, an unlabeled filing would come back next cycle as an untriaged defect the loop then has to triage itself — the loop would be manufacturing its own backlog, and its progress numbers would quietly include work it created for itself.
+This second check exists to stop a feedback loop. stella's ranker treats any issue carrying a `bug` or `triage` label as a defect. GitHub's own triage workflow adds a `triage` label to any issue with no type label, and issues opened through the API start with no labels at all. Without this check, an unlabeled filing would come back next cycle as an untriaged defect the loop then has to triage itself — the loop would be manufacturing its own backlog, and its progress numbers would quietly include work it created for itself.
 
-Stella learns your issue format instead of guessing it: it reads `.stella/issues/convention.json` if your workspace has saved one, or otherwise figures it out from the automation that enforces it. If nothing can be found, the loop *proposes* a format and files nothing under it until a human accepts — it can suggest any format, but it can't approve its own suggestion. If a filing is refused, stella lists every problem with it at once and says where the format came from, so you know both what went wrong and what rule it broke.
+stella learns your issue format instead of guessing it: it reads `.stella/issues/convention.json` if your workspace has saved one, or otherwise figures it out from the automation that enforces it. If nothing can be found, the loop *proposes* a format and files nothing under it until a human accepts — it can suggest any format, but it can't approve its own suggestion. If a filing is refused, stella lists every problem with it at once and says where the format came from, so you know both what went wrong and what rule it broke.
 
 ### work
 
@@ -112,7 +112,7 @@ Stella learns your issue format instead of guessing it: it reads `.stella/issues
 
 It starts a real `stella run`, rather than running a turn internally. Self-driving controls stella from the outside, so each unit of work gets exactly what a normal `stella run` gets on your machine — the same plugins, nothing extra. This matters: with no verification plugin installed, a completed work unit only means the turn finished, not that the change was proven correct. What actually makes an automatic merge safe is the CI check in `deliver`, not this step.
 
-Two things here are deliberate, and tested. Issue text is never a command: anyone who can file an issue could write anything in it, so its text always reaches the prompt as a quote, with no authority to instruct the agent. The quote marker is generated from the issue's own content rather than fixed in advance, so text inside the issue can't fake the end of the quote and pretend to speak as you.
+Issue text is never a command: anyone who can file an issue could write anything in it, so its text always reaches the prompt as a quote, with no authority to instruct the agent. The quote marker is generated from the issue's own content rather than fixed in advance, so text inside the issue can't fake the end of the quote and pretend to speak as you.
 
 **The outcome is measured from the actual files, never from what the turn says.** If a turn exits cleanly and claims success but changes nothing, stella reports `no_change` and releases the worktree. This matters exactly when a turn's own summary and the real result disagree — a loop that trusted the summary instead would open empty pull requests.
 
@@ -144,7 +144,7 @@ Asking a loop to stop when it's already stopping is not an error. The output tel
 
 `stella self-driving stats` shows what a session has done so far: issues claimed, attempted, changed, failed, escalated, and deferred; issues created, refused, and marked as duplicates; issues closed, broken down by how they were closed; pull requests opened, merged, and escalated; fixes, rebases, and time spent waiting on a broken base branch; reflections, memories, and proposals written; and turns run, including turns stopped by their limit.
 
-Stella writes these stats after **every step**, not just at the end. Since the loop never stops on its own, a report written only on exit would never get written at all — the point is a record you can read while the loop is still running. Each write is atomic, so a dashboard reading the file mid-write always sees the last complete version, never a half-written one.
+stella writes these stats after **every step**, not just at the end. Since the loop never stops on its own, a report written only on exit would never get written at all — the point is a record you can read while the loop is still running. Each write is atomic, so a dashboard reading the file mid-write always sees the last complete version, never a half-written one.
 
 #### Ratios
 
@@ -154,7 +154,7 @@ A raw count only tells you how busy the loop was, which always looks good. The r
 - `attempt yield` — the share of attempts that actually changed something.
 - `merge rate` — the share of opened pull requests that got merged.
 
-If a ratio has no denominator, stella prints `--` instead of `0.00`. A ratio of zero over zero isn't a small number, it's undefined, and showing `0.00` would suggest something false. Stella also checks that the three closure kinds add up to the total, and reports it if they don't — a dashboard showing a total that doesn't match its own breakdown is worse than showing neither, because people tend to trust whichever number they see first.
+If a ratio has no denominator, stella prints `--` instead of `0.00`. A ratio of zero over zero isn't a small number, it's undefined, and showing `0.00` would suggest something false. stella also checks that the three closure kinds add up to the total, and reports it if they don't — a dashboard showing a total that doesn't match its own breakdown is worse than showing neither, because people tend to trust whichever number they see first.
 
 ### triage
 
@@ -176,7 +176,7 @@ The same rule applies in both directions. `conform` decides whether a new issue 
 
 `--duplicate-of KEY` closes an issue as a duplicate and names the issue it duplicates. Without this, anyone reading the closure would go looking for an original they can't find.
 
-`--partial DONE --remaining KEY…` is the most important one. "Mostly done" is how most real work actually ends up, and it's tempting to round that up to "done." Stella refuses this outright unless the remaining work already exists as its own tracked issues. The closing comment links to them, so the backlog only shrinks by the amount of work actually finished.
+`--partial DONE --remaining KEY…` is the most important one. "Mostly done" is how most real work actually ends up, and it's tempting to round that up to "done." stella refuses this outright unless the remaining work already exists as its own tracked issues. The closing comment links to them, so the backlog only shrinks by the amount of work actually finished.
 
 All of these checks happen *before* anything reaches the tracker, so a closure that's missing its citation can never half-happen.
 
@@ -186,7 +186,7 @@ The `[issues]` section in `stella.toml` says which issue tracker is active, and 
 
 This is split on purpose. `stella.toml` is where you look for anything you can configure about stella, so *which tracker to use* belongs there. A specific vendor's exact wording doesn't belong there, and if a workspace uses two trackers, there needs to be somewhere to put the second one's settings.
 
-Stella only recognizes three resolutions: `completed`, `not_planned`, and `duplicate` — these are GitHub's own close reasons. If your tracker offers twenty resolutions, it maps to these three and the rest pass through as-is. You don't need to configure anything to use stella with GitHub: with no config, no `[issues]` section, and no manifest file, everything works with sensible defaults.
+stella only recognizes three resolutions: `completed`, `not_planned`, and `duplicate` — these are GitHub's own close reasons. If your tracker offers twenty resolutions, it maps to these three and the rest pass through as-is. You don't need to configure anything to use stella with GitHub: with no config, no `[issues]` section, and no manifest file, everything works with sensible defaults.
 
 ### deliver
 

--- a/website/content/docs/commands/stats.mdx
+++ b/website/content/docs/commands/stats.mdx
@@ -31,7 +31,7 @@ stella stats prune [--older-than <AGE>] [--max-rows <N>] [--force] [--vacuum] [-
 
 ## Reading the cache columns
 
-Every row also shows three columns about your cache savings. Stella works these out fresh each time you run the command from the raw token counts — it doesn't store them:
+Every row also shows three columns about your cache savings. stella works these out fresh each time you run the command from the raw token counts — it doesn't store them:
 
 <CardGrid size="md">
   <OptionCard name="HIT%">
@@ -113,7 +113,7 @@ stella stats prune --max-rows 5000
     `720h`, `3mo`. A plain number with no letter means days.
   </OptionCard>
   <OptionCard name="--max-rows <N>">
-    Sets the most executions to keep. Stella deletes the oldest ones first, until the
+    Sets the most executions to keep. stella deletes the oldest ones first, until the
     store is at or under this limit.
   </OptionCard>
   <OptionCard name="--dry-run">

--- a/website/content/docs/commands/stats.mdx
+++ b/website/content/docs/commands/stats.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella stats
-description: Summarize cost, tokens, and resolve rate per provider/model from local telemetry.
+description: See cost, tokens, and how often work finished, by provider and model, from your local data.
 ---
 
-Read back what your runs actually cost. `stella stats` summarizes cost, tokens, and resolve rate per provider and model from the local telemetry store — `$/resolved-task` receipts, computed entirely on your machine.
+See what your runs actually cost. `stella stats` shows cost, tokens, and how often work got finished, broken down by provider and model. It reads your local data and works out a cost-per-finished-task number, calculated entirely on your own machine.
 
 ## Synopsis
 
@@ -14,49 +14,51 @@ stella stats prune [--older-than <AGE>] [--max-rows <N>] [--force] [--vacuum] [-
 
 ## What it does
 
-`stella stats` reads `<workspace>/.stella/private/store.db` — the embedded SQLite store every run writes to — and aggregates it per provider/model: total tokens, total cost, and how often work resolved. It makes no network calls and needs no API key; it only reads local telemetry.
+`stella stats` reads `<workspace>/.stella/private/store.db`, a SQLite database that every run writes to. It adds up the numbers for each provider and model: total tokens, total cost, and how often work got finished. This command makes no network calls and needs no API key — it only reads data already on your machine.
 
 ## Flags
 
 <CardGrid size="md">
   <OptionCard name="--format <text|json|csv>" defaultValue="text">
-    Output format. `text` prints aligned columns with a `TOTAL` row (`table` still parses as an alias); `json` (under the versioned query envelope) and `csv`
-    are for piping into other tools.
+    Sets the output format. `text` prints lined-up columns with a `TOTAL` row at the
+    bottom (`table` also works and means the same thing). `json` and `csv` are for
+    piping into other tools. JSON output is wrapped in a versioned envelope.
   </OptionCard>
   <OptionCard name="--provider <id>">
-    Only include executions for this provider id — `zai`, `anthropic`, `local`, and so on.
+    Only shows runs from this provider, such as `zai`, `anthropic`, or `local`.
   </OptionCard>
 </CardGrid>
 
 ## Reading the cache columns
 
-Every row also carries three cache-economics columns, derived at display time from your local telemetry (they aren't stored — `stella stats` computes them fresh from the raw token counts each run):
+Every row also shows three columns about your cache savings. Stella works these out fresh each time you run the command from the raw token counts — it doesn't store them:
 
 <CardGrid size="md">
   <OptionCard name="HIT%">
-    Cache-read tokens over total input tokens for that row — the same figure the deck's
-    `CACHE` statline cell shows for the live session.
+    Cache-read tokens divided by total input tokens for that row. This is the same
+    number the deck's `CACHE` statline shows during a live session.
   </OptionCard>
   <OptionCard name="SAVED ($)">
-    Estimated USD saved by prompt caching, priced at **today's** catalog rates — not the
-    price in effect when each call actually ran. Signed: a negative value means the
-    provider's cache-write premium outran the reads it bought, which is the "the cache
-    never actually helped" incident worth investigating. Shows `-` when the model isn't
-    in the running catalog.
+    The estimated dollars you saved from prompt caching, priced at **today's** rates —
+    not the rate in effect when each call actually happened. This can be negative: a
+    negative number means the provider charged more to write to the cache than it saved
+    you by reading from it, which is worth investigating. Shows `-` when the model
+    isn't in the current price list.
   </OptionCard>
   <OptionCard name="TTL REWRITES">
-    Calls whose cache prefix went cold — the gap since that session's previous call
-    exceeded the provider's cache TTL — and got rewritten instead of read back. `0` for
-    a provider with no documented TTL. This is the tax cache-TTL-aware fleet scheduling
-    exists to cut: a session parked too long between turns pays the write premium again
-    for nothing.
+    Calls whose cache went cold before you used it again — too much time passed since
+    the session's last call, longer than the provider's cache time limit — and got
+    rewritten instead of read back. Shows `0` for a provider with no documented time
+    limit. This is the extra cost that cache-aware fleet scheduling exists to avoid: a
+    session left idle too long between turns pays the cache-write cost again for
+    nothing.
   </OptionCard>
 </CardGrid>
 
-A `0%` `HIT%` across several turns on an opt-in provider (Anthropic, Bedrock, or Claude-via-OpenRouter) with `CACHE WR` also at `0` usually means the opt-in cache marker never reached the wire — check your adapter config before assuming the model just isn't cacheable. If `CACHE WR` is nonzero but `HIT%` stays low, the prompt prefix is likely being rewritten between turns instead of reused.
+If `HIT%` stays at `0%` across several turns on a provider that requires opting in to caching (Anthropic, Bedrock, or Claude through OpenRouter), and `CACHE WR` is also `0`, the cache setting probably never reached the provider — check your adapter config before assuming the model just can't be cached. If `CACHE WR` is nonzero but `HIT%` stays low, your prompt prefix is likely being rewritten between turns instead of reused.
 
 <Callout type="info">
-The deck's statline shows the same `CACHE`/`SAVED`/`WARMTH` cells live per session, and `?` expands `WARMTH` into a countdown to when the lead lane's cached prefix expires. There is no per-agent cache breakdown: the SUB-AGENTS overlay's vitals row carries model, effort and spend.
+The deck's statline shows the same `CACHE`, `SAVED`, and `WARMTH` numbers live, for the current session. Press `?` to expand `WARMTH` into a countdown until the lead lane's cached prefix expires. There's no cache breakdown per agent — the SUB-AGENTS overlay's vitals row shows model, effort, and spend instead.
 </Callout>
 
 ## Examples
@@ -79,7 +81,7 @@ Emit JSON for a dashboard or a jq pipeline:
 stella stats --format json | jq '.rows[] | {model, total_cost_usd, resolve_rate}'
 ```
 
-Find providers/models with a suspiciously low cache hit rate:
+Find providers or models with a suspiciously low cache hit rate:
 
 ```bash
 stella stats --format json | jq '.rows[] | select(.cache_hit_rate < 0.2) | {provider, model, cache_hit_rate, cache_expired_rewrites}'
@@ -89,11 +91,9 @@ stella stats --format json | jq '.rows[] | select(.cache_hit_rate < 0.2) | {prov
 The store is a real SQLite file. Beyond `stella stats` you can query it directly with any SQLite client — see [Telemetry &amp; budget](/docs/telemetry).
 </Callout>
 
-## Bounding the store — `stella stats prune`
+## `stella stats prune`
 
-`store.db` grows monotonically: every run appends executions and everything keyed to
-them — events, telemetry, tool calls, context blocks, receipts. `prune` is the retention
-control.
+`store.db` only ever grows: every run adds new executions, plus everything linked to them — events, telemetry, tool calls, context blocks, and receipts. `prune` controls how much history you keep.
 
 ```bash
 # What would go, without touching anything.
@@ -108,34 +108,37 @@ stella stats prune --max-rows 5000
 
 <CardGrid size="md">
   <OptionCard name="--older-than <AGE>">
-    Drop executions older than this window. `N` followed by `d`, `w`, `h`, `mo`, or `y` —
-    `90d`, `12w`, `720h`, `3mo`. A bare number means days.
+    Deletes executions older than this amount of time. Write a number followed by `d`
+    (days), `w` (weeks), `h` (hours), `mo` (months), or `y` (years) — `90d`, `12w`,
+    `720h`, `3mo`. A plain number with no letter means days.
   </OptionCard>
   <OptionCard name="--max-rows <N>">
-    Hard ceiling on retained executions; the oldest prunable ones are evicted until the
-    store is at or under it.
+    Sets the most executions to keep. Stella deletes the oldest ones first, until the
+    store is at or under this limit.
   </OptionCard>
   <OptionCard name="--dry-run">
-    Report what would be pruned and delete nothing. Worth running first — the deletion
-    cascades to every table keyed to an execution.
+    Shows what would be deleted, without deleting anything. Worth running first — the
+    deletion cascades to every table linked to an execution.
   </OptionCard>
   <OptionCard name="--vacuum">
-    `VACUUM` afterwards, handing freed pages back to the filesystem. Deleting rows alone
-    shrinks the *contents* but not the file. Also runs automatically after a large prune.
+    Runs `VACUUM` after pruning, which returns freed space to your filesystem. Deleting
+    rows alone shrinks what's *inside* the file, but not the file's size on disk. Also
+    runs automatically after a large prune.
   </OptionCard>
   <OptionCard name="--force">
-    Also drop executions whose telemetry has not replicated into the usage hub. This
-    permanently loses that cost data — off by default.
+    Also deletes executions whose telemetry hasn't reached the usage hub yet. This
+    permanently loses that cost data. Off by default.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-Prune is **replication-safe by default**: an execution whose telemetry has not yet
-reached the usage hub is never dropped, so a prune run before a sync cannot silently
-destroy cost data you are still billing against. `--force` is the deliberate override,
-and it is irreversible.
+By default, prune is **safe for replication**: an execution whose telemetry hasn't
+reached the usage hub yet is never deleted, so running prune before a sync can't
+silently destroy cost data you're still billing against. `--force` turns this safety
+off on purpose, and it can't be undone.
 </Callout>
 
-The same flags are also mounted as [`stella storage prune`](/docs/commands/storage#stella-storage-prune) —
-one implementation with two entry points, so store retention is discoverable both from
-where you notice the store is too big and from where the rest of the store verbs live.
+These same flags are also available as [`stella storage prune`](/docs/commands/storage#stella-storage-prune) —
+the same feature under a second name, so you can find store retention either from
+where you noticed the store getting too big, or from where the other storage commands
+live.

--- a/website/content/docs/commands/storage.mdx
+++ b/website/content/docs/commands/storage.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella storage
-description: Inspect the storage map — every layer, namespace, relation, and field, with intent and boundaries from stella.storage.toml — and bound the store's growth.
+description: See every storage layer, namespace, table, and field in your workspace, with its purpose, and control how much history your store keeps.
 ---
 
-`stella storage` inspects the **storage map**: every storage layer, namespace, relation, and field in your workspace, annotated with intent and boundaries from `stella.storage.toml`. It reads the local index built by [`stella init`](/docs/commands/init) (`.stella/private/codegraph.db`) plus the manifest, so it is fully offline and needs no API key. One verb — `prune` — also does the store's retention housekeeping.
+`stella storage` shows the **storage map**: every storage layer, namespace, relation, and field in your workspace, along with its purpose and limits, taken from `stella.storage.toml`. It reads the local index that [`stella init`](/docs/commands/init) builds (`.stella/private/codegraph.db`), plus that manifest file, so it works fully offline and needs no API key. One command, `prune`, also manages how much history your store keeps.
 
 ## Synopsis
 
@@ -17,26 +17,28 @@ stella storage prune [--older-than <AGE>] [--max-rows <N>] [--force] [--vacuum] 
 
 ## What it does
 
-The storage map is stella's vendor-agnostic index of where your data lives — SQL tables, key-value namespaces, document collections, and their fields — so the agent (and you) can reason about persistence without re-deriving the schema every time. It is the zero-drift companion to [`stella search`](/docs/commands/search): search answers "who calls what," the storage map answers "what is stored where, and what does it mean."
+The storage map is stella's index of where your data actually lives: SQL tables, key-value namespaces, document collections, and their fields. It works the same way no matter what database or storage system you use, so the agent (and you) can understand how data is stored without re-reading the schema every time. It pairs with [`stella search`](/docs/commands/search): search answers "who calls what," and the storage map answers "what is stored where, and what does it mean."
 
 <CardGrid size="md">
   <OptionCard name="tree">
-    The full map — `layer → namespace → relation` tree, each with its declared intent.
+    The whole map, as a tree: `layer → namespace → relation`. Each one shows its
+    stated purpose.
   </OptionCard>
   <OptionCard name="show <address>">
-    One relation's card: fields, constraints, meaning, and provenance. Accepts a
-    `store://` address, a bare address, or a relation name.
+    Details for one relation: its fields, constraints, meaning, and where that
+    information came from. Accepts a `store://` address, a plain address, or just the
+    relation's name.
   </OptionCard>
   <OptionCard name="grep <name>">
-    Every relation and field whose normalized name contains the query.
+    Every relation and field whose name contains your search text.
   </OptionCard>
   <OptionCard name="drift">
-    A report-only drift check: near-duplicate relations, orphaned manifest meanings, and
-    intent coverage. Changes nothing.
+    Checks for problems without changing anything: near-duplicate relations, manifest
+    entries with no matching relation, and how much of your data has a stated purpose.
   </OptionCard>
   <OptionCard name="prune">
-    The one verb here that writes. Bounds `store.db`'s growth by dropping whole
-    executions and every row keyed to them — see [below](#stella-storage-prune).
+    The only command here that changes anything. It limits how big `store.db` gets by
+    deleting whole executions and every row linked to them — see [below](#stella-storage-prune).
   </OptionCard>
 </CardGrid>
 
@@ -48,18 +50,17 @@ stella storage drift
 ```
 
 <Callout type="info">
-The map is only as current as the last [`stella init`](/docs/commands/init). Intent and boundaries come from `stella.storage.toml`; `stella storage drift` tells you where that manifest has fallen behind the code.
+The map is only as up to date as your last [`stella init`](/docs/commands/init) run. Purpose and limits come from `stella.storage.toml`; run `stella storage drift` to see where that file has fallen behind your actual code.
 </Callout>
 
 ### stella storage prune
 
-Bound the growth of this workspace's session store, `<workspace>/.stella/private/store.db`
-— dropping whole executions past `--older-than` and `--max-rows`, along with every row
-keyed to them. It is the same implementation as
-[`stella stats prune`](/docs/commands/stats#bounding-the-store--stella-stats-prune) mounted
-at a second entry point: one `PruneArgs`, the same five flags, the same engine, so store
-retention is reachable both from where you notice the store is too big and from where the
-rest of the store verbs live.
+Limits the size of this workspace's session store, `<workspace>/.stella/private/store.db`,
+by deleting whole executions past `--older-than` and `--max-rows`, along with every row
+linked to them. This is the exact same feature as
+[`stella stats prune`](/docs/commands/stats#stella-stats-prune),
+just available under a second name — same five flags, same engine, so you can manage
+store retention from wherever you happen to be looking.
 
 ```bash
 # What would go, without touching anything.
@@ -74,27 +75,27 @@ stella storage prune --max-rows 5000
 
 <CardGrid size="sm">
   <OptionCard name="--older-than <AGE>">
-    Drop executions older than this window — `90d`, `12w`, `720h`, `3mo`.
+    Deletes executions older than this amount of time — `90d`, `12w`, `720h`, `3mo`.
   </OptionCard>
   <OptionCard name="--max-rows <N>">
-    Hard ceiling on retained executions.
+    The most executions to keep.
   </OptionCard>
   <OptionCard name="--dry-run">
-    Report what would be pruned and delete nothing.
+    Shows what would be deleted. Deletes nothing.
   </OptionCard>
   <OptionCard name="--vacuum">
-    `VACUUM` afterwards, handing freed pages back to the filesystem.
+    Runs `VACUUM` afterward, returning freed space to your filesystem.
   </OptionCard>
   <OptionCard name="--force">
-    Also drop executions whose telemetry has not reached the usage hub. Irreversible.
+    Also deletes executions whose telemetry hasn't reached the usage hub yet.
+    Irreversible.
   </OptionCard>
 </CardGrid>
 
-Each flag is documented in full — units, the replication-safety guarantee, and what
-`--force` actually costs you — on
-[`stella stats prune`](/docs/commands/stats#bounding-the-store--stella-stats-prune).
+Every flag is explained in full, including units, the replication-safety guarantee,
+and what `--force` actually costs you, on
+[`stella stats prune`](/docs/commands/stats#stella-stats-prune).
 
 <Callout type="warn">
-Unlike the other `stella storage` verbs, `prune` is not a read. It deletes rows from
-`store.db`, and only `--dry-run` makes it safe to run without thinking first.
+Unlike the other `stella storage` commands, `prune` does not just read data. It deletes rows from `store.db`, and only `--dry-run` makes it safe to run without thinking first.
 </Callout>

--- a/website/content/docs/commands/telemetry.mdx
+++ b/website/content/docs/commands/telemetry.mdx
@@ -1,16 +1,16 @@
 ---
 title: stella telemetry
-description: Inspect, flush, or explicitly discard the managed Oxagen Enterprise operational spool. Disabled by default; requires a signed org-managed enrollment.
+description: Check, send, or delete the managed Oxagen Enterprise data queue. Off by default; needs a signed org enrollment to turn on.
 ---
 
-`stella telemetry` is the operator surface on the **managed Oxagen Enterprise operational spool** — the durable, owner-only queue that holds content-free execution rollups awaiting delivery to an org intake.
+`stella telemetry` controls the **managed Oxagen Enterprise operational spool**. This is a queue on your machine that holds content-free summaries of your runs, waiting to be sent to your organization.
 
-It is **disabled by default**. Without a signed org-managed enrollment every subcommand prints `enterprise telemetry: disabled (no managed enrollment)` and exits successfully, having performed no network I/O and constructed no HTTP client.
+It is **off by default**. If your machine has not been signed up through a managed org enrollment, every subcommand just prints `enterprise telemetry: disabled (no managed enrollment)` and exits with success. It makes no network calls and does not even build an HTTP client.
 
 <Callout type="info">
-For the boundary itself — what the managed export may contain, what it structurally cannot, how enrollment is provisioned and verified — see [Enterprise telemetry](/docs/telemetry#oxagen-enterprise-managed-export). This page is the command reference.
+To learn what the managed export can and cannot contain, and how enrollment works, see [Enterprise telemetry](/docs/telemetry#oxagen-enterprise-managed-export). This page only covers the command itself.
 
-Nothing here concerns your **local** telemetry. That lives in `.stella/private/store.db`, never leaves the machine on its own, and is read by [`stella stats`](/docs/commands/stats) and the [Observatory](/docs/commands/observe).
+This page is not about your **local** telemetry. That data lives in `.stella/private/store.db`. It never leaves your machine on its own. You can read it with [`stella stats`](/docs/commands/stats) or the [Observatory](/docs/commands/observe).
 </Callout>
 
 ## Synopsis
@@ -19,104 +19,106 @@ Nothing here concerns your **local** telemetry. That lives in `.stella/private/s
 stella telemetry <status|flush|rollover-discard>
 ```
 
-All three need **no model provider and no API key** — managed operational export is independent of your model configuration.
+None of the three subcommands need a model provider or an API key. Managed export works independently of your model setup.
 
 ## Subcommands
 
 ### `stella telemetry status`
 
-Show enrollment state, what is queued, and every durable loss counter.
+Shows whether you are enrolled, what is queued, and every loss counter.
 
 ```bash
 stella telemetry status
 ```
 
-Unenrolled, it reports exactly that. Enrolled, it prints one line covering:
+If you are not enrolled, it says so. If you are enrolled, it prints one line covering:
 
 <CardGrid size="md">
   <OptionCard name="pending">
-    Rows and payload bytes queued for the **active** sink and awaiting delivery.
+    Rows and bytes waiting to be sent to the **current** sink.
   </OptionCard>
   <OptionCard name="stranded">
-    Rows and bytes belonging to a **superseded** sink fingerprint. They will never be
-    delivered to the new sink — see [rollover](#rollover-is-not-delivery) below.
+    Rows and bytes left over from an **old** sink. These will never be sent to the new
+    sink. See [rollover is not delivery](#rollover-is-not-delivery) below.
   </OptionCard>
   <OptionCard name="quarantine">
-    Rows quarantined as undecodable, with the diagnostic metadata bytes retained for them.
+    Rows that could not be read. Stella keeps some diagnostic details about them.
   </OptionCard>
   <OptionCard name="ledger_skipped">
-    Export-ledger rows skipped, broken out by cause: `missing_rollup`, `malformed_nonce`,
+    Rows skipped from the export ledger, split by reason: `missing_rollup`, `malformed_nonce`,
     `malformed_rollup`.
   </OptionCard>
   <OptionCard name="physical">
-    On-disk size of the spool database. Reported **separately** from payload bytes because
-    SQLite pages, indexes, WAL/SHM, and quarantine metadata all make the file larger than the
-    payload bound.
+    How big the spool file is on disk. This is reported separately from the payload size
+    because SQLite's own overhead (pages, indexes, WAL/SHM files, quarantine data) makes
+    the file bigger than the data it holds.
   </OptionCard>
   <OptionCard name="dropped / corrupt_dropped / rollover_discarded">
-    The three cumulative loss counters — capacity eviction, corruption, and explicit rollover
-    discard. Each is durable and monotonic.
+    Three running counts of lost rows: rows dropped for running out of space, rows dropped
+    for being corrupt, and rows discarded on purpose during a rollover. Each count only
+    ever goes up.
   </OptionCard>
 </CardGrid>
 
-Invalid or expired managed configuration **fails with a diagnostic** rather than reporting an enrolled state. A seat that has silently stopped exporting is the failure this command exists to make visible.
+If your enrollment is invalid or expired, the command **fails with a clear error** instead of pretending you are still enrolled. This command exists partly to catch a seat that has quietly stopped sending data.
 
 <Callout type="info">
-The loss counters are the reason `status` is worth reading rather than glancing at. Pending going to zero can mean "everything was delivered" or "everything was evicted" — only `dropped`, `corrupt_dropped`, and `rollover_discarded` distinguish the two.
+The loss counters are why you should read the full `status` output, not just glance at it. A `pending` count of zero can mean "everything was delivered" or "everything was lost." Only `dropped`, `corrupt_dropped`, and `rollover_discarded` tell you which one happened.
 </Callout>
 
 ### `stella telemetry flush`
 
-Attempt **one bounded delivery batch right now**, then report what moved.
+Tries to send **one batch of data right now**, then reports what happened.
 
 ```bash
 stella telemetry flush
 ```
 
-Prints the number sent, plus the resulting pending and dropped counts. The batch is bounded on every axis:
+It prints how many rows were sent, plus the pending and dropped counts afterward. Every batch has limits:
 
 <CardGrid size="sm">
   <OptionCard name="≤ 50 events">
-    The per-batch event ceiling.
+    The most events allowed in one batch.
   </OptionCard>
   <OptionCard name="≤ 256 KiB">
-    The per-request payload ceiling.
+    The most data allowed in one request.
   </OptionCard>
   <OptionCard name="30-second lease">
-    Rows are leased, not removed. A crashed flush releases them rather than losing them.
+    Rows are checked out, not deleted right away. If the flush crashes, the rows go back in
+    the queue instead of being lost.
   </OptionCard>
 </CardGrid>
 
-Delivery is **at least once and sink-scoped**: rows are acknowledged only after a successful HTTPS response, and redirects are refused. A credential, transport, or server failure releases the *exact* lease with capped exponential backoff plus jitter — from one second up to five minutes, with jitter capped at 25%.
+Delivery is **at least once**, and each row only goes to the sink it belongs to. A row is only marked as sent after a successful HTTPS response, and redirects are never followed. If sending fails for any reason (bad credentials, network trouble, server error), the row goes back in the queue and stella waits before trying again. The wait grows each time, from one second up to five minutes, with some randomness added (up to 25%) so retries do not pile up all at once.
 
 <Callout type="info">
-stella already starts a detached best-effort flush after enrollment is verified at process startup. That attempt never delays agent execution and is not waited on at shutdown. Use explicit `flush` when an operator needs a **synchronous** delivery attempt — before host maintenance, or to confirm an intake change took effect.
+Stella already starts a quiet, best-effort flush on its own right after your enrollment is verified when it starts up. That attempt never slows down the agent, and stella does not wait for it to finish before shutting down. Run `flush` yourself when you need a delivery attempt that finishes before you move on, for example before taking a machine down for maintenance, or to check that a change to your org's intake worked.
 </Callout>
 
 ### `stella telemetry rollover-discard`
 
-Explicitly and permanently discard rows bound to a **superseded** sink fingerprint.
+Permanently deletes rows left over from an **old** sink.
 
 ```bash
 stella telemetry rollover-discard
 ```
 
 <Callout type="warn">
-This is the one **destructive** subcommand. It deletes stranded rows outright and increments the durable `rollover_discarded` counter by the number removed. There is no undo, and the rows were never delivered anywhere.
+This is the only **destructive** subcommand. It deletes the leftover rows for good and adds their count to the `rollover_discarded` total. There is no undo, and these rows were never delivered anywhere.
 </Callout>
 
 #### Rollover is not delivery
 
-When the signed sink fingerprint changes, rows queued for the old sink are **not** re-pointed at the new one. Sending an org's rows to a sink it did not sign for would be a silent re-routing of its telemetry, so those rows become *stranded* instead. They stay stranded until either the old enrollment is restored — at which point they deliver normally — or an administrator runs this command.
+When your organization's sink changes, rows that were queued for the old sink are **not** automatically moved to the new one. Sending an organization's data to a sink it never approved would quietly reroute that data, so instead those rows become *stranded*. They stay stranded until you either restore the old enrollment, at which point they deliver as normal, or run `rollover-discard` to remove them.
 
-The discard is explicit and counted. Capacity eviction, corruption, and rollover loss each keep their own durable counter precisely so that none of them can be mistaken for successful delivery.
+Deleting stranded rows is always something you choose to do, and it is always counted. Rows lost to running out of space, rows lost to corruption, and rows lost to a rollover each get their own counter, so none of them can be mistaken for a successful delivery.
 
 ## Exit behavior
 
-Being unenrolled is **not** an error: all three subcommands print the disabled line and exit `0`. That keeps the command safe to call unconditionally from an operator script without branching on whether a given host holds a seat. A *malformed or expired* enrollment, by contrast, is an error — the distinction is between "this host has no seat" and "this host has a seat that no longer works."
+Not being enrolled is **not an error**. All three subcommands print the disabled message and exit with code `0`. That makes it safe to call this command from a script on any machine, whether or not it has a seat. A **broken or expired** enrollment is different: that is an error. The difference is between "this machine has no seat" and "this machine has a seat that stopped working."
 
 ## See also
 
-- [Enterprise telemetry boundary](/docs/telemetry#oxagen-enterprise-managed-export) — enrollment, the exported envelope, and what it structurally cannot contain.
-- [`stella stats`](/docs/commands/stats) — your local, non-managed cost and token metering.
-- [`stella cloud`](/docs/commands/cloud) — the separate `drain` pipe, with its own wire contract and endpoint.
+- [Enterprise telemetry boundary](/docs/telemetry#oxagen-enterprise-managed-export) — what enrollment does, what gets exported, and what it can never contain.
+- [`stella stats`](/docs/commands/stats) — your local, unmanaged cost and token numbers.
+- [`stella cloud`](/docs/commands/cloud) — the separate `drain` pipe, with its own format and endpoint.

--- a/website/content/docs/commands/telemetry.mdx
+++ b/website/content/docs/commands/telemetry.mdx
@@ -42,7 +42,7 @@ If you are not enrolled, it says so. If you are enrolled, it prints one line cov
     sink. See [rollover is not delivery](#rollover-is-not-delivery) below.
   </OptionCard>
   <OptionCard name="quarantine">
-    Rows that could not be read. Stella keeps some diagnostic details about them.
+    Rows that could not be read. stella keeps some diagnostic details about them.
   </OptionCard>
   <OptionCard name="ledger_skipped">
     Rows skipped from the export ledger, split by reason: `missing_rollup`, `malformed_nonce`,
@@ -92,7 +92,7 @@ It prints how many rows were sent, plus the pending and dropped counts afterward
 Delivery is **at least once**, and each row only goes to the sink it belongs to. A row is only marked as sent after a successful HTTPS response, and redirects are never followed. If sending fails for any reason (bad credentials, network trouble, server error), the row goes back in the queue and stella waits before trying again. The wait grows each time, from one second up to five minutes, with some randomness added (up to 25%) so retries do not pile up all at once.
 
 <Callout type="info">
-Stella already starts a quiet, best-effort flush on its own right after your enrollment is verified when it starts up. That attempt never slows down the agent, and stella does not wait for it to finish before shutting down. Run `flush` yourself when you need a delivery attempt that finishes before you move on, for example before taking a machine down for maintenance, or to check that a change to your org's intake worked.
+stella already starts a quiet, best-effort flush on its own right after your enrollment is verified when it starts up. That attempt never slows down the agent, and stella does not wait for it to finish before shutting down. Run `flush` yourself when you need a delivery attempt that finishes before you move on, for example before taking a machine down for maintenance, or to check that a change to your org's intake worked.
 </Callout>
 
 ### `stella telemetry rollover-discard`

--- a/website/content/docs/commands/tools.mdx
+++ b/website/content/docs/commands/tools.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella tools
-description: List every tool available to the agent this session — built-in tools, custom tools from .stella/tools/ manifests, and a --validate check for both.
+description: List every tool the agent can use this session, including built-in tools and custom tools from .stella/tools/, plus a --validate check for both.
 ---
 
-List every tool available to the agent for the current session — built-in tools, developer custom tools, and manifest diagnostics.
+Lists every tool the agent can use in the current session: built-in tools, custom tools you've added, and a check for any problems with them.
 
 ## Synopsis
 
@@ -14,45 +14,47 @@ stella tools [--validate [DIR]] [--adopt NAME] [--enable NAME]
 
 ## What it does
 
-`stella tools` prints the set of tools the agent can call this session:
+`stella tools` prints the tools the agent can call this session.
 
-- **Built-in tools** — the always-available and conditionally-registered tools. See the full [Built-in Tools](/docs/agent-tools) catalog for names and read-only/mutating flags.
-- **Developer custom tools** — loaded from `<name>.toml` manifests.
+- **Built-in tools** — always-available tools, plus a few that only show up in certain conditions. See the full [Built-in Tools](/docs/agent-tools) catalog for names and whether each one is read-only or can make changes.
+- **Custom tools you've added** — loaded from `<name>.toml` manifest files.
 
-Custom tools come from a `<name>.toml` manifest dropped in `<workspace>/.stella/tools/` (workspace-scoped) or `~/.stella/tools/` (user-global). On a name collision, the workspace copy wins.
+Custom tools come from a `<name>.toml` manifest placed in `<workspace>/.stella/tools/` (just for this project) or `~/.stella/tools/` (for all your projects). If a project tool and a global tool share a name, the project one wins.
 
 <Callout type="info">
-`stella tools` does **not** enumerate MCP tools — it prints a note that servers configured in `.stella/mcp.toml` merge more tools at session start. Use [`stella mcp list`](/docs/commands/mcp) to see configured MCP servers.
+`stella tools` does **not** list MCP tools. It just notes that any servers set up in `.stella/mcp.toml` add more tools when a session starts. Use [`stella mcp list`](/docs/commands/mcp) to see your configured MCP servers.
 </Callout>
 
 ## Flags
 
 <CardGrid size="md">
   <OptionCard name="--validate [DIR]">
-    Strict pre-flight check of custom-tool manifests instead of listing. Parses every
-    `<name>.toml` in `.stella/tools/` and `~/.stella/tools/` — or in the given `DIR` —
-    reports errors, warnings, and info per manifest, and exits non-zero if any manifest
-    has errors.
+    Checks your custom-tool manifests instead of listing tools. Reads every `<name>.toml`
+    file in `.stella/tools/` and `~/.stella/tools/`, or in the folder you give it, and
+    reports errors, warnings, and other notes for each one. Exits with an error code if any
+    manifest has a real error.
   </OptionCard>
   <OptionCard name="--adopt NAME">
-    Move a staged tool into `.stella/tools/` and run its **capability witness**: the same
-    call must fail on the existing tool surface and succeed with the new tool, producing a
-    real value. Records the proof. The tool stays **disabled**.
+    Moves a staged tool into `.stella/tools/` and runs its **capability witness**: a test
+    that must fail using the tools you already had, and succeed once the new tool is used,
+    producing a real result. The test result is saved. The tool stays **turned off** until
+    you enable it.
   </OptionCard>
   <OptionCard name="--enable NAME">
-    Approve an adopted tool, so the model is offered it. Refused if the manifest or script
-    changed since the witness ran.
+    Turns on an adopted tool so the model can use it. Refuses to enable it if the manifest
+    or script changed since the test ran.
   </OptionCard>
   <OptionCard name="--disable NAME">
-    Stop offering an adopted tool, keeping its proof on file.
+    Turns off an adopted tool. Its saved test result is kept.
   </OptionCard>
   <OptionCard name="--foundry">
-    Report every self-authored tool: its witness, whether it is enabled, and how often it
-    has been reused since adoption — including the ones never used.
+    Lists every tool you've built yourself: whether its test passed, whether it's turned
+    on, and how many times it has been used since you adopted it, including ones never used
+    at all.
   </OptionCard>
 </CardGrid>
 
-`stella tools` otherwise takes the [global flags](/docs/commands); model selection rarely matters for this diagnostic command.
+`stella tools` also accepts the [global flags](/docs/commands). Which model you're using rarely matters for this command, since it's just a diagnostic.
 
 ## Examples
 
@@ -62,85 +64,82 @@ List the tools available this session:
 stella tools
 ```
 
-Validate custom-tool manifests in CI (non-zero exit on any error):
+Check your custom-tool manifests in CI, and fail if any have errors:
 
 ```bash
 stella tools --validate
 ```
 
-Validate one directory of manifests before installing them:
+Check one folder of manifests before you install them:
 
 ```bash
 stella tools --validate ./contrib/stella-tools
 ```
 
-Take a staged tool all the way to a usable one:
+Take a staged tool all the way to something you can use:
 
 ```bash
-# Stage the pair by hand under .stella/tools/proposed/, where discovery
-# cannot see it: jq.toml (with a [foundry] table) + jq.sh.
+# Place the manifest and script by hand under .stella/tools/proposed/, where
+# stella won't see them yet: jq.toml (with a [foundry] table) + jq.sh.
 stella tools --validate .stella/tools/proposed
-stella tools --adopt jq          # run its witness; records the proof, stays disabled
-stella tools --enable jq         # the one human approval — prints what it grants and asks
-stella tools --foundry           # what was adopted, and what it has been worth
+stella tools --adopt jq          # run the test; saves the result, tool stays off
+stella tools --enable jq         # the one human approval step; shows what it grants, then asks
+stella tools --foundry           # what was adopted, and how useful it has been
 ```
 
 <Callout type="warn">
-  **`--enable` asks, and refuses when nobody can answer.** It prints the script
-  the model would run, the witness on file, and what that witness does *not*
-  establish, then waits for a `y`. With no terminal attached it refuses rather
-  than proceeding — otherwise an agent holding the `bash` tool could stage,
-  adopt and enable its own tool inside one turn, and "the approval a machine
-  never grants itself" would be enforced only by the habit that a CLI
-  invocation comes from a person. Pass `--yes` for a provisioning script, where
-  granting it is something somebody wrote down.
+  **`--enable` always asks, and refuses if nobody can answer.** It shows the script the
+  model would run, the saved test result, and what that test does *not* prove, then waits
+  for you to type `y`. If there's no terminal attached, it refuses instead of going ahead.
+  Without this check, an agent with the `bash` tool could stage, adopt, and enable its own
+  tool in a single turn, and the rule that "a machine never approves its own tool" would
+  only hold because someone happened to be typing at a terminal. Pass `--yes` when you're
+  running this from a provisioning script where someone has already signed off on it in
+  writing.
 
-  `--disable` asks nobody: withdrawing the authority must never be blocked by
-  the absence of a terminal.
+  `--disable` never asks. Turning a tool off must never be blocked just because there's no
+  terminal available.
 </Callout>
 
 ## Self-authored tools
 
-A self-authored tool is a manifest + script pair staged under
-`.stella/tools/proposed/`, where tool discovery cannot see it, and promoted from
-there by the `--adopt` → `--enable` sequence above. Write the script so every
-parameter is a quoted `"$STELLA_INPUT_*"` reference, so parameter values stay
-data rather than shell syntax.
+A self-authored tool is a manifest and script you write yourself and place under
+`.stella/tools/proposed/`, where stella's normal tool discovery cannot see it. From there,
+you move it through the `--adopt` then `--enable` steps above. Write the script so every
+parameter is a quoted `"$STELLA_INPUT_*"` reference. That keeps each value treated as plain
+data, not as shell code.
 
 <Callout type="warn">
-  **Staging is manual.** The gap detector that mines candidate shapes from recent
-  `bash` receipts ships in `stella-core`, and its only shipped consumer is the
-  offline `make replay-learning` report — no live session mines proposals. A pass
-  that rendered one candidate into a manifest + script pair also shipped, was never
-  called by anything, and was retired in
-  [#3629](https://github.com/macanderson/stella/issues/3629). So you write the pair
-  yourself; `--adopt` onwards is fully wired and is what the rest of this section
-  describes.
+  **You write the staged tool yourself.** There is no automatic step that scans your past
+  commands and writes a manifest for you. You create the `.toml` manifest and script by
+  hand, and everything from `--adopt` onward works exactly as described in this section.
 </Callout>
 
-What the detector reports is a shape that is genuinely *reused*: it must recur across
-at least two distinct argument sets, each of them retyped about three times over. A
-command whose arguments are different every single time — `sed -n '<expr>' <file>`
-across a thousand files — is the shell, not a tool. Proposals rank most-reused-first,
-not most-run-first.
+A useful custom tool covers a command shape you actually reuse: the same basic call with
+different arguments, used at least a couple of times with each set of arguments. A command
+where the arguments are different every single time, like running `sed` with a one-off
+expression across a thousand different files, isn't really a reusable tool. It's just you
+using the shell.
 
-A staged tool carries a `[foundry]` table, and a manifest carrying one registers only
-while **all three** of these hold:
+A staged tool includes a `[foundry]` table, but a manifest with one only actually registers
+once **all three** of these are true:
 
-1. it was **adopted** — its capability witness flipped;
-2. a human **enabled** it;
-3. the manifest and script still hold the exact bytes the witness ran against.
+1. it was **adopted** — its test passed;
+2. a person **enabled** it;
+3. the manifest and script still have the exact same bytes the test ran against.
 
-So moving a staged manifest into `.stella/tools/` by hand grants nothing, and editing an
-approved tool's script revokes its approval rather than inheriting it. Every withheld tool
-is reported by name and reason in `stella tools`, so a missing tool is never silent.
+So copying a staged manifest into `.stella/tools/` by hand does not grant anything on its
+own, and editing an approved tool's script cancels its approval rather than carrying it
+over. Every tool that gets held back is listed by name and reason in `stella tools`, so a
+missing tool is never a mystery.
 
 <Callout type="info">
-The witness is a fail→pass flip, not a smoke test. The call must fail on the tool surface
-you have today, succeed with the new tool, and assert on a value the tool really produced.
-A tool that answers in both worlds is a synonym for something you already had; one that
-prints nothing, or only echoes its own argument, proves nothing and is refused.
+The test is a fail-then-pass check, not a smoke test. The same call must fail using the
+tools you already had, succeed with the new tool, and check a real result the tool
+produced. A tool that works either way is just a different name for something you already
+had. A tool that prints nothing, or only repeats its own input back, proves nothing and is
+rejected.
 </Callout>
 
-Hand-written manifests are untouched by any of this — dropping your own `<name>.toml` in
-`.stella/tools/` works exactly as it always has.
+None of this affects manifests you write by hand. Dropping your own `<name>.toml` straight
+into `.stella/tools/` still works exactly like it always has.

--- a/website/content/docs/commands/tune.mdx
+++ b/website/content/docs/commands/tune.mdx
@@ -1,11 +1,11 @@
 ---
 title: stella tune
-description: Eval-driven self-tuning of stella's own policy — A/B one knob over two loop-bench runs, promote the winner only when it confidently wins, or roll it back.
+description: Test one setting against another over two loop-bench runs, then apply the winner only if it clearly wins, or roll it back.
 ---
 
-`stella tune` is how stella's own policy gets tuned by evidence instead of taste. It A/B tests one knob over two [loop-bench](https://github.com/macanderson/stella/tree/main/bench/loop-bench) runs, scores each arm from the per-trial rewards, and promotes the candidate **only** when it confidently beats the baseline — with a reversible rollback record either way.
+`stella tune` tunes stella's own settings using evidence instead of a gut feeling. It runs an A/B test on one setting over two [loop-bench](https://github.com/macanderson/stella/tree/main/bench/loop-bench) runs, scores each side using the reward from every trial, and applies the winning setting **only** when it clearly beats the current one. Either way, it saves a record so you can undo the change.
 
-The first knob is the worker's reasoning effort. Offline: reads two result files and the local ledger, writes settings only on `--promote`. No provider, no API key.
+The first setting you can tune this way is the worker's reasoning effort. This command works offline: it reads two result files and your local record of past tests, and only writes new settings when you pass `--promote`. It needs no model provider and no API key.
 
 ## Synopsis
 
@@ -19,56 +19,58 @@ stella tune status
 
 ## What it does
 
-Most "tuning" of an agent is somebody changing a default because a run felt better. That is unfalsifiable. The flow here is boring: run a fixed held-out task list twice, once per arm, and let the numbers decide.
+Most "tuning" of an agent is someone changing a default because one run felt better. That is not something you can prove one way or the other. This command works differently: run the same set of tasks twice, once per setting, and let the numbers decide.
 
 ```bash
-# 1. Run the held-out task list at each effort, capturing --json
+# 1. Run the same task list at each effort level, saving --json output
 loop-bench --json > base.json      # worker effort: medium
 loop-bench --json > cand.json      # worker effort: high
 
-# 2. Score the arms — reports only, changes nothing
+# 2. Score the two runs — this only reports, it changes nothing
 stella tune effort --baseline base.json --candidate cand.json
 
-# 3. Apply the winner, with a rollback record
+# 3. Apply the winner, with a record you can undo later
 stella tune effort --baseline base.json --candidate cand.json --promote
 ```
 
 ### `stella tune effort`
 
-A/B the worker reasoning-effort knob over two loop-bench `--json` result files and select the winner.
+Compares the worker reasoning-effort setting across two loop-bench `--json` result files and picks the winner.
 
 <CardGrid size="md">
   <OptionCard name="--baseline <file>" required>
-    loop-bench `--json` output for the baseline arm.
+    loop-bench `--json` output for the current setting.
   </OptionCard>
   <OptionCard name="--candidate <file>" required>
-    loop-bench `--json` output for the candidate arm.
+    loop-bench `--json` output for the setting you're testing.
   </OptionCard>
   <OptionCard name="--baseline-effort <effort>" defaultValue="medium">
-    The worker effort the baseline arm ran at.
+    The worker effort level used for the baseline run.
   </OptionCard>
   <OptionCard name="--candidate-effort <effort>" defaultValue="high">
-    The worker effort the candidate arm ran at.
+    The worker effort level used for the candidate run.
   </OptionCard>
   <OptionCard name="--promote" defaultValue="off">
-    Apply the winner to settings. Omitted, the command reports and records the A/B receipt but
-    changes nothing.
+    Applies the winner to your settings. Leave this off and the command just reports the
+    result and saves a record of the comparison, without changing anything.
   </OptionCard>
   <OptionCard name="--scope <project|user>" defaultValue="project">
-    Which settings scope to write on `--promote`.
+    Which settings scope to write to when you use `--promote`.
   </OptionCard>
   <OptionCard name="--min-samples <n>" defaultValue="5">
-    Minimum trials required in **every** arm before any promotion is allowed.
+    The minimum number of trials required in **each** run before stella will let you
+    promote a winner.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-`--min-samples` is a floor on promotion, not on reporting. A two-trial A/B still prints its comparison — it just cannot move your settings on the strength of it.
+`--min-samples` only limits promotion, not reporting. A test with just two trials on each
+side still prints its comparison. It just won't be allowed to change your settings.
 </Callout>
 
 ### `stella tune rollback`
 
-Revert the last effort promotion, restoring the prior worker effort. Every promotion writes the record that makes this possible, so a tuning decision is never one-way.
+Undoes the last effort change, restoring the worker effort setting you had before. Every promotion saves the record needed to undo it, so a tuning decision is never permanent.
 
 ```bash
 stella tune rollback
@@ -76,32 +78,32 @@ stella tune rollback
 
 ### `stella tune status`
 
-Show the self-tuning ledger — the experiments that have run, and the promotion currently in effect.
+Shows your tuning history: every test that has run, and which setting is active right now.
 
 ```bash
 stella tune status
 ```
 
-## Why promotion is conservative
+## Why promotion is cautious
 
-A/B testing an agent is noisy: the same task list at the same settings does not return the same reward twice. Promoting on a bare mean would ratchet the configuration around on noise, and every such move is invisible to you afterward. So promotion requires the candidate to *confidently* win, `--min-samples` sets a hard floor under both arms, and the write is recorded with a rollback — the three things that make an automatic policy change safe to leave switched on.
+A/B testing an agent is noisy. The same tasks with the same settings will not return the exact same reward score twice. If stella promoted a setting based on a simple average, your settings would drift around based on noise, and you would never see it happen. So a promotion only happens when the candidate **clearly** wins, `--min-samples` sets a hard minimum number of trials on both sides, and every change is saved with a way to undo it. Those three rules are what make it safe to leave this feature turned on.
 
 <Callout type="warn">
-`--promote` writes to your `settings.json` at the chosen scope, and it reports the prior value so you can see what it displaced. Run without it first and read the comparison; the receipt is recorded either way, so nothing is lost by looking.
+`--promote` writes to your `settings.json` at the scope you chose, and it shows you the old value it replaced. Run the command without `--promote` first and read the comparison. Either way, the record is saved, so looking first costs you nothing.
 </Callout>
 
-One promotion side effect is worth knowing: if `effort_auto` was on, promoting **turns it off**, because an automatic effort selector would otherwise override the pinned value the A/B just chose. `stella tune rollback` restores both the prior effort *and* `effort_auto`, so the pair is reverted together rather than leaving you pinned with the selector still disabled.
+One side effect is worth knowing about: if `effort_auto` was turned on, promoting a result **turns it off**. Otherwise the automatic effort selector would just override the value the A/B test just chose. `stella tune rollback` restores both the old effort level *and* the old `effort_auto` setting together, so you never end up stuck with the old value but the selector still disabled.
 
 ## Related
 
 <CardGrid size="sm">
   <SpecCard title="settings.json" href="/docs/configuration/settings">
-    Every key `--promote` can write, and how project and user scope resolve.
+    Every key `--promote` can write, and how project and user scope are resolved.
   </SpecCard>
   <SpecCard title="Agent engine config" href="/docs/configuration/agent-engine-config">
-    The reasoning-effort knob and the rest of the engine surface.
+    The reasoning-effort setting and the rest of the engine's options.
   </SpecCard>
   <SpecCard title="Determinism over intelligence" href="/docs/principles/determinism">
-    Why a deterministic oracle is preferred to a model's opinion wherever one exists.
+    Why stella prefers a clear, repeatable check over a model's own opinion, wherever one is available.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/commands/usage.mdx
+++ b/website/content/docs/commands/usage.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella usage
-description: Report, replicate, and prune the cross-project telemetry hub at ~/.stella/usage.db — the same cost numbers as stella stats, across every project.
+description: Report on, replicate, and prune the cross-project usage hub at ~/.stella/usage.db, the same cost numbers as stella stats, across every project.
 ---
 
-`stella stats` answers "what did *this* workspace cost." `stella usage` answers the same question across every project on this machine, by reading the **usage hub** — one SQLite database per developer at `~/.stella/usage.db`. It needs no provider and no API key, and nothing it does sends anything anywhere.
+`stella stats` answers "what did *this* project cost." `stella usage` answers the same question across every project on this machine, by reading the **usage hub**, a single SQLite file per developer at `~/.stella/usage.db`. It needs no provider and no API key, and nothing it does sends any data anywhere.
 
 ## Synopsis
 
@@ -14,65 +14,69 @@ stella usage sync [--all]
 stella usage prune [--older-than <AGE>] [--max-rows <N>] [--gc-deleted] [--force] [--vacuum] [--dry-run]
 ```
 
-A bare `stella usage` is `stella usage report` with the defaults. The flags belong to the subcommand, so name `report` explicitly when you pass one.
+A bare `stella usage` runs `stella usage report` with its defaults. Flags belong to a specific subcommand, so spell out `report` whenever you pass one.
 
 ## What it does
 
-Every project keeps its own source of truth at `<workspace>/.stella/private/store.db` — that is the store [`stella stats`](/docs/commands/stats) and [`stella inspect`](/docs/commands/inspect) read. The hub is **derived** from those stores: each finished turn rolls its telemetry up into `~/.stella/usage.db` so a cross-project question can be answered without opening every project database in turn.
+Every project keeps its own record at `<workspace>/.stella/private/store.db`. That's the file [`stella stats`](/docs/commands/stats) and [`stella inspect`](/docs/commands/inspect) read from. The hub is **built from** those project files: each time a turn finishes, its numbers get copied into `~/.stella/usage.db`, so you can answer a question across all your projects without opening each project's database one by one.
 
-Two properties fall out of that design, and they are the reason the command exists:
+This design gives you two things:
 
-- **It reads even when the project stores are busy.** A report from the hub does not contend with a live session holding `store.db`.
-- **It outlives the checkout.** A project you deleted six months ago still contributes to the totals, because its rows were replicated before the directory went away.
+- **It still works when a project's own database is busy.** Reading from the hub does not compete with a live session that's using `store.db`.
+- **It outlives the project folder.** A project you deleted six months ago still counts toward your totals, because its rows were already copied into the hub before the folder was removed.
 
-Flow is strictly one way — `store.db` → `usage.db`. Nothing here writes back into a project store, and a hub that is missing or briefly unopenable never fails a turn; replication is best-effort by design.
+Data only ever flows one way, from `store.db` to `usage.db`. Nothing here writes back into a project's own file, and if the hub is missing or briefly can't be opened, it never fails your turn. Copying data into the hub is always best-effort.
 
 <Callout type="info">
-The hub stores **metadata and rollups**, never source code or tool output. Prompts are reduced to a digest plus a short preview. Registration with [`stella cloud`](/docs/commands/cloud) changes which ids the rows carry, not what is in them, and does not upload anything today.
+The hub stores **summaries and metadata only**, never your source code or tool output. Prompts are reduced to a short digest and preview. Registering with [`stella cloud`](/docs/commands/cloud) changes which ids your rows carry, not what's in them, and it does not upload anything on its own.
 </Callout>
 
 ## Subcommands
 
 <CardGrid size="md">
   <OptionCard name="report">
-    Per (org, provider, model) totals across every replicated project: calls, tokens,
-    cache reads, cost, and how many distinct projects contributed. The default.
+    Totals grouped by org, provider, and model, across every project copied into the hub:
+    calls, tokens, cache reads, cost, and how many different projects contributed. This is
+    the default.
   </OptionCard>
   <OptionCard name="sync">
-    Replicate this workspace's telemetry into the hub from a cursor. Safe to re-run;
-    `--all` heals every project the hub has ever seen.
+    Copies this project's usage data into the hub, picking up where it left off. Safe to
+    run again; `--all` repairs every project the hub has ever seen.
   </OptionCard>
   <OptionCard name="prune">
-    Bound the hub's growth — by age, by a row ceiling, and by GC of projects whose
-    checkout is gone.
+    Keeps the hub from growing forever, by age, by a row limit, or by clearing out projects
+    whose folder is gone.
   </OptionCard>
 </CardGrid>
 
 ### `stella usage report`
 
-Group every hub row by org, provider, and model, and total it. Rows are ordered by cost, descending.
+Groups every row in the hub by org, provider, and model, and totals them up. Rows are sorted by cost, highest first.
 
 <CardGrid size="md">
   <OptionCard name="--format <text|json|csv>" defaultValue="text">
-    `text` prints aligned columns with a `TOTAL` row (`table` still parses as an alias); `json` (under the versioned query envelope) and `csv` are for piping
-    into other tools. The three text columns in CSV are RFC-4180 escaped, so an org id or
-    a model slug containing a comma cannot shift the following columns.
+    `text` prints lined-up columns with a `TOTAL` row at the bottom (`table` also works as
+    another name for the same thing). `json` (wrapped in a versioned envelope) and `csv` are
+    meant for piping into other tools. The three text columns in CSV follow the RFC-4180
+    escaping rule, so an org id or model name containing a comma can never shift the columns
+    after it.
   </OptionCard>
   <OptionCard name="--org <id>">
-    Only rows replicated under this org id. Rows written before you registered carry no
-    org and are excluded by any `--org` filter.
+    Only shows rows recorded under this org id. Rows written before you registered have no
+    org attached, so an `--org` filter always leaves those out.
   </OptionCard>
   <OptionCard name="--by-tool">
-    Per-tool reliability instead of per-model spend: cross-project calls, errors, and the
-    derived error rate per `(tool, surface)`, read from the hub's tool rollup. Each row also
-    splits its errors by `ErrorClass` token
-    (`errors_by_class` in JSON/CSV, `CLASSES` in the table; `unclassified` for calls recorded
-    before their error site was audited), so "bash's error rate excluding `invalid_input`"
-    is arithmetic, not string matching. This is the
-    scriptable surface for a tool-reliability ceiling — the same numbers the Observatory
-    leaderboard draws, unwindowed and pipeable. Cannot combine with `--org` (the rollup is
-    project-keyed, and a silently unhonored filter would misreport). Named `--by-tool`
-    because `--tools` is the session-wide [tool-policy global](/docs/commands#--tools-narrowing-for-one-run).
+    Shows tool reliability instead of spend: calls, errors, and the error rate for each
+    `(tool, surface)` pair, across every project, read from the hub's tool summary. Each
+    row also breaks its errors down by `ErrorClass`
+    (`errors_by_class` in JSON/CSV, `CLASSES` in the table view; `unclassified` covers calls
+    recorded before their error type was tracked), so a question like "bash's error rate,
+    not counting `invalid_input`" is simple math, not text matching. This gives you the same
+    numbers behind the Observatory leaderboard, but with no time window and in a form you
+    can pipe to other tools. It cannot be combined with `--org`, because this summary is
+    keyed by project, not by org, and silently ignoring the filter would give you a wrong
+    answer. It's called `--by-tool` rather than `--tools`, because `--tools` is already
+    used for the session-wide [tool-policy setting](/docs/commands#--tools-narrowing-for-one-run).
   </OptionCard>
 </CardGrid>
 
@@ -83,7 +87,7 @@ stella usage report --org acme --format csv > acme-spend.csv
 stella usage report --by-tool --format json | jq '.rows[] | select(.error_rate > 0.03)'
 ```
 
-Representative table output (illustrative):
+Sample table output (for illustration only):
 
 ```text
 ORG            PROVIDER   MODEL                           CALLS        INPUT       OUTPUT   CACHE-READ       COST  PROJECTS
@@ -92,30 +96,31 @@ ORG            PROVIDER   MODEL                           CALLS        INPUT    
 TOTAL                                                       680     12115559       699324      8023214    36.3259
 ```
 
-An unregistered installation reports its rows under `(local)` — the display for a `NULL` org id. An empty hub says so and points you at `stella usage sync`.
+An installation that isn't registered shows its rows under `(local)`, which is what stella prints for a missing org id. An empty hub tells you so and points you to `stella usage sync`.
 
 ### `stella usage sync`
 
-Replication normally happens on its own: each finished turn ships its telemetry into the hub best-effort. `sync` is the explicit and the repair path — it walks the hub's per-project cursor forward, so re-running it is safe and only ever ships rows the hub does not already have.
+Normally, copying into the hub just happens on its own: each finished turn ships its data over best-effort. `sync` is the manual and the repair option. It moves each project's saved position forward, so running it again is always safe and only sends rows the hub doesn't already have.
 
 <CardGrid size="md">
   <OptionCard name="--all">
-    Walk every project in the hub's registry instead of just the current directory. This
-    is the repair path: a project whose best-effort sync failed mid-turn has a cursor that
-    fell behind, and `--all` heals all of them in one pass. A registered project with no
-    local `store.db` is reported as skipped rather than treated as an error.
+    Walks every project the hub already knows about, instead of just the current folder.
+    Use this to repair things: if a project's background sync failed partway through, its
+    position falls behind, and `--all` fixes every project like that in one pass. A
+    registered project whose local `store.db` is missing is reported as skipped, not as an
+    error.
   </OptionCard>
 </CardGrid>
 
 ```bash
-# This workspace only.
+# This project only.
 stella usage sync
 
 # Every project the hub knows about — the repair pass.
 stella usage sync --all
 ```
 
-The single-workspace form reports one number; `--all` reports per project first:
+Syncing one project reports a single number. `--all` reports each project first:
 
 ```text
 acme-api                 128 row(s)
@@ -126,79 +131,81 @@ replicated 128 telemetry row(s) across 3 project(s)
 
 ### `stella usage prune`
 
-The hub keeps one telemetry row per model call, across every project, forever — including rows from checkouts that no longer exist. `prune` is the retention control. It refuses to run with none of `--older-than`, `--max-rows`, or `--gc-deleted` set, so a bare `stella usage prune` can never mean "delete something."
+The hub keeps one row per model call, from every project, forever, including projects that no longer exist. `prune` controls how much it keeps. It refuses to run unless you give it at least one of `--older-than`, `--max-rows`, or `--gc-deleted`, so a bare `stella usage prune` can never accidentally delete anything.
 
 <CardGrid size="md">
   <OptionCard name="--older-than <AGE>">
-    Drop rows older than this window. `N` followed by `d`, `w`, `h`, `mo`, or `y` — `90d`,
-    `12w`, `720h`, `3mo`, `1y`. A bare number means days. The window must be positive: `0`
-    would prune everything older than now, which is almost always a typo.
+    Deletes rows older than this window. Use a number followed by `d`, `w`, `h`, `mo`, or
+    `y`, for example `90d`, `12w`, `720h`, `3mo`, `1y`. A bare number means days. The value
+    must be positive; `0` would delete everything up to right now, which is almost always a
+    mistake.
   </OptionCard>
   <OptionCard name="--max-rows <N>">
-    Hard ceiling on retained telemetry rows; the oldest prunable ones are evicted until
-    the hub is at or under it.
+    A hard cap on how many rows the hub keeps. The oldest deletable rows are removed until
+    the hub is at or under this number.
   </OptionCard>
   <OptionCard name="--gc-deleted">
-    Also drop everything the hub holds for a project whose checkout is gone *and* that was
-    never org-registered — its telemetry, its rollups, its sync cursor, and its registry
-    row. "Gone" means the project root is missing while its parent directory still exists,
-    which is a deletion. A whole volume being absent — an unplugged drive, a down network
-    share — is deliberately **not** a deletion, so an unmounted disk never GCs your local
-    history. A project that does come back re-replicates on its next sync.
+    Also removes everything the hub holds for a project whose folder is gone *and* that was
+    never registered to an org: its usage data, its summaries, its saved sync position, and
+    its entry in the hub. "Gone" means the project's own folder is missing while its parent
+    folder still exists, since that's what a real deletion looks like. A whole drive being
+    unavailable, like an unplugged drive or an offline network share, is deliberately
+    **not** treated as a deletion, so a temporarily disconnected disk never wipes out your
+    local history. A project that comes back gets re-added on its next sync.
   </OptionCard>
   <OptionCard name="--dry-run">
-    Compute the report and delete nothing. Worth running first.
+    Shows what would be deleted, without deleting anything. Worth running first.
   </OptionCard>
   <OptionCard name="--vacuum">
-    `VACUUM` afterwards, handing freed pages back to the filesystem, and re-anchor the
-    cloud cursors across it. Also runs automatically after a large prune.
+    Runs SQLite's `VACUUM` afterward, giving the freed disk space back to your filesystem,
+    and resets the cloud sync positions to match. This also runs automatically after a
+    large prune.
   </OptionCard>
   <OptionCard name="--force">
-    Also drop un-acked cloud rows, breaking a pending drain. Off by default.
+    Also deletes rows that haven't been confirmed as sent to the cloud yet, which breaks a
+    pending upload. Off by default.
   </OptionCard>
 </CardGrid>
 
 ```bash
-# What would go, without touching anything.
+# See what would be removed, without touching anything.
 stella usage prune --older-than 1y --dry-run
 
-# A year of history, plus everything held for repos you have since deleted.
+# A year of history, plus everything held for projects you've since deleted.
 stella usage prune --older-than 1y --gc-deleted --vacuum
 
-# Or bound it by row count instead of age.
+# Or limit by row count instead of age.
 stella usage prune --max-rows 100000
 ```
 
 <Callout type="warn">
-Prune is **cloud-safe by default**: a row belonging to a registered org that the cloud
-drain has not yet acknowledged is never dropped, even when it falls inside the age window.
-Those rows are reported back to you as kept — `--force` is the deliberate override, and it
-breaks the pending drain permanently. Rollup rows never drain, so they age out
-unconditionally.
+Prune is **safe for cloud users by default**. A row that belongs to a registered org and
+that the cloud upload hasn't confirmed yet is never deleted, even if it falls inside your
+age window. Those rows are reported back to you as kept. `--force` is the deliberate way to
+override that, and it permanently breaks the pending upload. Summary rows never get
+uploaded, so they age out and get deleted no matter what.
 </Callout>
 
-If the ceiling could not be met because the excess rows were un-acked, `prune` says so rather than silently leaving the hub over budget: drain them, or re-run with `--force`.
+If a row limit can't be reached because the extra rows are all unconfirmed uploads, `prune` tells you that directly instead of quietly leaving the hub over its limit. Either wait for the upload to finish, or run again with `--force`.
 
 ## Relationship to `stella stats`
 
 <CardGrid size="md">
   <OptionCard name="stella stats">
-    One workspace. Reads `<workspace>/.stella/private/store.db`, the source of truth, with
-    the per-run cache-economics columns. Its `prune` bounds *that* store.
+    One project. Reads `<workspace>/.stella/private/store.db`, the original source of the
+    data, including the per-run cache-cost columns. Its `prune` only affects *that* file.
   </OptionCard>
   <OptionCard name="stella usage">
-    Every workspace. Reads `~/.stella/usage.db`, derived from the above. Its `prune` bounds
-    *the hub*, and the two retention commands are independent — pruning one never touches
-    the other.
+    Every project. Reads `~/.stella/usage.db`, which is built from the file above. Its
+    `prune` only affects *the hub*. Pruning one never touches the other.
   </OptionCard>
 </CardGrid>
 
-The two `--older-than` vocabularies are shared code precisely so `--older-than 3mo` cannot work on one command and fail on the other.
+Both commands use the same `--older-than` format on purpose, so `--older-than 3mo` always works the same way on either command.
 
 ## Examples
 
-Your five most expensive models across every project — the rows already arrive sorted by
-cost:
+Your five most expensive models across every project, since rows already come back sorted by cost:
 
 ```bash
 stella usage report --format json | jq '.rows[0:5] | .[] | {provider, model, cost_usd}'
@@ -210,7 +217,7 @@ Find the models you use across the most projects:
 stella usage report --format json | jq '.rows[] | select(.projects > 2) | {provider, model, projects, cost_usd}'
 ```
 
-Heal every stale cursor after a stretch of interrupted sessions, then report:
+Fix every out-of-date project after a stretch of interrupted sessions, then report:
 
 ```bash
 stella usage sync --all
@@ -224,7 +231,7 @@ stella usage prune --older-than 6mo --gc-deleted --vacuum
 ```
 
 <Callout type="info">
-The hub is a real SQLite file at `~/.stella/usage.db` (`STELLA_DATA_DIR` overrides the
-directory). Beyond this command you can query it with any SQLite client — see
+The hub is a real SQLite file at `~/.stella/usage.db` (set `STELLA_DATA_DIR` to use a
+different folder). Beyond this command, you can query it with any SQLite client. See
 [Telemetry &amp; budget](/docs/telemetry).
 </Callout>

--- a/website/content/docs/commands/version.mdx
+++ b/website/content/docs/commands/version.mdx
@@ -3,7 +3,7 @@ title: stella version
 description: Print the installed stella version and exit.
 ---
 
-Print the version of the installed `stella` binary and exit.
+Prints the version of your installed `stella` binary, then exits.
 
 ## Synopsis
 
@@ -11,30 +11,28 @@ Print the version of the installed `stella` binary and exit.
 stella version
 ```
 
-Two top-level flags print it too, and they do **not** print the same thing:
+Two other flags also print the version, but they don't print the same thing:
 
 ```bash
-stella -V         # one line, bare version
+stella -V         # one line, just the version number
 stella --version  # three lines, with the build's target and profile
 ```
 
 ## Output
 
-The `version` subcommand prints a `v`-prefixed line:
+The `version` subcommand prints a line starting with `v`:
 
 ```text
 stella v0.9.86
 ```
 
-`stella -V` prints the short form — the binary name, a space, then the bare version, no
-`v`:
+`stella -V` prints the short form: the binary name, a space, then the version number with no `v` in front:
 
 ```text
 stella 0.9.86
 ```
 
-`stella --version` prints the **long** form: the same first line, then the target triple
-and the build profile the binary was compiled with.
+`stella --version` prints the **long** form: the same first line, then the target platform and the build profile the binary was built with.
 
 ```text
 stella 0.9.86
@@ -42,12 +40,9 @@ target:  aarch64-apple-darwin
 profile: release
 ```
 
-The exact number tracks the release you installed. Binaries built in dev mode
-(`scripts/dev.sh`) append a git-sha stamp, e.g. `stella v0.9.86-dev.abc1234`; released
-binaries print the bare semver.
+The number you see matches the release you installed. A binary built in dev mode (using `scripts/dev.sh`) adds a git-sha tag at the end, for example `stella v0.9.86-dev.abc1234`. A released binary just shows the plain version number.
 
-Use it to confirm an install or upgrade, or to capture the version in a CI log. This
-command needs no provider or API key configured.
+Use this command to confirm an install or upgrade, or to save the version in a CI log. It needs no provider or API key.
 
 ## Examples
 
@@ -57,21 +52,19 @@ Confirm what you just installed:
 stella version
 ```
 
-Capture the bare semver for a CI log or a build label. Use `-V`, not `--version`:
-the long form's extra lines would each be fed through `cut` too, so you would get the
-version, a blank, and the profile.
+Capture just the version number for a CI log or a build label. Use `-V`, not `--version`: the long form's extra lines would also get piped through `cut`, giving you the version, then a blank line, then the profile.
 
 ```bash
 stella -V | cut -d' ' -f2
 ```
 
-Or take just the first line of either flag:
+Or take just the first line from either flag:
 
 ```bash
 stella --version | head -1 | cut -d' ' -f2
 ```
 
-Check that a binary is on `PATH` at all before a script depends on it:
+Check that stella is installed and on your `PATH` before a script depends on it:
 
 ```bash
 stella version >/dev/null 2>&1 || { echo "stella is not installed"; exit 1; }

--- a/website/content/docs/commands/whistle.mdx
+++ b/website/content/docs/commands/whistle.mdx
@@ -1,9 +1,9 @@
 ---
 title: stella whistle
-description: Broadcast steering guidance to every live non-interactive session on this machine, or a chosen few.
+description: Send steering instructions to every live non-interactive session on this machine, or to a few you pick.
 ---
 
-A message reaches a running [`run`](/docs/commands/run) or [`goal`](/docs/commands/goal) session — foreground or daemon-supervised alike — without switching to its window: "stop running the full workspace build, let CI handle the gate" lands in every one of them at once.
+A message reaches a running [`run`](/docs/commands/run) or [`goal`](/docs/commands/goal) session, whether it's running in the foreground or supervised by a daemon, without you switching to its window. For example, "stop running the full workspace build, let CI handle the gate" lands in every matching session at once.
 
 ## Synopsis
 
@@ -15,13 +15,13 @@ stella whistle "<message>" --session <id> --session <id>
 
 ## How delivery works
 
-Each targeted session binds a small Unix domain socket beside its existing session sidecar when it starts, and already carries `stella-core`'s `TurnSteering` seam — the same one [`stella chat`](/docs/commands/chat)'s `>` steer and `stella-serve`'s `POST /v1/turns/{id}/steer` drive, one in-process, one over HTTP. `stella whistle` is a second process reaching that seam over the socket: it connects, sends the message, and waits for an acknowledgment.
+Each session you can reach opens a small Unix domain socket next to its normal session files when it starts. It listens on the same steering channel that [`stella chat`](/docs/commands/chat)'s `>` command and `stella-serve`'s `POST /v1/turns/{id}/steer` also use, one from inside the process and one over HTTP. `stella whistle` is a separate process that connects to that same channel over the socket, sends your message, and waits for confirmation it arrived.
 
-Delivery lands at the target's next safe step boundary — strictly between model calls, never mid-tool. The turn is never paused; it absorbs the guidance and keeps going, wrapped as `[whistle — steering from another session] <message>` so the model reads it as a priority directive rather than an ordinary trailing remark.
+Your message lands at the target's next safe point, always between model calls, never in the middle of using a tool. The current turn is never paused; it takes in your message and keeps going. The model sees it wrapped as `[whistle — steering from another session] <message>`, so it reads it as an instruction to prioritize rather than just another passing comment.
 
 ## Targeting
 
-Omit `--session` and the broadcast reaches every session [`stella resume --list`](/docs/commands/resume) shows as live. Pass `--session <id>` (repeatable) to narrow it to specific sessions instead — an id that is not currently live, or never existed, is reported unreachable rather than silently dropped.
+Leave off `--session` and your message reaches every session that [`stella resume --list`](/docs/commands/resume) shows as currently live. Pass `--session <id>` (you can repeat this flag) to send it to specific sessions only. If an id isn't currently live, or never existed, stella reports it as unreachable instead of just skipping it silently.
 
 ```text
 $ stella whistle "stop running the full workspace build, let CI handle the gate"
@@ -29,18 +29,18 @@ delivered    ses-1785956826121-25167  stella: migrate the config loader to serde
 unreachable  ses-1785956700004        stella: fix the flaky test (no listener — the session isn't currently reachable)
 ```
 
-`stella whistle` exits non-zero when any targeted session could not be reached, after printing every session's outcome.
+`stella whistle` exits with a non-zero code if any target session could not be reached, after it prints the outcome for every session.
 
 ## What is reachable today
 
-Foreground [`stella run`](/docs/commands/run), any wrapper-plugin-driven turn, and both of [`stella chat`](/docs/commands/chat)'s interactive modes — the default one and `--plain`'s — are all reachable. So are daemon-supervised runs of the same, since supervision launches the identical code path.
+Foreground [`stella run`](/docs/commands/run), any turn driven by a wrapper plugin, and both of [`stella chat`](/docs/commands/chat)'s interactive modes (the default one and `--plain`) can all receive a whistle. So can daemon-supervised runs of the same, since supervision uses the exact same code path.
 
-Interactive mode mints a steering tap per turn and has none between turns, so its socket is bound to a session-scoped relay instead. A whistle at a session sitting idle is delivered, held, and put in front of the model the moment the next turn opens; one during a running turn lands at that turn's next step boundary like any other.
+Interactive mode opens a fresh steering channel for each turn, so between turns it listens through a session-level channel instead. If you whistle an idle session, the message waits and gets shown to the model as soon as the next turn starts. If you whistle a session mid-turn, it arrives at that turn's next safe point, just like any other message.
 
 Not reachable yet:
 
-- **`stella-serve`-hosted turns** are a separate binary. It has a steer route of its own, but a served session registers in no registry `stella whistle` can enumerate, and neither its address nor its token reaches a file on disk — so this is a discovery problem before it is a transport one.
+- **Sessions hosted by `stella-serve`** run in a separate program. It has its own steering route, but a session it hosts is not listed in any registry `stella whistle` can check, and neither its address nor its access token is saved to a file on disk. So right now, the problem is finding these sessions, not sending to them.
 
 ## Platform support
 
-Unix only — `tokio::net::UnixListener` has no Windows counterpart, and stella ships no Windows binary yet. On a non-Unix build every session reports unreachable rather than the command silently doing nothing.
+This command only works on Unix systems, because the underlying tool (`tokio::net::UnixListener`) has no Windows version, and stella does not ship a Windows binary yet. On any non-Unix build, every session is reported as unreachable instead of the command doing nothing silently.

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent engine config
-description: Configure the session agent's model, gateway, prompt, reasoning effort, and sampling parameters via agent_engine_config — and assign models to the roles installed plugins declare.
+description: Configure the session agent's model, gateway, prompt, reasoning effort, and sampling parameters with agent_engine_config, and assign models to the roles installed plugins declare.
 ---
 
 The `agent_engine_config` object in [`settings.json`](/docs/configuration/settings)
@@ -8,29 +8,29 @@ configures the engine:
 
 <CardGrid size="md">
   <OptionCard name="default">
-    The one role the core loop has — `stella chat`, the Command Deck, a plain
-    `stella run`. `default_model` is its model, and the one model setting
-    stella ships.
+    The one role the core loop has: `stella chat`, the Command Deck, and a plain
+    `stella run`. `default_model` sets its model. This is the only model setting
+    stella ships with.
   </OptionCard>
   <OptionCard name="seats">
-    A model for a participant an **installed plugin** declared. Keyed
-    `<plugin-id>/<role>`, unset by default, so a plugin's process is
-    single-model until you say otherwise. See [Seats](#seats).
+    A model for a participant an **installed plugin** declares. Keyed as
+    `<plugin-id>/<role>`. Unset by default, so a plugin runs on one model until
+    you say otherwise. See [Seats](#seats).
   </OptionCard>
 </CardGrid>
 
-Every field is optional, and it merges across the same user → org-managed →
-project scope chain as the rest of `settings.json`, per field — a project can
-pin the model while your user scope keeps everything else.
+Every field is optional. It merges across the same user, org-managed, and
+project scope chain as the rest of `settings.json`, field by field. A project
+can pin the model while your user scope keeps everything else.
 
 <Callout type="info">
-An unrecognized key **loads normally and prints a line naming what to write
-instead** — nothing breaks, and nothing is silently ignored either. Set
+An unrecognized key loads normally and prints a line naming what to write
+instead — nothing breaks, and nothing is silently ignored either. Set
 `default_model` for the session's own model, and a [seat](#seats) for anything
 a plugin runs.
 </Callout>
 
-## The full schema
+## Full schema
 
 ```jsonc title="~/.stella/settings.json"
 {
@@ -89,10 +89,10 @@ a plugin runs.
 
 ## Seats
 
-A plugin describes a *process*, and that process may have several
-participants — a planner, a reviewer, a second opinion. It never asks for a
-model: it declares the roles it needs, and you decide which of them is worth a
-model of its own.
+A plugin describes a process. That process can have several participants: a
+planner, a reviewer, a second opinion. The plugin never asks for a model. It
+declares the roles it needs, and you decide which ones are worth a model of
+their own.
 
 ```json title=".stella/settings.json"
 {
@@ -112,71 +112,71 @@ Or in `stella.toml`, where it is a section of its own:
 "vera/verifier" = "anthropic/claude-fable-5"
 ```
 
-Three rules follow, each deliberate:
-
-- **A seat with no entry runs on the session's model.** Installing a plugin
-  with five participants costs exactly what a single-model session costs
-  until you write a line here. stella never picks a "sensible" second model
-  for you, because that is an opinion about a role it does not understand.
-- **The key is always `<plugin-id>/<role>`.** The plugin declares only the
-  bare role name; stella applies the prefix. So one plugin cannot capture the
-  assignment you made about another, and a `reviewer` you configured for one
-  plugin is not silently inherited by the next one that happens to declare a
-  role of that name.
-- **`allowed_models` is the ceiling here too.** A seat naming a model outside
-  a non-empty list is refused with a notice and falls back to the session's
-  model.
+- **A seat with no entry runs on the session's model.** If a plugin has five
+  participants, installing it costs the same as a single-model session, until
+  you add a line here. stella never picks a second model for you on its own —
+  that would be a guess about a role it doesn't understand.
+- The key is always `<plugin-id>/<role>`. The plugin declares only the plain
+  role name, and stella adds the prefix. This means one plugin can't take over
+  a setting you made for another. A `reviewer` role you configured for one
+  plugin is never inherited by a different plugin that also declares a
+  `reviewer` role.
+- `allowed_models` sets the ceiling here too. If a seat names a model outside
+  a non-empty list, stella refuses it, shows a notice, and falls back to the
+  session's model.
 
 Quote the key in TOML. `vera.verifier` is dotted-key syntax and would parse as
 a table `vera` containing `verifier`.
 
 ## Model precedence
 
-**The session's model** — first hit wins:
+**The session's model.** First hit wins:
 
-1. The `--model` CLI flag (or `STELLA_MODEL`) — suppresses the settings below
-   for this invocation
+1. The `--model` CLI flag (or `STELLA_MODEL`). This suppresses the settings
+   below for this invocation.
 2. `agents.default.model`, sent verbatim to `agents.default.provider` when
    that is set
 3. `default_model`
 4. Auto-detection / the provider's own default
 
-**A plugin's seat** — first hit wins:
+**A plugin's seat.** First hit wins:
 
 1. `seat_models["<plugin-id>/<role>"]`
-2. No entry — the seat runs on the session's model resolved above
+2. No entry: the seat runs on the session's model resolved above.
 
 <Callout type="info">
-  When `--model` suppresses a configured model, the run says so on stderr —
-  `engine config: model ... skipped — --model pinned ... for this invocation` —
-  so a dropped setting is never silent. Settings own the model whenever the
-  flag is absent.
+  When `--model` suppresses a configured model, the run prints a note on
+  stderr — `engine config: model ... skipped — --model pinned ... for this
+  invocation` — so a dropped setting is never silent. Settings control the
+  model whenever the flag is absent.
 </Callout>
 
-Every override here is **soft**. A configured model whose provider has no
-resolvable credential — or whose adapter fails to build — is skipped with a
-notice on stderr, and falls back exactly as it would with no config at all.
-The notice names what was skipped and what runs instead:
+Every override here is soft. If a configured model's provider has no
+credential, or its adapter fails to build, stella skips it with a notice on
+stderr. It then falls back to the session's model, exactly as it would with no
+config at all. The notice names what was skipped and what runs instead:
 
 ```text
   ! seat `vera/verifier`: no credential resolved for provider `openrouter` —
     this seat runs on the session's model.
 ```
 
-`stella config` prints the resolved provider, session-default model, credential
-source, base URL, and dialect — the inputs those chains start from — and
-`stella models list --all` shows which slugs each provider will accept:
+`stella config` prints the resolved provider, session-default model,
+credential source, base URL, and dialect. These are the inputs those chains
+start from. `stella models list --all` shows which slugs each provider will
+accept:
 
 ```bash
 stella config
 stella models list --all
 ```
 
-## One gateway per role (BYOK per role)
+## One gateway per role
 
-The agent's `provider` field routes its model slug through **that** provider
-verbatim — no prefix splitting. Seat assignments take a full `provider/slug`
-string. Together, that is how you mix billing relationships in one run:
+The agent's `provider` field sends its model slug straight to that provider,
+with no prefix splitting. Seat assignments take a full `provider/slug` string.
+Together, this lets you mix billing relationships — your own key for each
+provider — in one run:
 
 ```jsonc title="~/.stella/settings.json"
 {
@@ -197,14 +197,14 @@ export OPENROUTER_API_KEY=sk-or-...
 stella run --pipeline vera "add a per-provider breaker cooldown"
 ```
 
-Without a `provider` field, model strings use `--model` semantics:
+Without a `provider` field, model strings follow `--model` rules:
 `provider/slug` splits on the first `/` when the prefix names a known
-provider (so `openrouter/openai/gpt-5.5` routes `openai/gpt-5.5` through
-OpenRouter), and a bare slug resolves through the model catalog.
+provider. So `openrouter/openai/gpt-5.5` routes `openai/gpt-5.5` through
+OpenRouter. A bare slug resolves through the model catalog instead.
 
 ## Auto modes
 
-Set any of the three autos to `"on"` and stop thinking about it:
+Set any of these to `"on"` and stop thinking about it:
 
 <CardGrid size="md">
   <OptionCard name="auto_mode" defaultValue="off">
@@ -218,40 +218,37 @@ Set any of the three autos to `"on"` and stop thinking about it:
     Thinking mode chosen for you, overriding `agents.default.reasoning`.
   </OptionCard>
   <OptionCard name="minimal_prompt" defaultValue="off">
-    Run every session on the minimal base system prompt — a bare tool
-    advertisement in place of the built-in persona, so the prose the model is
-    steered by comes from what you configure: `agents.default.prompt` (which
-    appends after the minimal base instead of replacing it), workspace
-    memories, rules, and SessionStart hook context. `--minimal` (or
-    `STELLA_MINIMAL=1`) forces it on for one invocation; the flag can never
-    turn a configured mode off. In `stella.toml` this is `[agents]
-    minimal_prompt`, and the interactive session's SETTINGS → AGENTS pane
-    carries it as a GLOBAL toggle.
+    Run every session on the minimal base system prompt. This is a bare tool
+    list in place of the built-in persona, so the model is steered by what you
+    configure instead: `agents.default.prompt` (which adds to the minimal
+    base rather than replacing it), workspace memories, rules, and
+    SessionStart hook context. `--minimal` (or `STELLA_MINIMAL=1`) forces it
+    on for one run. The flag can never turn off a mode you configured. In
+    `stella.toml` this is `[agents] minimal_prompt`, and the interactive
+    session's SETTINGS → AGENTS pane shows it as a GLOBAL toggle.
   </OptionCard>
   <OptionCard name="headless_scope_bypass" defaultValue="off">
-    **Inert — setting this changes nothing.** Nothing reads the value, at any
-    setting.
+    **Setting this does nothing.** No code reads this value, at any setting.
 
-    The key still parses and merges rather than being rejected as unknown, and
-    that is deliberate: it is part of a registered benchmark posture whose
-    digest is published, so removing it would invalidate numbers that have
-    already been reported. Nothing here is waiting on you — if you set it,
-    delete it.
+    The key still loads and merges instead of being rejected as unknown. This
+    is on purpose: it's part of a published benchmark setup, and removing the
+    key would break scores that were already reported. If you have this set,
+    delete it — nothing is waiting on you to use it.
   </OptionCard>
   <OptionCard name="model_timeout_secs" defaultValue="816">
-    Seconds of provider **silence** that end a single generation — it bounds
-    the gap between stream fragments, not elapsed time, so a step that keeps
-    streaming is never cut by it. `0` removes the backstop entirely.
+    Seconds of silence from the provider that end a single generation. This
+    limits the gap between stream fragments, not the total time, so a step
+    that keeps streaming is never cut off. `0` removes this limit entirely.
 
-    Set it with `params.max_tokens`, not instead of it. The two are one
-    budget: a step allowed 128,000 output tokens against a timeout sized for
-    64,000 stops on the timeout, which looks like a model that could not
-    finish rather than a ceiling nobody scaled.
+    Set it alongside `params.max_tokens`, not instead of it. The two work as
+    one budget. If you allow 128,000 output tokens but size the timeout for
+    64,000, a step can hit the timeout first. That looks like a model that
+    couldn't finish, when really the timeout just wasn't scaled to match.
   </OptionCard>
 </CardGrid>
 
-When an auto is `"on"` it overrides the corresponding per-agent setting —
-that is its contract.
+When an auto is `"on"`, it overrides the matching per-agent setting. That's
+the rule.
 
 The smallest useful config is one line:
 
@@ -277,29 +274,29 @@ running on one:
 
 ## Output token ceilings
 
-**By default every model is asked for its own maximum.** stella reads that
-ceiling from the model catalog, which learns it from the provider's own
-`/models` endpoint, so you never have to configure anything to get a
-full-length answer. A cap set below the model's ceiling decides where work
-stops instead of the model doing so — and a step cut off mid-reasoning emits
-no tool call and does no work at all.
+**By default, every model is asked for its own maximum output.** stella reads
+that ceiling from the model catalog, which learns it from the provider's own
+`/models` endpoint. You never have to configure anything to get a full-length
+answer. A cap set below the model's ceiling decides where work stops instead
+of the model deciding, and a step cut off in the middle of reasoning sends no
+tool call and does no work at all.
 
-So the only thing worth configuring here is spending **less** than the model
-allows: bounding cost on a long unattended run, cutting latency, or matching a
-comparator that stops lower. You can bound cost, cut latency, or match a shorter comparator.
+So the only thing worth configuring here is asking for less than the model
+allows. You might want to bound cost on a long unattended run, cut latency, or
+match a comparator that stops lower.
 
-### `--max-output-tokens` — this run
+### `--max-output-tokens`
 
 ```bash
 stella run "audit the auth module" --max-output-tokens 32000
 ```
 
-Global flag, applies to every call, also readable as
-`STELLA_MAX_OUTPUT_TOKENS`. Use it when you want one invocation to behave
-differently, or when a configured value is the thing you are debugging — it
-outranks both settings surfaces below for exactly that reason.
+This applies for one run only. It's a global flag that applies to every call
+in that run, also settable as `STELLA_MAX_OUTPUT_TOKENS`. Use it when you want
+one run to behave differently, or when you're debugging a configured value —
+it outranks both settings below for exactly that reason.
 
-### `[models.output_caps]` — this workspace
+### `[models.output_caps]`
 
 ```toml
 [models.output_caps]
@@ -307,38 +304,39 @@ outranks both settings surfaces below for exactly that reason.
 "deepseek-chat" = 32000               # this model on any route
 ```
 
-Keys are `provider/slug` or a bare slug; the provider-qualified form wins when
-both match, so you can cap a model only on the gateway you pay per-token for.
-Entries merge per model across settings scopes, so a project pinning one model
-never drops your pins on others.
+This applies for the current workspace. Keys are `provider/slug` or a bare
+slug. The provider-qualified form wins when both match, so you can cap a
+model only on the gateway you pay per token for. Entries merge per model
+across settings scopes, so a project pinning one model never drops your pins
+on others.
 
-This is an **override, never a definition**. A model absent from the table
-simply gets its own maximum, so a model that ships tomorrow needs no entry —
-and deleting an entry restores a correct default rather than leaving a stale
-number behind.
+This only overrides the default; it never defines a new one. A model that's
+missing from the table just gets its own maximum, so a model that ships
+tomorrow needs no entry. Deleting an entry restores the correct default
+instead of leaving a stale number behind.
 
-### Precedence, and two rules
+### Precedence
 
 Highest wins:
 
 1. `--max-output-tokens` (this invocation)
 2. `[models.output_caps]` (per model)
 3. `agents.default.params.max_tokens` under `agent_engine_config`
-4. the model's own ceiling, from the catalog — **the default**
+4. the model's own ceiling, from the catalog (**the default**)
 
 <Callout type="warn">
 **A value above the model's real ceiling is clamped, not sent.** Asking a
-provider for more than the model can write is not a longer answer — it is a
-rejection on every request, which bills the round trip and then needs another
-call to retry. Clamping gives you what an over-large number was asking for
-anyway.
+provider for more output than the model can write doesn't get you a longer
+answer. It gets a rejection on every request, which still bills the round
+trip and then needs a retry. Clamping gives you what an oversized number was
+asking for anyway.
 
-**`0` is refused, not read as "unlimited".** Absence already means "the
-model's own maximum", so zero has no second meaning left to carry. (This
-differs from `model_timeout_secs`, where `0` *does* mean "no ceiling".)
+**`0` is refused, not read as "unlimited."** Leaving the field empty already
+means "the model's own maximum," so `0` has no second meaning left to carry.
+This is different from `model_timeout_secs`, where `0` does mean "no limit."
 </Callout>
 
-### Where the ceiling comes from
+### Where ceilings come from
 
 | provider | field read from its `/models` |
 | --- | --- |
@@ -347,34 +345,35 @@ differs from `model_timeout_secs`, where `0` *does* mean "no ceiling".)
 | Gemini | `outputTokenLimit` |
 | OpenAI-compatible | `max_output_tokens` or `max_completion_tokens` |
 
-A bare `max_tokens` on an OpenAI-compatible listing is deliberately **not**
-read: it means the output cap on some gateways and the whole context window on
-others, and reading it the wrong way round would seed a ceiling several times
-the model's real one.
+stella deliberately does not read a bare `max_tokens` field on an
+OpenAI-compatible listing. On some gateways it means the output cap; on
+others it means the whole context window. Reading it the wrong way would set
+a ceiling many times larger than the model's real one.
 
-Bedrock and Vertex publish no listing stella can read, so those rows carry a
-seeded value instead. `stella models refresh` (and the startup sync) replaces
-seeded numbers with the provider's own wherever one is published.
+Bedrock and Vertex don't publish a listing stella can read, so those rows
+carry a seeded value instead. `stella models refresh` (and the startup sync)
+replaces seeded numbers with the provider's own numbers wherever one is
+published.
 
 <Callout type="info">
-**One model is a documented estimate: `grok-4`.** No catalog source publishes a
-cap for that exact slug. Its generation siblings — `grok-4.3` and the
-`grok-4.20-*` variants — all report 30,000, so that is what ships. The later
-`grok-4.5` reports 500,000, but taking a different generation's number would
-risk a rejection on every request rather than merely leaving headroom unused.
-It is corrected automatically the first time xAI's listing publishes a real
-figure.
+**One model's number is an estimate: `grok-4`.** No catalog source publishes
+a cap for that exact slug. Its close relatives — `grok-4.3` and the
+`grok-4.20-*` variants — all report 30,000, so that's what ships. The newer
+`grok-4.5` reports 500,000, but using a different generation's number could
+cause a rejection on every request, instead of just leaving some headroom
+unused. This gets corrected automatically the first time xAI's listing
+publishes a real number.
 </Callout>
 
 ## Generation parameters
 
-Every entry under `params` follows **include-when-set** semantics: an absent
-field leaves the provider's own default untouched (the request body is
-byte-identical to having no config at all — which keeps prompt caching
-intact), and a set field goes on the wire.
+Every entry under `params` follows one rule: if you don't set a field, it's
+left out and the provider's own default applies. This keeps the request body
+identical to having no config at all, which keeps prompt caching intact. If
+you do set a field, it's sent on the wire.
 
-Each provider adapter forwards only the parameters its wire supports, and
-maps reasoning to the provider's native mechanism:
+Each provider adapter forwards only the parameters its wire format supports,
+and maps reasoning to that provider's own mechanism:
 
 <CardGrid size="md">
   <SpecCard
@@ -388,111 +387,114 @@ maps reasoning to the provider's native mechanism:
     title="OpenRouter"
     meta={[{ label: "Reasoning", value: "reasoning object (effort / enabled)" }]}
   >
-    The normalized reasoning object. Some upstreams OpenRouter fronts make
-    reasoning mandatory and answer `reasoning: {enabled: false}` with a hard
-    400 — stella resends once without the object rather than losing the call,
-    since "off" is an economy preference, not a correctness requirement.
+    The normalized reasoning object. Some upstream models behind OpenRouter
+    make reasoning mandatory and reject `reasoning: {enabled: false}` with a
+    hard 400 error. When that happens, stella resends the request once
+    without the object, instead of losing the call — turning reasoning "off"
+    is a cost preference, not a requirement for correct output.
   </SpecCard>
   <SpecCard
     title="xAI (Grok)"
     meta={[{ label: "Reasoning", value: "top-level reasoning_effort" }]}
   >
-    Sent only for Grok models that accept the parameter — the retired `grok-4`
-    400s on it, so it is gated by model, not just by provider. The `grok-4.3`
-    default accepts it.
+    Sent only for Grok models that accept this parameter. `grok-4` answers it
+    with a 400 error, so this is limited by model, not just by provider. The
+    `grok-4.3` default accepts it.
   </SpecCard>
   <SpecCard
     title="Anthropic"
     meta={[{ label: "Reasoning", value: "extended thinking, two dialects" }]}
   >
-    Current models (Claude 4.6+ and the 5-family) take
-    `thinking: {"type": "adaptive"}` plus `output_config.effort`, and **reject**
-    `budget_tokens` and the sampling parameters. Legacy models (≤ 4.5) keep
-    `{"type": "enabled", "budget_tokens": N}` with an effort-tiered budget, and
-    do accept sampling — though `temperature` is omitted whenever thinking is
-    on, because the Messages API rejects any value but 1 alongside it.
+    Models from Claude 4.6 onward, including the 5 family, take
+    `thinking: {"type": "adaptive"}` plus `output_config.effort`, and reject
+    `budget_tokens` and the sampling parameters. Models 4.5 and earlier use
+    `{"type": "enabled", "budget_tokens": N}` with a budget based on effort
+    tier, and do accept sampling — though `temperature` is left out whenever
+    thinking is on, because the Messages API rejects any value but 1 alongside
+    it.
   </SpecCard>
   <SpecCard
     title="OpenAI"
     meta={[{ label: "Reasoning", value: "reasoning.effort" }]}
   >
     Plus `text.verbosity` and `service_tier` from `params`. `temperature` and
-    `top_p` are omitted for reasoning models — an API rule, not a stella
-    choice.
+    `top_p` are left out for reasoning models — an API rule, not a choice
+    stella makes.
   </SpecCard>
   <SpecCard
     title="Gemini / Vertex"
     meta={[{ label: "Reasoning", value: "thinkingConfig.thinkingLevel" }]}
   >
-    Gemini 3 cannot fully disable thinking, so `"off"` maps to the lowest level
-    the model documents — the closest the model will let it get to "suppress thinking".
-    `verbosity`, `service_tier`, and `repetition_penalty` are dropped.
+    Gemini 3 can't fully turn off thinking, so `"off"` maps to the lowest
+    level the model documents — as close to "no thinking" as the model
+    allows. `verbosity`, `service_tier`, and `repetition_penalty` are dropped.
   </SpecCard>
   <SpecCard
     title="DeepSeek, local, and settings-defined providers"
     meta={[{ label: "Reasoning", value: "not sent" }]}
   >
-    There is no portable Chat Completions reasoning field, and an unknown key
-    risks a hard 400 on a server you never opted into experimenting with — so
-    these identities send neither shape. Sampling parameters still go through.
+    There's no reasoning field that works across every Chat Completions
+    server, and an unknown key risks a hard 400 error on a server you didn't
+    choose to experiment with — so these providers send neither shape.
+    Sampling parameters still go through.
   </SpecCard>
 </CardGrid>
 
-Parameters a provider cannot express are silently dropped — an unsupported
-knob never fails a request.
+If a provider can't accept a parameter, stella drops it silently. An
+unsupported setting never fails a request.
 
 ## Custom prompts
 
-`agents.default.prompt` **replaces the built-in base instructions** for the
-session agent. Workspace memories and rules still append to it — they are
+`agents.default.prompt` replaces the built-in base instructions for the
+session agent. Workspace memories and rules still get added on top — they're
 workspace context, not part of the base persona.
 
 A plugin's participants are the plugin's own: it ships their instructions, and
 `agent_engine_config` decides only which model each one runs on.
 
-## The config panel in the Command Deck
+## Config panel
 
-Everything above is editable interactively. The editor is the full-width body
-of the **SETTINGS** tab — the home of all config (the former `/engine` popup,
-then the AGENT ENGINE tab's right column, now a tab of its own; open it with
-`/settings` or by tabbing to it):
+Everything above is editable in the Command Deck. The editor is the
+full-width body of the **SETTINGS** tab, the home for all config. Open it with
+`/settings` or by tabbing to it:
 
-- **`e`** on the SETTINGS tab focuses the panel — a GLOBAL tab (auto modes,
-  `allowed_models`) and the agent's own, in the order `GLOBAL default`.
-  Navigate with ↑/↓, press ⏎ to edit a row (enum rows cycle; numeric and text
-  rows take inline input), `x` clears a field back to "provider default", Esc
-  hands the keyboard back to the tab.
-- **⏎ on the model row** opens a type-to-filter model picker, listing your
-  `allowed_models` (or the full catalog when the list is empty). The SETTINGS
-  tab is the one place models are configured — there are no per-agent slash
-  commands.
-- **`s`** saves to your user settings (`~/.stella/settings.json`);
-  **`S`** saves to the project (`<workspace>/.stella/settings.json`). Saves
-  preserve every other key in the file, and apply to runs started from then
-  on.
+- Press **`e`** on the SETTINGS tab to focus the panel. It has a GLOBAL tab
+  (auto modes, `allowed_models`) and the agent's own tab, in the order
+  `GLOBAL default`. Navigate with ↑/↓. Press ⏎ to edit a row: enum rows cycle,
+  and numeric or text rows take inline input. Press `x` to clear a field back
+  to "provider default." Press Esc to hand the keyboard back to the tab.
+- Press ⏎ on the model row to open a type-to-filter model picker. It lists
+  your `allowed_models`, or the full catalog when that list is empty. The
+  SETTINGS tab is the one place you configure models — there are no
+  per-agent slash commands.
+- Press `s` to save to your user settings (`~/.stella/settings.json`). Press
+  `S` to save to the project (`<workspace>/.stella/settings.json`). Saves
+  keep every other key in the file untouched, and apply to runs started from
+  then on.
 
 ## Degradation is always soft
 
-Configuration can never turn a runnable session into an error. A configured
-model whose provider has no resolvable credential — or whose adapter fails to
-build — is skipped with a visible notice, and rides the session's model
-exactly as it would with no config at all.
+Configuration can never turn a runnable session into an error. If a
+configured model's provider has no credential, or its adapter fails to build,
+stella skips it with a visible notice. It then falls back to the session's
+model, exactly as it would with no config at all.
 
-The router that resolves each seat carries the same posture at run time:
+The router that resolves each seat follows the same rule while a run is in
+progress:
 
-- **Per-provider circuit breakers.** Three consecutive transport failures open
-  a provider's breaker; routing skips it and reports the fallback visibly —
-  never a silent mid-session switch. After a cooldown, one trial call decides
-  whether the breaker closes. See
-  [Troubleshooting](/docs/guides/troubleshooting) for what an open breaker
-  looks like.
+- **Per-provider circuit breakers.** Three transport failures in a row open a
+  provider's breaker. Routing then skips that provider and reports the
+  fallback visibly — it never switches silently in the middle of a session.
+  After a cooldown, one trial call decides whether the breaker closes again.
+  See [Troubleshooting](/docs/guides/troubleshooting) for what an open
+  breaker looks like.
 - **Soft degradation everywhere.** A configured seat model whose provider has
   no credential falls back to the session's model with a notice.
 
 <Callout type="info">
-  `agent_engine_config` carries no credential routing of its own — an
-  agent's `provider` references provider ids whose `base_url` and
-  `api_key_env` remain protected by the project-scope
+  `agent_engine_config` carries no credential routing of its own. An agent's
+  `provider` field references provider ids, and their `base_url` and
+  `api_key_env` stay protected by the project-scope
   [trust boundary](/docs/configuration/settings). A cloned repo can suggest
-  models, but it cannot redirect your keys.
+  models, but it can't redirect your keys.
 </Callout>

--- a/website/content/docs/configuration/credentials.mdx
+++ b/website/content/docs/configuration/credentials.mdx
@@ -1,39 +1,38 @@
 ---
 title: Credentials
-description: How stella stores and resolves API keys — the credential chain and the credentials.toml file.
+description: How stella stores and finds API keys — the credential chain and the credentials.toml file.
 ---
 
-stella resolves an API key for the selected provider through a well-defined chain, and can
-persist keys in a permission-restricted file so you're only prompted once.
+stella finds an API key for your selected provider by checking a fixed list of places in
+order. It can also save keys in a locked-down file, so you're only asked once.
 
 ## The credential chain
 
 <CredentialChainDiagram />
 
-For the selected provider, the key is resolved in this order — **first hit wins**,
-and nothing below the first hit is ever read:
+For the selected provider, stella checks these places in order. The first one that has a
+key wins, and stella never reads the ones below it:
 
-1. **`--api-key` flag** — highest precedence. Requires an explicit `--model provider/...`
-   (a bare key is ambiguous about which provider it belongs to).
-2. **Provider env var** — e.g. `ANTHROPIC_API_KEY`, plus aliases like `GOOGLE_API_KEY`
-   for Gemini. A `providers.<id>.api_key_env` in
-   [settings.json](/docs/configuration/settings) **renames the primary variable**: the
-   named variable becomes the one checked first and the provider's original env var
-   demotes to an alias — handy for team key rotation (`MY_TEAM_ZAI_KEY`) without
-   touching anyone's shell profile. Project
-   [dotenv files](/docs/getting-started/providers) are loaded into the environment before
-   this step runs, so a repo's `.env.local` reaches it — but an exported shell value
-   always wins.
-3. **`settings.json`** — `providers.<id>.api_key` (an empty string is treated as unset; see
+1. **`--api-key` flag.** Checked first. You must also pass an explicit `--model provider/...`
+   — a bare key alone doesn't say which provider it belongs to.
+2. **Provider env var.** For example `ANTHROPIC_API_KEY`, plus aliases like `GOOGLE_API_KEY`
+   for Gemini. A `providers.<id>.api_key_env` entry in
+   [settings.json](/docs/configuration/settings) can rename the main variable. The named
+   variable is then checked first, and the provider's original env var still works as an
+   alias — handy for team key rotation (`MY_TEAM_ZAI_KEY`) without touching anyone's shell
+   profile. Project [dotenv files](/docs/getting-started/providers) load into the environment
+   before this step runs, so a repo's `.env.local` reaches it. An exported shell value always
+   wins over the dotenv value.
+3. **`settings.json`** — `providers.<id>.api_key` (an empty string counts as unset; see
    [settings.json](/docs/configuration/settings)).
-4. **`~/.stella/credentials.toml`** — the stored-keys file below.
-5. **Interactive prompt** — on a TTY, when you've named a provider with
-   `--model provider/model_id` (e.g. `--model anthropic/claude-fable-5`), stella prompts for
-   the key and saves it to `credentials.toml`, so you are only asked once. A bare invocation
-   with no `--model` uses auto-detection, which does **not** prompt — it errors with guidance
-   to name a provider instead.
+4. **`~/.stella/credentials.toml`** — the stored-keys file described below.
+5. **Interactive prompt** — on a terminal, if you named a provider with
+   `--model provider/model_id` (for example `--model anthropic/claude-fable-5`), stella asks
+   for the key and saves it to `credentials.toml`, so you're only asked once. Running stella
+   with no `--model` uses auto-detection, which does **not** prompt — it shows an error
+   telling you to name a provider instead.
 
-Each rung, as you would actually reach for it:
+Here is each one, the way you'd actually use it:
 
 ```bash
 # 1. The flag — needs an explicit provider, and lands in your shell history.
@@ -49,13 +48,12 @@ stella --model anthropic/claude-fable-5 run "…"
 
 <Callout type="warn">
   Prefer an env var, `settings.json`, or `credentials.toml` over `--api-key` for anything
-  long-lived — a flag value is visible in shell history and in `ps` output.
+  long-lived. A flag value shows up in shell history and in `ps` output.
 </Callout>
 
 ## credentials.toml
 
-Keys can be stored in `~/.stella/credentials.toml`. It is a flat table keyed by
-provider id:
+You can store keys in `~/.stella/credentials.toml`. It's a flat table, keyed by provider id:
 
 ```toml title="~/.stella/credentials.toml"
 [credentials]
@@ -66,14 +64,14 @@ openai = "sk-..."
 together = "..."
 ```
 
-- The file is written with **owner-only (`0600`) permissions** — it holds secrets in
-  plaintext, the same threat model as `~/.ssh/config`.
+- The file is written with **owner-only (`0600`) permissions** — it holds secrets in plain
+  text, the same risk as `~/.ssh/config`.
 - Writes are atomic (a temp file is renamed into place), so a reader never sees a
   half-written file.
 - When you enter a key at the interactive prompt, stella writes it here automatically.
-- If the file arrived some other way — hand-written, restored from a backup, checked
-  out from a dotfiles repo — and its mode lets your group or anyone else read it,
-  stella **warns at startup and reads it anyway**:
+- The file might arrive some other way: hand-written, restored from a backup, or checked
+  out from a dotfiles repo. If its permissions let your group or anyone else read it, stella
+  **warns at startup and reads it anyway**:
 
   ```text
   ⚠ credentials: ~/.stella/credentials.toml is mode 0644 — its plaintext provider keys
@@ -81,35 +79,33 @@ together = "..."
     `chmod 600 ~/.stella/credentials.toml` (the keys were still read for this run).
   ```
 
-  It does not refuse the read (that would lock you out of your own keys)
-  and does not silently `chmod` a file it did not create. Run the suggested `chmod`
+  stella doesn't refuse to read the file — that would lock you out of your own keys. It
+  also won't silently `chmod` a file it didn't create. Run the suggested `chmod` command
   and the warning goes away.
 
-## Managing stored keys — `stella auth`
+## Managing stored keys
 
-You do not have to hand-edit the file. `stella auth` is the write surface for
-`credentials.toml`:
+You don't have to edit the file by hand. Use `stella auth` to write to `credentials.toml`:
 
 <CardGrid size="md">
   <OptionCard name="stella auth set <provider>">
-    Store or replace a provider's key. With neither `--key` nor `--stdin` it
-    prompts with the input masked, which is the form to prefer.
+    Store or replace a provider's key. If you skip both `--key` and `--stdin`, it asks for
+    the key with hidden input. This is the safest way to run it.
   </OptionCard>
   <OptionCard name="stella auth set <provider> --stdin">
-    Read the key from stdin — one line, trimmed. The scriptable form, and the
-    one that keeps the secret out of your shell history and `ps`.
+    Read the key from standard input, one line, trimmed. Good for scripts — it keeps the
+    secret out of your shell history and `ps`.
   </OptionCard>
   <OptionCard name="stella auth set <provider> --key <KEY>">
-    Pass the key directly on the command line. Visible in shell history and
-    `ps` output — use `--stdin` instead unless you know you want this.
+    Pass the key directly on the command line. This is visible in shell history and `ps`
+    output — use `--stdin` instead unless you have a reason not to.
   </OptionCard>
   <OptionCard name="stella auth remove <provider>">
     Drop a provider's stored key from `credentials.toml`.
   </OptionCard>
   <OptionCard name="stella auth list">
-    List every provider with a stored key — redacted preview plus the
-    resolution source, so you can see which rung of the chain is actually
-    answering.
+    List every provider with a stored key. Shows a redacted preview and which link in the
+    chain is actually supplying it.
   </OptionCard>
 </CardGrid>
 
@@ -129,26 +125,24 @@ stella auth remove openai
 ```
 
 <Callout type="info">
-  `stella auth set` writes to a **settings-defined** provider id just as happily
-  as a built-in one — the key simply has to match the id you gave the entry in
-  `settings.json`.
+  `stella auth set` works the same for a provider id you defined in settings as it does for
+  a built-in one — the key just has to match the id you used in `settings.json`.
 </Callout>
 
-## Which key is active?
+## Active key
 
 ```bash
 stella config
 ```
 
-This prints the provider, model, and a **redacted preview** of the active key (a few
-leading and trailing characters, middle elided) so you can confirm *which* key is in use
-without printing the secret. It also shows the base URL, the wire dialect, the workspace
-root, and which `.env*` files were loaded.
+This prints the provider, model, and a redacted preview of the active key: a few characters
+at the start and end, with the middle hidden. You can confirm which key is in use without
+seeing the full secret. It also shows the base URL, the wire dialect, the workspace root,
+and which `.env*` files loaded.
 
 ## Cloud provider credentials
 
-Some providers need more than a single key, and read the extras from the
-environment:
+Some providers need more than one key. They read the extra values from the environment:
 
 <CardGrid size="md">
   <SpecCard
@@ -159,9 +153,9 @@ environment:
       { label: "Location", value: "VERTEX_LOCATION (default: global)" },
     ]}
   >
-    The access token rides the normal credential chain; the project id and
-    location are read straight from the environment. A missing project id is a
-    named error, not a silent default.
+    The access token goes through the normal credential chain. stella reads the project id
+    and location straight from the environment. A missing project id shows a clear error
+    instead of silently falling back to a default.
   </SpecCard>
   <SpecCard
     title="Amazon Bedrock"
@@ -172,8 +166,8 @@ environment:
       { label: "Region", value: "AWS_REGION → AWS_DEFAULT_REGION → us-east-1" },
     ]}
   >
-    SigV4 cannot sign without the secret, so `AWS_ACCESS_KEY_ID` alone is a
-    named error rather than a failed request later.
+    SigV4 signing needs the secret key. If you set only `AWS_ACCESS_KEY_ID`, stella shows a
+    clear error right away instead of letting the request fail later.
   </SpecCard>
 </CardGrid>
 

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -1,30 +1,30 @@
 ---
 title: Configuration
-description: How stella is configured — settings.json, credentials, workspace files, and the scope hierarchy.
+description: How stella is configured: settings.json, credentials, workspace files, and the scope hierarchy.
 ---
 
-stella reads configuration from a few well-defined places. Most users need only an API
-key; teams and power users reach for `settings.json`.
+stella reads its configuration from a few places. Most people only need an API key.
+Teams and power users also reach for `settings.json`.
 
 ## What lives where
 
 <CardGrid size="md">
   <OptionCard name="~/.stella/settings.json">
-    User-scope [settings](/docs/configuration/settings): provider overrides, hooks, tools,
-    the `context` block.
+    Your personal [settings](/docs/configuration/settings): provider overrides, hooks, tools,
+    and the `context` block.
   </OptionCard>
   <OptionCard name="<workspace>/.stella/settings.json">
-    Project-scope settings — highest precedence, and a
+    Settings for this project. These win over every other scope, and this file is also a
     [trust boundary](/docs/configuration/settings#the-project-trust-boundary).
   </OptionCard>
   <OptionCard name="<repo>/stella.toml">
-    The same configuration as [settings.json](/docs/configuration/settings), in a
-    comment-preserving TOML format — see [stella.toml](/docs/configuration/stella-toml).
+    The same settings as [settings.json](/docs/configuration/settings), written in TOML so
+    your comments survive edits. See [stella.toml](/docs/configuration/stella-toml).
     Lives at the repository root, not under `.stella/`.
   </OptionCard>
   <OptionCard name="org-managed settings.json">
-    Organization defaults ([see below](#the-settings-hierarchy)). The only scope that may
-    carry `authority` or `enterprise_telemetry`.
+    Organization-wide defaults ([see below](#the-settings-hierarchy)). The only scope that can
+    set `authority` or `enterprise_telemetry`.
   </OptionCard>
   <OptionCard name="~/.stella/credentials.toml">
     Stored [API keys](/docs/configuration/credentials), written with owner-only permissions.
@@ -36,7 +36,7 @@ key; teams and power users reach for `settings.json`.
     [Custom script tools](/docs/agent-tools/custom-tools).
   </OptionCard>
   <OptionCard name="<workspace>/.stella/domains.toml">
-    Domain taxonomy, inferred by `stella init`.
+    The domain list `stella init` builds for your project.
   </OptionCard>
   <OptionCard name="<workspace>/.stella/memories/*.md">
     Saved [workspace memories](/docs/context-engine).
@@ -45,47 +45,45 @@ key; teams and power users reach for `settings.json`.
     Promoted rules and guard rules. Also read from `.claude/rules/` and `~/.stella/rules/`.
   </OptionCard>
   <OptionCard name="<workspace>/.stella/private/store.db">
-    Local [telemetry &amp; store](/docs/telemetry) — embedded SQLite.
+    Local [telemetry &amp; store](/docs/telemetry), stored in SQLite on your machine.
   </OptionCard>
 </CardGrid>
 
 ## The settings hierarchy
 
-`settings.json` is read across three scopes and merged **field by field**, with the more
-specific scope winning:
+stella reads `settings.json` from three scopes and merges them **field by field**. The more
+specific scope wins:
 
-1. **project** — `<workspace>/.stella/settings.json` (highest preference)
-2. **org-managed** — a system-level managed file (middle)
-3. **user** — `~/.stella/settings.json` (lowest preference)
+1. **project** — `<workspace>/.stella/settings.json` (checked first)
+2. **org-managed** — a file your organization manages (checked second)
+3. **user** — `~/.stella/settings.json` (checked last)
 
-A project entry overrides an org-managed one, which overrides a user one — per field, so a
-project can change just a base URL while inheriting an API key from a higher scope. This is
-the same layering the rest of stella's settings use.
+A project setting overrides an org-managed one. An org-managed setting overrides a user one.
+This happens field by field, so a project can set just a base URL and still inherit an API
+key from a higher scope. The rest of stella's settings follow this same layering.
 
 <SettingsCascadeDiagram />
 
-See **[settings.json](/docs/configuration/settings)** for the full schema — all ten
-top-level sections — the org-managed path, and worked examples. The same configuration is
-also available as **[stella.toml](/docs/configuration/stella-toml)**, a comment-preserving
-format with a `stella migrate config` command to convert an existing `settings.json`.
+See [settings.json](/docs/configuration/settings) for the full schema: all ten top-level
+sections, the org-managed path, and worked examples. The same settings are also available as
+[stella.toml](/docs/configuration/stella-toml), a format that keeps your comments. Run
+`stella migrate config` to convert an existing `settings.json` to TOML.
 
 ## Configuration vs. credentials
 
-Two separate concerns:
+- [settings.json](/docs/configuration/settings) configures *behavior*: which base URL a
+  provider uses, its display name, default model, and lifecycle hooks. It can also hold an
+  API key.
+- [credentials.toml](/docs/configuration/credentials) stores *only* API keys, written with
+  owner-only permissions.
 
-- **[settings.json](/docs/configuration/settings)** configures *behavior* — which base URL
-  a provider uses, its display name, default model, and lifecycle hooks. It may also carry
-  an API key.
-- **[credentials.toml](/docs/configuration/credentials)** stores *only* API keys, written
-  with owner-only permissions.
-
-Both feed the [credential chain](/docs/getting-started/providers#the-credential-chain).
+Both feed the [credential chain](/docs/getting-started/providers#credential-chain).
 
 ## Everything you can configure
 
-stella is configured through three kinds of surface — **files**, **environment variables**,
-and **command-line flags** — with flags winning over env vars winning over files. What
-follows is the complete map; each card links to its detail page.
+You can configure stella three ways: files, environment variables, and command-line flags.
+Flags win over environment variables. Environment variables win over files. Each card below
+links to its own detail page.
 
 ### Providers, models, and keys
 
@@ -102,7 +100,7 @@ follows is the complete map; each card links to its detail page.
   </SpecCard>
   <SpecCard
     title="A provider's API key"
-    href="/docs/getting-started/providers#the-credential-chain"
+    href="/docs/getting-started/providers#credential-chain"
     meta={[
       { label: "Surface", value: "--api-key · provider env var · api_key · credentials.toml" },
       { label: "Example", value: "export ANTHROPIC_API_KEY=…" },
@@ -129,7 +127,7 @@ follows is the complete map; each card links to its detail page.
   </SpecCard>
 </CardGrid>
 
-### Output, budget, and the run itself
+### Output and run options
 
 <CardGrid size="md">
   <SpecCard
@@ -150,7 +148,7 @@ follows is the complete map; each card links to its detail page.
       { label: "Example", value: 'stella --spend-limit 2.00 goal "…"' },
     ]}
   >
-    Enforced, not advisory: work aborts cleanly once spend passes the cap.
+    Enforced, not advisory: work stops cleanly once spend passes the cap.
   </SpecCard>
   <SpecCard
     title="Force the plain REPL (no TUI)"
@@ -160,7 +158,7 @@ follows is the complete map; each card links to its detail page.
       { label: "Example", value: "stella --plain chat" },
     ]}
   >
-    For pipes, dumb terminals, and recordings.
+    For pipes, plain terminals, and recordings.
   </SpecCard>
   <SpecCard
     title="Freeze TUI animation"
@@ -203,28 +201,29 @@ follows is the complete map; each card links to its detail page.
     href="/docs/configuration/settings#the-tools-section"
     meta={[{ label: "Surface", value: 'settings.json tools.mcp: "off"' }]}
   >
-    Groups such as `task`, `scratch`, `mcp`, or `custom` — or `"*"` for everything.
+    Groups such as `task`, `scratch`, `mcp`, or `custom`. Or use `"*"` for everything.
   </SpecCard>
   <SpecCard
     title="Per-tool permission gates"
     href="/docs/agent-tools/permissions"
     meta={[{ label: "Surface", value: "hooks PreToolUse matchers + tools switches" }]}
   >
-    A programmable veto in front of any tool call.
+    A script that can block any tool call before it runs.
   </SpecCard>
   <SpecCard
     title="The adaptive-context lifecycle"
     href="/docs/configuration/settings#the-context-block"
     meta={[{ label: "Surface", value: "settings.json context" }]}
   >
-    Learning, governance, promotion, efficacy, and retention knobs. Disabled by default.
+    Settings for learning, governance, promotion, efficacy, and retention. Off by default.
   </SpecCard>
   <SpecCard
     title="Third-party context sources"
     href="/docs/configuration/settings#external-context-providers"
     meta={[{ label: "Surface", value: "settings.json context_providers" }]}
   >
-    CGP providers over stdio or HTTP, admitted only after conformance and consent.
+    CGP providers reached over stdio or HTTP. Each one must pass a conformance check and get
+    your consent first.
   </SpecCard>
   <SpecCard
     title="MCP servers to connect"
@@ -242,7 +241,7 @@ follows is the complete map; each card links to its detail page.
   </SpecCard>
 </CardGrid>
 
-### Fleet defaults, trust, and diagnostics
+### Fleet, trust, diagnostics
 
 <CardGrid size="md">
   <SpecCard
@@ -276,21 +275,21 @@ follows is the complete map; each card links to its detail page.
 </CardGrid>
 
 <Callout type="warn">
-  `STELLA_DEBUG` and `STELLA_MEDIA_LIVE` were previously spelled `OXAGEN_DEBUG` and
-  `OXAGEN_MEDIA_LIVE`. The old names still work as deprecated aliases for one release;
-  the `STELLA_`-prefixed spelling wins when both are set.
+  `OXAGEN_DEBUG` and `OXAGEN_MEDIA_LIVE` also work as names for `STELLA_DEBUG` and
+  `STELLA_MEDIA_LIVE`. If you set both the old and new name, the `STELLA_` name wins.
 </Callout>
 
 <Callout type="info">
-  stella **auto-detects** the provider from whichever API keys are present in your
-  environment — the minimum viable configuration is a single `*_API_KEY` env var and nothing
-  else. Everything above is for when you want to override that default behavior.
+  stella detects your provider automatically from whichever API key is present in your
+  environment. The smallest setup you need is one `*_API_KEY` environment variable.
+  Everything above is for when you want to change that default.
 </Callout>
 
 ### Common tasks
 
-**Point a Z.ai coding-plan subscription at its endpoint** (user scope — a subscription is
-personal, and project scope would need [`STELLA_TRUST_PROJECT=1`](/docs/configuration/settings#the-project-trust-boundary)):
+**Point a Z.ai coding-plan subscription at its endpoint.** Set this in user scope, since a
+subscription is personal. Project scope needs
+[`STELLA_TRUST_PROJECT=1`](/docs/configuration/settings#the-project-trust-boundary):
 
 ```json title="~/.stella/settings.json"
 { "providers": { "zai": { "base_url": "https://api.z.ai/api/coding/paas/v4" } } }
@@ -305,27 +304,27 @@ STELLA_MODEL=anthropic/claude-fable-5 STELLA_SPEND_LIMIT=5 \
   stella run --output-format json "port the utils module to the new API"
 ```
 
-**Ship org-wide defaults every project inherits** (a gateway URL + team key), leaving
-projects free to override per field:
+**Ship org-wide defaults every project inherits**, such as a gateway URL and team key.
+Projects can still override any field:
 
 ```bash
 export STELLA_MANAGED_SETTINGS=/etc/stella/settings.json
 ```
 
-**Run against a local OpenAI-compatible server** (Ollama, vLLM, LM Studio):
+**Run against a local OpenAI-compatible server**, such as Ollama, vLLM, or LM Studio:
 
 ```bash
 stella --model local/llama3.1 --base-url http://localhost:11434/v1 run "…"
 ```
 
-**Gate a tool call through a guard script** (`settings.json`):
+**Gate a tool call through a guard script**, in `settings.json`:
 
 ```json title="~/.stella/settings.json"
 { "hooks": { "PreToolUse": [ { "matcher": "mcp__github__push_files",
   "hooks": [ { "command": "./scripts/guard.sh", "timeoutMs": 5000 } ] } ] } }
 ```
 
-## Inspecting the resolved configuration
+## Check your configuration
 
 ```bash
 stella config    # the fully resolved provider, model, key preview, and base URL

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: How stella is configured: settings.json, credentials, workspace files, and the scope hierarchy.
+description: "How stella is configured: settings.json, credentials, workspace files, and the scope hierarchy."
 ---
 
 stella reads its configuration from a few places. Most people only need an API key.

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -7,11 +7,11 @@ description: Configure providers, agents, tools, context, and managed authority 
 merge rule across the [scope hierarchy](#the-scope-hierarchy):
 
 <Callout type="info">
-  The same configuration is also available as
-  **[`stella.toml`](/docs/configuration/stella-toml)** — a comment-preserving format with a
-  `[meta]` schema-version seam, converted from an existing `settings.json` with
-  `stella migrate config`. Every merge rule, trust boundary, and section below applies
-  identically to both formats; only the file shape differs.
+  The same settings are also available as
+  **[`stella.toml`](/docs/configuration/stella-toml)** — a format that keeps your comments
+  and adds a `[meta]` block for tracking schema versions, converted from an existing
+  `settings.json` with `stella migrate config`. Every merge rule, trust boundary, and
+  section below works the same in both formats — only the file shape is different.
 </Callout>
 
 <CardGrid size="md">
@@ -20,7 +20,7 @@ merge rule across the [scope hierarchy](#the-scope-hierarchy):
     href="#the-providers-map"
     meta={[{ label: "Merges", value: "per field", mono: false }]}
   >
-    Override any built-in provider — or define a new one.
+    Override any built-in provider, or define a new one.
   </SpecCard>
   <SpecCard
     title={<code>agent_engine_config</code>}
@@ -34,15 +34,15 @@ merge rule across the [scope hierarchy](#the-scope-hierarchy):
     href="#lifecycle-hooks"
     meta={[{ label: "Merges", value: "concatenate", mono: false }]}
   >
-    Shell commands on lifecycle events. Every scope may add matchers; none replaces
-    another's.
+    Shell commands that run on lifecycle events. Every scope can add matchers, and none
+    replaces another's.
   </SpecCard>
   <SpecCard
     title={<code>tools</code>}
     href="#the-tools-section"
     meta={[{ label: "Merges", value: "last scope wins, per key", mono: false }]}
   >
-    Per-tool switches — any tool name, group, or `"*"`.
+    Switches for individual tools — by tool name, by group, or with `"*"`.
   </SpecCard>
   <SpecCard
     title={<code>mcp</code>}
@@ -77,8 +77,8 @@ merge rule across the [scope hierarchy](#the-scope-hierarchy):
     href="#managed-authority-ceilings"
     meta={[{ label: "Scope", value: "org-managed only", mono: false }]}
   >
-    Managed ceilings for project prompts, custom tools, bash, web, and media approval. A
-    denial cannot be overridden.
+    Managed limits for project prompts, custom tools, bash, web, and media approval. A
+    denial can never be overridden.
   </SpecCard>
   <SpecCard
     title={<code>enterprise_telemetry</code>}
@@ -90,21 +90,21 @@ merge rule across the [scope hierarchy](#the-scope-hierarchy):
 </CardGrid>
 
 <Callout type="info">
-  `authority_policy` is **not** a file key. It is the effective authority stella computes
-  while loading the scope chain, and it is skipped during parsing precisely so repository
-  text cannot supply it.
+  `authority_policy` is not a file key. It's the effective authority stella computes
+  while loading the scope chain. Parsing skips it on purpose, so repository text can
+  never supply it.
 </Callout>
 
-The `providers` map lets you override the built-in defaults for any provider — **without
-reaching for a provider-specific environment variable**. In **user scope**
-(`~/.stella/settings.json`) it is the recommended way to, for example, route a Z.ai
-coding-plan subscription through its dedicated endpoint — see the
+The `providers` map lets you override the built-in defaults for any provider, without
+needing a provider-specific environment variable. In **user scope**
+(`~/.stella/settings.json`), it's the recommended way to route a Z.ai coding-plan
+subscription through its dedicated endpoint, for example — see the
 [coding-plan recipe](/docs/api-providers#zai).
 
 ## The `providers` map
 
-Keyed by provider id. Every field is optional — supply only what differs from the built-in
-default:
+Keyed by provider id. Every field is optional. Supply only what's different from the
+built-in default:
 
 ```json title="~/.stella/settings.json"
 {
@@ -121,66 +121,69 @@ default:
 
 <CardGrid size="md">
   <OptionCard name="id">
-    Optional restatement of the map key; if present it **must equal the key** — a mismatch
-    is a hard, named load error, which guards against copy-pasting the wrong provider.
+    An optional restatement of the map key. If present it **must equal the key** — a
+    mismatch is a hard, named load error, which guards against copy-pasting the wrong
+    provider.
   </OptionCard>
   <OptionCard name="name">
     Display name shown by `stella config` / `stella models`.
   </OptionCard>
   <OptionCard name="base_url">
-    Base URL requests go to — a coding-plan endpoint, a proxy, a gateway.
+    The base URL requests go to: a coding-plan endpoint, a proxy, or a gateway.
   </OptionCard>
   <OptionCard name="api_key">
     API key for this provider. It slots into the
-    [credential chain](/docs/getting-started/providers#the-credential-chain).
+    [credential chain](/docs/getting-started/providers#credential-chain).
   </OptionCard>
   <OptionCard name="api_key_env">
-    Name of an environment variable to read the key from — safer than an inline `api_key`
-    in a committed project file.
+    The name of an environment variable to read the key from — safer than an inline
+    `api_key` in a committed project file.
   </OptionCard>
   <OptionCard name="default_model">
     Model used when none is pinned with `--model`.
   </OptionCard>
   <OptionCard name="dialect" defaultValue="openai-compatible">
-    Wire adapter for a **new** provider: `openai-compatible`, `openai-responses`,
-    `anthropic`, or `gemini`. `vertex` and `bedrock` are reserved to built-ins.
+    The wire adapter for a new provider: `openai-compatible`, `openai-responses`,
+    `anthropic`, or `gemini`. `vertex` and `bedrock` are reserved for built-in providers.
   </OptionCard>
   <OptionCard name="cache_ttl">
-    Prompt-cache window: `"5m"` or `"1h"`. Leave it out and the **surface** decides —
+    The prompt-cache window: `"5m"` or `"1h"`. Leave it out and the **surface** decides —
     `stella chat` / `stella resume` ask for the 1-hour window, every headless run keeps
-    the 5-minute provider default. Honored today by the `anthropic` provider only.
+    the 5-minute provider default. Only the `anthropic` provider honors this today.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-  **Why `cache_ttl` defaults by surface.** A 1-hour cache write bills 2x the input rate
-  against the 5-minute window's 1.25x. That premium only pays for itself when turns are
-  far enough apart to lose the prefix: an eviction re-bills the whole prefix at the write
-  rate *and* forfeits the ~0.9x read discount on it. Interactive turns routinely sit
-  minutes apart, so the wider window is nearly free insurance; a headless run's calls are
-  seconds apart, so it would pay the premium for a prefix that was never going to expire.
-  Pin the field to override either default.
+  **Why `cache_ttl` defaults by surface.** A 1-hour cache write bills at 2x the input
+  rate, against the 5-minute window's 1.25x. That premium only pays off when turns are
+  far enough apart to lose the cached prefix. If the cache expires, stella re-bills the
+  whole prefix at the write rate, and also loses the roughly 0.9x read discount on it.
+  Interactive turns usually sit minutes apart, so the wider window is nearly free
+  insurance. A headless run's calls happen seconds apart, so it would pay the premium for
+  a prefix that was never going to expire anyway. Set the field yourself to override
+  either default.
 </Callout>
 
-The map key **is** the provider id (`zai` above). Leave a field out entirely to inherit the
-built-in default. An **empty string** for `base_url`, `name`, or
-`default_model` overwrites the built-in with an empty value, breaking the provider or its
-model selection; only `api_key` treats empty as unset.
+The map key is the provider id (`zai` above). Leave a field out entirely to inherit the
+built-in default. An empty string for `base_url`, `name`, or `default_model` overwrites
+the built-in with an empty value, which breaks the provider or its model selection.
+**Only `api_key` treats an empty string as unset.**
 
 <Callout type="info">
-  `providers` both overrides built-ins and **defines brand-new providers**: use an id that
-  isn't built-in, set the required `base_url`, and optionally a `dialect` (defaults to
-  `openai-compatible`). That is how you point stella at any OpenAI-compatible gateway from
-  config alone.
+  `providers` does two things: it overrides built-ins, and it **defines brand-new
+  providers**. To define one, use an id that isn't built-in, set the required `base_url`,
+  and optionally a `dialect` (defaults to `openai-compatible`). This is how you point
+  stella at any OpenAI-compatible gateway from config alone.
 </Callout>
 
 ## The scope hierarchy
 
-`settings.json` is read across three scopes and merged, applied lowest to highest so the
-more specific scope wins. The merge is **field by field** for `providers` and
-`agent_engine_config` (whose `allowed_models` list replaces wholesale rather than
-merging), **last-scope-wins** for `mcp` and `tools`, and `hooks` are the exception — they
-**concatenate** across scopes (see [Lifecycle hooks](#lifecycle-hooks)).
+stella reads `settings.json` from three scopes and merges them, applying the lowest
+scope first so the more specific scope wins. The merge is **field by field** for
+`providers` and `agent_engine_config` (though `agent_engine_config`'s `allowed_models`
+list replaces wholesale instead of merging), **last-scope-wins** for `mcp` and `tools`,
+and `hooks` is the exception — scopes **concatenate** instead (see
+[Lifecycle hooks](#lifecycle-hooks)).
 
 <SettingsCascadeDiagram />
 
@@ -192,7 +195,8 @@ merging), **last-scope-wins** for `mcp` and `tools`, and `hooks` are the excepti
       { label: "Path", value: <code>{"<workspace>/.stella/settings.json"}</code> },
     ]}
   >
-    The repository's own file — and a [trust boundary](#the-project-trust-boundary).
+    The repository's own file. Also a
+    [trust boundary](#the-project-trust-boundary).
   </SpecCard>
   <SpecCard
     title="org-managed"
@@ -201,7 +205,7 @@ merging), **last-scope-wins** for `mcp` and `tools`, and `hooks` are the excepti
       { label: "Path", value: <code>STELLA_MANAGED_SETTINGS</code> },
     ]}
   >
-    Or the platform default, resolved below. The only scope that may carry `authority` or
+    Or the platform default, resolved below. The only scope that can carry `authority` or
     `enterprise_telemetry`.
   </SpecCard>
   <SpecCard
@@ -211,26 +215,26 @@ merging), **last-scope-wins** for `mcp` and `tools`, and `hooks` are the excepti
       { label: "Path", value: <code>~/.stella/settings.json</code> },
     ]}
   >
-    Your personal defaults — the right home for a subscription endpoint or a personal key.
+    Your personal defaults. The right home for a subscription endpoint or a personal key.
   </SpecCard>
 </CardGrid>
 
-The org-managed path is resolved as:
+stella resolves the org-managed path this way:
 
-1. The `STELLA_MANAGED_SETTINGS` environment variable (an explicit path — for MDM/CI), else
+1. The `STELLA_MANAGED_SETTINGS` environment variable, an explicit path for MDM or CI, if
+   set, else
 2. `/Library/Application Support/stella/settings.json` on macOS, or
-3. `/etc/stella/settings.json` on other Unix.
+3. `/etc/stella/settings.json` on other Unix systems
 
-Ordinary fields merge project over org-managed over user. Authority-sensitive fields are
-stricter: a project may narrow a grant with `"off"`, but it may not enable tools, replace
+Ordinary fields merge project over org-managed over user. Fields tied to authority are
+stricter: a project can narrow a grant with `"off"`, but it can't enable tools, replace
 an agent prompt, redirect credentials, register a context provider, or load executable
-custom tools until the user sets `STELLA_TRUST_PROJECT=1`. An org-managed denial is a
-ceiling even after that explicit trust. The legacy `STELLA_PROJECT_HOOKS=1` flag grants
-hooks only.
+custom tools, until you set `STELLA_TRUST_PROJECT=1`. An org-managed denial stays a limit
+even after that trust is granted. The `STELLA_PROJECT_HOOKS=1` flag grants hooks only.
 
 <Callout type="info">
-  A missing file at any scope is fine — it is simply skipped. A file that is present but
-  malformed is reported as a named error rather than silently dropping your configuration.
+  A missing file at any scope is fine — stella just skips it. A file that exists but is
+  malformed shows a clear error instead of silently dropping your configuration.
 </Callout>
 
 ### Worked example
@@ -270,41 +274,42 @@ Suppose three files are present:
 }
 ```
 
-The merged result for `zai` — **with the project trusted** (`STELLA_TRUST_PROJECT=1`):
+Here's the merged result for `zai`, **with the project trusted**
+(`STELLA_TRUST_PROJECT=1`):
 
-- `base_url` → `https://api.z.ai/api/coding/paas/v4` — **project wins**
-- `name` → `Org Gateway` — **org-managed wins** over user (project didn't set it)
-- `api_key` → `sk-personal` — from user (only the user scope set it)
+- `base_url` → `https://api.z.ai/api/coding/paas/v4` (**project wins**)
+- `name` → `Org Gateway` (**org-managed wins** over user, since project didn't set it)
+- `api_key` → `sk-personal` (from user; only the user scope set it)
 
 <Callout type="warn">
-  Without `STELLA_TRUST_PROJECT=1` — the default for any repo you didn't explicitly
-  trust — the project's `base_url` is a **credential-routing field** and is dropped by the
-  [trust boundary](#the-project-trust-boundary): the merged `base_url` above would be the
-  org gateway's, with a stderr notice naming the skipped field. Project-scope
-  `base_url`/`api_key`/`api_key_env` examples in these docs assume a trusted
-  project; personal routing in user scope needs no flag.
+  Without `STELLA_TRUST_PROJECT=1` (the default for any repo you haven't explicitly
+  trusted), the project's `base_url` is a **credential-routing field**, and the
+  [trust boundary](#the-project-trust-boundary) drops it. The merged `base_url` above
+  would then be the org gateway's, with a stderr notice naming the skipped field.
+  Project-scope `base_url`/`api_key`/`api_key_env` examples in these docs assume a
+  trusted project; personal routing in user scope needs no flag.
 </Callout>
 
 ## Precedence within a field
 
 `settings.json` values are one link in a larger chain. Command-line flags still win:
 
-**Base URL** — `--base-url` flag &gt; the `ZAI_GLM_CODING_PLAN=1` toggle (Z.ai only) &gt;
+**Base URL.** `--base-url` flag &gt; the `ZAI_GLM_CODING_PLAN=1` toggle (Z.ai only) &gt;
 `settings.json` `base_url` &gt; the built-in default. So if both the env toggle and a
 `settings.json` `base_url` are set for Z.ai, the env toggle wins.
 
-**API key** — `--api-key` flag &gt; the provider's env var &gt; `settings.json`
+**API key.** `--api-key` flag &gt; the provider's env var &gt; `settings.json`
 `api_key` &gt; `~/.stella/credentials.toml` &gt; interactive prompt. See the
-[credential chain](/docs/getting-started/providers#the-credential-chain).
+[credential chain](/docs/getting-started/providers#credential-chain).
 
-An API key configured **only** in `settings.json` is enough for stella to auto-detect and
-run that provider — no provider-specific environment variable required.
+An API key configured only in `settings.json` is enough for stella to auto-detect and
+run that provider — you don't need a provider-specific environment variable.
 
-## The Z.ai coding-plan example
+## Z.ai coding-plan example
 
 If you subscribe to a Z.ai coding plan, point `providers.zai.base_url` at the coding
-endpoint instead of setting the bespoke `ZAI_GLM_CODING_PLAN=1` variable. A subscription
-is personal, so this belongs in **user scope** — project scope would silently drop the
+endpoint, instead of setting the `ZAI_GLM_CODING_PLAN=1` variable. A subscription is
+personal, so this belongs in **user scope** — project scope would silently drop the
 `base_url` unless the repo is trusted with `STELLA_TRUST_PROJECT=1`:
 
 ```json title="~/.stella/settings.json"
@@ -317,29 +322,29 @@ is personal, so this belongs in **user scope** — project scope would silently 
 }
 ```
 
-The full walkthrough — plan tiers, verification, and routing every seat at the
-subscription — is the [coding-plan recipe](/docs/api-providers#zai).
+For the full walkthrough on plan tiers, verification, and routing every seat at the
+subscription, see the [coding-plan recipe](/docs/api-providers#zai).
 
-Your `ZAI_API_KEY` env var (or a `settings.json` `api_key`) supplies the key; the base URL
-now comes from the file. Verify:
+Your `ZAI_API_KEY` env var (or a `settings.json` `api_key`) supplies the key. The base
+URL now comes from the file. Verify:
 
 ```bash
 stella config    # Base URL should read https://api.z.ai/api/coding/paas/v4
 ```
 
 <Callout type="warn">
-  The `ZAI_GLM_CODING_PLAN=1` environment toggle still works and actually takes precedence
-  over a `settings.json` `base_url` for Z.ai — so if you switch to the provider-agnostic
-  setting, unset the env toggle to avoid a surprising override. It may be removed in a future
-  release.
+  The `ZAI_GLM_CODING_PLAN=1` environment toggle still works, and it takes precedence
+  over a `settings.json` `base_url` for Z.ai. If you switch to the settings-based
+  approach, unset the env toggle too, or it will override your setting without warning.
 </Callout>
 
 ## The `mcp` section
 
-`settings.json` also has a top-level `mcp` section. Its `registry_url` sets the base URL of
-the MCP Server Registry that `stella mcp search` and the deck's MCP tab query; when unset it
-falls back to the official registry. Like `providers`, it merges last-scope-wins per field,
-so a project can point at a different registry than the user default.
+`settings.json` also has a top-level `mcp` section. Its `registry_url` field sets the
+base URL of the MCP Server Registry that `stella mcp search` and the deck's MCP tab
+query. When unset, it falls back to the official registry. Like `providers`, it merges
+last-scope-wins per field, so a project can point at a different registry than the user
+default.
 
 ```json title="~/.stella/settings.json"
 {
@@ -351,9 +356,9 @@ so a project can point at a different registry than the user default.
 
 ## The `tools` section
 
-stella ships with **every tool on**. The top-level
-`tools` section is the one way to turn something off, and it works identically for
-built-ins, MCP-server tools, and tools you registered yourself:
+stella ships with every tool on. The top-level `tools` section is the one way to turn
+something off, and it works the same way for built-in tools, MCP-server tools, and tools
+you registered yourself:
 
 ```json title="settings.json"
 {
@@ -364,56 +369,52 @@ built-ins, MCP-server tools, and tools you registered yourself:
 }
 ```
 
-A key is one of the following, and the most specific one wins:
+A key can be one of these, and the most specific one wins:
 
-1. an exact **tool name** — `task_assign`, `delegate`, `mcp__github__create_issue`,
-   your own `deploy_to_staging`;
-2. a **group** — the families in [Built-in tools](/docs/agent-tools): `shell`,
+1. an exact **tool name**, like `task_assign`, `delegate`, `mcp__github__create_issue`,
+   or your own `deploy_to_staging`;
+2. a **group**, one of the families in [Built-in tools](/docs/agent-tools): `shell`,
    `file`, `search`, `task`, `scratch`, `environment`, plus
-   `mcp` and `custom` for anything the built-in catalog has never heard of;
-3. `"*"`, every tool.
+   `mcp` and `custom` for anything the built-in catalog doesn't recognize;
+3. `"*"`, meaning every tool.
 
 Anything unmentioned is on. So `{"*": "off", "task_list": "on"}` is an agent that can
 read the board and nothing else, and `{"task": "off", "task_list": "on"}` keeps exactly
 the read-only member of the task family.
 
 No group shares a name with a tool, so a key is never ambiguous: `task` is the family
-(the six board tools plus `delegate`), and `delegate` alone is the sub-agent spawn. That
-is why `{"delegate": "off"}` stops sub-agents without touching the board — a distinction
-`task` could not express while it was both a tool name and a group name.
+name (the six board tools plus `delegate`), and `delegate` alone is the sub-agent spawn
+tool. That is why `{"delegate": "off"}` stops sub-agents without touching the board.
 
-A switched-off tool is **withheld from the schema list and refused if it is called
-anyway** — the refusal reads like the unknown-tool error, so a disabled tool is
-indistinguishable from one that was never built. The gate is at the tool boundary, not in
-the prompt.
+A switched-off tool is left out of the schema list, and refused if it is called
+anyway — the refusal looks just like the unknown-tool error, so a disabled tool is
+indistinguishable from one that was never built. This check happens at the tool
+boundary, not in the prompt.
 
-The values are the strings `"on"`/`"off"` — a bare boolean or a typo is a hard, named
-parse error rather than a silent ignore. Keys merge independently across scopes, later
-scope winning. A project `"off"` always narrows an earlier grant; project `"on"` requires
-`STELLA_TRUST_PROJECT=1`. A managed `"off"` remains a ceiling even for a trusted project,
-at any level of specificity: a managed `{"task": "off"}` cannot be defeated by a
-project naming `{"task_assign": "on"}`.
+The values are always the strings `"on"`/`"off"` — a bare boolean or a typo is a clear
+parse error, not a silent ignore. Keys merge independently across scopes, with the later
+scope winning. A project `"off"` always narrows an earlier grant; project `"on"`
+requires `STELLA_TRUST_PROJECT=1`. A managed `"off"` stays a limit even for a trusted
+project, at any level of detail: a managed `{"task": "off"}` can't be beaten by a
+project setting `{"task_assign": "on"}`.
 
 ## The end-of-run recap
 
-`enable_recap` (bare root key) and its TOML home `run.recap` were **retired** in #3870:
-the renderer read the built-in staged pipeline's verdict types and was left with that
-crate when it was deleted (#3865), so nothing assembles a recap now. Setting the key is
-not a typo and is not reported as one — the config walker names it and says what it
-used to do. There is no replacement key; a run's outcome is still visible from the
-files and cost panels a text-mode run already prints.
+`enable_recap` (bare root key) and its TOML home `run.recap` do nothing. Setting the key
+is not a typo and is not reported as one — the config loader recognizes the key and
+tells you it's inactive. There is no replacement key; a run's outcome is still visible
+from the files and cost panels a text-mode run already prints.
 
 ## Trajectory trace capture
 
-`trace_capture` (bare root key) and its TOML home `run.trace_capture` were **retired**
-in #3870 for the same reason as `enable_recap` above: the module that assembled the
-per-execution trajectory record was orphaned by the staged pipeline's removal (#3865)
-and deleted with it. Setting the key is not a typo and is not reported as one — the
-config walker names it and says what it used to do. There is no replacement key today.
+`trace_capture` (bare root key) and its TOML home `run.trace_capture` do nothing, for the
+same reason as `enable_recap` above. Setting the key is not a typo and is not reported as
+one — the config loader recognizes the key and tells you it's inactive. There is no
+replacement key today.
 
 ## The probe's gitignore filter
 
-`ignore_gitignore` uses the same strict `"on"`/`"off"` vocabulary — and it is the one
+`ignore_gitignore` uses the same strict `"on"`/`"off"` values — and it is the one
 toggle in this family that **defaults on**: an absent key means the filter runs, and
 only an explicit `"off"` restores the unfiltered walk.
 
@@ -423,19 +424,19 @@ only an explicit `"off"` restores the unfiltered walk.
 }
 ```
 
-With it on (the default), the workspace probe — the walk that attributes what an
+With it on (the default), the workspace probe — the walk that figures out what an
 opaque shell command changed — skips every path the repository's own `.gitignore`
-excludes. Build churn (`target/`, `node_modules/`, an object tree) is never walked,
-never recorded as a file touch, and never fed to the Files tab or the verification
-ladder, because the repository has already declared it uninteresting. Source edits in
-the same delta are attributed exactly as before.
+excludes. Build output like `target/`, `node_modules/`, or an object tree is never
+walked, never recorded as a file touch, and never fed to the Files tab or the
+verification ladder, because the repository has already marked it as unimportant. Source
+edits in the same change are attributed exactly as before.
 
-Two boundaries keep the filter narrow. It consults only the repository rooted **at
-the workspace itself** — a workspace that merely sits under someone else's repository
-(say, a scratch directory beneath a `$HOME` dotfiles repo whose `.gitignore` says
-`*`) inherits nothing, so an ancestor's rules can never blind the probe. Outside
-a git repository the switch is inert: nothing is ignored, and the probe stays fully
-sighted — producing build output there is often the whole job.
+Two limits keep the filter narrow. It only checks the repository rooted **at the
+workspace itself** — a workspace that just sits under someone else's repository (say, a
+scratch directory beneath a `$HOME` dotfiles repo whose `.gitignore` says `*`) inherits
+nothing, so a parent repository's rules can never blind the probe. Outside a git
+repository the switch does nothing: nothing is ignored, and the probe sees everything —
+producing build output there is often the whole point.
 
 ## The `ui` section
 
@@ -444,16 +445,17 @@ section behaves exactly as the defaults.
 
 <CardGrid size="md">
   <OptionCard name="theme" defaultValue="stella-dark">
-    The deck's colour theme slug — `stella-dark` (electric blue on deep space, the
-    default) or `stella-light` (the same blue darkened onto paper). The short forms
-    `dark` and `light` also resolve. An unrecognised value falls back to the default
-    rather than failing the file.
+    The deck's color theme: `stella-dark` (electric blue on deep space, the
+    default) or `stella-light` (the same blue, darkened onto paper). The short forms
+    `dark` and `light` also work. An unrecognized value falls back to the default
+    instead of failing the file.
   </OptionCard>
   <OptionCard name="mid_turn_prompt" defaultValue="queue">
-    What a plain prompt typed at a **running** agent does. `queue` waits as the lead's
-    next turn, so `Esc` can steer the whole backlog into the turn in flight. `ask` raises
-    a routing card per prompt (`s` steer / `n` next turn / `p` sidecar). `spawn` forks every
-    plain prompt to a sidecar sub-session. An unrecognised value keeps the default.
+    What happens when you type a plain prompt while an agent is **running**. `queue`
+    waits as the next turn, so `Esc` can steer the whole backlog into the turn in
+    progress. `ask` raises a routing card per prompt (`s` steer / `n` next turn / `p`
+    sidecar). `spawn` forks every plain prompt to a sidecar sub-session. An unrecognized
+    value keeps the default.
     See [Typing while a turn is running](/docs/commands/chat#typing-while-a-turn-is-running).
   </OptionCard>
 </CardGrid>
@@ -467,23 +469,23 @@ section behaves exactly as the defaults.
 <Callout type="info">
 This is the **deck's** theme, and it is a different setting from `/color`, which sets a
 session accent in the plain line-based REPL (`--plain`) from a fixed list — `sky`,
-`cyan`, `azure`, `violet`, `magenta`, `mint`. The two surfaces have separate colour
+`cyan`, `azure`, `violet`, `magenta`, `mint`. The two surfaces have separate color
 models; setting one does not change the other.
 </Callout>
 
-Writing this section is a read-modify-write that preserves every other key
-byte-for-byte at the value level, so changing a theme from the deck's SETTINGS tab never
-drops `providers`, `hooks`, or a forward-compatible key it does not recognise. Clearing
-the theme removes the `ui` key rather than leaving an empty `{}` behind.
+Writing this section reads the file, changes only this part, and writes it back,
+keeping every other key exactly as it was. Changing a theme from the deck's SETTINGS tab
+never drops `providers`, `hooks`, or a key it doesn't recognize yet. Clearing the theme
+removes the `ui` key rather than leaving an empty `{}` behind.
 
 ## The `voice` section
 
 Dictation from the composer: speak, and the transcript lands at the cursor. Off by
-default — recording streams microphone audio to the provider named below, an egress you
-opt into by name. The provider id resolves through `providers` (or the built-in table)
-for its endpoint and API key, so this section holds no credential of its own; any
-provider with an OpenAI-compatible `audio/transcriptions` endpoint works, a local
-Whisper server included.
+default — recording sends microphone audio to the provider named below, an off-machine
+transfer you opt into by name. The provider id resolves through `providers` (or the
+built-in table) for its endpoint and API key, so this section holds no credential of its
+own; any provider with an OpenAI-compatible `audio/transcriptions` endpoint works, a
+local Whisper server included.
 
 `/voice tap`, `/voice hold` and `/voice off` write both fields below and take effect in
 the session that runs them, so nothing here has to be edited by hand.
@@ -493,12 +495,12 @@ the session that runs them, so nothing here has to be edited by hand.
     Whether Space records at all. Until this is `true`, the spacebar just types spaces.
   </OptionCard>
   <OptionCard name="mode" defaultValue="hold">
-    Which gesture dictates. `hold` holds Space through a short warmup and stops on
-    release; `tap` taps Space on an empty prompt to start and taps again to stop.
+    Which gesture starts dictation. `hold` holds Space through a short warmup and stops
+    on release; `tap` taps Space on an empty prompt to start and taps again to stop.
 
     Pick `tap` if holding Space never starts a recording: hold mode needs either a
-    terminal that reports key releases or OS key repeat, and with neither one a hold
-    cannot be told from a tap. Tap mode needs neither.
+    terminal that reports key releases or OS key repeat, and without either one stella
+    can't tell a hold from a tap. Tap mode needs neither.
   </OptionCard>
   <OptionCard name="provider" defaultValue="openai">
     The provider id whose `audio/transcriptions` endpoint transcribes. Any `providers`
@@ -520,21 +522,22 @@ the session that runs them, so nothing here has to be edited by hand.
 
 ## The `plan_review` section
 
-The deck's plan gate. Before the first step of a plan runs, the task board goes to whoever
-is driving as a card they can approve or send back — and both of its facts are settings
-rather than constants (#4611).
+The deck's plan gate. Before the first step of a plan runs, the task board goes to
+whoever is driving as a card they can approve or send back, and both parts of this gate
+are settings you can change.
 
 <CardGrid size="md">
   <OptionCard name="enabled" defaultValue="on">
-    `off` withholds the gate entirely, so no card is ever raised. This is the person
-    driving saying they do not want to be asked; a run with nobody at the keyboard already
-    installs no gate, because nobody is there to answer one.
+    `off` removes the gate entirely, so no card is ever raised. This is for when the
+    person driving doesn't want to be asked; a run with nobody at the keyboard already
+    skips the gate, because nobody is there to answer one.
   </OptionCard>
   <OptionCard name="min_steps" defaultValue="3">
     How many **open** board rows a plan needs before the card goes up. Finished and
-    cancelled rows do not count, so a board most of the way through its work does not raise
-    a card over its last remaining step. `1` asks about every plan. `0` is refused at launch
-    by name: an empty board has no open rows, and `enabled` is how you say off.
+    canceled rows don't count, so a board that's mostly done doesn't raise a card over
+    its last remaining step. `1` asks about every plan. `0` is refused at launch with a
+    clear error: an empty board has no open rows, and `enabled` is how you turn the gate
+    off.
   </OptionCard>
 </CardGrid>
 
@@ -544,34 +547,35 @@ rather than constants (#4611).
 }
 ```
 
-Whole-block last-wins across scopes, like `ui` and `reward` — the switch and the threshold
-are one policy, so a project that declares either states both rather than inheriting half of
-a user-scope answer. `stella run --plan-mode` overrides both for one invocation: the gate is
-installed and every plan is put to the driver, whatever the file says.
+This whole block is last-wins across scopes, like `ui` and `reward` — the switch and the
+threshold are one policy, so a project that sets either one sets both, rather than
+inheriting half of a user-scope answer. `stella run --plan-mode` overrides both for one
+invocation: the gate goes up and every plan is put to the driver, whatever the file says.
 
 ## The `context` block
 
-The `context` block configures the **adaptive-context lifecycle**: mining observations
-from your sessions, inducing directive proposals from them, governing which of those get
-promoted, and measuring whether the context selected actually helped.
+The `context` block configures the **adaptive-context lifecycle**: gathering
+observations from your sessions, drafting directive proposals from them, deciding which
+of those get promoted, and measuring whether the context it picked actually helped.
 
 <Callout type="info">
-  The block is currently **inert**. Every field parses, round-trips, and merges, but no
-  code reads it yet — `context.lifecycle.enabled` defaults to `false`, which is what
-  preserves today's behavior. The schema ships ahead of the loop so a later release can
-  turn it on without a settings migration, and so the vocabulary below is pinned by
+  This block is currently **inert**. Every field parses, round-trips, and merges, but no
+  code reads it yet — `context.lifecycle.enabled` defaults to `false`, which keeps
+  today's behavior unchanged. The schema ships ahead of the feature so a later release
+  can turn it on without a settings migration, and so the vocabulary below is settled by
   round-trip tests rather than invented later. Read the values here as the committed
   vocabulary and defaults, not as a description of a running mechanism.
 </Callout>
 
-Two dimensions are kept separate: **learning mode** (how much of the loop
-runs) and **governance mode** (who signs off on a promotion). Every mode enum is *loud* —
-an unrecognized value such as `"advisary"` is a hard parse error, never a silent fallback.
-Omitted fields fall back to the defaults below, so `"context": {}` and an absent block are
-equivalent in effect.
+Two things are kept separate: **learning mode** (how much of the loop
+runs) and **governance mode** (who signs off on a promotion). Every mode value is
+strict — an unrecognized value such as `"advisary"` is a hard parse error, never a
+silent fallback. Omitted fields fall back to the defaults below, so `"context": {}` and
+an absent block do the same thing.
 
 Unlike `providers`, the block merges **whole**: a higher-precedence scope that declares
-`context` replaces the lower scope's block outright rather than overlaying field by field.
+`context` replaces the lower scope's block completely, instead of merging field by
+field.
 
 ### Lifecycle and modes
 
@@ -581,36 +585,37 @@ Unlike `providers`, the block merges **whole**: a higher-precedence scope that d
     `context` block is ignored.
   </OptionCard>
   <OptionCard name="context.learning.mode" defaultValue="off">
-    How much of the learning loop runs. `off` disables mining, proposal induction, and
-    efficacy learning. `record_only` captures observations, proposals, uses, and outcomes
-    without selecting or promoting inferred records. `advisory` enables governed inferred
-    *advisory* use.
+    How much of the learning loop runs. `off` turns off observation gathering, proposal
+    drafting, and efficacy learning. `record_only` captures observations, proposals,
+    uses, and outcomes without selecting or promoting any of them. `advisory` turns on
+    governed, advisory use of what's inferred.
   </OptionCard>
   <OptionCard name="context.governance.mode" defaultValue="solo">
-    Who governs promotions: `solo`, `team`, or `regulated`. Orthogonal to the learning
-    mode — the two dimensions do not collapse into one another.
+    Who governs promotions: `solo`, `team`, or `regulated`. Separate from the learning
+    mode — the two settings don't affect each other.
   </OptionCard>
 </CardGrid>
 
 ### Promotion
 
-Thresholds gating when a set of observations may become an inferred directive, and the
-confirmation a blocking directive requires. Confidence values are on a `0`–`100` scale.
+These settings control when a set of observations can become an inferred directive, and
+what confirmation a blocking directive needs. Confidence values are on a `0`–`100` scale.
 
 <CardGrid size="sm">
   <OptionCard name="context.promotion.inferred_directive.min_observations" defaultValue="3">
     The minimum observation count. A whole number.
   </OptionCard>
   <OptionCard name="context.promotion.inferred_directive.min_distinct_tasks" defaultValue="3">
-    The minimum number of *distinct* tasks those observations must span — the guard against
-    one repetitive task promoting itself into a rule.
+    The minimum number of *distinct* tasks those observations must span. This guards
+    against one repeated task promoting itself into a directive.
   </OptionCard>
   <OptionCard name="context.promotion.inferred_directive.auto_activate_at_confidence" defaultValue="85">
     The confidence, `0`–`100`, at which an inferred directive activates without being asked.
   </OptionCard>
   <OptionCard name="context.promotion.inferred_directive.initial_enforcement" defaultValue="advisory">
-    The enforcement a newly inferred directive carries. Only two states exist — `advisory`
-    and `blocking` — and an inferred directive may only ever *start* advisory.
+    The enforcement level a newly inferred directive starts with. Only two states exist —
+    `advisory` and `blocking` — and a new inferred directive can only ever start as
+    `advisory`.
   </OptionCard>
   <OptionCard
     name="context.promotion.blocking_directive.requires_explicit_confirmation"
@@ -623,7 +628,8 @@ confirmation a blocking directive requires. Confidence values are on a `0`–`10
 
 ### Efficacy
 
-Efficacy-attribution thresholds. Confidence values are on a `0`–`100` scale;
+These settings control how confident stella must be before crediting or blaming a piece
+of context for a result. Confidence values are on a `0`–`100` scale;
 `not_helpful_ratio_threshold` is a `0.0`–`1.0` ratio.
 
 <CardGrid size="sm">
@@ -640,8 +646,8 @@ Efficacy-attribution thresholds. Confidence values are on a `0`–`100` scale;
     name="context.efficacy.receipt_display_min_attribution_confidence"
     defaultValue="80"
   >
-    The minimum attribution confidence a use needs before it is *displayed* on a receipt —
-    a knob of its own, separate from the attribution threshold above.
+    The minimum attribution confidence a use needs before it's shown on a receipt — a
+    setting of its own, separate from the attribution threshold above.
   </OptionCard>
 </CardGrid>
 
@@ -662,10 +668,11 @@ expiry, in days.
   </OptionCard>
 </CardGrid>
 
-### A fully written-out `context` block
+### A complete context block
 
-Every value below is the shipped default, so this file changes nothing — it is the
-copy-paste starting point you edit down to the two or three keys you actually want:
+Every value below is the shipped default, so this file changes nothing on its own — it
+is the copy-paste starting point you edit down to the two or three keys you actually
+want:
 
 ```json title="~/.stella/settings.json"
 {
@@ -700,12 +707,12 @@ copy-paste starting point you edit down to the two or three keys you actually wa
 ## External context providers
 
 `context_providers.<id>` registers a third-party
-[Context Graph Protocol](/docs/context-engine#the-context-graph-protocol) source — a
-company wiki, an issue tracker, a vector store — so it can feed the recall block alongside
-the built-in workspace-memory and code-graph providers. Until this section exists, every
-provider is in-process; with it, a third-party source is a config entry rather than a fork.
+[Context Graph Protocol](/docs/context-engine#the-context-graph-protocol) source, such as
+a company wiki, an issue tracker, or a vector store, so it can feed the recall block
+alongside the built-in workspace-memory and code-graph providers. Without this section,
+every provider runs in-process; with it, a third-party source is just a config entry.
 
-The block is **empty by default**, which registers nothing and leaves recall exactly as it
+This block is empty by default, which registers nothing and leaves recall exactly as it
 is today.
 
 ```json title="~/.stella/settings.json"
@@ -734,53 +741,54 @@ is today.
     `http` (a remote endpoint). An unrecognized transport is a hard parse error.
   </OptionCard>
   <OptionCard name="command">
-    The program to spawn. Required, and non-empty, when `transport` is `stdio` — a missing
-    one is reported as a configuration error naming the field, not as a process that would
-    not start.
+    The program to spawn. Required, and can't be empty, when `transport` is `stdio` — a
+    missing value shows a configuration error naming the field, instead of a process
+    that fails to start.
   </OptionCard>
   <OptionCard name="args">
     Arguments for `command`.
   </OptionCard>
   <OptionCard name="url">
-    The endpoint to connect to. Required, and non-empty, when `transport` is `http`.
+    The endpoint to connect to. Required, and can't be empty, when `transport` is `http`.
   </OptionCard>
   <OptionCard name="enabled" defaultValue="false">
-    Whether the entry is live. Declaring a provider is not turning it on: that is a
-    separate, deliberate act, so an org-managed entry merged in from a lower scope never
+    Whether the entry is live. Declaring a provider doesn't turn it on — that is a
+    separate, deliberate step, so an org-managed entry merged in from a lower scope never
     starts serving a turn just because someone defined it.
   </OptionCard>
   <OptionCard name="egress_consent">
-    The off-machine egress scopes you have consented to for this provider, as CGP scope
+    The off-machine scopes you have consented to for this provider, as CGP scope
     strings — `org_tenant`, `third_party_index`, `third_party_model`, or a namespaced one
     like `acme:vector-store`.
   </OptionCard>
   <OptionCard name="consent_grantor">
-    Who granted that consent, for the audit ledger. Free text — a user id, an email, a
+    Who granted that consent, for the audit log. Free text — a user id, an email, a
     policy name. Absent means the local operator.
   </OptionCard>
 </CardGrid>
 
-Two properties are required, and not optional:
+**Conformance is checked before a provider ever runs.** A provider goes through the
+protocol's own conformance suite before it's registered on the session host, so a
+source that lies about token cost, serves frames with no citation label, or cannot shut
+down cleanly never serves a turn. Checking after registration would mean the first sign
+of trouble is a corrupted prompt.
 
-- **Conformance is an admission gate, not a badge.** A provider is run through the
-  protocol's own conformance suite *before* it is registered on the session host, so a
-  source that lies about token cost, serves frames with no citation label, or cannot shut
-  down cleanly never serves a turn. Register-first-discover-later would mean the first
-  evidence of non-conformance is a corrupted prompt.
-- **Egress is consented, never assumed.** Every built-in provider is non-egressing, so the
-  consent store has never had occasion to prompt. An external provider is the first thing
-  that can send workspace content off the machine, and it stays gated until the config
-  records consent for every off-machine scope it declares — the host refuses to transmit,
-  and the query payload, which carries workspace content, never leaves.
+**Consent is required, never assumed.** Every built-in provider stays on your machine,
+so the consent step has never had to prompt before. An external provider is the first
+thing that can send workspace content off the machine, and it stays blocked until the
+config records consent for every off-machine scope it declares. Until then, the host
+refuses to send anything, and the query payload (which carries workspace content)
+never leaves.
 
 Entries merge **per entry** across scopes, so a project can enable a provider the user
 scope declared without restating its transport. A higher scope's entry replaces the lower
-one's *wholesale*: field-level merging would let a project file inherit a user's
+one's *whole entry*: merging field by field would let a project file inherit a user's
 `egress_consent` while swapping the `url`, silently reusing consent granted for a
 different endpoint.
 
-The map key is the routing **and** consent key, so renaming an entry creates a new
-provider whose consent must be granted afresh. That is the point, not an inconvenience.
+The map key is both the routing key and the consent key, so renaming an entry creates a
+new provider whose consent must be granted again. That is the intended behavior, not an
+inconvenience.
 
 <Callout type="warn">
   `context_providers` sits on the same code-execution boundary as `hooks` and
@@ -791,10 +799,10 @@ provider whose consent must be granted afresh. That is the point, not an inconve
 
 ## Managed authority ceilings
 
-Only the org-managed settings file may define the top-level `authority` section. User and
-project copies do not contribute runtime authority. Every value uses the same strict
-`"on"`/`"off"` vocabulary, and an unknown key is a hard load error so a misspelled policy
-cannot silently become permissive.
+Only the org-managed settings file can define the top-level `authority` section. User
+and project copies do not contribute any runtime authority. Every value uses the same
+strict `"on"`/`"off"` values, and an unknown key is a hard load error, so a misspelled
+policy can never silently become permissive.
 
 ```json title="org-managed (STELLA_MANAGED_SETTINGS)"
 {
@@ -806,28 +814,28 @@ cannot silently become permissive.
 }
 ```
 
-Those three are the whole section — it takes no others, and because the block is
-`deny_unknown_fields`, adding one is the hard load error described above rather than a
-key that is quietly ignored. In particular it is deliberately **not** a second tool
-table: to pin a tool or a group off from the managed scope, use the managed `"tools"`
-table, which addresses any tool, group, or `*`.
+Those three fields are the whole section — it takes no others, and because the block is
+`deny_unknown_fields`, adding one causes the hard load error described above rather than
+being quietly ignored. This is deliberately **not** a second tool table: to turn off a
+tool or a group from the managed scope, use the managed `"tools"` table instead, which
+addresses any tool, group, or `*`.
 
-An `"off"` capability is a non-overridable ceiling. `"on"` only permits a later explicit
-grant; it never enables a capability by itself. For example, `project_custom_tools: "on"`
+An `"off"` value is a limit that can't be overridden. `"on"` only allows a later explicit
+grant; it never turns on a capability by itself. For example, `project_custom_tools: "on"`
 still requires `STELLA_TRUST_PROJECT=1`, while `project_custom_tools: "off"` keeps
-workspace manifests disabled even when that trust flag is present. Media host approval
+workspace manifests off even when that trust flag is present. Media host approval
 defaults to required when the field is absent.
 
 ## Enterprise telemetry enrollment
 
 `enterprise_telemetry` is the other org-managed-only section: the signed enrollment
-document that authorizes Oxagen Enterprise operational export. It is captured from the
-managed snapshot alone — a project or user file carrying the key contributes nothing —
-and is validated by its adapter, so an invalid, missing, expired, or unsupported
-enrollment simply leaves export inactive rather than failing the run.
+document that authorizes Oxagen Enterprise operational export. It comes from the
+managed snapshot alone. A project or user file carrying the key contributes nothing.
+It's checked by its own adapter, so an invalid, missing, expired, or unsupported
+enrollment just leaves export off rather than failing the run.
 
-Community and default mode construct no spool and no HTTP client at all. The full
-schema, the sink-authorization rules, and the closed event envelope are documented on
+Community and default mode build no spool and no HTTP client at all. The full schema,
+the sink-authorization rules, and the closed event format are documented on
 [Telemetry &amp; budget](/docs/telemetry#oxagen-enterprise-managed-export).
 
 ## The project trust boundary
@@ -835,27 +843,27 @@ schema, the sink-authorization rules, and the closed event envelope are document
 A repository you just cloned can carry a `<workspace>/.stella/settings.json` — and an
 untrusted repo must not be able to run commands on your machine or route your API keys to
 a server it controls. stella therefore holds back the dangerous parts of a project-scope
-file until you opt in with **`STELLA_TRUST_PROJECT=1`** — or, to avoid typing that on every
-launch, `run.auto_trust_project = true` in **your own** `~/.stella/stella.toml` (or the
-org-managed file). That key is inert in a project's own `stella.toml`: a
-project voting itself trusted is exactly the hole this boundary exists to close, so a
-project-scope `auto_trust_project` still parses and is then discarded, with a stderr
-notice saying so. An explicit `STELLA_TRUST_PROJECT` env var always overrides the config
-default, either direction, for that one launch — so `STELLA_TRUST_PROJECT=0` still closes
-trust for a repository you have set `auto_trust_project` on generally, and
+file until you opt in with **`STELLA_TRUST_PROJECT=1`** — or, to avoid typing that on
+every launch, `run.auto_trust_project = true` in **your own** `~/.stella/stella.toml` (or
+the org-managed file). That key does nothing in a project's own `stella.toml`: a
+project can't vote itself trusted, since that's exactly the hole this boundary exists to
+close, so a project-scope `auto_trust_project` still parses and is then discarded, with a
+stderr notice saying so. An explicit `STELLA_TRUST_PROJECT` env var always overrides the
+config default, either direction, for that one launch — so `STELLA_TRUST_PROJECT=0` still
+closes trust for a repository you have set `auto_trust_project` on generally, and
 `STELLA_TRUST_PROJECT=1` still opens it for one you have not.
 
-- **Hooks.** Project-scope `hooks` load only when the project is trusted. (The legacy
-  `STELLA_PROJECT_HOOKS=1` flag still unlocks hooks — and only hooks.)
+- **Hooks.** Project-scope `hooks` load only when the project is trusted. (The
+  `STELLA_PROJECT_HOOKS=1` flag also unlocks hooks — and only hooks.)
 - **Context providers.** Project-scope `context_providers` entries are dropped in favour
   of whatever the user and org-managed scopes declared. An enabled `stdio` entry spawns
-  its `command` at admission time — the same `git clone && stella` exposure that gates
+  its `command` at admission time — the same `git clone && stella` risk that gates
   `.stella/mcp.toml` — and an `http` entry is no safer, because the same untrusted file
   would be supplying the `egress_consent` that lets workspace content leave the machine.
 - **Credential routing.** Project-scope values for `providers.<id>.base_url`,
   `providers.<id>.api_key`, `providers.<id>.api_key_env`, and `mcp.registry_url` are
   **silently dropped** (the trusted-scope values win) — otherwise a malicious repo could
-  point a provider at its own base URL and exfiltrate the key you attach.
+  point a provider at its own base URL and steal the key you attach.
 - **Tool switches.** A project-scope `"on"` for any key does not grant that capability
   until full project trust is present — it reverts to whatever the user/org-managed
   scopes said, or to the shipped default. Project `"off"` remains effective as a
@@ -875,25 +883,24 @@ changing the file takes effect on the next settings load.
 
 ## Lifecycle hooks
 
-`settings.json` also carries `hooks` — shell commands that fire on agent lifecycle events.
-That schema is documented on the [Hooks](/docs/agent-tools/hooks) page. Most of the
-events name a point inside a turn; the rest fire around a
+`settings.json` also carries `hooks` — shell commands that fire on agent lifecycle
+events. That schema is documented on the [Hooks](/docs/agent-tools/hooks) page. Most of
+the events name a point inside a turn; the rest fire around a
 [self-driving](/docs/self-improvement) run, cycle, issue, pull request or set of checks.
-`PreIssueWork` can hold the loop off an issue entirely; every other loop event reports and
-cannot veto.
+`PreIssueWork` can hold the loop off an issue entirely; every other loop event reports
+and cannot block anything.
 
-Unlike `providers`, hooks **concatenate** across scopes — every scope can add matchers and
-none replaces another's. Hooks from the user and org-managed scopes always load, but hooks
-declared in a repository's project-scope file load **only** behind the
+Unlike `providers`, hooks **concatenate** across scopes — every scope can add matchers
+and none replaces another's. Hooks from the user and org-managed scopes always load, but
+hooks declared in a repository's project-scope file load **only** behind the
 [project trust boundary](#the-project-trust-boundary) (`STELLA_TRUST_PROJECT=1`, or the
-legacy hooks-only `STELLA_PROJECT_HOOKS=1`); a stderr notice names any skipped project
-hooks.
+hooks-only `STELLA_PROJECT_HOOKS=1`); a stderr notice names any skipped project hooks.
 
 ## A complete example file
 
 Everything above, in one user-scope file — a routed provider, a narrowed tool surface, a
-guard hook, the recap on, and a `context` block with only the keys that differ from the
-defaults. Copy it, delete what you don't want:
+guard hook, and a `context` block with only the keys that differ from the defaults. Copy
+it, and delete what you don't want:
 
 ```json title="~/.stella/settings.json"
 {
@@ -949,7 +956,7 @@ stella models    # every provider with its effective base URL and key status
 ## Security
 
 `settings.json` may contain an API key in plaintext. If you store keys there, treat the
-file like any other secret — restrict its permissions and keep the project-scope file out
-of version control (add `.stella/settings.json` to `.gitignore` if it holds credentials).
-For keys specifically, [`credentials.toml`](/docs/configuration/credentials) is written
-with owner-only permissions and is the safer home.
+file like any other secret — restrict its permissions and keep the project-scope file
+out of version control (add `.stella/settings.json` to `.gitignore` if it holds
+credentials). For keys specifically, [`credentials.toml`](/docs/configuration/credentials)
+is written with owner-only permissions and is the safer home.

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -567,8 +567,8 @@ of those get promoted, and measuring whether the context it picked actually help
   vocabulary and defaults, not as a description of a running mechanism.
 </Callout>
 
-Two things are kept separate: **learning mode** (how much of the loop
-runs) and **governance mode** (who signs off on a promotion). Every mode value is
+**Learning mode** (how much of the loop runs) and **governance mode** (who
+signs off on a promotion) are separate settings. Every mode value is
 strict — an unrecognized value such as `"advisary"` is a hard parse error, never a
 silent fallback. Omitted fields fall back to the defaults below, so `"context": {}` and
 an absent block do the same thing.

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -1,24 +1,26 @@
 ---
 title: stella.toml
-description: The comment-preserving, schema-versioned TOML config format — where each scope's file lives, what moved from settings.json, what stays identical, and what is not built yet.
+description: The TOML config format that keeps comments and tracks schema versions — where each scope's file lives, what moved from settings.json, what stays the same, and what isn't built yet.
 ---
 
-`stella.toml` is stella's config file in TOML instead of JSON. It reads across the same
-three scopes as [`settings.json`](/docs/configuration/settings), merges by the same rules,
-and is gated by the same [project trust boundary](/docs/configuration/settings#the-project-trust-boundary)
-— the file format changed, nothing about who is trusted did. What TOML adds is what JSON
-structurally cannot hold: comments that survive a write, and a `[meta]` block that turns
-forward compatibility into a mechanism instead of a warning.
+`stella.toml` is stella's config file, written in TOML instead of JSON. It reads across
+the same three scopes as [`settings.json`](/docs/configuration/settings), merges by the
+same rules, and is gated by the same
+[project trust boundary](/docs/configuration/settings#the-project-trust-boundary). The
+file format is different, but who is trusted is not. TOML adds what JSON can't hold:
+comments that survive a write, and a `[meta]` block that helps stella handle future
+versions safely instead of just guessing.
 
 <Callout type="info">
-  This page documents the **TOML shape**. For the full meaning of every section — merge
-  rules, the trust boundary, worked examples — [settings.json](/docs/configuration/settings)
-  remains the canonical reference; the two formats lower into the same `Settings` and behave
-  identically once loaded. This page exists to answer the questions specific to the file
-  itself: where it lives, what its keys are called, and what changed in the port.
+  This page documents the **TOML shape**. For the full meaning of every section, including
+  merge rules, the trust boundary, and worked examples,
+  [settings.json](/docs/configuration/settings) is the main reference — the two formats
+  load into the same settings and behave identically once loaded. This page answers the
+  questions specific to the file itself: where it lives, what its keys are called, and
+  what changed when it was ported to TOML.
 </Callout>
 
-## Where each scope's file lives
+## Where files live
 
 <CardGrid size="sm">
   <SpecCard
@@ -28,8 +30,8 @@ forward compatibility into a mechanism instead of a warning.
       { label: "Path", value: <code>{"<repo>/stella.toml"}</code> },
     ]}
   >
-    At the **repository root**, not under `.stella/` — a committed, human-reviewed file
-    belongs where `Cargo.toml` and `pyproject.toml` live, in a PR diff rather than three
+    At the repository root, not under `.stella/`. A committed, reviewed file belongs
+    where `Cargo.toml` and `pyproject.toml` live: in a pull request diff, not three
     directories deep.
   </SpecCard>
   <SpecCard
@@ -39,7 +41,7 @@ forward compatibility into a mechanism instead of a warning.
       { label: "Path", value: <code>~/.stella/stella.toml</code> },
     ]}
   >
-    Your personal defaults — the same role `~/.stella/settings.json` plays today.
+    Your personal defaults, the same role `~/.stella/settings.json` plays.
   </SpecCard>
   <SpecCard
     title="managed"
@@ -48,36 +50,35 @@ forward compatibility into a mechanism instead of a warning.
       { label: "Path", value: <code>STELLA_MANAGED_SETTINGS</code> },
     ]}
   >
-    Or the platform default — `/Library/Application Support/stella/stella.toml` on macOS,
-    `/etc/stella/stella.toml` elsewhere. Deployed by an administrator, and the extension on
-    that one named file decides its format; there is never a second managed file competing
-    with it.
+    Or the platform default: `/Library/Application Support/stella/stella.toml` on macOS,
+    `/etc/stella/stella.toml` elsewhere. An administrator deploys this file, and its
+    extension decides its format. There is never a second managed file competing with it.
   </SpecCard>
 </CardGrid>
 
-The scope hierarchy — precedence, the trust boundary, which fields merge per-field versus
-whole-block versus concatenate — is unchanged from JSON. See
-[The scope hierarchy](/docs/configuration/settings#the-scope-hierarchy) for the full rules;
-<SettingsCascadeDiagram /> shows the same shape either format reads through.
+The scope hierarchy is unchanged from JSON: precedence, the trust boundary, and which
+fields merge per field, whole block, or by concatenating. See
+[The scope hierarchy](/docs/configuration/settings#the-scope-hierarchy) for the full
+rules; <SettingsCascadeDiagram /> shows the same shape either format reads through.
 
-## Getting there: `stella migrate config`
+## Migrating to TOML
 
 ```bash
 stella migrate config          # write the TOML for every scope that has JSON
 stella migrate config --dry-run
 ```
 
-Every value it writes is serialized from the `settings.json` stella actually parsed —
-never re-typed — and the generated file is re-parsed and re-validated before it touches
-disk. The original JSON is never deleted; you remove it once you've confirmed the TOML
-says what you meant. Full walkthrough: [`stella migrate`](/docs/commands/migrate).
+Every value it writes comes straight from the `settings.json` stella actually parsed —
+it's never retyped by hand — and the generated file is re-parsed and re-validated before
+it touches disk. The original JSON is never deleted; you remove it yourself once you've
+confirmed the TOML says what you meant. Full walkthrough: [`stella migrate`](/docs/commands/migrate).
 
-## TOML and settings.json are never merged
+## TOML or JSON
 
-If both files exist at a scope, stella reads the TOML **whole** and ignores the JSON —
-never a field-by-field composite of the two. A composite would make "which file configures
-this?" unanswerable from either file alone; the actual failure mode that guards against is
-someone editing the JSON, seeing no effect, and having nothing to look at.
+If both files exist at a scope, stella reads the whole TOML file and ignores the JSON —
+it never combines them field by field. A combined file would make "which file configures
+this?" impossible to answer from either file alone. This rule guards against someone
+editing the JSON, seeing no effect, and having nothing to check.
 
 ```text
 ! ~/.stella/stella.toml and ~/.stella/settings.json both exist — reading the TOML and
@@ -85,28 +86,28 @@ someone editing the JSON, seeing no effect, and having nothing to look at.
 ```
 
 This notice prints once per launch, at every scope where it applies. A missing TOML file
-falls back to the JSON exactly as before; a missing file at either format is fine and is
+falls back to the JSON exactly as before; a missing file in either format is fine and is
 simply skipped.
 
 ## The `[meta]` block
 
-The one section with no JSON equivalent — `settings.json` has no version field at all, so a
-typo and a key from a future release look identical to serde. `[meta]` is what makes that
-distinguishable.
+This is the one section with no JSON equivalent. `settings.json` has no version field at
+all, so a typo and a key from a future release look identical to the parser. `[meta]` is
+what tells them apart.
 
 <CardGrid size="md">
   <OptionCard name="meta.schema_version">
     This build reads exactly one schema version. A file naming a version this build does
-    not understand is a **named load error** telling you to upgrade stella or pin the file
-    back — never a silent partial read. A file with no `[meta]` block at all is version 1 by
-    definition, which is what will eventually make it safe to stop reading `settings.json`.
+    not understand shows a **named load error** telling you to upgrade stella or pin the
+    file back — never a silent partial read. A file with no `[meta]` block at all is
+    version 1 by definition.
   </OptionCard>
   <OptionCard name="meta.scope">
     Self-declared as `"user"`, `"managed"`, or `"project"` — checked against the file's
     actual **location**, not the other way around. The path decides the scope; this field
-    only has to agree with it. A project file declaring `scope = "managed"` is refused with
-    a named error, because that mismatch is either a copy-paste mistake or an attempt to
-    borrow authority the file's location does not grant.
+    only has to agree with it. A project file declaring `scope = "managed"` is refused
+    with a named error, because that mismatch is either a copy-paste mistake or an attempt
+    to claim authority the file's location doesn't grant.
   </OptionCard>
 </CardGrid>
 
@@ -116,25 +117,26 @@ schema_version = 1
 scope          = "project"   # "user" | "managed" | "project"
 ```
 
-## What moved, and why
+## What moved
 
-These changed shape in the port. Everything else kept its name.
+These changed shape when TOML was added. Everything else kept its name.
 
 | settings.json | stella.toml | Why |
 | --- | --- | --- |
-| `enable_recap` (bare root key) | `[run].recap` | TOML attaches a bare key to whatever `[table]` precedes it — move one line in the file and it silently reassigns. Every scalar gets a table home; there are no bare keys at the document root. |
-| `agent_engine_config` | `[agents]` | Shorter, and the JSON name described the Rust struct rather than the thing it configures. |
-| `agent_engine_config.agents.<name>` | `[agents.<name>]` | One nesting level removed. Safe today because the agent set is **closed** and holds one name — `default` is a struct field, not a map key, so the per-agent table can never collide with a root field. It held six until #3908 collapsed the engine to one role; a file still naming `worker`, `verifier`, `triage`, `research` or `plan` loads and reports the key. |
-| `agent_engine_config.allowed_models` | `[models].allowed` | Promoted out of the agents block — it's a statement about models, not about any one agent. Still replaces wholesale across scopes rather than concatenating. |
+| `enable_recap` (bare root key) | `[run].recap` | TOML attaches a bare key to whatever `[table]` precedes it, so moving one line in the file can silently reassign it. Every scalar gets a table home; there are no bare keys at the document root. |
+| `agent_engine_config` | `[agents]` | Shorter, and clearer — the JSON name described an internal structure rather than the thing it configures. |
+| `agent_engine_config.agents.<name>` | `[agents.<name>]` | One nesting level removed. This is safe because the agent set is **closed** and holds one name — `default` is a fixed field, not a map key, so the per-agent table can never collide with a root field. A file still naming `worker`, `verifier`, `triage`, `research` or `plan` loads normally and reports the key. |
+| `agent_engine_config.allowed_models` | `[models].allowed` | Promoted out of the agents block, since it's a statement about models, not about any one agent. Still replaces wholesale across scopes rather than concatenating. |
 
 `trace_capture`, `create_worktrees`, `candidate_isolation` and `ignore_gitignore`
 needed no such move: each shipped straight into its `[run]` table home, so none ever
 had a bare-root JSON form to retire.
 
-## Every section, in the TOML shape
+## Every section
 
-Merge rules below are identical to their JSON counterparts — restated here only so this
-page is a complete reference on its own; see the linked section for the full explanation.
+The merge rules below are identical to their JSON counterparts. They're restated here so
+this page works as a complete reference on its own — see the linked section for the full
+explanation.
 
 ### `[run]`
 
@@ -147,13 +149,14 @@ page is a complete reference on its own; see the linked section for the full exp
   <OptionCard name="run.candidate_isolation" defaultValue="worktree">
     `"worktree"` or `"copy-tree"` — how a best-of-N fan-out isolates one candidate's
     tree from the next. `"worktree"` cuts a git worktree per candidate and promotes the
-    winner as a patch, so a candidate cannot land anything you could not have written
-    yourself and an adoption that no longer applies refuses. `"copy-tree"` copies the
-    whole directory instead, gitignored files included, and promotes by **replacing**
-    the tree's contents with the winner's — right for a disposable benchmark container
-    whose `node_modules/` or `.venv/` the task's own tests execute, and destructive
-    anywhere else. Never selected for you. An empty string, `null`, or the key being
-    absent all mean `"worktree"`; anything else is a hard parse error.
+    winner as a patch, so a candidate can't land anything you couldn't have written
+    yourself, and adopting the patch is refused if it no longer applies cleanly.
+    `"copy-tree"` copies the whole directory instead, gitignored files included, and
+    promotes by **replacing** the tree's contents with the winner's — right for a
+    disposable benchmark container whose `node_modules/` or `.venv/` the task's own
+    tests execute, and destructive anywhere else. Never selected for you. An empty
+    string, `null`, or the key being absent all mean `"worktree"`; anything else is a
+    hard parse error.
   </OptionCard>
   <OptionCard name="run.ignore_gitignore" defaultValue="on">
     Same name as JSON, and the one toggle here that defaults **on**. See
@@ -161,12 +164,12 @@ page is a complete reference on its own; see the linked section for the full exp
   </OptionCard>
   <OptionCard name="run.auto_trust_project" defaultValue="false">
     `true` trusts every project this machine opens by default — the config-file
-    alternative to typing `STELLA_TRUST_PROJECT=1` on every launch. **Honored only
-    from the user or org-managed file.** Set in a project's own `stella.toml` it
-    still parses, but is discarded before it can affect anything and a stderr
-    notice says so: a project cannot vote on its own trust. An explicit
-    `STELLA_TRUST_PROJECT` env var always overrides this, either direction, for
-    one launch. See [The project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
+    alternative to typing `STELLA_TRUST_PROJECT=1` on every launch. **Only honored from
+    the user or org-managed file.** Set in a project's own `stella.toml`, it still
+    parses, but is discarded before it can affect anything, with a stderr notice saying
+    so: a project cannot vote on its own trust. An explicit `STELLA_TRUST_PROJECT` env
+    var always overrides this, either direction, for one launch. See
+    [The project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
   </OptionCard>
 </CardGrid>
 
@@ -177,22 +180,20 @@ ignore_gitignore = "on"
 auto_trust_project = false
 ```
 
-`run.recap` and `run.trace_capture` were **retired** in #3870: both renderers read the
-built-in staged pipeline's verdict types and left the workspace with that crate (#3865).
-Setting either is not a typo and is not reported as one — the config walker names the key
-and says what it used to do.
+`run.recap` and `run.trace_capture` do nothing. Setting either one is not a typo and is
+not reported as one — the config loader recognizes the key and tells you it's inactive.
 
 ### `[workspace]`
 
-Facts about the tree this config belongs to, rather than how one run behaves. Its own
-section for exactly that reason: `allowed_dirs` states what the workspace *is*.
+This section holds facts about the tree this config belongs to, not how one run behaves.
+`allowed_dirs` states what the workspace *is*, which is why it gets a section of its own.
 
 <CardGrid size="md">
   <OptionCard name="workspace.allowed_dirs">
     Directories outside the workspace root that the write tools may touch. Relative
     entries resolve against the **workspace root**, never the directory you launched
     from, so a committed entry means the same directory for every teammate. Blank
-    entries are dropped rather than read as a grant of the root itself, and a
+    entries are dropped instead of being read as a grant of the root itself, and a
     directory that does not exist yet is carried through unchanged.
   </OptionCard>
 </CardGrid>
@@ -208,8 +209,9 @@ allowed_dirs = ["../shared-fixtures", "/opt/vendor-src"]
 
 ### `[providers]`
 
-Identical shape and rules to JSON's `providers` map — a table keyed by provider id,
-merged per-id and per-field. See [The providers map](/docs/configuration/settings#the-providers-map).
+This has the same shape and rules as JSON's `providers` map: a table keyed by provider
+id, merged per id and per field. See
+[The providers map](/docs/configuration/settings#the-providers-map).
 
 ```toml title="stella.toml"
 [providers.zai]
@@ -222,13 +224,13 @@ default_model = "n-5.2"
 <Callout type="warn">
   **A literal `api_key` is refused at project scope.** `<repo>/stella.toml` sits next to
   `README.md` and is committed and reviewed like source. A plaintext secret in it leaks
-  into version control the moment someone runs `git add .` — unlike `.stella/settings.json`,
-  which was at least one gitignore line away from that mistake. The refusal is enforced on
-  both the load path and `stella migrate config`'s write path, from one check, so a key
-  sitting in an untracked `settings.json` can never be silently copied into the committed
-  file. Use `api_key_env = "..."` to name an environment variable, or
-  `stella auth set <provider>` to store it in
-  [`credentials.toml`](/docs/configuration/credentials) instead — owner-only permissions,
+  into version control the moment someone runs `git add .` — a risk that
+  `.stella/settings.json` was at least one gitignore line away from. This refusal is
+  enforced on both the load path and `stella migrate config`'s write path, from one
+  check, so a key sitting in an untracked `settings.json` can never be silently copied
+  into the committed file. Use `api_key_env = "..."` to name an environment variable
+  instead, or `stella auth set <provider>` to store it in
+  [`credentials.toml`](/docs/configuration/credentials) with owner-only permissions and
   never committed. User and managed scope keep accepting `api_key` unchanged.
 </Callout>
 
@@ -236,12 +238,12 @@ default_model = "n-5.2"
 
 <CardGrid size="md">
   <OptionCard name="models.allowed">
-    Was `agent_engine_config.allowed_models`. Replaces wholesale across scopes — one
-    vocabulary, so a project can narrow the user's list without needing to restate it.
+    The TOML name for `agent_engine_config.allowed_models`. Replaces wholesale across
+    scopes — one list, so a project can narrow the user's list without restating it.
   </OptionCard>
   <OptionCard name="models.output_caps">
     Per-model output-token ceilings, merged **per key** (unlike `allowed` above). See
-    [`[models.output_caps]`](/docs/configuration/agent-engine-config#modelsoutput_caps--this-workspace)
+    [`[models.output_caps]`](/docs/configuration/agent-engine-config#modelsoutput_caps)
     for the full precedence chain.
   </OptionCard>
 </CardGrid>
@@ -260,13 +262,13 @@ allowed = ["anthropic/claude-fable-5", "zai/glm-5.2", "openrouter/openai/gpt-5.5
 The flattened, closed-set engine config — see
 [Agent engine config](/docs/configuration/agent-engine-config) for the full schema, model
 precedence, auto modes, and generation parameters, all unchanged. Flattening
-`[agents.default]` (rather than the JSON nesting's `[agents.agents.default]`) is safe only
-because the set of agent names is closed and none of them can collide with a root scalar
-like `default_model`.
+`[agents.default]` (instead of the JSON nesting's `[agents.agents.default]`) is safe
+only because the set of agent names is closed and none of them can collide with a root
+value like `default_model`.
 
-That closed set is exactly why plugin seats get a section of their own rather
-than joining this one: a seat name comes from whatever you installed, and
-user-chosen keys must not share a namespace with `auto_mode`.
+That closed set is exactly why plugin seats get a section of their own instead of
+joining this one: a seat name comes from whatever you installed, and user-chosen keys
+must not share a namespace with `auto_mode`.
 
 ```toml title="stella.toml"
 [agents]
@@ -299,10 +301,10 @@ entry runs on the session's model.
 
 ### `[plugins]`
 
-The per-plugin retraction switches — one `name = "on" | "off"` entry per installed
-plugin, the same shape JSON carries. An absent entry means the plugin runs; `"off"`
-withholds it without uninstalling it, which is what you want when a plugin is
-misbehaving mid-task and reinstalling it later should be a no-op.
+The per-plugin on/off switches — one `name = "on" | "off"` entry per installed plugin,
+the same shape JSON carries. An absent entry means the plugin runs; `"off"` turns it off
+without uninstalling it, which is what you want when a plugin is misbehaving mid-task
+and you want reinstalling it later to be a no-op.
 
 Keys are plugin ids, so like `[seats]` this is an **open** map: it cannot join
 `[agents]`, whose closed name set is what makes that table's flattening safe.
@@ -314,9 +316,9 @@ vera = "off"
 
 ### `[tools]`
 
-Same open map, same deny-list, same name-over-group-over-`"*"` precedence as
-[The tools section](/docs/configuration/settings#the-tools-section). The one TOML-specific
-wrinkle: `*` is not a valid bare TOML key, so the wildcard needs quotes.
+This is the same open map, deny-list, and name-over-group-over-`"*"` precedence as
+[The tools section](/docs/configuration/settings#the-tools-section). The one
+TOML-specific difference: `*` isn't a valid bare TOML key, so the wildcard needs quotes.
 
 ```toml title="stella.toml"
 [tools]
@@ -327,10 +329,10 @@ mcp         = "off"
 
 ### `[hooks]`
 
-Same schema and the same **concatenate-across-scopes** rule (the one block that isn't
-per-field or whole-block last-wins) as [Lifecycle hooks](/docs/agent-tools/hooks) — and the
-same project-trust gate. TOML expresses the event arrays as
-[array-of-tables](https://toml.io/en/v1.0.0#array-of-tables) rather than JSON's bracketed
+This has the same schema and the same **concatenate-across-scopes** rule (the one block
+that isn't per-field or whole-block last-wins) as [Lifecycle hooks](/docs/agent-tools/hooks),
+and the same project-trust gate. TOML expresses the event arrays as
+[array-of-tables](https://toml.io/en/v1.0.0#array-of-tables) instead of JSON's bracketed
 arrays:
 
 ```toml title="stella.toml"
@@ -347,11 +349,11 @@ matcher = "mcp__github__push_files"
 `registry_url` carries over unchanged — see [The mcp section](/docs/configuration/settings#the-mcp-section).
 
 <Callout type="warn">
-  **`[mcp.servers]` parses, but does nothing yet.** MCP servers still load exclusively from
-  [`.stella/mcp.toml`](/docs/agent-tools/mcp). A `stella.toml` declaring `[mcp.servers.*]`
-  entries loads without error and prints a startup notice naming the count — stated loudly
-  rather than silently dropped — but those servers will not start until the fold lands.
-  Keep server definitions in `.stella/mcp.toml` for now.
+  **`[mcp.servers]` parses, but does nothing yet.** MCP servers still load only from
+  [`.stella/mcp.toml`](/docs/agent-tools/mcp). A `stella.toml` declaring
+  `[mcp.servers.*]` entries loads without error and prints a startup notice naming the
+  count, so nothing is silently dropped — but those servers won't start yet. Keep server
+  definitions in `.stella/mcp.toml` for now.
 </Callout>
 
 ```toml title="stella.toml"
@@ -361,9 +363,10 @@ registry_url = "https://registry.example.internal/mcp"
 
 ### `[context]` and `[context_providers]`
 
-Unchanged shape and rules — whole-block last-wins for `context`, per-entry last-wins for
-`context_providers`. See [The context block](/docs/configuration/settings#the-context-block)
-and [External context providers](/docs/configuration/settings#external-context-providers).
+The shape and rules are unchanged: whole-block last-wins for `context`, per-entry
+last-wins for `context_providers`. See
+[The context block](/docs/configuration/settings#the-context-block) and
+[External context providers](/docs/configuration/settings#external-context-providers).
 
 ### `[ui]`
 
@@ -379,14 +382,14 @@ mid_turn_prompt = "queue"   # queue | ask | spawn
 
 Dictation from the composer: speak, and the transcript lands at the cursor. Hold Space
 through a warmup and release, or set `mode = "tap"` to tap Space on an empty prompt to
-start and tap again to stop — the mode to pick when holding Space never starts anything,
-because your terminal reports no key releases and OS key repeat is off. `/voice tap`,
+start and tap again to stop. Pick `tap` when holding Space never starts anything, because
+your terminal reports no key releases and OS key repeat is off. `/voice tap`,
 `/voice hold` and `/voice off` write these fields for you. Whole-block last-wins, like
-`[ui]`. Off by default — recording
-streams microphone audio to the provider named below, an egress you opt into by name.
-The provider id resolves through `[providers]` (or the built-in table) for its endpoint
-and API key, so this section holds no credential of its own; any provider with an
-OpenAI-compatible `audio/transcriptions` endpoint works, a local Whisper server included.
+`[ui]`. Off by default — recording sends microphone audio to the provider named below, a
+transfer you opt into by name. The provider id resolves through `[providers]` (or the
+built-in table) for its endpoint and API key, so this section holds no credential of its
+own; any provider with an OpenAI-compatible `audio/transcriptions` endpoint works, a
+local Whisper server included.
 
 ```toml title="stella.toml"
 [voice]
@@ -399,14 +402,14 @@ language = "en"              # BCP 47 hint; omit to auto-detect
 
 ### `[reward]`
 
-What a finished turn's verdict is worth as a training label (#1043). Whole-block last-wins,
-like `[ui]`; carries no credential or egress authority, so a project setting a weight is
-stating an opinion about its own evidence, not borrowing permission.
+What a finished turn's verdict is worth as a training label. Whole-block last-wins,
+like `[ui]`; it carries no credential or off-machine authority, so a project setting a
+weight is stating an opinion about its own evidence, not borrowing permission.
 
 <CardGrid size="sm">
   <OptionCard name="reward.deterministic_weight" defaultValue="1.0">
-    Magnitude of a deterministic pass or fail — the unit the shaping prices are measured
-    against.
+    The size of a deterministic pass or fail — the unit the other prices below are
+    measured against.
   </OptionCard>
   <OptionCard name="reward.per_step" defaultValue="0.02">
     Subtracted per model call.
@@ -424,26 +427,24 @@ stating an opinion about its own evidence, not borrowing permission.
 per_usd = 0.05   # price a dollar of spend at a tenth of the default
 ```
 
-`reward.verifier_weight` is **retired**. It priced a model verifier's opinion against
-`deterministic_weight`, and the verdict call that produced that tier no longer runs, so the
-weight steered nothing. A file that still sets it loads normally and reports the key as
-unrecognized.
+`reward.verifier_weight` does nothing. A file that sets it loads normally and reports
+the key as unrecognized.
 
 ### `[plan_review]`
 
-The deck's plan gate: before the first step of a plan runs, the task board goes to whoever is
-driving, as a card they can approve or send back. Both of its facts live here rather than
-compiled in (#4611). Whole-block last-wins, like `[ui]` and `[reward]` — the switch and the
-threshold are one policy, so a scope that declares either states both.
+The deck's plan gate: before the first step of a plan runs, the task board goes to
+whoever is driving, as a card they can approve or send back. Both parts of this gate are
+settings you can change here. Whole-block last-wins, like `[ui]` and `[reward]` — the
+switch and the threshold are one policy, so a scope that declares either one states both.
 
 <CardGrid size="sm">
   <OptionCard name="plan_review.enabled" defaultValue="on">
-    `off` withholds the gate, and no card is ever raised. Distinct from an unattended run,
-    which installs no gate anyway because nobody is there to answer one.
+    `off` removes the gate, and no card is ever raised. This is different from an
+    unattended run, which installs no gate anyway because nobody is there to answer one.
   </OptionCard>
   <OptionCard name="plan_review.min_steps" defaultValue="3">
-    How many **open** board rows raise a card. `1` asks about every plan; `0` is refused,
-    because an empty board has no open rows and `enabled` is how you say off.
+    How many **open** board rows raise a card. `1` asks about every plan; `0` is
+    refused, because an empty board has no open rows and `enabled` is how you say off.
   </OptionCard>
 </CardGrid>
 
@@ -457,22 +458,22 @@ put to the driver, whatever the file says.
 
 ### `[self_driving]`
 
-What [`stella self-driving`](/docs/commands/self-driving) signs its work with, which checks
-may block a merge, how it proves a change when CI cannot, how it decides where two operators
-would decide differently, and what vocabulary it places an issue in.
+What [`stella self-driving`](/docs/commands/self-driving) signs its work with, which
+checks can block a merge, how it proves a change when CI can't, how it decides things two
+operators would decide differently, and what vocabulary it places an issue in.
 
-Read from the **project** file alone. The loop resolves `<repo>/stella.toml` directly instead
-of through the scope merge, so a `[self_driving]` block in `~/.stella/stella.toml` parses
-without complaint and steers nothing. A project file the loop cannot parse prints a warning
-and the loop runs on its defaults — a typo in a section a run may never reach is not a reason
-to refuse to start. Everything here defaults, so a repository that writes none of it still
-gets a working loop.
+Read from the **project** file alone. The loop resolves `<repo>/stella.toml` directly
+instead of through the scope merge, so a `[self_driving]` block in
+`~/.stella/stella.toml` parses without complaint and steers nothing. A project file the
+loop cannot parse prints a warning and the loop runs on its defaults — a typo in a
+section a run may never reach is not a reason to refuse to start. Everything here has a
+default, so a repository that writes none of it still gets a working loop.
 
 #### `[self_driving.attribution]`
 
 What the loop appends to what it writes, and how it names branches and pull requests. It
 travels with the repository and an installed plugin may rewrite it, so a downstream
-distribution signs in its own name without forking.
+distribution can sign in its own name without forking.
 
 <CardGrid size="sm">
   <OptionCard name="self_driving.attribution.commit" defaultValue="created by stella*">
@@ -488,24 +489,25 @@ distribution signs in its own name without forking.
     Footer on every issue comment it posts.
   </OptionCard>
   <OptionCard name="self_driving.attribution.branch_prefix" defaultValue="stella/">
-    Namespace for every branch it creates. A prefix that does not end in `/` is used
-    verbatim rather than corrected — some teams namespace with `-`. An **empty** prefix is
-    read as unset and falls back to the default: an unnamespaced branch is indistinguishable
-    from a human's ref, and it is also what `stella fleet gc` would believe it owned.
+    The namespace for every branch it creates. A prefix that does not end in `/` is used
+    exactly as written, not corrected — some teams namespace with `-`. An **empty**
+    prefix is read as unset and falls back to the default: an unnamespaced branch is
+    indistinguishable from a human's ref, and it is also what `stella fleet gc` would
+    believe it owned.
   </OptionCard>
   <OptionCard name="self_driving.attribution.title_prefix" defaultValue="stella self-driving:">
-    Prefix on the **title** of every pull request it opens, so an autonomous one is
-    distinguishable in the list where a maintainer actually triages. Not applied
+    A prefix on the **title** of every pull request it opens, so an autonomous one
+    stands out in the list where a maintainer actually triages. Not applied
     to commit messages: those follow Conventional Commits, and a prefix in front of
     `fix(stella-cli):` would break the scope. An already-prefixed title is left alone, so
-    re-opening a pull request for the same issue cannot stack it twice.
+    reopening a pull request for the same issue cannot stack it twice.
   </OptionCard>
 </CardGrid>
 
 A footer lands after the body's last non-blank character, separated by a blank line and a
 `---` rule; trailing whitespace on the body is normalized first, so two callers whose bodies
 differ only in how they ended produce identical output. Setting a surface's string to `""`
-suppresses its footer and leaves the body untouched. The separator itself is fixed.
+turns off its footer and leaves the body untouched. The separator itself is fixed.
 
 ```toml title="stella.toml"
 [self_driving.attribution]
@@ -518,15 +520,17 @@ title_prefix  = "auto:"
 
 #### `[self_driving.merge]`
 
-Which checks are allowed to block a merge. Filtering to a repository's *required* contexts is
-necessary and not sufficient: a required check fails identically whether the code is wrong or
-the billing account is suspended, and only one of those is fixable by a pull request.
+Which checks are allowed to block a merge. Filtering down to a repository's *required*
+contexts is necessary but not enough on its own: a required check fails the same way
+whether the code is wrong or the billing account is suspended, and only one of those
+problems can be fixed by a pull request.
 
 <CardGrid size="sm">
   <OptionCard name="self_driving.merge.ignore_checks" defaultValue="[]">
-    Checks that never block, whatever their history. The operator's escape hatch — automatic
-    detection needs several commits of evidence, and somebody who already knows their deploy
-    provider is suspended should not have to wait for the loop to infer it.
+    Checks that never block, whatever their history. The operator's escape hatch —
+    automatic detection needs several commits of evidence, and somebody who already
+    knows their deploy provider is suspended should not have to wait for the loop to
+    infer it.
   </OptionCard>
   <OptionCard name="self_driving.merge.stuck_after" defaultValue="3">
     Consecutive failing base commits after which a check is treated as unwinnable. `0`
@@ -536,41 +540,42 @@ the billing account is suspended, and only one of those is fixable by a pull req
 
 #### `[self_driving.verify]`
 
-How to prove a change when CI cannot. A repository whose remote checks cannot go green — a
-suspended account, an exhausted quota — still has a test suite. Running it on this machine is
-a weaker signal than a clean CI run and a far stronger one than nothing.
+How to prove a change when CI can't. A repository whose remote checks can't go green — a
+suspended account, an exhausted quota — still has a test suite. Running it on this
+machine is a weaker signal than a clean CI run and a far stronger one than nothing.
 
 <CardGrid size="sm">
   <OptionCard name="self_driving.verify.command" defaultValue="unset">
-    The command that proves a change, run in the work worktree. Absent means detect it from
-    the project's own tooling.
+    The command that proves a change, run in the work worktree. Absent means detect it
+    from the project's own tooling.
   </OptionCard>
   <OptionCard name="self_driving.verify.timeout_secs" defaultValue="1800">
-    Seconds before the command is abandoned — long enough for a monorepo suite, short enough
-    that a wedged process does not hold the loop overnight.
+    Seconds before the command is abandoned — long enough for a monorepo suite, short
+    enough that a stuck process does not hold the loop overnight.
   </OptionCard>
 </CardGrid>
 
 #### `[self_driving.doctrine]`
 
-How the loop decides, where two operators would decide differently. These are judgements
-about a team's norms rather than facts about the code, which is why they are declared instead
-of compiled in: the person who starts the loop is the person who decides how it decides, and
-that is only true if what it will do is legible before it does it.
+How the loop decides things where two operators would decide differently. These are
+judgment calls about a team's norms rather than facts about the code, which is why they
+are declared instead of built in: the person who starts the loop is the person who
+decides how it decides, and that is only true if what it will do is clear before it does
+it.
 
 <CardGrid size="sm">
   <OptionCard name="self_driving.doctrine.foreign_breakage" defaultValue="file_and_adopt">
     What to do about breakage the loop did not cause. `file_and_adopt` files it and then
     fixes it at the top of the queue; `file_and_wait` leaves the fix to a human; `ignore`
-    does neither. Adopting is the default because a red base blocks this loop exactly as hard
-    as it blocks its author, so a loop that files and waits has handed its throughput to
-    somebody else's response time.
+    does neither. Adopting is the default because a broken base blocks this loop exactly
+    as hard as it blocks its author, so a loop that files and waits has handed its
+    progress to somebody else's response time.
   </OptionCard>
   <OptionCard name="self_driving.doctrine.contention" defaultValue="defer">
-    How much weight another actor's apparent work carries. `defer` treats any sign — a branch,
-    a worktree, a held ledger claim — as reason to leave the issue alone; `claims_only`
-    defers on a held claim and reads branches and worktrees as advisory; `proceed` claims
-    regardless.
+    How much weight another actor's apparent work carries. `defer` treats any sign — a
+    branch, a worktree, a held ledger claim — as reason to leave the issue alone;
+    `claims_only` defers on a held claim and reads branches and worktrees as advisory;
+    `proceed` claims regardless.
   </OptionCard>
   <OptionCard name="self_driving.doctrine.abandon_escalated" defaultValue="false">
     Whether an escalated pull request is abandoned so the loop can carry on, rather than
@@ -581,10 +586,11 @@ that is only true if what it will do is legible before it does it.
 
 #### `[self_driving.triage]`
 
-The vocabulary the loop places issues in — which labels mean urgent, which mean "this is ours
-to work", which mean "this is not". It lives here rather than in the tracker manifest because
-these are *this operator's* judgements about their own backlog, not how a tracker spells a
-concept every tracker has; two teams on one GitHub can want different ladders.
+The vocabulary the loop places issues in: which labels mean urgent, which mean "this is
+ours to work," and which mean "this is not." It lives here rather than in the tracker
+manifest because these are *this operator's* judgment calls about their own backlog, not
+how a tracker spells a concept every tracker has; two teams on one GitHub can want
+different ladders.
 
 <CardGrid size="sm">
   <OptionCard name="self_driving.triage.priorities" defaultValue='["P0", "P1", "P2", "P3"]'>
@@ -594,15 +600,16 @@ concept every tracker has; two teams on one GitHub can want different ladders.
     Labels meaning "this loop works this".
   </OptionCard>
   <OptionCard name="self_driving.triage.excluded_kinds" defaultValue='["enhancement", "feature", "documentation", "question"]'>
-    Labels meaning "this loop does not work this". Named explicitly rather than inferred from
-    "not a defect kind": an issue labelled `enhancement` has been judged and excluded, while
-    an issue labelled only `P0` has been judged on one axis and not the other, and only the
-    first may be dropped silently.
+    Labels meaning "this loop does not work this". Named explicitly rather than inferred
+    from "not a defect kind": an issue labelled `enhancement` has been judged and
+    excluded, while an issue labelled only `P0` has been judged on one axis and not the
+    other, and only the first may be dropped silently.
   </OptionCard>
 </CardGrid>
 
-Each list defaults on its own, and declaring one **replaces** it wholesale rather than adding
-to it — a partial override would leave you unable to *remove* a built-in you disagree with.
+Each list defaults on its own, and declaring one **replaces** it wholesale rather than
+adding to it — a partial override would leave you unable to *remove* a built-in you
+disagree with.
 
 ```toml title="stella.toml"
 [self_driving.triage]
@@ -610,21 +617,21 @@ priorities   = ["Sev1", "Sev2", "Sev3"]
 defect_kinds = ["defect"]
 ```
 
-**An issue carrying no rung is not ranked last.** It is separated out as unassessed, and the
-loop spends a turn triaging it before claiming any work — so a `Sev1` filed thirty seconds
-ago with no labels yet does not sort beneath a `Sev3` from March. That turn judges the issue
-against the workspace's [context records](/docs/commands/context), which means the
-ladder is changed by publishing and retiring records rather than by editing code. A turn that
-cannot place an issue in the declared vocabulary labels it for a human instead of meeting it
-again on the next pass. The design behind this is `doc:backlog-self-driving` §3.2.
+**An issue carrying no rung is not ranked last.** It is set aside as unassessed, and the
+loop spends a turn triaging it before claiming any work — so a `Sev1` filed thirty
+seconds ago with no labels yet does not sort beneath a `Sev3` from March. That turn
+judges the issue against the workspace's [context records](/docs/commands/context),
+which means the ladder is changed by publishing and retiring records rather than by
+editing code. A turn that cannot place an issue in the declared vocabulary labels it for
+a human instead of meeting it again on the next pass.
 
 ### `[issues]`
 
-Which tracker is active, and where its vocabulary lives. Two fields and no more: *which*
-tracker is a stella-level decision and belongs in `stella.toml`; *how that tracker spells
-things* is the tracker's own vocabulary and belongs in its manifest, which this points at.
-Collapsing them would leave a workspace spanning two trackers nowhere to put the second one's
-words. Read from the project file alone, like `[self_driving]`.
+Which tracker is active, and where its vocabulary lives. Two fields and no more: which
+tracker to use is a stella-level decision and belongs in `stella.toml`; how that tracker
+spells things is the tracker's own vocabulary and belongs in its manifest, which this
+points at. Combining them would leave a workspace spanning two trackers with nowhere to
+put the second one's words. Read from the project file alone, like `[self_driving]`.
 
 <CardGrid size="sm">
   <OptionCard name="issues.provider" defaultValue="github">
@@ -632,9 +639,9 @@ words. Read from the project file alone, like `[self_driving]`.
     name warns and falls back to GitHub's until you declare the manifest.
   </OptionCard>
   <OptionCard name="issues.manifest" defaultValue=".stella/issues/<provider>.toml">
-    Path to the provider's manifest, relative to the workspace root. An absent **file** is
-    the built-in defaults for that provider rather than an error, so a workspace that has
-    configured nothing still works.
+    Path to the provider's manifest, relative to the workspace root. A missing file just
+    means the built-in defaults for that provider, not an error, so a workspace with no
+    configuration still works.
   </OptionCard>
 </CardGrid>
 
@@ -644,43 +651,43 @@ provider = "github"
 manifest = ".stella/issues/github.toml"
 ```
 
-What the manifest holds, and the three resolutions stella branches on, are covered in
-[Which tracker, and how it talks](/docs/commands/self-driving#which-tracker-and-how-it-talks).
+The manifest fields, and how stella reads them, are covered in
+[Tracker support](/docs/commands/self-driving#tracker-support).
 
-### `[authority]` — managed scope only
+### `[authority]`
 
-Unchanged — see [Managed authority ceilings](/docs/configuration/settings#managed-authority-ceilings).
+Only valid at managed scope. Unchanged from JSON — see
+[Managed authority ceilings](/docs/configuration/settings#managed-authority-ceilings).
 Present in a user or project `stella.toml`, it is ignored; only the file at the
 managed-scope path grants it.
 
-### `[enterprise_telemetry]` — managed scope only
+### `[enterprise_telemetry]`
 
-Unchanged — see [Enterprise telemetry enrollment](/docs/configuration/settings#enterprise-telemetry-enrollment).
-Round-trips as an untyped table and is validated fail-open by its own adapter, so its shape
-is not pinned by this schema.
+Only valid at managed scope. Unchanged from JSON — see
+[Enterprise telemetry enrollment](/docs/configuration/settings#enterprise-telemetry-enrollment).
+It round-trips as an untyped table and is checked by its own adapter, which fails open,
+so its shape is not fixed by this schema.
 
-## Comments and edits survive a write
+## Comments survive a write
 
-The whole reason to migrate: `stella.toml` is edited through
+This is the whole reason to migrate: `stella.toml` is edited through
 [`toml_edit`](https://docs.rs/toml_edit), which rewrites only the keys a save actually
-touches and preserves everything else — comments, key order, blank lines — byte-for-byte.
-`/theme`, the tool-switch editor, and the [engine config panel](/docs/configuration/agent-engine-config#the-config-panel-in-the-command-deck)
-all edit `stella.toml` in place once one exists for that scope. A `settings.json` re-render
-through `serde_json::Value` cannot make this promise — JSON has nothing to preserve besides
-keys — which is why comment loss was the risk this whole format port was built to avoid.
+touches and preserves everything else (comments, key order, blank lines) exactly as
+they were. `/theme`, the tool-switch editor, and the
+[engine config panel](/docs/configuration/agent-engine-config#config-panel) all edit
+`stella.toml` in place once one exists for that scope. A `settings.json` re-render can't
+make this promise, since JSON has nothing to preserve besides keys — comment loss is the
+risk this whole format was built to avoid.
 
-## What is not built yet
+## Not built yet
 
-Phase 1 — the format port covered on this page — is complete. `docs/spec/config-system/DESIGN.md`
-lays out five further phases that are **design only**, not yet functional: wrapper-stage
-toggles, per-agent tool scope over an agent set wider than the engine's, `[models]` pin /
-track_latest policy, provider fallback (`provider_preference`), and declarative
-`[integrations.<id>]` blocks for tools with interchangeable backends. The engine's own set
-is no longer the four names that phrase was written against: #3908 collapsed it to one role
-(`[agents.default]`), and the open, user-chosen half of the problem is already answered for
-plugin-declared roles by `[seats]`. None of those keys do
-anything if you write them today — read the design doc on GitHub if you want the plan before
-it ships:
+Several features are planned but not built yet: wrapper-stage toggles, per-agent tool scope over an agent set
+wider than the engine's, `[models]` pin / track_latest policy, provider fallback
+(`provider_preference`), and declarative `[integrations.<id>]` blocks for tools with
+interchangeable backends. The engine's own agent set is one role today
+(`[agents.default]`), and the open, user-chosen half of that problem is already
+answered for plugin-declared roles by `[seats]`. None of the planned keys above do
+anything if you write them today — see the design document for the full plan:
 [`docs/spec/config-system/DESIGN.md`](https://github.com/macanderson/stella/blob/main/docs/spec/config-system/DESIGN.md).
 
 ## A complete example file
@@ -728,7 +735,8 @@ matcher = "mcp__github__push_files"
 theme = "stella-dark"
 ```
 
-Check what actually resolved — the same two commands regardless of which format loaded it:
+Check what actually resolved. These are the same two commands regardless of which
+format loaded it:
 
 ```bash
 stella config
@@ -737,8 +745,8 @@ stella models
 
 ## Security
 
-Same posture as `settings.json`: a `stella.toml` may carry an `api_key` in plaintext at
-user or managed scope, so treat it like any other secret file at those scopes. Project
-scope removes the temptation entirely — see [`[providers]`](#providers) above — which is
-the one thing the JSON format could never enforce, because `.stella/settings.json` had no
-single canonical location to enforce it from.
+This follows the same rule as `settings.json`: a `stella.toml` may carry an `api_key` in
+plaintext at user or managed scope, so treat it like any other secret file at those
+scopes. Project scope removes the temptation entirely — see [`[providers]`](#providers)
+above — which is one thing the JSON format could never enforce, because
+`.stella/settings.json` had no single fixed location to enforce it from.

--- a/website/content/docs/context-engine.mdx
+++ b/website/content/docs/context-engine.mdx
@@ -1,12 +1,11 @@
 ---
 title: Context Engine
-description: How stella remembers — bi-temporal memory, prompt-cache-native recall, the citation loop, reflections, the tree-sitter code graph, and the domain taxonomy.
+description: How stella remembers — memory that tracks when facts were true, recall that works with prompt caching, the citation loop, reflections, the code graph, and domain tags.
 ---
 
-stella accumulates knowledge about your workspace so each session starts
-smarter than a blank slate — and it does so **prompt-cache-natively**: durable
-knowledge rides the provider's prompt cache instead of being re-billed at
-full price every call.
+stella builds up knowledge about your workspace, so each session starts smarter than a
+blank slate. It does this in a way that works with your model provider's prompt cache:
+durable knowledge rides the cache instead of getting billed at full price on every call.
 
 ## Where knowledge lives
 
@@ -17,13 +16,14 @@ Everything is on your disk, under `.stella/`:
     Workspace memories — one Markdown lesson per file, loaded into every session's prompt.
   </OptionCard>
   <OptionCard name=".stella/private/context.db">
-    The **bi-temporal** context store: episodes, reflection memories, domain facts.
+    The context store: episodes, reflection memories, and domain facts. It keeps track
+    of both when a fact was true and when stella learned it.
   </OptionCard>
   <OptionCard name=".stella/private/reflections.jsonl">
-    The reflection mining log — one JSON lesson per line.
+    The reflection log — one JSON lesson per line.
   </OptionCard>
   <OptionCard name=".stella/private/codegraph.db">
-    The tree-sitter code-graph index.
+    The code-graph index that powers structural code search.
   </OptionCard>
   <OptionCard name=".stella/rules/*.md">
     Rules — promoted memories and guard rules. Also read from `.claude/rules/` and
@@ -33,277 +33,263 @@ Everything is on your disk, under `.stella/`:
     Project [skills](/docs/agent-tools/skills).
   </OptionCard>
   <OptionCard name=".stella/domains.toml">
-    The domain taxonomy — the shared tagging vocabulary.
+    The domain tags: a shared vocabulary for tagging things in your project.
   </OptionCard>
   <OptionCard name=".stella/private/store.db">
     The citation ledger and [telemetry](/docs/telemetry).
   </OptionCard>
 </CardGrid>
 
-*Bi-temporal* means the context store keeps both when a fact was true and
-when stella believed it: re-running `stella init` **supersedes** stale facts
-rather than deleting them, so "what did we believe then?" stays answerable.
+The context store keeps track of two things: when a fact was true, and when stella
+learned it. Running `stella init` again replaces stale facts with new ones instead of
+deleting them, so you can still answer "what did stella believe back then?"
 
 ### Where rules come from
 
-Rules are read from **three** directories, in precedence order — a later one overrides an
-earlier one *by rule id*, so a repository can replace a personal rule that shares its name:
+Rules are read from three directories, in this order. A later directory overrides an
+earlier one when two rules share the same id, so a repository can replace a personal
+rule that has the same name:
 
 <CardGrid size="sm">
   <OptionCard name="~/.stella/rules/">
-    Your own rules, applied in every workspace. Lowest precedence, and the only directory
-    that survives when project prompts are not permitted.
+    Your own rules, applied in every workspace. This has the lowest precedence, and it's
+    the only directory stella still reads when project prompts aren't allowed.
   </OptionCard>
   <OptionCard name=".claude/rules/">
-    Claude Code interop — an existing rules directory works unchanged.
+    Works with Claude Code: an existing rules directory here works without any changes.
   </OptionCard>
   <OptionCard name=".stella/rules/">
-    The workspace's own rules, and where `stella memory promote` writes. Highest
-    precedence.
+    The workspace's own rules, and where `stella memory promote` writes new ones. This
+    has the highest precedence.
   </OptionCard>
 </CardGrid>
 
-Both project directories are skipped entirely when the effective
-[managed authority](/docs/configuration/settings#managed-authority-ceilings) does not
-permit project prompts, leaving your user rules armed. Prompt-only (Tier-1) rules follow
-that plain latest-wins precedence. User-global **hard guards** are monotonic instead: a
-project rule with the same id can never disarm one, and a distinct project guard is added
-under a provenance-qualified id so both constraints stay in force.
+Both project directories are skipped entirely when your
+[managed authority](/docs/configuration/settings#managed-authority-ceilings) setting
+doesn't allow project prompts. In that case, only your own user rules apply. Normal
+rules follow the precedence order above: the latest one wins. Hard guards in your user
+directory are different. A project rule can never turn one off. If a project adds its
+own guard with the same name, both guards stay active.
 
-## Local-first today; share rules through Git
+## Local by default
 
-The stores above are **workspace-local**. stella does not currently aggregate
-memories, reflection logs, or telemetry into a hosted team graph, and it does
-not silently publish a learned pattern as organization policy.
+The stores above stay on your workspace. stella does not combine memories, reflection
+logs, or telemetry into a shared team graph, and it does not automatically turn a
+learned pattern into organization policy.
 
-The shareable boundary is `.stella/rules/*.md`: commit a reviewed rule file to
-the repository and every contributor receives the same repository steering on
-their next session. `stella memory promote <id>` creates that local rule file
-after a memory has earned promotion; it does **not** stage, commit, push, or
-open a pull request.
+The one thing you can share is `.stella/rules/*.md`. Commit a reviewed rule file to the
+repository, and every contributor gets the same guidance in their next session.
+`stella memory promote <id>` creates that rule file once a memory has earned promotion,
+but it does not stage, commit, push, or open a pull request for you.
 
-This distinction is intentional:
+### What stays local
 
-- **Local observations** and personal preferences remain private by default.
-- **Repository rules** are durable, human-readable instructions that can be
-  reviewed, versioned, and reverted with ordinary Git workflows.
-- **Context retrieval** remains local and bounded to the current workspace and
-  task.
+- Local observations and personal preferences stay private by default.
+- Repository rules are durable, human-readable instructions you can review, version,
+  and revert with normal Git workflows.
+- Context retrieval stays local, scoped to the current workspace and task.
 
 For the current promotion command, see [`stella memory`](/docs/commands/memory).
-Any future team-level Context PR workflow should extend this Git-governed rule
-boundary rather than make private local telemetry a shared source of truth.
 
-## Two injection points, one cache discipline
+## How context reaches the model
 
-stella feeds context to the model at exactly two places, chosen so the
+stella feeds context to the model in exactly two places. Both are chosen so the
 expensive part never changes:
 
-1. **The baked prefix (stable).** At session start, workspace memories and
-   Tier-1 rules are concatenated into the system prompt — deterministically,
-   byte-stable for the whole session. That stability is what lets the entire
-   prefix ride the provider's prompt cache (~0.1× input cost on cached
-   reads). A memory saved mid-session takes effect **next**
-   session: hot-injecting it would invalidate the cache on every save.
-2. **The recall block (volatile).** Each turn, a single `[auto-recalled
-   context]` message is refreshed **in place** right after the stable prefix
-   — never accumulating. It carries what's relevant to *this* prompt:
-   matching memories (similarity + domain overlap + recency), code-graph
-   hits, past episodes, and selected [skills](/docs/agent-tools/skills) —
-   capped by default at 5 frames / ~1,200 tokens. Nothing relevant? No block
-   at all.
+1. **The fixed prefix.** At the start of a session, workspace memories and rules get
+   combined into the system prompt. This prefix stays exactly the same, byte for byte,
+   for the whole session. That's what lets it ride your provider's prompt cache, which
+   costs roughly a tenth of the price of a normal call. A memory you save mid-session
+   takes effect in your next session, not this one. Adding it right away would break
+   the cache every time you saved something.
+2. **The recall block.** Every turn, stella refreshes a single `[auto-recalled
+   context]` message in place, right after the fixed prefix. It never grows or piles
+   up. It carries whatever's relevant to this specific prompt: matching memories (based
+   on similarity, shared tags, and recency), code-graph hits, past episodes, and
+   selected [skills](/docs/agent-tools/skills). By default, it's capped at 5 items and
+   about 1,200 tokens. If nothing is relevant, there's no block at all.
 
-Recall fans out through the **Context Graph Protocol (CGP)** host to
-in-process providers — the workspace memory store and the code graph — fused
-by score under one token budget.
+Recall works through the Context Graph Protocol (CGP), reaching out to the workspace
+memory store and the code graph, then combining the results by score under one shared
+token budget.
 
 <RecallLoopDiagram />
 
-## Invalidation doesn't happen — and why that matters
+## No invalidation
 
-Most agents treat memory as dynamic injection: retrieve per turn, splice
-into the prompt. It maximizes relevance and **destroys prompt-cache
-locality** — every turn's prompt is different, the cache misses every call,
-and the whole system prompt re-bills at full input price, forever.
+Many AI agents treat memory as something to inject fresh on every turn: look things up,
+then splice them into the prompt. This maximizes relevance, but it wrecks prompt
+caching. Every turn's prompt ends up different, so the cache misses every time, and the
+whole system prompt gets billed at full price, forever.
 
-stella is built so invalidation *structurally cannot happen*, at two layers:
+stella is built so this can't happen, at two levels:
 
-- **The cache layer.** The prefix is byte-stable by discipline — same
-  memories, same order, same bytes, every call of the session — and the
-  volatile recall block lives in its own message *after* the prefix,
-  refreshed in place. Nothing ever rewrites the cached bytes, so the cache
-  entry is never invalidated mid-session. That is the difference between
-  paying ~0.1× (cache-read) and 1.0× (cache-miss) on every call — a
-  **10× structural cost gap that compounds across a session**. It is also
-  why a freshly saved memory waits for the next session: hot-injecting it
-  would convert every subsequent cache hit into a miss.
-- **The knowledge layer.** The context store is bi-temporal: new facts
-  **supersede** old ones with validity windows — they never overwrite or
-  delete them. Re-initializing a workspace doesn't invalidate what stella
-  believed before; it records what changed and when. History stays
-  queryable, provenance stays intact, and a recalled fact can always say
-  *when* it was true.
+- **The cache.** The prefix stays byte-for-byte identical for the whole session: same
+  memories, same order, same bytes, every call. The recall block lives in its own
+  message after the prefix and gets refreshed in place. Nothing ever rewrites the
+  cached bytes, so the cache never breaks mid-session. That's the difference between
+  paying about a tenth of the price on a cache hit versus full price on a cache miss, a
+  gap that adds up across a whole session. It's also why a memory you just saved waits
+  until the next session: injecting it right away would turn every future cache hit
+  back into a miss.
+- **The knowledge store.** New facts replace old ones for a given time window; they
+  never overwrite or delete the old ones outright. Re-running setup on a workspace
+  doesn't erase what stella believed before. It records what changed and when. You can
+  still look back at old facts, trace where they came from, and a recalled fact can
+  always tell you when it was true.
 
-The practical significance: stella's memory gets **cheaper and richer** as a
-session runs and as a workspace ages — where per-turn-injection designs get
-more expensive with every memory they add. Cost architecture, not a cache
-trick.
+In practice, this means stella's memory gets cheaper and richer the longer a session
+runs and the older a workspace gets. Systems that inject memory fresh every turn get
+more expensive with every memory they add. This is a difference in how the system is
+built, not a clever cache trick.
 
 ## The Context Graph Protocol
 
-The recall seam isn't private plumbing — it is a versioned, open wire
-protocol: the **[Context Graph Protocol](https://github.com/macanderson/context-graph-protocol)**
-(`contextgraph/1.0-draft`), now its own project, with stella as its reference host.
+Recall doesn't run on private, one-off code. It runs on an open, versioned protocol
+called the
+[Context Graph Protocol](https://github.com/macanderson/context-graph-protocol)
+(`contextgraph/1.0-draft`). It's its own project, and stella is its reference
+implementation.
 
-- **Zero-dependency wire types.** The protocol's types depend on nothing but
-  a JSON codec — a context provider can be written in any language without
-  importing a line of stella.
-- **Machine-checked conformance.** "CGP conformant" isn't marketing — it's
-  green on the public conformance suite. A conforming provider works with
-  any CGP host, checked at CI time rather than discovered at integration
-  time.
-- **A trust architecture**, not just a transport: provenance (every frame
-  says where it came from), budget discipline (providers respect the token
-  budget they're given), consent, citation guarantees, version stability,
-  and temporal validity — the bi-temporal "invalidation doesn't happen"
-  property, standardized.
+- **No dependencies to adopt.** The protocol's data types need nothing but a JSON
+  encoder and decoder. You can write a context provider in any language without
+  importing a single line of stella's code.
+- **Tested compliance.** A provider that calls itself "CGP conformant" has actually
+  passed the public conformance test suite. A conforming provider works with any CGP
+  host, and you find that out by running the tests, not by discovering a mismatch
+  later.
+- **Built-in trust rules**, not just a way to move data: every frame says where it came
+  from, providers respect the token budget they're given, and the protocol also
+  standardizes consent, citation, version stability, and the same "facts never get
+  erased, only replaced" behavior described above.
 
-The consequence for you: the context engine is **extensible without forks**.
-Your company wiki, your issue tracker, your vector store — anything that
-speaks CGP can feed stella's recall block under the same budget, scoring,
-and citation rules as the built-in providers. The full analysis lives in
+What this means for you: you can extend the context engine without forking stella's
+code. Your company wiki, your issue tracker, your vector store: anything that speaks
+CGP can feed stella's recall block, under the same budget, scoring, and citation rules
+as the built-in providers. For more detail, see
 [the CGP advantages paper](https://github.com/macanderson/context-graph-protocol/blob/main/docs/protocol-advantages.md).
 
+## The citation loop
 
-## The citation loop: memories that earn their place
+Memory in stella isn't just write and forget. It's a feedback loop:
 
-Memory in stella is not write-only. It is a feedback loop:
-
-- A memory is a lesson — a slug plus ≤ 2,000 chars of Markdown — saved as
+- A memory is a lesson: a short name plus up to 2,000 characters of Markdown, saved as
   one file in `.stella/memories/`.
-- Recalled memories carry a stable id (`nod_…`). Citations against those
-  ids — a usefulness score (1–5), a truthfulness flag, and a remark —
-  aggregate into a ledger in `.stella/private/store.db`.
-- **`stella memory list`** ranks memories by citation count, average
-  usefulness, and truthful rate. **`stella memory validate`** flags memories
-  whose file-path anchors no longer exist.
-- **Promotion:** a memory cited successfully **more than 10 consecutive
-  times** (one negative citation resets the streak) becomes eligible for
-  `stella memory promote <id>`, which turns it into a durable rule at
-  `.stella/rules/<slug>.md`.
-- **Quarantine:** a memory repeatedly cited as *untruthful* is filtered out
-  of every future recall block. Bad memories don't just rank lower — they
-  disappear.
+- Recalled memories carry a stable id, starting with `nod_`. Each time a memory gets
+  cited, that citation records a usefulness score from 1 to 5, whether it was true, and
+  a short note. These citations build up in a ledger at `.stella/private/store.db`.
+- `stella memory list` ranks memories by how often they're cited, their average
+  usefulness, and how often they turn out to be true. `stella memory validate` flags
+  memories that point to a file path that no longer exists.
+- **Promotion.** A memory cited successfully more than 10 times in a row (one bad
+  citation resets the count to zero) becomes eligible for `stella memory promote <id>`,
+  which turns it into a durable rule at `.stella/rules/<slug>.md`.
+- **Quarantine.** A memory that keeps getting cited as untrue gets filtered out of every
+  future recall block. Bad memories don't just rank lower; they stop showing up at all.
 
-### One memory's arc: from lesson to rule
+### From lesson to rule
 
 Concretely, over a few sessions:
 
-1. **Save.** A durable lesson — say, *"the integration suite needs
-   `TEST_DB=memory`; against a real socket it hangs"* — lands as a
-   slug-named file (at most 2,000 characters of Markdown) in
-   `.stella/memories/` and, per the cache discipline above, takes effect
-   from the **next** session.
-2. **Recall.** In a later session, a prompt about the integration tests
-   matches; recall surfaces the lesson in the `[auto-recalled context]`
-   block as a frame tagged with its stable id (`nod_` plus 24 hex
-   characters) — competing with everything else relevant for the default
-   cap of 5 frames / ~1,200 tokens.
-3. **Cite.** The lesson actually informs the turn, and a citation against
-   that `nod_…` id — a usefulness score (1–5), a truthfulness flag, and a
-   one-line remark — lands in the ledger in `.stella/private/store.db`.
-4. **Inspect.** `stella memory list` shows the memory climbing the ranking
-   — citation count, average usefulness, truthful rate — and flags it once
-   it has earned promotion.
-5. **Promote.** After **more than 10 consecutive positive citations** (one
-   negative citation resets the streak to zero), the memory is eligible:
-   `stella memory promote <id>` writes it as a durable rule at
-   `.stella/rules/<slug>.md`.
-6. **Graduate.** From the next session on, the promoted rule rides the
-   byte-stable prompt prefix as a Tier-1 rule — standing guidance on every
-   call, at cached-read prices, no longer needing to win recall's 5-frame
-   contest to be seen.
+1. **Save.** A durable lesson, for example "the integration suite needs
+   `TEST_DB=memory`; against a real socket it hangs," gets saved as a file (up to 2,000
+   characters of Markdown) in `.stella/memories/`. As described above, it takes effect
+   starting with the next session.
+2. **Recall.** In a later session, a prompt about the integration tests matches this
+   lesson. Recall surfaces it in the `[auto-recalled context]` block, tagged with its
+   stable id (`nod_` plus 24 hex characters). It competes with everything else relevant
+   for the default limit of 5 items and about 1,200 tokens.
+3. **Cite.** The lesson actually helps with the turn, so a citation against that
+   `nod_…` id lands in the ledger at `.stella/private/store.db`: a usefulness score
+   from 1 to 5, whether it was true, and a one-line note.
+4. **Inspect.** `stella memory list` shows the memory climbing the ranking (citation
+   count, average usefulness, truthful rate) and flags it once it has earned
+   promotion.
+5. **Promote.** After more than 10 positive citations in a row (one negative citation
+   resets the count to zero), the memory becomes eligible. `stella memory promote <id>`
+   writes it as a durable rule at `.stella/rules/<slug>.md`.
+6. **Graduate.** From the next session on, the promoted rule rides the fixed prompt
+   prefix as standing guidance on every call, at cached-read prices, without needing to
+   compete for one of recall's 5 slots to be seen.
 
-## Reflections: learning from every working turn
+## Reflections
 
-After any turn that did real work (a pure chat turn is
-skipped to save the call), stella spends one cheap, deterministic model call
-to extract **0–3 lessons**. Each is tagged with allowed domains and written to both the
-context store and `.stella/private/reflections.jsonl`. Failed turns get a dedicated
-root-cause prompt — failure is treated as the highest-value learning signal,
-not something to forget.
+After any turn that did real work, stella makes one cheap, predictable model call to
+pull out 0 to 3 lessons. A pure chat turn skips this step to save the cost. Each lesson
+gets tagged with a domain and written to both the context store and
+`.stella/private/reflections.jsonl`. A failed turn gets its own prompt asking what went
+wrong, because stella treats failure as the most valuable thing to learn from, not
+something to move past quickly.
 
-Every working turn is also recorded as an **episode** — a summary, the files
-touched, the outcome, and its time window — so future recall can surface
-"the last time we touched this area."
+Every working turn also gets recorded as an episode: a summary, the files touched, the
+outcome, and when it happened. This lets future recall surface things like "the last
+time we touched this area."
 
-Recurring lessons that keep showing up in the reflection log are
-**auto-promoted into skills** (a new `.stella/skills/<slug>/SKILL.md`),
-capped per session and never clobbering an existing skill.
+Lessons that keep coming up in the reflection log get automatically turned into skills,
+written to a new `.stella/skills/<slug>/SKILL.md`. There's a cap on how many happen per
+session, and this never overwrites an existing skill.
 
-### Measuring recall: A/B control turns
+### Measuring recall
 
-Does recall actually help? stella measures instead of assuming: at a fixed
-rate (every 10th turn by default), recall is deterministically suppressed and
-the turn recorded as a **control turn** — its episode summary carries an
-`[ab-control]` marker. Comparing outcomes with and against controls keeps the
-memory system accountable for real, measured lift.
+Does recall actually help? stella checks instead of assuming. At a fixed rate (every
+10th turn, by default), recall gets turned off on purpose, and that turn is recorded as
+a control turn, marked `[ab-control]` in its episode summary. Comparing outcomes with
+and without recall keeps the memory system honest about how much it actually helps.
 
-A control turn is frameless *everywhere*: the worker's recall block, the
-planner's context, and the witness author all see nothing, so the two arms
-differ by recall and nothing else. The schedule is counted per workspace in
-`context.db`, not per session. That lets one-turn-per-process
-surfaces — `stella run`, a `/goal` run, a fleet task — share the same
-interleaved sequence as a long chat session. Set
-`context.retrieval.ab_recall_rate` to change the rate, or to `0` to switch the
-experiment off.
+On a control turn, nothing gets recalled anywhere: the worker's recall block, the
+planner's context, and the evidence-gathering step all see nothing. That way, the only
+difference between the two groups is recall, and nothing else. This schedule is
+counted per workspace in `context.db`, not per session, so single-turn commands like
+`stella run`, a goal run, or a fleet task share the same rotation as a long chat
+session. Set `context.retrieval.ab_recall_rate` to change how often this happens, or
+set it to `0` to turn the experiment off.
 
 ## The code graph
 
-The code graph gives structural answers instead of grep guesses, backed by
-a native **tree-sitter** index of your code:
+The code graph gives structural answers instead of grep-style guesses. It's backed by
+a tree-sitter index of your code, tree-sitter being a tool that parses code instead of
+just searching its text:
 
 - **Languages:** Rust, Python, JavaScript, TypeScript, TSX, Go, Java, C, C++,
   PHP, SQL, and Markdown.
-- **Indexed:** symbol definitions, import edges, and call sites (the callee
-  *name* at each call — unresolved by design).
-- **Queries:** `definitions`, `references`, `callees`, and `callers`
-  (by symbol name — `callers` is a best-effort name match and says so);
-  `imports`, `importers`, and `neighbors` (by file path).
-  [`stella search`](/docs/commands/search) is the door onto the index:
-  a single ranked query rather than seven individual operations.
+- **Indexed:** symbol definitions, import connections, and call sites. For each call,
+  it records the name of the function being called, not a fully resolved link to it —
+  that's intentional.
+- **Queries:** by symbol name, you can ask for `definitions`, `references`, `callees`,
+  and `callers` (`callers` does its best to match by name and tells you when it's
+  guessing). By file path, you can ask for `imports`, `importers`, and `neighbors`.
+  [`stella search`](/docs/commands/search) is the way into the index: one ranked query
+  instead of running each of these separately.
 
-The deck puts the whole index behind one tab. Every answer on it is computed
-rather than asked for, which is why it prices at `$0.00`; the coupling ranking
-at the bottom is the useful one, because it is the blast radius if you edit
-the file you are looking at.
+The deck puts the whole index behind one tab. Every answer there is computed locally
+rather than sent to a model, which is why it costs `$0.00`. The coupling ranking at the
+bottom is especially useful: it shows how much would be affected if you edit the file
+you're looking at.
 
 <DeckShot id="graph" />
 
-The index builds automatically: [`stella init`](/docs/getting-started/initialization)
-builds it eagerly, and recall's graph-backed retrieval refreshes it as it
-reads. An in-process file watcher (200 ms debounce, no daemon) keeps it
-fresh as files change, for exactly as long as a session runs.
+The index builds itself. [`stella init`](/docs/getting-started/initialization) builds
+it right away, and recall refreshes it as it reads from it. A file watcher built into
+the running session (with a 200ms delay, and no background service) keeps it up to
+date as files change, for as long as the session runs.
 
 <Callout type="info">
-  `importers` edges resolve for relative TypeScript/JavaScript and Python
-  imports, and for Rust `use`/`mod` paths through the workspace module tree
-  (file-level edges; external crates stay unresolved). Remaining
-  gaps: Go and Java package imports, and PHP namespace `use`, are indexed
-  unresolved.
+  `importers` connections work for relative TypeScript/JavaScript and Python imports,
+  and for Rust `use`/`mod` paths through the workspace's module tree (at the file
+  level; external crates aren't resolved). Go and Java package imports, and PHP
+  namespace `use`, are indexed but not resolved.
 </Callout>
 
-## The domain taxonomy
+## Domain tags
 
-`stella init` infers a short tagging vocabulary for *your* project —
-`.stella/domains.toml` — and it becomes the connective tissue of the whole
-engine: memories, reflections, episodes, skills, and code-graph nodes all
-carry domain tags, so recall can relate a lesson, a past episode, and a file
-to the same area of the codebase.
+`stella init` figures out a short set of tags for your project and saves them to
+`.stella/domains.toml`. These tags connect everything in the engine: memories,
+reflections, episodes, skills, and code-graph nodes all carry domain tags, so recall
+can connect a lesson, a past episode, and a file to the same area of your codebase.
 
-## Version-control your agent's brain
+## Put it under version control
 
-Memories, rules, skills, and the taxonomy are plain files — commit them, and
-your whole team's agents share the same accumulated knowledge. The `.db`
-files are local state; see
+Memories, rules, skills, and domain tags are all plain files. Commit them, and your
+whole team's agents share the same accumulated knowledge. The `.db` files hold local
+state and shouldn't be committed; see
 [what to commit](/docs/getting-started/initialization#what-to-commit).

--- a/website/content/docs/context-engine.mdx
+++ b/website/content/docs/context-engine.mdx
@@ -234,7 +234,7 @@ session, and this never overwrites an existing skill.
 Does recall actually help? stella checks instead of assuming. At a fixed rate (every
 10th turn, by default), recall gets turned off on purpose, and that turn is recorded as
 a control turn, marked `[ab-control]` in its episode summary. Comparing outcomes with
-and without recall keeps the memory system honest about how much it actually helps.
+and without recall shows how much the memory system actually helps.
 
 On a control turn, nothing gets recalled anywhere: the worker's recall block, the
 planner's context, and the evidence-gathering step all see nothing. That way, the only

--- a/website/content/docs/diagnostics.mdx
+++ b/website/content/docs/diagnostics.mdx
@@ -1,32 +1,25 @@
 ---
 title: Diagnostics
-description: The fourth plane — why stella behaved the way it did, as distinct from what it did and what it cost. -v, --log-level, --log-file, the crash file, and the privacy contract that makes a log safe to attach to a bug report.
+description: How to turn on logging, read the crash file, and safely share a log with -v, --log-level, and --log-file.
 ---
 
-Every mature CLI can say "run it again with `-v` and attach the log." Until this
-plane existed, stella could not — for a coding agent that is a sharper gap than
-usual, because runs are nondeterministic and expensive, so "reproduce it with
-verbose on" is frequently not a request you can fulfil. This page is the plane
-that fixes that: what it is, how to turn it on, what it promises never to
-contain, and the one artifact it writes without being asked.
+Diagnostics tell you why stella behaved the way it did during a run. They are
+different from the event stream, which shows what the agent did, and
+telemetry, which shows what a run cost.
 
-## Three questions, three planes
-
-stella already answers two other questions about a run, and diagnostics is
-deliberately not a second copy of either:
+## Three planes
 
 | Plane | Question it answers | Where it lives |
 | --- | --- | --- |
-| **Event stream** | *What did the agent do?* | [`--output-format stream-json`](/docs/scripting), the session journal |
-| **Telemetry** | *What did it cost, and can I prove it?* | [receipts and the local store](/docs/telemetry) |
-| **Diagnostics** | *Why did it behave this way?* | `-v`, `--log-level`, `--log-file`, this page |
+| **Event stream** | What did the agent do? | [`--output-format stream-json`](/docs/scripting), the session journal |
+| **Telemetry** | What did it cost, and can I prove it? | [receipts and the local store](/docs/telemetry) |
+| **Diagnostics** | Why did it behave this way? | `-v`, `--log-level`, `--log-file`, this page |
 
-A diagnostic record *references* an event by its sequence number rather than
-restating it — so if you want to know what the agent did, read the event
-stream, and if you want to know why it did it, cross-reference the diagnostic
-record at the same point in the timeline.
+A diagnostic record points to an event by its sequence number instead of
+repeating it. To see what the agent did, read the event stream. To see why,
+find the diagnostic record at the same point in the timeline.
 
-## Turning it on
+## Turn it on
 
 ```bash
 stella run "…" -vv                                    # debug everywhere
@@ -37,36 +30,31 @@ stella run "…" --log-file ./run.jsonl                  # JSONL to a file, crea
 <CardGrid size="md">
   <OptionCard name="-v / -vv / -vvv" defaultValue="warn">
     Global flag. One `v` is `info`, two is `debug`, three is `trace`. Applies to
-    stderr; a `--log-file` is unaffected and floors at `info` regardless (see
-    below).
+    stderr only. A `--log-file` always writes at `info` or above, no matter this
+    setting.
   </OptionCard>
   <OptionCard name="--log-level <spec>" defaultValue="none">
-    The full filter grammar — see below. Wins over both `-v` and `STELLA_LOG`,
-    because a flag you just typed must never be silently outranked by a
-    variable you exported once.
+    The full filter grammar — see below. Wins over both `-v` and `STELLA_LOG`. A
+    flag you just typed always beats a variable you set earlier.
   </OptionCard>
   <OptionCard name="--log-file <path>" defaultValue="none">
-    Write diagnostics as JSONL to a file, created `0600`. Defaults to `info`
-    even when stderr is at `warn` — a file nobody reads until something breaks
-    may as well be able to explain it. An unwritable path is reported on
-    stderr and the run continues; a diagnostic request is never allowed to
-    take a run hostage.
+    Write diagnostics as JSONL to a file, created `0600`. Always writes at
+    `info` level or above, even when stderr is set to `warn`. If the path can't
+    be opened, stella prints a warning on stderr and the run continues.
   </OptionCard>
   <OptionCard name="STELLA_LOG" defaultValue="warn">
-    Environment form of `--log-level`, same grammar. `STELLA_SERVE_LOG` is
-    checked as a fallback when `STELLA_LOG` is unset — the variable
-    [`stella-serve`](/docs/agent-engine-paths) shipped first, kept working
-    rather than retired.
+    Environment form of `--log-level`, same grammar. If `STELLA_LOG` is unset,
+    stella checks `STELLA_SERVE_LOG` instead.
   </OptionCard>
 </CardGrid>
 
-Resolution order, most specific first: **`--log-level`**, then **`-v`/`-vv`/`-vvv`**,
-then **`STELLA_LOG`** (or `STELLA_SERVE_LOG`), then the default, `warn`.
-`--log-level` does not also read from the environment — with it,
+Resolution order, most specific first: **`--log-level`**, then
+**`-v`/`-vv`/`-vvv`**, then **`STELLA_LOG`** (or `STELLA_SERVE_LOG`), then the
+default, `warn`. `--log-level` never reads from the environment. If it did,
 `STELLA_LOG=warn stella -vv run "…"` would silently ignore the `-vv` you just
-typed, because a flag parser cannot tell an env-sourced value from a typed one.
+typed.
 
-### The filter grammar
+### Filter grammar
 
 ```text
 warn                                    # global default
@@ -74,132 +62,120 @@ warn,stella_store=debug                 # quiet, except one crate at debug
 off,stella=trace,stella_model=trace     # silent except two targets
 ```
 
-A comma-separated spec. A bare level sets the default; `target=level`
-overrides it for that module subtree, **longest match wins** — so
-`warn,stella_store=debug,stella_model=trace` is quiet everywhere except the two
-places you're looking. Levels are `off`, `error`, `warn`, `info`, `debug`,
+A comma-separated spec. A bare level sets the default. `target=level`
+overrides it for one part of the code, and the longest match wins. So
+`warn,stella_store=debug,stella_model=trace` stays quiet everywhere except the
+two places you're looking. Levels are `off`, `error`, `warn`, `info`, `debug`,
 `trace`.
 
-A target is a Rust module path: library crates are `stella_store`,
-`stella_model`, `stella_diag`, and so on, while the binary's own records are
-under `stella` — not `stella_cli`, which is only the package name, not the
-compiled target. Hyphens are accepted too (`stella-store=debug`).
+A target is a Rust module path. Library crates are named `stella_store`,
+`stella_model`, `stella_diag`, and so on. The binary's own records are under
+`stella`, not `stella_cli` (that's just the package name). Hyphens work too
+(`stella-store=debug`).
 
-An unrecognised clause is **skipped and reported**, never fatal — a typo in a
-log knob must not take a process down. The report lands as a `warn` record of
-its own (`diag.filter.bad_clause`) once there is somewhere to write it.
+An unrecognized clause is skipped and reported, never fatal. A typo in a log
+setting should never stop a run. The report itself becomes a `warn` record
+(`diag.filter.bad_clause`) once logging is set up.
 
 ## The privacy contract
 
-Records carry a stable `code` and typed fields, and **never** prompts, paths,
-model output, or full identifiers. That is a much stronger claim than "we try
-not to log secrets," and it is worth stating precisely because it decides
-whether you can hand a log to a stranger:
+Diagnostic records carry a stable `code` and typed fields. They never carry
+prompts, paths, model output, or full identifiers. That means you can safely
+hand a log to a stranger.
 
-**It is enforced by the type system, not by review.** A diagnostic field value
-is not `String`, not `Path`, and not anything with a blanket `Display` impl —
-it is a closed type constructible only from things that structurally cannot
-carry runtime content: integers, `bool`, `Duration`, `&'static str`, a closed
-`log_enum!` vocabulary, an 8-character `ShortId` (never a whole identifier),
-and `PathClass` (a path's *shape* — `inside_workspace`, four levels deep, a
-`.rs` file — never its bytes). Writing this does not compile:
+**The type system enforces this, not a review process.** A diagnostic field
+can't be a plain string or path. It can only be one of a small set of safe
+types: integers, `bool`, `Duration`, a fixed set of known strings
+(`&'static str`), a closed vocabulary (`log_enum!`), an 8-character `ShortId`
+(never a full identifier), and `PathClass` (a path's shape, like "inside the
+workspace, four levels deep, a `.rs` file" — never its actual text). Code
+like this will not compile:
 
 ```rust
 diag!(warn, "tools.write.denied", path = user_path);   // ← String; will not build
 ```
 
-`tracing` or a hand-rolled logger would happily print that with `%user_path`.
-Here it is a type error, checked once at compile time instead of on every call
-site forever. There is a single, deliberate escape hatch (`Redacted`, gated
-behind a written justification that ships in the diff), and a single way
-around the type system entirely (`Box::leak`ing a `String` into `&'static
-str`) — which is why it is on the workspace's `clippy.toml` disallowed-methods
-list. The claim is not "impossible," it is *"impossible by accident, and loud
-on purpose."* See [`crates/stella-diag`](https://github.com/macanderson/stella/tree/main/crates/stella-diag)
+A typical logging library would print that value without complaint. Here it's
+a compile error, checked once instead of on every call site forever. There is
+one deliberate escape hatch (`Redacted`, which requires a written
+justification in the code change) and one way around the type system
+entirely, which is blocked by the project's lint rules. Nothing here is
+impossible by accident — if a rule is bypassed, it's on purpose and it shows
+up loudly. See [`crates/stella-diag`](https://github.com/macanderson/stella/tree/main/crates/stella-diag)
 for the full mechanism.
 
 ## The crash file
 
-Every record at every level, filter notwithstanding, also lands in a bounded
-in-memory ring (2,000 records or 1 MiB, whichever binds first). On a panic —
-or any non-zero exit from `main` — that ring is written to disk:
+Every record, at every level, also lands in a bounded in-memory buffer (2,000
+records or 1 MiB, whichever fills first). If the process panics or exits with
+a non-zero code, that buffer is written to disk:
 
 ```text
 .stella/private/crash-<timestamp>.jsonl
 ```
 
-`0700` directory, `0600` file — the same permissions the receipts plane
-already uses. Print the newest one:
+Same permissions as the receipts plane: `0700` on the directory, `0600` on
+the file. Print the newest one:
 
 ```bash
 stella doctor --last-failure
 ```
 
-Because content cannot enter a record, this file is content-free **by
-construction**. That is what turns "please attach your log" from a request
-that needs a privacy review into one a stranger on the internet can act on
-immediately, and it is the sentence stella could not say before this plane
-existed. You need no flag set in advance for this — it works at the default
-`warn`, because the ring captures every level regardless of what the filter
-sends to a visible sink.
+Because no record can hold real content, this file is safe to share as-is.
+That's what turns "attach your log" into something a stranger can act on
+right away, with no privacy review needed. You don't need to turn on any flag
+ahead of time — the buffer captures every level by default, even at the
+default `warn` setting.
 
 <Callout type="info">
-The filter governs **sinks**, never **emission**. Raising `-vv` changes what
-you see on stderr or in `--log-file`; it does not change what the crash ring
-holds, so a crash dump is complete however quiet the run looked.
+The filter controls what you **see**, not what gets **recorded**. Turning on
+`-vv` changes what appears on stderr or in `--log-file`. It does not change
+what the crash buffer holds, so a crash dump is complete no matter how quiet
+the run looked.
 </Callout>
 
 ## Reading the codes
 
-A record's `code` is stable, versioned, public surface — the same idea as
-`rustc`'s `E0308`: you can alert on it, link to it in a runbook, and it
-outlives whatever the message text says this release. A curated set worth
-knowing while chasing a specific symptom:
+A record's `code` is stable and public, the same idea as `rustc`'s `E0308`.
+You can alert on it, link to it in a runbook, and count on it to outlive
+whatever the message text says this release. Some codes worth knowing when
+you're chasing a specific problem:
 
 | Code | Level | What it means |
 | --- | --- | --- |
-| `cli.boot` | info | The process came up with diagnostics wired. The first record of every run — a log that doesn't start with this was produced some other way. |
-| `agent.loop.detected` | warn | The loop detector matched a repeating action pattern. If `aborted` is true, this is why the run ended. |
-| `agent.budget.denied` | error | A step was refused because spend hit the configured cap — the engine working as configured, not a fault. |
-| `agent.model.retry` | warn | A model call failed and is being retried. A cluster against one provider is usually rate limiting or an outage. |
-| `agent.model.retries_exhausted` | error | Every retry failed and the turn could not proceed — almost always upstream availability or auth. |
-| `agent.provider.fallback` | warn | The configured provider failed and the engine fell back to another. Answers "which model actually served this turn." |
-| `agent.tool.result` | debug / warn | A tool finished. Emitted at `warn` only on failure, so a default `stderr` filter shows failures and only failures. |
-| `agent.turn.parked` / `agent.turn.woken` | info | The turn parked to wait on something external. A run that looks hung right after `parked` is doing exactly what the record says. |
-| `agent.unknown` | warn | An event variant this build doesn't recognise crossed the stream — almost always version skew between producer and consumer. |
-| `diag.log_file.unavailable` | warn | `--log-file` was requested but couldn't be opened. The run continues without it; this record on stderr says why. |
-| `diag.panic` | error | The process panicked. Carries the panic's file/line/column in stella's own source — never the panic message, which routinely interpolates runtime content. |
+| `cli.boot` | info | The process started with diagnostics on. This is the first record of every run — a log missing this record was produced some other way. |
+| `agent.loop.detected` | warn | The loop detector found a repeating pattern. If `aborted` is true, this is why the run ended. |
+| `agent.budget.denied` | error | A step was refused because it hit the configured spend cap. That means the limit worked as set, not that something broke. |
+| `agent.model.retry` | warn | A model call failed and is being retried. Many of these in a row against one provider usually means rate limiting or an outage. |
+| `agent.model.retries_exhausted` | error | Every retry failed and the turn could not continue. Usually a sign of upstream downtime or an auth problem. |
+| `agent.provider.fallback` | warn | The configured provider failed, and stella switched to another one. Tells you which model actually served the turn. |
+| `agent.tool.result` | debug / warn | A tool finished. Only shows at `warn` level when it fails, so a default filter shows failures and nothing else. |
+| `agent.turn.parked` / `agent.turn.woken` | info | The turn paused to wait on something outside stella. If a run looks stuck right after `parked`, that's expected. |
+| `agent.unknown` | warn | An event type this build doesn't recognize showed up in the stream. Usually means the producer and consumer are different versions. |
+| `diag.log_file.unavailable` | warn | `--log-file` was requested but couldn't be opened. The run continues without it, and this record on stderr explains why. |
+| `diag.panic` | error | The process panicked. Carries the file, line, and column in stella's own source, never the panic message itself, since that can contain runtime content. |
 
-This is a subset, hand-picked for the symptoms in
-[When something isn't working](/docs/guides/troubleshooting). The complete,
-generated list — every code the tree emits, its level, its emit site, and its
-full field set — is
-[`docs/reference/diagnostics.md`](https://github.com/macanderson/stella/blob/main/docs/reference/diagnostics.md)
-in the repository, regenerated from the emit sites themselves.
-
-Which codes this table shows, and how it describes them, are editorial: they
-are picked and written for a reader chasing a symptom. Which codes *exist* and
-what level each is emitted at are not, and this table is held to the same scan
-the generated reference is — a code here that the tree no longer emits, or a
-level cell that stops matching the emit site, fails the build
-([#3045](https://github.com/macanderson/stella/issues/3045)).
+This is a hand-picked subset for the problems covered in
+[When something isn't working](/docs/guides/troubleshooting). The full list of
+every code, its level, where it's emitted, and its complete set of fields
+lives at
+[`docs/reference/diagnostics.md`](https://github.com/macanderson/stella/blob/main/docs/reference/diagnostics.md),
+generated straight from the code.
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="When something isn't working" href="/docs/guides/troubleshooting">
-    Symptom-first checks — config, keys, hooks, cost — most of which need no
+    Checks organized by symptom — config, keys, hooks, cost. Most need no
     diagnostic flag at all.
   </SpecCard>
   <SpecCard title="stella doctor" href="/docs/commands/doctor">
     Local-state checks, and what `--last-failure` prints.
   </SpecCard>
   <SpecCard title="Telemetry" href="/docs/telemetry">
-    What it cost, and the receipts that prove it — the plane diagnostics
-    deliberately doesn't duplicate.
+    What a run cost, and the receipts that prove it.
   </SpecCard>
   <SpecCard title="Event stream compatibility" href="/docs/event-stream-compatibility">
-    What the agent did — the other plane diagnostics references but never
-    restates.
+    What the agent did — the plane diagnostics points to but never repeats.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/donate.mdx
+++ b/website/content/docs/donate.mdx
@@ -1,82 +1,87 @@
 ---
 title: Donate
-description: stella is free, BYOK, zero-telemetry-egress, and vendor-agnostic — built and funded by one person. If it saves you time or money, consider sponsoring.
+description: stella is free, BYOK, and built by one person. If it saves you time or money, consider sponsoring the project.
 ---
 
-stella is free software. Community/default use has no account or subscription and zero
-telemetry egress — and keeping that independent default is the point. Organizations
-may separately provision the explicit, signed
-[Oxagen Enterprise managed mode](/docs/telemetry#oxagen-enterprise-managed-export);
-that narrow operational boundary does not change the Community default.
+stella is free software. Community use has no account, no subscription, and
+sends no telemetry anywhere by default. Keeping that independent default is
+the point. Organizations can separately turn on the explicit, signed
+[Oxagen Enterprise managed mode](/docs/telemetry#oxagen-enterprise-managed-export),
+but that doesn't change the Community default for anyone else.
 
-If stella saves you time or money, please consider sponsoring its development:
+If stella saves you time or money, please consider sponsoring its
+development:
 
 <Callout type="info">
   **[Sponsor @macanderson on GitHub →](https://github.com/sponsors/macanderson)**
 </Callout>
 
-## Why sponsorship matters here
+## Why sponsor
 
-stella is not a thin wrapper around one vendor's API. It is a large, serious
-piece of systems engineering, built and maintained by one person:
+stella is not a thin wrapper around one vendor's API. It's a large, serious
+piece of engineering, built and maintained by one person.
 
-- **A workspace of focused Rust crates** — a deterministic agent engine, a
-  plugin socket for independent judging, a tree-sitter code
-  graph, a bi-temporal context store, a multi-tab terminal UI, fleet
-  orchestration over git worktrees, and native wire adapters for nine hosted
-  providers plus any local OpenAI-compatible server.
-- **Verification engineering** — witness tests replayed against the previous
-  code in a shadow worktree, fail→pass flip oracles, and cross-family judges
-  are much harder to build than "the model said it's done." This machinery
-  ships as Vera, stella's installable verification plugin — it's what makes an
-  agent worth using unattended.
-- **Real, ongoing costs.** Developing, benchmarking, and regression-testing an
-  agent against frontier models is paid for in real API bills — every
-  self-improvement benchmark run, every provider-adapter conformance pass,
-  every multi-model verifier evaluation costs actual money. Sponsorship goes
-  directly to keeping that work funded.
+- **Focused Rust code** powers a deterministic agent engine, a plugin system
+  for independent judging, a code graph built with tree-sitter, a context
+  store that keeps track of when facts were true and when stella learned
+  them, a multi-tab terminal UI, fleet orchestration over git worktrees, and
+  native support for nine hosted providers plus any local
+  OpenAI-compatible server.
+- **Verification work** is what makes an agent worth using unattended. This
+  includes tests replayed against the previous code in a separate worktree,
+  checks that confirm a fix actually turns a failing test into a passing
+  one, and judges pulled from a different model family than the one that
+  wrote the code. This is much harder to build than just asking the model if
+  it's done. It ships as Vera, stella's installable verification plugin.
+- **Real, ongoing costs** come with all of this. Developing, benchmarking,
+  and testing an agent against frontier models costs real money in API
+  bills — every benchmark run, every provider check, every verification
+  pass. Sponsorship goes straight to keeping that work funded.
 
-## What open source is supposed to look like
+## Our principles
 
-stella is built on a few non-negotiable principles:
+stella is built on a few rules that don't bend:
 
-- **Zero telemetry egress by default.** Community/default telemetry — executions,
-  tokens, cost, the files-touched ledger, and content — stays in local SQLite. Your
-  selected model provider remains the normal BYOK network path. Sending telemetry
-  anywhere takes one of [two explicit configurations](/docs/telemetry): an enrolled
-  Oxagen Enterprise managed seat, which can export only the documented minimal,
-  content-free operational rollup to its exact allowlisted HTTPS sink; or a `drain`
-  block you write into `~/.stella/cloud.json` and push with `stella cloud sync`.
+- **No telemetry leaves your machine by default.** Executions, tokens, cost,
+  the list of files touched, and content all stay in local SQLite. The only
+  network calls stella makes are to your own model provider — that's normal
+  operation, not telemetry. Sending telemetry anywhere else takes one of
+  [two explicit setups](/docs/telemetry): an enrolled Oxagen Enterprise seat,
+  which can send only a documented, content-free summary to its exact
+  approved address; or a `drain` block you write yourself into
+  `~/.stella/cloud.json` and push with `stella cloud sync`.
 - **Bring your own key.** Your credentials, your provider relationship, your
   bill. No middleman markup, no metered proxy, no lock-in.
-- **Model and vendor agnostic.** Anthropic, OpenAI, Google (Gemini and
-  Vertex), Amazon Bedrock, xAI, DeepSeek, Z.ai, OpenRouter, or any local
-  OpenAI-compatible server — pick per agent, per role, per run. stella has no
-  favorite and takes no rebate.
-- **Open source, and staying that way.** stella is licensed under
-  **AGPL-3.0-only** — free to use, read, fork, and ship, with one condition: if
-  you distribute a modified stella, or offer one to users over a network, you
-  publish your changes too. The copyleft is the point. It keeps improvements
-  flowing back instead of disappearing into someone's closed fork. Building
-  proprietary software *with* stella is unaffected — the license covers stella
-  itself, not the code you write using it. If you need to embed it in a
+- **Any model, any vendor.** Anthropic, OpenAI, Google (Gemini and Vertex),
+  Amazon Bedrock, xAI, DeepSeek, Z.ai, OpenRouter, or any local
+  OpenAI-compatible server — pick per agent, per role, per run. stella
+  doesn't favor any of them.
+- **Open source, staying open source.** stella is licensed under
+  **AGPL-3.0-only**: free to use, read, fork, and ship, with one condition.
+  If you distribute a modified stella, or offer it to users over a network,
+  you publish your changes too. This keeps improvements flowing back
+  instead of disappearing into a closed fork. Building your own proprietary
+  software *with* stella is unaffected — the license covers stella itself,
+  not the code you write using it. If you need to embed stella in a
   closed-source product, a [commercial license](https://github.com/macanderson/stella/blob/main/LICENSING.md)
-  is available and is part of what funds the work.
+  is available, and it helps fund the work too.
 
-That combination — local-first, BYOK, vendor-neutral, copyleft — is what open
-source is supposed to be like. It is also precisely the combination the
-Community edition can offer without an account or hosted telemetry dependency.
+Local-first, bring-your-own-key, vendor-neutral, and copyleft: that's what
+open source should look like. It's also exactly what the Community edition
+offers, with no account and no hosted telemetry required.
 
 ## Other ways to help
 
-Sponsorship is the most direct support, but not the only kind:
+Sponsorship helps the most, but it isn't the only way:
 
-- **Star and share** the repo — discovery is oxygen for independent projects.
-- **File sharp issues** with reproductions; fix one if you can.
-- **Write about your setup** — provider configs, fleet plans, and skills that
+- **Star and share** the repo. Discovery matters a lot for independent
+  projects.
+- **File clear bug reports** with steps to reproduce them, and fix one if
+  you can.
+- **Write about your setup.** Provider configs, fleet plans, and skills that
   worked for you help the next person.
 
-Thank you for using stella — and thank you for keeping independent,
-local-first developer tooling alive.
+Thank you for using stella, and for keeping independent, local-first
+developer tools alive.
 
 **[github.com/sponsors/macanderson](https://github.com/sponsors/macanderson)**

--- a/website/content/docs/event-stream-compatibility.mdx
+++ b/website/content/docs/event-stream-compatibility.mdx
@@ -1,23 +1,22 @@
 ---
 title: Event stream compatibility
-description: The versioning contract behind stella's event stream — what stays stable, what may change, and what a client must do to keep working across upgrades.
+description: What stays the same, what can change, and what your client needs to do to keep working after a stella upgrade.
 ---
 
-Every machine-readable surface stella exposes carries the same event objects:
+Every machine-readable output stella produces uses the same event objects:
 
 - [`--output-format stream-json`](/docs/scripting) — one event per line on stdout
 - `--output-format json` — the same objects, batched under an `events` key
 - the session journal stella writes to `.stella/private/` and replays on `stella resume`
 
-So there is one compatibility contract to learn, and it applies everywhere. This
-page is that contract, stated for someone writing a client in a language other
-than Rust.
+Learn this contract once, and it works for every one of these surfaces,
+whether your client is written in Rust or anything else.
 
 ## The guarantee
 
-**A client written against one version of stella keeps working against later
-versions, without changes.** Concretely, upgrading stella will not make your
-parser fail on a stream it used to handle.
+**A client built against one version of stella keeps working with later
+versions, unchanged.** Upgrading stella will not break a parser that already
+works.
 
 That holds in both directions:
 
@@ -38,7 +37,8 @@ That holds in both directions:
       { label: "Newer client", value: "never appears", mono: false },
     ]}
   >
-    An unknown event must survive the round trip, not abort the parse.
+    An event your client doesn't recognize must pass through safely, not
+    break the parser.
   </SpecCard>
   <SpecCard
     title="A renamed event type"
@@ -47,83 +47,75 @@ That holds in both directions:
       { label: "Newer client", value: "never sees the old name", mono: false },
     ]}
   >
-    Rare, and it has happened once — see the rename below. A rename is a breaking
-    change, announced as one, not a routine event.
+    Rare. A rename is a breaking change, and stella always announces it as
+    one — never as a routine update.
   </SpecCard>
 </CardGrid>
 
-Field names are never repurposed once shipped: a field that is renamed keeps the
-old spelling as an accepted alias, so a recorded stream never stops parsing. `text`
-carries `#[serde(alias = "delta")]` for exactly this reason, and `text_delta`
-accepts the reverse.
+A field's name is never reused for something else once it ships. If a field
+is renamed, the old name still works as an alias, so a recorded stream keeps
+parsing. That's why `text` accepts `#[serde(alias = "delta")]`, and
+`text_delta` accepts the reverse.
 
-**Event type names are a weaker promise, and one rename has happened.** The
-terminal event was `complete` until [#3379](https://github.com/macanderson/stella/issues/3379).
-The problem it fixed: one word meant "this turn is over" when the engine said it
-and "the whole job is over" when a wrapper — a wrapper plugin, goal mode — said
-it, and nothing reading the journal could tell which contract it was holding. So
-the word was split in two:
+**Event type names are a weaker promise than field names.** They can be
+renamed, though rarely. Two separate events mark completion today:
 
-| Today | Means | Fires |
+| Event | Means | Fires |
 | --- | --- | --- |
-| `turn_complete` | One turn finished | Once per turn, several times in a wrapped run |
+| `turn_complete` | One turn finished | Once per turn — several times in a wrapped run |
 | `run_complete` | The run finished — the stream's terminator | Exactly once, last, on success |
 
-`complete` is **not** aliased to either; every call site was moved. A client
-written before #3379 that waits for `{"type":"complete"}` will read the whole
-stream, treat the terminator as an unrecognized event under rule 1 below, and
-then wait forever. Match on `run_complete` for "nothing more is coming", and on
-`turn_complete` if you want per-turn boundaries.
+Match on `run_complete` to know that nothing more is coming. Match on
+`turn_complete` if you want per-turn boundaries. There is no event called
+`complete` — build your client around the two names above, not the single
+word you might expect from other tools.
 
-This is the case the vocabulary tries hard to avoid, and the reason the row above
-says "rare" rather than "ruled out": the contract is that new facts get new
-names, and that a rename is a breaking change announced as one.
+## The two rules
 
-## The two rules that matter
-
-Everything above reduces to a single distinction that your client should mirror,
-because stella's own reader enforces it exactly:
+Everything above comes down to one distinction. stella's own reader enforces
+it exactly, and your client should too:
 
 <EventContractDiagram />
 
 **1. An event `type` you do not recognize is normal. Skip it and keep going.**
 
-It means the stream came from a newer stella than your client knows about. It is
-not an error, and it is not a reason to stop reading. stella's own decoder
-preserves such events whole rather than failing the line.
+It means the stream came from a newer version of stella than your client
+knows about. This is not an error, and it's not a reason to stop reading.
+stella's own decoder keeps these events whole instead of failing on that
+line.
 
-**2. A `type` you *do* recognize, carrying a body that does not fit, is a real
-error. Fail loudly.**
+**2. A `type` you *do* recognize, carrying a body that does not fit, is a
+real error. Fail loudly.**
 
-That is not a version skew — it is corruption, or a bug in whatever produced the
-stream. Treating it as "probably just something new" converts a loud failure into
-silent data loss, which is how a bad record ends up in your database instead of
-in your logs.
+That's not a version mismatch. It's corruption, or a bug in whatever
+produced the stream. Treating it as "probably just something new" turns a
+loud failure into silent data loss — a bad record ends up in your database
+instead of in your error log.
 
 <Callout type="warn">
-  The tempting shortcut is a single `try { parse } catch { skip }` around each
-  line. Do not do that. It collapses both rules into rule 1 and will quietly
-  swallow malformed events that you needed to hear about. Branch on whether the
-  `type` is one you know, *then* parse.
+  It's tempting to wrap each line in a single `try { parse } catch { skip }`.
+  Don't. That treats every failure like rule 1 and quietly swallows
+  malformed events you needed to know about. Check whether the `type` is one
+  you recognize first, *then* parse.
 </Callout>
 
 ## What a client must do
 
 A conforming client:
 
-1. Reads the stream **line by line** and parses each line as an independent JSON
-   object. Never buffer the whole stream and parse it as one document.
+1. Reads the stream **line by line** and parses each line as an independent
+   JSON object. Never buffer the whole stream and parse it as one document.
 2. Dispatches on the `"type"` string.
-3. On an unrecognized `"type"`: does not fail, does not warn loudly, and does not
-   guess at semantics from the name. Count it, log it at debug level, or pass it
-   through — nothing more.
-4. On a recognized `"type"` whose body does not parse: surfaces a real error.
+3. On an unrecognized `"type"`, doesn't fail, doesn't warn loudly, and
+   doesn't guess what it means from its name. Counts it, logs it at debug
+   level, or passes it through — nothing more.
+4. On a recognized `"type"` whose body doesn't parse, raises a real error.
 5. Ignores unknown *fields* on events it does recognize.
-6. Tolerates a torn final line. A writer killed mid-line leaves a partial JSON
-   object; the clean prefix before it is still valid.
+6. Tolerates a cut-off final line. A process killed mid-write can leave a
+   partial JSON object at the end — everything before it is still valid.
 
-Point 6 matters more than it sounds — a crashed or cancelled run is a normal
-occurrence, not an exceptional one.
+Point 6 matters more than it looks. A crashed or cancelled run is normal, not
+an edge case.
 
 ```ts
 // TypeScript: the shape the contract asks for.
@@ -157,8 +149,8 @@ for (const line of stream) {
 
 ## Unrecognized events in practice
 
-Suppose a future stella adds a `quantum_reticulation` event. A client built before
-it existed sees:
+Suppose a future stella adds a `quantum_reticulation` event. A client built
+before it existed sees:
 
 ```json
 {"type":"stage","name":"execute","scope":"run"}
@@ -167,89 +159,95 @@ it existed sees:
 {"type":"run_complete","model":"m","cost_usd":0.002}
 ```
 
-It processes `stage`, `text`, and `run_complete` exactly as before, and treats
-line 2 as inert. The run is fully usable. Nothing is lost that the client could
-have understood anyway.
+It processes `stage`, `text`, and `run_complete` exactly as before, and
+treats line 2 as inert. The run is fully usable. Nothing is lost that the
+client could have understood anyway.
 
-That is not a hypothetical spelling: `quantum_reticulation` is one of the two
-invented types in the conformance fixture below, so this snippet is a slice of a
-file you can actually run your client against.
+This isn't just a made-up example. `quantum_reticulation` is one of two
+invented event types in the conformance fixture below, so this snippet comes
+straight from a file you can run your own client against.
 
-If your client re-emits or stores events, keep unrecognized ones **whole**. A
-proxy or recorder that drops them silently degrades the stream for whatever reads
-it next, which may be a newer client that would have understood them.
+If your client re-emits or stores events, keep unrecognized ones **whole**.
+A proxy or recorder that drops them quietly weakens the stream for whatever
+reads it next — which might be a newer client that would have understood
+them fine.
 
 <Callout type="info">
-  Object key order is not part of the contract and may change — JSON object keys
-  are unordered by definition. Compare parsed values, never raw lines.
+  Object key order isn't part of the contract and can change, since JSON
+  keys are unordered by definition. Compare parsed values, never raw lines.
 </Callout>
 
 ## The `ts` stamp
 
-Every line carries an optional `ts`: the wall-clock instant the sink wrote it, in
-milliseconds since the Unix epoch (UTC).
+Every line carries an optional `ts`: the wall-clock instant the sink wrote
+it, in milliseconds since the Unix epoch (UTC).
 
 ```json
 {"ts":1754582400123,"type":"tool_result","call_id":"c1","duration_ms":4200}
 ```
 
-It is stamped by the *sink*, not carried by the event, and three consequences
-follow that a client has to hold:
+It's stamped by the *sink*, not by the event itself.
 
-- **It is optional forever.** A line recorded before the field existed has none —
-  which is every archived `stella-events.jsonl` — so read it as
-  `ts ?? null`, never as a required key.
-- **It is not monotonic.** It comes from the system clock, so an NTP step can put
-  a later line before an earlier one. Clamp a negative delta to zero rather than
-  rendering it.
-- **It measures the write, not the event.** The same event published to two sinks
-  carries each sink's own instant. Use it for offsets within one stream; do not
-  align two streams to the millisecond with it.
+### What that means for a client
 
-Durations remain the right tool for spans: `tool_result` and `step_usage` carry a
-`duration_ms` measured by the engine, which is exact where `ts` is only an
-anchor.
+- **It is optional forever.** Lines recorded before this field existed have
+  none of it — that includes every archived `stella-events.jsonl` file — so
+  read it as `ts ?? null`, never as a required field.
+- **It isn't guaranteed to increase.** It comes from the system clock, so a
+  clock correction can put a later line before an earlier one. Clamp a
+  negative time difference to zero instead of displaying it.
+- **It measures when the line was written, not when the event happened.**
+  The same event sent to two different sinks gets each sink's own
+  timestamp. Use it to compare timing within one stream, not to line up two
+  different streams to the millisecond.
 
-## What is *not* guaranteed
+For measuring how long something took, use durations instead. `tool_result`
+and `step_usage` carry a `duration_ms` measured directly by the engine,
+which is exact where `ts` is only a rough anchor.
 
-- **Ordering between event types** beyond what this page documents. `text_delta`
-  lines interleave with other events.
-- **That `stage` events form one sequence.** Two disjoint authorities emit them,
-  and `scope` says which: the engine emits its own vocabulary once per turn with
-  `"scope":"turn"`, while a wrapper — a wrapper plugin, a goal loop — emits its
-  own once per run with `"scope":"run"`. A client that branches on stage
-  transitions must select on `scope` first, or it reads two interleaved
-  vocabularies as one and sees a wrapper's backwards-looking boundary as an engine
-  regression.
-- **A monotonic `ts`.** See above: it is a wall clock, and it can repeat or move
-  backwards.
-- **That every event has a stable meaning to you.** `text_delta` is an explicit
-  best-effort preview: the `text` event that follows carries the authoritative
-  step text, and you must *replace* accumulated deltas with it rather than append
-  (a retried model call re-streams its deltas from the start). See
+## What isn't guaranteed
+
+- **Ordering between event types** beyond what this page documents.
+  `text_delta` lines interleave with other events.
+- **That `stage` events form one single sequence.** Two separate sources
+  emit them, and the `scope` field tells you which. The engine emits its
+  own set once per turn with `"scope":"turn"`. A wrapper — a plugin or a
+  goal loop — emits its own set once per run with `"scope":"run"`. If your
+  client tracks stage transitions, check `scope` first. Otherwise you'll
+  read two separate sequences as one, and mistake a wrapper's boundary for
+  an engine problem.
+- **A `ts` that always increases.** As covered above, it's a wall clock, and
+  it can repeat or move backward.
+- **That every event always means the same thing to you.** `text_delta` is
+  a best-effort preview only. The `text` event that follows it carries the
+  final, correct text for that step, and you must *replace* your
+  accumulated deltas with it rather than appending to them (a retried model
+  call re-streams its deltas from the start). See
   [Scripting & automation](/docs/scripting).
-- **Internal lifecycle events.** stella's adaptive-context machinery emits its own
-  versioned envelope, kept off this stream. Do not build on it.
+- **Internal lifecycle events.** stella's context-management system emits
+  its own separate, versioned events that never appear on this stream.
+  Don't build against them.
 - **Byte-level stability.** Whitespace and key order may vary.
 
 ## Conformance
 
-The repository ships a `from_a_newer_stella.jsonl` fixture whose only purpose is
-to break clients that get rule 1 wrong.
+stella ships a `from_a_newer_stella.jsonl` fixture whose only job is to
+break clients that get rule 1 wrong.
 
-It is a well-formed turn containing two event types that do not exist. A client
-that parses it end to end, reports two unrecognized events, and reconstructs the
-run from the rest is forward compatible. A client that throws is not — however
-well it handles today's vocabulary.
+It's a well-formed turn that contains two event types that don't exist. A
+client that parses it from end to end, reports two unrecognized events, and
+reconstructs the run from everything else is forward compatible. A client
+that throws an error is not, no matter how well it handles today's event
+types.
 
-If you maintain a stella client, run it against that fixture in CI. It is the
-cheapest possible guard against the failure mode this contract exists to
-prevent, and it costs one test.
+If you maintain a stella client, run it against that fixture in CI. It's the
+cheapest possible guard against the exact failure this contract is meant to
+prevent, and it only costs one test.
 
 ## Detecting a version gap
 
-You do not need to know stella's version to consume the stream correctly — that
-is the point of rule 1. But if you want to *report* a gap ("this run used
-features your dashboard cannot display"), count unrecognized types and surface
-the count. stella's Rust decoder exposes the same information through the
-`KNOWN_TYPE_TAGS` list in `stella-protocol`.
+You don't need to know stella's version to read the stream correctly —
+that's the whole point of rule 1. But if you want to *report* a gap
+(something like "this run used features your dashboard can't display"),
+count the unrecognized event types and show that count. stella's own Rust
+decoder tracks the same list, called `KNOWN_TYPE_TAGS`, in `stella-protocol`.

--- a/website/content/docs/examples.mdx
+++ b/website/content/docs/examples.mdx
@@ -1,6 +1,6 @@
 ---
 title: Examples & recipes
-description: Complete, copy-pasteable settings files — pick the row that matches your keys and budget, paste the config, verify with stella config.
+description: Copy a settings file that matches your keys and budget, paste it in, and verify with stella config.
 ---
 
 Pick the profile that matches the keys you hold, paste its file whole, and verify with
@@ -8,8 +8,8 @@ Pick the profile that matches the keys you hold, paste its file whole, and verif
 fragment.
 
 <Callout type="info">
-This page answers *how do I set stella up*. For *how do I get this done* — a red CI
-run, an unfamiliar repository, a budget you have to hold — see the
+This page answers *how do I set stella up*. For *how do I get this done* (fixing a red
+CI run, working in an unfamiliar repo, holding to a budget), see the
 **[Guides](/docs/guides)**.
 </Callout>
 
@@ -25,23 +25,22 @@ run, an unfamiliar repository, a budget you have to hold — see the
 | [Local / air-gapped](#local-and-air-gapped) | 0 | your server | your server | your server | $0 |
 | [Enterprise cloud](#enterprise-cloud-vertex-and-bedrock) | cloud creds | Vertex or Bedrock | same | same | contract rates |
 
-Estimates are for a medium task — a focused multi-file change with one revision — at
-catalog list prices with prompt caching working normally. They are illustrative, derived
-from list price and a typical token mix, **not** measured run data: your real numbers are
-in [`stella stats`](/docs/commands/stats) and the
+These estimates are for a medium task: a focused, multi-file change with one revision,
+priced at catalog list prices with prompt caching working normally. They're rough
+guides based on list price and a typical mix of tokens, not measured data from real
+runs. For your actual numbers, check [`stella stats`](/docs/commands/stats) and the
 [Observatory](/docs/telemetry/dashboard).
 
-The two rows using `claude-fable-5` are the expensive ones because Fable lists at
-$10/$50 per Mtok. If those ranges are more than the task needs, `claude-opus-5` (half
-Fable's price) and `claude-sonnet-5` (roughly a third) are drop-in swaps on the same 1M
-window — see [the catalog](/docs/api-providers/models#the-catalog).
+The two rows using `claude-fable-5` cost more because Fable lists at $10/$50 per Mtok.
+If a task doesn't need that much, `claude-opus-5` (half Fable's price) and
+`claude-sonnet-5` (about a third) are drop-in swaps on the same 1M window. See
+[the catalog](/docs/api-providers/models#the-catalog).
 
 ## Where the money goes
 
-A plain `stella run` spends almost everything in the worker's own step loop. A
-run wrapped by a [verification plugin](/docs/plugins) adds that plugin's own
-roles around it — the shape below is typical, though what a wrapper actually
-runs is its manifest's business:
+A plain `stella run` spends almost everything in the worker's own step loop. Wrapping a
+run with a [verification plugin](/docs/plugins) adds extra roles around it. The table
+below shows a typical shape, though the exact roles depend on the plugin's own setup.
 
 | Role | Model calls | Rough size | Cost share |
 | --- | --- | --- | --- |
@@ -53,23 +52,23 @@ runs is its manifest's business:
 | Verifier | 0–1 per verification | ~3–10k in, ~0.5–1k out | cents |
 | Revise | 0–2 extra worker rounds | like the worker, smaller | proportional |
 
-Three consequences:
+## What this means
 
 1. **The worker's output price dominates.** Moving the worker from $15/Mtok output to
    $2.20 (Fable 5 → GLM-5.2) changes the bill roughly 5–7×. Moving the verifier barely
    changes it at all.
-2. **A flagship verifier is cheap insurance.** One verifier call is a few thousand input tokens
-   and under a thousand out — 1–2¢ on `gpt-5.5`, 2–3¢ on `claude-fable-5`. Make it a
-   *different family* than the worker. Arm the plugin's oracle with
-   `--test-command` and many runs skip it.
-3. **Prompt caching does the heavy lifting.** stella keeps the system prefix byte-stable
-   so most worker-step input bills at the cached rate, 4–10× cheaper. See the
-   [context engine](/docs/context-engine).
+2. **A flagship verifier is cheap insurance.** One verifier call uses a few thousand
+   input tokens and under a thousand output tokens: 1–2¢ on `gpt-5.5`, 2–3¢ on
+   `claude-fable-5`. Use a *different model family* than the worker. Set up the plugin's
+   oracle with `--test-command`, and many runs skip the verifier call entirely.
+3. **Prompt caching does most of the work.** stella keeps the system prefix identical
+   between calls, so most of the worker's input tokens bill at the cached rate, which is
+   4–10× cheaper. See the [context engine](/docs/context-engine).
 
-Multipliers: [goal mode](/docs/agent-modes#outcome-driven-goal-mode) repeats rounds until
-the verifier signs off, up to 8. [Fleets](/docs/agent-fleets) run one worker per task, and
-`--spend-limit` is enforced fleet-wide across the concurrency width. Cap either with
-`--spend-limit <usd>`, a hard limit enforced between steps.
+Two settings multiply this cost. [Goal mode](/docs/agent-modes#outcome-driven-goal-mode)
+repeats rounds until the verifier signs off, up to 8 times. [Fleets](/docs/agent-fleets)
+run one worker per task, and `--spend-limit` applies across the whole fleet at once. Use
+`--spend-limit <usd>` to set a hard limit that's checked between every step.
 
 ## Single key
 
@@ -82,11 +81,11 @@ stella config                            # confirm provider, model, redacted key
 stella run "fix the flaky retry test"
 ```
 
-That is already a working setup — auto-detection does the rest, every seat rides
-the same model, and the deterministic half of the
-[verification ladder](/docs/plugins) still gates the result.
+This is already a working setup. Auto-detection handles the rest, every role uses the
+same model, and the deterministic half of the [verification ladder](/docs/plugins) still
+checks the result.
 
-Two habits make one-key runs materially better:
+Two habits make single-key runs noticeably better:
 
 ```bash
 # Arm an installed plugin's flip oracle — deterministic evidence, verifier often skipped
@@ -97,7 +96,8 @@ stella run --pipeline my-verifier --test-command "cargo test -p api" \
 stella --spend-limit 2.00 goal "the linter passes and the snapshot tests are green"
 ```
 
-One key is one model, so the whole config is the model and how hard it thinks:
+With one key, you have one model, so the whole config is just picking the model and how
+hard it should think:
 
 ```json title="~/.stella/settings.json"
 {
@@ -116,9 +116,9 @@ One key is one model, so the whole config is the model and how hard it thinks:
 }
 ```
 
-`reasoning_auto: "on"` chooses thinking for you, so `reasoning` is left out on purpose —
-the auto would override it. `effort_auto` stays off, which is what lets the `effort` value
-above apply.
+`reasoning_auto: "on"` picks thinking mode for you, so `reasoning` is left out on
+purpose (the auto setting would override it anyway). `effort_auto` is off, which is what
+allows the `effort` value above to take effect.
 
 To use another provider, swap the model string and `allowed_models`:
 
@@ -129,24 +129,25 @@ To use another provider, swap the model string and `allowed_models`:
 | Z.ai | `zai/glm-5.2` | 200k | 0.60 / 2.20 | **no — dropped on the wire** |
 | DeepSeek | `deepseek/deepseek-chat` | 128k | 0.27 / 1.10 | **no — dropped on the wire** |
 
-Where effort is dropped, shape the run with `prompt` and `params.max_tokens` instead.
-Only OpenAI puts `service_tier` on the wire, so
-`"params": { "service_tier": "priority" }` is worth setting there and inert everywhere
-else.
+Where effort isn't supported, shape the run with `prompt` and `params.max_tokens`
+instead. Only OpenAI actually uses `service_tier`, so
+`"params": { "service_tier": "priority" }` only does something there. Everywhere else,
+it's ignored.
 
 <Callout type="warn">
-  One model reviewing its own work shares its own blind spots — it is real review, not
-  independent review. Compensate deterministically: bind a verification plugin and arm
-  its oracle with `--test-command` wherever a test can express "done" — the flag is
-  refused on the raw loop, which has no oracle. A genuinely independent second opinion comes from an installed
-  verification plugin with a [seat](/docs/configuration/agent-engine-config#seats) of its
-  own, on a model from another family.
+  A model reviewing its own work shares its own blind spots. That's real review, but it
+  isn't independent review. Add a deterministic check instead: connect a verification
+  plugin and set its oracle with `--test-command` wherever a test can define "done" (the
+  raw loop has no oracle, so this flag isn't available there). A real independent second
+  opinion comes from an installed verification plugin with its own
+  [seat](/docs/configuration/agent-engine-config#seats), running a model from a different
+  family.
 </Callout>
 
 ## Dirt cheap
 
-Point the session at the cheapest capable model, turn thinking off, cap output, and put a
-hard `--spend-limit` under it. Good for lint sweeps, docstrings, and mechanical
+Point the session at the cheapest capable model, turn thinking off, cap the output, and
+set a hard `--spend-limit`. Good for lint cleanup, docstrings, and mechanical
 migrations.
 
 ```json title="~/.stella/settings.json"
@@ -177,14 +178,14 @@ stella --spend-limit 0.25 run "add docstrings to every public function in src/ap
 stella stats --format text
 ```
 
-DeepSeek drops `effort` on the wire, so the `effort` line above records intent only —
-`reasoning: "off"` and `params.max_tokens` are what actually do the work.
+DeepSeek ignores `effort`, so that line above only records intent. `reasoning: "off"`
+and `params.max_tokens` are what actually control behavior.
 
 <Callout type="warn">
-  Cheap models revise more and resolve less on hard tasks, and a run that fails three
-  times isn't cheap. Watch **$/resolved** in the
-  [Observatory](/docs/telemetry/dashboard); when a chore class keeps failing here, move
-  that class to [balanced](#balanced).
+  Cheap models revise more and succeed less on hard tasks, and a run that fails three
+  times isn't actually cheap. Watch **$/resolved** in the
+  [Observatory](/docs/telemetry/dashboard). When one type of task keeps failing here,
+  move it to [balanced](#balanced).
 </Callout>
 
 ## Balanced
@@ -218,13 +219,13 @@ stella run --pipeline my-verifier \
   --test-command "pnpm test orders"
 ```
 
-The autos choose effort and thinking for you and *override* any `effort`/`reasoning` you
-set, which is why this profile carries no `agents` block at all. Roughly 5–7× cheaper than
-[maximum quality](#maximum-quality).
+The auto settings choose effort and thinking for you, and *override* any `effort` or
+`reasoning` value you set — that's why this profile has no `agents` block at all. It
+costs roughly 5–7× less than [maximum quality](#maximum-quality).
 
-Swap to `gemini/gemini-3-pro` when tasks need the 1M window; at $1.25/$10.00 it is exactly
-`gpt-5.5`'s list price. For one hard task, `--model` outranks the settings for that
-invocation and leaves the autos in place:
+Switch to `gemini/gemini-3-pro` when a task needs the 1M window. At $1.25/$10.00, it's
+priced exactly like `gpt-5.5`. For one hard task, `--model` overrides the settings just
+for that run and leaves the auto settings in place:
 
 ```bash
 stella --model anthropic/claude-fable-5 run "the hard one"
@@ -232,9 +233,9 @@ stella --model anthropic/claude-fable-5 run "the hard one"
 
 ## Maximum quality
 
-The strongest model, effort and thinking high, and — where you have a verification
-plugin installed — a second opinion from a *different family* on a seat of its own. For
-gnarly multi-file changes and unfamiliar codebases.
+The strongest model, with effort and thinking set high, plus a second opinion from a
+*different model family* if you have a verification plugin installed with its own seat.
+Good for tricky multi-file changes and unfamiliar codebases.
 
 ```json title="~/.stella/settings.json"
 {
@@ -275,18 +276,19 @@ stella --spend-limit 8.00 run --pipeline vera \
   --test-command "cargo test -p auth"
 ```
 
-The seat is GPT-5.5 rather than another Claude because cross-family judging is the point —
-a reviewer that shares the author's blind spots passes the same mistakes twice.
-`service_tier: "priority"` is only worth setting here: OpenAI's is the one dialect that
-puts it on the wire. Autos are off so the values above stand.
+The seat uses GPT-5.5 instead of another Claude model because judging across model
+families is the whole point. A reviewer that shares the author's blind spots will miss
+the same mistakes twice. `service_tier: "priority"` only matters here, since OpenAI is
+the only provider that actually uses it. The auto settings are off, so the values above
+take effect exactly as written.
 
-The seat line is the only thing that buys a second model. Drop it and the plugin's
-verifier runs on the session's model — the same process, one bill.
+The seat line is what buys you a second model. Remove it, and the plugin's verifier runs
+on the session's own model instead, in the same process on one bill.
 
 <Callout type="info">
-  If Fable 5 resolves in one attempt what cheaper models need three for, this profile can
-  be the *cheap* one per outcome. Check **$/resolved** after a week before concluding
-  otherwise.
+  If Fable 5 solves in one try what a cheaper model needs three attempts for, this
+  profile can end up being the *cheapest* one per finished task. Check **$/resolved**
+  after a week before deciding either way.
 </Callout>
 
 ## One gateway key (OpenRouter)
@@ -313,10 +315,11 @@ export OPENROUTER_API_KEY="sk-or-..."
 stella run --pipeline vera "add cursor pagination to /orders" --test-command "pnpm test orders"
 ```
 
-Family is read from the routed slug's vendor prefix, so `openrouter/openai/gpt-5.5` counts
-as OpenAI and the seat is genuinely cross-family even though both calls bill to one key.
-The [OpenRouter section](/docs/api-providers#openrouter) covers the first-slash split and
-the `openrouter/openrouter/auto` doubling.
+Model family is read from the prefix after `openrouter/`, so
+`openrouter/openai/gpt-5.5` counts as OpenAI. This makes the seat genuinely
+cross-family, even though both calls bill to the same key. The
+[OpenRouter section](/docs/api-providers#openrouter) explains how the prefix works and
+the `openrouter/openrouter/auto` option.
 
 ## Local and air-gapped
 
@@ -330,8 +333,8 @@ stella --model local/llama3.3 --base-url http://localhost:11434/v1 chat
 stella --model local/qwen2.5-coder --base-url http://localhost:8000/v1 run "…"
 ```
 
-For a daily setup, define the endpoint once as a config-defined provider in **user
-scope** and it behaves like a built-in:
+For everyday use, define the endpoint once as a custom provider in **user scope**, and
+it works like a built-in provider:
 
 ```json title="~/.stella/settings.json"
 {
@@ -351,14 +354,14 @@ scope** and it behaves like a built-in:
 }
 ```
 
-`effort` is dropped on local endpoints, so shape the run with `prompt` and
-`params.max_tokens` instead. The seat line splits a verification plugin's reviewer onto a
-second local model; drop it and it shares the session's. The
-[local-server section](/docs/api-providers#local-servers) has the dialect and credential
-rules.
+Local endpoints ignore `effort`, so shape the run with `prompt` and
+`params.max_tokens` instead. The seat line puts a verification plugin's reviewer on a
+second local model. Remove it, and the reviewer shares the session's model instead. The
+[local-server section](/docs/api-providers#local-servers) covers the exact format and
+credential rules.
 
-For a strict air gap, turn off the one remaining automatic outbound call — the
-model-catalog refresh from `models.dev`, at most once per 24h:
+For a strict air gap, turn off the one remaining automatic network call: the
+model-catalog refresh from `models.dev`, which happens at most once every 24 hours.
 
 ```bash
 export STELLA_CATALOG_AUTO_REFRESH=0
@@ -367,30 +370,29 @@ stella config    # every resolved value, computed from local files alone
 stella doctor    # checks the local session store's integrity; reads local state only
 ```
 
-Community/default telemetry stays in `.stella/private/store.db`; the
-[Observatory](/docs/telemetry/dashboard) binds `127.0.0.1`; memories and the code graph
-are files in your workspace; and `stella init` works offline with a heuristic fallback.
-To keep it that way, leave both telemetry-egress paths unconfigured — stella has
-[exactly two](/docs/telemetry): leave
-[Oxagen Enterprise telemetry](/docs/telemetry#oxagen-enterprise-managed-export)
-unenrolled, and write no `drain` block into `~/.stella/cloud.json` (without one,
-`stella cloud sync` performs no network I/O). Then configure only loopback model
-endpoints.
+Community telemetry stays in `.stella/private/store.db`. The
+[Observatory](/docs/telemetry/dashboard) only listens on `127.0.0.1`. Memories and the
+code graph are files in your workspace. `stella init` works offline with a fallback. To
+keep it fully offline, leave both telemetry paths turned off: don't enroll in
+[Oxagen Enterprise telemetry](/docs/telemetry#oxagen-enterprise-managed-export), and
+don't add a `drain` block to `~/.stella/cloud.json` (without one, `stella cloud sync`
+makes no network calls at all). Then point every model endpoint at a local address.
 
 <Callout type="info">
-  Local models have no catalog prices, so `stella stats` dollar columns read zero and
-  `--spend-limit` has nothing to meter against. Bound runs with a verification plugin's
-  `--test-command` oracle and goal-mode round caps instead.
+  Local models have no listed prices, so `stella stats` shows zero in the dollar
+  columns, and `--spend-limit` has nothing to measure against. Use a verification
+  plugin's `--test-command` oracle and goal-mode round limits to bound runs instead.
 </Callout>
 
 ## Enterprise cloud (Vertex and Bedrock)
 
-When models must flow through your existing cloud agreement. Both providers sit **last**
-in auto-detection, so pin them explicitly. Setup and credential rules are in
-[API providers](/docs/api-providers#google-vertex-ai); this is the org-wide half.
+Use this when models need to run through your existing cloud agreement. Both providers
+come **last** in auto-detection, so you need to set them explicitly. Setup and
+credential rules live in [API providers](/docs/api-providers#google-vertex-ai) — this
+page covers the org-wide setup.
 
-The **org-managed scope** is the enterprise deployment surface: a `settings.json` outside
-any repo, shipped by MDM, that every stella on the machine inherits.
+The **org-managed scope** is where enterprise settings live: a `settings.json` outside
+any repo, delivered by MDM, that every stella install on the machine picks up.
 
 ```json title="/Library/Application Support/stella/settings.json (macOS) · /etc/stella/settings.json (Linux)"
 {
@@ -430,9 +432,10 @@ any repo, shipped by MDM, that every stella on the machine inherits.
 
 ## Team-shared settings
 
-A team setup divides work across the three
-[settings scopes](/docs/configuration/settings#the-scope-hierarchy): the repo carries what
-is true for everyone, each user carries keys and taste, the org carries policy.
+A team setup splits configuration across three
+[settings scopes](/docs/configuration/settings#the-scope-hierarchy). The repo holds
+what's true for everyone. Each user holds their own keys and preferences. The org holds
+policy.
 
 Commit `domains.toml`, `memories/`, `rules/`, `skills/`, `commands/`, `tools/`,
 `mcp.toml`, and `settings.json` (as long as it holds no inline `api_key`). Ignore the
@@ -463,22 +466,25 @@ local state:
 }
 ```
 
-`api_key_env` points every teammate at one variable name while each supplies their own
-value, so rotation is a vault change rather than a settings edit.
+`api_key_env` points every teammate at one variable name, while each person supplies
+their own value. That way, rotating a key is a change in your vault, not a settings
+edit.
 
 <Callout type="warn">
-  A fresh clone's `hooks`, `providers.*.base_url`/`api_key`/`api_key_env`,
-  `mcp.registry_url`, `context_providers`, per-agent `prompt`s, and the whole of
-  `.stella/mcp.toml` are held back until the user opts in — otherwise any repo you clone
-  could run commands on your machine or route your keys through its server.
+  When you clone a repo for the first time, stella holds back some settings until you
+  opt in: `hooks`, `providers.*.base_url`, `api_key`, `api_key_env`, `mcp.registry_url`,
+  `context_providers`, per-agent `prompt`s, and everything in `.stella/mcp.toml`.
+  Without this, any repo you clone could run commands on your machine or send your keys
+  through its own server.
 
   ```bash
   export STELLA_TRUST_PROJECT=1   # scope it per-repo with direnv or a shell guard
   ```
 
-  A stderr notice names anything skipped. `STELLA_PROJECT_HOOKS=1` is the narrower legacy
-  form: it trusts hooks, MCP, and context providers but leaves credential routing gated.
-  See [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
+  stella prints a notice on stderr naming anything it skipped.
+  `STELLA_PROJECT_HOOKS=1` is a narrower option: it trusts hooks, MCP, and context
+  providers, but still blocks credential routes. See
+  [the project trust boundary](/docs/configuration/settings#the-project-trust-boundary).
 </Callout>
 
 Merge semantics you will rely on:
@@ -490,9 +496,9 @@ Merge semantics you will rely on:
 | `tools`, `mcp` | Last scope wins per key. Untrusted, a repo may narrow the tool surface, never widen it |
 | `allowed_models` | Replaces wholesale — whichever scope sets it owns the entire list |
 
-Scope precedence for everything that merges is **user → org-managed → project**, later
-winning. The exception runs the other way: an org-managed `tools` denial is a ceiling
-applied last.
+For settings that merge, the order is **user → org-managed → project**, with later
+scopes winning. The one exception runs backward: an org-managed `tools` denial always
+applies last, as a ceiling nothing can raise.
 
 ## Verify any of these
 
@@ -502,5 +508,5 @@ stella config    # the resolved provider, model, and a redacted key preview
 stella stats     # after a run: cost and resolve rate per provider and model
 ```
 
-Let the observed **$/resolved** number, not the sticker price, pick your lineup — see the
+Let the actual **$/resolved** number pick your lineup, not the sticker price. See the
 [model guide](/docs/api-providers/models).

--- a/website/content/docs/extensions.mdx
+++ b/website/content/docs/extensions.mdx
@@ -1,24 +1,25 @@
 ---
 title: Extension hooks
-description: A typed, in-process event bus that lets extensions observe stella's activity and gate sensitive actions with allow, modify, deny, or require-approval.
+description: An event bus that lets extensions watch what stella does, and approve, block, or change sensitive actions before they run.
 ---
 
-stella's engine (`stella-core`) exposes a typed **event bus** that extensions and embedders
-use to *observe* everything the agent does and, on an explicit allowlist of
-policy-sensitive actions, to *intercept* it. Every event flows through one uniform
-envelope, and every subscription is disposable and cleanup-safe.
+stella's engine (`stella-core`) exposes an **event bus** that extensions and
+embedders use to *watch* everything the agent does. For a specific, listed
+set of sensitive actions, they can also *intercept* it. Every event uses the
+same format, and every subscription cleans up after itself.
 
 <Callout type="info">
-  Two different things are both called "hooks" in stella. **[Lifecycle hooks](/docs/agent-tools/hooks)**
-  are shell commands you declare in `settings.json` — no code required. **Extension hooks**
-  (this page) are the *programmatic* in-process bus you register handlers against when you
-  embed stella's engine as a library. They share the event vocabulary but not the wiring.
+  stella uses "hooks" for two different things. **[Lifecycle hooks](/docs/agent-tools/hooks)**
+  are shell commands you write in `settings.json` — no code needed.
+  **Extension hooks** (this page) are code you write and register when you
+  embed stella's engine as a library. Both use the same event names, but
+  they connect differently.
 </Callout>
 
 ## The event envelope
 
-Every event — whether an observer notification or a policy decision point — is delivered as
-a `HookEvent`:
+Every event, whether it's just a notification or a point where you can make
+a decision, arrives as a `HookEvent`:
 
 ```ts
 type HookEvent<TPayload = unknown> = {
@@ -33,21 +34,28 @@ type HookEvent<TPayload = unknown> = {
 };
 ```
 
-`sequence` is monotonic per session, so a consumer that needs a total order across threads
-sorts by it. The timestamp is fixed-width, so lexicographic order equals time order.
+`sequence` always increases within a session, so sort by it if you need a
+strict order across threads. The timestamp has a fixed width, so sorting it
+as text gives you time order too.
 
 ## Two kinds of handler
 
-### Observers — watch everything, change nothing
+### Observers
 
-Observers subscribe with `on` and are notified via `emit`. They **cannot** veto, fail, or
-corrupt the primary operation — an observer that returns an `Err` is logged, surfaced as an
-`extension.error` event, and skipped; the operation continues regardless. Observers do run
-**inline on the emitting thread**, though, so a slow handler *delays* the operation — move
-expensive work off-thread (e.g. `forward_to`) rather than blocking in the handler. Returning
-`Err` is the supported failure signal: a panic is only contained in unwinding (debug/test)
-builds, and under the release profile's `panic = "abort"` a panicking observer aborts the
-whole process.
+Observers watch everything and change nothing. Subscribe with `on`, and
+stella notifies you through `emit`. An observer **cannot** block, fail, or
+corrupt the action it's watching. If an observer returns an `Err`, stella
+logs it, raises an `extension.error` event, and skips it — the original
+operation continues either way.
+
+Observers run **inline on the same thread that emitted the event**, so a
+slow handler *delays* the operation it's watching. Move expensive work
+off-thread (for example with `forward_to`) instead of blocking inside the
+handler.
+
+Return `Err` to signal a failure — that's the safe way. A panic is only
+caught in debug and test builds. In a release build, where the process is
+set to abort on panic, a panicking observer takes down the whole process.
 
 ```rust
 // exact name, namespace wildcard, or "*" for everything
@@ -61,24 +69,25 @@ Matching:
 
 <CardGrid size="sm">
   <OptionCard name="file.read">
-    An exact name — exactly that event, nothing else.
+    Matches only that exact event.
   </OptionCard>
   <OptionCard name="file.*">
-    A namespace wildcard — `file.read`, `file.created`, `file.diff.computed`, and the rest
-    of the namespace.
+    Matches every event in that group: `file.read`, `file.created`,
+    `file.diff.computed`, and more.
   </OptionCard>
   <OptionCard name="tool.*">
-    Likewise: `tool.call.requested`, `tool.call.completed`, …
+    Same idea: `tool.call.requested`, `tool.call.completed`, and more.
   </OptionCard>
   <OptionCard name="*">
     Every event the host emits.
   </OptionCard>
 </CardGrid>
 
-### Policy hooks — gate the sensitive actions
+### Policy hooks
 
-Policy hooks subscribe with `on_blocking` and run **sequentially, in registration order**,
-*before* a policy-sensitive action proceeds. Each returns a decision:
+Policy hooks gate sensitive actions. Subscribe with `on_blocking`, and each
+hook runs **in order, one after another**, *before* the sensitive action
+happens. Each hook returns a decision:
 
 ```ts
 type HookDecision =
@@ -88,12 +97,12 @@ type HookDecision =
   | { action: "modify"; payload: unknown };
 ```
 
-The chain folds every `modify` into the payload (the next handler sees the modified version)
-and **stops at the first `deny` or `require_approval`**. A chain that only ever allows or
-modifies ends in `allow`. A policy handler that panics fails closed **only in unwinding
-(debug/test) builds**; the release profile compiles with `panic = "abort"`, where a panic
-aborts the whole process instead of denying — so signal refusal by returning `deny`, never
-by panicking.
+Each `modify` decision updates the payload before the next handler sees it.
+The chain **stops at the first `deny` or `require_approval`**. If every
+handler only allows or modifies, the final result is `allow`. A policy
+handler that panics fails safely **only in debug and test builds**. In a
+release build, a panic aborts the whole process instead of denying the
+action — so always signal refusal by returning `deny`, never by panicking.
 
 ```rust
 // Require a human for production deploys.
@@ -112,7 +121,7 @@ bus.on_blocking("file.updated", |event| {
 });
 ```
 
-Only these events are interceptable — the explicit allowlist of policy-sensitive actions:
+Only these events can be intercepted:
 
 ```text
 tool.call.requested   file.created   file.updated   file.deleted
@@ -120,29 +129,30 @@ command.started       git.commit.requested          git.push.requested
 pull_request.requested                               deployment.requested
 ```
 
-Every gated action records its outcome as a `policy.evaluated` event plus one of
-`policy.allowed` / `policy.blocked` / `approval.requested`.
+Every gated action logs its outcome as a `policy.evaluated` event, plus one
+of `policy.allowed`, `policy.blocked`, or `approval.requested`.
 
 ## Payload hygiene
 
 The bus never exposes secrets or full file contents to observers by default:
 
-- The **raw** payload of a blocking event (which may hold a whole file or a shell command)
-  reaches only **blocking handlers** — the explicitly privileged interception point. Never
-  an observer.
-- Observable tool events carry a **sanitized** input: content-bearing fields (`content`,
-  `new_string`, `old_string`) are replaced with `"<omitted: N bytes, M lines>"`.
-- Writes are scanned for high-precision secret shapes (PEM keys, AWS / GitHub / Slack /
-  Google / `sk-` tokens) → a `secret.detected` event that names only the *kind*, never the
-  match. Touches to credential-shaped paths (`.env*`, `*.pem`, `id_rsa`, …) →
-  `sensitive_operation.detected` with the path only.
+- The **raw** payload of a blocking event, which can include a whole file or
+  a shell command, only reaches **blocking handlers** — never an observer.
+- Tool events sent to observers carry **sanitized** input. Fields that hold
+  content (`content`, `new_string`, `old_string`) are replaced with
+  `"<omitted: N bytes, M lines>"`.
+- Writes are scanned for secret patterns (PEM keys, AWS, GitHub, Slack,
+  Google, and `sk-` tokens). A match raises a `secret.detected` event that
+  names only the *kind* of secret, never the actual value. Writes to
+  credential-shaped paths (`.env*`, `*.pem`, `id_rsa`, and similar) raise
+  `sensitive_operation.detected` with just the path.
 
 ## Disposal
 
-`on` / `on_blocking` return a subscription. **Dropping it unsubscribes** — cleanup is
-automatic. Call `.detach()` to keep a handler for the session's lifetime, or
-`.unsubscribe()` to remove it explicitly. Removal is idempotent and safe even after the bus
-is gone.
+`on` and `on_blocking` both return a subscription. **Dropping it removes the
+handler automatically.** Call `.detach()` to keep a handler for the whole
+session, or `.unsubscribe()` to remove it yourself. Removing a handler is
+safe to call more than once, and safe even after the bus itself is gone.
 
 ```rust
 let sub = bus.on("*", audit);
@@ -152,8 +162,8 @@ sub.unsubscribe();          // or: drop(sub);  — same effect
 
 ## The event catalog
 
-The host emits events across these namespaces. Extensions may also emit their own names —
-the catalog is the contract for what the *host* emits.
+stella emits events grouped into these categories. Extensions can also emit
+their own event names — this list only covers what *stella itself* emits.
 
 <CardGrid size="md">
   <OptionCard name="session.*">
@@ -196,22 +206,25 @@ the catalog is the contract for what the *host* emits.
   </OptionCard>
 </CardGrid>
 
-`extension.quarantined` is the one worth knowing about before you need it: an observer
-that repeatedly overruns its per-dispatch time budget is **quarantined** — skipped for the
-rest of the session — and the event is how you find out. Observers run inline on the
-emitting thread, so this is the resilience valve that stops a wedged extension from
-silently stalling the agent. If your handler is doing real work, move it off-thread rather
-than discovering it in a quarantine event.
+`extension.quarantined` is worth knowing about ahead of time. If an observer
+repeatedly takes too long to run, stella **quarantines** it — skips it for
+the rest of the session — and raises this event to tell you. Since observers
+run on the same thread that triggered them, this is what stops a slow
+extension from silently stalling the whole agent. If your handler does real
+work, move it off-thread now, rather than finding out through a quarantine
+event later.
 
-## Relationship to file-touch telemetry
+## File events and telemetry
 
-The bus is how you react to file changes *as they happen*: the same
-[file-touch telemetry](/docs/telemetry) that stella records also drives `file.created`,
-`file.updated`, `file.deleted`, and `files_touched.updated` events, each carrying the path,
-reason, and line deltas of the touch (never the file contents).
+The bus is how you react to file changes *as they happen*. The same
+[file-touch telemetry](/docs/telemetry) stella records also drives
+`file.created`, `file.updated`, `file.deleted`, and `files_touched.updated`
+events. Each one carries the path, the reason, and the line changes, but
+never the file's actual contents.
 
 <Callout type="warn">
-  The extension hook bus is the in-process API surfaced by `stella-core` for embedders. If
-  you only need to run a shell command on a tool call, reach for the config-driven
-  [lifecycle hooks](/docs/agent-tools/hooks) instead — no code, no build.
+  The extension hook bus is the in-process API that `stella-core` exposes
+  for embedders. If you just need to run a shell command on a tool call, use
+  [lifecycle hooks](/docs/agent-tools/hooks) instead — no code, no build
+  required.
 </Callout>

--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -149,4 +149,3 @@ When you want more detail:
 - **[Agent modes](/docs/agent-modes)** — deck, run, goal, monitor, fleet: which to use when.
 - **[Configuration](/docs/configuration)** — settings.json, per-agent models, credentials.
 - **[Scripting](/docs/scripting)** — run stella headlessly in CI with JSON output.
-</content>

--- a/website/content/docs/getting-started/index.mdx
+++ b/website/content/docs/getting-started/index.mdx
@@ -1,17 +1,20 @@
 ---
 title: Getting Started
-description: Install stella, set a provider key, initialize your repo, and run your first verified change — in under five minutes.
+description: Install stella, set a provider key, start your repo, and run your first change. Takes under five minutes.
 ---
 
-This walks you from zero to a verified change:
-**[install](/docs/getting-started/installation)** the binary, set a provider
-key, **[initialize](/docs/getting-started/initialization)** the repo, and run.
-The full provider matrix (OpenRouter, local servers, Vertex, Bedrock, custom
-gateways) lives in **[Providers & models](/docs/getting-started/providers)**.
+## Quick path
+
+1. **[Install](/docs/getting-started/installation)** stella.
+2. Set a provider key.
+3. **[Start](/docs/getting-started/initialization)** your repo.
+4. Run a task.
+
+Need a provider besides the big ones? OpenRouter, local servers, Vertex, Bedrock, and custom gateways are covered in **[Providers & models](/docs/getting-started/providers)**.
 
 <QuickstartDiagram />
 
-If you would rather paste one block and read afterwards, this is the whole path:
+Want the whole thing in one block? Paste this:
 
 ```bash
 # 1. Install.
@@ -29,14 +32,14 @@ stella run "explain what this repository does, then list the riskiest files"
 
 ## 1. Set an API key
 
-stella is bring-your-own-key. Export a key for any one provider — stella auto-detects it:
+stella is bring-your-own-key. Export a key for any provider, and stella finds it for you:
 
 ```bash
 export ANTHROPIC_API_KEY=your_key_here   # or OPENAI_API_KEY, GEMINI_API_KEY, ZAI_API_KEY, …
 ```
 
-No key handy? Point stella at a local OpenAI-compatible server instead — see
-[Providers &amp; models](/docs/getting-started/providers#local--any-openai-compatible-server).
+No key handy? Point stella at a local OpenAI-compatible server instead. See
+[Providers &amp; models](/docs/getting-started/providers#local-servers).
 
 Confirm what stella resolved:
 
@@ -44,7 +47,7 @@ Confirm what stella resolved:
 stella config    # provider, model, redacted key, base URL, workspace
 ```
 
-## 2. Initialize the repo (recommended)
+## 2. Start your repo (recommended)
 
 From inside a project directory:
 
@@ -52,33 +55,35 @@ From inside a project directory:
 stella init
 ```
 
-This infers a domain taxonomy and builds the tree-sitter code graph the agent
-queries instead of grepping blind — see
-[Repo initialization](/docs/getting-started/initialization). It's optional
-(and offline-safe), but every session afterwards starts smarter.
+This scans your code, builds a searchable map called the code graph, and guesses
+your project's domains (like auth, storage, api). See
+[Repo initialization](/docs/getting-started/initialization) for details. It's
+optional and works offline, but every session after this one will be smarter
+for it.
 
-## 3. Run a one-shot prompt
+## 3. Run once
+
+`stella run` does one task and prints the result. No back-and-forth. By
+default it uses a single, raw step loop. Add `--pipeline <variant>` to run it
+through an installed [wrapper plugin](/docs/plugins) instead. It can read
+files, run commands, and edit code as it works.
 
 ```bash
 stella run "explain what this repository does, then list the riskiest files"
 ```
 
-`stella run` runs a one-shot, non-interactive task and prints the result. By default it runs
-a single raw step loop; pass `--pipeline <variant>` to route it through an installed
-[wrapper plugin](/docs/plugins) instead. It can read files, run
-commands, and edit code as needed.
+## 4. Chat
 
-## 4. Chat interactively
-
-Running `stella` with no subcommand opens the **Command Deck**, a tabbed terminal UI. Pass
-`--plain` (or set `STELLA_PLAIN=1`) for a plain line-based REPL instead:
+Run `stella` with no arguments to open the **Command Deck**, a tabbed
+terminal window. Want a simpler view? Pass `--plain` (or set
+`STELLA_PLAIN=1`) for a plain, line-by-line chat instead:
 
 ```bash
 stella
 ```
 
-Inside the deck, type a message to send it, or use a slash command to open a tab. The ones
-worth knowing on day one:
+Type a message to send it. Type a slash command to open a tab. Here are the
+ones worth knowing on day one:
 
 <CardGrid size="sm">
   <OptionCard name="/help">Show help.</OptionCard>
@@ -91,21 +96,24 @@ worth knowing on day one:
   <OptionCard name="/clear">Clear the session.</OptionCard>
 </CardGrid>
 
-Press **Ctrl-C** to quit. That is a partial list — see [`stella chat`](/docs/commands/chat)
-for the full deck command set, and for the plain REPL's separate, smaller one.
+Press **Ctrl-C** to quit. This is a partial list. See
+[`stella chat`](/docs/commands/chat) for the full command set for the deck,
+and the smaller one for the plain REPL.
 
 ## 5. Give it a goal
 
-Goal mode works in judged rounds until a **separate verifier model** confirms the objective
-is met from evidence — not just because the worker says so:
+Goal mode runs in rounds. After each round, a **separate verifier model**
+checks the evidence and confirms whether the goal is actually met. It won't
+stop just because the worker says it's done:
 
 ```bash
 stella goal "the test suite passes and there are no clippy warnings"
 ```
 
-See [Goal mode](/docs/agent-modes#outcome-driven-goal-mode) for how the verifier is chosen and how the loop ends.
+See [Goal mode](/docs/agent-modes#outcome-driven-goal-mode) for how the
+verifier is chosen and how the loop ends.
 
-## 6. Pin a specific model (optional)
+## 6. Pin a model (optional)
 
 By default stella auto-detects the provider. Pin one explicitly with `--model`:
 
@@ -116,7 +124,7 @@ stella --model zai/glm-5.2 goal "CI is green on the current branch"
 
 ## Where to go next
 
-The fastest next step is a real task rather than another reference page:
+The fastest next step is a real task, not another reference page:
 
 <CardGrid size="sm">
   <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
@@ -133,7 +141,7 @@ The fastest next step is a real task rather than another reference page:
   </SpecCard>
 </CardGrid>
 
-Then, when you want the underlying account:
+When you want more detail:
 
 - **[Providers &amp; models](/docs/getting-started/providers)** — the full provider matrix and the
   credential chain.
@@ -141,3 +149,4 @@ Then, when you want the underlying account:
 - **[Agent modes](/docs/agent-modes)** — deck, run, goal, monitor, fleet: which to use when.
 - **[Configuration](/docs/configuration)** — settings.json, per-agent models, credentials.
 - **[Scripting](/docs/scripting)** — run stella headlessly in CI with JSON output.
+</content>

--- a/website/content/docs/getting-started/initialization.mdx
+++ b/website/content/docs/getting-started/initialization.mdx
@@ -1,10 +1,10 @@
 ---
 title: Repo initialization
-description: Prime a workspace with stella init — the domain taxonomy, the tree-sitter code graph, the semantic embedding pass, extension adoption, and everything that lands under .stella/.
+description: What `stella init` builds — the domain taxonomy, the code graph, semantic search, extension adoption, and everything that lands under .stella/.
 ---
 
-stella works in any directory with zero setup — but one command primes it
-with structured knowledge of your codebase:
+stella works in any directory with no setup. One command gives it a head
+start by mapping out your codebase:
 
 ```bash
 cd your-project
@@ -13,54 +13,55 @@ stella init
 
 ## What `stella init` does
 
-1. **Infers the domain taxonomy** → `.stella/domains.toml`. A short, shared
-   tagging vocabulary (auth, storage, api, …) used to label memories,
-   reflections, and every code-graph node — so the
-   [context engine](/docs/context-engine) can relate a memory, a reflection,
-   and a file to the same area of your project. Also persisted into the
-   context plane at `.stella/private/context.db`.
-2. **Builds the code-graph index** → `.stella/private/codegraph.db`. A tree-sitter
-   symbol/import index you query from your shell through
-   [`stella search`](/docs/commands/search) instead of grepping blind.
-3. **Embeds the indexed files for semantic search**, when an embedding
-   backend is configured (`VOYAGE_API_KEY`, `OPENAI_API_KEY`, or
-   `STELLA_EMBED_URL` + `STELLA_EMBED_MODEL`). That is what lets
-   `stella search` answer *"which file strips secrets before logging"*
-   by meaning rather than by substring.
-   With no backend configured init says so in one line and does nothing else;
-   with one, it prints how many files it embedded and how many a large
-   repository left for later (they embed on demand as searches reach them).
-4. **Adopts existing agent extensions.** Commands, skills, and agents already
-   defined for other tools (`.claude/` and `.agents/` directories, workspace
-   and user scope) are adopted as symlinks under `.stella/` — your existing
-   setup carries over instead of starting from scratch.
+1. **Guesses the domains in your code** → `.stella/domains.toml`. This is a
+   short list of tags (auth, storage, api, and so on) that labels memories,
+   reflections, and every node in the code graph. It lets the
+   [context engine](/docs/context-engine) connect a memory, a reflection, and
+   a file that all belong to the same part of your project. It's also saved
+   to `.stella/private/context.db`.
+2. **Builds the code graph** → `.stella/private/codegraph.db`. This is an
+   index of your code's symbols and imports. Query it from your shell with
+   [`stella search`](/docs/commands/search) instead of guessing with grep.
+3. **Embeds your files for search by meaning**, if you've set up an
+   embedding backend (`VOYAGE_API_KEY`, `OPENAI_API_KEY`, or
+   `STELLA_EMBED_URL` plus `STELLA_EMBED_MODEL`). This is what lets
+   `stella search` answer a question like "which file strips secrets before
+   logging" instead of only matching exact text. Without a backend, init
+   says so in one line and skips this step. With one, it tells you how many
+   files it embedded, and how many a large repo left for later, embedding
+   them the first time a search reaches them.
+4. **Reuses your existing setup.** Commands, skills, and agents already
+   defined for other tools — in `.claude/` and `.agents/` directories, at
+   both workspace and user scope — are linked into `.stella/`. You keep what
+   you already built instead of starting over.
 
-`stella init` works **offline** with a heuristic fallback, so it never
-hard-fails: you can initialize before configuring any provider key.
+`stella init` works **offline**. With no provider key, it falls back to a
+simpler guess instead of failing, so you can run it before setting up any key.
 
 <Callout type="info">
-  In interactive sessions the graph also auto-builds in the background and
-  refreshes live as files change — `stella init` is about doing it once,
-  eagerly, and generating the taxonomy alongside. Re-run it after large
-  refactors to rebuild the index and re-infer the taxonomy.
+  In interactive sessions, the code graph also builds itself in the
+  background and updates as files change. `stella init` does this once,
+  right away, and also builds the domain list. Run it again after a big
+  refactor to refresh both.
 </Callout>
 
 ## What lands where
 
-Everything stella knows about a workspace lives under `.stella/` — plain
-files and SQLite databases you can inspect, version, or delete at will:
+Everything stella knows about your workspace lives under `.stella/`. It's
+all plain files and SQLite databases. Inspect them, put them in version
+control, or delete them — your choice.
 
-### Shared — commit these
+### Files to commit
 
 <CardGrid size="md">
   <OptionCard name=".stella/domains.toml">
-    The domain taxonomy — the tagging vocabulary `stella init` infers.
+    The domain tags `stella init` guesses.
   </OptionCard>
   <OptionCard name=".stella/memories/*.md">
     Workspace [memories](/docs/context-engine), as plain Markdown.
   </OptionCard>
   <OptionCard name=".stella/rules/*.md">
-    Workspace rules — promoted memories and guard rules.
+    Workspace rules: memories that got promoted, plus guard rules.
   </OptionCard>
   <OptionCard name=".stella/skills/">
     Project-scope [skills](/docs/agent-tools/skills).
@@ -80,56 +81,64 @@ files and SQLite databases you can inspect, version, or delete at will:
   </OptionCard>
 </CardGrid>
 
-### Local state — never commit these
+### Local state
+
+Never commit these:
 
 <CardGrid size="md">
   <OptionCard name=".stella/private/codegraph.db">
-    The tree-sitter code-graph index.
+    The code graph index.
   </OptionCard>
   <OptionCard name=".stella/private/context.db">
-    The context plane — memory nodes, reflections, episodes, bi-temporal facts.
+    The context store: memory nodes, reflections, episodes, and facts that
+    keep track of when they were true and when stella learned them.
   </OptionCard>
   <OptionCard name=".stella/private/store.db">
-    Executions, events, token/cost telemetry, the files-touched ledger, and the
-    `file_locks` table fleets coordinate through.
+    Executions, events, token and cost data, the list of files touched, and
+    the `file_locks` table fleets use to coordinate.
   </OptionCard>
   <OptionCard name=".stella/private/fleet.db">
-    The [fleet](/docs/agent-fleets) ledger — runs, tasks, attempts, commits.
+    The [fleet](/docs/agent-fleets) log: runs, tasks, attempts, commits.
   </OptionCard>
   <OptionCard name=".stella/private/reflections.jsonl">
-    Post-turn reflection log — lessons the
-    [context engine](/docs/context-engine) distills.
+    The reflection log written after each turn — lessons the
+    [context engine](/docs/context-engine) pulls out.
   </OptionCard>
   <OptionCard name=".stella/private/mcp_oauth.json">
-    **OAuth tokens** for MCP servers you have logged into. A secret — never
-    commit it.
+    **OAuth tokens** for MCP servers you've logged into. This is a secret.
+    Never commit it.
   </OptionCard>
   <OptionCard name=".stella/worktrees/">
     Dedicated worktrees for fleet tasks marked `isolation = "isolated"`.
   </OptionCard>
   <OptionCard name=".stella/exports/">
-    Session telemetry [exports](/docs/telemetry/dashboard) — ZIP + HTML.
+    Session telemetry [exports](/docs/telemetry/dashboard): ZIP and HTML
+    files.
   </OptionCard>
 </CardGrid>
 
-When upgrading from a release that wrote private files directly under
-`.stella/`, stella migrates safe, closed legacy files into `.stella/private/`
-on first use. Unsafe permissions or live SQLite WAL/SHM sidecars fail closed
-with an actionable error and remain untouched.
+If you're upgrading from an older version that wrote files directly under
+`.stella/`, stella moves the safe ones into `.stella/private/` automatically
+the first time you run it. If a file has unsafe permissions, or is an active
+SQLite WAL or SHM file, stella leaves it alone and shows a clear error
+instead of touching it.
 
-User-scope counterparts live under `~/.stella/` (settings, skills,
-agents, credentials).
+The same kinds of files exist at user scope under `~/.stella/`: settings,
+skills, agents, and credentials.
 
 ### What to commit
 
-The shared group above is team-shareable and version-control-friendly — with one
-caveat: if `.stella/settings.json` carries an inline `api_key`, keep it out of
-version control (prefer
-[`api_key_env` or `credentials.toml`](/docs/configuration/credentials)).
+The files listed above under "files to commit" are safe to share with your
+team and put in version control, with one exception. If
+`.stella/settings.json` has an inline `api_key`, keep that file out of
+version control. Use
+[`api_key_env` or `credentials.toml`](/docs/configuration/credentials)
+instead.
 
-Everything under `.stella/private/` is local state, including MCP OAuth tokens.
-stella generates `.stella/.gitignore` for you, covering the private directory
-and any stray database or reflection log left by an older layout:
+Everything under `.stella/private/` is local only, including MCP OAuth
+tokens. stella writes a `.stella/.gitignore` for you that covers the private
+directory, plus any stray database or reflection log left by an older
+layout:
 
 ```text title=".stella/.gitignore"
 *.db
@@ -139,8 +148,8 @@ reflections.jsonl
 private/
 ```
 
-If your repository uses a root ignore file instead, exclude the whole private
-directory plus the two derived directories that ride outside it:
+If your project uses one root `.gitignore` file instead, add the private
+directory plus the two extra directories that sit outside it:
 
 ```text title=".gitignore"
 .stella/private/
@@ -167,10 +176,12 @@ stella doctor
 stella config
 ```
 
-Re-run `stella init` after a large refactor to rebuild the index and re-infer
-the taxonomy. It is idempotent and works offline — the code graph is built with
-no provider at all, only the taxonomy degrades to a directory heuristic, and the
-semantic embedding pass simply says it was skipped.
+Run `stella init` again after a big refactor to rebuild the index and
+refresh the domain list. It's safe to run more than once, and it works
+offline: the code graph builds with no provider at all, the domain list
+falls back to a simple guess based on your folders, and the semantic
+embedding step just says it was skipped.
 
-Next: [configure your provider keys](/docs/getting-started/providers), then
+Next: [set up your provider keys](/docs/getting-started/providers), then
 run your first task from the [quickstart](/docs/getting-started).
+</content>

--- a/website/content/docs/getting-started/initialization.mdx
+++ b/website/content/docs/getting-started/initialization.mdx
@@ -184,4 +184,3 @@ embedding step just says it was skipped.
 
 Next: [set up your provider keys](/docs/getting-started/providers), then
 run your first task from the [quickstart](/docs/getting-started).
-</content>

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -129,4 +129,3 @@ stella --spend-limit 1 run "explain what this repo builds and how it is laid out
 Next: the [Quickstart](/docs/getting-started), or
 [repo initialization](/docs/getting-started/initialization) to see what
 `stella init` creates.
-</content>

--- a/website/content/docs/getting-started/installation.mdx
+++ b/website/content/docs/getting-started/installation.mdx
@@ -3,46 +3,48 @@ title: Installation
 description: Install the stella CLI via the install script, Homebrew, cargo, or from source.
 ---
 
-stella ships as a single self-contained binary named `stella`. There is no runtime to
-install alongside it. Installing is the first of four steps:
+stella is one self-contained program called `stella`. There's no separate
+runtime to install. This is the first of four steps:
 
 <QuickstartDiagram />
 
 ## Prerequisites
 
 - **macOS or Linux**, `x86_64` or `arm64`.
-- For the prebuilt / Homebrew paths: nothing but `curl`.
-- For `cargo install` / building from source: **Rust 1.90+** (via [rustup](https://rustup.rs)) and `git`.
-- **An API key** for any one supported provider — *or* a local OpenAI-compatible model
-  server (Ollama, vLLM, LM Studio, llama.cpp) and no key at all. See
-  [Providers &amp; models](/docs/getting-started/providers).
+- For the prebuilt binary or Homebrew: just `curl`.
+- For `cargo install` or building from source: **Rust 1.90 or later** (via [rustup](https://rustup.rs)) and `git`.
+- **An API key** for any one supported provider. Or, skip the key and use a
+  local OpenAI-compatible model server instead (Ollama, vLLM, LM Studio,
+  llama.cpp). See [Providers &amp; models](/docs/getting-started/providers).
 - Optional: `gh` on your `PATH`, for the GitHub-backed workflows.
 
 ## Install
 
 ### Prebuilt binary (`curl | sh`)
 
-Installs the latest tagged release for your platform, verifies its SHA-256, and falls
-back to `cargo install` on platforms without a prebuilt binary (unsupported targets, and
-musl-libc Linux even on supported architectures):
+This installs the newest release for your platform, checks its SHA-256, and
+falls back to `cargo install` when there's no prebuilt binary for your
+platform. That covers unsupported targets, and musl-based Linux even on a
+supported architecture:
 
 ```bash
 curl -fsSL https://stella.oxagen.sh/install.sh | sh
 stella --version
 ```
 
-The binary lands in `~/.local/bin` by default — if `stella` isn't found afterwards, the
-script says so and prints the `export` line to add. Two env vars tune it:
+By default, the binary lands in `~/.local/bin`. If `stella` isn't found
+afterward, the script tells you and prints the `export` line to add. Two
+environment variables control this:
 
 <CardGrid size="md">
   <OptionCard name="STELLA_INSTALL_DIR" defaultValue="$HOME/.local/bin">
-    Where the binary lands. On the `cargo install` fallback path, a value
-    ending in `/bin` is honored as the cargo root's `bin` directory, so the
-    same variable works either way.
+    Where the binary goes. On the `cargo install` fallback, a value ending
+    in `/bin` is treated as the cargo root's `bin` directory, so the same
+    variable works for both paths.
   </OptionCard>
   <OptionCard name="STELLA_VERSION" defaultValue="the latest release">
-    Pin a specific release tag. With or without the leading `v` — both forms
-    normalize to the same tag.
+    Pin a specific release tag. Works with or without a leading `v`; both
+    point to the same tag.
   </OptionCard>
 </CardGrid>
 
@@ -51,15 +53,15 @@ STELLA_INSTALL_DIR=/usr/local/bin STELLA_VERSION=v0.9.0 \
   sh -c "$(curl -fsSL https://stella.oxagen.sh/install.sh)"
 ```
 
-`v0.9.0` there is only a shape — every merge to `main` cuts a patch release, so
-pick the tag you want from the
+`v0.9.0` here is just an example. Every merge to `main` cuts a new patch
+release, so pick the tag you actually want from the
 [releases page](https://github.com/macanderson/stella/releases). This page
-cannot keep up with a line that moves daily.
+can't keep up with a version that changes daily.
 
 ### Homebrew
 
-Installs the prebuilt binary from the tap — no Rust toolchain needed. The release workflow
-keeps the formula in sync on every tag:
+This installs the prebuilt binary from the tap. No Rust toolchain needed.
+The formula stays up to date automatically with every release tag:
 
 ```bash
 brew install macanderson/tap/stella
@@ -69,7 +71,7 @@ brew tap macanderson/tap && brew install stella
 
 ### From cargo
 
-Requires Rust 1.90+ and git:
+Requires Rust 1.90 or later, and git:
 
 ```bash
 cargo install --locked --git https://github.com/macanderson/stella stella-cli
@@ -86,16 +88,16 @@ cargo build --release
 ```
 
 <Callout type="info">
-  The `curl | sh` and Homebrew paths fetch binaries published by the release workflow,
-  which runs on every `v*` tag. They cover macOS and glibc Linux on `x86_64`/`arm64`;
-  anything else (musl Linux included) falls back to `cargo install`, which needs the
-  Rust toolchain.
+  The `curl | sh` script and Homebrew both fetch binaries built by the release
+  workflow, which runs on every `v*` tag. They cover macOS and glibc Linux on
+  `x86_64` and `arm64`. Anything else, including musl Linux, falls back to
+  `cargo install`, which needs the Rust toolchain.
 </Callout>
 
 ## Verify
 
-Three commands that work before you have configured anything at all — they
-resolve no provider and need no API key:
+These three commands work before you've set up anything. They don't need a
+provider or an API key:
 
 ```bash
 stella version                  # the build you just installed
@@ -103,18 +105,19 @@ stella models list --all        # every provider, its slugs, pricing, and key st
 stella doctor                   # the integrity of this workspace's local state
 ```
 
-`stella models` on its own scopes to providers whose credential resolves —
-which makes it the fastest way to answer "did my key land?". `--all` lifts that
-scope so you can read the whole catalog before configuring anything.
+On its own, `stella models` only shows providers with a working credential,
+so it's the fastest way to check "did my key work?" Add `--all` to see the
+whole catalog before you've set anything up.
 
-Once a key is in place, `stella config` reports what actually resolved — and it
-is the one verification command that does require a credential:
+Once a key is in place, `stella config` shows exactly what it resolved to.
+This is the one verification command that does need a credential:
 
 ```bash
 stella config
 ```
 
-Then run something. With one key exported, this is the whole install-to-first-change arc:
+Then try it. With one key exported, here's the whole path from install to
+your first change:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -124,5 +127,6 @@ stella --spend-limit 1 run "explain what this repo builds and how it is laid out
 ```
 
 Next: the [Quickstart](/docs/getting-started), or
-[repo initialization](/docs/getting-started/initialization) for what `stella init`
-leaves behind.
+[repo initialization](/docs/getting-started/initialization) to see what
+`stella init` creates.
+</content>

--- a/website/content/docs/getting-started/providers.mdx
+++ b/website/content/docs/getting-started/providers.mdx
@@ -1,89 +1,97 @@
 ---
 title: Providers & models
-description: The full provider matrix, how to select a model, the credential chain, and pointing stella at a local OpenAI-compatible server.
+description: The full list of providers, how to pick a model, how stella finds your API key, and how to point it at a local OpenAI-compatible server.
 ---
 
-stella is model-agnostic. It speaks each provider's native wire dialect and auto-detects
-which provider to use from the API keys you have set.
+stella works with any model provider. It speaks each provider's own
+protocol, and figures out which one to use from the API keys you have set.
 
-This page is the quick reference. For per-provider deep dives — setup walkthroughs,
-provider-specific configuration, and slugs — see **[API Providers](/docs/api-providers)**,
-and for choosing between models (pricing, release dates, what each is best at) see the
-**[model guide](/docs/api-providers/models)**.
+For setup walkthroughs, provider-specific configuration, and model names,
+see **[API Providers](/docs/api-providers)**. For help choosing between
+models, including pricing, release dates, and what each one is best at, see
+the **[model guide](/docs/api-providers/models)**.
 
 ## Supported providers
 
-Each card carries what you need to start: the provider id you put before the `/` in
-`--model`, the env var stella reads, the model you get if you name none, and the wire
-dialect it speaks. Click through for setup and provider-specific configuration.
+Each card shows what you need: the provider id you put before the `/` in
+`--model`, the environment variable stella reads, the model you get by
+default, and the protocol it speaks. Click through for setup and
+provider-specific configuration.
 
 <ProviderGrid />
 
-List them at any time — with live key status and the effective base URL each one resolves
-to:
+List every provider at any time, along with live key status and the base
+URL each one resolves to:
 
 ```bash
 stella models
 ```
 
-That listing is the authority on your machine — it is the only view that knows which keys
-you actually have. The cards above are rendered from one typed record shared with the
-[API Providers](/docs/api-providers) index, so the two pages cannot disagree with each
-other.
+That listing is the source of truth on your machine. It's the only view
+that knows which keys you actually have. The cards above come from the same
+data as the [API Providers](/docs/api-providers) index, so the two pages
+always agree.
 
-## Selecting a model
+## Pick a model
 
-Pin the worker model for a single invocation with `--model provider/model_id`, or set the
-`STELLA_MODEL` environment variable for the whole shell:
+Set the model for one run with `--model provider/model_id`. Or set the
+`STELLA_MODEL` environment variable to use it for the whole shell session:
 
 ```bash
 stella --model zai/glm-5.2 run "fix the failing test"
 export STELLA_MODEL=anthropic/claude-fable-5
 ```
 
-With no `--model`, stella **auto-detects**: it selects the first provider that has a
-resolvable credential, in preference order — `zai`, `anthropic`, `openai`, `xai`,
-`deepseek`, `gemini`, `openrouter`, then `vertex` and `bedrock` **last**.
+With no `--model` set, stella picks a provider automatically. It uses the
+first one with a working credential, in this order: `zai`, `anthropic`,
+`openai`, `xai`, `deepseek`, `gemini`, `openrouter`, then `vertex` and
+`bedrock` **last**.
 
 <Callout type="info">
-  Vertex and Bedrock sit last in auto-detection on purpose: they key off generic cloud
-  credentials (`VERTEX_ACCESS_TOKEN`, `AWS_ACCESS_KEY_ID`) that are often present for
-  unrelated reasons. Auto-detection never prefers them over an explicitly-configured
-  provider — pin them with `--model vertex/…` or `--model bedrock/…` when you want them.
+  Vertex and Bedrock come last on purpose. They rely on general cloud
+  credentials (`VERTEX_ACCESS_TOKEN`, `AWS_ACCESS_KEY_ID`) that are often set
+  for unrelated reasons. Auto-detection never picks them over a provider you
+  configured on purpose. Use `--model vertex/…` or `--model bedrock/…` when
+  you want them.
 </Callout>
 
-## The credential chain
+## Credential chain
 
-For the selected provider, stella resolves the API key in this order — **first hit wins**:
+For the provider you're using, stella looks for an API key in this order.
+**The first one it finds wins**:
 
 1. `--api-key` flag (needs an explicit `--model provider/...`)
-2. The provider's env var (and aliases, e.g. `GOOGLE_API_KEY` for Gemini)
+2. The provider's environment variable, and its aliases — for example,
+   `GOOGLE_API_KEY` for Gemini
 3. [`settings.json`](/docs/configuration/settings) `providers.<id>.api_key`
 4. `~/.stella/credentials.toml`
-5. Interactive prompt (on a TTY) — the entered key is saved to `credentials.toml`, so you
-   are only prompted once
+5. An interactive prompt, if you're in a terminal. The key you enter is
+   saved to `credentials.toml`, so you're only asked once.
 
 <Callout type="info">
-  Before the env-var step (2) runs, stella first loads project **dotenv files** into the
-  environment: `.env.<mode>.local` → `.env.local` → `.env`, most-specific first, and
-  **nearest-scope-wins** — confined to the enclosing git repository (never the home
-  directory or above). It never loads `.env.example` or a committed `.env.<mode>`, an
-  exported shell value always overrides a file value, and `STELLA_NO_ENV_FILE=1` disables
-  the whole mechanism.
+  Before step 2 (the environment variable) runs, stella first loads project
+  **dotenv files** into the environment, most specific first: `.env.<mode>.local`
+  → `.env.local` → `.env`. The nearest scope wins, and this search never goes
+  past the enclosing git repository — never the home directory or above. It
+  never loads `.env.example` or a committed `.env.<mode>` file. A value you
+  export in your shell always wins over a file value, and
+  `STELLA_NO_ENV_FILE=1` turns this off entirely.
 </Callout>
 
-See [Credentials](/docs/configuration/credentials) for the file format and precedence
-details.
+See [Credentials](/docs/configuration/credentials) for the file format and
+precedence details.
 
 <Callout type="warn">
-  Prefer an env var, `settings.json`, or `credentials.toml` over `--api-key` for anything
-  long-lived — a flag value is visible in shell history and in `ps` output.
+  For anything long-lived, use an environment variable, `settings.json`, or
+  `credentials.toml` instead of `--api-key`. A flag value shows up in your
+  shell history and in `ps` output.
 </Callout>
 
-## Cloud providers with extra configuration
+## Cloud provider setup
 
-**Vertex AI** also needs a project — set `VERTEX_PROJECT_ID` (or `GOOGLE_CLOUD_PROJECT`),
-and optionally `VERTEX_LOCATION` (defaults to `global`). The access token is typically
+**Vertex AI** also needs a project. Set `VERTEX_PROJECT_ID` (or
+`GOOGLE_CLOUD_PROJECT`), and optionally `VERTEX_LOCATION` (defaults to
+`global`). Get the access token with
 `export VERTEX_ACCESS_TOKEN=$(gcloud auth print-access-token)`.
 
 ```bash
@@ -93,9 +101,9 @@ export VERTEX_PROJECT_ID="my-gcp-project"
 stella --model vertex/gemini-3-pro run "audit the IAM bindings module"
 ```
 
-**Amazon Bedrock** needs `AWS_SECRET_ACCESS_KEY` alongside `AWS_ACCESS_KEY_ID`, plus an
-optional `AWS_SESSION_TOKEN` and `AWS_REGION` / `AWS_DEFAULT_REGION` (defaults to
-`us-east-1`).
+**Amazon Bedrock** needs `AWS_SECRET_ACCESS_KEY` along with
+`AWS_ACCESS_KEY_ID`. It also accepts an optional `AWS_SESSION_TOKEN` and
+`AWS_REGION` (or `AWS_DEFAULT_REGION`), which defaults to `us-east-1`.
 
 ```bash
 export AWS_ACCESS_KEY_ID="AKIA..."
@@ -106,38 +114,43 @@ stella --model bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 run "harden 
 ```
 
 <Callout type="info">
-  Only `AWS_ACCESS_KEY_ID` — Bedrock's primary credential — rides the credential chain
-  above. The secondary variables (`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`,
-  `AWS_REGION`) are read from the environment and **nowhere else**: no
-  `credentials.toml` entry, no `settings.json` field, no prompt. See
-  [Amazon Bedrock](/docs/api-providers#amazon-bedrock) for the full split.
+  Only `AWS_ACCESS_KEY_ID`, Bedrock's main credential, follows the credential
+  chain above. The other variables (`AWS_SECRET_ACCESS_KEY`,
+  `AWS_SESSION_TOKEN`, `AWS_REGION`) are read only from the environment.
+  There's no `credentials.toml` entry, no `settings.json` field, and no
+  prompt for them. See [Amazon Bedrock](/docs/api-providers#amazon-bedrock)
+  for the full details.
 </Callout>
 
-## Local / any OpenAI-compatible server
+## Local servers
 
-The `local` pseudo-provider points at any OpenAI-compatible endpoint — Ollama, vLLM, LM
-Studio, or a llama.cpp server. It is never auto-detected and needs no API key:
+The `local` provider points at any OpenAI-compatible endpoint: Ollama,
+vLLM, LM Studio, or a llama.cpp server. It's never chosen automatically, and
+it needs no API key:
 
 ```bash
 stella --model local/llama3.3 --base-url http://localhost:11434/v1 chat
 ```
 
-The id `local` is reserved and **cannot** be redefined in `settings.json` — `--base-url`
-(or its env form `STELLA_BASE_URL`) is always required with `--model local/<model>`. To
-avoid retyping the endpoint, either export `STELLA_BASE_URL`, or define your own custom
-provider under a non-reserved id in [`settings.json`](/docs/configuration/settings) — e.g.
-`providers.myollama` with a `base_url` (its `dialect` defaults to `openai-compatible`) — and
-select it with `--model myollama/<model>`.
+The id `local` is reserved. You **cannot** redefine it in `settings.json`,
+and `--base-url` (or the environment variable `STELLA_BASE_URL`) is always
+required with `--model local/<model>`. To avoid typing the endpoint every
+time, either export `STELLA_BASE_URL`, or define your own provider under a
+different id in [`settings.json`](/docs/configuration/settings) — for
+example `providers.myollama` with a `base_url` set (its `dialect` defaults
+to `openai-compatible`) — and use it with `--model myollama/<model>`.
 
-## Overriding a provider's defaults
+## Override provider defaults
 
-Override any built-in provider's base URL, key, display name, or default model in
-[`settings.json`](/docs/configuration/settings) — e.g. to
-route Z.ai through its coding-plan endpoint without a provider-specific env
-var. For personal routing like a subscription endpoint, put the override in **user
-scope** (`~/.stella/settings.json`): project-scope `base_url`/`api_key` overrides
-are held back by the
-[trust boundary](/docs/configuration/settings#the-project-trust-boundary) until you set
-`STELLA_TRUST_PROJECT=1`. Ready-to-paste setups, organized by use case, live in
-[Examples &amp; recipes](/docs/examples) — including the
+You can override any built-in provider's base URL, key, display name, or
+default model in [`settings.json`](/docs/configuration/settings). For
+example, you could route Z.ai through its coding-plan endpoint without a
+provider-specific environment variable. For personal routing, like a
+subscription endpoint, put the override in **user scope**
+(`~/.stella/settings.json`) instead. Project-scope `base_url` and `api_key`
+overrides are held back by the
+[trust boundary](/docs/configuration/settings#the-project-trust-boundary)
+until you set `STELLA_TRUST_PROJECT=1`. Ready-to-paste setups, organized by
+use case, live in [Examples &amp; recipes](/docs/examples), including the
 [Z.ai coding-plan recipe](/docs/api-providers#zai).
+</content>

--- a/website/content/docs/getting-started/providers.mdx
+++ b/website/content/docs/getting-started/providers.mdx
@@ -153,4 +153,3 @@ overrides are held back by the
 until you set `STELLA_TRUST_PROJECT=1`. Ready-to-paste setups, organized by
 use case, live in [Examples &amp; recipes](/docs/examples), including the
 [Z.ai coding-plan recipe](/docs/api-providers#zai).
-</content>

--- a/website/content/docs/guides/ci-engine-gate.mdx
+++ b/website/content/docs/guides/ci-engine-gate.mdx
@@ -1,74 +1,80 @@
 ---
 title: Gate on engine quality in CI
-description: Run stella and Claude Code side by side on one task set every pull request. Block the merge on loop correctness; report the quality delta, never gate on it.
+description: Run stella and Claude Code side by side on one task set on every pull request. Block the merge on loop correctness. Report the quality difference, but never block on it.
 ---
 
-Once an agent engine is a dependency of your product, it regresses like any
-other dependency — except the regression does not announce itself with a stack
-trace. A prompt change, a model swap, a settings edit, an upstream release: the
-turn still exits zero, still prints something plausible, and does less work than
-it did last week.
+Once an agent engine is part of your product, it can break like any other
+dependency. But it breaks quietly — there's no stack trace. A prompt change,
+a model swap, a settings edit, a new release from your provider: the turn
+still exits with no error, still prints something that sounds right, and
+quietly does less work than it did last week.
 
 This guide sets up a CI job that catches that. It runs stella and Claude Code
-over the same committed task set on every pull request, and — this is the part
-that matters — it treats their two outputs as answers to two different
-questions.
+on the same set of committed tasks on every pull request. The important part:
+it treats their two results as answers to two different questions.
 
-## The idea: two questions, two kinds of exit
+## Two kinds of check
 
-Almost every attempt at this fails the same way. Someone builds a harness, scores
-both engines, gets a number, wires the number to a threshold, and within a month
-the check is disabled because it fails on days when nothing changed.
+Most attempts at this fail the same way. Someone builds a test harness,
+scores both engines, gets a number, and sets a threshold on that number.
+Within a month, the check gets turned off because it fails on days when
+nothing actually changed.
 
-The reason is that "did the engine work" and "was the answer good" are not the
-same measurement, and only one of them is stable enough to block a merge.
+"Did the engine work" and "was the answer good" are two different questions.
+Only one of them gives a steady enough answer to block a merge on.
 
 <EngineGateDiagram />
 
 <CardGrid size="md">
-  <SpecCard title="Loop correctness — deterministic, so it blocks">
-    Did the turn execute real work? Did it terminate and say why? Did it call a tool
-    at all? These are facts about the run, readable from the receipt, and they do not
-    move when the model has an off day. A regression here is a bug. Exit non-zero.
+  <SpecCard title="Loop correctness blocks the merge">
+    Did the turn actually do work? Did it stop and say why? Did it call a
+    tool at all? These are facts about the run. You can read them straight
+    from the receipt, and they don't change just because the model had an
+    off day. A regression here is a real bug — exit with a non-zero code.
   </SpecCard>
-  <SpecCard title="Quality — stochastic, so it informs">
-    Did it solve the task, and at what cost? Real signal, but it moves with sampling
-    noise, provider routing, and the weather. Post it as a comment and let a human
-    read the trend. A threshold here buys you a flaky gate and nothing else.
+  <SpecCard title="Quality tells you, it doesn't block">
+    Did it solve the task, and at what cost? This is real signal, but it
+    shifts with random sampling, which provider handled the request, and
+    factors outside your control. Post it as a comment and let a person read
+    the trend over time. Setting a hard threshold here only gets you a gate
+    that fails at random.
   </SpecCard>
 </CardGrid>
 
-Everything below is built on that split. If you take one thing from this page,
-take that.
+Everything below is built on that split between the two questions. If you
+remember one thing from this page, remember that.
 
 ## Before you start
 
 <CardGrid size="md">
   <OptionCard name="Both engines on PATH in CI">
-    `stella` and `claude`. Pin both versions explicitly — an engine comparison whose
-    engines float is measuring the float.
+    `stella` and `claude`. Pin both versions exactly. If the versions can
+    change on their own, you're measuring the version change, not the
+    engines.
   </OptionCard>
   <OptionCard name="A key per engine, as repository secrets">
-    These runs cost real money on every PR. Budget for it in step 1 by keeping the
-    task set small, and cap it in step 2 with `--spend-limit`.
+    These runs spend real money on every pull request. Keep costs down in
+    step 1 by keeping the task set small, and set a hard cap in step 2 with
+    `--spend-limit`.
   </OptionCard>
   <OptionCard name="Tasks with deterministic verifiers">
-    A task nobody can grade automatically is a task this job cannot gate on. If a
-    test command cannot say pass or fail, leave it out.
+    If nobody can grade a task automatically, this job can't gate on it. If
+    a test command can't say pass or fail, leave that task out.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-This job runs a coding agent with tool access against a checkout on every pull
-request. Run it on a disposable runner, scope its credentials to nothing you
-would mind losing, and do not run it on `pull_request_target` — that trigger
-gives a fork's code access to your secrets.
+This job runs a coding agent with real tool access on every pull request.
+Run it on a runner you can throw away. Give it credentials for nothing you'd
+mind losing. Never run it on `pull_request_target` — that trigger lets code
+from a forked repo access your secrets.
 </Callout>
 
 ## Step 1: Commit the task set
 
-Small, fixed, and in the repository. Five to ten tasks is plenty; the gate is
-looking for a loop that stopped working, and a broken loop is broken on task one.
+Keep the list small, fixed, and checked into the repository. Five to ten
+tasks is plenty. This gate is only looking for a loop that stopped working,
+and a broken loop shows up on the very first task.
 
 ```
 ci/engine-tasks/
@@ -79,31 +85,34 @@ ci/engine-tasks/
   003-rename-across-files/
 ```
 
-What makes a task earn its place:
+### What makes a good task
 
 <CardGrid size="sm">
   <SpecCard title="It requires editing a file">
-    The single most useful loop-correctness signal is "did anything get written."
-    A task answerable in prose cannot produce it.
+    The most useful loop-correctness signal is simple: did anything get
+    written? A task you can answer in words alone can't produce that signal.
   </SpecCard>
-  <SpecCard title="Its verifier is a test, not a verifier">
-    `verify.sh` should run a test and exit. The moment a model grades the outcome,
-    the deterministic half of your gate stops being deterministic.
+  <SpecCard title="Use a real test, not a judgment call">
+    `verify.sh` should run a real test and exit with a code. The moment a
+    model grades the result instead, the deterministic half of your gate
+    stops being deterministic.
   </SpecCard>
   <SpecCard title="It fails before the change">
-    A verifier that was already passing proves nothing about the work. This is the
-    same flip-oracle discipline a [verification plugin](/docs/plugins)
-    uses internally, and it applies just as much to your harness.
+    If the verifier was already passing, it proves nothing about the work.
+    This is the same fail-then-pass rule a
+    [verification plugin](/docs/plugins) uses on its own. It applies to your
+    test harness too.
   </SpecCard>
 </CardGrid>
 
 ## Step 2: Run both engines headless
 
-Both take a prompt and emit machine-readable JSON. The shapes are different, and
-the difference is a real trip hazard, so it is worth being exact.
+Both engines take a prompt and print JSON you can parse. The JSON has a
+different shape for each one, and that difference trips people up — so read
+this part carefully.
 
-Give each engine its own copy of the checkout, so their edits cannot see each
-other and each workspace can be graded on its own:
+Give each engine its own copy of the code, so their edits can't see each
+other, and each copy can be graded on its own:
 
 ```bash
 task=ci/engine-tasks/001-add-pagination
@@ -120,20 +129,21 @@ for e in stella claude; do rm -rf "work/$e"; git worktree add -f "work/$e" HEAD;
   "$(cat "../../$task/TASK.md")" ) > work/claude/claude.json
 ```
 
-Both need to be able to edit without a human at the keyboard.
-`--permission-mode acceptEdits` is what gets Claude Code there; check
-`claude --help` on the version you pinned rather than copying a flag list,
-since this surface moves between releases.
+Both engines need to be able to edit files without a person approving each
+change. `--permission-mode acceptEdits` does that for Claude Code. Check
+`claude --help` on the exact version you pinned, rather than copying a flag
+list from somewhere else — these flags change between releases.
 
 <Callout type="warn">
-`claude --output-format json` does not emit a single object. It emits an array of
-every message in the session, and the summary is the final element, tagged
-`"type": "result"`. Read it with `jq '.[] | select(.type == "result")'` — not
-`jq '.result'`, which returns `null` and will quietly grade every run as a
-failure.
+`claude --output-format json` does not print one JSON object. It prints an
+array with every message from the session. The summary is the last item in
+that array, marked `"type": "result"`. Read it with
+`jq '.[] | select(.type == "result")'`. Do not use `jq '.result'` — that
+returns `null` and will quietly mark every run as a failure.
 </Callout>
 
-Here is what each one gives you, trimmed to the keys a gate reads:
+Here's what each one gives you, cut down to the keys your gate actually
+reads:
 
 ```jsonc
 // stella.json — see /docs/scripting for the full envelope contract
@@ -163,55 +173,59 @@ Here is what each one gives you, trimmed to the keys a gate reads:
 }
 ```
 
-Two notes before you write the comparison.
+Two things to know before you write the comparison script.
 
-**Read `model`, not your own flag.** stella reports the model that actually
-served the worker turns, which a
-[worker-model route](/docs/configuration/agent-engine-config) can change out from
-under your `--model` argument. Attribute spend to what the receipt says.
+**Read the `model` field, not the flag you passed.** stella reports the
+model that actually ran the worker turns. A
+[worker-model route](/docs/configuration/agent-engine-config) can swap out
+the model you asked for with `--model`. Always attribute spend to what the
+receipt says, not to your own flag.
 
-**`files_touched` is not on the wrapped path.** The default (raw) run
-summarizes with a top-level `files_touched` key; `task_class`, `verdict`,
-`revisions`, and `candidates_run` appear only on `--pipeline <variant>`
-runs, and the array itself
-sits one level in at `.files_touched.files_touched`. Counting `tool_start` events
-works on both paths, which is why the assertions below use events.
+**`files_touched` isn't in the same place on every run.** A plain (default)
+run puts it at the top level, as `files_touched`. A `--pipeline <variant>`
+run also adds `task_class`, `verdict`, `revisions`, and `candidates_run` —
+but its file list sits one level deeper, at `.files_touched.files_touched`.
+Counting `tool_start` events works the same way on both, which is why the
+checks below use events instead.
 
-## Step 3: The blocking half — loop correctness
+## Step 3: Loop correctness
 
-This is stella's own gate on itself, and the vocabulary is worth borrowing
-because it was built by watching real failures. `loop-bench` collapses a run into
-one of four verdicts, checked in this order:
+This is the same gate stella runs on itself. The vocabulary is worth
+reusing, since it comes from watching real failures happen. `loop-bench`
+sorts every run into one of four results, checked in this order:
 
 <LoopVerdictDiagram />
 
-The ordering is required. **Reward outranks everything** — a task that got
-solved did the work by definition, so it is never called silent no matter what
-its event stream lost. And the two verdicts that trip the gate are the two where
-*nothing happened*: `loop_broken` is `zero_work && reward != 1.0`.
+The order matters. **A solved task always outranks everything else** — if
+the task got solved, work happened, by definition, no matter what the event
+log is missing. The two results that fail the gate are the two where
+*nothing happened at all*: `loop_broken` means `zero_work && reward != 1.0`.
 
-Read against the receipts from step 2, that becomes four assertions:
+Applied to the receipts from step 2, that becomes four checks:
 
 <CardGrid size="md">
   <OptionCard name="1. A receipt exists at all">
-    No JSON on stdout is the worst outcome, not a skip. Report it as a failure with
-    a `no receipt` reason. Skipping it once made a launch failure look like a clean
-    run with fewer rows — gate still green.
+    No JSON printed at all is the worst outcome — treat it as a real
+    failure, not something to skip over. Mark it failed with a `no receipt`
+    reason. Skipping this check once let a launch failure look like a clean
+    run with fewer rows, and the gate stayed green anyway.
   </OptionCard>
   <OptionCard name="2. Work happened">
-    At least one `tool_start` event for stella; `num_turns > 1` and a non-empty
-    diff for Claude Code. Zero tool calls on a task that requires an edit is the
-    failure this whole job exists to catch.
+    Check for at least one `tool_start` event from stella, or
+    `num_turns > 1` plus a non-empty diff from Claude Code. Zero tool calls
+    on a task that needs an edit is exactly the failure this whole job is
+    built to catch.
   </OptionCard>
   <OptionCard name="3. It terminated, and said why">
-    stella: `status` is `completed`, or `reason` is non-null. Claude Code:
-    `terminal_reason` is present. A run that ends with neither vanished, and that
-    is `SILENT-DEATH`.
+    For stella, check that `status` is `completed` or `reason` is filled in.
+    For Claude Code, check that `terminal_reason` is present. A run that
+    ends with neither one just vanished — call that `SILENT-DEATH`.
   </OptionCard>
   <OptionCard name="4. Nothing was silently blocked">
-    A non-empty `permission_denials`, or a stella run aborted on a scope gate with
-    nobody to ask, means the agent was stopped rather than finished. Fail loudly —
-    this reads as low quality otherwise, and you will spend a week tuning prompts.
+    If `permission_denials` isn't empty, or a stella run stopped at a scope
+    gate with nobody around to approve it, the agent was blocked, not
+    finished. Fail loudly here. Otherwise this looks like low quality, and
+    you'll waste a week tuning prompts to fix a problem that isn't there.
   </OptionCard>
 </CardGrid>
 
@@ -248,17 +262,18 @@ jq -e '.terminal_reason != null' <<<"$result" > /dev/null \
 echo "loop healthy: $tools tool calls, clean termination"
 ```
 
-Note what is *not* in that script: any check on whether the task was solved. A
-task nobody solves still passes this gate, provided the loop ran. That is the
-point — you are gating on the machine, not on the model.
+Notice what's missing from that script: any check on whether the task got
+solved. A task nobody solves can still pass this gate, as long as the loop
+actually ran. That's the point. You're gating on the machine, not on the
+model.
 
-## Step 4: The advisory half — the quality delta
+## Step 4: The quality delta
 
-Now the part that gets reported rather than enforced. Same two receipts, read for
-outcome instead of health.
+This part gets reported, not enforced. Same two receipts as before, but now
+read for the outcome instead of the health check.
 
-Each engine ran in its own copy of the checkout — that is what makes them
-comparable at all — so each has its own workspace to grade.
+Each engine ran in its own copy of the code. That's what makes them
+comparable at all, and each one has its own workspace to grade.
 
 ```bash
 #!/usr/bin/env bash
@@ -282,14 +297,15 @@ claude_cost=$(jq -r '[.[] | select(.type == "result")] | .[0].total_cost_usd' \
 } >> "$GITHUB_STEP_SUMMARY"
 ```
 
-Resist the urge to wire a threshold to that table. With a five-task set, one
-task flipping is a twenty-point swing, and twenty points of sampling noise is
-entirely ordinary. The table's job is to make a *trend* visible across many PRs.
-When it moves consistently in one direction, a human decides what it means.
+Don't set a hard threshold based on that table. With only five tasks, one
+task flipping changes the score by twenty points, and that much random
+swing is completely normal. The table's job is to show a *trend* across many
+pull requests. When it moves the same direction again and again, let a
+person decide what that means.
 
 ## The workflow
 
-Two things about the shape of this file matter more than its contents.
+Two things about how this file is built matter more than what's in it.
 
 ```yaml
 name: engine-gate
@@ -323,22 +339,25 @@ jobs:
         run: ./ci/quality-delta.sh
 ```
 
-**Make it a required status check.** A check that is not required does not block a
-merge, and a check that does not block a merge does not do anything. stella
-learned this the expensive way: a dependency bump broke the bench workflow, the
-workflow reported failure, and the pull request merged twelve minutes later. It
-stayed broken for five days.
+**Mark it as a required status check.** A check that isn't required can't
+block a merge, and a check that can't block a merge doesn't do anything.
+This was learned the hard way: a dependency update once broke the benchmark
+workflow, the workflow reported failure, and the pull request merged twelve
+minutes later anyway. It stayed broken for five days.
 
-**Filter the scope in a step, not in the trigger.** A workflow filtered with
-`on.pull_request.paths` does not run at all when nothing matches, so its check
-never reports — and a required context that never reports blocks the pull request
-forever. The job above always runs and always reports; only the expensive part is
-conditional. An unrelated PR pays one runner start-up, not two agent runs.
+**Filter the scope inside a step, not in the trigger.** If you filter with
+`on.pull_request.paths`, the workflow doesn't run at all when nothing
+matches — so it never reports a result, and a required check that never
+reports blocks the pull request forever. The job above always runs and
+always reports something. Only the expensive part is conditional. An
+unrelated pull request just pays for one runner starting up, not for two
+full agent runs.
 
-## If you are working on stella itself
+## Changing stella itself
 
-The harness described above is the portable version. stella ships its own, and it
-is cheaper and sharper if the thing you are changing *is* the engine:
+The harness above works for any product using stella. But if you're
+changing the engine itself, stella has its own version built in, and it's
+cheaper and more precise:
 
 ```bash
 cargo run -p loop-bench -- --n 4                     # four tasks, the default pool
@@ -346,55 +365,61 @@ cargo run -p loop-bench -- --json-out report.json    # table on stdout, report o
 cargo run -p loop-bench -- --analyze-only --jobs-dir <dir> --job-name <name>   # free
 ```
 
-It reads `stella-events.jsonl` per trial, produces exactly the verdict ladder
-above, and exits `1` if any trial is `loop_broken` — even when other trials
-passed. Exit `2` means the task list resolved to nothing (or an unwritable
-report path). Exit `3` means no trial artifacts were found at all — an infrastructure
-failure, distinguished from a loop regression. Exit `4` means the
-loop was healthy but fewer trials passed than `--min-pass` demanded.
+It reads `stella-events.jsonl` for each trial, sorts each one into the same
+four results as above, and exits with code `1` if any trial comes back
+`loop_broken` — even if other trials passed. Exit code `2` means the task
+list came up empty, or the report couldn't be written. Exit code `3` means
+no trial results were found at all. That's an infrastructure problem, not a
+loop problem. Exit code `4` means the loop worked fine, but fewer trials
+passed than `--min-pass` required.
 
-stella runs it against itself nightly, not per-PR: it needs Docker, a task
-runner, a provider key, and real money. Two details of that job are worth
-copying. The task list is pinned **by name** rather than taken as "the first
-four of the pool", because the pool is an ordinary source constant and
-reordering it would silently change what is measured. And the pass-rate floor
-ships **disabled**, to be raised only once the job's own uploaded reports say
-what normal is — a floor set by intuition on a cheap model is red every night,
-and a gate that is always red is a gate nobody reads.
+stella runs this nightly, not on every pull request, since it needs Docker,
+a task runner, a provider key, and real money. Two details of that setup are
+worth copying. First, the task list is pinned **by name**, not just "the
+first four in the list" — since the list order can change and would
+silently change what gets measured. Second, the pass-rate floor ships
+**turned off** at first. It only gets turned on once the job's own reports
+show what normal looks like. A floor picked by guesswork on a cheap model
+fails every single night, and a gate that always fails is a gate nobody
+reads.
 
 <Callout type="info">
-Its whole design premise is worth stealing: the expensive benchmark measures
-*pass rate*, which is dominated by model quality, so a cheap model tells you
-almost nothing. Loop health is the opposite — a cheap model exposes a broken loop
-just as clearly as an expensive one, and costs a twentieth as much to ask.
+The whole idea here is worth copying. An expensive benchmark measures *pass
+rate*, which mostly reflects model quality — so testing with a cheap model
+tells you almost nothing. Loop health is the opposite. A cheap model can
+catch a broken loop just as well as an expensive one, for a fraction of the
+cost.
 </Callout>
 
 ## What this cannot tell you
 
-Being straight about the limits, because a comparison harness that oversells
-itself is worse than none.
+Here are the honest limits. A comparison harness that oversells itself is
+worse than no harness at all.
 
 <CardGrid size="md">
   <OptionCard name="Five tasks is not a benchmark">
-    It is a smoke test with opinions. It catches a loop that stopped working. It
-    does not rank engines, and a table built from it should never be published as
-    if it did.
+    It's a smoke test, nothing more. It catches a loop that stopped working.
+    It does not rank engines against each other, and you should never
+    publish a table from it as if it does.
   </OptionCard>
   <OptionCard name="Self-reported cost is not comparable">
-    Each engine reports its own accounting. A one-word reply through Claude Code
-    headless cost $0.034 in a real measurement — almost entirely cache-creation
-    tokens for the system prompt. Startup overhead dominates small tasks, so
-    comparing cost on trivial work compares system prompts, not engines.
+    Each engine reports its own cost, its own way. In one real test, a
+    one-word reply through Claude Code cost $0.034 — almost all of it
+    cache-creation tokens for the system prompt. Startup cost dominates on
+    small tasks, so comparing cost on a trivial task really just compares
+    system prompts, not the engines themselves.
   </OptionCard>
   <OptionCard name="Routing is a confound">
-    Two runs against the same model id can land on different upstream providers with
-    different reasoning settings, especially through an aggregator. Pin the provider
-    and the effort tier, or you are measuring the router.
+    Two runs using the same model name can still land on different
+    providers with different reasoning settings, especially if you go
+    through an aggregator. Pin down the provider and the effort level, or
+    you end up measuring the router instead of the engines.
   </OptionCard>
   <OptionCard name="Tool counts are a fingerprint, not a score">
-    Raw call counts reflect design — how much a tool does per call — not
-    efficiency. Report wins, dollars, tokens, and minutes. A leaner call count is a
-    different shape, not a better one.
+    The number of tool calls just reflects design choices — how much work
+    each tool does per call — not how efficient the engine is. Report wins,
+    dollars, tokens, and minutes instead. Fewer tool calls is a different
+    shape, not a better one.
   </OptionCard>
 </CardGrid>
 
@@ -402,18 +427,20 @@ itself is worse than none.
 
 <CardGrid size="sm">
   <SpecCard title="Drop stella in as your agent engine" href="/docs/guides/embed-the-engine">
-    The companion guide. Get the engine inside your app and under test first — this
-    page assumes a loop CI can already run.
+    The guide that pairs with this one. Get the engine running inside your
+    app and under test first — this page assumes your loop can already run
+    in CI.
   </SpecCard>
   <SpecCard title="Scripting stella" href="/docs/scripting">
-    The full JSON envelope contract, the `schema_version` rule, and the jq patterns
-    the scripts above are built from.
+    The full JSON output format, the `schema_version` rule, and the jq
+    patterns the scripts above are built on.
   </SpecCard>
   <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
-    The other side of this coin: what to do when the gate you just built goes red.
+    The flip side of this guide: what to do when the gate you just built
+    turns red.
   </SpecCard>
   <SpecCard title="Plugins" href="/docs/plugins">
-    The verify ladder and the flip oracle — the deterministic-evidence discipline
-    this page borrows for its own harness.
+    The verification steps and the fail-then-pass check — the same
+    evidence-based approach this page borrows for its own harness.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/ci-engine-gate.mdx
+++ b/website/content/docs/guides/ci-engine-gate.mdx
@@ -173,8 +173,6 @@ reads:
 }
 ```
 
-Two things to know before you write the comparison script.
-
 **Read the `model` field, not the flag you passed.** stella reports the
 model that actually ran the worker turns. A
 [worker-model route](/docs/configuration/agent-engine-config) can swap out
@@ -305,8 +303,6 @@ person decide what that means.
 
 ## The workflow
 
-Two things about how this file is built matter more than what's in it.
-
 ```yaml
 name: engine-gate
 on: pull_request          # never pull_request_target — that hands forks your secrets
@@ -393,7 +389,7 @@ cost.
 
 ## What this cannot tell you
 
-Here are the honest limits. A comparison harness that oversells itself is
+A comparison harness that oversells itself is
 worse than no harness at all.
 
 <CardGrid size="md">

--- a/website/content/docs/guides/embed-the-engine.mdx
+++ b/website/content/docs/guides/embed-the-engine.mdx
@@ -3,64 +3,65 @@ title: Drop stella in as your agent engine
 description: Replace your hand-rolled agent loop with stella's, keeping your own models, tools, keys, and data — and end on an integration test that needs no API key.
 ---
 
-You shipped an LLM feature. The first version was a `while` loop around a
-completions call, and it worked. Then it met production, and the loop grew:
-a step cap, because a model called the same tool nine times. A truncation, because
-the history outgrew the context window. A retry, then a *smarter* retry, because
-a 429 and a 400 should not be treated the same. Somewhere in there it stopped
-being a feature and started being a distributed system nobody owns.
+You shipped an AI feature. The first version was a `while` loop around a
+completions call, and it worked. Then it went into production, and the loop
+grew: a step cap, because a model called the same tool nine times. A way to
+shorten the history, because it outgrew the context window. A retry, then a
+*smarter* retry, because a 429 and a 400 shouldn't be treated the same way.
+At some point it stopped being a feature and started being a system nobody
+really owns.
 
-None of that is your product. All of it is on your critical path.
+None of that is your product. All of it sits on your critical path.
 
-This guide replaces that loop with stella's, without giving up a single thing
-you care about — your models, your keys, your tools, your data, your bill.
+This guide replaces that loop with stella's, without giving up anything you
+care about — your models, your keys, your tools, your data, your bill.
 
 ## The move, in one paragraph
 
-You run `stella-serve` as a process next to your app. When you start a turn, the
-engine drives the loop and **asks your app** to do the two things that touch
-anything sensitive: make the model call, and run the tool. It has no HTTP
-client, no TLS stack, and no provider adapter, so it is not able to make either
-call itself.
+You run `stella-serve` as a process next to your app. When a turn starts,
+the engine drives the loop and **asks your app** to do the two things that
+touch anything sensitive: call the model, and run the tool. The engine has
+no HTTP client, no TLS stack, and no provider code of its own, so it simply
+can't make either call itself.
 
 <EngineOwnershipDiagram />
 
-That inversion is the whole design, and it is why this is a reasonable thing to
-put inside a product: the engine is a scheduler for work your app performs. It
-never holds a credential, so it cannot leak one.
+That's the whole design, and it's why this is safe to put inside a product:
+the engine is just a scheduler for work your app does. It never holds a
+credential, so it can never leak one.
 
 ## Before you start
 
 <CardGrid size="md">
   <OptionCard name="A Rust toolchain, once">
-    Only to build the server. Your app can be TypeScript, Python, Go, or anything
-    else that speaks HTTP — nothing you write is Rust unless you choose the linked
-    shape below.
+    Only to build the server. Your app can be TypeScript, Python, Go, or
+    anything else that speaks HTTP — nothing you write has to be Rust unless
+    you pick the linked option below.
   </OptionCard>
-  <OptionCard name="An LLM feature that already works">
-    Port something running, not something you are also designing. You want exactly
-    one variable changing this afternoon.
+  <OptionCard name="An AI feature that already works">
+    Port something that's running today, not something you're still
+    designing. You want exactly one thing changing this afternoon.
   </OptionCard>
   <OptionCard name="A decision on shape, made first">
-    Sidecar or linked crates. It changes your licensing obligations, so make it
-    before you build, not after.
+    Sidecar process, or code linked directly into your binary. This changes
+    your licensing, so decide before you build, not after.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-Pick the shape first. Linking `stella-core` into a closed-source binary is a
-combined work and needs a commercial license. The sidecar depends on facts about
-your deployment. Neither is automatically free — the
+Pick the shape first. Linking `stella-core` directly into a closed-source
+binary needs a commercial license. Whether the sidecar needs one depends on
+facts about your deployment. Neither option is automatically free — the
 [licensing section](/docs/agent-engine-in-your-app#licensing-agpl-or-commercial)
-is specific about which facts decide it, and
-[licensing@oxagen.sh](mailto:licensing@oxagen.sh) will tell you if the answer is
-"you need nothing."
+spells out exactly which facts decide it, and
+[licensing@oxagen.sh](mailto:licensing@oxagen.sh) will tell you if the
+answer is "you need nothing."
 </Callout>
 
 ## Step 1: Get a server running
 
-Two commands. There is no `stella serve` subcommand and no release tarball ships
-the server — it is a separate crate with its own binary.
+Two commands. There's no `stella serve` subcommand, and no release download
+includes the server — it's a separate program with its own binary.
 
 ```bash
 cargo build --release -p stella-serve --bin stella-serve
@@ -71,60 +72,66 @@ STELLA_SERVE_TOKEN="$(openssl rand -base64 32)" \
 # stella-serve listening on 127.0.0.1:8137
 ```
 
-It is a fast build; the server pulls in two crates, not the CLI or the TUI.
+It's a fast build — the server only pulls in two libraries, not the full CLI
+or the terminal UI.
 
-Record the version it prints next to your client code. The wire format is
-additive, but a pin plus a round-trip test is how you find out about a change on
-your schedule instead of in production.
+Write down the version it prints, next to your client code. The message
+format only ever adds fields, but pinning a version and running a
+round-trip test is how you find out about a change on your own schedule
+instead of in production.
 
 ## Step 2: Port the loop, not the feature
 
-Here is the part people over-plan. Your existing feature already contains the
-two functions the engine needs. Find them:
+Here's the part people over-plan. Your existing feature already has the two
+functions the engine needs. Find them:
 
 <CardGrid size="md">
   <SpecCard title="The one that calls the model">
-    Whatever wraps your gateway today. It becomes the handler for
-    `provider_request` frames. Keep your routing, your keys, your logging, your
-    rate limiting — all of it stays exactly where it is.
+    Whatever code wraps your model gateway today. It becomes the handler for
+    `provider_request` messages. Your routing, your keys, your logging, your
+    rate limits — all of it stays exactly where it is.
   </SpecCard>
-  <SpecCard title="The one that dispatches a tool">
-    Your `switch` over tool names, behind whatever authorization you already
-    enforce. It becomes the handler for `tool_request` frames. The engine never
-    sees your database, your sandbox, or your permission model.
+  <SpecCard title="The one that runs a tool">
+    Your `switch` statement over tool names, behind whatever checks you
+    already run. It becomes the handler for `tool_request` messages. The
+    engine never sees your database, your sandbox, or your permission
+    system.
   </SpecCard>
 </CardGrid>
 
-Everything between those two functions — the stepping, the history threading,
-the compaction, the retries — is what you are deleting.
+Everything between those two functions — the step counting, threading the
+history, shortening it, retrying — is what you get to delete.
 
 The [complete working host](/docs/agent-engine-in-your-app#step-4-write-the-host)
-is about eighty lines of dependency-free Node, and the reference page walks the
-six routes, the four frame types, and the error classes. Do not restate it here;
-open it in another tab and come back when your first turn completes.
+is about eighty lines of plain Node with no dependencies. The reference page
+walks through the six routes, the four message types, and the error types.
+Don't re-read all of that here — open it in another tab and come back once
+your first turn completes.
 
 <Callout type="warn">
-Three assumptions a correct host must not make, because each one produces a bug
-that only shows up under load. `event` frames are **not ordered** against request
-frames. **Several `tool_request`s can be outstanding at once**, because the engine
-runs read-only tools concurrently — answer by `request_id` and never serialize
-them. And the auth check runs **before** routing, so a wrong path returns 401,
-not 404; a 401 is not proof your token is bad.
+Three assumptions a correct host must avoid, because each one causes a bug
+that only shows up under load. `event` messages are **not** guaranteed to
+arrive in the same order as request messages. **More than one `tool_request`
+can be outstanding at once**, because the engine runs read-only tools at the
+same time — match responses by `request_id` and never process them one at a
+time. And the login check runs **before** routing, so a wrong path returns
+401, not 404 — a 401 doesn't necessarily mean your token is bad.
 </Callout>
 
 ## Step 3: The payoff — a test that costs nothing
 
-This is the reason to do the port, and it is worth doing on day one rather than
-day thirty.
+This is the real reason to do this port, and it's worth doing on day one
+instead of day thirty.
 
-Because your app is the model, you can substitute a scripted reply for your
-gateway. The engine cannot tell the difference: it emits the same frames, runs
-the same steps, threads the same history, and settles the same outcome.
+Because your app owns the model call, you can swap in a scripted reply
+instead of calling your real gateway. The engine can't tell the difference:
+it sends the same messages, runs the same steps, threads the same history,
+and reaches the same outcome.
 
 <EngineTestHarnessDiagram />
 
-So a full multi-step agent turn becomes an ordinary unit test. No network, no
-key, no spend, milliseconds.
+So a full, multi-step agent turn becomes an ordinary unit test. No network,
+no key, no spend, and it runs in milliseconds.
 
 ```js
 import { test } from "node:test";
@@ -151,71 +158,75 @@ test("the model can call a tool and answer from its result", async () => {
 });
 ```
 
-What that test actually covers is larger than it looks: the engine recorded the
+That test covers more than it looks like. The engine recorded the
 assistant's tool call, matched your result to it by `call_id`, rebuilt the
-conversation in your provider's shape, and ran the second step from it. That is
-the machinery you deleted in step 2, under test, for free.
+conversation in your provider's format, and ran the second step from there.
+That's the machinery you deleted in step 2 — now under test, for free.
 
-Write these for the cases you cannot afford to hit in production — a tool that
-errors, a model that returns malformed arguments, a rate limit mid-turn, a turn
-that hits its step cap. Each one is a scripted array, and none of them cost a
-cent.
+Write tests like this for the cases you can't afford to hit in production: a
+tool that errors, a model that returns bad arguments, a rate limit in the
+middle of a turn, a turn that hits its step cap. Each one is just a scripted
+array, and none of them cost a cent.
 
 <Callout type="info">
-Report failures as the `error` arm of a tool result rather than throwing. The
-model reads that text and can correct itself, which is usually what you want. And
-say *why* a model call failed: `transport` and `rate_limited` are retried with
-backoff, while `auth`, `unknown_model`, `malformed`, `cancelled`, and `terminal`
-fail the turn at once. Reporting a rate limit as `terminal` silently disables the
-backoff you were trying to get.
+Report failures as the `error` result of a tool call, instead of throwing an
+exception. The model reads that text and can often correct itself, which is
+usually what you want. And say *why* a model call failed: `transport` and
+`rate_limited` get retried with backoff, while `auth`, `unknown_model`,
+`malformed`, `cancelled`, and `terminal` fail the turn right away. Reporting
+a rate limit as `terminal` silently turns off the backoff you were trying to
+get.
 </Callout>
 
 ## Step 4: Before it carries traffic
 
-Short list, each item a real failure someone has had:
+A short list. Every item here is a real failure someone has actually hit.
 
 <CardGrid size="md">
   <OptionCard name="One process per trust boundary">
-    Several provider and sandbox settings are process-global, so multi-tenant in
-    one process is not safe. Run an engine per tenant, inside the isolation you
-    already use for untrusted code.
+    Several provider and sandbox settings apply to the whole process, so
+    running multiple tenants in one process isn't safe. Run one engine per
+    tenant, inside whatever isolation you already use for untrusted code.
   </OptionCard>
   <OptionCard name="Keep the port private">
-    Loopback, or a private network behind the token. There is no `Host` guard and
-    no CORS handling — never expose it to a browser directly.
+    Use loopback, or a private network behind the token. There's no `Host`
+    check and no CORS handling — never expose this port directly to a
+    browser.
   </OptionCard>
   <OptionCard name="Cancel turns you abandon">
-    Each live turn holds an OS thread, and at most 32 are allowed at once. Past
-    that you get a 429. `POST /v1/turns/{id}/cancel` unwinds cleanly and still
-    reports a settled cost.
+    Each running turn holds an OS thread, and at most 32 can run at once.
+    Past that limit you get a 429. `POST /v1/turns/{id}/cancel` shuts a turn
+    down cleanly and still reports a final cost.
   </OptionCard>
   <OptionCard name="Record every step_usage event">
-    Per-step tokens, cost, model, and duration. `cost_usd` is the sum of what
-    *your* app reported, so your billing system stays the authority — these events
-    are how you cross-check it.
+    Per-step tokens, cost, model, and duration. `cost_usd` is just the sum of
+    what *your* app reported, so your own billing system stays the source of
+    truth — these events are how you double-check it.
   </OptionCard>
 </CardGrid>
 
-There is also a list of things that genuinely do not exist yet — no stream
-resumption, no server-side conversation state, no approval routes, no `/metrics`.
-Design around them rather than discovering them:
-[what is not built yet](/docs/agent-engine-in-your-app#what-is-not-built-yet).
+Some things genuinely don't exist yet: no resuming a stream, no
+server-side conversation state, no approval routes, no `/metrics` endpoint.
+Plan around these instead of discovering them the hard way:
+[not built yet](/docs/agent-engine-in-your-app#not-built-yet).
 
 ## Where this goes next
 
-You now have an agent loop that runs in CI without a key. The natural next move
-is to make CI *care* about it — because the engine is a dependency now, and
-dependencies regress.
+You now have an agent loop that runs in CI without needing a key. The
+natural next step is to make CI actually *care* about it, because the engine
+is a real dependency now, and dependencies can break.
 
 <CardGrid size="md">
   <SpecCard title="Gate on engine quality in CI" href="/docs/guides/ci-engine-gate">
-    Run stella and Claude Code side by side on the same committed task set on every
-    pull request. Block the merge on loop correctness, which is deterministic and
-    cheap; report the quality delta, which is neither. The companion to this guide.
+    Run stella and Claude Code side by side on the same set of tasks on
+    every pull request. Block the merge on loop correctness, which is exact
+    and cheap to check. Report the quality difference separately, since
+    that part is neither. The guide that pairs with this one.
   </SpecCard>
   <SpecCard title="Agent Engine in your app" href="/docs/agent-engine-in-your-app">
-    The reference this guide links into — six routes, four frame types, the full
-    environment surface, the licensing detail, and the eighty-line host in full.
+    The reference this guide links into — all six routes, the four message
+    types, the full environment settings, the licensing details, and the
+    eighty-line host in full.
   </SpecCard>
 </CardGrid>
 
@@ -223,14 +234,15 @@ dependencies regress.
 
 <CardGrid size="sm">
   <SpecCard title="Event stream compatibility" href="/docs/event-stream-compatibility">
-    The `AgentEvent` vocabulary you receive in `event` frames, and the
-    forward-compatibility rule your parser has to follow.
+    The `AgentEvent` types you get back in `event` messages, and the rule
+    your parser needs to follow to stay compatible going forward.
   </SpecCard>
   <SpecCard title="Plugins" href="/docs/plugins">
-    What a wrapper plugin contributes around a turn, if you want to know what you bought.
+    What a wrapper plugin adds around a turn, if you want to know what you
+    bought.
   </SpecCard>
   <SpecCard title="Agent Engine paths" href="/docs/agent-engine-paths">
-    The command-line doors into the same engine, for the parts of your workflow
-    that are not a product surface.
+    The command-line ways into the same engine, for the parts of your
+    workflow that aren't a product surface.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/fix-failing-ci.mdx
+++ b/website/content/docs/guides/fix-failing-ci.mdx
@@ -3,11 +3,11 @@ title: Fix a failing CI run
 description: A branch is red. Walk it to green with stella monitor — what it does each round, what happens when a fix doesn't hold, and what "green" means here.
 ---
 
-You pushed a branch and CI went red. You want it green, you would rather not
-read four thousand lines of log to find out why, and you want the fix to be a
-real fix rather than a test deletion.
+You pushed a branch and CI went red. You want it green, you'd rather not read
+four thousand lines of logs to find out why, and you want a real fix, not
+just a deleted test.
 
-This is the task [`stella monitor`](/docs/commands/monitor) exists for.
+This is the task [`stella monitor`](/docs/commands/monitor) is built for.
 
 ## The whole thing, first
 
@@ -16,86 +16,86 @@ This is the task [`stella monitor`](/docs/commands/monitor) exists for.
 stella --spend-limit 5.00 monitor feature/payments-refactor
 ```
 
-That is the guide. The rest of this page is what that command is doing, how to
-tell whether it worked, and what to do when it doesn't.
-
 <Callout type="warn">
-The `target` argument defaults to **`main`**. `monitor` commits and pushes its
-fixes to the branch it is watching, so a bare `stella monitor` pushes commits
-directly to `main`. Name your branch or PR explicitly — `feature/…`, or `"#128"`
-for a pull request.
+The `target` argument defaults to **`main`**. `monitor` commits and pushes
+its fixes to whatever branch it's watching, so running a bare
+`stella monitor` pushes commits straight to `main`. Always name your branch
+or pull request — `feature/…`, or `"#128"` for a pull request.
 </Callout>
 
 ## Before you start
 
 <CardGrid size="md">
   <OptionCard name="gh, installed and authenticated">
-    `monitor` reads CI state through GitHub's `gh` CLI.
-    `gh auth status` should be clean. Without it, the run fails at
-    the first status check rather than silently doing nothing.
+    `monitor` reads CI status through GitHub's `gh` command-line tool.
+    `gh auth status` should come back clean. Without it, the run fails at
+    the first status check instead of silently doing nothing.
   </OptionCard>
   <OptionCard name="A branch you are willing to have pushed to">
-    Fixes are committed and pushed between checks — that is how the next CI run gets
-    triggered at all. There is no dry-run mode; the feedback loop *is* the remote.
+    Fixes get committed and pushed between checks — that's how the next CI
+    run gets triggered at all. There's no dry-run mode. The feedback loop
+    *is* the remote branch.
   </OptionCard>
   <OptionCard name="A spend limit, realistically">
-    Reading failure logs is input-token-heavy. `--spend-limit` is a
-    [global flag](/docs/commands#global-flags), so it goes before the subcommand.
+    Reading failure logs uses a lot of input tokens. `--spend-limit` is a
+    [global flag](/docs/commands#global-flags), so it goes before the
+    subcommand.
   </OptionCard>
 </CardGrid>
 
 ## What each round actually does
 
-`monitor` is not a bespoke CI robot. It is [goal mode](/docs/agent-modes#outcome-driven-goal-mode)
-with one fixed objective compiled in:
+`monitor` isn't a special-purpose CI robot. It's
+[goal mode](/docs/agent-modes#outcome-driven-goal-mode) with one fixed
+objective built in:
 
-> Drive CI for `<target>` to fully green. Watch the latest runs, read the failure
-> logs, fix each root cause in the code, commit and push the fix, then re-check.
-> The goal is met only when the latest CI run has completed with every check
-> successful.
+> Drive CI for `<target>` to fully green. Watch the latest runs, read the
+> failure logs, fix each root cause in the code, commit and push the fix,
+> then re-check. The goal is met only when the latest CI run has completed
+> with every check successful.
 
-Which means it inherits goal mode's machinery wholesale, and that machinery is
-the interesting part:
+That means it uses all of goal mode's machinery, and that machinery is the
+interesting part:
 
-1. **Watch.** The engine waits until the latest run for the target finishes,
-   then reads its conclusion and the failing jobs' logs.
-2. **Diagnose and fix.** A working round is a step-loop turn over the failing
-   jobs' logs. `monitor` takes no wrapper flag of its own — it is
-   [goal mode](/docs/agent-modes#outcome-driven-goal-mode) with the objective
-   pinned to "CI is green", and the outer goal verifier is what judges it.
-3. **Commit and push.** The remote is the only thing that can produce the next
-   round's evidence.
-4. **Verifier.** A separate verifier model — by preference from a
-   [different family](/docs/api-providers/models) than the
-   worker — assesses whether the objective is met. It reads the CI state
-   itself, so it is checking the run rather than reading the worker's account of
-   the run.
-5. **Repeat**, up to a hard cap of **8** judged rounds.
+1. **Watch.** The engine waits for the latest run on the target to finish,
+   then reads its result and the logs from any jobs that failed.
+2. **Diagnose and fix.** A round of work steps through the failing jobs'
+   logs. `monitor` doesn't add any flag of its own here — it's
+   [goal mode](/docs/agent-modes#outcome-driven-goal-mode) with the goal set
+   to "CI is green," and the outer verifier is what judges whether that's
+   true.
+3. **Commit and push.** The remote branch is the only thing that can
+   produce evidence for the next round.
+4. **Verify.** A separate verifier model — ideally from a
+   [different family](/docs/api-providers/models) than the model doing the
+   work — checks whether the goal is met. It reads the CI status itself,
+   so it's checking the actual run, not trusting the worker's account of it.
+5. **Repeat**, up to a hard limit of **8** checked rounds.
 
-## "Fixed" means something specific here
+## What "fixed" means here
 
-This is where `monitor` differs from a script that retries until the exit code
-is zero, and it is worth being precise about, because it is the whole reason to
-use it.
+This is where `monitor` is different from a script that just retries until
+the exit code is zero, and it's worth understanding, because it's the whole
+reason to use this tool instead.
 
-**Inside each round**, an installed [verification plugin](/docs/plugins) can run
-the deterministic evidence ladder before any model is asked for an opinion. The
-required rung is the **flip oracle**: the relevant test must have *failed
-before* the change and *passed after* it. A suite that was already green proves
-nothing about the fix, so it cannot be used to claim one. That structurally
-excludes the failure mode you actually fear — a change that makes the red go
-away without making the bug go away.
+**Inside each round**, an installed [verification plugin](/docs/plugins) can
+run a set of deterministic checks before any model gives an opinion. The
+required check is the **flip test**: the relevant test must have *failed
+before* the change and *passed after* it. A test suite that was already
+green proves nothing about the fix, so it can't be used as proof of one.
+That rules out the exact failure you're worried about — a change that makes
+the red go away without actually fixing the bug.
 
-**Across rounds**, the outer goal verifier only ends the loop when the *latest CI
-run for the target has completed with every check successful*. Not "the tests I
-ran locally passed". Not "I believe this is fixed". A run on the remote, green,
-that you can open in a browser.
+**Across rounds**, the outer verifier only ends the loop when the *latest CI
+run for the target has finished with every check passing*. Not "the tests I
+ran locally passed." Not "I believe this is fixed." An actual run on the
+remote, green, that you can open in a browser.
 
 <Callout type="info">
-Rounds wrapped by a verification plugin mean **double verification**: the
-plugin's own evidence covers each round's work, and the outer goal verifier
-checks the objective. A fix that passes locally but doesn't turn CI green gets
-caught by the second one.
+Rounds wrapped by a verification plugin get checked **twice**: the plugin's
+own evidence covers each round's work, and the outer verifier checks the
+overall goal. A fix that passes locally but doesn't turn CI green gets
+caught by the second check.
 </Callout>
 
 ## When the fix doesn't hold
@@ -104,87 +104,90 @@ The interesting cases are the ones where it doesn't just work.
 
 ### The next run is red for a different reason
 
-This is the normal case and needs nothing from you. The round ends "not met",
-the new failure logs come back with the next status check, and the next round
-works on the new root cause. That is what the round loop is for.
+This is normal, and needs nothing from you. The round ends "not met," the
+new failure logs come back with the next status check, and the next round
+works on the new root cause. That's exactly what the round loop is for.
 
 ### The same failure comes back
 
-A revision whose candidate has already deterministically failed a **second** time
-(the failures need not be consecutive) re-enters the revise loop
-carrying the sealed, redacted account of the test that went red, and nothing else. The
-worker is told what failed, not what to do about it.
+Once a fix has deterministically failed the **same** check a **second**
+time (the two failures don't need to be back to back), the next attempt
+gets the full, unedited record of what failed, and nothing else. The worker
+is told what failed, not what to do about it.
 
-There is no model **distress-guidance** call here — no verifier reading the diff and
-appending a course-correction note to the evidence. A model's reading of a bounded diff
-is a claim, a claim appended to a measurement inherits that measurement's authority, and
-a worker cannot tell the two apart. The failing test is already conclusive; there is
-nothing a reviewer could add to it except a way to be wrong about it.
+There's no model **guidance step** here — no verifier reading the diff and
+adding a note about how to fix it. A model reading a limited diff is making
+a guess, and a guess attached to a measurement can look like it carries the
+same authority as that measurement, even though a worker can't tell the two
+apart. The failing test already proves the point. There's nothing a
+reviewer could add to it except a way to get it wrong.
 
-### It hits the round cap
+### It hits the round limit
 
-At 8 judged rounds `monitor` **stops and reports the goal as not met**, even
-with CI still red. It is not a daemon and it will not sit on your branch
-overnight. Re-run it to continue — the branch state carries over, so a second
-invocation resumes from the work the first one landed.
+At 8 checked rounds, `monitor` **stops and reports the goal as not met**,
+even if CI is still red. It isn't a background daemon and won't sit on your
+branch overnight. Run it again to keep going — the branch state carries
+over, so a second run picks up from where the first one left off.
 
-That cap exists because the failure it protects against is expensive: an agent
-looping on an infrastructure problem it cannot fix from the code. If two
-`monitor` invocations in a row end at the cap, the constraint is usually not in
-the diff — read on.
+That limit exists because the failure it protects against is expensive: an
+agent stuck looping on an infrastructure problem it has no way to fix from
+the code. If two `monitor` runs in a row both hit the limit, the problem is
+usually not in the code — see the next section.
 
 ### It cannot be fixed from the code
 
-Some red CI is not a code problem: an expired token, a billing cap, a runner
-that no longer exists, a required check whose workflow file never starts. stella
-will keep proposing code changes because code changes are what it can make. The
-tell is a CI conclusion that never reaches the test step at all — a job
-that fails in setup, or a run whose conclusion is `startup_failure`.
+Some red CI isn't a code problem: an expired token, a billing limit, a
+runner that no longer exists, a required check whose workflow file never
+even starts. stella will keep proposing code changes, because code changes
+are what it knows how to make. The tell is a CI result that never reaches
+the test step at all — a job that fails during setup, or a run whose result
+is `startup_failure`.
 
-Read the raw job yourself at that point:
+Check the raw job yourself at that point:
 
 ```bash
 gh run list --branch feature/payments-refactor --limit 5
 gh run view <run-id> --log-failed
 ```
 
-### The spend limit aborts it
+### The spend limit stops it
 
-`--spend-limit` is a hard cap, checked **between** steps and stages — never
-mid-tool-call, so you are never left with a half-applied edit. An aborted run
-leaves its already-pushed commits in place; nothing is rolled back. Raise the
-cap and re-run, or see [Work within a spend limit](/docs/guides/spend-limit).
+`--spend-limit` is a hard cap, checked **between** steps and stages, never
+in the middle of a tool call — so you never end up with a half-finished
+edit. A stopped run leaves its already-pushed commits in place. Nothing is
+rolled back. Raise the limit and run it again, or see
+[Work within a spend limit](/docs/guides/spend-limit).
 
-## Confirming it, afterwards
+## Confirming it, afterward
 
-`monitor` renders human-readable text and does **not** take
-`--output-format` (it is an interactive mode; passing the flag is a parse
-error). So the confirmation is the same one anybody else on your team would
-use:
+`monitor` prints plain text for people to read and does **not** support
+`--output-format` (it's meant to be watched live; passing that flag is an
+error). So confirm it the same way anyone else on your team would:
 
 ```bash
 gh pr checks 128
 ```
 
-Then read what it cost you:
+Then check what it cost you:
 
 ```bash
 stella stats --format text
 ```
 
 <Callout type="info">
-Want a machine-readable verdict instead? Drive the objective through
-[`stella run`](/docs/commands/run) with `--output-format json` and your own test
-command, and gate on `verdict.deterministic` — the
-[scripting guide](/docs/scripting) has the full pattern for CI-side automation.
+Want a machine-readable result instead? Run the same goal through
+[`stella run`](/docs/commands/run) with `--output-format json` and your own
+test command, and check `verdict.deterministic` in the result. The
+[scripting guide](/docs/scripting) has the full pattern for automating this
+from CI.
 </Callout>
 
 ## Running it *from* CI instead of *at* CI
 
-`monitor` watches a remote CI run from your machine. The other arrangement —
-stella running headlessly *inside* a CI job — is a different setup with
-different requirements (a non-TTY surface, JSON output, an explicit scope-review
-bypass):
+`monitor` watches a remote CI run from your own machine. Running stella
+headlessly *inside* a CI job is a different setup, with different
+requirements (no interactive terminal, JSON output, and skipping the scope
+review manually):
 
 ```bash
 stella --spend-limit 2.00 \
@@ -193,23 +196,24 @@ stella --spend-limit 2.00 \
   | jq -e '.status == "completed"'
 ```
 
-There is no scope-review gate to opt past here, and the
-`agent_engine_config.headless_scope_bypass` key is inert — setting it changes
-nothing. See [Scripting](/docs/scripting).
+There's no scope-review step to skip here, and the
+`agent_engine_config.headless_scope_bypass` setting does nothing — turning
+it on changes nothing. See [Scripting](/docs/scripting).
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="stella monitor" href="/docs/commands/monitor">
-    The reference: synopsis, flags, exit behavior.
+    The reference: syntax, flags, and exit behavior.
   </SpecCard>
   <SpecCard title="Goal mode" href="/docs/agent-modes#outcome-driven-goal-mode">
     The round loop `monitor` is built on, and how the verifier is chosen.
   </SpecCard>
   <SpecCard title="Work within a spend limit" href="/docs/guides/spend-limit">
-    Where the abort lands, and how to make the money go further.
+    Where a stopped run leaves off, and how to make the money go further.
   </SpecCard>
   <SpecCard title="stella fleet" href="/docs/commands/fleet">
-    Several red branches at once — `--watch` reconciles each one's CI and PR status.
+    Several red branches at once — `--watch` keeps each one's CI and pull
+    request status in sync.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/index.mdx
+++ b/website/content/docs/guides/index.mdx
@@ -1,88 +1,93 @@
 ---
 title: Guides
-description: Task-shaped walkthroughs — fix a red CI run, land a change in an unfamiliar codebase, find out what a run cost. Each one carried to a verified result.
+description: Step-by-step guides for real tasks — fix a red CI run, make a change in a codebase you don't know, find out what a run cost.
 ---
 
 The rest of the documentation is organized around stella's parts: a page per
 command, a page per subsystem. This section is organized around **your
-afternoon**. Each guide is one real task carried from the symptom to a verified
+afternoon**. Each guide walks through one real task from start to a checked
 result, in the order you would actually type the commands.
 
-Nothing here restates the reference. Every step links down into it, so you can
-stop and read the whole flag surface at the moment you need it and not before.
+Nothing here repeats the reference pages. Every step links down to them, so
+you can go read the full details when you need them, and skip them when you
+don't.
 
 ## Start here
 
 <CardGrid size="md">
   <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
-    CI is red on a branch you own. `stella monitor` watches it, fixes root
-    causes, pushes, and re-checks — and stops only on a green run somebody else can
-    see. Includes what to do when the fix doesn't hold.
+    CI is red on a branch you own. `stella monitor` watches it, fixes the root
+    cause, pushes the fix, and checks again. It stops only when the run is
+    green and anyone can see it. Covers what to do when the fix doesn't stick.
   </SpecCard>
   <SpecCard title="Fix a backlog in parallel" href="/docs/guides/parallel-fixes">
-    A list of independent fixes and one afternoon. `stella fleet` runs them
-    concurrently in one tree, with file claims keeping the workers off each other —
-    including how to decompose the list and how to review what landed.
+    A list of small, separate fixes and one afternoon to do them. `stella
+    fleet` runs them at the same time in one project folder, using file
+    claims to keep workers from stepping on each other. Covers how to split
+    up the list and how to check the results.
   </SpecCard>
   <SpecCard title="Change an unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
-    A repository you have never read, and a change that has to land in it. `stella
-    init` builds the code graph, `stella search` answers the blast-radius question
-    before you commit to an approach, and the change ships verified.
+    A codebase you have never read, and a change you have to make in it.
+    `stella init` builds a map of the code. `stella search` tells you what
+    else your change might break, before you write any code. Then you make
+    the change and check it.
   </SpecCard>
   <SpecCard title="Find out what a run cost" href="/docs/guides/what-a-run-cost">
-    A run cost more than you expected. Follow it from the dollar figure down to the
-    exact bytes of the model call that produced it — `stats`, `observe`, `inspect`.
+    A run cost more than you expected. Trace it from the total dollar amount
+    down to the exact model call that caused it, using `stats`, `observe`,
+    and `inspect`.
   </SpecCard>
   <SpecCard title="Work within a spend limit" href="/docs/guides/spend-limit">
-    A hard ceiling in dollars, and what stella does as it approaches one: where the
-    abort lands, what compaction costs, and how to spend the money on the task
-    instead of on the transcript.
+    Set a hard dollar limit and see what stella does as it gets close to it:
+    where it stops, what compacting the conversation costs, and how to spend
+    money on the task instead of on chat history.
   </SpecCard>
   <SpecCard title="Drop stella in as your agent engine" href="/docs/guides/embed-the-engine">
-    You have a product with an LLM feature and a hand-rolled loop. Replace the loop
-    and keep your models, tools, keys, and data — ending on an integration test that
-    exercises the whole agent loop without an API key.
+    You have a product with an AI feature and a loop you built by hand. Swap
+    in stella's loop and keep your own models, tools, keys, and data. Ends
+    with a test that runs your whole agent loop without needing an API key.
   </SpecCard>
   <SpecCard title="Gate on engine quality in CI" href="/docs/guides/ci-engine-gate">
-    Run stella and Claude Code side by side on the same committed task set on every
-    pull request. Block the merge on loop correctness, which is deterministic; report
-    the quality delta, which is not.
+    Run stella and Claude Code side by side on the same set of tasks on every
+    pull request. Block the merge only on loop correctness, which you can
+    measure exactly. Report the quality difference separately, since that
+    part is never exact.
   </SpecCard>
   <SpecCard title="Benchmark against Claude Code" href="/docs/guides/terminal-bench-head-to-head">
-    Terminal-Bench 2.1 with stella in one arm and Claude Code in the other. The
-    setup, the parity checks that make the comparison mean something, and the traps
-    that quietly void a result.
+    Run Terminal-Bench 2.1 with stella and Claude Code in separate runs.
+    Covers the setup, the checks that make the comparison fair, and the
+    mistakes that quietly ruin a result.
   </SpecCard>
   <SpecCard title="When something isn't working" href="/docs/guides/troubleshooting">
-    Config that isn't applying, a key that won't resolve, a hook that never fires, a
-    graph that answers about code you deleted. The four checks in the order that
-    finds it fastest.
+    Settings that won't apply, a key that won't resolve, a hook that never
+    runs, a code map that answers about code you deleted. Four checks, in the
+    order that finds the problem fastest.
   </SpecCard>
 </CardGrid>
 
 ## What these assume
 
 Every guide assumes you have [installed stella](/docs/getting-started/installation)
-and that one provider key resolves — `stella config` prints a provider, a model,
-and a redacted key preview rather than an error. If that is not yet true,
-[Getting started](/docs/getting-started) is thirty seconds long and this section
-will still be here.
+and that a provider key works. Run `stella config` — it should print a
+provider, a model, and a partly hidden key, not an error. If it doesn't,
+[Getting started](/docs/getting-started) takes about thirty seconds, and this
+page will still be here after.
 
-Nothing else is assumed. Where a guide needs `gh`, a git remote, or an
-initialized code graph, it says so at the point of need and tells you what
-happens if you don't have it.
+Nothing else is assumed. If a guide needs `gh`, a git remote, or a code map
+that's already built, it says so at that point, and tells you what happens
+if you don't have it.
 
-## The idea the guides share
+## The idea behind every guide
 
-stella's distinguishing behavior is not any single command — it is that **work
-ends on evidence rather than on the worker's own claim**. A test that failed
-before the change and passes after it. A diff that exists. A CI run whose latest
-attempt is green. A verifier from a different model family than the worker, reading
-the diff and not the narration.
+stella's most important habit isn't any one command. It's that **work only
+counts as done when there's proof, not just a claim from the worker**. A test
+that failed before the change and passes after it. A diff that actually
+exists. A CI run that's green on its latest attempt. A different model
+checking the diff itself, instead of reading what the worker says it did.
 
-That is worth knowing before the first guide, because it explains a shape you
-will see in all of them: the fastest, cheapest path is usually the one that hands
-stella something deterministic to check.
+Keep that in mind before you read the first guide. It explains a pattern
+you'll see again and again: the fastest, cheapest path is usually the one
+where you give stella something it can check on its own.
 
 ```bash
 # --test-command arms an installed verification plugin's fail→pass flip oracle,
@@ -92,22 +97,22 @@ stella run --pipeline my-verifier --test-command "cargo test -p api" \
   "add cursor pagination to /orders"
 ```
 
-The [plugin socket](/docs/plugins) is the full account of how
-that works. You do not need it to follow any guide here.
+The [plugin socket](/docs/plugins) explains all of this in full. You don't
+need it to follow any guide here.
 
 ## Related reading
 
 <CardGrid size="sm">
   <SpecCard title="Examples & recipes" href="/docs/examples">
-    The configuration half — complete `settings.json` files for a given set of keys
-    and a given budget. Answers *how do I set stella up*, where the guides answer
-    *how do I get this done*.
+    Complete `settings.json` files for a given set of keys and a given
+    budget. Answers *how do I set stella up*, where the guides answer *how do
+    I get this done*.
   </SpecCard>
   <SpecCard title="Agent modes" href="/docs/agent-modes">
-    Deck, run, goal, monitor, fleet — which surface to reach for, and why.
+    Deck, run, goal, monitor, fleet — which one to use, and why.
   </SpecCard>
   <SpecCard title="Commands" href="/docs/commands">
-    The reference every guide links into: each subcommand's synopsis, flags, and
+    The reference every guide links into: each command's syntax, flags, and
     exit codes.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/parallel-fixes.mdx
+++ b/website/content/docs/guides/parallel-fixes.mdx
@@ -3,14 +3,14 @@ title: Fix a backlog in parallel
 description: A list of independent fixes and one afternoon. Decompose it into a fleet plan, run the workers concurrently under file claims, and review what actually landed.
 ---
 
-You have a list. Eleven clippy warnings across four crates, a dozen modules with
-no test coverage, every `TODO(deprecate)` left over from a migration. Each item
-is small, none of them depend on each other, and doing them one at a time is an
-afternoon of watching a progress bar.
+You have a list. Eleven clippy warnings across four crates, a dozen modules
+with no test coverage, every `TODO(deprecate)` left over from a migration.
+Each item is small, none of them depend on each other, and doing them one at
+a time would eat your whole afternoon watching a progress bar.
 
-This is what [`stella fleet`](/docs/commands/fleet) is for: many tasks at once,
-each handled by a full stella worker, coordinated so they don't overwrite each
-other.
+This is what [`stella fleet`](/docs/commands/fleet) is for: many tasks at
+once, each one handled by a full stella worker, coordinated so they don't
+overwrite each other.
 
 ## The whole thing, first
 
@@ -21,45 +21,48 @@ stella --spend-limit 6 fleet \
   "Add unit tests for the plan parser in stella-fleet"
 ```
 
-Three workers, running together in your repository root, committing to your
-current branch as they finish. That is the guide for a short list. The rest of
-this page is how to make a *long* list work, and how to tell what you got.
+Three workers run together in your repository root, committing to your
+current branch as each one finishes. That's all a short list needs.
 
 <Callout type="warn">
-Workers commit to the branch you are on. Start from a branch you are willing to
-have committed to — not `main` — and start from a **clean tree**, so
-`git log` afterwards separates their work from yours.
+Workers commit to the branch you're on. Start from a branch you're willing
+to have things committed to — not `main` — and start from a **clean
+working tree**, so `git log` afterward clearly separates their work from
+yours.
 </Callout>
 
-## Decide this first: does the list share files?
+## Check for shared files first
 
-Everything downstream follows from one question, and it is worth thirty seconds
+Everything else follows from one question, and it's worth thirty seconds
 before you type anything.
 
 <CardGrid size="md">
   <OptionCard name="Disjoint files → inline prompts">
-    Each item touches its own crate, module or directory. Nothing to declare. Pass
-    the prompts on the command line and let claim-on-first-write handle the rest.
+    Each item touches its own crate, module, or folder. Nothing to declare.
+    Pass the prompts on the command line and let claim-on-first-write handle
+    the rest.
   </OptionCard>
   <OptionCard name="Overlapping files → a plan with claims">
-    Two items might both edit `src/store/schema.rs`. Declare the paths up front so
-    the second dispatch fails *by name* instead of racing. This is the common case
-    for anything over about five items.
+    Two items might both edit `src/store/schema.rs`. Declare the paths up
+    front, so the second attempt fails *by name* instead of racing the
+    first. This is the common case for anything over about five items.
   </OptionCard>
   <OptionCard name="Ordered work → depends_on">
-    Item B only makes sense after item A lands — a migration before its read path.
-    Dependencies order the waves; they are not a performance hint.
+    Item B only makes sense after item A lands — a database migration
+    before the code that reads from it. Dependencies control the order
+    tasks run in. They are not just a speed hint.
   </OptionCard>
   <OptionCard name="Competing answers → isolation">
-    Two attempts at the *same* file, and you want to compare them. This is the one
-    case for `isolation = "isolated"`; see [when to isolate](#when-to-isolate-instead).
+    Two attempts at the *same* file, where you want to compare them. This
+    is the one case for `isolation = "isolated"`; see
+    [when to isolate](#when-to-isolate-instead).
   </OptionCard>
 </CardGrid>
 
 ## Turning a backlog into a plan
 
-For anything beyond a handful of prompts, write the list down. A plan file is a
-`.toml` (or `.json`) with one `[[tasks]]` entry per item:
+For anything beyond a handful of prompts, write the list down. A plan file
+is a `.toml` (or `.json`) file with one `[[tasks]]` entry per item:
 
 ```toml title="cleanup.toml"
 [[tasks]]
@@ -86,94 +89,101 @@ claims = ["Cargo.toml"]
 stella --spend-limit 6 fleet --plan cleanup.toml --max-concurrency 3
 ```
 
-Two crates get cleaned concurrently in wave one; the workspace-wide tidy runs
-alone in wave two, once both have actually succeeded. The
+Two crates get cleaned up at the same time in the first wave. The
+workspace-wide tidy-up runs alone in the second wave, once both earlier
+tasks have actually succeeded. The
 [full plan schema](/docs/agent-fleets#plan-files) has every field.
 
 <Callout type="info">
-Plans are validated **before** anything runs. A duplicate `id`, a self-dependency,
-an unknown dependency, or a cycle is rejected up front with the offending task
-named — so a typo costs you a message, not half a run.
+Plans get checked **before** anything runs. A duplicate `id`, a task that
+depends on itself, an unknown dependency, or a cycle gets rejected up front,
+with the problem task named — so a typo costs you one message, not half a
+run.
 </Callout>
 
 ### Writing prompts that survive being run alone
 
-The failure mode specific to fleets is the prompt that reads fine in a list and
-is ambiguous in isolation. Each worker sees **only its own prompt** — not the
-other tasks, not your intent, not the conversation you would have had.
+The mistake specific to fleets is a prompt that reads fine in a list but
+turns out ambiguous by itself. Each worker sees **only its own prompt** —
+not the other tasks, not your intent, not the conversation you'd have had
+with a person.
 
-Three habits that pay for themselves:
+Three habits that pay off:
 
-- **Name the scope in the prompt itself.** "Fix the clippy warnings in
-  `stella-store`" — not "fix the clippy warnings", which invites a worker into
-  the whole workspace and straight into another worker's claims.
-- **Say what a fix is not.** "Do not silence with `#[allow]`", "do not delete the
-  test". Left unsaid, the cheapest path to a green build is sometimes the wrong
-  one.
-- **Give it something deterministic to check.** A prompt that names a test
-  command lets the worker's [verify stage](/docs/plugins)
-  finish on evidence rather than on a verifier's opinion. It is the single biggest
-  lever on both cost and trustworthiness.
+- **Name the scope in the prompt itself.** Write "Fix the clippy warnings in
+  `stella-store`," not "fix the clippy warnings" — which invites a worker
+  into the whole codebase and straight into another worker's claimed files.
+- **Say what a fix should not do.** "Do not silence with `#[allow]`," "do
+  not delete the test." Left unsaid, the cheapest way to get to a green
+  build is sometimes the wrong one.
+- **Give it something it can check on its own.** A prompt that names a test
+  command lets the worker's [verify stage](/docs/plugins) finish based on
+  evidence instead of an opinion. This is the single biggest lever on both
+  cost and trust.
 
-### Claims are the thing that makes it safe
+### Claims are what makes it safe
 
-By default every worker runs in **one shared tree** — your repository root. That
-is a deliberate trade: the build cache stays warm and commits interleave on one
-branch, but two workers editing one file would be a silent race.
+By default, every worker runs in **one shared folder** — your repository
+root. That's a deliberate trade-off: the build cache stays warm and commits
+interleave on one branch, but two workers editing the same file would
+silently race each other.
 
-`claims` is what removes the race. A declared path is held as a cooperative lock
-for the attempt's duration; a second task claiming a held path fails that
-dispatch *by name*, in under a second, with the rival identified. Undeclared
-paths are claimed on first write at the tool layer, so you get the protection
-even for files you did not anticipate.
+`claims` removes that risk. A declared path is locked for the length of that
+task; a second task trying to claim a locked path fails right away, by
+name, in under a second, naming which task is holding it. Paths you didn't
+declare get claimed automatically on first write, so you're protected even
+for files you didn't think to list.
 
 <ClaimLockDiagram />
 
 <Callout type="warn">
-Claims are matched as **exact strings** — they are not path prefixes. Claiming
-`src/store/` does not protect `src/store/write.rs`. Name files, and spell each
-one the same way throughout the plan.
+Claims are matched as **exact strings** — they are not folder prefixes.
+Claiming `src/store/` does not protect `src/store/write.rs`. Name each file
+directly, and spell it the same way everywhere in the plan.
 </Callout>
 
-The locks live in `.stella/private/store.db`, separate from the fleet ledger, so
-they coordinate across *concurrent fleet runs* too — a second `stella fleet` in
-another terminal cannot walk into the first one's files.
+The locks live in `.stella/private/store.db`, separate from the fleet's own
+records, so they also protect you across *separate fleet runs* — a second
+`stella fleet` running in another terminal can't step on the first one's
+files.
 
 ### When to isolate instead
 
-`isolation = "isolated"` gives a task its own git worktree under
-`.stella/worktrees/<slug>`, on a `fleet/<slug>-<hash>` branch. Reach for it when
-the work is genuinely **divergent** — two attempts at the same rewrite, where
-you want both and will pick one — or when a task mutates checkout state.
+`isolation = "isolated"` gives a task its own git worktree, under
+`.stella/worktrees/<slug>`, on a `fleet/<slug>-<hash>` branch. Use it when
+the work is genuinely **different attempts at the same thing** — two takes
+on the same rewrite, where you want to see both and pick one — or when a
+task needs to change files outside the normal checkout.
 
-It is not the safer default. Isolation costs a cold build cache per tree and
-defers every conflict to integration time. For a backlog of independent fixes,
-claims are cheaper and catch the collision an hour earlier.
+It is not the safer default. Isolation means a cold build cache for every
+tree, and it pushes every merge conflict to later, when you combine the
+work. For a backlog of independent fixes, claims are cheaper, and they
+catch a collision an hour earlier.
 
 ## What the spend limit actually does here
 
-`--spend-limit` is a [global flag](/docs/commands#global-flags), and in a fleet it is
-divided, not shared: each child worker is guarded by
-`spend limit ÷ max-concurrency`. The fleet stops launching new waves once total
-metered spend crosses the cap.
+`--spend-limit` is a [global flag](/docs/commands#global-flags), and in a
+fleet it gets divided, not shared: each worker is limited to
+`spend limit ÷ max-concurrency`. The fleet stops starting new waves once
+total spend crosses the cap.
 
-The practical consequence is that **concurrency and per-task headroom trade off
-against each other**. `--spend-limit 6 --max-concurrency 3` gives each worker $2;
-raising concurrency to 6 halves that, and a task that needed $1.50 now aborts
-partway. If tasks are dying early, lower the concurrency before raising the
-spend limit.
+In practice, this means **concurrency and per-task budget trade off against
+each other**. `--spend-limit 6 --max-concurrency 3` gives each worker $2.
+Raising concurrency to 6 cuts that in half, and a task that needed $1.50
+will now stop partway through. If tasks are dying early, lower the
+concurrency before raising the spend limit.
 
 ## Reading the result
 
-This is the part that distinguishes a fleet from a script, and it is where the
-time you save gets spent if you skip it.
+This is the part that separates a fleet from a script, and it's where the
+time you saved gets spent back if you skip it.
 
-Nothing is retried automatically. A failed task does **not** unblock its
-dependents — they end the run as `skipped`, which is a distinct outcome from
-"failed" and means the work was never attempted.
+Nothing gets retried automatically. A failed task does **not** unblock the
+tasks that depend on it — they end the run marked `skipped`, a different
+outcome from "failed" that means the work was never even attempted.
 
-Start with the ledger, `.stella/private/fleet.db` — local SQLite, like all
-[stella telemetry](/docs/telemetry):
+Start with the ledger, `.stella/private/fleet.db` — a local SQLite file,
+like all [stella telemetry](/docs/telemetry):
 
 ```bash
 # What failed in the most recent run, and what the worker said about it.
@@ -184,71 +194,76 @@ sqlite3 .stella/private/fleet.db \
       AND a.success = 0;"
 ```
 
-Then read the diff, because eleven workers producing eleven small commits on one
-branch is exactly the shape that hides a bad one:
+Then read the diff. Eleven workers each making a small commit on one branch
+is exactly the shape that lets a bad one hide:
 
 ```bash
 git log --oneline main..HEAD
 git diff main...HEAD --stat
 ```
 
-Past runs also surface on the **Fleet runs** card of the
-[Observatory dashboard](/docs/telemetry/dashboard) if you would rather not write
-SQL.
+Past runs also show up on the **Fleet runs** card of the
+[Observatory dashboard](/docs/telemetry/dashboard), if you'd rather not
+write SQL.
 
 <Callout type="info">
-Isolated tasks' worktrees and `fleet/*` branches are deliberately **left in
-place** — those branches *are* the work product. `git worktree list` shows them
-all. Nothing is merged for you.
+Worktrees and `fleet/*` branches from isolated tasks are **left in place** on
+purpose — those branches *are* the finished work. `git worktree list` shows
+all of them. Nothing gets merged for you automatically.
 </Callout>
 
 ## When it doesn't go cleanly
 
 ### A task failed and took its dependents with it
 
-Expected, and the design is deliberate: a dependent that ran anyway would be
-building on work that isn't there. Fix the cause, then re-run — either the whole
-plan (completed work is cheap to redo and the claims still protect you) or a
-trimmed plan containing just the failed subtree.
+This is expected, and it's by design: a dependent task that ran anyway
+would be building on work that isn't actually there. Fix the cause, then
+run it again — either the whole plan (finished work is cheap to redo, and
+the claims still protect you) or a trimmed plan with just the failed
+branch of tasks.
 
-### A dispatch failed naming another task
+### A dispatch failed, naming another task
 
-Your claims overlap. That is the system working — it caught at dispatch what
-would otherwise have been a corrupted file. Either widen the split so the two
-tasks own disjoint files, or add a `depends_on` edge so they run in different
-waves.
+Your claims overlap. That's the system working as intended — it caught at
+launch time what would otherwise have corrupted a file. Either split the
+work so the two tasks own separate files, or add a `depends_on` link so
+they run in different waves.
 
 ### Everything is fighting over one file
 
-If three tasks all need `Cargo.toml`, they are not three tasks. Collapse them
-into one prompt, or sequence them with `depends_on`. A fleet parallelizes work
-that is *already* parallel; it cannot make a serial dependency concurrent.
+If three tasks all need `Cargo.toml`, they aren't really three tasks.
+Combine them into one prompt, or order them with `depends_on`. A fleet
+speeds up work that's *already* independent. It can't turn work that's
+inherently sequential into work that runs at the same time.
 
 ### The workers went wider than you meant
 
-Almost always an under-scoped prompt. Re-read the item as if you knew nothing
-else about the repository — that is the worker's position. Naming the crate,
-directory or file in the prompt fixes it more reliably than any flag.
+This is almost always a prompt that didn't say enough. Re-read the item as
+if you knew nothing else about the codebase — that's exactly the worker's
+position. Naming the crate, folder, or file in the prompt fixes this more
+reliably than any flag does.
 
 ## Following it through to CI
 
-If your task prompts push their branches and open PRs, `--watch` keeps the run
-alive afterwards to watch each branch's CI to completion and reconcile PR status
-through `gh`. It exits non-zero if any watched branch ends red.
+If your task prompts push branches and open pull requests, `--watch` keeps
+the fleet run alive afterward, watching each branch's CI until it finishes
+and checking pull request status through `gh`. It exits with an error if any
+watched branch ends up red.
 
 ```bash
 stella --spend-limit 8 fleet --plan cleanup.toml --watch
 ```
 
-It needs `gh` installed and authenticated, and it only does something once the
-branches are actually pushed — watching an unpushed branch has nothing to watch.
+It needs `gh` installed and signed in, and it can only watch a branch once
+it's actually pushed — there's nothing to watch on a branch that never left
+your machine.
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="Agent Fleets" href="/docs/agent-fleets">
-    The concept page: wave scheduling, the full plan schema, and how file claims
-    work underneath.
+    The concept page: how waves are scheduled, the full plan schema, and how
+    file claims work underneath.
   </SpecCard>
   <SpecCard title="stella fleet" href="/docs/commands/fleet">
     The reference — every flag, the ledger layout, exit behavior.
@@ -257,6 +272,7 @@ branches are actually pushed — watching an unpushed branch has nothing to watc
     One branch instead of many, driven to green by `stella monitor`.
   </SpecCard>
   <SpecCard title="Work within a spend limit" href="/docs/guides/spend-limit">
-    Why per-worker headroom is the number that matters, and where an abort lands.
+    Why per-worker budget is the number that matters, and where a stopped
+    run leaves off.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/spend-limit.mdx
+++ b/website/content/docs/guides/spend-limit.mdx
@@ -195,7 +195,7 @@ Shortening happens in four steps, from **least to most lossy**:
 The system message and your latest message are never touched.
 
 <Callout type="info">
-Keeping the **earliest** copy during deduplication is deliberate.
+Deduplication keeps the **earliest** copy.
 Identical content doesn't depend on where it sits, so shortening the later
 copy instead would put the change in the *newest* part of the conversation
 and break the provider's cached prefix. Doing it the other way would save a

--- a/website/content/docs/guides/spend-limit.mdx
+++ b/website/content/docs/guides/spend-limit.mdx
@@ -1,11 +1,11 @@
 ---
 title: Work within a spend limit
-description: A hard dollar ceiling, and what stella does as it approaches one — where the abort lands and what the scope gate stops before you spend anything.
+description: A hard dollar ceiling, and what stella does as it approaches one — where the run stops and what the scope gate stops before you spend anything.
 ---
 
-You have a number in mind and you do not want to find out you passed it
-afterwards. This guide is about the mechanisms that hold a ceiling, in the order
-they fire — one of them before any money is spent at all.
+You have a number in mind, and you don't want to find out you went over it
+afterward. Several mechanisms hold that ceiling. One of them fires before you
+spend anything at all.
 
 <BudgetGuardDiagram />
 
@@ -15,100 +15,102 @@ they fire — one of them before any money is spent at all.
 stella --spend-limit 2.00 run "port the utils module to the new API"
 ```
 
-`--spend-limit` is a [global flag](/docs/commands#global-flags), so it can go on
-either side of the subcommand — but the habit of putting it first is a good one,
-because it reads as a property of the whole invocation, which is what it is.
+`--spend-limit` is a [global flag](/docs/commands#global-flags), so it can
+go on either side of the subcommand. Putting it first is a good habit,
+since it reads as a property of the whole command, which is what it is.
 
 <CardGrid size="md">
   <SpecCard title="Observed — no --spend-limit">
-    The default. Spend is metered for the end-of-run cost summary and the local store,
-    but never blocks. Use it to find out what a class of task actually costs before
-    picking a ceiling for it.
+    The default. Spend is tracked for the end-of-run cost summary and the
+    local store, but it never stops a run. Use this to find out what a kind
+    of task actually costs before you pick a ceiling for it.
   </SpecCard>
   <SpecCard title="Enforced — --spend-limit <usd>">
-    A hard cap on the **whole run or session** — not per turn, not per round. Must be
-    positive and finite.
+    A hard cap on the **whole run or session** — not per turn, not per
+    round. Must be a positive, finite number.
   </SpecCard>
 </CardGrid>
 
-Set it once for a shell or a CI job instead:
+Set it once for a whole shell session or CI job instead:
 
 ```bash
 export STELLA_SPEND_LIMIT=5
 ```
 
-## Where the abort lands
+## Where the run stops
 
-This is the part worth trusting, because it determines whether a tripped spend limit
-leaves you with work or with wreckage.
+This part is worth trusting, because it decides whether a stopped run leaves
+you with usable work or a mess.
 
-The meter is checked **between steps and stages** — never in the middle of a
-tool call. An abort therefore never leaves a half-applied edit, a partially
-written file, or a tool whose side effects landed but whose result never made it
-back into the transcript. Work already committed to disk stays; nothing is
-rolled back.
+Spend is checked **between** steps and stages, never in the middle of a
+tool call. So stopping a run never leaves a half-finished edit, a partly
+written file, or a tool whose changes happened but never got recorded. Work
+already saved to disk stays there. Nothing gets rolled back.
 
-The exit code is `1`, the same as any other failure. If you need to distinguish
-*the spend limit stopped this* from *this failed*, read the JSON:
+The exit code is `1`, the same as any other failure. If you need to tell
+*the spend limit stopped this* apart from *this just failed*, read the
+JSON output:
 
 ```bash
 stella --spend-limit 2.00 run --output-format json "…" | jq '{status, cost_usd, files_touched}'
 ```
 
 <Callout type="info">
-`--spend-limit` is metered against **catalog prices**. Local and air-gapped models
-have no catalog price, so the dollar columns read zero and a spend limit has nothing
-to meter against. Bound those runs with a verification plugin's `--test-command`
-oracle and goal-mode round caps instead — see
+`--spend-limit` is measured against **published catalog prices**. Local and
+offline models have no catalog price, so their cost always reads zero, and
+a spend limit has nothing to measure against for them. Instead, bound those
+runs with a verification plugin's `--test-command` check and goal-mode
+round limits — see
 [Local and air-gapped](/docs/examples#local-and-air-gapped).
 </Callout>
 
-## The gate that fires *before* you spend
+## The check that runs *before* you spend
 
 <Callout type="warn">
-**This gate is not built into stella.** A plain `stella run` does not have it,
-and the `agent_engine_config.headless_scope_bypass` key is inert — setting it
-changes nothing either way. The section below describes what a scope gate is
-*for*, because that shape is what a verification plugin implements on its own
-side of the wrapper socket; treat it as the contract to look for in a plugin,
-not as behavior this binary has.
+**This check is not built into stella itself.** A plain `stella run` does
+not have it, and the `agent_engine_config.headless_scope_bypass` setting
+does nothing either way. The section below describes what a scope review is
+*for*, because that behavior is something a verification plugin can add on
+its own side of the connection. Treat it as something to look for in a
+plugin, not as behavior this program has by default.
 </Callout>
 
-A spend limit stops a run partway. A scope review stops it *before the first
-edit*, which is usually the outcome you actually wanted.
+A spend limit stops a run partway through. A scope review stops it *before
+the first edit*, which is usually what you actually wanted.
 
-When a plan's blast radius crosses any of three thresholds, stella pauses and
-shows you the plan:
+When a plan's size crosses any of three limits, stella pauses and shows you
+the plan:
 
 <CardGrid size="sm">
   <OptionCard name="max_steps" defaultValue="5">
     More than this many steps in the plan.
   </OptionCard>
   <OptionCard name="max_files" defaultValue="8">
-    Estimated files-touched count above this.
+    Estimated number of files touched above this.
   </OptionCard>
   <OptionCard name="max_cost_usd" defaultValue="1.00">
     Estimated cost above this.
   </OptionCard>
 </CardGrid>
 
-Every comparison is a strict `>`, so a plan sitting exactly on a threshold
-passes without a gate. At the card, `a` approves, `t` trims to the largest
-prefix that would not have tripped review, and `x` aborts. Anything longer than
-one of those words is read as *what you want changed*, sending the plan back to
-the planner with your note attached.
+Every check is a strict "greater than," so a plan that lands exactly on a
+limit passes without pausing. When it pauses, `a` approves the plan, `t`
+trims it down to the largest version that would not have triggered the
+pause, and `x` cancels it. Anything longer than one of those letters is
+read as *what you want changed*, and sends the plan back with your note
+attached.
 
-The rule a headless run needs from a gate like this is that it must never
-silently auto-approve itself: with nobody to ask, a plan over the thresholds
-should end the run rather than wave itself through, because a scope gate that
-approves itself in CI is not a scope gate. That is a property to check a
-verification plugin for — it is not something this binary decides any more, and
-no setting here turns it on or off.
+A gate like this needs one rule to be useful in an unattended run: it must
+never approve itself automatically. With nobody there to answer, a plan
+that's over the limits should stop the run, not wave itself through —
+because a scope check that approves itself in CI isn't really a check.
+That's something to verify a plugin actually does. It isn't a setting this
+program controls, and no flag here turns it on or off.
 
 ## What the money is actually spent on
 
-Before tuning anything, know the shape of the bill — most attempts to economize
-target the wrong stage.
+Before you tune anything, know the shape of the bill. Most attempts to save
+money target the wrong stage.
 
 | Stage | Model calls | Cost share |
 | --- | --- | --- |
@@ -116,21 +118,22 @@ target the wrong stage.
 | Plan | 1 (+1 repair, rarely) | small |
 | Witness | ~1 engine turn | only when you pass no `--test-command` |
 | **Execute** | **5–40+ steps** | **most of the bill** |
-| Verify | 0 | free — the deterministic ladder |
+| Verify | 0 | free — the deterministic checks |
 | Verifier | 0–1 per verification | cents |
 
-Three consequences follow, and they are most of what you need:
+Three things follow from that, and they're most of what you need to know:
 
-1. **The worker's output price dominates.** Moving the worker to a cheaper model
-   changes the bill several-fold. Moving the verifier barely changes it at all.
-2. **A flagship verifier is cheap insurance.** One verifier call is a few thousand
-   input tokens and under a thousand out. Keep it in a *different family* than
-   the worker.
-3. **`--test-command` is the strongest cost flag on a wrapped run.** It arms the
-   bound plugin's deterministic flip oracle, so most runs finish on evidence
-   alone with the **verifier skipped entirely** — and it skips the
-   witness-author call too. It is refused on the raw loop, which spends none of
-   those calls in the first place.
+1. **The worker's model price dominates the bill.** Switching the worker to
+   a cheaper model changes the total by several times over. Switching the
+   verifier barely moves it at all.
+2. **A top-tier verifier is cheap insurance.** One verifier call is a few
+   thousand input tokens and under a thousand output tokens. Keep it on a
+   *different model family* than the worker.
+3. **`--test-command` is the strongest cost-saving flag on a wrapped run.**
+   It arms the plugin's built-in fail-then-pass check, so most runs finish
+   on that evidence alone, **skipping the verifier entirely** — and it also
+   skips the witness-writing call. It's not accepted on the raw loop, which
+   never makes those calls in the first place.
 
 ```bash
 # Cheapest correct shape when the result must carry evidence:
@@ -141,68 +144,75 @@ stella --spend-limit 1.50 run --pipeline my-verifier \
 
 ## The multipliers
 
-A ceiling only helps if you know what is pushing against it.
+A ceiling only helps if you know what's pushing against it.
 
 <CardGrid size="md">
   <OptionCard name="Goal mode">
-    Repeats judged rounds until the objective is met, up to **8**. Each round is a
-    full working turn. `stella monitor` is goal mode, so it has the same shape.
+    Repeats checked rounds until the goal is met, up to **8**. Each round is
+    a full working turn. `stella monitor` runs on goal mode, so it costs the
+    same way.
   </OptionCard>
   <OptionCard name="Fleets">
-    One engine run per task. Worker spend meters into the **parent** spend limit, so
-    `--spend-limit` is a single shared ceiling across the whole fan-out rather than a
-    per-worker allowance — and the run stops early once it trips.
+    One engine run per task. Worker spend counts against the **parent**
+    spend limit, so `--spend-limit` is one shared ceiling across the whole
+    group of tasks, not a separate allowance per worker — and the whole run
+    stops early once it's used up.
   </OptionCard>
   <OptionCard name="Best-of-N">
-    Generates N candidate executions and keeps the best by verification score, at N×
-    the execution cost. Strictly opt-in, for exactly this reason.
+    Runs N different attempts and keeps the best one by verification score,
+    at N times the normal cost. This is strictly something you turn on, for
+    exactly this reason.
   </OptionCard>
   <OptionCard name="Revisions">
-    A failed verification sends the worker back with the evidence, bounded at 2
-    revision turns by default.
+    A failed verification sends the worker back with the evidence attached,
+    limited to 2 revision attempts by default.
   </OptionCard>
 </CardGrid>
 
-## When the transcript outgrows the window
+## When the conversation outgrows the window
 
-A long run's cost is not only what it does — it is how much conversation it
-carries while doing it. When the transcript approaches the compaction budget
-(**150,000 tokens** by default), stella compacts it and keeps going, rather than
-failing or silently truncating.
+A long run's cost isn't only what it does. It's also how much conversation
+it has to carry while doing it. When the conversation gets close to the
+compaction budget (**150,000 tokens** by default), stella shortens it and
+keeps going, instead of failing or silently cutting content.
 
-Compaction applies four mechanisms, **least-lossy first**:
+Shortening happens in four steps, from **least to most lossy**:
 
-1. **Dedup.** A byte-identical tool output appearing more than once keeps only
-   its earliest copy; later ones become a pointer to it.
-2. **Supersession.** When the same call ran twice with identical input, only the
-   latest result reflects current state — the older ones are stale by
-   construction and get stubbed.
-3. **Aging.** Still over budget, large old outputs are middle-out truncated to
-   head plus tail. The head carries the tool's framing (a `PASSED`/`FAILED` line,
-   file headers) and the tail carries the errors, so what survives is the part
-   worth reading.
-4. **Eviction.** Only then are the oldest large tool outputs replaced with a
-   stub — and a result whose call is still the most recent one is never evicted.
+1. **Remove duplicates.** If the exact same tool output appears more than
+   once, only the earliest copy is kept — later copies just point back to
+   it.
+2. **Remove outdated results.** When the same call ran twice with the same
+   input, only the newest result reflects the current state, so the older
+   ones are stripped out as stale.
+3. **Trim old content.** If it's still over budget, large old outputs get
+   cut down to their beginning and end. The beginning keeps the tool's
+   framing (a `PASSED`/`FAILED` line, file headers), and the end keeps the
+   errors — so what's left is the part worth reading.
+4. **Drop content entirely.** Only after that are the oldest large outputs
+   replaced with a placeholder — and a result that's still the most recent
+   one for its call is never dropped.
 
-The system message and the latest user message are never touched.
+The system message and your latest message are never touched.
 
 <Callout type="info">
-Dedup keeps the **earliest** copy on purpose. Byte-identical content is
-position-independent, so stubbing the later one puts the change in the *newest*
-part of the conversation and leaves the provider's prompt-cache prefix
-byte-identical. Compacting the other way around would save tokens and then lose
-far more money to a cold cache than it saved.
+Keeping the **earliest** copy during deduplication is deliberate.
+Identical content doesn't depend on where it sits, so shortening the later
+copy instead would put the change in the *newest* part of the conversation
+and break the provider's cached prefix. Doing it the other way would save a
+few tokens and then lose much more money to a cold cache than it saved.
 </Callout>
 
-If a conversation is still over budget after all four passes, an **overflow
-summarizer** runs — a real extra model call, recorded at `--call-seq 1` for that
-step. Seeing those in [`stella inspect`](/docs/commands/inspect) is the sign a
-run's transcript, not its work, is what got expensive.
+If a conversation is still over budget after all four steps, an **overflow
+summarizer** runs — a real, extra model call, recorded as `--call-seq 1` for
+that step. Seeing these in [`stella inspect`](/docs/commands/inspect) is
+the sign that a run's conversation, not its actual work, is what got
+expensive.
 
 ## Picking the number
 
-Set the spend limit by observation, not by intuition. Run the class of task once
-unbounded, read what it cost, then set a ceiling with headroom:
+Set your spend limit from what you've actually seen, not a guess. Run the
+kind of task once with no limit, check what it cost, then set a ceiling
+with some room to spare:
 
 ```bash
 stella run "the representative task"           # observed mode
@@ -210,25 +220,27 @@ stella stats --format text                    # what it actually cost
 stella --spend-limit 2.00 run "the next one"   # now with a ceiling
 ```
 
-The number to steer on over time is **$/resolved**, not sticker price — a cheap
-model that needs three attempts is not cheap. The
-[Observatory](/docs/telemetry/dashboard) tracks it per model, and
-[Examples & recipes](/docs/examples) has complete configurations at four
-different price points.
+The number worth tracking over time is **cost per task solved**, not the
+sticker price — a cheap model that needs three tries isn't actually cheap.
+The [Observatory](/docs/telemetry/dashboard) tracks this per model, and
+[Examples & recipes](/docs/examples) has full setups at four different
+price points.
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="Telemetry & budget" href="/docs/telemetry#budget-observed-vs-enforced">
-    The reference for observed vs. enforced, and what the local store records.
+    The reference for observed versus enforced spend, and what the local
+    store records.
   </SpecCard>
   <SpecCard title="Examples & recipes" href="/docs/examples">
-    Complete settings files from dirt-cheap to maximum-quality, with cost estimates.
+    Complete settings files from very cheap to maximum quality, with cost
+    estimates.
   </SpecCard>
   <SpecCard title="Find out what a run cost" href="/docs/guides/what-a-run-cost">
     Accounting for a run after the fact, down to the individual model call.
   </SpecCard>
   <SpecCard title="Plugins" href="/docs/plugins">
-    Every stage, what it costs, and when it is skipped.
+    Every stage, what it costs, and when it gets skipped.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/terminal-bench-head-to-head.mdx
+++ b/website/content/docs/guides/terminal-bench-head-to-head.mdx
@@ -1,63 +1,68 @@
 ---
 title: Benchmark stella against Claude Code
-description: Run Terminal-Bench 2.1 with stella in one arm and Claude Code in the other — the setup, and the parity checks that make the comparison mean anything.
+description: Run Terminal-Bench 2.1 with stella in one arm and Claude Code in the other — the setup, and the checks that make the comparison mean anything.
 ---
 
 You want a number: on the same tasks, with the same model, does stella solve
-more than Claude Code — and at what cost? Terminal-Bench 2.1 is 89 containerized
-terminal tasks with a deterministic grader, which makes it the right instrument.
-Running it *twice*, once per agent, is the head-to-head.
+more than Claude Code, and at what cost? Terminal-Bench 2.1 is 89
+containerized terminal tasks with an automatic grader, which makes it a
+solid tool for this. Running it *twice*, once per agent, gives you the
+head-to-head.
 
-The hard part is not running the benchmark. It is making the two runs
-**comparable**, and most of this page is about that, because a head-to-head that
-differs in a second variable measures nothing and costs the same money.
+The hard part isn't running the benchmark. It's making the two runs
+**comparable**, and most of this page is about that, because a comparison
+where a second variable also changes tells you nothing, and costs the same
+money either way.
 
 ## The shape of it
 
-Two Harbor jobs over one frozen dataset. Arm A is stella, arm B is Claude Code:
+Two Harbor jobs over one frozen set of tasks. Arm A is stella, arm B is
+Claude Code:
 
 ```
 <tag>-armA-stella        harbor run --agent-import-path stella_harbor:StellaAgent
 <tag>-armB-claudecode    harbor run --agent claude-code
 ```
 
-Same dataset digest, same model, same concurrency, same task list, one attempt
-each. Then both job directories are ingested into SQLite and joined on
+Same task set, same model, same concurrency, same task list, one attempt
+each. Then both sets of results get loaded into SQLite and joined by
 `task_name`.
 
 <Callout type="warn">
-This is the **development-baseline** path — a number you can trust internally and
-publish with its method attached. It is deliberately *not* the audited public
-claim path, which adds a preregistration ledger, host attestations and a
-spend-capped key on a dedicated Linux host. That procedure is
+This is the **internal-baseline** path — a number you can trust for your own
+use and publish alongside its method. It is deliberately *not* the path used
+for an audited public claim, which adds a preregistration log, host checks,
+and a spend-capped key on a dedicated Linux machine. That process is
 [`bench/RUNBOOK.md`](https://github.com/macanderson/stella/blob/main/bench/RUNBOOK.md);
 read [`bench/README.md`](https://github.com/macanderson/stella/blob/main/bench/README.md)
-for the line between them before publishing anything from here.
+to understand the line between the two before you publish anything from
+here.
 </Callout>
 
 ## Before you start
 
 <CardGrid size="md">
   <OptionCard name="A Docker host that runs linux/amd64">
-    Native x86_64 is simplest. Apple Silicon works through Rosetta — measured at
-    roughly native speed on a fixed CPU workload, with no degradation at three
-    concurrent containers, so no timeout multiplier is warranted.
+    Native x86_64 is simplest. Apple Silicon works through Rosetta — tests
+    show roughly native speed on a fixed CPU workload, with no slowdown at
+    three containers running at once, so no extra timeout is needed.
   </OptionCard>
   <OptionCard name="Memory for the largest task">
-    Eight tasks want 8 GiB and three want 4 CPU. A host smaller than the largest
-    task must split the run by resource class rather than shrink the tasks.
+    Eight tasks need 8 GiB, and three need 4 CPUs. A host smaller than the
+    largest task has to split the run by resource size instead of shrinking
+    the tasks.
   </OptionCard>
-  <OptionCard name="~20 GiB of disk and patience">
-    The 89 task images are about 18.5 GiB. On a slow link the pull dominates the
-    schedule.
+  <OptionCard name="About 20 GiB of disk and some patience">
+    The 89 task images add up to about 18.5 GiB. On a slow connection, the
+    download is the slowest part.
   </OptionCard>
   <OptionCard name="uv, zig, cargo-zigbuild, rustup">
-    `uv` provisions the adapter venv; the zig toolchain cross-compiles the stella
-    binary that runs *inside* the task containers.
+    `uv` sets up the adapter's environment. The zig toolchain cross-compiles
+    the stella binary that runs *inside* the task containers.
   </OptionCard>
   <OptionCard name="Two API keys, one per arm">
-    Not one key shared. See [keys](#give-each-arm-its-own-key) — this is a
-    measurement decision, not bookkeeping.
+    Not one key shared between both. See [keys](#give-each-arm-its-own-key)
+    — this is about getting an accurate measurement, not just bookkeeping.
   </OptionCard>
 </CardGrid>
 
@@ -70,131 +75,138 @@ export TB_ROOT=/absolute/path/for/run/scratch     # dataset, jobs, logs
 uv sync --project "$TB_REPO/bench/harbor_adapter" --locked --extra dev
 ```
 
-That installs **Harbor 0.6.1**, and the pin is required. It is an *audited
-constant*, not an upgrade candidate: the adapter refuses to launch unless
-`harbor.__version__` matches exactly, five other sites name it, and
-`.github/dependabot.yml` ignores the package because an automated bump to 0.20.0
-once broke the run path for five days.
+That installs **Harbor 0.6.1**, and this exact version is required, not
+optional. It's a fixed, checked constant, not something to casually upgrade:
+the adapter refuses to start unless `harbor.__version__` matches exactly,
+five other places name this version directly, and `.github/dependabot.yml`
+ignores this package because an automatic update to 0.20.0 once broke the
+whole run path for five days.
 
-The version also decides the CLI spelling. In 0.6.1 the stella arm is selected
-with `--agent-import-path`; 0.20.0 folded that into `--agent`. If you ever move
-off the pin, check the help text before spending anything —
-`harbor run --help` is the authority, and Harbor renders it through Rich, so
-scrub ANSI before searching it:
+The version also decides how you type the command. In 0.6.1, you select the
+stella arm with `--agent-import-path`. In 0.20.0, that became `--agent`. If
+you ever move off this pinned version, check the help text before spending
+any money — `harbor run --help` is the source of truth, and since Harbor
+renders that help text with color codes, strip those out before searching
+it:
 
 ```bash
 harbor run --help 2>&1 | LC_ALL=C sed $'s/\033\[[0-9;?]*[a-zA-Z]//g' \
   | rg -- '--agent|--ak'
 ```
 
-Check `--ak` (the agent-kwargs flag, used below to pass Claude Code its effort
-tier) at the same time — it is the other spelling that has moved. Asserting the
-flags a script passes still appear in the help text costs one subprocess and
-turns a mid-run `No such option` into one message before launch.
+Check `--ak` (the flag used below to set Claude Code's effort level) at the
+same time — it's the other flag name that has changed between versions.
+Checking that both flags still appear in the help text costs one command
+and turns a mid-run "no such option" error into a warning before you've
+spent anything.
 
 ## 2. Build a binary that can actually run in the containers
 
-The single most expensive mistake in this whole procedure, so it gets its own
-step.
+This is the single most expensive mistake in the whole process, so it gets
+its own step.
 
 ```bash
 bench/evidence/run/build_sut.sh
 ```
 
-This cross-compiles stella against `x86_64-unknown-linux-gnu.2.17` via
-`cargo-zigbuild`. That glibc floor is what lets **one** binary execute in every
-task image — including the two on `debian:bullseye-slim`, whose glibc 2.31 is the
-oldest in the dataset.
+This cross-compiles stella for `x86_64-unknown-linux-gnu.2.17` using
+`cargo-zigbuild`. That minimum glibc version is what lets **one** binary run
+in every task image, including the two built on `debian:bullseye-slim`,
+which has the oldest glibc (2.31) in the whole set.
 
 <Callout type="warn">
-Do **not** substitute a plain `cargo build --release` artifact into the path the
-scripts export as `STELLA_BINARY`. On 2026-07-31 a run provisioned that way lost
-five trials before the agent ever started. Every integrity check still passed,
-because they all answer *did the file arrive intact* — and it had. Nothing
-answered *can this file run here*. Harbor recorded `NonZeroAgentExitCodeError`
-and scored each trial 0.0, which under a fixed denominator is arithmetically
-indistinguishable from stella failing those tasks.
+Do **not** swap in a binary from a plain `cargo build --release` for the
+path the scripts export as `STELLA_BINARY`. On 2026-07-31, a run set up
+that way lost five trials before the agent even started. Every integrity
+check still passed, because those checks only answer *did the file arrive
+intact* — and it had. Nothing answered *can this file actually run here*.
+Harbor logged `NonZeroAgentExitCodeError` and scored each trial 0.0, which
+under a fixed denominator looks exactly the same as stella actually failing
+those tasks.
 </Callout>
 
-A host-side preflight now refuses to start a run whose binary requires a glibc
-symbol above the floor. To inspect one directly:
+A check on the host machine now refuses to start a run if the binary needs a
+glibc feature above that minimum. To check one directly:
 
 ```bash
 python3 bench/harbor_adapter/stella_harbor/portability.py "$STELLA_BINARY" --json
 ```
 
-No musl build is needed, and that is a checked property of the pinned dataset
-rather than an assumption: all 89 task images are glibc-based. Repin the dataset
-and the tally has to be re-run.
+No musl build is needed, and that's a checked fact about this specific task
+set, not an assumption: all 89 task images are built on glibc. If you ever
+swap in a different task set, this needs to be checked again.
 
-## 3. Fetch and pre-pull the dataset
+## 3. Fetch and pre-download the dataset
 
 ```bash
 bench/evidence/run/fetch_dataset.sh    # the pinned 89-task set, by digest
 bench/evidence/run/prepull.sh          # ~18.5 GiB, with retries
 ```
 
-The pre-pull is not optional. The first attempt at a measured run lost four
-trials in its opening minutes to `TLS handshake timeout` while Docker Hub served
-image blobs. The container never started and spend was `$0.0000` — but with
-`--max-retries 0` each one is a permanent reward-`0` row, indistinguishable from
-a genuine failure. **Registry flakiness must not be able to enter the score.**
+The pre-download step is not optional. The first attempt at a real
+measured run lost four trials in its opening minutes to a
+`TLS handshake timeout` while Docker Hub was serving image data. The
+container never started, and it recorded spend of `$0.0000` — but with
+`--max-retries 0`, each one of those becomes a permanent zero-score row,
+indistinguishable from a real failure. **A flaky registry connection must
+never be able to affect the score.**
 
-The dataset is pinned by digest, not by name. An unversioned name is not a
-freeze, and the bare-name path (`harbor datasets download`) does not resolve
-anyway — use `harbor download <org/name@sha256:…>` and pass that same literal
+The task set is pinned by digest, not by name. An unversioned name is not a
+real freeze, and the plain-name path (`harbor datasets download`) doesn't
+even work — use `harbor download <org/name@sha256:…>` and pass that exact
 string to `harbor run --dataset`.
 
 ## 4. Make the two arms comparable
 
-Everything so far applies to a solo stella run. This step is what makes it a
-head-to-head, and it is the step people skip.
+Everything up to here works for a solo stella run. This step is what turns
+it into a real head-to-head, and it's the step people skip.
 
 ### Pick one API surface for both arms
 
-Route both arms **directly at the provider**, on the same model. Proxying one
-arm through an aggregator introduces two confounds at once: the same model slug
-can be served by different upstream providers depending on app identity — a
-price spread of more than 3x has been observed — and Claude Code proxied that way
-runs with reasoning **off**, which is not the tool anyone means to compare
-against.
+Send both arms **directly to the provider**, using the same model. Routing
+one arm through an aggregator introduces two problems at once: the same
+model name can be served by different backend providers depending on the
+app's identity — a price difference of more than 3x has been seen — and
+Claude Code routed that way runs with reasoning turned **off**, which isn't
+the tool anyone actually means to compare.
 
-Hitting `api.anthropic.com` directly on a single model gives one backend and no
-routing lottery — Claude Code on its home API, where thinking engages
-natively.
+Hitting `api.anthropic.com` directly, on one model, gives you one backend
+and no routing lottery — Claude Code running on its home API, with
+reasoning working the normal way.
 
 ### Pin the upstream when either arm goes through a gateway
 
-Sometimes routing directly at the provider is not an option — a gateway may be
-the only surface with the model or the credential you need. If either arm goes
-through OpenRouter (or any other gateway), the routing lottery in the section
-above is not merely a confound to avoid by routing around it; it is a variable
-you can pin instead: **`--upstream-pin <vendor>`** fixes stella's arm to a
-named upstream, in order, and refuses fallback rather than letting the gateway
-silently pick per app identity.
+Sometimes you can't route directly to the provider — a gateway may be the
+only way to reach the model or credential you need. If either arm goes
+through OpenRouter (or any other gateway), the routing lottery from the
+section above isn't just something to avoid by routing around it. It's a
+variable you can pin instead: **`--upstream-pin <vendor>`** locks stella's
+arm to a named backend, in order, and refuses to silently fall back to a
+different one the way a gateway might on its own.
 
 ```bash
 stella run "…" --model openrouter/anthropic/claude-fable-5 \
   --upstream-pin anthropic
 ```
 
-This is the flag's actual reason to exist: a run's `--model` names a model
-family, not a vendor, and two arms that both say "Claude" through a gateway
-have not shown they were served by the same silicon unless the pin — or a
-direct endpoint — says so. Pass `--upstream-pin` on the launch command
-directly, never through `settings.json`. The Harbor trial launches stella with
-**`STELLA_NO_SETTINGS=1`** — filesystem isolation so a task repository cannot
-plant configuration a trial would trust — and a settings-defined pin would
-therefore never reach the process being measured. A command-line argument is
-the only authority that survives that isolation, which is the same reason
-`--base-url` is passed as a flag here rather than configured.
+This is the actual reason this flag exists: a run's `--model` names a model
+family, not a specific vendor, and two arms that both say "Claude" through
+a gateway haven't proven they were served by the same hardware unless the
+pin, or a direct connection, confirms it. Pass `--upstream-pin` directly on
+the launch command, never through `settings.json`. The Harbor trial starts
+stella with **`STELLA_NO_SETTINGS=1`** — meaning it can't read local
+settings files, so a task's own repository can't quietly plant
+configuration a trial would trust. A pin set in `settings.json` would
+never reach the process being measured. A command-line flag is the only
+setting that survives that isolation, which is also why `--base-url` is
+passed as a flag here instead of being set in configuration.
 
 See [API providers → pinning the upstream](/docs/api-providers#pinning-the-upstream)
-for why this exists and what it does on the wire.
+for why this exists and what it changes on the wire.
 
 ### Give each arm its own key
 
-Two keys on the same account, one per arm:
+Use two keys on the same account, one per arm:
 
 ```bash
 # ~/.env.harbor-anthropic.local — loaded, never echoed, never passed in argv
@@ -202,55 +214,58 @@ STELLA_ANTHROPIC_API_KEY=...
 CLAUDE_CODE_ANTHROPIC_API_KEY=...
 ```
 
-This buys two things. Spend becomes attributable per arm without parsing
-trajectories, and neither arm's rate limiting can starve the other — which would
-otherwise show up as the slower arm timing out and losing tasks it would have
-solved.
+This gets you two things. You can tell how much each arm spent without
+digging through logs, and neither arm's rate limits can slow down the
+other — which would otherwise look like the slower arm timing out and
+losing tasks it could have solved.
 
-### Pin reasoning effort on both, then prove it landed
+### Pin reasoning effort on both, then prove it worked
 
-Both arms should be pinned to the same effort tier, by whatever mechanism each
-one actually honors:
+Both arms should use the same effort level, by whatever setting each one
+actually respects:
 
-- **stella** — the frozen benchmark posture (`agents.<role>.effort`), which is
-  asserted by digest rather than by reading the constant, so the value the
-  launcher delivers and the value you assert cannot drift apart.
+- **stella** — the frozen benchmark setting (`agents.<role>.effort`), which
+  gets checked against a stored digest instead of just reading the setting
+  value, so what actually gets used and what you think you set can't drift
+  apart without you noticing.
 - **Claude Code** — `harbor --ak reasoning_effort=<tier>`, which Harbor's
-  `ClaudeCode` agent maps onto the CLI's real `--effort` flag. Pass it
-  explicitly rather than trusting the documented default, so the setting is a
-  property of the recorded command.
+  `ClaudeCode` agent turns into the CLI's real `--effort` flag. Set it
+  explicitly rather than trusting the documented default, so the value is
+  captured in the recorded command.
 
-Then check it, before spending:
+Then check it actually landed, before you spend anything:
 
 ```bash
 bench/evidence/run/preflight_effort.sh claude-sonnet-5 xhigh
 ```
 
 <Callout type="info">
-Why a separate instrument: the older parity preflight proved both keys reached
-the same model with thinking **on**, and said nothing about **effort** — the
-headline setting of a pinned-effort run. A flag that is passed, assumed
-effective, and never checked on the wire is what voided three earlier
-head-to-heads. The probe is behavioral (same prompt at `low` versus the target
-tier, asserting strictly greater) because *accepted* and *acted on* are
-different claims, and only one of them is the point.
+Why a separate check is needed: an earlier version of this check confirmed
+both keys reached the same model with reasoning **on**, but said nothing
+about the **effort level** — the actual setting this whole comparison
+depends on. A flag that gets passed, assumed to work, and never verified on
+the wire is what invalidated three earlier comparisons. This check actually
+tests behavior — the same prompt at `low` versus the target level, checking
+that the result is clearly different — because *the flag was accepted* and
+*the flag changed anything* are different claims, and only one of them
+matters.
 </Callout>
 
-That check hit two traps on itself, both now encoded in it. A probe saturated at
-`max_tokens` compares the cap to itself and "passes" while proving nothing. And
-a non-streaming request with a large `max_tokens` dies on the read timeout
-before it returns.
+That check ran into two problems of its own, both fixed in how it works
+now. A test that maxes out `max_tokens` just compares the limit to itself,
+and "passes" without proving anything. And a request without streaming and
+a high `max_tokens` can time out before it ever returns.
 
-### Decide the per-trial spend cap deliberately
+### Decide the per-trial spend cap on purpose
 
-stella can be given a per-trial budget. Claude Code, as Harbor runs it, has no
-spend ceiling. Leaving stella's default cap in place therefore hands the
-comparator an advantage that will not appear anywhere in the output — stella's
-capped trials simply abort and score 0.
+stella can be given a spending limit per trial. Claude Code, as Harbor runs
+it, has no spending limit at all. Leaving stella's default cap in place
+gives the other agent an advantage that won't show up anywhere in the
+results — stella's capped trials just stop and score 0.
 
-Setting `STELLA_SPEND_LIMIT` to the empty string means *no per-trial cap*, and that
-posture is reachable on purpose. Choose it explicitly, and record which you
-chose.
+Setting `STELLA_SPEND_LIMIT` to an empty value means *no per-trial cap*,
+and that's a real, intentional choice you can make. Pick it on purpose, and
+write down which one you picked.
 
 ```bash
 export STELLA_SPEND_LIMIT=          # empty: no per-trial cap, matching the comparator
@@ -258,22 +273,22 @@ export STELLA_SPEND_LIMIT=          # empty: no per-trial cap, matching the comp
 
 ## 5. Run both arms
 
-Sentinel first — one paid synthetic trial that must return reward 1.0 before 89
-of them depend on the same path:
+Run a check first: one paid test trial that must score 1.0 before 89 real
+trials depend on the same setup:
 
 ```bash
 bench/evidence/run/sentinel.sh
 ```
 
-Then the arms. The committed scripts drive **arm A**:
+Then the arms. The scripts already in the repository run **arm A**:
 
 ```bash
 bench/evidence/run/primary.sh ALL "<tag>-armA-stella"
 ```
 
-Arm B is the same `harbor run` with the agent swapped and the comparator's
-effort passed through — same dataset literal, same task list, same concurrency,
-same `--n-attempts 1 --max-retries 0`:
+Arm B is the same `harbor run` command with the agent swapped and the
+comparator's effort level passed through — same task set, same task list,
+same concurrency, same `--n-attempts 1 --max-retries 0`:
 
 ```bash
 source bench/evidence/run/env.sh     # exports TB_DATASET and JOBS
@@ -289,112 +304,121 @@ harbor run \
   --n-attempts 1 --n-concurrent 3 --max-retries 0
 ```
 
-Set `--n-concurrent` to the number arm A actually ran at, and pass the same
-`--include-task-name` list if you scoped arm A to a subset. Concurrency is not a
-free parameter in a head-to-head: it changes how much CPU and memory each trial
-gets, and a comparator run at a different width is running a different benchmark.
+Set `--n-concurrent` to whatever arm A actually ran at, and pass the same
+`--include-task-name` list if you limited arm A to a subset of tasks.
+Concurrency isn't a free choice in a head-to-head — it changes how much CPU
+and memory each trial gets, so running the comparator at a different width
+is really running a different benchmark.
 
-The `armA` / `armB` segments in the job names are not cosmetic — the ingester
-matches on them, and it matches on the segment rather than the whole suffix so
-an archived or voided run still resolves.
+The `armA` and `armB` labels in the job names aren't just cosmetic — the
+tool that loads the results matches on that part of the name specifically,
+so an archived or renamed run can still be found.
 
 <Callout type="info">
-**Splitting by resource class.** On a host that cannot hold the largest task
-alongside its neighbours, run in two phases: phase A is tasks wanting ≤4 GiB and
-1 CPU at `n_concurrent=3`, phase B is the rest at `n_concurrent=1`
-(`primary.sh A` / `primary.sh B`). The union is still every task, one attempt
-each, over one denominator. Run phase B first if images are still downloading.
-The split is a host limitation, not part of the measurement.
+**Splitting by resource size.** On a host that can't fit the largest task
+alongside its neighbors, run in two phases: phase A is tasks needing ≤4 GiB
+and 1 CPU, at `n_concurrent=3`; phase B is everything else, at
+`n_concurrent=1` (`primary.sh A` / `primary.sh B`). Together they still
+cover every task, one attempt each, over one total count. Run phase B first
+if images are still downloading. This split is a limit of your host, not
+part of the actual measurement.
 </Callout>
 
 ### Rules the run has to follow to mean anything
 
-- **Fixed denominator.** Every task counts. Errors, timeouts, budget-cap hits and
-  missing rows all score 0 and stay in.
-- **No outcome-selected anything.** A discouraging early score is not a reason to
-  stop, change a parameter, or start over. Operational aborts — registry, VM,
-  balance, credentials — are allowed, must be disclosed, and must relaunch under
-  a **new job name**. A claim job never resumes.
-- **Publish the failures.** The per-task table lists every task, including the
-  ones that failed for infrastructure reasons.
+- **Fixed total count.** Every task counts. Errors, timeouts, budget-cap
+  hits, and missing rows all score 0 and stay in the total.
+- **No stopping or restarting based on the outcome.** A discouraging early
+  score is not a reason to stop, change a setting, or start over. You can
+  cancel a run for operational reasons — a registry outage, a VM problem, a
+  billing issue, bad credentials — but you must say so, and restart under a
+  **new job name**. A run meant to support a public claim never resumes.
+- **Publish the failures too.** The per-task table should list every task,
+  including the ones that failed for infrastructure reasons.
 
-## 6. Score it — and recompute the cost
+## 6. Score it, and recompute the cost
 
 ```bash
 python3 bench/telemetry_store/ingest.py \
   --db ~/.stella/bench.db --jobs "$JOBS" --run "<tag>" --kind scored
 ```
 
-Ingest is idempotent: re-running replaces a run rather than duplicating it. The
-unit of truth is the **trial**; a run is a bag of trials and the comparison is a
-join of the two arms over `task_name`. No derived verdict is stored — pass/fail
-is `reward >= 1` from the benchmark's own grader, kept raw so a later reader can
-re-derive it instead of trusting it.
+Loading results is safe to redo — running it again replaces a run instead
+of duplicating it. The basic unit is the **trial**. A run is just a
+collection of trials, and the comparison joins the two arms together by
+`task_name`. No pass/fail verdict is stored on its own — it's `reward >= 1`
+from the benchmark's own grader, kept as raw data so anyone reading it
+later can recompute it instead of just trusting a stored value.
 
 <Callout type="warn">
-**Self-reported cost can invert the ranking.** On one smoke dataset the agents'
-own numbers said Claude Code $2.65 / stella $3.27, while a single price table
-applied to both said Claude Code $3.00 / stella $1.93 — the opposite ordering.
-Always publish a recomputed, normalized cost. The price table in
-`bench/terminal_bench_analysis/normalized_cost.py` strips the routing prefix
-stella carries and the comparator does not, so `anthropic/claude-sonnet-5` and
-`claude-sonnet-5` hit one row — but it still needs an entry for the model
-itself, and for the date the run happened on when that model's rate has
-changed.
+**Numbers reported by the agents themselves can flip the ranking.** On one
+small test set, the agents' own self-reported costs said Claude Code $2.65
+and stella $3.27, while applying one shared price table to both said Claude
+Code $3.00 and stella $1.93 — the opposite order. Always publish a
+recomputed, standardized cost. The price table in
+`bench/terminal_bench_analysis/normalized_cost.py` strips the routing
+prefix stella includes that the comparator doesn't, so
+`anthropic/claude-sonnet-5` and `claude-sonnet-5` match up as the same
+model — but it still needs an entry for that model, and for whatever day
+the run happened, in case the price changed since.
 </Callout>
 
-Ingest computes the normalized cost itself rather than leaving it for a later
-step, because it already holds every input: the token counts, the model the
-trial ran (`config.agent.model_name`, which beats the `--model` label when they
-disagree), and the day it ran on. It writes `wall_seconds`, `started_at` and
-`finished_at` at the same time.
+Loading results computes the standardized cost itself instead of leaving it
+for a later step, since it already has everything it needs: the token
+counts, the model the trial actually ran on
+(`config.agent.model_name`, which is used over the `--model` label whenever
+they disagree), and the date it ran. It also records `wall_seconds`,
+`started_at`, and `finished_at` at the same time.
 
-When it *cannot* price a trial it writes NULL and says why in
-`cost_norm_status`, so an absent figure can never be read as a computed zero:
+When it *can't* price a trial, it writes an empty value and records why in
+`cost_norm_status`, so a missing number can never be mistaken for a real
+zero:
 
 | `cost_norm_status` | Meaning |
 | --- | --- |
-| `priced` | The only state in which `cost_usd_norm` means anything. A genuine $0.00 here is a real measurement. |
+| `priced` | The only state where `cost_usd_norm` means anything. A real $0.00 here is a genuine result. |
 | `no_model` | Neither the trial nor `--model` named a model. |
-| `unpriced_model` | No rate in the table applies to that model on that day. |
-| `no_tokens` | The trial crashed before reporting usage. Charging it zero would make a crash look free. |
-| `no_run_date` | The model's rate changed and the trial has no readable start time, so no entry can be chosen. |
-| `unmigrated` | Written by an ingester that predates the column. |
+| `unpriced_model` | No price in the table applies to that model on that day. |
+| `no_tokens` | The trial crashed before reporting any usage. Charging it zero would make a crash look free. |
+| `no_run_date` | The model's price changed and the trial has no readable start time, so no price could be chosen. |
+| `unmigrated` | Written before this column existed. |
 
-**Any query that aggregates `cost_usd_norm` must filter on
-`cost_norm_status = 'priced'`.** Ingest also prints a count of the unpriced
-trials per run, so a comparable-cost column that is empty for a whole arm shows
-up at load time rather than as a hole in a published table.
+**Any query that adds up `cost_usd_norm` must filter for
+`cost_norm_status = 'priced'`.** Loading results also prints how many
+trials per run couldn't be priced, so a comparable-cost column that's empty
+for a whole arm shows up right away instead of as a silent gap in a
+published table.
 
-## The two things you cannot pin
+## The two things you cannot pin down
 
 Worth knowing before you write up a result.
 
-**Claude Code's version is not pinned.** Harbor installs it per trial from
-`claude.ai/install.sh`, so the comparator can move between your run and someone
-else's. Read the resolved version out of the per-trial trajectory and report it;
-never assume it.
+**Claude Code's version isn't pinned.** Harbor installs it fresh for each
+trial from `claude.ai/install.sh`, so the version you compared against can
+be different from someone else's run. Read the actual version out of each
+trial's log and report it. Never assume it stayed the same.
 
-**The grader is the benchmark's, not yours.** That is a feature — it is why the
-number is worth anything — but it means a task the grader scores 0 for a reason
-you disagree with is still a 0. Argue with it in the write-up, not in the
-denominator.
+**The grader belongs to the benchmark, not to you.** That's actually a good
+thing — it's what makes the number worth anything — but it means a task the
+grader scores 0 for a reason you disagree with is still a 0. Argue with the
+grader in your write-up, not by changing the count.
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="Agent modes" href="/docs/agent-modes">
-    What the benchmarked configuration actually is — which surface a headless run
-    uses, and what it does per task.
+    What the benchmarked setup actually is — which mode a headless run uses,
+    and what it does per task.
   </SpecCard>
   <SpecCard title="Plugins" href="/docs/plugins">
-    Triage, plan, witness, execute, verify — the staged loop each trial runs.
+    Triage, plan, witness, execute, verify — the staged loop each trial runs
+    through.
   </SpecCard>
   <SpecCard title="Telemetry" href="/docs/telemetry">
-    The local stores a run writes, and how to query them.
+    The local records a run writes, and how to query them.
   </SpecCard>
   <SpecCard title="Scripting" href="/docs/scripting">
-    Driving stella headlessly with JSON output — the same surface the adapter
-    uses.
+    Running stella headlessly with JSON output — the same interface the
+    adapter uses.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/troubleshooting.mdx
+++ b/website/content/docs/guides/troubleshooting.mdx
@@ -3,10 +3,10 @@ title: When something isn't working
 description: Config that isn't applying, a key that won't resolve, hooks that never fire, a run that does nothing — the checks in the order that finds it fastest.
 ---
 
-Most stella problems are one of a small number of things, and nearly all of them
-are answerable locally in a few seconds. This page is organized by **symptom**,
-and each section is ordered so the cheapest check that could explain it comes
-first.
+Most stella problems come down to one of a small number of causes, and
+nearly all of them can be answered locally in a few seconds. This page is
+organized by **symptom**, and inside each section, the cheapest check that
+could explain it comes first.
 
 ## The three commands that answer most of it
 
@@ -16,83 +16,91 @@ stella models     # every provider, its key status, and which source supplied it
 stella doctor     # is the local state — and the model config — sound?
 ```
 
-Run these before forming a theory. `stella config` in particular resolves every
-source — flags, environment, all three `settings.json` scopes, `credentials.toml`
-— and prints the **effective** result, which is the single most common way a
-config mystery ends.
+Run these before you form a theory. `stella config` in particular checks
+every source — flags, environment variables, all three `settings.json`
+levels, `credentials.toml` — and prints the **actual result**, which
+answers most config mysteries on its own.
 
 ## "My `settings.json` isn't applying"
 
 Four checks, in this order.
 
-### 1. Is stella reading the file you are editing?
+### 1. Check you're editing the right file
 
-There are three scopes, and they are merged rather than chosen:
+There are three levels, and they get combined, not just picked from:
 
-| Scope | Path | Preference |
+| Level | Path | Priority |
 | --- | --- | --- |
 | project | `<workspace>/.stella/settings.json` | highest |
 | org-managed | `STELLA_MANAGED_SETTINGS`, else `/Library/Application Support/stella/settings.json` (macOS) or `/etc/stella/settings.json` | middle |
 | user | `~/.stella/settings.json` | lowest |
 
-A missing file at any scope is fine — it is skipped. A file that is **present but
-malformed** is reported as a named error rather than silently dropping your
-configuration, so if you are not seeing an error, the file parsed.
+A missing file at any level is fine — it just gets skipped. A file that
+**exists but has bad syntax** shows up as a named error instead of silently
+being dropped, so if you're not seeing an error, the file parsed fine.
 
-### 2. Is a higher scope overriding it?
+### 2. Check for a higher-level override
 
-Ordinary fields merge project over org-managed over user, and `stella config`
-shows the merged result. If your user-scope value is losing, something more
-specific set it too. On a machine with MDM you may have an org-managed file you
-did not know about — check the platform path above.
+Most fields combine in this order: project, then org-managed, then user.
+`stella config` shows you the final, combined result. If your user-level
+value is losing, something more specific is also setting it. On a
+company-managed machine, you may have an org-managed file you didn't know
+about — check the path in the table above.
 
-### 3. Is the field one that merges the way you assumed?
+### 3. Check how the field combines
 
-This is the check people skip, and the merge rules genuinely differ per field:
+This is the check people skip, and the rules genuinely differ by field:
 
 <CardGrid size="md">
   <OptionCard name="providers, agent_engine_config">
-    Merge **per field** — even `agents.<role>.params` composes per knob.
+    Combine **field by field** — even `agents.<role>.params` merges one
+    setting at a time.
   </OptionCard>
   <OptionCard name="allowed_models">
-    **Replaces wholesale.** Whichever scope sets it owns the entire list. A project
-    file listing one model does not *add* to your user list; it replaces it.
+    **Replaces the whole list.** Whichever level sets it owns the entire
+    list. A project file listing one model does not *add* to your user
+    list — it replaces it.
   </OptionCard>
   <OptionCard name="hooks">
-    **Concatenate.** Org, repo, and personal hooks all fire, and no scope can remove
-    another's.
+    **All combine together.** Org, repo, and personal hooks all run, and no
+    level can remove another's hooks.
   </OptionCard>
   <OptionCard name="tools, mcp">
-    **Last scope wins per key** — and an org-managed `off` is a *ceiling* no lower
-    scope can grant back.
+    **The last level wins, per key** — and an org-managed `off` is a
+    **ceiling** no lower level can turn back on.
   </OptionCard>
 </CardGrid>
 
-### 4. Is something outranking `settings.json` entirely?
+### 4. Check for something outside settings.json
 
-Command-line flags and some environment variables sit **above** settings:
+Command-line flags and some environment variables sit **above**
+`settings.json`:
 
-- **Model** — `--model` > `STELLA_MODEL` > `agents.default.model` >
-  `default_model` > auto-detection. The flag and the variable are the *same*
-  slot, so the flag wins when both are set, and either wins over every
-  settings key. A settings-pinned model never silently outranks an override.
-- **API key** — `--api-key` > provider env var > `settings.json` `api_key` >
-  `credentials.toml` > interactive prompt.
-- **Base URL** — `--base-url` > the `ZAI_GLM_CODING_PLAN=1` toggle (Z.ai only) >
-  `settings.json` `base_url` > the built-in default.
+- **Model** — `--model` beats `STELLA_MODEL`, which beats
+  `agents.default.model`, which beats `default_model`, which beats
+  auto-detection. The flag and the environment variable fill the same slot,
+  so the flag wins if both are set, and either one wins over any setting.
+  A model set in settings can never silently override a flag or variable.
+- **API key** — `--api-key` beats the provider's environment variable,
+  which beats `settings.json`'s `api_key`, which beats
+  `credentials.toml`, which beats an interactive prompt.
+- **Base URL** — `--base-url` beats the `ZAI_GLM_CODING_PLAN=1` toggle
+  (Z.ai only), which beats `settings.json`'s `base_url`, which beats the
+  built-in default.
 
 <Callout type="warn">
-`--base-url` / `STELLA_BASE_URL` is **not** part of the model chain. It replaces
-the endpoint of whichever provider the chain already picked — without changing
-the pick, or the credential that goes with it. That is how one provider's key
-ends up at another provider's host. `stella doctor` flags the pairing by name.
+`--base-url` and `STELLA_BASE_URL` are **not** part of the model chain.
+They just replace the address of whichever provider the chain already
+picked, without changing that pick or the credential that goes with it.
+That's how one provider's key can end up being sent to a different
+provider's address. `stella doctor` flags this pairing by name.
 </Callout>
 
-An exported shell variable beats the file almost every time, which is the
-resolution to most "but I set it in settings.json" reports.
+An environment variable you exported almost always beats the settings
+file, which explains most "but I set it in settings.json" reports.
 
 <Callout type="info">
-Preview a change without starting a run — global flags first:
+Preview a change without starting a run — global flags go first:
 
 ```bash
 stella --model anthropic/claude-fable-5 config
@@ -106,44 +114,49 @@ stella models         # every provider, key status, and the source that supplied
 stella auth list      # what credentials.toml holds, redacted, with resolution source
 ```
 
-The chain is **first hit wins**, and nothing below the first hit is ever read:
+The chain is **first match wins**, and nothing after the first match is
+ever read:
 
-1. `--api-key` (requires an explicit `--model provider/…`)
+1. `--api-key` (needs an explicit `--model provider/…`)
 2. the provider's environment variable
-3. `settings.json` → `providers.<id>.api_key`
+3. `settings.json` under `providers.<id>.api_key`
 4. `~/.stella/credentials.toml`
-5. an interactive prompt, on a TTY, when you named a provider
+5. an interactive prompt, in a terminal, once you've named a provider
 
 Three specific traps:
 
 <CardGrid size="md">
   <SpecCard title="The key is only in a .env file your shell never loads">
-    Project dotenv files are loaded into the environment before step 2, so a repo's
-    `.env.local` does reach stella — but an **exported shell value always wins**, and a
-    dotenv loaded by an interactive-shell hook is not loaded for a non-interactive
-    invocation. `stella auth set <provider>` is the durable fix.
+    Project dotenv files load into the environment before step 2, so a
+    repo's `.env.local` does reach stella. But an **exported shell value
+    always wins**, and a dotenv file loaded by an interactive-shell hook
+    doesn't load for a non-interactive command. `stella auth set <provider>`
+    is the fix that sticks.
   </SpecCard>
   <SpecCard title="api_key_env renamed the variable">
-    A `providers.<id>.api_key_env` in settings **renames the primary variable** — the
-    named one is checked first, and the provider's original env var demotes to an
-    alias. If a teammate committed that, your usual variable is now the fallback.
+    A `providers.<id>.api_key_env` setting **renames the main variable** —
+    the named one gets checked first, and the provider's usual variable
+    becomes a fallback. If a teammate committed that setting, your usual
+    variable is now second in line.
   </SpecCard>
   <SpecCard title="An empty string is not unset">
-    `providers.<id>.api_key: ""` is treated as unset — but a value that is whitespace,
-    or a stale key, resolves and then fails at the provider. A 401 means the chain
-    worked and the key is wrong.
+    `providers.<id>.api_key: ""` counts as unset. But a value that's just
+    whitespace, or an old expired key, still resolves and then fails at the
+    provider. A 401 error means the chain worked and the key itself is
+    wrong.
   </SpecCard>
 </CardGrid>
 
 ### A 401 that names the wrong provider
 
-A base URL selects nothing. If `--base-url`, `STELLA_BASE_URL`, or a
-`settings.json` `base_url` points at one provider's host while the model chain
-resolved a *different* provider, that provider's key is sent to the other one's
-endpoint. The rejection is reported by the adapter that sent it, so the
-error blames the wrong party.
+A base URL doesn't select which provider is used. If `--base-url`,
+`STELLA_BASE_URL`, or a `settings.json` `base_url` points at one provider's
+address while the model chain resolved a *different* provider, that other
+provider's key gets sent to the first provider's address. Whichever
+provider received the request reports the error, so the error message
+blames the wrong side.
 
-`stella doctor` detects the pairing and names both sides:
+`stella doctor` catches this mismatch and names both sides:
 
 ```text
   ✗ model config — 1 model setting(s) name something the provider will reject
@@ -152,111 +165,120 @@ error blames the wrong party.
       OPENROUTER_API_KEY credential would be sent to Z.ai (GLM 5.2) …
 ```
 
-The fix is to make the two agree: pin the provider to the host
-(`--model zai/glm-5.2`), or drop the override. A host stella does not recognize
-is left alone — a proxy or a private gateway is a legitimate use of the flag.
+The fix is to make both sides agree: pin the provider to match the address
+(`--model zai/glm-5.2`), or remove the override. A host stella doesn't
+recognize is left alone — using this flag for a private proxy or gateway is
+a normal use case.
 
-### Auto-detection picked a provider you did not expect
+### Auto-detection picked a provider you didn't expect
 
-With no `--model`, stella takes the first provider with a resolvable credential,
-in this order:
+With no `--model` set, stella picks the first provider with a working
+credential, checked in this order:
 
 ```text
 openrouter, zai, anthropic, openai, xai, deepseek, gemini, then vertex, and bedrock LAST
 ```
 
-OpenRouter sits first because nobody exports `OPENROUTER_API_KEY` by accident —
-having one is a deliberate statement about routing. Vertex and Bedrock sit last
-so generic AWS or Google credentials present for other reasons never hijack
-selection. Any leftover key earlier in that list wins over the one you meant —
-`unset` it, or pin `--model`. `stella doctor` prints which provider and model
-the next run would use, and why.
+OpenRouter comes first because nobody sets `OPENROUTER_API_KEY` by
+accident — having one means you deliberately chose it for routing. Vertex
+and Bedrock come last so that generic AWS or Google credentials left over
+from something else never get picked automatically. Any leftover key
+earlier in that list wins over the one you actually meant to use — run
+`unset` on it, or pin `--model` yourself. `stella doctor` prints which
+provider and model the next run would pick, and why.
 
 ## "Hooks, MCP servers, or custom tools never load"
 
-This is almost always the **project trust boundary**, working as designed.
+This is almost always the **project trust boundary**, working as intended.
 
-A fresh clone's `hooks`, `providers.*.base_url` / `api_key` / `api_key_env`,
-`mcp.registry_url`, `context_providers`, per-agent `prompt`s, and the whole of
-`.stella/mcp.toml` are held back until you opt in — otherwise any repository you
-cloned could run commands on your machine or route your keys through its server.
+A fresh clone's `hooks`, `providers.*.base_url` / `api_key` /
+`api_key_env`, `mcp.registry_url`, `context_providers`, per-agent `prompt`
+settings, and the whole `.stella/mcp.toml` file are all **held back until
+you opt in**. Otherwise, any repository you cloned could run commands on
+your machine or route your keys through its own server.
 
-A stderr notice names everything that was skipped. To grant it:
+A message on stderr names everything that got skipped. To allow it:
 
 ```bash
 export STELLA_TRUST_PROJECT=1   # scope it per-repo with direnv or a shell guard
 ```
 
-`STELLA_PROJECT_HOOKS=1` is the narrower legacy form — it trusts hooks, MCP, and
-context providers but leaves credential routing gated.
+`STELLA_PROJECT_HOOKS=1` is a narrower, older version of this — it trusts
+hooks, MCP, and context providers, but still blocks credential routing.
 
 <Callout type="warn">
 An **org-managed denial is a ceiling**: `tools: { "web": "off" }` or
-`authority.project_custom_tools: "off"` in the managed scope cannot be granted
-back by a project file, or by `STELLA_TRUST_PROJECT=1`. If a capability stays
-off after trusting the project, look at the managed file.
+`authority.project_custom_tools: "off"` set at the org-managed level can
+never be turned back on by a project file, or by `STELLA_TRUST_PROJECT=1`.
+If a capability stays off after trusting the project, check the
+org-managed file.
 </Callout>
 
 ## "The model I configured isn't the one that ran"
 
 <CardGrid size="md">
   <SpecCard title="Check allowed_models first">
-    It **replaces wholesale** across scopes. A model absent from the effective list is
-    not selectable, however it was configured.
+    It **replaces the whole list**, not just adds to it. A model missing
+    from the final list can't be selected, no matter how it was configured.
   </SpecCard>
   <SpecCard title="A role fell back">
-    A configured seat model whose provider has no credential **falls back to the
-    session's model with a notice** rather than erroring. Configuration can never
-    turn a runnable session into an error — so read the notice.
+    A role assigned to a model whose provider has no working credential
+    **falls back to the session's main model, with a notice**, rather than
+    causing an error. A working configuration can never turn a runnable
+    session into a broken one, so read the notice to see what happened.
   </SpecCard>
   <SpecCard title="A circuit breaker opened">
-    Three consecutive transport failures open a provider's breaker; routing skips it
-    and reports the fallback visibly. After a cooldown, one trial call decides whether
-    it closes.
+    Three connection failures in a row for a provider open a breaker for
+    it, and routing skips that provider, reporting the fallback clearly.
+    After a cooldown period, one test call decides whether it closes again.
   </SpecCard>
   <SpecCard title="Cross-family judging moved the verifier">
-    The verifier prefers a healthy provider whose model *family* differs from the
-    worker's. With one family configured it degrades to the same family — with a
-    caveat, never an error.
+    The verifier prefers a healthy provider running a different model
+    *family* than the worker. With only one family configured, it falls
+    back to the same family, with a warning, never an error.
   </SpecCard>
 </CardGrid>
 
 ## "`effort` or `reasoning` seems to be ignored"
 
-Two separate causes, and they are easy to confuse:
+Two separate causes, easy to mix up:
 
-1. **The provider drops it on the wire.** Z.ai, DeepSeek, and local endpoints do
-   not carry `effort` at all. The setting records intent and changes nothing.
-   Differentiate those roles with a strict `prompt` and `params.max_tokens`
-   instead.
-2. **An auto is overriding you.** `effort_auto` and `reasoning_auto` *override*
-   per-agent `effort` and `reasoning`. If you want per-agent values to apply,
-   the corresponding auto has to be `"off"`.
+1. **The provider drops the setting entirely.** Z.ai, DeepSeek, and local
+   endpoints never send `effort` at all. The setting records what you
+   wanted, but changes nothing. For those, tell the roles apart with a
+   specific `prompt` and `params.max_tokens` instead.
+2. **An automatic setting is overriding you.** `effort_auto` and
+   `reasoning_auto` *override* the per-agent `effort` and `reasoning`
+   settings. If you want your per-agent values to apply, turn the matching
+   automatic setting `"off"`.
 
-That second one is why the [balanced profile](/docs/examples#balanced) carries no
-`agents` block at all and the [maximum-quality profile](/docs/examples#maximum-quality)
-turns both autos off.
+That second point is why the
+[balanced profile](/docs/examples#balanced) has no `agents` block at all,
+and the
+[maximum-quality profile](/docs/examples#maximum-quality) turns both
+automatic settings off.
 
 ## "The agent answered about code that isn't there"
 
-The code graph re-indexes on every query, so a stale answer usually means the
-catch-up pass **failed** rather than that it was never run. That failure is
-non-fatal and reported rather than hidden:
+The code map rebuilds itself on every query, so a stale answer usually
+means the update pass **failed**, not that it never ran. That failure is
+reported, not hidden:
 
 ```text
 warning: the code graph index pass failed — answering from what the index already
 holds, which may be stale
 ```
 
-If you see that, rebuild explicitly:
+If you see that, rebuild it directly:
 
 ```bash
 stella init
 stella search "where is the_symbol_you_expected defined"
 ```
 
-A symbol that legitimately has two definitions is listed rather than silently
-resolved — that is not a bug, and it is usually the more interesting finding.
+A symbol that genuinely has two definitions gets listed as two results
+instead of being silently picked for you — that's not a bug, and it's
+often the more useful finding.
 
 ## "A session won't open, or a command mentions `store.db`"
 
@@ -265,37 +287,40 @@ stella doctor            # read-only diagnosis, always safe
 stella doctor --repair   # quarantine a store SQLite judged corrupt
 ```
 
-`--repair` **renames, never deletes** — the database and both sidecars move
-aside under one timestamp, whatever is still readable is copied to a separate
-salvaged database, and your next session starts fresh. Every quarantine is
-undoable with `mv`.
+`--repair` **renames files, it never deletes them**. The database and both
+side files get moved aside together, under one timestamp. Whatever is
+still readable gets copied into a separate recovered database, and your
+next session starts fresh. Every quarantine can be undone with `mv`.
 
-`doctor` runs before configuration loads, on purpose: a workspace whose store is
-corrupt has to stay diagnosable without a working model config. There is no JSON
-form of its output — `--output-format` is a flag of `run` and `fleet`, and
-`doctor` does not take it.
+`doctor` runs before settings are loaded, on purpose — a workspace with a
+corrupted store needs to stay diagnosable even without a working model
+config. It has no JSON output. `--output-format` is a flag for `run` and
+`fleet`, and `doctor` doesn't accept it.
 
 ## "The run ended without doing anything"
 
 <CardGrid size="md">
   <SpecCard title="A verification plugin stopped it">
-    A plugin driving the turn can end a run before it edits anything — over a
-    blast-radius threshold, say. Its rule is the plugin's, so check its manifest
-    for what it refuses. There is no built-in scope gate, and the
-    `agent_engine_config.headless_scope_bypass` key is inert — it is not what
-    ended your run.
+    A plugin driving the turn can end a run before it edits anything — for
+    example, if the change is bigger than some threshold. The rule belongs
+    to that plugin, so check its manifest for what it refuses to do. There
+    is no built-in scope check in stella itself, and the
+    `agent_engine_config.headless_scope_bypass` setting does nothing — it's
+    not what ended your run.
   </SpecCard>
   <SpecCard title="The spend limit tripped">
-    `--spend-limit` aborts cleanly between steps. Exit code `1`; already-committed work
-    stays. Read `cost_usd` from `--output-format json` to confirm.
+    `--spend-limit` stops the run cleanly, between steps. Exit code `1`,
+    and already-committed work stays. Check `cost_usd` from
+    `--output-format json` to confirm.
   </SpecCard>
   <SpecCard title="Verification found nothing to verify">
-    The zero-diff guard means a run that changed nothing can never claim success. If a
-    task was already done, that is the correct outcome.
+    A run that changed nothing can never claim success, by design. If the
+    task was already done, that's actually the correct outcome.
   </SpecCard>
   <SpecCard title="It was interrupted">
-    Exit `130` is `SIGINT`, `143` is `SIGTERM` — distinguishable from a failure
-    exactly so a wrapping script can treat them differently.
+    Exit code `130` means `SIGINT`, and `143` means `SIGTERM` —
+    distinguishable from a real failure, so a wrapping script can treat
+    them differently.
   </SpecCard>
 </CardGrid>
 
@@ -308,28 +333,31 @@ stella stats --format json |
   jq '.rows[] | select(.cache_hit_rate < 0.2) | {provider, model, cache_hit_rate, cache_expired_rewrites}'
 ```
 
-Then find what changed between turns, which is the usual culprit behind a cold
-prefix:
+Then find out what changed between turns, since that's usually what caused
+a cold cache:
 
 ```bash
 stella inspect <EXEC> --step 0 --diff --only system
 ```
 
-[Understand what a run cost](/docs/guides/what-a-run-cost) walks that whole chain.
+[Understand what a run cost](/docs/guides/what-a-run-cost) walks through
+that whole process.
 
 ## Working entirely offline
 
-If you are diagnosing on a plane or inside an air gap, this much needs no
-network and no key: `stella config`, `stella doctor`, `stella models` (listing),
-`stella scripts`, `stella storage`, `stella commands`,
-`stella stats`, `stella usage`, `stella inspect`, `stella context`,
-`stella proposals`, `stella memory`, and `stella observe`. `stella search` also
-works with no key configured, degrading to symbol-name matching and a file
-scan instead of ranking by meaning. With an embedder configured it makes
-network calls to embed the query and any files still pending.
+If you're troubleshooting on a plane or somewhere with no network, this
+much needs no connection and no key at all: `stella config`,
+`stella doctor`, `stella models` (listing), `stella scripts`,
+`stella storage`, `stella commands`, `stella stats`, `stella usage`,
+`stella inspect`, `stella context`, `stella proposals`, `stella memory`,
+and `stella observe`. `stella search` also works with no key configured —
+it falls back to matching symbol names and scanning files instead of
+ranking by meaning. If you have an embedding model configured, it will
+make network calls to embed your query and any files still waiting to be
+indexed.
 
-The one remaining automatic outbound call is the model-catalog refresh, at most
-once per 24 hours:
+The one remaining automatic network call is the model-catalog refresh,
+which happens at most once every 24 hours:
 
 ```bash
 export STELLA_CATALOG_AUTO_REFRESH=0
@@ -337,22 +365,24 @@ export STELLA_CATALOG_AUTO_REFRESH=0
 
 ## Still stuck
 
-Collect the three outputs at the top of this page plus the failing command, and
-open an issue. `stella config` redacts the key to a preview, so its output is
-safe to paste; `stella inspect` output is **not** — it contains your prompts and
-source excerpts, and receipts never leave your machine unless you move them.
+Collect the three command outputs from the top of this page, plus the
+command that's failing, and open an issue. `stella config` hides your key
+behind a preview, so its output is safe to paste. `stella inspect` output
+is **not** safe to paste — it contains your prompts and source code, and
+records never leave your machine unless you move them yourself.
 
 <CardGrid size="sm">
   <SpecCard title="Settings reference" href="/docs/configuration/settings">
-    Every field, the scope hierarchy, and the trust boundary in full.
+    Every field, the priority order between levels, and the full trust
+    boundary.
   </SpecCard>
   <SpecCard title="Credentials" href="/docs/configuration/credentials">
     The credential chain, `credentials.toml`, and cloud-provider extras.
   </SpecCard>
   <SpecCard title="stella doctor" href="/docs/commands/doctor">
-    What each verdict means, and exactly what `--repair` does to your disk.
+    What each result means, and exactly what `--repair` does to your disk.
   </SpecCard>
   <SpecCard title="API providers" href="/docs/api-providers">
-    Per-provider dialects, base URLs, and what each one drops on the wire.
+    Per-provider quirks, base URLs, and what each one drops on the wire.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/unfamiliar-codebase.mdx
+++ b/website/content/docs/guides/unfamiliar-codebase.mdx
@@ -3,12 +3,12 @@ title: Make a change in an unfamiliar codebase
 description: A repository you have never read, and a change that has to land in it. Orient with the code graph, find the blast radius, and ship the change verified.
 ---
 
-You have been handed a repository you did not write. The change itself is
-probably small. The expensive part is finding out *where* it goes and *what
-else* it breaks — and that is exactly the part an agent does badly when its only
-instrument is `grep`.
+You've been handed a codebase you didn't write. The change itself is
+probably small. The hard part is finding out *where* it goes and *what else*
+it breaks, and that's exactly the part an agent does badly if `grep` is the
+only tool it has.
 
-This guide is about doing that part with the code graph instead.
+The code map fixes that.
 
 ## The whole thing, first
 
@@ -26,28 +26,30 @@ stella run --pipeline my-verifier --test-command "pnpm test orders" \
 stella init
 ```
 
-`stella init` does three things worth knowing here. It infers a **domain
-taxonomy** into `.stella/domains.toml` (the tagging vocabulary memories and
-graph nodes use), builds the **code-graph index** at
-`.stella/private/codegraph.db`, and adopts any commands, skills, and agents
-already sitting in `.claude/` or `.agents/` directories as symlinks.
+`stella init` does three things worth knowing about. It builds a **domain
+map** at `.stella/domains.toml` (the labels memories and code-map nodes
+use), builds the **code map** at `.stella/private/codegraph.db`, and picks
+up any commands, skills, and agents already sitting in `.claude/` or
+`.agents/` folders as symlinks.
 
-It works **offline** through a heuristic fallback, so it succeeds even with no
-provider credential resolved — useful on a machine where you have not set up
+It works **offline**, using a fallback method, so it succeeds even with no
+provider key set up — useful on a machine where you haven't set up your
 keys yet.
 
 <Callout type="info">
-`init` is a head start, not a prerequisite. `stella search`
-**bootstraps the index on first use** if it isn't there, and each query
-runs a catch-up pass over changed files. Running `init` up front just means the
-first query isn't the one that pays for the full index build — and you get the
-domain taxonomy, which querying alone does not produce.
+`init` gives you a head start — it isn't required first. `stella search`
+**builds the index itself on first use** if it isn't there yet, and every
+query runs a quick update pass over changed files. Running `init` up front
+just means your first query doesn't have to pay for building the full
+index — and it also gives you the domain map, which just searching doesn't
+produce.
 </Callout>
 
-## 2. Ask the questions you would otherwise guess at
+## 2. Ask the questions you'd otherwise guess at
 
-This is the step people skip, and it is the one that pays. Before deciding *how*
-to make a change, find out what depends on the thing you are about to touch.
+This is the step people skip, and it's the one that pays off. Before
+deciding *how* to make a change, find out what depends on the thing you're
+about to touch.
 
 ```bash
 # Where is this defined — and is it defined exactly once?
@@ -66,66 +68,72 @@ stella search "what does src/api/orders.ts import"
 stella search "the graph neighborhood of src/api/orders.ts"
 ```
 
-Every one of these reads the local index and, with no embedder configured,
-makes no model calls and needs no API key — so it costs nothing and you can
-afford to be thorough. Ask five questions before you write a prompt.
+Every one of these reads the local index, and with no embedding model
+configured, makes no model calls and needs no API key. So it costs nothing,
+and you can afford to be thorough. Ask five questions before you write a
+prompt.
 
-Two of them are worth calling out as habits:
+Two of these are worth turning into habits:
 
 <CardGrid size="md">
-  <SpecCard title="definitions, before a rename">
-    A symbol with two definitions is a rename that silently half-lands. Search
-    surfaces every site rather than picking one, so you find that out before
-    the edit and not during review.
+  <SpecCard title="Check definitions before a rename">
+    A symbol with two definitions is a rename that will silently half-land.
+    Search shows every location instead of picking one for you, so you find
+    this out before the edit, not during review.
   </SpecCard>
-  <SpecCard title="importers, before an edit">
-    The answer to "is this change small?" Twelve importers of a schema file
-    means the change is a migration, whatever the diff size suggests.
+  <SpecCard title="Check importers before an edit">
+    This answers "is this change actually small?" Twelve files importing a
+    schema file means the change is really a migration, whatever the diff
+    size suggests.
   </SpecCard>
 </CardGrid>
 
-## 3. Make the change, with an oracle
+## 3. Make the change, with a real check
 
-Now the actual work. In an unfamiliar codebase the single highest-value thing
-you can supply is the **test command** — and the thing that turns it into
-evidence is an installed [verification plugin](/docs/plugins), bound to the run
-with `--pipeline <variant>`:
+Now the actual work. In an unfamiliar codebase, the single most valuable
+thing you can supply is a **test command**, and what turns it into real
+proof is an installed [verification plugin](/docs/plugins), attached to the
+run with `--pipeline <variant>`:
 
 ```bash
 stella run --pipeline my-verifier --test-command "pnpm test orders" \
   "add a nullable archived_at column to orders and thread it through the API"
 ```
 
-`--test-command` arms that plugin's **flip oracle**: the command must *fail
-before* the change and *pass after* it. A suite that was already green cannot
-be used as proof, which is what makes the flip meaningful rather than
-decorative. stella grades what the plugin reports against the verdict rule the
-plugin declared at install; it does not re-run the check itself. Without
-`--pipeline`, the flag is refused — a plain `stella run` has no oracle to arm
-and makes no claim about proof.
+`--test-command` arms that plugin's **fail-then-pass check**: the command
+has to *fail before* the change and *pass after* it. A suite that was
+already passing can't be used as proof, which is what makes this check
+meaningful instead of just for show. stella grades what the plugin reports
+against the rule the plugin set up when it was installed. It doesn't
+re-run the check itself. Without `--pipeline`, this flag is rejected — a
+plain `stella run` has no way to check the result and makes no claim of
+proof.
 
-Don't know the test command in a repo you have never read? Ask the repo:
+Don't know the test command in a repo you've never read? Ask the repo
+itself:
 
 ```bash
 stella scripts list          # canonical verbs — install/build/check/test/lint/format
 ```
 
-`stella scripts` detects them statically from the manifests (cargo, npm, uv, go,
-make, just, …). It is offline and needs no API key.
+`stella scripts` finds them by reading the project files (cargo, npm, uv,
+go, make, just, and so on). It's offline and needs no API key.
 
-### If you can't express "done" as a test
+### If you can't turn "done" into a test
 
-Then the oracle has to come from the plugin. A verification plugin may spend
-one model call on a **witness author** — an independent model, never the
-worker — that writes a minimal *failing* test pinning the intended behavior,
-and arms the flip against that instead. Whether it does, and whether it
-watches the witness files for tampering, is that plugin's business: stella
-grades the evidence it reports against its declared rule and re-runs nothing.
+Then the check has to come from the plugin instead. A verification plugin
+may spend one model call on a **witness step** — a separate model, never
+the one doing the work — that writes a small, *failing* test describing the
+intended behavior, and checks the fail-then-pass rule against that instead.
+Whether it does this, and whether it watches those test files for tampering,
+is up to that plugin. stella grades the evidence it reports against its own
+declared rule and doesn't re-run anything itself.
 `stella plugin list` shows what you have installed.
 
-`--keep-witness` and `--require-verified` belonged to the built-in staged
-pipeline and are refused on every path since it was removed; a plugin that
-promotes a witness into a committable test does so on its own terms.
+`--keep-witness` and `--require-verified` were flags for the built-in
+staged pipeline. That pipeline is gone, and both flags are now rejected on
+every path. A plugin that turns a witness into a real committed test does
+so on its own terms.
 
 ## 4. Review what actually changed
 
@@ -134,16 +142,17 @@ stella search "what imports src/db/schema.ts"   # re-ask: did the blast radius m
 git diff
 ```
 
-In the [Command Deck](/docs/commands/chat), `/diff` and `/files` are the same
-review from inside the session.
+In the [Command Deck](/docs/commands/chat), `/diff` and `/files` give you
+the same review from inside the session.
 
 <Callout type="warn">
-Cloning an unfamiliar repository means running unfamiliar configuration. A fresh
-clone's `hooks`, `providers.*.base_url` / `api_key` / `api_key_env`,
-`mcp.registry_url`, `context_providers`, per-agent `prompt`s, and the whole of
-`.stella/mcp.toml` are **held back until you opt in** — otherwise any repo you
-cloned could run commands on your machine or route your keys through its server.
-A stderr notice names anything skipped.
+Cloning an unfamiliar repository means running unfamiliar configuration. A
+fresh clone's `hooks`, `providers.*.base_url` / `api_key` / `api_key_env`,
+`mcp.registry_url`, `context_providers`, per-agent `prompt` settings, and
+the whole `.stella/mcp.toml` file are **held back until you opt in**.
+Otherwise, any repo you cloned could run commands on your machine or route
+your keys through its own server. A message on stderr names anything that
+got skipped.
 
 ```bash
 export STELLA_TRUST_PROJECT=1   # scope it per-repo with direnv or a shell guard
@@ -154,9 +163,9 @@ See [the project trust boundary](/docs/configuration/settings#the-project-trust-
 
 ## When the repository already documents itself
 
-Most repositories you inherit already contain the instructions an agent needs —
-`AGENTS.md`, `CLAUDE.md`, a `CONTRIBUTING.md`, architecture notes. They are just
-written for people, scattered, and partly out of date.
+Most codebases you inherit already contain the instructions an agent
+needs — `AGENTS.md`, `CLAUDE.md`, a `CONTRIBUTING.md`, architecture notes.
+They're just written for people, scattered around, and partly out of date.
 
 ```bash
 stella ingest                    # what steering does this repo already contain?
@@ -165,26 +174,28 @@ stella context review            # read what was proposed, and its probe verdict
 stella context keep a1b2c3       # publish the ones that are actually true
 ```
 
-[`stella ingest`](/docs/commands/ingest) mines that prose into atomic claims,
-each carrying its provenance and each **probed against the tree for staleness**.
-That probing is the part that matters in an inherited repository, where the README
-confidently describes a build system that was replaced two years ago. Nothing
-steers anything until you keep it. [`stella context`](/docs/commands/context) is
-the review surface.
+[`stella ingest`](/docs/commands/ingest) pulls that writing into individual
+claims, each one tracking where it came from and each one **checked
+against the actual code for staleness**. That check matters most in an
+inherited repo, where the README confidently describes a build system that
+was swapped out two years ago. Nothing changes stella's behavior until you
+keep a claim. [`stella context`](/docs/commands/context) is where you
+review them.
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="stella search" href="/docs/commands/search">
-    The ranking ladder, and how `--format json` reads for scripting.
+    The ranking order, and how `--format json` reads for scripting.
   </SpecCard>
   <SpecCard title="Context engine" href="/docs/context-engine">
-    How the graph, memories, and rules become recall — and why it stays cheap.
+    How the graph, memories, and rules turn into recall, and why it stays
+    cheap.
   </SpecCard>
   <SpecCard title="stella init" href="/docs/commands/init">
     Exactly which files initialization generates.
   </SpecCard>
   <SpecCard title="Agent tools" href="/docs/agent-tools">
-    The full toolbelt, the read-only partition, and the permission model.
+    The full toolset, the read-only tools, and the permission model.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/guides/what-a-run-cost.mdx
+++ b/website/content/docs/guides/what-a-run-cost.mdx
@@ -58,8 +58,6 @@ explain a surprising bill:
   </OptionCard>
 </CardGrid>
 
-Two things worth recognizing right away:
-
 - **`HIT%` near 0 with `CACHE WR` also 0**, on a provider that needs
   caching turned on (Anthropic, Bedrock, Claude through OpenRouter) —
   the cache marker probably never reached the request. Check the adapter

--- a/website/content/docs/guides/what-a-run-cost.mdx
+++ b/website/content/docs/guides/what-a-run-cost.mdx
@@ -4,11 +4,11 @@ description: Follow one expensive run from the dollar figure down to the exact b
 ---
 
 A run cost more than you expected. Most tools can tell you *that*. stella can
-tell you **which model call**, **what it was sent**, and **what changed between
-that call and the one before it** — from local records, with no network access
-and no API key.
+tell you **which model call**, **what it was sent**, and **what changed
+between that call and the one before it**, all from local records, with no
+network access and no API key.
 
-This guide walks that chain top to bottom. Each step narrows the question.
+Each step below narrows the question further.
 
 ## The chain
 
@@ -22,7 +22,8 @@ stella inspect 42 --step 3 --diff --only system   # 5. what changed since last t
 
 <CostChainDiagram />
 
-Everything below reads `<workspace>/.stella/private/store.db` and never writes.
+Everything below reads `<workspace>/.stella/private/store.db` and never
+writes to it.
 
 ## 1. Which model, and how much — `stella stats`
 
@@ -30,37 +31,42 @@ Everything below reads `<workspace>/.stella/private/store.db` and never writes.
 stella stats
 ```
 
-Aggregates the local store per provider and model: total tokens, total cost,
-resolve rate, and a `TOTAL` row. It is the "where is the money going" view.
+This adds up the local records by provider and model: total tokens, total
+cost, resolve rate, and a `TOTAL` row. It's the "where is the money going"
+view.
 
-The three columns people miss are the cache-economics ones, and they are usually
-where a surprising bill is explained:
+The three columns people miss are the ones about caching, and they usually
+explain a surprising bill:
 
 <CardGrid size="md">
   <OptionCard name="HIT%">
-    Cache-read tokens over total input tokens. Prompt caching is 4–10× cheaper than
-    fresh input, so this number is most of your bill's variance.
+    Cache-read tokens divided by total input tokens. Prompt caching is
+    4–10x cheaper than fresh input, so this number explains most of your
+    bill's variation.
   </OptionCard>
   <OptionCard name="SAVED ($)">
-    Estimated dollars saved by caching, at today's catalog rates. **Signed** — a
-    negative value means the provider's cache-write premium outran the reads it
-    bought, which is a real incident and not a rounding artifact.
+    Estimated dollars saved by caching, at today's listed rates. **Can be
+    negative** — a negative value means the provider charged more to write
+    to the cache than it saved you by reading from it, which is a real
+    problem, not a rounding error.
   </OptionCard>
   <OptionCard name="TTL REWRITES">
-    Calls whose cached prefix went cold because the gap since the session's previous
-    call exceeded the provider's cache TTL, and got rewritten instead of read back.
-    A session parked between turns pays the write premium again for nothing.
+    Calls whose cached prefix went cold because too much time passed since
+    the session's last call, exceeding the provider's cache lifetime, so it
+    got rewritten instead of reused. A session left idle between turns pays
+    the write cost again for nothing.
   </OptionCard>
 </CardGrid>
 
-Two diagnoses worth knowing by heart:
+Two things worth recognizing right away:
 
-- **`HIT%` near 0 with `CACHE WR` also 0**, on an opt-in provider (Anthropic,
-  Bedrock, Claude-via-OpenRouter) — the cache marker probably never reached the
-  wire. Check the adapter config before concluding the model isn't cacheable.
-- **`CACHE WR` nonzero but `HIT%` low** — the prefix is being *rewritten*
-  between turns instead of reused. Something upstream of the cache breakpoint is
-  changing per turn. Step 5 finds out what.
+- **`HIT%` near 0 with `CACHE WR` also 0**, on a provider that needs
+  caching turned on (Anthropic, Bedrock, Claude through OpenRouter) —
+  the cache marker probably never reached the request. Check the adapter
+  setup before concluding the model can't be cached.
+- **`CACHE WR` above 0 but `HIT%` low** — the prefix is being *rewritten*
+  between turns instead of reused. Something before the cache breakpoint is
+  changing on every turn. Step 5 tells you what.
 
 ```bash
 # Everything with a suspiciously cold cache, as JSON.
@@ -69,9 +75,11 @@ stella stats --format json |
 ```
 
 <Callout type="info">
-`stella stats` is **this workspace**. For the same numbers across every project on
-this machine, [`stella usage report`](/docs/commands/usage#stella-usage-report)
-reads the local hub at `~/.stella/usage.db`. Local-only — nothing is uploaded.
+`stella stats` covers **this workspace only**. For the same numbers across
+every project on this machine,
+[`stella usage report`](/docs/commands/usage#stella-usage-report) reads the
+local hub at `~/.stella/usage.db`. This stays local — nothing gets
+uploaded.
 </Callout>
 
 ## 2. Which run — the Observatory
@@ -80,17 +88,18 @@ reads the local hub at `~/.stella/usage.db`. Local-only — nothing is uploaded.
 stella observe --open
 ```
 
-A local web dashboard over the same stores, served on `127.0.0.1` only, embedded
-in the binary — no install and no build step. Its executions tab gives you
-per-run drill-down, which is how you get from "this month cost $40" to "this
-*run* cost $4".
+A local web dashboard over the same records, served only on `127.0.0.1`,
+built into the program itself — no install and no build step needed. Its
+executions tab lets you drill into a single run, which is how you go from
+"this month cost $40" to "this *run* cost $4."
 
-Take the **execution id** from the run you care about; the rest of this guide
-uses it.
+Take the **execution id** from the run you care about. The rest of this
+guide uses it.
 
 <Callout type="info">
-The Observatory opens the stores strictly read-only and never exports anything.
-See [the dashboard tour](/docs/telemetry/dashboard) for what each tab shows.
+The Observatory only reads the local records, never writes or exports
+anything. See [the dashboard tour](/docs/telemetry/dashboard) for what each
+tab shows.
 </Callout>
 
 ## 3. Which call inside the run — `stella inspect`
@@ -100,68 +109,73 @@ stella inspect          # executions that have receipts
 stella inspect 42       # that execution's model calls, with roles and seq numbers
 ```
 
-Every model call records a **receipt**: the ordered list of context blocks it
-sent, plus the bytes of the blocks the event journal cannot otherwise resolve.
-`stella inspect 42` lists them, so you rarely have to guess.
+Every model call gets a **receipt**: the ordered list of context it was
+sent, plus the actual bytes for any part the event log can't otherwise
+resolve. `stella inspect 42` lists them, so you rarely have to guess.
 
-A single step can hold several calls, and the numbering is fixed:
+A single step can hold several calls, and they're numbered a fixed way:
 
 <CardGrid size="md">
   <OptionCard name="--call-seq 0" defaultValue="default">
     The engine's own worker call. Always `0`.
   </OptionCard>
   <OptionCard name="--call-seq 1">
-    The overflow summarizer that may run during that step's compaction.
+    The overflow summarizer that may run while that step's conversation
+    gets shortened.
   </OptionCard>
   <OptionCard name="--call-seq 2+">
-    A wrapper plugin's management roles — `triage`, `research`, `plan`, and `witness_author`,
-    plus the `plan_repair` / `witness_repair` retries. There is no `verdict` call and no
-    `distress_guidance` call: [verification is deterministic](/docs/plugins).
+    A wrapper plugin's management roles — `triage`, `research`, `plan`, and
+    `witness_author`, plus the `plan_repair` / `witness_repair` retries.
+    There is no `verdict` call and no `distress_guidance` call:
+    [verification is deterministic](/docs/plugins).
   </OptionCard>
 </CardGrid>
 
-Those auxiliary calls assemble prompts that exist nowhere else, so their receipt
-is the only record of what they sent. If a run's cost is concentrated in
-something other than seq `0`, that is itself the finding.
+Those extra calls build prompts that exist nowhere else, so their receipt
+is the only record of what they sent. If a run's cost is mostly in
+something other than seq `0`, that's the finding right there.
 
 ## 4. What the call was sent
 
 ```bash
 stella inspect 42 --step 3            # role-delimited transcript
-stella inspect 42 --step 3 --full     # …with nothing elided
+stella inspect 42 --step 3 --full     # …with nothing hidden
 ```
 
-This reconstructs the exact `Vec<CompletionMessage>` the model received — system
-prompt included — and re-checks it against the digests taken at emission. The
-banner reports the verdict, and the two failure modes are kept separate because
-they mean very different things:
+This rebuilds the exact `Vec<CompletionMessage>` the model received, system
+prompt included, and checks it against digests recorded at the time. The banner
+reports the result, and there are two different failure types that mean
+very different things:
 
 <CardGrid size="md">
   <OptionCard name="! N block(s) could not be resolved">
-    A documented coverage gap — budget-abort synthetic tool results, discarded
-    speculation, attachments. The rest of the transcript is still faithful.
+    A known, expected gap in coverage — budget-abort placeholder results,
+    discarded speculation, attachments. The rest of the transcript is still
+    reliable.
   </OptionCard>
   <OptionCard name="!! N block(s) did NOT re-hash">
-    Nothing routine accounts for these bytes. Treat the reconstruction as untrustworthy.
+    Nothing routine explains these bytes. Treat the rebuilt transcript as
+    unreliable.
   </OptionCard>
   <OptionCard name="! N block(s) did NOT re-hash … as a matter of course">
-    An older journal, where compaction rewrote a tool result in place without
-    recording the replacement. Ordinary, not a signal.
+    An older log format, where a shortening pass rewrote a tool result in
+    place without recording the replacement. Normal, not a warning sign.
   </OptionCard>
 </CardGrid>
 
-The last two are the same failure on different journals, and the era each execution
-was written in is recorded rather than guessed — see
+The last two are the same underlying issue on different log formats, and
+which format a given execution used is recorded, not guessed — see
 [`stella inspect`](/docs/commands/inspect#reading-the-verification-banner).
 
 ## 5. What changed since the previous call — `--diff`
 
-This is the step that actually explains a cache regression, and it is the one
-capability here with no real equivalent elsewhere.
+This is the step that actually explains a cache problem, and there's really
+nothing else like it.
 
-A transcript shows the **sum**. It never shows the **delta**. A system prompt is
-hundreds of stable lines, and finding the paragraph that moved by reading two of
-them side by side is not something a person does reliably.
+A transcript shows you the **total**. It never shows you the **change**. A
+system prompt is hundreds of stable lines long, and finding the one
+paragraph that moved by reading two versions side by side isn't something a
+person can do reliably.
 
 ```bash
 stella inspect 42 --step 0 --diff --only system
@@ -177,32 +191,34 @@ stella inspect 42 --step 0 --diff --only system
  - Make minimal, surgical edits.
 ```
 
-That single added line is a plausible cause of a cold cache: anything that
-changes above the cache breakpoint invalidates the prefix for the whole turn.
+That one added line is a likely cause of a cold cache: anything that
+changes above the cache breakpoint invalidates the cached prefix for the
+whole turn.
 
-Three baselines, all **same-role** (diffing a worker prompt against a verifier
-prompt produces noise, not a delta):
+Three baselines, all comparing the **same role** (comparing a worker prompt
+against a verifier prompt just produces noise, not a real difference):
 
 <CardGrid size="md">
   <OptionCard name="prev" defaultValue="default">
-    Whatever ran immediately before in the same role — the previous step, or the last
-    call of the previous turn when this is a turn's first call. Searches the whole
-    session, because a system prompt is byte-stable *within* an execution by design,
-    so drift can only appear across turns.
+    Whatever ran immediately before, in the same role — the previous step,
+    or the last call of the previous turn if this is a turn's first call.
+    It searches the whole session, because a system prompt stays
+    byte-for-byte the same *within* one execution by design, so any drift
+    can only show up across turns.
   </OptionCard>
   <OptionCard name="first">
     The first call of this role in the session.
   </OptionCard>
   <OptionCard name="prompt">
-    Your prompt exactly as you submitted it, before any context was added.
+    Your prompt exactly as you typed it, before anything else was added.
   </OptionCard>
 </CardGrid>
 
 ### Why `prompt` is a baseline at all
 
-The words you type are all you *know* exist when you submit them. The system
-prefix, recalled memories, rules, and skills are added afterwards, and no other
-view shows that mutation.
+The words you type are the only thing you *know* exists when you submit
+them. The system prefix, recalled memories, rules, and skills all get added
+afterward, and no other view shows you that change.
 
 ```bash
 stella inspect 42 --step 0 --diff
@@ -215,18 +231,19 @@ stella inspect 42 --step 0 --diff
 ```
 
 Three words in, 8,730 lines out. That ratio is the answer to "why did a
-one-sentence prompt cost that much".
+one-sentence prompt cost that much."
 
 <Callout type="info">
-"no change" is a **result**, not a failure. `--only system` reporting the prompt
-byte-identical to the previous turn is a direct confirmation that the
-prompt-cache stability rule is holding — which is exactly what you want to
-see when `HIT%` is healthy.
+"No change" is a **good result**, not a failure. If `--only system` shows
+the prompt is exactly the same as the previous turn, that directly confirms
+the prompt-cache stability rule is holding, which is exactly what you want
+to see when `HIT%` is healthy.
 </Callout>
 
 ## Making it a check instead of an investigation
 
-Everything above has a JSON form, so the forensics can run unattended:
+Everything above has a JSON version, so this forensic work can run
+unattended:
 
 ```bash
 # Did the system prompt drift between turns? `base` reports which baseline
@@ -239,49 +256,52 @@ stella inspect 42 --step 3 --format json |
   jq '{verified, unresolved, digest_mismatches, digest_mismatch_severity}'
 ```
 
-## The other cost question: was it worth it?
+## Cost vs. value
 
-Dollars are half the story. `stella scoreboard` answers the other half without
-letting a model grade its own homework — model calls, characters a human had to
-type, follow-ups, and a verdict read from a pull request somebody actually
-merged or closed. An open PR is deliberately **not** a verdict.
+Dollars are only half the story. `stella scoreboard` answers the other half
+without letting a model grade its own work — model calls, characters a
+person had to type, follow-ups, and a result read from a pull request
+someone actually merged or closed. An open pull request is deliberately
+**not** counted as a result either way.
 
 ```bash
 stella scoreboard
 ```
 
-The number worth steering on is **$/resolved**, not sticker price: a cheap model
-that needs three attempts is not cheap. See
-[Examples & recipes](/docs/examples) for the profiles that trade those off.
+The number worth tracking is **cost per task solved**, not the sticker
+price — a cheap model that needs three attempts isn't actually cheap. See
+[Examples & recipes](/docs/examples) for setups that balance this
+trade-off.
 
 ## Keeping the store from growing forever
 
-`store.db` grows monotonically — every run appends executions, events, tool
-calls, context blocks, and receipts.
+`store.db` only ever grows — every run adds executions, events, tool calls,
+context, and receipts.
 
 ```bash
 stella stats prune --older-than 90d --dry-run   # look first; deletion cascades
 stella stats prune --older-than 90d --vacuum    # then keep a quarter of history
 ```
 
-Prune is **replication-safe by default**: an execution whose telemetry has not
-yet reached the usage hub is never dropped, so pruning before a sync cannot
-silently destroy cost data you are still billing against. `--force` overrides
-that and is irreversible.
+Pruning is **safe for syncing by default**: an execution whose data hasn't
+reached the usage hub yet is never deleted, so pruning before a sync can't
+accidentally destroy cost data you're still being billed against.
+`--force` overrides that protection and cannot be undone.
 
 ## Next
 
 <CardGrid size="sm">
   <SpecCard title="stella inspect" href="/docs/commands/inspect">
-    Every flag, the verification banner, and what receipts cannot show.
+    Every flag, the verification banner, and what receipts can't show you.
   </SpecCard>
   <SpecCard title="stella stats" href="/docs/commands/stats">
-    The cache columns and the prune surface in full.
+    The cache columns and the prune options in full.
   </SpecCard>
   <SpecCard title="Telemetry & budget" href="/docs/telemetry">
-    What the store holds, how to query it yourself, and the two egress paths.
+    What the store holds, how to query it yourself, and the two ways data
+    can leave it.
   </SpecCard>
   <SpecCard title="Work within a spend limit" href="/docs/guides/spend-limit">
-    Spending less next time, rather than accounting for it afterwards.
+    Spending less next time, instead of accounting for it after the fact.
   </SpecCard>
 </CardGrid>

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -3,10 +3,11 @@ title: Introduction
 description: stella is a fast, bring-your-own-key, model-agnostic terminal coding agent. Point it at any provider, give it a goal, and let a verifier decide when done.
 ---
 
-stella is a model-agnostic coding agent that runs in your terminal. It is
-bring-your-own-key: Community/default use has no account and no sign-up, runs on provider
-credentials you already have, records locally, and sends telemetry nowhere unless you
-[configure it to](/docs/telemetry).
+stella is a coding agent that runs in your terminal and works with any model
+provider. It's bring-your-own-key: there's no account or sign-up for
+Community use, it runs on credentials you already have, it records
+everything locally, and it sends telemetry nowhere unless you
+[turn that on yourself](/docs/telemetry).
 
 ```bash
 export ANTHROPIC_API_KEY=your_key_here
@@ -17,17 +18,18 @@ stella run "add a --json flag to the export command and update the tests"
 
 | | |
 | --- | --- |
-| **BYOK, no lock-in** | Auto-detects the provider from whichever keys you have set. Anthropic, OpenAI, Gemini, Vertex, Bedrock, xAI, DeepSeek, Z.ai, OpenRouter, or any OpenAI-compatible local server. |
-| **Verified outcomes** | [Goal mode](/docs/agent-modes#outcome-driven-goal-mode) does not stop on a hunch — a separate verifier model verifies the definition of done from evidence before the loop ends. |
-| **Tools behind a permission model** | A lean built-in core — the shell, file CRUD, code search, sub-agents, the task board, scratch state, the environment probe — plus MCP servers and developer-defined script tools, each gated per tool with optional [lifecycle hooks](/docs/agent-tools/hooks). |
-| **Config that scales to a team** | Override any provider's base URL, key, or model in [`settings.json`](/docs/configuration/settings), merged across a user → org-managed → project hierarchy. |
+| **BYOK, no lock-in** | Finds your provider automatically from whatever keys you have set: Anthropic, OpenAI, Gemini, Vertex, Bedrock, xAI, DeepSeek, Z.ai, OpenRouter, or any OpenAI-compatible local server. |
+| **Verified outcomes** | [Goal mode](/docs/agent-modes#outcome-driven-goal-mode) doesn't stop on a guess. A separate verifier model checks the evidence against the definition of done before the loop ends. |
+| **Tools behind a permission model** | A small built-in toolset — the shell, file editing, code search, sub-agents, the task board, scratch state, and an environment check — plus MCP servers and your own script tools, each one gated with optional [lifecycle hooks](/docs/agent-tools/hooks). |
+| **Config that scales to a team** | Set a different base URL, key, or model per provider in [`settings.json`](/docs/configuration/settings), merged across a user, org, and project hierarchy. |
 | **Local-first telemetry** | Usage, cost, and per-step metering land in `.stella/private/store.db` on your disk. |
 
 ## Bring your own provider
 
-stella speaks each provider's native wire dialect rather than funnelling everything
-through one OpenAI-shaped adapter, so provider features — Anthropic's thinking blocks,
-Gemini's thinking levels, Bedrock's Converse shape — are native rather than emulated.
+stella speaks each provider's own protocol instead of forcing every call
+through one OpenAI-shaped adapter. That means provider features like
+Anthropic's thinking blocks, Gemini's thinking levels, and Bedrock's
+Converse format work natively, not as an imitation.
 
 <ProviderGrid />
 
@@ -35,56 +37,60 @@ Gemini's thinking levels, Bedrock's Converse shape — are native rather than em
 
 <HeroFlowDiagram />
 
-stella sends your prompt to the model you selected, lets the model call tools to read and
-change your workspace, feeds the results back, and repeats until the task is done. Inside
-the box: the tool registry, MCP servers from `.stella/mcp.toml`, and the memory and
-code-graph context engine. In [goal mode](/docs/agent-modes#outcome-driven-goal-mode) a
-second model judges the result from evidence, so the loop ends on a verified outcome
-rather than the worker's own say-so.
+stella sends your prompt to the model you picked. The model calls tools to
+read and change your workspace, stella feeds the results back, and this
+repeats until the task is done. Behind the scenes: the tool registry, MCP
+servers from `.stella/mcp.toml`, and the memory and code-graph context
+engine. In [goal mode](/docs/agent-modes#outcome-driven-goal-mode), a second
+model checks the evidence, so the loop ends on a verified result instead of
+the worker's own claim that it's done.
 
-## Start with the thing you came here to do
+## Common tasks
 
-Each of these is one real task carried to a finished, verified result. They link
-down into the reference rather than replacing it, so you read a whole flag
-surface only when you need it.
+Each of these walks through one real task to a finished, verified result.
+They link down to the full reference instead of repeating it, so you only
+read the complete flag list when you actually need it.
 
 <CardGrid size="md">
   <SpecCard title="Fix a failing CI run" href="/docs/guides/fix-failing-ci">
-    Watch a red branch, fix root causes, push, re-check — and stop only on a green run
-    somebody else can see.
+    Watch a red branch, fix the root cause, push, and check again. Stop only
+    when the run is green for everyone, not just you.
   </SpecCard>
   <SpecCard title="Change an unfamiliar codebase" href="/docs/guides/unfamiliar-codebase">
-    Find the blast radius with the code graph before committing to an approach, then
-    ship the change verified.
+    Use the code graph to see what a change would affect before you commit
+    to an approach. Then ship it verified.
   </SpecCard>
   <SpecCard title="Find out what a run cost" href="/docs/guides/what-a-run-cost">
-    From the dollar figure down to the exact bytes one model call was sent — all of it
-    local.
+    From the total dollar cost down to the exact bytes sent in one model
+    call, all stored on your own machine.
   </SpecCard>
   <SpecCard title="Work within a spend limit" href="/docs/guides/spend-limit">
-    A hard ceiling, where the abort lands, and what compaction does when the transcript
-    outgrows the window.
+    Set a hard spending ceiling, see where a run stops if it hits that
+    ceiling, and understand what happens when the transcript outgrows the
+    model's context window.
   </SpecCard>
 </CardGrid>
 
-Never run it before? **[Get started](/docs/getting-started)** is thirty seconds —
-install, one key, `stella init`, first verified change. Something not working?
+New to stella? **[Get started](/docs/getting-started)** takes about thirty
+seconds: install, set one key, run `stella init`, and make your first
+verified change. Something not working?
 **[Troubleshooting](/docs/guides/troubleshooting)** is organized by symptom.
 
 ## Where to go
 
 | Section | Read it for |
 | --- | --- |
-| **[Start](/docs/getting-started)** | Install, configure a provider key, initialize a repo, make a first verified change. |
-| **[Do](/docs/guides)** | Task-shaped walkthroughs: red CI, an unfamiliar repo, cost forensics, budgets, [fleets](/docs/agent-fleets), [headless scripting](/docs/scripting), and [the engine in your app](/docs/agent-engine-in-your-app). |
-| **Understand** | How [plugins](/docs/plugins) prove work, the [engine's one loop](/docs/agent-engine-paths), how the [context engine](/docs/context-engine) makes recall cheap, the [modes](/docs/agent-modes) you drive it with, and [where telemetry goes](/docs/telemetry). |
+| **[Start](/docs/getting-started)** | Installing stella, setting up a provider key, starting a project, and making your first verified change. |
+| **[Do](/docs/guides)** | Step-by-step guides for real tasks: fixing red CI, working in an unfamiliar repo, tracking costs, setting budgets, [fleets](/docs/agent-fleets), [headless scripting](/docs/scripting), and [embedding the engine in your app](/docs/agent-engine-in-your-app). |
+| **Understand** | How [plugins](/docs/plugins) prove work is done, how the [engine's loop](/docs/agent-engine-paths) works, how the [context engine](/docs/context-engine) keeps recall cheap, the [modes](/docs/agent-modes) you can run stella in, and [where telemetry goes](/docs/telemetry). |
 | **Configure** | [`settings.json`](/docs/configuration), [providers](/docs/api-providers), [tools and permissions](/docs/agent-tools), and ready-made [recipes](/docs/examples). |
 | **Reference** | Every [command and flag](/docs/commands), the [event bus](/docs/extensions), and [release notes](/docs/release-notes). |
 | **Project** | The [showcase](/docs/showcase), and [supporting stella](/docs/donate). |
 
 <Callout type="info">
-  stella never proxies model traffic through a hosted service — your keys call your
-  provider directly. Community/default telemetry stays local; only an explicitly enrolled
-  Oxagen Enterprise seat can send the documented minimal operational envelope to its exact
-  allowlisted HTTPS sink. See [Telemetry](/docs/telemetry).
+  stella never routes model traffic through a hosted service of its own.
+  Your keys call your provider directly. Community telemetry stays on your
+  machine. Only an Oxagen Enterprise seat you've explicitly enrolled can
+  send a small, content-free operational summary to one approved address.
+  See [Telemetry](/docs/telemetry).
 </Callout>

--- a/website/content/docs/multimodal-input.mdx
+++ b/website/content/docs/multimodal-input.mdx
@@ -49,9 +49,9 @@ stella run "implement the retry policy described in @docs/rfc-042.pdf"
 | Text-like file (via `@`) | Its contents, inlined as text |
 | Any other binary | A text note describing what was attached |
 
-Stella has no size limit of its own. Attachments live on disk and are only
+stella has no size limit of its own. Attachments live on disk and are only
 converted to base64 when a request is built, so only your provider's own
-limits apply. Stella does cap you at 32 attachments per prompt, to stop a
+limits apply. stella does cap you at 32 attachments per prompt, to stop a
 runaway request.
 
 ## What each provider can see

--- a/website/content/docs/multimodal-input.mdx
+++ b/website/content/docs/multimodal-input.mdx
@@ -1,37 +1,39 @@
 ---
 title: Multimodal input
-description: Attach images, PDFs, audio, and video to any prompt — paste a screenshot with Ctrl-V or just mention the file's path. stella sends what your model can see, and tells it what it can't.
+description: Attach images, PDFs, audio, and video to any prompt. Paste a screenshot with Ctrl-V, or just mention a file's path.
 ---
 
-Prompts are not text-only. A screenshot of a broken layout, a PDF spec, a
-recording of a bug — any of them can ride into the model alongside your words,
-on every input surface: the interactive deck, `stella run`, and `stella chat`.
+You don't have to describe a problem in words. A screenshot of a broken
+layout, a PDF spec, or a recording of a bug can ride along with your prompt.
+This works on every input surface: the interactive deck, `stella run`, and
+`stella chat`.
 
-## Three ways to attach
+## Ways to attach
 
-**Paste an image — Ctrl-V.** In the deck, **Ctrl-V** reads the system
-clipboard directly. An image (a screenshot, a copied figure) is stored and
-attached to your prompt as a chip in the composer; plain text pastes like any
-other paste, so Ctrl-V is safe as a universal paste key.
+**Paste an image with Ctrl-V.** In the deck, Ctrl-V reads your clipboard
+directly. If you copied an image, such as a screenshot or a figure, it's
+saved and attached to your prompt as a chip in the composer. Plain text still
+pastes normally, so Ctrl-V is safe to use for every paste.
 
-Terminals cannot deliver a bitmap through a normal paste — Cmd-V of a
-screenshot arrives as nothing at all, which is why the explicit shortcut
-exists. Pasted images are PNG-encoded into `.stella/attachments/` in your
-workspace so the session transcript has a stable file to replay from; the
-store keeps the most recent hundred pastes and prunes older ones.
+Terminals can't normally receive a pasted image. A regular Cmd-V of a
+screenshot arrives as nothing. That's why this explicit shortcut exists.
+Pasted images are saved as PNG files in `.stella/attachments/` in your
+workspace, so your session has a stable file to replay later. The store
+keeps your most recent 100 pastes and removes older ones.
 
-**Mention a path.** Name a media file in your prompt and stella attaches the
-file itself as model input:
+**Mention a file's path.** Name a media file in your prompt and stella
+attaches the file itself:
 
 ```bash
 stella run "the header overlaps the nav on mobile — see shots/header.png"
 ```
 
-**`@`-mention a file.** `@` is a stronger signal than a bare path: media
-files attach, and text-like files (source, markdown, JSON) are **inlined** as
-text. A bare path-shaped token never inlines a text file — prose mentions
-paths all the time, and inlining every one would bloat context. A mention
-that does not resolve to a real file is left alone as plain text.
+**`@`-mention a file.** An `@`-mention is a stronger signal than a plain
+path. Media files get attached, and text-like files (source code, markdown,
+JSON) get inlined as text. A plain path-shaped word never gets inlined as
+text on its own — prose mentions paths all the time, and inlining every one
+would flood the model with context. If an `@`-mention doesn't match a real
+file, stella leaves it as plain text.
 
 ```bash
 stella run "implement the retry policy described in @docs/rfc-042.pdf"
@@ -41,21 +43,21 @@ stella run "implement the retry policy described in @docs/rfc-042.pdf"
 
 | You attach | The model receives |
 | --- | --- |
-| Image (`image/*`) | A native image block — the model sees the pixels |
+| Image (`image/*`) | A native image block. The model sees the pixels. |
 | PDF | A native document block |
-| Audio, video | Native media where the provider ingests it (see below) |
+| Audio, video | Native media, where the provider supports it (see below) |
 | Text-like file (via `@`) | Its contents, inlined as text |
 | Any other binary | A text note describing what was attached |
 
-There is no stella-side size cap — payloads live on disk and are only
-base64-encoded at the moment a request is built, so only your provider's own
-request limits apply. Attachments are capped at 32 per prompt as a
-runaway-token backstop.
+Stella has no size limit of its own. Attachments live on disk and are only
+converted to base64 when a request is built, so only your provider's own
+limits apply. Stella does cap you at 32 attachments per prompt, to stop a
+runaway request.
 
 ## What each provider can see
 
-Providers diverge here, and stella tracks the divergence per wire dialect
-rather than assuming parity:
+Providers differ in what they can look at, and stella tracks these
+differences instead of assuming every provider works the same way:
 
 | Provider | Images | PDFs | Audio | Video |
 | --- | --- | --- | --- | --- |
@@ -65,24 +67,24 @@ rather than assuming parity:
 | `bedrock` | yes | yes | — | yes |
 | OpenAI-compatible (`zai`, `openrouter`, `xai`, `deepseek`, `local`) | vision models only | — | — | — |
 
-On the OpenAI-compatible dialect, image support is per-model: GLM vision
-variants (the `v` in `glm-4.5v`) take images, plain GLM text models do not,
-and other vendors' models reached through a gateway are assumed
-vision-capable rather than having an image silently withheld.
+On the OpenAI-compatible path, image support depends on the model. GLM
+vision models (the `v` in `glm-4.5v`) can take images; plain GLM text models
+can't. For other vendors reached through a gateway, stella assumes the model
+can see images rather than silently dropping them.
 
-## When the model can't see it
+## Unsupported attachments
 
-An attachment a model cannot ingest **never errors the turn**. Sending an
-image to a text-only model would be a hard API failure that loses your
-prompt; stella instead replaces the payload with a short text note telling
-the model exactly what was attached — the filename, the kind, and that it
-cannot view it. The model can then say so, or open the file with a
-tool where that makes sense (a text-extractable PDF, a file worth
-inspecting), instead of hallucinating contents it never saw.
+If a model can't handle an attachment, the turn still works. Sending an
+image to a text-only model would normally fail the whole request and lose
+your prompt. Instead, stella swaps the attachment for a short text note that
+tells the model what was attached: the filename, the kind, and that it
+can't view it. The model can then say so, or open the file with a tool when
+that makes sense, such as reading a text-extractable PDF, instead of
+guessing at contents it never saw.
 
-The practical consequence: you can paste a screenshot without first checking
-which model is resolved. On a vision model it is seen; on anything else the
-model knows what it missed and tells you.
+In practice, this means you can paste a screenshot without checking which
+model is running first. A vision model sees it. Anything else knows what it
+missed, and tells you.
 
-Video is currently understood natively on Gemini, Vertex, and Bedrock;
-elsewhere it degrades to the descriptive note.
+Right now, video works natively on Gemini, Vertex, and Bedrock. Everywhere
+else, it degrades to the text note.

--- a/website/content/docs/plugins.mdx
+++ b/website/content/docs/plugins.mdx
@@ -1,68 +1,98 @@
 ---
 title: Plugins
-description: The turn-loop plugin platform — participation grades, the wrapper socket, the plugin.toml manifest, and how to write one in Python, TypeScript, or Rust with no stella SDK.
+description: How stella plugins work — participation levels, the plugin.toml manifest, and how to write one in Python, TypeScript, or Rust without an SDK.
 ---
 
-A **plugin** is a directory with a `plugin.toml` manifest and, usually, a program. The manifest declares exactly how much say the plugin wants in your turn loop and what it wants to reach outside it; you read that declaration once, at install, and say yes or no. Nothing a plugin does is inferred from its code — the manifest is the whole contract, and it is designed so a non-Rust author never has to read this repository to write one.
-
-This page covers what a plugin is, the manifest, how to install one, how to write one in Python (the worked example) or briefly in TypeScript and Rust, who verifies what, and what does not work yet.
+A plugin is a directory with a `plugin.toml` manifest, and usually a
+program. The manifest states exactly how much say the plugin gets in your
+turn loop, and what it wants to reach outside it. You read that once, when
+you install it, and say yes or no. The manifest is the whole contract.
+Stella never guesses what a plugin does from its code. You can write one
+without knowing Rust or reading stella's own source code.
 
 ## What a plugin is
 
-A plugin answers up to four points in the turn loop. You can send a message to two of them; two of them it can never receive, in any language:
+A plugin can answer up to four points in your turn loop. Two of them can
+receive a message from stella. The other two never receive one, in any
+language:
 
 | Point | Who runs it | Shape |
 | --- | --- | --- |
-| `before_turn` | **the plugin**, out of process | async — contribute context, narrow scope, name a role, publish a signal for a later stage |
-| `after_turn` | **the plugin**, out of process | async — gather evidence: run a test, read a diff, spend a declared model role and report the result |
-| `judge` | **the host**, in process | synchronous — evidence in, verdict out |
-| `again?` | **the host**, in process | synchronous — verdict in, continuation out: another turn with a correction, or stop |
+| `before_turn` | the plugin, outside stella | Async. Adds context, narrows scope, names a role, or sends a signal for a later stage. |
+| `after_turn` | the plugin, outside stella | Async. Gathers evidence: runs a test, reads a diff, spends a declared model role, and reports the result. |
+| `judge` | stella, inside the process | Synchronous. Takes evidence in, returns a verdict. |
+| `again?` | stella, inside the process | Synchronous. Takes a verdict in, decides what happens next: another turn with a correction, or stop. |
 
-`judge` and `again?` are not messages a plugin can be sent — the wire has exactly two request/response pairs, `before_turn` and `after_turn`, and neither one is a verdict. That is the design, not an oversight: a plugin declares its verdict **rule** as data in `plugin.toml` — the requirements it wants met, the flip policy, the checks — and stella evaluates that rule against the evidence the plugin reported. There is no `.await` inside `judge`, no subprocess it can spawn, and no way to smuggle a model call through it.
+A plugin can never be sent a `judge` or `again?` message. The wire only has
+two request/response pairs: `before_turn` and `after_turn`. Neither one is a
+verdict. This is deliberate, not a gap. A plugin declares its verdict rule
+as data in `plugin.toml`: the requirements it wants met, the flip policy,
+and the checks. Stella evaluates that rule against the evidence the plugin
+reports. `judge` can't wait on anything, spawn a subprocess, or call a
+model — that path doesn't exist for it.
 
-This is a feature, not a limitation, and it is worth being explicit about why. A verification plugin that could implement its own `judge` could quietly call a model to decide "done" — and in the output, a model ruling on its own work looks identical to one that never got the chance. Keeping `judge` a host function a plugin cannot touch makes "a verification plugin grades its own work with a model" impossible **by construction**, in Rust, in Python, in anything — rather than a rule a reviewer must keep re-checking by hand.
+Here's why that matters. If a verification plugin could write its own
+`judge`, it could quietly call a model to decide "done." In the output,
+that would look identical to a real, independent check. Keeping `judge`
+inside stella, where a plugin can never reach it, makes it impossible for a
+plugin to grade its own work with a model. No language can get around
+this — it's built into how the wire works, not a rule someone has to
+remember to enforce.
 
 <Callout type="info">
-Every capability a plugin needs arrives **in the request**. There is no ambient authority to reach for — no environment variable beyond what its manifest declared, no working directory, no terminal, no credential. That is what lets the identical plugin process run under the CLI, a headless server, or an application that embedded the loop, unchanged.
+Every capability a plugin needs arrives in the request. A plugin can't reach
+for anything else: no environment variable beyond what its manifest
+declared, no working directory, no terminal, no credential. That's what
+lets the same plugin process run unchanged under the CLI, a headless
+server, or an app that embeds the loop.
 </Callout>
 
-What that looks like from the driver's seat. A red gate is not something the
-model can talk its way past: it answers with a proposed plan revision naming
-the cause, the merge stays blocked until the board is green, and nothing runs
-until you approve it.
+Here's what that looks like in practice. A red gate can't be talked past by
+the model. It responds with a proposed plan revision that names the cause,
+the merge stays blocked until the board is green, and nothing runs until
+you approve it.
 
 <DeckShot id="gate" />
 
-## The participation ladder
+## Participation levels
 
-`[loop].participation` is how much say a plugin has asked for, on a four-rung ladder. Each grade includes every grade below it, and the power that separates two rungs is rejected below the rung that grants it — a manifest cannot quietly hold more than its declared grade.
+`[loop].participation` sets how much say a plugin gets, on a scale of four
+levels. Each level includes everything the levels below it can do. A
+plugin can't quietly do more than its declared level allows — stella
+rejects anything above it.
 
 <CardGrid size="md">
   <OptionCard name="none">
-    Nothing — a content bundle of skills, commands, agents, or custom tools. Never invoked inside a turn at all. The default when a manifest has no `[loop]` block.
+    No say at all. Just a bundle of skills, commands, agents, or custom tools — never called during a turn. This is the default when a manifest has no `[loop]` block.
   </OptionCard>
   <OptionCard name="observer">
-    May subscribe to the turn event stream. Cannot influence anything.
+    Can watch the turn event stream. Can't change anything.
   </OptionCard>
   <OptionCard name="steering">
-    May act at declared hook points and at `before_turn` / `after_turn` — inject context, rewrite tool input, decide permissions, gather evidence. May **not** touch completion.
+    Can act at its declared hook points and at `before_turn` / `after_turn`: add context, rewrite tool input, decide permissions, gather evidence. Cannot decide when a turn is done.
   </OptionCard>
   <OptionCard name="arbiter">
-    Everything steering may do, plus it binds the `Stop` gate: at each would-be completion the host asks the plugin's declared rule for a verdict, and an unmet requirement re-enters the loop, bounded by `max_holds`. The strongest grant.
+    Everything steering can do, plus it controls the `Stop` gate. At each point where a turn would finish, stella asks the plugin's declared rule for a verdict. If a requirement isn't met, the turn goes back into the loop, up to `max_holds` times. This is the strongest level.
   </OptionCard>
 </CardGrid>
 
-These rules hold regardless of grade:
+These rules hold at every level:
 
-- **An undeclared hook is never invoked.** Registering a process that listens for `PreToolUse` buys nothing if `[loop].hooks` does not name it — the manifest is the authority, not what the process does at runtime.
-- **An undeclared wrapper point is never dispatched.** `[loop].points` names which of `before_turn` / `after_turn` this plugin answers, exhaustively. A plugin that only gathers evidence declares `points = ["after_turn"]` and nothing else; the host never asks it for `before_turn`.
-- **Unknown keys are a load error, everywhere.** Every table in `plugin.toml` denies unknown fields. A typo'd grant fails loudly at install, rather than silently granting nothing.
+- **An undeclared hook is never called.** If `[loop].hooks` doesn't name `PreToolUse`, registering a process that listens for it does nothing. The manifest decides what runs, not what the process itself is built to do.
+- **An undeclared wrapper point is never called.** `[loop].points` lists every point this plugin answers, out of `before_turn` and `after_turn`. A plugin that only gathers evidence declares `points = ["after_turn"]`. Stella never asks it for `before_turn`.
+- **An unknown key always fails to load.** Every table in `plugin.toml` rejects fields it doesn't recognize. A typo in a grant fails loudly at install, instead of silently granting nothing.
 
-`[[capabilities]]` — what a plugin wants to reach *outside* the turn (a tool, at a named risk level, with the reason a human reads) — is orthogonal to this ladder on purpose. A `none`-grade content bundle shipping one custom tool that runs `git push` asks for more of the world than an `observer` that only watches; tying the two together would let the widest grant hide behind the weakest participation grade.
+`[[capabilities]]` (what a plugin wants to reach outside the turn, such as
+a tool, at a named risk level, with a reason a human can read) is kept
+separate from participation on purpose. A `none`-level content bundle that
+ships one custom tool running `git push` is asking for more than an
+`observer` that only watches. If the two were tied together, the widest
+grant could hide behind the weakest participation level.
 
 ## The manifest
 
-A complete, working manifest — an arbiter that holds a turn open until a test command it is handed goes from failing to passing:
+Here's a complete, working manifest: an arbiter that holds a turn open
+until a test command it's given goes from failing to passing.
 
 ```toml title="plugin.toml"
 name = "verify"
@@ -109,47 +139,55 @@ purpose = "run the test invocation the request's candidate grant names"
 scope = ["the program and args in `candidate.test`, spawned in `candidate.root`"]
 ```
 
-Every block, in the shape the manifest parser accepts:
+Here's every block the manifest parser accepts:
 
 <CardGrid size="md">
   <OptionCard name="[loop]">
-    `participation` (the ladder above), `hooks` (which lifecycle events — `SessionStart`, `PreToolUse`, `PostToolUse`, `Stop`, `PreCompact` — this plugin acts at), `points` (which of `before_turn` / `after_turn` it answers), and `max_holds` (arbiter only — the most completion-vetoes it asks for per turn). Absent entirely, a manifest defaults to `none`: a content bundle with no say in the loop at all.
+    `participation` sets the level, described above. `hooks` lists which lifecycle events this plugin acts at: `SessionStart`, `PreToolUse`, `PostToolUse`, `Stop`, `PreCompact`. `points` lists which of `before_turn` / `after_turn` it answers. `max_holds` (arbiter only) sets the most times it can veto completion per turn. If `[loop]` is missing entirely, the manifest defaults to `none`: a content bundle with no say in the loop.
   </OptionCard>
   <OptionCard name="[requirements]">
-    Arbiter only. A table of `name = "human-readable statement"` — the enumerable definition of done. Keys are what an unmet hold cites; must be non-empty if declared, and every statement must be non-blank.
+    Arbiter only. A table of `name = "human-readable statement"` pairs that define what "done" means. An unmet hold cites these keys by name. If you declare `[requirements]`, it can't be empty, and every statement must have text.
   </OptionCard>
   <OptionCard name="[oracle]">
-    Arbiter only, and it must declare `points = ["after_turn"]` alongside it — that is the one response its evidence rides on. `flip` is `"required"` (the plugin reports a fail→pass transition) or `"not-applicable"` (this oracle's evidence is a measurement, not a transition — every requirement must then be decided by a `[[oracle.checks]]` entry, or the manifest is refused). `measurements` names the numbers the plugin's process reports; `[[oracle.checks]]` states a rule over one of them (`<measurement> <op> <integer>`) that decides one named requirement. `command` is optional when `[runtime]` is declared — absent means "the oracle is this plugin's own process," which is the common case and keeps a manifest from writing the same argv out twice.
+    Arbiter only, and it must also declare `points = ["after_turn"]` — that's the one response its evidence rides on. `flip` is either `"required"` (the plugin reports a fail-to-pass change) or `"not-applicable"` (the evidence is a measurement, not a change — every requirement must then be decided by a `[[oracle.checks]]` entry, or stella refuses to load the manifest). `measurements` names the numbers the plugin's process reports. `[[oracle.checks]]` states a rule over one of them (`<measurement> <op> <integer>`) that decides one named requirement. `command` is optional when `[runtime]` is declared. Leaving it out means "the oracle is this plugin's own process," which is the common case, and saves you from writing the same argv twice.
   </OptionCard>
   <OptionCard name="[runtime]">
-    Observer and above. `argv` — program and arguments, never a shell string, with `${plugin_dir}` interpolated by the host to the plugin's install directory. `timeout_secs` — at least 1. `env` — the **allowlist**, exact names and nothing else: the child process starts with an empty environment and receives only the variables named here. There is no `language` field; `["python3", "${plugin_dir}/main.py"]` already says everything the host needs to know.
+    Observer and above. `argv` is the program and its arguments, never a shell string. Stella replaces `${plugin_dir}` with the plugin's install directory. `timeout_secs` must be at least 1. `env` is an allowlist: the child process starts with no environment variables at all, and gets only the exact names listed here. There's no `language` field — `["python3", "${plugin_dir}/main.py"]` already says everything stella needs to know.
   </OptionCard>
   <OptionCard name="[wrapper]">
-    Steering and above, optional. Declares this plugin as a turn-loop wrapper: an `id` (the variant name recorded on the run, for A/B comparison) and an ordered `[[wrapper.stages]]` list, each naming a stage and carrying an optional `if` condition over a closed, published signal vocabulary (`questions > 0`, `no-conversational`, …). A condition naming a signal the host does not publish, or one only a later or conditionally-run stage produces, is a load error — a manifest that would quietly do nothing is refused instead.
+    Steering and above, optional. Declares this plugin as a turn-loop wrapper: an `id` (the variant name recorded on the run, for A/B comparison), and an ordered `[[wrapper.stages]]` list. Each stage has a name and an optional `if` condition over a fixed set of published signals (`questions > 0`, `no-conversational`, and others). If a condition names a signal stella doesn't publish, or one that only a later or conditional stage produces, stella refuses to load the manifest rather than run a stage that quietly does nothing.
 
-    **The stage name is an open vocabulary.** A stage may be one of the host's own boundaries (`triage`, `recall`, `research`, `plan`, `scope`, `execute`, `witness`, `verify`, `verdict`, `reflect`, `contextwrite`, `complete`) or a word your plugin contributes — `name = "triage-lite"` runs a stage the host has never heard of, under your name for it, and the statline and transcript render it in its own colour. A contributed name must be lowercase ASCII letters, digits and `-`, start with a letter, be at most 32 characters, and must not be the wire spelling of a host boundary (`context_recall`, `scope_review`, `context_write`, `judge`, `verifier`) — that would make your stage read as one of the host's. A contributed stage may be conditional on any published signal; it publishes none of its own.
+    **A stage name can be one of stella's own stages** (`triage`, `recall`, `research`, `plan`, `scope`, `execute`, `witness`, `verify`, `verdict`, `reflect`, `contextwrite`, `complete`), or a name your plugin makes up. `name = "triage-lite"` runs a stage stella has never seen, under the name you gave it, shown in its own color in the statline and transcript. A name you make up must use lowercase letters, digits, and `-`, start with a letter, be 32 characters or fewer, and can't match the internal spelling of a real stella stage (`context_recall`, `scope_review`, `context_write`, `judge`, `verifier`) — that would make your stage look like one of stella's own. A stage you name can react to any published signal, but it can't publish signals of its own.
   </OptionCard>
   <OptionCard name="[roles]">
-    Requires `[subloop]` (steering and above — a declared list of stages the host runs as bounded child turns, a separate block from `[wrapper]`). Each `[roles.<name>]` declares a routing **intent** for one subloop stage — `tier = "cheap"` — never a model id, provider, or credential. The host resolves the intent against your configured providers at run time and refuses an intent the manifest never declared.
+    Requires `[subloop]` (steering and above): a declared list of stages stella runs as bounded child turns, separate from `[wrapper]`. Each `[roles.<name>]` declares a routing intent for one subloop stage, such as `tier = "cheap"` — never a model ID, provider, or credential. Stella resolves that intent against your configured providers at run time, and refuses any intent the manifest didn't declare.
   </OptionCard>
   <OptionCard name="[[capabilities]]">
-    Zero or more. `tool` (free text — the tool name, matched against the host's registry at install), `risk` (`low` / `medium` / `high` / `destructive`, the same grade the authorization gate refuses on), `purpose` (required — why the plugin needs it, shown at consent), and `scope` (the plugin's own claimed limit, shown verbatim and labeled as a claim the gate does not verify). Orthogonal to `[loop]` by design — see the ladder section above.
+    Zero or more entries. `tool` is free text — the tool name, matched against stella's registry at install. `risk` is `low`, `medium`, `high`, or `destructive` — the same scale the authorization gate uses. `purpose` is required: why the plugin needs it, shown when you're asked to approve it. `scope` is the plugin's own claimed limit, shown to you word for word and labeled as a claim stella does not check. This is kept separate from `[loop]` on purpose — see participation levels above.
   </OptionCard>
 </CardGrid>
 
-## What a package ships beside the manifest
+## Package contents
 
-`plugin.toml` declares; the directory beside it carries. Three conventions, each handed to the loader that already owns that format:
+`plugin.toml` declares what the plugin can do. The rest of its directory
+carries three kinds of content, each read by the part of stella that
+already understands that format:
 
-- `<plugin_dir>/tools/*.toml` — [custom script tools](/docs/agent-tools/custom-tools), advertised to the model beside the built-ins and executed as the plugin, never as you.
-- `<plugin_dir>/skills/<slug>/SKILL.md` — [skills](/docs/agent-tools/skills), selected against the prompt and injected as context. Never enforced.
-- `<plugin_dir>/rules/*.toml` — context records, in the format `.stella/rules/` holds. Advisory only: a plugin's record cannot arm itself to deny a tool call.
+- `<plugin_dir>/tools/*.toml` — [custom script tools](/docs/agent-tools/custom-tools), shown to the model alongside the built-in tools, and run as the plugin, never as you.
+- `<plugin_dir>/skills/<slug>/SKILL.md` — [skills](/docs/agent-tools/skills), matched against your prompt and added as context. Never enforced.
+- `<plugin_dir>/rules/*.toml` — context records, in the same format `.stella/rules/` uses. Advisory only: a plugin's rule can't block a tool call on its own.
 
-Everything under these is named in the install prompt before any of it exists on your machine. A `tools/` entry the manifest does not declare is a load error, in both directions.
+Every file under these directories is named in the install prompt before
+any of it lands on your machine. If a `tools/` file exists but the manifest
+doesn't declare it, or the manifest declares one that doesn't exist,
+loading fails.
 
 ### `${plugin_dir}` in a package's tools
 
-A shipped tool does not know where it will be installed, so its manifest writes the same placeholder `[runtime].argv` does, and the host expands it to the package's own directory — in **every** `command` element and **every** `[env]` value:
+A shipped tool doesn't know where it'll be installed. So its manifest uses
+the same placeholder that `[runtime].argv` uses, and stella expands it to
+the package's own directory, in every `command` element and every `[env]`
+value:
 
 ```toml title="tools/lint-fix.toml"
 name = "lint-fix"
@@ -160,9 +198,15 @@ command = ["${plugin_dir}/scripts/lint-fix.sh"]
 RULESET = "${plugin_dir}/rules/strict.yaml"
 ```
 
-Ship `scripts/lint-fix.sh` executable — the host spawns it directly, never through a shell, and never invokes an interpreter you did not name in `command`.
+Ship `scripts/lint-fix.sh` as an executable file. Stella runs it directly,
+never through a shell, and never invokes an interpreter you didn't name in
+`command`.
 
-The placeholder is expanded **only** for a manifest read out of a package. Your own `.stella/tools/` and `~/.stella/tools/` manifests are left verbatim: no package is in scope there, and quietly expanding `${plugin_dir}/x.sh` to `/x.sh` would run a different file rather than fail with a message naming what the manifest actually asked for.
+Stella only expands the placeholder for a manifest that comes from a
+package. Your own `.stella/tools/` and `~/.stella/tools/` manifests are
+left exactly as written, because there's no package directory to expand it
+to. Silently turning `${plugin_dir}/x.sh` into `/x.sh` would run the wrong
+file instead of failing with a clear error.
 
 ## Installing a plugin
 
@@ -172,7 +216,11 @@ stella plugin list
 stella plugin remove <name>
 ```
 
-`install` reads and validates `plugin.toml`, then prints the **whole** declared grant — the participation grade, every hook point, the process it runs as, the exact environment slice it inherits, every requirement it will hold a turn open for, and every capability it asks for outside the turn — and installs nothing until you accept it:
+`install` reads and checks `plugin.toml`, then prints the whole grant it's
+asking for: the participation level, every hook point, the process it runs
+as, the exact environment variables it gets, every requirement it can hold
+a turn open for, and every capability it wants outside the turn. Nothing
+installs until you accept it:
 
 ```text
 Install `verify`?
@@ -202,23 +250,46 @@ Nothing above is granted until you accept.
 Install it? [y/N]
 ```
 
-`stella plugin list` shows what is installed and — separately — the dispatches stella would actually make from that declaration; `stella plugin remove <name>` deletes it from every tier that holds the name. Full flag reference: [`stella plugin`](/docs/commands/plugin).
+`stella plugin list` shows what's installed, and separately, what stella
+would actually call based on that declaration. `stella plugin remove <name>`
+deletes it from every tier that has it. Full flag reference:
+[`stella plugin`](/docs/commands/plugin).
 
-### The project-tier trust gate
+### Project trust gate
 
-Two tiers are read as one roster: `~/.stella/plugins/` (installed once, visible everywhere) and `<workspace>/.stella/plugins/` (this repository only). The second one is content a `git clone` can bring with it, and **a plugin is strictly more powerful than a hook or an MCP server** — it declares a `[runtime]` process the host spawns and, at `arbiter`, a grant that can hold your turn loop open indefinitely. So a cloned repository's plugins do **not** load until you trust the workspace:
+Stella reads plugins from two places as one list: `~/.stella/plugins/`
+(installed once, visible in every project) and
+`<workspace>/.stella/plugins/` (this project only). The second one is
+something a `git clone` can bring with it. A plugin is more powerful than a
+hook or an MCP server: it declares a `[runtime]` process that stella runs,
+and at the `arbiter` level, a grant that can hold your turn loop open
+indefinitely. So a cloned project's plugins don't load until you trust the
+workspace:
 
 ```bash
 export STELLA_TRUST_PROJECT=1
 ```
 
-Without it, `<workspace>/.stella/plugins/` is skipped and a stderr notice names what was skipped, the same shape used for [project-scope hooks](/docs/agent-tools/hooks) and [`.stella/mcp.toml`](/docs/agent-tools/mcp). The user tier is not gated — nothing arrives there except through `stella plugin install`'s own consent prompt, which is already a transaction you approved.
+Without it, stella skips `<workspace>/.stella/plugins/` and prints a notice
+on stderr naming what it skipped — the same pattern used for
+[project-scope hooks](/docs/agent-tools/hooks) and
+[`.stella/mcp.toml`](/docs/agent-tools/mcp). The user tier isn't gated,
+because nothing lands there except through `stella plugin install`'s own
+consent prompt, which you already approved.
 
 ## Writing one in Python
 
-This is the point of the whole page: a plugin needs no SDK, in any language. The `verify` plugin above is real and shipped — [`plugins/verify-py/`](https://github.com/macanderson/stella-examples/tree/main/plugins/verify-py) in `stella-examples` — and its [`main.py`](https://github.com/macanderson/stella-examples/blob/main/plugins/verify-py/main.py) is about 320 lines of Python using only `json`, `subprocess`, `sys`, and `time` from the standard library. If you want to learn the protocol, that file is the shortest complete statement of it that exists.
+A plugin needs no SDK, in any language. The `verify` plugin above is real
+and ready to use — [`plugins/verify-py/`](https://github.com/macanderson/stella-examples/tree/main/plugins/verify-py)
+in `stella-examples` — and its
+[`main.py`](https://github.com/macanderson/stella-examples/blob/main/plugins/verify-py/main.py)
+is about 320 lines of Python, using only `json`, `subprocess`, `sys`, and
+`time` from the standard library. If you want to learn the protocol, that
+file is the shortest complete example there is.
 
-The wire is one exchange per call: the host spawns `[runtime].argv` directly — never through a shell — writes one JSON request on stdin, closes it, and reads one JSON response from stdout.
+Each call is one exchange. Stella spawns `[runtime].argv` directly, never
+through a shell, writes one JSON request to stdin, closes it, and reads one
+JSON response from stdout.
 
 ```jsonc
 // stdin — an after_turn request
@@ -241,14 +312,15 @@ The wire is one exchange per call: the host spawns `[runtime].argv` directly —
                        "measurements": {"test-command-exit-code": 0}}}}
 ```
 
-Four properties of that exchange are worth internalizing, because each one is something a naive implementation gets wrong:
+Four things about this exchange matter, because each one is easy to get
+wrong:
 
-1. **Every table denies unknown fields, the envelope included.** `protocol_version` rides on every message and the contract only ever grows additively, but a field the host does not know at a version it accepts is a typo — and a message that quietly does nothing is worse than one that refuses.
-2. **There is no error variant.** A response type cannot carry a failure. A plugin that cannot answer *fails*: non-zero exit, one line on stderr, nothing on stdout — and the host substitutes an "unobservable" evidence set on its behalf, which makes `judge` abstain rather than blame the worker for evidence nobody collected.
-3. **Every capability arrives in the request.** The `candidate` field is a grant: a handle, the canonical workspace `root`, and — when the host has one to give — the `test` to run there, as a program, its arguments, and what that same invocation reported *before* the turn (`baseline`). A wrapper never reaches for a terminal, a git checkout, a credential, an environment variable, or a working directory of its own.
-4. **A plugin cannot report a tamper finding.** The response type has no field for one, in any language. Snapshotting witness-artifact identity is the host's job, and the host merges its own finding in before `judge` ever runs — a plugin vouching for its own witness is exactly what that split exists to prevent.
+1. **Every table rejects fields it doesn't know, including the envelope itself.** `protocol_version` is on every message, and the contract only ever adds fields over time. But a field stella doesn't recognize at a version it accepts is a typo. A message that quietly does nothing is worse than one that fails outright.
+2. **There's no way to report an error in the response itself.** A plugin that can't answer fails outright: a non-zero exit code, one line on stderr, nothing on stdout. Stella then fills in an "unobservable" evidence set for it, so `judge` abstains instead of blaming the plugin for evidence that was never collected.
+3. **Every capability arrives in the request.** The `candidate` field is a grant: a handle, the workspace `root`, and, when stella has one to give, the `test` to run there — a program, its arguments, and what that same test reported before the turn (`baseline`). A wrapper never reaches for a terminal, a git checkout, a credential, an environment variable, or a working directory of its own.
+4. **A plugin can't report a tamper finding.** The response type has no field for one, in any language. Checking witness-artifact identity is stella's job, and stella adds its own finding before `judge` ever runs. This is deliberate — a plugin vouching for its own witness is exactly what this split is meant to prevent.
 
-The whole shape, condensed to what `main.py` actually does:
+Here's the whole shape, condensed to what `main.py` actually does:
 
 ```python title="main.py — the shape, condensed"
 import json, subprocess, sys, time
@@ -290,7 +362,14 @@ if __name__ == "__main__":
     main()
 ```
 
-The real `main.py` is stricter than this — it denies unknown fields at every level, distinguishes a timed-out test from a signal-killed one, and never guesses at a command it was not given — but the shape above is the entire protocol. Read the [real file](https://github.com/macanderson/stella-examples/blob/main/plugins/verify-py/main.py) and its [README](https://github.com/macanderson/stella-examples/blob/main/plugins/verify-py/README.md) for the complete, defensive version, including how to run it by hand with a single `echo | python3 main.py` and how its test suite grades it against the same golden vectors the Rust and TypeScript versions use.
+The real `main.py` is stricter than this: it rejects unknown fields at
+every level, tells a timed-out test apart from a signal-killed one, and
+never guesses at a command it wasn't given. But the shape above is the
+whole protocol. Read the [real file](https://github.com/macanderson/stella-examples/blob/main/plugins/verify-py/main.py)
+and its [README](https://github.com/macanderson/stella-examples/blob/main/plugins/verify-py/README.md)
+for the full version, including how to run it by hand with
+`echo | python3 main.py`, and how its tests check it against the same
+reference cases the Rust and TypeScript versions use.
 
 Install it the same way as any plugin:
 
@@ -299,46 +378,61 @@ stella plugin install plugins/verify-py            # this workspace
 stella plugin install plugins/verify-py --scope user  # every workspace
 ```
 
-## TypeScript and Rust, briefly
+## TypeScript and Rust
 
-The same plugin ships two more times in `stella-examples`, to prove the wire — not the SDK — is the platform. All three manifests are generated from one template and differ in exactly the `[runtime].argv` line naming the program; a script in CI (`check-manifests-identical.py`) fails the build if that ever stops being true.
+The same plugin also ships in TypeScript and Rust in `stella-examples`, to
+prove the wire itself, not an SDK, is what makes a plugin work. All three
+manifests come from one template and differ only in the `[runtime].argv`
+line naming the program. A script called `check-manifests-identical.py`
+checks this stays true.
 
 <CardGrid size="md">
   <OptionCard name="verify-ts">
-    [`plugins/verify-ts/`](https://github.com/macanderson/stella-examples/tree/main/plugins/verify-ts). Zero runtime dependencies — not even `@types/node`. The Node surface it touches is hand-declared in a 14-line `.d.ts` file. `npm run build` compiles `src/main.ts` to `dist/main.js`, and `[runtime].argv` is `["node", "${plugin_dir}/dist/main.js"]` — build before you install; the host never invokes a compiler.
+    [`plugins/verify-ts/`](https://github.com/macanderson/stella-examples/tree/main/plugins/verify-ts). No runtime dependencies at all, not even `@types/node`. The small part of Node it uses is declared by hand in a 14-line `.d.ts` file. `npm run build` compiles `src/main.ts` to `dist/main.js`, and `[runtime].argv` is `["node", "${plugin_dir}/dist/main.js"]`. Build it before you install it — stella never runs a compiler for you.
   </OptionCard>
   <OptionCard name="verify-rs">
-    [`plugins/verify-rs/`](https://github.com/macanderson/stella-examples/tree/main/plugins/verify-rs). The reference implementation, and the one CI still exercises over the *wire* rather than in-process — its own rule for itself, so the wire path never rots for lack of use. Depends only on `serde` / `serde_json`, not on any crate from this workspace: a third-party Rust author could not link `stella-plugin` either. `cargo build --release` produces the binary `[runtime].argv` names directly — the cheapest thing a host can spawn.
+    [`plugins/verify-rs/`](https://github.com/macanderson/stella-examples/tree/main/plugins/verify-rs). The reference version, and the one tested over the actual wire protocol rather than in-process, so that path stays exercised. It depends only on `serde` and `serde_json`, not on any of stella's own code — a third-party Rust author couldn't link against stella's internals either. `cargo build --release` produces the binary that `[runtime].argv` names directly, the simplest thing stella can run.
   </OptionCard>
 </CardGrid>
 
-## How much a plugin can do
+## What plugins can do
 
-Read this before installing a verification plugin, and match it to what the install prompt already tells you — this is architecture, not an apology.
+Read this before installing a verification plugin, and compare it with what
+the install prompt tells you. This is how the system is built, not an
+excuse.
 
-**Verification is delivered by an installed plugin.** A plugin's `[oracle]` runs in the plugin's own process. stella does not run that oracle, and it does not re-check what comes back: the fail→pass flip, and every number a declared check compares against a budget, are what the plugin's own process said it saw. stella applies the declared rule — `[requirements]`, the flip policy, the checks — to those reported claims, and it will not credit a requirement they leave undecided. What it cannot do is tell an earned result from a typed one.
+Verification is delivered by an installed plugin. A plugin's `[oracle]`
+runs in the plugin's own process. Stella doesn't run that oracle itself,
+and it doesn't double-check the result: the fail-to-pass change, and every
+number a check compares against a limit, come from what the plugin's own
+process reports. Stella applies the declared rule (`[requirements]`, the
+flip policy, the checks) to those reported claims, and won't credit a
+requirement the plugin leaves undecided. What stella can't do is tell a
+result the plugin actually earned from one it just typed in.
 
-Two guarantees stay in the host no matter what a manifest declares:
+Two things always stay under stella's own control, no matter what a
+manifest declares:
 
-- **`judge` is still synchronous, I/O-free, and total**, over the evidence the plugin reported. A plugin cannot decide "done" for itself, in any language — see [What a plugin is](#what-a-plugin-is) above. What changed with this architecture is not that guarantee; it is where the *evidence* comes from.
-- **The tamper finding is the host's, never the plugin's.** Snapshotting witness-artifact identity happens host-side, and the response type a plugin sends has no field for a tamper finding in any language — a plugin cannot vouch for its own witness even if it wanted to.
+- **`judge` still runs inside stella, with no I/O**, over the evidence the plugin reported. A plugin can't decide "done" for itself, in any language — see [What a plugin is](#what-a-plugin-is) above. What changes is where the evidence comes from, not who decides.
+- **The tamper check is always stella's, never the plugin's.** Checking witness-artifact identity happens inside stella, and a plugin's response has no field for a tamper finding, in any language. A plugin can't vouch for its own witness even if it tried.
 
-Installing a verification plugin means trusting it to report what it saw. That is the same trust you place in a third-party test runner or CI check you did not write yourself.
+Installing a verification plugin means trusting it to report what it
+actually saw. That's the same trust you already place in a third-party
+test runner or a CI check you didn't write yourself.
 
-## What does not work yet
-
-Named plainly, because a platform whose documentation describes only the finished half is not documented.
+## What's not built yet
 
 <Callout type="warn">
-**Dispatch into a live turn is not wired.** `stella plugin install`, `list`, and `remove` are complete: they parse and validate manifests, render the full consent text, write to `.stella/plugins/` or `~/.stella/plugins/`, and (for `list`) show you the hook and wrapper-socket dispatches that *would* happen. But nothing in a real `stella run` or Command Deck session reads that installed roster yet — no `PreToolUse`/`Stop`/etc. hook process is spawned, and no `before_turn` / `after_turn` request is sent, during an actual turn. The wrapper socket itself (the wire contract, the subprocess and in-process transports, `judge`, `again?`) is implemented and covered by its own integration tests, and the three reference plugins are graded against a shared conformance harness that replays the wire protocol directly, not against a live session. Verify it yourself: today a plugin manifest changes what `stella plugin list` prints, and nothing else.
+**A plugin doesn't run during a real turn yet.** `stella plugin install`, `list`, and `remove` are complete: they read and check manifests, show you the full consent text, write to `.stella/plugins/` or `~/.stella/plugins/`, and, for `list`, show you the hook and wrapper dispatches that would happen. But nothing in a real `stella run` or Command Deck session reads that installed list yet. No `PreToolUse`, `Stop`, or other hook process gets started, and no `before_turn` or `after_turn` request gets sent, during an actual turn. The wrapper system itself — the wire contract, the transports, `judge`, and `again?` — is built and tested on its own. The three example plugins are checked against a shared test harness that replays the wire protocol directly, not against a live session. You can check this yourself: today, a plugin manifest only changes what `stella plugin list` prints, nothing else.
 </Callout>
 
-Smaller, standing gaps in the wire contract itself, worth knowing before you rely on them:
+Smaller gaps in the wire contract itself, worth knowing before you rely on
+it:
 
-- **`unobservable` covers several different problems with one value.** A root that does not resolve, a program that is not there, a run that outlived its budget, and a baseline that never watched an assertion in the first place all report the same `FlipObservation::Unobservable` — the host cannot currently tell them apart.
-- **A `TestPlan` names no environment and no timeout.** The grant says which program to run and where, but not what environment it would have run in or how long it would have waited — so "the same invocation" is the same argv, not provably the same run, and each plugin author has to pick their own internal budget.
-- **The version check is the reader's job, not the wire type's.** A body claiming `protocol_version: 2` still decodes as a structurally valid request; a host (or a careful plugin) has to compare the number itself rather than have decoding fail for it.
-- **A plugin cannot declare a measurement as "absent on purpose."** A number a plugin's oracle simply did not compute this run and a number the author forgot to report both arrive the same way: missing.
+- **`unobservable` covers several different problems with one value.** A root that doesn't resolve, a program that isn't there, a run that went over its time budget, and a baseline that never checked anything in the first place all report the same `FlipObservation::Unobservable`. Stella can't currently tell them apart.
+- **A `TestPlan` doesn't name an environment or a timeout.** The grant says which program to run and where, but not what environment it ran in or how long it waited. So "the same invocation" means the same command and arguments, not provably the same run. Each plugin author has to pick their own timeout.
+- **Checking the version is up to the reader, not the wire format.** A message claiming `protocol_version: 2` still decodes as a valid request. Stella, or a careful plugin, has to check the number itself — decoding won't fail on its own.
+- **A plugin can't mark a measurement as "left out on purpose."** A number the plugin's oracle didn't compute this run, and a number the author simply forgot to report, both show up the same way: missing.
 
 ## See also
 

--- a/website/content/docs/plugins.mdx
+++ b/website/content/docs/plugins.mdx
@@ -7,7 +7,7 @@ A plugin is a directory with a `plugin.toml` manifest, and usually a
 program. The manifest states exactly how much say the plugin gets in your
 turn loop, and what it wants to reach outside it. You read that once, when
 you install it, and say yes or no. The manifest is the whole contract.
-Stella never guesses what a plugin does from its code. You can write one
+stella never guesses what a plugin does from its code. You can write one
 without knowing Rust or reading stella's own source code.
 
 ## What a plugin is
@@ -25,9 +25,9 @@ language:
 
 A plugin can never be sent a `judge` or `again?` message. The wire only has
 two request/response pairs: `before_turn` and `after_turn`. Neither one is a
-verdict. This is deliberate, not a gap. A plugin declares its verdict rule
+verdict. A plugin declares its verdict rule
 as data in `plugin.toml`: the requirements it wants met, the flip policy,
-and the checks. Stella evaluates that rule against the evidence the plugin
+and the checks. stella evaluates that rule against the evidence the plugin
 reports. `judge` can't wait on anything, spawn a subprocess, or call a
 model — that path doesn't exist for it.
 
@@ -79,7 +79,7 @@ rejects anything above it.
 These rules hold at every level:
 
 - **An undeclared hook is never called.** If `[loop].hooks` doesn't name `PreToolUse`, registering a process that listens for it does nothing. The manifest decides what runs, not what the process itself is built to do.
-- **An undeclared wrapper point is never called.** `[loop].points` lists every point this plugin answers, out of `before_turn` and `after_turn`. A plugin that only gathers evidence declares `points = ["after_turn"]`. Stella never asks it for `before_turn`.
+- **An undeclared wrapper point is never called.** `[loop].points` lists every point this plugin answers, out of `before_turn` and `after_turn`. A plugin that only gathers evidence declares `points = ["after_turn"]`. stella never asks it for `before_turn`.
 - **An unknown key always fails to load.** Every table in `plugin.toml` rejects fields it doesn't recognize. A typo in a grant fails loudly at install, instead of silently granting nothing.
 
 `[[capabilities]]` (what a plugin wants to reach outside the turn, such as
@@ -152,7 +152,7 @@ Here's every block the manifest parser accepts:
     Arbiter only, and it must also declare `points = ["after_turn"]` — that's the one response its evidence rides on. `flip` is either `"required"` (the plugin reports a fail-to-pass change) or `"not-applicable"` (the evidence is a measurement, not a change — every requirement must then be decided by a `[[oracle.checks]]` entry, or stella refuses to load the manifest). `measurements` names the numbers the plugin's process reports. `[[oracle.checks]]` states a rule over one of them (`<measurement> <op> <integer>`) that decides one named requirement. `command` is optional when `[runtime]` is declared. Leaving it out means "the oracle is this plugin's own process," which is the common case, and saves you from writing the same argv twice.
   </OptionCard>
   <OptionCard name="[runtime]">
-    Observer and above. `argv` is the program and its arguments, never a shell string. Stella replaces `${plugin_dir}` with the plugin's install directory. `timeout_secs` must be at least 1. `env` is an allowlist: the child process starts with no environment variables at all, and gets only the exact names listed here. There's no `language` field — `["python3", "${plugin_dir}/main.py"]` already says everything stella needs to know.
+    Observer and above. `argv` is the program and its arguments, never a shell string. stella replaces `${plugin_dir}` with the plugin's install directory. `timeout_secs` must be at least 1. `env` is an allowlist: the child process starts with no environment variables at all, and gets only the exact names listed here. There's no `language` field — `["python3", "${plugin_dir}/main.py"]` already says everything stella needs to know.
   </OptionCard>
   <OptionCard name="[wrapper]">
     Steering and above, optional. Declares this plugin as a turn-loop wrapper: an `id` (the variant name recorded on the run, for A/B comparison), and an ordered `[[wrapper.stages]]` list. Each stage has a name and an optional `if` condition over a fixed set of published signals (`questions > 0`, `no-conversational`, and others). If a condition names a signal stella doesn't publish, or one that only a later or conditional stage produces, stella refuses to load the manifest rather than run a stage that quietly does nothing.
@@ -160,7 +160,7 @@ Here's every block the manifest parser accepts:
     **A stage name can be one of stella's own stages** (`triage`, `recall`, `research`, `plan`, `scope`, `execute`, `witness`, `verify`, `verdict`, `reflect`, `contextwrite`, `complete`), or a name your plugin makes up. `name = "triage-lite"` runs a stage stella has never seen, under the name you gave it, shown in its own color in the statline and transcript. A name you make up must use lowercase letters, digits, and `-`, start with a letter, be 32 characters or fewer, and can't match the internal spelling of a real stella stage (`context_recall`, `scope_review`, `context_write`, `judge`, `verifier`) — that would make your stage look like one of stella's own. A stage you name can react to any published signal, but it can't publish signals of its own.
   </OptionCard>
   <OptionCard name="[roles]">
-    Requires `[subloop]` (steering and above): a declared list of stages stella runs as bounded child turns, separate from `[wrapper]`. Each `[roles.<name>]` declares a routing intent for one subloop stage, such as `tier = "cheap"` — never a model ID, provider, or credential. Stella resolves that intent against your configured providers at run time, and refuses any intent the manifest didn't declare.
+    Requires `[subloop]` (steering and above): a declared list of stages stella runs as bounded child turns, separate from `[wrapper]`. Each `[roles.<name>]` declares a routing intent for one subloop stage, such as `tier = "cheap"` — never a model ID, provider, or credential. stella resolves that intent against your configured providers at run time, and refuses any intent the manifest didn't declare.
   </OptionCard>
   <OptionCard name="[[capabilities]]">
     Zero or more entries. `tool` is free text — the tool name, matched against stella's registry at install. `risk` is `low`, `medium`, `high`, or `destructive` — the same scale the authorization gate uses. `purpose` is required: why the plugin needs it, shown when you're asked to approve it. `scope` is the plugin's own claimed limit, shown to you word for word and labeled as a claim stella does not check. This is kept separate from `[loop]` on purpose — see participation levels above.
@@ -198,11 +198,11 @@ command = ["${plugin_dir}/scripts/lint-fix.sh"]
 RULESET = "${plugin_dir}/rules/strict.yaml"
 ```
 
-Ship `scripts/lint-fix.sh` as an executable file. Stella runs it directly,
+Ship `scripts/lint-fix.sh` as an executable file. stella runs it directly,
 never through a shell, and never invokes an interpreter you didn't name in
 `command`.
 
-Stella only expands the placeholder for a manifest that comes from a
+stella only expands the placeholder for a manifest that comes from a
 package. Your own `.stella/tools/` and `~/.stella/tools/` manifests are
 left exactly as written, because there's no package directory to expand it
 to. Silently turning `${plugin_dir}/x.sh` into `/x.sh` would run the wrong
@@ -257,7 +257,7 @@ deletes it from every tier that has it. Full flag reference:
 
 ### Project trust gate
 
-Stella reads plugins from two places as one list: `~/.stella/plugins/`
+stella reads plugins from two places as one list: `~/.stella/plugins/`
 (installed once, visible in every project) and
 `<workspace>/.stella/plugins/` (this project only). The second one is
 something a `git clone` can bring with it. A plugin is more powerful than a
@@ -287,7 +287,7 @@ is about 320 lines of Python, using only `json`, `subprocess`, `sys`, and
 `time` from the standard library. If you want to learn the protocol, that
 file is the shortest complete example there is.
 
-Each call is one exchange. Stella spawns `[runtime].argv` directly, never
+Each call is one exchange. stella spawns `[runtime].argv` directly, never
 through a shell, writes one JSON request to stdin, closes it, and reads one
 JSON response from stdout.
 
@@ -312,13 +312,10 @@ JSON response from stdout.
                        "measurements": {"test-command-exit-code": 0}}}}
 ```
 
-Four things about this exchange matter, because each one is easy to get
-wrong:
-
 1. **Every table rejects fields it doesn't know, including the envelope itself.** `protocol_version` is on every message, and the contract only ever adds fields over time. But a field stella doesn't recognize at a version it accepts is a typo. A message that quietly does nothing is worse than one that fails outright.
-2. **There's no way to report an error in the response itself.** A plugin that can't answer fails outright: a non-zero exit code, one line on stderr, nothing on stdout. Stella then fills in an "unobservable" evidence set for it, so `judge` abstains instead of blaming the plugin for evidence that was never collected.
+2. **There's no way to report an error in the response itself.** A plugin that can't answer fails outright: a non-zero exit code, one line on stderr, nothing on stdout. stella then fills in an "unobservable" evidence set for it, so `judge` abstains instead of blaming the plugin for evidence that was never collected.
 3. **Every capability arrives in the request.** The `candidate` field is a grant: a handle, the workspace `root`, and, when stella has one to give, the `test` to run there — a program, its arguments, and what that same test reported before the turn (`baseline`). A wrapper never reaches for a terminal, a git checkout, a credential, an environment variable, or a working directory of its own.
-4. **A plugin can't report a tamper finding.** The response type has no field for one, in any language. Checking witness-artifact identity is stella's job, and stella adds its own finding before `judge` ever runs. This is deliberate — a plugin vouching for its own witness is exactly what this split is meant to prevent.
+4. **A plugin can't report a tamper finding.** The response type has no field for one, in any language. Checking witness-artifact identity is stella's job, and stella adds its own finding before `judge` ever runs. A plugin vouching for its own witness is exactly what this split prevents.
 
 Here's the whole shape, condensed to what `main.py` actually does:
 
@@ -402,15 +399,15 @@ the install prompt tells you. This is how the system is built, not an
 excuse.
 
 Verification is delivered by an installed plugin. A plugin's `[oracle]`
-runs in the plugin's own process. Stella doesn't run that oracle itself,
+runs in the plugin's own process. stella doesn't run that oracle itself,
 and it doesn't double-check the result: the fail-to-pass change, and every
 number a check compares against a limit, come from what the plugin's own
-process reports. Stella applies the declared rule (`[requirements]`, the
+process reports. stella applies the declared rule (`[requirements]`, the
 flip policy, the checks) to those reported claims, and won't credit a
 requirement the plugin leaves undecided. What stella can't do is tell a
 result the plugin actually earned from one it just typed in.
 
-Two things always stay under stella's own control, no matter what a
+These stay under stella's own control, no matter what a
 manifest declares:
 
 - **`judge` still runs inside stella, with no I/O**, over the evidence the plugin reported. A plugin can't decide "done" for itself, in any language — see [What a plugin is](#what-a-plugin-is) above. What changes is where the evidence comes from, not who decides.
@@ -429,9 +426,9 @@ test runner or a CI check you didn't write yourself.
 Smaller gaps in the wire contract itself, worth knowing before you rely on
 it:
 
-- **`unobservable` covers several different problems with one value.** A root that doesn't resolve, a program that isn't there, a run that went over its time budget, and a baseline that never checked anything in the first place all report the same `FlipObservation::Unobservable`. Stella can't currently tell them apart.
+- **`unobservable` covers several different problems with one value.** A root that doesn't resolve, a program that isn't there, a run that went over its time budget, and a baseline that never checked anything in the first place all report the same `FlipObservation::Unobservable`. stella can't currently tell them apart.
 - **A `TestPlan` doesn't name an environment or a timeout.** The grant says which program to run and where, but not what environment it ran in or how long it waited. So "the same invocation" means the same command and arguments, not provably the same run. Each plugin author has to pick their own timeout.
-- **Checking the version is up to the reader, not the wire format.** A message claiming `protocol_version: 2` still decodes as a valid request. Stella, or a careful plugin, has to check the number itself — decoding won't fail on its own.
+- **Checking the version is up to the reader, not the wire format.** A message claiming `protocol_version: 2` still decodes as a valid request. stella, or a careful plugin, has to check the number itself — decoding won't fail on its own.
 - **A plugin can't mark a measurement as "left out on purpose."** A number the plugin's oracle didn't compute this run, and a number the author simply forgot to report, both show up the same way: missing.
 
 ## See also

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -1,64 +1,65 @@
 ---
 title: Determinism over intelligence
-description: Why stella is a deterministic single-thread engine, not a multi-agent swarm — the MAST failure taxonomy, the Agentless result, and what follows from both.
+description: Why stella runs one deterministic thread instead of a swarm of agents, what research on multi-agent failures found, and what that means for how it works.
 ---
 
-The dominant trend in agent architecture is the swarm: a navigator agent, a
-coder agent, a reviewer agent, a tester agent, and a coordinator conducting
-them. stella went the other way — **one deterministic,
-single-threaded step loop** — and treats that as a feature, not a
-limitation. This page distills
-[the full research note](https://github.com/macanderson/stella/blob/main/docs/papers/deterministic-engine.md).
+Most agent tools use a swarm: a navigator agent, a coder agent, a reviewer
+agent, a tester agent, and a coordinator managing all of them. stella does
+the opposite. It runs **one deterministic, single-threaded loop**, and
+that's a deliberate choice, not a limitation. The research behind it is in
+[this note](https://github.com/macanderson/stella/blob/main/docs/papers/deterministic-engine.md).
 
 ## What the research found
 
-The first comprehensive empirical study of multi-agent LLM failures — the
-**MAST** taxonomy (Cemri et al., UC Berkeley, NeurIPS 2025) — identified
-three dominant failure classes across AutoGen, MetaGPT, ChatDev, and peers:
+The first large study of multi-agent LLM failures, the **MAST** taxonomy
+(Cemri et al., UC Berkeley, NeurIPS 2025), found three common ways swarms of
+agents fail across tools like AutoGen, MetaGPT, and ChatDev:
 
-1. **Inter-agent misalignment** — agents disagree about the task state and
-   each other's outputs: contradictory actions, re-explored territory,
-   cascading errors through the coordinator.
-2. **Verification difficulty** — no single thread of execution to replay or
-   audit; diagnosing *which* agent went wrong means archaeology over
-   message logs.
-3. **Information degradation** — every agent-to-agent handoff summarizes,
-   and every summary loses information. The navigator's rich understanding
-   reaches the coder as a vague directive.
+1. **Agents disagree.** They lose track of the task state and what other
+   agents already did. This leads to actions that contradict each other,
+   work that gets redone, and errors that spread through the coordinator.
+2. **No one can check the work.** There's no single thread of execution to
+   replay or check. Finding out which agent went wrong means digging
+   through message logs one by one.
+3. **Information gets lost.** Every time one agent hands off to another, it
+   has to summarize, and every summary drops something. The first agent's
+   full understanding reaches the last agent as a vague instruction.
 
-And the cost dimension: Kapoor et al. (Princeton, TMLR 2025) show agent
-systems must be judged on cost as well as accuracy — swarms are
-systematically more expensive per task, usually without commensurate gains.
+Cost matters too. Kapoor et al. (Princeton, TMLR 2025) show agent systems
+need to be judged on cost, not just accuracy. Swarms tend to cost more per
+task, usually without much to show for it.
 
-Meanwhile, two of the strongest SWE-bench systems — **Agentless** (Xia et
-al., FSE 2025) and **SWE-agent** — are explicitly single-agent: a
-well-designed localize → repair → verify pipeline beats orchestration
-complexity.
+Meanwhile, two of the strongest systems on the SWE-bench benchmark,
+**Agentless** (Xia et al., FSE 2025) and **SWE-agent**, use a single agent
+on purpose. A well-designed find → fix → check pipeline beats a
+complicated multi-agent setup.
 
 <SingleThreadDiagram />
 
-## stella's answer, by construction
+## How stella avoids this
 
-- **One loop.** Plan, fan tool calls out in parallel, observe, compact if
-  noisy, repeat. No coordinator to go stale, no peer to disagree with, no
-  handoff to degrade — the "swarm failure modes" are not mitigated, they
-  are *unrepresentable*.
-- **One transcript.** Every decision is a step in a single, ordered event
-  stream you can replay and audit — feeding the local
-  [telemetry](/docs/telemetry) ledgers step by step.
-- **A pure decision core.** The engine performs no I/O; its logic is
-  synchronous functions over owned data, which is what makes it
-  property-testable — and what makes its behavior *reproducible* at all.
+- **One loop.** Plan, run tool calls in parallel, look at the results, trim
+  down anything noisy, repeat. There's no coordinator to fall out of sync,
+  no peer to disagree with, and no handoff to lose information in. The
+  swarm failure modes above aren't reduced here. They simply can't happen.
+- **One transcript.** Every decision is a step in one ordered event stream.
+  You can replay it and check it, and it feeds the local
+  [telemetry](/docs/telemetry) records step by step.
+- **A pure decision core.** The engine does no reading or writing on its
+  own. Its logic is plain, synchronous functions over data it owns. That's
+  what makes it testable, and what makes its behavior *reproducible* at
+  all.
 
-Where parallelism pays, stella provides it **without a shared
-coordinator or shared engine state**: [fleets](/docs/agent-fleets) run N
-independent single-thread engines over one shared tree, coordinated only by
-cooperative file claims (dedicated git worktrees per task on opt-in).
-Parallel work, no swarm coordination, no inter-agent messages to degrade.
+When parallel work pays off, stella still avoids a shared coordinator or
+shared state. [Fleets](/docs/agent-fleets) run several independent
+single-thread engines over one shared project, and the only coordination
+between them is a shared list of file claims (with a dedicated git worktree
+per task if you turn that on). You get parallel work with no swarm
+coordination and no messages between agents to lose information.
 
-The coordination is a lock table, not a conversation. Two workers that declare
-overlapping `claims` do not negotiate; the second dispatch fails by name,
-before it starts:
+The coordination is a lock table, not a conversation. If two workers claim
+overlapping files, they don't negotiate. The second one fails immediately,
+by name, before it even starts:
 
 ```toml title="parallel.toml"
 [[tasks]]
@@ -78,51 +79,52 @@ claims = ["src/store/error.rs"]   # same path — one of these two will not run
 stella fleet --plan parallel.toml --max-concurrency 2
 ```
 
-That is the whole coordination protocol. There is no message for the two agents
-to misread, and no summary between them to lose information — the third MAST
-failure class has nowhere to occur.
+That's the whole coordination protocol. There's no message for two agents
+to misread, and no summary between them to lose information. The third MAST
+failure class, information loss, has nowhere to happen.
 
-## The principle generalized
+## The bigger idea
 
-"Prefer determinism over intelligence" is not anti-model — stella exists to
-put frontier models to work. It is a statement about **where to spend
-them**:
+Preferring determinism over intelligence doesn't mean stella avoids using
+models. The whole point of stella is to put strong models to work. It's a
+statement about **where to spend them**:
 
-- Verification is a [wrapper plugin](/docs/plugins) you bind with
-  `--pipeline <variant>`, and its oracle is a **flip** — a test that fails
-  before the change and passes after. The plugin runs that check and reports
-  the evidence; stella grades the report against the verdict rule the plugin
-  declared at install, and never re-runs it. Nothing on that path asks a model
-  to rule on inconclusive evidence: a report that does not satisfy the rule
-  is a "not proven".
-- The one model call such a plugin spends on evidence is the witness
-  *author*, which writes the failing test. It never judges the result — the
-  test's own fail→pass flip does that, by running.
-- Goal mode is a separate mechanism with its own standing verifier: after
-  every round, unconditionally, an independent model assesses the transcript
-  against the goal. It is not a fallback for inconclusive evidence — it runs
-  every round regardless, and degrades gracefully rather than fabricating a
-  verdict if the call itself fails.
-- Routing, budgets, compaction, retries, memory injection — all
-  deterministic, all boring, all auditable. The model's tokens go to the
-  two things only intelligence can do: **writing the change** and
-  **judging what mechanisms can't measure**.
+- Verification comes from a [wrapper plugin](/docs/plugins) you turn on
+  with `--pipeline <variant>`. It works with a **flip**: a test that fails
+  before your change and passes after it. The plugin runs that check and
+  reports what it found. stella checks that report against the rule the
+  plugin set up when it was installed, and never re-runs the check itself.
+  No model is ever asked to judge unclear evidence. If a report doesn't
+  meet the rule, the result is "not proven".
+- The one model call a plugin like this spends on evidence writes the
+  failing test. It never judges the result. The test's own fail-then-pass
+  flip does that, just by running.
+- Goal mode works differently, with its own verifier. After every round,
+  without exception, a separate model checks the transcript against the
+  goal. This isn't a fallback for unclear evidence. It runs every round no
+  matter what, and if the check itself fails to run, it reports that
+  honestly instead of making up a verdict.
+- Routing, budgets, trimming context, retries, and pulling in memory are
+  all handled by plain, boring, checkable code. The model's attention goes
+  to the two things only a model can do: **writing the change**, and
+  **judging what a mechanism can't measure**.
 
-The payoff compounds: deterministic mechanisms cost nothing per run, never
-rate-limit, never hallucinate, and give the *same answer twice* — which is
-exactly what you want from the parts of an agent that decide whether to
-trust it.
+This adds up. Deterministic mechanisms cost nothing to run, never hit a
+rate limit, never make things up, and give you the *same answer twice*.
+That's exactly what you want from the part of an agent that decides whether
+to trust it.
 
-The deck shows that split rather than describing it. A task opens to its
-contract: what "done" means, which of its checks are computed and which need a
-model, and what the work actually cost. Below the contract, the plan it was
-given sits beside what happened — a divergence is recorded, not smoothed over.
+The Command Deck shows this split instead of just describing it. Open a
+task and you see its contract: what "done" means, which checks are
+computed and which need a model, and what the work actually cost. Below
+that, the plan it was given sits next to what actually happened. If they
+differ, that's recorded, not glossed over.
 
 <DeckShot id="task" />
 
-And because the distinction is structural rather than rhetorical, it is
-machine-readable. A raw run reports what it did and nothing about proof —
-`status`, what it spent, and the files it touched:
+Because this split is built into the system, not just a way of talking
+about it, it's also machine-readable. A raw run reports what it did, and
+nothing about proof: its `status`, what it spent, and the files it touched:
 
 ```bash
 stella run --output-format json \
@@ -130,8 +132,8 @@ stella run --output-format json \
   | jq '{status, cost_usd, files_touched}'
 ```
 
-Bind a verification plugin and the same envelope carries its standing, so a
-CI gate can insist on evidence instead of a claim:
+Turn on a verification plugin, and the same output now carries its verdict,
+so a CI gate can require evidence instead of a claim:
 
 ```bash
 stella run --output-format json --pipeline my-verifier --test-command "make test" "$TASK" \
@@ -139,12 +141,13 @@ stella run --output-format json --pipeline my-verifier --test-command "make test
   || { echo "nothing proved this run — holding it for review" >&2; exit 1; }
 ```
 
-`--test-command` is refused on the raw loop, which has no oracle to arm — see
+The raw loop has no check to arm, so `--test-command` is refused there. See
 [`stella run`](/docs/commands/run).
 
 <Callout type="info">
-  Read the full papers in the repo:
+  Read the full papers:
   [the deterministic engine](https://github.com/macanderson/stella/blob/main/docs/papers/deterministic-engine.md)
   and
   [the seven defensible properties](https://github.com/macanderson/stella/blob/main/docs/papers/stella-defensible-position.md).
 </Callout>
+</content>

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -5,8 +5,8 @@ description: Why stella runs one deterministic thread instead of a swarm of agen
 
 Most agent tools use a swarm: a navigator agent, a coder agent, a reviewer
 agent, a tester agent, and a coordinator managing all of them. stella does
-the opposite. It runs **one deterministic, single-threaded loop**, and
-that's a deliberate choice, not a limitation. The research behind it is in
+the opposite. It runs **one deterministic, single-threaded loop**.
+The research behind it is in
 [this note](https://github.com/macanderson/stella/blob/main/docs/papers/deterministic-engine.md).
 
 ## What the research found
@@ -102,8 +102,8 @@ statement about **where to spend them**:
 - Goal mode works differently, with its own verifier. After every round,
   without exception, a separate model checks the transcript against the
   goal. This isn't a fallback for unclear evidence. It runs every round no
-  matter what, and if the check itself fails to run, it reports that
-  honestly instead of making up a verdict.
+  matter what, and if the check itself fails to run, it says so
+  instead of making up a verdict.
 - Routing, budgets, trimming context, retries, and pulling in memory are
   all handled by plain, boring, checkable code. The model's attention goes
   to the two things only a model can do: **writing the change**, and
@@ -114,7 +114,7 @@ rate limit, never make things up, and give you the *same answer twice*.
 That's exactly what you want from the part of an agent that decides whether
 to trust it.
 
-The Command Deck shows this split instead of just describing it. Open a
+Interactive mode shows this split instead of just describing it. Open a
 task and you see its contract: what "done" means, which checks are
 computed and which need a model, and what the work actually cost. Below
 that, the plan it was given sits next to what actually happened. If they

--- a/website/content/docs/principles/determinism.mdx
+++ b/website/content/docs/principles/determinism.mdx
@@ -150,4 +150,3 @@ The raw loop has no check to arm, so `--test-command` is refused there. See
   and
   [the seven defensible properties](https://github.com/macanderson/stella/blob/main/docs/papers/stella-defensible-position.md).
 </Callout>
-</content>

--- a/website/content/docs/principles/index.mdx
+++ b/website/content/docs/principles/index.mdx
@@ -1,91 +1,94 @@
 ---
 title: Engineering Principles
-description: The design rules behind stella — determinism over intelligence, evidence over opinion, a zero-I/O engine, and budgets enforced at safe boundaries.
+description: The design rules behind stella — determinism over intelligence, evidence over opinion, an engine with no I/O of its own, and spend limits enforced at safe points.
 ---
 
-stella's repository ships two research papers alongside the code — a
-[capstone analysis of seven architectural rules](https://github.com/macanderson/stella/blob/main/docs/papers/stella-defensible-position.md)
-and a focused study of
+stella ships two research papers alongside its code: a
+[study of seven architectural rules](https://github.com/macanderson/stella/blob/main/docs/papers/stella-defensible-position.md)
+and a closer look at
 [the deterministic engine](https://github.com/macanderson/stella/blob/main/docs/papers/deterministic-engine.md).
-This page is the distilled version: the principles, and why they were chosen.
-Every claim is grounded in the shipping implementation.
+Here are the principles behind stella, and why they were chosen. Every claim
+below matches what actually ships.
 
 <Callout type="info">
-**"Witnessed, not asserted" is a property of the path, not of the binary.**
-The witness-test / flip-oracle machinery below (rule 3 below, and the "Is the
-work done?" and "What proves the change?" mechanisms) is what an installed
-**verification plugin** implements on its own side of the
-[wrapper socket](/docs/plugins) — Oxagen's Vera is the reference one. A plugin
-reports its own evidence and stella evaluates it against the rule the plugin
-declared at install; stella does not re-run the check itself. A plain
-`stella run` with no `--pipeline <variant>` has nothing verifying it, and
-says so rather than implying otherwise.
+**"Witnessed, not asserted" describes the path you choose, not the program
+itself.** The witness-test and flip-check machinery described below, and
+the "Is the work done?" and "What proves the change?" mechanisms, are
+things an installed **verification plugin** implements on its own side of
+the [wrapper socket](/docs/plugins). Oxagen's Vera is the reference plugin.
+A plugin reports its own evidence, and stella checks that evidence against
+the rule the plugin set up at install time. stella never re-runs the check
+itself. A plain `stella run` with no `--pipeline <variant>` has nothing
+verifying it, and it tells you that instead of implying otherwise.
 </Callout>
 
-## The master rule: given a choice, prefer determinism over intelligence
+## The master rule
 
-Wherever stella can decide something with a deterministic mechanism *or* a
-model's judgment, it chooses the mechanism — and reserves the model for the
-places only intelligence can fill. [The full argument](/docs/principles/determinism)
-has the research grounding; the shape of it:
+When stella can decide something with a plain mechanism or a model's
+judgment, it uses the mechanism, and saves the model for the places only
+intelligence can handle. [The full argument](/docs/principles/determinism)
+has the research behind it. Here's the shape of it:
 
-- A deterministic check is **reproducible** — it gives the same verdict on
-  the same inputs tomorrow, in CI, and on a colleague's machine. A model
-  opinion is a sample.
-- A deterministic check is **auditable** — when it fails, you can read
-  exactly why. A model verdict must itself be verified.
-- A deterministic check is **free** — no tokens, no latency, no rate limit.
+- A plain check is **reproducible**. It gives the same answer on the same
+  input tomorrow, in CI, and on a coworker's machine. A model's opinion is
+  just one sample.
+- A plain check is **auditable**. When it fails, you can read exactly why.
+  A model's verdict has to be checked itself before you can trust it.
+- A plain check is **free**. No tokens, no delay, no rate limit.
 
 You can see the rule everywhere in the product:
 
 <CardGrid size="md">
   <SpecCard title="Is the work done?">
-    **Mechanism:** the [flip oracle](/docs/plugins) — the same test
-    fails before the change and passes after — plus the zero-diff guard and a
-    400-line diff budget.
+    **Mechanism:** the [flip oracle](/docs/plugins) — a test that fails
+    before the change and passes after — plus a guard against empty diffs
+    and a 400-line diff budget.
 
-    **Model, as fallback:** none. The ladder is terminal at every rung — when
-    the evidence does not add up it reports `Unverified`, not a guess. (Goal
-    mode's standing verifier is a different mechanism: it runs every round,
-    unconditionally, never as an inconclusive-evidence fallback.)
+    **Model, as fallback:** none. When the evidence doesn't add up, stella
+    reports `Unverified` instead of guessing. (Goal mode's verifier is
+    different: it runs every round, always, and it's never a fallback for
+    unclear evidence.)
   </SpecCard>
   <SpecCard title="What proves the change?">
-    **Mechanism:** the [witness step](/docs/plugins) replays the
-    witness test against the pre-change code — it must fail there and pass on
-    the change.
+    **Mechanism:** the [witness step](/docs/plugins) runs the witness test
+    against the code before your change. It has to fail there and pass
+    after.
 
-    **Model, as fallback:** none. A merely-green suite is *weak* evidence, never
-    proof, whoever asserts it.
+    **Model, as fallback:** none. A test suite that's simply green is weak
+    evidence, never proof, no matter who says otherwise.
   </SpecCard>
   <SpecCard title="Which model serves a role?">
-    **Mechanism:** explicit pins and typed absence (`Option::None`) — never an
-    `"auto"` magic string.
+    **Mechanism:** you pin a model explicitly, or explicitly set none.
+    There's no hidden `"auto"` string doing something unclear.
 
-    **Model, as fallback:** `auto_mode` picks from *your* `allowed_models`, by
-    stated rules — different family first, then price tier, then list order.
+    **Model, as fallback:** `auto_mode` picks from your `allowed_models`
+    list, using clear rules: a different model family first, then price
+    tier, then list order.
   </SpecCard>
   <SpecCard title="What goes in the prompt?">
-    **Mechanism:** a byte-stable system prefix plus one fixed-position recall
-    block, so prompt caching survives across turns.
+    **Mechanism:** a system prompt that never changes byte-for-byte, plus
+    one fixed-position block for recalled context, so prompt caching keeps
+    working across turns.
 
     **Model, as fallback:** none.
   </SpecCard>
   <SpecCard title="When does a run stop?">
-    **Mechanism:** the budget guard, checked between steps — never mid-tool, so
-    an abort never leaves a half-applied edit.
+    **Mechanism:** a spend guard, checked between steps, never in the
+    middle of a tool call. That means stopping never leaves a half-finished
+    edit.
 
     **Model, as fallback:** none.
   </SpecCard>
   <SpecCard title="What happened?">
-    **Mechanism:** an append-only event stream and local SQLite ledgers you can
-    query yourself.
+    **Mechanism:** an append-only event log and local SQLite records you
+    can query yourself.
 
     **Model, as fallback:** none.
   </SpecCard>
 </CardGrid>
 
-Two of those are one command away. The mechanisms are not aspirational — they
-are the surfaces you already use:
+Two of these are one command away, and they aren't just plans on paper.
+They're what you're already using:
 
 ```bash
 # The flip oracle, armed: a run that cannot prove fail→pass does not submit.
@@ -96,54 +99,65 @@ stella run --pipeline my-verifier --test-command "cargo test -p stella-core" \
 stella stats
 ```
 
-## The seven rules, briefly
+## The seven rules
 
-1. **Ports, not direct dependencies.** Every provider and tool sits behind a trait;
-   adding a vendor is an adapter, never a rewrite. Nine providers plus any
-   local server, one engine.
-2. **No I/O in the engine.** `stella-core` performs zero I/O — routing,
-   retry, compaction, loop detection, and budget are synchronous functions
-   over owned data, property-testable with no network and no filesystem.
-3. **The witness-test contract.** An agent must *prove* its change is the
-   change that fixed the problem: fail on `HEAD`, pass on the diff,
-   tamper-excluded — "the suite is green" is not a proof. An installed
-   verification plugin (Vera is the reference one) runs this check and reports
-   the result.
-4. **BYOK + zero telemetry egress by default.** Your keys call your provider
-   directly, and Community/default telemetry remains in local SQLite. Two
-   explicit configurations, and only these two, send telemetry anywhere:
+1. **Ports, not direct dependencies.** Every provider and tool sits behind
+   a shared interface. Adding a new one is an adapter, never a rewrite.
+   Nine providers plus any local server, one engine.
+2. **No I/O in the engine.** `stella-core` does no reading or writing of
+   its own. Routing, retries, trimming context, loop detection, and spend
+   limits are all plain functions over data it already owns. That makes
+   them testable, with no network and no filesystem needed.
+3. **The witness-test contract.** An agent has to *prove* its change
+   actually fixed the problem: fail on the old code, pass on the new code,
+   with tampering ruled out. "The test suite is green" is not proof on its
+   own. An installed verification plugin (Vera is the reference one) runs
+   this check and reports the result.
+4. **Bring your own key, and no telemetry leaves your machine by default.**
+   Your keys talk to your provider directly, and by default all telemetry
+   stays in a local SQLite file. Exactly two setups send telemetry
+   anywhere, and only these two:
    [Oxagen Enterprise enrollment](/docs/telemetry#oxagen-enterprise-managed-export)
-   — a signed policy, process-free execution, a closed content-free rollup, and
-   one exact allowlisted HTTPS sink — and a
+   — a signed policy, no runaway processes, a closed and content-free
+   summary, and one exact allowed HTTPS destination — and a
    [`drain` block](/docs/commands/cloud) in `~/.stella/cloud.json` that
-   `stella cloud sync` posts to. Neither exists until you write it.
-5. **Prompt-cache-native memory.** Durable knowledge loads once into a
-   byte-stable prefix and rides the cache at ~0.1× — see
-   ["invalidation doesn't happen"](/docs/context-engine#invalidation-doesnt-happen--and-why-that-matters).
-6. **Spend limits enforced at safe boundaries.** `--spend-limit` is a hard cap checked
-   between steps — an abort is always clean, never a half-applied edit.
-7. **An open retrieval standard.** Context recall speaks the
-   [Context Graph Protocol](/docs/context-engine#the-context-graph-protocol) —
-   versioned wire types, machine-checked conformance, a trust architecture.
+   `stella cloud sync` sends to. Neither one exists until you set it up.
+5. **Memory built for prompt caching.** Durable knowledge loads once into a
+   prefix that never changes byte-for-byte, and rides the cache at about a
+   tenth of the cost. See
+   [No invalidation](/docs/context-engine#no-invalidation).
+6. **Spend limits enforced at safe points.** `--spend-limit` is a hard cap
+   checked between steps, so stopping is always clean and never leaves a
+   half-finished edit.
+7. **An open standard for pulling in context.** Context recall uses the
+   [Context Graph Protocol](/docs/context-engine#the-context-graph-protocol):
+   versioned wire types, automatic conformance checks, and a clear trust
+   model.
 
-No single one is the moat; the **combination** is. Each constrains the
-others: you can't retrofit cache-native memory onto per-turn injection, or
-witness verification onto an engine that can't replay deterministically.
+No single rule here is the advantage. The **combination** is. Each one
+constrains the others: you can't bolt cache-friendly memory onto a system
+that re-sends everything each turn, or witness verification onto an engine
+that can't replay the same way twice.
 
-## What this buys you, concretely
+## What this gets you
 
-- **Trust:** "done" means *witnessed*, not *asserted* — self-reported by an
-  installed verification plugin and evaluated against its declared rule.
-- **Reasoning:** one single-threaded loop you can read top to bottom — no
-  coordinator, no hidden control plane, no swarm state to desynchronize.
-- **Cost:** the cache discipline and the evidence ladder mean you pay for
-  intelligence only where intelligence is the only tool that works.
-- **Sovereignty:** local-first state, BYOK credentials, a copyleft license that
-  keeps the source open, and zero telemetry egress by default. Both egress paths
-  — Enterprise operational export and the `cloud.json` drain — are explicit,
-  bounded, and off until configured; the Enterprise one is additionally
-  content-free and governed by org-managed enrollment.
+- **Trust:** "done" means *witnessed*, not *asserted*. It's reported by an
+  installed verification plugin and checked against the rule that plugin
+  declared.
+- **Reasoning you can follow:** one single-threaded loop, readable top to
+  bottom. No coordinator, no hidden control layer, no swarm state to fall
+  out of sync.
+- **Cost:** the caching discipline and the evidence checks mean you pay for
+  a model's judgment only where a model's judgment is the only tool that
+  works.
+- **You stay in control:** state lives on your machine first, credentials
+  are yours, the license keeps the source open, and no telemetry leaves by
+  default. Both ways telemetry can leave — the Enterprise export and the
+  `cloud.json` drain — are explicit, limited, and off until you configure
+  them. The Enterprise path is also content-free and controlled by your
+  organization's enrollment.
 
-Continue: [Why single-thread beats the swarm →](/docs/principles/determinism)
-· [No agent silently overwrites another's work →](/docs/principles/no-clobber)
+Continue: [Why one thread beats a swarm →](/docs/principles/determinism)
+· [No agent overwrites another's work →](/docs/principles/no-clobber)
 · [A session is an artifact, not a service →](/docs/principles/session-artifacts)
+</content>

--- a/website/content/docs/principles/index.mdx
+++ b/website/content/docs/principles/index.mdx
@@ -109,7 +109,7 @@ stella stats
    limits are all plain functions over data it already owns. That makes
    them testable, with no network and no filesystem needed.
 3. **The witness-test contract.** An agent has to *prove* its change
-   actually fixed the problem: fail on the old code, pass on the new code,
+   actually fixed the problem: fail before the change, pass after it,
    with tampering ruled out. "The test suite is green" is not proof on its
    own. An installed verification plugin (Vera is the reference one) runs
    this check and reports the result.

--- a/website/content/docs/principles/index.mdx
+++ b/website/content/docs/principles/index.mdx
@@ -160,4 +160,3 @@ that can't replay the same way twice.
 Continue: [Why one thread beats a swarm →](/docs/principles/determinism)
 · [No agent overwrites another's work →](/docs/principles/no-clobber)
 · [A session is an artifact, not a service →](/docs/principles/session-artifacts)
-</content>

--- a/website/content/docs/principles/no-clobber.mdx
+++ b/website/content/docs/principles/no-clobber.mdx
@@ -1,22 +1,23 @@
 ---
-title: No agent silently overwrites another's work
-description: stella refuses a write that would land on top of a change it never saw — without a lock, a daemon, or any knowledge that the other party exists. How the guarantee works, what it does not claim, and which way it fails after a crash.
+title: No silent overwrites
+description: stella refuses to write over a change it never saw, with no lock, no background service, and no need to know who else is working on the file. How this works, what it doesn't promise, and what happens after a crash.
 ---
 
-Point two agents at one repository and the failure is not a corrupted file.
-It is a *quiet* one. Agent A reads `handler.rs`, spends four minutes forming a
-plan against what it read, and writes the result. In between, agent B — or a
-person in an editor — changed the same file. A's write succeeds. Nothing
-errors. B's work is gone, and the only record that it existed is a diff
-nobody is going to read.
+Point two agents at one project, and the failure you get is not a corrupted
+file. It's a *quiet* one. Agent A reads `handler.rs`, spends a few minutes
+planning a change based on what it read, then writes the result. In
+between, agent B, or a person in an editor, changes the same file. A's
+write goes through. Nothing errors. B's work is gone, and the only trace it
+ever existed is a diff nobody will read.
 
 stella refuses that write.
 
 ## The guarantee
 
-**A mutation is refused when the file changed since this session last looked
-at it.** Not deferred, not merged, not warned about afterwards — refused
-before anything is written, with a message naming the file and the fix:
+**stella refuses a write when the file changed since this session last read
+it.** It doesn't defer the write, merge it, or warn you after the fact.
+It's blocked before anything is written, with a message that names the
+file and tells you what to do:
 
 ```
 refusing to write: src/handler.rs changed since you last read it. Another
@@ -28,81 +29,79 @@ Re-read the file and redo the change against what is there now. Your edit
 is not lost — nothing was written.
 ```
 
-That is returned as a tool error, not a turn abort, and the distinction is
-deliberate. The condition is recoverable and the model can act on it: re-read
-the file, redo the edit. One cheap step, where aborting would throw away a
-whole turn.
+This comes back as a tool error, not as a failed turn, and that difference
+matters. The model can act on it: re-read the file, then redo the edit.
+That's one cheap extra step, instead of losing the whole turn.
 
 ## Why not a lock
 
 A lock is the obvious answer and it is strictly weaker.
 
-Locks serialize *writers*. They do nothing about *staleness*. Agent B waits,
-takes the lock, and then overwrites the file A just changed — using a plan
-that A's content no longer justifies. B did everything right and still
-destroyed the work. Serializing the writes never addressed the problem,
-because the problem was never simultaneity; it was acting on a belief that
-had expired.
+A lock only serializes *writers*. It does nothing about *stale
+information*. Agent B waits, gets the lock, and then overwrites the file A
+just changed, using a plan based on content that's no longer there. B did
+everything right and still destroyed the work. Serializing the writes never
+fixes this, because the real problem was never two writes happening at
+once. It was acting on a belief that had already gone stale.
 
-Waiting is also the wrong cost model for an agent. Being told "that moved,
-read it again" is a cheap retry. Blocking burns a turn.
+Waiting is also the wrong tradeoff for an agent. Being told "that changed,
+read it again" is a cheap retry. Blocking and waiting burns a whole turn.
 
-## How it works: no shared state at all
+## How it works
 
-Each session keeps one map: **the path it touched, and the digest of what it
-saw there.** Before any update or delete, the bytes on disk are re-hashed and
-compared with what this session remembers.
+Each session keeps one simple record: **which paths it touched, and a
+fingerprint of what it saw there.** Before any update or delete, stella
+re-checks the bytes on disk and compares them against what this session
+remembers.
 
-There is no registry, no daemon, no lease, and no channel between agents.
-That is not a simplification — it is the point. *Agent B's write is what makes
-agent A's memory stale*, so A detects it locally, with no knowledge that B
-exists. Two processes, two containers, a CI job, and a human typing in Vim are
-all the same case, and none of them has to be running stella.
+There's no registry, no background service, no lease, and no channel
+between agents. That's not a shortcut. It's the whole point. *Agent B's
+write is what makes agent A's memory stale*, so A detects that on its own,
+with no idea that B even exists. Two separate processes, two containers, a
+CI job, and a person typing in Vim are all the same case to stella, and
+none of them even needs to be running stella.
 
-Reads count. A read is how an agent acquires the belief a later write acts on,
-so it is recorded exactly as a write is. A delete drops the entry — after a
-delete there is nothing left to clobber, and the next agent to create the file
-is starting fresh rather than overwriting.
+Reads count too. A read is how an agent forms the belief that a later
+write acts on, so it's recorded the same way a write is. A delete removes
+the record entirely. Once a file is deleted, there's nothing left to
+overwrite, so the next agent to create it is starting fresh, not
+overwriting anything.
 
 ## What it does not claim
 
-The guard's claim is precise: *you are about to overwrite a change you never
-saw*. It can only make that claim about a file it watched this session look
-at. So:
+The guard makes one precise claim: *you're about to overwrite a change you
+never saw*. It can only make that claim about a file this session actually
+looked at. That means:
 
-- **A path this session never touched is not flagged.** Blind writes to
-  never-read files are a separate policy question, left alone here. The result
-  is a guard with no false positives — every refusal names a real conflict.
-- **Creates are not checked by the guard.** The filesystem itself already
-  answers "does this exist".
-- **An unreadable file is not a conflict.** The tool's own error path reports
-  that far better than a staleness message would.
+- **A path this session never touched isn't flagged.** Writing blindly to
+  a file the session never read is a separate question, and this guard
+  doesn't try to answer it. The upshot: this guard has no false positives.
+  Every refusal points at a real conflict.
+- **Creating a new file isn't checked by this guard.** The filesystem
+  itself already answers "does this exist".
+- **A file stella can't read isn't treated as a conflict.** The tool's own
+  error message explains that far better than a staleness warning would.
 
-A guard that cried wolf would be turned off, and then it would protect
-nothing.
+A guard that cried wolf would just get turned off, and then it would
+protect nothing at all.
 
-## What a crash costs, and which way the guard fails
+## After a crash
 
-The map lives in memory, so a session that dies takes it along — and the guard
+This record lives in memory, so a session that crashes loses it. The guard
 is built to fail **closed** when that happens. A
-[resumed](/docs/commands/resume) session starts with an empty map while its
-restored transcript still says the agent read the file, so the model keeps
-acting on content it believes it knows. The guard does not take the
-transcript's word for it: with no recorded read, every overwrite of an
-existing file is refused until the resumed session has read the file whole
-again. The cost of a crash is re-reading, never a silent clobber.
-
-A durable copy of the map — written at step boundaries and restored on resume,
-so a resumed session could keep the coverage it had earned — was reserved in
-the work journal but never wired up, and the unwired half was removed rather
-than left claiming otherwise (#3780). Carrying coverage across a resume is a
-design still open.
+[resumed](/docs/commands/resume) session starts with an empty record, even
+though its restored transcript still says the agent read the file. So the
+model may believe it already knows the content. The guard doesn't take the
+transcript's word for it. With no recorded read, it refuses every
+overwrite of an existing file until the resumed session reads the whole
+file again. The cost of a crash is re-reading a file, never a silent
+overwrite.
 
 ## Where this sits
 
-The guard is enforced in the tool registry, above every file-touching tool at
-once — built-ins, MCP-server tools, and custom tools alike. It is not
-something a tool opts into, and not something the model can decide to skip.
-That is the same reasoning as
+This guard is enforced in one place, above every tool that touches files at
+once: built-in tools, MCP server tools, and custom tools alike. No tool
+opts into it, and no model can decide to skip it. That's the same idea as
 [determinism over intelligence](/docs/principles/determinism): where a
 mechanism can decide something, the mechanism decides it.
+</content>

--- a/website/content/docs/principles/no-clobber.mdx
+++ b/website/content/docs/principles/no-clobber.mdx
@@ -104,4 +104,3 @@ once: built-in tools, MCP server tools, and custom tools alike. No tool
 opts into it, and no model can decide to skip it. That's the same idea as
 [determinism over intelligence](/docs/principles/determinism): where a
 mechanism can decide something, the mechanism decides it.
-</content>

--- a/website/content/docs/principles/session-artifacts.mdx
+++ b/website/content/docs/principles/session-artifacts.mdx
@@ -1,210 +1,221 @@
 ---
-title: A session is an artifact, not a service
-description: stella will hand you a session you can carry to another machine — and will not carry it for you. Why the line sits there, what stella still owes you when the artifact lands somewhere new, and what it refuses to own.
+title: Session artifacts
+description: stella can hand you a session you can carry to another machine, but it won't carry it there for you. Why that line is drawn there, what stella still owes you, and what it won't take on.
 ---
 
-stella already survives a crash. Kill the process mid-turn and the next run
-picks up the resume point, with the [no-clobber
-guarantee](/docs/principles/no-clobber) intact, because both live in a durable
-git store stella keeps in its own directory.
+stella already survives a crash. If you kill the process mid-turn, the next
+run picks up right where it left off, with the
+[no-clobber guarantee](/docs/principles/no-clobber) still intact, because
+both live in a durable git store stella keeps in its own directory.
 
-What it does not survive is a *machine*. Your laptop dies, or you want to hand a
-half-finished session to a colleague, or start something on a desktop and finish
-it on a plane. None of that works today, and the reason is worth being precise
-about, because it points straight at where the line belongs.
+What it doesn't survive is a *machine*. If your laptop dies, or you want to
+hand a half-finished session to a coworker, or start something on your
+desktop and finish it on a plane, none of that works today. The reason is
+worth being precise about, because it shows exactly where the line belongs.
 
 <Callout type="info">
-  This page describes a **decided boundary, not shipped behaviour**. The
-  reasoning below is settled in
-  [ADR 0013](https://github.com/macanderson/stella/blob/main/docs/adr/0013-session-artifact-boundary.md);
-  the export and replay APIs it describes are not built yet. Everything said
-  about *current* behaviour — the local store, the reverse-RPC model — is
-  shipping today. The durable staleness map is **not**: it was removed in
-  #3780 as a map nothing ever wrote or read, so the fingerprint described
-  below has yet to be founded on a mechanism that exists.
+  **Heads up: this describes a planned design, not shipped behavior.** The
+  checkpoint and replay APIs below don't exist yet. What is real today: the
+  local store and the remote-call model described in "Why not build sync
+  in" are both live. The fingerprint check described below is not: it
+  depends on a mechanism that hasn't been built yet.
 </Callout>
 
-## Why local state is local on purpose
+## Why state stays local
 
-stella's durable store is keyed on a machine-local workspace id. That id lives
-in `.stella/private/`, which is gitignored by construction, so a clone never
-carries it. Identity is decided by comparing absolute paths — a comparison with
-no meaning across machines. And when stella sees the same id at a path where
-another copy is still live, it mints a *fresh* id, so two copies of
-a project can never silently write into each other's history.
+stella's durable store is keyed to a workspace id that only means something
+on one machine. That id lives in `.stella/private/`, which is gitignored by
+default, so cloning a project never carries it along. stella decides
+identity by comparing absolute paths, and that comparison means nothing
+across machines. If stella sees the same id at a path where another copy
+is still running, it creates a *fresh* id instead, so two copies of a
+project can never silently write into each other's history.
 
-Every one of those choices is right for the question that module answers: *is
-this the same working copy I saw last time?* Every one of them is fatal to
-resuming somewhere else.
+Every one of these choices is right for the question this part of stella
+is answering: *is this the same working copy I saw last time?* And every
+one of them rules out resuming somewhere else.
 
-The obvious fix is to give stella a portable identity — an account, a project
-id, a login. That is the fix this project declines, and declining it is the
-whole decision.
+The obvious fix is to give stella a portable identity: an account, a
+project id, a login. stella doesn't do this, and that choice is the whole
+point of this page.
 
 ## The line
 
-**stella provides a checkpoint API and a replay API. The checkpoint API returns
-a self-contained artifact; the replay API accepts one.** Identifying a
-workspace, storing the artifact, moving it, authenticating it, and deciding who
-may read it are the caller's concerns.
+**stella provides a checkpoint API and a replay API. Checkpoint returns a
+self-contained artifact. Replay accepts one.** Identifying a workspace,
+storing the artifact, moving it around, authenticating it, and deciding who
+can read it are all up to whatever calls these APIs.
 
-That is not a division invented for this feature. It is the line stella already
-draws everywhere else.
+This isn't a line invented just for this feature. It's the same line
+stella draws everywhere else.
 
-When stella runs as a headless engine behind a host — the `stella-serve` crate —
-every governed side effect is remoted back to the host. Model calls and tool
-calls are *requests the host answers*. The engine never holds ambient authority,
-which means a served turn is structurally incapable of reading one of your
-files: it can only ask, and something else decides. The workspace was never
-stella's in that model.
+When stella runs headlessly behind a host, using the `stella-serve` crate,
+every governed side effect goes back to the host. Model calls and tool
+calls are *requests the host answers*. The engine never has authority of
+its own, so a turn running this way literally cannot read one of your
+files on its own. It can only ask, and something else decides. In this
+setup, the workspace was never stella's to begin with.
 
-Durability is the same shape of problem, so it gets the same answer. Extending
-an existing line costs nothing to explain. Carving an exception into it costs
-you the ability to say what the system does.
+## Why not sync
 
-## Why not just build sync in
+Building sync in would mean one integration instead of two, which is a real
+advantage if you're one person with two machines. But it loses anyway, for
+three reasons.
 
-It is one integration instead of two, and for a single user with two machines
-that is a real advantage. It loses anyway, on three counts.
-
-**It requires an identity nobody can derive.** stella sees a directory. It has
-no way to know that `~/src/api` on your laptop and `/work/api` on the build box
-are the same project — only something with a concept of *project* knows that.
-Every scheme that guesses eventually binds two unrelated codebases together,
-which is worse than a miss.
+**It needs an identity nobody can derive.** stella only sees a directory.
+It has no way to know that `~/src/api` on your laptop and `/work/api` on a
+build machine are the same project. Only something with a concept of
+*project* can know that. Any scheme that tries to guess will eventually
+link two unrelated codebases together, which is worse than just missing
+the match.
 
 **It contradicts what this project promises.** Local-first state, BYOK
-credentials, and [zero telemetry egress by
-default](/docs/principles#the-seven-rules-briefly) are claims the project's
-whole premise depends on,
-with exactly two explicit opt-in exceptions. A first-party upload path makes
-them conditional — and the condition is precisely the thing people choose stella
-to avoid. An artifact API adds no third path: producing an artifact writes bytes
-locally, and stella still uploads nothing.
+credentials, and
+[zero telemetry egress by default](/docs/principles#the-seven-rules)
+are claims the project's whole premise depends on, with exactly two
+explicit opt-in exceptions. A first-party upload path makes them
+conditional, and the condition is precisely the thing people choose stella
+to avoid. An artifact API adds no third path: producing an artifact writes
+bytes locally, and stella still uploads nothing.
 
-**It builds the easy half twice.** Storage, auth, tenancy, retention, audit —
-these are solved, and they do not get better for being reimplemented inside a
-CLI.
+**It builds the easy half twice.** Storage, auth, tenancy, retention,
+audit — these are solved problems, and they don't get better for being
+rebuilt inside a CLI.
 
 ## What stella still owes you
 
-"Identity is the caller's problem" is right. "Any artifact may be replayed into
-any tree" is not.
+"Identity is the caller's problem" is the right line. "Any artifact can be
+replayed into any tree" is not.
 
-Replay an artifact into the wrong checkout and you get a session whose
-transcript describes files that were never there. The model reasons confidently
-from content that does not exist in the tree it is about to edit, and *nothing
-reports it*. That is a worse failure than the one the no-clobber guard exists to
-prevent, for the same reason it is worse to be quietly misinformed than loudly
-blocked.
+Replay an artifact into the wrong checkout, and you get a session whose
+transcript describes files that were never there. The model reasons
+confidently from content that doesn't exist in the tree it's about to
+edit, and *nothing reports it*. That's worse than the failure the
+no-clobber guard exists to prevent, for the same reason it's worse to be
+quietly misinformed than loudly blocked.
 
-So the artifact carries a fingerprint of the tree it came from, and **replay
-verifies it and refuses by default**. stella is not naming your workspace. It is
-checking that this artifact belongs to this tree.
+So the artifact carries a fingerprint of the tree it came from, and
+**replay checks it and refuses by default** if it doesn't match. stella
+isn't naming your workspace. It's checking that this artifact belongs to
+this tree.
 
-The fingerprint was to be founded on the staleness map the no-clobber guard was
-thought to keep — every path this session touched, and the digest of what it saw
-there. That map was removed in #3780: nothing wrote it and nothing read it, so
-the fingerprint needs a mechanism this tree actually has before it can be built.
-What follows describes the intended shape, not a mechanism in place.
-Verifying it is re-hashing those paths in the target tree. A mismatch
-names the exact files, exactly as a refused write does, and nothing is consumed.
-Overriding it is possible, but it is a distinct argument you pass, never a
-fallback stella takes on your behalf when the check fails.
+This fingerprint would need to build on the same kind of tracking the
+no-clobber guard uses: every path a session touched, and a fingerprint of
+what it saw there. That tracking doesn't currently exist in a form the
+fingerprint could use, so what follows describes the intended design, not
+something built yet.
 
-That map covers the files the session actually touched and no others — so it
-cannot cry wolf over unrelated churn elsewhere in the repo, and it cannot detect
-a tree that differs *only* in files the session never read. Same precision, same
-reasoning as the guard it comes from: a check that fired on noise would get
-overridden by reflex, and then it would protect nothing.
+Checking it means re-hashing those paths in the tree being replayed into.
+A mismatch names the exact files, the same way a refused write does, and
+nothing is lost. It can be overridden, but only by passing an explicit
+argument. It's never automatic, and never a fallback stella takes for you
+when the check fails.
 
-## Two ways to land, and you pick
+This tracking would only cover the files the session actually touched,
+nothing else. So it can't cry wolf over unrelated changes elsewhere in the
+project, and it can't catch a tree that differs only in files the session
+never read. That's the same reasoning as the guard it's based on: a check
+that fires on noise gets overridden out of habit, and then it protects
+nothing.
 
-Replaying against a tree you already have and building a tree from scratch are
-different operations with different failure modes, so they are different modes —
-never inferred from what happens to be on disk.
+## Two ways to land
 
-- **Apply** (the default) replays against a checkout you already have, gated on
-  the fingerprint. The same-laptop-next-morning case.
-- **Materialize** writes the session's files out first. The cross-machine case.
+Replaying into a tree you already have and building a tree from scratch
+are different operations with different failure modes. So they're two
+different modes you choose, never guessed from what happens to be on disk.
 
-Materialize has a limit worth stating plainly: the artifact holds *the files the
-agent touched*, not your whole repository. stella records the base commit so a
-caller can name it, but does not carry the base and never will. Bundling your
-tree into an artifact would move files the agent never read — an egress
-decision stella has no standing to make for you.
+- **Apply** (the default) replays against a checkout you already have,
+  checked against the fingerprint. This is the same-laptop-the-next-morning
+  case.
+- **Materialize** writes the session's files out first. The cross-machine
+  case.
 
-Fetching the base is exactly the kind of thing a control plane is for. It has
-the repository, the credentials, and the policy about who may use them.
+Materialize has a real limit: the artifact holds *the files the agent
+touched*, not your whole project. stella records the base commit so a
+caller can name it, but it doesn't carry that base, and never will.
+Bundling your whole project into an artifact would move files the agent
+never even read, and that's a decision about what leaves your machine that
+stella has no business making for you.
 
-## What is actually in the artifact
+Fetching the base commit is exactly the kind of thing a control plane is
+for. It already has the repository, the credentials, and the policy about
+who can use them.
 
-The conversation, verbatim. Which means **the full content of every file the
-agent read** — including whatever was in those files: the credentials in the
-`.env` you asked it to debug, the customer rows in a fixture, a key in a test.
+## What's in the artifact
 
-That sentence belongs in the documentation of the type that holds it, where
-someone reads it before writing the code that moves the bytes — not in a release
-note and not in a banner.
+The conversation, word for word. That means **the full content of every
+file the agent read**, including whatever was in those files: the
+credentials in the `.env` you asked it to debug, customer rows in a test
+fixture, a key in a test file.
 
-stella does not encrypt it, redact it, classify it, or expire it. Those need to
-know whose data it is, what jurisdiction it sits in, and who may read it, and
-stella knows none of those. Its entire obligation here is to be accurate about
-the contents so your decision is an informed one. That is not a gap in the
-design; it is the boundary doing its job.
+Keep that in mind every time — it's not a one-time warning in a release
+note.
+
+stella doesn't encrypt it, redact it, classify it, or expire it. Doing any
+of that requires knowing whose data it is, what jurisdiction it's under,
+and who's allowed to read it, and stella knows none of that. Its only job
+here is to be honest about what's in the artifact, so you can make an
+informed decision. That's not a gap. It's the boundary working as
+intended.
 
 ## Forks stay visible
 
-Two machines replay the same artifact. Which one wins is a policy question, and
-stella does not answer it.
+Two machines replay the same artifact. Which one wins is a policy
+question, and stella does not answer it.
 
-What it guarantees is that the divergence is *visible*: every replay starts its
-own session, with its own ref in the durable store, and the artifact's origin is
-kept as provenance. You get two histories with a common ancestor that can be
-named — not one history with two sessions interleaved into it, which is the
-outcome that cannot be untangled afterwards.
+What stella guarantees is that the split is *visible*. Every replay starts
+its own session, with its own reference in the durable store, and where
+the artifact came from is kept on record. You get two histories with a
+common starting point you can point to, not one history with two sessions
+tangled together, which you could never untangle afterward.
 
 ## Where the line falls
 
 | stella owns | Your control plane owns |
 |---|---|
 | what is in the artifact | naming a workspace or project |
-| byte-exact round-trip | storing artifacts, and keeping them |
-| refusing a tree the artifact did not come from | transport, auth, tenancy |
-| the version contract, and how long old artifacts stay readable | encryption at rest and in flight |
-| making a fork visible | retention, deletion, audit |
+| an exact round trip | storing artifacts, and keeping them |
+| refusing a tree the artifact did not come from | moving it, checking who it's from, keeping customers separate |
+| the version rules, and how long old artifacts stay readable | encryption, at rest and in transit |
+| making a fork visible | how long it's kept, deleting it, and auditing it |
 | telling you what the artifact contains | who wins a conflict, and when |
 
-[Oxagen](https://oxagen.sh) is that control plane at enterprise scale —
-accounts and projects as the portable identity stella refuses to invent, a
-store, access control, audit, and resuming a session from a browser.
+[Oxagen](https://oxagen.sh) is that control plane at enterprise scale:
+accounts and projects as the portable identity stella won't invent on its
+own, plus storage, access control, auditing, and resuming a session right
+from a browser.
 
-That is a **layering, not a dependency**, and the distinction is the test of
-whether the line is in the right place. stella has to stay fully usable and
-fully durable on its own: the work journal, crash resume, and the no-clobber
-guarantee are local mechanisms and stay local mechanisms. If a change ever made
-one of them conditional on a control plane existing, the change would be the
-thing that is wrong.
+This is a **layer on top, not a dependency**, and that difference is the
+test of whether the line sits in the right place. stella has to stay fully
+usable and fully durable on its own. The work journal, crash resume, and
+the no-clobber guarantee are local mechanisms, and they stay local
+mechanisms. If a future change ever made one of them depend on a control
+plane existing, that change would be the mistake, not this design.
 
 ## What this does not claim
 
-- **It is not sync.** There is no `stella login`, no stella-hosted store, and no
-  first-party upload path. Not deferred — declined.
-- **Old artifacts do not read forever.** A stored artifact stays replayable
-  across a stated support window, not indefinitely. When a build genuinely
-  cannot read one, it says so and names what can — it does not guess at a format
-  it half-understands, which would resume your session subtly wrong.
-- **stella does not merge forks.** It makes them visible. Resolving them needs
-  to know which one matters, which is exactly what stella does not know.
-- **The artifact is not a backup of your repository.** It is what the agent did,
-  plus the identity of what it did it to.
+- **This is not sync.** There's no `stella login`, no stella-hosted store,
+  and no built-in upload path. This isn't a "later" feature. It's a
+  deliberate no.
+- **Old artifacts don't stay readable forever.** A stored artifact stays
+  replayable for a stated support window, not forever. When a build
+  genuinely can't read an old one, it tells you and names what can, instead
+  of guessing at a format it only half understands, which would resume
+  your session subtly wrong.
+- **stella doesn't merge forks.** It just makes them visible. Resolving a
+  fork means knowing which one matters, and that's exactly what stella
+  doesn't know.
+- **The artifact isn't a backup of your project.** It's a record of what
+  the agent did, plus a fingerprint of what it did it to.
 
 ## Where this sits
 
-The same rule as everywhere else in this codebase: where a mechanism can decide
-something, [the mechanism decides it](/docs/principles/determinism). Whether an
-artifact belongs to a tree is checkable, so it is checked, and the check refuses
-rather than warns. Everything genuinely not checkable from inside a directory —
-whose project this is, who may read it, which copy wins — is handed to the layer
-that can actually answer it, instead of being guessed at by the layer that
-cannot.
+The same rule shows up everywhere in stella: where something can be
+decided by a mechanism,
+[the mechanism decides it](/docs/principles/determinism). Whether an
+artifact belongs to a tree is checkable, so it gets checked, and the check
+refuses rather than just warning. Anything genuinely not checkable from
+inside a directory, like whose project this is, who may read it, or which
+copy wins, gets handed to a layer that can actually answer it, instead of
+being guessed at by a layer that can't.
+</content>

--- a/website/content/docs/principles/session-artifacts.mdx
+++ b/website/content/docs/principles/session-artifacts.mdx
@@ -154,7 +154,7 @@ note.
 stella doesn't encrypt it, redact it, classify it, or expire it. Doing any
 of that requires knowing whose data it is, what jurisdiction it's under,
 and who's allowed to read it, and stella knows none of that. Its only job
-here is to be honest about what's in the artifact, so you can make an
+here is to say exactly what's in the artifact, so you can make an
 informed decision. That's not a gap. It's the boundary working as
 intended.
 
@@ -196,7 +196,7 @@ plane existing, that change would be the mistake, not this design.
 
 - **This is not sync.** There's no `stella login`, no stella-hosted store,
   and no built-in upload path. This isn't a "later" feature. It's a
-  deliberate no.
+  hard no.
 - **Old artifacts don't stay readable forever.** A stored artifact stays
   replayable for a stated support window, not forever. When a build
   genuinely can't read an old one, it tells you and names what can, instead

--- a/website/content/docs/principles/session-artifacts.mdx
+++ b/website/content/docs/principles/session-artifacts.mdx
@@ -218,4 +218,3 @@ refuses rather than just warning. Anything genuinely not checkable from
 inside a directory, like whose project this is, who may read it, or which
 copy wins, gets handed to a layer that can actually answer it, instead of
 being guessed at by a layer that can't.
-</content>

--- a/website/content/docs/release-notes.mdx
+++ b/website/content/docs/release-notes.mdx
@@ -1,45 +1,47 @@
 ---
 title: Release notes
-description: Where stella's release notes live — the per-line changelog at /releases, and the per-tag notes on GitHub.
+description: Where stella's release notes live — the changelog at /releases, and the per-build notes on GitHub.
 ---
 
-Release notes live in two places, and which one you want depends on the
-question you are asking.
+Release notes live in two places. Which one you want depends on what
+you're trying to find out.
 
-## What changed in the line I am upgrading across
+## Upgrade notes
 
-**[stella.oxagen.sh/releases](/releases)** — one section per **minor line**,
-searchable, filterable by kind. This is the curated record: what a line
-delivered, written for someone deciding whether to upgrade.
+**[stella.oxagen.sh/releases](/releases)** has one section per minor
+version, searchable and filterable by kind. This is the record to read when
+you're deciding whether to upgrade: what a version added, fixed, or
+changed.
 
-It is generated from [`CHANGELOG.md`](https://github.com/macanderson/stella/blob/main/CHANGELOG.md)
-at build time, so the page and the repository cannot drift.
+It's generated straight from [`CHANGELOG.md`](https://github.com/macanderson/stella/blob/main/CHANGELOG.md)
+when the site builds, so the page always matches the file in the project.
 
-## What changed in this exact build
+## Build notes
 
 **[The releases page on GitHub](https://github.com/macanderson/stella/releases)**
-— notes for every tag, generated from that tag's own diff.
+has notes for every tagged build, generated from that build's own changes.
 
-Every merge to `main` cuts a patch release (the 0.6 line was 127 of them in
-eight days), so this is the surface to reach for when you are bisecting a
-regression or want the commit-level log for one version.
+Every merge to `main` cuts a new patch release, so this is the page to use
+when you're tracking down a regression or want the exact commit-level
+history for one version.
 
-<Callout title="Why this page is not the changelog">
-It used to be — a hand-maintained copy of the same notes, which is exactly why
-it stopped being one. It sat on "Current release: 0.6.44" while the tree was on
-0.6.131. A second copy of a record that changes every day is a copy that is
-wrong every day; `/releases` renders the repository's own file instead.
+<Callout title="Why GitHub's page and /releases differ">
+`/releases` is the curated, human-readable record, built straight from
+[`CHANGELOG.md`](https://github.com/macanderson/stella/blob/main/CHANGELOG.md)
+so it can never fall out of sync with the project. GitHub's per-build page
+is the finer-grained one, with a note for every single tagged build.
 </Callout>
 
-## How a section gets written
+## Writing an entry
 
-Contributors and coding agents do not write changelog entries — CI does, so the
-file keeps one voice instead of whatever each PR happened to say about itself.
-When a minor or major release is cut,
+Changelog entries are written by an automated process, not by individual
+contributors, so every entry reads in one consistent voice. When a minor or
+major version is cut,
 [`scripts/changelog-ai.sh`](https://github.com/macanderson/stella/blob/main/scripts/changelog-ai.sh)
-drafts the section from the whole series diff and
+drafts the section from the full set of changes, and
 [`scripts/changelog-roll.sh`](https://github.com/macanderson/stella/blob/main/scripts/changelog-roll.sh)
-rolls it into place under the new version heading.
+adds it under the new version heading.
 
-If your change needs context the diff alone will not convey, put it in the pull
-request description: the drafter reads commit bodies, not just code.
+If your change needs context that the code alone won't convey, put it in
+the pull request description. The drafter reads that too, not just the
+code.

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -3,51 +3,53 @@ title: Scripting & automation
 description: Run stella headlessly in CI with JSON and streaming-JSON output, environment-variable configuration, and enforced budgets.
 ---
 
-stella is built to run unattended. The `--output-format` flag switches from the
-human-oriented terminal rendering to machine-readable output, and every important flag has
-an environment-variable equivalent for CI.
+Stella can run unattended. The `--output-format` flag switches from the
+human-friendly terminal display to output a script can read, and every
+important flag also has an environment variable for use in CI.
 
 ## Output formats
 
-`--output-format` (env `STELLA_OUTPUT_FORMAT`) is a flag of the two commands that honor
-it — [`stella run`](/docs/commands/run) and [`stella fleet`](/docs/commands/fleet) — so it
-goes **after** the subcommand token. It is not a global flag: on any other
-command it is a parse error rather than a promise the output silently breaks
-([#1493](https://github.com/macanderson/stella/issues/1493)). It takes one of three
-values:
+`--output-format` (or the `STELLA_OUTPUT_FORMAT` environment variable) only
+works on two commands: [`stella run`](/docs/commands/run) and
+[`stella fleet`](/docs/commands/fleet). It goes after the subcommand, not
+before it. It's not a global flag — using it on any other command is a
+parse error, so you'll never wonder whether the output silently changed
+format. It takes one of three values:
 
 <CardGrid size="md">
   <OptionCard name="text">
-    The default. Interactive human rendering, for local use — and the only
-    format that keeps stdout clean on failure, routing the diagnostic to
-    stderr instead.
+    The default. Interactive, human-friendly display, for local use. It's
+    also the only format that keeps stdout clean on failure — the error
+    message goes to stderr instead.
   </OptionCard>
   <OptionCard name="json">
-    One final JSON object summarizing the turn, pretty-printed. Capture a result
-    in a script.
+    One JSON object, printed once the turn ends, formatted for readability.
+    Use it to capture a result in a script.
   </OptionCard>
   <OptionCard name="stream-json">
-    One compact JSON line per agent event, as it happens. Live progress in a
-    pipeline.
+    One compact JSON line per event, printed as it happens. Use it for live
+    progress in a pipeline.
   </OptionCard>
 </CardGrid>
 
-`stream-json` is a line-per-event serialization of stella's internal event enum — a stable
-machine interface you can parse incrementally. Each line is one event object tagged
-`"type"` in snake_case (`stage`, `text`, `reasoning`, `tool_start`, `tool_result`, …).
-The vocabulary is additive-only: skip lines whose `type` you don't recognize, and a
-client that does so keeps working across stella upgrades without changes. Note the
-converse — a `type` you *do* recognize carrying a body that doesn't fit is a real error,
-not something to skip. See
-[Event stream compatibility](/docs/event-stream-compatibility) for the full contract and
-a conformance fixture to test your client against.
+`stream-json` prints one line per stella event, a stable interface you can
+parse as it arrives. Each line is one event object with a `"type"` field in
+snake_case (`stage`, `text`, `reasoning`, `tool_start`, `tool_result`, and
+others). New types can be added later, but existing ones never go away, so
+skip any line with a `type` you don't recognize and your client keeps
+working across stella upgrades. The opposite case is different: if you do
+recognize the `type` but the body doesn't match what you expect, that's a
+real error, not something to skip. See
+[Event stream compatibility](/docs/event-stream-compatibility) for the full
+contract and a test fixture to check your client against.
 
-In particular, `text_delta` lines stream the answer token by token as a best-effort live
-preview — the `text` event that follows carries the full step text and is authoritative
-(replace any accumulated deltas with it; a retried model call re-streams its deltas).
-The fragment rides in `text_delta`'s `delta` field and the full body in `text`'s `text`
-field. Older stellas recorded streams with the two fields crossed, so a reader that
-also processes archives should accept either spelling on either event.
+`text_delta` lines stream the answer token by token, as a live preview. The
+`text` event that follows it carries the full, final text for that step —
+replace any deltas you've accumulated with it. If a model call is retried,
+its deltas stream again. The delta text is in `text_delta`'s `delta` field,
+and the full text is in `text`'s `text` field. If you're reading older
+recorded streams too, accept either field name on either event, since some
+older ones have the two swapped.
 
 ```bash
 # One final JSON object
@@ -59,98 +61,105 @@ stella run --output-format stream-json "fix the failing test" | while IFS= read 
 done
 ```
 
-`json` embeds those same event objects under an `events` key in its single summary
-object — exactly what `stream-json` would have emitted line by line. Every summary object
-declares `schema_version` (see [The envelope contract](#the-envelope-contract) below). The
-summary's other keys depend on the execution path: a default run drives the raw step loop
-and summarizes as `status`, `text`, `cost_usd`, `reason`, `model`, and `events`, plus a
-top-level `files_touched` key holding the
-[file-touch telemetry](/docs/telemetry) payload and a top-level `withheld` key holding what
-this checkout's trust gate held back; `--pipeline <variant>` runs the turn under
-an installed [wrapper plugin](/docs/plugins) instead and summarizes as `status`, `text`,
-`cost_usd`, `reason`, `task_class`,
-`verdict`, `revisions`, `candidates_run`, `model`, `events`, and `reflection` — which does
-**not** carry `files_touched`. The `files_touched` payload is the serialized telemetry
-object, so the array of records sits one level in, at `.files_touched.files_touched`.
+`json` puts those same event objects under an `events` key inside one
+summary object — the same events `stream-json` would print line by line.
+Every summary object has a `schema_version` field (see
+[The envelope contract](#the-envelope-contract) below). The rest of the
+keys depend on how the run happened. A default run uses the raw step loop
+and reports `status`, `text`, `cost_usd`, `reason`, `model`, and `events`,
+plus a top-level `files_touched` key holding the
+[file-touch telemetry](/docs/telemetry) payload, and a top-level `withheld`
+key holding whatever this checkout's trust gate held back. `--pipeline
+<variant>` runs the turn through an installed
+[wrapper plugin](/docs/plugins) instead, and reports `status`, `text`,
+`cost_usd`, `reason`, `task_class`, `verdict`, `revisions`,
+`candidates_run`, `model`, `events`, and `reflection` — this shape does not
+include `files_touched`. The `files_touched` payload is the full telemetry
+object, so the actual list of records is one level in, at
+`.files_touched.files_touched`.
 
-The `model` value is `provider/model_id` for the model that **actually ran** —
-on the wrapped path that is the model serving the worker turns, which is what
-`cost_usd` was spent on. It is not an echo of what you requested: a
-[`default_model`](/docs/configuration/agent-engine-config) that routes
-the worker somewhere other than the session default is reflected here. Read
-this key, not your own `--model` argument, when attributing spend.
+`model` is `provider/model_id` for the model that actually ran. On the
+wrapped path, that's the model serving the worker turns — the one
+`cost_usd` was spent on. It doesn't just echo back what you requested: if a
+[`default_model`](/docs/configuration/agent-engine-config) setting routes
+the worker to a different model than your session default, this key shows
+that. When attributing spend, read this key, not your own `--model`
+argument.
 
-The `status` value is the first thing most scripts branch on. A raw run
-reports one of three, since nothing verified it; a `--pipeline <variant>`
-run reports one of four:
+`status` is usually the first thing a script checks. A raw run, which
+nothing verified, reports one of three values. A `--pipeline <variant>` run
+reports one of four:
 
 <CardGrid size="sm">
   <OptionCard name="completed">
-    The turn finished. On the wrapped path this also means verification
-    passed — check `verdict.deterministic` to see whether a verifier was spent.
+    The turn finished. On the wrapped path, this also means verification
+    passed. Check `verdict.deterministic` to see whether a verifier was
+    used.
   </OptionCard>
   <OptionCard name="verification_failed">
-    Wrapped runs only. The work happened but did not verify; `reason` carries the
-    verdict summary. Exits non-zero.
+    Wrapped runs only. The work happened, but didn't pass verification;
+    `reason` carries the verdict summary. Exits non-zero.
   </OptionCard>
   <OptionCard name="aborted">
-    A backstop ended the run — the budget cap, a loop escalation, a scope gate
-    with nobody to ask, a signal. `reason` says which. Exits non-zero: `3` when
-    the stop was the engine's own deliberate policy, `1` when the run fell
-    over underneath it.
+    A safety limit ended the run: the budget cap, a loop escalation, a scope
+    gate with nobody to ask, or a signal. `reason` says which. Exits
+    non-zero — `3` when stella stopped itself on purpose, `1` when the run
+    failed underneath it.
   </OptionCard>
   <OptionCard name="error">
-    The run failed outright, including every pre-flight failure. Exits non-zero.
+    The run failed outright, including every failure before the run even
+    started. Exits non-zero.
   </OptionCard>
 </CardGrid>
 
-**Failures keep the same key set.** A `--pipeline <variant>` run that errors emits every key
-above, with `text` and the wrapper-only keys (`task_class`, `verdict`, `revisions`,
-`candidates_run`) as explicit `null` rather than missing — so a strict deserializer written against the
-success shape still parses. A failure *before* the agent is constructed — no API key
-configured, an unknown provider or model, a malformed `settings.json` — has no
-model or event log to report, so it emits the minimal envelope on stdout alongside the `stella: …`
-line on stderr:
+**A failure still has the same set of keys.** A `--pipeline <variant>` run
+that errors out still emits every key listed above, with `text` and the
+wrapper-only keys (`task_class`, `verdict`, `revisions`, `candidates_run`)
+set to `null` instead of left out — so a strict parser written for the
+success shape still works. A failure that happens before stella even
+builds the agent (no API key, an unknown provider or model, a broken
+`settings.json`) has no model or event log to report. It prints a minimal
+envelope on stdout, alongside a `stella: …` line on stderr:
 
 ```json
 { "schema_version": 1, "status": "error", "text": null, "reason": "no API key found. …" }
 ```
 
-Under `--output-format text` stdout stays clean in both cases; the diagnostic is the stderr
-line.
+Under `--output-format text`, stdout stays clean in both cases — the error
+message is the stderr line.
 
 ## The envelope contract
 
-Every summary object above — the raw-loop summary, the `--pipeline <variant>` summary, and the
-pre-flight error envelope — carries a `schema_version` integer. It is **1** today. The
-three shapes always declare the same value: it versions the envelope contract, not the
-execution path, so you never have to special-case which run you got.
+Every summary object above (the raw-loop summary, the `--pipeline
+<variant>` summary, and the pre-flight error envelope) carries a
+`schema_version` number. It's `1` today. All three shapes use the same
+value, because this number versions the envelope contract itself, not the
+kind of run you got — so you never have to write a special case for which
+one you're reading.
 
-`schema_version` increments only when a change could break a script written against the
-previous version:
+`schema_version` only goes up when a change could break a script written
+against the version before it:
 
-- a key is **removed** or **renamed**,
-- a key's value **type** changes (`string` → `object`, scalar → array),
-- a key's **meaning** changes while its name and type stay the same.
+- a key is removed or renamed,
+- a key's value type changes (`string` to `object`, a single value to an array),
+- a key's meaning changes while its name and type stay the same.
 
-It does **not** increment when a key is added. New keys may appear in any release, so your
-parser must ignore keys it does not recognize — the same rule the
-[event stream](/docs/event-stream-compatibility) asks of clients. If additions bumped the
-version, the number would change so often it would tell you nothing.
+Adding a key never bumps the version. New keys can show up in any release,
+so your parser has to ignore keys it doesn't recognize — the same rule the
+[event stream](/docs/event-stream-compatibility) asks of its clients. If
+adding a key bumped the version, the number would change so often it
+wouldn't tell you anything.
 
-The `events` array is outside this contract: the event vocabulary has its
-[own forward-compatibility guarantee](/docs/event-stream-compatibility), and a new event
-type never bumps `schema_version`. Everything else the envelope owns — including the nested
-`verdict`, `reflection`, and `files_touched` payloads — is covered by it.
+The `events` array sits outside this contract. Event types have their
+[own forward-compatibility guarantee](/docs/event-stream-compatibility),
+and a new event type never bumps `schema_version`. Everything else the
+envelope owns, including the nested `verdict`, `reflection`, and
+`files_touched` payloads, is covered by this contract.
 
-Two practical consequences for a consumer:
+Two things this means for you:
 
-- **Pin what you require, not what you receive.** Assert on the keys you actually read;
-  do not assert the full key set, and do not reject an object because it carries keys you
-  have never seen.
-- **Treat an unexpected `schema_version` as the branch point.** A number higher than the
-  one you were written against means the shape may have changed under you; fail loudly
-  there rather than silently misreading a renamed key.
+- **Check only the keys you use, not the whole set.** Don't assert on every key you'd expect, and don't reject an object just because it has keys you've never seen.
+- **Treat an unexpected `schema_version` as your signal to stop.** A number higher than the one your script was written for means the shape may have changed. Fail loudly there, instead of silently misreading a renamed key.
 
 ```bash
 # Refuse to parse a shape this script was not written for
@@ -158,17 +167,20 @@ stella run --output-format json "…" | jq -e '
   if .schema_version == 1 then .status else error("unsupported schema_version") end'
 ```
 
-Key order is not part of the contract — read by key, never by position.
+Key order isn't part of the contract. Always read by key, never by
+position.
 
-### Query commands version their JSON too
+### Query command JSON
 
 The read-only query commands — `stats`, `usage report`, `inspect`,
-`calibration`, `memory list`, `context list|validate` — take `--format json` (their
-human rendering is `--format text`, the default) and wrap their JSON in the **query
-envelope**: `schema_version` first, then the payload. Array reports put their rows
-under a `rows` key; object reports keep their own keys after the version. It is **1**
-today, versions independently of the turn envelope above, and bumps by the same rules
-(never for an added key).
+`calibration`, `memory list`, and `context list|validate` — take `--format
+json` (their default, human-readable output is `--format text`). Their
+JSON uses its own query envelope: `schema_version` first, then the payload.
+A report that returns a list puts its rows under a `rows` key; a report
+that returns a single object keeps its own keys after the version. This
+version number is `1` today, is tracked separately from the turn envelope
+above, and follows the same bump rules — it never changes just because a
+key was added.
 
 ```bash
 # Rows ride under `rows`
@@ -180,69 +192,74 @@ stella inspect 42 --step 3 --format json | jq '{schema_version, verified}'
 
 ## Configure via environment
 
-Every core global flag has an environment variable, so a CI job can be configured without
-editing the command line:
+Every core global flag has a matching environment variable, so you can
+configure a CI job without editing the command line:
 
 <CardGrid size="md">
   <OptionCard name="STELLA_MODEL">
-    Equivalent to `--model`. The worker model for this invocation:
-    `provider/model_id`, e.g. `anthropic/claude-fable-5`.
+    Same as `--model`. Sets the worker model for this run, as
+    `provider/model_id` — for example, `anthropic/claude-fable-5`.
   </OptionCard>
   <OptionCard name="STELLA_BASE_URL">
-    Equivalent to `--base-url`. Required alongside `--model local/<model>` to
-    point at a local OpenAI-compatible server; optional elsewhere to route
-    through a proxy.
+    Same as `--base-url`. Required together with `--model local/<model>` to
+    point at a local OpenAI-compatible server. Optional otherwise, to route
+    requests through a proxy.
   </OptionCard>
   <OptionCard name="STELLA_OUTPUT_FORMAT" defaultValue="text">
-    Equivalent to `--output-format`: `text`, `json`, or `stream-json`. Read
-    exactly where the flag exists — `run` and `fleet` — so exporting it for a
-    whole session never garbles the other commands' output.
+    Same as `--output-format`: `text`, `json`, or `stream-json`. Only read
+    where the flag itself exists — `run` and `fleet` — so exporting it for a
+    whole terminal session never changes another command's output.
   </OptionCard>
   <OptionCard name="STELLA_SPEND_LIMIT">
-    Equivalent to `--spend-limit`. Hard USD cap for the whole run. Unset means
-    spend is metered but never blocked.
+    Same as `--spend-limit`. A hard dollar limit for the whole run. If
+    unset, spend is tracked but never blocked.
   </OptionCard>
   <OptionCard name="STELLA_TURN_TIMEOUT">
-    Equivalent to `--turn-timeout`. Wall-clock seconds one turn may spend — the
-    one to set when the *runner* will kill the job on elapsed time. Set it
-    slightly below that deadline and the run stops at a safe boundary, so the
-    work on disk is reported instead of destroyed with the process.
+    Same as `--turn-timeout`. The maximum real time, in seconds, one turn
+    may take. Set this when your CI runner will kill the job after a time
+    limit. Set it slightly below that limit, and stella stops at a safe
+    point on its own, so the work already done gets reported instead of
+    being lost when the process is killed.
   </OptionCard>
   <OptionCard name="STELLA_MAX_OUTPUT_TOKENS">
-    Equivalent to `--max-output-tokens`. Caps output per step below the model's
-    own ceiling, to bound cost or latency on a long unattended run.
+    Same as `--max-output-tokens`. Limits output per step below the model's
+    own maximum, to control cost or speed on a long unattended run.
   </OptionCard>
   <OptionCard name="STELLA_UPSTREAM_PIN">
-    Equivalent to `--upstream-pin`. Pins a gateway to named upstreams and
-    refuses fallback — set it when two CI runs have to be comparable.
+    Same as `--upstream-pin`. Locks a gateway to the upstreams you name and
+    refuses to fall back to another. Set this when two CI runs need to be
+    directly comparable.
   </OptionCard>
   <OptionCard name="STELLA_DETACH">
-    Equivalent to `--detach`. Launch the run and return immediately; the exit
-    code is the launch's, and the run's own answer comes from
-    [`stella daemon list`](/docs/commands/daemon). Needs no terminal, so it
-    works from a pipe or a container.
+    Same as `--detach`. Starts the run and returns right away. The exit
+    code is only for the launch itself — the run's actual result comes from
+    [`stella daemon list`](/docs/commands/daemon). Works with no terminal
+    at all, so it runs fine from a pipe or a container.
   </OptionCard>
   <OptionCard name="STELLA_LOG" defaultValue="warn">
-    Equivalent to `--log-level`. Per-crate diagnostic filter, e.g.
-    `warn,stella_model=trace`. Resolution is most-specific-first: `--log-level`,
-    then `-v`/`-vv`/`-vvv`, then this, then `warn` — so a typed `-vv` is never
-    silently overridden by an exported value.
+    Same as `--log-level`. A diagnostic filter per module, for example
+    `warn,stella_model=trace`. Stella checks the most specific setting
+    first: `--log-level`, then `-v`/`-vv`/`-vvv`, then this variable, then
+    `warn` as the fallback — so typing `-vv` is never silently overridden by
+    an exported value.
   </OptionCard>
   <OptionCard name="STELLA_PLAIN">
-    Set to `1` for the plain line-based REPL instead of the Command Deck. Rarely
-    needed in CI — the deck already steps aside when stdout is not a terminal.
+    Set to `1` to use the plain, line-based REPL instead of the Command
+    Deck. Rarely needed in CI, since the deck already steps aside on its
+    own when stdout isn't a terminal.
   </OptionCard>
   <OptionCard name="STELLA_NO_ANIM">
-    Freeze all deck animation to a static frame, for CI logs and
-    asciinema-style recordings. `NO_COLOR` forces the same.
+    Freezes all deck animation to a single static frame, useful for CI logs
+    and screen recordings. `NO_COLOR` has the same effect.
   </OptionCard>
 </CardGrid>
 
 <Callout type="warn">
-  `--api-key` has **no** `STELLA_*` equivalent. Supply the key
-  through the provider's own variable (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, …),
-  which is step 2 of the [credential chain](/docs/configuration/credentials)
-  and never lands in a process argument list.
+  `--api-key` has **no** `STELLA_*` equivalent. Supply your key through the
+  provider's own variable instead (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, and
+  so on) — this is step 2 of the
+  [credential chain](/docs/configuration/credentials), and it never ends up
+  in a process argument list.
 </Callout>
 
 ```bash
@@ -252,18 +269,19 @@ export STELLA_SPEND_LIMIT=5
 stella run "update the changelog for the pending release"
 ```
 
-stella also loads project dotenv files into the environment before any of this
-resolves — `.env.<mode>.local`, then `.env.local`, then `.env`, most-specific
-first, confined to the enclosing git repository. An exported shell value always
-beats a file value, `.env.example` and committed `.env.<mode>` files are never
-read, and `STELLA_NO_ENV_FILE=1` disables the mechanism entirely. In CI, prefer
-the runner's secret store over a checked-in file.
+Stella also loads project dotenv files into the environment before any of
+this is resolved: `.env.<mode>.local`, then `.env.local`, then `.env`, most
+specific first, and only within the enclosing git repository. A value
+already exported in your shell always wins over a file value.
+`.env.example` and any committed `.env.<mode>` files are never read.
+`STELLA_NO_ENV_FILE=1` turns this off entirely. In CI, prefer your runner's
+secret store over a checked-in file.
 
 ## Headless credentials
 
-In CI, supply the provider key through the environment (or a mounted
-[`settings.json`](/docs/configuration/settings)) — never the interactive prompt, which is
-skipped when there is no TTY:
+In CI, supply your provider key through the environment, or a mounted
+[`settings.json`](/docs/configuration/settings) — never the interactive
+prompt, which is skipped whenever there's no terminal to show it in:
 
 ```bash
 export ANTHROPIC_API_KEY="$SECRET_ANTHROPIC_KEY"
@@ -271,24 +289,26 @@ stella run --output-format json "generate release notes from the diff since the 
 ```
 
 <Callout type="warn">
-  With no resolvable key and no TTY, stella fails fast with a clear error rather than
-  hanging on a prompt that can never be answered. Make sure a key is in the environment
-  before the run.
+  With no usable key and no terminal, stella fails fast with a clear error
+  instead of hanging on a prompt nobody can answer. Make sure a key is set
+  in the environment before the run starts.
 </Callout>
 
 ## Enforced budgets in CI
 
-Pair headless runs with an [enforced budget](/docs/telemetry#budget-observed-vs-enforced)
-so an automated job can never overspend:
+Pair a headless run with an
+[enforced budget](/docs/telemetry#budget-observed-vs-enforced) so an
+automated job can never spend more than you allow:
 
 ```bash
 stella --spend-limit 3 run --output-format json "port the utils module to the new client"
 ```
 
-Work aborts cleanly once the cap is reached — never mid-tool — so the workspace is left in
-a consistent state, and the summary comes back `"status": "aborted"` with the cap named in
-`reason`. A fleet divides the same cap across its concurrency width, so the number you set
-is the number you spend:
+Work stops cleanly once the cap is reached, never in the middle of a tool
+call, so your workspace is left in a consistent state. The summary comes
+back with `"status": "aborted"`, and `reason` names the cap that stopped
+it. A fleet splits the same cap across its concurrency width, so the
+number you set is the number you actually spend:
 
 ```bash
 stella --spend-limit 10 fleet --plan cleanup.toml --max-concurrency 4
@@ -298,24 +318,26 @@ stella --spend-limit 10 fleet --plan cleanup.toml --max-concurrency 4
 
 <CardGrid size="sm">
   <OptionCard name="0">
-    Success. On the wrapped path that means verification passed, not merely
+    Success. On the wrapped path, this means verification passed, not just
     that the model stopped talking.
   </OptionCard>
   <OptionCard name="1">
-    Failure — an unresolved credential, an invalid flag, a failed verification,
-    or a run that fell over mid-turn (a model call that would not commit).
+    Failure: a credential that couldn't be resolved, an invalid flag, a
+    failed verification, or a run that failed partway through a turn (a
+    model call that wouldn't complete).
   </OptionCard>
   <OptionCard name="3">
-    Deliberate stop. The engine chose to end the run: a stuck loop escalated
-    past its steering warning, an enforced budget or deadline, the step cap, a
-    scope review the operator ended. The work did not finish, but nothing
-    crashed — a wrapper can retry with a different strategy, and a benchmark
-    should score "gave up", not "died".
+    A deliberate stop. Stella chose to end the run: a stuck loop that
+    passed its warning threshold, an enforced budget or deadline, the step
+    limit, or a scope review the operator ended. The work didn't finish,
+    but nothing crashed. A wrapper can retry with a different approach, and
+    a benchmark should score this as "gave up," not "died".
   </OptionCard>
   <OptionCard name="128 + signal">
-    The run was interrupted: `130` for `SIGINT` (Ctrl-C), `143` for `SIGTERM`
-    (a CI job cancellation or timeout kill). The shell convention, so a wrapper
-    script can tell "someone stopped this" from "this failed".
+    The run was interrupted: `130` for `SIGINT` (Ctrl-C), `143` for
+    `SIGTERM` (a CI job cancellation or timeout kill). This follows the
+    normal shell convention, so a wrapper script can tell "someone stopped
+    this" apart from "this failed on its own".
   </OptionCard>
 </CardGrid>
 
@@ -334,9 +356,9 @@ esac
 
 ## A complete CI job
 
-The whole contract in one GitHub Actions step: a budget cap that cannot be
-exceeded, a deterministic oracle that settles the run without asking a model, JSON on
-stdout, and the summary parsed for the job log.
+Here's the whole contract in one GitHub Actions job: a budget cap that
+can't be exceeded, a deterministic check that settles the run without
+asking a model, JSON on stdout, and the summary parsed into the job log.
 
 ```yaml title=".github/workflows/autofix.yml"
 name: autofix
@@ -393,17 +415,17 @@ jobs:
 ```
 
 <Callout type="warn">
-  There is no built-in headless-only gate to configure here.
-  `agent_engine_config.headless_scope_bypass` is inert, so setting it neither
-  loosens nor tightens anything. A run under a verification plugin can still
-  refuse on the plugin's own rule; read that plugin's manifest for what it
-  refuses and when.
+  There's no separate headless-only setting to configure here.
+  `agent_engine_config.headless_scope_bypass` has no effect — setting it
+  neither loosens nor tightens anything. A run under a verification plugin
+  can still be refused by the plugin's own rule. Read that plugin's
+  manifest to see what it refuses, and when.
 </Callout>
 
 ## Parsing the output with jq
 
-The summary object and the event stream answer different questions. A few
-pipelines worth keeping:
+The summary object and the event stream answer different questions. Here
+are a few pipelines worth keeping:
 
 ```bash
 # Gate a script on deterministic evidence only — refuse a verifier-only pass.
@@ -451,8 +473,8 @@ stella run --output-format json "$TASK" \
 ```
 
 <Callout type="info">
-  Skip lines and keys you do not recognize — that is what makes these pipelines
-  survive an upgrade. See
-  [Event stream compatibility](/docs/event-stream-compatibility) for the event
-  vocabulary's own guarantee.
+  Skip lines and keys you don't recognize — that's what lets these
+  pipelines survive a stella upgrade. See
+  [Event stream compatibility](/docs/event-stream-compatibility) for the
+  event vocabulary's own guarantee.
 </Callout>

--- a/website/content/docs/scripting.mdx
+++ b/website/content/docs/scripting.mdx
@@ -3,7 +3,7 @@ title: Scripting & automation
 description: Run stella headlessly in CI with JSON and streaming-JSON output, environment-variable configuration, and enforced budgets.
 ---
 
-Stella can run unattended. The `--output-format` flag switches from the
+stella can run unattended. The `--output-format` flag switches from the
 human-friendly terminal display to output a script can read, and every
 important flag also has an environment variable for use in CI.
 
@@ -156,8 +156,6 @@ and a new event type never bumps `schema_version`. Everything else the
 envelope owns, including the nested `verdict`, `reflection`, and
 `files_touched` payloads, is covered by this contract.
 
-Two things this means for you:
-
 - **Check only the keys you use, not the whole set.** Don't assert on every key you'd expect, and don't reject an object just because it has keys you've never seen.
 - **Treat an unexpected `schema_version` as your signal to stop.** A number higher than the one your script was written for means the shape may have changed. Fail loudly there, instead of silently misreading a renamed key.
 
@@ -238,7 +236,7 @@ configure a CI job without editing the command line:
   </OptionCard>
   <OptionCard name="STELLA_LOG" defaultValue="warn">
     Same as `--log-level`. A diagnostic filter per module, for example
-    `warn,stella_model=trace`. Stella checks the most specific setting
+    `warn,stella_model=trace`. stella checks the most specific setting
     first: `--log-level`, then `-v`/`-vv`/`-vvv`, then this variable, then
     `warn` as the fallback — so typing `-vv` is never silently overridden by
     an exported value.
@@ -269,7 +267,7 @@ export STELLA_SPEND_LIMIT=5
 stella run "update the changelog for the pending release"
 ```
 
-Stella also loads project dotenv files into the environment before any of
+stella also loads project dotenv files into the environment before any of
 this is resolved: `.env.<mode>.local`, then `.env.local`, then `.env`, most
 specific first, and only within the enclosing git repository. A value
 already exported in your shell always wins over a file value.
@@ -327,7 +325,7 @@ stella --spend-limit 10 fleet --plan cleanup.toml --max-concurrency 4
     model call that wouldn't complete).
   </OptionCard>
   <OptionCard name="3">
-    A deliberate stop. Stella chose to end the run: a stuck loop that
+    A deliberate stop. stella chose to end the run: a stuck loop that
     passed its warning threshold, an enforced budget or deadline, the step
     limit, or a scope review the operator ended. The work didn't finish,
     but nothing crashed. A wrapper can retry with a different approach, and

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -1,219 +1,282 @@
 ---
 title: Self-improvement
-description: The track where stella makes stella measurably more capable — seven components, their dependency order, what's built today, and the guardrails on each.
+description: How stella becomes measurably more capable over time — the parts involved, what depends on what, what's built today, and the safety rules for each.
 ---
 
-Most of what gets called agent "self-improvement" is recall: a note file the agent writes to and reads back. That is useful, and stella does it — see [Memory](/docs/context-engine). It is also not the same thing as getting *better*.
+Most of what people call agent "self-improvement" is really just recall: a
+note file the agent writes to and reads back later. That's useful, and
+stella does it — see [Memory](/docs/context-engine). But writing notes
+isn't the same thing as getting better.
 
-This track is the other thing. Each component below changes what stella can do, not just what it remembers, and each one carries a **success metric and a guardrail** so that "improvement" is something proven rather than asserted.
+This page is about the other thing. Each part below changes what stella
+can actually do, not just what it remembers. Each one has a way to measure
+success and a safety rule, so "improvement" has to be proven, not just
+claimed.
 
 <Callout type="warn">
-**This page describes a direction, much of which is not built.** Four slices have shipped —
-[`stella tune`](/docs/commands/tune), `stella dataset export`, the Tool Foundry, and the nightly
-loop-bench gate. Everything else is a design under active discussion in the issue tracker, and the
-details will change. Read it as a map of where stella is heading, and check the linked issue for
-the current state of any one component.
+**Much of this is a plan, not shipped behavior.** Four pieces are shipped:
+[`stella tune`](/docs/commands/tune), `stella dataset export`, the Tool
+Foundry, and the nightly loop-bench gate. Everything else is still being
+designed, and the details will change. Read this as a map, not a feature
+list, and check the linked issue for the current state of any one part.
 </Callout>
 
-## The shape of the problem
+## The core problem
 
-Every component here answers the same question in a different place: *what would it take to make this improvement believable?* The failure mode being designed against is a system that reports its own progress — an agent that grades its own homework will always be improving.
+Every part here answers the same question in a different place: what would
+it take to make an improvement believable? The problem this is designed to
+avoid is a system that just reports its own progress. An agent that grades
+its own homework will always look like it's improving.
 
-So the pattern repeats. A candidate change is generated cheaply, evaluated against a **held-out** set it did not train on, and promoted on a measured lift.
+So the same pattern repeats everywhere. A candidate change is generated
+cheaply, tested against a held-out set it never trained on, and only
+promoted if it shows a real, measured improvement.
 
-That last clause is the design target, and it is not what ships today. The measured-lift gate exists and is **off by default** — `AutoCreateConfig::require_measured_lift` is `false` — so the shipped default promotes a skill on mining eligibility: frequency and recurrence, which is exactly what the target rules out. Turning the switch on is what closes the gap, and the section on skills below says which components still promote that way.
+That last part, measured improvement, is the goal, but it isn't what ships
+today. The setting that would enforce it exists but is off by default
+(`AutoCreateConfig::require_measured_lift` is `false`). So right now, a
+skill gets promoted based on how often and how recently it's used, which is
+exactly what the real goal is meant to rule out. Turning that setting on is
+what closes the gap. The section below on what's built today says which
+parts still promote this simpler way.
 
-## The seven components
+## The components
 
 <CardGrid size="md">
-  <SpecCard title="Tool Foundry (#830)">
-    A capability gap — the same shell incantation reconstructed three times — becomes a typed
-    tool, proved by a witness test and registered only after a human adopts and enables it.
-    Expands the *action space*, not just memory. Today the last two steps ship and the first
-    does not: nothing turns a detected gap into a staged tool, so the pair is written by hand.
+  <SpecCard title="Tool Foundry">
+    When stella rebuilds the same shell command by hand several times,
+    that's a capability gap. This turns it into a typed, reusable tool,
+    proven by a test, and only registered after a person adopts and enables
+    it. It grows what stella can *do*, not just what it remembers. Today,
+    the adopt-and-enable steps work, but the first step doesn't: nothing
+    yet turns a detected gap into a ready-to-adopt tool automatically, so
+    someone has to write it by hand.
   </SpecCard>
-  <SpecCard title="Eval-driven self-tuning (#831)">
-    A bandit over stella's own prompts, policies, and model routing. Variants run A/B on real
-    tasks, scored from receipts; the winner is promoted. Optimizes the *policy that acts on
-    facts* rather than the facts.
+  <SpecCard title="Eval-driven self-tuning">
+    Tests different versions of stella's own prompts, policies, and model
+    routing against each other on real tasks, scores them from the actual
+    results, and promotes the winner. This improves how stella decides to
+    act, not what it knows.
   </SpecCard>
-  <SpecCard title="stella-maintains-stella (#832)">
-    The most literal version: stella audits its own source, opens gated draft PRs against
-    itself, drives them through the witness gate, and lands verified improvements behind a
-    human merge gate.
+  <SpecCard title="stella-maintains-stella">
+    The most direct version of this idea: stella reviews its own source
+    code, opens draft pull requests against itself, runs them through the
+    same test gate as any other change, and only lands a verified
+    improvement after a person approves the merge.
   </SpecCard>
-  <SpecCard title="Experience distillation (#833)">
-    Turn repeated successful trajectories into parameterized Skills and evaluated few-shot
-    exemplar sets. A distilled Skill is a reusable *procedure*, not a recalled fact — and it is
-    promoted only on measured lift.
+  <SpecCard title="Experience distillation">
+    Turns repeated successful approaches into reusable Skills and tested
+    example sets. A distilled Skill is a reusable procedure, not just a
+    remembered fact, and it's only promoted when it shows a measured
+    improvement.
   </SpecCard>
-  <SpecCard title="Causal self-model (#834)">
-    A model of stella's own failure modes — wrong-model pick, tool-choice error, loop, budget
-    blow-out — that predicts the likely failure of the *current* plan and intervenes before it
-    costs a turn.
+  <SpecCard title="Causal self-model">
+    A model of how stella tends to fail: picking the wrong model, choosing
+    the wrong tool, looping, or blowing through budget. It predicts when
+    the current plan is likely to fail, and steps in before that costs a
+    whole turn.
   </SpecCard>
-  <SpecCard title="Capability curriculum (#835)">
-    Map the capability frontier from failed and low-confidence tasks, generate graded practice
-    tasks, attempt them in sandboxed worktrees under `verify`, and expand the *verified*
-    capability set. Self-directed practice.
+  <SpecCard title="Capability curriculum">
+    Finds the edge of what stella can currently do by looking at failed and
+    low-confidence tasks, generates practice tasks at the right difficulty,
+    attempts them in an isolated sandbox under `verify`, and grows the set
+    of things stella can verifiably do. Self-directed practice.
   </SpecCard>
-  <SpecCard title="Weight-space adapters (#836)">
-    The frontier item, and the only one that changes the model rather than the harness around it:
-    curate a redacted trajectory dataset, train and evaluate LoRA adapters offline, and — gated by
-    eval **and** human sign-off — promote one that measurably improves behavior. Planned and
-    unbuilt. The export half ships (`stella dataset export`); there is no trainer, no adapter
-    registry, and no promotion loop in the workspace yet.
+  <SpecCard title="Weight-space adapters">
+    The most ambitious piece, and the only one that changes the model
+    itself rather than the tools around it: build a redacted training
+    dataset, train and test LoRA adapters offline, and, only with both a
+    passing evaluation and a person's sign-off, promote one that measurably
+    improves behavior. This is planned but not built. The dataset export
+    half ships today (`stella dataset export`); there's no trainer, no
+    adapter registry, and no promotion process yet.
   </SpecCard>
 </CardGrid>
 
 ## Dependency order
 
-Four of the seven form a spine, because each one needs the previous one's output to be judged at all. You cannot evaluate an adapter without an evaluator, and you cannot build an evaluator's training set without a dataset.
+Four of these parts form a chain, because each one needs the output of the
+one before it to even be judged. You can't evaluate an adapter without an
+evaluator, and you can't build an evaluator's training set without a
+dataset first.
 
-The last link is drawn dashed because it is planned rather than built — the dashes say what exists, not what is intended.
+In the diagram below, the last link is dashed because it's planned but not
+built yet. The dashes show what exists today, not what's intended.
 
 ```text
-  parallel — need nothing from the spine
+  runs in parallel — needs nothing else first
   ┌──────────────────────────┐   ┌──────────────────────────┐
-  │ #830 Tool Foundry        │   │ #835 Capability          │
-  │ authors new tools        │   │      curriculum (drills) │
+  │ Tool Foundry              │   │ Capability                │
+  │ authors new tools         │   │ curriculum (drills)       │
   └──────────────────────────┘   └──────────────────────────┘
                 │                            │
                 └──────── wins feed ─────────┤
                                              ▼
-  the spine
+  the main chain
   ┌───────────────┐   ┌───────────────┐   ┌───────────────┐   ┌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┐
-  │ #872 dataset  │──▶│ #831 eval     │──▶│ #833 distill  │┈ ▷│ #836 adapters │
-  │  trajectories │   │  A/B + gate   │   │ Skills/exemp. │   │  LoRA + eval  │
+  │ Dataset        │──▶│ Eval          │──▶│ Distill       │┈ ▷│ Adapters      │
+  │ trajectories   │   │ A/B + gate    │   │ Skills/exemp. │   │ LoRA + eval   │
   └───────────────┘   └───────────────┘   └───────────────┘   └╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┘
                               ▲
                               │ the same gate promotes everything above
   ┌──────────────────────────────────────────────────────────────────────────┐
-  │ #834 Causal self-model — predicts and preempts failures underneath it all │
+  │ Causal self-model — predicts and prevents failures underneath it all      │
   └──────────────────────────────────────────────────────────────────────────┘
 
-  its own lane
+  its own separate path
   ┌──────────────────────────────────────────────────────────────────────────┐
-  │ #832 stella-maintains-stella — audit → gated draft self-PR → human merge  │
+  │ stella-maintains-stella — audit → gated draft self-PR → human merge       │
   └──────────────────────────────────────────────────────────────────────────┘
 ```
 
-The required edge is **dataset → eval**. #836's stated first slice is "just the dataset + eval halves, no training" — prove you can *measure* an improvement before you try to *train* one. Every other promotion in the track reuses that same evaluator, which is why the edge is worth building first whether or not the training half follows immediately.
+The one link that everything needs is dataset to eval. The stated first
+step for weight-space adapters is "just the dataset and eval halves, no
+training yet" — prove you can measure an improvement before trying to
+train one. Every other promotion in this system reuses that same
+evaluator, which is why it's worth building first, whether or not training
+comes right after.
 
-## What is actually built today
+## What's built today
 
 <CardGrid size="md">
   <SpecCard title="Shipped — stella tune">
-    [`stella tune`](/docs/commands/tune) is #831's first slice: A/B one policy knob (worker
-    reasoning effort) over two loop-bench runs, promote the winner only when it confidently
-    wins, and keep a reversible rollback record. Offline, no API key.
+    [`stella tune`](/docs/commands/tune) is the first working slice of
+    eval-driven self-tuning: it A/B tests one policy setting (worker
+    reasoning effort) over two loop-bench runs, promotes the winner only
+    when it clearly wins, and keeps a record so you can roll it back. Runs
+    offline, no API key needed.
   </SpecCard>
   <SpecCard title="Partly there — mining without the gate">
-    A rules miner ships and writes mined rules to `.stella/rules/`, and reflections are mined
-    into skills. Both still promote on **frequency and recurrence**, not on measured lift. The
-    appraisal that would judge lift exists (`stella-core`'s `skills::appraisal`, which scores a
-    skill as helping, harming, or guard-blocked); what has not landed is the evaluation *run*
-    that feeds it. Closing that loop is precisely what #833 is.
+    A rules miner writes rules it finds to `.stella/rules/`, and
+    reflections get mined into skills. Both still promote based on how
+    often and how recently something is used, not on a measured
+    improvement. The piece that would judge real improvement already
+    exists (`stella-core`'s `skills::appraisal`, which scores a skill as
+    helping, hurting, or blocked by a guard) — what's missing is the
+    evaluation run that feeds it real data. Closing that gap is exactly
+    what experience distillation is for.
   </SpecCard>
   <SpecCard title="Shipped — the nightly loop-bench gate">
-    #873. `.github/workflows/nightly-bench.yml` runs `loop-bench` on a cron schedule against a
-    fixed task pool on a flash-tier model, so stella is now run against real tasks in CI rather
-    than only the analysis tooling's pytest suite.
+    `.github/workflows/nightly-bench.yml` runs `loop-bench` on a schedule,
+    against a fixed set of tasks, on a fast, low-cost model. This means
+    stella is tested against real tasks automatically, not just through
+    the analysis tooling's own test suite.
   </SpecCard>
   <SpecCard title="Shipped — the dataset">
-    #872. [`stella dataset export`](/docs/commands/dataset) writes one JSONL record per accepted
-    turn plus a `manifest.json` describing the filter that selected them — `--since` / `--until`
-    / `--require-verdict`, every string through the secret redactor, written owner-only.
+    [`stella dataset export`](/docs/commands/dataset) writes one JSONL
+    record per accepted turn, plus a `manifest.json` describing the filter
+    used to select them (`--since` / `--until` / `--require-verdict`).
+    Every string passes through the secret redactor first, and the output
+    file is written owner-only.
   </SpecCard>
   <SpecCard title="Shipped in slices — the Tool Foundry">
-    #830. The capability-gap detector is `stella-core`'s `tool_foundry`; the witness and the
-    adoption gate are `stella-tools`' `foundry_witness` / `foundry_gate`. The promotion half
-    ships as [`stella tools --adopt`, `--enable`, `--disable` and
-    `--foundry`](/docs/commands/tools), and a proposed tool is inert until it is **both**
-    adopted and enabled. The detector's only shipped consumer is the offline
-    `make replay-learning` report — no live session mines proposals — and the pass that used to
-    render one into a staged manifest+script pair was retired for want of a caller
-    ([#3629](https://github.com/macanderson/stella/issues/3629)), so staging is by hand.
+    The capability-gap detector is `stella-core`'s `tool_foundry`. The
+    witness check and the adoption gate are `stella-tools`'
+    `foundry_witness` and `foundry_gate`. The promotion half ships as
+    [`stella tools --adopt`, `--enable`, `--disable`, and
+    `--foundry`](/docs/commands/tools), and a proposed tool does nothing
+    until it's both adopted and enabled. Today, the detector's only
+    consumer is the offline `make replay-learning` report — no live
+    session mines proposals on its own — and turning a detected gap into a
+    ready-to-stage tool is done by hand.
   </SpecCard>
 </CardGrid>
 
-Nothing in #832, #834, #835, or #836 is implemented.
+stella-maintains-stella, the causal self-model, the capability curriculum,
+and weight-space adapters are not implemented yet.
 
 ## Guardrails
 
-These are not per-component footnotes; they are the conditions under which any of this is allowed to ship. They repeat across all seven issues because they are the actual design.
+These aren't footnotes on individual parts — they're the conditions that
+any of this has to meet before it can ship. They repeat across every part
+described above because they're the actual design, not an afterthought.
 
 <CardGrid size="md">
   <SpecCard title="Human sign-off on anything that sticks">
-    Self-authored PRs open as **drafts** and never auto-merge. An adapter is never promoted to
-    default without a person approving it. New self-authored tools land disabled behind the
-    same authority gate as any other capability.
+    Self-authored pull requests open as drafts and never merge on their
+    own. An adapter is never promoted to the default without a person
+    approving it. New self-authored tools land disabled, behind the same
+    authorization gate as any other capability.
   </SpecCard>
   <SpecCard title="Promotion requires measured lift on held-out data">
-    Never frequency, never plausibility, never recency. A promotion needs a statistically real
-    improvement on a task set the candidate did not see, plus no regression on a guard set.
+    Never based on frequency, plausibility, or recency alone. A promotion
+    needs a real, statistically meaningful improvement on a set of tasks
+    the candidate never saw, with no regression on a separate guard set.
   </SpecCard>
   <SpecCard title="Reversibility">
-    The prior state is kept, so every promotion can be rolled back — a prior config overlay, a
-    pinned and revertible adapter version, an auto-retired Skill that stopped helping.
+    The previous state is always kept, so every promotion can be rolled
+    back: a previous config overlay, a pinned adapter version you can
+    revert to, or a Skill that gets automatically retired once it stops
+    helping.
   </SpecCard>
-  <SpecCard title="Provenance and redaction">
-    Training data and distilled artifacts carry their lineage, and are scrubbed before they are
-    stored. Never train on secrets or PII. Publish the eval and the dataset lineage.
+  <SpecCard title="Data origin and redaction">
+    Training data and distilled results keep a record of where they came
+    from, and are cleaned before they're stored. Stella never trains on
+    secrets or personal information. The evaluation and the data's origin
+    are both published.
   </SpecCard>
   <SpecCard title="Advisory before autonomous">
-    Interventions warn before they act, and a firing intervention logs predicted versus actual
-    outcome so the predictor stays calibrated. **No silent plan changes on safety-relevant paths.**
+    An intervention warns before it acts, and every time one fires, it
+    logs what it predicted against what actually happened, so its
+    predictions stay accurate over time. **Stella never silently changes a
+    plan on a safety-relevant path.**
   </SpecCard>
   <SpecCard title="Sandboxed practice">
-    Practice and drill runs are isolated in worktrees and budget-capped. Nothing from a practice
-    run touches the real workspace or ships without the same gate as ordinary work.
+    Practice runs are isolated in their own worktrees and have a spending
+    cap. Nothing from a practice run touches your real workspace, or ships
+    without passing the same gate as ordinary work.
   </SpecCard>
 </CardGrid>
 
 <Callout type="info">
-The reversibility and provenance guardrails are not new to this track — they are the same
-discipline the [memory lifecycle](/docs/commands/memory) already runs on, where retirement is
-reversible, nothing is ever deleted, and the agent's own self-reports are explicitly barred from
-driving a retirement. Self-improvement inherits that posture rather than inventing one.
+The reversibility and data-origin rules aren't new here — they're the same
+discipline the [memory lifecycle](/docs/commands/memory) already follows,
+where retirement is reversible, nothing is ever deleted, and the agent's
+own self-reports can never be the reason something gets retired.
+Self-improvement follows that same approach rather than inventing a new
+one.
 </Callout>
 
-## What the loop looks like
+## The deck view
 
-The deck is where the self-maintenance track becomes something you watch
-rather than read about.
+The Command Deck is where this becomes something you can watch, not just
+read about.
 
-A tracker backlog arrives over [MCP](/docs/agent-tools/mcp) and sorts by
-heat: the coupling of the files an issue touches, weighted by its age, read
-off the [code graph](/docs/context-engine) rather than guessed at.
+A backlog of issues arrives over [MCP](/docs/agent-tools/mcp) and gets
+sorted by "heat": how connected the files an issue touches are, weighted
+by the issue's age, read directly from the [code graph](/docs/context-engine)
+instead of guessed at.
 
 <DeckShot id="issues" />
 
-Starting work on one drafts a plan and stops. The sources line names exactly
-what went into it — the issue text, the coupled files, the memory rules that
-applied — every task carries a "done means" clause before any of them runs,
-and the estimate is on the table. Nothing is touched until the plan is
-approved.
+Starting work on one drafts a plan, then stops there. A sources line names
+exactly what went into the plan: the issue text, the related files, and
+any memory rules that applied. Every task states what "done" means before
+it runs, and the time estimate is shown up front. Nothing is touched until
+you approve the plan.
 
 <DeckShot id="start-work" />
 
 ## Following along
 
-Each component has an issue carrying its vision, grounded mechanism, success metric, guardrail, and first slice:
+Each part has an issue describing its goal, how it would actually work,
+how success is measured, its safety rule, and its first step:
 
-- [#830 — Tool Foundry](https://github.com/macanderson/stella/issues/830)
-- [#831 — Eval-driven self-tuning](https://github.com/macanderson/stella/issues/831)
-- [#832 — stella-maintains-stella](https://github.com/macanderson/stella/issues/832)
-- [#833 — Experience distillation](https://github.com/macanderson/stella/issues/833)
-- [#834 — Causal self-model](https://github.com/macanderson/stella/issues/834)
-- [#835 — Capability curriculum](https://github.com/macanderson/stella/issues/835)
-- [#836 — Weight-space adapters](https://github.com/macanderson/stella/issues/836)
+- [Tool Foundry](https://github.com/macanderson/stella/issues/830)
+- [Eval-driven self-tuning](https://github.com/macanderson/stella/issues/831)
+- [stella-maintains-stella](https://github.com/macanderson/stella/issues/832)
+- [Experience distillation](https://github.com/macanderson/stella/issues/833)
+- [Causal self-model](https://github.com/macanderson/stella/issues/834)
+- [Capability curriculum](https://github.com/macanderson/stella/issues/835)
+- [Weight-space adapters](https://github.com/macanderson/stella/issues/836)
 
-The two first slices, [#872 — dataset export](https://github.com/macanderson/stella/issues/872) and [#873 — nightly loop-bench gate](https://github.com/macanderson/stella/issues/873), have both shipped; see "What is actually built today" above.
+The two first steps, [dataset export](https://github.com/macanderson/stella/issues/872)
+and [the nightly loop-bench gate](https://github.com/macanderson/stella/issues/873),
+have both shipped. See "What's built today" above.
 
 ## See also
 
 - [`stella tune`](/docs/commands/tune) — the one piece of this you can run today.
-- [Memory](/docs/context-engine) — the recall layer this track is explicitly *beyond*.
+- [Memory](/docs/context-engine) — the recall layer this goes beyond.
 - [Plugins](/docs/plugins) — the witness and verify machinery every self-authored change has to pass.
-- [`stella scoreboard`](/docs/commands/scoreboard) — outcome measurement that refuses to ask the model how it did.
+- [`stella scoreboard`](/docs/commands/scoreboard) — measures outcomes without asking the model how it did.

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -189,7 +189,7 @@ and weight-space adapters are not implemented yet.
 
 These aren't footnotes on individual parts — they're the conditions that
 any of this has to meet before it can ship. They repeat across every part
-described above because they're the actual design, not an afterthought.
+described above because they're the actual design.
 
 <CardGrid size="md">
   <SpecCard title="Human sign-off on anything that sticks">
@@ -211,14 +211,14 @@ described above because they're the actual design, not an afterthought.
   </SpecCard>
   <SpecCard title="Data origin and redaction">
     Training data and distilled results keep a record of where they came
-    from, and are cleaned before they're stored. Stella never trains on
+    from, and are cleaned before they're stored. stella never trains on
     secrets or personal information. The evaluation and the data's origin
     are both published.
   </SpecCard>
   <SpecCard title="Advisory before autonomous">
     An intervention warns before it acts, and every time one fires, it
     logs what it predicted against what actually happened, so its
-    predictions stay accurate over time. **Stella never silently changes a
+    predictions stay accurate over time. **stella never silently changes a
     plan on a safety-relevant path.**
   </SpecCard>
   <SpecCard title="Sandboxed practice">
@@ -239,7 +239,7 @@ one.
 
 ## The deck view
 
-The Command Deck is where this becomes something you can watch, not just
+Interactive mode is where this becomes something you can watch, not just
 read about.
 
 A backlog of issues arrives over [MCP](/docs/agent-tools/mcp) and gets

--- a/website/content/docs/showcase.mdx
+++ b/website/content/docs/showcase.mdx
@@ -1,41 +1,42 @@
 ---
 title: Showcase
-description: Teams and projects shipping real software with stella, and stella-examples, the open cookbook with a working example for every configurable surface.
+description: Teams shipping real software with stella, and stella-examples, an open library with a working example for every setting you can configure.
 ---
 
-Real teams, shipping real software, with stella in the loop. Each entry names
-who they are, what they ship, and how stella fits the way they work.
+Real teams ship real software with stella in the loop. Each entry below
+names who they are, what they build, and how stella fits into their work.
 
 ## Oxagen
 
-**[oxagen.sh](https://oxagen.sh)** ships **Oxagen** with the stella CLI as
-their **code agent of choice**. Day-to-day feature work, refactors, and
-fix-ups run through stella sessions: the [Command Deck](/docs/commands/chat)
-for interactive work, [goal mode](/docs/agent-modes#outcome-driven-goal-mode) when there's a
-definition of done to drive to green, and
-[fleets](/docs/agent-fleets) when a batch of tasks can fan out across
-isolated worktrees — with every run's cost and outcome metered in the
+[oxagen.sh](https://oxagen.sh) builds Oxagen using the stella CLI as its
+code agent. Day-to-day feature work, refactors, and fixes all run through
+stella sessions: the [Command Deck](/docs/commands/chat) for interactive
+work, [goal mode](/docs/agent-modes#outcome-driven-goal-mode) when there's
+a clear definition of done to work toward, and
+[fleets](/docs/agent-fleets) when a batch of tasks can run in parallel
+across isolated worktrees. Every run's cost and outcome is tracked in the
 workspace's [local telemetry](/docs/telemetry).
 
-Oxagen also hosts this documentation site — `stella.oxagen.sh` runs on their
-infrastructure.
+Oxagen also hosts this documentation site. `stella.oxagen.sh` runs on
+their infrastructure.
 
 <Callout type="info">
-stella is BYOK and local-first for showcased teams too. Community/default sessions use
-their own provider keys and send telemetry nowhere until someone configures a path for it.
-There are [exactly two such paths](/docs/telemetry): the governed Enterprise mode an
-organization may explicitly enroll, which can send only the documented content-free
-operational rollup from process-free eligible runs; and a `drain` block in
-`~/.stella/cloud.json`, which `stella cloud sync` uses to POST staged rows to an org
-intake you name. The full local store stays on the machine either way.
+Stella is bring-your-own-key and local-first for every team shown here, not
+just Oxagen. By default, sessions use your own provider keys and send
+telemetry nowhere, until you set up a path for it yourself. There are
+[exactly two such paths](/docs/telemetry): the Enterprise mode an
+organization can choose to enroll in, which sends only a documented,
+content-free usage summary, and a `drain` block in `~/.stella/cloud.json`,
+which `stella cloud sync` uses to send staged rows to an intake you name.
+Either way, the full local record always stays on your machine.
 </Callout>
 
 ## stella-examples
 
-**[github.com/macanderson/stella-examples](https://github.com/macanderson/stella-examples)**
-is the open configuration cookbook for stella itself: a working example for
-**every configurable surface** in the CLI, each file matching the schema
-stella actually parses, each directory README saying where the file goes on
+[github.com/macanderson/stella-examples](https://github.com/macanderson/stella-examples)
+is an open library of working examples for stella: one for every
+configurable part of the CLI. Each file matches the format stella actually
+reads, and each directory's README says exactly where the file goes on
 disk. Clone it, copy a file into place, and it works.
 
 <CardGrid size="md">
@@ -48,16 +49,16 @@ disk. Clone it, copy a file into place, and it works.
     and [team](https://github.com/macanderson/stella-examples/blob/main/settings/team.settings.json)
     `settings.json` profiles, plus the
     [`credentials.toml`](https://github.com/macanderson/stella-examples/blob/main/settings/credentials.example.toml)
-    shape — the model lineups from the docs as ready-to-copy files.
+    shape. These are the model lineups from the docs, ready to copy.
 
     [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/settings) · [Examples docs](/docs/examples)
   </SpecCard>
   <SpecCard title="Lifecycle hooks">
     A [`SessionStart` context injector](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/session-context.sh),
     a [`PreToolUse` bash guard](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/guard-bash.sh)
-    that vetoes destructive commands, and a
-    [`PostToolUse` JSONL audit log](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/log-tool-use.sh)
-    — wired together in one
+    that blocks destructive commands, and a
+    [`PostToolUse` JSONL audit log](https://github.com/macanderson/stella-examples/blob/main/hooks/scripts/log-tool-use.sh),
+    all wired together in one
     [`hooks` block](https://github.com/macanderson/stella-examples/blob/main/hooks/settings.json).
 
     [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/hooks) · [Hooks docs](/docs/agent-tools/hooks)
@@ -87,11 +88,11 @@ disk. Clone it, copy a file into place, and it works.
     [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/skills) · [Skills docs](/docs/agent-tools/skills)
   </SpecCard>
   <SpecCard title="Rules &amp; guards">
-    Hard guards —
+    Hard guards:
     [`no-force-push`](https://github.com/macanderson/stella-examples/blob/main/rules/no-force-push.md),
     [`protect-migrations`](https://github.com/macanderson/stella-examples/blob/main/rules/protect-migrations.md),
-    [`no-shell`](https://github.com/macanderson/stella-examples/blob/main/rules/no-shell.md)
-    — and a soft
+    and [`no-shell`](https://github.com/macanderson/stella-examples/blob/main/rules/no-shell.md).
+    Plus a soft
     [`code-conventions`](https://github.com/macanderson/stella-examples/blob/main/rules/code-conventions.md)
     rule.
 
@@ -112,32 +113,32 @@ disk. Clone it, copy a file into place, and it works.
     [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/mcp) · [MCP servers docs](/docs/agent-tools/mcp)
   </SpecCard>
   <SpecCard title="Fleet plans">
-    A feature build-out DAG in
+    A feature build-out plan in
     [TOML](https://github.com/macanderson/stella-examples/blob/main/fleet/plan.toml)
     and a parallel cleanup sweep in
     [JSON](https://github.com/macanderson/stella-examples/blob/main/fleet/plan.json),
-    with claims and worktree isolation.
+    both using claims and worktree isolation.
 
     [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/fleet) · [Agent fleets docs](/docs/agent-fleets)
   </SpecCard>
   <SpecCard title="Memory &amp; domains">
     A hand-tuned
-    [`domains.toml`](https://github.com/macanderson/stella-examples/blob/main/memory/domains.toml)
-    and the lesson → skill → rule promotion loop.
+    [`domains.toml`](https://github.com/macanderson/stella-examples/blob/main/memory/domains.toml),
+    and the lesson-to-skill-to-rule promotion loop.
 
     [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/memory) · [Memory docs](/docs/commands/memory)
   </SpecCard>
   <SpecCard title="Scripting &amp; CI">
     [`ci-autofix.sh`](https://github.com/macanderson/stella-examples/blob/main/scripting/ci-autofix.sh)
-    (budget-capped, oracle-armed) and
+    (budget-capped, with a verification check armed) and
     [`nightly-goal.sh`](https://github.com/macanderson/stella-examples/blob/main/scripting/nightly-goal.sh)
-    (cron-able goal runs).
+    (goal runs you can schedule with cron).
 
     [Browse the directory](https://github.com/macanderson/stella-examples/tree/main/scripting) · [Scripting docs](/docs/scripting)
   </SpecCard>
 </CardGrid>
 
-Clone it once and the whole cookbook is a `cp` away:
+Clone it once, and the whole library is a single `cp` away:
 
 ```bash
 git clone https://github.com/macanderson/stella-examples.git
@@ -157,17 +158,17 @@ stella tools --validate
 
 <Callout type="info">
 Everything in stella-examples respects the trust boundary: project-scope
-hooks, MCP servers, and credential-routing fields stay inert in a cloned
-repo until you opt in with `STELLA_TRUST_PROJECT=1`.
+hooks, MCP servers, and credential-routing fields stay inactive in a
+cloned repository until you opt in with `STELLA_TRUST_PROJECT=1`.
 </Callout>
 
 ## Add your project
 
 Shipping with stella? Open a pull request against
-[macanderson/stella](https://github.com/macanderson/stella) that adds an entry
-to `website/content/docs/showcase.mdx` — who you are, a link, and a few
-sentences on how stella fits your workflow. Entries should be things that
-actually ship; hello-worlds are better served by the
-[examples](/docs/examples). Have a hook, agent, profile, or plan worth
-sharing instead? Send it to
+[macanderson/stella](https://github.com/macanderson/stella) that adds an
+entry to `website/content/docs/showcase.mdx`: who you are, a link, and a
+few sentences on how stella fits your workflow. Entries should be real,
+shipped projects — a hello-world example fits better in the
+[examples](/docs/examples) page. If you have a hook, agent, profile, or
+plan worth sharing instead, send it to
 [stella-examples](https://github.com/macanderson/stella-examples).

--- a/website/content/docs/showcase.mdx
+++ b/website/content/docs/showcase.mdx
@@ -21,7 +21,7 @@ Oxagen also hosts this documentation site. `stella.oxagen.sh` runs on
 their infrastructure.
 
 <Callout type="info">
-Stella is bring-your-own-key and local-first for every team shown here, not
+stella is bring-your-own-key and local-first for every team shown here, not
 just Oxagen. By default, sessions use your own provider keys and send
 telemetry nowhere, until you set up a path for it yourself. There are
 [exactly two such paths](/docs/telemetry): the Enterprise mode an

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -219,4 +219,3 @@ and neither one produces a file that leaves your machine.
   watch spend and resolve rates as you work. `/export` is for *sharing*: a
   frozen, portable snapshot anyone can open without installing stella.
 </Callout>
-</content>

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -1,10 +1,10 @@
 ---
-title: The Observatory dashboard
-description: stella observe opens a local, loopback-only dashboard over your workspace telemetry — runs, spend, models, tools, files, and the fleet ledger.
+title: Observatory dashboard
+description: stella observe opens a local, loopback-only dashboard over your workspace's telemetry — runs, spend, models, tools, files, and the fleet log.
 ---
 
-`stella observe` opens the **Observatory** — a local web dashboard over the
-telemetry your own runs recorded:
+`stella observe` opens the **Observatory**, a local web dashboard over the
+telemetry your own runs have recorded:
 
 ```bash
 stella observe            # serves http://127.0.0.1:7787/
@@ -14,198 +14,209 @@ stella observe --port 0   # pick any free port
 
 ## Local by construction
 
-The Observatory is built to the same no-phone-home standard as the rest of
-stella — not as a policy, as a construction:
+The Observatory follows the same no-phone-home rule as the rest of stella.
+This isn't a policy choice, it's built into how it works:
 
-- **Loopback only.** It binds `127.0.0.1` and nothing else. There is no
-  remote mode, no auth because there is no exposure.
-- **Read-only.** Every database open is SQLite read-only — the dashboard can
-  never mutate your telemetry or block a live session (the store runs WAL, so
-  readers never block writers).
-- **Zero external references.** The page is a single embedded HTML file with
-  its assets inlined — no CDN, no web fonts, no analytics. A test in the
-  repository enforces that the served HTML contains no external URL at all.
-- **Graceful on empty.** A missing table or a workspace with no runs renders
-  as empty panels, never an error.
+- **Loopback only.** It only binds to `127.0.0.1`. There's no remote mode,
+  and no login needed, because nothing is exposed.
+- **Read-only.** Every database it opens is SQLite in read-only mode. The
+  dashboard can never change your telemetry or block a live session,
+  because the store runs in WAL mode, so readers never block writers.
+- **No external references.** The page is a single HTML file with
+  everything built in: no CDN, no web fonts, no analytics. A test checks
+  that the page it serves contains no external URL at all.
+- **Handles empty data.** A missing table, or a workspace with no runs yet,
+  shows empty panels, not an error.
 
 ## What you can see
 
-The nav has eleven tabs, plus a **window** selector — `24h` / `7d` / `30d` /
-`all` (the default). The Overview KPIs, the tokens-per-run timeline, the
-Executions table, and every Activity chart honor the window; the leaderboard
-panels labeled *all-time* ignore it. A twelfth, **transcript**, appears only
-while you have a turn open — it is a child route of Sessions, not a section
-you visit.
+The navigation has eleven tabs, plus a **window** selector: `24h`, `7d`,
+`30d`, or `all` (the default). The Overview KPIs, the tokens-per-run
+timeline, the Executions table, and every Activity chart follow the
+selected window. The leaderboard panels labeled *all-time* ignore it. A
+twelfth tab, **transcript**, only appears while you have a turn open. It's
+a sub-page of Sessions, not something you navigate to directly.
 
 <CardGrid size="md">
   <OptionCard name="overview">
-    KPI tiles (runs, resolve rate, total spend, tokens in/out, cache hits, model time), a
-    tokens-per-run timeline, the **Models** breakdown (**$/resolved task** per
-    provider/model), the tool leaderboard (calls, errors, p50/max latency, bytes returned),
-    the most-touched files, the **fleet ledger** (per fleet run: tasks, attempts,
-    successes, commits) with MCP traffic, and a memory/reflections/skills digest — plus the
-    **Executions** table: every run's kind, prompt, model, outcome, steps, tool calls,
-    files touched, tokens, and cost. Clicking a row opens that run's **transcript** page
-    (below).
+    KPI tiles for runs, resolve rate, total spend, tokens in and out, cache
+    hits, and model time. A tokens-per-run timeline. The **Models**
+    breakdown, showing **cost per resolved task** for each provider and
+    model. A tool leaderboard with calls, errors, typical and worst
+    latency, and bytes returned. Your most-touched files. The **fleet
+    log**, showing tasks, attempts, successes, and commits per fleet run,
+    plus MCP traffic. A summary of memory, reflections, and skills. And the
+    **Executions** table: every run's kind, prompt, model, outcome, steps,
+    tool calls, files touched, tokens, and cost. Click a row to open that
+    run's **transcript** page.
   </OptionCard>
   <OptionCard name="sessions">
-    Every session this workspace has run, merged from the cross-process registry and the
-    store (a session the registry has pruned but the store still remembers is marked *store
-    only*), with its live/crashed status, turns, spend, and cache rate. Selecting one lists
-    its turns oldest-first, alongside the skills and subagents it used, its MCP traffic, the
-    self-improvement residue it left, and its task board and pull requests. Each turn opens
-    its transcript; the `± diff` control expands what that turn changed on disk without
+    Every session this workspace has run, combining the cross-process
+    registry with the store. A session the registry has cleared but the
+    store still remembers is marked *store only*. Each one shows its live
+    or crashed status, turns, spend, and cache rate. Select a session to
+    see its turns, oldest first, along with the skills and subagents it
+    used, its MCP traffic, what it left behind for self-improvement, and
+    its task board and pull requests. Each turn opens its transcript, and
+    the `± diff` control shows what that turn changed on disk without
     leaving the list.
   </OptionCard>
   <OptionCard name="transcript">
-    One turn, inspected, at `#transcript/<execution>` — a page with an address, so it
-    reloads and links like one. **Prompt & what changed** lists every model call the run
-    recorded and, for the one you pick, either the unified diff against the previous call
-    of that role (the newest call's diff is open on arrival) or **context sent** — the whole
-    message array that call was given, system prompt included, rebuilt from its context
-    receipt and checked against the digests recorded when it was emitted. That is what
-    `stella inspect` prints, with the same two readings of a failed check: routine on a
-    journal written before compaction recorded its rewrites, a real integrity signal on one
-    written since. Below it: the **transcript** replayed from the run's event journal —
-    answer text, reasoning, and each tool call's arguments and output, with long bodies
-    clipped until you ask for them in full — then per-step tokens and latency, every tool
-    call, the files touched, and the post-turn self-reflection. ← / → step through the
-    owning session's turns without going back to the list.
+    One turn, shown in detail, at `#transcript/<execution>`. It has its own
+    address, so you can reload it or link to it directly. **Prompt & what
+    changed** lists every model call the run recorded. For the one you
+    pick, you see either the diff against the previous call of that role
+    (the newest call's diff is open when the page loads), or **context
+    sent**: the full set of messages that call received, system prompt
+    included, rebuilt from its context receipt and checked against the
+    digests recorded when it was sent. This is the same thing
+    `stella inspect` prints, with the same two readings of a failed check:
+    routine, if the journal was written before compaction recorded its
+    rewrites, or a real integrity problem if it was written after. Below
+    that is the **transcript** replayed from the run's event log: answer
+    text, reasoning, and each tool call's arguments and output (long ones
+    stay collapsed until you expand them), then per-step tokens and
+    latency, every tool call, the files touched, and the self-review
+    written after the turn. Use ← and → to step through the session's
+    other turns without going back to the list.
   </OptionCard>
   <OptionCard name="activity">
-    Per-day time series over the window: cost, tokens (input vs output), runs (resolved vs
-    other outcomes), and tool calls (calls vs errors).
+    Day-by-day charts over the selected window: cost, tokens (input vs.
+    output), runs (resolved vs. other outcomes), and tool calls (calls vs.
+    errors).
   </OptionCard>
   <OptionCard name="code graph">
-    The tree-sitter code-graph index of the workspace — a searchable force-directed canvas
-    of files (with per-file symbol counts) and their resolved import edges, plus a
-    selection detail panel.
+    The code graph for this workspace: a searchable, movable map of files,
+    each with its symbol count, connected by their import relationships.
+    Click a file for a detail panel.
   </OptionCard>
   <OptionCard name="skills">
     Installed and learned skills, with per-skill usage.
   </OptionCard>
   <OptionCard name="mcp">
-    Configured servers (`.stella/mcp.toml`) and observed per-server / per-tool traffic.
+    Configured servers (from `.stella/mcp.toml`) and the traffic seen per
+    server and per tool.
   </OptionCard>
   <OptionCard name="memory & rules">
-    The memory plane: memories on disk (`.stella/memories`), citation receipts (were they
-    useful and truthful?), and promoted rules.
+    Memories on disk (`.stella/memories`), citation records showing
+    whether they were useful and accurate, and promoted rules.
   </OptionCard>
   <OptionCard name="self-improve">
-    The self-improvement loop, receipted from `.stella`: self-rating per reflection, owned
-    shortcomings, distilled lessons, and auto-extracted learned skills.
+    The self-improvement loop, tracked from `.stella`: a self-rating for
+    each reflection, shortcomings the agent owns up to, lessons it pulled
+    out, and skills it learned automatically.
   </OptionCard>
   <OptionCard name="org / hub">
-    Spend across **every project on this machine**, not just this workspace — read from the
-    cross-project hub at `~/.stella/usage.db`. See below.
+    Spend across **every project on this machine**, not just this one.
+    Reads from the cross-project hub at `~/.stella/usage.db`. See below.
   </OptionCard>
   <OptionCard name="config">
-    The merged engine config (user → org → project), where every store and database lives,
-    and the per-scope config files.
+    The combined engine config (user → org → project), where every store
+    and database lives, and the config file for each scope.
   </OptionCard>
 </CardGrid>
 
-Everything except **org / hub** is served from
-`<workspace>/.stella/private/store.db` (and `.stella/private/fleet.db` for the
-fleet view) — the same SQLite files you can query directly with any SQLite
-client.
+Every tab except **org / hub** reads from
+`<workspace>/.stella/private/store.db` (and `.stella/private/fleet.db` for
+the fleet view). These are the same SQLite files you can query yourself
+with any SQLite client.
 
-## The `org / hub` tab: spend beyond this workspace
+## Org / hub tab
 
-Every other tab answers "what did *this* repo cost". The **org / hub** tab
-answers "what did all of them cost", reading the cross-project telemetry hub at
-`~/.stella/usage.db` — which finished turns replicate into, and which
-`stella usage sync --all` repairs if a best-effort replication was missed.
+Every other tab answers "what did *this* project cost?" The **org / hub**
+tab answers "what did all of them cost?" It reads the cross-project
+telemetry hub at `~/.stella/usage.db`, which finished turns copy their data
+into automatically. If that copy is ever missed, `stella usage sync --all`
+repairs it.
 
-It opens on a KPI row (calls, cost, input/output tokens, cache-read rate,
-projects, orgs) over everything the hub has ever seen, and a breadcrumb reading
-**all orgs**. From there it is a drill-down: click a row in the breakdown panel
-to descend **org → workspace → repo → project**, with the breadcrumb popping you
-back to any level. Clicking a *project* row leaves the hub entirely and reopens
-the Overview tab scoped to that project.
+It opens on a KPI row (calls, cost, input and output tokens, cache-read
+rate, projects, orgs) covering everything the hub has ever seen, with a
+breadcrumb reading **all orgs**. From there, you can drill down: click a
+row in the breakdown panel to go from **org → workspace → repo → project**,
+and the breadcrumb lets you jump back to any level. Clicking a *project*
+row leaves the hub entirely and reopens the Overview tab for that project.
 
 Three panels re-scope as you drill:
 
 <CardGrid size="sm">
   <OptionCard name="Breakdown">
-    One level in from the current scope, with calls, cost, cache rate, tokens in/out, and
-    a contributing-projects count per row.
+    One level in from where you are, with calls, cost, cache rate, tokens
+    in and out, and how many projects contributed to each row.
   </OptionCard>
   <OptionCard name="Models">
-    Per provider/model spend across every project in scope — the same aggregation
-    `stella usage report` prints, plus a cache-read rate.
+    Spend per provider and model across every project in scope. Same
+    numbers `stella usage report` prints, plus a cache-read rate.
   </OptionCard>
   <OptionCard name="Spend per day / By repo">
     Daily spend bars, and a per-repository table for the current scope.
   </OptionCard>
 </CardGrid>
 
-Rows whose org, workspace, or repo id is unset render as `(local)` — that is
-what you see before `stella cloud register` mints the durable ids. An empty hub
-says so and points you at `stella usage sync --all`, rather than rendering a
-blank panel. The tab is never cached: its payload depends on the live
-drill scope, so each entry and each drill re-queries.
+Rows with no org, workspace, or repo id show as `(local)`. That's what
+you'll see before `stella cloud register` creates the permanent ids. An
+empty hub tells you so, and points you at `stella usage sync --all`,
+instead of just showing a blank panel. Nothing here is cached: every
+drill-down re-queries the data live.
 
 <Callout type="info">
-  The hub is local like everything else — `~/.stella/usage.db` is a file on your machine,
-  and nothing about the org/hub view involves a network call.
+  The hub is local, like everything else. `~/.stella/usage.db` is a file on
+  your machine, and the org/hub view never makes a network call.
 </Callout>
 
-## `$/resolved` — the metric that matters
+## Cost per resolved task
 
-The models view computes **dollars per resolved task** per provider/model —
-the unit price of your agent work. A cheap model that rarely resolves
-can cost more per outcome than an expensive one that resolves reliably; this
-is the number that tells you which. [`stella stats`](/docs/commands/stats)
-prints the same aggregation in the terminal (`table`, `json`, or `csv`).
+The models view calculates **dollars per resolved task** for each provider
+and model. Think of it as the unit price of your agent's work. A cheap
+model that rarely finishes the job can cost more per outcome than an
+expensive one that reliably gets it done. This number tells you which is
+which. [`stella stats`](/docs/commands/stats) prints the same numbers in
+the terminal, as a table, JSON, or CSV.
 
-## Portable reports: `/export`
+## Exporting a report
 
 Inside the [Command Deck](/docs/agent-modes), the `/export` slash command
 packages the session's telemetry into
-`.stella/exports/session-<timestamp>.zip`. `<timestamp>` is the archive's
-**watermark**: the timestamp of the last log entry included — the data's own
-clock, not the moment you typed `/export`. Every entry nests under a matching
-`<timestamp>/` folder inside the archive:
+`.stella/exports/session-<timestamp>.zip`. The `<timestamp>` is the
+archive's **watermark**: the time of the last log entry included, not the
+moment you typed `/export`. Everything in the archive nests under a
+matching `<timestamp>/` folder:
 
-- `<timestamp>/raw/<table>.json` — a pretty-printed dump of each telemetry
-  table (executions, telemetry, tool calls, files touched, MCP usage, skill
-  usage, reflections, …), holding **this session's rows only**
-- `<timestamp>/dashboard.html` — a **self-contained** HTML dashboard (no
-  external CSS or JS) with KPI insights, cost &amp; efficiency by model, token
-  economy, tool usage, files touched, and execution outcomes — openable
-  offline, emailable, or committable to a PR as the receipt for what an agent
-  run did and cost. Its totals cover the exported session, and it names that
-  session and what was excluded at the top of the page
-- `<timestamp>/manifest.json` — the watermark (as `exported_at`), the
-  exported `session` id, per-table row counts, and an `excluded` census of
-  what the scope left behind
+- `<timestamp>/raw/<table>.json`: a readable dump of each telemetry table
+  (executions, telemetry, tool calls, files touched, MCP usage, skill
+  usage, reflections, and more), holding **this session's rows only**
+- `<timestamp>/dashboard.html`: a **self-contained** HTML dashboard (no
+  external CSS or JavaScript) with KPI insights, cost and efficiency by
+  model, token usage, tool usage, files touched, and run outcomes. Open it
+  offline, email it, or attach it to a PR as a receipt for what an agent
+  run did and cost. Its totals cover only the exported session, and it
+  names that session and what was left out at the top of the page
+- `<timestamp>/manifest.json`: the watermark (as `exported_at`), the
+  exported `session` id, row counts per table, and an `excluded` count of
+  what was left out
 
-### The archive covers one session
+### One session at a time
 
-`/export` packages the session you are in — never the whole workspace store.
-That is a safety property, not a convenience: the archive is built to be
-shared, so credentials in the telemetry are masked and the file is written
-`0600`, and both of those defences assume the blast radius is one session.
-  Until [#2558](https://github.com/macanderson/stella/issues/2558) it was every
-  run the workspace had ever recorded. Attaching an export to a public PR to
-  show one run disclosed every unrelated run in that project — its prompts, its
-  tool arguments, its touched files' contents.
+`/export` only packages the session you're in, never the whole workspace
+store. This is a safety feature, not just a convenience. The archive is
+built to be shared, so credentials in the telemetry are masked and the
+file is written with permissions of `0600`. Both of those protections
+assume the risk is limited to one session.
 
-Because rows are excluded rather than absent, the archive says so. The
-manifest's `excluded` object counts the executions belonging to other sessions,
-the executions carrying no session stamp at all (recorded before the
-`session_id` column existed), and reflections linked to no execution. Without
-those counts a reader cannot tell "this session did nothing else" from "the
-exporter dropped the rest".
+Since rows are excluded rather than just missing, the archive says so. The
+manifest's `excluded` object counts executions that belong to other
+sessions, executions with no session id at all (from before that column
+existed), and reflections not linked to any execution. Without these
+counts, you couldn't tell "this session did nothing else" apart from "the
+export just dropped the rest."
 
-Workspace-wide analytics have their own home:
-[`stella stats`](/docs/commands/stats) and the
-[Observatory](/docs/telemetry/dashboard) both read across every session, and
-neither produces a file that leaves the machine.
+For analytics across your whole workspace, use
+[`stella stats`](/docs/commands/stats) or the
+[Observatory](/docs/telemetry/dashboard). Both read across every session,
+and neither one produces a file that leaves your machine.
 
 <Callout type="info">
-  The Observatory is for *living* workspaces — point it at your repo and
-  watch spend and resolve rates as you work. `/export` is for *sharing* — a
-  frozen, portable snapshot anyone can open without stella installed.
+  The Observatory is for *living* workspaces: point it at your project and
+  watch spend and resolve rates as you work. `/export` is for *sharing*: a
+  frozen, portable snapshot anyone can open without installing stella.
 </Callout>
+</content>

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -1,73 +1,82 @@
 ---
 title: Telemetry & budget
-description: Local-first metering, the opt-in Oxagen Enterprise operational export boundary, spool diagnostics, and how --spend-limit becomes a hard spend cap.
+description: How stella tracks usage locally, the opt-in Oxagen Enterprise export, spool diagnostics, and how --spend-limit becomes a hard spend cap.
 ---
 
-stella meters every run **locally**. Token usage, cost, per-step accounting, and the
-full execution record land in SQLite on your disk.
+stella tracks every run **locally**. Token usage, cost, step-by-step
+accounting, and the full record of what happened land in a SQLite file on
+your disk.
 
 <TelemetryFlowDiagram />
 
-**Telemetry leaves your machine only if you configure it to.** A default install
-constructs no telemetry spool and no telemetry HTTP client. The model provider you
-selected remains stella's normal BYOK network path; the local Observatory remains
-loopback-only.
+**Telemetry only leaves your machine if you set it up to.** A default
+install creates no telemetry spool and no telemetry network client at all.
+The model provider you picked stays stella's only normal network path, and
+the local Observatory stays loopback-only.
 
-Exactly two things count as configuring telemetry egress. Both are explicit local
-configuration, both are inert until you write them, and neither can be turned on by a
-file a repository ships:
+Exactly two things count as turning on telemetry export. Both need explicit
+local configuration, both do nothing until you write them, and neither can
+be switched on by a file that ships inside a project:
 
-1. **Oxagen Enterprise managed enrollment.** Not a user preference and not readable from
-   a project file: a valid signed document in the org-managed settings scope must
-   authorize one minimal operational event class, one exact HTTPS sink, and process-free
-   execution. Invalid, missing, expired, or unsupported enrollment leaves export
-   inactive. [Details below](#oxagen-enterprise-managed-export).
-2. **A `drain` block in `~/.stella/cloud.json`.** [`stella cloud sync`](/docs/commands/cloud)
-   POSTs staged telemetry rows to the org intake named there. This is a *separate pipe*
-   from the Enterprise export — its own wire contract, its own encoder, its own endpoint
-   — and it fires only when the file carries **both** an `org_id` (written by `stella
-   cloud register`) and a `drain` block. With either absent, `stella cloud sync` performs
-   no network I/O, and nothing else in stella invokes it.
+1. **Oxagen Enterprise managed enrollment.** This isn't a personal setting,
+   and it can't be read from a project file. It needs a valid, signed
+   document in the org-managed settings scope that authorizes one minimal
+   category of operational events, one exact HTTPS destination, and
+   execution with no extra background processes. If the enrollment is
+   invalid, missing, expired, or unsupported, export stays off.
+   [Details below](#oxagen-enterprise-managed-export).
+2. **A `drain` block in `~/.stella/cloud.json`.**
+   [`stella cloud sync`](/docs/commands/cloud) sends staged telemetry rows
+   to the destination named there. This is a *separate path* from the
+   Enterprise export, with its own format, its own encoding, and its own
+   endpoint. It only runs when the file has **both** an `org_id` (written
+   by `stella cloud register`) and a `drain` block. If either is missing,
+   `stella cloud sync` makes no network calls at all, and nothing else in
+   stella triggers it.
 
-That list is complete: those two transports are the only code paths in the tree that send
-telemetry anywhere.
+That's the complete list. Those two paths are the only ones in stella that
+send telemetry anywhere.
 
 ## Local metering
 
-Everything lands in one SQLite file: `<workspace>/.stella/private/store.db`. Because the store is
-a real SQLite file, you can inspect it with any SQLite client after a run — e.g.
-`sqlite3 <workspace>/.stella/private/store.db` — and every execution, its model, and its cost are
-queryable on your own machine. WAL is enabled, so a read-only reader like
-[`stella stats`](/docs/commands/stats) is never blocked by a live session. This local
-store stays canonical even when an Enterprise seat is enrolled; the managed adapter
-can only derive the closed rollup described below.
+Everything lands in one SQLite file: `<workspace>/.stella/private/store.db`.
+Because it's a real SQLite file, you can inspect it with any SQLite client
+after a run. For example: `sqlite3 <workspace>/.stella/private/store.db`.
+Every execution, its model, and its cost are queryable right on your own
+machine. WAL mode is on, so a read-only tool like
+[`stella stats`](/docs/commands/stats) never blocks a live session. This
+local store stays the source of truth even when an Enterprise seat is
+enrolled. The managed adapter can only build the closed summary described
+below from it.
 
 ### What's in the store
 
-Metering is only part of it. The store owns **21 tables** — a full record of what each run
-*did*, not just what it cost — and the [Observatory](/docs/telemetry/dashboard) reads these
-same tables.
+Metering is only part of it. The store has **21 tables**, a full record of
+what each run *did*, not just what it cost. The
+[Observatory](/docs/telemetry/dashboard) reads these same tables.
 
 <CardGrid size="md">
   <OptionCard name="executions">
-    One row per run / goal / chat turn — kind, prompt, provider/model, outcome, cost. The
-    spine every other table keys off.
+    One row per run, goal, or chat turn: kind, prompt, provider and model,
+    outcome, cost. Every other table is keyed off this one.
   </OptionCard>
   <OptionCard name="events">
-    The full, ordered event stream of each execution — replayable, reasoning deltas
-    included.
+    The full, ordered event stream for each execution. You can replay it,
+    and it includes reasoning as it streamed in.
   </OptionCard>
   <OptionCard name="telemetry">
-    One row per model call: input/output tokens, cache read/write/miss, cost, latency,
-    retries.
+    One row per model call: input/output tokens, cache read/write/miss,
+    cost, latency, retries.
   </OptionCard>
   <OptionCard name="files_touched">
-    The per-execution file-touch ledger — CRUD letters, line deltas, JSON audit log.
-    Rows come from the surfaces that report file changes.
+    The file-touch record for each execution: create/read/update/delete
+    letters, line changes, and a JSON audit log. Rows come from whatever
+    surface reported the file change.
   </OptionCard>
   <OptionCard name="tool_calls">
-    One row per tool call (native, MCP, skill, or agent) — shape, timing, success, bytes
-    returned. Large outputs are never stored, only their size.
+    One row per tool call, whether native, MCP, skill, or agent: its
+    shape, timing, success, and bytes returned. Large outputs are never
+    stored, only their size.
   </OptionCard>
   <OptionCard name="mcp_usage">
     Per-call MCP log: server, tool, reason, call time.
@@ -76,103 +85,117 @@ same tables.
     One row per skill applied in a turn, with the skill's pinned version.
   </OptionCard>
   <OptionCard name="agent_uses">
-    One row per invocation of an installed agent definition, with its pinned version.
+    One row per invocation of an installed agent definition, with its
+    pinned version.
   </OptionCard>
   <OptionCard name="memory_citations">
-    Recall receipts: per memory cited in a turn, its usefulness score and truthfulness
-    verdict.
+    A record for each memory cited in a turn: its usefulness score and
+    whether it held up as true.
   </OptionCard>
   <OptionCard name="forgotten">
-    Explicit human tombstones over anything that steers the agent — one verdict per item,
-    with the forgotten text copied in at forget time. That copy is what makes the tombstone
-    survive re-learning: the reflection recorder and the skill miner compare *candidates*
-    against it, so a re-mined paraphrase with a brand-new id is still caught. Unlike
-    quarantine, which is derived from citation counts, this is a stored judgment — a
-    person read it and said remove it. Restoring is a plain delete.
+    Records of anything a person has explicitly told stella to forget,
+    whether it's steering the agent or not. One entry per item, with the
+    forgotten text copied in at the moment it was forgotten. That copy is
+    what makes the removal stick even if stella tries to relearn it: the
+    reflection recorder and the skill miner compare new *candidates*
+    against it, so a reworded version with a brand-new id still gets
+    caught. This is different from quarantine, which is based on citation
+    counts. This one is a person's judgment: they read it and said remove
+    it. Undoing it is a plain delete.
   </OptionCard>
   <OptionCard name="rules">
-    Promoted workspace rules — the full rule markdown, one row per rule.
+    Promoted workspace rules: the full rule text, one row per rule.
   </OptionCard>
   <OptionCard name="reflections">
     Durable lessons and self-critiques, tagged by domain.
   </OptionCard>
   <OptionCard name="execution_reflection">
-    The post-turn self-review, tied 1:1 to its execution — the model's self-rating beside
-    the objective companions (did it produce output, did it write files, was it truncated),
-    so a silent zero-output turn is visibly a failure even if the model rated itself kindly.
+    The self-review written after each turn, linked one-to-one with its
+    execution. It pairs the model's own rating with objective facts (did
+    it produce output, did it write files, was it cut off), so a silent,
+    zero-output turn shows up as a failure even if the model rated itself
+    well.
   </OptionCard>
   <OptionCard name="tasks">
     The latest task-board snapshot, one row per task per session.
   </OptionCard>
   <OptionCard name="pull_requests">
-    Tracked pull requests — status and CI verdict, keyed by URL.
+    Tracked pull requests: status and CI result, keyed by URL.
   </OptionCard>
   <OptionCard name="file_locks">
     Cooperative file claims for multi-agent work.
   </OptionCard>
   <OptionCard name="graph_nodes / graph_edges">
-    Two tables: reserved schema for a future context-plane seam — the code graph itself
-    lives in `.stella/private/codegraph.db`.
+    Two tables reserved for future use. The code graph itself lives in
+    `.stella/private/codegraph.db`, not here.
   </OptionCard>
 </CardGrid>
 
-#### The receipts plane: what made a past step
+#### Step receipts
 
-Three of the twenty-one exist for one question — *what exactly did the model see on step
-N, and why was it allowed to see that much?* Together they make a past step
-reconstructable without keeping a copy of the prompt: replay the ordering and the numbers
-line up with the decision that was actually made.
+Three of the twenty-one tables exist to answer one question: *what exactly
+did the model see at step N, and why was it allowed to see that much?*
+Together, they let you reconstruct a past step without keeping a copy of
+the prompt. Replay the order, and the numbers match the decision that was
+actually made.
 
 <CardGrid size="md">
   <OptionCard name="context_blocks">
-    One row per durable, individually attributable unit that entered a step's prompt, born
-    once and keyed by its content-addressed `block_id`. Carries `kind`, `token_cost`,
-    `content_digest`, and `citation_label` — and is deliberately **content-free**: the
-    digest, never the payload bytes, whose preimage lives in the originating event in the
-    journal. `call_id` / `memory_id` join back to the tool call or memory node that
-    produced the block. A byte-identical block re-entering context resolves to the same id,
-    so the second registration is an idempotent no-op rather than data.
+    One row for every durable, separately trackable piece that entered a
+    step's prompt. Each one is created once and keyed by a `block_id` based
+    on its content. It carries `kind`, `token_cost`, `content_digest`, and
+    `citation_label`, and it's deliberately **content-free**: it only holds
+    a fingerprint of the content, never the content itself, which lives in
+    the original event in the journal. `call_id` and `memory_id` link back
+    to the tool call or memory node that created it. If the exact same
+    block enters context again, it resolves to the same id, so registering
+    it a second time changes nothing instead of creating a duplicate.
   </OptionCard>
   <OptionCard name="step_manifest">
-    One row per (step, block) in **wire order** — the receipt that makes a past step
-    reconstructable, because replaying the fold plus this ordering yields exactly what the
-    model saw. `call_seq` separates the several model calls that can share one step (the
-    worker, an overflow summarizer, allocated management roles), `cache_zone` and
-    `resident_since_step` record where a block sat and how long it had been carried, and
-    `call_id` gives per-occurrence attribution that content-addressed block ids cannot.
-    Its reverse index — every step a given block was resident for — is what cost-of-carry
-    and eviction analysis read.
+    One row per step-and-block pair, in the exact order they were sent.
+    This is the receipt that lets you reconstruct a past step: replay the
+    content plus this order, and you get exactly what the model saw.
+    `call_seq` separates the several model calls that can share one step
+    (the worker, an overflow summarizer, other management roles).
+    `cache_zone` and `resident_since_step` record where a block sat and how
+    long it had been carried. `call_id` gives per-occurrence attribution
+    that a content-based block id can't. Its reverse index — every step a
+    given block was present for — is what cost-of-carry and eviction
+    analysis read.
   </OptionCard>
   <OptionCard name="step_receipt">
-    The manifest header: one row per **model call**, not per step. Records `provider`,
-    `model`, `call_role`, `effective_budget_tokens`, `calibration_factor`, and
-    `estimated_input_tokens` — the budget the compaction pass actually compared against,
-    so a receipt's numbers reconcile with the decision it documents rather than with a
-    figure recomputed later.
+    The header for the manifest: one row per **model call**, not per step.
+    It records `provider`, `model`, `call_role`, `effective_budget_tokens`,
+    `calibration_factor`, and `estimated_input_tokens`. This is the exact
+    budget the compaction pass compared against, so a receipt's numbers
+    match the decision it documents instead of a number recalculated
+    later.
   </OptionCard>
 </CardGrid>
 
 <Callout type="info">
-  Those twenty-one are the tables the store *owns* — the ones versioned by the migration
-  chain. `store.db` additionally carries the optional `enterprise_export_*` tables, which
-  converge by column probing **outside** that chain and are created after the fresh-file
-  probe runs. They exist only where a managed enrollment does.
+  Those twenty-one are the tables the store *owns*, the ones tracked by the
+  migration history. `store.db` also has the optional `enterprise_export_*`
+  tables, which are set up separately, outside that history, and only
+  created after a fresh-file check runs. They only exist where a managed
+  enrollment does.
 </Callout>
 
 ### The same stream, on screen
 
-The event stream is what the deck's transcript renders, and each kind of event
-carries its own rail: gold where stella acted on the world, silver where the
-world came in, red for failure and nothing else. A delete shows the graph
-check that ran before the tool did; a memory shows its promotion from
-observation to rule; a compaction is one dim line rather than a wall of text.
+The event stream is what the Command Deck's transcript displays, and each
+kind of event gets its own color: gold for when stella acted on the world,
+silver for when the world sent something back, and red only for failures.
+A delete shows the check that ran before the tool did. A memory shows its
+promotion from observation to rule. A compaction shows as one dim line
+instead of a wall of text.
 
 <DeckShot id="events" />
 
 ### Querying it yourself
 
-It is an ordinary SQLite file, so anything that speaks SQLite speaks to it. The five most
-expensive runs in this workspace:
+It's an ordinary SQLite file, so any tool that speaks SQLite can read it.
+Here are the five most expensive runs in this workspace:
 
 ```bash
 sqlite3 -json .stella/private/store.db \
@@ -183,8 +206,8 @@ sqlite3 -json .stella/private/store.db \
   | jq -r '.[] | "\(.cost_usd)\t\(.model)\t\(.outcome // "—")\t\(.kind)"'
 ```
 
-And the receipts for one run — every model call, what it estimated it was sending, and the
-budget it was measured against:
+And the receipts for one run: every model call, what it estimated it was
+sending, and the budget it was measured against:
 
 ```bash
 sqlite3 -json .stella/private/store.db \
@@ -195,14 +218,15 @@ sqlite3 -json .stella/private/store.db \
   | jq -r '.[] | "step \(.step).\(.call_seq)\t\(.call_role)\t\(.estimated_input_tokens)/\(.effective_budget_tokens)"'
 ```
 
-### Who actually served a gateway-routed call
+### Who served the call
 
-`step_receipt.provider` (and the `telemetry` table's own provider column) name the provider
-you **configured** — for an OpenRouter run, that is always the string `openrouter`, the
-gateway, never the vendor it routed to. [Pinning the upstream](/docs/api-providers#pinning-the-upstream)
-stops the gateway from routing inconsistently between calls; *auditing* which vendor served
-a past call reads `step_receipt.upstream_provider`, the receipt column added for exactly
-that question ([#3054](https://github.com/macanderson/stella/issues/3054)):
+`step_receipt.provider` (and the `telemetry` table's own provider column)
+names the provider you **configured**. For an OpenRouter run, that's
+always the string `openrouter`, the gateway itself, never the vendor it
+routed to. [Pinning the upstream](/docs/api-providers#pinning-the-upstream)
+stops the gateway from routing inconsistently between calls. To *audit*
+which vendor actually served a past call, read
+`step_receipt.upstream_provider`, the column that records exactly that:
 
 ```bash
 sqlite3 .stella/private/store.db \
@@ -211,12 +235,13 @@ sqlite3 .stella/private/store.db \
    ORDER BY turn_instance, step, call_seq"
 ```
 
-[`stella inspect`](/docs/commands/inspect) shows the same fact without any SQL: the call
-listing renders `openrouter→Amazon Bedrock` in its PROVIDER column, and
-`--format json` carries `upstream_provider` per call. The column is `NULL` on a direct
-endpoint (where `provider` is already the honest answer) and on any receipt recorded
-before the column existed — for those older executions the raw `events` payload of the
-`step_usage` event remains the only source:
+[`stella inspect`](/docs/commands/inspect) shows the same thing without any
+SQL. The call listing shows `openrouter→Amazon Bedrock` in its PROVIDER
+column, and `--format json` includes `upstream_provider` for each call.
+This column is `NULL` on a direct endpoint, where `provider` is already
+the right answer, and on any receipt recorded before this column existed.
+For those older executions, the raw `events` payload of the `step_usage`
+event is the only place to find it:
 
 ```bash
 sqlite3 -json .stella/private/store.db \
@@ -226,35 +251,37 @@ sqlite3 -json .stella/private/store.db \
 
 ## Oxagen Enterprise managed export
 
-Managed mode exists for cross-seat operational visibility, capacity planning, and
-cost/reliability diagnostics. It does not ingest `stella fleet` runs; that execution
-surface is rejected under the current process-free authority. This is **operational
-telemetry, not compliance evidence**: it does not produce an audit trail, attest policy
-conformance, capture content for investigations, or replace an organization's SIEM or
-records-retention controls. The `compliance_audit` event class is explicitly
-unsupported.
+Managed mode exists for visibility across seats, capacity planning, and
+cost and reliability diagnostics. It does not take in `stella fleet` runs;
+that execution surface is rejected under the current process-free rules.
+This is **operational telemetry, not compliance evidence**: it doesn't
+produce an audit trail, prove policy compliance, capture content for
+investigations, or replace an organization's SIEM or records-retention
+tools. The `compliance_audit` event class is explicitly not supported.
 
-### Option A product boundary
+### Product boundary
 
-stella remains the local execution product: provider calls, tools, workspace access,
-the full event stream, context, and the Observatory stay on the developer host. Oxagen
-is the optional Enterprise control plane: it may provision signed enrollment and
-receive the minimal operational envelope described here.
+stella stays the local execution tool: provider calls, tools, workspace
+access, the full event stream, context, and the Observatory all stay on
+your machine. Oxagen is the optional Enterprise control plane. It can
+provision signed enrollment and receive the minimal operational summary
+described here.
 
-This repository implements stella's enrollment verification, projection, durable
-spool, and HTTPS delivery client. A production Oxagen intake with matching
-authentication, schema validation, idempotency, tenancy, retention, and observability
-is a **companion server requirement**; these stella docs do not claim that intake is
-already deployed.
+stella implements enrollment verification, the projection step, a durable
+spool, and the HTTPS delivery client. A production Oxagen intake, with
+matching authentication, schema checks, safe retries, multi-tenant
+support, retention, and monitoring, is a **separate server requirement**.
+These docs don't claim that intake is already running.
 
-### Enrollment and sink authorization
+### Enrollment and authorization
 
-Only the org-managed settings file can carry `enterprise_telemetry` (normally
-`/Library/Application Support/stella/settings.json` on macOS or
-`/etc/stella/settings.json` on Linux). Project and user scopes cannot enroll a seat.
-Provisioning writes a shape like this; the signature is generated over canonical claim
-bytes, so this is an administrator/provisioning artifact rather than a hand-edited
-example:
+Only the org-managed settings file can carry `enterprise_telemetry`
+(normally `/Library/Application Support/stella/settings.json` on macOS, or
+`/etc/stella/settings.json` on Linux). Project and user scopes can't
+enroll a seat. Provisioning writes something shaped like this. The
+signature is generated over the exact bytes of the claim, so this is
+something your administrator's provisioning tool produces, not something
+you'd hand-edit yourself:
 
 ```json title="org-managed settings.json (provisioning shape)"
 {
@@ -288,72 +315,82 @@ example:
 }
 ```
 
-The signed endpoint and an administrator allowlist entry must parse to the **same exact
-credential-free HTTPS URL**. Redirects, URL credentials, query strings, fragments,
-HTTP endpoints, proxy-derived destinations, and merely matching hosts are refused.
-Issuer, audience, event class, process-free mode, lifetime, signature, signing-secret
-reference, and distinct bearer-secret reference are also verified before activation.
-An enrollment is valid for at most 90 days and must be renewed by provisioning.
+The signed endpoint and an administrator's allowed-list entry must resolve
+to the **exact same credential-free HTTPS URL**. Redirects, credentials in
+the URL, query strings, fragments, plain HTTP endpoints, proxy-derived
+destinations, and hosts that merely look similar are all refused. The
+issuer, audience, event class, process-free mode, lifetime, signature, and
+secret references are also checked before activation. An enrollment is
+valid for at most 90 days, and provisioning has to renew it.
 
 ### Eligible execution path
 
-An enrolled process activates a restricted execution authority. Today the only eligible
-surface is the raw one-shot step loop:
+An enrolled process runs under restricted authority. Right now, the only
+eligible surface is the raw one-shot step loop:
 
 ```bash
 stella run "update the parser and run its in-process checks"
 ```
 
-The registry proof disables shell/process, test-process, skill-install/search, web, and
-host-readable media paths. Wrapped runs, `goal`, `fleet`, Command Deck/chat,
-interactive sessions, workspace-port assembly, and candidate-workspace execution are
-rejected while managed export authority is active. Enrollment therefore narrows what
-may execute; it never silently exports from an ineligible path.
+This mode disables shell and process access, test-process access, skill
+install and search, web access, and reading host media paths. Wrapped
+runs, `goal`, `fleet`, the Command Deck, chat, interactive sessions, and
+workspace-port or candidate-workspace execution are all rejected while
+managed export is active. Enrollment narrows what can run. It never
+quietly exports from a surface that isn't eligible.
 
 ### Exported envelope
 
-Only a finalized, post-enrollment run can produce one
-`stella.operational.v1` / `execution_rollup` event. Its closed schema contains:
+Only a finished run, after enrollment, can produce one
+`stella.operational.v1` / `execution_rollup` event. Its fixed schema
+contains:
 
 - managed enrollment, organization, and workspace identifiers;
-- an allowlisted provider/model pair, or the bounded `other` bucket;
-- finalized outcome, duration, input/output token totals, and cost in micro-USD;
+- an approved provider and model pair, or a limited `other` bucket;
+- finalized outcome, duration, input/output token totals, and cost in
+  micro-USD;
 - tool-call count, changed-file count, and whether output was produced; and
-- a deterministic, sink-scoped event ID used for idempotent at-least-once delivery.
+- a consistent, destination-specific event ID used for safe at-least-once
+  delivery.
 
-It has no fields for prompts, responses, paths or filenames, tool names, tool
-arguments/results, reasoning, errors, git state, memories, rules, full local events,
-local execution IDs, or raw installation/store identifiers. Those values are not
-redacted after collection; they are unrepresentable in the export type.
+It has no fields for prompts, responses, paths or filenames, tool names,
+tool arguments or results, reasoning, errors, git state, memories, rules,
+full local events, local execution IDs, or raw installation or store
+identifiers. These values aren't removed after the fact. There's simply no
+place for them in the export format.
 
-### Durable spool, retry, and rollover
+### Spool and retry
 
-Finalization first records a durable local export intent, then projects an eligible
-rollup into an owner-only SQLite spool outside the model-writable workspace. On a later
-runtime, up to 256 pending intents are backfilled before delivery. Retained event
-payloads are bounded to **10,000 rows and 16 MiB**; SQLite pages, indexes, WAL/SHM, and
-quarantine metadata can make the physical database larger, so `status` reports physical
-bytes separately. When the payload bound is exceeded, the oldest unleased row for the
-active sink is discarded and the durable `dropped` counter increments.
+When a run finishes, stella first records a durable local export intent,
+then builds an eligible summary into an owner-only SQLite spool, kept
+outside the workspace the model can write to. On a later run, up to 256
+pending intents are caught up before delivery. Stored event data is
+capped at **10,000 rows and 16 MiB**. SQLite's own pages, indexes, WAL/SHM
+files, and quarantine metadata can make the actual database bigger than
+that, so `status` reports the physical size separately. When the data cap
+is hit, the oldest row not already being sent for the active destination
+is dropped, and the durable `dropped` counter goes up.
 
-Delivery is at least once and sink-scoped. A flush leases at most **50 events** and
-**256 KiB** for 30 seconds, refuses redirects, and acknowledges rows only after a
-successful HTTPS response. Credential, transport, or server failures release the exact
-lease with deterministic exponential backoff plus jitter: from one second up to five
-minutes, with jitter capped at 25%. Clock rollback is repaired under a sink-specific
-generation fence.
+Delivery happens at least once, per destination. A flush reserves at most
+**50 events** and **256 KiB** for 30 seconds, refuses redirects, and only
+marks rows as sent after a successful HTTPS response. If a credential,
+connection, or server error happens, the reservation is released and
+retried with growing delays plus some randomness: from one second up to
+five minutes, with the randomness capped at 25%. If your system clock goes
+backward, that's corrected using a destination-specific safeguard.
 
-Changing the signed sink fingerprint never sends old rows to the new sink. Those rows
-become **stranded** until the old enrollment is restored or an administrator explicitly
-discards them:
+Changing the signed destination never sends old rows to the new one. Those
+rows become **stranded** until the old enrollment is restored, or an
+administrator explicitly discards them:
 
 ```bash
 stella telemetry rollover-discard
 ```
 
-That destructive action increments a durable `rollover_discarded` counter. Capacity,
-corruption, and rollover loss therefore remain visible rather than being silently
-treated as delivery.
+This is a destructive action, and it increases a durable
+`rollover_discarded` counter. Capacity limits, corruption, and rollover
+loss all stay visible this way, instead of being silently counted as
+delivered.
 
 ### Status and flushing
 
@@ -364,28 +401,31 @@ stella telemetry status
 stella telemetry flush
 ```
 
-`status` reports either `disabled (no managed enrollment)` or `enrolled`, followed by
-pending and stranded rows/bytes, quarantined diagnostic rows/bytes, physical spool
-bytes, and cumulative dropped, corrupt-dropped, and rollover-discarded counts. Invalid
-or expired managed configuration fails with a diagnostic rather than reporting an
-enrolled state.
+`status` reports either `disabled (no managed enrollment)` or `enrolled`,
+then pending and stranded rows and bytes, quarantined diagnostic rows and
+bytes, the physical size of the spool, and running totals for dropped,
+corrupt-dropped, and rollover-discarded rows. Invalid or expired managed
+configuration shows an error instead of falsely reporting that it's
+enrolled.
 
-`flush` attempts one bounded delivery batch immediately and reports sent, pending, and
-dropped counts. stella also starts a detached best-effort flush after enrollment is
-verified at process startup. That background attempt is non-blocking: it never delays
-agent execution and stella does not wait for it during shutdown. Use explicit `flush`
-when an operator needs a synchronous delivery attempt before maintenance.
+`flush` tries one delivery batch right away and reports sent, pending, and
+dropped counts. stella also starts a background best-effort flush after
+enrollment is checked at startup. That background attempt never blocks
+anything: it never delays agent work, and stella doesn't wait for it when
+shutting down. Run `flush` yourself when you need to make sure delivery
+happens right before maintenance.
 
 ## Budget: observed vs. enforced
 
-The `--spend-limit` flag (or the `STELLA_SPEND_LIMIT` environment variable) attaches a USD spend
-limit to the whole run or session.
+The `--spend-limit` flag (or the `STELLA_SPEND_LIMIT` environment variable)
+sets a dollar limit for the whole run or session.
 
-- **Observed mode (default, no `--spend-limit`)** — stella meters spend for the end-of-run cost
-  summary but never blocks. Use it to *see* what a task costs.
-- **Enforced mode (`--spend-limit <usd>`)** — a hard cap. Once total spend exceeds the limit,
-  work aborts **cleanly** — never in the middle of a tool call — so you are never left with
-  a half-applied edit.
+- **Observed mode (the default, no `--spend-limit`)** tracks spend for the
+  end-of-run cost summary, but never blocks anything. Use it to *see* what
+  a task costs.
+- **Enforced mode (`--spend-limit <usd>`)** is a hard cap. Once total spend
+  goes over the limit, work stops **cleanly**, never in the middle of a
+  tool call, so you're never left with a half-finished edit.
 
 ```bash
 # Observed: meter the cost, never block
@@ -400,26 +440,28 @@ stella run "port the utils module to the new API"
 ```
 
 <Callout type="info">
-  The budget must be a positive, finite dollar amount. It applies to the entire run or
-  interactive session, not per turn.
+  The limit must be a positive dollar amount. It applies to the whole run
+  or interactive session, not to each turn.
 </Callout>
 
 ## Cost summary
 
-Every run ends with a cost summary derived from the same metering that feeds the local
-SQLite store, so the number you see matches what was recorded locally.
+Every run ends with a cost summary built from the same tracking that feeds
+the local SQLite store, so the number you see matches what was recorded
+locally.
 
 ## Seeing your usage
 
-Three ways to read the canonical local telemetry back:
+Three ways to read your local telemetry back:
 
-- **[`stella observe`](/docs/telemetry/dashboard)** — the Observatory, a loopback-only web
-  dashboard (default `http://127.0.0.1:7787/`): runs, spend, resolve rates, **$/resolved**
-  per model, tool and file leaderboards, the memory plane, MCP traffic, and the fleet
-  ledger.
-- **[`stella stats`](/docs/commands/stats)** — the same per-provider/model aggregation in
-  the terminal, as a table, JSON, or CSV.
-- **`/export`** (in the Command Deck) — a portable ZIP with raw JSON dumps and a
-  self-contained `dashboard.html` report, scoped to the session you are in so
-  the archive is safe to share. See
+- **[`stella observe`](/docs/telemetry/dashboard)**: the Observatory, a
+  loopback-only web dashboard (default `http://127.0.0.1:7787/`). Shows
+  runs, spend, resolve rates, **cost per resolved task** by model, tool
+  and file leaderboards, memory, MCP traffic, and the fleet log.
+- **[`stella stats`](/docs/commands/stats)**: the same per-provider and
+  per-model numbers, right in the terminal, as a table, JSON, or CSV.
+- **`/export`** (in the Command Deck): a portable ZIP with raw JSON dumps
+  and a self-contained `dashboard.html` report, scoped to the session
+  you're in so it's safe to share. See
   [the dashboard page](/docs/telemetry/dashboard).
+</content>

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -183,7 +183,7 @@ actually made.
 
 ### The same stream, on screen
 
-The event stream is what the Command Deck's transcript displays, and each
+The event stream is what the interactive transcript displays, and each
 kind of event gets its own color: gold for when stella acted on the world,
 silver for when the world sent something back, and red only for failures.
 A delete shows the check that ran before the tool did. A memory shows its

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -452,8 +452,6 @@ locally.
 
 ## Seeing your usage
 
-Three ways to read your local telemetry back:
-
 - **[`stella observe`](/docs/telemetry/dashboard)**: the Observatory, a
   loopback-only web dashboard (default `http://127.0.0.1:7787/`). Shows
   runs, spend, resolve rates, **cost per resolved task** by model, tool
@@ -464,4 +462,3 @@ Three ways to read your local telemetry back:
   and a self-contained `dashboard.html` report, scoped to the session
   you're in so it's safe to share. See
   [the dashboard page](/docs/telemetry/dashboard).
-</content>


### PR DESCRIPTION
## What

Rewrites every page under `website/content/docs` (92 MDX files) into plain, customer-facing prose:

- **8th-grade reading level.** Short sentences, common words. Jargon like "bi-temporal", "monotonic", "provenance-qualified" is translated into plain language.
- **Headings are short nouns/verbs**, not sentences ("Which tracker, and how it talks" → "Tracker support").
- **No internal or historical references.** Issue/PR numbers, ADR citations, internal source paths, "used to / no longer / was retired" narration, and features-that-don't-exist sections are gone. Pages describe what the product does now.
- **No meta prose.** "This page covers…", "Three things matter here: 1. 2. 3." and similar announcements replaced by headings and direct content.

## What is preserved

- Every command, flag, config key, default value, and code block byte-for-byte.
- All MDX components and frontmatter structure.
- All technical facts — this is a language pass, not a behavior change.
- Cross-page anchors: every `#anchor` link re-validated against the new heading slugs after renames (script-checked, 0 broken).

## Verification

- `pnpm build` in `website/` is green: all 92 `/docs/*` paths prerender statically.
- Rendered pages spot-checked in the built site (screenshots captured locally).
- Release notes keep their version-history content (that's their job) with simplified language.

Closes #5472
