### PR TITLE
ci(macos-check): compile stella-cli's macOS-only dependency table

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -1,0 +1,81 @@
+name: macos-check
+
+# windows-check.yml's other leg: the only compiler in this project that ever
+# looks at a `cfg(target_os = "macos")` dependency table.
+#
+# `ci.yml` runs on `ubuntu-latest`, so it never resolves
+# `[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]`
+# in `crates/stella-cli/Cargo.toml` — the `cpal` microphone-capture dependency
+# `command_deck::voice` (ADR 0020) needs on those two platforms. `release.yml`
+# does build macOS targets, but only on a tag push, long after a PR has
+# already merged; a PR gate that never touches this table can go green on a
+# change that does not build there at all. That happened for real: a
+# dependabot bump merged with `main` broken on macOS, because nothing in the
+# required check ever compiled `cpal` (#5542, filed as the general gap #5543).
+#
+# So this compiles `stella-cli` itself on a real macOS runner, on the paths
+# that can move the target table: the crate's own sources, the workspace
+# `Cargo.toml` `cpal` is declared against, and the resolved `Cargo.lock`.
+#
+# `cargo check`, not `clippy` or `build`: the question this job answers is
+# narrower than windows-check.yml's — does the macOS-only dependency table
+# still resolve and typecheck — not whether the macOS arms are lint-clean or
+# link a working binary. `--all-targets` so the target-scoped `[dev-dependencies]`
+# and test bodies are checked too, not just the library and bin crates; unlike
+# windows-check.yml, stella-cli carries no `#[cfg(unix)]`-only test fixture
+# that would fail here for a reason unrelated to the platform split.
+# `--locked` so a `Cargo.lock` drift fails here the same way it fails
+# `lockfile-sync` in `make gate`.
+#
+# Its own file rather than a job in `ci.yml`, for the same reason
+# `windows-check.yml` has one: a macOS runner is minutes of wall clock a diff
+# touching neither `stella-cli` nor the lockfile has no use for. Not a
+# required check.
+on:
+  pull_request:
+    paths:
+      - "crates/stella-cli/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/macos-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/stella-cli/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/macos-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    name: the macOS-only dependency table still compiles
+    runs-on: macos-14
+    # The bundled C in the dependency graph (rusqlite's SQLite, the
+    # tree-sitter grammars, cpal's CoreAudio bindings) is the expensive part
+    # on a cold cache.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Despite the action's name this does not build on `stable`:
+      # rust-toolchain.toml pins the repo to a concrete toolchain and rustup
+      # honors it for every cargo invocation inside the checkout. This step
+      # exists to put *a* rustup on PATH.
+      - name: Install Rust (rustup; the build uses the rust-toolchain.toml pin)
+        id: rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+
+      - name: cargo check stella-cli, all targets, on macOS
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: cargo check -p stella-cli --all-targets --locked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,18 @@ existed. `reserved-paths` (`scripts/check-reserved-paths.sh`) is the fast
 half of that finding, because a failed checkout reports one bad path per run
 and there were two.
 
+`windows-check.yml`'s other leg is `macos-check.yml`, same shape and the
+same reason: `crates/stella-cli/Cargo.toml` carries a
+`cfg(any(target_os = "macos", target_os = "windows"))` dependency table for
+`cpal`, the microphone-capture crate `command_deck::voice` needs (ADR 0020),
+and `ci.yml`'s `ubuntu-latest` job never resolves it. `release.yml` does
+build macOS targets, but only on a tag push, well after a PR has already
+merged — so a dependabot bump to `cpal` merged with `main` broken on macOS,
+with nothing in the required check having ever compiled it. This job runs
+`cargo check -p stella-cli --all-targets --locked` on `macos-14`,
+path-triggered on `crates/stella-cli/**`, `Cargo.lock` and the workspace
+`Cargo.toml`. Not a required check.
+
 A ninth, `rebase-replay.yml`, is the only check here that reads a branch's
 **history** rather than its tree, and it exists for a composition hazard the
 shared-cell paragraph above does not cover: **rebasing a stale branch can


### PR DESCRIPTION
## What / why

`ci.yml` runs on `ubuntu-latest`, so it never resolves the
`[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]`
table in `crates/stella-cli/Cargo.toml` — the `cpal` microphone-capture
dependency `command_deck::voice` (ADR 0020) needs on those two platforms.
`release.yml` does build macOS targets, but only on a tag push, well after a
PR has merged, so a dependabot bump to `cpal` merged green while `main` did
not build on macOS at all (fixed in #5542; this issue is the general gap).

This PR adds `macos-check.yml`, `windows-check.yml`'s other leg: `cargo
check -p stella-cli --all-targets --locked` on `macos-14`. Same shape as
`windows-check.yml` — its own workflow file, path-triggered
(`crates/stella-cli/**`, `Cargo.lock`, the workspace `Cargo.toml`, the
workflow file itself) so it does not run on every PR, every action pinned by
commit SHA, not a required check. AGENTS.md's `windows-check.yml` paragraph
now names it, so a reader following that paragraph finds both legs.

`cargo check` rather than `clippy`, per the maintainer's design pointer on
the issue: the question this job answers is narrower than
`windows-check.yml`'s — does the macOS-only dependency table still resolve
and typecheck, not whether the macOS arms are lint-clean.

## Witness

CI itself is the witness here — there is no unit test for "does a target
table compile on a runner that resolves it." The mechanism: on `main` today
the only workflow with a macOS runner (`release.yml`) never runs on a pull
request, and `ci.yml`'s `ubuntu-latest` job cannot resolve a
`cfg(target_os = "macos")` table at all — `cargo` never evaluates a
target-cfg predicate for a platform it isn't building on. So before this PR,
no PR-time check could have caught the exact defect #5542 fixed: a `cpal`
bump that only breaks the macOS leg. This PR's own run is the fail→pass
proof — the job did not exist before this PR (nothing to fail on `main`),
and it runs green here, on the same crate and the same target table that
broke:

**[`the macOS-only dependency table still compiles` — green on `e63e2f2`](https://github.com/macanderson/stella/actions/runs/33692730835/job/100454868018)**

with the log showing the macOS-only audio stack compiling on the runner:

```
22:57:26  Compiling cpal v0.18.2
22:57:27   Checking coreaudio-rs v0.14.2
22:57:23   Checking objc2-core-audio v0.3.2
22:57:21   Checking objc2-core-audio-types v0.3.2
22:57:25   Checking objc2-audio-toolbox v0.3.2
22:57:28  Compiling stella-cli v0.9.305
22:58:05   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 35s
```

`cpal` and its CoreAudio bindings are compiled only because the runner is
`macos-14`; none of those lines can appear in `ci.yml`'s Linux job.

## Exemplar

`windows-check.yml` — same file shape, same rationale for why it is not
folded into `ci.yml` (a platform runner most diffs have no use for).

## Tests deleted

None.

## Definition of done

All six boxes on #5543 are ticked, each verified against this PR's diff or
its CI run — see the verification comment on this PR for the per-item
evidence.

Closes #5543

## Summary by Sourcery

Add a path-triggered macOS compile check to catch platform-specific stella-cli dependency failures before changes merge.

New Features:
- Add a macOS CI workflow that checks the stella-cli crate and its macOS-specific dependency resolution on macOS runners.

Enhancements:
- Trigger the macOS check only for relevant crate, workspace manifest, lockfile, or workflow changes and document its relationship to the Windows check.

CI:
- Run locked, all-target cargo checks on macos-14 with pinned actions, caching, concurrency cancellation, and a bounded timeout.

Documentation:
- Update AGENTS.md to document the macOS platform check and its scope.
