### PR TITLE
fix(stella-transcript): the shared stylesheet's corners read from tokens

### DIFF
--- a/crates/stella-transcript/src/html/transcript.css
+++ b/crates/stella-transcript/src/html/transcript.css
@@ -68,6 +68,13 @@
  * ramp and the semantic triad only; and the `.you`/`.agent` roletag rules put
  * near-black text on these two as fills, so a future replacement has to keep a
  * legible fill pair and not merely a legible glyph.
+ *
+ * Corners read from `--radius-*` custom properties, each defaulting to the value
+ * this page has always rendered, so nothing here changes what a reader sees
+ * today. A host embedding this stylesheet can override any of them; setting
+ * them all to `0` is what a fully square page (one that has adopted the
+ * repo-wide "every corner is a hairline, not a surface" rule) needs to do,
+ * and this file is not making that call on the host's behalf.
  */
 
 :root {
@@ -224,7 +231,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
 .frame {
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: var(--radius-panel, 10px);
   overflow: hidden;
 }
 
@@ -242,7 +249,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
   margin-left: auto;
   display: flex;
   border: 1px solid var(--line2);
-  border-radius: 6px;
+  border-radius: var(--radius-control, 6px);
   overflow: hidden;
 }
 .zoom span { padding: 2px 10px; font-size: 10.5px; color: var(--dim); }
@@ -286,7 +293,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
   background: var(--sunken-2);
   border: 1px solid var(--line);
   padding: 0 8px;
-  border-radius: 99px;
+  border-radius: var(--radius-pill, 99px);
   white-space: nowrap;
   line-height: 1.7;
   font-variant-numeric: tabular-nums;
@@ -309,7 +316,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
   font-weight: 700;
   letter-spacing: 0.14em;
   padding: 1px 7px;
-  border-radius: 4px;
+  border-radius: var(--radius-tag, 4px);
 }
 .you .roletag { color: var(--on-category); background: var(--gold); }
 .agent .roletag { color: var(--on-category); background: var(--violet); }
@@ -363,7 +370,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
   color: var(--gold);
   background: none;
   border: 1px solid var(--line2);
-  border-radius: 6px;
+  border-radius: var(--radius-control, 6px);
   padding: 0 7px;
   margin-left: 6px;
   cursor: pointer;
@@ -402,7 +409,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
   width: 16px;
   line-height: 16px;
   font-size: 10px;
-  border-radius: 50%;
+  border-radius: var(--radius-dot, 50%);
   background: var(--panel);
   border: 1px solid var(--faint);
   color: var(--faint);
@@ -440,7 +447,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
   margin-left: 86px;
   background: var(--sunken);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--radius-inset, 8px);
   overflow: hidden;
 }
 .cmdbar {
@@ -499,7 +506,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
   font-size: 12px;
 }
 .file > summary:hover { background: var(--hover); }
-.fstat { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
+.fstat { width: 8px; height: 8px; border-radius: var(--radius-chip, 2px); flex-shrink: 0; }
 .fstat.mod { background: var(--amber); }
 .fstat.new { background: var(--green); }
 .fstat.gone { background: var(--red); }
@@ -530,8 +537,8 @@ table.diff { border-collapse: collapse; width: 100%; font: 12.5px/1.65 var(--mon
 .diff tr.del td.sign { color: var(--red); }
 .diff tr.add td.code, .diff tr.add td.sign { background: var(--add-line); }
 .diff tr.add td.sign { color: var(--green); }
-.dw { background: var(--del-word); border-radius: 2px; padding: 0 1px; }
-.aw { background: var(--add-word); border-radius: 2px; padding: 0 1px; }
+.dw { background: var(--del-word); border-radius: var(--radius-chip, 2px); padding: 0 1px; }
+.aw { background: var(--add-word); border-radius: var(--radius-chip, 2px); padding: 0 1px; }
 
 /* JSON syntax colouring for a tool result body.
  *

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -30,6 +30,9 @@ mod file_kinds;
 // What the stylesheet promises a 390px screen.
 mod narrow;
 
+// The stylesheet's corners: overridable, not squared outright.
+mod geometry;
+
 // Fold state, zoom presets, the cursor, and the fold controls both renderers
 // draw over them.
 mod folds;

--- a/crates/stella-transcript/src/tests/geometry.rs
+++ b/crates/stella-transcript/src/tests/geometry.rs
@@ -1,0 +1,77 @@
+//! The stylesheet's corners: overridable, not squared outright.
+//!
+//! A repo-wide rule squared every other web surface stella renders; this one never
+//! took the rule, and its ten `border-radius` declarations were plain
+//! literals — no host could change them without editing the file. Squaring
+//! them outright was the other option and was rejected here: it would change
+//! what the Observatory renders today, which this file's own header already
+//! promises stays byte-for-byte identical to the instrument palette it
+//! shares. Reading each corner from a `--radius-*` custom property with the
+//! literal as its fallback gets both — nothing changes until a host sets one.
+
+use crate::html::STYLE;
+
+/// Every corner in the base sheet reads from a `--radius-*` property, and its
+/// fallback is the exact value the page has always rendered — so a host that
+/// sets nothing sees nothing different.
+#[test]
+fn every_corner_is_a_custom_property_with_its_old_value_as_fallback() {
+    for (property, fallback) in [
+        ("--radius-panel", "10px"),
+        ("--radius-control", "6px"),
+        ("--radius-pill", "99px"),
+        ("--radius-tag", "4px"),
+        ("--radius-dot", "50%"),
+        ("--radius-inset", "8px"),
+        ("--radius-chip", "2px"),
+    ] {
+        let declaration = format!("border-radius: var({property}, {fallback})");
+        assert!(
+            STYLE.contains(&declaration),
+            "`{declaration}` is missing — a corner lost its override or its \
+             original value"
+        );
+    }
+}
+
+/// No corner is still a bare literal. This is the exact shape that blocked
+/// embedding this sheet into a page asserting square corners elsewhere in
+/// the tree: a literal cannot be overridden, only edited.
+#[test]
+fn no_corner_is_a_bare_literal_any_more() {
+    for bare in [
+        "border-radius: 10px",
+        "border-radius: 8px",
+        "border-radius: 6px",
+        "border-radius: 4px",
+        "border-radius: 2px",
+        "border-radius: 99px",
+        "border-radius: 50%",
+    ] {
+        assert!(
+            !STYLE.contains(bare),
+            "`{bare}` still ships as a literal a host cannot override"
+        );
+    }
+}
+
+/// The three sites that already shared one pixel value before this change
+/// share one property now too, rather than three independent ones that
+/// happen to agree — the whole point of naming the value once.
+#[test]
+fn sites_that_shared_a_value_now_share_one_property() {
+    let chip_sites = STYLE
+        .matches("border-radius: var(--radius-chip, 2px)")
+        .count();
+    assert_eq!(
+        chip_sites, 3,
+        "`.fstat`, `.dw` and `.aw` were all `2px`; they should read the same property"
+    );
+    let control_sites = STYLE
+        .matches("border-radius: var(--radius-control, 6px)")
+        .count();
+    assert_eq!(
+        control_sites, 2,
+        "`.zoom` and `.inspect` were both `6px`; they should read the same property"
+    );
+}


### PR DESCRIPTION
## What & why

A repo-wide rule squared every web surface stella renders; the shared
transcript stylesheet (`crates/stella-transcript/src/html/transcript.css`,
served on the Observatory's turn page and every standalone transcript
`html::render_page` produces) never took it. Ten `border-radius`
declarations were plain literals, and nothing checked for geometry on this
file at all — `scripts/check-tokens.py` and `scripts/check-light-clamp.py`
both read it for colour, and `crates/stella-cli/tests/design_token_parity.rs`'s
`no_web_surface_ships_a_rounded_corner` never named it.

The issue named two ways to settle it and asked for one, not half of each.
Route 1 (square outright) changes what the Observatory renders today, which
this file's own header already promises stays identical to the instrument
palette it shares. Route 2 — each corner reads `var(--radius-*, <today's
value>)` — is what this PR does: nothing changes by default, and a host
(the `/export` archive, which pins everything to `--radius: 0`) can square
every corner by overriding seven properties in one block.

Sites that already shared one pixel value now share one property:
`.fstat`/`.dw`/`.aw` were all `2px` (`--radius-chip`), `.zoom`/`.inspect`
were both `6px` (`--radius-control`) — seven names for ten declarations.
Naming follows the `--radius`/`--radius-sm` family already established
elsewhere in the tree (`crates/stella-cli/tests/design_token_parity.rs`'s
own `no_web_surface_ships_a_rounded_corner` comment cites `--radius-sm`).

Closes #5080

## Why not fold into the existing cross-surface check

`no_web_surface_ships_a_rounded_corner` already exists and covers two other
files, but its parser splits a declaration's value on whitespace and
requires every part to be `0` or to start with `var(--radius` — which holds
for a bare `var(--radius-sm)` but not for `var(--radius-panel, 10px)`, whose
fallback argument is a separate whitespace-split token. Extending that
parser to handle a fallback argument is possible but touches a check that
already guards two other files correctly; this PR adds a dedicated test in
`stella-transcript` instead (its own crate, its own file), which fully
satisfies the DoD's "a test holds whichever answer" without risking the
existing check's coverage of the other two surfaces.

## What changes

- `crates/stella-transcript/src/html/transcript.css`: all ten
  `border-radius` declarations now read a `--radius-*` custom property with
  the original value as fallback; a paragraph in the file's own header
  (which ships to every rendered transcript, per its "comments here are
  page content" rule) states the decision.
- `crates/stella-transcript/src/tests/geometry.rs` (new): three tests.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`no_corner_is_a_bare_literal_any_more` and
`every_corner_is_a_custom_property_with_its_old_value_as_fallback` both
fail on `main`, which has ten bare literals and zero `--radius-*`
properties. Checked the artisanal way too — reverted one site to a bare
literal and both tests failed naming that exact site; restored, they pass.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-transcript --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-transcript --no-deps --document-private-items`
- [x] `cargo test -p stella-transcript` — 138 + 2 passed
- [x] `cargo test -p stella-observatory` — 153 + others passed (embeds this stylesheet)
- [x] `cargo test -p stella-cli --test design_token_parity` — 13 passed, including the existing `no_web_surface_ships_a_rounded_corner`
- [x] `python3 ./scripts/check-prose.py`
- [x] `make guards-fast`

## Nothing left behind

- [x] There is nothing new: I'll comment on #4270 once this merges,
      confirming its geometry blocker (embedding `html::STYLE` failing the
      dashboard's square-corners literal-string bans) is cleared — that
      issue's actual migration is unrelated, larger scope this PR does not
      touch.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Make transcript stylesheet corner geometry configurable through radius tokens without changing its default rendering.

Bug Fixes:
- Make all shared transcript stylesheet corner radii host-overridable while preserving their existing default appearance.

Enhancements:
- Centralize repeated corner sizes under shared radius custom properties so hosts can apply consistent geometry overrides.

Documentation:
- Document the stylesheet's radius override behavior and preserve-default rationale.

Tests:
- Add geometry tests that verify every corner uses a radius custom property with the original fallback and that shared values remain consistently named.