### PR TITLE
fix(gate): the prose density ratchet stops leaving zero headroom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,8 +469,15 @@ prose-report: ## Name every remaining content-free construction, with its remedy
 	@python3 ./scripts/check-prose.py --report
 
 .PHONY: prose-update
-prose-update: ## Retighten both prose ratchets — the counts and the header-length means
+prose-update: ## Lower the count ratchet; leave every unit's header-length ceiling where it stands
 	@python3 ./scripts/check-prose.py --update
+
+# The other direction, and a PR of its own: reclaiming the slack a shortened
+# header earns is safe exactly when nothing is blocked on it, the same
+# reasoning file-size-retighten is built on.
+.PHONY: prose-retighten
+prose-retighten: ## Lower every unit's header-length ceiling to its current mean (a deliberate, separate pass)
+	@python3 ./scripts/check-prose.py --update --retighten
 
 .PHONY: line-citations
 line-citations: ## Assert prose cites code by name, never by line number (down-only ratchet, #4392)

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -58,11 +58,33 @@ blocks, and a unit may lower that mean and never raise it. A file can be
 entirely within the count ratchet and still be three times longer than it
 needs to be.
 
+The baseline is a shared cell in the sense AGENTS.md describes for
+`Cargo.lock`: two branches each landing one ordinary header are green alone
+and compose into a red `main`. Two doors close that, mirroring
+`check-file-size.sh`'s own split:
+
+- The plain check judges a unit against `max(its baseline, its mean in the
+  base tree)`. Inherited drift is reported as drift and does not fail a
+  branch that did not cause it, so landing one ordinary header cannot
+  redden `main` on its own. `--absolute` opts out of the base comparison for
+  the one caller that must not get this mercy: a post-merge canary is
+  exactly asking whether drift already reached `main`, and the base-relative
+  reading would forgive the thing it exists to catch.
+- `--update` alone leaves every unit's ceiling where it stands; only
+  `--update --retighten` lowers a ceiling to its current mean, as a
+  deliberate, separately-landed pass. Retightening on every `--update` run
+  is what put every unit at exactly its ceiling with zero headroom in the
+  first place.
+
 Usage:
 
     ./scripts/check-prose.py [--update] [--adopt=NAME] [--report] [ROOT]
 
-    --update      rewrite both baselines downward only (`make prose-update`)
+    --update      lower the count baseline; leave every unit's header-length
+                  ceiling where it stands (`make prose-update`)
+    --retighten   with --update, also lower every unit's header-length
+                  ceiling to its current mean -- a deliberate, separate pass
+                  (`make prose-retighten`)
     --adopt=NAME  record the pre-existing debt of a pattern added to PATTERNS
                   after the baseline was written, and nothing else. Once per
                   pattern: a pattern already in the baseline is refused
@@ -75,10 +97,14 @@ Usage:
                   density ratchet arrived
     --report      print every offending line, grouped by file, then each
                   unit's mean header length; changes nothing
+    --absolute    judge every unit's density against its baseline alone,
+                  ignoring the base tree. For the post-merge canary, which
+                  must catch drift a base-relative check would forgive.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -254,8 +280,8 @@ DENSITY_HEADER = """\
 # Each line is `<unit> <mean>` -- the mean length, in lines, of every leading
 # `//!` block in that crate's Rust files, recorded in hundredths so the
 # comparison is integer arithmetic. A unit may lower its mean; it may never
-# raise it, and a unit absent from this list is held to 12.00. Regenerate with
-# `make prose-update`, which refuses to raise a number.
+# raise it, and a unit absent from this list is held to 12.00. Lower one with
+# `make prose-retighten`; `make prose-update` never touches this file.
 #
 # Mean header length rather than comment share, because share is a bad proxy on
 # its own: a well-documented pure-function crate should be comment-heavy, and
@@ -421,6 +447,73 @@ def density(root: Path, paths: list[str]) -> dict[str, int]:
         total[unit] = total.get(unit, 0) + length
         files[unit] = files.get(unit, 0) + 1
     return {unit: round(total[unit] * 100 / files[unit]) for unit in total}
+
+
+def _git(root: Path, args: list[str]) -> str:
+    """`git <args>` from `root`, or "" on any failure. Fails closed: a
+    broken or absent git must never grant base-relative leniency."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def resolve_base_commit(root: Path, absolute: bool) -> str:
+    """The commit a unit's density is judged against, or "" for none.
+
+    Mirrors `check-file-size.sh`'s `resolve_base_commit`: an explicit
+    override (`PROSE_BASE_REF`, for hermetic tests with no `origin/main`),
+    a merge commit (a `refs/pull/N/merge` checkout, where `HEAD^1` is the
+    base branch tip), a local feature branch's merge-base with
+    `origin/main`, or the immediate parent on a linear push. Empty under
+    `--absolute` or on any git failure -- both collapse `max(ceiling,
+    base)` to the ceiling, the strict whole-tree check.
+    """
+    if absolute:
+        return ""
+    override = os.environ.get("PROSE_BASE_REF")
+    if override:
+        return _git(root, ["rev-parse", "--verify", "--quiet", f"{override}^{{commit}}"])
+    if _git(root, ["rev-parse", "--verify", "--quiet", "HEAD^2"]):
+        return _git(root, ["rev-parse", "--verify", "--quiet", "HEAD^1^{commit}"])
+    mb = _git(root, ["merge-base", "HEAD", "origin/main"])
+    head = _git(root, ["rev-parse", "HEAD"])
+    if mb and mb != head:
+        return mb
+    return _git(root, ["rev-parse", "--verify", "--quiet", "HEAD^1^{commit}"])
+
+
+def base_tracked_paths(root: Path, commit: str, unit: str) -> list[str]:
+    """Every `.rs` path under `unit/` that `git ls-tree` names at `commit`."""
+    if not commit:
+        return []
+    out = _git(root, ["ls-tree", "-r", "--name-only", commit, "--", unit])
+    return [p for p in out.splitlines() if p]
+
+
+def density_at_commit(root: Path, commit: str, unit: str, paths: list[str]) -> int:
+    """[`density`] for one unit, reading each file's content from `commit`
+    via `git show` rather than the working tree. 0 when the unit had no
+    headers there (including when it did not exist at all)."""
+    total = 0
+    files = 0
+    for path in paths:
+        if not path.endswith(".rs"):
+            continue
+        text = _git(root, ["show", f"{commit}:{path}"])
+        length = header_length(text)
+        if not length:
+            continue
+        total += length
+        files += 1
+    return round(total * 100 / files) if files else 0
 
 
 def read_density_baseline(path: Path) -> dict[str, int]:
@@ -688,22 +781,46 @@ def main() -> int:
             if pair not in per_pair:
                 merged.pop(pair, None)
         write_baseline(baseline_path, merged)
-        tightened = {
-            unit: min(mean, density_baseline.get(unit, NEW_UNIT_MEAN))
-            for unit, mean in per_unit.items()
-        }
-        write_density_baseline(density_path, tightened)
-        print(
-            f"check-prose: {BASELINE} retightened to {sum(merged.values())}, "
-            f"{DENSITY_BASELINE} to {len(tightened)} unit(s)."
-        )
+        # Retightening every unit to its current mean on every `--update` run
+        # is what left each crate sitting at exactly its ceiling with zero
+        # headroom: the reclaim is unconditional and global, so clearing one
+        # crate's drift silently removes every other crate's slack too. Split
+        # the same way `check-file-size.sh --update`/`--retighten` are:
+        # `--update` alone leaves `DENSITY_BASELINE` untouched (nothing here
+        # can have grown past it, or the refusal above would have already
+        # fired), and `--retighten` is the deliberate, separately-landed pass
+        # that reclaims slack across every unit at once.
+        if "--retighten" in flagset:
+            tightened = {
+                unit: min(mean, density_baseline.get(unit, NEW_UNIT_MEAN))
+                for unit, mean in per_unit.items()
+            }
+            write_density_baseline(density_path, tightened)
+            density_msg = f"{DENSITY_BASELINE} retightened to {len(tightened)} unit(s)."
+        else:
+            density_msg = f"{DENSITY_BASELINE} left alone -- pass --retighten to reclaim slack."
+        print(f"check-prose: {BASELINE} retightened to {sum(merged.values())}, {density_msg}")
         return 0
 
-    over = [
-        (unit, density_baseline.get(unit, NEW_UNIT_MEAN), mean)
-        for unit, mean in sorted(per_unit.items())
-        if mean > density_baseline.get(unit, NEW_UNIT_MEAN)
-    ]
+    # Judged against max(the recorded ceiling, this unit's mean in the base
+    # tree) -- the same rule check-file-size.sh uses, and for the same
+    # reason: a unit already over its ceiling before this change landed is
+    # inherited drift, and failing the branch that merely did not fix it is
+    # what turned this ratchet into a main-red generator. `--absolute` (the
+    # post-merge canary) skips the base entirely, because that is exactly
+    # the drift a canary exists to catch.
+    absolute = "--absolute" in flagset
+    base_commit = resolve_base_commit(root, absolute)
+    over = []
+    for unit, mean in sorted(per_unit.items()):
+        ceiling = density_baseline.get(unit, NEW_UNIT_MEAN)
+        if mean <= ceiling:
+            continue
+        if base_commit:
+            base_paths = base_tracked_paths(root, base_commit, unit)
+            ceiling = max(ceiling, density_at_commit(root, base_commit, unit, base_paths))
+        if mean > ceiling:
+            over.append((unit, ceiling, mean))
 
     failures = []
     for pair in sorted(set(per_pair) | set(baseline)):

--- a/scripts/main-canary.sh
+++ b/scripts/main-canary.sh
@@ -203,14 +203,14 @@ checks=(
   "compile|cargo check --workspace --all-targets --locked${manifest_dir:+ --offline --manifest-path $manifest_dir/Cargo.toml}"
   # A third shared cell: `scripts/prose-baseline.txt`. It earns its row the
   # same way the two above do, and the mechanism is the one that makes a
-  # post-merge check the only possible catcher — `check-prose` judges the
-  # whole tree with no base-relative branch, so the moment drift lands on
+  # post-merge check the only possible catcher — the count ratchet judges
+  # the whole tree with no base-relative branch, so the moment drift lands on
   # `main` it fails every open PR at once, for a reason none of their authors
   # caused and none of them can see coming.
   #
   # That is worse than the file-size case rather than milder. `check-file-size`
-  # at least reports inherited drift as drift and passes the branch; the prose
-  # gate has no such arm, so the first PR to run after the drift lands simply
+  # at least reports inherited drift as drift and passes the branch; the count
+  # ratchet has no such arm, so the first PR to run after the drift lands simply
   # goes red and its author starts debugging their own diff.
   #
   # It has happened: at a7a46d3b6 this canary ran, reported `FAIL file-size`
@@ -220,8 +220,15 @@ checks=(
   # unrelated repair PR's `gate steps` job, where it read as that PR's fault
   # and cost a full CI cycle to attribute (#4828).
   #
-  # No `--absolute` equivalent is needed or available: the guard is already
-  # whole-tree, which is the property that makes it belong here.
+  # `--absolute` IS needed here now, for the density ratchet's own half of
+  # this file: `scripts/prose-density-baseline.txt` was whole-tree the same
+  # way, and the same shared-cell shape described above cost `main` its own
+  # red window — two ordinary module headers landing near one another were
+  # each green alone. The plain check now judges a unit's density against
+  # `max(its baseline, its mean in the base tree)`, the same mercy
+  # `check-file-size` already had, so this canary needs the strict reading
+  # back: `--absolute` skips the base tree, exactly like the row above.
+  # The count ratchet is unaffected and stays whole-tree by construction.
   #
   # The trailing positional argument is `check-prose.py`'s own `ROOT` — it
   # already resolves the baseline and walks the tree relative to whatever
@@ -230,7 +237,7 @@ checks=(
   # the real repository, so the canary's own fixture-based self-tests could
   # never construct a hermetic prose failure — a fixture already red on
   # something else stayed red, but for the wrong row's reason.
-  "prose|python3 ./scripts/check-prose.py${manifest_dir:+ $manifest_dir}"
+  "prose|python3 ./scripts/check-prose.py --absolute${manifest_dir:+ $manifest_dir}"
 )
 
 # The remediation for ONE failing check. Per-check on purpose: this block used

--- a/scripts/prose-density-baseline.txt
+++ b/scripts/prose-density-baseline.txt
@@ -3,8 +3,8 @@
 # Each line is `<unit> <mean>` -- the mean length, in lines, of every leading
 # `//!` block in that crate's Rust files, recorded in hundredths so the
 # comparison is integer arithmetic. A unit may lower its mean; it may never
-# raise it, and a unit absent from this list is held to 12.00. Regenerate with
-# `make prose-update`, which refuses to raise a number.
+# raise it, and a unit absent from this list is held to 12.00. Lower one with
+# `make prose-retighten`; `make prose-update` never touches this file.
 #
 # Mean header length rather than comment share, because share is a bad proxy on
 # its own: a well-documented pure-function crate should be comment-heavy, and

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -386,18 +386,36 @@ else
   no "D4 --update left the ceiling alone" "the ceiling moved"
 fi
 
+# Retightening every unit's ceiling on every --update run is what left each
+# one sitting at exactly its ceiling with zero headroom, so bare --update
+# leaves a shortened header's ceiling alone; only --update --retighten
+# reclaims that slack, as its own deliberate pass.
 r="$(new_root d5)"
 baseline "$r"
 density_baseline "$r" crates/alpha 20.00
 rs_with_header "$r" alpha 6 lib
 if python3 "$SCRIPT" --update "$r" >/dev/null 2>&1; then
-  if grep -qx "crates/alpha 6.00" "$r/scripts/prose-density-baseline.txt"; then
-    ok "D5 --update retightens a shortened header"
+  if grep -qx "crates/alpha 20.00" "$r/scripts/prose-density-baseline.txt"; then
+    ok "D5 bare --update leaves a shortened header's ceiling alone"
   else
-    no "D5 --update retightens a shortened header" "the ceiling did not fall"
+    no "D5 bare --update leaves a shortened header's ceiling alone" "the ceiling moved"
   fi
 else
-  no "D5 --update retightens a shortened header" "--update exited non-zero"
+  no "D5 bare --update leaves a shortened header's ceiling alone" "--update exited non-zero"
+fi
+
+r="$(new_root d5b)"
+baseline "$r"
+density_baseline "$r" crates/alpha 20.00
+rs_with_header "$r" alpha 6 lib
+if python3 "$SCRIPT" --update --retighten "$r" >/dev/null 2>&1; then
+  if grep -qx "crates/alpha 6.00" "$r/scripts/prose-density-baseline.txt"; then
+    ok "D5b --update --retighten reclaims a shortened header's slack"
+  else
+    no "D5b --update --retighten reclaims a shortened header's slack" "the ceiling did not fall"
+  fi
+else
+  no "D5b --update --retighten reclaims a shortened header's slack" "--update --retighten exited non-zero"
 fi
 
 # A crate with no entry is held to the new-unit ceiling, so a new crate cannot
@@ -561,6 +579,60 @@ Two things follow from that, and the second is the hard one.
 EOF
 baseline "$r"
 expect_update_refused "R5 an unaskable git still refuses a first-time offender" "$r"
+
+# ── B: a unit's density is judged against the base tree too ─────────────────
+#
+# `--update` retightens every unit to its current value on every run, so a
+# crate sits at exactly its ceiling with zero headroom the moment anyone runs
+# it. B1 is the witness for the fix: a unit already over its recorded
+# ceiling in the tree this branch started from must not fail a branch that
+# never touched it. B2 is the mercy's boundary -- growing the header further
+# still fails. B3 is `--absolute`, which the post-merge canary needs: it
+# must see the same drift B1 forgives, or it stops being able to catch drift
+# that already reached `main`.
+#
+# $1 = root. Point refs/remotes/origin/main at the current HEAD, so
+# merge-base has something to compare against without a real remote.
+mark_as_main() {
+  (cd "$1" && git update-ref refs/remotes/origin/main HEAD) >/dev/null 2>&1
+}
+
+r="$(new_root b1)"
+density_baseline "$r" crates/alpha 10.00
+rs_with_header "$r" alpha 25 lib
+commit_all "$r"
+mark_as_main "$r"
+doc "$r" docs/unrelated.md <<'EOF'
+The store keys every child table off `executions.id`.
+EOF
+baseline "$r"
+commit_all "$r"
+expect_pass "B1 inherited drift on the base tree does not fail an untouched unit" "$r"
+
+r="$(new_root b2)"
+density_baseline "$r" crates/alpha 10.00
+rs_with_header "$r" alpha 25 lib
+commit_all "$r"
+mark_as_main "$r"
+rs_with_header "$r" alpha 30 lib
+commit_all "$r"
+expect_fail "B2 growing a header past even the base tree's mean still fails" "$r"
+
+r="$(new_root b3)"
+density_baseline "$r" crates/alpha 10.00
+rs_with_header "$r" alpha 25 lib
+commit_all "$r"
+mark_as_main "$r"
+doc "$r" docs/unrelated.md <<'EOF'
+The store keys every child table off `executions.id`.
+EOF
+baseline "$r"
+commit_all "$r"
+if python3 "$SCRIPT" --absolute "$r" >/dev/null 2>&1; then
+  no "B3 --absolute still sees inherited drift" "the guard passed"
+else
+  ok "B3 --absolute still sees inherited drift"
+fi
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

`scripts/prose-density-baseline.txt`'s per-crate mean module-header-length
ceiling is a shared cell in exactly the sense AGENTS.md describes for
`Cargo.lock`: `make prose-update` retightened every unit to its current
value on every run, so a crate sat at exactly its ceiling with zero
headroom the moment anyone ran it. Two branches each landing one ordinary
header were each green alone and composed into a red `main`. It already
cost a multi-PR window (#5124/#5129/#5131/#5133) and the claim collision in
#5134.

This ports `check-file-size.sh`'s own two-part fix for the identical shape
of problem — the issue's own recommended option (3), plus the
`--update`/`--retighten` split its DoD also asks for:

1. **The plain check judges a unit against `max(its recorded ceiling, its
   mean in the base tree)`.** Inherited drift is reported as drift and does
   not fail a branch that did not cause it, so landing one ordinary header
   cannot redden `main` on its own. `--absolute` opts a caller out of that
   mercy — `main-canary.sh`'s prose row now passes it, since a post-merge
   canary is exactly asking whether drift already reached `main`, and the
   base-relative reading would forgive the thing it exists to catch.
2. **`--update` alone no longer touches the density baseline at all.**
   `--update --retighten` is the new door that reclaims slack, as its own
   deliberate, separately-landed pass — mirroring `file-size-update` vs
   `file-size-retighten` exactly.

Closes #5136

## What changes

- `scripts/check-prose.py`: `resolve_base_commit`, `base_tracked_paths`,
  `density_at_commit` (new) mirror `check-file-size.sh`'s base-tree
  machinery; the plain check's `over` computation uses the effective
  ceiling; `--update`'s density write is gated behind a new `--retighten`
  flag; module doc and usage string updated.
- `scripts/main-canary.sh`: prose row passes `--absolute`; its header
  comment (previously "no `--absolute` equivalent is needed or available:
  the guard is already whole-tree") is rewritten — that claim is still true
  for the count ratchet, no longer true for the density ratchet.
- `Makefile`: new `prose-retighten` target; `prose-update`'s description
  corrected.
- `scripts/prose-density-baseline.txt`: header comment hand-synced to the
  new `DENSITY_HEADER` constant (byte-for-byte, verified) — no ceiling
  numbers touched, since that's exactly what `--retighten`, run separately,
  is for.
- `scripts/test-prose-guard.sh`: three new tests (B1–B3) for the base-tree
  comparison; D5 updated for the `--update`/`--retighten` split, plus a new
  D5b for the retighten side.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`B1 inherited drift on the base tree does not fail an untouched unit` fails
on `main` (a unit already over its ceiling before the branch started fails
the branch even though nothing in it touched that unit) and passes here.
Checked the artisanal way too: stashed `check-prose.py` alone (keeping the
new test), reran — `B1` failed with "the guard exited non-zero"; restored,
all 46 pass. `D5`/`D5b` are the same proof for the `--update`/`--retighten`
split.

## The gate

- [x] `bash scripts/test-prose-guard.sh` — 46 passed (was 42; +3 for B1–B3,
      +1 net for the D5/D5b split)
- [x] `bash scripts/test-main-canary.sh` — 34 passed, unaffected by the
      `--absolute` addition
- [x] `python3 ./scripts/check-prose.py` — clean on the real tree
- [x] `make guards-fast`

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (pure Python/bash, no Rust
      touched)
- [x] No new outbound network calls

## Summary by Sourcery

Make prose-density enforcement base-tree-aware while separating routine baseline updates from deliberate ceiling retightening.

New Features:
- Add base-tree-aware prose density checking with an `--absolute` mode for strict whole-tree validation.
- Add a separate `prose-retighten` workflow for deliberately reclaiming density-baseline slack.

Bug Fixes:
- Prevent inherited prose-density drift from failing branches that did not introduce it.
- Prevent ordinary prose baseline updates from unexpectedly retightening every unit’s density ceiling.

Build:
- Update Make targets and prose baseline guidance to distinguish routine updates from deliberate density retightening.

CI:
- Run the main canary’s prose check in absolute mode so it continues detecting drift already present on the default branch.

Tests:
- Expand prose guard coverage for inherited drift, further density growth, and the update/retighten split.