### PR TITLE
fix(stella-cli): compile the microphone recorder against cpal 0.18 on macOS/Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,9 +316,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/crates/stella-cli/src/command_deck/voice.rs
+++ b/crates/stella-cli/src/command_deck/voice.rs
@@ -374,7 +374,7 @@ mod capture {
                     let config = device
                         .default_input_config()
                         .map_err(|e| format!("voice: no input config: {e}"))?;
-                    let sample_rate = config.sample_rate().0;
+                    let sample_rate = config.sample_rate();
                     let channels = config.channels();
                     let cap = sample_rate as usize * channels as usize * max_secs as usize;
                     let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::<i16>::new()));
@@ -383,16 +383,16 @@ mod capture {
                     // restarted) ends the useful audio; the capture then
                     // finishes short and the transcription step reports
                     // "heard nothing", which is the user-visible truth.
-                    let on_err = |_e: cpal::StreamError| {};
+                    let on_err = |_e: cpal::Error| {};
                     let stream = match config.sample_format() {
                         cpal::SampleFormat::I16 => device.build_input_stream(
-                            &config.into(),
+                            config.into(),
                             move |data: &[i16], _| push_capped(&sink, data.iter().copied(), cap),
                             on_err,
                             None,
                         ),
                         cpal::SampleFormat::F32 => device.build_input_stream(
-                            &config.into(),
+                            config.into(),
                             move |data: &[f32], _| {
                                 push_capped(
                                     &sink,


### PR DESCRIPTION
Closes #5541

3cbf7e95d bumped cpal 0.16 → 0.18.2 with only Linux CI. The recorder in `command_deck::voice` is a macOS/Windows-only target dependency, so main has not compiled on macOS since. Three call-site adaptations, no behavior change:
- `config.sample_rate().0` → `config.sample_rate()` (`SampleRate` is `u32` now)
- `cpal::StreamError` → `cpal::Error` in the error callback
- `&config.into()` → `config.into()` (`build_input_stream` takes `StreamConfig` by value)

Verified locally on macOS: `cargo check -p stella-cli --all-targets`, `cargo clippy -p stella-cli --bin stella -- -D warnings`, `cargo fmt --check` all clean.

## Summary by Sourcery

Restore cross-platform microphone recorder compatibility with cpal 0.18 without changing recording behavior.

Bug Fixes:
- Restore macOS and Windows compilation of the Stella CLI microphone recorder after upgrading to cpal 0.18.

Chores:
- Update the lockfile for the cpal compatibility changes.