### PR TITLE
fix(stella-core): delete the dead steering-record gates and produce the findings nothing constructed

### DIFF
--- a/crates/stella-cli/src/ingest_cmd/extract.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract.rs
@@ -920,6 +920,7 @@ fn build_proposal(
         .probe
         .clone()
         .filter(|p| gate::probe_honored(Origin::Imported, p.kind));
+    let refused_as_gated = claim.probe.is_some() && gated_probe.is_none();
     // And keep only probes that could refute the claim they are attached to. A
     // `path_exists` on a cardinality claim goes green whatever the count is
     // (#4262), so it is declined and the claim abstains instead.
@@ -1003,6 +1004,14 @@ fn build_proposal(
     // its validation or quarantine finding.
     let refutation = outcome.is_eligible().then(|| match &honored_probe {
         Some(p) => probe::evaluate(root, p, observed_at),
+        // The refusal is stated: "no probe could judge" would read as an
+        // unfalsifiable claim, when the truth is that a probe was offered and
+        // the gate declined to run it.
+        None if refused_as_gated => abstained(
+            observed_at,
+            "the probe offered runs a command or reaches the network, which is \
+             never honored on imported content",
+        ),
         None if declined_as_indiscriminate => abstained(
             observed_at,
             "the claim states a count, and the probe offered for it could not \

--- a/crates/stella-cli/src/ingest_cmd/extract/tests.rs
+++ b/crates/stella-cli/src/ingest_cmd/extract/tests.rs
@@ -169,10 +169,18 @@ fn a_gated_probe_is_stripped_and_the_claim_is_unfalsifiable() {
     // The gated probe never reaches the record.
     let truth = proposal.record.truth.as_ref().expect("truth");
     assert!(truth.probe.is_none(), "a gated probe must be stripped");
-    // With no honored probe, the claim is honestly unfalsifiable.
+    // With no honored probe, the claim is honestly unfalsifiable — and the
+    // reviewer is told the probe was refused rather than that none was offered.
     let refutation = proposal.refutation.as_ref().expect("refutation");
     assert_eq!(refutation.verdict, Verdict::Unfalsifiable);
     assert_eq!(refutation.probe_kind, ProbeKind::None);
+    assert!(
+        refutation
+            .detail
+            .contains("never honored on imported content"),
+        "the reviewer is not told the probe was refused: {}",
+        refutation.detail
+    );
     let _ = std::fs::remove_dir_all(&root);
 }
 

--- a/crates/stella-cli/src/memory/proposals.rs
+++ b/crates/stella-cli/src/memory/proposals.rs
@@ -156,6 +156,12 @@ pub(crate) fn induce_proposals(
         } else {
             RecordProposalStatus::Collecting
         };
+        // An observation whose hash does not match its content is evidence
+        // nothing vouches for; a candidate resting on one is skipped the same
+        // way an unscorable one is.
+        let Ok(pool) = EvidencePool::from_observations(supporting) else {
+            continue;
+        };
         let Ok(proposal) = ProposalRecord::new(
             RecordProposalKind::Knowledge,
             status,
@@ -163,7 +169,7 @@ pub(crate) fn induce_proposals(
             &candidate.description,
             &candidate.body,
             candidate.domains.clone(),
-            EvidencePool::from_observations(supporting),
+            pool,
             score,
             confidence,
             proposal_observed_at(&candidate),

--- a/crates/stella-cli/src/memory/rules_mining.rs
+++ b/crates/stella-cli/src/memory/rules_mining.rs
@@ -145,6 +145,12 @@ pub(crate) fn induce_rule_proposals(
         } else {
             RecordProposalStatus::Collecting
         };
+        // An observation whose hash does not match its content is evidence
+        // nothing vouches for; a candidate resting on one is skipped the same
+        // way an unscorable one is.
+        let Ok(pool) = EvidencePool::from_observations(supporting) else {
+            continue;
+        };
         let Ok(proposal) = ProposalRecord::new(
             RecordProposalKind::Directive,
             status,
@@ -152,7 +158,7 @@ pub(crate) fn induce_rule_proposals(
             &candidate.description,
             &candidate.text,
             Vec::new(),
-            EvidencePool::from_observations(supporting),
+            pool,
             score,
             confidence,
             stella_context::format_rfc3339(

--- a/crates/stella-cli/src/proposals_cmd/tests.rs
+++ b/crates/stella-cli/src/proposals_cmd/tests.rs
@@ -15,6 +15,11 @@ use stella_core::context_record::{
 /// Reflection lessons across `tasks` distinct tasks — the evidence a mined
 /// knowledge proposal stands on, so the fixture grades the way the production
 /// path grades (#2782).
+fn pool_of(observations: &[ObservationRecord]) -> Option<EvidencePool> {
+    EvidencePool::from_observations(observations)
+        .expect("constructor-built observations hash clean")
+}
+
 fn supporting_observations(tasks: &[&str]) -> Vec<ObservationRecord> {
     tasks
         .iter()
@@ -53,7 +58,7 @@ fn seed_proposal(store: &ContextStore, candidate_id: &str) -> ProposalRecord {
         "Prefer rg over grep",
         "Use ripgrep instead of grep in this repository.",
         vec!["tooling".into()],
-        EvidencePool::from_observations(&supporting_observations(&["task-a", "task-b", "task-c"])),
+        pool_of(&supporting_observations(&["task-a", "task-b", "task-c"])),
         score,
         confidence_from_score(&score).expect("confidence"),
         "2026-07-26T12:00:00Z",
@@ -294,7 +299,7 @@ fn list_shows_one_row_per_lineage() {
         "Prefer rg over grep",
         "Use ripgrep instead of grep in this repository.",
         vec!["tooling".into()],
-        EvidencePool::from_observations(&supporting_observations(&["task-a"])),
+        pool_of(&supporting_observations(&["task-a"])),
         score,
         confidence_from_score(&score).expect("confidence"),
         "2026-07-27T12:00:00Z",

--- a/crates/stella-cli/src/self_driving_cmd/learning/tests.rs
+++ b/crates/stella-cli/src/self_driving_cmd/learning/tests.rs
@@ -81,7 +81,8 @@ fn propose(store: &ContextStore, candidate_id: &str) {
         "Prefer rg over grep",
         "Use ripgrep instead of grep in this repository.",
         vec!["tooling".into()],
-        EvidencePool::from_observations(&supporting_observations()),
+        EvidencePool::from_observations(&supporting_observations())
+            .expect("constructor-built observations hash clean"),
         score,
         confidence_from_score(&score).expect("confidence"),
         "2026-07-26T12:00:00Z",

--- a/crates/stella-cli/src/skill_manager.rs
+++ b/crates/stella-cli/src/skill_manager.rs
@@ -846,7 +846,8 @@ mod tests {
             "money is minor units",
             "money amounts must be stored as minor units",
             Vec::new(),
-            EvidencePool::from_observations([&observation]),
+            EvidencePool::from_observations([&observation])
+                .expect("constructor-built observations hash clean"),
             score,
             confidence,
             "2026-01-01T00:00:00Z",

--- a/crates/stella-core/src/context_record/lifecycle.rs
+++ b/crates/stella-core/src/context_record/lifecycle.rs
@@ -344,7 +344,10 @@ pub struct PromotionEventRecord {
     /// Never `Blocking` for a system actor — see [`Self::new`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enforcement: Option<DirectiveEnforcement>,
-    /// A user's replacement text, for an `Edit`. Absent for every other action.
+    /// The reviewer's replacement text. Carried only on a `Confirmed` event —
+    /// a review edit confirms the proposal with new text, and that is the one
+    /// action whose materialization reads this field. [`Self::new`] refuses it
+    /// on every other action, where it would record an edit nothing performs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edited_body: Option<String>,
     /// Human-readable justification. Required — a governance decision with no
@@ -374,6 +377,14 @@ pub enum PromotionEventError {
     /// A governance decision must record why it was made.
     #[error("a promotion event must carry a reason")]
     MissingReason,
+    /// Replacement text travels only on the `Confirmed` event a review edit
+    /// produces. On any other action nothing reads it, so carrying it there
+    /// records an edit that never happened.
+    #[error("edited_body travels only on a confirmed promotion, not on {action}")]
+    EditedBodyOutsideConfirmed {
+        /// The action that tried to carry it.
+        action: &'static str,
+    },
     /// The record could not be hashed. Flattened to a message rather than
     /// wrapping [`RecordHashError`], which is neither `Clone` nor `PartialEq`
     /// (it carries a `serde_json::Error`) — and a governance error a caller
@@ -403,6 +414,11 @@ impl PromotionEventRecord {
         let reason = reason.into();
         if reason.trim().is_empty() {
             return Err(PromotionEventError::MissingReason);
+        }
+        if edited_body.is_some() && action != PromotionAction::Confirmed {
+            return Err(PromotionEventError::EditedBodyOutsideConfirmed {
+                action: action.as_str(),
+            });
         }
         if enforcement == Some(DirectiveEnforcement::Blocking) {
             if actor == PromotionActor::System {

--- a/crates/stella-core/src/context_record/lifecycle/tests.rs
+++ b/crates/stella-core/src/context_record/lifecycle/tests.rs
@@ -46,7 +46,8 @@ fn proposal(score: ProposalScore) -> ProposalRecord {
             observation("task-1", "Prefer rg over grep."),
             observation("task-2", "Prefer rg over grep."),
             observation("task-3", "Prefer rg over grep."),
-        ]),
+        ])
+        .expect("constructor-built observations hash clean"),
         score,
         confidence_from_score(&score).expect("confidence"),
         AT,
@@ -263,6 +264,37 @@ fn a_promotion_event_must_carry_a_reason() {
         ),
         Err(PromotionEventError::MissingReason)
     ));
+}
+
+/// Replacement text on anything but a confirmation records an edit nothing
+/// performs — the confirmed promotion is the only action whose projection
+/// reads the field — so every other action refuses to carry it.
+#[test]
+fn edited_body_travels_only_on_a_confirmation() {
+    for action in [
+        PromotionAction::Proposed,
+        PromotionAction::AutoActivated,
+        PromotionAction::Published,
+        PromotionAction::Rejected,
+        PromotionAction::Retired,
+        PromotionAction::Reverted,
+    ] {
+        assert!(
+            matches!(
+                PromotionEventRecord::new(
+                    "prp_x",
+                    action,
+                    PromotionActor::User,
+                    None,
+                    Some("replacement text".into()),
+                    "trying it on",
+                    AT,
+                ),
+                Err(PromotionEventError::EditedBodyOutsideConfirmed { .. })
+            ),
+            "{action:?} carried replacement text"
+        );
+    }
 }
 
 // ---- GATE: Keep/Edit/Ignore replay identically from the event log ----

--- a/crates/stella-core/src/context_record/provenance.rs
+++ b/crates/stella-core/src/context_record/provenance.rs
@@ -29,6 +29,7 @@
 
 use stella_protocol::provenance::ProvenanceGrade;
 
+use super::hash::record_hash;
 use super::lifecycle::{ObservationRecord, ObservationSource};
 
 /// The evidence grade an observation of this source carries.
@@ -59,11 +60,34 @@ pub fn observation_grade(source: ObservationSource) -> ProvenanceGrade {
     }
 }
 
+/// An observation whose stored `record_hash` does not match its own content.
+///
+/// [`ObservationRecord`]'s fields are public (the CLI and the observatory read
+/// them), so nothing stops a caller literal-constructing one instead of going
+/// through the hashing constructor. The pool re-derives the hash and refuses a
+/// mismatch, because folding such a record would mint a grade from evidence
+/// whose identity nothing vouches for.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "observation {record_id} carries record_hash \"{stored}\", but its content \
+     hashes to {recomputed} — a grade cannot fold over evidence whose identity \
+     nothing vouches for"
+)]
+pub struct EvidenceIntegrityError {
+    /// The observation's claimed id.
+    pub record_id: String,
+    /// The hash the record carried.
+    pub stored: String,
+    /// The hash its content actually has.
+    pub recomputed: String,
+}
+
 /// The observations behind a proposal, together with the grade they fold to.
 ///
 /// Construction is the enforcement: [`EvidencePool::from_observations`] is the
-/// only public way to make one, so a proposal's grade is always a fold over
-/// records that exist rather than a value chosen by whoever is promoting.
+/// only public way to make one, and it re-verifies each observation's
+/// `record_hash`, so a proposal's grade is always a fold over records that
+/// exist rather than a value chosen by whoever is promoting.
 ///
 /// An empty pool is [`None`] rather than a pool with a weak grade — no
 /// evidence is not weak evidence, and rounding the two together is what lets a
@@ -75,18 +99,32 @@ pub struct EvidencePool {
 }
 
 impl EvidencePool {
-    /// Fold real observations into a pool, or [`None`] if there are none.
+    /// Fold real observations into a pool, or `Ok(None)` if there are none.
     ///
     /// The grade is [`ProvenanceGrade::weakest`] over the pool, so adding a
     /// weak observation to a strong pool weakens it and adding a strong one to
-    /// a weak pool does not lift it.
-    #[must_use]
+    /// a weak pool does not lift it. Each observation's `record_hash` is
+    /// re-derived from its content first — see [`EvidenceIntegrityError`] —
+    /// and an unhashable record fails the same way, since a record the
+    /// canonical hash cannot cover is one nothing can vouch for either.
     pub fn from_observations<'a>(
         observations: impl IntoIterator<Item = &'a ObservationRecord>,
-    ) -> Option<Self> {
+    ) -> Result<Option<Self>, EvidenceIntegrityError> {
         let mut grade: Option<ProvenanceGrade> = None;
         let mut observation_ids = Vec::new();
         for observation in observations {
+            let recomputed = record_hash(observation).map_err(|err| EvidenceIntegrityError {
+                record_id: observation.record_id.clone(),
+                stored: observation.record_hash.clone(),
+                recomputed: format!("(unhashable: {err})"),
+            })?;
+            if recomputed != observation.record_hash {
+                return Err(EvidenceIntegrityError {
+                    record_id: observation.record_id.clone(),
+                    stored: observation.record_hash.clone(),
+                    recomputed,
+                });
+            }
             let observed = observation_grade(observation.source);
             grade = Some(match grade {
                 Some(current) => current.min(observed),
@@ -94,10 +132,10 @@ impl EvidencePool {
             });
             observation_ids.push(observation.record_id.clone());
         }
-        grade.map(|grade| Self {
+        Ok(grade.map(|grade| Self {
             grade,
             observation_ids,
-        })
+        }))
     }
 
     /// The grade this evidence folds to.

--- a/crates/stella-core/src/context_record/provenance/tests.rs
+++ b/crates/stella-core/src/context_record/provenance/tests.rs
@@ -83,7 +83,9 @@ fn a_proposal_carries_the_grade_of_the_observations_behind_it() {
             "the build failed again",
         ),
     ];
-    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+    let pool = EvidencePool::from_observations(&observations)
+        .expect("constructor-built observations hash clean")
+        .expect("a non-empty pool");
 
     assert_eq!(pool.grade(), ProvenanceGrade::EnvironmentObservation);
 
@@ -119,7 +121,9 @@ fn three_agreeing_reflections_across_three_tasks_still_cannot_publish_a_tool() {
             "prefer rg again",
         ),
     ];
-    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+    let pool = EvidencePool::from_observations(&observations)
+        .expect("constructor-built observations hash clean")
+        .expect("a non-empty pool");
     let proposal = proposal(Some(pool));
 
     assert!(
@@ -151,7 +155,9 @@ fn a_single_critique_weakens_a_pool_of_measurements() {
         observation(ObservationSource::ToolOutcome, "task-b", "exit 1"),
         observation(ObservationSource::ReflectionLesson, "task-c", "felt slow"),
     ];
-    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+    let pool = EvidencePool::from_observations(&observations)
+        .expect("constructor-built observations hash clean")
+        .expect("a non-empty pool");
 
     assert_eq!(pool.grade(), ProvenanceGrade::ModelCritique);
 }
@@ -160,7 +166,7 @@ fn a_single_critique_weakens_a_pool_of_measurements() {
 /// being smoothed into the weakest one.
 #[test]
 fn a_proposal_with_no_observations_stores_no_grade() {
-    assert_eq!(EvidencePool::from_observations(&[]), None);
+    assert_eq!(EvidencePool::from_observations(&[]), Ok(None));
 
     let proposal = proposal(None);
     assert_eq!(proposal.provenance, None);
@@ -215,9 +221,24 @@ fn a_graded_proposal_serializes_its_grade_under_the_protocol_tag() {
         "task-a",
         "exit 0",
     )];
-    let pool = EvidencePool::from_observations(&observations).expect("a non-empty pool");
+    let pool = EvidencePool::from_observations(&observations)
+        .expect("constructor-built observations hash clean")
+        .expect("a non-empty pool");
     let proposal = proposal(Some(pool));
 
     let json = serde_json::to_value(&proposal).expect("a proposal serializes");
     assert_eq!(json["provenance"], "environment_observation");
+}
+
+/// The pool re-derives every observation's `record_hash` before folding, so a
+/// literal-constructed record — the fields are public — cannot mint an
+/// environment-observation grade the hashing constructor never sealed.
+#[test]
+fn a_forged_observation_cannot_mint_a_grade() {
+    let mut forged = observation(ObservationSource::ToolOutcome, "task-a", "exit 0");
+    forged.text = "exit 0, with edits the hash never saw".to_string();
+    let err = EvidencePool::from_observations(std::slice::from_ref(&forged))
+        .expect_err("a hash that does not cover this content must refuse to fold");
+    assert_eq!(err.record_id, forged.record_id);
+    assert_eq!(err.stored, forged.record_hash);
 }

--- a/crates/stella-core/src/ingest.rs
+++ b/crates/stella-core/src/ingest.rs
@@ -332,11 +332,29 @@ fn segments(path: &str) -> Vec<String> {
 pub fn supersession_marker(content: &str) -> Option<String> {
     content.lines().take(HEAD_LINES).find_map(|line| {
         let lower = line.to_ascii_lowercase();
-        SUPERSESSION_PHRASES
-            .iter()
-            .find(|phrase| lower.contains(**phrase))
-            .map(|phrase| (*phrase).to_string())
+        SUPERSESSION_PHRASES.iter().find_map(|phrase| {
+            let start = lower.find(*phrase)?;
+            (!negated(&lower[..start])).then(|| (*phrase).to_string())
+        })
     })
+}
+
+/// Whether the text leading up to a matched phrase negates it. "This document
+/// is not deprecated" asserts the opposite of what the bare phrase says, and
+/// demoting on it would demote a document for stating that it is current.
+/// Only the last two words of the same clause are read: a phrase after a
+/// clause boundary is a fresh claim, whatever the earlier clause said.
+fn negated(before: &str) -> bool {
+    const NEGATORS: &[&str] = &["not", "never", "isn't", "isn\u{2019}t", "aren't", "wasn't"];
+    let clause = before
+        .rsplit(['.', ';', ',', ':', '!', '?'])
+        .next()
+        .unwrap_or(before);
+    clause
+        .split_whitespace()
+        .rev()
+        .take(2)
+        .any(|word| NEGATORS.contains(&word))
 }
 
 /// `true` when the body is a table of contents pointing at sibling documents.

--- a/crates/stella-core/src/ingest/record.rs
+++ b/crates/stella-core/src/ingest/record.rs
@@ -355,24 +355,6 @@ impl Record {
         }
     }
 
-    /// The truth probe that may be re-run to re-check this record's claim, if
-    /// any. Returns the record's own probe only when it is **honored** for the
-    /// record's origin — a gated probe (`command_succeeds`/`http_ok`) is never
-    /// honored on an imported/inferred record, so it is filtered out and can
-    /// never run during a staleness sweep. `None` when there is no probe or it
-    /// is gated. Origin defaults to `imported` (ingest output) when unset.
-    pub fn honored_probe(&self) -> Option<&Probe> {
-        let probe = self.truth.as_ref()?.probe.as_ref()?;
-        let origin = self.origin.unwrap_or(Origin::Imported);
-        super::gate::probe_honored(origin, probe.kind).then_some(probe)
-    }
-
-    /// The record's `on_expiry` policy string (`stale`/`drop`/`block`), if set —
-    /// what to do when a re-check refutes the claim.
-    pub fn on_expiry(&self) -> Option<&str> {
-        self.truth.as_ref()?.on_expiry.as_deref()
-    }
-
     /// This record's declared [`Steering::precedence`], or `0` when it declared
     /// none.
     ///

--- a/crates/stella-core/src/ingest/tests.rs
+++ b/crates/stella-core/src/ingest/tests.rs
@@ -58,6 +58,27 @@ fn a_document_that_supersedes_others_is_not_itself_superseded() {
     assert!(supersession_marker(retired).is_some());
 }
 
+/// A bare `contains` would demote a document for *denying* the phrase —
+/// "this document is not deprecated" reading as deprecated.
+#[test]
+fn a_negated_phrase_does_not_demote() {
+    assert_eq!(
+        supersession_marker("# Current Spec\n\nThis document is not deprecated.\n"),
+        None
+    );
+    assert_eq!(
+        supersession_marker("# Current Spec\n\nThis page was never obsolete.\n"),
+        None
+    );
+    // The negation reaches only its own clause: a denial earlier in the line
+    // does not shield a real marker after a clause boundary.
+    assert_eq!(
+        supersession_marker("# Old Spec\n\nNot maintained here: deprecated, see docs/new.md.\n")
+            .as_deref(),
+        Some("deprecated")
+    );
+}
+
 #[test]
 fn supersession_is_not_read_from_the_body() {
     // A migration guide discusses deprecation at length without being deprecated.

--- a/crates/stella-core/src/records.rs
+++ b/crates/stella-core/src/records.rs
@@ -67,7 +67,7 @@ pub use render::{
 pub use select::{TurnFacts, applies_this_turn};
 pub use sweep::{Disposition, ExpiryAction, SweepInput, disposition, honored_probe, probe_is_due};
 pub use trust::Trust;
-pub use validate::{Conflict, check_record, detect_conflicts, is_suspended, validate_records};
+pub use validate::{Conflict, check_record, detect_conflicts, is_suspended};
 
 /// One record as the engine sees it: the typed record, where it came from, the
 /// name it can be cited by, and everything wrong with it.
@@ -182,8 +182,9 @@ pub enum RecordFinding {
         /// Which field the forbidden content was found in.
         field: &'static str,
     },
-    /// The record asked for a gated probe (`command_succeeds`, `http_ok`) on an
-    /// origin where gated probes are never honored. Reported, not honored.
+    /// The record declared a gated probe (`command_succeeds`, `http_ok`) that
+    /// [`sweep::honored_probe`] refuses for its origin or truth basis, so the
+    /// claim will never be re-checked. Reported, not honored.
     GatedProbeRefused(ProbeKind),
     /// The record asked to block at the tool boundary and was refused. See
     /// [`BlockingRefusal`] for which precondition failed.
@@ -243,8 +244,9 @@ impl std::fmt::Display for RecordFinding {
             ),
             Self::GatedProbeRefused(kind) => write!(
                 f,
-                "probe kind {} runs a command or reaches the network, which is never \
-                 honored on an imported or inferred record",
+                "probe kind {} runs a command or reaches the network, which is honored \
+                 only on a decreed record a named human verified — this claim will \
+                 never be re-checked",
                 kind.as_str()
             ),
             Self::BlockingRefused(refusal) => write!(f, "{refusal}"),

--- a/crates/stella-core/src/records/registry.rs
+++ b/crates/stella-core/src/records/registry.rs
@@ -287,7 +287,7 @@ pub fn load(user_files: &[RuleFile], project_files: &[RuleFile], facts: &Facts<'
 
     // Pass 3: sweep and arm.
     let mut entries: Vec<Entry> = Vec::new();
-    for (record, markdown) in records.into_iter().zip(markdown) {
+    for (mut record, markdown) in records.into_iter().zip(markdown) {
         let mut disposition = super::disposition(&SweepInput {
             record: &record.record,
             verdict: facts.verdicts.get(&record.record.lineage_id).copied(),
@@ -306,13 +306,16 @@ pub fn load(user_files: &[RuleFile], project_files: &[RuleFile], facts: &Facts<'
         if let Some(reason) = blocking_reason(&record) {
             disposition = Disposition::Block { reason };
         }
-        let guard = resolve_guard(
-            &record,
-            markdown.as_ref(),
-            facts,
-            &conflicts,
-            &mut diagnostics,
-        );
+        let guard = resolve_guard(&record, markdown.as_ref(), facts, &conflicts);
+        // A refusal is a fact about the record, so it lands in the record's own
+        // findings — where `stella context explain` and `validate` already look —
+        // rather than in the registry-level diagnostics, which describe files.
+        // Warning severity: the record still steers, it just does not block.
+        if let Some(refusal) = guard.refusal.clone() {
+            record
+                .findings
+                .push(RecordFinding::BlockingRefused(refusal));
+        }
         entries.push(Entry {
             record,
             disposition,
@@ -470,7 +473,6 @@ fn resolve_guard(
     markdown: Option<&Rule>,
     facts: &Facts<'_>,
     conflicts: &[Conflict],
-    diagnostics: &mut Vec<Diagnostic>,
 ) -> GuardDecision {
     if let Some(rule) = markdown {
         // Grandfathered: a shipped markdown guard keeps working exactly as it did.
@@ -495,14 +497,7 @@ fn resolve_guard(
         };
     }
     let approved = facts.approves(record.trust, &record.record.lineage_id);
-    let decision = super::guard_for(&record.record, record.trust, approved);
-    if let Some(refusal) = decision.refusal.as_ref() {
-        diagnostics.push(Diagnostic {
-            source: record.source.clone(),
-            detail: format!("^{} {refusal}", record.handle),
-        });
-    }
-    decision
+    super::guard_for(&record.record, record.trust, approved)
 }
 
 /// The `Rule` an entry contributes to the tool boundary.

--- a/crates/stella-core/src/records/registry/tests.rs
+++ b/crates/stella-core/src/records/registry/tests.rs
@@ -249,12 +249,13 @@ guard_deny_command = "git push --force*"
         "an imported record must never start blocking, however it is committed"
     );
     assert!(
-        registry
-            .diagnostics
+        entry
+            .record
+            .findings
             .iter()
-            .any(|d| d.detail.contains("no-force-push") && d.detail.contains("origin is imported")),
+            .any(|finding| finding.to_string().contains("origin is imported")),
         "the refusal must be reported so the author knows the guard is inert: {:?}",
-        registry.diagnostics
+        entry.record.findings
     );
     assert!(
         !registry
@@ -551,12 +552,13 @@ fn a_repository_record_cannot_approve_its_own_blocking() {
         "a repository record reaches the tool boundary only through the ledger"
     );
     assert!(
-        registry
-            .diagnostics
+        registry.entries[0]
+            .record
+            .findings
             .iter()
-            .any(|d| d.detail.contains("approve it locally")),
+            .any(|finding| finding.to_string().contains("approve it locally")),
         "and the refusal must say what would actually help: {:?}",
-        registry.diagnostics
+        registry.entries[0].record.findings
     );
 }
 

--- a/crates/stella-core/src/records/tests.rs
+++ b/crates/stella-core/src/records/tests.rs
@@ -404,7 +404,8 @@ pattern = "20"
 "#;
     let mut records = load_context_file(".stella/rules/acme.web.toml", file).expect("loads");
     assign_handles(&mut records);
-    let conflicts = validate_records(&mut records);
+    records.iter_mut().for_each(validate::check_record);
+    let conflicts = validate::detect_conflicts(&mut records);
     assert!(conflicts.is_empty(), "{conflicts:?}");
     assert_eq!(
         records
@@ -908,4 +909,59 @@ fn an_explicitly_scoped_record_without_a_trigger_is_named() {
             .contains(&RecordFinding::ScopedWithoutTrigger),
         "a derived retrieved record carries no scoped-without-trigger finding"
     );
+}
+
+/// A record that asked to block and was refused carries the refusal as a
+/// finding on the record itself, where `stella context explain` and `validate`
+/// already look. A registry-level diagnostic describes a file, so a refusal
+/// surfaced only there is invisible to everything that reads a record's own
+/// findings.
+#[test]
+fn a_refused_blocking_request_is_a_finding_on_the_record() {
+    let corpus = r#"
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+sharing_scope = "repository"
+origin = "user"
+status = "active"
+
+[[record]]
+lineage_id = "ctx.acme.web.no-force-push"
+kind = "constraint"
+statement = "Never force-push to main."
+
+[record.steering]
+force = "must"
+precedence = 60
+
+[record.enforcement]
+mode = "hard"
+guard_tool = "Bash"
+guard_deny_command = "git push --force*"
+"#;
+    let files = [crate::rules::RuleFile {
+        path: ".stella/rules/acme.web.toml".to_string(),
+        contents: corpus.to_string(),
+        contributed_by: None,
+    }];
+    let facts = registry::Facts {
+        verdicts: std::collections::BTreeMap::new(),
+        last_checked: std::collections::BTreeMap::new(),
+        approved_blocking: std::collections::BTreeSet::new(),
+        now: "2026-08-08T00:00:00Z",
+    };
+    let loaded = registry::load(&[], &files, &facts);
+    let entry = loaded.entries.first().expect("the record loaded");
+    assert!(
+        entry
+            .record
+            .findings
+            .iter()
+            .any(|finding| matches!(finding, RecordFinding::BlockingRefused(_))),
+        "the refusal must be visible on the record: {:?}",
+        entry.record.findings
+    );
+    assert!(entry.guard.guard.is_none(), "a refused guard must not arm");
 }

--- a/crates/stella-core/src/records/validate.rs
+++ b/crates/stella-core/src/records/validate.rs
@@ -15,7 +15,7 @@
 //! Two records at equal precedence matching the same paths with different
 //! enforcement is a governance failure, not an input to a tiebreak. §12 is explicit:
 //! the frame carries a conflict record and **enforcement falls back to the less
-//! restrictive behavior** until an owner resolves it. So [`validate_records`] does
+//! restrictive behavior** until an owner resolves it. So [`detect_conflicts`] does
 //! both — it attaches the conflict to both records *and* suspends the more
 //! restrictive one's enforcement. Picking a winner silently would mean a repository
 //! could start hard-blocking tool calls because of an ordering accident.
@@ -68,19 +68,7 @@ pub struct Conflict {
     pub suspended: String,
 }
 
-/// Run every publication check over the whole loaded set.
-///
-/// Findings are attached to the records in place; conflicts are also returned so a
-/// caller can report them as a set (a conflict belongs to a pair, not to a record).
-/// Call after [`super::assign_handles`] — conflict detail names records by handle.
-pub fn validate_records(records: &mut [LoadedRecord]) -> Vec<Conflict> {
-    for loaded in records.iter_mut() {
-        check_record(loaded);
-    }
-    detect_conflicts(records)
-}
-
-/// The per-record half of [`validate_records`] — the checks that need no
+/// The per-record half of the validation pass — the checks that need no
 /// neighbours.
 ///
 /// Separate from the conflict pass because the two apply to different populations:
@@ -116,7 +104,7 @@ pub fn detect_conflicts(records: &mut [LoadedRecord]) -> Vec<Conflict> {
 }
 
 /// Whether this record's enforcement is suspended by a conflict — the caller must
-/// not arm its guard. Derived from the conflicts [`validate_records`] returned.
+/// not arm its guard. Derived from the conflicts [`detect_conflicts`] returned.
 pub fn is_suspended(handle: &str, conflicts: &[Conflict]) -> bool {
     conflicts
         .iter()
@@ -131,7 +119,27 @@ fn check_one(record: &Record) -> Vec<RecordFinding> {
     findings.extend(unknown_tasks(record));
     findings.extend(atomicity(record));
     findings.extend(scoped_without_trigger(record));
+    findings.extend(gated_probe_refused(record));
     findings
+}
+
+/// A declared gated probe (`command_succeeds`/`http_ok`) the staleness sweep
+/// will never run: [`super::sweep::honored_probe`] refuses it for this record's
+/// origin or truth basis. Without this finding the record loads clean and its
+/// claim silently never gets re-checked — the author believes a probe is
+/// standing guard, and nothing is.
+fn gated_probe_refused(record: &Record) -> Vec<RecordFinding> {
+    let declared = record
+        .truth
+        .as_ref()
+        .and_then(|truth| truth.probe.as_ref())
+        .filter(|probe| probe.kind.is_gated());
+    match declared {
+        Some(probe) if super::sweep::honored_probe(record).is_none() => {
+            vec![RecordFinding::GatedProbeRefused(probe.kind)]
+        }
+        _ => Vec::new(),
+    }
 }
 
 /// An explicit `tier = "scoped"` with no `applies_to` trigger (#2709). Only
@@ -403,7 +411,7 @@ pub fn globs_overlap(left: &str, right: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::ingest::record::Enforcement;
+    use super::super::super::ingest::record::{Enforcement, Probe, ProbeKind, Truth, TruthBasis};
     use super::super::tests::{hard_guard, loaded_from, record_named, with_scope};
     use super::*;
 
@@ -447,7 +455,8 @@ mod tests {
                 50,
             ),
         ];
-        let conflicts = validate_records(&mut records);
+        records.iter_mut().for_each(check_record);
+        let conflicts = detect_conflicts(&mut records);
         assert_eq!(conflicts.len(), 1, "{conflicts:?}");
         let conflict = &conflicts[0];
         assert!(
@@ -492,7 +501,8 @@ mod tests {
             ),
             at("general", EnforcementMode::None, &["routes/**"], 50),
         ];
-        assert!(validate_records(&mut records).is_empty());
+        records.iter_mut().for_each(check_record);
+        assert!(detect_conflicts(&mut records).is_empty());
     }
 
     #[test]
@@ -501,7 +511,8 @@ mod tests {
             at("one", EnforcementMode::None, &["src/api/**"], 50),
             at("two", EnforcementMode::None, &["src/api/**"], 50),
         ];
-        assert!(validate_records(&mut records).is_empty());
+        records.iter_mut().for_each(check_record);
+        assert!(detect_conflicts(&mut records).is_empty());
     }
 
     #[test]
@@ -510,7 +521,8 @@ mod tests {
             at("web", EnforcementMode::Hard, &["apps/web/**"], 50),
             at("api", EnforcementMode::None, &["services/api/**"], 50),
         ];
-        assert!(validate_records(&mut records).is_empty());
+        records.iter_mut().for_each(check_record);
+        assert!(detect_conflicts(&mut records).is_empty());
     }
 
     #[test]
@@ -519,7 +531,8 @@ mod tests {
             at("scoped", EnforcementMode::Hard, &["src/api/**"], 50),
             at("unscoped", EnforcementMode::None, &[], 50),
         ];
-        let conflicts = validate_records(&mut records);
+        records.iter_mut().for_each(check_record);
+        let conflicts = detect_conflicts(&mut records);
         assert_eq!(conflicts.len(), 1);
         assert!(
             conflicts[0].detail.contains("unscoped"),
@@ -661,6 +674,61 @@ mod tests {
     }
 
     // Atomicity on publish
+
+    // Gated probes — a declared probe the sweep will never run must be reported.
+
+    fn probing(kind: ProbeKind, basis: TruthBasis, verified_by: Option<&str>) -> Record {
+        let mut record = record_named("ctx.a.b.c");
+        record.truth = Some(Truth {
+            basis,
+            confidence: None,
+            verified_by: verified_by.map(str::to_string),
+            verified_at: None,
+            valid_from: None,
+            ttl: None,
+            on_expiry: None,
+            review_every: None,
+            probe: Some(Probe {
+                kind,
+                path: None,
+                pattern: None,
+                expect: None,
+                note: None,
+            }),
+        });
+        record
+    }
+
+    #[test]
+    fn a_gated_probe_the_sweep_refuses_is_reported_not_silently_inert() {
+        let findings = check_one(&probing(ProbeKind::HttpOk, TruthBasis::Measured, None));
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f, RecordFinding::GatedProbeRefused(ProbeKind::HttpOk))),
+            "{findings:?}"
+        );
+        assert_eq!(
+            findings.iter().map(RecordFinding::severity).max(),
+            Some(super::super::Severity::Warning),
+            "reported, not blocking — the record still steers, it just never re-checks"
+        );
+    }
+
+    #[test]
+    fn a_gated_probe_on_a_decreed_human_verified_record_is_honored_silently() {
+        let mut record = probing(ProbeKind::CommandSucceeds, TruthBasis::Decree, Some("mac"));
+        // `record_named` stamps an imported origin, which the sweep refuses on
+        // its own; the honored case needs the trusted one.
+        record.origin = Some(super::super::super::context_record::kind::Origin::User);
+        assert!(check_one(&record).is_empty(), "{:?}", check_one(&record));
+    }
+
+    #[test]
+    fn an_ungated_probe_is_never_reported() {
+        let record = probing(ProbeKind::FileContains, TruthBasis::Measured, None);
+        assert!(check_one(&record).is_empty(), "{:?}", check_one(&record));
+    }
 
     #[test]
     fn a_compound_statement_edited_in_after_ingest_is_caught_on_load() {

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -1168,7 +1168,8 @@ tags       = ["testing", "pins"]
             "money is minor units",
             "money amounts must be stored as minor units",
             Vec::new(),
-            EvidencePool::from_observations([&observation]),
+            EvidencePool::from_observations([&observation])
+                .expect("constructor-built observations hash clean"),
             score,
             confidence,
             "2026-01-01T00:00:00Z",

--- a/crates/stella-observatory/tests/schema_conformance.rs
+++ b/crates/stella-observatory/tests/schema_conformance.rs
@@ -818,7 +818,8 @@ fn real_context_workspace() -> (tempfile::TempDir, String, String) {
         "Grep before you guess",
         "Search the tree before assuming a symbol's location.",
         Vec::new(),
-        EvidencePool::from_observations(std::slice::from_ref(&observation)),
+        EvidencePool::from_observations(std::slice::from_ref(&observation))
+            .expect("constructor-built observations hash clean"),
         ProposalScore {
             occurrences: 4,
             distinct_tasks: 3,


### PR DESCRIPTION
## What & why

The record plane declared several steering APIs that nothing produced or called — each one a drift hazard (two gates that can disagree) or a silent gap (a refusal that never reaches the person who wrote the record). This PR settles every item of #5331 on `main` as it stands today, item by item: delete, fix, or produce, never a declared signal with no producer.

- **Deleted `Record::honored_probe` and `Record::on_expiry`** (`crates/stella-core/src/ingest/record.rs`): zero callers anywhere, and the former answered the gating question differently from the live `sweep::honored_probe` — two gate functions, different answers, one uncalled. The live gate's own laxness on `origin: None` is handed to #5329 (comment posted there naming the case).
- **Deleted `validate::validate_records`**: the loader can never use it — `registry::load` runs `check_record` on TOML records only and `detect_conflicts` on everything, and the wrapper runs both halves over one population. Its six test call sites now run the loader's real two-step, which makes them faithful to the shipping path.
- **Produced `RecordFinding::GatedProbeRefused`**: `validate::check_one` now emits it whenever a record declares a gated probe (`command_succeeds`/`http_ok`) that `sweep::honored_probe` refuses, and the extract path's abstention says the probe was refused rather than "no probe could judge this claim". The finding's `Display` and doc now state the real gate (decreed + human-verified), which the old text under-described. Producer shape mirrors `scoped_without_trigger`.
- **Produced `RecordFinding::BlockingRefused`** (found during verification, same defect one variant over): a guard refusal now lands in the record's own findings — where `stella context explain`/`validate` read — instead of a registry-level diagnostic string about a file. The two registry tests that asserted the diagnostic now assert the finding.
- **`PromotionEventRecord::new` refuses `edited_body` off `Confirmed`** (new `PromotionEventError::EditedBodyOutsideConfirmed`), and the field doc names the real action — it used to name a `PromotionAction::Edit` variant that does not exist. Constructor-level refusal, matching the rationale `new()`'s doc already states for the blocking guards.
- **`EvidencePool::from_observations` verifies each observation's `record_hash`** and returns `Result`, refusing a mismatch (`EvidenceIntegrityError`). `ObservationRecord`'s fields are public, so a literal-constructed record could previously mint an `EnvironmentObservation` grade the hashing constructor never sealed. The two production callers (`memory/proposals.rs`, `memory/rules_mining.rs`) skip such a candidate the same way they skip an unscorable one.
- **`supersession_marker` gets a negation guard**: "this document is not deprecated" demoted the document to Historical; a negator in the last two words of the same clause now blocks the match, while a marker after a clause boundary still fires.

Item 2 of the issue (`decision::blocking_approved`'s substring match) landed separately in #5400, which chose fix over delete; nothing here touches it. Item 5 (`tool_foundry` doc claims + reconnect) is deliberately untouched: PR #5476 gives `detect_tool_gaps` its live caller (ADR 0023, Option A of #5433), and touching that file here would collide with it.

## Witnesses (each fails on `main` without the change)

- `records::validate::tests::a_gated_probe_the_sweep_refuses_is_reported_not_silently_inert` (+ the honored and ungated negative cases)
- `records::tests::a_refused_blocking_request_is_a_finding_on_the_record`
- `ingest_cmd::extract::tests::a_gated_probe_is_stripped_and_the_claim_is_unfalsifiable` (extended: the detail must say the probe was refused)
- `context_record::lifecycle::tests::edited_body_travels_only_on_a_confirmation`
- `context_record::provenance::tests::a_forged_observation_cannot_mint_a_grade`
- `ingest::tests::a_negated_phrase_does_not_demote` (both polarities plus the clause-boundary case)

The pure deletions carry no witness; their evidence is the call-site census in the plan comment on #5331 (re-verified on current `main`).

No `#[test]` was deleted.

## Test evidence

Targeted runs (SCR-001): `cargo test -p stella-core --lib` green; `cargo test -p stella-cli` filters over `proposals`, `rules_mining`, `extract`, `learning`, `skill_manager` green; `stella-observatory` schema-conformance green. CI's workspace run is the full evidence.

Closes #5331

## Summary by Sourcery

Remove unproductive steering interfaces and ensure every declared refusal or integrity failure is surfaced at the record boundary.

New Features:
- Surface refused gated probes and blocking requests as findings on the affected records.
- Reject promotion edits outside confirmed events and forged observations with invalid hashes.
- Prevent negated supersession phrases from incorrectly demoting documents.

Bug Fixes:
- Make extraction explain when a declared probe is refused instead of implying that no probe was offered.

Enhancements:
- Remove unused record steering APIs and the redundant validate_records wrapper.
- Align validation and evidence handling with the production loading and proposal-generation paths.

Documentation:
- Clarify promotion edit semantics and gated-probe behavior.

Tests:
- Add coverage for gated-probe refusals, record-level blocking findings, invalid evidence hashes, restricted promotion edits, and negated supersession markers.