### PR TITLE
fix(stella-cli): drop the doc link rustdoc cannot resolve

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -120,7 +120,7 @@ pub(crate) use skill_files::{
 // here, so exactly one place in the crate resolves a `context.*` sub-block.
 pub use tuning::session_lifecycle_enabled;
 
-/// Marker prefixing a recalled-context message so [`inject_recall_block`]
+/// Marker prefixing a recalled-context message so `inject_recall_block`
 /// can find the newest one for dedup. Blocks land at the conversation
 /// tail and stay in place as durable history (L-E8: the byte-stable
 /// prefix — system prompt AND replayed turns — is never rewritten, which


### PR DESCRIPTION
## Problem

`main` is red at `23bea5745`: `cargo doc -D warnings` fails with "unresolved link to `inject_recall_block`" in `crates/stella-cli/src/memory.rs`. The comment sits on a re-export (`pub use stella_core::receipts::RECALL_MARKER`), so rustdoc resolves its link in `stella-core`'s scope, where that function does not exist. Every open PR inherits the red check.

## Fix

The bracketed link becomes a plain code span. One line.

## Check

`RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps --document-private-items` exits 0 with the fix, and fails without it.

Trivial one-line doc repair; carries the `no-issue` label per SCR-003.

## Summary by Sourcery

Bug Fixes:
- Fix the stella-cli rustdoc warning by replacing an unresolved function link with a plain code reference.