### PR TITLE
feat(stella-cli): triage sizes, flips ready, and drive watches the release workflow

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd/audit.rs
+++ b/crates/stella-cli/src/self_driving_cmd/audit.rs
@@ -71,6 +71,9 @@ pub(super) enum Action {
     Waived,
     /// The base branch was found broken with no issue open, so one was filed.
     FiledBaseBreakage,
+    /// The release workflow was found red with no issue open, so one was
+    /// filed.
+    FiledDeployBreakage,
     /// A turn was asked to place an issue nobody had judged.
     TriageStarted,
     /// An issue was placed, and the labels written.
@@ -111,7 +114,7 @@ impl Action {
             Self::Verified => "verified",
             Self::VerifyFailed => "unverified",
             Self::Waived => "waived",
-            Self::FiledBaseBreakage => "filed",
+            Self::FiledBaseBreakage | Self::FiledDeployBreakage => "filed",
             Self::TriageStarted => "triaging",
             Self::Triaged => "triaged",
             Self::PrOpened => "pr opened",

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -373,6 +373,106 @@ pub(super) fn file_base_breakage(
         .map_err(|error| error.to_string())
 }
 
+/// The label that marks an issue as *the release workflow is red*.
+///
+/// A sibling of [`BASE_BREAKAGE_LABEL`] with the same contract. The label
+/// is the dedup key. A restarted process — or a second one — finds the
+/// emergency already filed instead of filing it again.
+pub(super) const DEPLOY_BREAKAGE_LABEL: &str = "release-red";
+
+/// The open deploy-breakage issue, if one exists.
+///
+/// Matched on [`DEPLOY_BREAKAGE_LABEL`] and read through the port. It
+/// degrades as [`open_base_breakage`] does. An unreachable tracker answers
+/// `None`, the filing that follows fails too, and the loop waits rather
+/// than acting on a guess.
+#[must_use]
+pub(super) fn open_deploy_breakage(provider: &dyn IssueProvider) -> Option<String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()?;
+    let issues = runtime
+        .block_on(provider.list_open(QUEUE_READ_LIMIT))
+        .ok()?;
+
+    issues
+        .into_iter()
+        .find(|issue| {
+            issue
+                .labels
+                .iter()
+                .any(|label| label.name == DEPLOY_BREAKAGE_LABEL)
+        })
+        .map(|issue| issue.key.as_str().to_owned())
+}
+
+/// File the report that the release workflow is red — once.
+///
+/// The dedup lives in this function, not in the caller. The property that
+/// matters is one open issue per outage, and a caller that filed first and
+/// checked second would already have the duplicate in the tracker.
+/// `Ok(None)` is the ordinary answer on every poll after the first: the
+/// emergency is known, nothing was sent.
+///
+/// Like [`file_base_breakage`] it bypasses [`file_finding`]. There is one
+/// deploy outage at a time, its dedup key is "is one already open", and a
+/// convention refusal here would leave releases broken over a label
+/// spelling.
+pub(super) fn file_deploy_breakage(
+    provider: &dyn IssueProvider,
+    workflow: &str,
+    run_url: &str,
+    attribution: &stella_autonomy::Attribution,
+) -> Result<Option<String>, String> {
+    if open_deploy_breakage(provider).is_some() {
+        return Ok(None);
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+
+    let body = stella_autonomy::sign(
+        &format!(
+            "The `{workflow}` workflow's most recent run finished red, so the \
+             release path is broken: nothing can ship until it is green again.\n\n\
+             Failing run: {run_url}\n\n\
+             ## Reproduce\n\n\
+             ```\n\
+             gh run list --workflow {workflow} --limit 3\n\
+             ```\n\n\
+             Read the newest failing run, then reproduce the failing step \
+             locally where the job permits it.\n\n\
+             ## Done when\n\n\
+             A run of `{workflow}` completes green, and the fix names which run \
+             it was diagnosed from.\n\n\
+             Filed automatically on noticing the release workflow was red and no \
+             issue was open. The label `{DEPLOY_BREAKAGE_LABEL}` is what marks it \
+             as this — removing the label makes the loop file a second one."
+        ),
+        &attribution.issue,
+    );
+
+    let draft = IssueDraft {
+        title: format!("{workflow} is red — the release path is broken"),
+        body,
+        labels: vec![
+            IssueLabel::from(DEPLOY_BREAKAGE_LABEL),
+            IssueLabel::from("bug"),
+            IssueLabel::from("P0"),
+        ],
+        parent: None,
+        assignee: None,
+    };
+
+    runtime
+        .block_on(provider.file(&draft))
+        .map(|key| Some(key.as_str().to_owned()))
+        .map_err(|error| error.to_string())
+}
+
 /// Mark an issue as one the loop tried and could not resolve, and say why.
 ///
 /// Both halves matter. The label is what the next run reads, so it stops
@@ -1050,6 +1150,58 @@ mod tests {
             Some(Demand::default()),
             "and is distinguishable from a backlog that really is empty"
         );
+    }
+
+    /// **The deploy-watch witness.** A red release run is filed exactly
+    /// once. The first pass files, with the dedup label riding the draft.
+    /// A pass that finds the label already open sends nothing.
+    #[test]
+    fn a_red_release_run_is_filed_exactly_once() {
+        let attribution = stella_autonomy::Attribution::default();
+        let run_url = "https://example.invalid/actions/runs/1";
+
+        // Nobody has filed it: one draft goes out, carrying the dedup label.
+        let provider = FixtureProvider::default();
+        let filed = file_deploy_breakage(&provider, "release.yml", run_url, &attribution)
+            .expect("the port was reachable");
+        assert_eq!(filed, Some("1001".to_owned()));
+        let drafts = provider.filed();
+        assert_eq!(drafts.len(), 1);
+        assert!(
+            drafts[0]
+                .labels
+                .iter()
+                .any(|label| label.name == DEPLOY_BREAKAGE_LABEL),
+            "the dedup label must ride the draft, or the next pass re-files"
+        );
+        assert!(
+            drafts[0].body.contains(run_url),
+            "the report must name the failing run"
+        );
+
+        // The issue is open: the same red run files nothing further.
+        let already = FixtureProvider::with(vec![issue(
+            "77",
+            &[DEPLOY_BREAKAGE_LABEL, "bug", "P0"],
+            "2026-08-19T00:00:00Z",
+        )]);
+        let second = file_deploy_breakage(&already, "release.yml", run_url, &attribution)
+            .expect("the port was reachable");
+        assert_eq!(second, None, "already filed — nothing to send");
+        assert!(already.filed().is_empty());
+    }
+
+    /// An unreachable tracker fails the deploy filing rather than
+    /// swallowing it — the contract every write in this module keeps.
+    #[test]
+    fn an_unreachable_tracker_fails_the_deploy_filing() {
+        let outcome = file_deploy_breakage(
+            &DeadProvider,
+            "release.yml",
+            "https://example.invalid/actions/runs/1",
+            &stella_autonomy::Attribution::default(),
+        );
+        assert!(outcome.is_err(), "{outcome:?}");
     }
 
     /// The limit bounds what crosses the port, not what the ranker discards

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -60,6 +60,9 @@ pub(crate) struct LoopConfig {
     /// Whether the end-of-turn residue gate scans and files leftover work
     /// (`residue_gate = "on" | "off"`, absent means on).
     pub residue_gate: bool,
+    /// Whether the drive loop also watches the release workflow's latest run
+    /// and files on red. On unless `stella.toml` says `deploy_watch = "off"`.
+    pub deploy_watch: bool,
 }
 
 impl Default for LoopConfig {
@@ -73,6 +76,7 @@ impl Default for LoopConfig {
             verify_command: None,
             verify_timeout_secs: 1800,
             residue_gate: true,
+            deploy_watch: true,
         }
     }
 }
@@ -98,6 +102,7 @@ pub(crate) fn load(root: &Path) -> LoopConfig {
         verify_command: parsed.self_driving.verify.command.clone(),
         verify_timeout_secs: parsed.self_driving.verify.timeout_secs.unwrap_or(1800),
         residue_gate: parsed.self_driving.residue_gate.enabled(),
+        deploy_watch: parsed.self_driving.deploy_watch.enabled(),
     }
 }
 
@@ -320,6 +325,30 @@ foreign_breakage = "file_and_wait"
             stella_autonomy::Doctrine::default(),
             "and a workspace that declares nothing gets the shipped default"
         );
+    }
+
+    /// The deploy watch is on for a workspace that says nothing, and an
+    /// operator stands it down with one line — the default direction matters,
+    /// because a watch that must be asked for is off exactly when nobody
+    /// thought about it.
+    #[test]
+    fn the_deploy_watch_defaults_on_and_can_be_stood_down() {
+        assert!(load(workspace().path()).deploy_watch);
+
+        let ws = workspace();
+        write(
+            ws.path(),
+            "stella.toml",
+            r#"
+[meta]
+schema_version = 1
+scope = "project"
+
+[self_driving]
+deploy_watch = "off"
+"#,
+        );
+        assert!(!load(ws.path()).deploy_watch);
     }
 
     /// A malformed manifest falls back to a working vocabulary rather than

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -66,6 +66,7 @@ use stella_autonomy::{
 };
 use stella_fleet::issue_claim_key;
 
+mod deploy;
 mod ending;
 mod notify;
 mod settlement;
@@ -315,6 +316,23 @@ pub(super) fn drive(
     for kind in &cfg.triage.defect_kinds {
         let _ = crate::issue_provider::ensure_label(kind, "Work the self-driving loop may take.");
     }
+    // The size scale and the readiness pair ride the same install pass as
+    // the rungs. Triage writes them, and a tracker that lacks a label
+    // rejects the write. The rung loop above holds the full argument.
+    for size in super::triage::SIZES {
+        let _ = crate::issue_provider::ensure_label(
+            &super::triage::size_label(size),
+            "Effort estimate written by the self-driving loop's triage.",
+        );
+    }
+    let _ = crate::issue_provider::ensure_label(
+        super::triage::READY_LABEL,
+        "Assessed, with no open blocker remaining — ready to take.",
+    );
+    let _ = crate::issue_provider::ensure_label(
+        super::triage::BLOCKED_LABEL,
+        "Waiting on another issue named in the body as `Blocked by`.",
+    );
 
     // The run's USD ceiling, and the accounting that makes `--spend-limit`
     // mean what its help says (#4353). Every child turn is spawned through
@@ -384,6 +402,14 @@ pub(super) fn drive(
             max_issues,
             tally.opened,
         );
+
+        // The deploy watch rides the same poll as the base watch, and it
+        // yields to it. A red base already has the loop's full attention.
+        // A parked loop must not spend the forge's rate limit either.
+        // `deploy::pass` says what one pass does.
+        if cfg.deploy_watch && !obs.stop_requested && !obs.base_broken {
+            deploy::pass(durable, &provider, &mut state, &cfg.attribution);
+        }
 
         let next = step(&state, &obs, &doctrine);
         // A pass that is not blocked clears the latch, so a block that returns

--- a/crates/stella-cli/src/self_driving_cmd/drive/deploy.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive/deploy.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The standing deploy watch.
+//!
+//! The base watch guards `main`. This one guards the release path. A red
+//! release run blocks every ship, and it is nobody's one change. So the
+//! answer has the base watch's shape: file the issue if none is open, adopt
+//! it, and let the work path fix it. `deploy_watch = "off"` in `stella.toml`
+//! stands the watch down.
+
+use stella_autonomy::IssueRef;
+
+use super::{Audit, Durable, audit};
+
+/// The workflow file the watch reads.
+///
+/// A repository without it has no release path to watch. The read below
+/// answers `None` there, so the watch sits inert rather than wrong.
+const RELEASE_WORKFLOW: &str = "release.yml";
+
+/// The latest completed release run, as the forge tells it.
+struct ReleaseRun {
+    conclusion: String,
+    url: String,
+}
+
+impl ReleaseRun {
+    /// Whether this run's conclusion is an emergency.
+    ///
+    /// `cancelled`, `skipped` and `neutral` are not red. Each is a person's
+    /// call about one run, not proof the release path broke. Filing on them
+    /// would teach humans to ignore the filings.
+    fn is_red(&self) -> bool {
+        matches!(
+            self.conclusion.as_str(),
+            "failure" | "timed_out" | "startup_failure"
+        )
+    }
+}
+
+/// One pass of the watch: look, and file-and-adopt on red.
+///
+/// Anything short of "red and unfiled" is a quiet no-op. The watch runs on
+/// the poll cadence, and one that talks every pass is noise. The filing
+/// dedups through the tracker label. A restarted process finds the issue
+/// already open and files nothing — the contract the base watch keeps.
+pub(super) fn pass(
+    durable: &Durable,
+    provider: &crate::issue_provider::GhIssueProvider,
+    state: &mut stella_autonomy::LoopState,
+    attribution: &stella_autonomy::Attribution,
+) {
+    let Some(run) = latest_release_run() else {
+        return;
+    };
+    if !run.is_red() {
+        return;
+    }
+
+    match crate::self_driving_cmd::backlog::file_deploy_breakage(
+        provider,
+        RELEASE_WORKFLOW,
+        &run.url,
+        attribution,
+    ) {
+        Ok(Some(key)) => {
+            audit::record(
+                durable,
+                Audit::FiledDeployBreakage,
+                Some(&key),
+                "the release workflow is red and nobody had filed it",
+            );
+            // Adopted the way a base breakage is. A broken release path
+            // outranks queued work. The work path takes it from here.
+            audit::record(
+                durable,
+                Audit::Claimed,
+                Some(&key),
+                "adopting the deploy breakage — nothing ships until it is fixed",
+            );
+            state.claimed.push(IssueRef(key));
+        }
+        // Already filed. The issue carries a defect kind and the most
+        // urgent rung, so the ranked queue brings it to a worker.
+        Ok(None) => {}
+        Err(error) => audit::record(
+            durable,
+            Audit::Transient,
+            None,
+            &format!("the release workflow is red and this could not file it ({error})"),
+        ),
+    }
+}
+
+/// The latest completed release run, or `None` when nobody can say.
+///
+/// It degrades the way the base watch does. An unreadable forge — no `gh`,
+/// no such workflow, a rate limit — makes the watch wait. It must never file
+/// a report about nothing. Completed runs only: a run still going has not
+/// answered yet, and the one before it already did.
+fn latest_release_run() -> Option<ReleaseRun> {
+    let out = std::process::Command::new("gh")
+        .args([
+            "api",
+            &format!(
+                "repos/{{owner}}/{{repo}}/actions/workflows/{RELEASE_WORKFLOW}/runs?status=completed&per_page=1"
+            ),
+            "--jq",
+            ".workflow_runs[0] | {conclusion: (.conclusion // \"\"), url: (.html_url // \"\")}",
+        ])
+        .env("NO_COLOR", "1")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let row: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&out.stdout).trim()).ok()?;
+    Some(ReleaseRun {
+        conclusion: row.get("conclusion")?.as_str()?.to_owned(),
+        url: row.get("url")?.as_str()?.to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only a conclusion that says the path broke counts as red. A cancelled
+    /// or skipped run is somebody's call, not an outage.
+    #[test]
+    fn only_a_broken_conclusion_reads_as_red() {
+        let run = |conclusion: &str| ReleaseRun {
+            conclusion: conclusion.into(),
+            url: String::new(),
+        };
+        assert!(run("failure").is_red());
+        assert!(run("timed_out").is_red());
+        assert!(run("startup_failure").is_red());
+        assert!(!run("success").is_red());
+        assert!(!run("cancelled").is_red());
+        assert!(!run("skipped").is_red());
+        assert!(!run("").is_red(), "an unanswerable run is not an emergency");
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
@@ -92,9 +92,41 @@ pub(super) fn assess_one(
     // The body, so the turn judges the report rather than the headline. An
     // unreadable body is not a reason to skip the issue; a title-only
     // judgement is still better than leaving it unplaced forever.
-    let body = crate::self_driving_cmd::backlog::resolve(provider, &issue.key)
-        .map(|resolved| resolved.body)
+    let resolved = crate::self_driving_cmd::backlog::resolve(provider, &issue.key).ok();
+    let body = resolved
+        .as_ref()
+        .map(|full| full.body.clone())
         .unwrap_or_default();
+
+    // An issue this loop sized, back again as unassessed, was not un-judged.
+    // The triage guard stripped its priority label: the guard takes
+    // priorities only from logins it allows, and the runner's is not one.
+    // Re-triaging would relabel, get stripped, and loop forever. So it
+    // escalates once, and a human fixes the guard's login list.
+    // `crate::self_driving_cmd::triage::assessment_stripped` says why the
+    // size label is the tell.
+    if let Some(full) = &resolved
+        && crate::self_driving_cmd::triage::assessment_stripped(full, &cfg.triage)
+    {
+        crate::self_driving_cmd::backlog::escalate_blocking(
+            provider,
+            &issue.key,
+            "this loop placed the issue, and the triage guard stripped the \
+             priority it wrote — the drive runner's login is not on the \
+             guard's list. Add it to TRIAGE_LOGINS in the guard workflow, or \
+             set the priority from an allowed login. Then remove the \
+             escalation label to requeue",
+            &cfg.attribution.issue_comment,
+        )?;
+        audit::record(
+            durable,
+            Audit::Escalated,
+            Some(&issue.key),
+            "placed before, then stripped by the triage guard — escalated \
+             once rather than re-triaged forever",
+        );
+        return Ok(());
+    }
 
     let prompt = crate::self_driving_cmd::triage::prompt(&issue, &body, &cfg.triage);
     let output = crate::self_driving_cmd::work::run_turn(root, root, &prompt, budget)?;
@@ -129,5 +161,25 @@ pub(super) fn assess_one(
         Some(&issue.key),
         &assessment.reason(),
     );
+
+    // The assessment passed, so readiness is decidable now, and deciding it
+    // costs no model call. A failure here is transient like any other
+    // tracker write. The placed labels already stand, and the next reader
+    // re-derives readiness from the same facts.
+    match crate::self_driving_cmd::triage::flip_ready(provider, &issue.key, &body) {
+        Ok(true) => audit::record(
+            durable,
+            Audit::Triaged,
+            Some(&issue.key),
+            "no open blocker remains — flipped `status:blocked` to `status:ready`",
+        ),
+        Ok(false) => {}
+        Err(error) => audit::record(
+            durable,
+            Audit::Transient,
+            Some(&issue.key),
+            &format!("could not decide readiness ({error}); the labels stand"),
+        ),
+    }
     Ok(())
 }

--- a/crates/stella-cli/src/self_driving_cmd/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/triage.rs
@@ -37,17 +37,50 @@
 //! costs one issue a human glance. Guessing costs an unbounded number of turns.
 
 use stella_autonomy::priority::{TriagePolicy, Unassessed};
-use stella_protocol::issue::{IssueKey, IssueProvider};
+use stella_protocol::issue::{IssueKey, IssueProvider, IssueState};
+
+/// The size vocabulary a triage turn answers in, smallest first.
+///
+/// Fixed rather than declared in [`TriagePolicy`]. A size is an effort
+/// estimate for a human reader, not a rung the ranker consumes, so no
+/// operator needs to respell it. If a workspace ever wants its own scale,
+/// this graduates into the policy the way the ladder did.
+pub(super) const SIZES: [&str; 5] = ["XS", "S", "M", "L", "XL"];
+
+/// Prefix a size answer wears as a tracker label — `M` becomes `size/M`.
+///
+/// The prefix is also the durable mark that this loop placed the issue.
+/// No other actor writes `size/` labels here. That is what lets
+/// [`assessment_stripped`] tell "placed, then stripped by the triage
+/// guard" from "never placed at all".
+pub(super) const SIZE_LABEL_PREFIX: &str = "size/";
+
+/// The label meaning an assessed issue has no open blockers left.
+///
+/// One definition, owned by `stella_autonomy::ready` — the backlog
+/// generator reads the same label this flip writes.
+pub(super) const READY_LABEL: &str = stella_autonomy::ready::READY_LABEL;
+
+/// The label meaning an issue waits on another issue named in its body.
+pub(super) const BLOCKED_LABEL: &str = "status:blocked";
+
+/// The tracker spelling of a size answer.
+#[must_use]
+pub(super) fn size_label(size: &str) -> String {
+    format!("{SIZE_LABEL_PREFIX}{size}")
+}
 
 /// Where a turn decided an issue belongs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum Assessment {
-    /// Work for this loop: a defect kind and a rung.
+    /// Work for this loop: a defect kind, a rung, and an effort size.
     Place {
         /// The kind label to add, from `defect_kinds`.
         kind: String,
         /// The rung label to add, from the ladder.
         priority: String,
+        /// The size answer, from [`SIZES`] — written as [`size_label`].
+        size: String,
     },
     /// Not this loop's work: a kind from `excluded_kinds`.
     Exclude {
@@ -60,7 +93,11 @@ impl Assessment {
     /// The labels this assessment adds to the issue.
     pub(super) fn labels(&self) -> Vec<String> {
         match self {
-            Self::Place { kind, priority } => vec![kind.clone(), priority.clone()],
+            Self::Place {
+                kind,
+                priority,
+                size,
+            } => vec![kind.clone(), priority.clone(), size_label(size)],
             Self::Exclude { kind } => vec![kind.clone()],
         }
     }
@@ -68,8 +105,12 @@ impl Assessment {
     /// A one-line account for the audit log and the issue comment.
     pub(super) fn reason(&self) -> String {
         match self {
-            Self::Place { kind, priority } => {
-                format!("placed as `{kind}` at `{priority}`")
+            Self::Place {
+                kind,
+                priority,
+                size,
+            } => {
+                format!("placed as `{kind}` at `{priority}`, sized `{size}`")
             }
             Self::Exclude { kind } => format!("placed as `{kind}` — not this loop's work"),
         }
@@ -90,19 +131,23 @@ pub(super) fn prompt(issue: &Unassessed, body: &str, policy: &TriagePolicy) -> S
     let rungs = policy.ladder.rungs.join(", ");
     let defects = policy.defect_kinds.join(", ");
     let excluded = policy.excluded_kinds.join(", ");
+    let sizes = SIZES.join(", ");
 
     format!(
         "Triage one issue for this repository. Do not change any code.\n\n\
          Issue #{key}: {title}\n\n\
          --- body ---\n{body}\n--- end body ---\n\n\
-         Decide two things, judged against this project's context records and \
+         Decide three things, judged against this project's context records and \
          steering documents — they are the standard, not your own preferences:\n\n\
          1. Is this a defect this repository's self-driving loop should work, \
          or is it something else?\n\
-         2. If it is work, how urgent is it?\n\n\
+         2. If it is work, how urgent is it?\n\
+         3. If it is work, how large is it — judged on the largest of risk, \
+         blast radius and effort?\n\n\
          Answer on a single final line, in exactly one of these two forms, using \
          only the words listed:\n\n\
-         {MARKER} kind=<one of: {defects}>; priority=<one of: {rungs}>\n\
+         {MARKER} kind=<one of: {defects}>; priority=<one of: {rungs}>; \
+         size=<one of: {sizes}>\n\
          {MARKER} exclude=<one of: {excluded}>\n\n\
          Any other vocabulary is not an answer. If the issue is too poorly \
          described to place, say so in prose and emit no {MARKER} line.",
@@ -170,6 +215,7 @@ pub(super) fn parse(output: &str, policy: &TriagePolicy) -> Option<Assessment> {
 
     let mut kind = None;
     let mut priority = None;
+    let mut size = None;
     let mut exclude = None;
 
     for field in line.split(';') {
@@ -180,6 +226,7 @@ pub(super) fn parse(output: &str, policy: &TriagePolicy) -> Option<Assessment> {
         match name.trim() {
             "kind" => kind = Some(value),
             "priority" => priority = Some(value),
+            "size" => size = Some(value),
             "exclude" => exclude = Some(value),
             _ => {}
         }
@@ -196,8 +243,18 @@ pub(super) fn parse(output: &str, policy: &TriagePolicy) -> Option<Assessment> {
 
     let kind = kind?;
     let priority = priority?;
-    (policy.defect_kinds.contains(&kind) && policy.ladder.rungs.contains(&priority))
-        .then_some(Assessment::Place { kind, priority })
+    // A placement without a size is half an answer, and a half answer is
+    // a refusal. Accepting it would ship an issue with no size label, and
+    // the caller promises exactly one size per assessed issue.
+    let size = size?;
+    (policy.defect_kinds.contains(&kind)
+        && policy.ladder.rungs.contains(&priority)
+        && SIZES.contains(&size.as_str()))
+    .then_some(Assessment::Place {
+        kind,
+        priority,
+        size,
+    })
 }
 
 /// Write an assessment onto the issue.
@@ -238,6 +295,85 @@ pub(super) fn apply(
         .map_err(|error| error.to_string())
 }
 
+/// Did the loop place this issue, and did the guard then strip it?
+///
+/// `triage-guard.yml` strips a priority applied by any login outside its
+/// `TRIAGE_LOGINS` list, and re-queues the issue as unassessed. The queue
+/// read cannot tell that issue from one nobody judged. A runner on a
+/// disallowed login would re-triage it, get stripped again, and pay for
+/// the same turn forever.
+///
+/// The size label is the tell. Only this loop writes `size/` labels, the
+/// guard strips only priorities, and every placement writes both. So
+/// "sized with no rung" can only mean the placement landed and its
+/// priority was removed. The caller escalates once instead of re-asking,
+/// and the escalation label keeps the issue out of the queue.
+#[must_use]
+pub(super) fn assessment_stripped(
+    issue: &stella_protocol::issue::Issue,
+    policy: &TriagePolicy,
+) -> bool {
+    let sized = issue
+        .labels
+        .iter()
+        .any(|label| label.name.starts_with(SIZE_LABEL_PREFIX));
+    let runged = policy
+        .ladder
+        .rungs
+        .iter()
+        .any(|rung| issue.labels.iter().any(|label| &label.name == rung));
+    sized && !runged
+}
+
+/// Flip a placed issue from blocked to ready, if nothing blocks it.
+///
+/// The `Blocked by:` lines are parsed by `stella_autonomy::ready` — the
+/// one definition the backlog generator reads too. Each declared blocker
+/// is then resolved through the port. The body is a claim and the tracker
+/// holds the fact: a blocker that has since closed is not a blocker, and
+/// one the tracker cannot find never was. The flip happens only when no
+/// blocker is still open — one relabel adding [`READY_LABEL`] and removing
+/// [`BLOCKED_LABEL`]. For an issue never labelled blocked, the removal is
+/// a no-op.
+///
+/// A blocker the forge cannot answer for fails the whole decision. Reading
+/// an outage as "closed" would mark waiting work ready.
+pub(super) fn flip_ready(
+    provider: &dyn IssueProvider,
+    key: &str,
+    body: &str,
+) -> Result<bool, String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+
+    for blocker in stella_autonomy::ready::blocker_refs(body) {
+        let blocker = blocker.to_string();
+        // An issue cannot hold itself out of the queue.
+        if blocker == key {
+            continue;
+        }
+        match runtime.block_on(provider.get(&IssueKey::from(blocker.as_str()))) {
+            Ok(issue) if issue.state == IssueState::Open => return Ok(false),
+            Ok(_) => {}
+            // A key the tracker cannot find is not an open blocker — the
+            // declaration outlived the issue, or never named one.
+            Err(stella_protocol::issue::IssueError::NotFound { .. }) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+
+    runtime
+        .block_on(provider.relabel(
+            &IssueKey::from(key),
+            &[READY_LABEL.to_owned()],
+            &[BLOCKED_LABEL.to_owned()],
+        ))
+        .map_err(|error| error.to_string())?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,11 +395,44 @@ mod tests {
     #[test]
     fn a_declared_answer_places_the_issue() {
         assert_eq!(
-            parse("ASSESSMENT: kind=bug; priority=P0", &policy()),
+            parse("ASSESSMENT: kind=bug; priority=P0; size=M", &policy()),
             Some(Assessment::Place {
                 kind: "bug".into(),
-                priority: "P0".into()
+                priority: "P0".into(),
+                size: "M".into()
             })
+        );
+    }
+
+    /// **The sizing witness.** A sized placement parses, and its labels carry
+    /// exactly one `size/` label alongside the kind and the rung — the shape
+    /// the tracker convention asks for.
+    #[test]
+    fn a_sized_assessment_parses_and_writes_exactly_one_size_label() {
+        let assessment =
+            parse("ASSESSMENT: kind=bug; priority=P1; size=XL", &policy()).expect("a placement");
+        let labels = assessment.labels();
+        assert_eq!(labels, vec!["bug", "P1", "size/XL"]);
+        assert_eq!(
+            labels
+                .iter()
+                .filter(|label| label.starts_with(SIZE_LABEL_PREFIX))
+                .count(),
+            1,
+            "exactly one size label per assessed issue"
+        );
+    }
+
+    /// A placement that names no size is half an answer, and half an answer
+    /// is a refusal — otherwise the issue ships without the size label the
+    /// convention promises.
+    #[test]
+    fn a_placement_without_a_size_is_not_an_answer() {
+        assert_eq!(parse("ASSESSMENT: kind=bug; priority=P0", &policy()), None);
+        assert_eq!(
+            parse("ASSESSMENT: kind=bug; priority=P0; size=huge", &policy()),
+            None,
+            "an invented size is no better than a missing one"
         );
     }
 
@@ -279,7 +448,7 @@ mod tests {
     fn an_answer_inside_the_json_envelope_is_still_an_answer() {
         let envelope = serde_json::json!({
             "status": "ok",
-            "result": "Looking at the context records, this blocks a release.\nASSESSMENT: kind=bug; priority=P0",
+            "result": "Looking at the context records, this blocks a release.\nASSESSMENT: kind=bug; priority=P0; size=S",
         })
         .to_string();
 
@@ -293,7 +462,8 @@ mod tests {
             parse(&envelope, &policy()),
             Some(Assessment::Place {
                 kind: "bug".into(),
-                priority: "P0".into()
+                priority: "P0".into(),
+                size: "S".into()
             })
         );
     }
@@ -318,11 +488,11 @@ mod tests {
     #[test]
     fn a_label_outside_the_vocabulary_is_not_an_answer() {
         assert_eq!(
-            parse("ASSESSMENT: kind=bug; priority=urgent", &policy()),
+            parse("ASSESSMENT: kind=bug; priority=urgent; size=M", &policy()),
             None
         );
         assert_eq!(
-            parse("ASSESSMENT: kind=defect; priority=P0", &policy()),
+            parse("ASSESSMENT: kind=defect; priority=P0; size=M", &policy()),
             None
         );
         assert_eq!(parse("ASSESSMENT: exclude=whatever", &policy()), None);
@@ -331,14 +501,15 @@ mod tests {
     /// Thinking out loud before committing is fine — the last line wins.
     #[test]
     fn the_last_assessment_line_wins() {
-        let output = "ASSESSMENT: kind=bug; priority=P2\n\
+        let output = "ASSESSMENT: kind=bug; priority=P2; size=S\n\
                       on reflection this blocks a release\n\
-                      ASSESSMENT: kind=bug; priority=P0";
+                      ASSESSMENT: kind=bug; priority=P0; size=S";
         assert_eq!(
             parse(output, &policy()),
             Some(Assessment::Place {
                 kind: "bug".into(),
-                priority: "P0".into()
+                priority: "P0".into(),
+                size: "S".into()
             })
         );
     }
@@ -380,6 +551,218 @@ mod tests {
             Some(Assessment::Exclude {
                 kind: "enhancement".into()
             })
+        );
+    }
+
+    use async_trait::async_trait;
+    use stella_protocol::issue::{Issue, IssueClass, IssueDraft, IssueError, IssueLabel};
+
+    fn issue(key: &str, state: IssueState, labels: &[&str], body: &str) -> Issue {
+        Issue {
+            key: IssueKey::from(key),
+            title: format!("issue {key}"),
+            body: body.into(),
+            state,
+            class: IssueClass::Bug,
+            labels: labels.iter().copied().map(IssueLabel::from).collect(),
+            created_at: "2026-08-19T00:00:00Z".into(),
+            updated_at: "2026-08-19T00:00:00Z".into(),
+            url: String::new(),
+            parent: None,
+        }
+    }
+
+    /// One recorded relabel: the key, the labels added, the labels removed.
+    type Relabel = (String, Vec<String>, Vec<String>);
+
+    /// A tracker that answers `get` from a fixed set and records relabels —
+    /// no GitHub, no credential, no subprocess.
+    #[derive(Default)]
+    struct FlipFixture {
+        known: Vec<Issue>,
+        relabels: std::sync::Mutex<Vec<Relabel>>,
+    }
+
+    impl FlipFixture {
+        fn relabels(&self) -> Vec<Relabel> {
+            self.relabels.lock().expect("fixture lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl IssueProvider for FlipFixture {
+        fn id(&self) -> &str {
+            "fixture"
+        }
+
+        async fn list_open(&self, limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(self
+                .known
+                .iter()
+                .filter(|issue| issue.state == IssueState::Open)
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+
+        async fn get(&self, key: &IssueKey) -> Result<Issue, IssueError> {
+            self.known
+                .iter()
+                .find(|issue| issue.key == *key)
+                .cloned()
+                .ok_or_else(|| IssueError::NotFound { key: key.clone() })
+        }
+
+        async fn file(&self, _draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            Ok(IssueKey::from("1000"))
+        }
+
+        async fn close(
+            &self,
+            _key: &IssueKey,
+            _receipt: &str,
+            _state: &str,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn relabel(
+            &self,
+            key: &IssueKey,
+            add: &[String],
+            remove: &[String],
+        ) -> Result<(), IssueError> {
+            self.relabels.lock().expect("fixture lock").push((
+                key.as_str().to_owned(),
+                add.to_vec(),
+                remove.to_vec(),
+            ));
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            _body: Option<&str>,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+    }
+
+    /// **The ready-flip witness.** The flip happens only when no declared
+    /// blocker is still open, and it is one relabel — ready on, blocked off.
+    #[test]
+    fn the_ready_flip_happens_only_when_no_blocker_is_still_open() {
+        let body = "Fix the thing.\n\nBlocked by: #7\n";
+
+        // #7 is open: no flip, and the tracker is not written to at all.
+        let blocked = FlipFixture {
+            known: vec![issue("7", IssueState::Open, &["bug"], "")],
+            ..FlipFixture::default()
+        };
+        assert_eq!(flip_ready(&blocked, "42", body), Ok(false));
+        assert!(
+            blocked.relabels().is_empty(),
+            "a blocked issue must not be relabelled"
+        );
+
+        // #7 has closed: the flip happens, as exactly one relabel.
+        let cleared = FlipFixture {
+            known: vec![issue("7", IssueState::Closed, &["bug"], "")],
+            ..FlipFixture::default()
+        };
+        assert_eq!(flip_ready(&cleared, "42", body), Ok(true));
+        assert_eq!(
+            cleared.relabels(),
+            vec![(
+                "42".to_owned(),
+                vec![READY_LABEL.to_owned()],
+                vec![BLOCKED_LABEL.to_owned()]
+            )]
+        );
+    }
+
+    /// A blocker the tracker never heard of is not an open blocker — the
+    /// declaration outlived the issue, and the flip proceeds.
+    #[test]
+    fn a_blocker_the_tracker_cannot_find_does_not_block() {
+        let fixture = FlipFixture::default();
+        assert_eq!(flip_ready(&fixture, "42", "Blocked by: #9\n"), Ok(true));
+        assert_eq!(fixture.relabels().len(), 1);
+    }
+
+    /// Several blockers on one line all count, and any one still open holds
+    /// the flip back.
+    #[test]
+    fn any_one_open_blocker_holds_the_flip() {
+        let fixture = FlipFixture {
+            known: vec![
+                issue("7", IssueState::Closed, &["bug"], ""),
+                issue("8", IssueState::Open, &["bug"], ""),
+            ],
+            ..FlipFixture::default()
+        };
+        assert_eq!(
+            flip_ready(&fixture, "42", "Blocked by: #7, #8\n"),
+            Ok(false)
+        );
+        assert!(fixture.relabels().is_empty());
+    }
+
+    /// **The strip witness.** An issue this loop sized whose rung has been
+    /// removed reads as stripped — and once the caller's one escalation
+    /// lands, the queue drops it on the escalation label, so a guard that
+    /// disagrees with the runner's login costs one human glance, never an
+    /// infinite re-triage loop.
+    #[test]
+    fn a_stripped_assessment_escalates_once_rather_than_looping() {
+        let policy = policy();
+
+        let stripped = issue("42", IssueState::Open, &["bug", "size/M", "triage"], "");
+        assert!(
+            assessment_stripped(&stripped, &policy),
+            "sized with no rung — only the guard produces this shape"
+        );
+        assert!(
+            !assessment_stripped(
+                &issue("43", IssueState::Open, &["bug", "size/M", "P1"], ""),
+                &policy
+            ),
+            "an intact assessment is not a strip"
+        );
+        assert!(
+            !assessment_stripped(
+                &issue("44", IssueState::Open, &["bug", "triage"], ""),
+                &policy
+            ),
+            "an issue never assessed has no size label and is a question, not a strip"
+        );
+
+        // The once-ness: after the caller escalates, the issue leaves the
+        // queue on the escalation label — neither ranked nor re-asked.
+        let escalated = stella_autonomy::priority::triage(
+            vec![stella_autonomy::QueueIssue {
+                number: 42,
+                title: "stripped".into(),
+                created_at: "2026-08-19T00:00:00Z".into(),
+                labels: ["bug", "size/M", stella_autonomy::ESCALATION_LABEL]
+                    .iter()
+                    .map(|name| stella_autonomy::IssueLabel {
+                        name: (*name).to_owned(),
+                    })
+                    .collect(),
+                url: String::new(),
+            }],
+            &policy,
+        );
+        assert!(
+            escalated.is_empty(),
+            "an escalated strip must not come back as work or as a question"
         );
     }
 }

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -409,6 +409,12 @@ pub struct SelfDrivingSection {
     /// find it to turn the gate on.
     #[serde(default)]
     pub residue_gate: ResidueGateSwitch,
+    /// `deploy_watch = "on" | "off"` — whether the drive loop also watches
+    /// the release workflow's latest run and files on red. On unless an
+    /// operator stands it down: a watch that must be asked for is a watch
+    /// that is off exactly when nobody thought about it.
+    #[serde(default)]
+    pub deploy_watch: DeployWatch,
 }
 
 /// The end-of-turn residue gate's switch (`doc:backlog-self-driving` B5).
@@ -430,6 +436,29 @@ impl ResidueGateSwitch {
     #[must_use]
     pub fn enabled(self) -> bool {
         matches!(self, Self::On)
+    }
+}
+
+/// The two positions of the deploy watch.
+///
+/// A named switch rather than a bare boolean so the config reads as the
+/// operator speaks — `deploy_watch = "off"` — and so an unset field has a
+/// default the type itself declares.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeployWatch {
+    /// Watch the release workflow, and file-and-adopt on red.
+    #[default]
+    On,
+    /// Do not watch it.
+    Off,
+}
+
+impl DeployWatch {
+    /// Whether the watch runs.
+    #[must_use]
+    pub fn enabled(self) -> bool {
+        self == Self::On
     }
 }
 

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -429,21 +429,32 @@ evolution_surfaces! {
          parks the loop at its next boundary, and applying the escalation label withdraws an \
          issue from the queue across restarts";
 
-    /// Issues Stella files about its own leftover work.
+    /// The backlog Stella governs for itself. These labels steer what its
+    /// own loop takes next. It also files alarms to itself here.
     Backlog => "backlog",
         EvolutionPosture::Shipped {
-            mechanism: "the end-of-turn residue gate (`doc:backlog-self-driving` phase B5). \
-                        `detect_residue` scans the turn's transcript with a fixed phrase \
-                        list. No model call. Each hit is filed through `file_finding`. \
-                        The seen-set dedup and the convention check apply here too. \
-                        `residue_gate = \"off\"` in `stella.toml` turns the gate off",
-            witness: "two_residue_statements_file_two_issues_and_a_rerun_files_none",
+            mechanism: "drive's triage places an issue in the operator's own words — \
+                        kind, rung, and a `size/` scale — and writes the labels through \
+                        the issue port. It flips `status:blocked` to `status:ready` once \
+                        every `Blocked by` in the body has closed. The base and deploy \
+                        watches file-and-adopt a breakage issue when `main` or the \
+                        release run goes red with none open. The end-of-turn residue \
+                        gate (`doc:backlog-self-driving` phase B5) files leftover work \
+                        too: `detect_residue` scans the turn's transcript with a fixed \
+                        phrase list. No model call. Each hit is filed through \
+                        `file_finding`, under the seen-set dedup and the convention \
+                        check. Every write is a label or a filing, signed and deduped — \
+                        never an edit to anybody's words",
+            witness: "a_sized_assessment_parses_and_writes_exactly_one_size_label",
         },
         EvolutionTiming::BetweenTurns,
-        ImpactClass::AdvisoryRecord,
-        "close the filed issue. The digest stays in the seen-set, so the same statement \
-         never re-files. `residue_gate = \"off\"` stops the gate. Deleting a digest line \
-         from `seen.txt` re-arms that one statement";
+        ImpactClass::SteeringDirective,
+        "re-label the issue by hand — the next cycle reads the labels, not the loop's \
+         comment. The triage guard strips a rung set by a login off its list. Removing \
+         the escalation label requeues the issue. `deploy_watch = \"off\"` in \
+         `stella.toml` stands the release watch down, and `residue_gate = \"off\"` \
+         stops the residue gate. A filed residue statement's digest stays in the \
+         seen-set, so it never re-files; deleting its line from `seen.txt` re-arms it";
 }
 
 /// How many live rows name no witness.
@@ -482,7 +493,7 @@ pub const UNWITNESSED_EVOLUTION_BASELINE: usize = 0;
 /// check it asserts the row's own mechanism.** A row is a claim like any other
 /// (CLAUDE.md), and the name of a test is not evidence for it.
 #[cfg(test)]
-fn evolution_sources() -> [&'static str; 12] {
+fn evolution_sources() -> [&'static str; 13] {
     [
         // The Delivery row's witness: what the backlog picks and the
         // ledger row it writes, proven on a fixture tracker.
@@ -501,8 +512,11 @@ fn evolution_sources() -> [&'static str; 12] {
         // The SkillInvocation row's witness: an auto-selected skill's
         // directives reach the plane through the recall seam.
         include_str!("../../stella-cli/src/memory/tests/skill_event.rs"),
-        // The Backlog row's witness sits beside the gate it proves.
+        // The residue gate's proof sits beside the gate it proves.
         include_str!("../../stella-cli/src/self_driving_cmd/residue.rs"),
+        // The Backlog row's witness. A sized answer becomes the labels
+        // the tracker convention asks for.
+        include_str!("../../stella-cli/src/self_driving_cmd/triage.rs"),
     ]
 }
 

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -371,6 +371,42 @@ no-workspace-dependency property that lets the Observatory link its folds. That
 is the same trade `rank_defects` already makes, and the one mapping from a
 tracker's shape into this one lives in the caller.
 
+### 3.1b Sizing, readiness, and the guard's logins
+
+A passing assessment answers three axes, not two: kind, priority, and a size.
+The size scale is `XS`/`S`/`M`/`L`/`XL`, judged on the largest of risk, blast
+radius and effort. It lands on the tracker as exactly one `size/<answer>`
+label. The size is an estimate for a human reader, not an input to the
+ranker, so the scale is fixed in code rather than declared per workspace.
+The drive loop's own label pass installs the labels, so a fresh repository
+needs no preparation.
+
+The same pass decides readiness. An issue body may declare
+`Blocked by: #<key>` lines. After an assessment lands, each declared blocker
+is resolved through the issue port. When none is still open, the loop flips
+`status:blocked` to `status:ready` in one relabel. A blocker the tracker
+cannot answer for holds the flip — an outage must not mark work ready.
+
+**The expected login story.** `triage-guard.yml` enforces separation of
+duties. A priority set by a login outside its `TRIAGE_LOGINS` list is
+stripped, and the issue is re-queued as `triage`. So the drive runner must
+authenticate `gh` as a login on that list — the triage identity, or the
+maintainer holding interim triage authority. A runner on any other login
+still judges correctly, but the guard undoes its priority writes. The loop
+detects that shape — an issue carrying its own `size/` label with no rung —
+as *placed, then stripped*. It escalates the issue once to a human instead
+of re-triaging forever. The fix is operational, not code: add the runner's
+login to `TRIAGE_LOGINS`, or run the loop under a login already there. Then
+remove the escalation label to requeue.
+
+**The deploy watch.** Beside the base watch, each poll may also read the
+release workflow's latest completed run, through the same forge pathway. On
+a red conclusion with no open report, the loop files one and adopts it. The
+`release-red` label dedups it, exactly as base breakage dedups on
+`main-red`. `deploy_watch = "off"` under `[self_driving]` in `stella.toml`
+stands the watch down. This is only the watch half of shipping. The
+autonomous release verb stays deferred, as §6.4 argues it should.
+
 ### 3.2 `work` — one unit of backlog, through Stella's own loop
 
 | Call | Returns | What it does |


### PR DESCRIPTION
Closes #5570

## What this does

**(a) Triage completeness**
- The `ASSESSMENT` line gains a third axis: `size=<XS|S|M|L|XL>`. A placement without a valid size is a refusal, and `labels()` writes exactly one `size/<answer>` label beside the kind and the rung. The drive label pass installs the `size/` scale and the `status:ready`/`status:blocked` pair, so a fresh repository needs no preparation.
- After a passing assessment, every `Blocked by: #N` in the body is resolved through the issue port. When none is still open, one relabel flips `status:blocked` → `status:ready`. A blocker the forge cannot answer for holds the flip.
- Guard collision: an issue carrying its own `size/` label with no rung can only mean *placed, then stripped by `triage-guard.yml`* — the drive runner's login is outside `TRIAGE_LOGINS`. `assess_one` escalates it once, naming the fix, instead of re-triaging forever. The runner's expected login story is documented in `docs/spec/backlog-self-driving.md` §3.1b.

**(b) Deploy watch**
- `drive/deploy.rs` extends the standing base watch: each poll (when the base is fine and no stop is requested) reads the release workflow's latest completed run over the same `gh api` pathway. On a red conclusion with no open report, it files a `release-red` issue via `file_deploy_breakage` — deduped by label, the `file_base_breakage` pattern — and adopts it into the claimed set.
- Config switch: `deploy_watch = "on" | "off"` under `[self_driving]` in `stella.toml`, default on.

## Witnesses (fixture/mock forge, no network)

- `a_sized_assessment_parses_and_writes_exactly_one_size_label`, `a_placement_without_a_size_is_not_an_answer`
- `the_ready_flip_happens_only_when_no_blocker_is_still_open`, `any_one_open_blocker_holds_the_flip`, `a_blocker_the_tracker_cannot_find_does_not_block`
- `a_stripped_assessment_escalates_once_rather_than_looping`
- `a_red_release_run_is_filed_exactly_once`, `an_unreachable_tracker_fails_the_deploy_filing`, `only_a_broken_conclusion_reads_as_red`
- `the_deploy_watch_defaults_on_and_can_be_stood_down`

## Ledger

- Evolution row `Backlog` added (Shipped, witness named, `SteeringDirective`); `UNWITNESSED_EVOLUTION_BASELINE` stays 0.

## Verification

- `cargo test -p stella-cli --bin stella -- self_driving_cmd` — 178 passed
- `cargo test -p stella-parity` — 23 passed
- `cargo clippy -p stella-cli -p stella-parity --all-targets` — clean
- `check-prose`, `check-line-citations`, `check-file-size` — OK

## Summary by Sourcery

Make the self-driving backlog loop size and unblock assessed work while monitoring failed release workflows.

New Features:
- Extend self-driving triage assessments with validated XS–XL sizing and automatic readiness updates based on issue blockers.
- Add an opt-out release workflow watch that files and adopts a deduplicated issue when the latest completed release run fails.

Bug Fixes:
- Detect assessments whose priority labels were stripped by the triage guard and escalate them once instead of repeatedly re-triaging them.

Enhancements:
- Install the size and readiness label vocabulary automatically for fresh repositories.
- Document triage guard login requirements and the new sizing, readiness, and deployment-watch behavior.

Documentation:
- Document sizing and readiness semantics, guard-login expectations, and release workflow monitoring in the self-driving backlog specification.

Tests:
- Add fixture-based coverage for sizing validation, blocker-dependent ready flips, stripped-assessment escalation, release failure filing and deduplication, and deployment-watch configuration.

Chores:
- Promote the Backlog evolution entry to a witnessed steering directive while keeping the unwitnessed baseline unchanged.