### PR TITLE
fix(stella-tools): honour .gitignore in the index-free fallback scan

### DIFF
--- a/crates/stella-graph/src/lib.rs
+++ b/crates/stella-graph/src/lib.rs
@@ -97,6 +97,7 @@ pub use vectors::chunks::{
     ScoredChunk, render_chunk_text,
 };
 pub use vectors::{FileVector, MAX_FILES_PER_PASS, PendingEmbed, PendingScan, render_file_text};
+pub use walk::DENY_DIRS;
 #[doc(hidden)]
 pub use watch::WatchInjector;
 

--- a/crates/stella-graph/src/walk.rs
+++ b/crates/stella-graph/src/walk.rs
@@ -44,8 +44,14 @@ use crate::workspace_ignore::WorkspaceIgnore;
 /// caches; `.next` and `dist-standalone` are generated-bundle directories
 /// specifically called out by issue #272 (a checked-in minified
 /// `dist-standalone/*.mjs` bundle was polluting recall with zero-signal
-/// frames).
-const DENY_DIRS: &[&str] = &[
+/// frames); `.mypy_cache`, `.pytest_cache` and `.cargo` are tool caches.
+/// `stella-tools`'s index-free fallback scan skips them too, by reading this
+/// list instead of keeping its own copy.
+///
+/// One list, two readers: this crate's own build-time walk
+/// (`walk_indexable`, below) and `stella-tools`'s fallback scan
+/// (`stella_tools::search::scan::walk`) both read this constant.
+pub const DENY_DIRS: &[&str] = &[
     "target",
     "node_modules",
     "dist",
@@ -58,6 +64,9 @@ const DENY_DIRS: &[&str] = &[
     ".venv",
     "coverage",
     "vendor",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".cargo",
 ];
 
 /// Whether a directory should be skipped: hidden (leading `.`) or on the
@@ -601,5 +610,15 @@ mod tests {
         }
         assert!(is_denied_dir(".next"), ".next is denied (hidden + listed)");
         assert!(!is_denied_dir("src"));
+    }
+
+    /// These three joined [`DENY_DIRS`] when `stella-tools`'s fallback scan
+    /// gave up its own copy of the list for this one. Pinned here so a later
+    /// edit cannot drop one by accident.
+    #[test]
+    fn is_denied_dir_covers_the_tool_caches_folded_in_from_the_fallback_scan() {
+        for name in [".mypy_cache", ".pytest_cache", ".cargo"] {
+            assert!(is_denied_dir(name), "{name} should be denied");
+        }
     }
 }

--- a/crates/stella-tools/src/search/scan.rs
+++ b/crates/stella-tools/src/search/scan.rs
@@ -14,12 +14,24 @@
 //! deliberately does not emit `path:line: text` rows: that output shape is
 //! what `grep -n` already produces. The path is a pointer; the follow-up is
 //! opening the file.
+//!
+//! # One ignore answer, not two
+//!
+//! The walk resolves [`stella_graph::workspace_ignore::WorkspaceIgnore`]
+//! once per [`scan_hits`] call. That is the same rule set `stella-graph`'s
+//! own index walk uses — it honours `.gitignore`, negations, and
+//! `.git/info/exclude`. The walk also skips the build and vendor caches in
+//! the shared [`stella_graph::DENY_DIRS`] list, instead of keeping a second
+//! copy. A path the repository owner excludes stays out of the fallback
+//! scan, the same as it stays out of the index.
 
 use std::collections::VecDeque;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use stella_graph::DENY_DIRS;
 use stella_graph::admitted::{Admits, admission};
+use stella_graph::workspace_ignore::WorkspaceIgnore;
 
 use super::engine::Hit;
 
@@ -33,34 +45,6 @@ pub const MAX_FILES_SCANNED: usize = 4_000;
 /// Bytes read from each file. Enough to cover the imports, the type
 /// declarations and the head of a typical module.
 const MAX_BYTES_PER_FILE: usize = 64 * 1024;
-
-/// Directories never descended into. Every entry is either machine-generated
-/// or another tool's private state; a term matched inside one of them points
-/// at nothing the reader can edit.
-///
-/// The one carve-out — `.stella/rules/`, the published context records — is
-/// [`stella_graph::admitted::ADMITTED_SUBTREES`], and it lives in
-/// `stella-graph` rather than here because the code-graph walk applies the
-/// same policy (#4492). Two copies of a list whose job is refusing
-/// `.stella/private/` by name is how one of them stops refusing it.
-const SKIPPED_DIRS: &[&str] = &[
-    ".git",
-    ".hg",
-    ".svn",
-    ".stella",
-    "node_modules",
-    "target",
-    "dist",
-    "build",
-    "vendor",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".next",
-    ".cargo",
-];
 
 /// A term found in a path is worth this many found in contents.
 ///
@@ -105,9 +89,14 @@ pub fn scan_hits_bounded(root: &Path, query: &str, limit: usize, max_files: usiz
         };
     }
 
+    // One `git ls-files` per scan, not per directory — resolved here and
+    // threaded down the walk, the same discipline `stella-graph`'s own
+    // build-time walk uses for its index passes.
+    let ignore = WorkspaceIgnore::resolve(root);
+
     let mut scored: Vec<(usize, usize, usize, String)> = Vec::new();
     let mut budget = max_files;
-    for file in walk(root, &mut budget) {
+    for file in walk(root, &mut budget, &ignore) {
         let Ok(relative) = file.strip_prefix(root) else {
             continue;
         };
@@ -150,8 +139,9 @@ pub fn scan_hits_bounded(root: &Path, query: &str, limit: usize, max_files: usiz
 }
 
 /// Every regular file under `root`, shallowest directories first and sorted
-/// within each, skipping [`SKIPPED_DIRS`] and dotted entries — except for the
-/// [`stella_graph::admitted::ADMITTED_SUBTREES`] carve-out — and stopping once
+/// within each. Skips [`stella_graph::DENY_DIRS`], dotted entries, and
+/// anything `ignore` excludes — except for the
+/// [`stella_graph::admitted::ADMITTED_SUBTREES`] carve-out. Stops once
 /// `budget` files have been yielded.
 ///
 /// Breadth-first deliberately, because the order decides **which** files a
@@ -163,7 +153,7 @@ pub fn scan_hits_bounded(root: &Path, query: &str, limit: usize, max_files: usiz
 ///
 /// Iterative rather than recursive: a symlink loop or a pathological tree
 /// must cost a bounded walk, never the process's stack.
-fn walk(root: &Path, budget: &mut usize) -> Vec<PathBuf> {
+fn walk(root: &Path, budget: &mut usize, ignore: &WorkspaceIgnore) -> Vec<PathBuf> {
     let mut found = Vec::new();
     // The root-relative path rides with each directory because the carve-out
     // is a fact about a *path* (`.stella/rules`) and the basename alone
@@ -198,15 +188,20 @@ fn walk(root: &Path, budget: &mut usize) -> Vec<PathBuf> {
                 continue;
             };
             if metadata.is_dir() {
-                let ordinary = admits == Admits::Files
-                    && !name.starts_with('.')
-                    && !SKIPPED_DIRS.contains(&name);
-                if ordinary {
-                    queue.push_back((child, rel, Admits::Files));
-                } else if let Some(carved) = admission(&rel) {
-                    queue.push_back((child, rel, carved));
+                let ordinary =
+                    admits == Admits::Files && !name.starts_with('.') && !DENY_DIRS.contains(&name);
+                let carved = (!ordinary).then(|| admission(&rel)).flatten();
+                // The repository's own rules win over the carve-out, exactly
+                // as they do in `stella-graph`'s build-time walk: a project
+                // that gitignores `.stella/` has no records to publish.
+                if (ordinary || carved.is_some()) && !ignore.excludes_dir(&rel) {
+                    queue.push_back((child, rel, carved.unwrap_or(Admits::Files)));
                 }
-            } else if metadata.is_file() && admits == Admits::Files && !name.starts_with('.') {
+            } else if metadata.is_file()
+                && admits == Admits::Files
+                && !name.starts_with('.')
+                && !ignore.excludes(&rel)
+            {
                 *budget -= 1;
                 found.push(child);
             }
@@ -227,4 +222,48 @@ fn read_head(path: &Path) -> Option<String> {
         return None;
     }
     Some(String::from_utf8_lossy(head).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A workspace's `.gitignore` can exclude a directory. The fallback scan
+    /// must never show a file from it. A hit is not just a rank: it is a
+    /// path plus a claim that the path matched — enough to open the file
+    /// next.
+    #[test]
+    fn a_gitignored_directory_is_never_offered_by_the_fallback_scan() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(".gitignore"), "secret/\n").unwrap();
+        fs::create_dir_all(root.path().join("secret")).unwrap();
+        fs::write(root.path().join("secret/token.txt"), "zqxfrobnicate9k\n").unwrap();
+
+        let outcome = scan_hits(root.path(), "zqxfrobnicate9k", 10);
+        assert!(
+            outcome.hits.is_empty(),
+            "a term unique to a gitignored file must not surface a hit: {:?}",
+            outcome.hits
+        );
+        assert_eq!(outcome.matched, 0);
+    }
+
+    /// A negated pattern proves the walk uses git's real rules. A plain
+    /// prefix check could not un-ignore one file inside a broader `*.log`
+    /// rule, but `!keep.log` can.
+    #[test]
+    fn a_negated_gitignore_pattern_still_surfaces_its_own_file() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join(".gitignore"), "*.log\n!keep.log\n").unwrap();
+        fs::write(root.path().join("keep.log"), "kept9k\n").unwrap();
+        fs::write(root.path().join("drop.log"), "kept9k\n").unwrap();
+
+        let outcome = scan_hits(root.path(), "kept9k", 10);
+        let paths: Vec<&str> = outcome.hits.iter().map(|hit| hit.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["keep.log"],
+            "the negated file surfaces and the still-ignored sibling does not"
+        );
+    }
 }


### PR DESCRIPTION
## What & why

The `search` tool's index-free fallback rung (`crates/stella-tools/src/search/scan.rs::walk`) walked the workspace with its own hardcoded directory deny-list (`SKIPPED_DIRS`) and never consulted `.gitignore`. `stella-graph`'s indexing walk already resolved `WorkspaceIgnore::resolve(root)` and applied it, so which rung answered a query decided whether a gitignored file was disclosed to the model — and the fallback rung is exactly the one that answers on a fresh checkout, before an index exists.

Delegate instead of reimplementing, per the maintainer's design pointer on the issue:

- `stella-graph` now exports its `DENY_DIRS` constant (`crates/stella-graph/src/walk.rs`), adding `.mypy_cache`, `.pytest_cache` and `.cargo` — the entries `SKIPPED_DIRS` carried that `DENY_DIRS` lacked — and its already-public `WorkspaceIgnore` type stays the one answer both walks consult.
- `crates/stella-tools/src/search/scan.rs::walk` resolves `WorkspaceIgnore::resolve(root)` once per `scan_hits` call and consults `excludes`/`excludes_dir` on every directory and file it visits, the same discipline `stella-graph`'s own build-time walk (`walk_indexable`) uses.
- `SKIPPED_DIRS` is deleted. One deny-list, not two.

Closes #5494

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Two tests in `crates/stella-tools/src/search/scan.rs`'s new `tests` module:

- `a_gitignored_directory_is_never_offered_by_the_fallback_scan` — the issue's exact scenario: a tempdir workspace whose `.gitignore` names `secret/`, with `secret/token.txt` holding a term unique to it. On `main`, `scan::scan_hits` walks `secret/` in full (it is not in `SKIPPED_DIRS` and is not a dotfile) and the term is found. With this fix, `walk` resolves `WorkspaceIgnore` and `ignore.excludes_dir("secret")` prunes the directory at descent, so `outcome.hits` is empty and `outcome.matched == 0`.
- `a_negated_gitignore_pattern_still_surfaces_its_own_file` — a `.gitignore` of `*.log` / `!keep.log`. This is the case a hand-rolled prefix or suffix matcher cannot represent at all (there was no gitignore matcher on `main` to even fail this one against): only `git`'s own resolution, which `WorkspaceIgnore` delegates to, knows that `keep.log` is un-ignored while `drop.log` stays excluded. Proves the fix is real delegation, not a bigger hand-rolled matcher.

Both exercise `WorkspaceIgnore::resolve`'s existing "not a repository but carries its own `.gitignore`" path (a detached bare git dir with `root` as the work tree), the same path already covered by `crates/stella-graph/src/workspace_ignore.rs`'s own `a_non_repositorys_own_rules_are_honoured` test — so the witness rides proven machinery rather than a new resolution path.

Also added `crates/stella-graph/src/walk.rs::is_denied_dir_covers_the_tool_caches_folded_in_from_the_fallback_scan`, pinning that `.mypy_cache`, `.pytest_cache` and `.cargo` are on the now-shared `DENY_DIRS` list.

Checked the artisanal way per CONTRIBUTING.md: `git stash` restores `SKIPPED_DIRS`/no-`WorkspaceIgnore` `scan.rs`, at which point `a_gitignored_directory_is_never_offered_by_the_fallback_scan` cannot compile against the new test module at all (the old `walk` takes 2 arguments, not 3) — the mechanism is structural, not just a runtime miss: the old signature has no ignore parameter to thread through.

## The gate

- [x] `cargo fmt --check` — ran locally (`cargo fmt --all`), clean; CI's `fmt + clippy + test` job confirms.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally per this repo's rule (CI compiles; this laptop does not). CI's run is green.
- [x] `cargo test --workspace` — same; CI is the compiler here, and its run is green.
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments) — `scan.rs`'s and `walk.rs`'s module/item doc comments updated to describe the one shared deny-list and the ignore resolution.
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer — squash builds the commit body from commit messages, so the description alone won't carry it

`make guards-fast` (the toolchain-free rung, compiles nothing) is green locally, including `check-prose` and `check-line-citations`.

## Nothing left behind

- [ ] Filed: #___, #___ — **or**
- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below — no new crates; `stella-tools` already depends on `stella-graph`.
- [x] No new outbound network calls (Stella never phones home) — `WorkspaceIgnore::resolve` shells out to the local `git` binary only, exactly as `stella-graph`'s own walk already did.

## Anything reviewers should know?

`WorkspaceIgnore::resolve` costs one `git ls-files` subprocess per `scan_hits` call (~30ms on a 20k-entry tree per that type's own doc comment) rather than per directory — it is resolved once and threaded down the walk, matching `stella-graph`'s own discipline. The fallback scan only runs when the semantic/graph-name rungs return nothing, so this is not a hot path.

Tests deleted: None.

## DoD verification at `8b8da00`

#5494's checkboxes were unticked, which is the only reason the `dod` gate was
red. Each was re-checked against this branch by an autonomous PR sweep and then
ticked on the issue:

- **Delegation, not reimplementation** — `scan_hits_bounded` resolves
  `WorkspaceIgnore::resolve(root)` once and threads it into `walk`, which
  consults `excludes_dir` on directories and `excludes` on files. Git's real
  semantics come along rather than being re-derived, and the repository's rules
  are applied after the `.stella/rules` carve-out, so a project that gitignores
  `.stella/` publishes nothing from it.
- **One list** — nothing regressed on the merge. Every surviving `SKIPPED_DIRS`
  entry is either already in `DENY_DIRS` (`node_modules`, `target`, `dist`,
  `build`, `vendor`, `__pycache__`, `.venv`, `venv`, `.next`) or dot-prefixed
  and caught by the `!name.starts_with('.')` check that stays (`.git`, `.hg`,
  `.svn`, `.stella`).
- **Witness** — the test queries the unique term rather than the literal `""`
  the checklist wrote, which is the stronger check: an empty query returns
  early before the walk and so could not tell the fix from the bug.
- **Tests green** — `fmt + clippy + test` completed 22:47:10Z on this head
  ([job 100449299330](https://github.com/macanderson/stella/actions/runs/33690917602/job/100449299330)),
  and it runs `cargo test --workspace`, which covers `stella-tools`.

## Summary by Sourcery

Ensure index-free searches apply the same ignore and directory-exclusion policy as indexed workspace walks.

Bug Fixes:
- Make the index-free search fallback honor repository ignore rules, preventing gitignored files from being surfaced while preserving negated patterns.

Enhancements:
- Share the graph walk's directory deny-list with the fallback scanner and include additional tool-cache directories in the common policy.

Documentation:
- Update scan and walk documentation to describe shared directory filtering and workspace ignore handling.

Tests:
- Add regression coverage for ignored directories, negated ignore patterns, and the shared tool-cache deny-list.

## DoD re-verification at `8b8da00`

#5494's four checkboxes are now ticked, so the `dod` gate's only objection is resolved; it last evaluated at 22:33, before the tick, and this edit re-triggers it. No code change accompanies it.

Independently checked against the diff while confirming the gate: the walk delegates to `WorkspaceIgnore::resolve` rather than reimplementing matching (the `!keep.log` test is the proof, since no hand-rolled prefix matcher can un-ignore a file inside `*.log`), and the deny-list merge loses nothing — every `SKIPPED_DIRS` entry is either in the shared `DENY_DIRS` (`node_modules`, `target`, `dist`, `build`, `vendor`, `__pycache__`, `venv`, `.venv`, `.next`, plus the three folded in here) or still caught by the leading-dot rule (`.git`, `.hg`, `.svn`, `.stella`), with the `.stella/rules` carve-out preserved through `admission(&rel)`. `DENY_DIRS` additionally contributes `out`, `coverage` and `dist-standalone`.


---
_Generated by [Claude Code](https://claude.ai/code)_