### PR TITLE
fix(stella-store): keep the store error a failed audit write carries

### DIFF
--- a/crates/stella-autonomy/src/stats.rs
+++ b/crates/stella-autonomy/src/stats.rs
@@ -133,6 +133,16 @@ pub struct SessionStats {
     pub turns_run: u32,
     /// Turns that stopped because they hit their spend ceiling.
     pub turns_over_budget: u32,
+
+    // -- what the record lost -----------------------------------------------
+    /// Audit writes the session gave up on. This many turns have a hole in
+    /// their record.
+    ///
+    /// It is counted because the record is the proof for the rest of this
+    /// list. A store that turns a write away does not stop the work. The loop
+    /// runs on and the hole is quiet, so the count is what makes it a number
+    /// a person can see.
+    pub audit_records_incomplete: u32,
 }
 
 impl SessionStats {

--- a/crates/stella-autonomy/src/stats.rs
+++ b/crates/stella-autonomy/src/stats.rs
@@ -317,6 +317,10 @@ mod tests {
             "turns_over_budget",
             "drive.rs — a turn hit its spend ceiling",
         ),
+        (
+            "audit_records_incomplete",
+            "self_driving_cmd/stats.rs — a store write the close-out lost",
+        ),
     ];
 
     /// **The witness.** Every field the report renders names the code that

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -43,6 +43,7 @@ use crate::runtime::{SystemClock, TokioSleeper};
 use crate::{OutputFormat, config::Config};
 use stella_context::EpisodeOutcome;
 
+pub(crate) mod audit_writes;
 mod budget;
 mod engine;
 mod goal;
@@ -62,6 +63,14 @@ mod summary;
 pub(crate) mod tool_stack;
 pub(crate) mod tools;
 mod turn_close;
+// The count of audit writes that were lost, and the warnings that name them.
+// A turn that could not write its own record says so through these. The turn
+// close-out sets the count. The run summary prints it. The self-driving loop
+// adds it up over a run.
+pub(crate) use audit_writes::{
+    dropped_audit_writes, note_child_dropped_audit_writes, take_dropped_audit_writes,
+    warn_dropped_audit_writes, warn_store_write_failed,
+};
 pub(crate) use budget::{build_budget_guard, remaining_budget, settle_reflection_budget};
 pub(crate) use graph_view::{graph_query_snapshot, graph_snapshot, graph_snapshot_focus};
 
@@ -84,13 +93,13 @@ pub(crate) use output::{
 pub(crate) use persistence::{
     PersistOutcome, ReasoningRun, begin_execution, close_event_stream, flush_reasoning_tail,
     persist_event, persist_owed, record_execution_end, seed_calibration, spawn_renderer,
-    warn_store_write_failed,
 };
 pub(crate) use presence::SessionPresence;
 pub(crate) use prompt::*;
 use reflect::reflect_on_interactive_turn;
 pub(crate) use reflect::surface_reflection;
 pub(crate) use skill_usage::stamp_and_record_skill_usage;
+pub(crate) use summary::RawRunSummary;
 pub(crate) use tools::*;
 
 /// Whether this process may touch durable workspace state, as the
@@ -155,34 +164,6 @@ pub async fn run_one_shot(
         invoked_skill,
     )
     .await
-}
-
-/// The `--output-format json` summary of a raw (`--no-pipeline`) step-loop run.
-/// A struct rather than `serde_json::json!` so the version leads the object
-/// (`json!` builds a sorted map and would bury it mid-envelope); key order is
-/// not contractual either way — this is for whoever reads the output by eye.
-///
-/// [`schema_version`](Self::schema_version) is governed by the bump rule on
-/// [`crate::SUMMARY_SCHEMA_VERSION`].
-#[derive(serde::Serialize)]
-pub(crate) struct RawRunSummary {
-    pub(crate) schema_version: u32,
-    pub(crate) status: &'static str,
-    pub(crate) text: Option<String>,
-    pub(crate) cost_usd: Option<f64>,
-    pub(crate) reason: Option<String>,
-    pub(crate) model: String,
-    pub(crate) events: Vec<AgentEvent>,
-    /// The file-touch telemetry envelope. Filled from the turn's own measured
-    /// `FileChange` events (`agent::summary::files_touched`) — the key stays
-    /// even on a quiet turn because the envelope's key set is the versioned
-    /// contract.
-    pub(crate) files_touched: serde_json::Value,
-    /// What this checkout's trust gate held back, or `null` (#4465). Folded
-    /// from the turn's own `SteeringWithheld` event, so this and the
-    /// `stream-json` carrier of the same fact are one event read twice.
-    /// Present on every raw summary for the same reason `files_touched` is.
-    pub(crate) withheld: serde_json::Value,
 }
 
 /// The REPL's productized command names — reserved: a custom definition can

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -68,8 +68,8 @@ mod turn_close;
 // close-out sets the count. The run summary prints it. The self-driving loop
 // adds it up over a run.
 pub(crate) use audit_writes::{
-    dropped_audit_writes, note_child_dropped_audit_writes, take_dropped_audit_writes,
-    warn_dropped_audit_writes, warn_store_write_failed,
+    note_child_dropped_audit_writes, take_dropped_audit_writes, warn_dropped_audit_writes,
+    warn_store_write_failed,
 };
 pub(crate) use budget::{build_budget_guard, remaining_budget, settle_reflection_budget};
 pub(crate) use graph_view::{graph_query_snapshot, graph_snapshot, graph_snapshot_focus};
@@ -99,7 +99,6 @@ pub(crate) use prompt::*;
 use reflect::reflect_on_interactive_turn;
 pub(crate) use reflect::surface_reflection;
 pub(crate) use skill_usage::stamp_and_record_skill_usage;
-pub(crate) use summary::RawRunSummary;
 pub(crate) use tools::*;
 
 /// Whether this process may touch durable workspace state, as the

--- a/crates/stella-cli/src/agent/audit_writes.rs
+++ b/crates/stella-cli/src/agent/audit_writes.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What happened when a turn could not write its audit record.
+//!
+//! Three writes close an execution: agent uses, MCP usage, and the outcome
+//! row. All three are best effort. A turn that ran is not less run because
+//! the store would not take a row. Saying why is not optional.
+//!
+//! A failed write keeps its [`StoreError`]. So the warning can name the
+//! SQLite result code, the database file, and whether a retry ran. A write
+//! turned away for a held lock is asked for again first, through
+//! [`stella_store::retry_busy`]. A write that is still lost is counted, so a
+//! run can say how much of its record is missing.
+//!
+//! The count is one [`AtomicU32`] for the whole process, because that is the
+//! shape of the thing it counts. A session's turns share one store across
+//! threads. A child turn of the self-driving loop reports its own count in
+//! the turn summary, and the loop adds it to this one.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use colored::Colorize;
+use stella_store::StoreError;
+
+/// Audit writes given up on since this process started.
+static DROPPED: AtomicU32 = AtomicU32::new(0);
+
+/// One audit write that never reached the store.
+#[derive(Debug)]
+pub(crate) struct DroppedWrite {
+    /// The record that was lost, named the way the warning shows it.
+    what: &'static str,
+    /// What the last attempt was refused with.
+    error: StoreError,
+    /// Attempts spent, retries included.
+    attempts: u32,
+}
+
+impl DroppedWrite {
+    /// One line to act on: the result code, whether the write was asked for
+    /// again, and what SQLite said.
+    ///
+    /// The code leads because it says where to look. `DatabaseBusy` points at
+    /// whatever else is writing the file. `ReadOnly` points at its file mode.
+    /// `Full` points at the disk.
+    fn diagnosis(&self) -> String {
+        let code = self
+            .error
+            .sqlite_code()
+            .map_or_else(|| "no SQLite code".to_owned(), |code| format!("{code:?}"));
+        let tries = if self.attempts > 1 {
+            format!("after {} attempts", self.attempts)
+        } else {
+            "not retried".to_owned()
+        };
+        format!(
+            "{what}: {code}, {tries} — {error}",
+            what = self.what,
+            error = self.error
+        )
+    }
+}
+
+/// Run one audit write. Ask again while the database is busy, and count the
+/// write if it is still turned away.
+///
+/// The count is kept here, not at the call sites, so the number and the
+/// warning cannot drift apart. A write is counted once, when it is given up
+/// on, whoever is closing the execution.
+pub(crate) fn audit_write(
+    what: &'static str,
+    write: impl FnMut() -> Result<(), StoreError>,
+) -> Option<DroppedWrite> {
+    let retry = stella_store::retry_busy(write);
+    match retry.outcome {
+        Ok(()) => None,
+        Err(error) => {
+            add(1);
+            Some(DroppedWrite {
+                what,
+                error,
+                attempts: retry.attempts,
+            })
+        }
+    }
+}
+
+/// Audit writes this process has given up on.
+pub(crate) fn dropped_audit_writes() -> u32 {
+    DROPPED.load(Ordering::Relaxed)
+}
+
+/// Read the count and set it back to zero. A caller adding it to a durable
+/// tally can then never count the same dropped write twice.
+pub(crate) fn take_dropped_audit_writes() -> u32 {
+    DROPPED.swap(0, Ordering::Relaxed)
+}
+
+/// Add what a child turn said it dropped.
+///
+/// The self-driving loop runs its turns in child processes. The drops it
+/// cares about happen where its own count cannot see them. The child prints
+/// its count in the turn summary, and the loop adds it here. That keeps one
+/// number true for both.
+pub(crate) fn note_child_dropped_audit_writes(count: u32) {
+    add(count);
+}
+
+fn add(count: u32) {
+    let _ = DROPPED.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(count))
+    });
+}
+
+/// The plain warning: a store write failed and `what` is now incomplete.
+///
+/// It is used for writes that have no error left to report, such as the
+/// prompt receipt. It is also the first line of
+/// [`warn_dropped_audit_writes`].
+pub(crate) fn warn_store_write_failed(what: &str) {
+    eprintln!(
+        "  {} store write failed — {what} for this execution is incomplete",
+        "⚠".yellow()
+    );
+}
+
+/// Warn about audit writes that were lost, naming each one and the file.
+pub(crate) fn warn_dropped_audit_writes(db_path: Option<&Path>, dropped: &[DroppedWrite]) {
+    if dropped.is_empty() {
+        return;
+    }
+    warn_store_write_failed("the audit record (agent uses / MCP usage / outcome)");
+    eprint!("{}", dropped_write_report(db_path, dropped));
+}
+
+/// The indented lines under the warning: one per lost write, then the file
+/// they were meant for.
+///
+/// It reads only what was lost, so both answers to "which file" can be tested
+/// without a database.
+fn dropped_write_report(db_path: Option<&Path>, dropped: &[DroppedWrite]) -> String {
+    let mut report = String::new();
+    for write in dropped {
+        report.push_str(&format!("      {}\n", write.diagnosis()));
+    }
+    let store = db_path.map_or_else(
+        || "in memory, so there is no file to inspect".to_owned(),
+        |path| path.display().to_string(),
+    );
+    report.push_str(&format!("      store: {store}\n"));
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{DroppedWrite, dropped_write_report};
+    use stella_store::{Store, StoreError};
+
+    /// A real turned-away write, so the code in the report is SQLite's own
+    /// and not one a test made up.
+    fn refused_write() -> StoreError {
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("run", "p", "anthropic", "claude")
+            .expect("execution");
+        let calls = [stella_store::McpUsageRow {
+            server: "github".into(),
+            tool: "search_issues".into(),
+            reason: String::new(),
+            called_at_ms: 1,
+        }];
+        store.record_mcp_usage(id, &calls).expect("first write");
+        store
+            .record_mcp_usage(id, &calls)
+            .expect_err("the seq is already taken")
+    }
+
+    /// **The witness.** A turned-away audit write is kept, counted, and
+    /// reported with the SQLite result code.
+    ///
+    /// The failure is a real one. The MCP usage table refuses a second row at
+    /// a `seq` it already holds, which is the clash `record_mcp_usage` names.
+    #[test]
+    fn a_refused_audit_write_is_counted_and_carries_its_code() {
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("run", "p", "anthropic", "claude")
+            .expect("execution");
+        let root = tempfile::tempdir().expect("root");
+        let registry = stella_tools::ToolRegistry::new(root.path().to_path_buf());
+        stella_core::mcp_usage::push_usage(
+            &registry.mcp_usage_ledger(),
+            stella_core::mcp_usage::McpUsageRecord::now("github", "search_issues", ""),
+        );
+        store
+            .record_mcp_usage(
+                id,
+                &[stella_store::McpUsageRow {
+                    server: "github".into(),
+                    tool: "search_issues".into(),
+                    reason: String::new(),
+                    called_at_ms: 1,
+                }],
+            )
+            .expect("occupy the seq the closeout will write");
+
+        let before = super::dropped_audit_writes();
+        let end = crate::agent::record_execution_end(&store, id, &registry, "completed", 0.0, true);
+
+        assert_eq!(super::dropped_audit_writes(), before + 1);
+        assert!(!end.write_ok, "the closeout knows the write was refused");
+        let report = dropped_write_report(store.db_path(), &end.dropped);
+        assert!(report.contains("MCP usage"), "{report}");
+        assert!(report.contains("ConstraintViolation"), "{report}");
+    }
+
+    #[test]
+    fn the_report_names_the_code_the_file_and_whether_a_retry_ran() {
+        let dropped = [DroppedWrite {
+            what: "MCP usage",
+            error: refused_write(),
+            attempts: 3,
+        }];
+
+        let report = dropped_write_report(Some(Path::new("/w/.stella/private/store.db")), &dropped);
+
+        assert!(report.contains("MCP usage"), "{report}");
+        assert!(report.contains("ConstraintViolation"), "{report}");
+        assert!(report.contains("after 3 attempts"), "{report}");
+        assert!(
+            report.contains("store: /w/.stella/private/store.db"),
+            "{report}"
+        );
+    }
+
+    /// A write that was tried once says so, so nobody reads one try as a
+    /// lock that was waited out.
+    #[test]
+    fn a_write_that_was_not_retried_says_so() {
+        let dropped = [DroppedWrite {
+            what: "the outcome",
+            error: refused_write(),
+            attempts: 1,
+        }];
+
+        let report = dropped_write_report(None, &dropped);
+
+        assert!(report.contains("not retried"), "{report}");
+        assert!(report.contains("in memory"), "{report}");
+    }
+}

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -1,5 +1,6 @@
 //! Event/telemetry persistence and execution closeout.
 
+use super::audit_writes::{DroppedWrite, audit_write};
 use super::*;
 use stella_core::ports::Clock;
 
@@ -478,7 +479,7 @@ fn defer_stream_terminal(
 /// cancelled execution can have the first true and the second false — every
 /// write succeeded, but the provider-side usage envelope is unknowably lost,
 /// not that anything failed to write.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct ExecutionEndOutcome {
     /// The agent-use, MCP-usage and outcome writes this function performs
     /// all reached the store.
@@ -486,6 +487,10 @@ pub(crate) struct ExecutionEndOutcome {
     /// Every fact this execution needs to export is present.
     /// `false` for a cancelled execution even when `write_ok` is true.
     pub(crate) audit_complete: bool,
+    /// The writes that were given up on, each with the error that refused it.
+    /// Empty whenever `write_ok` is true. Kept rather than collapsed, because
+    /// the SQLite result code is the only part of this an operator can act on.
+    pub(crate) dropped: Vec<DroppedWrite>,
 }
 
 impl ExecutionEndOutcome {
@@ -494,7 +499,7 @@ impl ExecutionEndOutcome {
     /// must hold. Equivalent to the pre-split `audit_complete && finish_ok`,
     /// since `audit_complete` already folds in the same write checks
     /// `write_ok` does.
-    pub(crate) fn fully_recorded(self) -> bool {
+    pub(crate) fn fully_recorded(&self) -> bool {
         self.write_ok && self.audit_complete
     }
 }
@@ -523,17 +528,35 @@ pub(crate) fn record_execution_end(
             kind: u.kind.as_str().to_string(),
         })
         .collect();
-    let uses_ok = uses.is_empty() || store.record_agent_uses(execution_id, &uses).is_ok();
+    let mut dropped = Vec::new();
+    // Each write keeps its `Err`, and a write refused because another
+    // connection held the lock is asked for again before it counts as lost —
+    // see [`audit_writes`] for why `.is_ok()` here was a hole in the record.
+    let uses_dropped = if uses.is_empty() {
+        None
+    } else {
+        audit_write("agent uses", || {
+            store.record_agent_uses(execution_id, &uses)
+        })
+    };
+    let uses_ok = uses_dropped.is_none();
+    dropped.extend(uses_dropped);
     let mcp_usage = mcp_usage_rows(registry);
-    let mcp_usage_ok = store.record_mcp_usage(execution_id, &mcp_usage).is_ok();
+    let mcp_dropped = audit_write("MCP usage", || {
+        store.record_mcp_usage(execution_id, &mcp_usage)
+    });
+    let mcp_usage_ok = mcp_dropped.is_none();
+    dropped.extend(mcp_dropped);
     // Cancellation can race a provider response after dispatch. Even when all
     // local writes succeed, the provider-side usage envelope is unknowable and
     // the execution must never become exportable.
     let terminal_usage_known = outcome_label != "cancelled";
     let audit_complete = persistence_complete && uses_ok && mcp_usage_ok && terminal_usage_known;
-    let finish_ok = store
-        .finish_execution_accounted(execution_id, outcome_label, cost_usd, audit_complete)
-        .is_ok();
+    let finish_dropped = audit_write("the outcome", || {
+        store.finish_execution_accounted(execution_id, outcome_label, cost_usd, audit_complete)
+    });
+    let finish_ok = finish_dropped.is_none();
+    dropped.extend(finish_dropped);
     let _ = store.materialize_tool_calls(execution_id);
     let _ = store.finalize_execution_reflection(execution_id);
     let _ = store.sync_to_usage_default(execution_id);
@@ -541,6 +564,7 @@ pub(crate) fn record_execution_end(
     ExecutionEndOutcome {
         write_ok: uses_ok && mcp_usage_ok && finish_ok,
         audit_complete,
+        dropped,
     }
 }
 
@@ -587,13 +611,6 @@ fn token_summary(partial: &stella_protocol::PartialUsage) -> String {
     } else {
         format!("{input} input ({qualifier}) + {output} output tokens")
     }
-}
-
-pub(crate) fn warn_store_write_failed(what: &str) {
-    eprintln!(
-        "  {} store write failed — {what} for this execution is incomplete",
-        "⚠".yellow()
-    );
 }
 
 /// Why an event's accounting came out incomplete — the distinction the old

--- a/crates/stella-cli/src/agent/summary.rs
+++ b/crates/stella-cli/src/agent/summary.rs
@@ -25,9 +25,48 @@
 
 use stella_protocol::event::AgentEvent;
 
-use super::RawRunSummary;
+use super::audit_writes::dropped_audit_writes;
 use crate::config::Config;
 use stella_core::TurnOutcome;
+
+/// The `--output-format json` summary of a raw (`--no-pipeline`) step-loop run.
+/// A struct rather than `serde_json::json!` so the version leads the object
+/// (`json!` builds a sorted map and would bury it mid-envelope); key order is
+/// not contractual either way — this is for whoever reads the output by eye.
+///
+/// It lives here, beside the code that fills it, rather than in `agent.rs`,
+/// which is a few lines under the 1500-line ceiling `make file-size` enforces
+/// and carries no baseline entry (AGENTS.md § *God files*).
+///
+/// [`schema_version`](Self::schema_version) is governed by the bump rule on
+/// [`crate::SUMMARY_SCHEMA_VERSION`].
+#[derive(serde::Serialize)]
+pub(crate) struct RawRunSummary {
+    pub(crate) schema_version: u32,
+    pub(crate) status: &'static str,
+    pub(crate) text: Option<String>,
+    pub(crate) cost_usd: Option<f64>,
+    pub(crate) reason: Option<String>,
+    pub(crate) model: String,
+    pub(crate) events: Vec<AgentEvent>,
+    /// The file-touch telemetry envelope. Filled from the turn's own measured
+    /// `FileChange` events (`agent::summary::files_touched`) — the key stays
+    /// even on a quiet turn because the envelope's key set is the versioned
+    /// contract.
+    pub(crate) files_touched: serde_json::Value,
+    /// What this checkout's trust gate held back, or `null`. Folded
+    /// from the turn's own `SteeringWithheld` event, so this and the
+    /// `stream-json` carrier of the same fact are one event read twice.
+    /// Present on every raw summary for the same reason `files_touched` is.
+    pub(crate) withheld: serde_json::Value,
+    /// Audit writes this turn gave up on — usually 0
+    /// ([`crate::agent::audit_writes`]).
+    ///
+    /// Carried because a self-driving loop runs its turns in child processes,
+    /// so the count only reaches the loop if the child says it. The loop reads
+    /// this key and folds it into `stella self-driving stats`.
+    pub(crate) audit_records_incomplete: u32,
+}
 
 /// Print the one-object JSON summary for a finished raw turn and record that
 /// the machine-readable contract has been satisfied, so `main`'s catch-all
@@ -55,6 +94,9 @@ pub(super) fn print_json_summary(cfg: &Config, outcome: &TurnOutcome, events: Ve
         model: format!("{}/{}", cfg.provider.id, cfg.model_id),
         files_touched: files_touched(&events),
         withheld: withheld(&events),
+        // Read after the execution has been closed out, which is where the
+        // count is moved (`agent::turn_close::close_turn`).
+        audit_records_incomplete: dropped_audit_writes(),
         events,
     };
     println!(

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -1170,6 +1170,7 @@ fn the_summary_envelope_leads_with_its_version() {
         events: Vec::new(),
         files_touched: serde_json::Value::Null,
         withheld: serde_json::Value::Null,
+        audit_records_incomplete: 0,
     };
 
     let encoded = serde_json::to_string(&raw).unwrap();

--- a/crates/stella-cli/src/agent/tests.rs
+++ b/crates/stella-cli/src/agent/tests.rs
@@ -1,3 +1,4 @@
+use super::summary::RawRunSummary;
 use super::*;
 use crate::config::{ConfiguredProvider, PROVIDERS, ProviderConfig};
 use stella_model::credential::ApiKey;

--- a/crates/stella-cli/src/agent/turn_close.rs
+++ b/crates/stella-cli/src/agent/turn_close.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use stella_store::Store;
 use stella_tools::ToolRegistry;
 
-use super::{record_execution_end, warn_store_write_failed};
+use super::{record_execution_end, warn_dropped_audit_writes, warn_store_write_failed};
 use crate::config::Config;
 
 /// How one turn ended, as the `executions` row records it.
@@ -63,18 +63,27 @@ pub(crate) fn close_turn(
     session_id: Option<&str>,
     outcome: TurnOutcomeRecord<'_>,
 ) {
-    if let Some((execution_store, id)) = execution
-        && !record_execution_end(
+    if let Some((execution_store, id)) = execution {
+        let end = record_execution_end(
             execution_store,
             *id,
             registry,
             outcome.label,
             outcome.cost_usd,
             outcome.persistence_complete,
-        )
-        .fully_recorded()
-    {
-        warn_store_write_failed("the audit record (agent uses / MCP usage / outcome)");
+        );
+        if end.dropped.is_empty() {
+            // No write failed, so there is no error to report. The record is
+            // short because the turn was cancelled, or because an event never
+            // reached the journal.
+            if !end.fully_recorded() {
+                warn_store_write_failed("the audit record (agent uses / MCP usage / outcome)");
+            }
+        } else {
+            // A write was turned away. That is the part a person can act on,
+            // so name the file, the result code, and whether we asked again.
+            warn_dropped_audit_writes(execution_store.db_path(), &end.dropped);
+        }
     }
     if let Some(session_id) = session_id {
         cfg.durability

--- a/crates/stella-cli/src/self_driving_cmd/stats.rs
+++ b/crates/stella-cli/src/self_driving_cmd/stats.rs
@@ -44,7 +44,31 @@ use super::work::WorkOutcome;
 /// caller's: `drive` escalates a failed issue and the `work` verb hands the
 /// failure straight back to whoever typed the command.
 pub(super) fn record_work(st: &LoopState, learned: LearningTally, outcome: &WorkOutcome) {
+    // Taken rather than read, so the same dropped write cannot be folded into
+    // the durable tally twice. Both producers land in that one counter: this
+    // process's own close-outs, and what the child turn reported.
+    fold_work(
+        st,
+        learned,
+        outcome,
+        crate::agent::take_dropped_audit_writes(),
+    );
+}
+
+/// The fold itself, over the dropped-write *count* rather than the process
+/// counter it comes from.
+///
+/// Split so these counters can be exercised without touching that counter: a
+/// test that reset it would race every other test in this binary, and the one
+/// test that does own it needs an exact number.
+fn fold_work(
+    st: &LoopState,
+    learned: LearningTally,
+    outcome: &WorkOutcome,
+    audit_records_incomplete: u32,
+) {
     st.update_stats(|s| {
+        s.audit_records_incomplete += audit_records_incomplete;
         // Both, for every outcome: the turn ran and the issue was attempted
         // whatever the turn then left behind. A one-shot invocation is a
         // session of one unit, not a unit outside every session — the `file`
@@ -142,6 +166,17 @@ pub(super) fn session_stats(st: &LoopState, format: QueryFormat) -> Result<(), S
     println!("  turns run       {:>5}", stats.turns_run);
     println!("  over budget     {:>5}", stats.turns_over_budget);
 
+    // Printed only when there is something to report. A zero here every run
+    // would train a reader to skip the line, and this is the line that says
+    // the rest of the numbers are missing a piece.
+    if stats.audit_records_incomplete > 0 {
+        println!(
+            "\nrecord\n  {} audit records incomplete this run — a store write was refused; \
+             the turn's own warning names the SQLite code and the file",
+            stats.audit_records_incomplete
+        );
+    }
+
     println!("\nyield");
     println!(
         "  inflation       {:>5}   created per closed; above 1.00 is losing ground",
@@ -194,7 +229,7 @@ mod tests {
         let st = loop_state(&dir);
         assert_eq!(st.stats(), stella_autonomy::SessionStats::default());
 
-        record_work(
+        fold_work(
             &st,
             LearningTally {
                 reflections: Some(3),
@@ -202,6 +237,7 @@ mod tests {
                 proposals: Some(2),
             },
             &changed(),
+            0,
         );
 
         let stats = st.stats();
@@ -211,6 +247,24 @@ mod tests {
         assert_eq!(stats.reflections_logged, 3);
         assert_eq!(stats.memories_created, 1);
         assert_eq!(stats.proposals_made, 2);
+    }
+
+    /// **Witness.** Audit writes the session gave up on reach the
+    /// session's counters, so `stella self-driving stats` can say how much of
+    /// the record is missing.
+    ///
+    /// Before this the count existed nowhere: each failed write was collapsed
+    /// to `.is_ok()`, warned about once, and forgotten.
+    #[test]
+    fn dropped_audit_writes_reach_the_session_counters() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let st = loop_state(&dir);
+        assert_eq!(st.stats().audit_records_incomplete, 0);
+
+        fold_work(&st, LearningTally::default(), &changed(), 2);
+        fold_work(&st, LearningTally::default(), &changed(), 1);
+
+        assert_eq!(st.stats().audit_records_incomplete, 3);
     }
 
     /// The three outcomes are three different counters, and the two that are
@@ -225,20 +279,22 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let st = loop_state(&dir);
 
-        record_work(&st, LearningTally::default(), &changed());
-        record_work(
+        fold_work(&st, LearningTally::default(), &changed(), 0);
+        fold_work(
             &st,
             LearningTally::default(),
             &WorkOutcome::NoChange {
                 why: "nothing to do".to_owned(),
             },
+            0,
         );
-        record_work(
+        fold_work(
             &st,
             LearningTally::default(),
             &WorkOutcome::Failed {
                 reason: "the turn exited 1".to_owned(),
             },
+            0,
         );
 
         let stats = st.stats();
@@ -260,12 +316,13 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let st = loop_state(&dir);
 
-        record_work(
+        fold_work(
             &st,
             LearningTally::default(),
             &WorkOutcome::Failed {
                 reason: "the turn exited 2 — budget exceeded".to_owned(),
             },
+            0,
         );
 
         let stats = st.stats();
@@ -284,7 +341,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let st = loop_state(&dir);
 
-        record_work(&st, LearningTally::default(), &changed());
+        fold_work(&st, LearningTally::default(), &changed(), 0);
 
         let stats = st.stats();
         assert_eq!(stats.issues_claimed, 0);

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -425,6 +425,10 @@ pub(super) fn run_turn(
         .map_err(|error| format!("the turn did not complete: {error}"))?;
 
     let summary = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    // A child turn counts the audit writes it gave up on, and this process is
+    // the only one that can add them up — the loop's own counter cannot see
+    // inside a child.
+    crate::agent::note_child_dropped_audit_writes(child_audit_drops(&summary));
     // Before the exit code is looked at, and deliberately: a turn that aborted
     // still spent, and its summary still carries the number. Charging only the
     // successes would let a run of failing turns spend without bound.
@@ -503,6 +507,23 @@ fn turn_command(exe: &Path, dir: &Path, state_root: &Path, flags: &TurnFlags) ->
         .arg("json");
     flags.push_onto(&mut cmd);
     cmd
+}
+
+/// How many audit writes the child turn reported giving up on.
+///
+/// Zero for a summary that cannot be parsed, or that carries no such key: an
+/// older binary reports nothing, and a number invented for it would be worse
+/// than none. The key is written by `agent::summary::print_json_summary`.
+fn child_audit_drops(summary: &str) -> u32 {
+    serde_json::from_str::<serde_json::Value>(summary)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("audit_records_incomplete")
+                .and_then(serde_json::Value::as_u64)
+        })
+        .and_then(|count| u32::try_from(count).ok())
+        .unwrap_or(0)
 }
 
 /// Pull the human-meaningful reason out of `stella run --output-format json`.
@@ -870,6 +891,22 @@ fn stale_attempt_hint(root: &Path, key: &str, error: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// **Witness.** The count of audit writes a child turn gave up on
+    /// is read out of the summary it printed.
+    ///
+    /// The turn runs in a child process, so the loop can learn this in no
+    /// other way. A summary with no such key — an older binary — is zero
+    /// rather than a guess.
+    #[test]
+    fn a_child_turns_dropped_audit_writes_are_read_from_its_summary() {
+        assert_eq!(
+            super::child_audit_drops(r#"{"status":"completed","audit_records_incomplete":2}"#),
+            2
+        );
+        assert_eq!(super::child_audit_drops(r#"{"status":"completed"}"#), 0);
+        assert_eq!(super::child_audit_drops("not json at all"), 0);
+    }
 
     /// A branch for a different issue is never mistaken for this one's.
     ///

--- a/crates/stella-store/src/busy.rs
+++ b/crates/stella-store/src/busy.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Asking again when the database says it is busy.
+//!
+//! WAL lets one writer work at a time. A second one that asks while the first
+//! holds the lock is turned away. It is not put in a queue. Store connections
+//! set a wait, so short holds pass by. What reaches a caller is a hold that
+//! lasted longer than that wait. A caller that takes it as final loses the row.
+//!
+//! [`retry_busy`] asks again a few times. It also says how many tries it took,
+//! so a caller knows whether a retry ran.
+//!
+//! [`is_busy`] is the test the file opener uses too. Both read it from here,
+//! so there is one answer to "was that the lock, or the data?".
+
+use std::time::Duration;
+
+use crate::Result;
+
+/// How many tries a busy write gets before it is dropped.
+const MAX_ATTEMPTS: u32 = 5;
+
+/// The wait before the second try. Each later wait doubles. Five tries wait
+/// 300 ms in all. That is long enough to outlast a peer turn's write, and
+/// short enough that a turn's exit never stalls on it.
+const FIRST_BACKOFF: Duration = Duration::from_millis(20);
+
+/// Whether a lock was held, rather than the query or the data being wrong.
+///
+/// Both codes mean "ask again later". One is another connection holding the
+/// write lock. The other is another query on this one.
+#[must_use]
+pub fn is_busy(error: &rusqlite::Error) -> bool {
+    matches!(
+        error.sqlite_error_code(),
+        Some(rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked)
+    )
+}
+
+/// How a write ended, and how many tries it took.
+#[derive(Debug)]
+pub struct BusyRetry<T> {
+    /// What the last attempt returned.
+    pub outcome: Result<T>,
+    /// Tries spent, counting the one that settled it. Never below 1.
+    pub attempts: u32,
+}
+
+impl<T> BusyRetry<T> {
+    /// Whether the write was asked for more than once.
+    #[must_use]
+    pub fn retried(&self) -> bool {
+        self.attempts > 1
+    }
+}
+
+/// Run `write`, asking again while a lock is held.
+///
+/// Any other failure comes back on the first try. A missing table or a bad
+/// value does not get better by waiting. Asking again would only make the
+/// same failure slower.
+///
+/// The write is run from the start each time, so it has to be safe to
+/// repeat. Each store write is one transaction, so a turned-away try wrote
+/// nothing.
+pub fn retry_busy<T>(mut write: impl FnMut() -> Result<T>) -> BusyRetry<T> {
+    let mut backoff = FIRST_BACKOFF;
+    for attempt in 1..MAX_ATTEMPTS {
+        match write() {
+            Err(error) if error.is_busy() => {
+                std::thread::sleep(backoff);
+                backoff *= 2;
+            }
+            outcome => {
+                return BusyRetry {
+                    outcome,
+                    attempts: attempt,
+                };
+            }
+        }
+    }
+    BusyRetry {
+        outcome: write(),
+        attempts: MAX_ATTEMPTS,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use rusqlite::Connection;
+
+    use super::{MAX_ATTEMPTS, retry_busy};
+    use crate::{Store, StoreError};
+
+    /// A workspace with a real `store.db`, plus the path to that file.
+    fn opened_workspace() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path()).expect("store");
+        drop(store);
+        let path = dir.path().join(".stella/private/store.db");
+        assert!(
+            path.exists(),
+            "the file the two connections will contend on"
+        );
+        (dir, path)
+    }
+
+    /// A connection that reports a held lock at once instead of waiting, so a
+    /// test never depends on how long a timeout is.
+    fn impatient(path: &Path) -> Connection {
+        let conn = Connection::open(path).expect("open");
+        conn.busy_timeout(std::time::Duration::ZERO)
+            .expect("no waiting");
+        conn
+    }
+
+    fn insert_one_use(conn: &Connection) -> crate::Result<()> {
+        conn.execute(
+            "INSERT INTO agent_uses (execution_id, agent, version, reason, kind) \
+             VALUES (1, 'reviewer', 1, '', 'definition')",
+            [],
+        )?;
+        Ok(())
+    }
+
+    /// **The witness.** A write refused because a competing transaction held
+    /// the write lock lands once that transaction commits. Before this helper
+    /// existed the first refusal was the whole answer, and the row was lost.
+    #[test]
+    fn a_write_refused_for_a_held_lock_lands_after_the_lock_clears() {
+        let (_dir, path) = opened_workspace();
+        let holder = impatient(&path);
+        let writer = impatient(&path);
+        holder
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("hold the write lock");
+
+        let mut attempt = 0;
+        let retry = retry_busy(|| {
+            attempt += 1;
+            // The competing turn commits between the first refusal and the
+            // second ask, which is the sequence this helper exists to survive.
+            if attempt == 2 {
+                holder.execute_batch("COMMIT").expect("release");
+            }
+            insert_one_use(&writer)
+        });
+
+        assert!(retry.outcome.is_ok(), "the row lands: {:?}", retry.outcome);
+        assert_eq!(retry.attempts, 2);
+        assert!(retry.retried());
+    }
+
+    /// Bounded: a lock nobody releases costs a fixed number of attempts and
+    /// then reports the code it was refused with.
+    #[test]
+    fn a_lock_that_never_clears_gives_up_after_a_bounded_number_of_attempts() {
+        let (_dir, path) = opened_workspace();
+        let holder = impatient(&path);
+        let writer = impatient(&path);
+        holder
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("hold the write lock");
+
+        let retry = retry_busy(|| insert_one_use(&writer));
+
+        assert_eq!(retry.attempts, MAX_ATTEMPTS);
+        let error = retry.outcome.expect_err("the lock is still held");
+        assert!(error.is_busy(), "and says so: {error}");
+        assert!(error.sqlite_code().is_some(), "with a code to report");
+    }
+
+    /// A failure that waiting cannot fix is answered at once. Retrying a
+    /// missing table would only make the same failure slower.
+    #[test]
+    fn a_failure_that_is_not_a_lock_is_answered_on_the_first_attempt() {
+        let (_dir, path) = opened_workspace();
+        let writer = impatient(&path);
+
+        let retry = retry_busy(|| {
+            writer.execute("INSERT INTO no_such_table (x) VALUES (1)", [])?;
+            Ok(())
+        });
+
+        assert_eq!(retry.attempts, 1);
+        assert!(!retry.retried());
+        let error = retry.outcome.expect_err("there is no such table");
+        assert!(!error.is_busy(), "not a lock: {error}");
+        assert!(matches!(error, StoreError::Sqlite(_)));
+    }
+}

--- a/crates/stella-store/src/error.rs
+++ b/crates/stella-store/src/error.rs
@@ -133,6 +133,27 @@ pub enum StoreError {
 }
 
 impl StoreError {
+    /// The SQLite result code behind this failure, when it has one.
+    ///
+    /// A caller reporting a dropped write needs the code, not the sentence:
+    /// `DatabaseBusy` sends an operator to whatever else is writing the file,
+    /// `ReadOnly` to its permissions, `Full` to the disk. Rendering it is the
+    /// caller's job; naming it is this crate's.
+    #[must_use]
+    pub fn sqlite_code(&self) -> Option<rusqlite::ErrorCode> {
+        match self {
+            Self::Sqlite(error) | Self::Corrupt { source: error, .. } => error.sqlite_error_code(),
+            _ => None,
+        }
+    }
+
+    /// Whether SQLite refused because a lock was held — see [`crate::busy`],
+    /// which owns the predicate and the retry built on it.
+    #[must_use]
+    pub fn is_busy(&self) -> bool {
+        matches!(self, Self::Sqlite(error) if crate::busy::is_busy(error))
+    }
+
     /// A filesystem failure, with the operation and path as context.
     pub(crate) fn io(context: impl Into<String>, source: std::io::Error) -> Self {
         Self::Io {

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -99,6 +99,7 @@ use stella_protocol::{AgentEvent, TaskStatus};
 //   ddl         (crate-private) every table/index DDL at the CURRENT schema
 //   dispatch    which turn dispatched which execution (#4628)
 //   migrations  (crate-private) versioned upgrades + the fresh-file bootstrap
+//   busy        the held-lock test and the retry built on it
 //   cache_gaps  per-call facts behind the `cache_expired_rewrite` counter
 //   cache_trend per-session cache trend — telemetry already persists these
 //               facts; this groups them by session for `stella stats`
@@ -122,6 +123,7 @@ use stella_protocol::{AgentEvent, TaskStatus};
 //   integrity   `PRAGMA quick_check`/`integrity_check` verdicts plus the
 //               opt-in, never-deleting quarantine behind `stella doctor`
 //   journal     append-only per-session sidecar journal (crash-safe resume)
+//   mcp_usage   the MCP call log and its fold
 //   notify      persist-until-read cross-session notifications
 //   prune       retention/deletion for `store.db`: the explicit
 //               execution-cascade delete `stella stats prune` drives (#616)
@@ -144,6 +146,7 @@ mod tests;
 mod tool_calls;
 
 pub mod agent_uses;
+pub mod busy;
 pub mod cache_gaps;
 pub mod cache_trend;
 pub mod catalog;
@@ -159,6 +162,7 @@ pub mod home;
 pub mod identity;
 pub mod integrity;
 pub mod journal;
+pub mod mcp_usage;
 pub mod notify;
 pub mod plan_graph;
 pub mod prune;
@@ -185,6 +189,7 @@ use migrations::{
 };
 
 pub use agent_uses::{AgentUseRow, KIND_DEFINITION, KIND_DELEGATION};
+pub use busy::{BusyRetry, is_busy, retry_busy};
 pub use cache_gaps::CacheCallGap;
 pub use catalog::CatalogStore;
 pub use drain::{
@@ -206,6 +211,7 @@ pub use session_stats::{PROMPT_SAMPLE, SessionStats};
 // live-session durability — two different artifacts that happen to share a
 // natural name. Reach the writer through its module.
 pub use journal::JournalRecord;
+pub use mcp_usage::{McpUsageRow, McpUsageStat, fold_mcp_usage_stats};
 pub use notify::{Notification, NotificationStore};
 pub use private::{
     WORKSPACE_PRIVATE_DIR, append_workspace_private_line, existing_workspace_private_sqlite_path,
@@ -360,32 +366,6 @@ pub struct MemoryCitationStats {
     /// harm to surface a memory multiple agents verified as wrong. Only
     /// `stella memory unquarantine` clears it.
     pub quarantined: bool,
-}
-
-/// One MCP tool call, ready to persist: which server + tool, an optional
-/// reason (best-effort — external MCP tools rarely carry one), and the call
-/// time in epoch millis. Unlike a file-touch (aggregated per path), this is a
-/// per-call log row, so repeat calls to the same tool are distinct rows.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct McpUsageRow {
-    pub server: String,
-    pub tool: String,
-    pub reason: String,
-    pub called_at_ms: i64,
-}
-
-/// Per-(server, tool) MCP usage aggregate — the data behind the MCP tab's
-/// "N calls" column and `stella mcp usage`. Ordered most-used first.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct McpUsageStat {
-    pub server: String,
-    pub tool: String,
-    /// How many times this tool was called (all executions).
-    pub calls: i64,
-    /// The most recent non-empty reason recorded, or empty if none ever was.
-    pub last_reason: String,
-    /// Epoch millis of the most recent call.
-    pub last_called_at_ms: i64,
 }
 
 /// One extension-authored workspace rule, as stored: the full rule markdown
@@ -613,6 +593,10 @@ pub struct Store {
     /// path-derived) without threading the root through every call site.
     /// `None` for in-memory/ephemeral stores.
     root: Option<PathBuf>,
+    /// The file this connection is open on. `None` in memory. It is kept so
+    /// that a write which fails can name the file to go and look at. That is
+    /// the one part of the failure a person can act on.
+    db_path: Option<PathBuf>,
 }
 
 impl Store {
@@ -669,6 +653,13 @@ impl Store {
         self.root.as_deref()
     }
 
+    /// The file this store writes to. `None` when it is in memory. It is the
+    /// same path the store was opened on, and it does not change.
+    #[must_use]
+    pub fn db_path(&self) -> Option<&Path> {
+        self.db_path.as_deref()
+    }
+
     /// `db_path` is the on-disk file behind `conn` (`None` for in-memory), and
     /// exists only so an unreadable file can be named in the error — see
     /// [`corrupt_store_error`], and [`Store::migrate_and_prepare_exports`] for
@@ -697,6 +688,7 @@ impl Store {
         let store = Self {
             conn: Mutex::new(conn),
             root,
+            db_path: db_path.map(Path::to_path_buf),
         };
         store.migrate_and_prepare_exports(db_path)?;
         Ok(store)
@@ -1091,58 +1083,6 @@ impl Store {
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
-    }
-
-    /// Persist the MCP tool calls recorded during an execution: one row per
-    /// call, in drain order. `seq` (the batch index) with UNIQUE
-    /// (execution_id, seq) makes re-persisting the same drained batch an error
-    /// rather than a silent double-count. One transaction — see
-    /// [`Self::record_files_touched`] — so a collision partway through leaves
-    /// no partial batch behind, and a corrected retry is possible.
-    pub fn record_mcp_usage(&self, execution_id: i64, calls: &[McpUsageRow]) -> Result<()> {
-        let mut conn = self.lock();
-        let tx = conn.transaction()?;
-        for (seq, row) in calls.iter().enumerate() {
-            tx.execute(
-                "INSERT INTO mcp_usage \
-                 (execution_id, seq, server, tool, reason, called_at_ms) \
-                 VALUES (?, ?, ?, ?, ?, ?)",
-                params![
-                    execution_id,
-                    seq as i64,
-                    row.server,
-                    row.tool,
-                    row.reason,
-                    row.called_at_ms,
-                ],
-            )?;
-        }
-        tx.commit()?;
-        Ok(())
-    }
-
-    /// Per-(server, tool) MCP usage aggregates ([`McpUsageStat`]) — the data
-    /// behind the MCP tab's call counts and `stella mcp usage`. Most-used
-    /// first (ties broken by server then tool, so output is deterministic).
-    pub fn mcp_usage_stats(&self) -> Result<Vec<McpUsageStat>> {
-        let conn = self.lock();
-        let mut stmt = conn.prepare(
-            "SELECT server, tool, reason, called_at_ms FROM mcp_usage \
-             ORDER BY called_at_ms ASC, rowid ASC",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(McpUsageRow {
-                server: row.get(0)?,
-                tool: row.get(1)?,
-                reason: row.get(2)?,
-                called_at_ms: row.get(3)?,
-            })
-        })?;
-        let mut calls = Vec::new();
-        for row in rows {
-            calls.push(row?);
-        }
-        Ok(fold_mcp_usage_stats(&calls))
     }
 
     /// Append a durable reflection/lesson, returning its row id.
@@ -1616,42 +1556,6 @@ impl Store {
                 })?;
         Ok(count)
     }
-}
-
-/// Fold chronologically-ordered MCP usage rows into per-(server, tool)
-/// aggregates: a call count, the most recent non-empty reason, and the latest
-/// call time. Input is expected in ascending call-time order (the shape
-/// [`Store::mcp_usage_stats`]'s query produces); output is most-used first,
-/// ties broken by server then tool for determinism.
-pub fn fold_mcp_usage_stats(rows: &[McpUsageRow]) -> Vec<McpUsageStat> {
-    use std::collections::BTreeMap;
-    let mut by_key: BTreeMap<(String, String), McpUsageStat> = BTreeMap::new();
-    for row in rows {
-        let entry = by_key
-            .entry((row.server.clone(), row.tool.clone()))
-            .or_insert_with(|| McpUsageStat {
-                server: row.server.clone(),
-                tool: row.tool.clone(),
-                calls: 0,
-                last_reason: String::new(),
-                last_called_at_ms: 0,
-            });
-        entry.calls += 1;
-        // Rows arrive in ascending time order, so the last non-empty reason
-        // seen is the most recent one.
-        if !row.reason.is_empty() {
-            entry.last_reason = row.reason.clone();
-        }
-        entry.last_called_at_ms = entry.last_called_at_ms.max(row.called_at_ms);
-    }
-    let mut stats: Vec<McpUsageStat> = by_key.into_values().collect();
-    stats.sort_by(|a, b| {
-        b.calls
-            .cmp(&a.calls)
-            .then_with(|| a.server.cmp(&b.server))
-            .then_with(|| a.tool.cmp(&b.tool))
-    });
-    stats
 }
 
 /// Fold chronologically-ordered citations (grouped by `memory_id` — the shape

--- a/crates/stella-store/src/mcp_usage.rs
+++ b/crates/stella-store/src/mcp_usage.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The `mcp_usage` call log. One row per MCP tool call under an execution,
+//! drained once per execution from the ledger `stella-mcp` writes to.
+//!
+//! It sits beside [`crate::agent_uses`] for the reason that module gives.
+//! `lib.rs` is a god file closed to growth (AGENTS.md § *God files*), so a
+//! table's rows, its writer and its reader live in the table's own module.
+//!
+//! Nothing is summed on the way in. Each call is its own row, because the
+//! thing being counted is "this tool ran under this execution at this time".
+//! [`fold_mcp_usage_stats`] sums them on the way out.
+
+use rusqlite::params;
+
+use crate::{Result, Store};
+
+/// One MCP tool call, ready to store: the server, the tool, a reason if the
+/// call carried one, and the time in epoch millis. Outside tools rarely give
+/// a reason. Each call is its own row, so two calls to one tool are two rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpUsageRow {
+    pub server: String,
+    pub tool: String,
+    pub reason: String,
+    pub called_at_ms: i64,
+}
+
+/// One server and tool, with its call count. This is what the MCP tab's
+/// "N calls" column shows. Most used first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpUsageStat {
+    pub server: String,
+    pub tool: String,
+    /// How many times this tool was called, across all executions.
+    pub calls: i64,
+    /// The last reason given, or empty if no call gave one.
+    pub last_reason: String,
+    /// The time of the last call, in epoch millis.
+    pub last_called_at_ms: i64,
+}
+
+impl Store {
+    /// Store one execution's MCP tool calls, one row per call, in drain
+    /// order. `seq` is the index in the batch, and the table holds it unique
+    /// per execution. So writing the same drained batch twice is an error
+    /// rather than a quiet double count. It is one transaction, like
+    /// [`Store::record_files_touched`]. A clash part way through leaves no
+    /// half batch behind, so a fixed batch can be written again.
+    pub fn record_mcp_usage(&self, execution_id: i64, calls: &[McpUsageRow]) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        for (seq, row) in calls.iter().enumerate() {
+            tx.execute(
+                "INSERT INTO mcp_usage \
+                 (execution_id, seq, server, tool, reason, called_at_ms) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+                params![
+                    execution_id,
+                    seq as i64,
+                    row.server,
+                    row.tool,
+                    row.reason,
+                    row.called_at_ms,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Call counts per server and tool ([`McpUsageStat`]). This is what the
+    /// MCP tab and `stella mcp usage` show. Most used first, with ties broken
+    /// by server then tool, so the order never wobbles.
+    pub fn mcp_usage_stats(&self) -> Result<Vec<McpUsageStat>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT server, tool, reason, called_at_ms FROM mcp_usage \
+             ORDER BY called_at_ms ASC, rowid ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(McpUsageRow {
+                server: row.get(0)?,
+                tool: row.get(1)?,
+                reason: row.get(2)?,
+                called_at_ms: row.get(3)?,
+            })
+        })?;
+        let mut calls = Vec::new();
+        for row in rows {
+            calls.push(row?);
+        }
+        Ok(fold_mcp_usage_stats(&calls))
+    }
+}
+
+/// Sum rows in time order into one row per server and tool: how many calls,
+/// the last reason given, and the last call time. Rows have to arrive oldest
+/// first, which is the order [`Store::mcp_usage_stats`] reads them in. The
+/// result is most used first, with ties broken by server then tool.
+pub fn fold_mcp_usage_stats(rows: &[McpUsageRow]) -> Vec<McpUsageStat> {
+    use std::collections::BTreeMap;
+    let mut by_key: BTreeMap<(String, String), McpUsageStat> = BTreeMap::new();
+    for row in rows {
+        let entry = by_key
+            .entry((row.server.clone(), row.tool.clone()))
+            .or_insert_with(|| McpUsageStat {
+                server: row.server.clone(),
+                tool: row.tool.clone(),
+                calls: 0,
+                last_reason: String::new(),
+                last_called_at_ms: 0,
+            });
+        entry.calls += 1;
+        // Rows arrive oldest first, so the last reason seen is the newest.
+        if !row.reason.is_empty() {
+            entry.last_reason = row.reason.clone();
+        }
+        entry.last_called_at_ms = entry.last_called_at_ms.max(row.called_at_ms);
+    }
+    let mut stats: Vec<McpUsageStat> = by_key.into_values().collect();
+    stats.sort_by(|a, b| {
+        b.calls
+            .cmp(&a.calls)
+            .then_with(|| a.server.cmp(&b.server))
+            .then_with(|| a.tool.cmp(&b.tool))
+    });
+    stats
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(server: &str, tool: &str, reason: &str, at: i64) -> McpUsageRow {
+        McpUsageRow {
+            server: server.to_string(),
+            tool: tool.to_string(),
+            reason: reason.to_string(),
+            called_at_ms: at,
+        }
+    }
+
+    /// Writing a drained batch twice is refused, not counted twice. The
+    /// closeout leans on that when it asks again.
+    #[test]
+    fn the_same_batch_written_twice_is_refused() {
+        let store = Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("run", "p", "anthropic", "claude")
+            .expect("execution");
+        let calls = [call("github", "search_issues", "", 10)];
+
+        store.record_mcp_usage(id, &calls).expect("first write");
+        let again = store
+            .record_mcp_usage(id, &calls)
+            .expect_err("the seq is already taken");
+        assert!(again.sqlite_code().is_some(), "SQLite names it: {again}");
+    }
+
+    #[test]
+    fn folding_orders_by_calls_and_keeps_the_last_reason() {
+        let stats = fold_mcp_usage_stats(&[
+            call("github", "search_issues", "find the bug", 10),
+            call("fs", "read", "", 20),
+            call("github", "search_issues", "", 30),
+        ]);
+
+        assert_eq!(stats.len(), 2);
+        assert_eq!(stats[0].tool, "search_issues");
+        assert_eq!(stats[0].calls, 2);
+        assert_eq!(stats[0].last_reason, "find the bug");
+        assert_eq!(stats[0].last_called_at_ms, 30);
+    }
+}

--- a/crates/stella-store/src/migrations/pragmas.rs
+++ b/crates/stella-store/src/migrations/pragmas.rs
@@ -129,10 +129,10 @@ pub(crate) fn initialize_store_pragmas(
              PRAGMA foreign_keys=ON;"
         ));
         match result {
-            Err(error)
-                if attempts < BUSY_ATTEMPTS
-                    && error.sqlite_error_code() == Some(rusqlite::ErrorCode::DatabaseBusy) =>
-            {
+            // The predicate is [`crate::busy::is_busy`] rather than a code
+            // compared here, so this opener and every retried write agree on
+            // what counts as a held lock.
+            Err(error) if attempts < BUSY_ATTEMPTS && crate::busy::is_busy(&error) => {
                 attempts += 1;
                 std::thread::sleep(BUSY_BACKOFF);
             }

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -167,6 +167,19 @@ Asking a loop to stop when it's already stopping is not an error. The output tel
 
 stella writes these stats after **every step**, not just at the end. Since the loop never stops on its own, a report written only on exit would never get written at all — the point is a record you can read while the loop is still running. Each write is atomic, so a dashboard reading the file mid-write always sees the last complete version, never a half-written one.
 
+#### Audit records
+
+When the store refuses a write, the turn keeps going and the record of that turn does not. stella counts every audit write it gives up on and adds one line for them:
+
+```
+record
+  3 audit records incomplete this run — a store write was refused; the turn's own warning names the SQLite code and the file
+```
+
+The line appears only when the count is above zero. The turn that lost the write also warns at the time, and that warning names the database file, the SQLite result code (`DatabaseBusy`, `ReadOnly`, `Full`), and whether stella asked again. A busy or locked database is retried a few times, with a growing pause between tries, before a write counts as lost — so a turn that only had to wait its turn still writes its record.
+
+A turn runs in a child process, so it reports its own count in the turn summary and the loop adds that to the session's.
+
 #### Ratios
 
 A raw count only tells you how busy the loop was, which always looks good. The ratios below tell you whether the work was worth it, and each can look bad for a real reason:


### PR DESCRIPTION
## What and why

`record_execution_end` closed an execution with three writes — agent uses, MCP usage, the outcome row — and collapsed each one to `.is_ok()` before anyone looked at it. The operator got one fixed sentence: *store write failed — the audit record for this execution is incomplete*. A locked database, a read-only file and a full disk all printed that same line, the typed `StoreError` one call away was never read, and nothing anywhere counted how often it happened. That is the hole in the audit trail #5626 describes, seen once per `drive --backlog` run.

Three changes:

1. **Keep the error.** `ExecutionEndOutcome` now carries the writes that were given up on, each with its `StoreError` and the number of tries spent. `warn_dropped_audit_writes` (`crates/stella-cli/src/agent/audit_writes.rs`) prints the database file, the SQLite result code (`DatabaseBusy`, `ReadOnly`, `Full`, …) and whether a retry ran. `Store::db_path` is the file the store actually opened, rather than a path the CLI rebuilds.
2. **Retry a held lock.** `stella_store::retry_busy` (`crates/stella-store/src/busy.rs`) asks again up to five times, waiting 20 ms and doubling, and reports the try count. Its predicate `is_busy` is the one `migrations::pragmas` already used to absorb a concurrent first open — that call site now reads it from here instead of comparing a code inline, so there is one answer to "was that the lock, or the data?" (it also widens the opener from `SQLITE_BUSY` alone to `SQLITE_LOCKED` as well, which is the same bounded wait).
3. **Count what is still lost.** A dropped write bumps a process-wide `AtomicU32`. A turn prints its count in the `--output-format json` summary (`audit_records_incomplete`); the self-driving loop reads that back out of the child turn's summary and folds it, with its own drops, into `SessionStats::audit_records_incomplete`, which `stella self-driving stats` renders as `N audit records incomplete this run`. Without the child hop the number would always be zero for a drive run, because `work` spawns `stella run` rather than dispatching in-process.

Typed end to end: no new `Result<_, String>`; the two new public accessors on `StoreError` (`sqlite_code`, `is_busy`) are what let a caller branch instead of reading prose.

## Witnesses and how each one fails on `main`

- `crates/stella-store/src/busy.rs::a_write_refused_for_a_held_lock_lands_after_the_lock_clears` — two connections on a real `store.db`, both with `busy_timeout` at zero so the test never waits on a clock. One holds `BEGIN IMMEDIATE`; the write is refused, the holder commits between the first refusal and the second ask, and the row lands on try 2. Fails on `main` by construction: `retry_busy` does not exist there, and the first refusal was the whole answer.
- `…::a_lock_that_never_clears_gives_up_after_a_bounded_number_of_attempts` — the same contention with no release: five tries, then the busy code is reported rather than swallowed.
- `…::a_failure_that_is_not_a_lock_is_answered_on_the_first_attempt` — a missing table is not retried.
- `crates/stella-cli/src/agent/audit_writes.rs::a_refused_audit_write_is_counted_and_carries_its_code` — the end-to-end one. The `mcp_usage` table refuses a second row at a `seq` it already holds, so the closeout's write is genuinely turned away: the drop counter moves by exactly one and the report names `MCP usage` and `ConstraintViolation`. On `main` there is no counter and no code — `.is_ok()` had already thrown the error away.
- `…::the_report_names_the_code_the_file_and_whether_a_retry_ran` and `…::a_write_that_was_not_retried_says_so` — the rendering, both "which file" branches.
- `crates/stella-cli/src/self_driving_cmd/stats.rs::dropped_audit_writes_reach_the_session_counters` — the count reaches `SessionStats`.
- `crates/stella-cli/src/self_driving_cmd/work.rs::a_child_turns_dropped_audit_writes_are_read_from_its_summary` — the child hop, including an older binary's summary with no such key reading as 0.

Contention through `Store::record_agent_uses` itself would need the competing transaction held for more than the store's own five-second `busy_timeout` before any busy error exists to retry; the witness reproduces the same refusal on the same table with a zero timeout instead, which is the same code path with a deterministic clock rather than a six-second sleep.

## Two moves the god-file rule forced

`crates/stella-store/src/lib.rs` is grandfathered and closed to growth, so declaring a new module there had to be paid for: the `mcp_usage` table's rows, writer and reader move into `crates/stella-store/src/mcp_usage.rs`, beside the `agent_uses` module they mirror (that module is the exemplar followed — same shape, same doc structure). Net effect on `lib.rs` is −99 lines. `RawRunSummary` likewise moved from `agent.rs` (7 lines under the 1500 ceiling, no baseline entry) into `agent/summary.rs`, the module that builds it. Both are pure moves plus re-exports; every public path is unchanged.

## Docs

`website/content/docs/commands/self-driving.mdx` gains an *Audit records* subsection under `stats`: what the line means, when it appears, and that a busy database is retried before a write counts as lost.

Tests deleted: None.

Closes #5626

## Summary by Sourcery

Preserve, retry, report, and count audit writes that fail during execution closeout.

New Features:
- Report incomplete audit records with actionable SQLite error codes, database paths, and retry information.
- Track dropped audit writes across individual turns and self-driving sessions, including child turn summaries and JSON statistics.
- Retry audit writes that fail because SQLite is busy or locked before treating them as lost.

Bug Fixes:
- Preserve previously discarded store errors during execution closeout instead of reducing audit write failures to boolean status.
- Recognize both busy and locked SQLite failures consistently during store initialization and audit writes.

Enhancements:
- Expose typed SQLite error-code and lock-status accessors on StoreError and the actual opened database path on Store.
- Move MCP usage persistence into its dedicated store module and relocate the raw run summary alongside its construction.

Documentation:
- Document incomplete audit record reporting and bounded retries in the self-driving command guide.

Tests:
- Add coverage for busy-lock retries, bounded retry exhaustion, non-lock failures, detailed audit failure reporting, and session-level propagation of dropped audit writes.