### PR TITLE
fix: eight correctness defects from a workspace-wide audit

### DIFF
--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -625,8 +625,15 @@ pub fn plan_cycle(
     // `Deserialize` with no range guard), and `AimdLimits` promises bounds
     // "the controller may never cross, whatever the evidence says" — so the
     // plan clamps here rather than trusting every load site to have done it.
-    let mut batch = ceilings.batch_ceiling.clamp(1, limits.batch_max);
-    let mut parallel = ceilings.parallel_ceiling.clamp(1, limits.parallel_max);
+    // `min` then `max`, not `clamp`: `u32::clamp` asserts `min <= max` and
+    // panics otherwise, and the ceiling here is the literal 1 while the limit
+    // is caller-supplied. `SELF_DRIVING_BATCH_MAX=0` in the environment reaches
+    // this as `clamp(1, 0)` and takes down the process before any branch below
+    // runs. Ordering the other way keeps the floor winning over a limit of 0,
+    // which is what a cycle of nothing would otherwise mean, and matches how
+    // `calibrate` above stays panic-free on the same untrusted numbers.
+    let mut batch = ceilings.batch_ceiling.min(limits.batch_max).max(1);
+    let mut parallel = ceilings.parallel_ceiling.min(limits.parallel_max).max(1);
 
     let reason: String;
     if supply.disk_free_gb < floors.disk_gb {

--- a/crates/stella-autonomy/src/tests.rs
+++ b/crates/stella-autonomy/src/tests.rs
@@ -357,6 +357,31 @@ fn assert_plan(supply: Supply, demand: Demand, want: (&str, bool, u32, &str, &st
     assert_eq!(got, want, "reason: {}", plan.reason);
 }
 
+/// The limits come from the environment, so a plan must survive a nonsense
+/// one rather than taking the process down.
+///
+/// `SELF_DRIVING_BATCH_MAX=0` — an operator trying to switch batching off —
+/// reached `u32::clamp(1, 0)`, which asserts `min <= max` and panics before
+/// any of the supply branches run. A limit of zero still means at least one
+/// unit of work, the same floor every other path applies.
+#[test]
+fn a_zero_limit_floors_the_plan_instead_of_panicking() {
+    let zeroed = AimdLimits {
+        batch_max: 0,
+        batch_min: 0,
+        parallel_max: 0,
+    };
+    let plan = plan_cycle(
+        base_supply(),
+        Demand::default(),
+        &ceilings(),
+        Floors::default(),
+        &zeroed,
+    );
+    assert_eq!(plan.batch, 1, "a cycle of nothing is not a plan");
+    assert_eq!(plan.parallel, 1);
+}
+
 #[test]
 fn the_supply_rungs_decide_the_tier() {
     let d = Demand::default();

--- a/crates/stella-cli/src/agents_installed.rs
+++ b/crates/stella-cli/src/agents_installed.rs
@@ -458,6 +458,8 @@ pub fn parse_generated_agent(text: &str) -> Result<GeneratedAgent, String> {
                 stella_core::extensions::ExtensionProblem::MissingName => "no usable name",
                 stella_core::extensions::ExtensionProblem::EmptyBody => "empty body",
                 stella_core::extensions::ExtensionProblem::Malformed => "not valid TOML",
+                stella_core::extensions::ExtensionProblem::NestedToolbelt =>
+                    "a nested `tools:` mapping, which would have granted every tool",
             }
         )
     })?;

--- a/crates/stella-cli/src/extensions.rs
+++ b/crates/stella-cli/src/extensions.rs
@@ -448,6 +448,10 @@ fn describe_diagnostic(diag: &stella_core::extensions::ExtensionDiagnostic) -> S
         stella_core::extensions::ExtensionProblem::MissingName => "no usable name",
         stella_core::extensions::ExtensionProblem::EmptyBody => "empty body",
         stella_core::extensions::ExtensionProblem::Malformed => "not valid TOML",
+        stella_core::extensions::ExtensionProblem::NestedToolbelt => {
+            "`tools:` is a nested mapping, which would have granted every tool — \
+             write it as a list, like `tools: read, search`"
+        }
     };
     format!("{}: {why}", diag.path)
 }

--- a/crates/stella-core/src/driver/live_services.rs
+++ b/crates/stella-core/src/driver/live_services.rs
@@ -123,8 +123,12 @@ pub(super) fn check(
     }
     let _ = events.send(AgentEvent::Text {
         text: format!(
+            // Not "confirm or stop": the nudge below offers keeping it and
+            // owning it as a leftover, and says a live service cannot be
+            // stopped. An operator told otherwise waits for a shutdown the
+            // model was never offered.
             "\n⚠ {} long-running {} still up at the end of this turn — asking the model to \
-             confirm or stop {}.",
+             account for {}.",
             services.len(),
             if services.len() == 1 {
                 "process is"
@@ -166,6 +170,33 @@ mod tests {
             name: name.map(str::to_string),
             display: "python3 -m http.server 8080".into(),
         }
+    }
+
+    /// The operator's line offers only what the model is offered.
+    ///
+    /// The nudge says plainly that a live service cannot be stopped, and the
+    /// port's own contract says asking must change nothing — least of all stop
+    /// anything. The narration said "confirm or stop", so an operator reading
+    /// the event stream waited for a shutdown the model was never offered and
+    /// the engine cannot perform.
+    #[test]
+    fn the_narration_offers_only_what_the_nudge_offers() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut messages = vec![CompletionMessage::user("serve the docs on 8080")];
+        assert!(check(
+            &mut messages,
+            &[service("proc-1", Some("docs"))],
+            "Done — the server is running.",
+            &EventSender::new(tx),
+        ));
+        let AgentEvent::Text { text } = rx.try_recv().expect("the check narrates what it did")
+        else {
+            panic!("the narration is a Text event");
+        };
+        assert!(
+            !text.contains("stop"),
+            "the operator must not be told a service can be stopped: {text}"
+        );
     }
 
     /// **The #2764 witness.** A turn that leaves a service up is asked about

--- a/crates/stella-core/src/extensions.rs
+++ b/crates/stella-core/src/extensions.rs
@@ -193,6 +193,17 @@ pub enum ExtensionProblem {
     /// either parses or does not, and guessing at a broken one would load a
     /// command whose author cannot tell it is broken.
     Malformed,
+    /// `tools:` was written as a nested mapping, which the flat frontmatter
+    /// parser cannot read.
+    ///
+    /// The tolerance every other field enjoys is wrong for this one, because
+    /// the unreadable value does not degrade to a smaller grant — it degrades
+    /// to `None`, which means *every* tool. An author writing
+    /// `tools:\n  read: true\n  write: false` asked for a restriction and
+    /// would have been handed the whole registry, with no diagnostic. So the
+    /// definition is refused instead, the way `rules.rs` refuses a record
+    /// carrying nested keys.
+    NestedToolbelt,
 }
 
 /// A malformed definition file, skipped during loading (never fatal).
@@ -433,7 +444,17 @@ pub fn parse_toolbelt(value: Option<&str>) -> Option<Vec<String>> {
 /// Parse one agent file.
 pub fn agent_from_file(path: &str, raw: &str) -> Result<AgentDef, ExtensionDiagnostic> {
     let (fm, name, description, body) = definition_from_file(path, raw, "AGENT.md")?;
-    let tools = parse_toolbelt(fm.data.get("tools").map(String::as_str));
+    let declared = fm.data.get("tools").map(String::as_str);
+    // A nested mapping leaves its parent key holding an empty value and its
+    // children in `nested_keys`, which is indistinguishable here from a bare
+    // `tools:` — and a bare one means every tool. Refuse rather than widen.
+    if declared.is_some_and(str::is_empty) && !fm.nested_keys.is_empty() {
+        return Err(ExtensionDiagnostic {
+            path: path.to_string(),
+            problem: ExtensionProblem::NestedToolbelt,
+        });
+    }
+    let tools = parse_toolbelt(declared);
     let model = trimmed(fm.data.get("model").map(String::as_str));
     Ok(AgentDef {
         name,
@@ -973,6 +994,36 @@ mod tests {
         let blank =
             agent_from_file("/x/helper.md", "---\nname: helper\nmodel:   \n---\nBody.").unwrap();
         assert_eq!(blank.model, None, "a blank value pins nothing");
+    }
+
+    /// A `tools:` mapping the flat parser cannot read must not resolve to
+    /// every tool.
+    ///
+    /// The frontmatter parser is tolerant on purpose, and for `description:`
+    /// or `model:` an unreadable value costs a fallback. For `tools:` it costs
+    /// the whole registry, because the parser leaves the key holding an empty
+    /// value, the children go to `nested_keys`, and an empty `tools:` is the
+    /// documented spelling of "all tools". The author asked for two tools and
+    /// was handed every one, silently.
+    #[test]
+    fn a_tools_mapping_is_refused_rather_than_read_as_every_tool() {
+        let raw =
+            "---\nname: reviewer\ndescription: d\ntools:\n  read: true\n  write: false\n---\nBody.";
+        let err = agent_from_file("/x/reviewer.md", raw).unwrap_err();
+        assert_eq!(err.problem, ExtensionProblem::NestedToolbelt);
+
+        let listed =
+            agent_from_file("/x/ok.md", "---\nname: ok\ntools: read, search\n---\nBody.").unwrap();
+        assert_eq!(
+            listed.tools,
+            Some(vec!["read".to_string(), "search".to_string()]),
+            "an ordinary list still parses"
+        );
+        let bare = agent_from_file("/x/bare.md", "---\nname: bare\ntools:\n---\nBody.").unwrap();
+        assert_eq!(
+            bare.tools, None,
+            "a bare key with nothing under it is still all tools"
+        );
     }
 
     #[test]

--- a/crates/stella-core/src/redact.rs
+++ b/crates/stella-core/src/redact.rs
@@ -353,7 +353,47 @@ fn assigned_value(chars: &[char], i: usize) -> Option<(usize, usize, usize)> {
             .find(|&k| chars[k].is_whitespace() || matches!(chars[k], ',' | ';' | ')' | '}'))
             .unwrap_or(chars.len()),
     };
+    // `Authorization: Bearer <token>` carries the credential in its *second*
+    // word. Stopping at the first space hid the scheme and published the token,
+    // and still reported `redacted: true` — the one outcome this module says it
+    // must never produce, because a caller then believes the line is clean.
+    let (value_start, value_end) = match quote {
+        Some(_) => (value_start, value_end),
+        None => past_auth_scheme(chars, value_start, value_end),
+    };
     (value_end > value_start).then_some((separator, value_start, value_end))
+}
+
+/// The credential's span when an unquoted value begins with an auth scheme.
+///
+/// Returns the input span unchanged when the first word is not a scheme, or
+/// when nothing follows it — `Authorization: Bearer` on its own has only the
+/// scheme to hide.
+fn past_auth_scheme(chars: &[char], value_start: usize, value_end: usize) -> (usize, usize) {
+    const SCHEMES: [&str; 4] = ["bearer", "basic", "token", "digest"];
+    let word: String = chars[value_start..value_end]
+        .iter()
+        .flat_map(|c| c.to_lowercase())
+        .collect();
+    if !SCHEMES.contains(&word.as_str()) {
+        return (value_start, value_end);
+    }
+    let mut j = value_end;
+    while matches!(chars.get(j), Some(' ') | Some('\t')) {
+        j += 1;
+    }
+    let credential = j;
+    while chars
+        .get(j)
+        .is_some_and(|c| !c.is_whitespace() && !matches!(c, ',' | ';' | ')' | '}'))
+    {
+        j += 1;
+    }
+    if j > credential {
+        (credential, j)
+    } else {
+        (value_start, value_end)
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-core/src/redact/tests.rs
+++ b/crates/stella-core/src/redact/tests.rs
@@ -106,6 +106,34 @@ fn sensitive_key_assignments_are_redacted_whatever_the_value_looks_like() {
     }
 }
 
+/// An auth header puts the credential in its second word, so stopping the
+/// value at the first space hid the scheme and published the token.
+///
+/// The token is not recognizable on its own evidence either: the entropy rule
+/// needs 32 characters and all three of upper, lower and digit, so a short or
+/// single-case token falls through both rules. Worse than missing it, the
+/// result still reported `redacted: true`, because rewriting `Bearer` did
+/// change the text — a caller reading that flag believes the line is clean.
+#[test]
+fn the_credential_after_an_auth_scheme_is_redacted_not_the_scheme_word() {
+    for (input, secret) in [
+        (
+            "Authorization: Bearer abcdefghij1234567890",
+            "abcdefghij1234567890",
+        ),
+        ("authorization: Basic dXNlcjpwYXNz", "dXNlcjpwYXNz"),
+        ("Authorization: Token deadbeefcafe, retry", "deadbeefcafe"),
+    ] {
+        assert_redacted(input, secret);
+    }
+    assert!(
+        redact_secrets("Authorization: Bearer abcdefghij1234567890")
+            .text
+            .contains("Bearer"),
+        "the scheme is not the secret and stays readable"
+    );
+}
+
 /// `*_env` names the environment variable to read a secret FROM, not the
 /// secret — the same exemption the settings scrubber makes.
 #[test]

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -107,9 +107,11 @@
 //! It re-exports and documents; it opens no sockets, spawns no processes and
 //! touches no files, exactly like the `stella-core` it fronts. Everything the
 //! engine needs from the outside world arrives through the ports
-//! ([`Provider`], [`ToolExecutor`], [`TurnGate`], [`TurnSteering`],
-//! [`SteeringRequery`], [`TurnHalt`], [`ProviderOutcomes`],
+//! ([`Provider`], [`ToolExecutor`], [`Sleeper`], [`TurnGate`],
+//! [`TurnSteering`], [`SteeringRequery`], [`TurnHalt`], [`ProviderOutcomes`],
 //! [`FallbackResolver`], [`CheckpointSink`]), which the host implements.
+//! [`Sleeper`] is first among them in practice: [`Engine::with_sleeper`] is the
+//! only constructor and takes one, where every other port is optional.
 //!
 //! # What earns a re-export: the closure rule
 //!
@@ -239,13 +241,30 @@ pub use stella_core::loop_detect::LoopDetectionConfig;
 // which is the second-source-of-truth defect `Engine::max_steps` exists to
 // avoid.
 pub use stella_core::budget::{BudgetAxis, BudgetGuard, BudgetOutcome, DeadlineOutcome};
+// The `ToolExecutor` half is obligation 1 read at the method level, which the
+// two earlier passes did not reach. Four of its methods carry a
+// "# Decorators MUST forward this" section, and a host that wraps its own
+// executor — a tap, a filter, a policy layer — could name none of their types
+// here: `WaitRequest`, `LiveService`, `DispatchGate` and `ToolContract`. Each
+// has a trait default, so the wrapper compiles clean and silently takes the
+// default instead of the inner executor's answer: parked waits are dropped and
+// the model goes back to burning steps on polling, the end-of-turn
+// live-service assertion stops firing, and a dispatching decorator above the
+// tap finds no gate and goes ungated. `DispatchAdmission` and `admit_dispatch`
+// come with the gate, because forwarding it is only half of what the port asks
+// — a decorator that dispatches a name of its own has to run the admission.
 pub use stella_core::ports::{
-    FallbackResolver, ProviderOutcomes, ResolvedFallback, SteeringRequery, ToolExecutor, TurnGate,
-    TurnSteering,
+    DispatchAdmission, DispatchGate, FallbackResolver, LiveService, ProviderOutcomes,
+    ResolvedFallback, SteeringRequery, ToolExecutor, TurnGate, TurnSteering, admit_dispatch,
 };
 pub use stella_core::receipts::RECALL_MARKER;
 pub use stella_core::retry::{RetryPolicy, Sleeper};
 pub use stella_core::steering::TurnSignal;
+// `WaitCall` rides along because it is the type of `WaitRequest`'s public
+// `probe` and `on_wake` fields: a host that can name the request and not its
+// call can forward one but never build one, which is obligation 1 again one
+// field deeper.
+pub use stella_core::waiting::{WaitCall, WaitRequest};
 // Obligation 1 of the closure rule (stated in full in this module's docs, and
 // not restated here — a rule written twice is a rule that
 // drifts). `Provider` alone was not enough — `complete_ref` takes a
@@ -267,7 +286,7 @@ pub use stella_protocol::{
     AgentEvent, Attachment, AttachmentKind, AttachmentSource, BudgetMode, CompletionMessage,
     CompletionRequestRef, CompletionResult, CompletionUsage, FinishReason, GenerationParams,
     MessageRole, ModelCallRole, Provider, ProviderError, ReasoningEffort, ServiceTier, ToolCall,
-    ToolCallObserver, ToolOutput, ToolResult, ToolSchema, Verbosity,
+    ToolCallObserver, ToolContract, ToolOutput, ToolResult, ToolSchema, Verbosity,
 };
 
 /// Encode a checkpoint for durable storage.

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -106,21 +106,18 @@
 //!
 //! It re-exports and documents; it opens no sockets, spawns no processes and
 //! touches no files, exactly like the `stella-core` it fronts. Everything the
-//! engine needs from the outside world arrives through the ports
-//! ([`Provider`], [`ToolExecutor`], [`Sleeper`], [`TurnGate`],
-//! [`TurnSteering`], [`SteeringRequery`], [`TurnHalt`], [`ProviderOutcomes`],
-//! [`FallbackResolver`], [`CheckpointSink`]), which the host implements.
-//! [`Sleeper`] is first among them in practice: [`Engine::with_sleeper`] is the
-//! only constructor and takes one, where every other port is optional.
+//! engine needs from the outside world arrives through the ports, which the
+//! host implements: [`Sleeper`], which [`Engine::with_sleeper`] requires
+//! because it is the only constructor, and then [`Provider`],
+//! [`ToolExecutor`], [`TurnGate`], [`TurnSteering`], [`SteeringRequery`],
+//! [`TurnHalt`], [`ProviderOutcomes`], [`FallbackResolver`] and
+//! [`CheckpointSink`], each of which is optional.
 //!
 //! # What earns a re-export: the closure rule
 //!
-//! This is the crate's whole editorial policy, and it is stated here and in
-//! `README.md` in the same words — the two used to disagree, one
-//! saying a re-export is earned only when a host "genuinely cannot drive a
-//! turn without it" and the other stating a strictly wider per-port closure,
-//! which left `Engine::with_requery` reachable through the facade and
-//! unusable through it (#3715).
+//! This is the crate's whole editorial policy, and `README.md` states it in
+//! the same words. A narrower rule in one of the two places is what leaves a
+//! builder reachable through the facade and uncallable through it.
 //!
 //! **The rule.** A host must be able to write, naming nothing but
 //! `stella_engine::` paths:

--- a/crates/stella-engine/tests/embedding.rs
+++ b/crates/stella-engine/tests/embedding.rs
@@ -45,9 +45,10 @@ use tokio::sync::mpsc;
 
 use stella_engine::{
     AbortKind, AgentEvent, BudgetGuard, BudgetMode, CheckpointSink, CompletionMessage,
-    CompletionRequestRef, CompletionResult, CompletionUsage, Engine, EngineConfig, Provider,
-    ProviderError, RECALL_MARKER, Sleeper, SteeringRequery, ToolCall, ToolExecutor, ToolOutput,
-    ToolSchema, TurnOutcome, TurnSignal,
+    CompletionRequestRef, CompletionResult, CompletionUsage, DispatchAdmission, DispatchGate,
+    Engine, EngineConfig, LiveService, Provider, ProviderError, RECALL_MARKER, Sleeper,
+    SteeringRequery, ToolCall, ToolContract, ToolExecutor, ToolOutput, ToolSchema, TurnOutcome,
+    TurnSignal, WaitCall, WaitRequest, admit_dispatch,
 };
 
 /// The one tool the host advertises. Its only job is to make the model's first
@@ -172,6 +173,135 @@ impl ToolExecutor for HostTools {
             .push(name.to_string());
         ToolOutput::ok("probed".to_string())
     }
+}
+
+/// An executor that answers every forwardable method with something other
+/// than its default, so a wrapper that drops one is visible.
+#[derive(Default)]
+struct LoadedTools {
+    inner: HostTools,
+}
+
+#[async_trait]
+impl ToolExecutor for LoadedTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        self.inner.schemas()
+    }
+
+    async fn execute(&self, name: &str, input: &serde_json::Value) -> ToolOutput {
+        self.inner.execute(name, input).await
+    }
+
+    fn drain_wait_request(&self) -> Option<WaitRequest> {
+        Some(WaitRequest {
+            description: "CI settles".to_string(),
+            probe: WaitCall {
+                name: HOST_TOOL.to_string(),
+                input: serde_json::json!({}),
+            },
+            baseline: "red".to_string(),
+            on_wake: None,
+            poll_interval_secs: 30,
+            timeout_secs: 600,
+        })
+    }
+
+    fn live_services(&self) -> Vec<LiveService> {
+        vec![LiveService {
+            handle: "proc-3".to_string(),
+            name: Some("dev server".to_string()),
+            display: "npm run dev".to_string(),
+        }]
+    }
+
+    fn dispatch_gate(&self) -> Option<&dyn DispatchGate> {
+        Some(&RefusingGate)
+    }
+}
+
+/// A gate that refuses everything, so "the gate was forwarded" and "no gate
+/// was found" cannot be confused for one another.
+struct RefusingGate;
+
+#[async_trait]
+impl DispatchGate for RefusingGate {
+    async fn admit(&self, _name: &str, _input: &serde_json::Value) -> DispatchAdmission {
+        DispatchAdmission::Refuse(ToolOutput::error("refused by the host's gate".to_string()))
+    }
+}
+
+/// The wrapper a host writes: a tap that adds behaviour of its own and
+/// forwards the rest.
+///
+/// Four of `ToolExecutor`'s methods carry a "# Decorators MUST forward this"
+/// section, and each has a trait default, so a wrapper that cannot name their
+/// types compiles clean and silently answers the default. Writing this impl
+/// through the facade is half the assertion; the test below is the other half.
+struct HostTap<'a> {
+    inner: &'a dyn ToolExecutor,
+}
+
+#[async_trait]
+impl ToolExecutor for HostTap<'_> {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        self.inner.schemas()
+    }
+
+    fn contracts(&self) -> Vec<ToolContract> {
+        self.inner.contracts()
+    }
+
+    async fn execute(&self, name: &str, input: &serde_json::Value) -> ToolOutput {
+        self.inner.execute(name, input).await
+    }
+
+    fn drain_wait_request(&self) -> Option<WaitRequest> {
+        self.inner.drain_wait_request()
+    }
+
+    fn live_services(&self) -> Vec<LiveService> {
+        self.inner.live_services()
+    }
+
+    fn dispatch_gate(&self) -> Option<&dyn DispatchGate> {
+        self.inner.dispatch_gate()
+    }
+}
+
+/// A host can wrap its own tool surface without losing the four mechanisms
+/// the port tells decorators to forward.
+///
+/// Before the facade exported these types the impl above could not be
+/// written at all: `WaitRequest`, `LiveService`, `DispatchGate` and
+/// `ToolContract` were unspellable here, so a host's tap took the trait
+/// defaults. Parked waits were dropped and the model went back to burning
+/// steps on polling, the end-of-turn live-service assertion stopped firing,
+/// and a dispatching decorator above the tap found no gate and ran ungated.
+#[tokio::test]
+async fn a_host_can_wrap_its_tool_surface_without_dropping_what_the_port_forwards() {
+    let base = LoadedTools::default();
+    let tap = HostTap { inner: &base };
+
+    let parked = tap.drain_wait_request().expect("the wait request survives");
+    assert_eq!(parked.description, "CI settles");
+    assert_eq!(parked.probe.name, HOST_TOOL);
+
+    let live = tap.live_services();
+    assert_eq!(live.len(), 1, "the live service survives");
+    assert_eq!(live[0].handle, "proc-3");
+
+    assert_eq!(
+        tap.contracts().len(),
+        tap.schemas().len(),
+        "every advertised tool still carries a contract"
+    );
+
+    let admitted = admit_dispatch(tap.dispatch_gate(), HOST_TOOL, &serde_json::json!({})).await;
+    assert!(
+        matches!(admitted, DispatchAdmission::Refuse(_)),
+        "the gate is forwarded, so the dispatch is still governed — a dropped \
+         gate reads as `Admit` and the call runs ungated"
+    );
 }
 
 struct NoopSleeper;

--- a/crates/stella-home/src/lib.rs
+++ b/crates/stella-home/src/lib.rs
@@ -93,9 +93,12 @@ pub fn home_dir() -> Option<PathBuf> {
 }
 
 /// [`home_dir`] over anchors the caller supplies.
+///
+/// An empty `HOME` falls through to `USERPROFILE` rather than resolving to the
+/// working directory — see [`anchor`].
 #[must_use]
 pub fn resolve_home_dir(home: Option<OsString>, userprofile: Option<OsString>) -> Option<PathBuf> {
-    home.or(userprofile).map(PathBuf::from)
+    anchor(home).or(anchor(userprofile)).map(PathBuf::from)
 }
 
 /// The stella home: `$STELLA_HOME`, else `~/.stella`. `None` only when no
@@ -106,12 +109,15 @@ pub fn stella_home() -> Option<PathBuf> {
 }
 
 /// [`stella_home`] over anchors the caller supplies.
+///
+/// An empty `STELLA_HOME` resolves to `~/.stella`, not to the working
+/// directory — see [`anchor`].
 #[must_use]
 pub fn resolve_stella_home(
     stella_home: Option<OsString>,
     home: Option<PathBuf>,
 ) -> Option<PathBuf> {
-    match stella_home {
+    match anchor(stella_home) {
         Some(dir) => Some(PathBuf::from(dir)),
         None => home.map(|home| home.join(DOT_STELLA)),
     }
@@ -131,9 +137,13 @@ pub fn data_dir() -> PathBuf {
 }
 
 /// [`data_dir`] over anchors the caller supplies.
+///
+/// An empty `STELLA_DATA_DIR` falls through to the stella home — see
+/// [`anchor`]. The current-directory fallback is reached only when no home is
+/// discoverable at all, never because a variable was exported blank.
 #[must_use]
 pub fn resolve_data_dir(data_dir: Option<OsString>, stella_home: Option<PathBuf>) -> PathBuf {
-    match data_dir {
+    match anchor(data_dir) {
         Some(dir) => PathBuf::from(dir),
         None => stella_home.unwrap_or_else(|| PathBuf::from(".")),
     }
@@ -172,14 +182,19 @@ pub fn systemd_user_unit_dir() -> Option<PathBuf> {
 }
 
 /// [`systemd_user_unit_dir`] over anchors the caller supplies.
+///
+/// The XDG spec requires an absolute path and says an empty or relative one is
+/// invalid and must be ignored, so both fall back to `~/.config`. A relative
+/// value honoured verbatim would write the unit file beside whatever directory
+/// the operator was standing in, where `systemctl --user` never looks.
 #[must_use]
 pub fn resolve_systemd_user_unit_dir(
     xdg_config_home: Option<OsString>,
     home: Option<PathBuf>,
 ) -> Option<PathBuf> {
-    let config = match xdg_config_home {
-        Some(dir) => PathBuf::from(dir),
-        None => home?.join(".config"),
+    let config = match anchor(xdg_config_home).map(PathBuf::from) {
+        Some(dir) if dir.is_absolute() => dir,
+        _ => home?.join(".config"),
     };
     Some(config.join("systemd").join("user"))
 }
@@ -233,7 +248,7 @@ pub const WORKSPACE_STATE_ROOT_ENV: &str = "STELLA_WORKSPACE_STATE_ROOT";
 /// Where a workspace's `.stella` lives, honouring [`WORKSPACE_STATE_ROOT_ENV`].
 #[must_use]
 pub fn workspace_state_root(workspace_root: &std::path::Path) -> PathBuf {
-    resolve_workspace_state_root(std::env::var_os(WORKSPACE_STATE_ROOT_ENV), workspace_root)
+    resolve_workspace_state_root(read(WORKSPACE_STATE_ROOT_ENV), workspace_root)
 }
 
 /// [`workspace_state_root`] over the value the caller supplies.
@@ -331,14 +346,34 @@ pub fn resolve_legacy_self_driving_roots(
 /// resolver, so a process that set it declined the migration while every
 /// path it opened still resolved to the defaults. Keeping the list exact is
 /// what makes this predicate mean what it says.
+/// An exported-but-empty variable redirects nothing, so it does not count as
+/// set here either. Counting one would decline the migration for a process
+/// whose paths all resolve to the defaults — the same failure an inert name on
+/// the list causes, reached through the value instead.
 #[must_use]
 pub fn any_override_set() -> bool {
-    OVERRIDE_ENV_VARS.iter().any(|var| read(var).is_some())
+    OVERRIDE_ENV_VARS
+        .iter()
+        .any(|var| anchor(read(var)).is_some())
 }
 
 /// The single point in this crate that touches the process environment.
 fn read(var: &str) -> Option<OsString> {
     std::env::var_os(var)
+}
+
+/// An override exported with an empty value, read as unset.
+///
+/// `STELLA_HOME=` is what a shell hands a process for an unset-but-exported
+/// variable, and `std::env::var_os` reports it as `Some("")` rather than
+/// `None`. Honouring it makes every user-tier path relative: `credentials.toml`
+/// is written into whatever repository happens to be open, `usage.db` becomes a
+/// different file per working directory, and `resolve_user_plugins_dir` returns
+/// the relative `plugins` its own contract forbids. Applied in the pure halves
+/// rather than in [`read`] so a host that supplies its own anchors gets the
+/// same answer as the wrappers.
+fn anchor(value: Option<OsString>) -> Option<OsString> {
+    value.filter(|value| !value.is_empty())
 }
 
 #[cfg(test)]
@@ -392,6 +427,71 @@ mod tests {
                 "{rejected:?} is not a durable root and must not be honoured"
             );
         }
+    }
+
+    /// The same rule for the user tier, which had it in neither half.
+    ///
+    /// `STELLA_HOME=` is what a shell hands a process for an unset-but-exported
+    /// variable. Honoured verbatim it wrote `credentials.toml` — provider API
+    /// keys — into whatever repository happened to be open, gave every working
+    /// directory a `usage.db` of its own, and made `resolve_user_plugins_dir`
+    /// return the relative `plugins` path its own contract forbids.
+    #[test]
+    fn an_empty_override_is_read_as_unset_not_as_the_working_directory() {
+        let home = Some(PathBuf::from("/home/dev"));
+        assert_eq!(
+            resolve_stella_home(os(""), home.clone()),
+            Some(PathBuf::from("/home/dev/.stella")),
+            "an exported-but-empty STELLA_HOME is not a home"
+        );
+        assert_eq!(
+            resolve_data_dir(os(""), resolve_stella_home(None, home)),
+            PathBuf::from("/home/dev/.stella"),
+            "nor is an exported-but-empty STELLA_DATA_DIR a data dir"
+        );
+        assert_eq!(
+            resolve_home_dir(os(""), os("C:\\Users\\dev")),
+            Some(PathBuf::from("C:\\Users\\dev")),
+            "an empty HOME falls through to the Windows spelling"
+        );
+        assert_eq!(
+            resolve_home_dir(os(""), None),
+            None,
+            "and to no path at all when there is nothing left to fall through to"
+        );
+        assert_eq!(
+            resolve_user_plugins_dir(resolve_stella_home(os(""), None)),
+            None,
+            "no home means no user tier, never a relative `plugins` directory \
+             that installs third-party code into whatever repository is open"
+        );
+    }
+
+    /// The XDG spec requires an absolute path and says an empty or relative one
+    /// is invalid and must be ignored.
+    ///
+    /// Honoured verbatim, a relative value writes the unit file beside the
+    /// operator's working directory, where `systemctl --user` never looks — and
+    /// the installer prints the path it wrote and exits 0.
+    #[test]
+    fn an_unusable_xdg_config_home_falls_back_to_the_default() {
+        let home = Some(PathBuf::from("/home/dev"));
+        for rejected in ["", ".config", "relative/config"] {
+            assert_eq!(
+                resolve_systemd_user_unit_dir(os(rejected), home.clone()),
+                Some(PathBuf::from("/home/dev/.config/systemd/user")),
+                "{rejected:?} is not a usable XDG_CONFIG_HOME"
+            );
+        }
+    }
+
+    /// The predicate `any_override_set` composes with [`read`] to answer
+    /// whether resolution is redirected.
+    #[test]
+    fn an_exported_empty_value_is_not_an_anchor() {
+        assert_eq!(anchor(os("")), None, "exported blank names no directory");
+        assert_eq!(anchor(os("/srv/stella")), os("/srv/stella"));
+        assert_eq!(anchor(None), None);
     }
 
     #[test]

--- a/crates/stella-home/src/lib.rs
+++ b/crates/stella-home/src/lib.rs
@@ -95,7 +95,7 @@ pub fn home_dir() -> Option<PathBuf> {
 /// [`home_dir`] over anchors the caller supplies.
 ///
 /// An empty `HOME` falls through to `USERPROFILE` rather than resolving to the
-/// working directory — see [`anchor`].
+/// working directory: a variable exported with no value names no directory.
 #[must_use]
 pub fn resolve_home_dir(home: Option<OsString>, userprofile: Option<OsString>) -> Option<PathBuf> {
     anchor(home).or(anchor(userprofile)).map(PathBuf::from)
@@ -111,7 +111,7 @@ pub fn stella_home() -> Option<PathBuf> {
 /// [`stella_home`] over anchors the caller supplies.
 ///
 /// An empty `STELLA_HOME` resolves to `~/.stella`, not to the working
-/// directory — see [`anchor`].
+/// directory: a variable exported with no value names no directory.
 #[must_use]
 pub fn resolve_stella_home(
     stella_home: Option<OsString>,
@@ -138,9 +138,10 @@ pub fn data_dir() -> PathBuf {
 
 /// [`data_dir`] over anchors the caller supplies.
 ///
-/// An empty `STELLA_DATA_DIR` falls through to the stella home — see
-/// [`anchor`]. The current-directory fallback is reached only when no home is
-/// discoverable at all, never because a variable was exported blank.
+/// An empty `STELLA_DATA_DIR` falls through to the stella home: a variable
+/// exported with no value names no directory. The current-directory fallback is
+/// reached only when no home is discoverable at all, never because a variable
+/// was exported blank.
 #[must_use]
 pub fn resolve_data_dir(data_dir: Option<OsString>, stella_home: Option<PathBuf>) -> PathBuf {
     match anchor(data_dir) {

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -681,7 +681,7 @@ impl PluginManifest {
         // among them: a panel is drawn between turns, so no standing inside one
         // could be required of it.
         if let Some(panel) = &self.panel {
-            panel.validate()?;
+            panel.validate(&self.name)?;
         }
 
         if grant.hooks.contains(&HookEvent::Stop) && !participation.includes(Participation::Arbiter)

--- a/crates/stella-plugin/src/panel.rs
+++ b/crates/stella-plugin/src/panel.rs
@@ -345,19 +345,30 @@ impl PanelGrant {
     /// register, [`ManifestError::DuplicatePanelDenial`] for a repeated limit,
     /// [`ManifestError::PanelDenialMissing`] for one the block never names, and
     /// whatever `[panel.process]` refuses.
-    pub fn validate(&self) -> Result<(), ManifestError> {
+    /// `plugin_id` is required because the slash name this grant registers is
+    /// [`PanelGrant::command_or`]'s answer, not the `command` field: an
+    /// undeclared name resolves to the plugin's own. Checking only a declared
+    /// one left the derived name unchecked, so a plugin named `vera:admin`
+    /// registered the namespace-shaped slash command
+    /// [`ManifestError::PanelCommandCarriesNamespace`] exists to refuse, and a
+    /// name with spaces or capitals registered a command nobody can type.
+    pub fn validate(&self, plugin_id: &str) -> Result<(), ManifestError> {
         if self.surfaces.is_empty() {
             return Err(ManifestError::PanelNoSurface);
         }
         if let Some(surface) = self.duplicate_surface() {
             return Err(ManifestError::PanelDuplicateSurface { surface });
         }
-        if let Some(command) = &self.command {
-            if !self.draws(PanelSurface::Command) {
-                return Err(ManifestError::PanelCommandWithoutSurface {
-                    command: command.clone(),
-                });
-            }
+        // Declaring a name for a popup that does not exist is a mistake only an
+        // author can make, so it stays keyed on the declared field.
+        if let Some(command) = &self.command
+            && !self.draws(PanelSurface::Command)
+        {
+            return Err(ManifestError::PanelCommandWithoutSurface {
+                command: command.clone(),
+            });
+        }
+        if let Some(command) = self.command_or(plugin_id) {
             validate_panel_command(command)?;
         }
         let mut seen = HashSet::with_capacity(self.denies.len());
@@ -1239,16 +1250,58 @@ mod tests {
     #[test]
     fn a_panel_that_draws_nowhere_is_refused() {
         assert!(matches!(
-            grant(Vec::new()).validate(),
+            grant(Vec::new()).validate("gates"),
             Err(ManifestError::PanelNoSurface)
         ));
         assert!(matches!(
-            grant(vec![PanelSurface::Settings, PanelSurface::Settings]).validate(),
+            grant(vec![PanelSurface::Settings, PanelSurface::Settings]).validate("gates"),
             Err(ManifestError::PanelDuplicateSurface {
                 surface: PanelSurface::Settings
             })
         ));
-        assert!(grant(vec![PanelSurface::Settings]).validate().is_ok());
+        assert!(
+            grant(vec![PanelSurface::Settings])
+                .validate("gates")
+                .is_ok()
+        );
+    }
+
+    /// The name a panel registers is the one `command_or` resolves, so the
+    /// derived name is held to the same shape rules as a declared one.
+    ///
+    /// A plugin that declares no `command` registers its own name. Left
+    /// unchecked, `name = "vera:admin"` bought the namespace-shaped slash
+    /// command the explicit path refuses by its own dedicated error, and the
+    /// consent document then told the reader the panel answers to
+    /// `/vera:admin` and to `/vera:admin:vera:admin`. The plugin name itself
+    /// is only checked for control characters, so spaces and capitals got
+    /// through too and registered a command nobody can type.
+    #[test]
+    fn a_derived_slash_name_is_held_to_the_same_shape_as_a_declared_one() {
+        let derived = |name: &str| grant(vec![PanelSurface::Command]).validate(name);
+
+        assert!(
+            matches!(
+                derived("vera:admin"),
+                Err(ManifestError::PanelCommandCarriesNamespace { .. })
+            ),
+            "a plugin cannot buy the alias namespace by spelling it in its name"
+        );
+        assert!(matches!(
+            derived("Vera Admin"),
+            Err(ManifestError::PanelCommandNotASlug { .. })
+        ));
+        assert!(
+            derived("vera").is_ok(),
+            "an ordinary slug name still passes"
+        );
+        assert!(
+            grant(vec![PanelSurface::Settings])
+                .validate("vera:admin")
+                .is_ok(),
+            "a panel with no popup registers no name, so its plugin's name is \
+             not a slash command and is not judged as one"
+        );
     }
 
     #[test]

--- a/crates/stella-runtime/src/wrapper/candidate_fanout.rs
+++ b/crates/stella-runtime/src/wrapper/candidate_fanout.rs
@@ -693,7 +693,12 @@ impl<W: CandidateWorkspaces> CandidateFanoutPlane for CandidateFanouts<W> {
         // `max(1)` rather than a refusal for a zero width: a plugin asking for
         // no candidates has asked for nothing, and the honest answer to an ask
         // is the clamp, not an error (`RecallArgs::limit`'s discipline).
-        let width = args.width.clamp(1, self.max_width());
+        //
+        // `min` then `max`, not `clamp`: the floor is a literal and the ceiling
+        // is the host's, and `with_max_width(0)` would make `clamp` assert
+        // `min <= max` and panic. The floor is what a zero of either kind
+        // means, so it wins over a zero ceiling too.
+        let width = args.width.min(self.max_width()).max(1);
         let share = self.budget_usd.map(|budget| budget / f64::from(width));
 
         // Creation is sequential and the turns are not. Two isolation

--- a/crates/stella-runtime/tests/wrapper_candidate_fanout.rs
+++ b/crates/stella-runtime/tests/wrapper_candidate_fanout.rs
@@ -440,6 +440,32 @@ async fn a_width_over_the_ceiling_is_clamped_and_the_clamp_is_reported_back() {
     assert_eq!(plane.spends()[0].width, 3);
 }
 
+/// A host that caps the width at zero gets one candidate, not a panic.
+///
+/// `with_max_width` is public and has no floor, and the width was resolved with
+/// `clamp(1, max_width())` — `clamp` asserts `min <= max`, so a ceiling of zero
+/// made the assertion fail rather than the clamp apply. The floor is what a
+/// zero of either kind means: the surrounding comment already argued that a
+/// plugin asking for no candidates gets the clamp rather than an error, and a
+/// host offering room for none is the same question from the other side.
+#[tokio::test]
+async fn a_zero_host_width_ceiling_floors_the_fanout_instead_of_panicking() {
+    use stella_runtime::wrapper::CandidateFanoutPlane;
+
+    let manifest = manifest();
+    let plane = CandidateFanouts::declare(&manifest, Substrate::default()).with_max_width(0);
+    let result = plane
+        .fanout(stella_plugin::CandidateFanoutArgs {
+            role: "attempt".to_string(),
+            instruction: "try it".to_string(),
+            width: 3,
+        })
+        .await
+        .expect("a zero ceiling clamps rather than refusing");
+    assert_eq!(result.candidates.len(), 1);
+    assert_eq!(plane.spends()[0].width, 1);
+}
+
 /// The allowance bounds the whole run, not the point. A ceiling that refreshed
 /// per point would be no ceiling at all across N rounds — the shape a hold
 /// allowance that resets would have.

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -134,14 +134,22 @@ impl SubAgentPolicy {
         if !self.enabled || !requested.enabled {
             return None;
         }
+        // Floored once, so both branches below answer the same ceiling, and
+        // `min`/`max` rather than `clamp`: `clamp` asserts `min <= max`, and
+        // the floor here is a literal while the ceiling is a `pub` field no
+        // constructor validates. `max_child_steps: 0` — a plausible reading of
+        // "cap children at nothing" — panicked on any request that named
+        // `max_steps`, and the release profile builds with `panic = "abort"`,
+        // so that ends the whole server rather than the one request.
+        let child_ceiling = self.max_child_steps.max(1);
         Some(EffectiveSubAgents {
             pool_usd: requested
                 .pool_limit_usd
                 .map_or(self.max_pool_usd, |asked| asked.min(self.max_pool_usd))
                 .max(0.0),
-            child_steps: requested.max_steps.map_or(self.max_child_steps, |asked| {
-                asked.clamp(1, self.max_child_steps)
-            }),
+            child_steps: requested
+                .max_steps
+                .map_or(child_ceiling, |asked| asked.max(1).min(child_ceiling)),
             provider_id: requested.provider_id,
         })
     }
@@ -1042,6 +1050,42 @@ mod tests {
         assert_eq!(effective.pool_usd, 0.25);
         assert_eq!(effective.child_steps, 4);
         assert_eq!(effective.provider_id, None);
+    }
+
+    /// The same reading applied to the operator's own ceiling.
+    ///
+    /// `max_child_steps` is a `pub` field no constructor validates, so an
+    /// operator reading it as "cap children at nothing" can set it to zero.
+    /// The ceiling reached `clamp(1, 0)`, which asserts `min <= max` and
+    /// panicked on any request naming `max_steps` — and the release profile
+    /// sets `panic = "abort"`, so that ended the server rather than the
+    /// request. Both branches answer the floored ceiling, so an unasked
+    /// request and an asked one cannot disagree.
+    #[test]
+    fn a_zero_operator_ceiling_floors_at_one_instead_of_panicking() {
+        let zeroed = SubAgentPolicy {
+            max_child_steps: 0,
+            ..SubAgentPolicy::allowed()
+        };
+        let asked = zeroed
+            .clamp(SubAgentRequest {
+                enabled: true,
+                max_steps: Some(5),
+                ..SubAgentRequest::default()
+            })
+            .expect("allowed");
+        assert_eq!(asked.child_steps, 1);
+
+        let unasked = zeroed
+            .clamp(SubAgentRequest {
+                enabled: true,
+                ..SubAgentRequest::default()
+            })
+            .expect("allowed");
+        assert_eq!(
+            unasked.child_steps, 1,
+            "naming max_steps or not must not change the ceiling"
+        );
     }
 
     /// Zero steps is not a request for a zero-step child (which would abort

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -1146,6 +1146,16 @@ impl ToolExecutor for CustomToolSet<'_> {
     fn parallel_safe_names(&self) -> std::collections::HashSet<String> {
         self.inner.get().parallel_safe_names()
     }
+
+    /// Forwarded: a decorator that let the empty default stand would silently
+    /// stop a live skill's procedure text surviving overflow summarization for
+    /// every surface composed through it (see the port's contract). This set
+    /// sits between the policy layer and the registry whenever a workspace has
+    /// any custom tool at all, so it is on the shipped path, and it was the one
+    /// forward in this impl that was missing.
+    fn active_skill_slugs(&self) -> Vec<String> {
+        self.inner.get().active_skill_slugs()
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-tools/src/custom/tests.rs
+++ b/crates/stella-tools/src/custom/tests.rs
@@ -408,6 +408,56 @@ impl ToolExecutor for FakeInner {
     }
 }
 
+/// An inner executor that answers every forwardable method with something
+/// other than its default, so a decorator that drops one is visible.
+struct LoadedInner;
+
+#[async_trait]
+impl ToolExecutor for LoadedInner {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        FakeInner.schemas()
+    }
+    async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
+        FakeInner.execute(name, input).await
+    }
+    fn active_skill_slugs(&self) -> Vec<String> {
+        vec!["release-checklist".to_string()]
+    }
+    fn live_services(&self) -> Vec<stella_core::LiveService> {
+        vec![stella_core::LiveService {
+            handle: "proc-3".to_string(),
+            name: None,
+            display: "npm run dev".to_string(),
+        }]
+    }
+}
+
+/// Every method the port tells a decorator to forward, checked together.
+///
+/// Each has a trait default that reads as "this executor mounts none of that"
+/// — right for a leaf, wrong for a wrapper — so a dropped forward compiles
+/// clean and answers the default. `active_skill_slugs` was the one this set
+/// dropped: a live skill's procedure text stopped surviving overflow
+/// summarization for any workspace that also had a custom tool installed.
+#[tokio::test]
+async fn the_set_forwards_what_a_decorator_must() {
+    let dir = tempfile::tempdir().unwrap();
+    let tool = script_tool(dir.path(), "s.sh", "#!/bin/sh\necho hi\n");
+    let inner = LoadedInner;
+    let set = CustomToolSet::new(&inner, vec![tool], dir.path().to_path_buf());
+
+    assert_eq!(
+        set.active_skill_slugs(),
+        vec!["release-checklist".to_string()],
+        "a live skill invocation must survive the custom set"
+    );
+    assert_eq!(
+        set.live_services().len(),
+        1,
+        "so must a still-running service"
+    );
+}
+
 #[tokio::test]
 async fn set_advertises_inner_plus_custom_schemas() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/stella-tui/src/panel_guard.rs
+++ b/crates/stella-tui/src/panel_guard.rs
@@ -229,11 +229,19 @@ fn paint_error_card(buf: &mut Buffer, card: Rect, label: &str, message: &str) {
 // The test-only injection seam.
 //
 // The boundary needs a witness that panics inside a *real* `render_deck` band,
-// and no crafted `WorkspaceModel`/`DeckUi` produces one: every view indexes
-// through `get`/`saturating_*`, and `tests/render_robustness.rs` already sweeps
-// all nine tabs and every overlay across 121 geometries without a panic. So the
-// panic is injected at the one place a view's panic would surface — inside the
-// guarded closure, before the draw — and compiled out of every non-test build.
+// and a crafted `WorkspaceModel`/`DeckUi` is not a dependable way to get one:
+// the geometry sweep in `tests/render_robustness.rs` walks all nine tabs and
+// every overlay without a panic, because a view's panicking branch is usually
+// reached by view *state* the sweep does not set rather than by size alone. So
+// the panic is injected at the one place a view's panic would surface — inside
+// the guarded closure, before the draw — and compiled out of every non-test
+// build.
+//
+// Not "no view can panic": `views::skills` did, on a `clamp` whose floor
+// outranked its ceiling on any tab under eight rows, and only while the search
+// pane was live. A test that asks whether the draw *returned* cannot see such a
+// panic, because this boundary catches it — so the witness for one asserts the
+// band's own cells, not the absence of an unwind.
 //
 // It is one seam, not one per caller: `SessionFold::refresh` calls
 // [`fail_if_armed`] from inside its fold loop too, which is how the "commit the

--- a/crates/stella-tui/src/views/skills.rs
+++ b/crates/stella-tui/src/views/skills.rs
@@ -55,7 +55,13 @@ use crate::envelope::SkillRow;
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     let hits = ui.skills.hits.len();
     let registry_h = if ui.skills.focus == SkillsFocus::Search || hits > 0 || ui.skills.searching {
-        (hits as u16 + 4).clamp(4, area.height / 2)
+        // Half the tab at most, and no floor: `hits + 4` is already 4 or more,
+        // so a `clamp(4, ..)` bought nothing and panicked whenever the tab was
+        // shorter than eight rows, because `clamp` asserts `min <= max`.
+        u16::try_from(hits)
+            .unwrap_or(u16::MAX)
+            .saturating_add(4)
+            .min(area.height / 2)
     } else {
         2
     };

--- a/crates/stella-tui/tests/render_robustness.rs
+++ b/crates/stella-tui/tests/render_robustness.rs
@@ -41,6 +41,51 @@ fn tiny_terminals_never_panic() {
     }
 }
 
+/// The SKILLS tab sizes its registry band only while the search pane is live,
+/// so the geometry sweep above walked every size with that branch switched off.
+///
+/// Inside it, `(hits + 4).clamp(4, area.height / 2)` asserted `min <= max` and
+/// panicked on any tab shorter than eight rows — an ordinary window. The floor
+/// of 4 bought nothing, since `hits + 4` is already 4 or more.
+///
+/// The assertion is on the painted cells, not on `catch_unwind`: `guarded_band`
+/// catches a band's panic and paints an error card in its place, so a test that
+/// only asked whether the draw returned would pass against the panicking code.
+#[test]
+fn a_short_skills_tab_with_a_live_search_draws_instead_of_failing_into_the_error_card() {
+    let model = folded_model();
+    for h in [1u16, 2, 3, 4, 5, 6, 7, 8, 12, 24] {
+        for hits in [0usize, 1, 7] {
+            let mut ui = DeckUi::default();
+            ui.splash.skip();
+            ui.tab = DeckTab::Skills;
+            ui.skills.focus = stella_tui::deck_ui::SkillsFocus::Search;
+            ui.skills.searching = hits == 0;
+            ui.skills.hits = (0..hits)
+                .map(|n| stella_tui::envelope::SkillSearchHit {
+                    id: format!("skill-{n}"),
+                    installs: "12".to_string(),
+                    installs_rank: 12,
+                    url: "https://example.invalid".to_string(),
+                })
+                .collect();
+            let mut terminal = Terminal::new(TestBackend::new(60, h)).unwrap();
+            terminal.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
+            let buf = terminal.backend().buffer();
+            let area = *buf.area();
+            let text: String = (0..area.height)
+                .flat_map(|y| (0..area.width).map(move |x| (x, y)))
+                .map(|(x, y)| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+                .collect();
+            assert!(
+                !text.contains("panicked"),
+                "the skills band failed into the panic card on a {h}-row tab \
+                 with {hits} hits"
+            );
+        }
+    }
+}
+
 #[test]
 fn tiny_terminals_with_overlays_never_panic() {
     use stella_tui::deck_ui::cards::Card;


### PR DESCRIPTION
## What & why

A correctness audit of all 25 crates. Eleven defects were small enough to fix
with a witness test each, one commit per crate. Everything else the audit found
is filed rather than fixed here.

Closes #5489

### The defects

**`stella-home` — an env var exported with no value is read as a path.**
`std::env::var_os` reports `STELLA_HOME=` as `Some("")`, and every user-tier
resolver took it as a real anchor. `credential.rs` then writes
`credentials.toml` — provider API keys — into whatever repository is open,
`usage.rs` opens a different `usage.db` per working directory, and
`resolve_user_plugins_dir` returns the relative `plugins` path its own doc
comment forbids. `resolve_workspace_state_root` already filtered empty and
relative overrides; nothing else did. `any_override_set` moves with them, or it
would decline the legacy-layout migration for a process sitting on the defaults.
`XDG_CONFIG_HOME` also now refuses a relative path, which is what the XDG spec
its doc comment cites requires.

**`stella-core` — the credential after an auth scheme was published.**
`redact_secrets` ends an unquoted value at the first space, right for `KEY=value`
and wrong for `Authorization: Bearer <token>` — the shape a logged header or a
pasted curl command takes. It replaced `Bearer` and left the token. The other
rules do not catch it either: `is_high_entropy_blob` needs 32 characters plus
upper, lower and digit all present, so a short or single-case token falls
through. And because rewriting `Bearer` did change the text, the result reported
`redacted: true` while the secret was still in it — the one outcome the module's
own doc says it must never produce.

**`stella-core` — a `tools:` mapping granted every tool.** The flat frontmatter
parser cannot read a nested mapping, so it leaves the key holding an empty value
and diverts the children into `nested_keys`, which `extensions.rs` never reads.
An empty `tools:` is the documented spelling of "all tools", so an author writing
`tools:\n  read: true\n  write: false` was handed the whole registry with no
diagnostic. Tolerance is right for every other field and wrong for this one,
because this is the field where an unreadable value fails *open*. `rules.rs`
already refuses nested keys in the same parser for the same reason.

**`stella-engine` — a host cannot forward what `ToolExecutor` says it must.**
Four of the port's methods carry a "Decorators MUST forward this" section, and
the facade exported none of the types their signatures name (`WaitRequest`,
`LiveService`, `DispatchGate`, `ToolContract`). Each has a trait default, so a
host's tap compiled clean and answered the default: parked waits dropped and the
model back to polling, the end-of-turn live-service assertion off, and a
dispatching decorator above the tap running ungated. This is the closure rule
read at the method level, which the two earlier passes over this facade
(#1494, #3715) did not reach.

**`stella-tools` — `CustomToolSet` dropped one of its six forwards.**
`active_skill_slugs` fell through to the empty default, so a live skill's
procedure text stops surviving overflow summarization for any workspace that also
has a custom tool installed. Dormant today, since nothing populates the plane
yet — and dormant is how it would stay until the first executor that does.

**`stella-plugin` — a panel's derived slash name skipped every shape check.**
A panel with no `command` registers the plugin's own name, and `validate` only
checked a declared one. `name = "vera:admin"` takes the namespace-shaped command
`PanelCommandCarriesNamespace` exists to refuse, and the consent document then
tells the reader the panel answers to `/vera:admin` and to
`/vera:admin:vera:admin`. `validate` now takes the plugin id, so the question
cannot be asked without the value that answers it.

**`stella-core` — the live-service narration offered what the model was not.**
The operator's line said the engine was "asking the model to confirm or stop" a
still-running service; the message sent to the model says a live service cannot
be stopped, and the port's contract says asking must change nothing.

**Four `clamp(literal, variable)` panics.** `clamp` asserts `min <= max`, and in
each the floor is a literal while the ceiling is caller- or operator-supplied. A
workspace sweep found these four and no others:

- `stella-autonomy` `plan_cycle` — `SELF_DRIVING_BATCH_MAX=0` in the environment
  reaches `clamp(1, 0)` and crashes `stella self-driving plan`. `calibrate`, ten
  lines above, already takes the same untrusted numbers on a `min`/`max` chain
  and says why.
- `stella-tui` `views::skills` — `(hits + 4).clamp(4, area.height / 2)` panics on
  any tab under eight rows. The floor was redundant (`hits + 4` is already 4 or
  more), so it only ever supplied the panic.
- `stella-serve` `SubAgentPolicy::clamp` — `max_child_steps` is a `pub` field no
  constructor validates, so `0` panics on any request naming `max_steps`. The
  release profile sets `panic = "abort"` and the connection runs in a spawned
  task, so that ends the whole process, not the request.
- `stella-runtime` `CandidateFanouts` — `with_max_width(0)` is a public builder
  with no floor. No caller in the tree, so this is a public-API floor rather than
  a live defect, and it ships without a witness.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)
- [ ] No witness needed

Every witness was checked by reverting the production change with the test in
place and re-running, then restoring. Two are worth naming:

- The first draft of the `stella-tui` witness asserted `catch_unwind` returned
  `Ok`, and **passed against the panicking code** — `guarded_band` catches a
  band's panic and paints an error card in its place. It now asserts the band's
  painted cells.
- The first version of the `stella-serve` fix dropped the floor on the
  *requested* value and broke `a_zero_step_request_floors_at_one`. The ceiling
  and the request each keep their own floor now.

The `stella-runtime` builder floor is the one change with no witness, and its
commit says so.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p <crate> --all-targets -- -D warnings` for every touched crate
- [x] `cargo test -p <crate>` for every touched crate
- [x] `make prose` — green, and it needed a real edit rather than a baseline
      entry: the `stella-engine` header gained a line for `Sleeper` (the port
      list named nine optional ports and omitted the one that is mandatory), so
      the closure-rule paragraph gave up its account of what the two copies of
      that rule used to say and the issue number standing in for the reason.
- [x] Docs updated where behaviour changed. `panel_guard`'s comment claimed no
      crafted state can panic a view, which this PR disproves.
- [x] `Closes #5489` in this description and as a commit trailer.

Not run locally, per CLAUDE.md's "CI builds and tests; this laptop does not": the
workspace build, the workspace test suite, and `make gate`. That is the right
call and it cost something — the new `ExtensionProblem` variant broke two
exhaustive matches in `stella-cli`, which a per-crate clippy cannot see and CI
caught on the first run. Fixed in `fix(stella-cli): describe the new
nested-toolbelt refusal`.

## Nothing left behind

The audit raised far more than it fixed. Every remaining finding is filed as a
handoff, `triage` label only:

Defects — #5491 (the dashboard's live stream holds a one-shot connection permit
until the tab closes, and the accept loop wedges when the pool drains), #5493
(release builds abort on panic, so every panic boundary in the tree is inert
where it ships), #5494 (the search tool's fallback scan ignores `.gitignore`),
#5495 (a password inside a provider `base_url` is served to the dashboard
unredacted), #5496 (a malformed Anthropic tool-call start drops the call and the
turn reports none), #5497 (the code-graph watcher indexes files a symlink points
at outside the workspace), #5498 (a fleet worker's cost is never checked, so NaN
wedges the budget and a negative value bypasses it), #5499 (the two transcript
renderers each drop the other's honesty marker), #5500 (five dashboard numbers
are wrong), #5501 (two sessions in one process cannot use two different Vertex
projects), #5502 (`edit_file` writes from a stale snapshot, destroying a
concurrent write), #5503 (a failed checkpoint delete answers `200 deleted`),
#5504 (`GateBoard` renders unlabelled on the plain transcript, plus four false
README claims), #5505 (store corruption found after open loses its remedy),
#5508 (editing a memory from the Command Deck panics the session), #5509 (a
synthesized tool template drops a shell redirect), #5510 (an abandoned lease
makes the telemetry spool grow without bound), #5511 (five smaller findings),
#5516 (several turn aborts hand back a transcript the next provider call
rejects).

Next steps — #5512 (make a decorator that forgets to forward fail loudly),
#5513 (a guard for `clamp` with a literal floor and a computed ceiling), #5514
(property tests for compaction, eviction and budget), #5515 (check a consumer
ledger site still points at live code, while the ledger is clean).

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**This is one PR for nine crates rather than nine PRs.** The commits are one per
crate and touch disjoint files, so a rebase-merge preserves them and any one is
revertable alone; a squash-merge collapses them into a single commit spanning
nine crates. Say the word and I will split it.

The four `clamp` fixes all order the operations `min` then `max`, so the floor
wins over a nonsense zero ceiling. That is the reading each site's own comment
already argued for a zero *input*; this extends it to a zero *limit*.

Two of the eleven are the same shape one layer apart — a decorator silently
taking a trait default because no compiler can see the omission (`stella-engine`
and `stella-tools`). #5512 proposes the guard that would catch the next one.

## Summary by Sourcery

Harden workspace-wide correctness by fixing unsafe path resolution, secret redaction, tool and panel validation, decorator forwarding, user-facing narration, and panic-prone limit handling.

Bug Fixes:
- Prevent empty or invalid home and XDG overrides from redirecting user data into the working directory.
- Redact credentials that follow common authentication schemes instead of exposing the credential token.
- Reject nested `tools:` mappings that would otherwise silently grant every tool.
- Expose the complete `ToolExecutor` forwarding surface through the engine facade.
- Forward active skill slugs through custom tool sets.
- Validate panel names derived from plugin identifiers.
- Align live-service narration with the actions actually available to the model.
- Replace panic-prone limit handling across autonomy, runtime, serving, and TUI paths with safe flooring behavior.

Enhancements:
- Improve diagnostics for unsupported nested tool mappings and clarify engine port documentation.
- Update affected behavioral documentation and add targeted regression coverage for the audited defects.

Documentation:
- Document the mandatory sleeper port, corrected panel guard behavior, and updated closure-rule guidance.

Tests:
- Add witness tests covering environment overrides, authentication redaction, nested tool mappings, facade forwarding, panel command validation, live-service narration, and zero-limit handling.