### PR TITLE
feat(stella-cli): the self-driving loop's worker is a setting, not a hardcoded child

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -17,6 +17,7 @@ mod audit;
 mod backlog;
 mod budget;
 pub(crate) mod claim;
+mod claude_worker;
 // `pub(crate)` rather than private: `plugin_cmd::configure` asserts against
 // this reader directly (#3999). A package that configures attribution has to
 // be shown changing what the loop *reads*, not merely what a file *holds* —

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -1183,7 +1183,8 @@ fn work_issue(
     let root = state::repo_root();
     let issue = backlog::resolve(&crate::issue_provider::GhIssueProvider, key)?;
 
-    let attribution = config::load(&root).attribution;
+    let loop_config = config::load(&root);
+    let attribution = &loop_config.attribution;
 
     // The `PreIssueWork` gate (#3599), before the worktree exists and before
     // any model call — so a skip costs nothing and leaves nothing behind.
@@ -1220,7 +1221,7 @@ fn work_issue(
     // child turn's ceiling is decided and one place its cost is folded back in
     // (#4353).
     let mut budget = budget::RunBudget::new(flags.clone());
-    let outcome = work::start(&root, &issue, &mut budget, &attribution)?;
+    let outcome = work::start(&root, &issue, &mut budget, attribution, &loop_config.worker)?;
     let learned = learning::tally(&root).since(learned_before);
     hooks::after_issue_work(&root, &settings, &hook_issue, hook_outcome(&outcome));
 

--- a/crates/stella-cli/src/self_driving_cmd/claude_worker.rs
+++ b/crates/stella-cli/src/self_driving_cmd/claude_worker.rs
@@ -1,0 +1,257 @@
+//! The claude worker — one issue through Claude Code, in the same worktree.
+//!
+//! Separated from the parent so each worker's child process is a file rather
+//! than a pair of arms in one function. What this module owns is everything
+//! specific to claude: how its command line is built, how its output is read,
+//! and the one thing it cannot honour. The parent still decides which worker
+//! runs, and still measures the outcome from the tree either way.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Why a dollar cap and a claude worker cannot be combined.
+///
+/// The cap is refused, not ignored. Claude Code reports no cost the run budget
+/// can read. Every turn would be charged nothing, so the ceiling would never
+/// be reached. Ask for a $5 run and you would get an unbounded one, with
+/// nothing said. A cap that is quietly infinite is worse than no cap at all.
+pub(super) fn uncappable(cap: f64) -> String {
+    format!(
+        "a claude worker cannot be held to --spend-limit ${cap:.2}: claude does \
+         not report what a turn cost in the form this loop reads. Set \
+         worker.max_turns, or drop the dollar cap."
+    )
+}
+
+/// The Claude Code child, built but not spawned.
+///
+/// Building and spawning are split so the whole command is a test seam. A
+/// test can then read what the settings put on the command line. It does not
+/// have to run an agent to find out.
+fn claude_command(
+    dir: &Path,
+    prompt: &str,
+    worker: &crate::settings::toml_config::WorkerSection,
+) -> Command {
+    let mut cmd = Command::new(&worker.command);
+    cmd.current_dir(dir)
+        .arg("-p")
+        .arg("--output-format")
+        .arg("json");
+    if let Some(model) = worker.model.as_deref() {
+        cmd.arg("--model").arg(model);
+    }
+    if let Some(max_turns) = worker.max_turns {
+        cmd.arg("--max-turns").arg(max_turns.to_string());
+    }
+    // Only when the operator asked for it in as many words. Choosing a worker
+    // and widening what that worker may do are two decisions, and this is the
+    // second one.
+    if worker.dangerously_skip_permissions {
+        cmd.arg("--dangerously-skip-permissions");
+    }
+    cmd.arg(prompt);
+    cmd
+}
+
+/// Run Claude Code non-interactively in one issue's isolated worktree.
+///
+/// The prompt rides as an argument, and stdin is closed. Nobody is watching
+/// this loop. A worker that stops to ask a question has to fail, rather than
+/// wait for a person who is not there.
+pub(super) fn run_claude(
+    dir: &Path,
+    prompt: &str,
+    worker: &crate::settings::toml_config::WorkerSection,
+) -> Result<String, String> {
+    let out = claude_command(dir, prompt, worker)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .output()
+        .map_err(|error| {
+            format!(
+                "could not start claude (`{}`): {error}. Set worker.command to \
+                 the executable's name on PATH, or an absolute path to it.",
+                worker.command
+            )
+        })?;
+
+    let summary = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if out.status.success() {
+        Ok(summary)
+    } else {
+        Err(format!(
+            "claude exited {}{}",
+            out.status.code().unwrap_or(-1),
+            match claude_reason(&summary) {
+                Some(reason) => format!(" — {reason}"),
+                None => String::new(),
+            }
+        ))
+    }
+}
+
+/// What Claude Code said about a run that ended badly.
+///
+/// Its `--output-format json` is not the shape the stella worker's parser
+/// reads, so that parser is not reused. Aimed at this document it finds none
+/// of its keys. It then falls back to the last line, and for one line of JSON
+/// that is the whole document.
+///
+/// `result` carries the text a person reads, in both the success and the error
+/// shape. `error` appears when a run failed before there was any result.
+fn claude_reason(summary: &str) -> Option<String> {
+    let condense = |text: &str| -> Option<String> {
+        let condensed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        if condensed.is_empty() {
+            return None;
+        }
+        let clipped: String = condensed.chars().take(600).collect();
+        Some(if condensed.chars().count() > 600 {
+            format!("{clipped}…")
+        } else {
+            clipped
+        })
+    };
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(summary) else {
+        return condense(summary.lines().last().unwrap_or(summary));
+    };
+    ["result", "error"]
+        .iter()
+        .find_map(|key| value.get(key).and_then(serde_json::Value::as_str))
+        .and_then(condense)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::toml_config::WorkerKind;
+
+    /// The claude child's argv, as strings.
+    fn claude_args(worker: &crate::settings::toml_config::WorkerSection) -> Vec<String> {
+        claude_command(Path::new("/tmp/worktree"), "fix #1", worker)
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// A worker section with claude selected and nothing else said.
+    fn claude_worker() -> crate::settings::toml_config::WorkerSection {
+        crate::settings::toml_config::WorkerSection {
+            kind: WorkerKind::Claude,
+            ..Default::default()
+        }
+    }
+
+    /// **Witness.** Selecting claude does not also hand it permission bypass.
+    ///
+    /// The two are separate decisions. This flag lets the worker write files
+    /// and run commands without asking. It appears only when someone wrote it
+    /// down.
+    #[test]
+    fn a_claude_worker_does_not_skip_permissions_unless_asked() {
+        let args = claude_args(&claude_worker());
+        assert!(
+            !args
+                .iter()
+                .any(|arg| arg == "--dangerously-skip-permissions"),
+            "the default claude worker must not bypass permissions: {args:?}"
+        );
+
+        let asked = crate::settings::toml_config::WorkerSection {
+            dangerously_skip_permissions: true,
+            ..claude_worker()
+        };
+        assert!(
+            claude_args(&asked)
+                .iter()
+                .any(|arg| arg == "--dangerously-skip-permissions"),
+            "asking for the bypass must put it on the command line"
+        );
+    }
+
+    /// **Witness.** The worker's settings reach claude's command line, and the
+    /// ones that were not set put nothing there.
+    #[test]
+    fn the_claude_worker_settings_reach_the_command_line() {
+        let bare = claude_args(&claude_worker());
+        assert_eq!(
+            bare,
+            ["-p", "--output-format", "json", "fix #1"],
+            "an unconfigured claude worker sends only the print-mode contract \
+             and the prompt"
+        );
+
+        let configured = crate::settings::toml_config::WorkerSection {
+            model: Some("opus".to_owned()),
+            max_turns: Some(40),
+            ..claude_worker()
+        };
+        assert_eq!(
+            claude_args(&configured),
+            [
+                "-p",
+                "--output-format",
+                "json",
+                "--model",
+                "opus",
+                "--max-turns",
+                "40",
+                "fix #1"
+            ]
+        );
+    }
+
+    /// **Witness.** A dollar cap against a claude worker is refused, and the
+    /// refusal says what to reach for instead.
+    ///
+    /// The alternative is the dangerous one. The run budget charges what a
+    /// turn reports. Claude reports nothing it can read, so every turn would
+    /// cost zero, and a $5 run would quietly become an unbounded one.
+    #[test]
+    fn a_dollar_cap_against_a_claude_worker_is_refused() {
+        let refusal = uncappable(5.0);
+        assert!(
+            refusal.contains("--spend-limit $5.00"),
+            "the refusal names the cap that was asked for: {refusal}"
+        );
+        assert!(
+            refusal.contains("worker.max_turns"),
+            "a refusal that names no alternative is a dead end: {refusal}"
+        );
+    }
+
+    /// **Witness.** Claude's own JSON is read by its own keys.
+    ///
+    /// The stella worker's parser reads a different shape. Aimed at this
+    /// document it matches nothing and falls back to the last line. For one
+    /// line of JSON that is the whole document, quoted at a person as if it
+    /// were a diagnosis.
+    #[test]
+    fn a_failed_claude_run_reports_what_claude_said() {
+        let summary =
+            r#"{"type":"result","is_error":true,"result":"I need write access to continue."}"#;
+        assert_eq!(
+            claude_reason(summary).as_deref(),
+            Some("I need write access to continue.")
+        );
+
+        assert_eq!(
+            claude_reason(r#"{"error":"credit balance is too low"}"#).as_deref(),
+            Some("credit balance is too low")
+        );
+
+        // Not JSON at all — a crash, a shell error — still yields the last
+        // line, so a missing executable reads as one.
+        assert_eq!(
+            claude_reason("boom\ncommand not found: claude").as_deref(),
+            Some("command not found: claude")
+        );
+
+        // JSON this parser does not recognise reports nothing, so the caller
+        // prints the bare exit code rather than a whole document.
+        assert_eq!(claude_reason(r#"{"type":"result"}"#), None);
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -63,6 +63,8 @@ pub(crate) struct LoopConfig {
     /// Whether the drive loop also watches the release workflow's latest run
     /// and files on red. On unless `stella.toml` says `deploy_watch = "off"`.
     pub deploy_watch: bool,
+    /// Which coding agent performs issue work.
+    pub worker: crate::settings::toml_config::WorkerSection,
 }
 
 impl Default for LoopConfig {
@@ -77,6 +79,7 @@ impl Default for LoopConfig {
             verify_timeout_secs: 1800,
             residue_gate: true,
             deploy_watch: true,
+            worker: crate::settings::toml_config::WorkerSection::default(),
         }
     }
 }
@@ -103,6 +106,7 @@ pub(crate) fn load(root: &Path) -> LoopConfig {
         verify_timeout_secs: parsed.self_driving.verify.timeout_secs.unwrap_or(1800),
         residue_gate: parsed.self_driving.residue_gate.enabled(),
         deploy_watch: parsed.self_driving.deploy_watch.enabled(),
+        worker: parsed.self_driving.worker,
     }
 }
 
@@ -223,6 +227,63 @@ branch_prefix = "oxagen/"
         assert_eq!(cfg.attribution.branch_prefix(), "oxagen/");
         // Unmentioned surfaces keep identifying the loop rather than blanking.
         assert_eq!(cfg.attribution.issue, stella_autonomy::SIGNATURE);
+    }
+
+    /// The witness for the worker seam: choosing claude, and the controls that
+    /// bound it, survive parsing into the configuration the work path reads.
+    /// Before this seam the worker was unconditionally a child `stella run`.
+    #[test]
+    fn claude_code_can_be_selected_as_the_issue_worker() {
+        let ws = workspace();
+        write(
+            ws.path(),
+            "stella.toml",
+            r#"
+[meta]
+schema_version = 1
+scope = "project"
+
+[self_driving.worker]
+kind = "claude"
+command = "/opt/bin/claude"
+model = "opus"
+max_turns = 40
+dangerously_skip_permissions = true
+"#,
+        );
+
+        let worker = load(ws.path()).worker;
+        assert_eq!(
+            worker.kind,
+            crate::settings::toml_config::WorkerKind::Claude
+        );
+        assert_eq!(worker.command, "/opt/bin/claude");
+        assert_eq!(worker.model.as_deref(), Some("opus"));
+        assert_eq!(worker.max_turns, Some(40));
+        assert!(worker.dangerously_skip_permissions);
+    }
+
+    /// The default is unchanged by the seam existing: a workspace that says
+    /// nothing about a worker still runs stella's own turn loop.
+    #[test]
+    fn the_worker_defaults_to_stella() {
+        let ws = workspace();
+        write(
+            ws.path(),
+            "stella.toml",
+            r#"
+[meta]
+schema_version = 1
+scope = "project"
+"#,
+        );
+
+        let worker = load(ws.path()).worker;
+        assert_eq!(
+            worker.kind,
+            crate::settings::toml_config::WorkerKind::Stella
+        );
+        assert!(!worker.dangerously_skip_permissions);
     }
 
     /// **The portability witness.** `stella.toml` says *which* tracker; the

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -645,7 +645,6 @@ pub(super) fn drive(
                         continue;
                     }
                 };
-
                 // Recorded before the work starts, so a failure cannot make the
                 // loop re-claim the same issue forever.
                 spent.entry(issue.0.clone()).or_default();
@@ -666,20 +665,25 @@ pub(super) fn drive(
                 // A `work` that cannot start is one issue's problem, not the
                 // loop's: a single leftover branch must not halt a run that has
                 // other issues to get on with.
-                let outcome =
-                    match super::work::start(&root, &resolved, &mut budget, &cfg.attribution) {
-                        Ok(outcome) => outcome,
-                        Err(reason) => {
-                            audit::record(
-                                durable,
-                                Audit::Deferred,
-                                Some(&issue.0),
-                                &format!("could not start ({reason}); moving on"),
-                            );
-                            durable.update_stats(|s| s.issues_deferred += 1);
-                            continue;
-                        }
-                    };
+                let outcome = match super::work::start(
+                    &root,
+                    &resolved,
+                    &mut budget,
+                    &cfg.attribution,
+                    &cfg.worker,
+                ) {
+                    Ok(outcome) => outcome,
+                    Err(reason) => {
+                        audit::record(
+                            durable,
+                            Audit::Deferred,
+                            Some(&issue.0),
+                            &format!("could not start ({reason}); moving on"),
+                        );
+                        durable.update_stats(|s| s.issues_deferred += 1);
+                        continue;
+                    }
+                };
                 let learned = super::learning::tally(&root).since(learned_before);
 
                 // Every counter this unit moves, in one write — shared with the

--- a/crates/stella-cli/src/self_driving_cmd/parallel.rs
+++ b/crates/stella-cli/src/self_driving_cmd/parallel.rs
@@ -23,12 +23,16 @@
 //!
 //! # What a worker is
 //!
-//! The same thing a serial work unit is: a real child `stella run`
-//! (`super::work::run_turn`) with the issue quoted as data, in a
-//! worktree, under a budget slice. Never an embedded engine holding the
-//! parent's keys. The run's spend cap is divided across the width before
-//! any child starts. So a wave's children, all in flight at once, cannot
-//! spend past what the operator granted the run.
+//! A real child `stella run` (`super::work::run_turn`) with the issue
+//! quoted as data, in a worktree, under a budget slice. Never an
+//! embedded engine holding the parent's keys. The run's spend cap is
+//! divided across the width before any child starts. So a wave's
+//! children, all in flight at once, cannot spend past what the operator
+//! granted the run.
+//!
+//! The serial path picks its worker. A wave does not. It runs stella's
+//! own turn loop. So a workspace that chose another agent is refused
+//! here, rather than given stella under a setting that names one.
 
 use std::path::{Path, PathBuf};
 
@@ -44,6 +48,27 @@ use super::budget::RunBudget;
 use super::config::LoopConfig;
 use super::state::LoopState as Durable;
 use super::turn_flags::TurnFlags;
+use crate::settings::toml_config::WorkerKind;
+
+/// Refuse a wave that cannot run the worker the workspace chose.
+///
+/// A wave dispatches to `super::work::run_turn`. That is a child `stella
+/// run`. The serial path's worker branch is not on this route. So a wave
+/// under `kind = "claude"` would run stella. The setting would name one
+/// agent and the loop would use another. That is the swap the typed choice
+/// exists to stop.
+fn refuse_unsupported_worker(
+    worker: &crate::settings::toml_config::WorkerSection,
+) -> Result<(), String> {
+    match worker.kind {
+        WorkerKind::Stella => Ok(()),
+        WorkerKind::Claude => Err("a parallel wave runs stella's own turn loop, so \
+             worker.kind = \"claude\" cannot be honoured here. Drop --parallel to work \
+             issues one at a time with the worker you chose, or set worker.kind = \
+             \"stella\" for the wave."
+            .to_owned()),
+    }
+}
 
 /// Run one wave of ready issues at `width` workers, then return.
 ///
@@ -62,6 +87,7 @@ pub(super) fn wave(
     max_issues: u32,
 ) -> Result<(), String> {
     super::work::refuse_if_unsteered(root)?;
+    refuse_unsupported_worker(&cfg.worker)?;
 
     let ready = super::ready::ready_full(provider, &cfg.triage.ladder)?;
     let bound = (max_issues.max(width)) as usize;
@@ -396,6 +422,37 @@ mod tests {
                 .prompt
                 .contains("open a pull request against main"),
             "a wave worker is told to deliver, not only to commit"
+        );
+    }
+
+    /// **Witness.** A wave refuses a worker it cannot run.
+    ///
+    /// A wave runs a child `stella run`. Under a claude worker it would run
+    /// stella instead. The refusal names both ways out, so the choice stays
+    /// with the operator.
+    #[test]
+    fn a_wave_refuses_a_worker_it_cannot_run() {
+        let stella = crate::settings::toml_config::WorkerSection::default();
+        assert_eq!(
+            stella.kind,
+            WorkerKind::Stella,
+            "the default worker is the one a wave runs"
+        );
+        assert!(refuse_unsupported_worker(&stella).is_ok());
+
+        let claude = crate::settings::toml_config::WorkerSection {
+            kind: WorkerKind::Claude,
+            ..Default::default()
+        };
+        let refusal = refuse_unsupported_worker(&claude)
+            .expect_err("a wave cannot run claude, so it must say so rather than run stella");
+        assert!(
+            refusal.contains("--parallel"),
+            "the refusal names the flag to drop: {refusal}"
+        );
+        assert!(
+            refusal.contains("worker.kind"),
+            "the refusal names the setting to change: {refusal}"
         );
     }
 }

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -450,107 +450,6 @@ pub(super) fn run_turn(
     }
 }
 
-/// The Claude Code child, built but not spawned.
-///
-/// Separated from [`run_claude`] for the reason [`turn_command`] is separated
-/// from [`run_turn`]: the whole command is then a test seam, so what the
-/// worker's settings actually put on the command line is assertable without
-/// running an agent.
-fn claude_command(
-    dir: &Path,
-    prompt: &str,
-    worker: &crate::settings::toml_config::WorkerSection,
-) -> Command {
-    let mut cmd = Command::new(&worker.command);
-    cmd.current_dir(dir)
-        .arg("-p")
-        .arg("--output-format")
-        .arg("json");
-    if let Some(model) = worker.model.as_deref() {
-        cmd.arg("--model").arg(model);
-    }
-    if let Some(max_turns) = worker.max_turns {
-        cmd.arg("--max-turns").arg(max_turns.to_string());
-    }
-    // Only when the operator asked for it in as many words. Choosing a worker
-    // and widening what that worker may do are two decisions, and this is the
-    // second one.
-    if worker.dangerously_skip_permissions {
-        cmd.arg("--dangerously-skip-permissions");
-    }
-    cmd.arg(prompt);
-    cmd
-}
-
-/// Run Claude Code non-interactively in one issue's isolated worktree.
-///
-/// The prompt rides as an argument rather than on stdin, and stdin is closed:
-/// this is an unattended loop, so a worker that stops to ask a question must
-/// fail rather than wait for a person who is not there.
-fn run_claude(
-    dir: &Path,
-    prompt: &str,
-    worker: &crate::settings::toml_config::WorkerSection,
-) -> Result<String, String> {
-    let out = claude_command(dir, prompt, worker)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .output()
-        .map_err(|error| {
-            format!(
-                "could not start claude (`{}`): {error}. Set worker.command to \
-                 the executable's name on PATH, or an absolute path to it.",
-                worker.command
-            )
-        })?;
-
-    let summary = String::from_utf8_lossy(&out.stdout).trim().to_owned();
-    if out.status.success() {
-        Ok(summary)
-    } else {
-        Err(format!(
-            "claude exited {}{}",
-            out.status.code().unwrap_or(-1),
-            match claude_reason(&summary) {
-                Some(reason) => format!(" — {reason}"),
-                None => String::new(),
-            }
-        ))
-    }
-}
-
-/// What Claude Code said about a run that ended badly.
-///
-/// Its `--output-format json` is not the shape [`turn_reason`] reads, so that
-/// parser is not reused: pointed at this document it finds none of the keys it
-/// looks for and falls back to the raw last line, which for a JSON document is
-/// the whole document. `result` carries the human-readable text in both the
-/// success and error shapes; `error` appears when the run failed before there
-/// was a result to report.
-fn claude_reason(summary: &str) -> Option<String> {
-    let condense = |text: &str| -> Option<String> {
-        let condensed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
-        if condensed.is_empty() {
-            return None;
-        }
-        let clipped: String = condensed.chars().take(600).collect();
-        Some(if condensed.chars().count() > 600 {
-            format!("{clipped}…")
-        } else {
-            clipped
-        })
-    };
-
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(summary) else {
-        return condense(summary.lines().last().unwrap_or(summary));
-    };
-    ["result", "error"]
-        .iter()
-        .find_map(|key| value.get(key).and_then(serde_json::Value::as_str))
-        .and_then(condense)
-}
-
 /// The child `stella run`, built but not spawned.
 ///
 /// Separated from [`run_turn`] so the *whole* command is a test seam rather
@@ -780,13 +679,10 @@ pub(super) fn start(
         // number this loop can read, so `RunBudget` would charge every turn
         // nothing and the ceiling would never be reached — a cap that is
         // silently infinite is worse than one the operator was told to remove.
-        WorkerKind::Claude if budget.cap().is_some() => Err(format!(
-            "a claude worker cannot be held to --spend-limit ${:.2}: claude does \
-             not report what a turn cost in the form this loop reads. Set \
-             worker.max_turns, or drop the dollar cap.",
-            budget.cap().unwrap_or_default()
+        WorkerKind::Claude if budget.cap().is_some() => Err(super::claude_worker::uncappable(
+            budget.cap().unwrap_or_default(),
         )),
-        WorkerKind::Claude => run_claude(&created.path, &prompt, worker),
+        WorkerKind::Claude => super::claude_worker::run_claude(&created.path, &prompt, worker),
     };
     let change = tree_change(&created.path, &base);
     let outcome = classify(turn, change, &wt);
@@ -1044,113 +940,6 @@ mod tests {
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect()
     }
-
-    /// The claude child's argv, as strings.
-    fn claude_args(worker: &crate::settings::toml_config::WorkerSection) -> Vec<String> {
-        claude_command(Path::new("/tmp/worktree"), "fix #1", worker)
-            .get_args()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect()
-    }
-
-    /// A worker section with claude selected and nothing else said.
-    fn claude_worker() -> crate::settings::toml_config::WorkerSection {
-        crate::settings::toml_config::WorkerSection {
-            kind: WorkerKind::Claude,
-            ..Default::default()
-        }
-    }
-
-    /// **Witness.** Selecting claude does not also hand it permission bypass.
-    ///
-    /// The two are separate decisions, and the flag that grants ambient write
-    /// and command authority must appear only when the operator wrote it down.
-    #[test]
-    fn a_claude_worker_does_not_skip_permissions_unless_asked() {
-        let args = claude_args(&claude_worker());
-        assert!(
-            !args
-                .iter()
-                .any(|arg| arg == "--dangerously-skip-permissions"),
-            "the default claude worker must not bypass permissions: {args:?}"
-        );
-
-        let asked = crate::settings::toml_config::WorkerSection {
-            dangerously_skip_permissions: true,
-            ..claude_worker()
-        };
-        assert!(
-            claude_args(&asked)
-                .iter()
-                .any(|arg| arg == "--dangerously-skip-permissions"),
-            "asking for the bypass must put it on the command line"
-        );
-    }
-
-    /// **Witness.** The worker's settings reach claude's command line, and the
-    /// ones that were not set put nothing there.
-    #[test]
-    fn the_claude_worker_settings_reach_the_command_line() {
-        let bare = claude_args(&claude_worker());
-        assert_eq!(
-            bare,
-            ["-p", "--output-format", "json", "fix #1"],
-            "an unconfigured claude worker sends only the print-mode contract \
-             and the prompt"
-        );
-
-        let configured = crate::settings::toml_config::WorkerSection {
-            model: Some("opus".to_owned()),
-            max_turns: Some(40),
-            ..claude_worker()
-        };
-        assert_eq!(
-            claude_args(&configured),
-            [
-                "-p",
-                "--output-format",
-                "json",
-                "--model",
-                "opus",
-                "--max-turns",
-                "40",
-                "fix #1"
-            ]
-        );
-    }
-
-    /// **Witness.** Claude's own JSON is read by its own keys.
-    ///
-    /// Fed to [`turn_reason`], which reads stella's summary shape, this
-    /// document matches nothing and falls back to "the last line" — which for
-    /// a one-line JSON document is the entire document, quoted at an operator
-    /// as though it were a diagnosis.
-    #[test]
-    fn a_failed_claude_run_reports_what_claude_said() {
-        let summary =
-            r#"{"type":"result","is_error":true,"result":"I need write access to continue."}"#;
-        assert_eq!(
-            claude_reason(summary).as_deref(),
-            Some("I need write access to continue.")
-        );
-
-        assert_eq!(
-            claude_reason(r#"{"error":"credit balance is too low"}"#).as_deref(),
-            Some("credit balance is too low")
-        );
-
-        // Not JSON at all — a crash, a shell error — still yields the last
-        // line, so a missing executable reads as one.
-        assert_eq!(
-            claude_reason("boom\ncommand not found: claude").as_deref(),
-            Some("command not found: claude")
-        );
-
-        // JSON this parser does not recognise reports nothing, so the caller
-        // prints the bare exit code rather than a whole document.
-        assert_eq!(claude_reason(r#"{"type":"result"}"#), None);
-    }
-
     /// **Witness (#4362).** The turn the loop spawns does not inherit the
     /// reflection opt-out.
     ///

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -1,24 +1,38 @@
-//! `work` — one issue through Stella's own turn loop, in an isolated worktree.
+//! `work` — one issue through a coding agent's turn loop, in an isolated
+//! worktree.
 //!
 //! `doc:backlog-self-driving` §3.2 (#3599 B2). This is the verb that does not
 //! exist in any other form, and it is the whole autonomous half: everything
 //! else in the loop ranks, decides, or reports.
 //!
-//! # Stella is started, not embedded
+//! # The worker is started, not embedded
 //!
-//! `work start` **spawns `stella run`** in the worktree rather than dispatching
-//! a turn in-process. That is the design's shape, not a convenience:
-//! `doc:pipeline-as-plugins` §10 settles that self-driving is a *host*, not a
-//! wrapper — *"Stella never starts this program — a person does, and then it
-//! starts Stella"* — and `plugins/stella-selfdriving/plugin.toml` already
-//! declares exactly this capability, so a human has read and granted it.
+//! `work start` **spawns a coding agent** in the worktree rather than
+//! dispatching a turn in-process. That is the design's shape, not a
+//! convenience: `doc:pipeline-as-plugins` §10 settles that self-driving is a
+//! *host*, not a wrapper — *"Stella never starts this program — a person does,
+//! and then it starts Stella"* — and `plugins/stella-selfdriving/plugin.toml`
+//! already declares exactly this capability, so a human has read and granted
+//! it.
 //!
-//! It also gets the definition of done right for free. There is no built-in
-//! verification pipeline any more (`stella-pipeline` was deleted, #3852/#3865),
-//! so a unit of work gets **the turn loop plus whatever plugins are installed**
-//! and nothing else. Spawning the real binary is what makes that true by
-//! construction rather than by a claim in a doc comment: whatever a `stella
-//! run` gets on this machine, a work unit gets.
+//! Which agent is [`WorkerKind`], and `stella run` is the default. The seam is
+//! here and nowhere else: ranking, claiming, worktree isolation, the pull
+//! request and the merge never learn which agent wrote the diff, because the
+//! outcome is measured from the tree rather than reported by the worker. That
+//! is what makes a second worker a setting rather than a second loop.
+//!
+//! Spawning also gets the definition of done right for free. There is no
+//! built-in verification pipeline any more (`stella-pipeline` was deleted,
+//! #3852/#3865), so a unit of work gets **the turn loop plus whatever plugins
+//! are installed** and nothing else. Spawning the real binary is what makes
+//! that true by construction rather than by a claim in a doc comment: whatever
+//! a `stella run` gets on this machine, a work unit gets.
+//!
+//! A claude worker is held to the same bar by the same mechanism, with one
+//! exception it is refused rather than allowed to ignore: `--spend-limit`.
+//! Claude Code reports no cost this loop can read, so the ceiling could never
+//! be reached, and a cap that is silently infinite is worse than one the
+//! operator was told to remove.
 //!
 //! What that is worth is stated plainly in §3.2 and repeated here because it is
 //! easy to over-read: with no verification plugin installed, a completed work
@@ -70,6 +84,7 @@ use stella_protocol::issue::Issue;
 
 use super::budget::RunBudget;
 use super::turn_flags::TurnFlags;
+use crate::settings::toml_config::WorkerKind;
 
 /// Where this verb's worktrees live — gitignored, and outside the fleet's
 /// namespace so `stella fleet gc` cannot see them.
@@ -435,6 +450,107 @@ pub(super) fn run_turn(
     }
 }
 
+/// The Claude Code child, built but not spawned.
+///
+/// Separated from [`run_claude`] for the reason [`turn_command`] is separated
+/// from [`run_turn`]: the whole command is then a test seam, so what the
+/// worker's settings actually put on the command line is assertable without
+/// running an agent.
+fn claude_command(
+    dir: &Path,
+    prompt: &str,
+    worker: &crate::settings::toml_config::WorkerSection,
+) -> Command {
+    let mut cmd = Command::new(&worker.command);
+    cmd.current_dir(dir)
+        .arg("-p")
+        .arg("--output-format")
+        .arg("json");
+    if let Some(model) = worker.model.as_deref() {
+        cmd.arg("--model").arg(model);
+    }
+    if let Some(max_turns) = worker.max_turns {
+        cmd.arg("--max-turns").arg(max_turns.to_string());
+    }
+    // Only when the operator asked for it in as many words. Choosing a worker
+    // and widening what that worker may do are two decisions, and this is the
+    // second one.
+    if worker.dangerously_skip_permissions {
+        cmd.arg("--dangerously-skip-permissions");
+    }
+    cmd.arg(prompt);
+    cmd
+}
+
+/// Run Claude Code non-interactively in one issue's isolated worktree.
+///
+/// The prompt rides as an argument rather than on stdin, and stdin is closed:
+/// this is an unattended loop, so a worker that stops to ask a question must
+/// fail rather than wait for a person who is not there.
+fn run_claude(
+    dir: &Path,
+    prompt: &str,
+    worker: &crate::settings::toml_config::WorkerSection,
+) -> Result<String, String> {
+    let out = claude_command(dir, prompt, worker)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .output()
+        .map_err(|error| {
+            format!(
+                "could not start claude (`{}`): {error}. Set worker.command to \
+                 the executable's name on PATH, or an absolute path to it.",
+                worker.command
+            )
+        })?;
+
+    let summary = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if out.status.success() {
+        Ok(summary)
+    } else {
+        Err(format!(
+            "claude exited {}{}",
+            out.status.code().unwrap_or(-1),
+            match claude_reason(&summary) {
+                Some(reason) => format!(" — {reason}"),
+                None => String::new(),
+            }
+        ))
+    }
+}
+
+/// What Claude Code said about a run that ended badly.
+///
+/// Its `--output-format json` is not the shape [`turn_reason`] reads, so that
+/// parser is not reused: pointed at this document it finds none of the keys it
+/// looks for and falls back to the raw last line, which for a JSON document is
+/// the whole document. `result` carries the human-readable text in both the
+/// success and error shapes; `error` appears when the run failed before there
+/// was a result to report.
+fn claude_reason(summary: &str) -> Option<String> {
+    let condense = |text: &str| -> Option<String> {
+        let condensed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        if condensed.is_empty() {
+            return None;
+        }
+        let clipped: String = condensed.chars().take(600).collect();
+        Some(if condensed.chars().count() > 600 {
+            format!("{clipped}…")
+        } else {
+            clipped
+        })
+    };
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(summary) else {
+        return condense(summary.lines().last().unwrap_or(summary));
+    };
+    ["result", "error"]
+        .iter()
+        .find_map(|key| value.get(key).and_then(serde_json::Value::as_str))
+        .and_then(condense)
+}
+
 /// The child `stella run`, built but not spawned.
 ///
 /// Separated from [`run_turn`] so the *whole* command is a test seam rather
@@ -608,6 +724,7 @@ pub(super) fn start(
     issue: &Issue,
     budget: &mut RunBudget,
     attribution: &stella_autonomy::Attribution,
+    worker: &crate::settings::toml_config::WorkerSection,
 ) -> Result<WorkOutcome, String> {
     use stella_fleet::git::{SystemGitCli, WorktreeManager};
 
@@ -656,12 +773,21 @@ pub(super) fn start(
         path: created.path.clone(),
     };
 
-    let turn = run_turn(
-        &created.path,
-        root,
-        &prompt_for(issue, &attribution.commit),
-        budget,
-    );
+    let prompt = prompt_for(issue, &attribution.commit);
+    let turn = match worker.kind {
+        WorkerKind::Stella => run_turn(&created.path, root, &prompt, budget),
+        // A spend limit is refused rather than ignored. Claude Code reports no
+        // number this loop can read, so `RunBudget` would charge every turn
+        // nothing and the ceiling would never be reached — a cap that is
+        // silently infinite is worse than one the operator was told to remove.
+        WorkerKind::Claude if budget.cap().is_some() => Err(format!(
+            "a claude worker cannot be held to --spend-limit ${:.2}: claude does \
+             not report what a turn cost in the form this loop reads. Set \
+             worker.max_turns, or drop the dollar cap.",
+            budget.cap().unwrap_or_default()
+        )),
+        WorkerKind::Claude => run_claude(&created.path, &prompt, worker),
+    };
     let change = tree_change(&created.path, &base);
     let outcome = classify(turn, change, &wt);
 
@@ -917,6 +1043,112 @@ mod tests {
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect()
+    }
+
+    /// The claude child's argv, as strings.
+    fn claude_args(worker: &crate::settings::toml_config::WorkerSection) -> Vec<String> {
+        claude_command(Path::new("/tmp/worktree"), "fix #1", worker)
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// A worker section with claude selected and nothing else said.
+    fn claude_worker() -> crate::settings::toml_config::WorkerSection {
+        crate::settings::toml_config::WorkerSection {
+            kind: WorkerKind::Claude,
+            ..Default::default()
+        }
+    }
+
+    /// **Witness.** Selecting claude does not also hand it permission bypass.
+    ///
+    /// The two are separate decisions, and the flag that grants ambient write
+    /// and command authority must appear only when the operator wrote it down.
+    #[test]
+    fn a_claude_worker_does_not_skip_permissions_unless_asked() {
+        let args = claude_args(&claude_worker());
+        assert!(
+            !args
+                .iter()
+                .any(|arg| arg == "--dangerously-skip-permissions"),
+            "the default claude worker must not bypass permissions: {args:?}"
+        );
+
+        let asked = crate::settings::toml_config::WorkerSection {
+            dangerously_skip_permissions: true,
+            ..claude_worker()
+        };
+        assert!(
+            claude_args(&asked)
+                .iter()
+                .any(|arg| arg == "--dangerously-skip-permissions"),
+            "asking for the bypass must put it on the command line"
+        );
+    }
+
+    /// **Witness.** The worker's settings reach claude's command line, and the
+    /// ones that were not set put nothing there.
+    #[test]
+    fn the_claude_worker_settings_reach_the_command_line() {
+        let bare = claude_args(&claude_worker());
+        assert_eq!(
+            bare,
+            ["-p", "--output-format", "json", "fix #1"],
+            "an unconfigured claude worker sends only the print-mode contract \
+             and the prompt"
+        );
+
+        let configured = crate::settings::toml_config::WorkerSection {
+            model: Some("opus".to_owned()),
+            max_turns: Some(40),
+            ..claude_worker()
+        };
+        assert_eq!(
+            claude_args(&configured),
+            [
+                "-p",
+                "--output-format",
+                "json",
+                "--model",
+                "opus",
+                "--max-turns",
+                "40",
+                "fix #1"
+            ]
+        );
+    }
+
+    /// **Witness.** Claude's own JSON is read by its own keys.
+    ///
+    /// Fed to [`turn_reason`], which reads stella's summary shape, this
+    /// document matches nothing and falls back to "the last line" — which for
+    /// a one-line JSON document is the entire document, quoted at an operator
+    /// as though it were a diagnosis.
+    #[test]
+    fn a_failed_claude_run_reports_what_claude_said() {
+        let summary =
+            r#"{"type":"result","is_error":true,"result":"I need write access to continue."}"#;
+        assert_eq!(
+            claude_reason(summary).as_deref(),
+            Some("I need write access to continue.")
+        );
+
+        assert_eq!(
+            claude_reason(r#"{"error":"credit balance is too low"}"#).as_deref(),
+            Some("credit balance is too low")
+        );
+
+        // Not JSON at all — a crash, a shell error — still yields the last
+        // line, so a missing executable reads as one.
+        assert_eq!(
+            claude_reason("boom\ncommand not found: claude").as_deref(),
+            Some("command not found: claude")
+        );
+
+        // JSON this parser does not recognise reports nothing, so the caller
+        // prints the bare exit code rather than a whole document.
+        assert_eq!(claude_reason(r#"{"type":"result"}"#), None);
     }
 
     /// **Witness (#4362).** The turn the loop spawns does not inherit the

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -384,6 +384,9 @@ pub struct SelfDrivingSection {
     /// `[self_driving.verify]` — how to prove a change when CI cannot.
     #[serde(default)]
     pub verify: VerifySection,
+    /// `[self_driving.worker]` — which coding agent executes one issue.
+    #[serde(default)]
+    pub worker: WorkerSection,
     /// `[self_driving.doctrine]` — how the loop decides, where two operators
     /// would decide differently.
     ///
@@ -460,6 +463,59 @@ impl DeployWatch {
     pub fn enabled(self) -> bool {
         self == Self::On
     }
+}
+
+/// `[self_driving.worker]` — which coding agent does the work on one issue.
+///
+/// The worker is the one part of the loop that writes code, and it is a seam
+/// rather than a hardcoded child process because the surrounding machinery —
+/// ranking, claiming, worktree isolation, the pull request, the merge — is
+/// agent-agnostic already. Only the turn itself ever knew it was stella.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct WorkerSection {
+    /// Which agent runs the turn.
+    pub kind: WorkerKind,
+    /// The Claude Code executable, by name on `PATH` or as an absolute path.
+    /// Read only when `kind = "claude"`.
+    pub command: String,
+    /// A model alias or full model id. Absent means Claude Code's own default.
+    pub model: Option<String>,
+    /// A ceiling on how many turns Claude may take on one issue. Absent means
+    /// Claude Code's own default.
+    pub max_turns: Option<u32>,
+    /// Whether the worker may write files and run commands without asking.
+    pub dangerously_skip_permissions: bool,
+}
+
+impl Default for WorkerSection {
+    fn default() -> Self {
+        Self {
+            kind: WorkerKind::default(),
+            command: "claude".to_owned(),
+            model: None,
+            max_turns: None,
+            dangerously_skip_permissions: false,
+        }
+    }
+}
+
+/// Which agent performs autonomous issue work.
+///
+/// A named two-value choice rather than a free-form string so a typo is
+/// rejected where it is written, naming both spellings it accepts. A string
+/// would defer that to the work path, where an unreadable name has no good
+/// answer left: refusing one issue at a time walks the whole queue into the
+/// same wall, and falling back to stella silently runs an agent the operator
+/// did not choose.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkerKind {
+    /// stella's own turn loop, run as a child process. The default.
+    #[default]
+    Stella,
+    /// Claude Code, run non-interactively in the same isolated worktree.
+    Claude,
 }
 
 /// `[self_driving.merge]` — which checks may block a merge.

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -649,6 +649,24 @@ command = "make gate"
 # overnight.
 timeout_secs = 1800
 
+[self_driving.worker]
+# Which coding agent does the work on one issue. stella (default) runs the
+# built-in turn loop; claude runs Claude Code non-interactively in the same
+# isolated worktree.
+kind = "stella"
+# The Claude Code executable, by name on PATH or as an absolute path. Read only
+# when kind = "claude".
+command = "claude"
+# An optional model alias or full model id. Absent = Claude Code's own default.
+model = "opus"
+# An optional ceiling on how many turns Claude may take on one issue. Absent =
+# Claude Code's own default.
+max_turns = 40
+# Let the worker write files and run commands without asking. Off by default,
+# and turning it on is a separate decision from choosing Claude: selecting a
+# worker must never quietly widen what that worker may do.
+dangerously_skip_permissions = false
+
 [self_driving.doctrine]
 # How the loop decides, where two operators would decide differently. These are
 # judgement calls about YOUR team's norms, not facts about the code.

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -118,6 +118,21 @@ Issue text is never a command: anyone who can file an issue could write anything
 
 Worktrees for this command live under `.stella/private/self-driving/`, on `self-driving/` branches. This is outside the fleet's namespace, because `stella fleet gc` cleans up by namespace, and it should never be allowed to delete checkouts it didn't create.
 
+By default, stella does the coding work itself. You can point it at Claude Code instead:
+
+```toml
+[self_driving.worker]
+kind = "claude"
+command = "claude"
+model = "opus"       # optional
+max_turns = 40       # optional limit per issue
+dangerously_skip_permissions = false
+```
+
+Claude runs as `claude -p --output-format json` inside the same isolated worktree, so your normal project and user settings still apply. Skipping permission prompts is a separate setting you have to turn on yourself, because it lets the worker write files and run commands without asking first.
+
+A Claude worker will not accept `--spend-limit`. Claude does not report what a run cost in the form stella measures, so stella cannot hold it to a dollar cap. Use `max_turns`, or your provider's own spending controls, instead.
+
 ### drive
 
 `stella self-driving drive` runs on its own, without you watching it. It keeps asking what to do next, does it, and asks again: claim the next issue from the ranked queue, run it through the turn loop, open a pull request, watch CI, and merge when it's ready.


### PR DESCRIPTION
## What this changes

`stella self-driving` could only do its coding work one way: `work::start` spawned a child `stella run`. This makes the worker a setting.

```toml
[self_driving.worker]
kind = "claude"
command = "claude"
model = "opus"
max_turns = 40
dangerously_skip_permissions = false
```

`stella` stays the default, so a workspace that says nothing about a worker behaves exactly as before.

The seam is in one place. Ranking, claiming, worktree isolation, the pull request and the merge never learn which agent wrote the diff, because the outcome is measured from the git tree rather than reported by the worker. That is what makes a second worker a setting rather than a second loop.

## Three decisions worth reviewing

**The kind is a typed choice, not a string.** A typo is rejected when the file is parsed, naming both spellings it accepts. As a string it would surface in the work path instead, where an unreadable name has no good answer left: refusing one issue at a time walks the whole queue into the same wall, and falling back to stella silently runs an agent the operator did not choose. This follows `ResidueGateSwitch`, the pattern already in the same file.

**`--spend-limit` is refused for a claude worker, not ignored.** Claude Code reports no cost `RunBudget` can read, so it would charge every turn nothing and the ceiling would never be reached. A cap that is silently infinite is worse than one the operator was told to remove, so the run stops and names `worker.max_turns` instead.

**Permission bypass is a separate opt-in.** Choosing a worker and widening what that worker may do are two decisions. `--dangerously-skip-permissions` reaches the command line only when the operator wrote it down, and there is a test on the built command asserting both directions.

## Witness

`cargo test -p stella-cli self_driving_cmd::work self_driving_cmd::config`

Four tests, all of which fail on `main` — there is no `WorkerSection` to select, so they do not compile there, which is the fail half:

- `claude_code_can_be_selected_as_the_issue_worker` — the section parses into what the work path reads
- `the_worker_defaults_to_stella` — the seam existing does not change the default
- `a_claude_worker_does_not_skip_permissions_unless_asked` — both directions of the bypass flag
- `the_claude_worker_settings_reach_the_command_line` — the settings that were set appear, the ones that were not put nothing there
- `a_failed_claude_run_reports_what_claude_said` — claude's JSON is read by claude's own keys

That last one is a real defect fixed, not just coverage: the first draft of this change fed claude's `--output-format json` to `turn_reason`, which reads stella's summary shape. It matches none of the keys it looks for and falls back to "the last line" — for a one-line JSON document, the entire document, quoted at an operator as though it were a diagnosis.

## Prose owned

`work.rs`'s module doc opened with "Stella is started, not embedded" and asserted that `work start` **spawns `stella run`**. This change makes that false, so the section is rewritten to say what is now true and to name where the seam is.

## Checks

Run locally in the worktree, on this branch:

- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- `cargo test -p stella-cli` — 2581 passed, 0 failed
- `make file-size` — green. `drive.rs` sits at 1495 of 1500 and is not grandfathered, so this change puts one line in it and the rest in `work.rs`
- `make prose`, `make line-citations`, `make left-behind`, `make typed-errors`, `make dead-code-allows`, `make brand-case`, `make command-docs`, `make doc-links`, `make invariants`, `make god-files` — all green

CI is the evidence that counts; the above is what was checked before pushing.

## No tests deleted

Closes #5596

## Residue filed

Refs #5602 — a mistyped `kind` fails `TomlConfig::parse` for the *whole* document, so `config::load` warns on stderr and returns `LoopConfig::default()`, whose worker is `WorkerKind::Stella`. The typed choice does reject the typo at parse time as intended, so #5596's box is met; what the fallback undoes is the *reason* given for it above — the operator asked for claude and the unattended loop runs stella. The same whole-document fallback also reverts the other eight `LoopConfig` fields on any typo anywhere in `stella.toml`. That leniency predates this change and altering `load`'s documented "never fails" contract is a design decision, so it is filed rather than made here.

## Summary by Sourcery

Make the self-driving issue worker configurable while preserving Stella as the default and keeping the surrounding workflow worker-agnostic.

New Features:
- Allow self-driving issue work to use either Stella's built-in worker or a configurable Claude Code worker.
- Expose Claude worker settings for its command, model, turn limit, and permission bypass behavior.

Bug Fixes:
- Report Claude Code failure messages using Claude's JSON output format instead of Stella's summary format.
- Refuse dollar spend limits for Claude workers rather than treating them as unenforced.

Enhancements:
- Keep the existing Stella worker as the default and reject unsupported Claude workers for parallel waves.
- Measure work outcomes from repository changes independently of which worker produced them.

Documentation:
- Document worker selection, Claude configuration, permission bypass behavior, and spending-limit restrictions.
- Update the example configuration with self-driving worker settings.

Tests:
- Add coverage for worker configuration parsing, default behavior, Claude command construction, permission handling, failure reporting, and unsupported parallel execution.