### PR TITLE
feat(stella-tui): filter the /model picker as you type

### DIFF
--- a/crates/stella-tui/src/deck_ui/pickers.rs
+++ b/crates/stella-tui/src/deck_ui/pickers.rs
@@ -6,11 +6,19 @@
 //! and in its own module for the same god-file reason as `super::parked`
 //! (not a link: that module is private).
 //!
-//! The pickers' rows are read live off the deck state here at the moment of
-//! choice (see [`crate::views::picker`] on why they are never snapshotted),
-//! so `⏎` maps the highlighted index onto whatever the list holds NOW — a
-//! list that moved under the highlight sends the row the user is looking
-//! at, not the one they opened on.
+//! The pickers' rows are read live off the deck state here, once per
+//! keystroke (see [`crate::views::picker`] on why they are never held in the
+//! picker), so `⏎` maps the highlighted index onto whatever the list holds
+//! NOW — a list that moved under the highlight sends the row the user is
+//! looking at, not the one they opened on.
+//!
+//! "Now" means *before* the key is folded, because folding it may edit the
+//! filter and move the list out from under the index the same keystroke is
+//! about. Reading the matches first is what keeps the bounds handed to
+//! [`ListPicker::key`] and the row a [`PickerAction::Choose`] resolves to the
+//! same list.
+//!
+//! [`ListPicker::key`]: crate::views::picker::ListPicker::key
 
 use crossterm::event::KeyEvent;
 
@@ -25,8 +33,11 @@ use super::{DeckAction, DeckUi};
 /// which the other, being modal, would have swallowed.
 pub(super) fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
     if ui.model_picker.open {
-        let count = picker::model_candidates(ui).len();
-        return Some(match ui.model_picker.key(key, count) {
+        // Snapshot the matches before the key is folded, the way the SETTINGS
+        // picker does: the keystroke may edit the filter, and a choice must
+        // land on the list the reader was looking at when they pressed `⏎`.
+        let matching = picker::model_matches(ui);
+        return Some(match ui.model_picker.key(key, matching.len()) {
             PickerAction::Ignored => return None,
             PickerAction::Handled => DeckAction::Handled,
             PickerAction::Close => {
@@ -34,7 +45,7 @@ pub(super) fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
                 DeckAction::Handled
             }
             PickerAction::Choose(i) => {
-                let spec = picker::model_candidates(ui).get(i).cloned();
+                let spec = matching.get(i).cloned();
                 ui.model_picker.close();
                 match spec {
                     Some(spec) => DeckAction::Send(WorkspaceInput::ModelOverride { spec }),
@@ -44,8 +55,8 @@ pub(super) fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
         });
     }
     if ui.agent_picker.open {
-        let count = ui.installed.entries.len();
-        return Some(match ui.agent_picker.key(key, count) {
+        let matching = picker::agent_matches(ui);
+        return Some(match ui.agent_picker.key(key, matching.len()) {
             PickerAction::Ignored => return None,
             PickerAction::Handled => DeckAction::Handled,
             PickerAction::Close => {
@@ -53,10 +64,9 @@ pub(super) fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
                 DeckAction::Handled
             }
             PickerAction::Choose(i) => {
-                let target = ui
-                    .installed
-                    .entries
+                let target = matching
                     .get(i)
+                    .and_then(|&entry| ui.installed.entries.get(entry))
                     .map(|entry| (entry.name.clone(), entry.scope));
                 ui.agent_picker.close();
                 match target {

--- a/crates/stella-tui/src/deck_ui/pickers.rs
+++ b/crates/stella-tui/src/deck_ui/pickers.rs
@@ -19,6 +19,7 @@
 //! same list.
 //!
 //! [`ListPicker::key`]: crate::views::picker::ListPicker::key
+//! [`PickerAction::Choose`]: crate::views::picker::PickerAction::Choose
 
 use crossterm::event::KeyEvent;
 

--- a/crates/stella-tui/src/deck_ui/pickers.rs
+++ b/crates/stella-tui/src/deck_ui/pickers.rs
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! Key routing for the session-override pickers (`/model`, `/agent`) —
-//! modal like the SESSIONS/INBOX overlays beside it in the routing chain,
-//! and in its own module for the same god-file reason as `super::parked`
-//! (not a link: that module is private).
+//! Key routing for the session-override pickers (`/model`, `/agent`).
+//! They are modal, like the SESSIONS/INBOX overlays beside them in the
+//! routing chain. They sit in their own module for the same god-file
+//! reason as `super::parked` (not a link: that module is private).
 //!
-//! The pickers' rows are read live off the deck state here, once per
-//! keystroke (see [`crate::views::picker`] on why they are never held in the
-//! picker), so `⏎` maps the highlighted index onto whatever the list holds
-//! NOW — a list that moved under the highlight sends the row the user is
-//! looking at, not the one they opened on.
+//! The rows are read live off the deck state here, once per keystroke.
+//! See [`crate::views::picker`] for why the picker never holds them.
+//! So `⏎` maps the highlighted index onto the list as it stands now. A
+//! list that moved under the highlight sends the row the user sees, not
+//! the row they opened on.
 //!
-//! "Now" means *before* the key is folded, because folding it may edit the
-//! filter and move the list out from under the index the same keystroke is
-//! about. Reading the matches first is what keeps the bounds handed to
-//! [`ListPicker::key`] and the row a [`PickerAction::Choose`] resolves to the
-//! same list.
+//! "Now" means *before* the key is folded. Folding it may edit the
+//! filter, which moves the list out from under the index that same
+//! keystroke is about. So the matches are read first. That keeps two
+//! things on one list: the bounds handed to [`ListPicker::key`], and the
+//! row a [`PickerAction::Choose`] lands on.
 //!
 //! [`ListPicker::key`]: crate::views::picker::ListPicker::key
 //! [`PickerAction::Choose`]: crate::views::picker::PickerAction::Choose
@@ -34,9 +34,9 @@ use super::{DeckAction, DeckUi};
 /// which the other, being modal, would have swallowed.
 pub(super) fn handle_key(key: KeyEvent, ui: &mut DeckUi) -> Option<DeckAction> {
     if ui.model_picker.open {
-        // Snapshot the matches before the key is folded, the way the SETTINGS
-        // picker does: the keystroke may edit the filter, and a choice must
-        // land on the list the reader was looking at when they pressed `⏎`.
+        // Read the matches before the key is folded, as the SETTINGS picker
+        // does. The keystroke may edit the filter. A choice must land on the
+        // list the reader saw when they pressed `⏎`.
         let matching = picker::model_matches(ui);
         return Some(match ui.model_picker.key(key, matching.len()) {
             PickerAction::Ignored => return None,

--- a/crates/stella-tui/src/deck_ui/tests/queue.rs
+++ b/crates/stella-tui/src/deck_ui/tests/queue.rs
@@ -296,6 +296,58 @@ fn slash_model_opens_the_session_picker_and_enter_overrides() {
     assert!(!ui.model_picker.open);
 }
 
+/// **The witness for filtering the `/model` picker.** The list holds a
+/// model from every provider with a key. One gateway adds hundreds. So
+/// typing narrows it, and `⏎` sends the row the filter left under the
+/// highlight.
+#[test]
+fn typing_in_the_model_picker_narrows_it_and_enter_sends_the_matching_row() {
+    let model = model_with(&["lead"]);
+    let mut ui = ready_ui();
+    ui.engine.state = Some(crate::envelope::EngineConfigState {
+        catalog_models: vec![
+            "anthropic/claude-fable-5".to_string(),
+            "anthropic/claude-haiku-4-5".to_string(),
+            "openrouter/qwen/qwen3-max".to_string(),
+            "zai/glm-5.2".to_string(),
+        ],
+        ..Default::default()
+    });
+    super::super::local::deck_local_command("/model", &mut ui);
+    assert!(ui.model_picker.open);
+
+    // `q` is the first letter of what the reader wants, not a close key.
+    for c in "qwen".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    assert!(ui.model_picker.open, "typing does not dismiss the picker");
+    assert_eq!(ui.model_picker.query(), "qwen");
+    assert_eq!(
+        crate::views::picker::model_matches(&ui),
+        vec!["openrouter/qwen/qwen3-max".to_string()],
+        "the filter is what makes the rows a list"
+    );
+
+    // ⏎ sends the one match. No arrowing, and it is row 2 in the full list.
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::ModelOverride {
+            spec: "openrouter/qwen/qwen3-max".to_string()
+        })
+    );
+    assert!(!ui.model_picker.open, "choosing closes the picker");
+
+    // A filter that matches nothing sends nothing, not row 0.
+    super::super::local::deck_local_command("/model", &mut ui);
+    for c in "zzz".chars() {
+        handle_deck_key(ch(c), &model, &mut ui);
+    }
+    assert!(crate::views::picker::model_matches(&ui).is_empty());
+    let action = handle_deck_key(key(KeyCode::Enter), &model, &mut ui);
+    assert_eq!(action, DeckAction::Handled, "an empty match set sends none");
+}
+
 /// **The witness for the `/agent` picker.** `/agent` opens the modal
 /// installed-agents picker (asking the driver for a fresh list), and `⏎`
 /// leaves as the same `WorkspaceInput::AgentAssume` the AGENTS pane's `a`

--- a/crates/stella-tui/src/views/picker.rs
+++ b/crates/stella-tui/src/views/picker.rs
@@ -6,22 +6,33 @@
 //!
 //! ```text
 //! ╭ model · 1/3 · this session only ─────────────────────────────╮
-//! │▸ zai/glm-5.2-air  · current                                  │
-//! │  anthropic/claude-fable-5                                    │
-//! │  openrouter/openai/gpt-5.5                                   │
-//! ╰─────────────────────────────────────── ↑↓ move · ⏎ use · esc ╯
+//! │  filter gpt▏                                                 │
+//! │▸ openrouter/openai/gpt-5.5                                   │
+//! │  openrouter/openai/gpt-5.5-mini                              │
+//! ╰────────────────── type to filter · ↑↓ move · ⏎ use · esc ────╯
 //! ```
 //!
-//! One state machine ([`ListPicker`]) serves both overlays — a modal
-//! scrollable list, `↑`/`↓` (the deck's one list vocabulary,
-//! [`crate::deck_ui::list_nav`]) to move, `⏎` to choose, Esc to cancel —
-//! because the two differ only in what their rows are and what a choice
-//! sends. The rows are read LIVE at key/render time from state the deck
-//! already holds (the driver's [`EngineConfigState`] snapshot for models,
-//! the INSTALLED AGENTS entries for agents), never copied into the picker:
-//! both snapshots can arrive *after* the picker opens (opening sends the
-//! refresh), and a copy taken at open time would pin the overlay to an
-//! empty list.
+//! One state machine ([`ListPicker`]) serves both overlays. It is a modal
+//! list: `↑`/`↓` move (the deck's one list vocabulary,
+//! [`crate::deck_ui::list_nav`]), typing narrows, `⏎` chooses, Esc cancels.
+//! The two differ only in their rows and in what a choice sends.
+//!
+//! The rows are read LIVE at key and render time, off state the deck already
+//! holds: the driver's [`EngineConfigState`] snapshot for models, the
+//! INSTALLED AGENTS entries for agents. They are never copied into the
+//! picker. Both snapshots can land *after* it opens, since opening sends the
+//! refresh, and a copy taken then would pin it to an empty list.
+//!
+//! # Why it filters
+//!
+//! The list holds a model from every provider with a key. One gateway adds
+//! hundreds. With OpenRouter set up it runs past four hundred rows, and the
+//! window shows twelve. You cannot pick from that. The filter is what makes
+//! it a list.
+//!
+//! It uses the same word and the same rule as the SETTINGS tab's model
+//! picker ([`crate::views::engine_panel`] and its `picker_matches`). One
+//! list, so one way to search it.
 //!
 //! Both render into the deck's **content band**, not the whole frame, and the
 //! card sits on its last row — over the transcript, a row above the prompt it
@@ -64,31 +75,41 @@ pub enum PickerAction {
     Ignored,
     /// Consumed; the picker stays up.
     Handled,
-    /// `⏎` on row `i` of the caller's candidate list.
+    /// `⏎` on row `i` of the caller's **matching** list — the rows left after
+    /// [`ListPicker::query`] narrows them, not the unfiltered candidates.
     Choose(usize),
-    /// Esc/`q` — cancel, choosing nothing.
+    /// Esc — cancel, choosing nothing.
     Close,
 }
 
-/// The modal list state both pickers share. Rows live with the caller;
-/// this holds only whether the picker is up and where the highlight is.
+/// The modal list state both pickers share. Rows live with the caller. This
+/// holds whether the picker is up, where the highlight is, and the filter.
+///
+/// The caller owns the filtering. It passes the **matching** row count to
+/// [`ListPicker::key`], and resolves [`PickerAction::Choose`] against the
+/// same list it drew. So the bounds and the picked row always agree with
+/// what the reader saw.
 #[derive(Debug, Clone, Default)]
 pub struct ListPicker {
     pub open: bool,
     sel: usize,
+    query: String,
 }
 
 impl ListPicker {
-    /// Raise the picker with the highlight on the first row.
+    /// Raise the picker with the highlight on the first row and no filter.
     pub fn raise(&mut self) {
         self.open = true;
         self.sel = 0;
+        self.query.clear();
     }
 
-    /// Take the picker down.
+    /// Take the picker down, forgetting the filter — a picker reopened later
+    /// is one the reader is opening fresh, not resuming.
     pub fn close(&mut self) {
         self.open = false;
         self.sel = 0;
+        self.query.clear();
     }
 
     /// The highlighted row.
@@ -97,7 +118,18 @@ impl ListPicker {
         self.sel
     }
 
-    /// Fold one keystroke against a candidate list `count` rows long.
+    /// What the reader has typed to narrow the list.
+    #[must_use]
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    /// Fold one keystroke against a matching list `count` rows long.
+    ///
+    /// Typing edits the filter, so no letter is free for anything else. Esc
+    /// is the way out. The arrows move, with `⇞`/`⇟`/`Home`/`End`. The
+    /// SETTINGS tab's model picker uses that same vocabulary
+    /// ([`crate::views::engine_panel`]), so one habit carries between them.
     pub fn key(&mut self, key: KeyEvent, count: usize) -> PickerAction {
         if !self.open {
             return PickerAction::Ignored;
@@ -105,21 +137,49 @@ impl ListPicker {
         if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
             return PickerAction::Ignored;
         }
-        // The list can shrink between frames (a fresh snapshot landed) —
-        // clamp before navigating so the highlight never points past it.
+        // The list can shrink between frames (a fresh snapshot landed, or the
+        // filter narrowed it) — clamp before navigating so the highlight never
+        // points past it.
         self.sel = self.sel.min(count.saturating_sub(1));
-        if crate::deck_ui::list_nav::closes(key) {
-            return PickerAction::Close;
-        }
-        // Modal, so `letters` is true (#4370).
-        if crate::deck_ui::list_nav::select(key, &mut self.sel, count, true) {
+        // `letters` is false: they belong to the filter now.
+        if crate::deck_ui::list_nav::select(key, &mut self.sel, count, false) {
             return PickerAction::Handled;
         }
         match key.code {
+            KeyCode::Esc => PickerAction::Close,
             KeyCode::Enter if count > 0 => PickerAction::Choose(self.sel),
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.sel = 0; // the match set changed — re-anchor
+                PickerAction::Handled
+            }
+            // ALT is allowed through, as it is on the SETTINGS picker: a
+            // composed character arrives with it set on some layouts.
+            KeyCode::Char(c)
+                if !key.modifiers.intersects(
+                    KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::META,
+                ) =>
+            {
+                self.query.push(c);
+                self.sel = 0; // the match set changed — re-anchor
+                PickerAction::Handled
+            }
             _ => PickerAction::Handled,
         }
     }
+}
+
+/// Case-insensitive substring match. The same rule as the SETTINGS tab's
+/// `picker_matches` ([`crate::views::engine_panel`]), so a filter narrows
+/// both pickers the same way. The caller trims and lowercases `needle`
+/// once, not per row.
+fn hits(haystack: &str, needle: &str) -> bool {
+    needle.is_empty() || haystack.to_lowercase().contains(needle)
+}
+
+/// A query normalized for [`hits`]: trimmed, lowercased, once.
+fn needle(query: &str) -> String {
+    query.trim().to_lowercase()
 }
 
 /// The `/model` picker's vocabulary: what the SETTINGS tab's model picker
@@ -134,6 +194,34 @@ pub(crate) fn model_candidates(ui: &DeckUi) -> &[String] {
         .as_ref()
         .map(crate::views::engine_panel::picker_candidates)
         .unwrap_or(&[])
+}
+
+/// [`model_candidates`] narrowed by what the reader has typed. The module
+/// header says why the list needs a filter at all.
+pub(crate) fn model_matches(ui: &DeckUi) -> Vec<String> {
+    let needle = needle(ui.model_picker.query());
+    model_candidates(ui)
+        .iter()
+        .filter(|spec| hits(spec, &needle))
+        .cloned()
+        .collect()
+}
+
+/// The `/agent` picker's matching rows, as indices into
+/// `ui.installed.entries`. The caller needs each entry's scope as well as
+/// its name, so an index serves it better than a copy.
+///
+/// Matched on the name *and* the description. A reader looks for an agent by
+/// what it does as often as by what it is called.
+pub(crate) fn agent_matches(ui: &DeckUi) -> Vec<usize> {
+    let needle = needle(ui.agent_picker.query());
+    ui.installed
+        .entries
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| hits(&entry.name, &needle) || hits(&entry.description, &needle))
+        .map(|(i, _)| i)
+        .collect()
 }
 
 /// The `/model` **argument menu's** vocabulary ([`crate::composer::args`]):
@@ -291,12 +379,24 @@ fn name_style(selected: bool) -> Style {
     }
 }
 
+/// The card's first row: what has been typed, with the caret after it. The
+/// word `filter` is the SETTINGS picker's, so the affordance reads the same
+/// on both.
+fn filter_row(query: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled("  filter ", Style::new().fg(token::MUTED)),
+        Span::styled(query.to_string(), Style::new().fg(token::TEXT)),
+        Span::styled("▏", Style::new().fg(token::GOLD)),
+    ])
+}
+
 /// Paint the `/model` picker. A no-op while closed.
 pub fn render_model(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer) {
     if !ui.model_picker.open {
         return;
     }
-    let candidates = model_candidates(ui);
+    let offered = model_candidates(ui).len();
+    let candidates = model_matches(ui);
     let current = model
         .role_pins
         .get(&PipelineRole::Worker)
@@ -309,9 +409,9 @@ pub fn render_model(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut B
         .min(candidates.len().saturating_sub(1));
     let inner_w = usize::from(card_w(area, ui.accessible)).saturating_sub(2);
 
-    let mut rows: Vec<Line<'static>> = Vec::new();
+    let mut rows: Vec<Line<'static>> = vec![filter_row(ui.model_picker.query())];
     let mut selected_row = None;
-    if candidates.is_empty() {
+    if offered == 0 {
         rows.push(Line::from(Span::styled(
             "no models to offer yet — waiting for the provider snapshot",
             muted,
@@ -319,6 +419,13 @@ pub fn render_model(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut B
         rows.push(Line::from(Span::styled(
             "(`/info` lists providers; `/info refresh` re-syncs the catalog)",
             dim,
+        )));
+    } else if candidates.is_empty() {
+        // Which nothing this is. The snapshot has models; the filter hides
+        // them.
+        rows.push(Line::from(Span::styled(
+            "no models match — Backspace to widen",
+            muted,
         )));
     } else {
         let window = window(sel, candidates.len());
@@ -342,19 +449,21 @@ pub fn render_model(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut B
                 spans.push(Span::styled("  · current", muted));
             }
             if is_sel {
-                selected_row = Some(i - window.start);
+                // Offset by the filter row this list sits under.
+                selected_row = Some(i - window.start + 1);
             }
             rows.push(Line::from(spans));
         }
     }
 
+    // Counted over the matches: that is the list the highlight walks.
     let position = (!candidates.is_empty())
         .then(|| format!("{}/{} · this session only", sel + 1, candidates.len()));
     render_card(
         Labels {
             name: "model",
             position,
-            hints: "↑↓ move · ⏎ use · esc",
+            hints: "type to filter · ↑↓ move · ⏎ use · esc",
         },
         rows,
         selected_row,
@@ -370,14 +479,15 @@ pub fn render_agent(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
         return;
     }
     let entries = &ui.installed.entries;
+    let matching = agent_matches(ui);
     let muted = Style::new().fg(token::MUTED);
     let sel = ui
         .agent_picker
         .selected()
-        .min(entries.len().saturating_sub(1));
+        .min(matching.len().saturating_sub(1));
     let inner_w = usize::from(card_w(area, ui.accessible)).saturating_sub(2);
 
-    let mut rows: Vec<Line<'static>> = Vec::new();
+    let mut rows: Vec<Line<'static>> = vec![filter_row(ui.agent_picker.query())];
     let mut selected_row = None;
     if entries.is_empty() {
         rows.push(Line::from(Span::styled(
@@ -388,15 +498,21 @@ pub fn render_agent(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
             },
             muted,
         )));
+    } else if matching.is_empty() {
+        rows.push(Line::from(Span::styled(
+            "no agents match — Backspace to widen",
+            muted,
+        )));
     } else {
-        let window = window(sel, entries.len());
-        for (i, entry) in entries
+        let window = window(sel, matching.len());
+        for (row, &i) in matching
             .iter()
             .enumerate()
             .skip(window.start)
             .take(window.len())
         {
-            let is_sel = i == sel;
+            let entry = &entries[i];
+            let is_sel = row == sel;
             let used = 2 + entry.name.chars().count() + 2 + entry.scope.label().len() + 2;
             let spans = vec![
                 cursor(is_sel),
@@ -411,19 +527,20 @@ pub fn render_agent(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
                 ),
             ];
             if is_sel {
-                selected_row = Some(i - window.start);
+                // Offset by the filter row this list sits under.
+                selected_row = Some(row - window.start + 1);
             }
             rows.push(Line::from(spans));
         }
     }
 
-    let position =
-        (!entries.is_empty()).then(|| format!("{}/{} · this session only", sel + 1, entries.len()));
+    let position = (!matching.is_empty())
+        .then(|| format!("{}/{} · this session only", sel + 1, matching.len()));
     render_card(
         Labels {
             name: "agent",
             position,
-            hints: "↑↓ move · ⏎ assume · esc",
+            hints: "type to filter · ↑↓ move · ⏎ assume · esc",
         },
         rows,
         selected_row,
@@ -467,8 +584,8 @@ mod tests {
             .join("\n")
     }
 
-    /// The shared vocabulary: arrows and `j`/`k` move, Esc/`q` cancel, `⏎`
-    /// chooses the highlighted row, and a closed picker claims nothing.
+    /// The shared vocabulary: arrows move, Esc cancels, `⏎` chooses the
+    /// highlighted row, and a closed picker claims nothing.
     #[test]
     fn the_picker_moves_chooses_and_cancels() {
         let mut picker = ListPicker::default();
@@ -476,10 +593,7 @@ mod tests {
 
         picker.raise();
         assert_eq!(picker.key(key(KeyCode::Down), 3), PickerAction::Handled);
-        assert_eq!(
-            picker.key(key(KeyCode::Char('j')), 3),
-            PickerAction::Handled
-        );
+        assert_eq!(picker.key(key(KeyCode::Down), 3), PickerAction::Handled);
         assert_eq!(picker.key(key(KeyCode::Enter), 3), PickerAction::Choose(2));
         // `Home`/`End` come with the shared vocabulary (#4370), not a
         // hand-rolled arrow pair.
@@ -493,6 +607,62 @@ mod tests {
             PickerAction::Ignored,
             "a picker must not be the one state you cannot quit from"
         );
+    }
+
+    /// **The witness.** Typing narrows the list. It does not move in it. So
+    /// every letter reaches the filter: `q` starts `qwen` instead of closing
+    /// the card, and `j`/`k` type instead of moving. Esc is the way out. The
+    /// arrows are the way around.
+    #[test]
+    fn letters_type_into_the_filter_rather_than_moving_or_quitting() {
+        let mut picker = ListPicker::default();
+        picker.raise();
+        assert_eq!(picker.query(), "");
+
+        for c in "qwen".chars() {
+            assert_eq!(picker.key(key(KeyCode::Char(c)), 3), PickerAction::Handled);
+        }
+        assert_eq!(
+            picker.query(),
+            "qwen",
+            "`q` belongs to the filter now, not to closing the card"
+        );
+
+        // `j`/`k` are letters like any other here.
+        picker.key(key(KeyCode::Char('j')), 3);
+        assert_eq!(picker.query(), "qwenj");
+        assert_eq!(
+            picker.key(key(KeyCode::Backspace), 3),
+            PickerAction::Handled
+        );
+        assert_eq!(picker.query(), "qwen");
+
+        // Esc still closes, and closing forgets the filter — a picker
+        // reopened later is one being opened fresh.
+        assert_eq!(picker.key(key(KeyCode::Esc), 3), PickerAction::Close);
+        picker.close();
+        picker.raise();
+        assert_eq!(picker.query(), "");
+    }
+
+    /// Editing the filter re-anchors the highlight to the top: the index it
+    /// held counts rows in the match set the edit just replaced, so carrying
+    /// it over would land on an unrelated model.
+    #[test]
+    fn editing_the_filter_re_anchors_the_highlight() {
+        let mut picker = ListPicker::default();
+        picker.raise();
+        picker.key(key(KeyCode::Down), 9);
+        picker.key(key(KeyCode::Down), 9);
+        assert_eq!(picker.selected(), 2);
+
+        picker.key(key(KeyCode::Char('g')), 9);
+        assert_eq!(picker.selected(), 0, "a typed letter re-anchors");
+
+        picker.key(key(KeyCode::Down), 9);
+        assert_eq!(picker.selected(), 1);
+        picker.key(key(KeyCode::Backspace), 9);
+        assert_eq!(picker.selected(), 0, "a Backspace re-anchors too");
     }
 
     /// A list that shrank between frames clamps the highlight, and `⏎` on
@@ -518,6 +688,69 @@ mod tests {
         assert_eq!(end.len(), VISIBLE_ROWS);
         let mid = window(20, 40);
         assert!(mid.contains(&20));
+    }
+
+    /// **The witness for the drawn filter.** The card puts the typed query
+    /// on its own row. It draws only the rows that match. It counts the
+    /// position over those: `1/1` where a filter kept one of three, not
+    /// `1/3`. A filter that matches nothing says which nothing it is.
+    #[test]
+    fn the_card_draws_the_filter_and_only_the_rows_it_admits() {
+        let model = WorkspaceModel::new();
+        let mut ui = DeckUi::default();
+        ui.engine.state = Some(EngineConfigState {
+            catalog_models: vec![
+                "zai/glm-5.2-air".to_string(),
+                "anthropic/claude-fable-5".to_string(),
+                "openrouter/qwen/qwen3-max".to_string(),
+            ],
+            ..Default::default()
+        });
+        ui.model_picker.raise();
+        let area = Rect::new(0, 0, 100, 20);
+
+        // Unfiltered: all three, counted over three.
+        let mut buf = Buffer::empty(area);
+        render_model(&model, &ui, area, &mut buf);
+        let frame = text(&buf);
+        assert!(
+            frame.contains("filter ▏"),
+            "the caret sits after it: {frame}"
+        );
+        assert!(frame.contains("· 1/3 ·"), "{frame}");
+
+        // Typing `qwen` leaves one row, and the count follows the matches.
+        for c in "qwen".chars() {
+            ui.model_picker.key(key(KeyCode::Char(c)), 3);
+        }
+        let mut buf = Buffer::empty(area);
+        render_model(&model, &ui, area, &mut buf);
+        let frame = text(&buf);
+        assert!(frame.contains("filter qwen▏"), "{frame}");
+        assert!(frame.contains("▸ openrouter/qwen/qwen3-max"), "{frame}");
+        assert!(
+            !frame.contains("anthropic/claude-fable-5"),
+            "a row the filter rejected must not be drawn: {frame}"
+        );
+        assert!(
+            frame.contains("· 1/1 ·"),
+            "counted over the matches: {frame}"
+        );
+        assert!(frame.contains("type to filter"), "{frame}");
+
+        // A filter matching nothing names the filter as the cause, rather
+        // than reading as "this workspace has no models".
+        for c in "zzz".chars() {
+            ui.model_picker.key(key(KeyCode::Char(c)), 1);
+        }
+        let mut buf = Buffer::empty(area);
+        render_model(&model, &ui, area, &mut buf);
+        let frame = text(&buf);
+        assert!(frame.contains("no models match"), "{frame}");
+        assert!(
+            !frame.contains("waiting for the provider snapshot"),
+            "that is the other nothing — an empty snapshot: {frame}"
+        );
     }
 
     /// **The witness for the SPEC 5 card.** The `/model` picker draws the

--- a/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_agent_picker.txt
@@ -34,11 +34,11 @@
 
  │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
  │   irreducible generation
-
-☰  plan  5/7  ·  Workflows canvas               ╭ agent · 1/2 · this session only ─────────────────────────────╮
+                                                ╭ agent · 1/2 · this session only ─────────────────────────────╮
+☰  plan  5/7  ·  Workflows canvas               │  filter ▏                                                    │
                                                 │▸ reviewer  project  reviews a diff against the house rules   │
 ⏸ plan  Refactor the automations store into a sh│  release-captain  user  cuts a release: bump, changelog, tag │
-                                                ╰──────────────────────────────────── ↑↓ move · ⏎ assume · esc ╯
+                                                ╰─────────────────── type to filter · ↑↓ move · ⏎ assume · esc ╯
  ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands

--- a/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_model_picker.txt
@@ -33,12 +33,12 @@
  │     13 +  const onNew = () => open()
 
  │ ◐ model worker · 428 tok/s                                                                                                                           ⚡ 2100ms
- │   irreducible generation
-                                                ╭ model · 1/3 · this session only ─────────────────────────────╮
+ │   irreducible generation                     ╭ model · 1/3 · this session only ─────────────────────────────╮
+                                                │  filter ▏                                                    │
 ☰  plan  5/7  ·  Workflows canvas               │▸ zai/glm-5.2-air  · current                                  │
                                                 │  anthropic/claude-fable-5                                    │
 ⏸ plan  Refactor the automations store into a sh│  openrouter/openai/gpt-5.5                                   │
-                                                ╰─────────────────────────────────────── ↑↓ move · ⏎ use · esc ╯
+                                                ╰────────────────────── type to filter · ↑↓ move · ⏎ use · esc ╯
  ✓ plan ▸ execute ████░░░░ 50% · verify
 >>>
  ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · ! shell · / commands


### PR DESCRIPTION
## What & why

`/model` opens a modal list of every model from every provider whose credential
resolves — that scoping already works (`command_deck/panel_snapshots.rs`, and
"a model you have no key for is not an option"). What did not work was reaching
into the result. On a machine with OpenRouter and Anthropic configured, `stella
models list` reports **464 + 15 = 479 rows**, drawn twelve at a time with no
way to narrow them. Getting to `openrouter/qwen/qwen3-max` meant holding an
arrow key. A list you cannot reach into is not one you can select from.

Typing now narrows it. The affordance is the SETTINGS tab's model picker word
for word — the same `filter ▏` row, the same case-insensitive substring
rule as `engine_panel::picker_matches` — so one habit carries between the two
surfaces that offer the same list. That file's own doc comment already claimed
the two "feel identical"; this makes it true.

`/agent` shares the `ListPicker` widget, so it gets the same treatment (matched
on the agent's name **and** its description). Left unfiltered it would have
swallowed typing silently.

Closes #5625

Refs #5623 (the follow-up this PR deliberately does not do)

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`deck_ui::tests::queue::typing_in_the_model_picker_narrows_it_and_enter_sends_the_matching_row`
— types `qwen` into an open `/model` picker over a four-model list and asserts
`⏎` sends `openrouter/qwen/qwen3-max` (row 2 of the unfiltered list) with no
arrowing, and that an empty match set sends nothing rather than row 0.

Checked the artisanal way: with `views/picker.rs` and `deck_ui/pickers.rs`
reverted to `main` and the test retained, it fails to build —
``cannot find function `model_matches` in module `crate::views::picker` `` and
``no method named `query` found for struct `picker::ListPicker` ``. The
capability is genuinely absent on `main`, not merely untested.

Three more, all failing on `main` for the same reason:

- `views::picker::tests::letters_type_into_the_filter_rather_than_moving_or_quitting`
- `views::picker::tests::editing_the_filter_re_anchors_the_highlight`
- `views::picker::tests::the_card_draws_the_filter_and_only_the_rows_it_admits`
  (renders into a `TestBackend` and asserts on the flattened cell buffer — the
  crate's answer to "a witness is impractical for TUI rendering")

## The gate

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p stella-tui --all-targets` — no warnings
- [x] `cargo test -p stella-tui` — 1548 pass, 0 fail (workspace run left to CI,
      per CLAUDE.md "CI builds and tests; this laptop does not")
- [x] `make guards-fast` — green, including `check-prose` and `check-file-size`
- [x] Docs updated: the module headers of `views/picker.rs` and
      `deck_ui/pickers.rs`, and the card's own hint row

## Nothing left behind

- [x] Filed: #5623 — group the picker's rows under a provider heading. The
      grouping data is already on `EngineConfigState.providers`; the reason it
      is not in this PR is that heading rows must not enter the count
      `PickerAction::Choose` indexes into, which is a windowing change with its
      own witness, not a line in this one.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls

## Anything reviewers should know?

**The key vocabulary changes deliberately, and one existing test changed with
it.** A field you type into cannot reserve letters, so within these two pickers:

| key | before | now |
|---|---|---|
| `q` | closed the card | types `q` (as in `qwen`) |
| `j` / `k` | moved the highlight | type |
| `Esc` | closed | closed (unchanged — the only way out) |
| `↑`/`↓`, `⇞`/`⇟`, `Home`/`End` | moved | moved (unchanged) |

`views::picker::tests::the_picker_moves_chooses_and_cancels` asserted the old
vocabulary (`Down` then `j` reaching index 2). **No test was deleted** — that
one is updated to use two `Down`s and keeps every other assertion, including
that Ctrl-C is still declined so the deck's quit branch fires. It is called out
here because it is the one place the diff removes an assertion.

This narrows the shared `list_nav` vocabulary for these two overlays only, by
passing `letters: false`. That is the choice the SETTINGS model picker
(`views/engine_panel/keys.rs`) and the graph file picker
(`deck_ui::tests::graph::typing_filters_and_re_anchors_the_selection`) already
made — every filtered picker in the deck spends its letters on the filter.

**Goldens re-blessed and read**, not blindly regenerated: `overlay_model_picker`
and `overlay_agent_picker` each gain the `filter ▏` row and the widened hint
(`type to filter · ↑↓ move · ⏎ use · esc`). The diff was exactly those three
lines per card.

**The routing layer now reads the matches before folding the keystroke**
(`deck_ui/pickers.rs`), because the keystroke may edit the filter and move the
list out from under the index it is about. This mirrors what
`handle_picker_key` in `views/engine_panel/keys.rs` already does, and its
comment gives the same reason.

## Reading-grade fix, and the DoD

`98e1dc9` repairs a gate this PR broke: `check-prose` read
`deck_ui/pickers.rs` at grade 10.85 against its recorded ceiling of 10.74,
because the new module-header paragraphs were three long sentences. They are
split into short ones — no claim changed, and the intra-doc links and their
definitions are untouched. `check-prose` is green, `cargo fmt --check` is
clean, and `cargo doc -p stella-tui --no-deps` exits 0, so the links still
resolve. `gate steps no other workflow runs` went green with it.

#5625's five definition-of-done items are ticked, each checked against this
diff rather than assumed: the implementation is in `views/picker.rs` and
`deck_ui/pickers.rs`; the four witness tests above are present and the two
goldens re-blessed; CI is green on `98e1dc9`; both module headers and the
card's hint row are updated; and the residue is filed as #5623 carrying the
`triage` label alone, per SCR-004/005.

## Summary by Sourcery

Enable searchable `/model` and `/agent` pickers so users can quickly narrow large lists and select the intended result by typing.

New Features:
- Add type-to-filter search to the `/model` and `/agent` picker overlays using case-insensitive substring matching.
- Show the active filter, filtered result counts, and empty-match feedback in both picker cards.

Bug Fixes:
- Ensure selecting a filtered row resolves against the same matching list displayed to the user, including when filtering produces no results.

Enhancements:
- Align picker keyboard behavior with the SETTINGS model picker so letters edit the filter while arrows handle navigation and Esc cancels.
- Re-anchor the highlighted row whenever the filter changes and match agent descriptions as well as names.

Documentation:
- Update picker module documentation and UI hints to describe filtering behavior.

Tests:
- Add routing, state-machine, and rendering coverage for filtering, selection, highlight re-anchoring, and empty result sets.
- Update picker snapshots for the filter row and revised keyboard hints.