### PR TITLE
feat(stella-cli): file stated leftover work at end of turn (B5 residue gate)

### DIFF
--- a/crates/stella-cli/src/agent/reflect.rs
+++ b/crates/stella-cli/src/agent/reflect.rs
@@ -96,6 +96,14 @@ pub(super) async fn reflect_on_interactive_turn<T, E: std::fmt::Display>(
     result: &Result<T, E>,
     budget: &mut BudgetGuard,
 ) {
+    // The residue gate (`doc:backlog-self-driving` B5) rides the same turn
+    // boundary, outside reflection's own gate. Work the turn said it left
+    // undone is filed even when the turn taught nothing. A filing failure
+    // is a notice, never a failed turn.
+    for notice in crate::self_driving_cmd::residue::end_of_turn(turn.turn_slice()).await {
+        println!("  {} {notice}", "✦".white());
+    }
+
     if should_reflect_on(result)
         && crate::agent::output::should_reflect_on_turn(
             turn_warrants_reflection(turn.turn_slice()),

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -34,6 +34,7 @@ pub(crate) mod probes;
 mod query;
 mod ready;
 mod report;
+pub(crate) mod residue;
 pub(crate) mod state;
 mod stats;
 mod stop;

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -57,6 +57,9 @@ pub(crate) struct LoopConfig {
     pub verify_command: Option<String>,
     /// Seconds before local verification is abandoned.
     pub verify_timeout_secs: u64,
+    /// Whether the end-of-turn residue gate scans and files leftover work
+    /// (`residue_gate = "on" | "off"`, absent means on).
+    pub residue_gate: bool,
 }
 
 impl Default for LoopConfig {
@@ -69,6 +72,7 @@ impl Default for LoopConfig {
             merge: stella_autonomy::BlockingPolicy::default(),
             verify_command: None,
             verify_timeout_secs: 1800,
+            residue_gate: true,
         }
     }
 }
@@ -93,6 +97,7 @@ pub(crate) fn load(root: &Path) -> LoopConfig {
         merge: parsed.self_driving.merge.policy(),
         verify_command: parsed.self_driving.verify.command.clone(),
         verify_timeout_secs: parsed.self_driving.verify.timeout_secs.unwrap_or(1800),
+        residue_gate: parsed.self_driving.residue_gate.enabled(),
     }
 }
 

--- a/crates/stella-cli/src/self_driving_cmd/residue.rs
+++ b/crates/stella-cli/src/self_driving_cmd/residue.rs
@@ -1,0 +1,480 @@
+//! The end-of-turn residue gate (`doc:backlog-self-driving` phase B5).
+//!
+//! A turn can say it is leaving work undone. That statement is residue.
+//! This module finds it and files it as an issue. Filing goes through
+//! [`super::backlog::file_finding`], so the seen-set dedup and the
+//! convention check hold here too.
+
+use stella_autonomy::BacklogConvention;
+use stella_protocol::issue::{IssueDraft, IssueLabel, IssueProvider};
+use stella_protocol::{CompletionMessage, MessageRole};
+
+use super::backlog::{self, Filed};
+
+/// Phrases that mark work a turn is not doing.
+///
+/// A fixed list, matched as lowercase substrings. Never a model call.
+/// The list stays small on purpose. A missed statement costs one unfiled
+/// issue. A false hit costs a wrong issue a human must close. The first
+/// error is cheaper, so the list leans that way.
+const MARKERS: &[&str] = &[
+    "follow-up:",
+    "follow up:",
+    "as a follow-up",
+    "in a follow-up",
+    "a follow-up issue",
+    "needs a follow-up",
+    "left as a follow-up",
+    "for a follow-up",
+    "deferred to a later",
+    "deferring this",
+    "left for later",
+    "left for a future",
+    "remains unhandled",
+    "still doesn't handle",
+    "still does not handle",
+    "not yet implemented",
+    "out of scope for this change",
+];
+
+/// Markers that count only at the start of a line.
+///
+/// A line that opens with "todo:" is a statement. The same word later in
+/// a sentence is usually a quote — a search command, a lint name.
+const LINE_START_MARKERS: &[&str] = &["todo:"];
+
+/// The most filings one turn may cause.
+///
+/// More hits than this is not eight deferrals. It is a detector misfiring.
+/// The cap turns that failure into bounded noise, not a filing storm.
+const MAX_STATEMENTS_PER_TURN: usize = 8;
+
+/// Longest title drawn from a statement, in characters.
+const TITLE_CHARS: usize = 90;
+
+/// The label every residue filing carries.
+///
+/// A residue statement names behavior the turn knows is missing. The type
+/// axis spells that `bug`. A convention without that member refuses the
+/// draft, and the refusal stands. The gate never invents a vocabulary.
+const RESIDUE_LABEL: &str = "bug";
+
+/// Statements of leftover work in a turn's prose.
+///
+/// Line by line, and conservative. Fenced code is skipped: a `TODO` in a
+/// quoted diff is the code's debt, not the turn's. Block quotes are
+/// skipped: quoted text is someone else's words. A line counts once, no
+/// matter how many markers it holds.
+pub(super) fn detect_residue(prose: &str) -> Vec<String> {
+    let mut statements = Vec::new();
+    let mut in_fence = false;
+
+    for line in prose.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence || trimmed.starts_with('>') || trimmed.is_empty() {
+            continue;
+        }
+        if statements.len() >= MAX_STATEMENTS_PER_TURN {
+            break;
+        }
+
+        let lower = trimmed.to_lowercase();
+        let hit = LINE_START_MARKERS.iter().any(|m| lower.starts_with(m))
+            || MARKERS.iter().any(|m| lower.contains(m));
+        if hit && !statements.iter().any(|s| s == trimmed) {
+            statements.push(trimmed.to_owned());
+        }
+    }
+
+    statements
+}
+
+/// What the gate scans, given the operator's switch.
+///
+/// The switch check lives here, not in the caller. That makes "off files
+/// nothing" a property a test can hold, not a habit of whoever wires the
+/// hook.
+pub(super) fn gate_statements(enabled: bool, prose: &str) -> Vec<String> {
+    if !enabled {
+        return Vec::new();
+    }
+    detect_residue(prose)
+}
+
+/// One statement's trip through the filing path.
+pub(super) struct ResidueOutcome {
+    /// The draft's title. The dedup digest is derived from it.
+    pub(super) title: String,
+    /// What the filing path decided, or why the tracker was out of reach.
+    pub(super) result: Result<Filed, String>,
+}
+
+/// The issue a statement becomes.
+fn residue_draft(statement: &str) -> IssueDraft {
+    let mut title: String = statement.trim().chars().take(TITLE_CHARS).collect();
+    if title.chars().count() == TITLE_CHARS && statement.trim().chars().count() > TITLE_CHARS {
+        title = format!("{}…", title.trim_end());
+    }
+    IssueDraft {
+        title: format!("residue: {title}"),
+        body: format!(
+            "The end-of-turn residue gate found an explicit leftover-work statement in a \
+             turn's transcript:\n\n> {}\n\nFiled automatically so stated follow-up work \
+             cannot evaporate when the session ends (`doc:backlog-self-driving` phase B5).",
+            statement.trim()
+        ),
+        labels: vec![IssueLabel {
+            name: RESIDUE_LABEL.to_owned(),
+        }],
+        parent: None,
+        assignee: None,
+    }
+}
+
+/// File every detected statement through [`backlog::file_finding`].
+///
+/// The seen-set grows as the loop runs. Two equal statements in one turn
+/// file once: the first filing's digest blocks the second.
+pub(super) async fn file_residue(
+    provider: &dyn IssueProvider,
+    convention: &BacklogConvention,
+    seen: &[String],
+    signature: &str,
+    statements: &[String],
+) -> Vec<ResidueOutcome> {
+    let mut session_seen: Vec<String> = seen.to_vec();
+    let mut outcomes = Vec::new();
+
+    for statement in statements {
+        let draft = residue_draft(statement);
+        let title = draft.title.clone();
+        let result = backlog::file_finding(provider, convention, &session_seen, &draft, signature)
+            .await
+            .map_err(|error| error.to_string());
+        if let Ok(Filed::New(_)) = &result {
+            session_seen.push(stella_autonomy::finding_digest(&title));
+        }
+        outcomes.push(ResidueOutcome { title, result });
+    }
+
+    outcomes
+}
+
+/// The end-of-turn hook: scan, file, report. Best-effort throughout.
+///
+/// Every failure is a notice, never a failed turn. Outcome counts land in
+/// the same session stats the `self-driving file` verb feeds. A gate whose
+/// drafts all get refused is visible, not silent.
+pub(crate) async fn end_of_turn(messages: &[CompletionMessage]) -> Vec<String> {
+    let Ok(root) = std::env::current_dir() else {
+        return Vec::new();
+    };
+    let cfg = super::config::load(&root);
+    let prose: String = messages
+        .iter()
+        .filter(|m| matches!(m.role, MessageRole::Assistant))
+        .map(|m| m.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let statements = gate_statements(cfg.residue_gate, &prose);
+    if statements.is_empty() {
+        return Vec::new();
+    }
+
+    let Ok(st) = super::state::LoopState::open() else {
+        return vec!["residue gate: cannot open the loop's state directory".to_owned()];
+    };
+    let bound = super::convention::load(&root);
+    let outcomes = file_residue(
+        &crate::issue_provider::GhIssueProvider,
+        &bound.convention,
+        &st.seen(),
+        &cfg.attribution.issue,
+        &statements,
+    )
+    .await;
+
+    let mut notices = Vec::new();
+    for outcome in &outcomes {
+        match &outcome.result {
+            Ok(Filed::New(key)) => {
+                let _ = st.add_seen(&stella_autonomy::finding_digest(&outcome.title));
+                st.update_stats(|s| s.record_filing("new"));
+                notices.push(format!("residue gate filed #{key}: {}", outcome.title));
+            }
+            Ok(Filed::Duplicate { .. }) => {
+                st.update_stats(|s| s.record_filing("duplicate"));
+            }
+            Ok(Filed::Refused { .. }) => {
+                st.update_stats(|s| s.record_filing("refused"));
+                notices.push(format!(
+                    "residue gate: the issue convention refused a draft for \"{}\"",
+                    outcome.title
+                ));
+            }
+            Err(error) => {
+                notices.push(format!("residue gate: could not file ({error})"));
+            }
+        }
+    }
+    notices
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use stella_autonomy::{Acceptance, AxisRequirement, ConventionSource, LabelAxis};
+    use stella_protocol::issue::{Issue, IssueError, IssueKey};
+
+    use super::*;
+
+    /// A tracker that is not GitHub and not a process. The witnesses below
+    /// file against it.
+    #[derive(Default)]
+    struct FixtureForge {
+        filed: std::sync::Mutex<Vec<IssueDraft>>,
+    }
+
+    impl FixtureForge {
+        fn filed(&self) -> Vec<IssueDraft> {
+            self.filed.lock().expect("fixture lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl IssueProvider for FixtureForge {
+        fn id(&self) -> &str {
+            "fixture"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(Vec::new())
+        }
+
+        async fn file(&self, draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            let mut filed = self.filed.lock().expect("fixture lock");
+            filed.push(draft.clone());
+            Ok(IssueKey::from(format!("{}", 2000 + filed.len()).as_str()))
+        }
+
+        async fn close(
+            &self,
+            _key: &IssueKey,
+            _receipt: &str,
+            _state: &str,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn relabel(
+            &self,
+            _key: &IssueKey,
+            _add: &[String],
+            _remove: &[String],
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            _body: Option<&str>,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+    }
+
+    /// This repository's convention, as `issue-triage.yml` enforces it.
+    fn convention() -> BacklogConvention {
+        BacklogConvention {
+            axes: vec![LabelAxis {
+                name: "type".into(),
+                members: ["bug", "feature", "epic", "documentation", "question"]
+                    .iter()
+                    .map(|s| (*s).to_owned())
+                    .collect(),
+                requirement: AxisRequirement::ExactlyOne,
+                source: ConventionSource::Enforced,
+            }],
+            reserved: vec!["triage".into()],
+            acceptance: Acceptance::Bound,
+        }
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(f)
+    }
+
+    const TRANSCRIPT: &str = "I fixed the retry loop and added the witness.\n\
+        The client still doesn't handle the 429 case — follow-up.\n\
+        Deferring this: the config reload path needs its own lock audit.\n\
+        Everything else is covered by the new tests.";
+
+    /// **The B5 witness.** Two stated leftovers file exactly two issues on
+    /// the mock forge. A re-run with those digests seen files zero.
+    #[test]
+    fn two_residue_statements_file_two_issues_and_a_rerun_files_none() {
+        let statements = detect_residue(TRANSCRIPT);
+        assert_eq!(
+            statements.len(),
+            2,
+            "expected exactly two residue statements, got {statements:?}"
+        );
+
+        let forge = FixtureForge::default();
+        let outcomes = block_on(file_residue(
+            &forge,
+            &convention(),
+            &[],
+            "Filed by stella.",
+            &statements,
+        ));
+        let digests: Vec<String> = outcomes
+            .iter()
+            .filter(|o| matches!(o.result, Ok(Filed::New(_))))
+            .map(|o| stella_autonomy::finding_digest(&o.title))
+            .collect();
+        assert_eq!(digests.len(), 2, "both statements must reach the tracker");
+        assert_eq!(forge.filed().len(), 2);
+
+        // The re-run: same transcript, first run's digests now seen.
+        let rerun_forge = FixtureForge::default();
+        let rerun = block_on(file_residue(
+            &rerun_forge,
+            &convention(),
+            &digests,
+            "Filed by stella.",
+            &detect_residue(TRANSCRIPT),
+        ));
+        assert!(
+            rerun
+                .iter()
+                .all(|o| matches!(o.result, Ok(Filed::Duplicate { .. }))),
+            "every re-run outcome must be a duplicate"
+        );
+        assert!(
+            rerun_forge.filed().is_empty(),
+            "a deduplicated statement must never reach the tracker again"
+        );
+    }
+
+    /// The same statement twice in one turn files once. The first filing's
+    /// digest blocks the second before the provider is reached.
+    #[test]
+    fn a_statement_repeated_within_one_turn_files_once() {
+        let forge = FixtureForge::default();
+        let statement = "Deferring this: the config reload path needs a lock audit.".to_owned();
+        let outcomes = block_on(file_residue(
+            &forge,
+            &convention(),
+            &[],
+            "Filed by stella.",
+            &[statement.clone(), statement],
+        ));
+        assert!(matches!(outcomes[0].result, Ok(Filed::New(_))));
+        assert!(matches!(outcomes[1].result, Ok(Filed::Duplicate { .. })));
+        assert_eq!(forge.filed().len(), 1);
+    }
+
+    /// **The off switch files nothing.** The gate hands the filing loop an
+    /// empty list, so no provider is ever reached.
+    #[test]
+    fn the_off_switch_detects_and_files_nothing() {
+        assert!(gate_statements(false, TRANSCRIPT).is_empty());
+
+        let forge = FixtureForge::default();
+        let outcomes = block_on(file_residue(
+            &forge,
+            &convention(),
+            &[],
+            "Filed by stella.",
+            &gate_statements(false, TRANSCRIPT),
+        ));
+        assert!(outcomes.is_empty());
+        assert!(forge.filed().is_empty());
+    }
+
+    /// Conformance refusal stands. An unaccepted convention refuses every
+    /// draft before the tracker is reached.
+    #[test]
+    fn a_refused_residue_draft_never_reaches_the_tracker() {
+        let mut proposed = convention();
+        proposed.acceptance = Acceptance::Proposed;
+
+        let forge = FixtureForge::default();
+        let outcomes = block_on(file_residue(
+            &forge,
+            &proposed,
+            &[],
+            "Filed by stella.",
+            &detect_residue(TRANSCRIPT),
+        ));
+        assert!(
+            outcomes
+                .iter()
+                .all(|o| matches!(o.result, Ok(Filed::Refused { .. }))),
+            "an unaccepted convention must refuse every draft"
+        );
+        assert!(forge.filed().is_empty());
+    }
+
+    /// Ordinary completion prose trips nothing. The detector's value is
+    /// what it does not match.
+    #[test]
+    fn ordinary_completion_prose_trips_nothing() {
+        let prose = "I fixed the retry loop, added the witness test, and the suite is \
+                     green. The change follows up on the earlier refactor and handles \
+                     every error class the caller can see.";
+        assert!(detect_residue(prose).is_empty());
+    }
+
+    /// A `TODO` in fenced code is the code's debt. A block quote is
+    /// someone else's words.
+    #[test]
+    fn code_fences_and_quotes_are_not_residue() {
+        let prose = "Here is the relevant snippet:\n\
+            ```rust\n// TODO: handle the 429 case\n```\n\
+            > TODO: the quoted issue body says this\n\
+            All of it is already tracked.";
+        assert!(detect_residue(prose).is_empty());
+    }
+
+    /// A line that opens with `todo:` is a statement. One that mentions
+    /// the word mid-sentence is usually a quote.
+    #[test]
+    fn todo_counts_only_at_the_start_of_a_line() {
+        assert_eq!(
+            detect_residue("TODO: wire the config reload lock.").len(),
+            1
+        );
+        assert!(detect_residue("I searched for the string todo: nothing matched.").is_empty());
+    }
+
+    /// `residue_gate = "off"` parses. An absent key means on.
+    #[test]
+    fn the_switch_parses_and_defaults_on() {
+        use crate::settings::toml_config::{ResidueGateSwitch, TomlConfig};
+        let path = std::path::Path::new("stella.toml");
+
+        let off = TomlConfig::parse("[self_driving]\nresidue_gate = \"off\"\n", path)
+            .expect("a valid document");
+        assert_eq!(off.self_driving.residue_gate, ResidueGateSwitch::Off);
+        assert!(!off.self_driving.residue_gate.enabled());
+
+        let absent = TomlConfig::parse("", path).expect("an empty document");
+        assert!(absent.self_driving.residue_gate.enabled());
+    }
+}

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -401,6 +401,36 @@ pub struct SelfDrivingSection {
     /// every tracker has. Two teams on one GitHub can want different ladders.
     #[serde(default)]
     pub triage: TriageSection,
+    /// `residue_gate = "on" | "off"` — whether the end-of-turn residue gate
+    /// files leftover-work statements from a turn's transcript as issues.
+    ///
+    /// Absent means on: filing stated follow-up work is the default, and the
+    /// switch exists so an operator can turn the gate off, not so they must
+    /// find it to turn the gate on.
+    #[serde(default)]
+    pub residue_gate: ResidueGateSwitch,
+}
+
+/// The end-of-turn residue gate's switch (`doc:backlog-self-driving` B5).
+///
+/// A named two-value switch rather than a bare boolean so the document reads
+/// `residue_gate = "off"` — the same spelling `[plugins]` switches use.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResidueGateSwitch {
+    /// The gate scans and files. The default.
+    #[default]
+    On,
+    /// The gate neither scans nor files.
+    Off,
+}
+
+impl ResidueGateSwitch {
+    /// Whether the gate runs.
+    #[must_use]
+    pub fn enabled(self) -> bool {
+        matches!(self, Self::On)
+    }
 }
 
 /// `[self_driving.merge]` — which checks may block a merge.

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -423,6 +423,26 @@ evolution_surfaces! {
          its issue, so the unit of undo is the unit of change. `stella self-driving stop` \
          parks the loop at its next boundary, and applying the escalation label withdraws an \
          issue from the queue across restarts";
+
+    /// The backlog Stella feeds itself: issues it files about its own
+    /// leftover work.
+    Backlog => "backlog",
+        EvolutionPosture::Shipped {
+            mechanism: "the end-of-turn residue gate (`doc:backlog-self-driving` phase B5): \
+                        `detect_residue` scans the turn's transcript for explicit \
+                        leftover-work statements against a fixed phrase list — no model \
+                        call — and each hit is filed through `file_finding`, so the \
+                        seen-set dedup and the convention conformance check apply to the \
+                        loop's own residue exactly as they do to an audit finding. \
+                        `residue_gate = \"off\"` in `stella.toml` turns the gate off",
+            witness: "two_residue_statements_file_two_issues_and_a_rerun_files_none",
+        },
+        EvolutionTiming::BetweenTurns,
+        ImpactClass::AdvisoryRecord,
+        "close the filed issue; its digest stays in the seen-set, so closing is terminal \
+         rather than a snooze — the same statement never re-files. `residue_gate = \"off\"` \
+         stops the gate wholesale, and deleting a digest line from `seen.txt` re-arms that \
+         one statement for the operator who wants it re-filed";
 }
 
 /// How many live rows name no witness.
@@ -461,7 +481,7 @@ pub const UNWITNESSED_EVOLUTION_BASELINE: usize = 0;
 /// check it asserts the row's own mechanism.** A row is a claim like any other
 /// (CLAUDE.md), and the name of a test is not evidence for it.
 #[cfg(test)]
-fn evolution_sources() -> [&'static str; 11] {
+fn evolution_sources() -> [&'static str; 12] {
     [
         // The Delivery row's witness: what the backlog picks and the
         // ledger row it writes, proven on a fixture tracker.
@@ -480,6 +500,8 @@ fn evolution_sources() -> [&'static str; 11] {
         // The SkillInvocation row's witness: an auto-selected skill's
         // directives reach the plane through the recall seam.
         include_str!("../../stella-cli/src/memory/tests/skill_event.rs"),
+        // The Backlog row's witness lives beside the residue gate it proves.
+        include_str!("../../stella-cli/src/self_driving_cmd/residue.rs"),
     ]
 }
 

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -424,25 +424,21 @@ evolution_surfaces! {
          parks the loop at its next boundary, and applying the escalation label withdraws an \
          issue from the queue across restarts";
 
-    /// The backlog Stella feeds itself: issues it files about its own
-    /// leftover work.
+    /// Issues Stella files about its own leftover work.
     Backlog => "backlog",
         EvolutionPosture::Shipped {
-            mechanism: "the end-of-turn residue gate (`doc:backlog-self-driving` phase B5): \
-                        `detect_residue` scans the turn's transcript for explicit \
-                        leftover-work statements against a fixed phrase list — no model \
-                        call — and each hit is filed through `file_finding`, so the \
-                        seen-set dedup and the convention conformance check apply to the \
-                        loop's own residue exactly as they do to an audit finding. \
+            mechanism: "the end-of-turn residue gate (`doc:backlog-self-driving` phase B5). \
+                        `detect_residue` scans the turn's transcript with a fixed phrase \
+                        list. No model call. Each hit is filed through `file_finding`. \
+                        The seen-set dedup and the convention check apply here too. \
                         `residue_gate = \"off\"` in `stella.toml` turns the gate off",
             witness: "two_residue_statements_file_two_issues_and_a_rerun_files_none",
         },
         EvolutionTiming::BetweenTurns,
         ImpactClass::AdvisoryRecord,
-        "close the filed issue; its digest stays in the seen-set, so closing is terminal \
-         rather than a snooze — the same statement never re-files. `residue_gate = \"off\"` \
-         stops the gate wholesale, and deleting a digest line from `seen.txt` re-arms that \
-         one statement for the operator who wants it re-filed";
+        "close the filed issue. The digest stays in the seen-set, so the same statement \
+         never re-files. `residue_gate = \"off\"` stops the gate. Deleting a digest line \
+         from `seen.txt` re-arms that one statement";
 }
 
 /// How many live rows name no witness.
@@ -500,7 +496,7 @@ fn evolution_sources() -> [&'static str; 12] {
         // The SkillInvocation row's witness: an auto-selected skill's
         // directives reach the plane through the recall seam.
         include_str!("../../stella-cli/src/memory/tests/skill_event.rs"),
-        // The Backlog row's witness lives beside the residue gate it proves.
+        // The Backlog row's witness sits beside the gate it proves.
         include_str!("../../stella-cli/src/self_driving_cmd/residue.rs"),
     ]
 }

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -6,7 +6,7 @@ status: living
 
 # Backlog Self-Driving — the loop that owns a queue, not a task
 
-Status: **B0 built, B1–B7 designed and unbuilt.** Phases in §9. The driver
+Status: **B0–B3 and B5 built; B4, B6 and B7 designed and unbuilt.** Phases in §9. The driver
 channel §3.0 specifies exists — `stella_plugin::driver` is its wire half,
 `stella_runtime::wrapper::DriverCallGate` its host half, and
 `plugins/stella-selfdriving/plugin.toml` declares the `[driver]` grant a human
@@ -81,7 +81,7 @@ Nothing below proposes changing it.
 | Capability | Where | State |
 |---|---|---|
 | The `Issue` kernel, provider manifests, `kind = "exec"` | [`doc:agent-native-delivery`](agent-native-delivery.md) §3–§4 | Design only. Epic closed `not_planned` under a freeze that has since lifted. |
-| The residue gate — a prose follow-up becomes undischargeable | [`doc:agent-native-delivery`](agent-native-delivery.md) §7 | Design only. This is the mechanism that makes "file new tickets" a *guarantee* rather than a habit. |
+| The residue gate — a prose follow-up becomes undischargeable | `crates/stella-cli/src/self_driving_cmd/residue.rs` | **Built** (§9 B5): an end-of-turn transcript check that files through `file_finding`. "File new tickets" is now a *guarantee*, not a habit. |
 | Backlog dedup + decay | [`doc:agent-native-delivery`](agent-native-delivery.md) §10.1 | Design only. |
 | Self-driving as a plugin that actually drives | #3546, [`doc:pipeline-as-plugins`](pipeline-as-plugins.md) §10 D6 | Manifest exists (`plugins/stella-selfdriving/plugin.toml`) and now declares a `[driver]` grant a human reads at install. It still starts nothing (B2), and every capability it declares answers `unsupported` (B1–B6) — but it **can** hold one, which it could not before B0. |
 | The host-call channel: `recall`, `child_turn`, `run_test`, `candidate_fanout`, `adopt_candidate` | `crates/stella-plugin/src/host_call.rs`, `crates/stella-runtime/src/wrapper/host_call.rs` | **Built** (#3590), and reachable only from inside a turn. |
@@ -884,11 +884,11 @@ its witness — a test that fails on `main` and passes with the change.
 | Phase | Deliverable | Witness | Unblocks |
 |---|---|---|---|
 | **B0** — **built** | **The driver channel** (§3.0). A second dispatch context for the existing host-call machinery, opened by a driver session rather than a wrapper point; a `[driver]` block with its own `calls` list and its own `permits_call`, *without* touching the `Participation` ladder; the grant rendered at install consent. `stella-plugin/src/driver.rs` is the wire half and `stella-runtime/src/wrapper/driver_call.rs` the host half. **A call carries no arguments and returns no payload yet** — no verb is implemented, so no argument or result table can be written honestly; each lands with the verb that needs it. `plugins/stella-selfdriving` declares its `[driver]` grant but is still not a program the host runs, which is B2. | `an_undeclared_call_is_refused_and_the_session_keeps_running` (`stella-runtime/src/wrapper/driver_call.rs`): a driver whose manifest omits a call is refused it with a `HostCallRefusal` code, is not charged for it, and **keeps running**; a declared one is served. Both directions, because either alone is half a gate. Plus `a_driver_holds_capabilities_without_a_participation_grade` (`stella-plugin/src/manifest.rs`) — the defect itself, that `participation = "none"` made every capability unreachable. | everything below |
-| **B1** — *port landed* | **The issue port.** `Issue` kernel in `stella-protocol`; `IssueProvider` port; GitHub as a shipped manifest under `.stella/issues/`; the `backlog` calls on the channel; the CLI's `queue` row reshaped, `HOST_SURFACE_VERSION` → 2. | The ranked queue is produced against a fixture provider with **no `gh` on `PATH`**. | "any issue provider" |
-| **B2** | **`work` + the loop step machine.** `LoopStep`/`step` pure in `stella-autonomy`; `work_start`/`work_status`/`work_abandon` served over the channel from `stella-cli`, built on the existing `child_turn` dispatcher rather than a second one; the plugin becomes a policy loop over declared calls; the eight slash commands and `scripts/self-driving.sh` retire **only after** `scripts/test-self-driving.sh` is green against the new path with every assertion intact. | One issue goes from `backlog next` to a verified diff with no Claude Code and no human. | the headline |
-| **B3** | **`deliver`.** `PrState` pure; open/observe/next/merge; `Escalated` reachable and terminal; `CiRed` vs `BaseBroken` distinguished. | A PR whose CI is red *on its base branch* transitions to `BaseBroken`, and the loop does not push a fix. |  PR rhythm (#2374's named weakness) |
+| **B1** — **built** | **The issue port.** `Issue` kernel in `stella-protocol`; `IssueProvider` port; GitHub as a shipped manifest under `.stella/issues/`; the `backlog` calls on the channel; the CLI's `queue` row reshaped, `HOST_SURFACE_VERSION` → 2. | The ranked queue is produced against a fixture provider with **no `gh` on `PATH`**. | "any issue provider" |
+| **B2** — **built** | **`work` + the loop step machine.** `LoopStep`/`step` pure in `stella-autonomy`; `work_start`/`work_status`/`work_abandon` served over the channel from `stella-cli`, built on the existing `child_turn` dispatcher rather than a second one; the plugin becomes a policy loop over declared calls; the eight slash commands and `scripts/self-driving.sh` retire **only after** `scripts/test-self-driving.sh` is green against the new path with every assertion intact. | One issue goes from `backlog next` to a verified diff with no Claude Code and no human. | the headline |
+| **B3** — **built** | **`deliver`.** `PrState` pure; open/observe/next/merge; `Escalated` reachable and terminal; `CiRed` vs `BaseBroken` distinguished. | A PR whose CI is red *on its base branch* transitions to `BaseBroken`, and the loop does not push a fix. |  PR rhythm (#2374's named weakness) |
 | **B4** | **Supply.** Ladder re-arm on baseline delta; `sweep regress` over closed-issue receipts; `sweep meta`. Per-supply switch, default queue-only. | A lens dry at `HEAD` re-opens after the declared baseline delta and yields **only** digests absent from `seen.txt`. | never runs out |
-| **B5** | **The residue gate** ([`doc:agent-native-delivery`](agent-native-delivery.md) §7) in `warn`, plus fingerprint dedup and decay. | A run stating a follow-up in prose and claiming `done` fails the gate; the same run with the item `filed` passes. | filing is a guarantee |
+| **B5** — **built** | **The residue gate** ([`doc:agent-native-delivery`](agent-native-delivery.md) §7), as an end-of-turn transcript check in `stella-cli` (`self_driving_cmd/residue.rs`). A fixed phrase list finds leftover-work statements — never a model call. Every hit is filed through `file_finding`, so the seen-set dedup and the convention check apply unchanged. `residue_gate = "off"` in `stella.toml` turns it off. | `two_residue_statements_file_two_issues_and_a_rerun_files_none` (`self_driving_cmd/residue.rs`): two stated leftovers file exactly two issues on a fixture provider. A re-run with those digests seen files none. | filing is a guarantee |
 | **B6** | **`curate`.** Proposals from ledger evidence; acceptance gated on declared authority; `regulated` keeps the human on context records. | A skill proposal reaching the recurrence threshold is *proposed* and, under `regulated`, **not** applied. | self-curation |
 | **B7** | **`release`,** opt-in, gated on green `main` + quiet canary + derivable changelog. | Deferred — see §6.4. | shipping |
 
@@ -916,8 +916,8 @@ drew its batch from. Both numbers are now folds of one ranking of one read.
 |---|---|
 | `LoopStep`, `step`, `PrState`, supply model, re-arm rule | `stella-autonomy` (pure; new modules — the crate has no god files and must keep none) |
 | `Issue`, `IssueState`, `IssueClass`, `PrId`, receipts | `stella-protocol` (types only) |
-| Residue detection, discharge rules | `stella-core` (pure, no I/O) |
-| The residue gate stage | **Homeless.** `stella-pipeline` is deleted (#3852/#3865) and this row named it; B5 has to pick a home before it can be built — a wrapper plugin's own side, or a `stella-cli` check over the turn's transcript. Tracked in #3901's sweep of the same stale claim. |
+| Residue detection | `stella-cli` (`self_driving_cmd/residue.rs`): a pure, fixed-phrase detector beside the gate. Its only caller is the filing path one file away, so it did not land in `stella-core`. |
+| The residue gate stage | **Built**, in `stella-cli`: the end-of-turn check over the turn's transcript (`self_driving_cmd/residue.rs`), hooked at the interactive turn boundary. Of the two homes this row once named, the transcript check won. It needs no plugin lifecycle and reuses the filing path whole. |
 | `backlog`/`work`/`deliver`/`sweep`/`curate` verbs, the forge adapter, provider manifests | `stella-cli` (`self_driving_cmd/` — `self_driving_cmd.rs` is close enough to the 1500-line ceiling that new logic lands in siblings; it carries no baseline entry, so a crossing fails the gate rather than being grandfathered) |
 | Issue claims | `stella-fleet` ledger |
 | The driver channel: dispatch context, `[driver]` block, `permits_call` | `stella-plugin` (wire + gate), `stella-runtime` (`src/wrapper/`, beside the existing host-call dispatch) |
@@ -929,8 +929,8 @@ hold any capability at all. It is also the smallest of the three, because the wi
 refusal codes, the manifest gate, the consent rendering and the subprocess
 transport all exist and are exercised by `stella-research` — B0 adds a dispatch
 context, not a platform. B3 and B4 are independent of
-each other and both need B2. B5 is independent of everything after B1 and could
-land early if the residue gate is wanted sooner than the autonomy.
+each other and both need B2. B5 depended only on B1 and landed early, as the
+end-of-turn transcript check.
 
 ---
 

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -597,6 +597,13 @@ min_steps = 3       # open steps that raise a card
 #
 # This whole block is strict — an unknown key is a load error, not a warning.
 # -----------------------------------------------------------------------------
+[self_driving]
+# The end-of-turn residue gate. When a turn states leftover work in prose
+# ("still doesn't handle the 429 case — follow-up"), the gate files it as an
+# issue through the same dedup and convention checks every automatic filing
+# takes. Absent means "on"; filing stated follow-up work is the default.
+residue_gate = "on"
+
 [self_driving.attribution]
 # What the loop appends to what it writes. Source-tracked so it travels with the
 # repository, and rewritable by an installed plugin — a downstream distribution


### PR DESCRIPTION
## What & why

Builds §9 **B5 — the residue gate** from `docs/spec/backlog-self-driving.md`, in the spec's named candidate home: a `stella-cli` end-of-turn check over the turn's transcript. A turn that states leftover work in prose ("still doesn't handle the 429 case — follow-up") now files it as an issue automatically, so SCR-004 (residue becomes issues) is code, not custom.

- `crates/stella-cli/src/self_driving_cmd/residue.rs` — `detect_residue` (a conservative fixed-phrase detector, never a model call; skips fenced code and block quotes), `file_residue` (every hit goes through the existing `backlog::file_finding`, so `seen.txt` dedup and convention conformance apply unchanged), and `end_of_turn` (the best-effort hook: reads the switch, files, appends new digests, records outcomes in session stats).
- Hook: `agent/reflect.rs` `reflect_on_interactive_turn` runs the gate at the interactive turn boundary, outside reflection's own gate. A filing failure is a notice, never a failed turn.
- Config: `residue_gate = "on" | "off"` under `[self_driving]` (default on; `ResidueGateSwitch` in `settings/toml_config.rs`, documented in `stella.example.toml`).
- Evolution ledger: a `Backlog` row in `crates/stella-parity/src/evolution.rs`, `Shipped`, witnessed; `UNWITNESSED_EVOLUTION_BASELINE` stays 0.
- Spec: stale §9 rows fixed — B1/B2/B3 marked built; B5 marked built and pointing at the implementation and its witness; the landing-map "homeless" row now names the home.

Closes #5567

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here): `two_residue_statements_file_two_issues_and_a_rerun_files_none` — two stated leftovers file exactly two issues on a mock forge; a re-run with those digests seen files none. Plus `a_statement_repeated_within_one_turn_files_once`, `the_off_switch_detects_and_files_nothing`, `a_refused_residue_draft_never_reaches_the_tracker`, `ordinary_completion_prose_trips_nothing`, `code_fences_and_quotes_are_not_residue`, `todo_counts_only_at_the_start_of_a_line`, `the_switch_parses_and_defaults_on`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-parity --all-targets` — clean (touched crates; full workspace is CI's job)
- [x] `cargo test -p stella-cli --bin stella residue` (8 passed), `self_driving_cmd` (176), `settings::` (155, includes the example-config completeness gate), `agent::` (256), `memory::reflection` (35); `cargo test -p stella-parity` (23)
- [x] Docs updated where behavior changed: `docs/spec/backlog-self-driving.md`, `stella.example.toml`
- [x] `Closes #5567` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls beyond the existing `gh` issue provider the filing path already uses

## Anything reviewers should know?

The detector is deliberately conservative (fixed phrase list, fence/quote skipping, an 8-filing cap per turn) — a missed statement costs one unfiled issue; a false hit costs a wrong issue a human must close. `scripts/check-prose.py`, `check-line-citations.py`, `check-file-size.sh`, `check-god-files.sh`, `check-left-behind.sh`, and `check-module-reachability.py` all pass locally.

## Summary by Sourcery

Automatically file explicitly stated leftover work from interactive turns as deduplicated backlog issues through the self-driving residue gate.

New Features:
- Automatically detect explicit leftover-work statements at the end of interactive turns and file them as backlog issues.
- Add a configurable residue gate that is enabled by default and can be disabled with `residue_gate = "off"`.

Enhancements:
- Reuse existing filing, convention validation, deduplication, and session-stat tracking for residue issues while keeping the gate best-effort.
- Record the residue gate as shipped in the evolution ledger and update the self-driving backlog specification to reflect the completed capabilities and implementation home.

Documentation:
- Document the residue-gate setting and update the backlog self-driving specification with its implementation status, witness, and ownership.

Tests:
- Add witness coverage for filing multiple residue statements, deduplication across reruns and within a turn, switch behavior, convention refusals, ordinary prose, and code/quote exclusions.