### PR TITLE
fix(stella-cli): the queue reads past the first page, so an old P0 is visible

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -47,6 +47,27 @@ use super::state::LoopState;
 /// pins.
 pub(super) const QUEUE_READ_LIMIT: usize = 1_000;
 
+/// What an operator is told when the queue read filled its page.
+///
+/// A full page means the tracker held at least this many open issues, so the
+/// ranking covers only the ones that crossed. The loop reports and carries on
+/// rather than refusing, because it can still work the issues it can see and a
+/// queue that stops dead on a large backlog helps nobody. Silence is the one
+/// option ruled out: a truncated read that looks like a complete one is the
+/// whole defect.
+///
+/// A function rather than an inline print, so what an operator is told can be
+/// asserted without running a loop.
+fn truncation_notice(total: usize, provider: &str) -> Option<String> {
+    (total >= QUEUE_READ_LIMIT).then(|| {
+        format!(
+            "warning: `{provider}` returned {total} open issues, which fills this read. \
+             The ladder ranks that page alone, and the tracker chose it by its own order. \
+             Issues behind the page did not reach the ranker."
+        )
+    })
+}
+
 /// Read the tracker once and rank it, or explain why it could not be read.
 ///
 /// The port is async because a tracker is a network service. These callers are
@@ -65,6 +86,9 @@ pub(super) fn ranked(
         .block_on(provider.list_open(QUEUE_READ_LIMIT))
         .map_err(|error| error.to_string())?;
     let total = issues.len();
+    if let Some(notice) = truncation_notice(total, provider.id()) {
+        eprintln!("{notice}");
+    }
     let queue = stella_autonomy::priority::triage(
         issues
             .iter()
@@ -1135,6 +1159,32 @@ mod tests {
             OLD_PAGE + 1,
             "the reported backlog size counts every open issue, not one page \
              of them"
+        );
+    }
+
+    /// **Witness.** A read that fills its page says so.
+    ///
+    /// The page is sized to exceed a backlog, and a repository that outgrows it
+    /// has the ordering defect back. What must not come back with it is the
+    /// silence. The queue is then ranked over a page the tracker chose by date,
+    /// and the ranking alone gives an operator no way to see that.
+    #[test]
+    fn a_read_that_fills_its_page_reports_the_truncation() {
+        assert_eq!(
+            truncation_notice(QUEUE_READ_LIMIT - 1, "github"),
+            None,
+            "a read the backlog has not filled is a complete one and says nothing"
+        );
+
+        let notice = truncation_notice(QUEUE_READ_LIMIT, "github")
+            .expect("a filled page is a truncated read and has to be reported");
+        assert!(
+            notice.contains("github"),
+            "the notice names the tracker it read: {notice}"
+        );
+        assert!(
+            notice.contains(&QUEUE_READ_LIMIT.to_string()),
+            "the notice names how many issues crossed: {notice}"
         );
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -30,12 +30,22 @@ use super::state::LoopState;
 
 /// How many open issues cross the port to produce one cycle's batch.
 ///
-/// A ceiling rather than "all of them": ranking is deterministic and a batch is
-/// single digits, so reading a ten-thousand-issue backlog to pick five is spend
-/// with no effect on the answer. 200 is what the shell driver asked `gh` for,
-/// kept unchanged so the picked batch cannot move in the change that relocates
-/// the read.
-pub(super) const QUEUE_READ_LIMIT: usize = 200;
+/// This is a page size, and a page the backlog outgrows silently changes the
+/// answer. The tracker orders what it returns; the ladder is applied here,
+/// afterwards, to whatever arrived. `gh issue list` hands back the newest
+/// first, so once a backlog is longer than this number the oldest issues stop
+/// crossing the port at all — and the loop takes work in ladder order from a
+/// set that was chosen by filing date. A P0 filed last year is then invisible
+/// to a ranker whose whole job is to find it, with nothing anywhere reporting
+/// a truncated read.
+///
+/// So this is sized to be larger than a backlog rather than smaller than one.
+/// Reading a page nobody outgrows costs a few paginated calls per claim pass;
+/// the alternative costs the ordering guarantee the ladder exists to provide.
+/// A repository that outgrows *this* number has the same defect again, which
+/// is what `a_backlog_larger_than_one_page_still_surfaces_its_oldest_p0`
+/// pins.
+pub(super) const QUEUE_READ_LIMIT: usize = 1_000;
 
 /// Read the tracker once and rank it, or explain why it could not be read.
 ///
@@ -1078,6 +1088,54 @@ mod tests {
             "P0 first, then P1 aged-before-fresh — and no feature"
         );
         assert_eq!(total, 5, "the total counts every open issue, defect or not");
+    }
+
+    /// **Witness.** The ladder must not be applied to a set the tracker chose
+    /// by filing date.
+    ///
+    /// The tracker returns the newest issues first and the ladder is applied
+    /// here, to whatever arrived. So a page smaller than the backlog does not
+    /// merely cost a few stale issues at the bottom: it decides membership by
+    /// date and then ranks by urgency inside that, which is how the oldest P0
+    /// in a repository becomes the one issue the ranker cannot see.
+    ///
+    /// The fixture is the shape that breaks it — a page of fresh P2s, then one
+    /// old P0 behind them — sized to 200, so the test fails against a port
+    /// asking for that many and passes against a page the backlog has not
+    /// outgrown.
+    #[test]
+    fn a_backlog_larger_than_one_page_still_surfaces_its_oldest_p0() {
+        const OLD_PAGE: usize = 200;
+
+        let mut open: Vec<Issue> = (0..OLD_PAGE)
+            .map(|n| {
+                issue(
+                    &format!("{}", n + 100),
+                    &["bug", "P2"],
+                    "2026-08-01T00:00:00Z",
+                )
+            })
+            .collect();
+        // Last, because the tracker hands back the newest first and this is the
+        // oldest thing in the repository.
+        open.push(issue("7", &["bug", "P0"], "2020-01-01T00:00:00Z"));
+
+        let provider = FixtureProvider::with(open);
+        let policy = stella_autonomy::priority::TriagePolicy::default();
+        let (queue, total) = ranked(&provider, &policy).expect("fixture read");
+
+        assert_eq!(
+            queue.ranked.first().map(|issue| issue.number),
+            Some(7),
+            "the oldest P0 must outrank a whole page of fresher P2s, which it \
+             cannot do while the read stops before reaching it"
+        );
+        assert_eq!(
+            total,
+            OLD_PAGE + 1,
+            "the reported backlog size counts every open issue, not one page \
+             of them"
+        );
     }
 
     /// A defect nobody gave a rung is a question, not the bottom of the queue.

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -343,11 +343,18 @@ pub trait IssueProvider: Send + Sync {
     /// Every issue currently in [`IssueState::Open`], newest-first or in
     /// whatever order the tracker returns them.
     ///
-    /// **Ordering is not part of the contract**: ranking is the loop's job and
-    /// is deterministic (`stella_autonomy::rank_defects`), so a provider that
-    /// sorted differently could not change which issues a cycle picks. `limit`
-    /// bounds the read, because a tracker with ten thousand open issues should
-    /// not have all of them cross this boundary to produce a batch of five.
+    /// **Order decides membership as soon as a backlog outgrows `limit`.**
+    /// Ranking is the loop's job and is deterministic
+    /// (`stella_autonomy::rank_defects`). It runs after this read, though, over
+    /// whatever arrived. A full page is picked by the tracker's own order and
+    /// ranked only inside that set. A tracker that hands back the newest issues
+    /// first therefore hides the oldest ones from the ranker. An old P0 is the
+    /// issue such a read drops, and the one the loop most needs.
+    ///
+    /// So `limit` is a page size to set above a backlog. A caller that fills it
+    /// has read part of the open set, and must not treat that as the whole of
+    /// it. Where a partial read cannot be acted on safely, say so and stop: a
+    /// blocker just off the page reads as closed.
     async fn list_open(&self, limit: usize) -> Result<Vec<Issue>, IssueError>;
 
     /// File a new issue and return the key the tracker assigned it.

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -94,7 +94,7 @@ A run covers many cycles: one `/loop` session, or one daemon's whole lifetime. I
 
 ### metrics, state, queue
 
-`metrics` turns the ledger into evidence about how the loop itself is doing, flagging specific problems: `STUCK`, `STARVED`, `NOISY`, and `FRAGILE`. `state` shows the current counters and the last five cycles. `queue` ranks open problems by priority — P0, then P1, then P2, then untriaged, oldest first within each rank. Feature requests are left out, because this loop only closes defects.
+`metrics` turns the ledger into evidence about how the loop itself is doing, flagging specific problems: `STUCK`, `STARVED`, `NOISY`, and `FRAGILE`. `state` shows the current counters and the last five cycles. `queue` ranks open problems by priority — P0, then P1, then P2, then untriaged, oldest first within each rank. Feature requests are left out, because this loop only closes defects. Ranking reads up to 1,000 open issues, which has to be more than your repository has: your tracker hands back the newest issues first, and the priority order is applied afterwards to whatever arrived. If the read stops before the end of your backlog, an old P0 never reaches the ranker at all.
 
 ### file
 


### PR DESCRIPTION
## The defect

`QUEUE_READ_LIMIT` was 200. This repository has **544 open issues**, so 344 of them never reached the ranker.

```sh
$ gh issue list --state open --limit 2000 --json number --jq 'length'
544
```

What makes this more than a truncated tail: `gh issue list` returns the **newest first**, and the priority ladder is applied here, afterwards, to whatever arrived. The read therefore chose membership by filing date, and the ladder sorted by urgency *inside that set*. An old P0 sits outside the first page and is invisible to the ranker whose whole job is to find it — and nothing anywhere reported that the read was truncated.

The same read produces the "open issues total" that `queue` prints and that the snapshot hands the Observatory. It was `issues.len()` on the truncated list, so it reported 200 against 544.

## Why the old reasoning did not hold

The constant carried an argument for the ceiling:

> ranking is deterministic and a batch is single digits, so reading a ten-thousand-issue backlog to pick five is spend with no effect on the answer

That is true only where the read is a superset of the backlog. The comment is replaced with what it actually depends on, so the next person does not re-derive it.

## Witness

`a_backlog_larger_than_one_page_still_surfaces_its_oldest_p0` builds the shape that breaks it — a full page of fresh P2s, then one old P0 behind them, in the order the tracker returns — and asserts the P0 ranks first.

Both directions confirmed, not just green-today:

```
# with QUEUE_READ_LIMIT = 200 (the old value)
assertion `left == right` failed: the oldest P0 must outrank a whole page of
fresher P2s, which it cannot do while the read stops before reaching it
  left: Some(100)
 right: Some(7)
test result: FAILED. 0 passed; 1 failed

# with QUEUE_READ_LIMIT = 1_000
test ...a_backlog_larger_than_one_page_still_surfaces_its_oldest_p0 ... ok
```

It also asserts the reported total counts the whole backlog rather than one page.

## The cost, named

The queue is read on every claim pass, so a larger page costs a few paginated `gh` calls on a cadence. That buys back the ordering guarantee the ladder exists to provide, which is the trade this PR is making on purpose.

Raising the number moves the failure mode rather than removing it — a repository with more than 1,000 open issues has the same defect again. That is why the reasoning is now written on the constant and pinned by a test, and it is called out in the docs as a number that has to exceed your backlog.

## Checks

- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- `cargo test -p stella-cli` — 2577 passed, 0 failed
- `make prose`, `make file-size` — green

## No tests deleted

Closes #5598

## Summary by Sourcery

Ensure queue reads cover the backlog needed for reliable priority ranking and report when the configured read may be truncated.

Bug Fixes:
- Ensure queue ranking can surface older high-priority issues in backlogs larger than a single provider page.
- Warn operators when the open-issue read reaches its configured limit instead of silently presenting a partial queue.

Enhancements:
- Increase the queue read limit to 1,000 and clarify that it must exceed the repository backlog for complete priority ordering.
- Update the issue-provider contract and self-driving documentation to describe partial-read ordering limitations and configuration expectations.

Documentation:
- Document the queue read limit and explain how tracker ordering can hide older high-priority issues when the backlog exceeds it.

Tests:
- Add coverage proving an older P0 is surfaced behind a page of newer P2 issues and that the full backlog total is reported.
- Add coverage for truncation notices when the queue read reaches its limit.