### PR TITLE
test(cgp): the registry-source guard stands down under the downstream canary

### DIFF
--- a/crates/stella-cli/tests/cgp_deps_centralized.rs
+++ b/crates/stella-cli/tests/cgp_deps_centralized.rs
@@ -159,6 +159,15 @@ fn no_member_manifest_repeats_the_cgp_version() {
 /// no-manifest-edit operation.
 #[test]
 fn lockfile_sources_cgp_crates_from_the_registry() {
+    // The CGP downstream canary rewrites the workspace manifest to source
+    // the CGP crates from a local checkout; the registry guarantee below is
+    // about the committed tree, which the canary never commits. Its patch
+    // block carries a named sentinel — stand down when it is present.
+    let manifest =
+        std::fs::read_to_string(workspace_root().join("Cargo.toml")).expect("workspace manifest");
+    if manifest.contains("downstream-canary-stella.sh") {
+        return;
+    }
     let lock = workspace_root().join("Cargo.lock");
     let doc = read_manifest(&lock);
     let packages = doc


### PR DESCRIPTION
CGP's downstream canary rewrites stella's workspace manifest with a local `[patch]` (sentinel comment `downstream-canary-stella.sh`) so the CGP crates resolve from a checkout rather than crates.io. `lockfile_sources_cgp_crates_from_the_registry` then fails on source = path — it was masked until the protocol tripwire (#5482) stopped failing first.

The guard's promise is about the committed tree, which the canary never commits: when the sentinel is present in `Cargo.toml`, the test returns early; otherwise the registry assertion is unchanged. Unblocks the canary on context-graph-protocol main.

## Summary by Sourcery

Keep the CGP registry-source guard focused on committed manifests while unblocking downstream canary runs.

Bug Fixes:
- Allow the CGP downstream canary to bypass the committed-tree registry-source assertion when it temporarily rewrites the workspace to use local CGP crates.

Tests:
- Update the CGP dependency test to recognize the downstream canary manifest sentinel and preserve the registry assertion otherwise.