### PR TITLE
feat(stella-store): record how each foundry tool enablement was authorised (#5403)

### DIFF
--- a/crates/stella-cli/src/tool_foundry/adopt.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt.rs
@@ -31,7 +31,7 @@ use colored::Colorize;
 use serde_json::Value;
 use stella_core::ports::ToolExecutor;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
-use stella_store::{AdoptedTool, Store};
+use stella_store::{AdoptedTool, EnableAuthority, Store};
 use stella_tools::custom::{self, CustomTool, CustomToolSet};
 use stella_tools::foundry_gate::PROPOSED_DIR;
 use stella_tools::foundry_witness::{WitnessVerdict, prove};
@@ -276,6 +276,7 @@ fn finish_adoption(
         enabled: false,
         adopted_at: String::new(),
         disabled_reason: String::new(),
+        enabled_authority: None,
     };
     store
         .adopt_foundry_tool(&record)
@@ -301,6 +302,13 @@ fn finish_adoption(
 ///
 /// `Ok(false)` means a human was asked and said no — the one outcome that is
 /// neither a grant nor an error.
+///
+/// Which consent path ran is stamped onto the row: a typed yes records
+/// [`EnableAuthority::InteractiveHuman`], `--yes` records
+/// [`EnableAuthority::FlagAssertion`]. They are different claims — a person
+/// the CLI saw at a terminal versus a claim by whatever process passed the
+/// flag — and recording them as one would throw away the difference the
+/// consent gate exists for.
 pub(crate) fn run_tools_enable_in(
     root: &Path,
     store: &Store,
@@ -328,7 +336,13 @@ pub(crate) fn run_tools_enable_in(
         }
     }
 
-    set_enabled_in(root, store, name, enabled)?;
+    let authority = match (enabled, yes) {
+        (false, _) => None,
+        (true, true) => Some(EnableAuthority::FlagAssertion),
+        // The prompt above ran and was answered yes, at a verified terminal.
+        (true, false) => Some(EnableAuthority::InteractiveHuman),
+    };
+    set_enabled_in(root, store, name, authority)?;
     Ok(true)
 }
 
@@ -399,7 +413,8 @@ fn confirm_enable(name: &str) -> Result<bool, String> {
 }
 
 /// Flip one adoption's enablement, refusing to enable a tool whose bytes no
-/// longer match the ones the witness ran against.
+/// longer match the ones the witness ran against. `Some(authority)` enables,
+/// saying how the grant was authorised; `None` disables.
 ///
 /// Checking here as well as at discovery is not redundant: the gate withholds
 /// a tampered tool silently-but-explainably at session start, whereas someone
@@ -408,7 +423,7 @@ pub(crate) fn set_enabled_in(
     root: &Path,
     store: &Store,
     name: &str,
-    enabled: bool,
+    authority: Option<EnableAuthority>,
 ) -> Result<(), String> {
     let record = store
         .adopted_foundry_tool(name)
@@ -420,7 +435,7 @@ pub(crate) fn set_enabled_in(
             )
         })?;
 
-    if enabled {
+    if authority.is_some() {
         let manifest_path = root.join(ADOPTED_DIR).join(format!("{name}.toml"));
         let text = std::fs::read_to_string(&manifest_path)
             .map_err(|e| format!("cannot read {}: {e}", manifest_path.display()))?;
@@ -445,7 +460,7 @@ pub(crate) fn set_enabled_in(
     }
 
     if !store
-        .set_foundry_tool_enabled(name, enabled)
+        .set_foundry_tool_enabled(name, authority)
         .map_err(|e| format!("cannot update the adoption ledger: {e}"))?
     {
         return Err(format!("`{name}` has not been adopted"));
@@ -474,10 +489,30 @@ pub(crate) fn render_report(store: &Store) -> Result<String, String> {
             "adopted, disabled"
         };
         out.push_str(&format!(
-            "  {} [{state}] {}\n    witness: {}\n    reuse:   {} call(s), {} failed{}\n",
-            row.tool.name,
-            row.tool.signature,
-            row.tool.witness,
+            "  {} [{state}] {}\n    witness: {}\n",
+            row.tool.name, row.tool.signature, row.tool.witness,
+        ));
+        // Only for enabled rows: the answer to "who approved this, and how?"
+        // is a fact about a live grant. `None` on an enabled row is a grant
+        // made before the ledger recorded the fact, and says so instead of
+        // guessing. The parenthesised tag is the provenance vocabulary
+        // (`stella_protocol::provenance::PublicationAuthority`): the
+        // strongest authority the recorded path proves.
+        if row.tool.enabled {
+            out.push_str(&format!(
+                "    enabled: {}\n",
+                match row.tool.enabled_authority {
+                    Some(authority) => format!(
+                        "{} (proves {})",
+                        authority.describe(),
+                        authority.established_authority().as_str()
+                    ),
+                    None => "unrecorded — turned on before the ledger kept this".to_string(),
+                }
+            ));
+        }
+        out.push_str(&format!(
+            "    reuse:   {} call(s), {} failed{}\n",
             row.calls,
             row.errors,
             match &row.last_used {

--- a/crates/stella-cli/src/tool_foundry/adopt/tests.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt/tests.rs
@@ -109,11 +109,11 @@ fn a_tool_is_unreachable_until_it_is_both_proven_and_approved() {
     );
 
     // 3. enabled → now, and only now, the model can reach it.
-    set_enabled_in(root, &store, &name, true).expect("enable");
+    set_enabled_in(root, &store, &name, Some(EnableAuthority::InteractiveHuman)).expect("enable");
     assert_eq!(session_tools(root), vec![name.clone()]);
 
     // ...and disabling takes it away again without discarding the proof.
-    set_enabled_in(root, &store, &name, false).expect("disable");
+    set_enabled_in(root, &store, &name, None).expect("disable");
     assert!(session_tools(root).is_empty());
     assert!(
         store
@@ -188,7 +188,8 @@ fn enabling_a_tool_whose_script_changed_is_refused() {
     let (_, script) = adopted_paths(root, &name);
     std::fs::write(&script, "#!/bin/sh\necho pwned\n").unwrap();
 
-    let err = set_enabled_in(root, &store, &name, true).expect_err("must refuse");
+    let err = set_enabled_in(root, &store, &name, Some(EnableAuthority::InteractiveHuman))
+        .expect_err("must refuse");
     assert!(err.contains("changed after adoption"), "{err}");
     assert!(session_tools(root).is_empty());
 }
@@ -202,7 +203,7 @@ fn re_adoption_proves_the_new_bytes_and_needs_a_new_approval() {
     let _home = crate::paths::test_user_home(root.to_path_buf());
     let name = author_cat(root, &store);
     adopt_in(root, &store, &name).expect("adopt");
-    set_enabled_in(root, &store, &name, true).expect("enable");
+    set_enabled_in(root, &store, &name, Some(EnableAuthority::InteractiveHuman)).expect("enable");
     assert_eq!(session_tools(root), vec![name.clone()]);
 
     // A reviewer edits the STAGED script and re-adopts.
@@ -342,7 +343,13 @@ fn adopting_an_unstaged_name_points_at_the_staging_step() {
 fn enabling_an_unadopted_name_points_at_the_adopt_command() {
     let ws = tempfile::tempdir().expect("tmp");
     let store = Store::open(ws.path()).expect("store");
-    let err = set_enabled_in(ws.path(), &store, "ghost", true).expect_err("not adopted");
+    let err = set_enabled_in(
+        ws.path(),
+        &store,
+        "ghost",
+        Some(EnableAuthority::InteractiveHuman),
+    )
+    .expect_err("not adopted");
     assert!(err.contains("stella tools --adopt ghost"), "{err}");
 }
 
@@ -419,12 +426,69 @@ fn an_explicit_yes_still_enables_without_a_terminal() {
 
     run_tools_enable_in(ws.path(), &store, &name, true, true).expect("--yes grants it");
 
+    let row = store
+        .adopted_foundry_tool(&name)
+        .expect("read")
+        .expect("adopted");
+    assert!(row.enabled);
+    assert_eq!(
+        row.enabled_authority,
+        Some(stella_store::EnableAuthority::FlagAssertion),
+        "--yes is recorded as the claim it is, not as a person the CLI saw"
+    );
+}
+
+/// **Witness.** The row records *how* the tool got turned on, and the two
+/// consent paths read back as distinct claims: a typed yes is a person the
+/// CLI saw at a terminal, `--yes` is a claim by whatever process passed
+/// the flag. One `approved_by_human` flag would erase that.
+///
+/// The prompt cannot run here — a test process has no terminal — so the
+/// typed-yes half goes through [`set_enabled_in`], the only write the
+/// prompt path makes after its yes.
+#[test]
+fn the_two_consent_paths_record_different_authorities() {
+    use stella_store::EnableAuthority;
+
+    let (ws, store) = workspace();
+    let name = author_cat(ws.path(), &store);
+    adopt_in(ws.path(), &store, &name).expect("adopt");
+
+    run_tools_enable_in(ws.path(), &store, &name, true, true).expect("--yes");
+    let by_flag = store
+        .adopted_foundry_tool(&name)
+        .expect("read")
+        .expect("adopted")
+        .enabled_authority;
+
+    set_enabled_in(ws.path(), &store, &name, None).expect("disable");
+    set_enabled_in(
+        ws.path(),
+        &store,
+        &name,
+        Some(EnableAuthority::InteractiveHuman),
+    )
+    .expect("enable interactively");
+    let interactive = store
+        .adopted_foundry_tool(&name)
+        .expect("read")
+        .expect("adopted")
+        .enabled_authority;
+
+    assert_eq!(by_flag, Some(EnableAuthority::FlagAssertion));
+    assert_eq!(interactive, Some(EnableAuthority::InteractiveHuman));
+    assert_ne!(by_flag, interactive, "the distinction is the field's point");
+
+    // And the report shows the answer, so nobody has to open the
+    // database.
+    let report = render_report(&store).expect("render");
     assert!(
-        store
-            .adopted_foundry_tool(&name)
-            .expect("read")
-            .expect("adopted")
-            .enabled
+        report.contains("a person answered the prompt at a terminal"),
+        "{report}"
+    );
+    assert!(
+        report.contains("proves local_human"),
+        "the provenance reading rides along: {report}"
     );
 }
 

--- a/crates/stella-cli/src/tool_foundry/autonomy.rs
+++ b/crates/stella-cli/src/tool_foundry/autonomy.rs
@@ -88,7 +88,12 @@ pub(crate) async fn run_autonomy(
         // draft staged for review — authored work is never silently thrown
         // away, and nothing unproven registers.
         match adopt::adopt_in_async(root, store, &pair.name, "adopt (autonomous)").await {
-            Ok(record) => match adopt::set_enabled_in(root, store, &pair.name, true) {
+            Ok(record) => match adopt::set_enabled_in(
+                root,
+                store,
+                &pair.name,
+                Some(stella_store::EnableAuthority::Autonomy),
+            ) {
                 Ok(()) => notices.push(format!(
                     "auto-adopted tool `{}` from gap {} — {}; network denied at spawn; \
                      disable with `stella tools --disable {}`",

--- a/crates/stella-cli/src/tool_foundry/ops.rs
+++ b/crates/stella-cli/src/tool_foundry/ops.rs
@@ -241,6 +241,7 @@ mod tests {
                     enabled: false,
                     adopted_at: String::new(),
                     disabled_reason: String::new(),
+                    enabled_authority: None,
                 })
                 .expect("adopt");
             store
@@ -255,7 +256,10 @@ mod tests {
                 .expect("version");
         }
         store
-            .set_foundry_tool_enabled("cat_file", true)
+            .set_foundry_tool_enabled(
+                "cat_file",
+                Some(stella_store::EnableAuthority::FlagAssertion),
+            )
             .expect("enable");
         let (manifest_path, script_path) = super::super::adopt::adopted_paths(root, "cat_file");
         std::fs::create_dir_all(manifest_path.parent().expect("parent")).expect("mkdir");
@@ -298,6 +302,11 @@ mod tests {
             .expect("row");
         assert!(row.enabled, "a rollback re-enables");
         assert_eq!(row.disabled_reason, "", "and clears the breaker verdict");
+        assert_eq!(
+            row.enabled_authority,
+            Some(stella_store::EnableAuthority::Rollback),
+            "and records the mechanism that re-enabled it"
+        );
         assert_eq!(
             row.script_digest,
             stella_tools::foundry_gate::digest(SCRIPT_V1.as_bytes()),

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -805,6 +805,12 @@ pub(crate) const STEP_RECEIPT_DDL: &str = "CREATE TABLE IF NOT EXISTS step_recei
 /// `enabled` defaults to 0 and `enabled_at` to NULL, which is the schema-level
 /// statement of #830's guardrail: adoption alone grants nothing.
 ///
+/// `enabled_authority` records which mechanism authorised the current
+/// enablement (`crate::foundry::EnableAuthority`'s tags). `''` — every
+/// disabled row and every row enabled before v42 — means no mechanism was
+/// recorded, which must read as unknown rather than as any particular
+/// grant.
+///
 /// No index beyond the implicit one on the primary key. The table holds one
 /// row per self-authored tool in a workspace — single digits, realistically —
 /// and every reader either fetches by name or scans the lot.
@@ -819,7 +825,8 @@ pub(crate) const FOUNDRY_TOOLS_DDL: &str = "CREATE TABLE IF NOT EXISTS foundry_t
        enabled INTEGER NOT NULL DEFAULT 0,
        adopted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
        enabled_at TEXT,
-       disabled_reason TEXT NOT NULL DEFAULT ''
+       disabled_reason TEXT NOT NULL DEFAULT '',
+       enabled_authority TEXT NOT NULL DEFAULT ''
      );";
 
 /// `foundry_tool_versions` DDL at [`SCHEMA_VERSION`](crate::migrations::SCHEMA_VERSION) — the append-only

--- a/crates/stella-store/src/foundry.rs
+++ b/crates/stella-store/src/foundry.rs
@@ -37,8 +37,98 @@
 //! adoption cannot inflate the number.
 
 use rusqlite::{OptionalExtension, params};
+use stella_protocol::provenance::PublicationAuthority;
 
 use crate::{Result, Store};
+
+/// How a tool got turned on — the fact the enabling path saw, kept on the
+/// row so "who approved this, and how?" has an answer later.
+///
+/// This records the *path taken*, not a second authority grading. The
+/// grading vocabulary is `stella_protocol::provenance`, and
+/// [`EnableAuthority::established_authority`] reads each path into it.
+/// Store the fact, derive the grade — the evolution ledger's own rule
+/// (`stella-parity/src/evolution.rs`): a stored authority column is a
+/// second copy of the policy, free to drift from it.
+///
+/// One `approved_by_human: bool` would not do. A typed yes and a `--yes`
+/// flag are claims of different strength: the first is a person the CLI
+/// saw at a terminal, the second is a claim by whatever process passed the
+/// flag — which an agent holding a shell can be.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnableAuthority {
+    /// A person at a terminal read the declaration and answered yes. The
+    /// one path where the CLI saw a human.
+    InteractiveHuman,
+    /// `--yes` on `stella tools --enable`: the caller claims the
+    /// declaration was read. Nobody was seen. The flag serves scripts with
+    /// no terminal, and an agent running a shell can pass it too.
+    FlagAssertion,
+    /// The `auto` autonomy loop turned on its own witness-proven
+    /// adoption, under the standing controls that replace the prompt.
+    Autonomy,
+    /// `stella tools --rollback` turned a restored prior version back on.
+    Rollback,
+}
+
+impl EnableAuthority {
+    /// The `snake_case` tag this path is stored as. `''` in the column is
+    /// not a tag: it means the grant predates the recording (or the row is
+    /// off), and reads as unknown rather than as any of these claims.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InteractiveHuman => "interactive_human",
+            Self::FlagAssertion => "flag_assertion",
+            Self::Autonomy => "autonomy",
+            Self::Rollback => "rollback",
+        }
+    }
+
+    /// The stored tag, read back. `None` for a tag not on the list — the
+    /// callers turn that into an error, not a guess, because the
+    /// schema-version gate means an unknown tag is a corrupt row, not a
+    /// newer writer.
+    #[must_use]
+    pub fn from_tag(tag: &str) -> Option<Self> {
+        match tag {
+            "interactive_human" => Some(Self::InteractiveHuman),
+            "flag_assertion" => Some(Self::FlagAssertion),
+            "autonomy" => Some(Self::Autonomy),
+            "rollback" => Some(Self::Rollback),
+            _ => None,
+        }
+    }
+
+    /// The strongest `provenance.rs` authority the recorded path *proves*
+    /// — not the one it claims.
+    ///
+    /// Only a typed yes proves [`PublicationAuthority::LocalHuman`].
+    /// `--yes` claims a human read the declaration, but what was seen is a
+    /// process saying so, and provenance's own rule is that a claim is not
+    /// promoted to a sighting — so it proves only
+    /// [`PublicationAuthority::Agent`], the weakest actor the evidence
+    /// allows. A rollback is the same: a command nobody checked. Autonomy
+    /// is the agent acting alone by definition.
+    #[must_use]
+    pub fn established_authority(self) -> PublicationAuthority {
+        match self {
+            Self::InteractiveHuman => PublicationAuthority::LocalHuman,
+            Self::FlagAssertion | Self::Autonomy | Self::Rollback => PublicationAuthority::Agent,
+        }
+    }
+
+    /// One line for the `stella tools --foundry` report.
+    #[must_use]
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::InteractiveHuman => "a person answered the prompt at a terminal",
+            Self::FlagAssertion => "--yes: asserted by the caller, no person observed",
+            Self::Autonomy => "the autonomy pipeline, under its standing controls",
+            Self::Rollback => "re-enabled by rolling back to a prior approved version",
+        }
+    }
+}
 
 /// One workspace's record that a foundry-authored tool was adopted.
 ///
@@ -73,6 +163,11 @@ pub struct AdoptedTool {
     /// human `--disable`, and every pre-v41 row: `enabled` says whether the
     /// tool is offered, this says which mechanism turned it off and why.
     pub disabled_reason: String,
+    /// How the tool got turned on, `disabled_reason`'s mirror: that says
+    /// what turned the tool off, this says what turned it on. `None` while
+    /// off — and for a row turned on before v42 kept the fact, which reads
+    /// as unknown rather than as any path.
+    pub enabled_authority: Option<EnableAuthority>,
 }
 
 /// One adopted tool with the use it has actually seen since — the #830
@@ -124,7 +219,8 @@ impl Store {
                enabled = 0, \
                adopted_at = CURRENT_TIMESTAMP, \
                enabled_at = NULL, \
-               disabled_reason = ''",
+               disabled_reason = '', \
+               enabled_authority = ''",
             params![
                 tool.name,
                 tool.signature,
@@ -139,17 +235,29 @@ impl Store {
     }
 
     /// Enable or disable an adopted tool — the one human decision in the
-    /// protocol. Returns `false` when no such adoption exists, so a caller can
-    /// tell "flipped it" from "there was nothing to flip" rather than
-    /// reporting success for a no-op.
-    pub fn set_foundry_tool_enabled(&self, name: &str, enabled: bool) -> Result<bool> {
+    /// protocol. `Some(authority)` enables and records how; `None` disables,
+    /// asks nobody, and records nothing. A caller cannot enable without
+    /// saying how, which is the point: the ledger answers "who approved
+    /// this?" only if every grant writes the answer. Returns `false` when no
+    /// such adoption exists, so a caller can tell "flipped it" from "there
+    /// was nothing to flip" rather than reporting success for a no-op.
+    pub fn set_foundry_tool_enabled(
+        &self,
+        name: &str,
+        authority: Option<EnableAuthority>,
+    ) -> Result<bool> {
         let conn = self.lock();
         let changed = conn.execute(
             "UPDATE foundry_tools SET enabled = ?2, \
                enabled_at = CASE WHEN ?2 = 1 THEN CURRENT_TIMESTAMP ELSE NULL END, \
+               enabled_authority = ?3, \
                disabled_reason = '' \
              WHERE name = ?1",
-            params![name, i64::from(enabled)],
+            params![
+                name,
+                i64::from(authority.is_some()),
+                authority.map(EnableAuthority::as_str).unwrap_or(""),
+            ],
         )?;
         Ok(changed > 0)
     }
@@ -167,7 +275,7 @@ impl Store {
         let conn = self.lock();
         let mut stmt = conn.prepare(
             "SELECT name, signature, manifest_digest, script_digest, witness, witness_input, \
-                    witness_expect, enabled, adopted_at, disabled_reason \
+                    witness_expect, enabled, adopted_at, disabled_reason, enabled_authority \
              FROM foundry_tools ORDER BY name ASC",
         )?;
         let rows = stmt.query_map([], row_to_adopted)?;
@@ -184,7 +292,7 @@ impl Store {
         let row = conn
             .query_row(
                 "SELECT name, signature, manifest_digest, script_digest, witness, witness_input, \
-                        witness_expect, enabled, adopted_at, disabled_reason \
+                        witness_expect, enabled, adopted_at, disabled_reason, enabled_authority \
                  FROM foundry_tools WHERE name = ?1",
                 params![name],
                 row_to_adopted,
@@ -206,6 +314,7 @@ impl Store {
         let mut stmt = conn.prepare(
             "SELECT f.name, f.signature, f.manifest_digest, f.script_digest, f.witness, \
                     f.witness_input, f.witness_expect, f.enabled, f.adopted_at, f.disabled_reason, \
+                    f.enabled_authority, \
                     (SELECT COUNT(*) FROM tool_calls t \
                       WHERE t.name = f.name AND t.ts >= f.adopted_at AND t.state != 'running'), \
                     (SELECT COUNT(*) FROM tool_calls t \
@@ -217,9 +326,9 @@ impl Store {
         let rows = stmt.query_map([], |r| {
             Ok(FoundryReuse {
                 tool: row_to_adopted(r)?,
-                calls: r.get(10)?,
-                errors: r.get(11)?,
-                last_used: r.get(12)?,
+                calls: r.get(11)?,
+                errors: r.get(12)?,
+                last_used: r.get(13)?,
             })
         })?;
         let mut out = Vec::new();
@@ -395,7 +504,8 @@ impl Store {
     pub fn disable_foundry_tool_with_reason(&self, name: &str, reason: &str) -> Result<bool> {
         let conn = self.lock();
         let changed = conn.execute(
-            "UPDATE foundry_tools SET enabled = 0, enabled_at = NULL, disabled_reason = ?2 \
+            "UPDATE foundry_tools SET enabled = 0, enabled_at = NULL, enabled_authority = '', \
+               disabled_reason = ?2 \
              WHERE name = ?1",
             params![name, reason],
         )?;
@@ -420,9 +530,14 @@ impl Store {
         let changed = conn.execute(
             "UPDATE foundry_tools SET manifest_digest = ?2, script_digest = ?3, \
                enabled = 1, enabled_at = CURRENT_TIMESTAMP, disabled_reason = '', \
-               adopted_at = CURRENT_TIMESTAMP \
+               enabled_authority = ?4, adopted_at = CURRENT_TIMESTAMP \
              WHERE name = ?1",
-            params![name, manifest_digest, script_digest],
+            params![
+                name,
+                manifest_digest,
+                script_digest,
+                EnableAuthority::Rollback.as_str(),
+            ],
         )?;
         Ok(changed > 0)
     }
@@ -460,9 +575,25 @@ impl Store {
     }
 }
 
-/// The ten leading columns every reader above selects, in one place so the
+/// The eleven leading columns every reader above selects, in one place so the
 /// column order and the struct cannot drift.
 fn row_to_adopted(r: &rusqlite::Row<'_>) -> rusqlite::Result<AdoptedTool> {
+    let authority_tag: String = r.get(10)?;
+    let enabled_authority = if authority_tag.is_empty() {
+        None
+    } else {
+        // The schema-version gate refuses a database newer than this build,
+        // so an unrecognised tag is a corrupt row and errors rather than
+        // reading as "unknown" — which is reserved for rows that genuinely
+        // predate the recording.
+        Some(EnableAuthority::from_tag(&authority_tag).ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                10,
+                rusqlite::types::Type::Text,
+                format!("unrecognised enabled_authority tag `{authority_tag}`").into(),
+            )
+        })?)
+    };
     Ok(AdoptedTool {
         name: r.get(0)?,
         signature: r.get(1)?,
@@ -474,6 +605,7 @@ fn row_to_adopted(r: &rusqlite::Row<'_>) -> rusqlite::Result<AdoptedTool> {
         enabled: r.get::<_, i64>(7)? != 0,
         adopted_at: r.get(8)?,
         disabled_reason: r.get(9)?,
+        enabled_authority,
     })
 }
 

--- a/crates/stella-store/src/foundry/tests.rs
+++ b/crates/stella-store/src/foundry/tests.rs
@@ -17,6 +17,7 @@ fn adopted(name: &str) -> AdoptedTool {
         enabled: false,
         adopted_at: String::new(),
         disabled_reason: String::new(),
+        enabled_authority: None,
     }
 }
 
@@ -62,7 +63,7 @@ fn an_adoption_survives_a_restart() {
             .expect("adopt");
         assert!(
             store
-                .set_foundry_tool_enabled("cat_file", true)
+                .set_foundry_tool_enabled("cat_file", Some(EnableAuthority::InteractiveHuman))
                 .expect("enable")
         );
     }
@@ -71,6 +72,11 @@ fn an_adoption_survives_a_restart() {
     assert_eq!(tools.len(), 1);
     assert_eq!(tools[0].name, "cat_file");
     assert!(tools[0].enabled, "the human decision must survive");
+    assert_eq!(
+        tools[0].enabled_authority,
+        Some(EnableAuthority::InteractiveHuman),
+        "and so must how it was made"
+    );
     assert_eq!(tools[0].witness_expect, "alpha-contents");
     assert_eq!(tools[0].witness_input, r#"{"p1":"a.txt"}"#);
     assert!(
@@ -104,7 +110,7 @@ fn re_adopting_revokes_the_approval() {
         .adopt_foundry_tool(&adopted("cat_file"))
         .expect("adopt");
     store
-        .set_foundry_tool_enabled("cat_file", true)
+        .set_foundry_tool_enabled("cat_file", Some(EnableAuthority::InteractiveHuman))
         .expect("enable");
 
     let mut edited = adopted("cat_file");
@@ -119,13 +125,89 @@ fn re_adopting_revokes_the_approval() {
     assert_eq!(stored.script_digest, "s1-different");
 }
 
+/// **Witness.** Every grant records how it was made, the paths read back
+/// as distinct, and withdrawing the grant withdraws the record:
+/// `enabled_authority` describes the grant in force, so a row that is off
+/// must not keep claiming an approval it lost.
+#[test]
+fn each_grant_records_its_authority_and_a_disable_clears_it() {
+    let store = Store::in_memory().expect("store");
+    store
+        .adopt_foundry_tool(&adopted("cat_file"))
+        .expect("adopt");
+
+    let read = |store: &Store| {
+        store
+            .adopted_foundry_tool("cat_file")
+            .expect("read")
+            .expect("present")
+            .enabled_authority
+    };
+
+    store
+        .set_foundry_tool_enabled("cat_file", Some(EnableAuthority::FlagAssertion))
+        .expect("enable");
+    assert_eq!(read(&store), Some(EnableAuthority::FlagAssertion));
+
+    store
+        .set_foundry_tool_enabled("cat_file", Some(EnableAuthority::InteractiveHuman))
+        .expect("re-enable");
+    assert_eq!(
+        read(&store),
+        Some(EnableAuthority::InteractiveHuman),
+        "the two consent paths are different recorded claims"
+    );
+
+    store
+        .set_foundry_tool_enabled("cat_file", None)
+        .expect("disable");
+    assert_eq!(read(&store), None, "no grant, no authority");
+
+    // The breaker's disable withdraws the record the same way.
+    store
+        .set_foundry_tool_enabled("cat_file", Some(EnableAuthority::Autonomy))
+        .expect("enable");
+    store
+        .disable_foundry_tool_with_reason("cat_file", "3 consecutive failures")
+        .expect("breaker");
+    assert_eq!(read(&store), None);
+}
+
+/// **Witness.** Re-adoption revokes the approval, and the record of how
+/// it was made goes with it. New bytes wearing the old grant's record would
+/// be the same laundering `re_adopting_revokes_the_approval` refuses.
+#[test]
+fn re_adopting_clears_the_recorded_authority() {
+    let store = Store::in_memory().expect("store");
+    store
+        .adopt_foundry_tool(&adopted("cat_file"))
+        .expect("adopt");
+    store
+        .set_foundry_tool_enabled("cat_file", Some(EnableAuthority::InteractiveHuman))
+        .expect("enable");
+
+    store
+        .adopt_foundry_tool(&adopted("cat_file"))
+        .expect("re-adopt");
+    let row = store
+        .adopted_foundry_tool("cat_file")
+        .expect("read")
+        .expect("present");
+    assert!(!row.enabled);
+    assert_eq!(row.enabled_authority, None);
+}
+
 /// Enabling something that was never adopted reports that, rather than
 /// silently succeeding — a no-op that answers "done" is how an approval gets
 /// believed for a tool that has none.
 #[test]
 fn enabling_an_unadopted_tool_says_so() {
     let store = Store::in_memory().expect("store");
-    assert!(!store.set_foundry_tool_enabled("ghost", true).expect("set"));
+    assert!(
+        !store
+            .set_foundry_tool_enabled("ghost", Some(EnableAuthority::InteractiveHuman))
+            .expect("set")
+    );
     assert!(store.adopted_foundry_tool("ghost").expect("read").is_none());
 }
 
@@ -137,7 +219,7 @@ fn forgetting_an_adoption_removes_its_approval() {
     let store = Store::in_memory().expect("store");
     store.adopt_foundry_tool(&adopted("gone")).expect("adopt");
     store
-        .set_foundry_tool_enabled("gone", true)
+        .set_foundry_tool_enabled("gone", Some(EnableAuthority::InteractiveHuman))
         .expect("enable");
     assert!(store.forget_foundry_tool("gone").expect("forget"));
     assert!(store.adopted_foundry_tools().expect("read").is_empty());

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -196,7 +196,7 @@ pub use efficacy::FinishedExecution;
 pub use error::StoreError;
 pub use export::ExportExclusions;
 pub use forget::{ContextSurface, SurfaceSuppression, is_restatement, is_suppressed};
-pub use foundry::{AdoptedTool, FoundryInvocation, FoundryReuse, FoundryVersion};
+pub use foundry::{AdoptedTool, EnableAuthority, FoundryInvocation, FoundryReuse, FoundryVersion};
 pub use integrity::{IntegrityDepth, IntegrityReport, StoreQuarantine};
 pub use session_stats::{PROMPT_SAMPLE, SessionStats};
 // The sidecar journal's writer is NOT re-exported at the top

--- a/crates/stella-store/src/migrations.rs
+++ b/crates/stella-store/src/migrations.rs
@@ -31,6 +31,7 @@
 //! | [`task_contract`] | v28 → v29 | what a task promised, beside what became of it |
 //! | [`task_events`] | v38 → v39 | which task an event is evidence for |
 //! | [`agent_use_kind`] | v30 → v31 | which of two writers minted an `agent_uses` name |
+//! | [`enable_authority`] | v41 → v42 | which mechanism enabled a foundry tool |
 //!
 //! A new step gets a new module (or joins the group whose shape it shares),
 //! declares itself here, and takes the next slot in the ladder. It does not
@@ -55,6 +56,7 @@ mod agent_use_kind;
 mod call_identity;
 mod delivered_runs;
 mod dispatched_executions;
+mod enable_authority;
 mod error_class;
 mod execution_plane;
 mod execution_role;
@@ -83,6 +85,7 @@ use additive_tables::{
     migrate_v2_to_v3, migrate_v3_to_v4, migrate_v4_to_v5, migrate_v5_to_v6, migrate_v6_to_v7,
     migrate_v13_to_v14, migrate_v19_to_v20, migrate_v20_to_v21, migrate_v39_to_v40,
 };
+use enable_authority::migrate_v41_to_v42;
 use error_class::migrate_v24_to_v25;
 use execution_plane::{
     migrate_v7_to_v8, migrate_v8_to_v9, migrate_v9_to_v10, migrate_v21_to_v22, migrate_v22_to_v23,
@@ -110,7 +113,7 @@ pub(crate) type Migration = fn(&rusqlite::Transaction<'_>) -> Result<()>;
 /// a file at `user_version` i to i + 1. Fresh files never run these — they
 /// get [`create_latest_schema`] and are stamped at [`SCHEMA_VERSION`]
 /// directly.
-pub(crate) const MIGRATIONS: [Migration; 41] = [
+pub(crate) const MIGRATIONS: [Migration; 42] = [
     // v0 → v1: dedupe events/telemetry, then retrofit the UNIQUE keys
     // their write paths have always assumed.
     migrate_v0_to_v1,
@@ -340,6 +343,12 @@ pub(crate) const MIGRATIONS: [Migration; 41] = [
     // the circuit breaker's recorded answer to "why is this tool off". See
     // the module's own doc.
     migrate_v40_to_v41,
+    // v41 → v42: `foundry_tools.enabled_authority` — how a tool got
+    // turned on: a typed yes, a `--yes` flag, the autonomy loop, or a
+    // rollback. Additive, column-guarded ADD COLUMN, defaulted to '' with
+    // no backfill: no old row wrote the fact, so every pre-v42 row reads as
+    // unknown rather than as any grant. See the module's own doc.
+    migrate_v41_to_v42,
     // ── APPEND POINT — RESERVED SLOTS ───────────────────────────────────
     // This is an INDEX-ORDERED array and `SCHEMA_VERSION` is its length, so
     // a slot is claimed by position, not by name. Two branches that each
@@ -397,7 +406,8 @@ pub(crate) const MIGRATIONS: [Migration; 41] = [
     //   v39 → v40: CLAIMED above by the plan graph's `plan_revisions` and
     //              `plan_edges` tables (#5037).
     //   v40 → v41: CLAIMED above by the autonomous-foundry plane.
-    // Nothing is reserved now: take v41 → v42 and add your own line here.
+    //   v41 → v42: CLAIMED above by `foundry_tools.enabled_authority`.
+    // Nothing is reserved now: take v42 → v43 and add your own line here.
     // If a reserved phase ships without needing its slot, delete its line
     // rather than leaving a hole — index order is the contract.
 ];

--- a/crates/stella-store/src/migrations/enable_authority.rs
+++ b/crates/stella-store/src/migrations/enable_authority.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! v41 → v42: `foundry_tools` learns how each tool got turned on.
+
+use crate::Result;
+use crate::migrations::{column_exists, table_exists};
+
+/// v41 → v42: `foundry_tools` grows `enabled_authority`. The column names
+/// how a tool got turned on: a typed yes, a `--yes` flag, the autonomy
+/// loop, or a rollback. The tags live in `crate::foundry::EnableAuthority`.
+///
+/// Nothing is backfilled. No old row wrote this fact, so `''` reads as
+/// unknown for all of them. That holds even for a row that is on. An old
+/// grant must not turn into a claim about how it was made.
+pub(super) fn migrate_v41_to_v42(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    // Column-guarded, like every ALTER in this chain: a legacy file that
+    // walked the ladder got today's `foundry_tools` shape at v19 → v20 (the
+    // DDL constants describe the current schema), so the column may already
+    // be there.
+    if table_exists(tx, "foundry_tools")?
+        && !column_exists(tx, "foundry_tools", "enabled_authority")?
+    {
+        tx.execute_batch(
+            "ALTER TABLE foundry_tools ADD COLUMN enabled_authority TEXT NOT NULL DEFAULT '';",
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::apply_migration;
+    use rusqlite::Connection;
+
+    /// A v41 file: the old table shape, with one tool a person had
+    /// already turned on.
+    fn v41_file() -> Connection {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "CREATE TABLE foundry_tools (
+               name TEXT PRIMARY KEY,
+               signature TEXT NOT NULL DEFAULT '',
+               manifest_digest TEXT NOT NULL,
+               script_digest TEXT NOT NULL,
+               witness TEXT NOT NULL DEFAULT '',
+               witness_input TEXT NOT NULL DEFAULT '{}',
+               witness_expect TEXT NOT NULL DEFAULT '',
+               enabled INTEGER NOT NULL DEFAULT 0,
+               adopted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+               enabled_at TEXT,
+               disabled_reason TEXT NOT NULL DEFAULT ''
+             );
+             INSERT INTO foundry_tools (name, manifest_digest, script_digest, enabled, enabled_at)
+               VALUES ('cat_file', 'm0', 's0', 1, CURRENT_TIMESTAMP);",
+        )
+        .expect("seed a v41 file");
+        conn
+    }
+
+    /// **Witness.** A row turned on before the column existed reads as
+    /// unknown — not as a typed yes, not as `--yes`. Nothing wrote the
+    /// fact, so nothing may claim it.
+    #[test]
+    fn a_pre_existing_enablement_reads_as_unknown() {
+        let mut conn = v41_file();
+        apply_migration(&mut conn, migrate_v41_to_v42, 42).expect("migrate");
+        let authority: String = conn
+            .query_row(
+                "SELECT enabled_authority FROM foundry_tools WHERE name = 'cat_file'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read back");
+        assert_eq!(authority, "", "unknown, never a back-dated grant");
+    }
+
+    /// Running it twice is a no-op. The column guard makes that true,
+    /// not the error handler.
+    #[test]
+    fn the_migration_is_idempotent() {
+        let mut conn = v41_file();
+        apply_migration(&mut conn, migrate_v41_to_v42, 42).expect("first");
+        apply_migration(&mut conn, migrate_v41_to_v42, 42).expect("second");
+    }
+
+    /// A file with no `foundry_tools` table still climbs the ladder. The
+    /// rebuild path can present that shape.
+    #[test]
+    fn a_file_with_no_foundry_table_still_migrates() {
+        let mut conn = Connection::open_in_memory().expect("db");
+        apply_migration(&mut conn, migrate_v41_to_v42, 42).expect("migrate");
+    }
+}

--- a/crates/stella-store/src/tests.rs
+++ b/crates/stella-store/src/tests.rs
@@ -1070,7 +1070,11 @@ fn skill_usage_records_per_execution_version_rows() {
     //       included), `foundry_invocations` (per-launch telemetry the
     //       circuit breaker folds over), and `foundry_tools.disabled_reason`
     //       (the breaker's recorded verdict; `''` means no breaker spoke).
-    assert_eq!(SCHEMA_VERSION, 41);
+    //       v42 `foundry_tools.enabled_authority` — how a tool got turned
+    //       on: a typed yes, a `--yes` flag, the autonomy loop, or a
+    //       rollback; `''` means the grant predates the recording and reads
+    //       as unknown.
+    assert_eq!(SCHEMA_VERSION, 42);
 
     let id = store
         .begin_execution("deck", "format the sql", "zai", "glm-5.2")

--- a/crates/stella-tools/src/custom/tests/execution.rs
+++ b/crates/stella-tools/src/custom/tests/execution.rs
@@ -400,9 +400,12 @@ fn adopt_enabled(root: &Path, name: &str) -> stella_store::Store {
             enabled: false,
             adopted_at: String::new(),
             disabled_reason: String::new(),
+            enabled_authority: None,
         })
         .expect("adopt");
-    store.set_foundry_tool_enabled(name, true).expect("enable");
+    store
+        .set_foundry_tool_enabled(name, Some(stella_store::EnableAuthority::FlagAssertion))
+        .expect("enable");
     store
 }
 

--- a/crates/stella-tools/src/foundry_gate/tests.rs
+++ b/crates/stella-tools/src/foundry_gate/tests.rs
@@ -59,6 +59,7 @@ fn record(name: &str, enabled: bool) -> AdoptedTool {
         enabled,
         adopted_at: "2026-08-04 00:00:00".into(),
         disabled_reason: String::new(),
+        enabled_authority: None,
     }
 }
 


### PR DESCRIPTION
## What & why

`stella tools --enable` gained a consent gate in #5402, but the adopted-tool row still recorded only `enabled: bool` — an interactive answer at a terminal, a `--yes` in a provisioning script, and a pre-gate enablement were indistinguishable after the fact.

Schema **v42** adds `foundry_tools.enabled_authority`: the path that made the grant. `Store::set_foundry_tool_enabled` now takes `Option<EnableAuthority>`, so no caller can enable without saying how:

- `interactive_human` — a typed yes at a verified terminal (`run_tools_enable_in`'s prompt path)
- `flag_assertion` — `--yes` (recorded as the claim it is, not as an observed person)
- `autonomy` — the `auto` autonomy pipeline enabling its own proven adoption
- `rollback` — `stella tools --rollback` re-enabling a restored version

A disable (human, `--disable`, or the circuit breaker) clears the record; re-adoption revokes it with the approval; **pre-v42 rows read as unknown** — the migration backfills nothing, so an absent record is never back-dated into a claim. `stella tools --foundry` prints an `enabled:` line for every live grant, unknown included.

**On the vocabulary DoD item:** the stored value is the observed *path*, not a `provenance.rs` value, because `PublicationAuthority` names actors and the `--yes` path's actor is unobservable — storing `local_human` would launder an assertion into a sighting, and storing `agent` would claim the opposite. Instead `EnableAuthority::established_authority()` derives the strongest `PublicationAuthority` each path proves (`interactive_human → local_human`; the other three → `agent`, the weakest actor the evidence allows), and the report prints both. Store the fact, derive the grade — the same rule `stella-parity/src/evolution.rs` follows for its own authority columns (the exemplar for this design). No second grading is invented: `EnableAuthority` is a flat record with no order.

Closes #5403

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

One per DoD claim:

- `migrations/enable_authority.rs::a_pre_existing_enablement_reads_as_unknown` — builds a real v41-shaped file, migrates, and asserts the enabled row reads `''`. Fails on `main` (the migration does not exist).
- `foundry/tests.rs::each_grant_records_its_authority_and_a_disable_clears_it` and `adopt/tests.rs::the_two_consent_paths_record_different_authorities` — interactive and `--yes` produce different recorded authority, and the report surfaces it (`proves local_human` included). Neither compiles on `main`: the field and the parameter are genuinely absent.
- `foundry/tests.rs::re_adopting_clears_the_recorded_authority`, plus the strengthened rollback witness in `ops.rs` (`enabled_authority == Some(Rollback)`) and the strengthened `--yes` witness (`Some(FlagAssertion)`).

The interactive prompt itself cannot run in a test (no terminal); its one post-yes write is `set_enabled_in`, which the witnesses drive directly.

## The gate

- [x] Formatting checked (rustfmt, default config)
- [x] Clippy clean at `-D warnings` for the three touched crates (`stella-store`, `stella-tools`, `stella-cli`), all targets — this PR's full evidence is its CI run, per the repo rule that CI builds and tests
- [x] Tests pass per-crate: `stella-store` 473 lib + 31 migration/doc, `stella-tools` 587, `stella-cli` `tool_foundry` filter 34 — the workspace run is CI's
- [x] Docs updated where behavior changed (schema doc in `ddl.rs`, migration ladder, `--foundry` report line)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #5616 — the `migrations.rs` submodule doc table has drifted: seven step modules (`foundry_plane`, `delivered_runs`, `dispatched_executions`, `telemetry_call_identity`, `sub_agent_calls`, `sub_agent_tool_calls`, `partial_reflection`) are absent from the table that says every step "declares itself here". This PR adds its own row but does not repair the drift.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- New cross-boundary type: `EnableAuthority` crosses the store→CLI boundary as a Rust enum, like `AdoptedTool` beside it — neither is serialized across a process boundary, so no serde round-trip applies (it round-trips through its SQL tag instead, covered by the store tests).

## Anything reviewers should know?

`set_foundry_tool_enabled(name, enabled: bool)` became `set_foundry_tool_enabled(name, authority: Option<EnableAuthority>)` rather than gaining a second parameter: a `bool` plus an authority that is meaningful only when `true` is two fields describing one state, and the `Option` makes "enabled without saying how" unrepresentable.

## Summary by Sourcery

Track and report how foundry tool enablements were authorised without inferring approval details for legacy grants.

New Features:
- Record the mechanism that authorised each enabled foundry tool, distinguishing interactive approval, `--yes`, autonomy, and rollback paths.
- Display live enablement authority and its derived provenance in the `stella tools --foundry` report, including unknown authority for legacy grants.

Bug Fixes:
- Clear recorded enablement authority whenever a tool is disabled, re-adopted, or disabled by the circuit breaker.
- Preserve pre-v42 enablements as unknown rather than backdating an authority claim.

Enhancements:
- Require callers to provide an explicit authority when enabling a foundry tool and derive provenance grades from the recorded enablement path.

Documentation:
- Document the new schema field, migration, and foundry report output.

Tests:
- Add migration, store, adoption, autonomy, and rollback coverage for authority recording, clearing, persistence, and legacy unknown values.