### PR TITLE
fix(stella-cli): surface a root-key typo in the managed settings file

### DIFF
--- a/crates/stella-cli/src/config/report.rs
+++ b/crates/stella-cli/src/config/report.rs
@@ -62,6 +62,21 @@ impl Config {
             println!("  Env files:  {}", summary.dimmed());
         }
         self.print_role_wiring();
+        Self::print_managed_advisory();
+    }
+
+    /// Unknown keys in the org-managed settings file, always shown here.
+    /// This is where an admin can catch a typo before it reaches a fleet.
+    /// Silent when there is nothing to say.
+    fn print_managed_advisory() {
+        let notices = crate::settings::Settings::managed_advisory();
+        if notices.is_empty() {
+            return;
+        }
+        println!("\n  {}", "Managed settings".bright_cyan().bold());
+        for line in notices {
+            println!("    {}", line.dimmed());
+        }
     }
 
     /// The four engine roles, what each will actually send, and which setting

--- a/crates/stella-cli/src/doctor.rs
+++ b/crates/stella-cli/src/doctor.rs
@@ -194,7 +194,42 @@ fn checks(
         fleet_ledger_orphans(workspace_root),
         orphan_session_sidecars(&stella_store::SessionRegistry::open_default(), repair),
         model_config(workspace_root, model_override, base_url_override),
+        managed_settings(),
     ]
+}
+
+/// The org-managed settings file's spelling. An admin runs
+/// `STELLA_MANAGED_SETTINGS=candidate.json stella doctor` to check a
+/// candidate file before it reaches a fleet.
+///
+/// Always a **Pass**: a typo here is not this workspace's fault, only news
+/// an admin needs. The fleet-ledger check above takes the same stance on
+/// its own inert rows.
+fn managed_settings() -> Check {
+    const NAME: &str = "managed settings";
+
+    // A frozen benchmark run must never touch a host path outside its own
+    // isolation, the same rule `Settings::load` itself follows.
+    if crate::settings::filesystem_settings_disabled() {
+        return Check::pass(NAME, "skipped under filesystem isolation");
+    }
+    let path = crate::settings::Settings::managed_path();
+    if !path.exists() {
+        return Check::pass(NAME, "no org-managed settings file on this machine");
+    }
+    let notices = crate::settings::Settings::managed_advisory();
+    if notices.is_empty() {
+        return Check::pass(NAME, format!("{}: no unrecognized keys", path.display()));
+    }
+    Check::pass(
+        NAME,
+        format!(
+            "{}: {} advisory line(s) — a root-key typo parses clean and denies nothing",
+            path.display(),
+            notices.len()
+        ),
+    )
+    .with_details(notices)
 }
 
 /// #895: the model the next run would actually send, checked before it costs
@@ -639,6 +674,10 @@ mod tests {
 
     #[test]
     fn doctor_passes_on_a_healthy_workspace_store() {
+        // The managed-settings check below reads `STELLA_MANAGED_SETTINGS`;
+        // hold the same lock the settings-scope tests mutate it under so this
+        // read never races an unsynchronized `set_var` on another thread.
+        let _env = crate::test_env::lock();
         let dir = workspace_with_store();
         assert_eq!(run_doctor_at(dir.path(), false, None, None), Ok(()));
 
@@ -649,7 +688,8 @@ mod tests {
                 "store integrity",
                 "fleet ledger",
                 "session sidecars",
-                "model config"
+                "model config",
+                "managed settings",
             ],
             "the shipped checks, in report order: {checks:?}"
         );
@@ -704,6 +744,7 @@ mod tests {
     /// leaves them alone — removing them would delete fleet history.
     #[test]
     fn doctor_reports_fleet_ledger_orphans_without_repairing_them() {
+        let _env = crate::test_env::lock();
         let dir = workspace_with_store();
         let db = dir.path().join(".stella/private/fleet.db");
 
@@ -759,6 +800,7 @@ mod tests {
 
     #[test]
     fn doctor_passes_on_a_workspace_that_has_never_run_a_session() {
+        let _env = crate::test_env::lock();
         let dir = tempfile::tempdir().expect("tempdir");
         assert_eq!(run_doctor_at(dir.path(), false, None, None), Ok(()));
         assert!(
@@ -769,6 +811,7 @@ mod tests {
 
     #[test]
     fn doctor_reports_a_corrupted_store_and_leaves_it_alone() {
+        let _env = crate::test_env::lock();
         let dir = workspace_with_store();
         let db_path = store_db(&dir);
         corrupt(&db_path);
@@ -812,6 +855,7 @@ mod tests {
     /// The exit-code contract, at both ends of the same corrupt store.
     #[test]
     fn doctor_exits_nonzero_on_corruption_and_zero_after_a_repair() {
+        let _env = crate::test_env::lock();
         let dir = workspace_with_store();
         corrupt(&store_db(&dir));
 
@@ -829,6 +873,7 @@ mod tests {
 
     #[test]
     fn doctor_repair_quarantines_the_corrupt_store_without_deleting_it() {
+        let _env = crate::test_env::lock();
         let dir = workspace_with_store();
         let db_path = store_db(&dir);
         corrupt(&db_path);
@@ -879,6 +924,7 @@ mod tests {
 
     #[test]
     fn doctor_repair_on_a_healthy_store_moves_nothing() {
+        let _env = crate::test_env::lock();
         let dir = workspace_with_store();
         let db_path = store_db(&dir);
         let before = std::fs::read(&db_path).expect("read db");

--- a/crates/stella-cli/src/settings/managed.rs
+++ b/crates/stella-cli/src/settings/managed.rs
@@ -1,14 +1,25 @@
-//! Secure administrator-managed settings snapshot.
+//! Reads the managed settings file.
 
 use std::path::{Path, PathBuf};
 
 use super::Settings;
 
 impl Settings {
-    /// Capture secure managed telemetry before project dotenv processing.
+    /// Get the managed telemetry field before dotenv files load.
     pub(crate) fn load_managed_telemetry_snapshot() -> Result<Option<serde_json::Value>, String> {
         let managed = Self::load_managed_scope(&managed_settings_path())?;
         Ok(managed.enterprise_telemetry)
+    }
+
+    /// The file [`Self::load`] reads for the managed scope.
+    pub fn managed_path() -> PathBuf {
+        resolve_managed_path()
+    }
+
+    /// Unknown keys in the org-managed settings file. See
+    /// [`super::unknown::managed_advisory`].
+    pub fn managed_advisory() -> Vec<String> {
+        super::unknown::managed_advisory()
     }
 
     pub(super) fn load_managed_scope(path: &Path) -> Result<Self, String> {
@@ -49,6 +60,26 @@ pub(super) fn managed_settings_path() -> PathBuf {
     } else {
         PathBuf::from("/etc/stella/settings.json")
     }
+}
+
+/// The file the loader reads for the managed scope.
+///
+/// `STELLA_MANAGED_SETTINGS` picks one file. Otherwise the default TOML path
+/// wins if it exists; the JSON path is the fallback. This mirrors
+/// `Settings::load_managed_scope_dual`'s own choice, named here in words
+/// since that function is private to `merge.rs`.
+///
+/// A test keeps the two in step: it loads real settings and reads this
+/// advisory on the same fixture, so a mismatch fails the test.
+pub(super) fn resolve_managed_path() -> PathBuf {
+    if std::env::var_os("STELLA_MANAGED_SETTINGS").is_some() {
+        return managed_settings_path();
+    }
+    let toml_path = super::toml_config::managed_toml_path();
+    if toml_path.exists() {
+        return toml_path;
+    }
+    managed_settings_path()
 }
 
 #[cfg(unix)]

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -617,10 +617,7 @@ impl Settings {
         // thing standing between `"provider"` and a settings file that
         // configures nothing at all. Advisory, never a gate, and latched with
         // the notices above so the several loads one launch performs cannot
-        // turn one finding into four. The managed scope is deliberately
-        // excluded: it is administrator-owned, its reader is a hardened
-        // O_NOFOLLOW path, and an operator cannot act on a warning printed on
-        // somebody else's machine.
+        // turn one finding into four.
         // Format-level notices (a shadowed JSON file, an inert [mcp.servers]).
         // Latched with everything else below so the several loads one launch
         // performs cannot turn one finding into four.
@@ -650,6 +647,20 @@ impl Settings {
                 for line in super::unknown::notices(&path.display().to_string(), found) {
                     eprintln!("{line}");
                 }
+            }
+        }
+
+        // The managed scope's own advisory. Withheld from every OTHER
+        // launch's stderr — a deployed employee cannot act on a warning about
+        // their org's file — but `STELLA_MANAGED_SETTINGS` being set at all
+        // IS the local-testing case: an administrator validating a candidate
+        // file runs `STELLA_MANAGED_SETTINGS=candidate.json stella run` (or
+        // `doctor`, or `config`, both of which show this advisory
+        // unconditionally — see `unknown::managed_advisory`) and that is the
+        // one moment the typo is cheap to find.
+        if announce && std::env::var_os("STELLA_MANAGED_SETTINGS").is_some() {
+            for line in super::unknown::managed_advisory() {
+                eprintln!("{line}");
             }
         }
 

--- a/crates/stella-cli/src/settings/tests.rs
+++ b/crates/stella-cli/src/settings/tests.rs
@@ -7,6 +7,7 @@
 //! to `crate::settings` exactly as it did inline, so this is a pure move.
 
 mod auto_trust_project;
+mod managed_advisory;
 mod private_state;
 mod toml;
 mod trust;

--- a/crates/stella-cli/src/settings/tests/managed_advisory.rs
+++ b/crates/stella-cli/src/settings/tests/managed_advisory.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for the managed-scope unknown-key advisory.
+//!
+//! Kept off `settings/tests.rs`, which is at its line limit.
+
+use super::*;
+
+/// A typo in a managed root key parses fine and denies nothing. The
+/// advisory names it. `STELLA_HOME` keeps this test off the real home.
+#[test]
+fn a_managed_root_key_typo_denies_nothing_but_the_advisory_names_it() {
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&crate::test_env::home_env_names(&[
+        "STELLA_MANAGED_SETTINGS",
+    ]));
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let managed = dir.path().join("managed.json");
+    let workspace = dir.path().join("repo");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(workspace.join(".stella")).unwrap();
+    std::fs::write(&managed, r#"{"toosl": {"bash": "off"}}"#).unwrap();
+    // SAFETY: the env lock above covers this.
+    unsafe {
+        crate::test_env::point_home_at(&home);
+        std::env::set_var("STELLA_MANAGED_SETTINGS", &managed);
+    }
+
+    let merged = Settings::load(&workspace).unwrap();
+    assert!(
+        merged.tool_policy().allows("bash"),
+        "a root-key typo must deny nothing — the advisory below is how it gets noticed instead"
+    );
+
+    let advisory = Settings::managed_advisory();
+    assert_eq!(advisory.len(), 1, "{advisory:?}");
+    assert!(
+        advisory[0].contains("toosl"),
+        "the advisory must name the misspelled root key: {advisory:?}"
+    );
+    assert!(
+        advisory[0].contains(&managed.display().to_string()),
+        "the advisory must name the file: {advisory:?}"
+    );
+}
+
+/// A second typo, in a different key, to show the check is general.
+#[test]
+fn a_second_managed_root_key_typo_is_also_named() {
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&crate::test_env::home_env_names(&[
+        "STELLA_MANAGED_SETTINGS",
+    ]));
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let managed = dir.path().join("managed.json");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::write(&managed, r#"{"authroity": {"project_prompts": "off"}}"#).unwrap();
+    // SAFETY: the env lock above covers this.
+    unsafe {
+        crate::test_env::point_home_at(&home);
+        std::env::set_var("STELLA_MANAGED_SETTINGS", &managed);
+    }
+
+    let advisory = Settings::managed_advisory();
+    assert_eq!(advisory.len(), 1, "{advisory:?}");
+    assert!(
+        advisory[0].contains("authroity"),
+        "the advisory must name the misspelled root key: {advisory:?}"
+    );
+}

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -601,6 +601,36 @@ pub(super) fn unknown_toml_keys_in(path: &Path) -> Vec<String> {
     found
 }
 
+/// Unknown keys in the org-managed settings file.
+///
+/// Always computed, whether or not `STELLA_MANAGED_SETTINGS` is set and
+/// whether or not [`super::Settings::load`] has run yet. `stella doctor`
+/// and `stella config` call it directly so an admin can catch a root-key
+/// typo (`"toosl"` for `"tools"`) while checking a candidate file, before
+/// it reaches a fleet. [`super::merge`]'s own stderr copy of these lines
+/// stays quiet unless `STELLA_MANAGED_SETTINGS` is set — a plain `stella
+/// run` against a fleet's real managed file must not print it.
+///
+/// Reads the file with a plain read, not the hardened
+/// [`super::managed::read_managed_settings`] the real load uses — this is
+/// only advisory text about key names, never a value. A missing or
+/// unreadable file yields no notices.
+///
+/// Skips the read under [`super::filesystem_settings_disabled`], so a
+/// frozen benchmark run never touches a host path.
+pub(crate) fn managed_advisory() -> Vec<String> {
+    if super::filesystem_settings_disabled() {
+        return Vec::new();
+    }
+    let path = super::managed::resolve_managed_path();
+    let found = if super::toml_config::path_is_toml(&path) {
+        unknown_toml_keys_in(&path)
+    } else {
+        unknown_keys_in(&path)
+    };
+    notices(&path.display().to_string(), found)
+}
+
 fn scan_toml_root(root: &Value, found: &mut Vec<String>) {
     let Some(object) = root.as_object() else {
         return;

--- a/crates/stella-cli/tests/doctor_cli.rs
+++ b/crates/stella-cli/tests/doctor_cli.rs
@@ -103,7 +103,11 @@ fn doctor_reports_a_healthy_store_and_exits_zero() {
         stdout.contains("model config"),
         "the model-config check is reported too: {stdout}"
     );
-    assert!(stdout.contains("4 ok, 0 failed"), "{stdout}");
+    assert!(
+        stdout.contains("managed settings"),
+        "the managed-settings check is reported too: {stdout}"
+    );
+    assert!(stdout.contains("5 ok, 0 failed"), "{stdout}");
 }
 
 #[test]

--- a/crates/stella-cli/tests/model_config_cli.rs
+++ b/crates/stella-cli/tests/model_config_cli.rs
@@ -197,7 +197,7 @@ fn doctor_reports_the_model_a_valid_config_resolves_to_and_where_it_came_from() 
         stdout.contains("zai/glm-5.2") && stdout.contains("default_model"),
         "the pass states the resolved model and its source: {stdout}"
     );
-    assert!(stdout.contains("4 ok, 0 failed"), "{stdout}");
+    assert!(stdout.contains("5 ok, 0 failed"), "{stdout}");
 }
 
 #[test]

--- a/website/content/docs/commands/doctor.mdx
+++ b/website/content/docs/commands/doctor.mdx
@@ -15,12 +15,13 @@ stella doctor --last-failure                     # print the newest crash dump
 
 ## What it does
 
-Four checks run today:
+Five checks run today:
 
 - **`store integrity`** — checks the soundness of this workspace's session store at `<workspace>/.stella/private/store.db`, using SQLite's own `quick_check` and `integrity_check` checks.
 - **`fleet ledger`** — finds rows in `.stella/private/fleet.db` that name a run no longer recorded. This check only reports; it never deletes, because removing these rows would delete fleet history.
 - **`session sidecars`** — finds sidecar directories whose session record is gone. `--repair` removes them. A damaged record is never treated as an orphan.
 - **`model config`** — checks the model your next run would actually use, and the address it would send it to. See below.
+- **`managed settings`** — checks the spelling of your org-managed settings file, if one is configured. This is where you catch a typo in a root key (like `toosl` for `tools`) before it reaches a whole fleet of machines. Always a pass: a typo in an org file is not your workspace's fault, just news you need.
 
 Every check is a pass or a fail. There is no "warning" state: if a check can't say a thing is fine, it counts as failed.
 
@@ -80,7 +81,7 @@ Checking never writes anything. The check opens the database in a read-only mode
 
 ## Exit codes
 
-`0` when every check passed, including a `--repair` that fixed something. `1` when any check failed, with `stella: 1 of 4 doctor checks failed` printed to stderr. That's the whole rule, which is what makes the command work as a gate:
+`0` when every check passed, including a `--repair` that fixed something. `1` when any check failed, with `stella: 1 of 5 doctor checks failed` printed to stderr. That's the whole rule, which is what makes the command work as a gate:
 
 ```bash
 stella doctor || echo "local state needs attention"


### PR DESCRIPTION
## What and why

`Settings::load`'s unknown-key advisory (`crates/stella-cli/src/settings/unknown.rs`) scanned only the project and user settings scopes. The managed scope was excluded on purpose, with the reasoning written in the old comment: the managed file is administrator-owned, its reader is a hardened `O_NOFOLLOW` path, and "an operator cannot act on a warning printed on somebody else's machine."

That reasoning covers a deployed employee's machine. It does not cover the administrator validating a candidate file with `STELLA_MANAGED_SETTINGS=candidate.json stella doctor`, the documented way to test one, and the last moment a root-key typo (`"toosl"` for `"tools"`, `"authroity"` for `"authority"`) is cheap to find. Before this PR that typo parsed clean, denied nothing, and printed nothing — anywhere, ever.

## The fix

- `Settings::managed_advisory()` (new, in `settings/unknown.rs` + a `Settings` wrapper in `settings/managed.rs`) computes the unknown-key advisory for the managed path unconditionally — independent of `STELLA_MANAGED_SETTINGS` being set, of trust, and of whether `Settings::load` has run in this process. It reuses the same path-resolution choice `Settings::load_managed_scope_dual` makes (`settings::managed::resolve_managed_path`), and reads the file with a plain read rather than the hardened `O_NOFOLLOW` reader — this is advisory text about key spelling, never a value, and the real load path still runs its own hardened read.
- `stella doctor` gets a new "managed settings" check (`doctor.rs::managed_settings`) that always shows it — a `Pass` either way, since a typo in an org file is not this workspace's fault, only news an admin needs.
- `stella config` prints a "Managed settings" section (`config/report.rs::print_managed_advisory`) whenever the advisory has something to say.
- `Settings::load`'s own per-launch stderr copy of these lines is now gated on `STELLA_MANAGED_SETTINGS` being set explicitly in the environment — that env var being set at all is the local-testing case; a plain `stella run` against a fleet's real managed file at its default OS path stays quiet, same as before.
- Both new public methods respect the existing `STELLA_NO_SETTINGS` filesystem-isolation boundary (`filesystem_settings_disabled`), so a frozen benchmark run never touches a host path outside its own isolation — checked in `doctor.rs`'s new check too.

## Witness

`crates/stella-cli/src/settings/tests/managed_advisory.rs` (split off `settings/tests.rs`, which is at its 1500-line ceiling):

- `a_managed_root_key_typo_denies_nothing_but_the_advisory_names_it` — a managed fixture `{"toosl": {"bash": "off"}}` behind `STELLA_MANAGED_SETTINGS`, with a `STELLA_HOME` tempdir so the test never reads the real `~/.stella`. Asserts `Settings::load` still allows `bash` (the typo denies nothing) **and** `Settings::managed_advisory()` names `toosl` and the file path.
- `a_second_managed_root_key_typo_is_also_named` — the same mechanism against `{"authroity": {...}}`, naming `authroity`.

Both call `Settings::managed_advisory()`, a function that does not exist on `main` — the mechanism by which this fails on the old code: it cannot compile against `main`, let alone pass. The old code's `Settings::load` also explicitly excluded the managed scope from every notice it prints (see the deleted comment in `merge.rs`), so even a stderr-capture test against `main` would find nothing to assert on.

Ran locally (targeted, one crate, per `SCR-001`):
- `cargo check -p stella-cli --bin stella --tests` — clean
- `cargo clippy -p stella-cli --bin stella --tests -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps --document-private-items` — clean (validates every new intra-doc link)
- `cargo test -p stella-cli --bin stella` — **2595 passed, 0 failed**, including both new witness tests and the seven `doctor::tests::*` I touched to add `test_env::lock()` (see below)
- `python3 scripts/check-prose.py`, `./scripts/check-file-size.sh`, `make guards-fast` — all green

## Design pointer followed

Followed the maintainer's design pointer on the issue verbatim: always compute the advisory for the managed path, surface it in `stella doctor` and `stella config`, and keep it off `stella run`'s stderr unless `STELLA_MANAGED_SETTINGS` is set explicitly.

## Incidental fix: a same-process env race in `doctor.rs`'s own tests

`doctor.rs`'s new "managed settings" check reads `STELLA_MANAGED_SETTINGS` (via `resolve_managed_path`). `doctor.rs`'s test module did not hold `test_env::lock()` before this PR — it had never needed to, since nothing it exercised touched an env var. Several `settings/tests.rs` tests mutate `STELLA_MANAGED_SETTINGS` under that same lock (`crates/stella-cli/src/settings/tests.rs`'s own `create_worktrees_survives_the_scope_merge` names the exact hazard, #3312). Since `cargo test` runs a crate's test modules on parallel threads, an unlocked read in `doctor.rs` could now race a locked mutation in `settings/tests.rs`. I added `let _env = crate::test_env::lock();` to the seven `doctor::tests` functions that call `checks()`/`run_doctor_at()` (the ones that reach the new check), matching the pattern `settings/tests.rs` already documents for the same hazard.

## Tests deleted

None.

Closes #5521

## Summary by Sourcery

Surface unknown root keys in managed settings so administrators can catch configuration typos before deploying them to a fleet.

New Features:
- Surface unknown root keys in the managed settings file through `stella doctor` and `stella config`.
- Expose managed-settings advisories for candidate files and report them during explicit managed-settings testing.

Bug Fixes:
- Make administrator-managed root-key typos visible instead of silently parsing and denying nothing.
- Keep normal launches quiet for default fleet-managed files while preserving advisories when `STELLA_MANAGED_SETTINGS` is explicitly set.

Enhancements:
- Respect filesystem isolation when inspecting managed settings and synchronize doctor tests with environment-variable access.

Documentation:
- Document the new managed-settings doctor check and update the documented check count and exit-code examples.

Tests:
- Add coverage for multiple managed root-key typos and update doctor command expectations for the additional check.