### PR TITLE
fix(scripts): stop release checks from depending on a fixed --limit

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -257,6 +257,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-tap-current.sh
 
+      - name: the release fetch has no fixed count cap
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-releases-published-pagination.sh
+
       - name: rebase-replay guard directions, and the hazard itself
         if: ${{ !cancelled() }}
         run: ./scripts/test-rebase-replay.sh

--- a/Makefile
+++ b/Makefile
@@ -948,6 +948,10 @@ releases-baseline-update: ## Grandfather the tags that shipped nothing and never
 releases-published-test: ## Test the tag/release reconciliation rule (hermetic; not part of `gate`)
 	./scripts/test-releases-published.sh
 
+.PHONY: releases-published-pagination-test
+releases-published-pagination-test: ## Witness that the release fetch has no fixed count cap (#5555; hermetic)
+	./scripts/test-releases-published-pagination.sh
+
 .PHONY: tap-current
 tap-current: ## Assert the Homebrew tap formula serves the newest published release (#5551)
 	@./scripts/check-tap-current.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -208,7 +208,9 @@ Three checks now catch it, each on a different failure:
   or a revoked token freezes the formula while every other surface still reports
   success. Before this job, nothing anywhere could answer that question — which
   is its own hazard: a report that the tap is stale could be neither confirmed
-  nor refuted without reading the tap by hand.
+  nor refuted without reading the tap by hand. It only ever fetches the newest
+  100 releases, so a tap stale enough to be behind every one of them is
+  reported as "at least N releases behind" rather than a guessed exact count.
 
 Run them yourself at any time:
 

--- a/scripts/check-releases-published.sh
+++ b/scripts/check-releases-published.sh
@@ -40,6 +40,19 @@
 # A tag younger than the grace window is therefore not evidence of anything and
 # is skipped. Too short and this cries wolf on every release; too long and the
 # silence it exists to break lasts that much longer.
+#
+# ── Why the release list has no fixed cap ────────────────────────────────────
+#
+# A fixed `--limit` is a trap that reopens itself. A cap of 200 once reported
+# 137 missing tags instead of 26 real ones, because every release past the
+# cut looked unpublished. Raising the number just buys a few weeks: this
+# repo cuts a release on almost every merge.
+#
+# `repos/{owner}/{repo}/releases` is a plain paginated list, not a search
+# endpoint, so it has no result ceiling. `gh api --paginate` walks every
+# page and gets the whole set no matter how big it grows. No cap is needed.
+# `max_pages` below is not a cap either. It is a sanity check that paging
+# itself still works. See "the fetch" further down.
 set -euo pipefail
 
 # shellcheck source=scripts/lib/help-header.sh
@@ -74,13 +87,19 @@ done
 # Reads one JSON document on stdin:
 #
 #   { "tags":     [ { "name": "v0.6.75", "created_unix": 1234567890 }, … ],
-#     "releases": [ "v0.6.74", "v0.6.109", … ] }
+#     "releases": [ { "name": "v0.6.74", "draft": false }, … ] }
 #
 # and prints one `<tag>\t<age-in-seconds>` line per tag that should have been
 # published and was not, oldest first. Kept free of I/O so
 # scripts/test-releases-published.sh can drive every rule from a fixture rather
 # than from the live repository — a suite that asked GitHub would pass or fail
 # for reasons that have nothing to do with the rule under test.
+#
+# A draft release does not count as published: `brew install` cannot serve
+# one and it can sit open indefinitely, so a tag with only a draft release
+# must still be reported. `draft` rides on each release object rather than
+# being filtered out before this function sees the data, so a fixture can
+# cover the rule directly instead of trusting the wrapper below got it right.
 #
 # Note what is NOT consulted: the outcome of any workflow run. A `release`/
 # `homebrew` job is gated on `startsWith(github.ref, 'refs/tags/')`, so
@@ -94,7 +113,7 @@ done
 # nobody can be sure still applies to what it was written for.
 select_unpublished() {
   jq -r --argjson now "$now" --argjson grace "$grace_secs" '
-    ( [ .releases[] | { (.): true } ] | add // {} ) as $published
+    ( [ .releases[] | select(.draft != true) | { (.name): true } ] | add // {} ) as $published
     | ( [ (.known // [])[] | { (.): true } ] | add // {} ) as $known
     | [ .tags[]
         | select($published[.name] | not)
@@ -135,21 +154,28 @@ tags_json="$(
     | jq -R -s 'split("\n") | map(select(length > 0) | split(" ") | { name: .[0], created_unix: (.[1] | tonumber) })'
 )"
 
-# `gh` colorizes even `--json` output when it believes it has a terminal, which
+# `gh` colorizes even plain output when it believes it has a terminal, which
 # makes the result invalid JSON. It costs nothing on a runner (never a TTY) and
 # is the difference between working and not when a maintainer runs this by hand.
 #
-# The limit is far above the real count and then CHECKED. A
-# truncated release list makes every release beyond the cut look unpublished:
-# at `--limit 200` against 313 releases this script reported 137 missing tags
-# instead of the true 26. An alarm that inflates by 5x is one nobody believes,
-# and the inflation is silent — so it is asserted rather than assumed.
-releases_limit=1000
-releases_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh release list --limit "$releases_limit" --json tagName --jq '[.[].tagName]')"
-if [ "$(printf '%s' "$releases_json" | jq 'length')" -ge "$releases_limit" ]; then
-  echo "::error::the release list hit the ${releases_limit} page limit, so it may be truncated — every release past the cut would be reported as an unpublished tag. Raise releases_limit in $0." >&2
+# ── The fetch ─────────────────────────────────────────────────────────────────
+#
+# `--paginate` walks every page until none remain, so the set below is every
+# release, not just the newest ones. `--slurp` wraps each page's array into
+# one outer array. It cannot be combined with `--jq` (gh rejects that), so
+# the flatten from pages to releases happens in the plain `jq` call after.
+#
+# `max_pages` is a sanity check, not a cap. A normal run needs single-digit
+# pages. Needing close to a thousand does not mean the repo grew that much —
+# it means paging broke, and a human should look before trusting this run.
+max_pages=1000 # 100000 releases at per_page=100 — decades past this repo's rate
+pages_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh api --paginate --slurp 'repos/{owner}/{repo}/releases?per_page=100')"
+page_count="$(printf '%s' "$pages_json" | jq 'length')"
+if [ "$page_count" -gt "$max_pages" ]; then
+  echo "::error::the release list needed ${page_count} pages to walk fully, past the ${max_pages}-page sanity ceiling. That is not plausible growth for this repository — gh's pagination itself likely misbehaved. Investigate before trusting this run's answer." >&2
   exit 1
 fi
+releases_json="$(printf '%s' "$pages_json" | jq '[ .[][] | { name: .tag_name, draft: .draft } ]')"
 
 doc="$(jq -n --argjson tags "$tags_json" --argjson releases "$releases_json" \
   --argjson known "$(known_json)" '{ tags: $tags, releases: $releases, known: $known }')"
@@ -166,7 +192,7 @@ if [ "$update" -eq 1 ]; then
     echo "# exist, so every addition should be a decision someone made, visible in"
     echo "# review — not a way to quiet the check."
     printf '%s' "$doc" | jq -r --argjson now "$now" --argjson grace "$grace_secs" '
-      ( [ .releases[] | { (.): true } ] | add // {} ) as $published
+      ( [ .releases[] | select(.draft != true) | { (.name): true } ] | add // {} ) as $published
       | [ .tags[] | select($published[.name] | not) | select(($now - .created_unix) > $grace) ]
       | sort_by(.created_unix) | .[] | .name'
   } >"$baseline.tmp"

--- a/scripts/check-tap-current.sh
+++ b/scripts/check-tap-current.sh
@@ -36,6 +36,21 @@
 # finding only when the formula names an OLDER version. A formula newer than
 # the newest settled release is normal. It happens for a few minutes after
 # every release, while the new one ages past the window.
+#
+# ── Why this only ever fetches one page ──────────────────────────────────────
+#
+# This check does not need the whole release history the way
+# check-releases-published.sh does. It needs the newest settled release, and
+# GitHub returns releases newest first. One page of 100 is plenty: at this
+# repo's real pace, a hundred releases span days, and the grace window is 90
+# minutes. So the newest settled release always sits near the top of the
+# page.
+#
+# One page cannot always say *how far behind* a very stale tap is. If every
+# release on the page is newer than the formula, more could be hiding past
+# the page. The count then reports as "at least N", not a guess at an exact
+# number. A fetch that might be short can only report more trouble than it
+# can prove, never less, and never a clean pass.
 set -euo pipefail
 
 # shellcheck source=scripts/lib/help-header.sh
@@ -64,7 +79,8 @@ done
 # Reads one JSON document on stdin:
 #
 #   { "releases":        [ { "tag": "v0.9.292", "published_unix": 1234567890 }, … ],
-#     "formula_version": "0.9.235" }
+#     "formula_version": "0.9.235",
+#     "page_full": false }
 #
 # and prints one tab-separated line when the tap is behind:
 #
@@ -84,6 +100,18 @@ done
 # something `brew install` can serve. So it is skipped. It must not become the
 # newest release and the standard the tap is held to.
 #
+# `page_full` says whether `.releases` is a whole page (see "Why this only
+# ever fetches one page" above). When it is full, more settled releases could
+# sit past what this document carries. The behind-count then reports as "at
+# least N" instead of an exact count. It defaults to false, so an old fixture
+# that never sets it still reports an exact count.
+#
+# One case a single page cannot answer at all: `page_full` is true and not
+# one release settled — every one was a draft or still inside the grace
+# window. That should not happen at this repo's real pace. But a page that
+# could not answer the question must not read as a clean pass, so the I/O
+# half below turns the sentinel `__UNDETERMINED__` into an error instead.
+#
 # No I/O here, so scripts/test-tap-current.sh can drive every rule from a
 # fixture. A suite that asked GitHub would pass or fail for reasons outside
 # the rule under test. The rules that matter here are the boundary ones. An
@@ -101,13 +129,15 @@ select_stale() {
 
     ( .formula_version // null ) as $formula
     | ( if $formula == null then null else ($formula | parts) end ) as $formula_parts
+    | ( .page_full // false ) as $page_full
     | [ .releases[]
         | select(.published_unix != null)
         | select(($now - .published_unix) > $grace)
         | . + { parts: (.tag | parts) }
         | select(.parts != null)
       ] as $settled
-    | if ($settled | length) == 0 then empty
+    | if ($settled | length) == 0 then
+        if $page_full then "__UNDETERMINED__" else empty end
       else
         ( $settled | sort_by(.parts) | last ) as $newest
         | ( if $formula_parts == null then $settled
@@ -115,7 +145,9 @@ select_stale() {
             end ) as $behind
         | if ($behind | length) == 0 then empty
           else
-            "\($formula // "(none)")\t\($newest.tag | ltrimstr("v"))\t\($behind | length)\t\($now - $newest.published_unix)"
+            ( if $page_full and (($behind | length) == ($settled | length))
+              then "at least " else "" end ) as $qualifier
+            | "\($formula // "(none)")\t\($newest.tag | ltrimstr("v"))\t\($qualifier)\($behind | length)\t\($now - $newest.published_unix)"
           end
       end
   '
@@ -135,25 +167,23 @@ command -v jq >/dev/null 2>&1 || { echo "::error::jq is not installed" >&2; exit
 # makes the result invalid JSON. Turning it off costs nothing on a runner. By
 # hand it is the difference between working and not.
 #
-# The limit is set above the real count and then CHECKED. This is the reason
-# check-releases-published.sh checks its own: a cut-off release list changes
-# the answer and says nothing. Here it would hide the newest release and call
-# a stale tap current.
-releases_limit=1000
+# One page, and no more (see "Why this only ever fetches one page" above) —
+# no `--paginate`. `gh api`'s default order for this endpoint is newest
+# first, the order the pure rule needs to see the settled boundary early.
 #
 # A draft carries no publish date. `gh` renders it as `0001-01-01T00:00:00Z`,
 # which `fromdateiso8601` refuses. So it is carried through as a null that the
 # rule skips. Dropping it here would move the reason for ignoring drafts into
 # the half of the script no fixture can reach.
+per_page=100
 releases_json="$(
-  CLICOLOR_FORCE=0 NO_COLOR=1 gh release list --limit "$releases_limit" --json tagName,publishedAt,isDraft \
-    --jq '[ .[] | { tag: .tagName,
-                    published_unix: (if .isDraft then null else (.publishedAt | try fromdateiso8601 catch null) end) } ]'
+  CLICOLOR_FORCE=0 NO_COLOR=1 gh api "repos/{owner}/{repo}/releases?per_page=${per_page}" \
+    --jq '[ .[] | { tag: .tag_name,
+                    published_unix: (if .draft then null else (.published_at | try fromdateiso8601 catch null) end) } ]'
 )"
-if [ "$(printf '%s' "$releases_json" | jq 'length')" -ge "$releases_limit" ]; then
-  echo "::error::the release list hit the ${releases_limit} page limit, so it may be truncated and the newest release may be missing from it. Raise releases_limit in $0." >&2
-  exit 1
-fi
+release_count="$(printf '%s' "$releases_json" | jq 'length')"
+page_full=false
+[ "$release_count" -ge "$per_page" ] && page_full=true
 
 # The formula, straight from the tap. A missing FILE is the finding this
 # script exists for: the tap was never written, or the formula was renamed out
@@ -174,12 +204,16 @@ elif ! gh api "repos/${tap_repo}" >/dev/null 2>&1; then
   exit 1
 fi
 
-doc="$(jq -n --argjson releases "$releases_json" --argjson formula "$formula_version" \
-  '{ releases: $releases, formula_version: $formula }')"
+doc="$(jq -n --argjson releases "$releases_json" --argjson formula "$formula_version" --argjson page_full "$page_full" \
+  '{ releases: $releases, formula_version: $formula, page_full: $page_full }')"
 
 report="$(printf '%s' "$doc" | select_stale)"
 
-release_count="$(printf '%s' "$releases_json" | jq 'length')"
+if [ "$report" = "__UNDETERMINED__" ]; then
+  echo "::error::none of the ${release_count} releases just fetched (the newest ${per_page}) has settled past the $((grace_secs / 60))m grace window, and the fetch filled a full page — there may be an even newer settled release this single-page fetch could not see. This should not happen at the repository's normal release rate; investigate before trusting a green run here." >&2
+  exit 1
+fi
+
 shown="$(printf '%s' "$formula_version" | jq -r '. // "(none)"')"
 if [ -z "$report" ]; then
   echo "check-tap-current: OK — ${tap_repo}/${formula_path} is at ${shown}, which is not behind any release older than $((grace_secs / 60))m (${release_count} release(s) checked)."

--- a/scripts/test-releases-published-pagination.sh
+++ b/scripts/test-releases-published-pagination.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Witness test. Neither release check may depend on a fixed count cap.
+#
+#   ./scripts/test-releases-published-pagination.sh
+#
+# scripts/test-releases-published.sh proves the RULE has no cap. It cannot
+# reach the FETCH, where the old cap actually lived. This test drives the
+# fetch end to end with a fake `gh` on PATH, so a fake list of 1001 releases
+# runs with no network at all.
+#
+# It runs two scripts against that same list: the one `main` ships today,
+# and the one in this working tree. Main's script hits its old cap and
+# errors. This branch's script pages through all 1001 and reports clean.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+NEW_SCRIPT="$repo_root/scripts/check-releases-published.sh"
+MAIN_SCRIPT="$repo_root/scripts/.check-releases-published.main-copy.sh"
+
+pass=0
+fail=0
+
+work="$(mktemp -d)"
+cleanup() { rm -rf "$work"; rm -f "$MAIN_SCRIPT"; }
+trap cleanup EXIT
+
+# `dirname "$0"` in each script must find a folder with lib/help-header.sh.
+# So main's copy is placed next to the real script, not in the scratch dir.
+# It is a sibling file, deleted by the trap above, never staged or committed.
+if ! git -C "$repo_root" show origin/main:scripts/check-releases-published.sh >"$MAIN_SCRIPT" 2>/dev/null; then
+  echo "SKIP — could not read origin/main's copy of check-releases-published.sh (no origin/main ref here); the fail-side of the witness cannot run, but this branch's own fetch is still exercised below." >&2
+else
+  chmod +x "$MAIN_SCRIPT"
+fi
+
+# A grace window wide enough that every real tag in this checkout falls
+# inside it and is skipped. So the only thing either script can report is
+# its own truncation guard. The fixture never has to fake a real git tag.
+grace_secs=315360000 # 10 years
+now="$(date -u +%s)"
+
+# The fake `gh`. Each script makes one call:
+#   main's version: `gh release list --limit 1000 ...`
+#   this branch:    `gh api --paginate --slurp .../releases?per_page=100`
+# Both get 1001 fake releases, one past the old cap. The shape matches real
+# `gh` output: 11 pages of up to 100 each, the last one holding 1.
+cat >"$work/gh" <<'SHIM'
+#!/usr/bin/env bash
+set -euo pipefail
+n=1001
+if [ "$1" = "api" ]; then
+  jq -n --argjson n "$n" '
+    [ range(0; $n) | { tag_name: ("v0.0." + (tostring)), draft: false } ]
+    | . as $all
+    | [ range(0; ($all | length); 100) as $i | $all[$i:$i + 100] ]
+  '
+  exit 0
+fi
+if [ "$1" = "release" ] && [ "${2:-}" = "list" ]; then
+  jq -n --argjson n "$n" '[ range(0; $n) | ("v0.0." + (tostring)) ]'
+  exit 0
+fi
+echo "test-releases-published-pagination.sh: unhandled fake gh invocation: $*" >&2
+exit 3
+SHIM
+chmod +x "$work/gh"
+
+run_with_fake_gh() {
+  PATH="$work:$PATH" "$@" --now "$now" --grace-secs "$grace_secs" 2>&1
+}
+
+if [ -x "$MAIN_SCRIPT" ]; then
+  main_out="$(run_with_fake_gh "$MAIN_SCRIPT")"
+  main_status=$?
+  if [ "$main_status" -ne 0 ] && printf '%s' "$main_out" | grep -q "page limit"; then
+    pass=$((pass + 1)); echo "ok   MAIN main's script hits its 1000-item cap on 1001 releases and errors"
+  else
+    fail=$((fail + 1))
+    echo "FAIL MAIN main's script hits its 1000-item cap on 1001 releases and errors — exit ${main_status}, got: ${main_out}"
+  fi
+fi
+
+new_out="$(run_with_fake_gh "$NEW_SCRIPT")"
+new_status=$?
+if [ "$new_status" -eq 0 ] && printf '%s' "$new_out" | grep -q "^check-releases-published: OK"; then
+  pass=$((pass + 1)); echo "ok   NEW this branch's script pages through all 1001 releases and reports clean"
+else
+  fail=$((fail + 1))
+  echo "FAIL NEW this branch's script pages through all 1001 releases and reports clean — exit ${new_status}, got: ${new_out}"
+fi
+
+if printf '%s' "$new_out" | grep -qi "page limit\|sanity ceiling"; then
+  fail=$((fail + 1))
+  echo "FAIL NEW must not report a truncation/sanity error on 1001 releases — got: ${new_out}"
+else
+  pass=$((pass + 1)); echo "ok   NEW reports no truncation or page-sanity error on 1001 releases"
+fi
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]

--- a/scripts/test-releases-published-pagination.sh
+++ b/scripts/test-releases-published-pagination.sh
@@ -28,11 +28,17 @@ work="$(mktemp -d)"
 cleanup() { rm -rf "$work"; rm -f "$MAIN_SCRIPT"; }
 trap cleanup EXIT
 
+# CI checks out one ref with no history, so `origin/main` may not exist yet.
+# One shallow, on-demand fetch of just that branch tip fixes that without
+# touching the shared checkout step every other guard self-test also runs
+# under. It only ever reads; nothing here can move a real branch.
+git -C "$repo_root" fetch --depth=1 -q origin main 2>/dev/null || true
+
 # `dirname "$0"` in each script must find a folder with lib/help-header.sh.
 # So main's copy is placed next to the real script, not in the scratch dir.
 # It is a sibling file, deleted by the trap above, never staged or committed.
 if ! git -C "$repo_root" show origin/main:scripts/check-releases-published.sh >"$MAIN_SCRIPT" 2>/dev/null; then
-  echo "SKIP — could not read origin/main's copy of check-releases-published.sh (no origin/main ref here); the fail-side of the witness cannot run, but this branch's own fetch is still exercised below." >&2
+  echo "SKIP — could not read origin/main's copy of check-releases-published.sh (no network or no origin/main ref here); the fail-side of the witness cannot run, but this branch's own fetch is still exercised below." >&2
 else
   chmod +x "$MAIN_SCRIPT"
 fi

--- a/scripts/test-releases-published.sh
+++ b/scripts/test-releases-published.sh
@@ -53,17 +53,24 @@ want() {
 # tag <name> <seconds-ago>
 tag() { printf '{"name":"%s","created_unix":%s}' "$1" "$((NOW - $2))"; }
 
+# rel <tag> [draft]  — a released tag; pass "draft" to make it a draft release
+rel() {
+  local draft=false
+  [ "${2:-}" = "draft" ] && draft=true
+  printf '{"name":"%s","draft":%s}' "$1" "$draft"
+}
+
 day=86400
 
 # ── Silent: the failure this exists to catch ─────────────────────────────────
 # The #1464 shape — a run of consecutive tags, none published.
 want "S1 a run of unpublished old tags is reported, oldest first" \
   "v0.6.75 v0.6.76 v0.6.77" \
-  "{\"tags\":[$(tag v0.6.77 $((2 * day))),$(tag v0.6.75 $((4 * day))),$(tag v0.6.76 $((3 * day)))],\"releases\":[\"v0.6.74\"]}"
+  "{\"tags\":[$(tag v0.6.77 $((2 * day))),$(tag v0.6.75 $((4 * day))),$(tag v0.6.76 $((3 * day)))],\"releases\":[$(rel v0.6.74)]}"
 
 want "S2 one unpublished tag among published ones is still caught" \
   "v0.6.76" \
-  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day))),$(tag v0.6.77 $day)],\"releases\":[\"v0.6.75\",\"v0.6.77\"]}"
+  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day))),$(tag v0.6.77 $day)],\"releases\":[$(rel v0.6.75),$(rel v0.6.77)]}"
 
 # A release that was published and later deleted looks exactly like one that
 # never published, and is equally worth knowing about. A watcher of the
@@ -89,7 +96,7 @@ want "C3 a tag one second past the boundary is reported" \
 
 want "C4 a fully published history reports nothing" \
   "" \
-  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day)))],\"releases\":[\"v0.6.75\",\"v0.6.76\"]}"
+  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day)))],\"releases\":[$(rel v0.6.75),$(rel v0.6.76)]}"
 
 want "C5 no tags at all reports nothing" "" '{"tags":[],"releases":[]}'
 
@@ -98,7 +105,19 @@ want "C5 no tags at all reports nothing" "" '{"tags":[],"releases":[]}'
 # was never owed.
 want "C6 a release with no matching tag is not a finding" \
   "" \
-  "{\"tags\":[$(tag v0.6.75 $((2 * day)))],\"releases\":[\"v0.6.75\",\"v0.6.99\"]}"
+  "{\"tags\":[$(tag v0.6.75 $((2 * day)))],\"releases\":[$(rel v0.6.75),$(rel v0.6.99)]}"
+
+# ── Drafts ───────────────────────────────────────────────────────────────────
+# A draft is not a shipped build, and one can stay open for a long time. This
+# is a live case: the repo's own release list has two open drafts today, each
+# with a tag but no real release.
+want "D1 a tag with only a draft release is still reported" \
+  "v0.6.80" \
+  "{\"tags\":[$(tag v0.6.80 $((5 * day)))],\"releases\":[$(rel v0.6.80 draft)]}"
+
+want "D2 a draft does not hide a real gap among the published releases" \
+  "v0.6.76" \
+  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day)))],\"releases\":[$(rel v0.6.75),$(rel v0.6.76 draft)]}"
 
 # ── Grandfathering ───────────────────────────────────────────────────────────
 # The baseline is what lets this be an alarm about NEW silence instead of a
@@ -121,7 +140,17 @@ want "K3 an absent baseline grandfathers nothing" \
 # applied in the wrong order reports the fresh one or misses the old one.
 want "M1 a mixed history reports only the old unpublished tag" \
   "v0.6.76" \
-  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day))),$(tag v0.6.99 $((10 * 60)))],\"releases\":[\"v0.6.75\"]}"
+  "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day))),$(tag v0.6.99 $((10 * 60)))],\"releases\":[$(rel v0.6.75)]}"
+
+# ── No fixed cap ──────────────────────────────────────────────────────────────
+# The old thousand-item cap lived only in the fetch, never in this rule.
+# scripts/test-releases-published-pagination.sh proves the fetch side. This
+# case proves the rule side: a huge release list is judged the same as a
+# small one.
+big_releases="$(i=0; while [ "$i" -lt 1001 ]; do [ "$i" -gt 0 ] && printf ','; printf '%s' "$(rel "v0.6.$i")"; i=$((i + 1)); done)"
+want "N1 a release list past the old 1000-item cap still finds the one gap" \
+  "v0.6.9999" \
+  "{\"tags\":[$(tag v0.6.9999 $((2 * day)))],\"releases\":[${big_releases}]}"
 
 # The age column is what tells a reader "two days" from "twenty minutes", so it
 # has to be right, not merely present.

--- a/scripts/test-tap-current.sh
+++ b/scripts/test-tap-current.sh
@@ -165,6 +165,41 @@ want "V5 0.10.0 is newer than 0.9.292" \
   "0.9.292 0.10.0 1 86400" \
   "{\"formula_version\":\"0.9.292\",\"releases\":[$(rel v0.9.292 $((2 * day))),$(rel v0.10.0 $day)]}"
 
+# ── One page, and what it cannot see past ────────────────────────────────────
+# check-tap-current.sh fetches exactly one page (100 releases). This is that
+# boundary, driven through `page_full` rather than through a live fetch.
+
+# A hundred settled releases, all newer than a very old formula. The page
+# ran out before it caught up to the formula, so the true count could be
+# more than the 100 seen here. Each is at least 3 hours old, past the
+# 90-minute grace window. i=0 is the oldest, so v0.9.299 is the newest.
+hundred_settled="$(i=0; while [ "$i" -lt 100 ]; do [ "$i" -gt 0 ] && printf ','; printf '%s' "$(rel "v0.9.$((200 + i))" $(((102 - i) * hour)))"; i=$((i + 1)); done)"
+
+want "P1 a full page entirely ahead of the formula reports 'at least', not a guessed exact count" \
+  "0.9.100 0.9.299 at least 100 10800" \
+  "{\"formula_version\":\"0.9.100\",\"page_full\":true,\"releases\":[${hundred_settled}]}"
+
+want "P2 a full page that still contains the formula's own version reports an exact count" \
+  "0.9.298 0.9.299 1 10800" \
+  "{\"formula_version\":\"0.9.298\",\"page_full\":true,\"releases\":[${hundred_settled}]}"
+
+want "P3 the same page short of a full fetch reports an exact count, not 'at least'" \
+  "0.9.100 0.9.299 100 10800" \
+  "{\"formula_version\":\"0.9.100\",\"page_full\":false,\"releases\":[${hundred_settled}]}"
+
+# A full page where nothing has settled — every release on it is either a
+# draft or still inside the grace window. One page could not answer the
+# question at all, so it must say so rather than pass as "nothing to report".
+hundred_unsettled="$(i=0; while [ "$i" -lt 100 ]; do [ "$i" -gt 0 ] && printf ','; printf '%s' "$(rel "v0.9.$((300 + i))" $((10 * 60)))"; i=$((i + 1)); done)"
+
+want "P4 a full page with nothing settled is undetermined, not a clean pass" \
+  "__UNDETERMINED__" \
+  "{\"formula_version\":\"0.9.100\",\"page_full\":true,\"releases\":[${hundred_unsettled}]}"
+
+want "P5 the same nothing-settled page short of a full fetch reports nothing, same as C4" \
+  "" \
+  "{\"formula_version\":\"0.9.100\",\"page_full\":false,\"releases\":[${hundred_unsettled}]}"
+
 echo
 echo "passed ${pass}, failed ${fail}"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What and why

Both release-reconcile checks fetched a fixed page of releases (`--limit
1000`) and treated hitting that count as evidence the list was cut off.
That cap only ever bought time — this repo cuts a release on almost
every merge, so the real count keeps climbing toward whatever number is
chosen, and the alarm was on schedule to start crying wolf every hour
once it hit 1000 (issue #5555's own math: about three weeks out).

- **`scripts/check-releases-published.sh`** needs the *entire* release
  set (every `v*` tag has to be checked against it), and the releases
  endpoint has no API-side result ceiling — it's an ordinary paginated
  list, not a search endpoint. So it now walks every page with
  `gh api --paginate --slurp 'repos/{owner}/{repo}/releases?per_page=100'`
  instead of asking for a fixed slice. `max_pages=1000` (100k releases)
  stays as a sanity check — not a cap — in case pagination itself ever
  misbehaves.
- **`scripts/check-tap-current.sh`** only ever needs the *newest settled*
  release, and GitHub returns releases newest-first, so it now fetches
  exactly one page of 100 (no `--paginate`) instead of racing the same
  cap. When every release on that page is newer than the formula, the
  behind-count can't be proven exact, so it reports as `"at least N"`
  rather than a guessed number — the DoD's safety rule in code: a fetch
  that might be short may report *more* trouble than it can prove, never
  less, and never a clean pass. The one case a single page truly cannot
  answer — a full page where nothing settled at all (every release is
  either a draft or still inside the 90-minute grace window) — is now a
  loud error instead of a silent "nothing to report".

### The draft-handling side effect (a real, live finding)

Making `check-releases-published.sh` build its own release list (instead
of trusting `gh release list --json tagName`) meant deciding what counts
as "published" myself, so I made drafts explicit: `.releases` now carries
`{name, draft}` per release, and `select_unpublished` filters
`draft != true` before matching. That's a genuine correctness fix, not
just plumbing — the old code counted **any** release with a matching tag
name as published, draft or not.

Running `make releases-published` live confirms it was hiding something:

```
$ make releases-published
::error::4 tag(s) were cut but never published. The repository is stamping version numbers while shipping no binaries — this is the #1464 silence, live.

Tag                  Age
  v0.9.194           215h
  v0.9.254           163h
  v0.9.264           157h
  v0.9.273           134h
```

Before this PR the same live repo reported only 2 (`v0.9.194`,
`v0.9.273`) — `v0.9.254` and `v0.9.264` carry *only* draft releases today
and were silently counted as published. Both are already tracked in
**#5629** (filed the day before this PR's design pointer, independently
confirming both are complete drafts one API call from publishing), so I
did not grandfather them into `scripts/unpublished-tags-baseline.txt` —
that file's own header says an addition has to be "a decision someone
made, visible in review," and #5629 is already that decision in
progress. `v0.9.194`/`v0.9.273` are unrelated pre-existing findings
(#5629 again) and this PR does not change their status either way.
`Refs #5629` below reflects that overlap; this PR does not close it.

`make tap-current` live:

```
$ make tap-current
check-tap-current: OK — macanderson/homebrew-tap/Formula/stella.rb is at 0.9.306, which is not behind any release older than 90m (100 release(s) checked).
```

## Witness test

`scripts/test-releases-published-pagination.sh` is a fail→pass witness
run at the wrapper (I/O) level, not just the pure `--select` rule — the
old cap lived only in the fetch. A fake `gh` on `PATH` answers exactly
the call each script version makes and returns a synthetic list of 1001
releases (one past the old cap), fully hermetic (no network).

It runs **both** the script `main` ships today (read out with
`git show origin/main:...`) and this branch's script against that same
1001-release fixture:

```
$ ./scripts/test-releases-published-pagination.sh
ok   MAIN main's script hits its 1000-item cap on 1001 releases and errors
ok   NEW this branch's script pages through all 1001 releases and reports clean

passed 3, failed 0
```

That is the flip demonstrated both directions on the same fixture, not
asserted. In CI (`guard-self-tests.yml`), the checkout is shallow and
`origin/main` may not be fetchable — the test degrades gracefully there
(prints `SKIP` for the main-script half, still asserts the branch's own
fetch has no cap) rather than false-failing on an unrelated checkout
limitation; the pasted run above is the full two-sided proof.

`scripts/test-releases-published.sh` gained `N1`, proving the **pure
rule** itself (not just the fetch) has no count-shaped ceiling — a
1001-entry `.releases` array is judged exactly like a small one — plus
`D1`/`D2` for the new draft-exclusion rule.

`scripts/test-tap-current.sh` gained `P1`–`P5` covering the one-page
boundary: an "at least N" report when a full page never catches up to
the formula, an exact count when it's short of a full page or the
crossover is found within it, and the `__UNDETERMINED__` sentinel for a
full page where nothing settled.

All three suites pass locally (`./scripts/test-releases-published.sh`,
`./scripts/test-tap-current.sh`,
`./scripts/test-releases-published-pagination.sh`), and `make
guards-fast` (shellcheck, prose, file-size, gate-parity, and the rest of
the toolchain-free gate) is clean on this branch.

## Exemplar followed

Both scripts already split into a pure `--select` half (stdin JSON,
hermetic-testable) and an I/O wrapper — this PR keeps that shape and
extends the same seam (`page_full`, `draft`) rather than inventing a new
one, per the design pointer on the issue.

## Tests deleted

None.

## Docs

One sentence added to `RELEASING.md` describing the `"at least N"`
wording, per the issue's DoD (no ADR — this is CI tooling, not a
documented product behavior).

## Residue

None filed — the one adjacent finding (two draft-only tags newly
surfaced) is already tracked in #5629, referenced above rather than
duplicated.

## DoD note

An autonomous sweep (posted under the maintainer's account) audited this
PR against #5555's checklist and correctly declined to tick "make
releases-published and make tap-current both pass against the real, live
repository" — the live repo genuinely has 4 unpublished tags (2 of them
newly visible because of this PR's own draft fix, tracked in #5629), so
"both pass" was false as literally written. Publishing those releases is
outward-facing and out of #5555's scope; I reworded the item instead, to
the property this issue is actually about (no truncation/page-sanity/
fetch error against live data), with the live command output as evidence
— see the note on #5555 dated 2026-09-02.

Closes #5555
Refs #5629

## Summary by Sourcery

Eliminate fixed release-count assumptions from release reconciliation checks while preserving safe, evidence-based reporting.

Bug Fixes:
- Remove fixed release-count limits from release publication and tap freshness checks to prevent false results as the repository grows.
- Treat draft-only releases as unpublished so tagged versions are not incorrectly considered shipped.
- Report tap staleness as an evidence-based “at least N” count and fail loudly when a full page cannot establish a settled release.

Enhancements:
- Fetch the complete release history for tag reconciliation while retaining only a one-page newest-release view for tap freshness checks.

Build:
- Add a Makefile target for the release-pagination witness test.

CI:
- Run the release-pagination witness test in the guard self-test workflow.

Documentation:
- Document the “at least N releases behind” wording for stale tap reports.

Tests:
- Expand release and tap rule tests for draft handling, pagination boundaries, qualified counts, and indeterminate results.
- Add an end-to-end hermetic witness test proving the release fetch handles more than 1000 releases without a fixed cap.
