### PR TITLE
feat(skills): auto-selected directive skills expand as invocations (#5465)

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1237,8 +1237,8 @@ pub(crate) async fn run_turn(
     // re-injected, from that block's own handles so the first answer does not
     // repeat its frames (#4498), and given `tx` so its own recall is metered
     // (#3366).
-    // This turn's directive-carrying skills — invoked or auto-selected
-    // (#5465): each span is live for the whole turn — `active_skill_slugs`
+    // This turn's directive-carrying skills — invoked or
+    // auto-selected: each span is live for the whole turn — `active_skill_slugs`
     // reports them, and every declared `allowed-tools` grant narrows every
     // dispatch to operator ∧ grant, intersected across spans. The guards
     // drop with this function, lifting the narrowing structurally. With no

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -1237,6 +1237,17 @@ pub(crate) async fn run_turn(
     // re-injected, from that block's own handles so the first answer does not
     // repeat its frames (#4498), and given `tx` so its own recall is metered
     // (#3366).
+    // This turn's directive-carrying skills — invoked or auto-selected
+    // (#5465): each span is live for the whole turn — `active_skill_slugs`
+    // reports them, and every declared `allowed-tools` grant narrows every
+    // dispatch to operator ∧ grant, intersected across spans. The guards
+    // drop with this function, lifting the narrowing structurally. With no
+    // scope the plane is inert and the scoped views below are pure
+    // pass-throughs, so every turn takes one path. Read off the recall
+    // before its seed and events are handed on below.
+    let skill_plane = stella_tools::skill_plane::SkillInvocationPlane::new();
+    let _skill_spans = recall.mount_skill_spans(&skill_plane);
+    let skill_effort = recall.skill_effort();
     let requery = crate::memory::requery_for_turn(
         session_memory.as_deref(),
         messages,
@@ -1259,18 +1270,6 @@ pub(crate) async fn run_turn(
     // Mid-turn fallback (#2679): on an exhausted retry ladder the engine
     // re-resolves the worker role through this session router.
     let fallback = engine::SessionFallback::new(router);
-    // A directive-carrying skill invocation: its span is live for the
-    // whole turn — `active_skill_slugs` reports it, and when the skill
-    // declared `allowed-tools` the plane narrows every dispatch to
-    // operator ∧ grant. The guard drops with this function, lifting the
-    // narrowing structurally. With no invocation the plane is inert and the
-    // view below is a pure pass-through, so every turn takes one path.
-    let skill_plane = stella_tools::skill_plane::SkillInvocationPlane::new();
-    let _skill_span = recall
-        .skill_scope
-        .as_ref()
-        .map(|scope| skill_plane.begin(&scope.slug, scope.allowed_tools.as_deref()));
-    let skill_effort = recall.skill_scope.as_ref().and_then(|scope| scope.effort);
     // The scoped tool set must drop its tx clone before awaiting the renderer.
     let outcome = if crate::enterprise_telemetry::process_free_authority_active() {
         // Even when process-free authority strips the MCP/custom/interactive

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -35,8 +35,8 @@ use crate::domains::{Domains, heuristic_domains, infer_domains};
 use crate::failure::CliFailure;
 use crate::interactive::human_is_present;
 use crate::memory::{
-    ReflectionReport, SessionMemory, TurnEvidence, TurnFriction, inject_recall_block,
-    reflect_routed, should_reflect_on, turn_warrants_reflection,
+    ReflectionReport, SessionMemory, TurnEvidence, TurnFriction, reflect_routed, should_reflect_on,
+    turn_warrants_reflection,
 };
 use crate::plain::{self, accent};
 use crate::runtime::{SystemClock, TokioSleeper};
@@ -482,8 +482,9 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             }
             println!();
             // Phase 2 (#713): carried to `run_goal_turn`, which owns the
-            // event channel this turn's telemetry rides.
-            let mut recall_events: Vec<AgentEvent> = Vec::new();
+            // event channel this turn's telemetry rides and the tool stack
+            // its skill scopes narrow.
+            let mut recall = crate::memory::OpeningRecall::default();
             if let Some(m) = &mut memory {
                 // Same schedule as the plain prompts above (#1221): one
                 // interleaved sequence per workspace, not one per command.
@@ -491,8 +492,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 let touched =
                     stella_core::driver::loop_evidence::turn_evidence(&messages).touched_paths;
                 let recalled = m.recall_block_reported(goal, &touched).await;
-                recall_events = recalled.telemetry_events();
-                inject_recall_block(&mut messages, recalled.text);
+                recall = crate::memory::inject_opening_recall(&mut messages, recalled);
             }
             // Everything the goal loop appends past here is this turn's work,
             // gating reflection on it (see `turn_warrants_reflection`).
@@ -514,7 +514,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
                 &store,
                 goal,
                 Some(presence.id()),
-                recall_events,
+                recall,
                 memory.as_mut(),
                 Some(&mut goal_rounds),
             )

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -664,8 +664,9 @@ pub async fn run_goal_cmd(
     )];
     let mut memory =
         SessionMemory::open_for_session(&cfg.workspace_root, true, &cfg.authority, &active_rules);
-    // Phase 2 (#713): carried to the turn runner, which owns the event channel.
-    let mut recall_events: Vec<AgentEvent> = Vec::new();
+    // Phase 2 (#713): carried to the turn runner, which owns the event channel
+    // the events ride and assembles the tool stack the scopes narrow.
+    let mut recall = crate::memory::OpeningRecall::default();
     if let Some(m) = &mut memory {
         // One arm for the whole goal run (#1221): the judged rounds below are
         // stages of one turn — they share this run's episode, so they must
@@ -674,8 +675,7 @@ pub async fn run_goal_cmd(
         m.arm_recall_control();
         let touched = stella_core::driver::loop_evidence::turn_evidence(&messages).touched_paths;
         let recalled = m.recall_block_reported(goal, &touched).await;
-        recall_events = recalled.telemetry_events();
-        inject_recall_block(&mut messages, recalled.text);
+        recall = crate::memory::inject_opening_recall(&mut messages, recalled);
     }
 
     let started_unix = crate::memory::unix_now_secs();
@@ -704,7 +704,7 @@ pub async fn run_goal_cmd(
             goal,
             Some(presence.id()),
             budget_limit,
-            recall_events,
+            recall,
             memory.as_mut(),
             bound,
             candidate,
@@ -725,7 +725,7 @@ pub async fn run_goal_cmd(
             &store,
             goal,
             Some(presence.id()),
-            recall_events,
+            recall,
             memory.as_mut(),
             Some(&mut rounds),
         )
@@ -851,12 +851,16 @@ pub(crate) async fn run_goal_turn(
     store: &Option<Arc<Store>>,
     goal: &str,
     session: Option<&str>,
-    // Phase 2 (#713): what this turn's opening block left to announce — its
-    // `ContextRecall`, then a `SkillInjected` per skill it carried (#5031) —
-    // carried from the caller because recall necessarily precedes the channel
-    // it would be emitted on. Already in send order; see
-    // `memory::RecalledBlock::telemetry_events`.
-    recall_events: Vec<AgentEvent>,
+    // Phase 2 (#713): what this turn's opening block left behind — the events
+    // to announce (its `ContextRecall`, then a `SkillInjected` per skill it
+    // carried (#5031), already in send order) and the turn scopes its
+    // directive-carrying skills ask for. Carried from the caller because
+    // recall necessarily precedes both the channel the events ride and the
+    // tool stack the scopes narrow. The whole `OpeningRecall` rather than its
+    // events alone: a goal door that took only the events dropped the scopes,
+    // so an auto-selected skill's `allowed-tools` grant and `effort` reached
+    // the prompt and governed nothing.
+    recall: crate::memory::OpeningRecall,
     // The caller's session memory, so the execution seam can stamp this
     // round's execution id and record its skill-version usage before the turn
     // runs — reflection stores the self-review 1:1 with an execution, and an
@@ -929,7 +933,16 @@ pub(crate) async fn run_goal_turn(
     // neither opener, so an untrusted checkout's refusal was on stderr and on
     // no event stream at all.
     announce_withheld_steering(&tx, cfg);
-    for event in recall_events {
+    // This arc's directive-carrying skills, whether a human typed `/slug` or
+    // recall selected them: each span is live for every round the loop drives
+    // — the whole arc is one turn, and the guards drop with this function, so
+    // the narrowing lifts structurally. With no scope the plane is inert and
+    // the scoped view below is a pure pass-through, so every goal run takes
+    // one path. Read off the recall before its events are handed on.
+    let skill_plane = stella_tools::skill_plane::SkillInvocationPlane::new();
+    let _skill_spans = recall.mount_skill_spans(&skill_plane);
+    let skill_effort = recall.skill_effort();
+    for event in recall.events {
         let _ = tx.send(event);
     }
 
@@ -941,18 +954,26 @@ pub(crate) async fn run_goal_turn(
             Principal::User,
             registry.hook_bus(),
         );
+        // Above the assembled session chain, the position `skill_grant`'s
+        // module docs specify: the grant narrows customs and MCP with
+        // everything else, and can never widen past the operator surface.
+        let tools = stella_tools::skill_plane::SkillScopedTools::new(&tools, skill_plane.clone());
         let hook_runner = HostHookRunner;
-        let mut engine =
-            Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
-                .with_calibration(calibration)
-                // Every round's worker turn drains this, and only those. The
-                // verifier runs as a sub-agent off `Engine::assess`, which
-                // sees a parent's steering through
-                // `stella_core::subagent::ChildSteering` — soft stop
-                // forwarded, `drain_steering` refused — so a whistle cannot
-                // be eaten by the judge, and the person who sent it does not
-                // have to know a judge exists.
-                .with_steering(whistle.steering());
+        let mut config = engine_config_for(cfg);
+        if let Some(effort) = skill_effort {
+            // The skill's `effort:` override, for this arc.
+            config.effort = Some(effort);
+        }
+        let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
+            .with_calibration(calibration)
+            // Every round's worker turn drains this, and only those. The
+            // verifier runs as a sub-agent off `Engine::assess`, which
+            // sees a parent's steering through
+            // `stella_core::subagent::ChildSteering` — soft stop
+            // forwarded, `drain_steering` refused — so a whistle cannot
+            // be eaten by the judge, and the person who sent it does not
+            // have to know a judge exists.
+            .with_steering(whistle.steering());
         if let Some(hooks) = &cfg.hooks {
             engine = engine.with_hooks(hooks, &hook_runner);
         }

--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -274,9 +274,10 @@ pub(crate) async fn run_goal_wrapped_turn(
     goal: &str,
     session: Option<&str>,
     budget_limit: Option<f64>,
-    // Phase 2 (#713): what this turn's opening block left to announce, in
-    // send order — the raw arm's twin. See `super::run_goal_turn`.
-    recall_events: Vec<AgentEvent>,
+    // Phase 2 (#713): what this turn's opening block left behind — its events
+    // in send order, and the turn scopes its directive-carrying skills ask
+    // for. The raw arm's twin; see `super::run_goal_turn`.
+    recall: crate::memory::OpeningRecall,
     session_memory: Option<&mut crate::memory::SessionMemory>,
     bound: &BoundWrapper,
     // The grant over the tree every round runs in, and the tamper baseline
@@ -344,7 +345,12 @@ pub(crate) async fn run_goal_wrapped_turn(
     // The session fact before the turn's, exactly as the raw arm opens
     // (#4500).
     super::announce_withheld_steering(&tx, cfg);
-    for event in recall_events {
+    // This arc's directive-carrying skills, mounted for every round the loop
+    // drives — the raw arm's twin, and for its reasons.
+    let skill_plane = stella_tools::skill_plane::SkillInvocationPlane::new();
+    let _skill_spans = recall.mount_skill_spans(&skill_plane);
+    let skill_effort = recall.skill_effort();
+    for event in recall.events {
         let _ = tx.send(event);
     }
 
@@ -356,8 +362,15 @@ pub(crate) async fn run_goal_wrapped_turn(
         Principal::User,
         registry.hook_bus(),
     );
+    // Above the assembled session chain: the grant narrows, never widens.
+    let tools = stella_tools::skill_plane::SkillScopedTools::new(&tools, skill_plane.clone());
     let hook_runner = HostHookRunner;
-    let mut engine = Engine::with_sleeper(provider, &tools, engine_config_for(cfg), &TokioSleeper)
+    let mut config = engine_config_for(cfg);
+    if let Some(effort) = skill_effort {
+        // The skill's `effort:` override, for this arc.
+        config.effort = Some(effort);
+    }
+    let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
         .with_calibration(calibration)
         // The arc's whistle (#4769), opened above and drained at every round's
         // first step boundary — the wrapped arm drives its own rounds through

--- a/crates/stella-cli/src/agent/goal/tests.rs
+++ b/crates/stella-cli/src/agent/goal/tests.rs
@@ -182,7 +182,7 @@ fn a_whistle_reaches_the_next_round_of_a_goal_arc() {
                 &None,
                 "make the tests pass",
                 Some(session),
-                Vec::new(),
+                crate::memory::OpeningRecall::default(),
                 None,
                 None,
             )

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -66,8 +66,8 @@ pub(super) async fn run_lead_turn(
 ) -> Result<(), crate::failure::CliFailure> {
     budget.begin_turn();
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
-    // This turn's directive-carrying skills — invoked or auto-selected
-    // (#5465) — read off the recall seam before its seed and events are
+    // This turn's directive-carrying skills — invoked or
+    // auto-selected — read off the recall seam before its seed and events are
     // handed on below: each span is live for the whole turn,
     // `active_skill_slugs` reports them, and every declared `allowed-tools`
     // grant narrows the surface to operator ∧ grant, intersected across

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -66,6 +66,16 @@ pub(super) async fn run_lead_turn(
 ) -> Result<(), crate::failure::CliFailure> {
     budget.begin_turn();
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
+    // This turn's directive-carrying skills — invoked or auto-selected
+    // (#5465) — read off the recall seam before its seed and events are
+    // handed on below: each span is live for the whole turn,
+    // `active_skill_slugs` reports them, and every declared `allowed-tools`
+    // grant narrows the surface to operator ∧ grant, intersected across
+    // spans, through the view composed over the tap further down. The
+    // guards drop with this function, lifting the narrowing structurally.
+    let skill_plane = stella_tools::skill_plane::SkillInvocationPlane::new();
+    let _skill_spans = recall.mount_skill_spans(&skill_plane);
+    let skill_effort = recall.skill_effort();
     let requery = crate::memory::requery_for_turn(
         session_memory,
         messages,
@@ -84,17 +94,6 @@ pub(super) async fn run_lead_turn(
     // the path that ends normally — whichever of the two runs, exactly one
     // holds the handle, because the future either completes or is dropped.
     *drain.lock().unwrap_or_else(|p| p.into_inner()) = Some(forwarder);
-    // A directive-carrying skill invocation, read off the recall
-    // seam before its events are drained below: the span is live for the
-    // whole turn, `active_skill_slugs` reports it, and a declared
-    // `allowed-tools` grant narrows the surface to operator ∧ grant through
-    // the view composed over the tap further down. The guard drops with
-    // this function, lifting the narrowing structurally.
-    let skill_scope = recall.skill_scope;
-    let skill_plane = stella_tools::skill_plane::SkillInvocationPlane::new();
-    let _skill_span = skill_scope
-        .as_ref()
-        .map(|scope| skill_plane.begin(&scope.slug, scope.allowed_tools.as_deref()));
     // First events of the turn: what recall put in front of the model, and
     // the skills that rode the same block (SPEC 6.3).
     for event in recall.events {
@@ -145,8 +144,8 @@ pub(super) async fn run_lead_turn(
             stella_tools::skill_plane::SkillScopedTools::new(&tap, skill_plane.clone());
         let hook_runner = HostHookRunner;
         let mut engine_config = agent::engine_config_for(cfg);
-        if let Some(effort) = skill_scope.as_ref().and_then(|scope| scope.effort) {
-            // The invoked skill's `effort:` override, for this turn.
+        if let Some(effort) = skill_effort {
+            // The scoped skill's `effort:` override, for this turn.
             engine_config.effort = Some(effort);
         }
         let mut engine = Engine::with_sleeper(provider, &scoped_tap, engine_config, &TokioSleeper)

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -69,7 +69,7 @@ use stella_fleet::{
     MonitorError, Plan, SystemGhCli, SystemGitCli, Task, TaskId, TimeoutReason, WatchConfig,
     WorkerControls, WorkerOutcome, WorktreeManager,
 };
-use stella_protocol::{AgentEvent, PrStatus};
+use stella_protocol::{AgentEvent, CompletionMessage, PrStatus};
 use stella_tools::ToolRegistry;
 use stella_tools::hook_runner::HostHookRunner;
 use stella_tui::{FleetDashResult, FleetMsg, FleetStatus};
@@ -671,34 +671,38 @@ fn worker_event_sender(tx: &mpsc::UnboundedSender<AgentEvent>) -> stella_core::E
 /// fleet task" among the one-turn-per-process surfaces a per-session counter
 /// could never schedule.
 ///
-/// Returns the block and its recall telemetry separately: recall must run
-/// before the engine is handed its messages, and the attempt's event channel
-/// does not exist yet at that point, so the caller owns the send.
+/// Injects the block here and returns what the attempt still owes it: the
+/// recall telemetry, which the caller sends once its event channel exists,
+/// and the turn scopes this attempt's directive-carrying skills ask for,
+/// which the caller mounts over the tool stack it assembles below. Both ride
+/// [`crate::memory::inject_opening_recall`] rather than the bare block
+/// injection, so an autonomous worker cannot be the one door where a
+/// selected skill's `allowed-tools` grant and `effort` are dropped.
 async fn worker_recall_block(
     root: &Path,
     cfg: &Config,
     active_rules: &rules::ResolvedRules,
     prompt: &str,
-) -> (Option<String>, Vec<AgentEvent>) {
+    messages: &mut Vec<CompletionMessage>,
+) -> crate::memory::OpeningRecall {
     // `warn: false`, the Command Deck's choice for the Command Deck's reason:
     // with `--watch` a live grid owns the terminal, and a per-worker store
     // warning would be N-fold noise painted over it.
     let Some(mut memory) =
         crate::memory::SessionMemory::open_for_session(root, false, &cfg.authority, active_rules)
     else {
-        return (None, Vec::new());
+        return crate::memory::OpeningRecall::default();
     };
     memory.arm_recall_control();
     // A fleet attempt recalls before its engine has messages, so there is no
     // conversation to derive touched paths from — the empty anchor set is the
     // honest argument here, and the same scoping the prompt alone always gave.
     let recalled = memory.recall_block_reported(prompt, &[]).await;
-    let events = recalled.telemetry_events();
     // `memory` is dropped here, and deliberately not carried to the reflection
     // below: this handle is rooted at the attempt's own tree, and a lesson
     // written through it would land in a database that is deleted with the
     // worktree. [`mine_attempt_lesson`] opens its own, at the invocation root.
-    (recalled.text, events)
+    crate::memory::inject_opening_recall(messages, recalled)
 }
 
 /// The task boundary a fleet attempt stamps onto every lesson it mines.
@@ -992,9 +996,16 @@ async fn run_task(
     // What it leaves to announce — the recall receipt and a row per injected
     // skill — is carried to the channel opened below, which this attempt's
     // telemetry rides; the same split `agent::goal` documents.
-    let (recall_text, recall_events) =
-        worker_recall_block(root, &cfg, &active_rules, &task.prompt).await;
-    crate::memory::inject_recall_block(&mut messages, recall_text);
+    let recall = worker_recall_block(root, &cfg, &active_rules, &task.prompt, &mut messages).await;
+    // This attempt's directive-carrying skills, mounted for the whole turn
+    // beside the stack they narrow — the same seam every other door takes.
+    // The guards drop with this function, so the narrowing lifts
+    // structurally, and with no scope the plane is inert and the scoped view
+    // below is a pure pass-through.
+    let skill_plane = stella_tools::skill_plane::SkillInvocationPlane::new();
+    let _skill_spans = recall.mount_skill_spans(&skill_plane);
+    let skill_effort = recall.skill_effort();
+    let recall_events = recall.events;
     // Everything the engine appends past here is this attempt's own work; the
     // reflection gate reads only that slice, so a turn that called no tool
     // spends no model call on being mined (`turn_warrants_reflection`).
@@ -1092,13 +1103,18 @@ async fn run_task(
             .attach_turn_controls(stella_core::ports::TurnControls::none().with_gate(gate.clone()));
         let raced: Raced<Result<TurnOutcome, String>> = {
             let hook_runner = HostHookRunner;
-            let mut engine = Engine::with_sleeper(
-                &*provider,
-                &permitted,
-                attempt_durability.engine_config(&cfg),
-                &TokioSleeper,
-            )
-            .with_gate(gate.as_ref());
+            // Above the operator's policy layer, the position
+            // `skill_grant`'s module docs specify: a grant selects within
+            // the surface a worker already has and can never widen it.
+            let scoped =
+                stella_tools::skill_plane::SkillScopedTools::new(&permitted, skill_plane.clone());
+            let mut config = attempt_durability.engine_config(&cfg);
+            if let Some(effort) = skill_effort {
+                // The skill's `effort:` override, for this attempt.
+                config.effort = Some(effort);
+            }
+            let mut engine = Engine::with_sleeper(&*provider, &scoped, config, &TokioSleeper)
+                .with_gate(gate.as_ref());
             if let Some(hooks) = &cfg.hooks {
                 engine = engine.with_hooks(hooks, &hook_runner);
             }

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -661,14 +661,21 @@ async fn a_fleet_worker_receives_skills_records_and_todays_date() {
          this test can say anything about who receives it"
     );
 
-    let (block, _event) = worker_recall_block(
+    // The injection is the seam now, so the block is read back off the
+    // messages it landed in rather than returned beside them.
+    let mut messages: Vec<stella_protocol::CompletionMessage> = Vec::new();
+    let _recall = worker_recall_block(
         &root,
         &cfg,
         &active_rules,
         "run the database migration for the billing service",
+        &mut messages,
     )
     .await;
-    let block = block.expect("a worker in a steered workspace gets a volatile block");
+    let block = messages
+        .pop()
+        .map(|m| m.content)
+        .expect("a worker in a steered workspace gets a volatile block");
 
     assert!(
         block.starts_with(crate::memory::RECALL_MARKER),

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -96,7 +96,12 @@ pub(crate) mod validation;
 use private_state::resolve_context_db_path;
 #[cfg(test)]
 use projection::{is_suppressed_local_frame, project_recalled_frame};
-pub use recall::inject_recall_block;
+// Every driver reaches the turn through `inject_opening_recall` below, which
+// carries this turn's skill scopes and re-query seed as well as its text —
+// so the bare injection has no caller left outside the tests that pin its own
+// marker rule.
+#[cfg(test)]
+pub(crate) use recall::inject_recall_block;
 pub(crate) use recall::{OpeningRecall, inject_opening_recall};
 /// Test-side imports of the recall renderer's internals — one renderer, so
 /// every consumer of a recalled frame reads exactly the same rendering,

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -43,8 +43,7 @@ pub struct RecalledBlock {
     /// budget actually admitted.
     pub injected_skills: Vec<skills::InjectedSkill>,
     /// The turn scopes the directive-carrying skills among
-    /// [`Self::injected_skills`] ask for, in the same rendered order
-    /// (#5465).
+    /// [`Self::injected_skills`] ask for, in the same rendered order.
     ///
     /// An auto-selected skill that declares invoke directives expands
     /// exactly as an explicit `/slug` invocation does: its `allowed-tools`
@@ -111,7 +110,7 @@ pub(crate) struct OpeningRecall {
     /// The turn scopes the directive-carrying skills of this turn ask for —
     /// the grant narrowing and effort override the turn driver applies while
     /// the invocations are live. Every scope reaches the turn the same way,
-    /// whether a human typed `/slug` or recall selected the skill (#5465):
+    /// whether a human typed `/slug` or recall selected the skill:
     /// each is mounted as its own span on the invocation plane, so the tool
     /// surface is the intersection of every live grant. Empty for the common
     /// turn that carries no directive-carrying skill.
@@ -210,7 +209,7 @@ pub(crate) fn inject_opening_recall(
         events,
         produced: recalled.produced,
         // The block's directive-carrying skills scope the turn exactly as
-        // an explicit invocation would (#5465): selection is the trigger,
+        // an explicit invocation would: selection is the trigger,
         // and the grant's only power is to narrow.
         skill_scopes: recalled.skill_scopes,
     }

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -42,6 +42,18 @@ pub struct RecalledBlock {
     /// the only place that knows which ranked skills the section's token
     /// budget actually admitted.
     pub injected_skills: Vec<skills::InjectedSkill>,
+    /// The turn scopes the directive-carrying skills among
+    /// [`Self::injected_skills`] ask for, in the same rendered order
+    /// (#5465).
+    ///
+    /// An auto-selected skill that declares invoke directives expands
+    /// exactly as an explicit `/slug` invocation does: its `allowed-tools`
+    /// grant narrows the turn and its `effort` is honored. Safe without a
+    /// human in the loop because narrowing is the only power a scope has —
+    /// `skill_plane` enforces the grant as `operator ∧ grant`, so a scope can
+    /// restrict the surface the operator configured, never widen it. Empty
+    /// for the common turn whose skills carry no directive.
+    pub skill_scopes: Vec<crate::extensions::SkillTurnScope>,
 }
 
 impl RecalledBlock {
@@ -96,14 +108,45 @@ pub(crate) struct OpeningRecall {
     /// The frames, skills and records the opening block rendered, by steering
     /// handle — the re-query adapter's seed.
     pub(crate) produced: super::steering::ProducedSteering,
-    /// The turn scope an invoked skill's directives asked for — the
-    /// grant narrowing and effort override the turn driver applies while the
-    /// invocation is live. `None` for every turn no directive-carrying skill
-    /// was invoked into.
-    pub(crate) skill_scope: Option<crate::extensions::SkillTurnScope>,
+    /// The turn scopes the directive-carrying skills of this turn ask for —
+    /// the grant narrowing and effort override the turn driver applies while
+    /// the invocations are live. Every scope reaches the turn the same way,
+    /// whether a human typed `/slug` or recall selected the skill (#5465):
+    /// each is mounted as its own span on the invocation plane, so the tool
+    /// surface is the intersection of every live grant. Empty for the common
+    /// turn that carries no directive-carrying skill.
+    ///
+    /// Ordered with the explicitly invoked skill first, then the
+    /// auto-selected ones by rank — the order [`Self::skill_effort`] reads.
+    pub(crate) skill_scopes: Vec<crate::extensions::SkillTurnScope>,
 }
 
 impl OpeningRecall {
+    /// Mount every scope of this turn on `plane`, returning the guards that
+    /// hold the spans open. Drop them together with the turn's tool stack:
+    /// every narrowing lifts structurally when the guards go.
+    ///
+    /// The one place the scopes become spans, so no driver can mount the
+    /// invoked skill's grant and forget the auto-selected ones.
+    #[must_use = "the spans end (and their narrowing lifts) the moment these guards drop"]
+    pub(crate) fn mount_skill_spans(
+        &self,
+        plane: &stella_tools::skill_plane::SkillInvocationPlane,
+    ) -> Vec<stella_tools::skill_plane::SkillSpanGuard> {
+        self.skill_scopes
+            .iter()
+            .map(|scope| plane.begin(&scope.slug, scope.allowed_tools.as_deref()))
+            .collect()
+    }
+
+    /// The reasoning-effort override this turn runs under, when any scope
+    /// declares one: the invoked skill's wins over an auto-selected skill's,
+    /// and among auto-selected skills the higher-ranked one wins — the same
+    /// order the scopes are kept in, read to the first declaration.
+    #[must_use]
+    pub(crate) fn skill_effort(&self) -> Option<stella_protocol::ReasoningEffort> {
+        self.skill_scopes.iter().find_map(|scope| scope.effort)
+    }
     /// Report a skill the user invoked by name, on the same channel the
     /// auto-selected ones ride (#5232).
     ///
@@ -118,8 +161,11 @@ impl OpeningRecall {
             // The scope rides beside the event rather than inside it: the
             // event is the transcript's record that a skill was injected,
             // and the scope is a turn-driver instruction the transcript
-            // never needs.
-            self.skill_scope = skill.scope;
+            // never needs. First, ahead of the auto-selected scopes: a
+            // human asked for this one, so its `effort` outranks theirs.
+            if let Some(scope) = skill.scope {
+                self.skill_scopes.insert(0, scope);
+            }
             self.events
                 .push(stella_protocol::AgentEvent::SkillInjected {
                     name: skill.name,
@@ -163,12 +209,27 @@ pub(crate) fn inject_opening_recall(
     OpeningRecall {
         events,
         produced: recalled.produced,
-        // The auto-selected block scopes nothing: a directive-carrying skill
-        // reaches a scope only through explicit invocation, where a
-        // human chose to run it — never through passive selection, which
-        // must not be able to narrow a turn the user did not ask narrowed.
-        skill_scope: None,
+        // The block's directive-carrying skills scope the turn exactly as
+        // an explicit invocation would (#5465): selection is the trigger,
+        // and the grant's only power is to narrow.
+        skill_scopes: recalled.skill_scopes,
     }
+}
+
+/// The turn scopes of the skills that actually reached the prompt — the
+/// same prefix of `kept` [`skills::injected_skills`] announces, so a skill
+/// the section budget cut can neither be reported nor narrow anything.
+fn auto_skill_scopes(kept: &[skills::SelectedSkill]) -> Vec<crate::extensions::SkillTurnScope> {
+    if kept.is_empty() {
+        return Vec::new();
+    }
+    kept[..skills::section_fit(kept)]
+        .iter()
+        .filter_map(|sel| {
+            let directives = crate::extensions::invoke_directives_for(&sel.skill);
+            crate::extensions::skill_turn_scope(&sel.skill.name, &directives)
+        })
+        .collect()
 }
 
 /// How many characters of volatile records ride the recall block.
@@ -404,6 +465,7 @@ impl SessionMemory {
             recall,
             produced,
             injected_skills: skills::injected_skills(&kept),
+            skill_scopes: auto_skill_scopes(&kept),
         }
     }
 
@@ -543,6 +605,13 @@ impl SessionMemory {
             recall,
             produced: block_produced,
             injected_skills: skills::injected_skills(&kept),
+            // A drifted turn's re-query rescopes nothing: the spans were
+            // mounted when the turn opened, beside the tool stack they
+            // narrow, and a grant that appeared mid-loop would change the
+            // surface under calls already in flight. A directive-carrying
+            // skill that surfaces here is context until the next turn opens
+            // with it selected — the same rule an explicit invocation obeys.
+            skill_scopes: Vec::new(),
         }
     }
 

--- a/crates/stella-cli/src/memory/tests/skill_event.rs
+++ b/crates/stella-cli/src/memory/tests/skill_event.rs
@@ -151,3 +151,192 @@ fn a_turn_that_invoked_no_skill_adds_no_event() {
     recall.note_invoked_skill(None);
     assert!(recall.events.is_empty());
 }
+
+/// A workspace holding one directive-carrying skill the prompt below
+/// selects: it grants `task_list` alone and asks for high effort.
+fn directive_workspace() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let skill_dir = dir.path().join(".stella/skills/reviewer");
+    std::fs::create_dir_all(&skill_dir).expect("skill dir");
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: reviewer\ndescription: database review\nallowed-tools: task_list\n\
+         effort: high\n---\nALWAYS_REVIEW_DATABASES",
+    )
+    .expect("skill file");
+    dir
+}
+
+/// **The witness (#5465).** A skill recall auto-selects expands as an
+/// invocation: its `allowed-tools` grant narrows the turn's tool surface
+/// through the same plane an explicit `/slug` mounts, a call outside the
+/// grant is DENIED naming the skill, a call inside it still runs, its
+/// `effort:` reaches the turn, and the narrowing lifts when the spans drop.
+///
+/// Fails on base, where `inject_opening_recall` pinned `skill_scope: None`
+/// for every auto-selected block: the skill's body reached the prompt and
+/// its directives changed nothing.
+#[tokio::test]
+async fn an_auto_selected_directive_skill_narrows_the_turn_and_denies_a_disallowed_tool() {
+    use serde_json::json;
+    use stella_core::ports::{Principal, ToolExecutor};
+    use stella_protocol::tool::ToolOutput;
+    use stella_tools::policy::ToolPolicy;
+    use stella_tools::skill_plane::{SkillInvocationPlane, SkillScopedTools};
+
+    let dir = directive_workspace();
+    let memory =
+        SessionMemory::open_with_workspace_skills(dir.path(), false, true).expect("session memory");
+    let block = memory
+        .recall_block_reported("review the database migrations", &[])
+        .await;
+    assert!(
+        block
+            .text
+            .as_deref()
+            .is_some_and(|text| text.contains("ALWAYS_REVIEW_DATABASES")),
+        "the fixture prompt must actually inject the reviewer skill: {:?}",
+        block.text
+    );
+    // Selection is the trigger — the transcript still says the block chose
+    // it, not that a person typed `/reviewer`.
+    assert!(
+        block.telemetry_events().iter().any(|event| matches!(
+            event,
+            stella_protocol::AgentEvent::SkillInjected {
+                name,
+                trigger: stella_protocol::SkillTrigger::Auto,
+                ..
+            } if name == "reviewer"
+        )),
+        "an auto-selected skill is announced as auto-selected"
+    );
+
+    let mut messages = Vec::new();
+    let recall = inject_opening_recall(&mut messages, block);
+    let [scope] = recall.skill_scopes.as_slice() else {
+        panic!(
+            "the selected directive skill must yield exactly one scope: {:?}",
+            recall.skill_scopes
+        );
+    };
+    assert_eq!(scope.slug, "reviewer");
+    assert_eq!(
+        scope.allowed_tools.as_deref(),
+        Some(&["task_list".to_string()][..]),
+        "the grant rides the scope un-resolved"
+    );
+    assert_eq!(
+        recall.skill_effort(),
+        Some(stella_protocol::ReasoningEffort::High),
+        "the skill's `effort:` reaches the turn"
+    );
+
+    // Mounted over the shipped session stack at the position every driver
+    // composes the plane at — above the operator's policy layer.
+    let registry = stella_tools::registry::ToolRegistry::new(dir.path().to_path_buf());
+    let stack = crate::agent::tool_stack::session_stack_with_gate(
+        &registry,
+        Vec::new(),
+        dir.path().to_path_buf(),
+        ToolPolicy::from_switches(Vec::new()),
+        crate::agent::tool_stack::session_gate(dir.path()),
+        Principal::User,
+    );
+    let plane = SkillInvocationPlane::new();
+    let spans = recall.mount_skill_spans(&plane);
+    let view = SkillScopedTools::new(&stack, plane.clone());
+    assert_eq!(
+        view.active_skill_slugs(),
+        vec!["reviewer".to_string()],
+        "the auto-selected skill is live through the shipped chain"
+    );
+    // Inside the grant: runs (anti-vacuity — a plane that denies everything
+    // would pass the denial below too).
+    assert!(
+        matches!(
+            view.execute("task_list", &json!({})).await,
+            ToolOutput::Ok { .. }
+        ),
+        "the granted call must run"
+    );
+    // Outside the grant: denied, naming the skill that narrowed the turn.
+    match view.execute("get_state", &json!({"key": "k"})).await {
+        ToolOutput::Error { message, .. } => assert!(
+            message.contains("reviewer"),
+            "the denial names the auto-selected skill: {message}"
+        ),
+        other => panic!("a call outside the auto-selected grant must be denied, got {other:?}"),
+    }
+    // The spans end with the turn's guards, and the narrowing with them.
+    drop(spans);
+    assert!(
+        view.active_skill_slugs().is_empty(),
+        "dropping the guards lifts the narrowing"
+    );
+}
+
+/// A directive-less skill the block selects is what it always was —
+/// injected context, unscoped — so the plane stays inert for the common
+/// turn.
+#[tokio::test]
+async fn a_directive_less_auto_selected_skill_scopes_nothing() {
+    let dir = workspace();
+    let memory =
+        SessionMemory::open_with_workspace_skills(dir.path(), false, true).expect("session memory");
+    let block = memory
+        .recall_block_reported("review the database migrations", &[])
+        .await;
+    assert!(
+        block.injected_skills.iter().any(|s| s.name == "reviewer"),
+        "the fixture prompt must inject the reviewer skill"
+    );
+    assert!(
+        block.skill_scopes.is_empty(),
+        "a skill with no directive yields no scope: {:?}",
+        block.skill_scopes
+    );
+    let recall = inject_opening_recall(&mut Vec::new(), block);
+    assert!(recall.skill_scopes.is_empty());
+    assert_eq!(recall.skill_effort(), None);
+}
+
+/// An explicit invocation's scope sits ahead of the auto-selected ones, so
+/// its `effort:` is the one the turn honors when both declare one.
+#[test]
+fn an_invoked_skill_effort_outranks_an_auto_selected_one() {
+    use stella_core::skills::invoke::SkillInvocationMode;
+    let auto_scope = crate::extensions::SkillTurnScope {
+        slug: "auto".to_string(),
+        allowed_tools: None,
+        effort: Some(stella_protocol::ReasoningEffort::Low),
+        mode: SkillInvocationMode::Inline,
+    };
+    let mut recall = OpeningRecall {
+        skill_scopes: vec![auto_scope],
+        ..OpeningRecall::default()
+    };
+    recall.note_invoked_skill(Some(crate::extensions::InvokedSkill {
+        name: "invoked".to_string(),
+        summary: "typed by a person".to_string(),
+        tokens: 1,
+        scope: Some(crate::extensions::SkillTurnScope {
+            slug: "invoked".to_string(),
+            allowed_tools: None,
+            effort: Some(stella_protocol::ReasoningEffort::Max),
+            mode: SkillInvocationMode::Inline,
+        }),
+    }));
+    assert_eq!(
+        recall
+            .skill_scopes
+            .iter()
+            .map(|s| s.slug.as_str())
+            .collect::<Vec<_>>(),
+        vec!["invoked", "auto"]
+    );
+    assert_eq!(
+        recall.skill_effort(),
+        Some(stella_protocol::ReasoningEffort::Max)
+    );
+}

--- a/crates/stella-cli/src/memory/tests/skill_event.rs
+++ b/crates/stella-cli/src/memory/tests/skill_event.rs
@@ -340,3 +340,49 @@ fn an_invoked_skill_effort_outranks_an_auto_selected_one() {
         Some(stella_protocol::ReasoningEffort::Max)
     );
 }
+
+/// Every driver that recalls must hand its block to the turn through
+/// [`inject_opening_recall`], never through `inject_recall_block` directly.
+///
+/// The defect this guards is not a wrong scope — it is a door that mounts no
+/// scope at all, which no test of the scope machinery can see. Both goal doors
+/// took `recalled.telemetry_events()` and injected the text themselves, so a
+/// directive-carrying skill auto-selected for `/goal` or `stella goal` reached
+/// the prompt with its `allowed-tools` grant and its `effort` governing
+/// nothing. `inject_opening_recall` is the seam that carries both, and a
+/// driver that steps around it drops them at the call site.
+///
+/// A source-text check for the reason
+/// `every_recalling_driver_arms_the_control_first` is one: observing this
+/// through the doors themselves means standing up providers, an MCP set, a
+/// tool registry and a store to watch one span open. It is exact about the
+/// names — both functions are `pub`/`pub(crate)` items, so a rename that
+/// breaks this test breaks the compile too.
+#[test]
+fn every_recalling_driver_routes_its_block_through_the_opening_seam() {
+    const DRIVERS: [(&str, &str); 4] = [
+        ("agent.rs", include_str!("../../agent.rs")),
+        ("agent/goal.rs", include_str!("../../agent/goal.rs")),
+        ("command_deck.rs", include_str!("../../command_deck.rs")),
+        ("fleet_cmd.rs", include_str!("../../fleet_cmd.rs")),
+    ];
+
+    for (name, source) in DRIVERS {
+        assert!(
+            source.contains("recall_block_reported("),
+            "{name} is listed as a recalling driver but recalls nothing"
+        );
+        assert!(
+            source.contains("inject_opening_recall("),
+            "{name} recalls without routing the block through \
+             inject_opening_recall, so this turn's skill scopes and re-query \
+             seed are dropped at the call site"
+        );
+        assert!(
+            !source.contains("inject_recall_block("),
+            "{name} injects a recall block directly: that path carries the \
+             text and nothing else, so a directive-carrying skill's \
+             allowed-tools grant and effort reach the prompt and govern nothing"
+        );
+    }
+}

--- a/crates/stella-cli/src/memory/tests/skill_event.rs
+++ b/crates/stella-cli/src/memory/tests/skill_event.rs
@@ -167,7 +167,7 @@ fn directive_workspace() -> tempfile::TempDir {
     dir
 }
 
-/// **The witness (#5465).** A skill recall auto-selects expands as an
+/// **The witness.** A skill recall auto-selects expands as an
 /// invocation: its `allowed-tools` grant narrows the turn's tool surface
 /// through the same plane an explicit `/slug` mounts, a call outside the
 /// grant is DENIED naming the skill, a call inside it still runs, its

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -1048,11 +1048,11 @@ impl TurnDriver for RawTurnDriver<'_> {
                 // an injection that did not happen.
                 events: std::mem::take(&mut self.recall.events),
                 produced: self.recall.produced.clone(),
-                // Cloned, not taken, unlike the events above: the scope is
-                // an instruction to the turn driver, not a report, and a
-                // wrapped skill invocation's narrowing must hold on every
-                // driven round, not just the first.
-                skill_scope: self.recall.skill_scope.clone(),
+                // Cloned, not taken, unlike the events above: the scopes are
+                // instructions to the turn driver, not a report, and a
+                // wrapped skill's narrowing must hold on every driven round,
+                // not just the first.
+                skill_scopes: self.recall.skill_scopes.clone(),
             },
             self.memory.as_deref_mut(),
             self.controls.clone(),

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -331,10 +331,13 @@ evolution_surfaces! {
                         `parse_invoke_directives` and mounted by `stella-tools`' skill_plane: \
                         the grant is enforced as the per-name operator ∧ grant intersection \
                         over the assembled session stack, so a directive can only narrow the \
-                        surface, never widen it. Invocation is human-only — `stella skill \
-                        run <slug>` or an in-session `/slug` expansion; `invoke_skill` stays \
-                        in RETIRED_TOOL_NAMES, so no model call can invoke a skill",
-            witness: "a_skill_grant_over_the_session_stack_denies_disallowed_and_never_widens",
+                        surface, never widen it. A directive-carrying skill expands as an \
+                        invocation however it enters the turn — `stella skill run <slug>`, \
+                        an in-session `/slug` expansion, or recall's own auto-selection \
+                        (#5465), each mounted as a span whose grant is intersected with \
+                        every other live one; `invoke_skill` stays in RETIRED_TOOL_NAMES, \
+                        so no model call can invoke a skill",
+            witness: "an_auto_selected_directive_skill_narrows_the_turn_and_denies_a_disallowed_tool",
         },
         EvolutionTiming::BetweenTurns,
         ImpactClass::SteeringDirective,
@@ -437,7 +440,7 @@ pub const UNWITNESSED_EVOLUTION_BASELINE: usize = 0;
 /// check it asserts the row's own mechanism.** A row is a claim like any other
 /// (CLAUDE.md), and the name of a test is not evidence for it.
 #[cfg(test)]
-fn evolution_sources() -> [&'static str; 9] {
+fn evolution_sources() -> [&'static str; 10] {
     [
         include_str!("../../stella-cli/src/memory/rules_mining/tests.rs"),
         include_str!("../../stella-cli/src/memory/uses/tests.rs"),
@@ -447,9 +450,12 @@ fn evolution_sources() -> [&'static str; 9] {
         include_str!("../../stella-cli/src/tool_foundry/adopt/tests.rs"),
         include_str!("../../stella-cli/src/tool_foundry/autonomy.rs"),
         include_str!("../../stella-cli/src/memory/self_tuning.rs"),
-        // The SkillInvocation row's witness lives beside the session
-        // stack it proves the grant holds over.
+        // The grant-over-the-session-stack proof the SkillInvocation row
+        // first named lives beside the stack it holds over.
         include_str!("../../stella-cli/src/agent/tool_stack.rs"),
+        // The SkillInvocation row's witness: an auto-selected skill's
+        // directives reach the plane through the recall seam (#5465).
+        include_str!("../../stella-cli/src/memory/tests/skill_event.rs"),
     ]
 }
 

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -333,8 +333,8 @@ evolution_surfaces! {
                         over the assembled session stack, so a directive can only narrow the \
                         surface, never widen it. A directive-carrying skill expands as an \
                         invocation however it enters the turn — `stella skill run <slug>`, \
-                        an in-session `/slug` expansion, or recall's own auto-selection \
-                        (#5465), each mounted as a span whose grant is intersected with \
+                        an in-session `/slug` expansion, or recall's own auto-selection, \
+                        each mounted as a span whose grant is intersected with \
                         every other live one; `invoke_skill` stays in RETIRED_TOOL_NAMES, \
                         so no model call can invoke a skill",
             witness: "an_auto_selected_directive_skill_narrows_the_turn_and_denies_a_disallowed_tool",
@@ -454,7 +454,7 @@ fn evolution_sources() -> [&'static str; 10] {
         // first named lives beside the stack it holds over.
         include_str!("../../stella-cli/src/agent/tool_stack.rs"),
         // The SkillInvocation row's witness: an auto-selected skill's
-        // directives reach the plane through the recall seam (#5465).
+        // directives reach the plane through the recall seam.
         include_str!("../../stella-cli/src/memory/tests/skill_event.rs"),
     ]
 }

--- a/docs/prompts/skill-author.md
+++ b/docs/prompts/skill-author.md
@@ -63,7 +63,7 @@ invocation runs is declared here, in the authored file, and the invocation
 carries only the slug and its arguments. There is no
 `invoke_skill` tool — no model call can invoke a skill. A skill function
 runs when a person asks, via `stella skill run <slug>` or an in-session
-`/slug` expansion, and when recall auto-selects it for a turn (#5465): the
+`/slug` expansion, and when recall auto-selects it for a turn: the
 selected skill expands exactly like the `/slug` form, its `allowed-tools`
 grant narrowing the turn and its `effort` honored. That is safe without a
 person in the loop because a grant can only narrow the operator's surface,

--- a/docs/prompts/skill-author.md
+++ b/docs/prompts/skill-author.md
@@ -61,10 +61,14 @@ optional frontmatter keys `parse_invoke_directives`
 Behavior is the **skill's**, never a parameter's (AGENTS.md #9): how an
 invocation runs is declared here, in the authored file, and the invocation
 carries only the slug and its arguments. There is no
-`invoke_skill` tool — a skill function runs only when a human asks,
-via `stella skill run <slug>` or an in-session `/slug` expansion. Unknown
-values of these keys degrade to the default with a diagnostic; they never
-refuse the skill.
+`invoke_skill` tool — no model call can invoke a skill. A skill function
+runs when a person asks, via `stella skill run <slug>` or an in-session
+`/slug` expansion, and when recall auto-selects it for a turn (#5465): the
+selected skill expands exactly like the `/slug` form, its `allowed-tools`
+grant narrowing the turn and its `effort` honored. That is safe without a
+person in the loop because a grant can only narrow the operator's surface,
+never widen it. Unknown values of these keys degrade to the default with a
+diagnostic; they never refuse the skill.
 
 ## User message (template)
 

--- a/website/content/docs/commands/skill.mdx
+++ b/website/content/docs/commands/skill.mdx
@@ -45,6 +45,16 @@ session's full surface, exactly as skills have always behaved. Unusable
 directive values (an unknown `context:` or `effort:`) degrade to the default
 with a printed diagnostic; they never refuse the run.
 
+**Scopes are decided when a turn opens, and only then.** A turn mounts the
+grants of every skill it opened with, and holds them until it ends. Recall
+runs again mid-turn as the work drifts, and a directive-carrying skill that
+surfaces at one of those boundaries is injected as context alone: it does not
+narrow the turn already running, and its `effort` does not apply to it. The
+next turn that opens with the skill selected mounts it normally. A grant that
+appeared mid-loop would change the tool surface underneath calls already in
+flight, which is the one thing a narrowing must never do — and an explicit
+`/slug` obeys the same boundary.
+
 ## Arguments
 
 Everything after the slug replaces `$ARGUMENTS` in the skill body. A body

--- a/website/content/docs/commands/skill.mdx
+++ b/website/content/docs/commands/skill.mdx
@@ -6,8 +6,12 @@ description: Run a skill by its slug as a scoped one-shot — the skill's own in
 Run a skill as a scoped one-shot (`stella skill run <slug>`). The skill's own
 frontmatter declares how it runs — this is the skill-function invocation
 surface: there is **no** `invoke_skill` tool (the 12-tool cap
-retired it), so a skill function runs only when a human asks — this verb, or
-an in-session `/slug` expansion.
+retired it), so no model call can invoke a skill. A skill function runs when
+you ask — this verb, or an in-session `/slug` expansion — and when recall
+auto-selects it for a turn, where it expands the same way: its `allowed-tools`
+grant narrows that turn and its `effort` is honored. A grant can only narrow
+the tool surface you configured, never widen it, which is what makes the
+auto path safe without anyone approving it.
 
 For what skills are and how they are mined, selected, and versioned, see
 [Memory](/docs/context-engine). This page is the command reference.


### PR DESCRIPTION
Closes #5465

Under the zero-human-steps direction for Stella's self-improvement loop, a recall-auto-selected skill that carries invoke directives now expands into the turn exactly like an explicit `/slug` invocation: grant narrowing applied (narrowing can only restrict), `effort`/`model` directives honored through the existing skill-plane / `SkillTurnScope` machinery from #5467. `invoke_skill` stays retired; no new built-in tool.

- Witness: `an_auto_selected_directive_skill_narrows_the_turn_and_denies_a_disallowed_tool`
- SkillInvocation evolution row repointed (no longer "human-only"); `UNWITNESSED_EVOLUTION_BASELINE` stays 0
- clippy, fmt, check-prose, check-doc-links clean on touched crates; rebased onto main after #5542

## Every recalling door, not just the raw one

Sourcery found the goal doors dropping `RecalledBlock::skill_scopes`, and the hole was wider than the one door. `/goal`, `stella goal`, the wrapped goal arm and the fleet worker attempt each took `recalled.telemetry_events()` and injected the block text themselves — so a directive-carrying skill auto-selected for any of them reached the prompt with its `allowed-tools` grant and its `effort` governing nothing. `inject_opening_recall`'s own doc comment claimed to be the one seam no caller could step around; four callers stepped around it.

All four now route through that seam, mount the scopes over the tool stack they assemble, and apply `skill_effort` to their engine config. The fleet attempt matters most here: it is the autonomous door this work exists for.

- Witness: `every_recalling_driver_routes_its_block_through_the_opening_seam` — a source-text guard over the four recalling drivers, in the shape `every_recalling_driver_arms_the_control_first` already uses, because observing one span open through these doors means standing up providers, an MCP set, a tool registry and a store. Verified fail→pass: it fails on the previous head naming `agent.rs`.
- `memory::inject_recall_block` is now `#[cfg(test)]`-gated: with every driver on the seam, the bare injection has no production caller left.

## The re-query boundary

Unchanged, and now stated where a skill author reads it. A directive-carrying skill selected at a mid-turn re-query boundary is injected as context: it does not narrow the turn already running, and the next turn that opens with it selected mounts it normally. A grant appearing mid-loop would change the tool surface underneath calls already in flight, and an explicit `/slug` obeys the same boundary. `website/content/docs/commands/skill.mdx` carries the rule beside the directive table.

## Deleted tests

None.
