### PR TITLE
feat(stella-cli): a context record changed mid-session reaches the next step boundary

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -1127,8 +1127,13 @@ pub async fn run_deck_session(
                         continue 'session;
                     }
                     // A steer at a worker, or one whose lead turn ended
-                    // before this recv read it — see `steer::steer_idle`.
-                    Some(WorkspaceInput::Steer { agent, texts }) if !texts.is_empty() => {
+                    // before this recv read it — see `steer::steer_idle`. An
+                    // interrupt landing here has nothing to stop, so it takes
+                    // the same "run this now" path.
+                    Some(
+                        WorkspaceInput::Steer { agent, texts }
+                        | WorkspaceInput::Interrupt { agent, texts },
+                    ) if !texts.is_empty() => {
                         match steer::steer_idle(&agent, &subs, &mut queue, texts, &in_tx) {
                             Some(first) => {
                                 dispatch.release();
@@ -1994,7 +1999,13 @@ pub async fn run_deck_session(
                         // Esc with something to say — see `steer`.
                         Some(WorkspaceInput::Steer { agent, texts }) if agent == LEAD =>
                             steer::steer_lead(&steering, &mut queue, texts),
-                        Some(WorkspaceInput::Steer { agent, texts }) =>
+                        // The composer's red mode: stop at the boundary, run the
+                        // words next. At a worker lane it lands as a steer — see
+                        // the envelope's `Interrupt` doc.
+                        Some(WorkspaceInput::Interrupt { agent, texts }) if agent == LEAD =>
+                            steer::interrupt_lead(&steering, &lead_pause, &mut queue, texts, &in_tx),
+                        Some(WorkspaceInput::Steer { agent, texts }
+                            | WorkspaceInput::Interrupt { agent, texts }) =>
                             steer::steer_worker(&subs, &mut queue, &agent, texts, &in_tx),
                         // An explicit front-insert stays a front-insert even
                         // if a turn started before it arrived — the deck's

--- a/crates/stella-cli/src/command_deck/steer.rs
+++ b/crates/stella-cli/src/command_deck/steer.rs
@@ -108,6 +108,33 @@ pub(super) fn steer_lead(tap: &SteeringTap, queue: &mut DurableQueue, texts: Vec
     }
 }
 
+/// Deliver the composer's red mode at the LEAD: the words are claimed and
+/// front-inserted so they run next — ahead of the parked backlog, which is
+/// what "interrupt" outranks — and the turn is asked to stop at its next
+/// boundary, keeping every completed step. Front-insertion happens before the
+/// stop is requested, so a turn that settles between the two still dispatches
+/// the words rather than losing them behind an older backlog.
+pub(super) fn interrupt_lead(
+    tap: &SteeringTap,
+    lead_pause: &super::lead_control::LeadPause,
+    queue: &mut DurableQueue,
+    texts: Vec<String>,
+    in_tx: &UnboundedSender<Inbound>,
+) {
+    for text in &texts {
+        claim(queue, text);
+    }
+    for text in texts.into_iter().rev() {
+        queue.push_front(unmarked(&text).to_string());
+    }
+    tap.request_soft_stop();
+    // A paused turn can never reach the stop's boundary on its own.
+    lead_pause.release_for_soft_stop();
+    let _ = in_tx.send(super::chrome_note(
+        "stopping at the next step boundary — your prompt runs next".to_string(),
+    ));
+}
+
 /// A plain stop (the first Esc) at a lead with prompts still parked: deliver
 /// the backlog into the running turn and keep it going. `false` when there
 /// was nothing parked, so the caller's soft stop still runs.

--- a/crates/stella-cli/src/command_deck/tests.rs
+++ b/crates/stella-cli/src/command_deck/tests.rs
@@ -444,6 +444,44 @@ fn stray_stop_and_hold_is_a_no_op() {
 
 // ISSUES tab: entity-hit assembly
 
+/// **The witness for the composer's red mode.** An interrupt at the lead
+/// front-queues the words ahead of the parked backlog, latches the soft stop
+/// (completed steps kept — never the hard cancel), injects nothing into the
+/// dying turn, and tells the deck what will happen.
+#[test]
+fn an_interrupt_front_queues_the_words_and_asks_the_turn_to_stop() {
+    use stella_core::ports::TurnSteering as _;
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let dir = std::env::temp_dir().join(format!("stella-interrupt-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let mut queue = crate::session_persist::DurableQueue::fresh(dir.clone());
+    queue.push_back("older parked prompt".to_string());
+    let tap = crate::subsession::SteeringTap::default();
+    let lead_pause = lead_control::LeadPause::new();
+    steer::interrupt_lead(
+        &tap,
+        &lead_pause,
+        &mut queue,
+        vec!["do this instead".to_string()],
+        &tx,
+    );
+    assert_eq!(
+        queue.iter().next().map(String::as_str),
+        Some("do this instead"),
+        "the interrupt outranks the backlog"
+    );
+    assert!(
+        tap.soft_stop_requested(),
+        "the turn is asked to stop at its next boundary"
+    );
+    assert!(
+        tap.drain_steering().is_empty(),
+        "nothing is injected into a turn that is being stopped"
+    );
+    assert!(rx.try_recv().is_ok(), "the deck is told what will happen");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// `requeue_front` front-inserts in push order and mirrors every insert
 /// to the deck as `PromptRequeued`, so the driver's backlog and the
 /// deck's queue view (which front-inserts each mirror in turn) agree.

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -65,6 +65,7 @@ mod private_state;
 mod projection;
 pub(crate) mod proposals;
 mod recall;
+mod records_refresh;
 // #2304: the trace-replay learning harness — the learning machinery driven from
 // recorded traces with zero model calls. Test-only by construction: the crate is
 // bin-only, so an in-crate module is the only place this can reach
@@ -366,11 +367,24 @@ pub struct SessionMemory {
     /// cacheable, facts are only worth tokens when they apply. The *registry* is
     /// stored rather than a pre-rendered string because rendering is per turn:
     /// `applies_to` selection needs the turn's prompt to decide which scoped
-    /// records are worth their tokens right now. Set once per session by
-    /// [`Self::open_for_session`] from the already-resolved rule registry —
-    /// re-deriving it here would re-walk the rule directories and re-run the
-    /// truth sweep on every turn.
-    record_registry: Option<stella_core::records::Registry>,
+    /// records are worth their tokens right now. Seeded per session by
+    /// [`Self::open_for_session`] from the already-resolved rule registry, and
+    /// refreshed mid-session when the rule files' bytes move — see
+    /// [`records_refresh`]. Behind a lock because the freshness check runs at
+    /// the re-query boundary, where the turn holds this memory by `&`.
+    record_registry: std::sync::RwLock<Option<stella_core::records::Registry>>,
+    /// Bumped on every mid-session registry swap and folded into the
+    /// re-query fingerprint, so a swap forces exactly one re-query at the
+    /// next boundary — path drift alone would never notice it.
+    records_generation: std::sync::atomic::AtomicU64,
+    /// Content digest of the rule files behind the loaded registry
+    /// ([`records_refresh::rules_digest`]), so the per-boundary freshness
+    /// check is a read-and-hash and a reload runs only when bytes moved.
+    records_fingerprint: std::sync::Mutex<u64>,
+    /// A one-shot section the next recall block leads with — what a
+    /// mid-session swap could not fully apply (a pinned change that binds
+    /// next session, a file that stopped parsing).
+    records_note: std::sync::Mutex<Option<String>>,
     /// The session's time source (#2320) — the only one the learning loop is
     /// allowed to read.
     ///
@@ -584,7 +598,10 @@ impl SessionMemory {
                     suppression::suppression_reader(workspace_root, store.clone()),
                 );
                 Some(Self {
-                    record_registry: None,
+                    record_registry: std::sync::RwLock::new(None),
+                    records_generation: std::sync::atomic::AtomicU64::new(0),
+                    records_fingerprint: std::sync::Mutex::new(0),
+                    records_note: std::sync::Mutex::new(None),
                     store,
                     host,
                     domains,

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -185,7 +185,12 @@ impl SessionMemory {
     /// string because rendering happens per turn: `applies_to` selection needs
     /// each turn's prompt to decide which scoped records apply.
     pub(super) fn set_record_registry(&mut self, registry: stella_core::records::Registry) {
-        self.record_registry = (!registry.entries.is_empty()).then_some(registry);
+        *self.record_registry.get_mut().expect("records lock") =
+            (!registry.entries.is_empty()).then_some(registry);
+        // Prime the freshness digest, so the first boundary check after open
+        // reads "unchanged" instead of reloading what was just handed in.
+        *self.records_fingerprint.get_mut().expect("records digest") =
+            super::records_refresh::rules_digest(&self.workspace_root);
     }
 
     /// This turn's volatile record channel, rendered: the registry's volatile
@@ -199,8 +204,11 @@ impl SessionMemory {
     fn turn_record_rendered(
         &self,
         prompt: &str,
-    ) -> Option<(&stella_core::records::Registry, RenderedChannel)> {
-        let registry = self.record_registry.as_ref()?;
+    ) -> Option<(stella_core::records::Registry, RenderedChannel)> {
+        // Cloned out of the lock rather than borrowed through it: the caller
+        // threads the registry across the rest of its selection pass, and a
+        // guard held that long would block a concurrent freshness swap.
+        let registry = self.record_registry.read().expect("records lock").clone()?;
         let paths = turn_path_tokens(prompt);
         let facts = stella_core::records::TurnFacts {
             text: prompt,
@@ -232,7 +240,7 @@ impl SessionMemory {
         mut report: impl FnMut(String),
     ) -> Option<String> {
         let (registry, rendered) = self.turn_record_rendered(prompt)?;
-        for drop in stella_core::steering::adapt::record_drops(registry, &rendered) {
+        for drop in stella_core::steering::adapt::record_drops(&registry, &rendered) {
             // A record channel drop is never also selected — the channel's
             // own budget cut it before the plane saw it.
             if let Some(message) = drop_message(&drop, false) {
@@ -296,6 +304,9 @@ impl SessionMemory {
         if self.ab_suppressed || !self.steering_enabled {
             return RecalledBlock::default();
         }
+        // A record edited since the last look joins this very block — see
+        // `records_refresh` for what a swap can and cannot apply.
+        self.refresh_records_if_changed();
         let RecalledFrames {
             recall,
             dropped: frame_drops,
@@ -352,6 +363,11 @@ impl SessionMemory {
         }
         if let Some(section) = record.and_then(|(_, rendered)| record_section_text(rendered)) {
             sections.push(section);
+        }
+        // What a mid-session registry swap could not fully apply, said once,
+        // first — see `records_refresh`.
+        if let Some(note) = self.take_records_note() {
+            sections.insert(0, note);
         }
 
         // The second operand of the knowledge-cutoff staleness clause
@@ -415,6 +431,9 @@ impl SessionMemory {
         if self.ab_suppressed || !self.steering_enabled {
             return RecalledBlock::default();
         }
+        // A no-op when the re-query boundary already refreshed (one digest
+        // read); real work only for a direct caller — see `records_refresh`.
+        self.refresh_records_if_changed();
         let prompt = signal.prompt;
 
         let anchors = self.anchors_for(prompt, signal.touched_paths);
@@ -439,23 +458,22 @@ impl SessionMemory {
                 paths.push(path.clone());
             }
         }
-        let record = self.record_registry.as_ref().map(|registry| {
+        let registry = self.record_registry.read().expect("records lock").clone();
+        let record = registry.map(|registry| {
             let facts = stella_core::records::TurnFacts {
                 text: prompt,
                 paths: &paths,
             };
-            (
-                registry,
-                // The per-record half of the #4498 dedup: the channel renders
-                // as one budgeted block, so leaving out what the turn has seen
-                // means re-rendering without those records, not filtering a
-                // list — the exclusion door is the registry's.
-                registry.render_volatile_for_turn_excluding(
-                    &facts,
-                    Some(RECORD_CHANNEL_BUDGET),
-                    produced.records(),
-                ),
-            )
+            // The per-record half of the #4498 dedup: the channel renders
+            // as one budgeted block, so leaving out what the turn has seen
+            // means re-rendering without those records, not filtering a
+            // list — the exclusion door is the registry's.
+            let rendered = registry.render_volatile_for_turn_excluding(
+                &facts,
+                Some(RECORD_CHANNEL_BUDGET),
+                produced.records(),
+            );
+            (registry, rendered)
         });
 
         let set = query_gathered_plane(
@@ -498,6 +516,11 @@ impl SessionMemory {
         }
         if let Some(section) = record.and_then(|(_, rendered)| record_section_text(rendered)) {
             sections.push(section);
+        }
+        // What a mid-session registry swap could not fully apply, said once,
+        // first — see `records_refresh`.
+        if let Some(note) = self.take_records_note() {
+            sections.insert(0, note);
         }
         RecalledBlock {
             text: (!sections.is_empty())
@@ -1030,7 +1053,7 @@ pub(super) fn query_gathered_plane(
     frames: &[RecalledFrame],
     frame_drops: &[stella_core::steering::DroppedCandidate],
     selected: &skills::SkillSelection,
-    record: Option<&(&stella_core::records::Registry, RenderedChannel)>,
+    record: Option<&(stella_core::records::Registry, RenderedChannel)>,
 ) -> stella_core::steering::SteeringSet {
     use stella_core::steering::{SteeringPlane, adapt};
 

--- a/crates/stella-cli/src/memory/records_refresh.rs
+++ b/crates/stella-cli/src/memory/records_refresh.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Mid-session freshness for the context-record registry.
+//!
+//! The registry is loaded once per session and rendered per turn; before this
+//! module a record edited, promoted, or retired while a session ran was
+//! invisible until restart. The freshness check is lazy rather than watched:
+//! it runs at the two moments the answer can matter — the turn-opening recall
+//! and each re-query boundary — by digesting the rule files' bytes and
+//! reloading only when they moved. No file watcher, no background task, no
+//! platform event quirks; the unchanged path costs one read of a handful of
+//! small policy files.
+//!
+//! What a swap can and cannot do is stated: the volatile channel picks the
+//! new registry up at the next boundary, and the swap forces one re-query by
+//! bumping the generation the fingerprint folds. The cached system prefix is
+//! byte-stable for the session (AGENTS.md's byte-stable-prompts rule), so a change to a
+//! pinned (`must`/`should`) record rides the next recall block as guidance,
+//! led by a line saying it binds fully — prompt and tool guards — next
+//! session. A file that stops parsing mid-edit keeps the last good registry
+//! and says so, because losing loaded steering to a half-saved buffer is the
+//! quiet failure this module exists to end.
+
+use std::collections::BTreeSet;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+use std::sync::atomic::Ordering;
+
+use stella_core::ingest::record::Tier;
+use stella_core::records::Registry;
+
+impl super::SessionMemory {
+    /// The registry swap counter the re-query fingerprint folds.
+    pub(crate) fn records_generation(&self) -> u64 {
+        self.records_generation.load(Ordering::Relaxed)
+    }
+
+    /// Reload the registry when the rule files' bytes have moved since the
+    /// last look; a no-op (one digest pass) when they have not.
+    pub(crate) fn refresh_records_if_changed(&self) {
+        let digest = rules_digest(&self.workspace_root);
+        {
+            let mut last = self.records_fingerprint.lock().expect("records digest");
+            if *last == digest {
+                return;
+            }
+            // Recorded before the reload, so a load that changes nothing is
+            // not re-attempted at every boundary; a further edit moves the
+            // digest again and gets a fresh look.
+            *last = digest;
+        }
+        let fresh = crate::context_records::load_registry(&self.workspace_root);
+        let mut lock = self.record_registry.write().expect("records lock");
+        let old = lock.take();
+        if let Some(broken) = newly_broken(old.as_ref(), &fresh) {
+            *lock = old;
+            drop(lock);
+            self.push_records_note(format!(
+                "## Workspace rules\n\nA rules file changed and does not parse \
+                 ({broken}); the rules loaded at session start stay in effect \
+                 until it parses again."
+            ));
+            return;
+        }
+        let pinned_note = pinned_changes(old.as_ref(), &fresh);
+        *lock = (!fresh.entries.is_empty()).then_some(fresh);
+        drop(lock);
+        self.records_generation.fetch_add(1, Ordering::Relaxed);
+        if let Some(note) = pinned_note {
+            self.push_records_note(note);
+        }
+    }
+
+    /// Park a one-shot section for the next recall block. A newer note
+    /// replaces an unread older one: both describe the same file set, and the
+    /// later look is the truer one.
+    fn push_records_note(&self, note: String) {
+        *self.records_note.lock().expect("records note") = Some(note);
+    }
+
+    /// Take the parked note, if any — consumed by the recall block builders.
+    pub(super) fn take_records_note(&self) -> Option<String> {
+        self.records_note.lock().expect("records note").take()
+    }
+}
+
+/// Digest of every rule file's path and bytes across both trust tiers — the
+/// same file set [`crate::context_records::load_registry`] parses, so the
+/// digest cannot say "unchanged" about a file the loader would read.
+pub(super) fn rules_digest(root: &Path) -> u64 {
+    let files = crate::context_records::rule_files(root, true, true);
+    let mut hasher = std::hash::DefaultHasher::new();
+    for file in files.all() {
+        (file.path.as_str(), file.contents.as_str()).hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// A source that contributed records before, contributes none now, and
+/// carries a diagnostic — the signature of a file that stopped parsing.
+/// `None` when the fresh load lost nothing it can be blamed for: a deleted
+/// file has no diagnostic (retirement, honored by the swap), and a diagnostic
+/// the old load already carried is not new damage.
+fn newly_broken(old: Option<&Registry>, fresh: &Registry) -> Option<String> {
+    let old = old?;
+    let sources = |registry: &Registry| -> BTreeSet<String> {
+        registry
+            .entries
+            .iter()
+            .map(|entry| entry.record.source.clone())
+            .collect()
+    };
+    let had = sources(old);
+    let has = sources(fresh);
+    fresh
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.source.clone())
+        .find(|source| had.contains(source) && !has.contains(source))
+}
+
+/// The recall-block section for pinned (`must`/`should`) records the swap
+/// could not bind into the byte-stable prefix: each changed or new pinned
+/// record, stating what applies now and what waits for the next session.
+fn pinned_changes(old: Option<&Registry>, fresh: &Registry) -> Option<String> {
+    let unchanged = |entry: &stella_core::records::Entry| {
+        old.is_some_and(|old| {
+            old.entries.iter().any(|prior| {
+                prior.record.record.lineage_id == entry.record.record.lineage_id
+                    && prior.record.record.statement == entry.record.record.statement
+                    && prior.record.record.record_hash == entry.record.record.record_hash
+            })
+        })
+    };
+    let listed: Vec<String> = fresh
+        .entries
+        .iter()
+        .filter(|entry| entry.record.record.tier() == Tier::Pinned && !unchanged(entry))
+        .map(|entry| {
+            format!(
+                "- ^{}: {}",
+                entry.record.handle, entry.record.record.statement
+            )
+        })
+        .collect();
+    if listed.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "## Workspace rules — changed while this session runs\n\n\
+         These binding (must/should) records changed after this session's \
+         prompt was built. Apply them now as if they were in the system \
+         prompt; they bind into it — and arm any tool guards they declare — \
+         when the next session starts.\n\n{}",
+        listed.join("\n")
+    ))
+}

--- a/crates/stella-cli/src/memory/steering.rs
+++ b/crates/stella-cli/src/memory/steering.rs
@@ -232,7 +232,7 @@ impl<'m> SessionRequery<'m> {
             state: std::sync::Mutex::new(RequeryState {
                 produced,
                 produced_steering: opening,
-                answered_fingerprint: fingerprint(&[], &[]),
+                answered_fingerprint: fingerprint(&[], &[], memory.records_generation()),
             }),
             events: None,
         }
@@ -267,13 +267,15 @@ pub(crate) fn requery_for_turn<'m>(
 }
 
 /// Order-free digest of the drift markers. `BTreeSet` so two signals that
-/// saw the same facts in a different order agree.
-fn fingerprint(paths: &[String], errors: &[&str]) -> u64 {
+/// saw the same facts in a different order agree. `records_generation` folds
+/// the registry's mid-session swap counter, so a record edited while the
+/// turn runs forces exactly one re-query even when no path or error drifted.
+fn fingerprint(paths: &[String], errors: &[&str], records_generation: u64) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::hash::DefaultHasher::new();
     let paths: std::collections::BTreeSet<&str> = paths.iter().map(String::as_str).collect();
     let errors: std::collections::BTreeSet<&str> = errors.iter().copied().collect();
-    (paths, errors).hash(&mut hasher);
+    (paths, errors, records_generation).hash(&mut hasher);
     hasher.finish()
 }
 
@@ -283,7 +285,15 @@ impl stella_core::ports::SteeringRequery for SessionRequery<'_> {
         if signal.since_last_query < MIN_STEPS_BETWEEN {
             return None;
         }
-        let current = fingerprint(signal.touched_paths, signal.errors_seen);
+        // The boundary is where a rules edit gets noticed: a swap bumps the
+        // generation below, which moves the fingerprint and forces this one
+        // re-query — see `records_refresh`.
+        self.memory.refresh_records_if_changed();
+        let current = fingerprint(
+            signal.touched_paths,
+            signal.errors_seen,
+            self.memory.records_generation(),
+        );
         if self
             .state
             .lock()
@@ -320,6 +330,20 @@ impl stella_core::ports::SteeringRequery for SessionRequery<'_> {
         // here is a block byte-identical to one already in history.
         state.produced_steering.absorb(&recalled.produced);
         state.produced.insert(block.clone()).then_some(block)
+    }
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    /// A registry swap alone moves the fingerprint, with no path or error
+    /// drifting — which is what turns a mid-session rules edit into exactly
+    /// one forced re-query.
+    #[test]
+    fn a_registry_swap_moves_the_fingerprint_alone() {
+        assert_ne!(
+            super::fingerprint(&[], &[], 0),
+            super::fingerprint(&[], &[], 1)
+        );
     }
 }
 

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -17,6 +17,7 @@ mod quarantine;
 // Which sessions actually receive the volatile record channel — a separate
 // question from what recall renders, and the one that went unasked (epic #897).
 mod record_channel;
+mod records_refresh;
 // Everything between a model's reflection response and a stored lesson: the
 // parser, the self-review, and what `reflect_and_record` writes. The largest
 // seam here, and the one this file kept growing on — #2465 is what took it

--- a/crates/stella-cli/src/memory/tests/records_refresh.rs
+++ b/crates/stella-cli/src/memory/tests/records_refresh.rs
@@ -1,0 +1,179 @@
+//! Witnesses for mid-session record freshness (`records_refresh`): a record
+//! added, retired, or broken while the session runs reaches — or visibly
+//! fails to reach — the next recall block, with the registry loaded at
+//! session start surviving a half-saved edit.
+
+use crate::memory::*;
+
+fn write_rule(root: &std::path::Path, name: &str, contents: &str) {
+    let dir = root.join(".stella").join("rules");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(name), contents).unwrap();
+}
+
+fn record_toml(force: &str, lineage: &str, statement: &str) -> String {
+    format!(
+        r#"
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+origin = "user"
+status = "active"
+
+[[record]]
+lineage_id = "{lineage}"
+kind = "preference"
+statement = "{statement}"
+
+[record.steering]
+force = "{force}"
+"#
+    )
+}
+
+fn session(root: &std::path::Path) -> SessionMemory {
+    SessionMemory::open_with_workspace_skills(root, false, true)
+        .expect("session memory opens in a temp workspace")
+}
+
+async fn next_block(memory: &SessionMemory) -> Option<String> {
+    let signal = stella_core::steering::TurnSignal {
+        prompt: "keep the service healthy",
+        ..Default::default()
+    };
+    memory
+        .signal_recall_block(
+            &signal,
+            &crate::memory::steering::ProducedSteering::default(),
+        )
+        .await
+        .text
+}
+
+/// **The witness for a mid-session edit.** A record file that lands while
+/// the session runs is picked up by the boundary refresh: the generation
+/// bumps (which is what forces the one re-query) and the very next recall
+/// block carries the record.
+#[tokio::test]
+async fn a_record_added_mid_session_reaches_the_next_recall_block() {
+    let dir = tempfile::tempdir().unwrap();
+    let memory = session(dir.path());
+    let before = memory.records_generation();
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "info",
+            "ctx.acme.web.staging-url",
+            "The staging deploy answers on port 8788.",
+        ),
+    );
+    let text = next_block(&memory).await.expect("the new record renders");
+    assert!(text.contains("port 8788"), "{text}");
+    assert!(
+        memory.records_generation() > before,
+        "a swap bumps the generation, so the re-query fingerprint moves"
+    );
+}
+
+/// **The witness for retirement.** A record file deleted mid-session leaves
+/// the volatile channel on the same refresh — suppression is one mechanism
+/// in the running session too.
+#[tokio::test]
+async fn a_record_deleted_mid_session_leaves_the_volatile_channel() {
+    let dir = tempfile::tempdir().unwrap();
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "info",
+            "ctx.acme.web.staging-url",
+            "The staging deploy answers on port 8788.",
+        ),
+    );
+    let memory = session(dir.path());
+    assert!(
+        next_block(&memory)
+            .await
+            .is_some_and(|text| text.contains("port 8788")),
+        "the record renders while its file exists"
+    );
+    std::fs::remove_file(dir.path().join(".stella/rules/acme.web.toml")).unwrap();
+    let after = next_block(&memory).await;
+    assert!(
+        !after.as_deref().unwrap_or_default().contains("port 8788"),
+        "a deleted record must stop steering: {after:?}"
+    );
+}
+
+/// **The witness for a half-saved edit.** A rules file that stops parsing
+/// keeps the registry loaded before the edit — the session is not silently
+/// un-steered by a buffer mid-save — and the next block says so.
+#[tokio::test]
+async fn a_rules_file_that_stops_parsing_keeps_the_last_good_registry() {
+    let dir = tempfile::tempdir().unwrap();
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "info",
+            "ctx.acme.web.staging-url",
+            "The staging deploy answers on port 8788.",
+        ),
+    );
+    let memory = session(dir.path());
+    assert!(
+        next_block(&memory)
+            .await
+            .is_some_and(|text| text.contains("port 8788")),
+        "the record renders before the bad edit"
+    );
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        "schema = \"context-record/v0.1\"\n[[record]\n",
+    );
+    let text = next_block(&memory)
+        .await
+        .expect("the kept registry still renders");
+    assert!(
+        text.contains("port 8788"),
+        "the last good registry stays in effect: {text}"
+    );
+    assert!(
+        text.contains("does not parse"),
+        "the failure is reported, never silent: {text}"
+    );
+}
+
+/// **The witness for the prefix wall.** A pinned (`must`) record that lands
+/// mid-session cannot enter the byte-stable system prompt, so the block says
+/// exactly what applies now and what binds next session — and says it once.
+#[tokio::test]
+async fn a_pinned_record_change_is_delivered_as_guidance_with_its_caveat() {
+    let dir = tempfile::tempdir().unwrap();
+    let memory = session(dir.path());
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "must",
+            "ctx.acme.web.no-force-push",
+            "Never force-push to main.",
+        ),
+    );
+    let text = next_block(&memory).await.expect("the note renders a block");
+    assert!(
+        text.contains("changed while this session runs") && text.contains("Never force-push"),
+        "the pinned change rides the volatile channel with its caveat: {text}"
+    );
+    let again = next_block(&memory).await;
+    assert!(
+        !again
+            .as_deref()
+            .unwrap_or_default()
+            .contains("changed while this session runs"),
+        "the note is one-shot: {again:?}"
+    );
+}

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -20,6 +20,7 @@ use unicode_width::UnicodeWidthChar;
 use crate::cache_panel;
 use crate::composer::{ComposerLayout, PaletteState, layout as composer_layout, split_row_at};
 use crate::deck::{DeckTab, WorkspaceModel};
+use crate::deck_ui::composer_mode::ComposerMode;
 use crate::deck_ui::{DeckUi, InstalledMode, IssuesMode};
 use crate::panel_guard::{guarded_band, guarded_overlay};
 use crate::render::{render_arg_popup, render_slash_popup, scroll_window_start, slash_popup_area};
@@ -163,7 +164,13 @@ pub fn render_deck(model: &WorkspaceModel, ui: &mut DeckUi, frame: &mut Frame) {
         }
     });
     guarded_band(buf, bands[3], "composer", |b| {
-        render_composer(&c_layout, bands[3], b, ui.voice.recording())
+        render_composer(
+            &c_layout,
+            bands[3],
+            b,
+            ui.voice.recording(),
+            crate::deck_ui::composer_mode::effective(ui, model),
+        )
     });
     guarded_band(buf, bands[4], "hints", |b| {
         crate::views::frame::render_hint_row(model, ui, bands[4], b)
@@ -1064,7 +1071,27 @@ fn caret_style(recording: bool) -> Style {
     }
 }
 
-fn render_composer(layout: &ComposerLayout, area: Rect, buf: &mut Buffer, recording: bool) {
+/// The chevron's style for the composer's mode — the one place the mode is
+/// painted, pure for the reason [`caret_style`] is: golden frames strip
+/// styling, so a unit test is what holds the color decision
+/// (`deck_render/tests.rs`). Gold stays the identity default; the two
+/// non-default intents take tones the palette already separates from it —
+/// teal to steer, the danger red to interrupt.
+fn prompt_prefix_style(mode: ComposerMode) -> Style {
+    match mode {
+        ComposerMode::Dispatch => Style::default().fg(theme::ACCENT),
+        ComposerMode::Steer => Style::default().fg(theme::TEAL),
+        ComposerMode::Interrupt => Style::default().fg(theme::DANGER),
+    }
+}
+
+fn render_composer(
+    layout: &ComposerLayout,
+    area: Rect,
+    buf: &mut Buffer,
+    recording: bool,
+    mode: ComposerMode,
+) {
     let visible = (area.height as usize).max(1);
     let total = layout.rows.len();
     let first = composer_scroll_first(layout.cursor_row, visible);
@@ -1072,12 +1099,9 @@ fn render_composer(layout: &ComposerLayout, area: Rect, buf: &mut Buffer, record
     let cursor_style = caret_style(recording).add_modifier(Modifier::REVERSED);
     let mut lines: Vec<Line<'static>> = Vec::new();
     for (i, row) in layout.rows.iter().enumerate().skip(first).take(visible) {
-        // The accent `>>> ` prefix rides every row and scrolls with it —
-        // exactly the four columns `PROMPT_PREFIX_W` reserves.
-        let mut spans = vec![Span::styled(
-            PROMPT_PREFIX,
-            Style::default().fg(theme::ACCENT),
-        )];
+        // The `>>> ` prefix rides every row and scrolls with it — exactly the
+        // four columns `PROMPT_PREFIX_W` reserves — in the mode's color.
+        let mut spans = vec![Span::styled(PROMPT_PREFIX, prompt_prefix_style(mode))];
         if i == layout.cursor_row {
             let (before, under, after) = split_row_at(row, layout.cursor_col);
             let under_ch = under.map(String::from).unwrap_or_else(|| " ".into());

--- a/crates/stella-tui/src/deck_render/tests.rs
+++ b/crates/stella-tui/src/deck_render/tests.rs
@@ -195,13 +195,31 @@ fn the_caret_recolours_while_the_microphone_is_live() {
     assert_eq!(caret_style(true).fg, Some(crate::theme::DANGER));
 }
 
+/// The golden frames strip styling, so the chevron's mode colors are held
+/// here: gold stays the identity default, and each intent is told apart from
+/// the other two (`prompt_prefix_style`).
+#[test]
+fn the_chevron_wears_one_color_per_composer_mode() {
+    let styles = [
+        prompt_prefix_style(ComposerMode::Dispatch),
+        prompt_prefix_style(ComposerMode::Steer),
+        prompt_prefix_style(ComposerMode::Interrupt),
+    ];
+    assert_eq!(styles[0].fg, Some(crate::theme::ACCENT));
+    assert_eq!(styles[1].fg, Some(crate::theme::TEAL));
+    assert_eq!(styles[2].fg, Some(crate::theme::DANGER));
+    assert_ne!(styles[0], styles[1]);
+    assert_ne!(styles[1], styles[2]);
+    assert_ne!(styles[0], styles[2]);
+}
+
 #[test]
 fn empty_composer_is_a_single_accent_prompt_line_with_the_caret() {
     let ui = DeckUi::default(); // blank composer
     let layout = crate::composer::layout(&ui.composer, 40);
     let area = Rect::new(0, 0, 40, 4);
     let mut buf = Buffer::empty(area);
-    render_composer(&layout, area, &mut buf, false);
+    render_composer(&layout, area, &mut buf, false, ComposerMode::Dispatch);
     let text = buffer_text(&buf);
     let rows: Vec<&str> = text.lines().collect();
     assert!(
@@ -238,7 +256,7 @@ fn a_multiline_paste_prefixes_every_row_and_scrolls_instead_of_chipping() {
     let layout = crate::composer::layout(&ui.composer, 40);
     let area = Rect::new(0, 0, 40, 4); // capped at DECK_COMPOSER_MAX_ROWS
     let mut buf = Buffer::empty(area);
-    render_composer(&layout, area, &mut buf, false);
+    render_composer(&layout, area, &mut buf, false, ComposerMode::Dispatch);
     let text = buffer_text(&buf);
     assert!(!text.contains("[pasted"), "not chipped:\n{text}");
     for (i, row) in text.lines().enumerate() {
@@ -263,7 +281,7 @@ fn the_prompt_prefix_is_a_steady_uniform_accent() {
     let layout = crate::composer::layout(&ui.composer, 40);
     let area = Rect::new(0, 0, 40, 4);
     let mut buf = Buffer::empty(area);
-    render_composer(&layout, area, &mut buf, false);
+    render_composer(&layout, area, &mut buf, false, ComposerMode::Dispatch);
     assert!(
         buffer_text(&buf)
             .lines()

--- a/crates/stella-tui/src/deck_ui.rs
+++ b/crates/stella-tui/src/deck_ui.rs
@@ -635,6 +635,9 @@ pub struct DeckUi {
     pub pending_dispatch: Option<PendingDispatch>,
     /// What a plain mid-turn prompt does (`ui.mid_turn_prompt`); see [`dispatch`].
     pub mid_turn_prompt: MidTurnPrompt,
+    /// The Shift-Tab-cycled composer intent; `None` follows the session.
+    /// See [`composer_mode::effective`].
+    pub composer_mode: Option<composer_mode::ComposerMode>,
     pub splash: SplashState,
     /// Startup system notifications, shown as a transient dialog rather than
     /// as transcript rows (see [`crate::notice`]).
@@ -915,6 +918,7 @@ impl Default for DeckUi {
             voice: crate::voice::VoiceUi::default(),
             pending_dispatch: None,
             mid_turn_prompt: MidTurnPrompt::default(),
+            composer_mode: None,
             splash: SplashState::new(),
             notice: NoticeState::new(),
             index_readiness: IndexReadiness::unknown(),
@@ -1701,6 +1705,7 @@ pub mod cards;
 /// the global composer, so a stop must leave a typed draft untouched. A
 /// pending ask-user gate never reaches them either — it folds the agent to
 /// [`AgentStatus::WaitingInput`], which fails rule 10's `Running` check.
+pub mod composer_mode;
 mod create;
 pub mod dispatch;
 /// The focus tree — `←`/`→` siblings, `⏎` open, `⌫` back.
@@ -2050,7 +2055,13 @@ fn handle_key_inner(key: KeyEvent, model: &WorkspaceModel, ui: &mut DeckUi) -> D
     if let Some(action) = local::model_arg_key(key, model, ui) {
         return action;
     }
-    let slash = slash_matches(model, ui);
+    // Shift-Tab with a draft cycles the composer's intent; empty keeps tabs.
+    if let Some(action) = composer_mode::backtab(key, ui, model, composer_empty) {
+        return action;
+    }
+    // The slash commands matching the composer — empty when the popup is idle.
+    let state = crate::deck_render::palette_state(model, ui);
+    let slash = slash_popup_matches(&ui.composer, &ui.slash_commands, &state);
     if slash.is_empty() {
         match key.code {
             KeyCode::Tab => {
@@ -2245,13 +2256,6 @@ fn submit_prompt(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> DeckA
         // The card is up and now holds the text; the keystroke is spent.
         None => DeckAction::Handled,
     }
-}
-
-/// The names of the slash commands matching the composer, or empty when the
-/// popup is inactive.
-fn slash_matches(model: &WorkspaceModel, ui: &DeckUi) -> Vec<String> {
-    let state = crate::deck_render::palette_state(model, ui);
-    slash_popup_matches(&ui.composer, &ui.slash_commands, &state)
 }
 
 /// Slash-popup navigation: ↑/↓ choose, Tab completes into the buffer, Enter

--- a/crates/stella-tui/src/deck_ui/composer_mode.rs
+++ b/crates/stella-tui/src/deck_ui/composer_mode.rs
@@ -1,0 +1,155 @@
+//! The composer's intent — what Enter does with the words.
+//!
+//! One prompt line, three intents, told apart by the chevron's color: gold
+//! dispatches a prompt (today's routing, `ui.mid_turn_prompt` included), teal
+//! steers the running turn — the text lands at its next step boundary as a
+//! real user message — and red interrupts: a soft stop that keeps every
+//! completed step, with the words front-queued to run next. Shift-Tab cycles
+//! the three while the composer holds a draft; with an empty composer it
+//! keeps its deck job of cycling tabs, resolving the collision on what the
+//! user is visibly doing.
+//!
+//! The mode is derived, never latched: with no override the chevron follows
+//! the session — gold at rest, teal while the focused agent runs under the
+//! `steer` policy — so there is no event hook to forget and no stale mode to
+//! submit through. A cycled override lasts until the next submission.
+
+use super::*;
+
+/// What Enter does with the composer's text.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ComposerMode {
+    /// A new prompt, routed by [`dispatch::route`].
+    #[default]
+    Dispatch,
+    /// Injected into the running turn at its next step boundary, as a real
+    /// user message the model answers on its very next call.
+    Steer,
+    /// Soft-stop the running turn — completed steps kept — and run the text
+    /// as the next thing. At an idle agent this degrades to "run this now".
+    Interrupt,
+}
+
+impl ComposerMode {
+    /// The next mode in the Shift-Tab cycle.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Dispatch => Self::Steer,
+            Self::Steer => Self::Interrupt,
+            Self::Interrupt => Self::Dispatch,
+        }
+    }
+}
+
+/// The mode in effect: the user's cycled override when one is set, else
+/// derived from the focused agent — [`ComposerMode::Steer`] while it runs
+/// under [`MidTurnPrompt::Steer`], [`ComposerMode::Dispatch`] everywhere
+/// else.
+pub fn effective(ui: &DeckUi, model: &WorkspaceModel) -> ComposerMode {
+    if let Some(mode) = ui.composer_mode {
+        return mode;
+    }
+    let running = model
+        .agents
+        .get(ui.focused)
+        .is_some_and(|a| a.status == crate::AgentStatus::Running);
+    if running && ui.mid_turn_prompt == MidTurnPrompt::Steer {
+        ComposerMode::Steer
+    } else {
+        ComposerMode::Dispatch
+    }
+}
+
+/// Claim Shift-Tab for mode-cycling while the composer holds a draft. `None`
+/// hands the key back to the deck's tab-cycling, which owns it when there is
+/// nothing to submit and therefore no intent to pick.
+pub(super) fn backtab(
+    key: KeyEvent,
+    ui: &mut DeckUi,
+    model: &WorkspaceModel,
+    composer_empty: bool,
+) -> Option<DeckAction> {
+    if key.code != KeyCode::BackTab || composer_empty {
+        return None;
+    }
+    ui.composer_mode = Some(effective(ui, model).next());
+    Some(DeckAction::Handled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{AgentMeta, Inbound};
+
+    fn model_with_lead(status: crate::AgentStatus) -> WorkspaceModel {
+        let mut m = WorkspaceModel::new();
+        m.apply_inbound(&Inbound::Register(AgentMeta::new("lead", "goal", 0)));
+        m.apply_inbound(&Inbound::Status {
+            agent: "lead".into(),
+            status,
+        });
+        m
+    }
+
+    #[test]
+    fn the_cycle_visits_all_three_modes_and_returns() {
+        let mut mode = ComposerMode::Dispatch;
+        let mut seen = vec![mode];
+        for _ in 0..3 {
+            mode = mode.next();
+            seen.push(mode);
+        }
+        assert_eq!(
+            seen,
+            vec![
+                ComposerMode::Dispatch,
+                ComposerMode::Steer,
+                ComposerMode::Interrupt,
+                ComposerMode::Dispatch,
+            ]
+        );
+    }
+
+    /// The chevron follows the session: under the `steer` policy the mode is
+    /// teal exactly while the focused agent runs, with no state to reset.
+    #[test]
+    fn under_the_steer_policy_the_mode_follows_the_running_turn() {
+        let mut ui = DeckUi {
+            mid_turn_prompt: MidTurnPrompt::Steer,
+            ..Default::default()
+        };
+        assert_eq!(
+            effective(&ui, &model_with_lead(crate::AgentStatus::Running)),
+            ComposerMode::Steer
+        );
+        assert_eq!(
+            effective(&ui, &model_with_lead(crate::AgentStatus::WaitingInput)),
+            ComposerMode::Dispatch,
+            "an idle agent has no turn to steer"
+        );
+        ui.mid_turn_prompt = MidTurnPrompt::Queue;
+        assert_eq!(
+            effective(&ui, &model_with_lead(crate::AgentStatus::Running)),
+            ComposerMode::Dispatch,
+            "the default policy keeps today's gold dispatch"
+        );
+    }
+
+    /// Shift-Tab with a draft cycles the mode; with an empty composer it is
+    /// declined, so tab-cycling keeps its key.
+    #[test]
+    fn backtab_cycles_only_while_the_composer_holds_a_draft() {
+        let model = model_with_lead(crate::AgentStatus::Running);
+        let mut ui = DeckUi::default();
+        let key = KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT);
+        assert_eq!(backtab(key, &mut ui, &model, true), None);
+        assert_eq!(ui.composer_mode, None);
+        assert_eq!(
+            backtab(key, &mut ui, &model, false),
+            Some(DeckAction::Handled)
+        );
+        assert_eq!(ui.composer_mode, Some(ComposerMode::Steer));
+        backtab(key, &mut ui, &model, false);
+        assert_eq!(ui.composer_mode, Some(ComposerMode::Interrupt));
+    }
+}

--- a/crates/stella-tui/src/deck_ui/dispatch.rs
+++ b/crates/stella-tui/src/deck_ui/dispatch.rs
@@ -18,6 +18,7 @@
 //! second-guessed: an explicit `>`, a slash command, a `!` shell line, and
 //! the first prompt after a double-Esc hold all carry their own intent.
 
+use super::composer_mode::{self, ComposerMode};
 use super::*;
 
 /// A submission parked at the routing card, with the text it will send once
@@ -151,12 +152,42 @@ pub fn route(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> Option<Wo
         }
         return Some(WorkspaceInput::EnqueueNext { text });
     }
+    // The composer's cycled intent outranks the policy — and never
+    // second-guesses a submission that states its own routing, which the
+    // markers already answer. A steer at an idle agent simply becomes the
+    // next turn driver-side (`steer_at_rest`), and an interrupt with no
+    // running turn degrades the same way, so neither needs a running gate.
+    if let Some(agent) = focused.map(|a| a.meta.id.clone())
+        && !carries_its_own_intent(&text)
+    {
+        match composer_mode::effective(ui, model) {
+            ComposerMode::Steer => {
+                ui.composer_mode = None;
+                return Some(WorkspaceInput::Steer {
+                    agent,
+                    texts: vec![text],
+                });
+            }
+            ComposerMode::Interrupt => {
+                ui.composer_mode = None;
+                return Some(WorkspaceInput::Interrupt {
+                    agent,
+                    texts: vec![text],
+                });
+            }
+            ComposerMode::Dispatch => {}
+        }
+    }
     let running = focused.is_some_and(|a| a.status == crate::AgentStatus::Running);
     if !running || carries_its_own_intent(&text) {
         return Some(WorkspaceInput::Enqueue { text });
     }
     match ui.mid_turn_prompt {
         MidTurnPrompt::Queue => return Some(WorkspaceInput::EnqueueNext { text }),
+        // Reachable only through an explicit gold override (the policy's own
+        // derived mode returned above): the user asked for plain dispatch,
+        // which mid-turn is the queue.
+        MidTurnPrompt::Steer => return Some(WorkspaceInput::EnqueueNext { text }),
         MidTurnPrompt::AlwaysSpawn => return Some(WorkspaceInput::Enqueue { text }),
         MidTurnPrompt::Ask => {}
     }
@@ -276,6 +307,11 @@ pub enum MidTurnPrompt {
     Ask,
     /// Never ask; a mid-turn prompt always forks to a sidecar lane.
     AlwaysSpawn,
+    /// A mid-turn prompt steers the running turn at its next step boundary —
+    /// the chevron turns teal while the turn runs, and the natural next thing
+    /// typed is a correction rather than a queued prompt. See
+    /// [`composer_mode::effective`].
+    Steer,
 }
 
 impl MidTurnPrompt {
@@ -286,6 +322,7 @@ impl MidTurnPrompt {
             "queue" => Some(Self::Queue),
             "ask" => Some(Self::Ask),
             "spawn" => Some(Self::AlwaysSpawn),
+            "steer" => Some(Self::Steer),
             _ => None,
         }
     }
@@ -341,14 +378,69 @@ mod tests {
 
     /// The settings slugs, and that an unknown one keeps the default.
     #[test]
-    fn the_policy_parses_its_three_slugs_and_nothing_else() {
+    fn the_policy_parses_its_four_slugs_and_nothing_else() {
         assert_eq!(MidTurnPrompt::parse("queue"), Some(MidTurnPrompt::Queue));
         assert_eq!(MidTurnPrompt::parse(" ask "), Some(MidTurnPrompt::Ask));
         assert_eq!(
             MidTurnPrompt::parse("spawn"),
             Some(MidTurnPrompt::AlwaysSpawn)
         );
+        assert_eq!(MidTurnPrompt::parse("steer"), Some(MidTurnPrompt::Steer));
         assert_eq!(MidTurnPrompt::parse("sidecar"), None);
+    }
+
+    /// **The witness for the `steer` policy.** With no override, a plain
+    /// prompt typed at a running agent under `ui.mid_turn_prompt = "steer"`
+    /// goes straight into the running turn — a `Steer`, never a queued
+    /// prompt — while a slash command still routes as itself.
+    #[test]
+    fn under_the_steer_policy_a_mid_turn_prompt_steers_the_running_turn() {
+        let model = model_with_lead(crate::AgentStatus::Running);
+        let mut ui = DeckUi {
+            mid_turn_prompt: MidTurnPrompt::Steer,
+            ..Default::default()
+        };
+        assert_eq!(
+            route(&mut ui, &model, "focus on the parser".into()),
+            Some(WorkspaceInput::Steer {
+                agent: "lead".into(),
+                texts: vec!["focus on the parser".into()],
+            })
+        );
+        assert!(
+            matches!(
+                route(&mut ui, &model, "/help".into()),
+                Some(WorkspaceInput::Enqueue { .. })
+            ),
+            "a stated route is never second-guessed by the policy"
+        );
+    }
+
+    /// **The witness for the red mode.** A cycled Interrupt override sends
+    /// the interrupt input and spends itself — the next submission is back
+    /// on the derived mode.
+    #[test]
+    fn an_interrupt_override_sends_the_interrupt_and_spends_itself() {
+        let model = model_with_lead(crate::AgentStatus::Running);
+        let mut ui = DeckUi {
+            composer_mode: Some(super::ComposerMode::Interrupt),
+            ..Default::default()
+        };
+        assert_eq!(
+            route(&mut ui, &model, "stop — wrong branch".into()),
+            Some(WorkspaceInput::Interrupt {
+                agent: "lead".into(),
+                texts: vec!["stop — wrong branch".into()],
+            })
+        );
+        assert_eq!(ui.composer_mode, None, "the override lasts one submission");
+        assert_eq!(
+            route(&mut ui, &model, "and the tests".into()),
+            Some(WorkspaceInput::EnqueueNext {
+                text: "and the tests".into()
+            }),
+            "back on the derived mode — the default policy queues"
+        );
     }
 
     /// Under `ask`, a prompt typed at a running agent parks on the card

--- a/crates/stella-tui/src/deck_ui/tests/queue.rs
+++ b/crates/stella-tui/src/deck_ui/tests/queue.rs
@@ -393,8 +393,9 @@ fn slash_on_the_mcp_tab_opens_the_command_menu_not_search() {
         "`/` no longer enters MCP search"
     );
     assert_eq!(ui.composer.buffer(), "/", "the slash query is typing");
+    let state = crate::deck_render::palette_state(&model, &ui);
     assert!(
-        !slash_matches(&model, &ui).is_empty(),
+        !slash_popup_matches(&ui.composer, &ui.slash_commands, &state).is_empty(),
         "…and the command menu is open over it"
     );
 }

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -936,6 +936,12 @@ pub enum WorkspaceInput {
     /// the turn going. See [`steering`] for why this is not a cancel, and why
     /// the whole queue travels in one message.
     Steer { agent: AgentId, texts: Vec<String> },
+    /// The composer's red mode: soft-stop `agent`'s running turn (completed
+    /// steps kept, exactly the first-Esc stop) and run `texts` next, ahead of
+    /// the parked backlog. With no running turn it degrades to "run this
+    /// now", and at a worker lane it lands as a steer — a lane's next prompt
+    /// is the lead's, so there is nothing for the words to outrank there.
+    Interrupt { agent: AgentId, texts: Vec<String> },
     /// Re-root the Graph tab on `file`: the deck's file picker sends this when
     /// the user selects a file, and the driver answers with a fresh
     /// [`Inbound::GraphSnapshot`] centered on it (the same out-of-band refresh

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -91,8 +91,15 @@ Two prefixes skip the queue:
 
 `ui.mid_turn_prompt` in [settings](/docs/configuration/settings#the-ui-section) changes what
 a plain prompt does while an agent is running: `queue` (the default above), `ask` (a card offers
-`s` steer / `n` next turn / `p` sidecar sub-session per prompt), or `spawn` (every plain
-prompt forks a sidecar sub-session, dispatched alongside the running turn).
+`s` steer / `n` next turn / `p` sidecar sub-session per prompt), `spawn` (every plain
+prompt forks a sidecar sub-session, dispatched alongside the running turn), or `steer`
+(the prompt lands inside the running turn at its next step boundary, and the chevron
+turns teal to say so).
+
+Whatever the policy, `Shift-Tab` with a draft in the composer cycles the submission's
+intent by hand — gold dispatches, teal steers the running turn, red interrupts: a soft
+stop that keeps every completed step, with your words front-queued to run next. With an
+empty composer `Shift-Tab` keeps its usual job of cycling tabs.
 
 <Callout type="info">
 A bare `⏎` **always** submits, even while an agent is busy — that is what makes queueing

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -454,8 +454,10 @@ section behaves exactly as the defaults.
     What happens when you type a plain prompt while an agent is **running**. `queue`
     waits as the next turn, so `Esc` can steer the whole backlog into the turn in
     progress. `ask` raises a routing card per prompt (`s` steer / `n` next turn / `p`
-    sidecar). `spawn` forks every plain prompt to a sidecar sub-session. An unrecognized
-    value keeps the default.
+    sidecar). `spawn` forks every plain prompt to a sidecar sub-session. `steer` sends
+    it straight into the running turn at its next step boundary — the composer's
+    chevron turns teal while the turn runs, so the line reads as a correction rather
+    than a queued prompt. An unrecognized value keeps the default.
     See [Typing while a turn is running](/docs/commands/chat#typing-while-a-turn-is-running).
   </OptionCard>
 </CardGrid>

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -375,7 +375,7 @@ Unchanged — see [The ui section](/docs/configuration/settings#the-ui-section).
 ```toml title="stella.toml"
 [ui]
 theme = "stella-light"
-mid_turn_prompt = "queue"   # queue | ask | spawn
+mid_turn_prompt = "queue"   # queue | ask | spawn | steer
 ```
 
 ### `[voice]`


### PR DESCRIPTION
## What & why

A context record edited, added, promoted, or retired while a session runs now reaches that session at its next step boundary, through the retrieval path that already exists, instead of waiting for a restart.

The registry was loaded once by `SessionMemory::open_for_session` and held as a clone for the session's life. The retrieval side re-decides which records render on every re-query, so the gap was exactly one stale clone. The fix (`crates/stella-cli/src/memory/records_refresh.rs`):

- **Lazy freshness, no watcher.** At the two moments the answer can matter — the turn-opening recall and each re-query boundary — the session digests the rule files' bytes (both trust tiers, the same file set `load_registry` parses) and reloads only when they moved. The unchanged path is one read of a handful of small policy files; there is no background task and no platform file-event quirk to get wrong. This is deliberately not the `notify` shape the issue sketched: a watcher adds a thread, a debounce, and an event model for something a digest at a boundary answers exactly.
- **A swap forces exactly one re-query.** The registry swap counter (`records_generation`) folds into the re-query fingerprint, which previously tracked only touched paths and error classes and so would never have noticed a rules edit until the turn happened to drift.
- **The prefix wall, handled as designed.** `must`/`should` records render into the byte-stable system prompt, which never changes mid-session. A pinned change rides the next recall block as guidance, led by a section stating it binds into the prompt — and arms any tool guards — next session. The note is one-shot.
- **Retirement propagates.** A deleted or retired record leaves the volatile channel on the same swap, so suppression is one mechanism in the running session too.
- **A half-saved edit keeps the last good registry.** A rules file that stops parsing does not un-steer the session: the loaded registry stays in effect and the next block says the file does not parse. The comparison is source-based (a source that contributed records before, contributes none now, and carries a diagnostic), so a deleted file reads as retirement rather than damage.

`SessionMemory`'s registry moves behind an `RwLock` because the freshness check runs where the turn holds the memory by `&`; the two render paths clone the registry out of the lock rather than borrowing through it, so a concurrent swap is never blocked by a selection pass.

Exemplars: the digest-then-reload shape is `stella_graph::CodeGraph::mount`'s own catch-up (byte-identical files are skipped), applied to a file set small enough that the digest *is* the catch-up; the one-shot note follows `RecalledBlock`'s existing section assembly.

## Witnesses (each fails on `main` without the change)

`crates/stella-cli/src/memory/tests/records_refresh.rs`:

- `a_record_added_mid_session_reaches_the_next_recall_block` — the record renders and the generation bumped
- `a_record_deleted_mid_session_leaves_the_volatile_channel`
- `a_rules_file_that_stops_parsing_keeps_the_last_good_registry` — the old record still renders and the failure is reported
- `a_pinned_record_change_is_delivered_as_guidance_with_its_caveat` — the note appears once and not on the following block

`memory/steering.rs::fingerprint_tests::a_registry_swap_moves_the_fingerprint_alone` pins the forced re-query.

The prompt-cache goldens (`memory/tests/golden_block.rs`) are untouched: nothing here writes to the system prefix.

Two DoD notes against #5432, stated plainly: the issue sketched a `notify` watcher and this lands a boundary-time digest instead, for the reasons above (the outcome the DoD asks for — pickup at the next step boundary — is what the witnesses pin); and the "corrupt ledger / bad governance file" case is covered by `load_registry`'s existing fail-closed behaviour plus the parse-failure witness — a governance file that fails to parse is #5328's subject and its own guard.

No `#[test]` was deleted.

## Test evidence

Targeted runs (SCR-001): `cargo test -p stella-cli memory` (334 passed) green, `make prose` clean, `cargo fmt` applied. CI's workspace run is the full evidence.

Closes #5432

## Summary by Sourcery

Deliver boundary-aware prompt interruption and context-record freshness while making composer intent explicit in the TUI.

New Features:
- Add composer modes for dispatching, steering, and interrupting prompts, with Shift-Tab cycling and color-coded intent indicators.
- Support a steer mid-turn policy that delivers prompts at the next step boundary.
- Refresh context records at session boundaries so edits, additions, retirements, and parse failures are reflected without restarting.

Bug Fixes:
- Ensure interrupt prompts stop the lead turn softly while preserving completed work and run ahead of parked prompts.
- Keep the last valid context-record registry active when a rules file becomes temporarily invalid.

Enhancements:
- Force a single re-query when the context-record registry changes and report pinned or unparsable rule changes through one-shot recall guidance.

Documentation:
- Document the steer policy and composer intent cycling, including the updated configuration option.

Tests:
- Add coverage for interrupt routing, composer mode behavior, mode-specific rendering, and mid-session context-record refresh scenarios.