### PR TITLE
fix(stella-cli): a clean cancel no longer warns of a store write failure

### DIFF
--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -472,6 +472,33 @@ fn defer_stream_terminal(
     }
 }
 
+/// The two facts a bare bool collapsed at this function's call sites: whether
+/// the writes this close-out performs actually reached the store, and
+/// whether the resulting audit record is complete enough to export. A
+/// cancelled execution can have the first true and the second false — every
+/// write succeeded, but the provider-side usage envelope is unknowably lost,
+/// not that anything failed to write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExecutionEndOutcome {
+    /// The agent-use, MCP-usage and outcome writes this function performs
+    /// all reached the store.
+    pub(crate) write_ok: bool,
+    /// Every fact this execution needs to export is present.
+    /// `false` for a cancelled execution even when `write_ok` is true.
+    pub(crate) audit_complete: bool,
+}
+
+impl ExecutionEndOutcome {
+    /// The old bare bool's meaning, for a caller that has not been split into
+    /// "did the write fail" versus "is the audit incomplete" yet: both facts
+    /// must hold. Equivalent to the pre-split `audit_complete && finish_ok`,
+    /// since `audit_complete` already folds in the same write checks
+    /// `write_ok` does.
+    pub(crate) fn fully_recorded(self) -> bool {
+        self.write_ok && self.audit_complete
+    }
+}
+
 /// Close out one execution's audit record: drain the registry's agent-use
 /// and MCP-usage ledgers (each already single-execution), settle the
 /// outcome, and hand the finished row to the downstream projections.
@@ -482,7 +509,7 @@ pub(crate) fn record_execution_end(
     outcome_label: &str,
     cost_usd: f64,
     persistence_complete: bool,
-) -> bool {
+) -> ExecutionEndOutcome {
     let uses: Vec<stella_store::AgentUseRow> = registry
         .drain_agent_uses()
         .into_iter()
@@ -511,7 +538,10 @@ pub(crate) fn record_execution_end(
     let _ = store.finalize_execution_reflection(execution_id);
     let _ = store.sync_to_usage_default(execution_id);
     let _ = crate::enterprise_telemetry::enqueue_finalized_execution(store, execution_id);
-    audit_complete && finish_ok
+    ExecutionEndOutcome {
+        write_ok: uses_ok && mcp_usage_ok && finish_ok,
+        audit_complete,
+    }
 }
 
 fn mcp_usage_rows(registry: &ToolRegistry) -> Vec<stella_store::McpUsageRow> {

--- a/crates/stella-cli/src/agent/tests/usage_completeness.rs
+++ b/crates/stella-cli/src/agent/tests/usage_completeness.rs
@@ -88,14 +88,10 @@ fn event_and_telemetry_persistence_failure_downgrades_later_successful_closeout(
 
     let root = tempfile::tempdir().expect("root");
     let registry = ToolRegistry::new(root.path().to_path_buf());
-    assert!(!record_execution_end(
-        &store,
-        execution_id,
-        &registry,
-        "completed",
-        0.01,
-        false,
-    ));
+    assert!(
+        !record_execution_end(&store, execution_id, &registry, "completed", 0.01, false)
+            .fully_recorded()
+    );
     assert!(
         !store
             .execution_usage_complete(execution_id)
@@ -122,14 +118,15 @@ fn cancelled_closeout_is_incomplete_even_when_every_write_succeeds() {
     let root = tempfile::tempdir().expect("root");
     let registry = ToolRegistry::new(root.path().to_path_buf());
 
-    assert!(!record_execution_end(
-        &store,
-        execution_id,
-        &registry,
-        "cancelled",
-        0.0,
-        true,
-    ));
+    let outcome = record_execution_end(&store, execution_id, &registry, "cancelled", 0.0, true);
+    assert!(
+        outcome.write_ok,
+        "the name of this test is the claim: nothing failed to write"
+    );
+    assert!(
+        !outcome.audit_complete,
+        "a cancelled execution's usage envelope is unknowable"
+    );
     assert!(!store.execution_usage_complete(execution_id).unwrap());
     // The flag is what keeps a cancelled turn out of the enterprise export
     // (`pending_enterprise_export_page` gates on it). The *rollup* stopped

--- a/crates/stella-cli/src/agent/turn_close.rs
+++ b/crates/stella-cli/src/agent/turn_close.rs
@@ -72,6 +72,7 @@ pub(crate) fn close_turn(
             outcome.cost_usd,
             outcome.persistence_complete,
         )
+        .fully_recorded()
     {
         warn_store_write_failed("the audit record (agent uses / MCP usage / outcome)");
     }

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -79,7 +79,7 @@ pub(super) fn close_dropped_execution(
     let Some((store, id)) = execution else {
         return;
     };
-    let recorded =
+    let outcome =
         agent::record_execution_end(store, *id, registry, "cancelled", dropped_cost, false);
     // After the close-out, because that is when the row carries the floor over
     // both sources. Before it, the receipts the driver missed are exactly the
@@ -91,7 +91,10 @@ pub(super) fn close_dropped_execution(
             summary.cost_usd,
         ));
     }
-    if recorded {
+    // `audit_complete` is false for every cancel — the provider-side usage
+    // envelope is unknowable, not that anything failed to write. Warn on
+    // `write_ok` alone, or this fires on every single cancel.
+    if outcome.write_ok {
         return;
     }
     let _ = in_tx.send(Inbound::Event {
@@ -220,6 +223,41 @@ mod tests {
             "the guard must report the $4.50 the receipts prove, not the $0.25 \
              prefix it accumulated: {}",
             budget.session_spent_usd()
+        );
+    }
+
+    /// A cancelled execution's usage envelope is unknowable, not unwritten —
+    /// closing one out against a real store where every write succeeds must
+    /// not tell the user their work was lost.
+    #[tokio::test]
+    async fn a_clean_cancel_warns_nobody() {
+        let root = tempfile::tempdir().expect("workspace");
+        let store = Arc::new(Store::open(root.path()).expect("store"));
+        let id = store
+            .begin_execution("chat", "a prompt", "zai", "glm-5.2")
+            .expect("execution");
+
+        let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
+        let (in_tx, mut in_rx) = tokio::sync::mpsc::unbounded_channel::<Inbound>();
+        let registry = ToolRegistry::new(std::env::temp_dir());
+
+        close_dropped_execution(
+            Some(&(Arc::clone(&store), id)),
+            &registry,
+            "cancelled",
+            0.0,
+            &mut budget,
+            &in_tx,
+        );
+        drop(in_tx);
+
+        let mut events = Vec::new();
+        while let Some(inbound) = in_rx.recv().await {
+            events.push(inbound);
+        }
+        assert!(
+            events.is_empty(),
+            "every write succeeded; the deck must not tell the user otherwise: {events:?}"
         );
     }
 

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -219,7 +219,9 @@ pub(super) async fn run_lead_turn(
             outcome_label,
             cost,
             persistence_complete,
-        ) {
+        )
+        .fully_recorded()
+        {
             forwarder::warn_audit_record_incomplete(in_tx, LEAD, persistence_complete);
             // That warning lands AFTER the turn's Complete event, and the
             // deck's status fold maps a retryable Error back to Running — so

--- a/crates/stella-cli/src/enterprise_telemetry/tests.rs
+++ b/crates/stella-cli/src/enterprise_telemetry/tests.rs
@@ -1177,14 +1177,10 @@ fn finalization_stays_successful_when_telemetry_host_state_is_rejected() {
         .unwrap();
     let registry = stella_tools::ToolRegistry::new(workspace.clone());
 
-    assert!(crate::agent::record_execution_end(
-        &store,
-        id,
-        &registry,
-        "completed",
-        0.01,
-        true,
-    ));
+    assert!(
+        crate::agent::record_execution_end(&store, id, &registry, "completed", 0.01, true)
+            .fully_recorded()
+    );
     assert_eq!(
         store
             .execution_rollup(id, &workspace)

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -1316,6 +1316,7 @@ fn finalize_fleet_execution(
         cost_usd,
         persistence_complete && !force_incomplete,
     )
+    .fully_recorded()
 }
 
 /// Run `git -C root <args>` and return trimmed stdout, or the stderr as the


### PR DESCRIPTION
## What & why

Every cancelled turn told the user the store write failed, whether or not it
did. `record_execution_end` folded two independent facts into one bare
bool — whether the writes it performs actually reached the store, and
whether the resulting audit record is complete enough to export — and
`close_dropped_execution` read that bool as "did the write fail". A
cancelled execution's audit record is deliberately incomplete (the
provider-side usage envelope is unknowable), so the combined bool was always
false on this path and the warning was unconditional.

Split the return into `ExecutionEndOutcome { write_ok, audit_complete }`.
`write_ok` is exactly the writes this function can actually fail on
(`uses_ok && mcp_usage_ok && finish_ok`); `audit_complete` is the existing
business-rule combination, unchanged. `write_ok && audit_complete` is
algebraically identical to the old bare bool — `audit_complete` already
folded `uses_ok`/`mcp_usage_ok` in — so every caller that has not been split
keeps its exact old behavior via `.fully_recorded()`.

- `dropped_turn.rs`'s `close_dropped_execution` now warns on `write_ok`
  alone — the actual fix.
- `turn_close.rs` and `lead_turn.rs` call `.fully_recorded()`, unchanged
  behavior, per the issue's own note that `lead_turn.rs`'s normal path
  (labels `completed`/`aborted`) is not affected.
- `fleet_cmd.rs`'s `finalize_fleet_execution` calls `.fully_recorded()` too,
  preserving its own `-> bool` signature (its one caller discards the
  result today).
- `subsession/closeout.rs` already discarded the whole result (`let _ =`)
  and needed no change.

Also strengthened `cancelled_closeout_is_incomplete_even_when_every_write_succeeds`
in `usage_completeness.rs`: its own name made a claim about `write_ok` it
never actually checked.

Closes #5074

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`dropped_turn.rs`'s `a_clean_cancel_warns_nobody`: closes a cancelled
execution against a real `Store` where every write succeeds, drains the
inbound channel, and asserts no event reached it. Checked the artisanal
way — temporarily swapped `outcome.write_ok` for `outcome.fully_recorded()`
(simulating the pre-fix conflated check) and the test failed with the exact
message the issue reports: `store write failed — this cancelled execution
was not recorded`. Restored, it passes.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-cli` — 2533+ passed, 0 failed, across every
      target
- [x] `make guards-fast` — green, including prose and file-size

## Nothing left behind

- [ ] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Distinguish successful persistence from incomplete cancellation audits so clean cancellations do not report false store-write failures.

Bug Fixes:
- Prevent cleanly cancelled executions from incorrectly warning users that their audit-store write failed.
- Separate store-write success from audit completeness when closing executions, preserving existing behavior for callers that need the combined result.

Tests:
- Add coverage proving a cancelled execution with successful writes emits no failure warning.
- Strengthen usage-completeness coverage to independently verify write success and audit incompleteness for cancelled executions.