### PR TITLE
feat(stella-cli): a context record changed mid-session reaches the next step boundary

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -65,6 +65,7 @@ mod private_state;
 mod projection;
 pub(crate) mod proposals;
 mod recall;
+mod records_refresh;
 // #2304: the trace-replay learning harness — the learning machinery driven from
 // recorded traces with zero model calls. Test-only by construction: the crate is
 // bin-only, so an in-crate module is the only place this can reach
@@ -366,11 +367,24 @@ pub struct SessionMemory {
     /// cacheable, facts are only worth tokens when they apply. The *registry* is
     /// stored rather than a pre-rendered string because rendering is per turn:
     /// `applies_to` selection needs the turn's prompt to decide which scoped
-    /// records are worth their tokens right now. Set once per session by
-    /// [`Self::open_for_session`] from the already-resolved rule registry —
-    /// re-deriving it here would re-walk the rule directories and re-run the
-    /// truth sweep on every turn.
-    record_registry: Option<stella_core::records::Registry>,
+    /// records are worth their tokens right now. Seeded per session by
+    /// [`Self::open_for_session`] from the already-resolved rule registry, and
+    /// refreshed mid-session when the rule files' bytes move — see
+    /// [`records_refresh`]. Behind a lock because the freshness check runs at
+    /// the re-query boundary, where the turn holds this memory by `&`.
+    record_registry: std::sync::RwLock<Option<stella_core::records::Registry>>,
+    /// Bumped on every mid-session registry swap and folded into the
+    /// re-query fingerprint, so a swap forces exactly one re-query at the
+    /// next boundary — path drift alone would never notice it.
+    records_generation: std::sync::atomic::AtomicU64,
+    /// Content digest of the rule files behind the loaded registry
+    /// ([`records_refresh::rules_digest`]), so the per-boundary freshness
+    /// check is a read-and-hash and a reload runs only when bytes moved.
+    records_fingerprint: std::sync::Mutex<u64>,
+    /// A one-shot section the next recall block leads with — what a
+    /// mid-session swap could not fully apply (a pinned change that binds
+    /// next session, a file that stopped parsing).
+    records_note: std::sync::Mutex<Option<String>>,
     /// The session's time source (#2320) — the only one the learning loop is
     /// allowed to read.
     ///
@@ -584,7 +598,10 @@ impl SessionMemory {
                     suppression::suppression_reader(workspace_root, store.clone()),
                 );
                 Some(Self {
-                    record_registry: None,
+                    record_registry: std::sync::RwLock::new(None),
+                    records_generation: std::sync::atomic::AtomicU64::new(0),
+                    records_fingerprint: std::sync::Mutex::new(0),
+                    records_note: std::sync::Mutex::new(None),
                     store,
                     host,
                     domains,

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -200,7 +200,12 @@ impl SessionMemory {
     /// string because rendering happens per turn: `applies_to` selection needs
     /// each turn's prompt to decide which scoped records apply.
     pub(super) fn set_record_registry(&mut self, registry: stella_core::records::Registry) {
-        self.record_registry = (!registry.entries.is_empty()).then_some(registry);
+        *self.record_registry.get_mut().expect("records lock") =
+            (!registry.entries.is_empty()).then_some(registry);
+        // Prime the freshness digest, so the first boundary check after open
+        // reads "unchanged" instead of reloading what was just handed in.
+        *self.records_fingerprint.get_mut().expect("records digest") =
+            super::records_refresh::rules_digest(&self.workspace_root);
     }
 
     /// This turn's volatile record channel, rendered: the registry's volatile
@@ -214,8 +219,11 @@ impl SessionMemory {
     fn turn_record_rendered(
         &self,
         prompt: &str,
-    ) -> Option<(&stella_core::records::Registry, RenderedChannel)> {
-        let registry = self.record_registry.as_ref()?;
+    ) -> Option<(stella_core::records::Registry, RenderedChannel)> {
+        // Cloned out of the lock rather than borrowed through it: the caller
+        // threads the registry across the rest of its selection pass, and a
+        // guard held that long would block a concurrent freshness swap.
+        let registry = self.record_registry.read().expect("records lock").clone()?;
         let paths = turn_path_tokens(prompt);
         let facts = stella_core::records::TurnFacts {
             text: prompt,
@@ -247,7 +255,7 @@ impl SessionMemory {
         mut report: impl FnMut(String),
     ) -> Option<String> {
         let (registry, rendered) = self.turn_record_rendered(prompt)?;
-        for drop in stella_core::steering::adapt::record_drops(registry, &rendered) {
+        for drop in stella_core::steering::adapt::record_drops(&registry, &rendered) {
             // A record channel drop is never also selected — the channel's
             // own budget cut it before the plane saw it.
             if let Some(message) = drop_message(&drop, false) {
@@ -311,6 +319,9 @@ impl SessionMemory {
         if self.ab_suppressed || !self.steering_enabled {
             return RecalledBlock::default();
         }
+        // A record edited since the last look joins this very block — see
+        // `records_refresh` for what a swap can and cannot apply.
+        self.refresh_records_if_changed();
         let RecalledFrames {
             recall,
             dropped: frame_drops,
@@ -367,6 +378,11 @@ impl SessionMemory {
         }
         if let Some(section) = record.and_then(|(_, rendered)| record_section_text(rendered)) {
             sections.push(section);
+        }
+        // What a mid-session registry swap could not fully apply, said once,
+        // first — see `records_refresh`.
+        if let Some(note) = self.take_records_note() {
+            sections.insert(0, note);
         }
 
         // The second operand of the knowledge-cutoff staleness clause
@@ -430,6 +446,9 @@ impl SessionMemory {
         if self.ab_suppressed || !self.steering_enabled {
             return RecalledBlock::default();
         }
+        // A no-op when the re-query boundary already refreshed (one digest
+        // read); real work only for a direct caller — see `records_refresh`.
+        self.refresh_records_if_changed();
         let prompt = signal.prompt;
 
         let anchors = self.anchors_for(prompt, signal.touched_paths);
@@ -454,23 +473,22 @@ impl SessionMemory {
                 paths.push(path.clone());
             }
         }
-        let record = self.record_registry.as_ref().map(|registry| {
+        let registry = self.record_registry.read().expect("records lock").clone();
+        let record = registry.map(|registry| {
             let facts = stella_core::records::TurnFacts {
                 text: prompt,
                 paths: &paths,
             };
-            (
-                registry,
-                // The per-record half of the #4498 dedup: the channel renders
-                // as one budgeted block, so leaving out what the turn has seen
-                // means re-rendering without those records, not filtering a
-                // list — the exclusion door is the registry's.
-                registry.render_volatile_for_turn_excluding(
-                    &facts,
-                    Some(RECORD_CHANNEL_BUDGET),
-                    produced.records(),
-                ),
-            )
+            // The per-record half of the #4498 dedup: the channel renders
+            // as one budgeted block, so leaving out what the turn has seen
+            // means re-rendering without those records, not filtering a
+            // list — the exclusion door is the registry's.
+            let rendered = registry.render_volatile_for_turn_excluding(
+                &facts,
+                Some(RECORD_CHANNEL_BUDGET),
+                produced.records(),
+            );
+            (registry, rendered)
         });
 
         let set = query_gathered_plane(
@@ -513,6 +531,11 @@ impl SessionMemory {
         }
         if let Some(section) = record.and_then(|(_, rendered)| record_section_text(rendered)) {
             sections.push(section);
+        }
+        // What a mid-session registry swap could not fully apply, said once,
+        // first — see `records_refresh`.
+        if let Some(note) = self.take_records_note() {
+            sections.insert(0, note);
         }
         RecalledBlock {
             text: (!sections.is_empty())
@@ -1045,7 +1068,7 @@ pub(super) fn query_gathered_plane(
     frames: &[RecalledFrame],
     frame_drops: &[stella_core::steering::DroppedCandidate],
     selected: &skills::SkillSelection,
-    record: Option<&(&stella_core::records::Registry, RenderedChannel)>,
+    record: Option<&(stella_core::records::Registry, RenderedChannel)>,
 ) -> stella_core::steering::SteeringSet {
     use stella_core::steering::{SteeringPlane, adapt};
 

--- a/crates/stella-cli/src/memory/records_refresh.rs
+++ b/crates/stella-cli/src/memory/records_refresh.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Mid-session freshness for the context-record registry.
+//!
+//! The registry is loaded once per session and rendered per turn; before this
+//! module a record edited, promoted, or retired while a session ran was
+//! invisible until restart. The freshness check is lazy rather than watched:
+//! it runs at the two moments the answer can matter — the turn-opening recall
+//! and each re-query boundary — by digesting the rule files' bytes and
+//! reloading only when they moved. No file watcher, no background task, no
+//! platform event quirks; the unchanged path costs one read of a handful of
+//! small policy files.
+//!
+//! What a swap can and cannot do is stated: the volatile channel picks the
+//! new registry up at the next boundary, and the swap forces one re-query by
+//! bumping the generation the fingerprint folds. The cached system prefix is
+//! byte-stable for the session (AGENTS.md's byte-stable-prompts rule), so a change to a
+//! pinned (`must`/`should`) record rides the next recall block as guidance,
+//! led by a line saying it binds fully — prompt and tool guards — next
+//! session. A file that stops parsing mid-edit keeps the last good registry
+//! and says so, because losing loaded steering to a half-saved buffer is the
+//! quiet failure this module exists to end.
+
+use std::collections::BTreeSet;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+use std::sync::atomic::Ordering;
+
+use stella_core::ingest::record::Tier;
+use stella_core::records::Registry;
+
+impl super::SessionMemory {
+    /// The registry swap counter the re-query fingerprint folds.
+    pub(crate) fn records_generation(&self) -> u64 {
+        self.records_generation.load(Ordering::Relaxed)
+    }
+
+    /// Reload the registry when the rule files' bytes have moved since the
+    /// last look; a no-op (one digest pass) when they have not.
+    pub(crate) fn refresh_records_if_changed(&self) {
+        let digest = rules_digest(&self.workspace_root);
+        {
+            let mut last = self.records_fingerprint.lock().expect("records digest");
+            if *last == digest {
+                return;
+            }
+            // Recorded before the reload, so a load that changes nothing is
+            // not re-attempted at every boundary; a further edit moves the
+            // digest again and gets a fresh look.
+            *last = digest;
+        }
+        let fresh = crate::context_records::load_registry(&self.workspace_root);
+        let mut lock = self.record_registry.write().expect("records lock");
+        let old = lock.take();
+        if let Some(broken) = newly_broken(old.as_ref(), &fresh) {
+            *lock = old;
+            drop(lock);
+            self.push_records_note(format!(
+                "## Workspace rules\n\nA rules file changed and does not parse \
+                 ({broken}); the rules loaded at session start stay in effect \
+                 until it parses again."
+            ));
+            return;
+        }
+        let pinned_note = pinned_changes(old.as_ref(), &fresh);
+        *lock = (!fresh.entries.is_empty()).then_some(fresh);
+        drop(lock);
+        self.records_generation.fetch_add(1, Ordering::Relaxed);
+        if let Some(note) = pinned_note {
+            self.push_records_note(note);
+        }
+    }
+
+    /// Park a one-shot section for the next recall block. A newer note
+    /// replaces an unread older one: both describe the same file set, and the
+    /// later look is the truer one.
+    fn push_records_note(&self, note: String) {
+        *self.records_note.lock().expect("records note") = Some(note);
+    }
+
+    /// Take the parked note, if any — consumed by the recall block builders.
+    pub(super) fn take_records_note(&self) -> Option<String> {
+        self.records_note.lock().expect("records note").take()
+    }
+}
+
+/// Digest of every rule file's path and bytes across both trust tiers — the
+/// same file set [`crate::context_records::load_registry`] parses, so the
+/// digest cannot say "unchanged" about a file the loader would read.
+pub(super) fn rules_digest(root: &Path) -> u64 {
+    let files = crate::context_records::rule_files(root, true, true);
+    let mut hasher = std::hash::DefaultHasher::new();
+    for file in files.all() {
+        (file.path.as_str(), file.contents.as_str()).hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// A source that contributed records before, contributes none now, and
+/// carries a diagnostic — the signature of a file that stopped parsing.
+/// `None` when the fresh load lost nothing it can be blamed for: a deleted
+/// file has no diagnostic (retirement, honored by the swap), and a diagnostic
+/// the old load already carried is not new damage.
+fn newly_broken(old: Option<&Registry>, fresh: &Registry) -> Option<String> {
+    let old = old?;
+    let sources = |registry: &Registry| -> BTreeSet<String> {
+        registry
+            .entries
+            .iter()
+            .map(|entry| entry.record.source.clone())
+            .collect()
+    };
+    let had = sources(old);
+    let has = sources(fresh);
+    fresh
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.source.clone())
+        .find(|source| had.contains(source) && !has.contains(source))
+}
+
+/// The recall-block section for pinned (`must`/`should`) records the swap
+/// could not bind into the byte-stable prefix: each changed or new pinned
+/// record, stating what applies now and what waits for the next session.
+fn pinned_changes(old: Option<&Registry>, fresh: &Registry) -> Option<String> {
+    let unchanged = |entry: &stella_core::records::Entry| {
+        old.is_some_and(|old| {
+            old.entries.iter().any(|prior| {
+                prior.record.record.lineage_id == entry.record.record.lineage_id
+                    && prior.record.record.statement == entry.record.record.statement
+                    && prior.record.record.record_hash == entry.record.record.record_hash
+            })
+        })
+    };
+    let listed: Vec<String> = fresh
+        .entries
+        .iter()
+        .filter(|entry| entry.record.record.tier() == Tier::Pinned && !unchanged(entry))
+        .map(|entry| {
+            format!(
+                "- ^{}: {}",
+                entry.record.handle, entry.record.record.statement
+            )
+        })
+        .collect();
+    if listed.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "## Workspace rules — changed while this session runs\n\n\
+         These binding (must/should) records changed after this session's \
+         prompt was built. Apply them now as if they were in the system \
+         prompt; they bind into it — and arm any tool guards they declare — \
+         when the next session starts.\n\n{}",
+        listed.join("\n")
+    ))
+}

--- a/crates/stella-cli/src/memory/steering.rs
+++ b/crates/stella-cli/src/memory/steering.rs
@@ -232,7 +232,7 @@ impl<'m> SessionRequery<'m> {
             state: std::sync::Mutex::new(RequeryState {
                 produced,
                 produced_steering: opening,
-                answered_fingerprint: fingerprint(&[], &[]),
+                answered_fingerprint: fingerprint(&[], &[], memory.records_generation()),
             }),
             events: None,
         }
@@ -267,13 +267,15 @@ pub(crate) fn requery_for_turn<'m>(
 }
 
 /// Order-free digest of the drift markers. `BTreeSet` so two signals that
-/// saw the same facts in a different order agree.
-fn fingerprint(paths: &[String], errors: &[&str]) -> u64 {
+/// saw the same facts in a different order agree. `records_generation` folds
+/// the registry's mid-session swap counter, so a record edited while the
+/// turn runs forces exactly one re-query even when no path or error drifted.
+fn fingerprint(paths: &[String], errors: &[&str], records_generation: u64) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::hash::DefaultHasher::new();
     let paths: std::collections::BTreeSet<&str> = paths.iter().map(String::as_str).collect();
     let errors: std::collections::BTreeSet<&str> = errors.iter().copied().collect();
-    (paths, errors).hash(&mut hasher);
+    (paths, errors, records_generation).hash(&mut hasher);
     hasher.finish()
 }
 
@@ -283,7 +285,15 @@ impl stella_core::ports::SteeringRequery for SessionRequery<'_> {
         if signal.since_last_query < MIN_STEPS_BETWEEN {
             return None;
         }
-        let current = fingerprint(signal.touched_paths, signal.errors_seen);
+        // The boundary is where a rules edit gets noticed: a swap bumps the
+        // generation below, which moves the fingerprint and forces this one
+        // re-query — see `records_refresh`.
+        self.memory.refresh_records_if_changed();
+        let current = fingerprint(
+            signal.touched_paths,
+            signal.errors_seen,
+            self.memory.records_generation(),
+        );
         if self
             .state
             .lock()
@@ -320,6 +330,20 @@ impl stella_core::ports::SteeringRequery for SessionRequery<'_> {
         // here is a block byte-identical to one already in history.
         state.produced_steering.absorb(&recalled.produced);
         state.produced.insert(block.clone()).then_some(block)
+    }
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    /// A registry swap alone moves the fingerprint, with no path or error
+    /// drifting — which is what turns a mid-session rules edit into exactly
+    /// one forced re-query.
+    #[test]
+    fn a_registry_swap_moves_the_fingerprint_alone() {
+        assert_ne!(
+            super::fingerprint(&[], &[], 0),
+            super::fingerprint(&[], &[], 1)
+        );
     }
 }
 

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -17,6 +17,7 @@ mod quarantine;
 // Which sessions actually receive the volatile record channel — a separate
 // question from what recall renders, and the one that went unasked (epic #897).
 mod record_channel;
+mod records_refresh;
 // Everything between a model's reflection response and a stored lesson: the
 // parser, the self-review, and what `reflect_and_record` writes. The largest
 // seam here, and the one this file kept growing on — #2465 is what took it

--- a/crates/stella-cli/src/memory/tests/records_refresh.rs
+++ b/crates/stella-cli/src/memory/tests/records_refresh.rs
@@ -1,0 +1,179 @@
+//! Witnesses for mid-session record freshness (`records_refresh`): a record
+//! added, retired, or broken while the session runs reaches — or visibly
+//! fails to reach — the next recall block, with the registry loaded at
+//! session start surviving a half-saved edit.
+
+use crate::memory::*;
+
+fn write_rule(root: &std::path::Path, name: &str, contents: &str) {
+    let dir = root.join(".stella").join("rules");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(name), contents).unwrap();
+}
+
+fn record_toml(force: &str, lineage: &str, statement: &str) -> String {
+    format!(
+        r#"
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+origin = "user"
+status = "active"
+
+[[record]]
+lineage_id = "{lineage}"
+kind = "preference"
+statement = "{statement}"
+
+[record.steering]
+force = "{force}"
+"#
+    )
+}
+
+fn session(root: &std::path::Path) -> SessionMemory {
+    SessionMemory::open_with_workspace_skills(root, false, true)
+        .expect("session memory opens in a temp workspace")
+}
+
+async fn next_block(memory: &SessionMemory) -> Option<String> {
+    let signal = stella_core::steering::TurnSignal {
+        prompt: "keep the service healthy",
+        ..Default::default()
+    };
+    memory
+        .signal_recall_block(
+            &signal,
+            &crate::memory::steering::ProducedSteering::default(),
+        )
+        .await
+        .text
+}
+
+/// **The witness for a mid-session edit.** A record file that lands while
+/// the session runs is picked up by the boundary refresh: the generation
+/// bumps (which is what forces the one re-query) and the very next recall
+/// block carries the record.
+#[tokio::test]
+async fn a_record_added_mid_session_reaches_the_next_recall_block() {
+    let dir = tempfile::tempdir().unwrap();
+    let memory = session(dir.path());
+    let before = memory.records_generation();
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "info",
+            "ctx.acme.web.staging-url",
+            "The staging deploy answers on port 8788.",
+        ),
+    );
+    let text = next_block(&memory).await.expect("the new record renders");
+    assert!(text.contains("port 8788"), "{text}");
+    assert!(
+        memory.records_generation() > before,
+        "a swap bumps the generation, so the re-query fingerprint moves"
+    );
+}
+
+/// **The witness for retirement.** A record file deleted mid-session leaves
+/// the volatile channel on the same refresh — suppression is one mechanism
+/// in the running session too.
+#[tokio::test]
+async fn a_record_deleted_mid_session_leaves_the_volatile_channel() {
+    let dir = tempfile::tempdir().unwrap();
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "info",
+            "ctx.acme.web.staging-url",
+            "The staging deploy answers on port 8788.",
+        ),
+    );
+    let memory = session(dir.path());
+    assert!(
+        next_block(&memory)
+            .await
+            .is_some_and(|text| text.contains("port 8788")),
+        "the record renders while its file exists"
+    );
+    std::fs::remove_file(dir.path().join(".stella/rules/acme.web.toml")).unwrap();
+    let after = next_block(&memory).await;
+    assert!(
+        !after.as_deref().unwrap_or_default().contains("port 8788"),
+        "a deleted record must stop steering: {after:?}"
+    );
+}
+
+/// **The witness for a half-saved edit.** A rules file that stops parsing
+/// keeps the registry loaded before the edit — the session is not silently
+/// un-steered by a buffer mid-save — and the next block says so.
+#[tokio::test]
+async fn a_rules_file_that_stops_parsing_keeps_the_last_good_registry() {
+    let dir = tempfile::tempdir().unwrap();
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "info",
+            "ctx.acme.web.staging-url",
+            "The staging deploy answers on port 8788.",
+        ),
+    );
+    let memory = session(dir.path());
+    assert!(
+        next_block(&memory)
+            .await
+            .is_some_and(|text| text.contains("port 8788")),
+        "the record renders before the bad edit"
+    );
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        "schema = \"context-record/v0.1\"\n[[record]\n",
+    );
+    let text = next_block(&memory)
+        .await
+        .expect("the kept registry still renders");
+    assert!(
+        text.contains("port 8788"),
+        "the last good registry stays in effect: {text}"
+    );
+    assert!(
+        text.contains("does not parse"),
+        "the failure is reported, never silent: {text}"
+    );
+}
+
+/// **The witness for the prefix wall.** A pinned (`must`) record that lands
+/// mid-session cannot enter the byte-stable system prompt, so the block says
+/// exactly what applies now and what binds next session — and says it once.
+#[tokio::test]
+async fn a_pinned_record_change_is_delivered_as_guidance_with_its_caveat() {
+    let dir = tempfile::tempdir().unwrap();
+    let memory = session(dir.path());
+    write_rule(
+        dir.path(),
+        "acme.web.toml",
+        &record_toml(
+            "must",
+            "ctx.acme.web.no-force-push",
+            "Never force-push to main.",
+        ),
+    );
+    let text = next_block(&memory).await.expect("the note renders a block");
+    assert!(
+        text.contains("changed while this session runs") && text.contains("Never force-push"),
+        "the pinned change rides the volatile channel with its caveat: {text}"
+    );
+    let again = next_block(&memory).await;
+    assert!(
+        !again
+            .as_deref()
+            .unwrap_or_default()
+            .contains("changed while this session runs"),
+        "the note is one-shot: {again:?}"
+    );
+}


### PR DESCRIPTION
## What & why

A context record edited, added, promoted, or retired while a session runs now reaches that session at its next step boundary, through the retrieval path that already exists, instead of waiting for a restart.

The registry was loaded once by `SessionMemory::open_for_session` and held as a clone for the session's life. The retrieval side re-decides which records render on every re-query, so the gap was exactly one stale clone. The fix (`crates/stella-cli/src/memory/records_refresh.rs`):

- **Lazy freshness, no watcher.** At the two moments the answer can matter — the turn-opening recall and each re-query boundary — the session digests the rule files' bytes (both trust tiers, the same file set `load_registry` parses) and reloads only when they moved. The unchanged path is one read of a handful of small policy files; there is no background task and no platform file-event quirk to get wrong. This is deliberately not the `notify` shape the issue sketched: a watcher adds a thread, a debounce, and an event model for something a digest at a boundary answers exactly.
- **A swap forces exactly one re-query.** The registry swap counter (`records_generation`) folds into the re-query fingerprint, which previously tracked only touched paths and error classes and so would never have noticed a rules edit until the turn happened to drift.
- **The prefix wall, handled as designed.** `must`/`should` records render into the byte-stable system prompt, which never changes mid-session. A pinned change rides the next recall block as guidance, led by a section stating it binds into the prompt — and arms any tool guards — next session. The note is one-shot.
- **Retirement propagates.** A deleted or retired record leaves the volatile channel on the same swap, so suppression is one mechanism in the running session too.
- **A half-saved edit keeps the last good registry.** A rules file that stops parsing does not un-steer the session: the loaded registry stays in effect and the next block says the file does not parse. The comparison is source-based (a source that contributed records before, contributes none now, and carries a diagnostic), so a deleted file reads as retirement rather than damage.

`SessionMemory`'s registry moves behind an `RwLock` because the freshness check runs where the turn holds the memory by `&`; the two render paths clone the registry out of the lock rather than borrowing through it, so a concurrent swap is never blocked by a selection pass.

Exemplars: the digest-then-reload shape is `stella_graph::CodeGraph::mount`'s own catch-up (byte-identical files are skipped), applied to a file set small enough that the digest *is* the catch-up; the one-shot note follows `RecalledBlock`'s existing section assembly.

## Witnesses (each fails on `main` without the change)

`crates/stella-cli/src/memory/tests/records_refresh.rs`:

- `a_record_added_mid_session_reaches_the_next_recall_block` — the record renders and the generation bumped
- `a_record_deleted_mid_session_leaves_the_volatile_channel`
- `a_rules_file_that_stops_parsing_keeps_the_last_good_registry` — the old record still renders and the failure is reported
- `a_pinned_record_change_is_delivered_as_guidance_with_its_caveat` — the note appears once and not on the following block

`memory/steering.rs::fingerprint_tests::a_registry_swap_moves_the_fingerprint_alone` pins the forced re-query.

The prompt-cache goldens (`memory/tests/golden_block.rs`) are untouched: nothing here writes to the system prefix.

Two DoD notes against #5432, stated plainly: the issue sketched a `notify` watcher and this lands a boundary-time digest instead, for the reasons above (the outcome the DoD asks for — pickup at the next step boundary — is what the witnesses pin); and the "corrupt ledger / bad governance file" case is covered by `load_registry`'s existing fail-closed behaviour plus the parse-failure witness — a governance file that fails to parse is #5328's subject and its own guard.

No `#[test]` was deleted.

## Test evidence

Targeted runs (SCR-001): `cargo test -p stella-cli memory` (334 passed) green, `make prose` clean, `cargo fmt` applied. CI's workspace run is the full evidence.

Closes #5432

## Summary by Sourcery

Make context-record changes visible at the next session step boundary while preserving stable prompts and safe behavior during invalid edits.

New Features:
- Refresh context records at session step boundaries so edits, additions, promotions, and retirements take effect without restarting.

Bug Fixes:
- Preserve the last known-good registry and report a one-shot warning when a rules file becomes invalid during a session.

Enhancements:
- Force a single re-query after a registry change and surface pinned-record changes as one-shot guidance without modifying the stable system prompt.

Tests:
- Add coverage for mid-session record additions, deletions, parse failures, pinned-record guidance, and registry-driven re-query fingerprints.