### PR TITLE
fix(stella-core): refuse a sub-agent ceiling too short for a child to run

### DIFF
--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -635,7 +635,7 @@ impl Engine<'_> {
         budget: &mut BudgetGuard,
         events: &EventSender,
     ) -> SubAgentOutcome {
-        let carve = budget.carve(spec.budget_usd);
+        let mut carve = budget.carve(spec.budget_usd);
         let _ = events.send(AgentEvent::SubAgent {
             phase: SubAgentPhase::Started {
                 agent_id: spec.agent_id.clone(),
@@ -681,7 +681,11 @@ impl Engine<'_> {
                 let deadline = deadline.expect(
                     "refusal() returns Some for every Err case above; reaching here means Ok",
                 );
-                self.run_child_turn(host, spec, carve, budget, events, &tally, deadline)
+                // Set here, on the carve the caller still owns, rather than
+                // adding a parameter to `run_child_turn` for one field of a
+                // struct it already receives.
+                carve.set_task_deadline(deadline);
+                self.run_child_turn(host, spec, carve, budget, events, &tally)
                     .await
             }
         };
@@ -715,7 +719,6 @@ impl Engine<'_> {
         budget: &mut BudgetGuard,
         events: &EventSender,
         tally: &Arc<CommittedTally>,
-        deadline: Option<std::time::Instant>,
     ) -> SubAgentOutcome {
         // Attribution is entered before anything the child could emit and
         // released by drop, so an unwind cannot leave the parent's later
@@ -852,11 +855,9 @@ impl Engine<'_> {
         let seeded = messages.len();
 
         let child_events = child_sender(events.clone(), spec.agent_id.clone(), tally.clone());
-        // A call may never be granted more than what is left of the ceiling the
-        // whole child runs under (#4488). The caller already derived this
-        // deadline, before the child's engine was even built. Recomputing it
-        // here would be a second seam reading the same config field.
-        carve.set_task_deadline(deadline);
+        // `carve` already carries its task deadline: the caller derived it
+        // from the ceiling and set it before this turn's engine was even
+        // built (#4488), so a too-short ceiling never reaches this far.
         // The carve is handed to the turn through a guard that settles it on
         // DROP, not on return (#1850). `settle_child` used to be a statement
         // after the await, so any exit that was not a return skipped it: a

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -665,10 +665,23 @@ impl Engine<'_> {
             armed: true,
         };
 
-        let outcome = match refusal(spec, &carve) {
-            Some(reason) => SubAgentOutcome::Refused { reason },
+        // The one seam that reads `self.config.tool_timeout`. Its result
+        // feeds `refusal()` first, then the child's own carve on every
+        // other path.
+        let deadline = bounded_by_ceiling(
+            carve.task_deadline(),
+            self.config.tool_timeout,
+            std::time::Instant::now(),
+        );
+        let outcome = match refusal(spec, &carve, &deadline) {
+            Some(refusal) => SubAgentOutcome::Refused {
+                reason: refusal.to_string(),
+            },
             None => {
-                self.run_child_turn(host, spec, carve, budget, events, &tally)
+                let deadline = deadline.expect(
+                    "refusal() returns Some for every Err case above; reaching here means Ok",
+                );
+                self.run_child_turn(host, spec, carve, budget, events, &tally, deadline)
                     .await
             }
         };
@@ -702,6 +715,7 @@ impl Engine<'_> {
         budget: &mut BudgetGuard,
         events: &EventSender,
         tally: &Arc<CommittedTally>,
+        deadline: Option<std::time::Instant>,
     ) -> SubAgentOutcome {
         // Attribution is entered before anything the child could emit and
         // released by drop, so an unwind cannot leave the parent's later
@@ -839,12 +853,10 @@ impl Engine<'_> {
 
         let child_events = child_sender(events.clone(), spec.agent_id.clone(), tally.clone());
         // A call may never be granted more than what is left of the ceiling the
-        // whole child runs under (#4488).
-        carve.set_task_deadline(bounded_by_ceiling(
-            carve.task_deadline(),
-            self.config.tool_timeout,
-            std::time::Instant::now(),
-        ));
+        // whole child runs under (#4488). The caller already derived this
+        // deadline, before the child's engine was even built. Recomputing it
+        // here would be a second seam reading the same config field.
+        carve.set_task_deadline(deadline);
         // The carve is handed to the turn through a guard that settles it on
         // DROP, not on return (#1850). `settle_child` used to be a statement
         // after the await, so any exit that was not a return skipped it: a
@@ -925,20 +937,68 @@ impl Drop for SettleChildOnDrop<'_, '_> {
     }
 }
 
+/// Why a sub-agent spawn is refused. A typed value, not a hand-built
+/// `String`, per AGENTS.md's typed-errors rule. Every option here is
+/// checked before the child's engine is built, so a refusal costs exactly
+/// zero (see [`SubAgentOutcome::Refused`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubAgentRefusal {
+    /// [`SubAgentSpec::depth`] exceeds [`MAX_SUB_AGENT_DEPTH`].
+    DepthExceeded { depth: u8, max: u8 },
+    /// The parent's enforced budget cap has no headroom left to carve a
+    /// child from.
+    NoBudgetHeadroom,
+    /// `ceiling` leaves no working time once [`CEILING_RESERVE`] is
+    /// subtracted. [`bounded_by_ceiling`] refuses rather than clamp the
+    /// deadline to "now".
+    CeilingTooShort {
+        ceiling: std::time::Duration,
+        reserve: std::time::Duration,
+    },
+}
+
+impl std::fmt::Display for SubAgentRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubAgentRefusal::DepthExceeded { depth, max } => {
+                write!(f, "nesting depth {depth} exceeds the maximum of {max}")
+            }
+            SubAgentRefusal::NoBudgetHeadroom => write!(
+                f,
+                "no budget headroom left in the parent's enforced cap — refused before spending"
+            ),
+            SubAgentRefusal::CeilingTooShort { ceiling, reserve } => write!(
+                f,
+                "ceiling {ceiling:?} leaves no working time once its {reserve:?} reserve is \
+                 subtracted — refused rather than handing the child a deadline of \"now\""
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SubAgentRefusal {}
+
 /// Why this spawn must not start, if it must not. Checked before the first
 /// model call so a refusal costs exactly nothing.
-fn refusal(spec: &SubAgentSpec, carve: &BudgetGuard) -> Option<String> {
+///
+/// `deadline` is [`bounded_by_ceiling`]'s result. The caller computes it
+/// once and hands it in; this function only decides whether to refuse.
+fn refusal(
+    spec: &SubAgentSpec,
+    carve: &BudgetGuard,
+    deadline: &Result<Option<std::time::Instant>, SubAgentRefusal>,
+) -> Option<SubAgentRefusal> {
     if spec.depth > MAX_SUB_AGENT_DEPTH {
-        return Some(format!(
-            "nesting depth {} exceeds the maximum of {MAX_SUB_AGENT_DEPTH}",
-            spec.depth
-        ));
+        return Some(SubAgentRefusal::DepthExceeded {
+            depth: spec.depth,
+            max: MAX_SUB_AGENT_DEPTH,
+        });
+    }
+    if let Err(refusal) = deadline {
+        return Some(*refusal);
     }
     if !carve.is_viable_carve() {
-        return Some(
-            "no budget headroom left in the parent's enforced cap — refused before spending"
-                .to_string(),
-        );
+        return Some(SubAgentRefusal::NoBudgetHeadroom);
     }
     None
 }
@@ -981,6 +1041,9 @@ impl CommittedTally {
 /// against the ceiling, so the child always reaches its own deadline before
 /// the engine's dispatch ceiling reaches the tool. Thirty seconds is generous
 /// for work that is pure local computation with no model call left in it.
+///
+/// A ceiling at or under this reserve is refused outright, not clamped to
+/// a deadline of "now". See [`bounded_by_ceiling`].
 const CEILING_RESERVE: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// The wall clock this child may spend, given what it inherited and the
@@ -1004,16 +1067,34 @@ const CEILING_RESERVE: std::time::Duration = std::time::Duration::from_secs(30);
 ///
 /// The tighter of the two always wins, so a parent already racing a deadline
 /// never hands a child more time than the parent itself has.
+///
+/// # Refusing a too-short ceiling
+///
+/// On its own, `now + ceiling.saturating_sub(CEILING_RESERVE)` floors at
+/// exactly `now` once `ceiling` falls to or below the reserve. A child
+/// given that deadline aborts having done no work. Nothing then tells that
+/// apart from a model that just declined to answer. `ceiling <=
+/// CEILING_RESERVE` is refused instead — the one way this function can
+/// fail — so the parent sees a one-line reason before any child spawns.
 fn bounded_by_ceiling(
     inherited: Option<std::time::Instant>,
     ceiling: Option<std::time::Duration>,
     now: std::time::Instant,
-) -> Option<std::time::Instant> {
-    let from_ceiling = ceiling.map(|ceiling| now + ceiling.saturating_sub(CEILING_RESERVE));
-    match (inherited, from_ceiling) {
+) -> Result<Option<std::time::Instant>, SubAgentRefusal> {
+    let from_ceiling = match ceiling {
+        Some(ceiling) if ceiling <= CEILING_RESERVE => {
+            return Err(SubAgentRefusal::CeilingTooShort {
+                ceiling,
+                reserve: CEILING_RESERVE,
+            });
+        }
+        Some(ceiling) => Some(now + ceiling.saturating_sub(CEILING_RESERVE)),
+        None => None,
+    };
+    Ok(match (inherited, from_ceiling) {
         (Some(inherited), Some(from_ceiling)) => Some(inherited.min(from_ceiling)),
         (only, None) | (None, only) => only,
-    }
+    })
 }
 
 /// The child's event sender: drops what must not cross ([`forwards_to_parent`]),

--- a/crates/stella-core/src/subagent/tests/spend_and_cancellation.rs
+++ b/crates/stella-core/src/subagent/tests/spend_and_cancellation.rs
@@ -392,8 +392,9 @@ fn a_childs_deadline_is_the_tighter_of_what_it_inherited_and_the_ceiling() {
     let now = std::time::Instant::now();
     let ceiling = Duration::from_secs(900);
 
-    let from_ceiling =
-        crate::subagent::bounded_by_ceiling(None, Some(ceiling), now).expect("a ceiling bounds it");
+    let from_ceiling = crate::subagent::bounded_by_ceiling(None, Some(ceiling), now)
+        .expect("a ceiling well above the reserve must not refuse")
+        .expect("a ceiling bounds it");
     assert!(
         from_ceiling < now + ceiling,
         "a deadline at the ceiling is a coin flip against the dispatch timeout"
@@ -402,17 +403,103 @@ fn a_childs_deadline_is_the_tighter_of_what_it_inherited_and_the_ceiling() {
     let sooner = now + Duration::from_secs(10);
     assert_eq!(
         crate::subagent::bounded_by_ceiling(Some(sooner), Some(ceiling), now),
-        Some(sooner),
+        Ok(Some(sooner)),
         "the parent's own deadline is not widened by having a child"
     );
     assert_eq!(
         crate::subagent::bounded_by_ceiling(Some(sooner), None, now),
-        Some(sooner),
+        Ok(Some(sooner)),
         "no ceiling leaves what was inherited exactly as it was"
     );
     assert_eq!(
         crate::subagent::bounded_by_ceiling(None, None, now),
-        None,
+        Ok(None),
         "and an unbounded parent with no ceiling stays unbounded"
     );
+}
+
+/// **Loud refusal, half one.** `bounded_by_ceiling` is the single seam
+/// reading the configured ceiling; it must refuse rather than floor at "now"
+/// on both sides of the boundary. Thirty seconds — exactly the reserve — is
+/// refused; one second more is not.
+#[test]
+fn a_ceiling_at_or_under_the_reserve_is_refused_not_floored() {
+    use std::time::Duration;
+    let now = std::time::Instant::now();
+
+    let at_the_reserve =
+        crate::subagent::bounded_by_ceiling(None, Some(crate::subagent::CEILING_RESERVE), now);
+    assert!(
+        matches!(
+            at_the_reserve,
+            Err(SubAgentRefusal::CeilingTooShort { ceiling, reserve })
+                if ceiling == crate::subagent::CEILING_RESERVE
+                    && reserve == crate::subagent::CEILING_RESERVE
+        ),
+        "a ceiling exactly at the reserve leaves zero working time and must refuse: \
+         {at_the_reserve:?}"
+    );
+
+    let one_second_of_headroom = crate::subagent::CEILING_RESERVE + Duration::from_secs(1);
+    let just_over = crate::subagent::bounded_by_ceiling(None, Some(one_second_of_headroom), now);
+    assert_eq!(
+        just_over,
+        Ok(Some(now + Duration::from_secs(1))),
+        "one second above the reserve is one second of working time, not a refusal"
+    );
+}
+
+/// **Loud refusal, half two.** The refusal is not just the seam function —
+/// it has to reach the parent as a [`SubAgentOutcome::Refused`] with zero
+/// model calls and zero cost, the same contract every other refusal keeps.
+#[tokio::test]
+async fn a_ceiling_too_short_refuses_the_whole_spawn_loudly() {
+    use std::time::Duration;
+
+    let parent_provider = ScriptedProvider::new(vec![]);
+    // Would answer happily if it were ever asked. It must not be.
+    let child_provider = ScriptedProvider::new(vec![Ok(text_result("hello", 0.01))]);
+    let tools = MixedTools::default();
+    let parent = Engine::with_sleeper(
+        &parent_provider,
+        &tools,
+        EngineConfig {
+            tool_timeout: Some(Duration::from_secs(30)),
+            ..EngineConfig::default()
+        },
+        &NoSleep,
+    );
+    let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = parent
+        .run_sub_agent(
+            SubAgentHost::new(&child_provider),
+            &SubAgentSpec::read_only("too-tight", "work"),
+            &mut budget,
+            &tx,
+        )
+        .await;
+
+    match &outcome {
+        SubAgentOutcome::Refused { reason } => {
+            assert!(
+                reason.contains("30s") || reason.contains("30"),
+                "the parent must see the ceiling that tripped it: {reason}"
+            );
+        }
+        other => panic!("expected Refused, got {other:?}"),
+    }
+    assert_eq!(
+        child_provider.calls.load(Ordering::SeqCst),
+        0,
+        "a ceiling refusal must cost exactly zero model calls, like every other refusal"
+    );
+    assert_eq!(outcome.cost_usd(), 0.0);
+
+    let events = drain(&mut rx);
+    assert!(matches!(
+        finished(&events),
+        SubAgentPhase::Finished { status, .. } if status == SubAgentStatus::Refused
+    ));
 }


### PR DESCRIPTION
## What

`bounded_by_ceiling` in `crates/stella-core/src/subagent.rs` derived a child sub-agent's deadline as `now + ceiling.saturating_sub(CEILING_RESERVE)`. Any configured `tool_timeout` at or under the 30s reserve saturated to zero, handing the child a deadline of exactly `now`. The child aborted at its first step boundary having done no work — a silent boundary cliff that read as a model declining to answer rather than a configuration mistake.

## Why

This function is the single seam that reads `self.config.tool_timeout` for a sub-agent's deadline. Loud refusal beats a silent floor: the module's other two refusal paths (nesting depth, no budget headroom) already refuse the spawn outright before the child's engine is built, so a too-short ceiling now joins them instead of degrading into a no-op child.

## How

- `bounded_by_ceiling` now returns `Result<Option<Instant>, SubAgentRefusal>` and returns `Err(SubAgentRefusal::CeilingTooShort { ceiling, reserve })` when `ceiling <= CEILING_RESERVE`.
- `SubAgentRefusal` is a new crate-private enum replacing the two prior refusal reasons' hand-built `String`s (`DepthExceeded`, `NoBudgetHeadroom`, `CeilingTooShort`), each with one `Display` impl. The design pointer on the issue named an "existing delegation error enum" to add a variant to — no such enum existed in `stella-core`, so this PR introduces it rather than hand-building a third `format!` call site next to the two that already existed; happy to fold this differently if that reads as scope creep.
- The deadline is now derived once, in `run_sub_agent_with_sender`, before the child's engine is ever assembled, and threaded through both `refusal()` (which turns `Err` into a loud refusal) and, on every other path, into the child's own budget carve — so there is exactly one call site reading the ceiling, not two computing it independently.

## Witness

Two new tests in `crates/stella-core/src/subagent/tests/spend_and_cancellation.rs`:

- `a_ceiling_at_or_under_the_reserve_is_refused_not_floored` calls `bounded_by_ceiling` directly at both sides of the boundary: `Duration::from_secs(30)` (the reserve exactly) returns `Err(CeilingTooShort { .. })`; `Duration::from_secs(31)` returns `Ok(Some(now + Duration::from_secs(1)))`, matching the design pointer's exact witness.
- `a_ceiling_too_short_refuses_the_whole_spawn_loudly` drives a full `run_sub_agent` with `tool_timeout: Some(Duration::from_secs(30))` and asserts the parent sees `SubAgentOutcome::Refused` naming the ceiling, zero model calls, zero cost, and a `Finished` event with `SubAgentStatus::Refused` — the same contract every other refusal keeps.

Both fail to compile against `main`'s `Option<Instant>`-returning signature, so they fail on the old code by construction rather than by assertion. The existing `a_childs_deadline_is_the_tighter_of_what_it_inherited_and_the_ceiling` test was updated for the new `Result` return type; no behavior it covered changed.

Verified locally with a targeted crate test (`cargo test -p stella-core --lib subagent`, allowed per CLAUDE.md as a single-crate, single-area run): all 39 sub-agent tests pass. `cargo fmt --all` and `make guards-fast` are clean.

## Tests deleted

None.

Closes #5386

## Summary by Sourcery

Reject sub-agent ceilings that leave no usable execution time before the child is created.

Bug Fixes:
- Refuse sub-agent spawns when the configured tool timeout is at or below the deadline reserve instead of starting a child with an immediately expired deadline.

Enhancements:
- Introduce typed sub-agent refusal reasons and centralize deadline calculation so refusal handling and child execution use the same deadline.

Tests:
- Add boundary and end-to-end coverage confirming short ceilings are reported loudly with no model calls or cost, while preserving existing deadline behavior.
