### PR TITLE
fix(stella-core): close the tool-call pairing on every top-of-step abort

### DIFF
--- a/crates/stella-core/src/driver/drive.rs
+++ b/crates/stella-core/src/driver/drive.rs
@@ -66,6 +66,16 @@ use super::{Engine, TurnOutcome, bus, lifecycle, settlement, step_cap_reason};
 use crate::event_sender::EventSender;
 use crate::step::{AbortKind, TurnState};
 
+/// The `ToolOutput::Error` that closes a `tool_use` left open when the step
+/// cap ends the turn.
+///
+/// A cap reached after a step lands on a well-paired transcript, so this
+/// finds nothing to close. A cap already met on entry does not: the transcript
+/// is still the caller's own, and a caller resuming at `max_steps` can hand in
+/// a tail nothing answered. Closing it is the repair every other exit at this
+/// boundary performs.
+const STEP_CAP_TOOL_RESULT: &str = "not executed — turn aborted at the step cap";
+
 impl Engine<'_> {
     /// Drive `state` to an ordinary end: a loop over [`Engine::run_step`],
     /// wrapped in the turn framing and the checkpoint and halt obligations a
@@ -117,6 +127,11 @@ impl Engine<'_> {
                 // failure: the run stopped by policy, it did not fall over
                 // (#1524).
                 let reason = step_cap_reason(self.config.max_steps);
+                crate::step::close_open_tool_calls(
+                    state.messages_mut(),
+                    STEP_CAP_TOOL_RESULT,
+                    events,
+                );
                 let _ = events.send(AgentEvent::Error {
                     message: reason.clone(),
                     retryable: false,

--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -82,6 +82,16 @@ use super::{EngineConfig, LOOP_STEER_PREFIX, TurnMemos, TurnOutcome};
 /// the number.
 pub(crate) const MAX_LOOP_STEERS: u32 = 2;
 
+/// The `ToolOutput::Error` that closes a `tool_use` left open when the ladder
+/// aborts the turn.
+///
+/// The abort fires at the top of a step, so the open call belongs to history
+/// the caller handed in — a resumed turn, or a reused transcript. Closing it
+/// is the same repair the cancel and soft-stop exits perform at this
+/// boundary, and without it the caller's next provider call is rejected for
+/// an unanswered `tool_use`.
+const LOOP_ABORT_TOOL_RESULT: &str = "not executed — turn aborted on a detected loop";
+
 /// How many stalled-turn warnings one turn may spend.
 ///
 /// The stall rung's warn-once is read off the transcript, and that is
@@ -388,6 +398,7 @@ pub(super) fn check_loop_detection(
         return None;
     };
     let reason = abort_reason(&warned, &identity, &evidence);
+    crate::step::close_open_tool_calls(messages, LOOP_ABORT_TOOL_RESULT, events);
     let _ = events.send(AgentEvent::Error {
         message: reason.clone(),
         retryable: false,

--- a/crates/stella-core/src/driver/overflow_recovery.rs
+++ b/crates/stella-core/src/driver/overflow_recovery.rs
@@ -71,6 +71,17 @@ use crate::step::{AbortKind, StepOutcome, TurnState};
 /// window, which compaction cannot fix.
 pub(crate) const MAX_RECOVERY_RUNGS: u8 = 2;
 
+/// The `ToolOutput::Error` that closes a `tool_use` left open when a model
+/// call ends the turn instead of committing — the retry ladder exhausted, or
+/// a recovery ladder spent.
+///
+/// The failed call appended nothing, so the open call belongs to history the
+/// caller handed in. It is closed for the reason the `SoftStopped` arm beside
+/// it closes one: the caller's `messages` is reused on the next turn, and a
+/// provider rejects an unanswered `tool_use` outright.
+const MODEL_CALL_FAILED_TOOL_RESULT: &str =
+    "not executed — turn aborted after the model call could not complete";
+
 /// Per-turn latch and budget clamp for reactive overflow recovery. Pure data,
 /// no I/O (AGENTS.md #2); lives on [`TurnState`] and dies with the turn.
 #[derive(Debug, Default)]
@@ -222,7 +233,15 @@ impl<'a> Engine<'a> {
                 ) {
                     return None;
                 }
-                // No fallback: surface the pre-#2679 terminal shape.
+                // No fallback: surface the pre-#2679 terminal shape. The
+                // pairing repair comes first so the synthetic results reach
+                // the stream ahead of the terminal events, matching the order
+                // `Engine::handle_committed_result` emits them in.
+                crate::step::close_open_tool_calls(
+                    &mut state.messages,
+                    MODEL_CALL_FAILED_TOOL_RESULT,
+                    events,
+                );
                 let _ = events.send(AgentEvent::RetriesExhausted {
                     turn_instance: self.config.turn_instance,
                     attempts: attempt_reasons.len() as u32,
@@ -351,13 +370,21 @@ impl<'a> Engine<'a> {
     /// The terminal shape a spent recovery ladder produces — shared by both
     /// ladders so an exhausted recovery is indistinguishable downstream from
     /// a failure that never had a recovery to spend.
+    ///
+    /// `state` is taken mutably to close any `tool_use` the caller's history
+    /// left open, the same repair the arms above perform.
     fn surface_unrecovered(
         &self,
         message: String,
         attempt_reasons: Vec<String>,
-        state: &TurnState,
+        state: &mut TurnState,
         events: &EventSender,
     ) -> StepOutcome {
+        crate::step::close_open_tool_calls(
+            &mut state.messages,
+            MODEL_CALL_FAILED_TOOL_RESULT,
+            events,
+        );
         let retryable = false;
         let _ = events.send(AgentEvent::RetriesExhausted {
             turn_instance: self.config.turn_instance,

--- a/crates/stella-core/src/driver/settlement.rs
+++ b/crates/stella-core/src/driver/settlement.rs
@@ -1,4 +1,4 @@
-use stella_protocol::{AgentEvent, MessageRole};
+use stella_protocol::{AgentEvent, CompletionMessage, MessageRole};
 
 use super::TurnOutcome;
 use crate::TurnState;
@@ -29,6 +29,14 @@ impl BudgetWarnings {
         !std::mem::replace(slot, true)
     }
 }
+
+/// The `ToolOutput::Error` that closes a `tool_use` left open when the task
+/// deadline stops the turn.
+///
+/// Its own wording, not [`super::BUDGET_ABORT_TOOL_RESULT`]'s. A turn out of
+/// clock is not a turn out of money, and this text is where a reader looks to
+/// find out why the call never ran.
+const DEADLINE_ABORT_TOOL_RESULT: &str = "not executed — turn stopped at the task deadline";
 
 pub(super) fn axis_label(axis: BudgetAxis) -> &'static str {
     match axis {
@@ -146,6 +154,7 @@ impl super::Engine<'_> {
             state.total_cost_usd += child_spend;
         }
         check_budget(
+            &mut state.messages,
             &state.budget,
             state.total_cost_usd,
             state.last_step,
@@ -164,7 +173,15 @@ impl super::Engine<'_> {
 /// `run_step_inner`, so a task already out of wall clock stops here just
 /// like an already-over-cap dollar budget does, before the next provider
 /// call is dispatched.
+///
+/// `messages` is taken mutably for the abort arms. Both fire at the top of a
+/// step. The transcript there is still the caller's own, and a caller can hand
+/// one in whose last `tool_use` nothing answered. Each arm closes that pairing
+/// before it returns, the way `Engine::handle_committed_result` does one
+/// boundary later. Hand back an open call and the caller's next provider call
+/// is rejected.
 fn check_budget(
+    messages: &mut Vec<CompletionMessage>,
     budget: &BudgetGuard,
     total_cost_usd: f64,
     last_step: Option<std::time::Duration>,
@@ -203,6 +220,7 @@ fn check_budget(
         DeadlineOutcome::Continue => None,
     };
     if let Some(reason) = reason {
+        crate::step::close_open_tool_calls(messages, DEADLINE_ABORT_TOOL_RESULT, events);
         let _ = events.send(AgentEvent::Error {
             message: reason.clone(),
             retryable: false,
@@ -227,6 +245,7 @@ fn check_budget(
     let axis = axis_label(axis);
     let reason =
         format!("budget exceeded: spent ${spent_usd:.4} against a ${limit_usd:.2} {axis} limit");
+    crate::step::close_open_tool_calls(messages, super::BUDGET_ABORT_TOOL_RESULT, events);
     let _ = events.send(AgentEvent::Error {
         message: reason.clone(),
         retryable: false,
@@ -405,7 +424,16 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let events = EventSender::new(tx);
         let mut warnings = BudgetWarnings::default();
-        let outcome = check_budget(&budget, 0.0, last_step, &mut warnings, &events, now);
+        let mut transcript = Vec::new();
+        let outcome = check_budget(
+            &mut transcript,
+            &budget,
+            0.0,
+            last_step,
+            &mut warnings,
+            &events,
+            now,
+        );
         let mut messages = Vec::new();
         while let Ok(event) = rx.try_recv() {
             if let AgentEvent::Error { message, .. } = event {
@@ -477,6 +505,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let mut warnings = BudgetWarnings::default();
         let outcome = check_budget(
+            &mut Vec::new(),
             &budget,
             0.0,
             Some(Duration::from_secs(600)),

--- a/crates/stella-core/src/driver/tests/budget_boundaries.rs
+++ b/crates/stella-core/src/driver/tests/budget_boundaries.rs
@@ -1,10 +1,135 @@
 //! Budget-boundary witnesses: an over-cap call is settled spend but the next
 //! provider call never starts, an already-breached turn never pays for
-//! compaction, and a billed completion is charged — and its usage envelope
-//! emitted — exactly once, including when the turn is cancelled with a
-//! speculation still in flight.
+//! compaction, a billed completion and its usage envelope land exactly once
+//! even when a speculation is still in flight, and both top-of-step aborts
+//! hand back a transcript the next provider call still accepts.
 
 use super::*;
+
+/// The call id the two pairing witnesses below start their transcript with and
+/// then look for an answer to.
+const DANGLING_CALL_ID: &str = "dangling-call";
+
+/// A transcript whose tail is an assistant `tool_use` nothing answered.
+///
+/// A caller reaches this shape without doing anything wrong: a hard-dropped
+/// turn hands its history back mid-step, and `Checkpoint::from_json` restores
+/// one after checking the version and never the pairing. Whatever produced it,
+/// the next provider call rejects it outright unless the abort that returned it
+/// closed the pairing first.
+fn transcript_with_an_unanswered_tool_call() -> Vec<CompletionMessage> {
+    vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+        CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: DANGLING_CALL_ID.into(),
+                name: "bash".into(),
+                input: serde_json::json!({}),
+            }],
+            tool_results: Vec::new(),
+            attachments: Vec::new(),
+        },
+    ]
+}
+
+/// Whether some `Tool` message answers [`DANGLING_CALL_ID`] — the pairing rule
+/// every provider enforces, asked of the vector the caller gets back.
+fn answers_the_dangling_call(messages: &[CompletionMessage]) -> bool {
+    messages.iter().any(|message| {
+        message.role == MessageRole::Tool
+            && message
+                .tool_results
+                .iter()
+                .any(|result| result.call_id == DANGLING_CALL_ID)
+    })
+}
+
+/// A provider that fails the test if the turn ever calls it — both witnesses
+/// below abort at the top of the step, before any model call.
+fn provider_that_must_not_be_called() -> ScriptedProvider {
+    ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(text_result("must never be called"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    }
+}
+
+#[tokio::test]
+async fn an_over_cap_budget_abort_hands_back_a_well_paired_transcript() {
+    // The dollar arm of `settlement::check_budget` fires at
+    // the top of the step, before any model call, on a transcript that is
+    // still exactly what the caller handed in. Every other exit at this
+    // boundary closes the pairing; this one returned the open `tool_use`
+    // untouched, and the caller's next turn was rejected by the vendor with
+    // nothing pointing back at the abort that caused it.
+    let provider = provider_that_must_not_be_called();
+    let provider_calls = provider.calls.clone();
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = transcript_with_an_unanswered_tool_call();
+    let mut budget = BudgetGuard::new(BudgetMode::Enforced, None, Some(0.05));
+    budget.reseed_session_spend(0.10);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Aborted { ref reason, .. } if reason.contains("budget")),
+        "expected the over-cap abort, got {outcome:?}"
+    );
+    assert_eq!(
+        provider_calls.load(Ordering::SeqCst),
+        0,
+        "the abort must land before the model call, which is what makes the transcript the \
+         caller's own"
+    );
+    assert!(
+        answers_the_dangling_call(&messages),
+        "a budget abort must answer the open tool_use it hands back, or the caller's next \
+         provider call is rejected: {messages:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_past_deadline_abort_hands_back_a_well_paired_transcript() {
+    // The same witness for the deadline arm, which is checked first and has
+    // its own reason string — and had the same missing repair.
+    let provider = provider_that_must_not_be_called();
+    let provider_calls = provider.calls.clone();
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = transcript_with_an_unanswered_tool_call();
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    budget.set_task_deadline(Some(
+        std::time::Instant::now() - std::time::Duration::from_secs(1),
+    ));
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Aborted { ref reason, .. } if reason.contains("deadline")),
+        "expected the deadline abort, got {outcome:?}"
+    );
+    assert_eq!(
+        provider_calls.load(Ordering::SeqCst),
+        0,
+        "a task past its deadline stops before the next call"
+    );
+    assert!(
+        answers_the_dangling_call(&messages),
+        "a deadline abort must answer the open tool_use it hands back: {messages:?}"
+    );
+}
 
 struct BilledResultWithBlockedSpeculation {
     provider_completed: Arc<tokio::sync::Notify>,


### PR DESCRIPTION
## What

Every abort that can return at the top of a step now calls
`crate::step::close_open_tool_calls` before it returns, so the `messages`
vector the caller gets back is one the next provider call still accepts.

Repaired here:

| File | Arm |
|---|---|
| `driver/settlement.rs` | `check_budget` — the dollar-budget arm and the task-deadline arm |
| `driver/overflow_recovery.rs` | the `Exhausted` arm of `settle_model_call_failure`, and `surface_unrecovered` (its `&TurnState` widened to `&mut`) |
| `driver/loop_escalation.rs` | the loop-detection abort |
| `driver/drive.rs` | the step-cap abort |

## Why

A clean abort must leave `messages` valid for reuse: the ordinary caller
pattern is to run the next turn on the same vector. Five abort paths already
upheld that (`TurnState::cancel_outcome`, the soft stop,
`handle_committed_result`, the mid-turn provider swap, the `SoftStopped` arm).
The arms above fire at the identical boundary and did not, so they handed back
a transcript still ending in an unanswered `tool_use`. The failure did not
surface at the abort — it surfaced on the caller's *next* turn, where the
vendor rejected the history with nothing pointing back at the abort that
caused it.

Each arm names its own `ToolOutput::Error` text rather than reusing
`BUDGET_ABORT_TOOL_RESULT` everywhere, so a transcript says which policy
stopped the turn instead of reporting a budget the turn never spent.

`driver.rs` and `driver/tests.rs` are untouched — both are god files closed to
growth (AGENTS.md § "God files"). The new constants live in the sibling
submodules that use them, following `model_fallback.rs`'s
`FALLBACK_TOOL_RESULT`, which is the in-tree exemplar for this exact shape.

## Witness

Two tests in `crates/stella-core/src/driver/tests/budget_boundaries.rs`:

- `an_over_cap_budget_abort_hands_back_a_well_paired_transcript`
- `a_past_deadline_abort_hands_back_a_well_paired_transcript`

Both build a transcript ending in an assistant `tool_use` with no answering
`Tool` message, arm an already-breached budget (session cap reseeded past its
limit) or an already-past task deadline, run one turn through `run_turn`, and
assert the vector the caller gets back holds a `Tool` message answering that
call id. Each also asserts the provider was never called, which is what
establishes the abort landed at the top of the step, on the caller's own
transcript, rather than after a model call that would have rejected it.

**Why they fail on `main`, stated by mechanism rather than by a run** (this
laptop does not compile; CI is the evidence): on `main` the deadline arm and
the dollar arm of `settlement::check_budget` build a `TurnOutcome::Aborted`
and return it with no write to `messages` at all — the free `check_budget` did
not even take the transcript, so there is no code path on `main` by which a
`Tool` message can appear. `BorrowedTurn::drop` copies `state.messages` back to
the caller, so what the assertion reads is exactly what the abort left. Both
`answers_the_dangling_call` assertions are therefore false on `main` and true
here.

The other three arms share the shape and are much harder to reach — loop
escalation needs a genuine repeat pattern alongside a dangling tail call, the
step cap needs `max_steps` already met on entry, and the overflow arms need a
spent recovery ladder. They are fixed with the same one-line call rather than
left as a second bug of the same kind.

## Not done, deliberately

The design pointer offered `Checkpoint::from_json` rejecting an unpaired tail
as an optional second witness. It is not here. Rejecting it and repairing it
point in opposite directions — reject makes a hard-dropped turn's checkpoint
unresumable, where this PR makes it resumable — and that is a maintainer's
call, not a side effect of a bug fix. Filed as #5660 with all three options
and what each costs.

## Tests deleted

None.

## Residue filed

- #5659 — a deadline notice can land between a `tool_use` and the
  `tool_result` that answers it. `push_if_due` appends a `User` message ahead
  of `check_budget`, so the repaired transcript can be correctly paired and
  still wrongly ordered for Anthropic. Narrower than this bug: it needs an
  unpaired tail *and* a notice due on the same step.
- #5660 — decide what `Checkpoint::from_json` should do with an unanswered
  tool call (above).

Closes #5516

## Summary by Sourcery

Repair all top-of-step abort paths so returned message histories remain provider-compatible and identify the policy that ended the turn.

Bug Fixes:
- Ensure every top-of-step abort closes unanswered tool calls so returned transcripts remain valid for reuse by subsequent provider calls.
- Use policy-specific tool error messages for deadline, budget, loop, step-cap, and exhausted model-recovery aborts.

Enhancements:
- Add coverage proving budget and deadline aborts repair dangling tool calls without invoking the provider.

Tests:
- Add boundary tests for well-paired transcripts returned by over-budget and expired-deadline aborts.