### PR TITLE
test(stella-cli): pin the enterprise enrollment signature to a conformance vector

### DIFF
--- a/crates/stella-cli/src/enterprise_telemetry/fixtures/enrollment_signature_conformance_v1.json
+++ b/crates/stella-cli/src/enterprise_telemetry/fixtures/enrollment_signature_conformance_v1.json
@@ -1,0 +1,23 @@
+{
+  "$comment": "Cross-language conformance vector for the enterprise enrollment signature (canonical_enrollment_bytes + HMAC-SHA256, domain 'stella.enterprise.telemetry.enrollment-signature.v1'). The Rust test beside this file pins this repository's implementation to it; oxagen vendors a byte-identical copy and pins its TypeScript signer (the enrollment-provisioning capability) to the same bytes. Change the encoding and BOTH tests go red — which is the point. secret_utf8 is the HMAC key as UTF-8 text.",
+  "secret_utf8": "conformance-secret-0123456789abcdef",
+  "claims": {
+    "schema": "stella.enterprise.telemetry.enrollment.v1",
+    "issuer": "oxagen-enterprise",
+    "audience": "stella-cli",
+    "enrollment_id": "sten_conformance0001",
+    "organization_id": "org_conformance",
+    "workspace_id": "ws_conformance",
+    "endpoint": "https://api.oxagen.sh/v1/telemetry/stella/operational",
+    "credential_env": "STELLA_ENTERPRISE_TELEMETRY_TOKEN",
+    "event_classes": ["execution_rollup"],
+    "host_data_isolation": "process_free",
+    "model_catalog": [
+      { "provider": "anthropic", "model": "anthropic/claude-fable-5" },
+      { "provider": "openai", "model": "openai/gpt-5" }
+    ],
+    "issued_at_unix_s": 1756600000,
+    "expires_at_unix_s": 1764376000
+  },
+  "signature_hex": "1b9950855f3680b1af313826aa99dfc853c2fafd4da90f233ca9f8365452f68e"
+}

--- a/crates/stella-cli/src/enterprise_telemetry/tests.rs
+++ b/crates/stella-cli/src/enterprise_telemetry/tests.rs
@@ -1236,8 +1236,8 @@ fn enrollment_signature_matches_the_committed_conformance_vector() {
     assert_eq!(
         signature_hex,
         fixture["signature_hex"].as_str().unwrap(),
-        "the enrollment signature no longer matches the conformance vector — \
-         if the encoding changed deliberately, update the fixture here AND the \
-         vendored copy in macanderson/oxagen in the same change"
+        "the enrollment signature does not match the conformance vector — an \
+         encoding change must update the fixture here AND the vendored copy in \
+         macanderson/oxagen in the same change"
     );
 }

--- a/crates/stella-cli/src/enterprise_telemetry/tests.rs
+++ b/crates/stella-cli/src/enterprise_telemetry/tests.rs
@@ -1210,3 +1210,34 @@ fn finalization_stays_successful_when_telemetry_host_state_is_rejected() {
         std::env::remove_var("STELLA_TEST_TELEMETRY_TOKEN");
     }
 }
+
+/// Cross-language conformance: the committed fixture pins the canonical
+/// enrollment encoding and its HMAC to exact bytes. Oxagen's
+/// enrollment-provisioning capability vendors the same fixture and pins its
+/// TypeScript signer to it, so the two implementations cannot drift apart
+/// silently — a change to `canonical_enrollment_bytes` turns this red here
+/// and the TS twin red there.
+#[test]
+fn enrollment_signature_matches_the_committed_conformance_vector() {
+    let fixture: Value = serde_json::from_str(include_str!(
+        "fixtures/enrollment_signature_conformance_v1.json"
+    ))
+    .unwrap();
+    let secret = fixture["secret_utf8"].as_str().unwrap().as_bytes().to_vec();
+    let bytes = canonical_enrollment_bytes(&fixture["claims"]).unwrap();
+    let mut mac = Hmac::<Sha256>::new_from_slice(&secret).unwrap();
+    mac.update(&bytes);
+    let signature_hex: String = mac
+        .finalize()
+        .into_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    assert_eq!(
+        signature_hex,
+        fixture["signature_hex"].as_str().unwrap(),
+        "the enrollment signature no longer matches the conformance vector — \
+         if the encoding changed deliberately, update the fixture here AND the \
+         vendored copy in macanderson/oxagen in the same change"
+    );
+}


### PR DESCRIPTION
## What

`canonical_enrollment_bytes` + HMAC-SHA256 is a cross-language wire contract: oxagen's new enrollment-provisioning capability re-implements the signer in TypeScript, and nothing tied the two implementations together — an encoding change here would strand every enrollment oxagen mints, discovered only when a managed install refused its settings.

The committed fixture (`crates/stella-cli/src/enterprise_telemetry/fixtures/enrollment_signature_conformance_v1.json`: claims + secret + signature_hex) is the tie. The new test pins this repository's implementation to it; oxagen vendors a byte-identical copy and pins its TS signer to the same bytes, so a deliberate encoding change turns both trees red and the fixture update names itself in both.

## Witness

The vector was produced by this repository's own implementation — the test was first run with a placeholder and failed, printing the true HMAC (`1b9950…f68e`), which was then pinned. It fails on any encoding change by construction; `cargo test -p stella-cli --bin stella enrollment_signature_matches` → 1 passed.

Exemplar for the shape: the wiremock-pinned wire-contract tests in stella-model — a recorded exact body, never a reasoned-about one.

## Evidence
- `cargo test -p stella-cli --bin stella enrollment_signature_matches`: 1 passed, 0 failed (local, targeted).
- Pure test + fixture; no shipping code changed. No witness-on-main needed beyond the fixture's own fail-then-pin above.

## Summary by Sourcery

Pin enrollment signing behavior to a shared conformance vector so cross-language implementations cannot silently diverge.

Enhancements:
- Add a committed cross-language conformance test that verifies enrollment claim encoding and HMAC signatures against a fixed vector.

Tests:
- Add a fixture-backed enrollment signature test to detect wire-format drift between implementations.