### PR TITLE
test(contextgraph): span the protocol tripwire across the CGP 1.0 freeze

### DIFF
--- a/crates/stella-cli/src/contextgraph/tests.rs
+++ b/crates/stella-cli/src/contextgraph/tests.rs
@@ -1001,14 +1001,19 @@ async fn the_in_tree_providers_still_declare_no_egress() {
 }
 
 #[test]
-fn pinned_protocol_version_is_the_expected_draft() {
-    // Tripwire: our conformance is verified against this exact wire
-    // version. If a pin bump moves the protocol version, this fails loudly
+fn pinned_protocol_version_is_a_conformance_verified_wire_version() {
+    // Tripwire: our conformance is verified against these exact wire
+    // versions. The released 0.1.x crates speak the draft string; the CGP
+    // 1.0 freeze graduates the same wire format to its frozen name, and
+    // the downstream canary re-runs this suite against CGP HEAD, so both
+    // spellings are conformance-verified. Any move past them fails loudly
     // so conformance is re-audited rather than silently assumed to hold.
-    assert_eq!(
-        contextgraph_types::PROTOCOL_VERSION,
-        "contextgraph/1.0-draft",
-        "CGP protocol version changed — re-verify the conformance suite before bumping the pin"
+    // Delete the draft entry when the workspace pin moves off 0.1.x.
+    let verified = ["contextgraph/1.0-draft", "contextgraph/1.0"];
+    assert!(
+        verified.contains(&contextgraph_types::PROTOCOL_VERSION),
+        "CGP protocol version changed to {} — re-verify the conformance suite before widening the pin",
+        contextgraph_types::PROTOCOL_VERSION
     );
 }
 


### PR DESCRIPTION
CGP froze its wire protocol at `contextgraph/1.0` (context-graph-protocol#77) while the published `contextgraph-*` crates stella pins (=0.1.2) still report `contextgraph/1.0-draft`. The pinned-version tripwire therefore fails in CGP's downstream canary (built against CGP HEAD) while passing in stella CI (built against crates.io) — no single literal satisfies both until CGP 2.0.0 ships to crates.io, which is blocked on the crates-io environment + token being set up by a human.

This keeps the tripwire but pins BOTH conformance-verified spellings: the draft string spoken by the released 0.1.x crates, and the frozen 1.0 string spoken by CGP HEAD (the canary run verifying that arm passed 2497/2498 stella tests, the sole failure being this literal). Any third value still fails loudly. The draft entry gets deleted when stella's crate pin moves off 0.1.x.

## Summary by Sourcery

Keep protocol-version conformance coverage valid across the CGP 1.0 protocol freeze.

Bug Fixes:
- Allow the protocol-version tripwire to pass for both the released draft identifier and the frozen CGP 1.0 identifier while continuing to reject unverified versions.

Enhancements:
- Rename the protocol-version test to reflect validation of multiple conformance-verified wire versions.

Tests:
- Update the pinned protocol-version conformance test to cover both released and frozen wire-version spellings.


Renamed test (not deleted): `pinned_protocol_version_is_the_expected_draft` → `pinned_protocol_version_is_a_conformance_verified_wire_version`, same file, assertion widened as described above.
