### PR TITLE
fix(stella-graph): refuse a symlink in the watcher and register_paths

### DIFF
--- a/crates/stella-graph/src/store.rs
+++ b/crates/stella-graph/src/store.rs
@@ -557,6 +557,18 @@ pub(crate) fn apply_changes(
     };
     let tx = conn.transaction()?;
     for abs in changed {
+        // A symlink is never indexed here. The walk already skips one,
+        // using lstat semantics. But the watcher and `register_paths` call
+        // this function directly and skip the walk. `Path::is_file()`
+        // below follows the link. Without this check, a symlink to a real
+        // file would go straight into `index_one` and read the target's
+        // bytes under the link's own path. `symlink_metadata` never
+        // follows the link, so this also catches a symlink whose target is
+        // gone. This skip matches the unrecognised-extension skip below:
+        // no stat changes, no row is touched.
+        if std::fs::symlink_metadata(abs).is_ok_and(|meta| meta.file_type().is_symlink()) {
+            continue;
+        }
         if abs.is_file() {
             if Language::from_path(abs).is_none() && !storage::indexes_without_language(abs) {
                 continue;

--- a/crates/stella-graph/src/watch.rs
+++ b/crates/stella-graph/src/watch.rs
@@ -116,6 +116,15 @@ fn is_watch_relevant(root: &Path, path: &Path, ignore: &WorkspaceIgnore) -> bool
     if walk::rel_is_ignored(root, path, ignore) {
         return false;
     }
+    // A symlink is never relevant. The walk already skips one, using
+    // lstat semantics. This filter guards the other path that can queue a
+    // re-index, so it needs the same rule. `Path::exists` below follows
+    // the link, which would treat a live symlink to a source file as a
+    // normal create or modify event. `symlink_metadata` never follows the
+    // link, so a symlink whose target is gone is still caught here.
+    if std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        return false;
+    }
     if !path.exists() {
         return true;
     }

--- a/crates/stella-graph/tests/live_index.rs
+++ b/crates/stella-graph/tests/live_index.rs
@@ -314,6 +314,43 @@ async fn irrelevant_paths_are_filtered_at_injection() {
     fx.graph.shutdown();
 }
 
+/// A symlink placed in the workspace during a live session must never
+/// enter the debounce pipeline. Its extension and the ignore rules alone
+/// would let it through. This test checks that path on its own, apart
+/// from the store-level guard `store::apply_changes` adds, so either
+/// guard can regress and this still catches it. It fails on the old
+/// code: the link's extension is `.rs`, and `Path::exists()` follows the
+/// link to a real target, so `is_watch_relevant` accepted it and
+/// `inject` returned `true`.
+#[tokio::test(start_paused = true)]
+async fn injected_symlink_never_enters_the_pipeline() {
+    let outside = TempDir::new().unwrap();
+    let secret_dir = outside.path().join("outside");
+    fs::create_dir(&secret_dir).unwrap();
+    fs::write(
+        secret_dir.join("secret.rs"),
+        "pub fn leaked_outside_the_workspace() {}\n",
+    )
+    .unwrap();
+
+    let fx = Live::build(&[("keep.rs", "pub fn kept() {}\n")]);
+    let link = fx.abs("notes.rs");
+    std::os::unix::fs::symlink(secret_dir.join("secret.rs"), &link).unwrap();
+
+    assert!(
+        !fx.injector.inject(&link),
+        "a symlink must never enter the debounce pipeline"
+    );
+    assert_eq!(fx.injector.batches_applied(), 0, "nothing was enqueued");
+    assert_eq!(
+        fx.graph.file_count().unwrap(),
+        1,
+        "the symlink is not a node"
+    );
+
+    fx.graph.shutdown();
+}
+
 /// Markdown is source to this crate (#3095): `AGENTS.md`, `CLAUDE.md` and
 /// every crate README are documents the agent has to be able to search. Live
 /// indexing has to agree with `Language::from_path`, so this asserts the flip

--- a/crates/stella-graph/tests/register_paths.rs
+++ b/crates/stella-graph/tests/register_paths.rs
@@ -56,6 +56,43 @@ fn a_path_spelled_through_a_symlinked_root_still_lands_where_queries_look() {
     assert_eq!(graph.all_files().unwrap(), vec!["fresh.rs".to_string()]);
 }
 
+/// A symlink in the workspace must never get its target's content
+/// indexed under the link's own path. `register_paths` calls
+/// `store::apply_changes` directly, skipping the walk's own symlink
+/// check, so it needs its own guard. Without that guard,
+/// `Path::is_file()` and `std::fs::read` both follow a symlink, so
+/// `apply_changes` and `index_one` read the outside file's bytes and
+/// file its symbols under `notes.rs`.
+#[test]
+fn a_symlinked_path_never_indexes_its_target() {
+    let outside = tempfile::tempdir().unwrap();
+    let secret_dir = outside.path().join("outside");
+    std::fs::create_dir(&secret_dir).unwrap();
+    std::fs::write(
+        secret_dir.join("secret.rs"),
+        "pub fn leaked_outside_the_workspace() {}\n",
+    )
+    .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let link = root.join("notes.rs");
+    std::os::unix::fs::symlink(secret_dir.join("secret.rs"), &link).unwrap();
+
+    let graph = opened(root);
+    graph.register_paths(std::slice::from_ref(&link)).unwrap();
+
+    assert!(!graph.indexes_file(&link).unwrap());
+    assert!(
+        graph
+            .definitions("leaked_outside_the_workspace")
+            .unwrap()
+            .is_empty(),
+        "no symbol from outside the workspace may enter the graph"
+    );
+    assert_eq!(graph.all_files().unwrap(), Vec::<String>::new());
+}
+
 /// A path that has vanished is pruned, exactly as a watcher event for a
 /// removed file is — the two callers share one pass.
 #[test]


### PR DESCRIPTION
## What

The code-graph's initial walk refuses to index a symlink — it uses
`DirEntry::file_type()` (lstat semantics), so a symlink is neither
`is_dir()` nor `is_file()` and is skipped, with a comment saying so.
The two other paths that feed the same indexer never made that check:

- `crates/stella-graph/src/watch.rs`'s `is_watch_relevant` filtered on
  ignore rules and `Language::from_path` only.
- `crates/stella-graph/src/store.rs`'s `apply_changes` (called by both
  the watcher's debounce loop and the public `register_paths`) used
  `Path::is_file()` and `std::fs::read`, both of which follow a
  symlink.

So a symlink placed inside the workspace during a live session — by
the agent's own `bash` tool, or by a build step — got its *target's*
content read, indexed, and made eligible for embedding, even when the
target sits outside the workspace.

## Why

Content from outside the workspace could leave the machine through
the user's own embedding call: `render_file_text` sends up to 6,000
characters of the indexed row to whatever backend is configured. A
full `index_tree` recomputes its file list from the walk and prunes
the row, but a live session runs a long time between full walks, and
the embedding call happens inside that window. This is invariant #3's
neighbourhood (zero telemetry egress by default) even though the
egress leg is the user's own configured backend, not Stella's.

## The fix

Followed the maintainer's design pointer on the issue: enforce the
walk's rule at the point indexing actually happens, not only at the
walk.

- `store::apply_changes` now stats every changed path with
  `std::fs::symlink_metadata` and skips it when `file_type().is_symlink()`
  is true — treated exactly like an unrecognised extension (no stat
  bump, no row touched). This single change covers both `register_paths`
  and the watcher's debounce loop, since both funnel through
  `apply_changes_blocking` → `store::apply_changes`.
- `watch::is_watch_relevant` gets the same check, so a symlink event
  never even reaches the debounce queue — defense in depth independent
  of the store-level guard.

Both checks use `symlink_metadata` rather than `exists`/`is_file`,
which never follows the link, so a symlink whose target has since
vanished is refused the same way a live one is.

## Witness

Two tests, each failing on the code before this fix — a tempdir
workspace, a *separate* tempdir with `outside/secret.rs` holding a
distinctive symbol, and a workspace symlink pointing at it:

- `a_symlinked_path_never_indexes_its_target`
  (`crates/stella-graph/tests/register_paths.rs`) calls
  `register_paths` on the symlink and asserts `indexes_file` is
  `false`, no `leaked_outside_the_workspace` definition exists, and
  `all_files()` is empty. On the code before this fix,
  `Path::is_file()` and `std::fs::read` follow the link, so this
  assertion fails (the symbol is indexed under `notes.rs`).
- `injected_symlink_never_enters_the_pipeline`
  (`crates/stella-graph/tests/live_index.rs`) injects the same symlink
  into the real debounce → `apply_changes` pipeline and asserts
  `inject` returns `false` and nothing gets enqueued. On the code
  before this fix, the link's own extension is `.rs` and
  `Path::exists()` follows it to a real target, so `is_watch_relevant`
  accepted it and `inject` returned `true`.

`cargo test -p stella-graph` runs in CI only — this laptop never
builds or tests the workspace (CLAUDE.md).

## Exemplar

None named — this mirrors the existing lstat-based check
`walk_indexable_with` already applies (`crates/stella-graph/src/walk.rs`),
just moved to the two other entry points named in the issue.

## Tests deleted

None.

Closes #5497

## DoD verification at `8664a82`

#5497's checkboxes were unticked, which is the only reason the `dod` gate was
red. Each was re-checked against this branch by an autonomous PR sweep and then
ticked on the issue:

- **Both paths refuse a symlink**, and the guard sits where the issue asked
  rather than only at the two callers: the `symlink_metadata` check in
  `apply_changes` lands ahead of the `abs.is_file()` branch that would have
  followed the link, so `register_paths` is covered by construction, and
  `is_watch_relevant`'s check lands ahead of its `path.exists()` call.
- **Witness** — the two tests split across the two paths, so either guard can
  regress alone and still be caught. `injected_symlink_never_enters_the_pipeline`
  asserts the link never enters the debounce pipeline rather than awaiting a
  batch that by then cannot exist, which is stronger and deterministic;
  `a_symlinked_path_never_indexes_its_target` carries the
  no-symbol-from-the-target assertion the checklist specifies.
- **Tests green** — `fmt + clippy + test` completed 22:47:35Z on this head
  ([job 100448579853](https://github.com/macanderson/stella/actions/runs/33690689121/job/100448579853)),
  and it runs `cargo test --workspace`, which covers `stella-graph`.

## Summary by Sourcery

Reject symlinks across all indexing entry points to prevent files outside the workspace from entering the code graph.

Bug Fixes:
- Prevent symlinks from being indexed through direct path registration or live filesystem events, avoiding accidental ingestion of target files outside the workspace.

Enhancements:
- Apply consistent symlink rejection at both the storage and watcher boundaries, including links whose targets no longer exist.

Tests:
- Add coverage confirming symlinks are excluded from both direct registration and the live indexing pipeline.