### PR TITLE
throwaway: #3932 required-check witness (never merge)

### DIFF
--- a/THROWAWAY-3932.md
+++ b/THROWAWAY-3932.md
@@ -1,0 +1,1 @@
+Throwaway file for the #3932 required-check witness. Never merged.


### PR DESCRIPTION
Throwaway. Witness for #3932: with issue #5632 open and labelled main-red, the required check `main is not known-broken` must block this PR; adding `unblocks-main` must clear it. Closed unmerged afterwards.

## Summary by Sourcery

Chores:
- Add a throwaway marker file for the required-check witness.