### PR TITLE
test(stella-tui): draw every SPEC 6.3 head from the wire event that sends it

### DIFF
--- a/crates/stella-tui/src/render/tests.rs
+++ b/crates/stella-tui/src/render/tests.rs
@@ -33,6 +33,8 @@ mod result_row;
 // #5031: SPEC 6.3's skill event, from the wire event to the rendered row.
 mod skill;
 mod slash;
+// Every head SPEC 6.3 draws, from the wire event that draws it.
+mod spine;
 mod steering;
 mod thinking;
 mod tool_output;

--- a/crates/stella-tui/src/render/tests/spine.rs
+++ b/crates/stella-tui/src/render/tests/spine.rs
@@ -20,7 +20,7 @@
 use super::*;
 use crate::tool_class::ToolClass;
 use crate::views::transcript::{EventKind, Extent};
-use stella_protocol::{MemoryClass, ModelCallRole, SkillTrigger, ToolCall};
+use stella_protocol::{MemoryClass, ModelCallRole, SkillTrigger, TaskId, ToolCall};
 
 /// What draws one head kind.
 enum Producer {
@@ -233,7 +233,9 @@ fn live() -> Vec<Row> {
                 tokens_per_sec: Some(84),
             },
             event: step_usage(),
-            marks: &["worker", "84 tok/s"],
+            // The rate, the call's own wall clock, and the footer — the three
+            // head fields beyond the glyph and the word, all from the fold.
+            marks: &["worker", "84 tok/s", "⚡5000ms", "irreducible generation"],
         },
         Row {
             kind: EventKind::Compaction {
@@ -297,6 +299,38 @@ fn every_live_head_kind_is_drawn_from_the_wire() {
             );
         }
     }
+}
+
+/// A live head carries the board tag the wire stamped on the call — SPEC
+/// 6.2's `→ task 3`.
+///
+/// `AgentEvent::ToolStart` carries `task_id`, the fold reads it onto
+/// `TranscriptEntry::ToolStart`, and the metric group draws it. The other
+/// tests for the tag hand `head_rows` a number they made up, so this is the
+/// one that starts where the engine does. An untagged call beside it, because
+/// a tag that always draws is as wrong as one that never does.
+#[test]
+fn a_live_tool_head_carries_the_task_tag_the_wire_stamped() {
+    let tagged = AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: "c1".into(),
+            name: "edit_file".into(),
+            input: serde_json::json!({ "path": "src/lib.rs" }),
+        },
+        sub_agent_id: None,
+        task_id: Some(TaskId::new("3")),
+    };
+    let drawn = rendered(&tagged);
+    assert!(drawn.contains("→ task 3"), "the tag was dropped: {drawn}");
+
+    let plain = rendered(&tool_start(
+        "edit_file",
+        serde_json::json!({ "path": "src/lib.rs" }),
+    ));
+    assert!(
+        !plain.contains("→ task"),
+        "an untagged call drew a tag the board cannot jump to: {plain}"
+    );
 }
 
 /// The one head nothing sends stays out of the table above and names the

--- a/crates/stella-tui/src/render/tests/spine.rs
+++ b/crates/stella-tui/src/render/tests/spine.rs
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The witness for `#5030`: every head SPEC 6.3 draws, from a wire event.
+//!
+//! `views/transcript.rs` holds the head words and glyphs, and its own tests
+//! build an `EventKind` by hand. That proves the painter and nothing more. A
+//! head no session sends still passes there, and passed there for months.
+//!
+//! Each row below starts at an `AgentEvent`. The fold turns it into a
+//! `TranscriptEntry`, and the draw turns that into rows. The head has to carry
+//! the glyph and the word its own `EventKind` states. That is what shows the
+//! row went through `views::transcript::event_rows` and not a second painter.
+//!
+//! [`declared`] covers every kind, so a new one stops this file from building
+//! until somebody says what sends it. A kind nothing sends is allowed and
+//! names the issue that will settle it. `EventKind::Gate` is the only one
+//! (`#5651`).
+
+use super::*;
+use crate::tool_class::ToolClass;
+use crate::views::transcript::{EventKind, Extent};
+use stella_protocol::{MemoryClass, ModelCallRole, SkillTrigger, ToolCall};
+
+/// What draws one head kind.
+enum Producer {
+    /// A wire event a session sends.
+    Live,
+    /// Nothing sends one, and the number of the issue that settles it.
+    Gap(u32),
+}
+
+/// What draws `kind`.
+///
+/// The match covers every kind, so adding one is a build error here rather
+/// than a head nobody notices is out of reach. It is the rule
+/// `stella-protocol` applies to its own events: a signal with no reader is
+/// allowed, and it has to say so.
+fn declared(kind: &EventKind) -> Producer {
+    match kind {
+        EventKind::Read { .. }
+        | EventKind::Edit { .. }
+        | EventKind::Write { .. }
+        | EventKind::Delete { .. }
+        | EventKind::Run { .. }
+        | EventKind::Skill { .. }
+        | EventKind::MemoryLog { .. }
+        | EventKind::MemoryPromote { .. }
+        | EventKind::Model { .. }
+        | EventKind::Compaction { .. }
+        | EventKind::Other { .. } => Producer::Live,
+        // SPEC 6.3's lone gate row. The engine sends a whole board
+        // (`AgentEvent::GateBoard`), never one gate, so no fold can build this
+        // head. `#5651` picks between routing the board through it and
+        // dropping the kind.
+        EventKind::Gate { .. } => Producer::Gap(5651),
+    }
+}
+
+/// One kind, the wire event that draws it, and text its head must carry on
+/// top of its own glyph and word.
+struct Row {
+    kind: EventKind,
+    event: AgentEvent,
+    marks: &'static [&'static str],
+}
+
+/// A dispatched call, as the wire sends it.
+fn tool_start(name: &str, input: serde_json::Value) -> AgentEvent {
+    AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: "c1".into(),
+            name: name.into(),
+            input,
+        },
+        sub_agent_id: None,
+        task_id: None,
+    }
+}
+
+/// One settled model call, as the driver meters it. 420 tokens over 5 seconds
+/// is 84 a second, which is the rate the head has to state.
+fn step_usage() -> AgentEvent {
+    AgentEvent::StepUsage {
+        step: 0,
+        turn_instance: Some(0),
+        call_seq: Some(0),
+        role: ModelCallRole::Worker,
+        provider: "openrouter".into(),
+        upstream_provider: None,
+        output_text: None,
+        model: "glm-5.2".into(),
+        input_tokens: 4_000,
+        output_tokens: 420,
+        cached_input_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: None,
+        estimated_input_tokens: 0,
+        cost_usd: 0.01,
+        duration_ms: 5_000,
+        retries: 0,
+        tool_calls: 1,
+        complete: true,
+        finish_reason: None,
+        effort: None,
+        max_output_tokens: None,
+        temperature: None,
+        params: None,
+        sub_agent_id: None,
+        task_id: None,
+    }
+}
+
+/// One compaction pass. The row reads four of these fields and the rest are
+/// the pass's own bookkeeping.
+fn compaction() -> AgentEvent {
+    AgentEvent::Compaction {
+        before_tokens: 74_000,
+        after_tokens: 69_000,
+        evicted: 3,
+        deduped: 1,
+        superseded: 0,
+        aged: 0,
+        summarized: 0,
+        evicted_blocks: Vec::new(),
+        deduped_blocks: Vec::new(),
+        superseded_blocks: Vec::new(),
+        aged_blocks: Vec::new(),
+        summarized_blocks: Vec::new(),
+        rewrites: Vec::new(),
+        effective_budget_tokens: 0,
+        calibration_factor: 1.0,
+    }
+}
+
+/// Every head kind a session can send, one row each.
+///
+/// The tool rows all arrive as one `AgentEvent::ToolStart`, because the head
+/// is drawn when the call goes out and the tool's name is what picks the kind
+/// (`views::transcript_source::kind_for`).
+fn live() -> Vec<Row> {
+    vec![
+        Row {
+            kind: EventKind::Read { lines: None },
+            event: tool_start("read_file", serde_json::json!({ "path": "src/lib.rs" })),
+            // A live read head folds, so it draws the open key beside it.
+            marks: &["lib.rs", "↵ open"],
+        },
+        Row {
+            kind: EventKind::Edit {
+                extent: Extent::default(),
+            },
+            event: tool_start("edit_file", serde_json::json!({ "path": "src/lib.rs" })),
+            marks: &["lib.rs"],
+        },
+        Row {
+            kind: EventKind::Write {
+                extent: Extent::default(),
+            },
+            event: tool_start("write_file", serde_json::json!({ "path": "src/new.rs" })),
+            marks: &["new file"],
+        },
+        Row {
+            kind: EventKind::Delete {
+                extent: Extent::default(),
+            },
+            event: tool_start("delete_file", serde_json::json!({ "path": "src/old.rs" })),
+            marks: &["git-backed"],
+        },
+        Row {
+            kind: EventKind::Run { touched: None },
+            event: tool_start("bash", serde_json::json!({ "command": "cargo test" })),
+            marks: &["cargo test"],
+        },
+        Row {
+            // A tool this host has no word for keeps its own name, and an MCP
+            // tool's name is its last segment.
+            kind: EventKind::Other {
+                class: ToolClass::Execute,
+                touched: None,
+            },
+            event: tool_start("mcp__github__create_pull_request", serde_json::json!({})),
+            marks: &["create_pull_request"],
+        },
+        Row {
+            kind: EventKind::Skill {
+                trigger: "auto".into(),
+                tokens: 1_200,
+            },
+            event: AgentEvent::SkillInjected {
+                name: "reviewer".into(),
+                summary: "database review".into(),
+                tokens: 1_200,
+                trigger: SkillTrigger::Auto,
+            },
+            marks: &["reviewer", "auto"],
+        },
+        Row {
+            kind: EventKind::MemoryLog {
+                memory_id: "nod_83b3f1d29a".into(),
+            },
+            event: AgentEvent::MemoryLogged {
+                memory_id: "nod_83b3f1d29a".into(),
+                text: "dedup keys must be stable across runs".into(),
+                class: MemoryClass::Observation,
+                confidence: 62,
+                kind: "domain".into(),
+                decays: true,
+                promotes_at: 85,
+                task_id: None,
+            },
+            marks: &["logged"],
+        },
+        Row {
+            kind: EventKind::MemoryPromote {
+                from: MemoryClass::Observation,
+                to: MemoryClass::Rule,
+                confidence: 87,
+                audit_event_id: "prm_dedup_keys_a1b2".into(),
+            },
+            event: AgentEvent::MemoryPromoted {
+                lineage_id: "prp_directive_dedup-keys".into(),
+                from: MemoryClass::Observation,
+                to: MemoryClass::Rule,
+                confidence: 87,
+                audit_event_id: "prm_dedup_keys_a1b2".into(),
+                task_id: None,
+            },
+            marks: &["promoted"],
+        },
+        Row {
+            kind: EventKind::Model {
+                tokens_per_sec: Some(84),
+            },
+            event: step_usage(),
+            marks: &["worker", "84 tok/s"],
+        },
+        Row {
+            kind: EventKind::Compaction {
+                from_tokens: 74_000,
+                to_tokens: 69_000,
+                evicted: 3,
+                deduped: 1,
+            },
+            event: compaction(),
+            marks: &["3 evicted", "1 deduped"],
+        },
+    ]
+}
+
+/// Fold one wire event and draw the whole transcript, joined.
+fn rendered(event: &AgentEvent) -> String {
+    let mut model = SessionModel::new();
+    model.apply(event);
+    transcript_lines(&model, false, 120)
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Every head kind with a live sender draws from one, through the same
+/// `event_rows` the fixture tests use.
+#[test]
+fn every_live_head_kind_is_drawn_from_the_wire() {
+    for row in live() {
+        assert!(
+            matches!(declared(&row.kind), Producer::Live),
+            "{:?} is listed here as live and declared a gap",
+            row.kind
+        );
+        let drawn = rendered(&row.event);
+        // The glyph and the word come from the kind, and the text comes from
+        // the fold. A row where they agree is a row that reached the painter.
+        let glyph = row.kind.head_glyph(row.kind.collapses_by_default());
+        assert!(
+            drawn.contains(glyph),
+            "{:?} drew no {glyph}: {drawn}",
+            row.kind
+        );
+        let word = row.kind.verb();
+        assert!(
+            word.is_empty() || drawn.contains(word),
+            "{:?} drew no `{word}`: {drawn}",
+            row.kind
+        );
+        for mark in row.marks {
+            assert!(
+                drawn.contains(mark),
+                "{:?} lost `{mark}`: {drawn}",
+                row.kind
+            );
+        }
+    }
+}
+
+/// The one head nothing sends stays out of the table above and names the
+/// issue that will settle it.
+#[test]
+fn the_gate_head_has_no_wire_event_and_names_its_issue() {
+    assert!(
+        !live()
+            .iter()
+            .any(|row| matches!(row.kind, EventKind::Gate { .. })),
+        "a gate row is listed as live, so it has a sender and belongs in `live`"
+    );
+    let gate = EventKind::Gate {
+        state: "green".into(),
+        deterministic: true,
+    };
+    match declared(&gate) {
+        Producer::Gap(issue) => assert!(issue > 0, "a gap has to name its issue: {issue}"),
+        Producer::Live => panic!("a gate head has a sender now, so it belongs in `live`"),
+    }
+}


### PR DESCRIPTION
## What & why

`crates/stella-tui/src/views/transcript.rs` holds the head vocabulary SPEC 6.3
draws — read, edit, write, delete, run, skill, memory log, memory promote,
gate, model, compaction, and the unrecognised-tool row. Its own tests
(`views/transcript/tests.rs`) reach every one of them by building an
`EventKind` by hand. That proves the painter and says nothing about what a
session actually draws: a head no wire event produces passes there and never
once appears on screen. That is the gap #5030 was filed about.

This PR adds `crates/stella-tui/src/render/tests/spine.rs`: one row per head
kind, each starting at an `AgentEvent` a session emits, folded through
`SessionModel::apply` and drawn with the deck's own `entry_lines`. The
assertion is that the drawn head carries the glyph and the word its own
`EventKind` states — the expectation comes from the kind, the text comes from
the fold, so a row where the two agree is a row that reached
`views::transcript::event_rows` on the live path rather than through some
second painter.

`declared` matches every kind, so adding one to the vocabulary stops this file
compiling until somebody says what sends it. That is the discipline
AGENTS.md invariant 10 applies to `AgentEvent` (`event/consumers.rs`), pointed
at the heads this crate draws.

Closes #5030

### Where this differs from the design pointer, and why

The pointer on the issue asks for `TranscriptEntry::{Skill, MemoryLog,
MemoryPromote, Gate, Model}` to be added to `crates/stella-tui/src/model/entry.rs`.
Four of the five are already there and already live end to end, landed by the
per-event producer issues that were meant to depend on this one:

| kind | fold | router arm | live test that already existed |
| --- | --- | --- | --- |
| `Skill` | `model.rs`'s `SkillInjected` arm | `render/entry.rs` | `render/tests/skill.rs` (#5031) |
| `MemoryLog` | `model/memory.rs`'s `fold_memory_write` | `render/entry.rs` | `render/tests.rs::a_logged_memory_renders_its_block_once_and_not_the_v1_row` (#5032) |
| `MemoryPromote` | `model/memory.rs`'s `fold_memory_write` | `render/entry.rs` | `render/tests.rs::a_promotion_renders_one_row_through_the_router` |
| `Model` | `model/turn.rs`'s `model_call_row` | `render/entry.rs` | `views/transcript_source/tests.rs::a_settled_model_call_renders_its_rate_from_the_drivers_own_metering` (#5033) |

So re-adding them would be a no-op, and `kind_for`, `task`, `duration_ms` and
`footer` are already wired (the `head_rows` comment citing this issue is
where the collapsed default and the task tag landed). What was missing is the
half this PR ships: a per-kind enumeration that starts at the wire, covering
the six tool kinds nothing had tested from an entry at all, plus a
compiler-enforced statement of which kind has no sender.

**`Gate` is not added**, and the maintainer's own earlier comment on the issue
is why: "adding `TranscriptEntry` variants with no fold constructor is the
expressible-but-unreachable shape #4180 removed from this very module". The
engine emits `AgentEvent::GateBoard`, a whole board, and never a single gate,
so a `TranscriptEntry::Gate` would have no fold to build it and no producer to
give it one. It is declared as the single gap here and filed as #5651, which
also records the live consequence: `views/gate_board.rs`'s `settled_row` and
`views/transcript.rs`'s `EventKind::Gate` arm push the identical
`" · $0.00 · det"` literal, and only one of them can be reached. Choosing
between routing the board through `EventKind::Gate` and dropping the kind
moves SPEC 8.1's rendering and the deck goldens, which is a decision with its
own diff to read, not a line in a plumbing change.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-tui/src/render/tests/spine.rs`, both tests.

**The mechanism, since it could not be run here** (CLAUDE.md: CI builds and
tests, this laptop does not). The file is new, so on `main` neither test
exists and neither can pass. What makes it a witness rather than a restatement
is the second half: `declared`'s match is exhaustive over `EventKind`, so the
moment a kind is added to the vocabulary this file stops compiling until its
sender is named or its gap is cited. Nothing in the tree asked that question
before — `views/transcript/tests.rs`'s
`every_head_glyph_is_in_the_vocabulary` walks the same kinds and is satisfied
by a hand-built fixture, which is exactly how `EventKind::Gate` reached
`main` reachable from tests alone.

Exemplar followed: `crates/stella-protocol/src/event/consumers.rs` — one row
per signal, a posture per row, an issue number on every declared gap, and
totality enforced by the compiler rather than by a test.

## The gate

- [ ] `cargo fmt --check` — run as `cargo fmt --all` locally; CI checks it
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI
- [ ] `cargo test --workspace` — CI
- [x] Docs updated where behavior/flags changed — no behaviour change; the
      new module's own header carries the reasoning
- [x] CLA signed
- [x] `Closes #5030` appears both above and as a commit trailer

`make guards-fast` passes locally, `check-prose` and `check-file-size`
included.

Tests deleted: None.

## Nothing left behind

- [x] Filed: #5651 — the standalone gate row has no sender, and its price text
      is written in two places.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

No production code changes: the diff is one new test module plus its `mod`
line. No snapshot golden should move, because nothing that draws changed — if
CI says otherwise, that is a finding worth reading rather than blessing.

## Summary by Sourcery

Add wire-to-render coverage that verifies every live SPEC 6.3 transcript head is reachable and correctly drawn.

Enhancements:
- Add end-to-end transcript rendering coverage for every live SPEC 6.3 head kind, verifying wire events fold and draw with the expected labels and metadata.
- Make unsupported head kinds explicit through exhaustive producer declarations, documenting the unreachable gate head and its tracking issue.
- Verify task identifiers on live tool events render only when supplied by the wire event.

Tests:
- Add spine witness tests covering live tool, skill, memory, model, compaction, and unrecognised-tool transcript heads from AgentEvent through SessionModel rendering.