### PR TITLE
docs: describe what ships, without internal tracker references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ exist in no default install. Written in Rust as a workspace of focused crates.
   plugin's declared rule and never re-runs it. Oxagen's Vera is the reference
   plugin, private and not shipped here.
 - **Embeddable** — link `stella-core` and supply the `Provider` and
-  `ToolExecutor` ports in process, or drive
-  [`stella-serve`](crates/stella-serve/README.md) over HTTP/SSE and keep every
-  model call, tool call and credential on your side of the wire.
-  `doc:engine-embedding` is the contract.
+  `ToolExecutor` ports in process. Or drive
+  [`stella-serve`](crates/stella-serve/README.md) over HTTP/SSE. Every model
+  call, tool call and credential stays on your side of the wire. See
+  [Agent Engine in Your App](https://stella.oxagen.sh/docs/agent-engine-in-your-app).
 - **Prompt-cache-native memory** — lessons in `.stella/memories/` load once at
   session start into a byte-stable system prompt (~0.1× input cost).
 - **Code graph** — a tree-sitter symbol/import index (Rust, TS/TSX/JS, Python,

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -49,7 +49,7 @@ a plugin runs.
     "allowed_models": ["anthropic/claude-fable-5", "zai/glm-5.2",
                         "openrouter/openai/gpt-5.5"],
 
-    // "on" = let stella choose rather than a pin. It no longer selects a
+    // "on" = let stella choose rather than a pin. It does not select a
     // model (see Auto modes); it marks whether a /profile holds the dials.
     "auto_mode": "off",
     // "on" = reasoning effort chosen for you, overriding "effort" below.

--- a/website/content/docs/self-improvement.mdx
+++ b/website/content/docs/self-improvement.mdx
@@ -18,7 +18,7 @@ claimed.
 [`stella tune`](/docs/commands/tune), `stella dataset export`, the Tool
 Foundry, and the nightly loop-bench gate. Everything else is still being
 designed, and the details will change. Read this as a map, not a feature
-list, and check the linked issue for the current state of any one part.
+list.
 </Callout>
 
 ## The core problem
@@ -247,23 +247,6 @@ it runs, and the time estimate is shown up front. Nothing is touched until
 you approve the plan.
 
 <DeckShot id="start-work" />
-
-## Following along
-
-Each part has an issue describing its goal, how it would actually work,
-how success is measured, its safety rule, and its first step:
-
-- [Tool Foundry](https://github.com/macanderson/stella/issues/830)
-- [Eval-driven self-tuning](https://github.com/macanderson/stella/issues/831)
-- [stella-maintains-stella](https://github.com/macanderson/stella/issues/832)
-- [Experience distillation](https://github.com/macanderson/stella/issues/833)
-- [Causal self-model](https://github.com/macanderson/stella/issues/834)
-- [Capability curriculum](https://github.com/macanderson/stella/issues/835)
-- [Weight-space adapters](https://github.com/macanderson/stella/issues/836)
-
-The two first steps, [dataset export](https://github.com/macanderson/stella/issues/872)
-and [the nightly loop-bench gate](https://github.com/macanderson/stella/issues/873),
-have both shipped. See "What's built today" above.
 
 ## See also
 


### PR DESCRIPTION
Closes #5606

## What &amp; Why

Three published pages sent the reader somewhere they cannot follow.

**`website/content/docs/self-improvement.mdx`** carried a "Following along" section
of nine links to issues in this repository, and its warning callout told the reader
to "check the linked issue for the current state of any one part". Both are gone.
The callout keeps the part that is useful to an outside reader — that four pieces
ship and the rest is a map rather than a feature list.

**`website/content/docs/configuration/agent-engine-config.mdx`** described
`auto_mode` as something that "no longer selects a model". A reader who never met
the old behaviour learns nothing from a sentence about what stopped. It now says
what the setting does.

**`README.md`** cited `doc:engine-embedding`. That id resolves for the repository
tooling and for nobody reading the README on GitHub, so it now links the published
page covering the same contract.

## The one non-obvious bit

Swapping the short citation for a full URL turned `make prose` red — that ratchet
counts a URL as words, and README moved from 16.14 to 16.17 against its own
ceiling. The fix was to split the long sentence in that bullet into three short
ones, which is what the guard is asking for. No baseline line was added.

## Verification

`make guards-fast` passes, and the three guards this diff can move:

- `make doc-links` — OK, 1133 citations resolve across 99 documents
- `make prose` — OK, none added; 2080 files within their reading-grade ceiling
- `make line-citations` — OK, 260 grandfathered citations, none added

No Rust changed, so no witness test applies; this is a prose-only diff.

## Definition of done

- [x] No page under `website/content/` links an issue or pull request in this repository
- [x] `self-improvement.mdx` no longer instructs the reader to consult an issue
- [x] `agent-engine-config.mdx` describes `auto_mode` by what it does
- [x] `README.md` cites no `doc:` id
- [x] `make doc-links`, `make prose` and `make line-citations` pass

## DoD re-verified on `954902b` (automated PR sweep)

The `dod` check was red because #5606's checkboxes were unticked. Each was
re-checked against this branch's head rather than against the claims above,
then ticked on the issue:

- `rg 'github\.com/macanderson/stella/(issues|pull)/' website/content/` — no matches.
- `rg 'doc:' README.md` — no matches; the embedding contract is reached by URL.
- The remaining "issue" mentions in `self-improvement.mdx` (lines 236-244) describe
  the agent sorting a backlog it reads over MCP. They are the feature, not an
  instruction to the reader, so that item stands.
- `make doc-links`, `make prose` and `make line-citations` each run clean on this
  head — exit 0, "none added" on both ratchets.

## Summary by Sourcery

Make public documentation self-contained by removing internal tracker references and clarifying current product behavior.

Enhancements:
- Update published documentation to describe current behavior and link readers to publicly accessible references instead of internal tracker items.

Documentation:
- Remove internal issue-tracking links and reader instructions from the self-improvement documentation.
- Clarify the behavior of the agent engine's auto_mode setting.
- Replace the README's internal embedding reference with the published Agent Engine in Your App documentation.