### PR TITLE
docs: correct four public claims the code contradicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,11 +347,13 @@ stella            # or: stella chat
 ```
 
 On a terminal this opens the tabbed interactive interface (Session · Agents ·
-Traces · Graph · Files · Skills · MCP) with PR-style diffs and an editable
-prompt queue. `--accessible` (or `STELLA_ACCESSIBLE=1`) runs the same interface
-for a screen reader: inline on your own screen, each finished message into
-normal scrollback exactly once, single-column panels, labelled rows instead of
-tables, and a spoken line on every tab, overlay, or focus change. `--plain` (or
+Traces · Graph · Files · Skills · MCP · Issues · Settings) with PR-style diffs
+and an editable prompt queue.
+
+`--accessible` (or `STELLA_ACCESSIBLE=1`) runs the same interface for a screen
+reader. It draws inline on your own screen. Each finished message goes into
+normal scrollback exactly once. Panels become single columns, rows replace
+tables, and every tab, overlay, or focus change is spoken. `--plain` (or
 `STELLA_PLAIN=1`, or piped stdio) falls back to the line-oriented prompt.
 
 **In-chat commands** — the two surfaces implement their own vocabularies, so

--- a/docs/why-stella.md
+++ b/docs/why-stella.md
@@ -90,8 +90,8 @@ default, an isolated git worktree per task on request · **lifecycle
 hooks** and an **MCP client** that merges external tools into the registry · and
 the **Command Deck** TUI with PR-style diffs and an editable prompt queue. Deep
 dives: [lifecycle hooks](https://stella.oxagen.sh/docs/agent-tools/hooks),
-[the files-touched ledger](https://stella.oxagen.sh/docs/telemetry/files-touched),
-[the memory citation loop](https://stella.oxagen.sh/docs/context-engine#the-citation-loop-memories-that-earn-their-place).
+[the files-touched ledger](https://stella.oxagen.sh/docs/telemetry),
+[the memory citation loop](https://stella.oxagen.sh/docs/context-engine#the-citation-loop).
 
 ## What it optimizes for
 

--- a/website/content/docs/agent-engine-in-your-app.mdx
+++ b/website/content/docs/agent-engine-in-your-app.mdx
@@ -438,7 +438,7 @@ you report a rate limit as `terminal`, you silently lose the backoff you wanted.
 
 ## Not built yet
 
-These are current as of version 0.9.86, so plan around them instead of hitting them
+These are the limits today, so plan around them instead of hitting them
 by surprise:
 
 - **A resume point can expire.** Frames are sequenced and can be replayed (see below),


### PR DESCRIPTION
Closes #5614

## What & Why

Four public claims, each checked against the source rather than against another document.

**`README.md:349` named seven Command Deck tabs.** `crates/stella-tui/src/deck.rs` declares `DeckTab::ALL` as `[DeckTab; 9]`; **Issues** and **Settings** were missing. The published site already had this right (`agent-modes.mdx` says "One surface, nine tabs"), so the README was the only wrong surface — and it contradicted itself, documenting `/settings` at line 368 as opening a tab the paragraph above never named.

**The embedding guide pinned its limits to "version 0.9.86"** against a workspace at `0.9.300`. I removed the stamp rather than bumping it: a version number in prose is a promise to update it that nobody keeps, and 214 releases of drift is what that promise is worth. The list of limits carries the value; the stamp only decays.

**Two links in `docs/why-stella.md` did not resolve.** `/docs/telemetry/files-touched` returns **404** and has no redirect in `next.config.mjs`; `files_touched` is documented on `/docs/telemetry`. The citation-loop anchor named a heading that does not exist — `context-engine.mdx:172` reads `## The citation loop`.

## Verification

Both replacements were fetched against the live site *before* being written, rather than assumed:

- `https://stella.oxagen.sh/docs/telemetry` → **200**
- `https://stella.oxagen.sh/docs/context-engine` contains `id="the-citation-loop"`

Guards:

- `make prose` — OK, none added; 2080 files within their reading-grade ceiling
- `make doc-links` — OK, 1133 citations resolve
- `make guards-fast` — OK

## The one non-obvious bit

Naming two more tabs pushed `README.md` from 16.14 to 16.15 against its own ceiling — the ratchet counts every added word, and that file sits within 0.01 of the line. The `--accessible` sentence beside it is split into shorter sentences to pay for it. **No baseline entry was added**, which is the only remedy the guard accepts.

No witness test applies — prose and link targets only.

## Definition of done

- [x] `README.md` names all nine tabs, matching `DeckTab::ALL`
- [x] The embedding guide states its limits without pinning them to a version number
- [x] Every link in `docs/why-stella.md` resolves, verified against the live site
- [x] `make prose`, `make doc-links` and `make guards-fast` pass with no baseline entry added

## Summary by Sourcery

Correct outdated public documentation claims and links so they match the current product and website.

Bug Fixes:
- Correct broken telemetry and context-engine links in the rationale documentation.
- Remove the stale version pin from the embedding guide's description of current limits.

Enhancements:
- Update the README to document all nine Command Deck tabs and improve the accessibility wording for readability.

Documentation:
- Align public documentation with the current Command Deck tabs, embedding limits, and live documentation URLs.

Tests:
- Validate prose, documentation links, and fast guard checks without adding a baseline exception.