### PR TITLE
feat(stella-tui): the wheel scrolls every tab and every dialog

### DIFF
--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -149,6 +149,91 @@ fn apply_voice_cmd(
     }
 }
 
+/// Apply one dispatch outcome to the deck, whichever device produced it —
+/// the key arm and the mouse arm both land here, so the queue mirror, the
+/// shell lane, and quit have one mutation site. Returns `true` when the
+/// session should end; the caller owns the loop and the `break`.
+fn apply_deck_action(
+    action: DeckAction,
+    model: &mut WorkspaceModel,
+    ui: &mut DeckUi,
+    submissions: &UnboundedSender<WorkspaceInput>,
+    local_tx: &UnboundedSender<Inbound>,
+    shell_active: &Arc<AtomicUsize>,
+    debug: &DebugLog,
+) -> bool {
+    match action {
+        DeckAction::Quit => {
+            debug.note("user quit");
+            let _ = submissions.send(WorkspaceInput::Quit);
+            true
+        }
+        DeckAction::Send(input) => {
+            // Queue edits are reflected locally so they show
+            // immediately, then forwarded for dispatch — the
+            // input path never blocks on a busy agent. (The
+            // queue is the labeled out-of-band fold of the
+            // OUTBOUND stream; this is its one mutation site.)
+            match &input {
+                WorkspaceInput::Enqueue { text } | WorkspaceInput::EnqueueNext { text } => {
+                    model.queue.enqueue(text.clone(), model.now_ms);
+                }
+                // The first submission after a double-Esc
+                // hold: front-insert, exactly as the
+                // driver will (it runs before the prompt
+                // the hold returned to the queue).
+                WorkspaceInput::EnqueueFront { text } => {
+                    model.queue.enqueue_front(text.clone(), model.now_ms);
+                }
+                WorkspaceInput::QueueRemove { index } => {
+                    model.queue.remove(*index);
+                }
+                WorkspaceInput::QueueClear => model.queue.clear(),
+                // Esc-with-something-to-say drains the
+                // backlog into the running turn, so the
+                // deck's mirror of it empties here — the
+                // same one-mutation-site discipline every
+                // other queue edit follows. Leaving the
+                // rows up would show prompts as "waiting"
+                // that are already in the model's hands.
+                WorkspaceInput::Steer { .. } => model.queue.clear(),
+                // `/clear`: a session reset to seq-0 has no
+                // backlog — the transcript itself resets on
+                // the driver's `Inbound::SessionReset`, so
+                // stale in-flight events can never repaint
+                // a pane the deck already blanked.
+                WorkspaceInput::SessionClear => model.queue.clear(),
+                _ => {}
+            }
+            let _ = submissions.send(input);
+            false
+        }
+        DeckAction::Shell(cmd) => {
+            // `!` commands run NOW — never queued, never
+            // waiting on the engine. Output returns on the
+            // local lane as ordinary events.
+            //
+            // It lands in the transcript the user is
+            // reading — the focused agent's — so `! pwd`
+            // answers where they asked, like Claude Code.
+            // Before any agent registers there is no such
+            // lane, and only then does it fall back to the
+            // synthetic one.
+            debug.note(&format!("shell: {cmd}"));
+            let target = focused_id(model, ui);
+            spawn_shell_command(
+                cmd,
+                local_tx.clone(),
+                model.now_ms,
+                shell_active.clone(),
+                target,
+            );
+            false
+        }
+        DeckAction::Handled | DeckAction::Ignored => false,
+    }
+}
+
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -802,74 +887,17 @@ pub async fn run_deck(
                         let space = is_plain_space(key);
                         let before_len = ui.composer.buffer().len();
                         let before_cursor = ui.composer.cursor();
-                        match handle_deck_key(key, &model, &mut ui) {
-                            DeckAction::Quit => {
-                                debug.note("user quit");
-                                let _ = submissions.send(WorkspaceInput::Quit);
-                                break 'run;
-                            }
-                            DeckAction::Send(input) => {
-                                // Queue edits are reflected locally so they show
-                                // immediately, then forwarded for dispatch — the
-                                // input path never blocks on a busy agent. (The
-                                // queue is the labeled out-of-band fold of the
-                                // OUTBOUND stream; this is its one mutation site.)
-                                match &input {
-                                    WorkspaceInput::Enqueue { text }
-                                    | WorkspaceInput::EnqueueNext { text } => {
-                                        model.queue.enqueue(text.clone(), model.now_ms);
-                                    }
-                                    // The first submission after a double-Esc
-                                    // hold: front-insert, exactly as the
-                                    // driver will (it runs before the prompt
-                                    // the hold returned to the queue).
-                                    WorkspaceInput::EnqueueFront { text } => {
-                                        model.queue.enqueue_front(text.clone(), model.now_ms);
-                                    }
-                                    WorkspaceInput::QueueRemove { index } => {
-                                        model.queue.remove(*index);
-                                    }
-                                    WorkspaceInput::QueueClear => model.queue.clear(),
-                                    // Esc-with-something-to-say drains the
-                                    // backlog into the running turn, so the
-                                    // deck's mirror of it empties here — the
-                                    // same one-mutation-site discipline every
-                                    // other queue edit follows. Leaving the
-                                    // rows up would show prompts as "waiting"
-                                    // that are already in the model's hands.
-                                    WorkspaceInput::Steer { .. } => model.queue.clear(),
-                                    // `/clear`: a session reset to seq-0 has no
-                                    // backlog — the transcript itself resets on
-                                    // the driver's `Inbound::SessionReset`, so
-                                    // stale in-flight events can never repaint
-                                    // a pane the deck already blanked.
-                                    WorkspaceInput::SessionClear => model.queue.clear(),
-                                    _ => {}
-                                }
-                                let _ = submissions.send(input);
-                            }
-                            DeckAction::Shell(cmd) => {
-                                // `!` commands run NOW — never queued, never
-                                // waiting on the engine. Output returns on the
-                                // local lane as ordinary events.
-                                //
-                                // It lands in the transcript the user is
-                                // reading — the focused agent's — so `! pwd`
-                                // answers where they asked, like Claude Code.
-                                // Before any agent registers there is no such
-                                // lane, and only then does it fall back to the
-                                // synthetic one.
-                                debug.note(&format!("shell: {cmd}"));
-                                let target = focused_id(&model, &ui);
-                                spawn_shell_command(
-                                    cmd,
-                                    local_tx.clone(),
-                                    model.now_ms,
-                                    shell_active.clone(),
-                                    target,
-                                );
-                            }
-                            DeckAction::Handled | DeckAction::Ignored => {}
+                        let action = handle_deck_key(key, &model, &mut ui);
+                        if apply_deck_action(
+                            action,
+                            &mut model,
+                            &mut ui,
+                            &submissions,
+                            &local_tx,
+                            &shell_active,
+                            &debug,
+                        ) {
+                            break 'run;
                         }
                         // A dispatched palette row changed the `recent` list;
                         // every other keystroke leaves this a no-op.
@@ -909,14 +937,25 @@ pub async fn run_deck(
                     // (L-T2 — capture takes the terminal's own text selection
                     // away); on a default session the keypress and the dwell
                     // timer are the notice's dismissal paths, and no click
-                    // ever reaches the process. The dispatch returns only
-                    // Handled/Ignored by contract (`handle_deck_mouse`), so
-                    // this arm carries none of the key arm's queue or quit
-                    // plumbing.
+                    // ever reaches the process. The outcome is applied by the
+                    // same `apply_deck_action` a key's is: a wheel notch over
+                    // a modal overlay re-enters the key dispatch (synthesized
+                    // arrows), so its action can be anything a key's can.
                     Some(Event::Mouse(mouse)) => {
                         ui.notice.dismiss();
                         let width = terminal.size()?.width;
-                        crate::mouse::handle_deck_mouse(mouse, width, &model, &mut ui);
+                        let action = crate::mouse::handle_deck_mouse(mouse, width, &model, &mut ui);
+                        if apply_deck_action(
+                            action,
+                            &mut model,
+                            &mut ui,
+                            &submissions,
+                            &local_tx,
+                            &shell_active,
+                            &debug,
+                        ) {
+                            break 'run;
+                        }
                     }
                     // Resize / focus change: the next draw picks them up.
                     Some(_) => {}

--- a/crates/stella-tui/src/deck_ui/list_nav.rs
+++ b/crates/stella-tui/src/deck_ui/list_nav.rs
@@ -86,6 +86,26 @@ pub fn scroll(
     true
 }
 
+/// Move a selection `n` items without a key — the wheel's entry into this
+/// vocabulary ([`crate::mouse`]), with [`select`]'s clamping.
+pub fn select_wheel(up: bool, n: usize, sel: &mut usize, count: usize) {
+    let last = count.saturating_sub(1);
+    *sel = if up {
+        sel.saturating_sub(n)
+    } else {
+        (*sel + n).min(last)
+    };
+}
+
+/// Scroll a body `n` lines without a key — [`select_wheel`]'s body twin.
+pub fn scroll_wheel(up: bool, n: usize, state: &mut ScrollState, total: usize, height: usize) {
+    if up {
+        state.scroll_up(n, total, height);
+    } else {
+        state.scroll_down(n, total, height);
+    }
+}
+
 /// Lines one `⇞`/`⇟` moves an unclamped offset.
 const OFFSET_PAGE: usize = 10;
 
@@ -197,5 +217,27 @@ mod tests {
         assert!(state.follow);
         assert!(scroll(key(KeyCode::Home), &mut state, 20, 5, true));
         assert_eq!(state.window(20, 5).start, 0);
+    }
+
+    /// The wheel entries clamp exactly as the arrows do: a selection stops
+    /// at the ends, an empty list stays at zero, a body leaves follow-mode
+    /// on the way up and re-arms it at the tail.
+    #[test]
+    fn the_wheel_entries_share_the_arrow_clamping() {
+        let mut sel = 1;
+        select_wheel(true, 3, &mut sel, 10);
+        assert_eq!(sel, 0, "clamped at the top");
+        select_wheel(false, 30, &mut sel, 10);
+        assert_eq!(sel, 9, "clamped at the last item");
+        let mut empty = 0;
+        select_wheel(false, 3, &mut empty, 0);
+        assert_eq!(empty, 0, "an empty list stays put");
+
+        let mut state = ScrollState::default();
+        scroll_wheel(true, 3, &mut state, 20, 5);
+        assert!(!state.follow);
+        assert_eq!(state.window(20, 5).start, 12, "three up from the tail");
+        scroll_wheel(false, 3, &mut state, 20, 5);
+        assert!(state.follow, "back at the tail re-arms follow");
     }
 }

--- a/crates/stella-tui/src/mouse.rs
+++ b/crates/stella-tui/src/mouse.rs
@@ -1,22 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! Mouse dispatch for the deck: a click on the tab row switches tabs, the
-//! wheel scrolls the Session transcript, and a click while the splash is up
-//! skips it — each routed to the state change its key equivalent makes.
-//! Capture is opt-in ([`crate::deck_shell::DeckOptions::mouse_capture`],
-//! L-T2), so a default session never reaches this module and keeps the
-//! terminal's own text selection.
+//! Mouse dispatch for the deck: a tab-row click switches tabs, the wheel
+//! scrolls the body or list under the reader — a tab's own, or a modal
+//! dialog's — and a click skips the splash. Capture is opt-in
+//! ([`crate::deck_shell::DeckOptions::mouse_capture`], L-T2), so a default
+//! session keeps the terminal's own text selection.
 
-use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
 use crate::WorkspaceModel;
 use crate::deck::DeckTab;
-use crate::deck_ui::{DeckAction, DeckUi, queue_issues_first_load};
+use crate::deck_ui::{DeckAction, DeckUi, handle_deck_key, queue_issues_first_load};
 
-/// Transcript lines one wheel notch moves. Three is the terminal-emulator
-/// convention (xterm and its descendants), so the deck scrolls at the speed
-/// the rest of the user's terminal does.
+/// Lines (or list items) one wheel notch moves. Three is the
+/// terminal-emulator convention (xterm and its descendants), so the deck
+/// scrolls at the speed the rest of the user's terminal does.
 const WHEEL_LINES: usize = 3;
 
 /// Route one mouse event to the deck.
@@ -25,11 +24,9 @@ const WHEEL_LINES: usize = 3;
 /// the tab hit test needs it because the tab row narrows with the frame
 /// (`views::frame::tab_row_hit`).
 ///
-/// Returns [`DeckAction::Handled`] or [`DeckAction::Ignored`] and nothing
-/// else, by construction: no mouse verb submits, quits, or runs a shell
-/// command, which is what lets `deck_shell`'s mouse arm stay free of the key
-/// arm's queue and quit plumbing. A future verb that sends must grow that
-/// arm to match the key arm's dispatch.
+/// The outcome goes through the same `apply_deck_action` a key's does
+/// (`deck_shell`): a wheel notch over a modal dialog re-enters the key
+/// dispatch, so this can return anything [`handle_deck_key`] can.
 ///
 /// Not wrapped in `accessible::announce`: accessible mode forces mouse
 /// capture off (`accessible::mouse_capture_enabled`), so no event reaches
@@ -50,11 +47,17 @@ pub fn handle_deck_mouse(
         return DeckAction::Ignored;
     }
     // A modal dialog owns the mouse on the terms it owns the keyboard: a
-    // click or a wheel notch must not reach the surface behind it. The
-    // AGENTS page replaces the bands outright, so the tab row a click would
-    // hit is not even drawn.
+    // click must not reach the surface behind it, and a wheel notch drives
+    // the dialog's own body. The AGENTS page replaces the bands outright —
+    // the tab row a click would hit is not even drawn — and its own key
+    // handler takes the same route.
     if ui.agents_page.open || crate::deck_render::overlay_owns_keyboard(model, ui) {
-        return DeckAction::Ignored;
+        return match ev.kind {
+            MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+                wheel_as_arrows(ev.kind == MouseEventKind::ScrollUp, model, ui)
+            }
+            _ => DeckAction::Ignored,
+        };
     }
     match ev.kind {
         // The tab row is the frame's top row (`deck_render`'s first band).
@@ -70,17 +73,87 @@ pub fn handle_deck_mouse(
                 None => DeckAction::Ignored,
             }
         }
-        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown if ui.tab == DeckTab::Session => {
-            let (total, height) = (ui.metrics.session_total, ui.metrics.session_height);
-            if ev.kind == MouseEventKind::ScrollUp {
-                ui.session_scroll.scroll_up(WHEEL_LINES, total, height);
-            } else {
-                ui.session_scroll.scroll_down(WHEEL_LINES, total, height);
-            }
-            DeckAction::Handled
+        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+            wheel_on_tab(ev.kind == MouseEventKind::ScrollUp, model, ui)
         }
         _ => DeckAction::Ignored,
     }
+}
+
+/// A wheel notch while a dialog owns the keyboard, re-entered as arrow keys
+/// so the dialog's own handler moves its own body — `list_nav`'s vocabulary,
+/// which every overlay that scrolls or selects already speaks, so there is
+/// no list of overlays here to fall out of date.
+///
+/// Synthesis is safe here and only here: on a bare tab, `↑`/`↓` carry
+/// affordances a wheel must not trigger — an empty-composer `↑` on SESSION
+/// opens the queue editor — which is why [`wheel_on_tab`] moves scroll state
+/// directly instead. An action other than Handled/Ignored is returned
+/// immediately, so nothing a dialog decides is dropped.
+fn wheel_as_arrows(up: bool, model: &WorkspaceModel, ui: &mut DeckUi) -> DeckAction {
+    let code = if up { KeyCode::Up } else { KeyCode::Down };
+    let key = KeyEvent::new(code, KeyModifiers::NONE);
+    let mut last = DeckAction::Ignored;
+    for _ in 0..WHEEL_LINES {
+        match handle_deck_key(key, model, ui) {
+            DeckAction::Handled => last = DeckAction::Handled,
+            DeckAction::Ignored => {}
+            other => return other,
+        }
+    }
+    last
+}
+
+/// A wheel notch on a bare tab: the tab's primary body or list, moved
+/// [`WHEEL_LINES`] at a time through `list_nav`'s wheel entries.
+///
+/// Each arm names the same state and count the tab's own key handler hands
+/// `list_nav::scroll` / `list_nav::select`, so the wheel and the arrows move
+/// one thing. A tab whose list moves elsewhere must move here in the same
+/// change.
+fn wheel_on_tab(up: bool, model: &WorkspaceModel, ui: &mut DeckUi) -> DeckAction {
+    use crate::deck_ui::list_nav::{scroll_wheel, select_wheel};
+    let n = WHEEL_LINES;
+    let m = ui.metrics;
+    match ui.tab {
+        DeckTab::Session => {
+            scroll_wheel(
+                up,
+                n,
+                &mut ui.session_scroll,
+                m.session_total,
+                m.session_height,
+            );
+        }
+        DeckTab::Traces => {
+            scroll_wheel(up, n, &mut ui.trace_scroll, m.trace_total, m.trace_height);
+        }
+        // The FILES tab is a list until a diff is open, then a body — the
+        // same split `handle_files_key` makes.
+        DeckTab::Files if ui.files_diff_open => {
+            scroll_wheel(
+                up,
+                n,
+                &mut ui.files_diff_scroll,
+                m.files_diff_total,
+                m.files_diff_height,
+            );
+        }
+        DeckTab::Files => select_wheel(up, n, &mut ui.files_sel, model.ledger.records.len()),
+        DeckTab::Agents => select_wheel(up, n, &mut ui.installed.sel, ui.installed.entries.len()),
+        DeckTab::Graph => {
+            let count = ui.graph.as_ref().map(|g| g.nodes.len()).unwrap_or(0);
+            select_wheel(up, n, &mut ui.graph_cursor, count);
+        }
+        DeckTab::Skills => select_wheel(up, n, &mut ui.skills.sel, ui.skills.view.rows.len()),
+        DeckTab::Mcp => select_wheel(up, n, &mut ui.mcp.selected, ui.mcp.servers.len()),
+        DeckTab::Issues => select_wheel(up, n, &mut ui.issues.sel, ui.issues.rows.len()),
+        // SETTINGS is two focus-claimed editors (modal while focused, so
+        // they take the synthesis path above); unfocused, the tab has no
+        // list for the wheel to move.
+        DeckTab::Settings => return DeckAction::Ignored,
+    }
+    DeckAction::Handled
 }
 
 #[cfg(test)]
@@ -188,6 +261,71 @@ mod tests {
             DeckAction::Ignored
         );
         assert_eq!(ui.tab, DeckTab::Session);
+    }
+
+    /// The wheel scrolls whichever tab is up, through the same state its
+    /// arrows move: a body tab (TRACES) by scroll state, a list tab with
+    /// nothing in it without panicking, and FILES as a body once a diff is
+    /// open.
+    #[test]
+    fn the_wheel_moves_every_tabs_own_surface() {
+        let (model, mut ui) = fixture();
+        ui.set_tab(DeckTab::Traces);
+        ui.metrics.trace_total = 40;
+        ui.metrics.trace_height = 8;
+        let action = handle_deck_mouse(wheel(MouseEventKind::ScrollUp), 100, &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled);
+        assert_eq!(ui.trace_scroll.top, 40 - 8 - WHEEL_LINES);
+
+        ui.set_tab(DeckTab::Agents);
+        assert_eq!(
+            handle_deck_mouse(wheel(MouseEventKind::ScrollDown), 100, &model, &mut ui),
+            DeckAction::Handled
+        );
+        assert_eq!(ui.installed.sel, 0, "an empty list stays put");
+
+        ui.set_tab(DeckTab::Files);
+        ui.files_diff_open = true;
+        ui.metrics.files_diff_total = 30;
+        ui.metrics.files_diff_height = 6;
+        handle_deck_mouse(wheel(MouseEventKind::ScrollUp), 100, &model, &mut ui);
+        assert_eq!(ui.files_diff_scroll.top, 30 - 6 - WHEEL_LINES);
+    }
+
+    /// A wheel notch while a modal dialog is up drives the dialog's body —
+    /// the help overlay here — and leaves the transcript behind it alone.
+    #[test]
+    fn a_wheel_notch_over_a_modal_scrolls_the_dialog_not_the_tab() {
+        let (model, mut ui) = fixture();
+        ui.help_open = true;
+        ui.metrics.help_total = 100;
+        ui.metrics.help_height = 10;
+        ui.metrics.session_total = 100;
+        ui.metrics.session_height = 10;
+        // Down, not up: help opens pinned to its top, where an upward notch
+        // is already a no-op.
+        let action = handle_deck_mouse(wheel(MouseEventKind::ScrollDown), 100, &model, &mut ui);
+        assert_eq!(action, DeckAction::Handled);
+        assert_eq!(ui.help_scroll.window(100, 10).start, WHEEL_LINES);
+        assert!(
+            ui.session_scroll.follow,
+            "the transcript behind it did not move"
+        );
+        assert!(ui.help_open, "scrolling does not close the overlay");
+    }
+
+    /// The wheel is not an arrow key on a bare tab: an empty-composer `↑` on
+    /// SESSION with prompts queued opens the queue editor, and a wheel notch
+    /// in the same state must scroll instead.
+    #[test]
+    fn a_wheel_notch_on_session_never_opens_the_queue_editor() {
+        let (mut model, mut ui) = fixture();
+        model.queue.enqueue("queued prompt".into(), 0);
+        ui.metrics.session_total = 100;
+        ui.metrics.session_height = 10;
+        handle_deck_mouse(wheel(MouseEventKind::ScrollUp), 100, &model, &mut ui);
+        assert!(!ui.queue_open, "the queue editor stayed closed");
+        assert_eq!(ui.session_scroll.top, 100 - 10 - WHEEL_LINES);
     }
 
     /// The wheel scrolls the Session transcript by [`WHEEL_LINES`], against


### PR DESCRIPTION
## What & why

The first mouse slice (#5397) scrolled only the Session transcript; every other tab and every modal overlay ignored the wheel. This finishes the wheel, split by modality:

- **Bare tab** — `wheel_on_tab` moves the same state and count each tab's key handler hands `list_nav`: TRACES and an open FILES diff by scroll state, the list tabs (AGENTS, FILES, GRAPH, SKILLS, MCP, ISSUES) by selection, through new `select_wheel` / `scroll_wheel` entries in `list_nav` so the clamping stays one vocabulary. Direct rather than synthesized, because a bare arrow carries affordances a wheel must not trigger — an empty-composer `↑` on SESSION opens the queue editor, and a witness test holds that a wheel notch in that exact state scrolls instead. SETTINGS is two focus-claimed editors and deliberately ignores the wheel while unfocused.
- **Modal dialog** — the wheel *is* arrows: three synthesized `↑`/`↓` re-entered through `handle_deck_key`, so the dialog's own handler moves its own body. Every overlay already speaks `list_nav`'s vocabulary, so there is no list of overlays here to fall out of date — the exemplar is `list_nav` itself, which exists because per-overlay key arms drifted.

Synthesis means a mouse outcome can be anything a key's can, so `deck_shell`'s key-arm action match is extracted as `apply_deck_action` and **both** arms land there: the queue mirror, the shell lane, and quit now have one mutation site regardless of input device.

Closes #5394

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`the_wheel_moves_every_tabs_own_surface` (TRACES body, an empty list clamping, the FILES diff body), `a_wheel_notch_over_a_modal_scrolls_the_dialog_not_the_tab` (help overlay scrolls, the transcript behind it does not, the overlay stays open), and `a_wheel_notch_on_session_never_opens_the_queue_editor` — on `main`, that wheel notch is ignored on every non-Session tab and under every overlay, so the first two fail there; the third pins the reason the tab path is not key synthesis. `the_wheel_entries_share_the_arrow_clamping` covers the new `list_nav` entries.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, green)
- [x] `cargo clippy -p stella-tui --all-targets -- -D warnings` — the workspace run is CI's
- [x] `cargo test -p stella-tui` (1428 lib tests + suites, golden frames included) — the workspace run is CI's
- [x] Docs: `DeckOptions::mouse_capture`, the module header, and the `deck_shell` arm comment updated to the new contract
- [x] CLA signed
- [x] `Closes #5394` above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR — #5395 (OSC 8 hyperlinks) and #5396 (test flake) remain the tracked neighbors from the first slice.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The per-tab table in `wheel_on_tab` intentionally repeats each tab handler's (state, count) pairing — the alternative, synthesizing arrows on bare tabs, misfires the queue-editor/sub-agents affordances, and the table's doc names the maintenance rule. The `apply_deck_action` extraction moves the key arm's match verbatim; no behavior change on the key path.

## Summary by Sourcery

Complete mouse-wheel navigation across every tab and modal dialog while preserving each surface’s native navigation behavior.

New Features:
- Enable mouse-wheel scrolling across all tab surfaces, including transcript bodies, diffs, and selectable lists.
- Enable modal overlays to consume wheel input by scrolling their own content without affecting the underlying tab.

Bug Fixes:
- Prevent wheel input on the Session tab from triggering keyboard-only queue-editor behavior.

Enhancements:
- Centralize deck action application so keyboard and mouse dispatch share queue, shell, and quit handling.
- Add shared wheel navigation helpers with arrow-compatible selection and scroll clamping.

Documentation:
- Update mouse-dispatch documentation to describe wheel behavior across tabs and modal dialogs.

Tests:
- Add coverage for wheel navigation across tab surfaces, modal ownership, Session queue-editor protection, and clamping behavior.