### PR TITLE
feat(stella-store): export bundles what Stella sent, not only what came back

### DIFF
--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -92,10 +92,11 @@ pub fn export_session(workspace_root: &Path, session_id: &str) -> Result<PathBuf
         .usage_stats_for_session(session_id)
         .map_err(|e| format!("cannot read usage stats: {e}"))?;
 
-    // The transcript. The nine dumped tables say what the session cost and
-    // which tools it called; none of them holds what it actually did, because
-    // the ordered event stream is not one of them. `session_events` is already
-    // scoped to this session by the same predicate the dumps use.
+    // The transcript. The dumped tables say what the session cost, which
+    // tools it called, and what was sent to the model; none of them holds
+    // what it actually did, because the ordered event stream is not one of
+    // them. `session_events` is already scoped to this session by the same
+    // predicate the dumps use.
     //
     // A journal that will not read must not sink the export: the tables and
     // the dashboard are still worth having, and an empty transcript reports

--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -1,10 +1,10 @@
 //! The session transcript — the replayable half of the `/export` archive.
 //!
-//! [`super::export_session`] bundles nine telemetry *tables*: what the session
-//! cost, which tools it called, which files it touched. None of that is the
-//! session. The session is the ordered stream of what the model said, what it
-//! ran, and what came back — and that lives in `events`, which the tables do
-//! not summarize and the dumps do not contain.
+//! [`super::export_session`] bundles telemetry *tables*: what the session
+//! cost, which tools it called, which files it touched, what was sent to the
+//! model. None of that is the session. The session is the ordered stream of
+//! what the model said, what it ran, and what came back — and that lives in
+//! `events`, which the tables do not summarize and the dumps do not contain.
 //!
 //! This module folds [`Store::session_events`](stella_store::Store::session_events)
 //! into that stream and renders it as the archive's readable half.

--- a/crates/stella-store/src/export.rs
+++ b/crates/stella-store/src/export.rs
@@ -179,6 +179,39 @@ const CHILD_TABLES: [(&str, &str, &str); 8] = [
     ),
 ];
 
+/// The receipts-plane tables, keyed off `execution_id` the same way
+/// [`CHILD_TABLES`] is — what Stella *sent*, alongside the telemetry tables'
+/// record of what came back. Without these an export could not answer a
+/// cache-behaviour question: the block sequence a call actually saw lives
+/// only in `step_manifest`, which no export bundle carried before this.
+///
+/// `context_blocks.content` is dropped from its `SELECT` — it is the one
+/// column here that can hold a tool-output preimage rather than a digest
+/// (spec §5.3's gap kinds), and [`crate::ContextBlockRow::content`] is
+/// documented as never leaving the local store. `content_digest` and
+/// `token_cost` are what a cache analysis over this export actually needs.
+const RECEIPT_TABLES: [(&str, &str, &str); 3] = [
+    (
+        "step_manifest",
+        "SELECT execution_id, turn_instance, step, call_seq, ordinal, block_id, cache_zone, \
+         resident_since_step, message_index, call_id FROM step_manifest",
+        "ORDER BY execution_id ASC, turn_instance ASC, step ASC, call_seq ASC, ordinal ASC",
+    ),
+    (
+        "context_blocks",
+        "SELECT execution_id, block_id, kind, origin_turn, origin_step, call_id, memory_id, \
+         token_cost, content_digest, citation_label, first_seen_ts FROM context_blocks",
+        "ORDER BY execution_id ASC, block_id ASC",
+    ),
+    (
+        "step_receipt",
+        "SELECT execution_id, turn_instance, step, call_seq, provider, upstream_provider, model, \
+         call_role, effective_budget_tokens, calibration_factor, estimated_input_tokens, \
+         compiled_frame_id, frame_hash, stall_seconds_requested FROM step_receipt",
+        "ORDER BY execution_id ASC, turn_instance ASC, step ASC, call_seq ASC",
+    ),
+];
+
 impl Store {
     /// Aggregate usage/cost analytics per (provider, model) across the **whole
     /// workspace** — the data behind `stella stats` and every
@@ -316,16 +349,13 @@ impl Store {
     /// Dump the telemetry tables for the **whole workspace** as JSON arrays.
     /// Each entry is `(table_name, json_array_string)`.
     ///
-    /// This is the analytics export, not a database dump: it covers exactly
-    /// the nine telemetry tables the export archive bundles — `executions`,
-    /// `telemetry`, `tool_calls`, `files_touched`, `mcp_usage`, `agent_uses`,
-    /// `skill_usage`, `execution_reflection`, and `reflections`. The rest of
-    /// the store stays out: `events` and the receipts plane
-    /// (`context_blocks` / `step_manifest` / `step_receipt`) carry full
-    /// payloads and reconstruction preimages the archive must not ship, and
-    /// the state tables (`rules`, `file_locks`, `memory_citations`,
-    /// `forgotten`, `tasks`, `pull_requests`) are live workspace state, not
-    /// session telemetry.
+    /// This is the analytics export, not a database dump: it covers
+    /// `executions`, every table [`CHILD_TABLES`] declares, and every table
+    /// [`RECEIPT_TABLES`] declares. The rest of the store stays out: `events`
+    /// carries full payloads and reconstruction preimages the archive must
+    /// not ship, and the state tables (`rules`, `file_locks`,
+    /// `memory_citations`, `forgotten`, `tasks`, `pull_requests`) are live
+    /// workspace state, not session telemetry.
     ///
     /// The JSON is constructed in Rust (not by SQLite's json1 extension,
     /// which may be absent from a bundled build), so the shape is stable
@@ -355,7 +385,8 @@ impl Store {
     fn export_json_scoped(&self, scope: ExportScope<'_>) -> Result<Vec<(&'static str, String)>> {
         let conn = self.lock();
         let bindings = scope.bindings();
-        let mut out: Vec<(&'static str, String)> = Vec::with_capacity(CHILD_TABLES.len() + 1);
+        let mut out: Vec<(&'static str, String)> =
+            Vec::with_capacity(CHILD_TABLES.len() + RECEIPT_TABLES.len() + 1);
 
         // Executions — the spine everything else keys off.
         {
@@ -399,6 +430,11 @@ impl Store {
         }
 
         for (name, select_from, order_by) in CHILD_TABLES {
+            let sql = format!("{select_from} {} {order_by}", scope.child_where());
+            out.push((name, self.query_to_json(&conn, &sql, bindings.as_slice())?));
+        }
+
+        for (name, select_from, order_by) in RECEIPT_TABLES {
             let sql = format!("{select_from} {} {order_by}", scope.child_where());
             out.push((name, self.query_to_json(&conn, &sql, bindings.as_slice())?));
         }
@@ -532,7 +568,7 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FileTouchRow, TelemetryRow};
+    use crate::{ContextBlockRow, FileTouchRow, ManifestBlockRow, StepManifestRow, TelemetryRow};
 
     /// Seed two sessions plus one unattributed execution, and return
     /// `(store, session_a_id)`. Every table the export covers gets a row on
@@ -606,7 +642,11 @@ mod tests {
         let (store, session) = two_session_store();
 
         let dumps = store.export_session_json(session).expect("scoped dump");
-        assert_eq!(dumps.len(), CHILD_TABLES.len() + 1, "every table present");
+        assert_eq!(
+            dumps.len(),
+            CHILD_TABLES.len() + RECEIPT_TABLES.len() + 1,
+            "every table present"
+        );
 
         for (table, json) in &dumps {
             assert!(
@@ -853,5 +893,96 @@ mod tests {
         assert_eq!(scope.executions_where("e."), "");
         assert_eq!(scope.child_where(), "");
         assert!(scope.bindings().is_empty());
+    }
+
+    /// The export can answer a cache question: the receipts plane rides
+    /// along with the telemetry tables, scoped the same way, and
+    /// `context_blocks` never carries its local-only preimage.
+    #[test]
+    fn the_export_carries_what_stella_sent_not_only_what_came_back() {
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("chat", "prompt", "anthropic", "claude-fable-5")
+            .expect("begin");
+
+        store
+            .record_context_block(
+                id,
+                &ContextBlockRow {
+                    block_id: "blk_abc".into(),
+                    kind: "tool_result".into(),
+                    origin_turn: 0,
+                    origin_step: 0,
+                    call_id: Some("call_1".into()),
+                    memory_id: None,
+                    token_cost: Some(42),
+                    content_digest: "sha256:deadbeef".into(),
+                    citation_label: None,
+                    content: Some("a secret tool output nobody should export".into()),
+                },
+            )
+            .expect("register block");
+        store
+            .record_step_manifest(
+                id,
+                &StepManifestRow {
+                    turn_instance: 0,
+                    step: 0,
+                    call_seq: 0,
+                    provider: "anthropic".into(),
+                    upstream_provider: None,
+                    model: "claude-fable-5".into(),
+                    call_role: "worker".into(),
+                    effective_budget_tokens: 1000,
+                    calibration_factor: 1.0,
+                    estimated_input_tokens: 100,
+                    compiled_frame_id: None,
+                    frame_hash: None,
+                    stall_seconds_requested: None,
+                    blocks: vec![ManifestBlockRow {
+                        block_id: "blk_abc".into(),
+                        cache_zone: "stable".into(),
+                        token_cost: Some(42),
+                        resident_since_step: 0,
+                        message_index: 0,
+                        call_id: Some("call_1".into()),
+                    }],
+                },
+            )
+            .expect("manifest");
+
+        let dumps = store.export_all_json().expect("dump");
+        assert_eq!(
+            dumps.len(),
+            CHILD_TABLES.len() + RECEIPT_TABLES.len() + 1,
+            "the receipts plane rides with the telemetry tables"
+        );
+
+        let dump = |table: &str| {
+            dumps
+                .iter()
+                .find(|(name, _)| *name == table)
+                .map(|(_, json)| json.as_str())
+                .unwrap_or_else(|| panic!("`{table}` missing from the export"))
+        };
+
+        assert!(
+            dump("step_manifest").contains("blk_abc"),
+            "the manifest's block sequence is what a cache analysis reads"
+        );
+        assert!(
+            dump("step_receipt").contains("effective_budget_tokens")
+                && dump("step_receipt").contains("1000"),
+            "the receipt header is what settles which budget a call ran against"
+        );
+        let context_dump = dump("context_blocks");
+        assert!(
+            context_dump.contains("sha256:deadbeef"),
+            "the digest is what a cache analysis joins on"
+        );
+        assert!(
+            !context_dump.contains("secret tool output"),
+            "context_blocks.content never leaves the local store: {context_dump}"
+        );
     }
 }

--- a/crates/stella-store/src/export.rs
+++ b/crates/stella-store/src/export.rs
@@ -350,8 +350,8 @@ impl Store {
     /// Each entry is `(table_name, json_array_string)`.
     ///
     /// This is the analytics export, not a database dump: it covers
-    /// `executions`, every table [`CHILD_TABLES`] declares, and every table
-    /// [`RECEIPT_TABLES`] declares. The rest of the store stays out: `events`
+    /// `executions`, every table `CHILD_TABLES` declares, and every table
+    /// `RECEIPT_TABLES` declares. The rest of the store stays out: `events`
     /// carries full payloads and reconstruction preimages the archive must
     /// not ship, and the state tables (`rules`, `file_locks`,
     /// `memory_citations`, `forgotten`, `tasks`, `pull_requests`) are live


### PR DESCRIPTION
## What & why

`stella export` bundled `executions` plus the eight tables in
`CHILD_TABLES` — every one of them records an *answer* the model or
provider gave. None recorded what Stella *sent*: the prompt's own
composition, call by call, lives only in `step_manifest`, `context_blocks`
and `step_receipt`, and none of the three reached the archive. #3690 sat
open for eight days asking a cache-behaviour question against a bundle that
could not contain the answer — settling it needed the live `store.db` on
the machine that produced the session, exactly what an export exists to
make unnecessary.

Add a `RECEIPT_TABLES` array beside `CHILD_TABLES` in
`crates/stella-store/src/export.rs`, scoped by the same
`ExportScope::child_where()` predicate, looped in the same
`export_json_scoped` — no second SQL body, no second scoping mechanism.

`context_blocks.content` is dropped from its `SELECT`. It is the one
column across these three tables that can hold a tool-output preimage
(gap kinds the journal cannot resolve, spec §5.3) rather than a digest, and
`ContextBlockRow::content`'s own doc comment already says it "never leaves
the local store." `content_digest` and `token_cost` are what the cache
question in #3690's shape actually needs.

Closes #5105

## What changes

- `crates/stella-store/src/export.rs`: new `RECEIPT_TABLES` array, looped
  into `export_json_scoped` alongside `CHILD_TABLES`; module doc comments
  updated to point at the arrays instead of counting tables in prose
  (CLAUDE.md, "a count in prose is a promise to update it").
- `crates/stella-cli/src/export.rs` and `.../export/transcript.rs`: two
  "nine telemetry tables" prose mentions updated for the same reason.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`stella-store::export::tests::the_export_carries_what_stella_sent_not_only_what_came_back`
records one context block and one step manifest, exports the workspace,
and asserts: all three receipt tables appear in the dump; `step_manifest`
carries the block id; `step_receipt` carries the budget the call ran
against; `context_blocks` carries the digest but not the raw content it
was registered with. Checked the artisanal way — temporarily removed the
new loop from `export_json_scoped` and the test failed on the exact
assertion the fix satisfies (`left: 9, right: 12`, naming the receipts
plane as missing); restored, it passes.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-store -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-store` — 468 + 31 passed
- [x] `cargo test -p stella-cli --bin stella export::` — 48 passed
- [x] `python3 ./scripts/check-prose.py`
- [x] `make guards-fast`

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] `redact_dump` (CLI-level) already runs over every `(table, json)` pair
      `export_session_json` returns, so the three new tables get the same
      credential masking as everything else with no extra wiring

## Summary by Sourcery

Extend Stella exports to include the metadata needed to understand model inputs without exporting sensitive local context content.

New Features:
- Include the receipts-plane tables in exported session and workspace JSON so bundles capture the context and call metadata Stella sent.

Enhancements:
- Exclude local-only context block content from exports while retaining digests and token accounting needed for cache analysis.
- Use shared table declarations for export coverage and scoping, and update related documentation to reflect the expanded archive contents.

Tests:
- Add coverage verifying receipt tables are exported, scoped data is present, and raw context content is omitted.