### PR TITLE
test(stella-cli,stella-parity): witness that a workspace SessionStart hook actually fires through CLI wiring

### DIFF
--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -1142,6 +1142,8 @@ mod usage_completeness;
 
 mod engine_wiring;
 
+mod hook_wiring;
+
 mod durability_isolation;
 
 mod code_graph;

--- a/crates/stella-cli/src/agent/tests/hook_wiring.rs
+++ b/crates/stella-cli/src/agent/tests/hook_wiring.rs
@@ -1,0 +1,55 @@
+//! The `hooks.lifecycle` parity row's CLI witness.
+//!
+//! `stella-core` tests its own hook matching and blocking; nothing proved
+//! that a hook configured in a real `Config` actually reaches
+//! `with_session_hook_context` through the CLI's own wiring rather than the
+//! core crate's. `session_start_hook_context` calls the real
+//! `HostHookRunner`, which spawns a real shell, so this drives an actual
+//! `echo` rather than a scripted fake.
+
+use stella_core::hooks::{HookAction, HookMatcher, Hooks};
+
+use super::*;
+
+fn cfg_with_session_start_hook(command: &str) -> Config {
+    let mut cfg = cfg_for("anthropic");
+    cfg.hooks = Some(Hooks {
+        session_start: Some(vec![HookMatcher {
+            matcher: None,
+            hooks: vec![HookAction::new(command)],
+        }]),
+        ..Hooks::default()
+    });
+    cfg
+}
+
+/// A `SessionStart` hook configured on a real `Config` fires through the
+/// CLI's own wiring — `session_start_hook_context` → `HostHookRunner` → a
+/// real shell — and its stdout lands in the assembled system prompt.
+#[tokio::test]
+async fn a_configured_session_start_hook_reaches_the_system_prompt() {
+    let cfg = cfg_with_session_start_hook("echo 'on-call: bob'");
+
+    let prompt = with_session_hook_context("BASE PROMPT".to_string(), &cfg).await;
+
+    assert!(
+        prompt.starts_with("BASE PROMPT"),
+        "the hook context is appended, not substituted: {prompt:?}"
+    );
+    assert!(
+        prompt.contains("on-call: bob"),
+        "the hook's real stdout must reach the prompt: {prompt:?}"
+    );
+}
+
+/// A `Config` with no hooks configured leaves the prompt untouched — the
+/// wiring must not fire on nothing.
+#[tokio::test]
+async fn no_hooks_configured_leaves_the_prompt_untouched() {
+    let cfg = cfg_for("anthropic");
+    assert!(cfg.hooks.is_none());
+
+    let prompt = with_session_hook_context("BASE PROMPT".to_string(), &cfg).await;
+
+    assert_eq!(prompt, "BASE PROMPT");
+}

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -120,7 +120,7 @@ pub const COMPOSITION_SEAMS: &[&str] = &[
 /// forces this DOWN in the same PR (the win is recorded), and adding a new
 /// unwitnessed claim forces it UP — a visible review decision instead of a
 /// silent one.
-pub const UNWITNESSED_BASELINE: usize = 4;
+pub const UNWITNESSED_BASELINE: usize = 3;
 
 /// The matrix. Ordered by area; ids are stable and unique.
 pub static CAPABILITIES: &[Capability] = &[
@@ -456,14 +456,13 @@ pub static CAPABILITIES: &[Capability] = &[
                       the #2684 stdout-decision plane in hooks::decision) and the observer-only \
                       HookBus",
         engine_entries: &["with_hooks", "with_bus", "with_hook_approval_route"],
-        cli: SurfacePosture::ShippedUnwitnessed {
+        cli: SurfacePosture::Shipped {
             mechanism: "workspace hooks wired via with_session_hook_context on every driver \
                         path. SessionStart firing is a HOST obligation (#2674): the engine \
                         has no method for it — a host fires hooks::run_hooks once \
                         while it assembles the system prompt, before any Engine exists, and \
                         owns surfacing the diagnostics the no-I/O engine cannot print",
-            missing: "a CLI-side test pinning that a configured workspace hook actually fires \
-                      through agent wiring (core has hook tests; the CLI wiring has none)",
+            witness: "a_configured_session_start_hook_reaches_the_system_prompt",
         },
         api: SurfacePosture::Shipped {
             mechanism: "operator-installed ServeExtensions on a per-turn HookBus (#1298): \
@@ -707,7 +706,7 @@ mod tests {
     /// the same trade `provider_parity` documents: a witness that moves to a
     /// file outside this list fails loudly (a false alarm to fix by extending
     /// the list), never silently (the rotted proof this exists to catch).
-    fn cli_sources() -> [&'static str; 14] {
+    fn cli_sources() -> [&'static str; 15] {
         [
             // The deck's session-scoped whistle relay (#4768) — home of the
             // `turn.whistle` witness.
@@ -732,6 +731,9 @@ mod tests {
             // moved into one of them is not missing, it is one `include_str!`
             // away from being invisible to this sweep.
             include_str!("../../stella-cli/src/agent/tests/engine_wiring.rs"),
+            // Home of `a_configured_session_start_hook_reaches_the_system_prompt`
+            // — the `hooks.lifecycle` CLI witness.
+            include_str!("../../stella-cli/src/agent/tests/hook_wiring.rs"),
             include_str!("../../stella-cli/src/subagent/tests.rs"),
             // `subsession.rs` crossed the ratchet with #4334 and its tests
             // moved out the same way — the `turn.steer` witness lives here.


### PR DESCRIPTION
## What & why

`stella-parity`'s `hooks.lifecycle` row was `ShippedUnwitnessed` on the CLI
surface: `stella-core` tests its own hook matching and blocking, but nothing
proved a hook configured in a real `Config` actually fires through the
CLI's own wiring — `with_session_hook_context` → `session_start_hook_context`
→ the real `HostHookRunner`, which spawns a real shell.

Added `crates/stella-cli/src/agent/tests/hook_wiring.rs` with two tests:
one drives a real `echo` through a configured `SessionStart` hook and
asserts its stdout lands in the assembled system prompt; the other confirms
a `Config` with no hooks configured leaves the prompt untouched. The engine
suggested in the issue (`agent/tests/engine_wiring.rs`) turned out to
already exist and cover an unrelated topic (model-routing precedence), so
this is a new sibling submodule instead, following the same file-size-ratchet
pattern.

Promoted `hooks.lifecycle`'s `cli` posture to `Shipped { witness: ... }` and
lowered `UNWITNESSED_BASELINE` from 4 to 3 in the same PR (it had drifted up
from the issue's stated 3 since it was filed — another row went unwitnessed
in the meantime, unrelated to this change).

Closes #2726

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Checked the artisanal way: temporarily made `session_start_hook_context`
return `None` unconditionally (simulating the wiring breaking) —
`a_configured_session_start_hook_reaches_the_system_prompt` failed. Restored,
both tests pass.

This is a coverage addition rather than a behavior fix, so there is no
old-vs-new production code difference — the witness proves the wiring
*was already correct* and is now pinned, per the issue's own framing
("no witness that a configured workspace hook actually fires").

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-parity --all-targets -- -D warnings`
- [x] `cargo test -p stella-parity` — 23 passed, including
      `every_cli_witness_exists` and
      `unwitnessed_claims_match_the_declared_baseline_exactly`
- [x] `cargo test -p stella-cli hook_wiring` — 2 passed
- [x] `make guards-fast` — green, including prose and file-size

## Nothing left behind

- [ ] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Pin the CLI SessionStart hook wiring with end-to-end witness tests and mark the lifecycle capability as witnessed.

Enhancements:
- Add CLI wiring coverage proving configured SessionStart hooks execute and contribute their output to the assembled system prompt.
- Verify that configurations without hooks leave the system prompt unchanged.
- Register the new hook-wiring witness in the parity capability matrix and update the unwitnessed baseline.

Tests:
- Add integration tests covering configured and absent SessionStart hooks through the CLI wiring.