### PR TITLE
fix(stella-fleet): validate a fleet worker's reported cost

### DIFF
--- a/crates/stella-fleet/src/fleet.rs
+++ b/crates/stella-fleet/src/fleet.rs
@@ -462,6 +462,21 @@ pub enum FleetError {
     /// budget skip, not a task failure.
     #[error("task `{task}` skipped: fleet budget exhausted before it could start")]
     BudgetExhausted { task: TaskId },
+    /// A worker reported a cost that fails `is_finite() && cost_usd >= 0.0`.
+    /// It is rejected, not trusted.
+    ///
+    /// A negative cost would shrink the running budget total. A later task
+    /// could then slip past an `Enforced` limit that real spend has already
+    /// crossed. A NaN cost is worse: it poisons every later sum against that
+    /// total for good.
+    ///
+    /// `Fleet::dispatch_claimed` records the attempt as failed, with zero
+    /// spend, and returns this error. `Fleet::run_plan` treats it like any
+    /// other dispatch failure.
+    #[error(
+        "task `{task}` reported an invalid cost ({reported}); recorded as failed with zero spend"
+    )]
+    InvalidWorkerCost { task: TaskId, reported: f64 },
 }
 
 /// The fleet orchestrator. Owns the worker, the worktree manager, the ledger,
@@ -802,7 +817,7 @@ where
         //    pause/stop. Re-dispatch a task after its previous attempt
         //    settles, not alongside it.
         let (controls, control_guard) = self.register_controls(task);
-        let outcome = match self.config.task_timeout {
+        let mut outcome = match self.config.task_timeout {
             None => self.worker.run(task, &workspace_root, controls).await,
             Some(limit) => {
                 let run = self.worker.run(task, &workspace_root, controls);
@@ -857,6 +872,35 @@ where
         // panicking or this future being cancelled mid-run.
         drop(control_guard);
 
+        // 3.5. A worker's reported cost is untrusted input, like its commits
+        //    or its summary. It feeds two running totals: the in-memory
+        //    `BudgetGuard` and the ledger's `spend` table. Neither survives a
+        //    value outside `is_finite() && >= 0.0`.
+        //
+        //    A negative cost SHRINKS the running total on the next
+        //    `record_spend`. A later task can then pass an `Enforced` limit
+        //    that real spend has already crossed — the budget gate never
+        //    trips `AbortTurn`. A NaN cost is worse:
+        //    `x + f64::NAN` is `NaN` for every `x`, so one bad report poisons
+        //    the total for the rest of the run. Every later check against a
+        //    `NaN` total reads `false`, which is not `Continue`.
+        //
+        //    Both are caught here, once, before either total ever sees the
+        //    number.
+        let reported_cost = outcome.cost_usd;
+        let invalid_cost = !reported_cost.is_finite() || reported_cost < 0.0;
+        if invalid_cost {
+            // Recorded as a failed attempt with ZERO spend, never the
+            // untrustworthy number.
+            outcome.success = false;
+            outcome.cost_usd = 0.0;
+            outcome.summary = format!(
+                "rejected: worker reported an invalid cost ({reported_cost}); recorded as \
+                 failed with zero spend. original summary: {}",
+                outcome.summary
+            );
+        }
+
         // 4. Meter the child's cost into the parent budget (L-E9), then stamp
         //    the outcome (attempt close + commits + spend) atomically.
         //
@@ -899,6 +943,16 @@ where
                 .err()
                 .map(|e| e.to_string())
         };
+
+        if invalid_cost {
+            // The attempt is already stored above, failed, with zero spend.
+            // This is just the signal to the caller: treat the dispatch as
+            // a failure, the same as a worktree or claim error.
+            return Err(FleetError::InvalidWorkerCost {
+                task: task.id.clone(),
+                reported: reported_cost,
+            });
+        }
 
         Ok(TaskHandle {
             task_id: task.id.clone(),

--- a/crates/stella-fleet/src/fleet/tests.rs
+++ b/crates/stella-fleet/src/fleet/tests.rs
@@ -858,6 +858,134 @@ async fn a_failed_prerequisite_skips_its_dependents() {
     assert_eq!(skipped, vec!["b".to_string(), "c".to_string()]);
 }
 
+// invalid worker cost: a worker's reported cost is untrusted input, the
+// same footing as its commits or summary.
+
+/// A negative reported cost is never trusted. Recording it would shrink the
+/// running budget total. A later task could then slip past an `Enforced`
+/// limit that real spend has already crossed.
+///
+/// `dispatch` must reject it, record the attempt as failed with ZERO spend
+/// (not -1000.0), and still keep the commits the worker actually made.
+#[tokio::test]
+async fn a_negative_reported_cost_is_rejected_and_recorded_as_zero_spend() {
+    let f = fleet(
+        FakeWorker::new(-1000.0),
+        OkGit::new(),
+        BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None),
+        FleetConfig::new("run1", "HEAD"),
+    );
+    let task = Task::new("t1", "t1", "p");
+
+    let err = f
+        .dispatch(&task)
+        .await
+        .expect_err("a negative cost must be rejected, not trusted");
+    match err {
+        FleetError::InvalidWorkerCost { task: t, reported } => {
+            assert_eq!(t, "t1");
+            assert_eq!(reported, -1000.0);
+        }
+        other => panic!("expected InvalidWorkerCost, got {other:?}"),
+    }
+
+    // Recorded as failed with ZERO spend, never the poisoned -1000.0.
+    assert_eq!(f.ledger_total_spend().unwrap(), 0.0);
+    assert_eq!(f.budget_snapshot().session_spent_usd(), 0.0);
+    // The worker's real commit still lands in the ledger — only the cost
+    // figure is distrusted, not the rest of the attempt's evidence.
+    assert_eq!(f.ledger_commits_for_task("t1").unwrap().len(), 1);
+}
+
+/// **The witness.** Without the rejection, `record_spend(-1000.0)` shrinks
+/// the running total by 1000.0. Two further $0.99 tasks (1.98 total) would
+/// then read as comfortably under an `Enforced` $1.00 cap, and neither would
+/// ever trip `AbortTurn` — the budget gate silently stops enforcing for the
+/// rest of the run. With the rejection in place, the running total is never
+/// corrupted: the second $0.99 task still trips the cap.
+///
+/// Chained across three `Fleet` instances — one worker cost per instance —
+/// carrying the same `BudgetGuard` forward via `budget_snapshot`.
+/// `BudgetGuard` is `Copy`, so the total survives the handoff unchanged.
+#[tokio::test]
+async fn a_negative_reported_cost_does_not_disable_the_enforced_budget_gate() {
+    let f1 = fleet(
+        FakeWorker::new(-1000.0),
+        OkGit::new(),
+        BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None),
+        FleetConfig::new("run1", "HEAD"),
+    );
+    f1.dispatch(&Task::new("poison", "poison", "p"))
+        .await
+        .expect_err("the negative report is rejected");
+    assert_eq!(
+        f1.budget_snapshot().session_spent_usd(),
+        0.0,
+        "the running total must not have moved"
+    );
+
+    let f2 = fleet(
+        FakeWorker::new(0.99),
+        OkGit::new(),
+        f1.budget_snapshot(),
+        FleetConfig::new("run1", "HEAD"),
+    );
+    let handle2 = f2
+        .dispatch(&Task::new("a", "a", "p"))
+        .await
+        .expect("the first legitimate 0.99 task fits under the 1.00 cap");
+    assert_eq!(handle2.budget, BudgetOutcome::Continue);
+
+    let f3 = fleet(
+        FakeWorker::new(0.99),
+        OkGit::new(),
+        f2.budget_snapshot(),
+        FleetConfig::new("run1", "HEAD"),
+    );
+    let handle3 = f3
+        .dispatch(&Task::new("b", "b", "p"))
+        .await
+        .expect("dispatch itself succeeds; the BUDGET gate trips, not the dispatch");
+    assert!(
+        matches!(handle3.budget, BudgetOutcome::AbortTurn { .. }),
+        "cumulative 1.98 must trip the enforced 1.00 cap — the gate was never disabled"
+    );
+}
+
+/// A NaN reported cost is worse than a negative one. `x + f64::NAN` is
+/// `NaN` for every `x`. Without the rejection, one bad report would poison
+/// `BudgetGuard::session_spent_usd` for the rest of the run: every later
+/// check against a NaN total reads `false`, not `Continue`, and the total
+/// never recovers. Rejected before it reaches `record_spend`, the running
+/// total stays exactly what it was.
+#[tokio::test]
+async fn a_nan_reported_cost_is_rejected_and_never_poisons_the_budget_total() {
+    let f = fleet(
+        FakeWorker::new(f64::NAN),
+        OkGit::new(),
+        BudgetGuard::new(BudgetMode::Enforced, Some(1.0), None),
+        FleetConfig::new("run1", "HEAD"),
+    );
+    let task = Task::new("t1", "t1", "p");
+
+    let err = f
+        .dispatch(&task)
+        .await
+        .expect_err("a NaN cost must be rejected, not trusted");
+    match err {
+        FleetError::InvalidWorkerCost { reported, .. } => assert!(reported.is_nan()),
+        other => panic!("expected InvalidWorkerCost, got {other:?}"),
+    }
+
+    let total = f.budget_snapshot().session_spent_usd();
+    assert!(
+        total.is_finite(),
+        "the running total must stay finite, not be poisoned to NaN: got {total}"
+    );
+    assert_eq!(total, 0.0);
+    assert_eq!(f.ledger_total_spend().unwrap(), 0.0);
+}
+
 #[tokio::test]
 async fn a_git_worktree_failure_is_a_recorded_dispatch_failure() {
     // Two independent isolated tasks in one wave; git worktree add fails

--- a/crates/stella-fleet/src/ledger.rs
+++ b/crates/stella-fleet/src/ledger.rs
@@ -257,6 +257,16 @@ impl Ledger {
     /// Close an attempt and stamp everything it produced — its commits and
     /// its spend row — in a single transaction (all-or-nothing). This is the
     /// durable half of the dispatch seam (`crate::fleet::Fleet::dispatch`).
+    ///
+    /// **Idempotent**, like [`record_lineage`](Self::record_lineage). A
+    /// second call for an attempt already closed is a no-op, not a second
+    /// commit/spend row: the `WHERE finished_at_ms IS NULL` guard on the
+    /// `attempts` update tells a first close from a retry by its
+    /// affected-row count, and a retry returns before touching `commits` or
+    /// `spend`. `spend.attempt_id`'s `UNIQUE` constraint plus
+    /// `INSERT OR IGNORE` back that up for any other caller of the insert —
+    /// a worker's stop/timeout race can settle one attempt twice, and
+    /// neither close may double the recorded spend.
     pub fn finish_attempt(&self, finish: &AttemptFinish) -> Result<(), LedgerError> {
         // `unchecked_transaction` (rather than `&mut self` + `transaction()`)
         // keeps every ledger method on `&self`, so the fleet can hold the whole
@@ -265,8 +275,9 @@ impl Ledger {
         // lock, and this is the only place that opens a transaction — so a
         // nested/interleaved transaction on this connection cannot arise.
         let tx = self.conn.unchecked_transaction()?;
-        tx.execute(
-            "UPDATE attempts SET finished_at_ms = ?2, success = ?3, summary = ?4 WHERE id = ?1",
+        let closed = tx.execute(
+            "UPDATE attempts SET finished_at_ms = ?2, success = ?3, summary = ?4 \
+             WHERE id = ?1 AND finished_at_ms IS NULL",
             params![
                 finish.attempt_id,
                 finish.finished_at_ms as i64,
@@ -274,6 +285,13 @@ impl Ledger {
                 finish.summary,
             ],
         )?;
+        if closed == 0 {
+            // Already closed by an earlier call — commit the (no-op) update
+            // and stop, rather than appending a second set of commits and a
+            // second spend row for the same attempt.
+            tx.commit()?;
+            return Ok(());
+        }
         for commit in &finish.commits {
             tx.execute(
                 "INSERT INTO commits \
@@ -291,7 +309,7 @@ impl Ledger {
             )?;
         }
         tx.execute(
-            "INSERT INTO spend (run_id, task_id, attempt_id, cost_usd, recorded_at_ms) \
+            "INSERT OR IGNORE INTO spend (run_id, task_id, attempt_id, cost_usd, recorded_at_ms) \
              VALUES (?1, ?2, ?3, ?4, ?5)",
             params![
                 finish.run_id,
@@ -484,7 +502,7 @@ impl Ledger {
 
 /// The schema version `migrate` brings a `fleet.db` up to. Bump it in the
 /// same commit that adds a `MIGRATION_V<n>` step and its `version < n` arm.
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 
 /// Apply pending migration steps inside ONE transaction that stamps
 /// `user_version` atomically with the DDL — the same shape `stella-store`'s
@@ -541,6 +559,9 @@ fn migrate(conn: &Connection) -> Result<(), LedgerError> {
     }
     if version < 3 {
         tx.execute_batch(MIGRATION_V3)?;
+    }
+    if version < 4 {
+        tx.execute_batch(MIGRATION_V4)?;
     }
     tx.pragma_update(None, "user_version", SCHEMA_VERSION)?;
     tx.commit()?;
@@ -652,8 +673,9 @@ CREATE TABLE spend (
     run_id         TEXT NOT NULL REFERENCES runs (id),
     task_id        TEXT NOT NULL,
     attempt_id     INTEGER NOT NULL REFERENCES attempts (id),
-    cost_usd       REAL NOT NULL,
-    recorded_at_ms INTEGER NOT NULL
+    cost_usd       REAL NOT NULL CHECK (cost_usd >= 0),
+    recorded_at_ms INTEGER NOT NULL,
+    UNIQUE (attempt_id)
 );
 CREATE INDEX spend_by_run ON spend (run_id);
 CREATE TABLE dispatch_claims (
@@ -773,12 +795,47 @@ CREATE TABLE IF NOT EXISTS dispatch_claims (
 CREATE INDEX IF NOT EXISTS dispatch_claims_by_expiry ON dispatch_claims (expires_at_ms);
 ";
 
+/// v4 — a validated `spend` table. `CHECK (cost_usd >= 0)` stops a negative
+/// cost from reaching storage, even if a future caller skips the Rust-side
+/// guard in `crate::fleet::Fleet::dispatch_claimed`. That Rust guard is the
+/// real stop for a NaN report, not this constraint: SQLite turns a bound
+/// NaN into NULL before a CHECK ever sees it. `UNIQUE (attempt_id)` is what
+/// makes `Ledger::finish_attempt`'s `INSERT OR IGNORE` an idempotent no-op
+/// on a retried close, instead of a second spend row.
+///
+/// Both constraints need a table rebuild — the same as `MIGRATION_V2`'s
+/// `lineage` fix, since SQLite has no `ALTER TABLE ADD CONSTRAINT`. An old
+/// row with a negative `cost_usd`, or `NULL` (what a bound NaN becomes on
+/// disk), is clamped to zero rather than left to fail the rebuild: it was
+/// already wrong money, and refusing to open the ledger over it would only
+/// trade a bad number for a locked-out one. A duplicate `attempt_id` from
+/// before this fix collapses to its earliest row (lowest `id`), matching
+/// `finish_attempt`'s "first close wins" rule.
+const MIGRATION_V4: &str = "\
+CREATE TABLE spend_v4 (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id         TEXT NOT NULL,
+    task_id        TEXT NOT NULL,
+    attempt_id     INTEGER NOT NULL REFERENCES attempts (id),
+    cost_usd       REAL NOT NULL CHECK (cost_usd >= 0),
+    recorded_at_ms INTEGER NOT NULL,
+    UNIQUE (attempt_id)
+);
+INSERT INTO spend_v4 (run_id, task_id, attempt_id, cost_usd, recorded_at_ms)
+    SELECT run_id, task_id, attempt_id, MAX(COALESCE(cost_usd, 0.0), 0.0), recorded_at_ms
+    FROM spend
+    WHERE id IN (SELECT MIN(id) FROM spend GROUP BY attempt_id);
+DROP TABLE spend;
+ALTER TABLE spend_v4 RENAME TO spend;
+CREATE INDEX IF NOT EXISTS spend_by_run ON spend (run_id);
+";
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// #617 item 5: a brand-new ledger enforces the run references, so no new
-    /// orphan can ever be created.
+    /// A brand-new ledger enforces the run references, so no new orphan can
+    /// ever be created.
     #[test]
     fn a_fresh_ledger_enforces_run_references_and_rejects_an_unknown_run() {
         let ledger = Ledger::open_in_memory().expect("open");
@@ -802,7 +859,8 @@ mod tests {
     /// orphan history it already holds. It is reported instead.
     #[test]
     fn a_legacy_ledger_keeps_its_orphans_and_reports_them() {
-        // Build a v0 file the old way, with an orphan row already in it.
+        // Build a v0 file with the unversioned schema, with an orphan row
+        // already in it.
         let conn = Connection::open_in_memory().expect("conn");
         conn.execute_batch(MIGRATION_V1).expect("legacy schema");
         conn.execute(
@@ -904,6 +962,20 @@ mod tests {
         ledger.record_task(run_id, &task("t1")).unwrap();
     }
 
+    /// Seed `run1`/`t1` and open one attempt on it.
+    fn seeded_attempt(ledger: &Ledger) -> AttemptId {
+        seed_run(ledger, "run1");
+        ledger
+            .start_attempt(&AttemptStart {
+                run_id: "run1".into(),
+                task_id: "t1".into(),
+                worktree_path: "/tmp/wt/t1".into(),
+                branch: "fleet/t1".into(),
+                started_at_ms: 10,
+            })
+            .unwrap()
+    }
+
     #[test]
     fn open_in_memory_applies_schema_and_is_empty() {
         let ledger = Ledger::open_in_memory().unwrap();
@@ -912,9 +984,9 @@ mod tests {
         assert!(ledger.lineage_children("run").unwrap().is_empty());
     }
 
-    /// The GC's ledger half (#1217): a worktree whose attempt never finished
-    /// must report as in flight, and a finished one must carry the finish
-    /// time the `--age` arithmetic reads.
+    /// The GC's ledger half: a worktree whose attempt never finished must
+    /// report as in flight, and a finished one must carry the finish time the
+    /// `--age` arithmetic reads.
     #[test]
     fn worktree_activity_separates_in_flight_from_finished() {
         let ledger = Ledger::open_in_memory().unwrap();
@@ -1008,6 +1080,100 @@ mod tests {
         assert_eq!(commits[1].sha, "bbb");
         assert!((ledger.total_spend("run1").unwrap() - 0.25).abs() < 1e-9);
         assert!((ledger.task_spend("run1", "t1").unwrap() - 0.25).abs() < 1e-9);
+    }
+
+    /// `MIGRATION_V4`'s own `CHECK (cost_usd >= 0)` rejects a negative cost
+    /// even if a caller skips `Fleet::dispatch_claimed`'s Rust-side guard.
+    /// The rejection happens inside the transaction, so the attempt's own
+    /// close rolls back too — a rejected finish must not half-apply.
+    #[test]
+    fn finish_attempt_rejects_a_negative_cost_at_the_storage_layer() {
+        let ledger = Ledger::open_in_memory().unwrap();
+        let attempt_id = seeded_attempt(&ledger);
+        let err = ledger.finish_attempt(&AttemptFinish {
+            attempt_id,
+            run_id: "run1".into(),
+            task_id: "t1".into(),
+            finished_at_ms: 20,
+            success: true,
+            summary: "done".into(),
+            commits: vec![],
+            cost_usd: -5.0,
+            spend_at_ms: 21,
+        });
+        assert!(
+            err.is_err(),
+            "a negative cost_usd must violate the spend table's CHECK constraint"
+        );
+        assert!(
+            !ledger.attempt_is_finished(attempt_id).unwrap(),
+            "a rejected finish must roll back the attempt's own close, not half-apply"
+        );
+        assert_eq!(ledger.total_spend("run1").unwrap(), 0.0);
+    }
+
+    /// SQLite turns a bound `NaN` into `NULL` before a `CHECK` sees it, so
+    /// `Fleet::dispatch_claimed`'s `is_finite()` guard is the real defense
+    /// against a NaN report, not this table. A direct caller stays safe
+    /// too: `SUM` skips a NULL row, so `total_spend` never breaks.
+    #[test]
+    fn finish_attempt_with_a_nan_cost_leaves_total_spend_finite() {
+        let ledger = Ledger::open_in_memory().unwrap();
+        let attempt_id = seeded_attempt(&ledger);
+        // A NaN cost_usd passes the CHECK (SQLite stores it as NULL).
+        ledger
+            .finish_attempt(&AttemptFinish {
+                attempt_id,
+                run_id: "run1".into(),
+                task_id: "t1".into(),
+                finished_at_ms: 20,
+                success: true,
+                summary: "done".into(),
+                commits: vec![],
+                cost_usd: f64::NAN,
+                spend_at_ms: 21,
+            })
+            .unwrap();
+
+        assert!(
+            ledger.total_spend("run1").unwrap().is_finite(),
+            "a NaN spend row must never make the run's authoritative total unusable"
+        );
+    }
+
+    /// A second `finish_attempt` for the SAME attempt must not double the
+    /// ledger's commits or spend — a retried dispatch can settle twice, and
+    /// the `WHERE finished_at_ms IS NULL` guard on the first close makes the
+    /// second call a no-op.
+    #[test]
+    fn a_second_finish_attempt_for_the_same_attempt_does_not_double_spend() {
+        let ledger = Ledger::open_in_memory().unwrap();
+        let attempt_id = seeded_attempt(&ledger);
+        let finish = AttemptFinish {
+            attempt_id,
+            run_id: "run1".into(),
+            task_id: "t1".into(),
+            finished_at_ms: 20,
+            success: true,
+            summary: "done".into(),
+            commits: vec![commit("t1", "aaa")],
+            cost_usd: 0.5,
+            spend_at_ms: 21,
+        };
+
+        ledger.finish_attempt(&finish).unwrap();
+        // A retried close for the same attempt, real spend unchanged.
+        ledger.finish_attempt(&finish).unwrap();
+
+        assert!(
+            (ledger.total_spend("run1").unwrap() - 0.5).abs() < 1e-9,
+            "spend must not double on a repeated finish_attempt"
+        );
+        assert_eq!(
+            ledger.commits_for_task("run1", "t1").unwrap().len(),
+            1,
+            "commits must not double on a repeated finish_attempt"
+        );
     }
 
     #[test]
@@ -1209,7 +1375,7 @@ mod tests {
         );
     }
 
-    // the warmth-signal reads (issue #1222)
+    // the warmth-signal reads
 
     /// Record one finished attempt for `task_id` in `run_id`, minimal shape.
     fn finished_attempt(ledger: &Ledger, run_id: &str, task_id: &str, finished_at_ms: u64) {

--- a/crates/stella-fleet/src/ledger.rs
+++ b/crates/stella-fleet/src/ledger.rs
@@ -264,9 +264,13 @@ impl Ledger {
     /// `attempts` update tells a first close from a retry by its
     /// affected-row count, and a retry returns before touching `commits` or
     /// `spend`. `spend.attempt_id`'s `UNIQUE` constraint plus
-    /// `INSERT OR IGNORE` back that up for any other caller of the insert —
-    /// a worker's stop/timeout race can settle one attempt twice, and
-    /// neither close may double the recorded spend.
+    /// `ON CONFLICT (attempt_id) DO NOTHING` back that up for any other
+    /// caller of the insert — a worker's stop/timeout race can settle one
+    /// attempt twice, and neither close may double the recorded spend.
+    /// `INSERT OR IGNORE` would ignore *every* constraint on the row: it
+    /// swallows the `CHECK` a negative cost raises and the `NOT NULL` a
+    /// bound `NaN` becomes, dropping the spend row and returning `Ok`.
+    /// Hence the named conflict target.
     pub fn finish_attempt(&self, finish: &AttemptFinish) -> Result<(), LedgerError> {
         // `unchecked_transaction` (rather than `&mut self` + `transaction()`)
         // keeps every ledger method on `&self`, so the fleet can hold the whole
@@ -309,8 +313,8 @@ impl Ledger {
             )?;
         }
         tx.execute(
-            "INSERT OR IGNORE INTO spend (run_id, task_id, attempt_id, cost_usd, recorded_at_ms) \
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO spend (run_id, task_id, attempt_id, cost_usd, recorded_at_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT (attempt_id) DO NOTHING",
             params![
                 finish.run_id,
                 finish.task_id,
@@ -797,11 +801,11 @@ CREATE INDEX IF NOT EXISTS dispatch_claims_by_expiry ON dispatch_claims (expires
 
 /// v4 — a validated `spend` table. `CHECK (cost_usd >= 0)` stops a negative
 /// cost from reaching storage, even if a future caller skips the Rust-side
-/// guard in `crate::fleet::Fleet::dispatch_claimed`. That Rust guard is the
-/// real stop for a NaN report, not this constraint: SQLite turns a bound
-/// NaN into NULL before a CHECK ever sees it. `UNIQUE (attempt_id)` is what
-/// makes `Ledger::finish_attempt`'s `INSERT OR IGNORE` an idempotent no-op
-/// on a retried close, instead of a second spend row.
+/// guard in `crate::fleet::Fleet::dispatch_claimed`. A NaN report is caught
+/// by `cost_usd REAL NOT NULL` rather than by this `CHECK`, since SQLite
+/// binds a NaN as NULL before a CHECK ever sees it. `UNIQUE (attempt_id)`
+/// is what makes `Ledger::finish_attempt`'s `ON CONFLICT (attempt_id) DO
+/// NOTHING` an idempotent no-op on a retried close, not a second spend row.
 ///
 /// Both constraints need a table rebuild — the same as `MIGRATION_V2`'s
 /// `lineage` fix, since SQLite has no `ALTER TABLE ADD CONSTRAINT`. An old
@@ -1112,29 +1116,34 @@ mod tests {
         assert_eq!(ledger.total_spend("run1").unwrap(), 0.0);
     }
 
-    /// SQLite turns a bound `NaN` into `NULL` before a `CHECK` sees it, so
-    /// `Fleet::dispatch_claimed`'s `is_finite()` guard is the real defense
-    /// against a NaN report, not this table. A direct caller stays safe
-    /// too: `SUM` skips a NULL row, so `total_spend` never breaks.
+    /// A NaN never reaches the `CHECK`: SQLite binds it as NULL, and
+    /// `cost_usd REAL NOT NULL` rejects that. A direct caller of `Ledger` —
+    /// it is `pub`, and `Fleet::dispatch_claimed`'s `is_finite()` guard sits
+    /// one layer above — gets a rejected close, not a poisoned total.
     #[test]
     fn finish_attempt_with_a_nan_cost_leaves_total_spend_finite() {
         let ledger = Ledger::open_in_memory().unwrap();
         let attempt_id = seeded_attempt(&ledger);
-        // A NaN cost_usd passes the CHECK (SQLite stores it as NULL).
-        ledger
-            .finish_attempt(&AttemptFinish {
-                attempt_id,
-                run_id: "run1".into(),
-                task_id: "t1".into(),
-                finished_at_ms: 20,
-                success: true,
-                summary: "done".into(),
-                commits: vec![],
-                cost_usd: f64::NAN,
-                spend_at_ms: 21,
-            })
-            .unwrap();
+        let err = ledger.finish_attempt(&AttemptFinish {
+            attempt_id,
+            run_id: "run1".into(),
+            task_id: "t1".into(),
+            finished_at_ms: 20,
+            success: true,
+            summary: "done".into(),
+            commits: vec![],
+            cost_usd: f64::NAN,
+            spend_at_ms: 21,
+        });
 
+        assert!(
+            err.is_err(),
+            "a NaN cost_usd binds as NULL and must violate cost_usd REAL NOT NULL"
+        );
+        assert!(
+            !ledger.attempt_is_finished(attempt_id).unwrap(),
+            "a rejected finish must roll back the attempt's own close, not half-apply"
+        );
         assert!(
             ledger.total_spend("run1").unwrap().is_finite(),
             "a NaN spend row must never make the run's authoritative total unusable"


### PR DESCRIPTION
## What and why

A fleet worker's `cost_usd: f64` was trusted at face value. Two ways that goes wrong:

- **Negative.** `record_spend` accumulates with plain `+=`, so a negative report *shrinks* the running total. A later, honestly-reported task can then pass an `Enforced` limit that real cumulative spend has already crossed — the budget gate never trips `AbortTurn`.
- **NaN.** `BudgetGuard::check_axis` gates on `spent_usd <= limit_usd`; that comparison is `false` for `NaN`, so the guard falls through to `Some(AbortTurn)`/`Some(Warn)` on *every* later `evaluate()` call for the rest of the run, no matter what is actually spent — the run wedges shut (`Enforced`) or warns forever (`Observed`), permanently, because `x + f64::NAN` is `NaN` for every `x`.

Fixed at the seam the design pointer named: `Fleet::dispatch_claimed`, right after the worker returns and before `record_spend`/`finish_attempt`. A report that fails `is_finite() && cost_usd >= 0.0` is rejected: the attempt is recorded **failed, with zero spend** (never the untrustworthy number, never silently dropped — its real commits are still kept), and `dispatch_claimed` returns the new `FleetError::InvalidWorkerCost { task, reported }` so the dispatch itself reads as a failure, same as a worktree or claim error.

`crates/stella-fleet/src/ledger.rs`'s `spend` table gets `CHECK (cost_usd >= 0)` as a second, independent layer (`MIGRATION_V4`) — SQLite has no `ALTER TABLE ADD CONSTRAINT`, so this is a table rebuild, the same shape `MIGRATION_V2` used for `lineage`. A NaN report is caught by the column's pre-existing `cost_usd REAL NOT NULL` rather than by the new `CHECK`, since SQLite binds a NaN parameter as `NULL` before a `CHECK` ever evaluates it. An old row with a negative cost, or the `NULL` a legacy NaN insert became, is clamped to zero during the rebuild rather than failing it — refusing to open a user's ledger over a row that was already wrong money would be worse than the bad number.

**Residue folded in from the issue's "Related, same crate" note:** `Ledger::finish_attempt` had no idempotency guard — the `attempts` UPDATE had no `WHERE finished_at_ms IS NULL`/affected-row check, and the `spend` insert was unconditional with no `UNIQUE` on `attempt_id`. A second call for one attempt (a timeout's stop-then-grace race settling twice, or any future caller — `Ledger` is `pub`) silently doubled the recorded spend. `finish_attempt` is now idempotent the way `record_lineage` already is: the `attempts` update is `WHERE finished_at_ms IS NULL`, a zero affected-row count makes the whole call a no-op (committed, not rolled back — there is nothing new to apply), and `spend.attempt_id` is `UNIQUE`, with `INSERT ... ON CONFLICT (attempt_id) DO NOTHING` as a second, independent layer for a retried close. That conflict target is named deliberately rather than `INSERT OR IGNORE`: `IGNORE` swallows *every* constraint on the row, not just the `UNIQUE` one — an earlier version of this PR used `IGNORE` and it silently absorbed the `CHECK`/`NOT NULL` rejections too, dropping the spend row and returning `Ok` instead of rejecting the value. Caught by a `cargo test -p stella-fleet --lib ledger::` run against the branch and fixed in this PR's second commit before any review round-trip.

Exemplar followed: `record_lineage`'s existing `UNIQUE` + conflict-target idempotency shape (`crates/stella-fleet/src/ledger.rs`), and `MIGRATION_V2`'s table-rebuild pattern for adding a constraint SQLite can't `ALTER TABLE` onto an existing table.

## Witness

Both levels the issue's DoD names, plus the idempotency witness from the "Related" note:

- `crates/stella-fleet/src/fleet/tests.rs::a_negative_reported_cost_does_not_disable_the_enforced_budget_gate` — a fake worker reports `-1000.0` under `BudgetMode::Enforced` with a `$1.00` limit; the dispatch is rejected and the running total does not move. Two further `$0.99` dispatches are then chained against the *same* `BudgetGuard` (carried forward via `budget_snapshot`, which is `Copy`): the first is `Continue`, the second trips `AbortTurn`. On `main`, `record_spend(-1000.0)` would shrink the total by 1000.0 and neither `$0.99` task would ever trip the cap — this fails by construction on the old code, since nothing there rejects the report.
- `a_nan_reported_cost_is_rejected_and_never_poisons_the_budget_total` — a fake worker reports `f64::NAN`; the dispatch is rejected and `budget_snapshot().session_spent_usd()` stays finite (`0.0`). On `main`, `record_spend(NaN)` would poison that total to `NaN` for the rest of the run.
- `crates/stella-fleet/src/ledger.rs::finish_attempt_with_a_nan_cost_leaves_total_spend_finite` — calls `Ledger::finish_attempt` directly with `cost_usd: f64::NAN` and asserts it returns `Err` (a NaN binds as NULL, `cost_usd REAL NOT NULL` rejects that) and that `total_spend()` stays finite. Not a fail→pass witness against `main` specifically — `spend.cost_usd` was already `NOT NULL` before this PR, so a raw NaN insert already errored there too. It stayed green through this PR's own history for the right reason only after the `ON CONFLICT` fix above; kept as direct-`Ledger`-caller coverage since `Ledger` is `pub` and `Fleet::dispatch_claimed`'s guard sits one layer above it.
- `finish_attempt_rejects_a_negative_cost_at_the_storage_layer` — calls `finish_attempt` directly with `cost_usd: -5.0`; fails on `main` (no constraint), rejected by `MIGRATION_V4`'s `CHECK` on the new code. Also asserts the attempt's own close rolls back with the rejected insert (one transaction, no half-apply).
- `a_second_finish_attempt_for_the_same_attempt_does_not_double_spend` — calls `finish_attempt` twice for one attempt; on `main` this doubles both the spend row and the commit rows, asserted here to stay at exactly one of each.
- `a_negative_reported_cost_is_rejected_and_recorded_as_zero_spend` — the direct-effect witness: the dispatch fails with `InvalidWorkerCost`, ledger + budget both read `0.0`, and the worker's real commit is still recorded (only the cost figure is distrusted).

`cargo test -p stella-fleet` (the DoD's third box) ran in CI's `fmt + clippy + test` job: `stella_fleet`'s unittest binary, 139 passed, 0 failed, including all six tests above — https://github.com/macanderson/stella/actions/runs/33694251397/job/100459752022.

## Notes for review

- `crates/stella-fleet/src/ledger.rs` was at 1519 lines with these changes before trimming (over the 1500-line ratchet, and this crate had no prior god file) — tightened the new doc comments and added a small `seeded_attempt` test helper to land at 1500/1500, no file split needed.
- Sourcery's review comment carries one ❌ against this PR's *first* commit, before the `ON CONFLICT` fix above landed — see the PR comment thread for why that row is addressed; a fresh Sourcery review is rate-limited for a few days.
- `Tests deleted: None.`

Closes #5498
