### PR TITLE
feat(stella-cli): stella whistle --deep reaches worker lanes, and >@all broadcasts from inside the deck

### DIFF
--- a/crates/stella-cli/src/agent/goal/tests.rs
+++ b/crates/stella-cli/src/agent/goal/tests.rs
@@ -75,6 +75,7 @@ async fn whistle_over_the_socket(socket: &std::path::Path, message: &str) {
         &mut stream,
         &crate::whistle::wire::WhistleRequest {
             text: message.to_string(),
+            deep: false,
         },
     )
     .await

--- a/crates/stella-cli/src/cli/command.rs
+++ b/crates/stella-cli/src/cli/command.rs
@@ -285,6 +285,10 @@ pub(crate) enum Command {
         /// Target only this session id (repeatable). Default: every live session.
         #[arg(long = "session")]
         session: Vec<String>,
+
+        /// Reach each session's live worker lanes as well as its lead
+        #[arg(long)]
+        deep: bool,
     },
 
     /// Analyze this workspace: domain taxonomy and code graph

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -960,6 +960,9 @@ pub async fn run_deck_session(
     // Sub-session bookkeeping: live-worker slots, and `task_assign` requests
     // waiting for one (drained oldest-first as workers end).
     let mut subs = SubSessions::resuming(&cfg.durability, &session_record.id);
+    // Each worker lane's tap is announced to the whistle relay, so a deep
+    // whistle can reach the lanes this session drives — see `whistle`.
+    subs.attach_lane_sink(whistle.clone());
     let mut pending_spawns: VecDeque<subsession::QueuedSpawn> = VecDeque::new();
     // Lanes whose Restart arrived while the worker was still live: stop
     // first, respawn on its Ended.
@@ -1108,6 +1111,22 @@ pub async fn run_deck_session(
                         }
                         dispatch.release();
                         text
+                    }
+                    // The composer's broadcast address — other sessions'
+                    // whistle sockets, reported as one note (`whistle`).
+                    Some(WorkspaceInput::Whistle {
+                        message,
+                        session,
+                        deep,
+                    }) => {
+                        whistle::broadcast_from_deck(
+                            message,
+                            session,
+                            deep,
+                            &session_record.id,
+                            &in_tx,
+                        );
+                        continue 'session;
                     }
                     // The agents page's new-task prompt: a lane, never the
                     // lead's next turn — that is this message's whole meaning.
@@ -1974,6 +1993,11 @@ pub async fn run_deck_session(
                             if !command_side::run(text.trim(), cfg, &in_tx, &session_record.id) {
                                 queue.push_back(text);
                             }
+                        }
+                        // A broadcast never waits on the lead's turn: it is
+                        // about other sessions (`whistle`).
+                        Some(WorkspaceInput::Whistle { message, session, deep }) => {
+                            whistle::broadcast_from_deck(message, session, deep, &session_record.id, &in_tx);
                         }
                         // The agents page's new-task prompt: a lane now,
                         // exactly as at idle — the lead's turn is untouched.

--- a/crates/stella-cli/src/command_deck/whistle.rs
+++ b/crates/stella-cli/src/command_deck/whistle.rs
@@ -46,6 +46,14 @@ pub(super) struct DeckWhistle {
     live: Mutex<Weak<SteeringTap>>,
     /// Steers that arrived with no turn to take them, oldest first.
     pending: Mutex<Vec<String>>,
+    /// The worker lanes this session drives, announced as each spawns
+    /// ([`crate::subsession::LaneTapSink`]) — what a deep whistle reaches
+    /// beyond the lead. `Weak` for the reason `live` is: the driver's
+    /// `SubSessions` owns each tap and drops it with the lane, and a lane
+    /// that ended must read as gone here rather than as a queue nobody
+    /// drains. A deep whistle at an idle lane set is not buffered: a lane
+    /// that does not exist yet has no work the guidance could be about.
+    lanes: Mutex<Vec<Weak<SteeringTap>>>,
     /// This session's bound socket. Replaced when the deck switches sessions;
     /// dropping it unbinds and removes the socket file.
     listener: Mutex<Option<crate::whistle::SessionListener>>,
@@ -111,6 +119,53 @@ impl DeckWhistle {
                 .push(text),
         }
     }
+
+    /// [`Self::deliver`] to the lead, and the same text into every worker
+    /// lane still able to drain one. Lanes that ended are dropped from the
+    /// list on the way past, so it never grows with a session's history.
+    fn deliver_deep(&self, text: String) {
+        self.deliver(text.clone());
+        let mut lanes = self.lanes.lock().unwrap_or_else(|p| p.into_inner());
+        lanes.retain(|lane| lane.upgrade().is_some());
+        for tap in lanes.iter().filter_map(Weak::upgrade) {
+            if !tap.is_settling() {
+                tap.push(text.clone());
+            }
+        }
+    }
+}
+
+impl crate::subsession::LaneTapSink for DeckWhistle {
+    fn register(&self, tap: &Arc<SteeringTap>) {
+        self.lanes
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(Arc::downgrade(tap));
+    }
+}
+
+/// The deck's half of the composer's broadcast address (`>@all …`,
+/// `>@<session-id> …`): send `message` to the other live sessions on this
+/// machine over their whistle sockets, off the driver's event pump, and
+/// report every outcome as one chrome note. This session is never a target
+/// of its own broadcast — a steer meant for the room lands here through the
+/// composer's ordinary route, not through its own socket.
+pub(super) fn broadcast_from_deck(
+    message: String,
+    session: Option<String>,
+    deep: bool,
+    own_session: &str,
+    in_tx: &tokio::sync::mpsc::UnboundedSender<stella_tui::Inbound>,
+) {
+    let own = own_session.to_string();
+    let in_tx = in_tx.clone();
+    tokio::spawn(async move {
+        let registry = stella_store::SessionRegistry::open_default();
+        let ids: Vec<String> = session.into_iter().collect();
+        let outcomes =
+            crate::whistle::cmd::broadcast(&registry, &message, &ids, deep, Some(&own)).await;
+        let _ = in_tx.send(super::chrome_note(crate::whistle::cmd::summary(&outcomes)));
+    });
 }
 
 /// What the listener actually holds: a weak handle back to the relay.
@@ -126,6 +181,12 @@ impl Whistleable for RelayHandle {
     fn push(&self, text: String) {
         if let Some(relay) = self.0.upgrade() {
             relay.deliver(text);
+        }
+    }
+
+    fn push_deep(&self, text: String) {
+        if let Some(relay) = self.0.upgrade() {
+            relay.deliver_deep(text);
         }
     }
 }
@@ -220,6 +281,7 @@ mod tests {
                     &mut stream,
                     &crate::whistle::wire::WhistleRequest {
                         text: "the deck is listening".to_string(),
+                        deep: false,
                     },
                 )
                 .await
@@ -238,6 +300,54 @@ mod tests {
                     vec!["the deck is listening"]
                 );
             });
+    }
+
+    /// **The witness for `--deep`.** A deep whistle reaches the lead's turn
+    /// and every live worker lane the session announced; a plain one reaches
+    /// the lead alone; a lane that ended is gone from the fan-out, and one
+    /// that is settling — past its last model step — takes nothing.
+    #[test]
+    fn a_deep_whistle_reaches_the_lead_and_every_live_lane() {
+        use crate::subsession::LaneTapSink as _;
+        let relay = Arc::new(DeckWhistle::default());
+        let lead = relay.mint_turn_tap();
+        let lane_a: Arc<SteeringTap> = Arc::default();
+        let lane_b: Arc<SteeringTap> = Arc::default();
+        let settling: Arc<SteeringTap> = Arc::default();
+        settling.mark_settling();
+        for lane in [&lane_a, &lane_b, &settling] {
+            relay.register(lane);
+        }
+        let ended: Arc<SteeringTap> = Arc::default();
+        relay.register(&ended);
+        drop(ended);
+
+        RelayHandle(Arc::downgrade(&relay)).push("lead only".to_string());
+        assert_eq!(lead.drain_steering(), vec!["lead only"]);
+        assert!(
+            lane_a.drain_steering().is_empty(),
+            "a plain whistle stops at the lead"
+        );
+
+        RelayHandle(Arc::downgrade(&relay)).push_deep("everyone: stop touching main".to_string());
+        assert_eq!(lead.drain_steering(), vec!["everyone: stop touching main"]);
+        assert_eq!(
+            lane_a.drain_steering(),
+            vec!["everyone: stop touching main"]
+        );
+        assert_eq!(
+            lane_b.drain_steering(),
+            vec!["everyone: stop touching main"]
+        );
+        assert!(
+            settling.drain_steering().is_empty(),
+            "a settling lane has no boundary left to drain at"
+        );
+        assert_eq!(
+            relay.lanes.lock().unwrap().len(),
+            3,
+            "the ended lane is pruned on the way past"
+        );
     }
 
     /// The turn that ended owns nothing: its tap is dropped with the loop

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -967,15 +967,22 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
                 _ => return daemon::run(cmd).map_err(failure::CliFailure::from),
             }
         }
-        Some(Command::Whistle { message, session }) => {
+        Some(Command::Whistle {
+            message,
+            session,
+            deep,
+        }) => {
             // A local broadcast over each target session's own control
             // socket — the local registry and a handful of Unix sockets, no
             // provider needed. This runs before provider resolution for the
             // same reason `Command::Daemon` does: an operator reaching for
             // this is trying to redirect work that is already running,
             // whatever this invocation's own model config looks like.
-            return signals::block_on_interruptible(rt()?, whistle::cmd::run(message, session))
-                .map_err(failure::CliFailure::from);
+            return signals::block_on_interruptible(
+                rt()?,
+                whistle::cmd::run(message, session, *deep),
+            )
+            .map_err(failure::CliFailure::from);
         }
         _ => {}
     }

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -112,6 +112,16 @@ pub(crate) struct SubSessions {
     winding_down: HashMap<String, u64>,
     /// Every lane's spec, retained past its end — what Restart respawns.
     specs: HashMap<String, SubSessionSpec>,
+    /// Where each spawned lane's tap is announced, when something listens —
+    /// the deck's whistle relay, so a deep whistle reaches the lanes this
+    /// tenancy drives without the relay holding a handle on the driver's
+    /// `SubSessions` itself.
+    lane_sink: Option<Arc<dyn LaneTapSink>>,
+}
+
+/// Something told about every worker lane's steering tap as the lane spawns.
+pub(crate) trait LaneTapSink: Send + Sync {
+    fn register(&self, tap: &Arc<SteeringTap>);
 }
 
 impl SubSessions {
@@ -127,6 +137,7 @@ impl SubSessions {
             cleared: std::collections::HashSet::new(),
             winding_down: HashMap::new(),
             specs: HashMap::new(),
+            lane_sink: None,
         }
     }
 
@@ -186,6 +197,9 @@ impl SubSessions {
         self.next_generation += 1;
         self.active += 1;
         let tap: Arc<SteeringTap> = Arc::default();
+        if let Some(sink) = &self.lane_sink {
+            sink.register(&tap);
+        }
         self.stops.insert(lane.to_string(), (generation, stop));
         self.pauses.insert(lane.to_string(), pause);
         self.taps.insert(lane.to_string(), tap.clone());
@@ -193,6 +207,11 @@ impl SubSessions {
         self.cleared.remove(lane);
         self.specs.insert(lane.to_string(), spec);
         (generation, tap)
+    }
+
+    /// Announce every lane spawned from now on to `sink`.
+    pub(crate) fn attach_lane_sink(&mut self, sink: Arc<dyn LaneTapSink>) {
+        self.lane_sink = Some(sink);
     }
 
     /// Inject `text` at `lane`'s next step boundary. `false` when no worker

--- a/crates/stella-cli/src/whistle/cmd.rs
+++ b/crates/stella-cli/src/whistle/cmd.rs
@@ -30,13 +30,13 @@ pub(crate) enum Delivery {
 /// non-empty. `Err` only when at least one targeted session could not be
 /// reached — the per-session outcomes are always printed first, so the
 /// caller sees exactly which.
-pub(crate) async fn run(message: &str, session_ids: &[String]) -> Result<(), String> {
+pub(crate) async fn run(message: &str, session_ids: &[String], deep: bool) -> Result<(), String> {
     if message.trim().is_empty() {
         return Err("stella whistle: message must not be empty".to_string());
     }
     let registry = SessionRegistry::open_default();
-    let targets = targets(&registry, session_ids);
-    if targets.is_empty() {
+    let outcomes = broadcast(&registry, message, session_ids, deep, None).await;
+    if outcomes.is_empty() {
         println!(
             "no {} to whistle at",
             if session_ids.is_empty() {
@@ -47,22 +47,63 @@ pub(crate) async fn run(message: &str, session_ids: &[String]) -> Result<(), Str
         );
         return Ok(());
     }
-    // Wrapped so the model reads this as an out-of-band directive rather
-    // than an ordinary trailing remark — `AgentEvent::Steered` already
-    // narrates the drain regardless, so the transcript records that a
-    // steer landed; this wrapping is what tells the model to prioritize it.
-    let wrapped = format!("[whistle — steering from another session] {message}");
     let mut any_unreachable = false;
-    for record in &targets {
-        let outcome = deliver_one(&registry, record, &wrapped).await;
+    for (record, outcome) in &outcomes {
         any_unreachable |= matches!(outcome, Delivery::Unreachable(_));
-        print_outcome(record, &outcome);
+        print_outcome(record, outcome);
     }
     if any_unreachable {
         Err("whistle: not every targeted session could be reached".to_string())
     } else {
         Ok(())
     }
+}
+
+/// Deliver `message` to every target ([`targets`], minus `exclude` — the
+/// session broadcasting from inside the deck, which must not whistle
+/// itself), all at once, and return each session's outcome in target order.
+///
+/// Concurrent rather than one after another because each delivery carries a
+/// connect and an ack timeout: at a dozen sessions with a few stale sockets
+/// among them, a sequential sweep made "broadcast" mean "wait". A stale
+/// socket now delays only its own row. `deep` asks each session to reach
+/// its worker lanes too ([`super::tap::Whistleable::push_deep`]).
+pub(crate) async fn broadcast(
+    registry: &SessionRegistry,
+    message: &str,
+    session_ids: &[String],
+    deep: bool,
+    exclude: Option<&str>,
+) -> Vec<(SessionRecord, Delivery)> {
+    let targets: Vec<SessionRecord> = targets(registry, session_ids)
+        .into_iter()
+        .filter(|record| exclude != Some(record.id.as_str()))
+        .collect();
+    // Wrapped so the model reads this as an out-of-band directive rather
+    // than an ordinary trailing remark — `AgentEvent::Steered` already
+    // narrates the drain regardless, so the transcript records that a
+    // steer landed; this wrapping is what tells the model to prioritize it.
+    let wrapped = format!("[whistle — steering from another session] {message}");
+    let outcomes = futures_util::future::join_all(
+        targets
+            .iter()
+            .map(|record| deliver_one(registry, record, &wrapped, deep)),
+    )
+    .await;
+    targets.into_iter().zip(outcomes).collect()
+}
+
+/// One line per session, the deck's chrome-note rendering of a broadcast's
+/// outcomes — the same rows `stella whistle` prints, joined.
+pub(crate) fn summary(outcomes: &[(SessionRecord, Delivery)]) -> String {
+    if outcomes.is_empty() {
+        return "whistle: no other live session to reach".to_string();
+    }
+    outcomes
+        .iter()
+        .map(|(record, outcome)| outcome_line(record, outcome))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// The sessions to whistle at: explicit ids if given (whether or not they
@@ -83,21 +124,30 @@ fn targets(registry: &SessionRegistry, session_ids: &[String]) -> Vec<SessionRec
 }
 
 fn print_outcome(record: &SessionRecord, outcome: &Delivery) {
+    println!("{}", outcome_line(record, outcome));
+}
+
+fn outcome_line(record: &SessionRecord, outcome: &Delivery) -> String {
     let title = if record.title.is_empty() {
         record.workspace.as_str()
     } else {
         record.title.as_str()
     };
     match outcome {
-        Delivery::Delivered => println!("delivered    {:<24} {title}", record.id),
+        Delivery::Delivered => format!("delivered    {:<24} {title}", record.id),
         Delivery::Unreachable(reason) => {
-            println!("unreachable  {:<24} {title} ({reason})", record.id);
+            format!("unreachable  {:<24} {title} ({reason})", record.id)
         }
     }
 }
 
 #[cfg(unix)]
-async fn deliver_one(registry: &SessionRegistry, record: &SessionRecord, text: &str) -> Delivery {
+async fn deliver_one(
+    registry: &SessionRegistry,
+    record: &SessionRecord,
+    text: &str,
+    deep: bool,
+) -> Delivery {
     use tokio::net::UnixStream;
     use tokio::time::timeout;
 
@@ -113,6 +163,7 @@ async fn deliver_one(registry: &SessionRegistry, record: &SessionRecord, text: &
     };
     let request = WhistleRequest {
         text: text.to_string(),
+        deep,
     };
     if write_frame(&mut stream, &request).await.is_err() {
         return Delivery::Unreachable("failed to send".to_string());
@@ -134,6 +185,7 @@ async fn deliver_one(
     _registry: &SessionRegistry,
     _record: &SessionRecord,
     _text: &str,
+    _deep: bool,
 ) -> Delivery {
     Delivery::Unreachable(
         "agent whistle needs a Unix domain socket — not supported on this platform yet".to_string(),
@@ -197,12 +249,52 @@ mod tests {
         registry.upsert(&unreachable).unwrap();
 
         assert_eq!(
-            deliver_one(&registry, &reachable, "test").await,
+            deliver_one(&registry, &reachable, "test", false).await,
             Delivery::Delivered
         );
         assert!(matches!(
-            deliver_one(&registry, &unreachable, "test").await,
+            deliver_one(&registry, &unreachable, "test", false).await,
             Delivery::Unreachable(_)
         ));
+
+        // The broadcast reaches both at once, reports each in target order,
+        // and leaves out the session that is broadcasting.
+        let mut outcomes = broadcast(&registry, "test", &[], false, Some("ses-unreachable")).await;
+        outcomes.sort_by(|a, b| a.0.id.cmp(&b.0.id));
+        assert_eq!(outcomes.len(), 1, "the excluded session is not a target");
+        assert_eq!(outcomes[0].0.id, "ses-reachable");
+        assert_eq!(outcomes[0].1, Delivery::Delivered);
+        assert!(summary(&outcomes).starts_with("delivered    ses-reachable"));
+        assert_eq!(
+            summary(&[]),
+            "whistle: no other live session to reach",
+            "an empty broadcast says so rather than printing nothing"
+        );
+    }
+
+    /// The fan-out is concurrent: two unreachable targets, each costing a
+    /// connect attempt, finish together rather than one after the other.
+    /// Measured against the sequential bound, which is the shape `run` had.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_broadcast_reaches_every_target_at_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = SessionRegistry::open(dir.path());
+        let ids = ["ses-a", "ses-b", "ses-c", "ses-d"];
+        for id in ids {
+            let mut r = record(id, stella_store::SessionStatus::InProgress);
+            r.id = id.to_string();
+            registry.upsert(&r).unwrap();
+        }
+        let outcomes = broadcast(&registry, "test", &[], false, None).await;
+        let mut got: Vec<&str> = outcomes.iter().map(|(r, _)| r.id.as_str()).collect();
+        got.sort_unstable();
+        assert_eq!(got, ids, "every target is reported, none dropped");
+        assert!(
+            outcomes
+                .iter()
+                .all(|(_, outcome)| matches!(outcome, Delivery::Unreachable(_))),
+            "no listener was bound, so every row is unreachable — and reported"
+        );
     }
 }

--- a/crates/stella-cli/src/whistle/listener.rs
+++ b/crates/stella-cli/src/whistle/listener.rs
@@ -94,7 +94,11 @@ async fn accept_loop(listener: UnixListener, tap: Arc<dyn Whistleable>) {
             let Ok(request) = read_frame::<_, WhistleRequest>(&mut stream).await else {
                 return;
             };
-            tap.push(request.text);
+            if request.deep {
+                tap.push_deep(request.text);
+            } else {
+                tap.push(request.text);
+            }
             let _ = write_frame(&mut stream, &WhistleAck { delivered: true }).await;
         });
     }
@@ -131,6 +135,7 @@ mod tests {
             &mut stream,
             &WhistleRequest {
                 text: "stop the compile".to_string(),
+                deep: false,
             },
         )
         .await

--- a/crates/stella-cli/src/whistle/tap.rs
+++ b/crates/stella-cli/src/whistle/tap.rs
@@ -17,6 +17,13 @@ pub(crate) trait Whistleable: Send + Sync {
     /// (`stella_core::driver::step_boundary::consult_hosts` — strictly
     /// between model calls, never mid-tool).
     fn push(&self, text: String);
+
+    /// As [`Self::push`], and into every live worker lane this session
+    /// drives as well. A tap that drives no lanes — every non-interactive
+    /// door — has nothing deeper to reach, so the default is the lead alone.
+    fn push_deep(&self, text: String) {
+        self.push(text);
+    }
 }
 
 /// A minimal steering tap for a non-interactive (non-deck) session: `stella run`

--- a/crates/stella-cli/src/whistle/wire.rs
+++ b/crates/stella-cli/src/whistle/wire.rs
@@ -20,6 +20,11 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct WhistleRequest {
     pub(crate) text: String,
+    /// Reach the session's live worker lanes as well as its lead. Absent on
+    /// the wire from a sender built before the field existed, which decodes
+    /// as the lead-only whistle that sender meant.
+    #[serde(default)]
+    pub(crate) deep: bool,
 }
 
 /// The receiving session's answer: the message was queued.
@@ -77,10 +82,21 @@ mod tests {
         let (mut a, mut b) = tokio::io::duplex(4096);
         let sent = WhistleRequest {
             text: "stop the compile, let CI handle the gate".to_string(),
+            deep: true,
         };
         write_frame(&mut a, &sent).await.unwrap();
         let received: WhistleRequest = read_frame(&mut b).await.unwrap();
         assert_eq!(received.text, sent.text);
+        assert!(received.deep);
+    }
+
+    /// A frame from a sender that predates `deep` carries no such key, and
+    /// decodes as the lead-only whistle that sender meant.
+    #[test]
+    fn a_frame_without_the_deep_key_is_a_lead_only_whistle() {
+        let received: WhistleRequest =
+            serde_json::from_str(r#"{"text":"read the failing test"}"#).unwrap();
+        assert!(!received.deep);
     }
 
     #[tokio::test]

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -248,7 +248,11 @@ pub static CAPABILITIES: &[Capability] = &[
             mechanism: "`stella whistle <message>` — one Unix domain socket per session inside \
                         its SessionRegistry sidecar, discovered exactly as `stella resume --list` \
                         discovers sessions; interactive mode reaches it through a session-scoped \
-                        relay, since its own steering tap exists only during a turn",
+                        relay, since its own steering tap exists only during a turn. `--deep` \
+                        fans the same text into the session's live worker lanes \
+                        (`a_deep_whistle_reaches_the_lead_and_every_live_lane`), and the deck's \
+                        `>@all` / `>@<id>` address broadcasts from inside a session \
+                        (`the_broadcast_address_parses_its_target_depth_and_message`)",
             witness: "a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn",
         },
         // Not "serve has POST /v1/turns/{id}/steer, so it is covered". It has

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -118,6 +118,20 @@ async fn main() -> std::io::Result<()> {
                         });
                     }
                 }
+                // The composer's broadcast address. The demo has no other
+                // sessions to reach, so it answers the way the driver does
+                // with nothing live to whistle at — one chrome note.
+                WorkspaceInput::Whistle { message, .. } => {
+                    let _ = react_tx.send(Inbound::Event {
+                        agent: "lead".to_string(),
+                        event: stella_protocol::AgentEvent::Text {
+                            text: format!(
+                                "{}whistle: no other live session to reach ({message})",
+                                stella_tui::NOTICE_MARKER
+                            ),
+                        },
+                    });
+                }
                 WorkspaceInput::Control { agent, control } => {
                     // Delete answers with the row's removal, like the driver.
                     if control == AgentControl::Delete {

--- a/crates/stella-tui/src/deck_ui/dispatch.rs
+++ b/crates/stella-tui/src/deck_ui/dispatch.rs
@@ -74,6 +74,9 @@ impl DispatchRoute {
 /// and the turn-coupled builtins (`/clear`, `/init`, `/reload`, …), which all
 /// keep their queue behavior.
 pub(super) fn sideband(ui: &DeckUi, text: &str) -> Option<WorkspaceInput> {
+    if let Some(input) = broadcast(text) {
+        return Some(input);
+    }
     let head = text.split_whitespace().next()?;
     if !head.starts_with('/') {
         return None;
@@ -84,6 +87,32 @@ pub(super) fn sideband(ui: &DeckUi, text: &str) -> Option<WorkspaceInput> {
         .map(|_| WorkspaceInput::Command {
             text: text.trim().to_string(),
         })
+}
+
+/// The broadcast address: `>@all <message>` reaches every other live
+/// session on this machine, `>@<session-id> <message>` one of them, and
+/// `--deep` right after the address reaches their worker lanes too. Read
+/// ahead of the `>` steer marker, which it extends — a steer aimed at the
+/// room rather than at this session's turn. `None` for an
+/// address with no message: there is nothing to send, so the text keeps its
+/// ordinary route and the user sees what they typed.
+fn broadcast(text: &str) -> Option<WorkspaceInput> {
+    let rest = text.trim_start().strip_prefix(">@")?;
+    let (address, rest) = rest.split_once(char::is_whitespace)?;
+    let (deep, message) = match rest.trim_start().strip_prefix("--deep") {
+        Some(after) if after.is_empty() || after.starts_with(char::is_whitespace) => {
+            (true, after.trim())
+        }
+        _ => (false, rest.trim()),
+    };
+    if address.is_empty() || message.is_empty() {
+        return None;
+    }
+    Some(WorkspaceInput::Whistle {
+        message: message.to_string(),
+        session: (address != "all").then(|| address.to_string()),
+        deep,
+    })
 }
 
 /// Whether `text` states its own routing and must not be second-guessed.
@@ -579,6 +608,55 @@ mod tests {
             WorkspaceInput::Enqueue {
                 text: "unrelated".into()
             }
+        );
+    }
+
+    /// **The witness for the broadcast address.** `>@all` reaches every
+    /// other session, `>@<id>` one of them, `--deep` reaches their lanes, and
+    /// an address with nothing to say keeps its ordinary route.
+    #[test]
+    fn the_broadcast_address_parses_its_target_depth_and_message() {
+        assert_eq!(
+            broadcast(">@all stop touching the release branch"),
+            Some(WorkspaceInput::Whistle {
+                message: "stop touching the release branch".into(),
+                session: None,
+                deep: false,
+            })
+        );
+        assert_eq!(
+            broadcast("  >@ses-17-9 --deep run the tests first"),
+            Some(WorkspaceInput::Whistle {
+                message: "run the tests first".into(),
+                session: Some("ses-17-9".into()),
+                deep: true,
+            })
+        );
+        assert_eq!(
+            broadcast(">@all --deeper is a word"),
+            Some(WorkspaceInput::Whistle {
+                message: "--deeper is a word".into(),
+                session: None,
+                deep: false,
+            }),
+            "only the exact flag is a flag"
+        );
+        for text in [
+            ">@all",
+            ">@all   ",
+            ">@ --deep",
+            "> @all hello",
+            "@all hello",
+        ] {
+            assert_eq!(broadcast(text), None, "{text:?} is not a broadcast");
+        }
+        let ui = DeckUi::default();
+        assert!(
+            matches!(
+                sideband(&ui, ">@all go"),
+                Some(WorkspaceInput::Whistle { .. })
+            ),
+            "the broadcast is queue-free, like a sideband command"
         );
     }
 

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -936,6 +936,19 @@ pub enum WorkspaceInput {
     /// the turn going. See [`steering`] for why this is not a cancel, and why
     /// the whole queue travels in one message.
     Steer { agent: AgentId, texts: Vec<String> },
+    /// The composer's broadcast address (`>@all …`, `>@<session-id> …`,
+    /// optionally `--deep`): send `message` to the other live sessions on
+    /// this machine over their whistle sockets — every live one when
+    /// `session` is `None`, that one otherwise — and, with `deep`, into
+    /// their worker lanes too. Queue-free like a sideband command: it is
+    /// about other sessions, so it never waits on this one's turn. The driver
+    /// answers with a chrome note of per-session outcomes, and this session
+    /// is never a target of its own broadcast.
+    Whistle {
+        message: String,
+        session: Option<String>,
+        deep: bool,
+    },
     /// Re-root the Graph tab on `file`: the deck's file picker sends this when
     /// the user selects a file, and the driver answers with a fresh
     /// [`Inbound::GraphSnapshot`] centered on it (the same out-of-band refresh

--- a/website/content/docs/commands/whistle.mdx
+++ b/website/content/docs/commands/whistle.mdx
@@ -11,6 +11,7 @@ A message reaches a running [`run`](/docs/commands/run) or [`goal`](/docs/comman
 stella whistle "<message>"
 stella whistle "<message>" --session <id>
 stella whistle "<message>" --session <id> --session <id>
+stella whistle "<message>" --deep
 ```
 
 ## How delivery works
@@ -29,7 +30,29 @@ delivered    ses-1785956826121-25167  stella: migrate the config loader to serde
 unreachable  ses-1785956700004        stella: fix the flaky test (no listener — the session isn't currently reachable)
 ```
 
-`stella whistle` exits with a non-zero code if any target session could not be reached, after it prints the outcome for every session.
+`stella whistle` exits with a non-zero code if any target session could not be reached, after it prints the outcome for every session. Every target is contacted at the same time, so a session whose socket is stale slows down only its own line.
+
+## Reaching a session's workers
+
+A whistle normally lands on a session's lead — the agent you talk to. An interactive session can also be driving worker lanes (a task worker, a sidecar prompt), and those never hear a plain whistle. Add `--deep` and the same message lands at each live worker lane's next safe point as well:
+
+```bash
+stella whistle "stop touching the release branch" --deep
+```
+
+A session with no workers treats `--deep` exactly like a plain whistle.
+
+## Broadcasting from inside a session
+
+You do not need a second terminal. In [`stella chat`](/docs/commands/chat), type the message with a broadcast address in front of it:
+
+```text
+>>> >@all stop touching the release branch
+>>> >@ses-1785956826121-25167 run the tests first
+>>> >@all --deep stop touching the release branch
+```
+
+`>@all` reaches every other live session on this machine, `>@<id>` one of them, and `--deep` right after the address reaches their worker lanes too. The outcome for every session appears as a note in your transcript, in the same rows the command prints. The message goes out at once — it never waits behind your own agent's turn — and your own session is never a target of its own broadcast.
 
 ## What is reachable today
 


### PR DESCRIPTION
## What & why

`stella whistle` already broadcasts steering to every live session on the machine, but it stopped at each session's front door and needed a second terminal. This PR gives it depth and an in-session door:

- **`--deep` reaches worker lanes.** `WhistleRequest` carries a `deep` flag (serde-defaulted, so a sender built before the field decodes as the lead-only whistle it meant). `Whistleable::push_deep` has a default of `push`, so every non-interactive door — which drives no lanes — behaves exactly as before. The deck's relay (`DeckWhistle`) implements it: `SubSessions` announces each spawned lane's tap through a new `LaneTapSink` (one line in the driver: `subs.attach_lane_sink(whistle.clone())`), the relay keeps `Weak` handles for the reason it already keeps one for the lead, and a deep whistle lands on the lead and every live, non-settling lane, pruning ended lanes on the way past. A deep whistle at a session with no lanes is a plain whistle.
- **`>@all` / `>@<session-id>` from the composer.** Parsed in `dispatch::sideband` (`stella-tui`), so a broadcast is queue-free like `/export` — it is about other sessions and never waits on this one's turn. `--deep` right after the address reaches lanes. The driver runs it off the event pump (`whistle::broadcast_from_deck`) and reports every session's outcome as one chrome note, in the same rows the command prints. The broadcasting session is excluded from its own targets.
- **Parallel fan-out.** `whistle::cmd::broadcast` delivers to every target at once (`futures_util::future::join_all`); a stale socket's connect timeout now delays only its own row. `run` is the printing wrapper over it.

**Deliberately not in this PR:** addressed steering for in-process `delegate` children. That is a `stella-core` engine seam (`ChildSteering` refuses steering by design so a child can never eat the parent's message), and #5431 says to split it when it grows past a reviewable slice. It is filed as #5520 under epic #4806 with the addressing sketch.

Exemplars: the relay's `Weak` lane list follows its own `live` field; `broadcast_from_deck` follows `command_side`'s spawn-and-report shape; the `deep` wire field follows `stella-protocol`'s `#[serde(default)]` additive-field discipline.

## Witnesses (each fails on `main` without the change)

- `command_deck::whistle::tests::a_deep_whistle_reaches_the_lead_and_every_live_lane` — lead and both live lanes receive the deep text, the plain whistle stops at the lead, a settling lane takes nothing, the ended lane is pruned
- `whistle::wire::tests::a_frame_without_the_deep_key_is_a_lead_only_whistle` — the wire-compatibility promise
- `whistle::cmd::tests::a_live_listener_is_delivered_to_and_an_absent_one_is_reported_unreachable` (extended: `broadcast` excludes the broadcasting session; `summary` renders the rows and names an empty result)
- `whistle::cmd::tests::a_broadcast_reaches_every_target_at_once` — every target is reported, none dropped
- `deck_ui::dispatch::tests::the_broadcast_address_parses_its_target_depth_and_message` — `>@all`, `>@<id>`, `--deep`, the exact-flag rule, and the no-message cases

The parity ledger's `turn.whistle` row names the two new witnesses in its mechanism text (the row's own witness is unchanged and still lives in the included file).

DoD notes against #5431, stated plainly: the delegate-child box is handed to #5520 rather than ticked; the SESSIONS-overlay `w` binding mentioned in the issue body (not its DoD) is not included — `>@<id>` from the composer covers the same action without a new key.

No `#[test]` was deleted.

## Test evidence

Targeted runs (SCR-001): `cargo test -p stella-cli whistle` (18 passed), `command_deck` (214), `goal`; `cargo test -p stella-tui --lib`; `cargo test -p stella-parity` (23); `make prose` clean; `cargo fmt` applied. CI's workspace run is the full evidence.

Closes #5431 — the delegate-child item continues in #5520.

## Summary by Sourcery

Extend whistle steering to worker lanes and enable concurrent broadcasts from within interactive sessions.

New Features:
- Add `--deep` whistle delivery to live worker lanes in addition to session leads.
- Add `>@all` and `>@<session-id>` composer addresses for queue-free broadcasts from inside a deck, with optional `--deep` delivery.

Bug Fixes:
- Preserve lead-only behavior when decoding whistle requests from older senders that omit the new depth field.

Enhancements:
- Fan out whistle broadcasts concurrently and report per-session delivery outcomes without allowing stale sockets to delay other targets.

Documentation:
- Document deep whistle delivery, in-session broadcasting, concurrent delivery behavior, and the new command syntax.

Tests:
- Add coverage for deep delivery to live lanes, wire compatibility, broadcast parsing, target exclusion, outcome reporting, and concurrent fan-out.