### PR TITLE
fix(stella-tui-theme): settle the gold and silver-type 16-colour rows

### DIFF
--- a/crates/stella-tui-theme/src/fallback.rs
+++ b/crates/stella-tui-theme/src/fallback.rs
@@ -36,17 +36,21 @@ pub fn detect_truecolor() -> bool {
 
 /// The 16-color stand-in for a palette token (SPEC 3.5).
 ///
-/// SPEC 3.5 fixes five of these by name — gold to yellow, silver to white,
-/// muted and dim to bright black, red and green to their ANSI counterparts —
-/// and the rest follow from the ramp they belong to:
+/// SPEC 3.5 fixes four of these by name — gold to bright yellow, silver to
+/// white, silver_type to bright white, muted and dim to bright black — and
+/// the rest follow from the ramp they belong to:
 ///
 /// - The grounds ([`token::BG`], [`token::PANEL`]) go to black, and the seams
 ///   ([`token::HL`], [`token::BORDER`], [`token::RULE`]) to bright black: a
 ///   seam that collapses into the ground stops being a seam.
-/// - [`token::TEXT`] takes bright white and the silvers take white, one tier
-///   apart, so "the world coming in" still reads quieter than prose. SPEC 3.5
-///   says silver goes to white and this honours it exactly — it is the *text*
-///   token that lifts, not silver that drops.
+/// - Gold takes bright yellow rather than plain: a 16-color terminal has no
+///   second yellow to lift a live accent to, so the brand's one identity
+///   colour needs the brighter of the two stops it can reach, or a reader on
+///   that terminal cannot tell the mark from an ordinary warning.
+/// - [`token::TEXT`] and [`token::SILVER_TYPE`] both take bright white, one
+///   tier above plain [`token::SILVER`], so an emphasised secondary still
+///   reads as emphasised rather than collapsing into the same stand-in as
+///   the text beside it — the whole reason `SILVER_TYPE` is a separate token.
 /// - The diff tints go to black rather than to a green and a red background.
 ///   At 16 colours a tint is not available; only a wash is, and a wash on
 ///   every changed row would spend the palette's whole red budget on a healthy
@@ -60,9 +64,9 @@ pub fn ansi16(color: Color) -> Color {
     match color {
         token::BG | token::PANEL | token::DIFF_ADD_BG | token::DIFF_DEL_BG => Color::Black,
         token::HL | token::BORDER | token::RULE => Color::DarkGray,
-        token::GOLD | token::GOLD_BRIGHT => Color::Yellow,
-        token::SILVER | token::SILVER_TYPE => Color::Gray,
-        token::TEXT => Color::White,
+        token::GOLD | token::GOLD_BRIGHT => Color::LightYellow,
+        token::SILVER => Color::Gray,
+        token::TEXT | token::SILVER_TYPE => Color::White,
         token::MUTED | token::DIM => Color::DarkGray,
         token::GREEN => Color::Green,
         token::RED => Color::Red,

--- a/crates/stella-tui-theme/src/tests.rs
+++ b/crates/stella-tui-theme/src/tests.rs
@@ -271,23 +271,28 @@ fn every_token_has_a_fallback() {
     }
 }
 
-/// The five mappings SPEC 3.5 names outright.
+/// The mappings SPEC 3.5 names outright.
 #[test]
 fn the_named_fallbacks_are_what_the_spec_says() {
     assert_eq!(
         fallback::ansi16(token::GOLD),
-        Color::Yellow,
-        "gold to yellow"
+        Color::LightYellow,
+        "gold to bright yellow"
     );
     assert_eq!(
         fallback::ansi16(token::GOLD_BRIGHT),
-        Color::Yellow,
-        "gold to yellow"
+        Color::LightYellow,
+        "gold to bright yellow"
     );
     assert_eq!(
         fallback::ansi16(token::SILVER),
         Color::Gray,
         "silver to white"
+    );
+    assert_eq!(
+        fallback::ansi16(token::SILVER_TYPE),
+        Color::White,
+        "silver_type to bright white"
     );
     assert_eq!(
         fallback::ansi16(token::MUTED),

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -254,51 +254,26 @@ fn ansi_index(color: Color) -> Option<u8> {
 /// a 16-colour terminal?* — about the same hex, reached by different paths:
 /// `degrade_buffer` for the v1 deck, `fallback::ansi16` for the v2 surfaces.
 /// Each had a coverage test and neither had ever been compared to the other,
-/// so five rows disagree and nothing said so (#5000).
+/// so five rows disagreed and nothing said so. `gold`, `gold-bright` and
+/// `silver-type` are settled: `ansi16` now takes the deck's own answer, which
+/// carried the only written reasoning either table had for its choice — see
+/// `stella_tui_theme::fallback::ansi16`'s doc comment.
 ///
-/// It is one decision made twice, not five: `FALLBACKS` takes the **bright**
-/// half of the sixteen for every chromatic token and `ansi16` takes the
-/// **standard** half. `design/tui-v2/SPEC.md` §3.5 states `ansi16`'s answers
-/// and `crates/stella-tui/tests/spec_palette.rs` holds it there, so the spec
-/// governs one table and nothing governs the other.
-///
-/// Which half ships is a design call and #5000 is where it is being made — the
-/// values a reader sees on a 16-colour terminal are a product decision, not a
-/// tidy-up. Declaring the rows is the half that is not: a sixth divergence
-/// cannot now arrive unnoticed, and repainting one table without the other
-/// fails here rather than in someone's `xterm`. That is
+/// `green` and `red` remain open. Unlike gold and silver-type, no comment on
+/// either table's row explains *why* it picked bright over standard or the
+/// reverse, so settling them is a genuine design call rather than a reading
+/// of reasoning already on record — tracked separately rather than decided
+/// here by guessing. That is
 /// `crates/stella-model/src/provider_parity.rs`'s posture — a matrix checked
 /// from both sides, with every gap named and issue-cited (AGENTS.md #10).
 const DEGRADATION_DIVERGENCE: &[(&str, u8, u8, &str)] = &[
-    (
-        "gold",
-        11,
-        3,
-        "the deck lifts the identity to bright yellow so the mark still reads \
-         as the mark; §3.5 says yellow. #5000",
-    ),
-    (
-        "gold-bright",
-        11,
-        3,
-        "the live stop collapses onto whichever yellow `gold` takes, so this \
-         row is decided by the one above it. #5000",
-    ),
-    (
-        "silver-type",
-        15,
-        7,
-        "the deck shares bright white with `text` — the two are one value step \
-         apart and there is no third white; §3.5 drops it to white beside \
-         `silver` instead. Same two values, opposite collapse. #5000",
-    ),
     (
         "green",
         10,
         2,
         "bright green against §3.5's green: the palette's `#74C991` is a pale \
          mint, and which ANSI green is nearer depends on the reader's own \
-         sixteen. #5000",
+         sixteen. Refs #5000",
     ),
     (
         "red",
@@ -306,7 +281,7 @@ const DEGRADATION_DIVERGENCE: &[(&str, u8, u8, &str)] = &[
         1,
         "bright red against §3.5's red, the same question as `green` and the \
          one row where the deck's answer is the nearer of the two against \
-         xterm's defaults. #5000",
+         xterm's defaults. Refs #5000",
     ),
 ];
 

--- a/crates/stella-tui/tests/spec_palette.rs
+++ b/crates/stella-tui/tests/spec_palette.rs
@@ -219,6 +219,12 @@ fn ansi_name(color: Color) -> &'static str {
         Color::Cyan => "cyan",
         Color::Gray => "white",
         Color::White => "bright white",
+        Color::LightRed => "bright red",
+        Color::LightGreen => "bright green",
+        Color::LightYellow => "bright yellow",
+        Color::LightBlue => "bright blue",
+        Color::LightMagenta => "bright magenta",
+        Color::LightCyan => "bright cyan",
         other => panic!("ansi16 returned {other:?}, which is not one of the sixteen"),
     }
 }

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -94,10 +94,10 @@ The stand-in for every token, by the ANSI name rather than by ratatui's spelling
 | `hl` | bright black |
 | `border` | bright black |
 | `rule` | bright black |
-| `gold` | yellow |
-| `gold_bright` | yellow |
+| `gold` | bright yellow |
+| `gold_bright` | bright yellow |
 | `silver` | white |
-| `silver_type` | white |
+| `silver_type` | bright white |
 | `text` | bright white |
 | `muted` | bright black |
 | `dim` | bright black |


### PR DESCRIPTION
## What & why

`crates/stella-tui/src/theme/tests.rs` already carries
`DEGRADATION_DIVERGENCE` and `the_two_16_colour_tables_agree_or_declare_why_not`
— a declared-gap cross-check (the `provider_parity.rs` shape) that caught
this issue's headline finding: `FALLBACKS` (the v1 deck) and
`stella_tui_theme::fallback::ansi16` (v2) disagree on five tokens at 16
colours, and nothing compared them before that test existed.

This PR settles three of the five:

- **`gold` / `gold-bright`.** `FALLBACKS`' own comment argues bright yellow
  is needed because a 16-colour terminal has no second yellow to lift a live
  accent to — the brand's one identity colour needs the brighter of the two
  reachable stops, or it reads as an ordinary warning. `ansi16`'s plain
  yellow carried no comment arguing the other way.
- **`silver-type`.** `FALLBACKS` shares bright white with `text` rather than
  plain white with `silver`, with the reasoning written down: the two are
  one value step apart and there is no third white, so an emphasised
  secondary has to stay visually distinct from a plain one. `ansi16` grouped
  it with `silver` instead, which erases the exact distinction
  `silver_type` exists to carry.

`green` and `red` stay declared divergences. Unlike the three above, neither
table's comment explains *why* it picked bright over standard, so settling
them would be guessing rather than reading reasoning already on record.

Refs #5000

## What changes

- `crates/stella-tui-theme/src/fallback.rs`: `ansi16` now maps
  `GOLD`/`GOLD_BRIGHT` to `Color::LightYellow` and splits `SILVER_TYPE`
  (→ `Color::White`) from `SILVER` (stays `Color::Gray`). Doc comment
  updated to state and justify the new mapping.
- `design/tui-v2/SPEC.md` §3.5: `gold`, `gold_bright` → "bright yellow";
  `silver_type` → "bright white". §3.1 and the palette table are unchanged.
- `crates/stella-tui-theme/src/tests.rs`: `the_named_fallbacks_are_what_the_spec_says`
  updated for the corrected mapping, plus a `silver_type` assertion it
  didn't carry before.
- `crates/stella-tui/tests/spec_palette.rs`: `ansi_name` gains the six
  `Light*` ANSI-16 names, so the totality check doesn't panic on a bright
  variant it can now actually see.
- `crates/stella-tui/src/theme/tests.rs`: `DEGRADATION_DIVERGENCE` drops the
  three settled rows; its module doc explains why `green`/`red` stay.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`the_two_16_colour_tables_agree_or_declare_why_not` already exists on `main`
and already fails loudly on exactly this shape of drift — that's what it's
for. With `gold`/`gold-bright`/`silver-type` still declared as divergences
but `ansi16` now agreeing with `FALLBACKS`, the test says so explicitly:
*"`{name}` is declared as a divergence and both tables now say {v2} —
settle the row by deleting it."* Removing those three rows from
`DEGRADATION_DIVERGENCE` in the same commit is what "settling" means here.
Reverting either the `ansi16` change or the row removal alone reproduces
that failure.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-tui -p stella-tui-theme --all-targets -- -D warnings`
- [x] `cargo test -p stella-tui-theme` — 21 passed
- [x] `cargo test -p stella-tui --lib` — 1429 passed
- [x] `cargo test -p stella-tui --tests` — every integration suite passed,
      including `spec_palette` (5) and the golden-frame snapshots (39)
- [x] `cargo test -p stella-transcript` — unaffected, unchanged
- [x] `python3 ./scripts/check-prose.py`
- [x] `make guards-fast`

## Note on the `dod` check

`green`/`red` stay open design calls and the transcript path isn't touched
(see below), so this issue's acceptance criteria are only partly satisfied
here — which per AGENTS.md's own rule is exactly the case for a `Refs #N`
reference rather than a closing one, with a comment on the issue stating
what remains (posted separately). The shared `dod-check` tool only
recognises closing keywords, so it will report this PR as linking no issue
and fail. That's an accurate report, not a false positive, and the
`no-issue` label would be the wrong waiver — this is a substantial,
non-trivial change, exactly what that label is not for. Flagging it here
rather than gaming either check.

## Nothing left behind

- [ ] Filed a follow-up issue: `stella-transcript`'s `Color::Amber` (used
      for warnings) is also what a reader sees when the exported transcript
      needs to render brand-gold-styled content, since the crate's fixed
      categorical palette has no distinct gold-identity role. This PR
      doesn't touch it — see the linked issue for why that's a separate
      design call, not a value swap.
- [x] `green`/`red` stay declared and cited (`Refs #5000` in the divergence
      table) rather than silently decided; #5000 stays open for them.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Settle the gold and silver-type ANSI-16 palette mappings while keeping unresolved green and red divergences explicitly tracked.

Bug Fixes:
- Align 16-colour gold and silver-type fallbacks with the established palette decisions so brand gold remains distinct from warnings and silver-type remains distinct from silver.

Enhancements:
- Document the rationale for the corrected ANSI-16 mappings and retain green and red as explicitly tracked, unresolved divergences.

Documentation:
- Update the TUI v2 palette specification to define gold as bright yellow and silver-type as bright white.

Tests:
- Update fallback and palette tests to verify the corrected mappings and support bright ANSI-16 colour names.