### PR TITLE
fix(stella-autonomy): make escalation a cooldown instead of a tombstone

### DIFF
--- a/crates/stella-autonomy/README.md
+++ b/crates/stella-autonomy/README.md
@@ -83,6 +83,8 @@ the CLI does — so the dashboard and the terminal cannot disagree.
 | [`src/deliver.rs`](src/deliver.rs) | The per-PR delivery machine: `PrState`/`Observation`/`deliver_next`, the fix/rebase ceilings, and the escalation reasons. |
 | [`src/doctrine.rs`](src/doctrine.rs) | The policy knobs a human sets: `Doctrine`, `ForeignBreakage`, contention policy and `contention_verdict`. |
 | [`src/priority.rs`](src/priority.rs) | `triage`: rank by the ladder the repo actually uses, with unassessed issues distinct from unrankable ones. |
+| [`src/ready.rs`](src/ready.rs) | `ready_queue`: which backlog issues may be taken next, and in what order. `Blocked by: #N` lines, the `status:ready` override, and the escalation cooldown. |
+| [`src/escalation.rs`](src/escalation.rs) | Escalation as a cooldown: `classify` reads an abort message, `retry_after` says how long to wait, `park_after` says when waiting ends. The record is written into the issue body and read back from it. |
 | [`src/gate.rs`](src/gate.rs) | Which checks are allowed to block a merge, and which have stopped earning that right. |
 | [`src/closure.rs`](src/closure.rs) | How an issue ends, and what has to be true first. |
 | [`src/convention.rs`](src/convention.rs) | How this repository writes issues, learned rather than assumed. |

--- a/crates/stella-autonomy/src/escalation.rs
+++ b/crates/stella-autonomy/src/escalation.rs
@@ -1,0 +1,419 @@
+//! Escalation as a cooldown, not a tombstone.
+//!
+//! The loop labels an issue it could not finish. Dropping it for good is
+//! right when the work is too hard. It is wrong when the machine broke: a
+//! stale install, a provider outage, a failed setup. Treat the two alike
+//! and one bad hour costs the backlog an issue.
+//!
+//! So an escalation carries a reason and a count. The reason sets how soon
+//! to try again. The count sets when to stop. Each rule here is a plain
+//! function over owned data. `stella-cli` reads the tracker, writes the
+//! record, and asks these rules what it means.
+//!
+//! Reached as `stella_autonomy::escalation::*`. Nothing is re-exported at
+//! the crate root. A type named [`crate::EscalationReason`] is already
+//! there, and it is about a pull request. One name at one address has to
+//! mean one thing.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Opening text of the record's marker in an issue body.
+pub const MARKER_OPEN: &str = "<!-- stella-escalation ";
+
+/// Closing text of that marker.
+pub const MARKER_CLOSE: &str = " -->";
+
+/// What broke, when the machine broke rather than the work being too hard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvCause {
+    /// The turn made one call over and over and got the same bytes back.
+    /// A stale checkout does this to every command that reads it.
+    StuckLoop,
+    /// The model provider refused the call or dropped it.
+    ProviderError,
+    /// A tool the turn needs was missing, or would not build.
+    InstallFailure,
+}
+
+/// Why the loop handed an issue back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EscalationReason {
+    /// The machine failed. The issue itself may be fine.
+    Environmental(EnvCause),
+    /// The turn ran and could not do the work.
+    BeyondLoop,
+}
+
+/// What the loop has already tried on one issue.
+///
+/// It goes in the issue body, inside [`MARKER_OPEN`]. So it lives through a
+/// restart and a move to a new box, and it needs no new store. The queue
+/// read already carries every body, so reading it back is free.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EscalationRecord {
+    /// How many times this issue has been escalated, this one included.
+    pub attempts: u32,
+    /// Why the last one happened.
+    pub last_reason: EscalationReason,
+    /// When the last one happened, in RFC 3339, for a person to read.
+    pub last_at: String,
+    /// The same moment in whole seconds since the epoch, for the math.
+    /// The text form takes a date parser to compare, and this crate has
+    /// none. [`crate::CycleRecord`] keeps both fields for the same reason.
+    pub last_at_unix: i64,
+}
+
+/// How long each kind of escalation waits, and when waiting ends.
+///
+/// Set in `[self_driving.escalation]` in `stella.toml`, beside the rest of
+/// the loop's judgement calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EscalationPolicy {
+    /// Seconds to wait when the machine broke.
+    pub environmental_cooldown_secs: u64,
+    /// Seconds to wait when the turn could not do the work.
+    pub beyond_loop_cooldown_secs: u64,
+    /// Tries after which the issue is parked and never taken again.
+    pub park_after: u32,
+}
+
+impl Default for EscalationPolicy {
+    /// Ten minutes for the machine, six hours for the work, parked on the
+    /// third try.
+    ///
+    /// A broken box clears in minutes. A rate-limit window closes, an
+    /// install is fixed, an outage ends. Ten minutes covers that, and the
+    /// issue is back inside the hour.
+    ///
+    /// A turn that ran and could not do the work needs something to change
+    /// first: a comment, a new model, a blocker that lands. None of that
+    /// happens in ten minutes. Trying again that fast buys the same
+    /// failure at full price.
+    ///
+    /// Three tries, because the count is what stops a broken box from
+    /// spending the whole backlog. Two would park work on one bad
+    /// afternoon. Ten would buy the same failure ten times.
+    fn default() -> Self {
+        Self {
+            environmental_cooldown_secs: 600,
+            beyond_loop_cooldown_secs: 21_600,
+            park_after: 3,
+        }
+    }
+}
+
+/// Phrases that name a broken box, and the cause each one names.
+///
+/// A fixed list, not a model call. The residue gate's detector has the same
+/// shape. Each phrase is text this tree writes: the loop guard says
+/// `byte-identical`, a failed spawn says `could not start`, and the rest
+/// are the words a provider uses for a bad call.
+const ENVIRONMENTAL_PHRASES: &[(&str, EnvCause)] = &[
+    ("byte-identical", EnvCause::StuckLoop),
+    ("identical output", EnvCause::StuckLoop),
+    ("identical arguments", EnvCause::StuckLoop),
+    ("stuck loop", EnvCause::StuckLoop),
+    ("rate limit", EnvCause::ProviderError),
+    ("rate-limit", EnvCause::ProviderError),
+    ("too many requests", EnvCause::ProviderError),
+    ("overloaded", EnvCause::ProviderError),
+    ("service unavailable", EnvCause::ProviderError),
+    ("bad gateway", EnvCause::ProviderError),
+    ("internal server error", EnvCause::ProviderError),
+    ("temporarily unavailable", EnvCause::ProviderError),
+    ("connection reset", EnvCause::ProviderError),
+    ("connection refused", EnvCause::ProviderError),
+    ("connection closed", EnvCause::ProviderError),
+    ("timed out", EnvCause::ProviderError),
+    ("could not start", EnvCause::InstallFailure),
+    ("command not found", EnvCause::InstallFailure),
+    ("no such file or directory", EnvCause::InstallFailure),
+    ("install failed", EnvCause::InstallFailure),
+    ("node_modules", EnvCause::InstallFailure),
+];
+
+/// Read an abort message and say which kind of escalation it is.
+///
+/// A message the list does not name is [`EscalationReason::BeyondLoop`].
+/// That is the longer of the two waits. So a message nobody planned for can
+/// only make the loop slower, never faster.
+#[must_use]
+pub fn classify(why: &str) -> EscalationReason {
+    let lower = why.to_ascii_lowercase();
+    for (phrase, cause) in ENVIRONMENTAL_PHRASES {
+        if lower.contains(phrase) {
+            return EscalationReason::Environmental(*cause);
+        }
+    }
+    EscalationReason::BeyondLoop
+}
+
+/// How long after [`EscalationRecord::last_at`] this issue may be taken
+/// again.
+///
+/// `None` means never. It has been escalated
+/// [`EscalationPolicy::park_after`] times, so it is parked.
+#[must_use]
+pub fn retry_after(record: &EscalationRecord, policy: &EscalationPolicy) -> Option<Duration> {
+    if parked(record, policy) {
+        return None;
+    }
+    let secs = match record.last_reason {
+        EscalationReason::Environmental(_) => policy.environmental_cooldown_secs,
+        EscalationReason::BeyondLoop => policy.beyond_loop_cooldown_secs,
+    };
+    Some(Duration::from_secs(secs))
+}
+
+/// Whether this issue is out of attempts.
+#[must_use]
+pub fn parked(record: &EscalationRecord, policy: &EscalationPolicy) -> bool {
+    record.attempts >= policy.park_after
+}
+
+/// Whether an escalated issue may be taken again at `now_unix`.
+///
+/// No record means no. An issue can carry the label and no record: a person
+/// put it there, or an older build did. Neither says what broke or when. A
+/// guess would put work back that somebody took out by hand.
+#[must_use]
+pub fn may_retry(
+    record: Option<&EscalationRecord>,
+    policy: &EscalationPolicy,
+    now_unix: i64,
+) -> bool {
+    let Some(record) = record else {
+        return false;
+    };
+    let Some(wait) = retry_after(record, policy) else {
+        return false;
+    };
+    let ready_at = record
+        .last_at_unix
+        .saturating_add(i64::try_from(wait.as_secs()).unwrap_or(i64::MAX));
+    now_unix >= ready_at
+}
+
+/// The record to write for one more escalation.
+///
+/// The count carries forward. A second abort is the second try, not a fresh
+/// first one.
+#[must_use]
+pub fn next(
+    previous: Option<&EscalationRecord>,
+    reason: EscalationReason,
+    at: &str,
+    at_unix: i64,
+) -> EscalationRecord {
+    EscalationRecord {
+        attempts: previous.map_or(0, |p| p.attempts).saturating_add(1),
+        last_reason: reason,
+        last_at: at.to_owned(),
+        last_at_unix: at_unix,
+    }
+}
+
+/// Read the record out of an issue body, if one is there.
+///
+/// A body with no marker gives `None`. So does a marker with no end, and
+/// JSON this build cannot read. The caller then sees an issue with no
+/// record, which is the parked answer.
+#[must_use]
+pub fn parse(body: &str) -> Option<EscalationRecord> {
+    let start = body.rfind(MARKER_OPEN)? + MARKER_OPEN.len();
+    let rest = &body[start..];
+    let end = rest.find(MARKER_CLOSE)?;
+    serde_json::from_str(rest[..end].trim()).ok()
+}
+
+/// Put the record into an issue body, over any record already there.
+///
+/// The old marker is cut out first. A body escalated five times carries one
+/// record, not five. The marker is an HTML comment, so a person reading the
+/// issue sees nothing.
+///
+/// A record that will not serialize leaves the body alone. Half a marker
+/// would hand the next reader a broken record instead of none.
+#[must_use]
+pub fn stamp(body: &str, record: &EscalationRecord) -> String {
+    let Ok(json) = serde_json::to_string(record) else {
+        return body.to_owned();
+    };
+    let stripped = strip(body);
+    let mut out = stripped.trim_end().to_owned();
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str(MARKER_OPEN);
+    out.push_str(&json);
+    out.push_str(MARKER_CLOSE);
+    out.push('\n');
+    out
+}
+
+/// The body with each marker cut out.
+fn strip(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut rest = body;
+    while let Some(start) = rest.find(MARKER_OPEN) {
+        let after = &rest[start + MARKER_OPEN.len()..];
+        let Some(end) = after.find(MARKER_CLOSE) else {
+            break;
+        };
+        out.push_str(&rest[..start]);
+        rest = &after[end + MARKER_CLOSE.len()..];
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(attempts: u32, reason: EscalationReason, at_unix: i64) -> EscalationRecord {
+        EscalationRecord {
+            attempts,
+            last_reason: reason,
+            last_at: "2026-09-02T00:00:00Z".to_owned(),
+            last_at_unix: at_unix,
+        }
+    }
+
+    /// **The witness.** A turn that stopped because every command gave back
+    /// the same bytes is a broken box, not work that is too hard. It waits
+    /// the short cooldown and comes back.
+    #[test]
+    fn an_environmental_abort_waits_the_short_cooldown_and_then_may_be_retried() {
+        let policy = EscalationPolicy::default();
+        let reason = classify(
+            "the turn exited 1 — the same `bash` call with identical arguments repeated 4 \
+             times consecutively, producing byte-identical output every time",
+        );
+        assert_eq!(
+            reason,
+            EscalationReason::Environmental(EnvCause::StuckLoop),
+            "a stuck-loop abort is about the machine, not the issue"
+        );
+
+        let first = next(None, reason, "2026-09-02T00:00:00Z", 1_000);
+        assert_eq!(first.attempts, 1);
+        assert_eq!(
+            retry_after(&first, &policy),
+            Some(Duration::from_secs(policy.environmental_cooldown_secs))
+        );
+        assert!(
+            !may_retry(Some(&first), &policy, 1_000),
+            "the cooldown has not run out at the moment it was written"
+        );
+        assert!(
+            may_retry(
+                Some(&first),
+                &policy,
+                1_000 + i64::try_from(policy.environmental_cooldown_secs).expect("fits")
+            ),
+            "once the cooldown is over the issue is takeable again, with no label removed"
+        );
+    }
+
+    /// Work the loop could not do waits far longer than a broken box.
+    #[test]
+    fn a_beyond_loop_abort_waits_longer_than_an_environmental_one() {
+        let policy = EscalationPolicy::default();
+        assert_eq!(
+            classify("the turn exited 0 — I cannot work out what this issue is asking for"),
+            EscalationReason::BeyondLoop,
+            "a message the phrase list does not name is the patient answer"
+        );
+
+        let env = record(
+            1,
+            EscalationReason::Environmental(EnvCause::ProviderError),
+            0,
+        );
+        let beyond = record(1, EscalationReason::BeyondLoop, 0);
+        assert!(
+            retry_after(&env, &policy) < retry_after(&beyond, &policy),
+            "environmental aborts are retried more eagerly"
+        );
+    }
+
+    /// **The parking witness.** After `park_after` tries the issue stops
+    /// coming back, however long anyone waits.
+    #[test]
+    fn an_issue_escalated_park_after_times_is_never_taken_again() {
+        let policy = EscalationPolicy::default();
+        let spent = record(
+            policy.park_after,
+            EscalationReason::Environmental(EnvCause::StuckLoop),
+            0,
+        );
+
+        assert!(parked(&spent, &policy));
+        assert_eq!(retry_after(&spent, &policy), None);
+        assert!(
+            !may_retry(Some(&spent), &policy, i64::MAX),
+            "parked means parked — no wait makes it takeable"
+        );
+    }
+
+    /// A label with no record means an older build, or a person's hand.
+    /// Both stay out of the queue.
+    #[test]
+    fn an_escalation_with_no_record_is_never_retried() {
+        assert!(!may_retry(None, &EscalationPolicy::default(), i64::MAX));
+    }
+
+    /// The record round-trips through a body. A second write takes the
+    /// place of the first rather than stacking on it.
+    #[test]
+    fn stamping_a_body_twice_leaves_one_record() {
+        let body = "## What happens\nThe queue never gets it back.\n";
+        let first = record(1, EscalationReason::BeyondLoop, 10);
+        let once = stamp(body, &first);
+        assert_eq!(parse(&once), Some(first));
+        assert!(once.starts_with("## What happens"), "the body is kept");
+
+        let second = record(2, EscalationReason::Environmental(EnvCause::StuckLoop), 20);
+        let twice = stamp(&once, &second);
+        assert_eq!(parse(&twice), Some(second));
+        assert_eq!(
+            twice.matches(MARKER_OPEN).count(),
+            1,
+            "a body escalated twice carries one record, not two"
+        );
+        assert!(twice.starts_with("## What happens"));
+    }
+
+    /// A body nobody escalated reads as no record. So does one whose
+    /// marker is broken.
+    #[test]
+    fn an_absent_or_damaged_marker_reads_as_no_record() {
+        assert_eq!(parse("plain issue text"), None);
+        assert_eq!(parse("<!-- stella-escalation {\"attempts\":1}"), None);
+        assert_eq!(parse("<!-- stella-escalation not json -->"), None);
+    }
+
+    /// The count carries forward, which is what makes parking reachable.
+    #[test]
+    fn attempts_accumulate_across_escalations() {
+        let first = next(None, EscalationReason::BeyondLoop, "t", 0);
+        let second = next(
+            Some(&first),
+            EscalationReason::Environmental(EnvCause::InstallFailure),
+            "t",
+            1,
+        );
+        assert_eq!(second.attempts, 2);
+        assert_eq!(
+            second.last_reason,
+            EscalationReason::Environmental(EnvCause::InstallFailure),
+            "the newest reason decides the next cooldown"
+        );
+    }
+}

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -56,6 +56,7 @@ mod closure;
 mod convention;
 mod deliver;
 mod doctrine;
+pub mod escalation;
 pub mod gate;
 pub mod priority;
 pub mod ready;

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -856,8 +856,13 @@ pub fn starved(cal: &Calibration) -> Option<Signal> {
 // The defect queue — ranked P0 > P1 > P2, oldest first inside a rank
 // ---------------------------------------------------------------------------
 
-/// One open issue as `gh issue list --json number,title,labels,createdAt,url`
-/// reports it.
+/// One open issue, in the shape every ranker here reads.
+///
+/// The field names follow `gh issue list --json
+/// number,title,labels,createdAt,url`, so a recorded page of that output
+/// still parses. The live path builds one from the issue port instead
+/// (`stella-cli`'s `to_queue_issue`), which is where `escalation` comes
+/// from: the tracker has no such field.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QueueIssue {
     pub number: u64,
@@ -868,6 +873,11 @@ pub struct QueueIssue {
     pub created_at: String,
     #[serde(default)]
     pub url: String,
+    /// What the loop has already tried on this issue, read out of its body.
+    /// `None` when nobody escalated it, or when a person applied the label
+    /// by hand and left no record.
+    #[serde(default)]
+    pub escalation: Option<escalation::EscalationRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -883,6 +893,18 @@ impl QueueIssue {
     /// "does it have this label" is how two rankers start disagreeing.
     pub(crate) fn has_label(&self, name: &str) -> bool {
         self.labels.iter().any(|l| l.name == name)
+    }
+
+    /// Whether an escalation is keeping this issue out of a queue right now.
+    ///
+    /// One rule, read by every queue here — the ready backlog and the defect
+    /// queue both ask this, so the two cannot start disagreeing about when
+    /// an escalated issue comes back. `false` for an issue nobody escalated.
+    /// See [`crate::escalation`] for how long each kind waits.
+    #[must_use]
+    pub fn escalation_holds(&self, policy: &escalation::EscalationPolicy, now_unix: i64) -> bool {
+        self.has_label(ESCALATION_LABEL)
+            && !escalation::may_retry(self.escalation.as_ref(), policy, now_unix)
     }
 
     /// P0 ranks 0, P1 ranks 1, P2 ranks 2, everything else 3 — an aged P1 is
@@ -901,15 +923,21 @@ impl QueueIssue {
 /// Feature work is excluded — this loop closes defects, and
 /// mixing the two makes the batch unreviewable.
 ///
-/// Issues carrying `ESCALATION_LABEL` are dropped: the loop already attempted
-/// them and could not resolve them, so keeping them in the queue would make a
-/// later run spend on the same wall it already hit. The label is how that
-/// decision survives across processes — `spent` in the drive loop is
-/// process-local and cannot.
-pub fn rank_defects(issues: Vec<QueueIssue>) -> Vec<QueueIssue> {
+/// An escalated issue is held back while its cooldown runs, and comes back on
+/// its own once that is over ([`QueueIssue::escalation_holds`]). The record in
+/// its body is how that survives across processes — `spent` in the drive loop
+/// is process-local and cannot.
+pub fn rank_defects(
+    issues: Vec<QueueIssue>,
+    escalation: &escalation::EscalationPolicy,
+    now_unix: i64,
+) -> Vec<QueueIssue> {
     let mut defects: Vec<QueueIssue> = issues
         .into_iter()
-        .filter(|i| (i.has_label("bug") || i.has_label("triage")) && !i.has_label(ESCALATION_LABEL))
+        .filter(|i| {
+            (i.has_label("bug") || i.has_label("triage"))
+                && !i.escalation_holds(escalation, now_unix)
+        })
         .collect();
     defects.sort_by(|a, b| {
         a.priority_rank()

--- a/crates/stella-autonomy/src/priority.rs
+++ b/crates/stella-autonomy/src/priority.rs
@@ -221,9 +221,12 @@ impl Default for TriagePolicy {
 ///
 /// The order of the checks is the whole content of this function:
 ///
-/// 1. **Escalated** issues are dropped. The loop already tried and could not
-///    resolve them; re-claiming spends the same money on the same wall. The
-///    label is how that survives a restart, which process-local state cannot.
+/// 1. **Escalated** issues are dropped while their cooldown runs. The loop
+///    tried and could not finish them. Taking one again now buys the same
+///    wall at the same price. Once the wait is over it comes back on its
+///    own, and nobody removes a label ([`QueueIssue::escalation_holds`]).
+///    The record in its body is what lives through a restart. State held in
+///    this process cannot.
 /// 2. **Excluded kinds** are dropped. Somebody judged this and said it is not
 ///    a defect.
 /// 3. **A defect kind *and* a rung** is rankable work.
@@ -231,12 +234,17 @@ impl Default for TriagePolicy {
 ///    unlabelled issue filed a minute ago, and the issue carrying a rung but
 ///    no kind. See the module docs for what that mistake costs.
 #[must_use]
-pub fn triage(issues: Vec<QueueIssue>, policy: &TriagePolicy) -> Queue {
+pub fn triage(
+    issues: Vec<QueueIssue>,
+    policy: &TriagePolicy,
+    escalation: &crate::escalation::EscalationPolicy,
+    now_unix: i64,
+) -> Queue {
     let mut rankable = Vec::new();
     let mut queue = Queue::default();
 
     for issue in issues {
-        if issue.has_label(crate::ESCALATION_LABEL) {
+        if issue.escalation_holds(escalation, now_unix) {
             continue;
         }
         if policy
@@ -284,7 +292,16 @@ mod tests {
                 })
                 .collect(),
             url: String::new(),
+            escalation: None,
         }
+    }
+
+    fn policy() -> crate::escalation::EscalationPolicy {
+        crate::escalation::EscalationPolicy::default()
+    }
+
+    fn split(issues: Vec<QueueIssue>, triage_policy: &TriagePolicy) -> Queue {
+        triage(issues, triage_policy, &policy(), i64::MAX)
     }
 
     /// An unlabelled issue is a question, not the bottom of the queue.
@@ -437,7 +454,7 @@ mod tests {
     #[test]
     fn an_unlabelled_new_issue_is_a_question_not_an_omission() {
         let policy = TriagePolicy::default();
-        let queue = triage(
+        let queue = split(
             vec![
                 issue(1, "2026-01-01T00:00:00Z", &["bug", "P2"]),
                 issue(2, "2026-08-19T00:00:00Z", &[]),
@@ -461,7 +478,7 @@ mod tests {
     #[test]
     fn a_rung_with_no_kind_is_unassessed() {
         let policy = TriagePolicy::default();
-        let queue = triage(vec![issue(1, "2026-01-01T00:00:00Z", &["P0"])], &policy);
+        let queue = split(vec![issue(1, "2026-01-01T00:00:00Z", &["P0"])], &policy);
         assert!(queue.ranked.is_empty());
         assert_eq!(queue.unassessed[0].key, "1");
     }
@@ -473,18 +490,20 @@ mod tests {
     #[test]
     fn a_judged_non_defect_is_dropped_rather_than_asked_about() {
         let policy = TriagePolicy::default();
-        let queue = triage(
+        let queue = split(
             vec![issue(1, "2026-01-01T00:00:00Z", &["enhancement", "P0"])],
             &policy,
         );
         assert!(queue.is_empty(), "somebody already answered this one");
     }
 
-    /// An escalated issue leaves the queue entirely, on either axis.
+    /// An escalated issue with no record leaves the queue on either axis.
+    /// The label alone says nothing about what broke or when. A person who
+    /// set it by hand meant it.
     #[test]
     fn an_escalated_issue_is_not_re_asked() {
         let policy = TriagePolicy::default();
-        let queue = triage(
+        let queue = split(
             vec![
                 issue(
                     1,
@@ -498,6 +517,67 @@ mod tests {
         assert!(
             queue.is_empty(),
             "an escalated issue must not come back as ranked work OR as a question"
+        );
+    }
+
+    /// **The defect-queue cooldown witness.** The default `drive` path is
+    /// this queue, not the ready backlog. So a defect has to come back here
+    /// too. It is out while the wait runs. It is in once the wait is over.
+    /// It is out for good once its tries are spent. Nobody removes a label.
+    #[test]
+    fn an_environmental_escalation_returns_to_the_defect_queue_once_its_cooldown_is_over() {
+        let triage_policy = TriagePolicy::default();
+        let escalation = policy();
+        let at = 10_000_i64;
+        let cooled = crate::escalation::next(
+            None,
+            crate::escalation::EscalationReason::Environmental(
+                crate::escalation::EnvCause::StuckLoop,
+            ),
+            "2026-09-02T00:00:00Z",
+            at,
+        );
+        let over = at + i64::try_from(escalation.environmental_cooldown_secs).expect("fits");
+        let defect = |record: crate::escalation::EscalationRecord| {
+            let mut issue = issue(
+                7,
+                "2026-01-01T00:00:00Z",
+                &["bug", "P0", crate::ESCALATION_LABEL],
+            );
+            issue.escalation = Some(record);
+            issue
+        };
+
+        assert!(
+            triage(
+                vec![defect(cooled.clone())],
+                &triage_policy,
+                &escalation,
+                at
+            )
+            .is_empty(),
+            "the cooldown has not run out, so the defect queue must not offer it yet"
+        );
+
+        let back = triage(
+            vec![defect(cooled.clone())],
+            &triage_policy,
+            &escalation,
+            over,
+        );
+        assert_eq!(
+            back.ranked.iter().map(|i| i.number).collect::<Vec<_>>(),
+            vec![7],
+            "an environmental abort must requeue here on its own, with no label surgery"
+        );
+
+        let spent = crate::escalation::EscalationRecord {
+            attempts: escalation.park_after,
+            ..cooled
+        };
+        assert!(
+            triage(vec![defect(spent)], &triage_policy, &escalation, i64::MAX).is_empty(),
+            "a parked defect stays parked however long anyone waits"
         );
     }
 

--- a/crates/stella-autonomy/src/ready.rs
+++ b/crates/stella-autonomy/src/ready.rs
@@ -14,6 +14,7 @@
 use std::collections::BTreeSet;
 
 use crate::QueueIssue;
+use crate::escalation::{EscalationPolicy, EscalationRecord, may_retry};
 use crate::priority::{PriorityLadder, by_age, rank_of};
 
 /// The label a human applies to say: work this now, whatever its
@@ -27,6 +28,10 @@ pub struct BacklogItem {
     pub issue: QueueIssue,
     /// Issue numbers this one declares it is blocked by.
     pub blocked_by: Vec<u64>,
+    /// What the loop has already tried on it, read from the same body.
+    /// `None` when nobody has escalated it, or when the label was applied
+    /// by hand and says nothing about when or why.
+    pub escalation: Option<EscalationRecord>,
 }
 
 /// Whether one issue may be taken now.
@@ -107,22 +112,31 @@ pub fn readiness(item: &BacklogItem, open: &BTreeSet<u64>) -> Readiness {
 
 /// The ready backlog, in the order the loop should take it.
 ///
-/// Escalated issues are dropped. The loop already tried them, and the
-/// label is how that survives a restart. The rest is filtered to the
-/// ready and ordered. Issues with a rung come first: most urgent rung,
-/// then oldest. The unranked follow, oldest first. The defect queue
-/// holds unranked issues for triage; this one does not. It drains a
-/// whole backlog, so work nobody ranked still ships in the end.
+/// An escalated issue is held back while its cooldown runs, and comes back
+/// on its own once that is over — see [`crate::escalation`] for how long
+/// each kind waits and when waiting ends. Nobody has to remove the label:
+/// it stays as the marker a person reads. An escalated issue with no
+/// record stays out, because nothing says what went wrong or when.
+///
+/// The rest is filtered to the ready and ordered. Issues with a rung come
+/// first: most urgent rung, then oldest. The unranked follow, oldest
+/// first. The defect queue holds unranked issues for triage; this one does
+/// not. It drains a whole backlog, so work nobody ranked still ships in
+/// the end.
 #[must_use]
 pub fn ready_queue(
     items: Vec<BacklogItem>,
     open: &BTreeSet<u64>,
     ladder: &PriorityLadder,
+    escalation: &EscalationPolicy,
+    now_unix: i64,
 ) -> Vec<QueueIssue> {
     let mut ranked = Vec::new();
     let mut unranked = Vec::new();
     for item in items {
-        if item.issue.has_label(crate::ESCALATION_LABEL) {
+        if item.issue.has_label(crate::ESCALATION_LABEL)
+            && !may_retry(item.escalation.as_ref(), escalation, now_unix)
+        {
             continue;
         }
         if readiness(&item, open) != Readiness::Ready {
@@ -168,7 +182,26 @@ mod tests {
         BacklogItem {
             issue: issue(number, "2026-08-01T00:00:00Z", labels),
             blocked_by: blocked_by.to_vec(),
+            escalation: None,
         }
+    }
+
+    fn bare(issue: QueueIssue) -> BacklogItem {
+        BacklogItem {
+            issue,
+            blocked_by: Vec::new(),
+            escalation: None,
+        }
+    }
+
+    fn queue(items: Vec<BacklogItem>, open: &BTreeSet<u64>, now_unix: i64) -> Vec<QueueIssue> {
+        ready_queue(
+            items,
+            open,
+            &PriorityLadder::default(),
+            &EscalationPolicy::default(),
+            now_unix,
+        )
     }
 
     fn open(numbers: &[u64]) -> BTreeSet<u64> {
@@ -232,42 +265,95 @@ mod tests {
     /// backlog; it does not hold unranked issues for triage.
     #[test]
     fn the_ready_queue_ranks_by_rung_then_age_and_appends_the_unranked() {
-        let ladder = PriorityLadder::default();
         let items = vec![
-            BacklogItem {
-                issue: issue(1, "2026-08-10T00:00:00Z", &["P1"]),
-                blocked_by: Vec::new(),
-            },
-            BacklogItem {
-                issue: issue(2, "2026-08-01T00:00:00Z", &["P0"]),
-                blocked_by: Vec::new(),
-            },
-            BacklogItem {
-                issue: issue(3, "2026-07-01T00:00:00Z", &[]),
-                blocked_by: Vec::new(),
-            },
+            bare(issue(1, "2026-08-10T00:00:00Z", &["P1"])),
+            bare(issue(2, "2026-08-01T00:00:00Z", &["P0"])),
+            bare(issue(3, "2026-07-01T00:00:00Z", &[])),
             // Blocked by an open issue: not in the queue at all.
             BacklogItem {
                 issue: issue(4, "2026-06-01T00:00:00Z", &["P0"]),
                 blocked_by: vec![1],
+                escalation: None,
             },
         ];
 
-        let order: Vec<u64> = ready_queue(items, &open(&[1, 2, 3, 4]), &ladder)
+        let order: Vec<u64> = queue(items, &open(&[1, 2, 3, 4]), 0)
             .iter()
             .map(|i| i.number)
             .collect();
         assert_eq!(order, vec![2, 1, 3]);
     }
 
-    /// An escalated issue never re-enters through the ready door.
+    /// An escalated issue with no record stays out. The label alone says
+    /// nothing about what went wrong or when, and a person who applied it
+    /// by hand meant it.
     #[test]
-    fn an_escalated_issue_never_enters_the_ready_queue() {
-        let ladder = PriorityLadder::default();
-        let items = vec![BacklogItem {
-            issue: issue(5, "2026-08-01T00:00:00Z", &["P0", crate::ESCALATION_LABEL]),
+    fn an_escalated_issue_with_no_record_never_enters_the_ready_queue() {
+        let items = vec![bare(issue(
+            5,
+            "2026-08-01T00:00:00Z",
+            &["P0", crate::ESCALATION_LABEL],
+        ))];
+        assert!(queue(items, &open(&[5]), i64::MAX).is_empty());
+    }
+
+    /// **The cooldown witness.** An issue escalated because the machine
+    /// broke is out of the queue while its cooldown runs and back in once
+    /// it is over — with the label still on it. Nobody removed anything.
+    #[test]
+    fn an_environmental_escalation_leaves_the_queue_and_returns_when_its_cooldown_is_over() {
+        let policy = EscalationPolicy::default();
+        let escalated_at = 10_000_i64;
+        let record = crate::escalation::next(
+            None,
+            crate::escalation::EscalationReason::Environmental(
+                crate::escalation::EnvCause::StuckLoop,
+            ),
+            "2026-09-02T00:00:00Z",
+            escalated_at,
+        );
+        let item = || BacklogItem {
+            issue: issue(17, "2026-08-01T00:00:00Z", &["P1", crate::ESCALATION_LABEL]),
             blocked_by: Vec::new(),
+            escalation: Some(record.clone()),
+        };
+
+        assert!(
+            queue(vec![item()], &open(&[17]), escalated_at).is_empty(),
+            "the cooldown has not run out, so the loop must not take it again yet"
+        );
+
+        let over = escalated_at + i64::try_from(policy.environmental_cooldown_secs).expect("fits");
+        let back: Vec<u64> = queue(vec![item()], &open(&[17]), over)
+            .iter()
+            .map(|i| i.number)
+            .collect();
+        assert_eq!(
+            back,
+            vec![17],
+            "an environmental abort must requeue on its own, with no label surgery"
+        );
+    }
+
+    /// An issue escalated to its ceiling stays parked however long anyone
+    /// waits. The cooldown has an end.
+    #[test]
+    fn an_issue_escalated_to_the_ceiling_stays_out_of_the_ready_queue() {
+        let policy = EscalationPolicy::default();
+        let spent = crate::escalation::EscalationRecord {
+            attempts: policy.park_after,
+            last_reason: crate::escalation::EscalationReason::Environmental(
+                crate::escalation::EnvCause::ProviderError,
+            ),
+            last_at: "2026-09-02T00:00:00Z".to_owned(),
+            last_at_unix: 0,
+        };
+        let items = vec![BacklogItem {
+            issue: issue(17, "2026-08-01T00:00:00Z", &["P1", crate::ESCALATION_LABEL]),
+            blocked_by: Vec::new(),
+            escalation: Some(spent),
         }];
-        assert!(ready_queue(items, &open(&[5]), &ladder).is_empty());
+
+        assert!(queue(items, &open(&[17]), i64::MAX).is_empty());
     }
 }

--- a/crates/stella-autonomy/src/ready.rs
+++ b/crates/stella-autonomy/src/ready.rs
@@ -14,7 +14,7 @@
 use std::collections::BTreeSet;
 
 use crate::QueueIssue;
-use crate::escalation::{EscalationPolicy, EscalationRecord, may_retry};
+use crate::escalation::EscalationPolicy;
 use crate::priority::{PriorityLadder, by_age, rank_of};
 
 /// The label a human applies to say: work this now, whatever its
@@ -28,10 +28,6 @@ pub struct BacklogItem {
     pub issue: QueueIssue,
     /// Issue numbers this one declares it is blocked by.
     pub blocked_by: Vec<u64>,
-    /// What the loop has already tried on it, read from the same body.
-    /// `None` when nobody has escalated it, or when the label was applied
-    /// by hand and says nothing about when or why.
-    pub escalation: Option<EscalationRecord>,
 }
 
 /// Whether one issue may be taken now.
@@ -134,9 +130,7 @@ pub fn ready_queue(
     let mut ranked = Vec::new();
     let mut unranked = Vec::new();
     for item in items {
-        if item.issue.has_label(crate::ESCALATION_LABEL)
-            && !may_retry(item.escalation.as_ref(), escalation, now_unix)
-        {
+        if item.issue.escalation_holds(escalation, now_unix) {
             continue;
         }
         if readiness(&item, open) != Readiness::Ready {
@@ -175,6 +169,7 @@ mod tests {
                 })
                 .collect(),
             url: String::new(),
+            escalation: None,
         }
     }
 
@@ -182,7 +177,6 @@ mod tests {
         BacklogItem {
             issue: issue(number, "2026-08-01T00:00:00Z", labels),
             blocked_by: blocked_by.to_vec(),
-            escalation: None,
         }
     }
 
@@ -190,8 +184,17 @@ mod tests {
         BacklogItem {
             issue,
             blocked_by: Vec::new(),
-            escalation: None,
         }
+    }
+
+    fn escalated(number: u64, record: crate::escalation::EscalationRecord) -> BacklogItem {
+        let mut issue = issue(
+            number,
+            "2026-08-01T00:00:00Z",
+            &["P1", crate::ESCALATION_LABEL],
+        );
+        issue.escalation = Some(record);
+        bare(issue)
     }
 
     fn queue(items: Vec<BacklogItem>, open: &BTreeSet<u64>, now_unix: i64) -> Vec<QueueIssue> {
@@ -273,7 +276,6 @@ mod tests {
             BacklogItem {
                 issue: issue(4, "2026-06-01T00:00:00Z", &["P0"]),
                 blocked_by: vec![1],
-                escalation: None,
             },
         ];
 
@@ -312,11 +314,7 @@ mod tests {
             "2026-09-02T00:00:00Z",
             escalated_at,
         );
-        let item = || BacklogItem {
-            issue: issue(17, "2026-08-01T00:00:00Z", &["P1", crate::ESCALATION_LABEL]),
-            blocked_by: Vec::new(),
-            escalation: Some(record.clone()),
-        };
+        let item = || escalated(17, record.clone());
 
         assert!(
             queue(vec![item()], &open(&[17]), escalated_at).is_empty(),
@@ -348,12 +346,6 @@ mod tests {
             last_at: "2026-09-02T00:00:00Z".to_owned(),
             last_at_unix: 0,
         };
-        let items = vec![BacklogItem {
-            issue: issue(17, "2026-08-01T00:00:00Z", &["P1", crate::ESCALATION_LABEL]),
-            blocked_by: Vec::new(),
-            escalation: Some(spent),
-        }];
-
-        assert!(queue(items, &open(&[17]), i64::MAX).is_empty());
+        assert!(queue(vec![escalated(17, spent)], &open(&[17]), i64::MAX).is_empty());
     }
 }

--- a/crates/stella-autonomy/src/stats.rs
+++ b/crates/stella-autonomy/src/stats.rs
@@ -55,6 +55,14 @@ pub struct SessionStats {
     pub issues_failed: u32,
     /// Issues marked `agent-escalated` — tried, unresolved, handed back.
     pub issues_escalated: u32,
+    /// Escalations that used up the last attempt, so the issue is parked
+    /// and the loop will not take it again.
+    ///
+    /// A subset of `issues_escalated`, counted apart because the two are
+    /// different news: an escalation is a pause, and this is the end of
+    /// one. Without it a reader cannot tell a backlog the loop is still
+    /// working through from one it has permanently given up on.
+    pub issues_parked: u32,
     /// Issues skipped because something else appeared to be working them.
     pub issues_deferred: u32,
 
@@ -258,6 +266,10 @@ mod tests {
         ("issues_no_change", "drive.rs — WorkOutcome::NoChange"),
         ("issues_failed", "drive.rs — WorkOutcome::Failed"),
         ("issues_escalated", "drive.rs — handed back to a human"),
+        (
+            "issues_parked",
+            "drive/triage.rs — the last attempt was spent",
+        ),
         (
             "issues_deferred",
             "drive.rs — a peer had it, or it would not start",

--- a/crates/stella-autonomy/src/tests.rs
+++ b/crates/stella-autonomy/src/tests.rs
@@ -701,7 +701,10 @@ fn rank_beats_age_across_ranks_triage_counts_and_features_do_not() {
     ]))
     .expect("fixture parses");
 
-    let ranked: Vec<u64> = rank_defects(issues).iter().map(|i| i.number).collect();
+    let ranked: Vec<u64> = rank_defects(issues, &crate::escalation::EscalationPolicy::default(), 0)
+        .iter()
+        .map(|i| i.number)
+        .collect();
     assert_eq!(ranked, [103, 102, 101, 104]);
 }
 

--- a/crates/stella-cli/src/issue_provider.rs
+++ b/crates/stella-cli/src/issue_provider.rs
@@ -496,6 +496,9 @@ pub(crate) fn to_queue_issue(issue: &Issue) -> stella_autonomy::QueueIssue {
             .collect(),
         created_at: issue.created_at.clone(),
         url: issue.url.clone(),
+        // The record lives in the body. So every queue read carries it,
+        // and a cooldown costs no second call.
+        escalation: stella_autonomy::escalation::parse(&issue.body),
     }
 }
 

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -287,6 +287,10 @@ pub(crate) enum SelfDrivingCmd {
     ///
     /// Written after every step rather than at the end, because a perpetual
     /// loop that only reported on exit would never report at all.
+    ///
+    /// `escalated` and `parked` are different news. An escalated issue is on
+    /// a cooldown and comes back on its own; a parked one has used up its
+    /// attempts and is waiting on a person.
     Stats {
         /// Output format.
         #[arg(long, value_enum, default_value = "text")]

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -778,10 +778,7 @@ fn gh_plain(args: &[&str]) -> Option<String> {
 /// which is the answer when the backlog really is empty — see
 /// [`backlog::demand_from`].
 fn demand(root: &std::path::Path) -> Result<Demand, String> {
-    backlog::demand_from(
-        &crate::issue_provider::GhIssueProvider,
-        &config::load(root).triage,
-    )
+    backlog::demand_from(&crate::issue_provider::GhIssueProvider, &config::load(root))
 }
 
 fn plan(st: &LoopState, explain: bool) -> Result<(), String> {

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -21,6 +21,7 @@
 //! backlog one cycle drew its batch from. One read, one definition, folded two
 //! ways.
 
+use stella_autonomy::escalation::{self, EscalationPolicy, EscalationRecord};
 use stella_autonomy::{BacklogConvention, Conformance, Demand, Violation, conform, finding_digest};
 use stella_protocol::issue::{IssueDraft, IssueError, IssueKey, IssueLabel, IssueProvider};
 
@@ -507,13 +508,6 @@ pub(super) fn file_deploy_breakage(
         .map_err(|error| error.to_string())
 }
 
-/// Mark an issue as one the loop tried and could not resolve, and say why.
-///
-/// Both halves matter. The label is what the next run reads, so it stops
-/// spending on a wall it has already hit; the comment is what a **human**
-/// reads, and without it the label is an accusation with no evidence — an
-/// issue sitting there marked unresolvable by a machine that did not say what
-/// went wrong is worse than one that was never attempted.
 /// [`escalate`] for a synchronous caller.
 ///
 /// The driver's arms are synchronous and each awaited port call would
@@ -523,37 +517,85 @@ pub(super) fn escalate_blocking(
     provider: &dyn IssueProvider,
     key: &str,
     why: &str,
+    body: &str,
+    policy: &EscalationPolicy,
     signature: &str,
-) -> Result<(), String> {
+) -> Result<EscalationRecord, String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
     runtime
-        .block_on(escalate(provider, &IssueKey::from(key), why, signature))
+        .block_on(escalate(
+            provider,
+            &IssueKey::from(key),
+            why,
+            body,
+            policy,
+            signature,
+        ))
         .map_err(|error| error.to_string())
 }
 
+/// Mark an issue as one the loop tried and could not resolve, and say why.
+///
+/// Three writes, each for a different reader. The label is the marker a
+/// **person** scans for. The comment is what that person reads to learn what
+/// went wrong — without it the label is an accusation with no evidence. The
+/// record stamped into the body is what the **next run** reads: how many
+/// times this has happened, why the last one did, and when.
+///
+/// The record goes in the body rather than in a comment because the queue
+/// read already carries every body (`ready::fold_ready`), so a cooldown
+/// costs no extra call to the tracker. It is an HTML comment, so nobody
+/// reading the rendered issue sees it.
+///
+/// Returns the record it wrote, so the caller can count an issue that has
+/// just used up its last attempt.
 pub(super) async fn escalate(
     provider: &dyn IssueProvider,
     key: &IssueKey,
     why: &str,
+    body: &str,
+    policy: &EscalationPolicy,
     signature: &str,
-) -> Result<(), IssueError> {
+) -> Result<EscalationRecord, IssueError> {
+    let record = escalation::next(
+        escalation::parse(body).as_ref(),
+        escalation::classify(why),
+        &crate::timefmt::rfc3339_utc_now(),
+        crate::timefmt::now_unix(),
+    );
+
     provider
         .relabel(key, &[stella_autonomy::ESCALATION_LABEL.to_owned()], &[])
         .await?;
+    provider
+        .edit(key, None, Some(&escalation::stamp(body, &record)))
+        .await?;
 
-    let body = format!(
+    let next_step = match escalation::retry_after(&record, policy) {
+        Some(wait) => format!(
+            "The loop will take it again by itself in about {} minutes, once \
+             the cooldown is over. Nobody has to remove the label.",
+            wait.as_secs() / 60
+        ),
+        None => format!(
+            "That was attempt {} of {}, so the loop will not take it again. \
+             It is waiting on a person now.",
+            record.attempts, policy.park_after
+        ),
+    };
+    let note = format!(
         "This loop attempted this issue and could not resolve it, so it is \
-         labelled `{}` and will be skipped by later runs.\n\n\
+         labelled `{}`.\n\n\
          What happened: {why}\n\n\
-         The work is still wanted — this is not a closure. Remove the label to \
-         put it back in the queue, once whatever stopped the attempt has \
-         changed.",
+         {next_step}\n\n\
+         The work is still wanted — this is not a closure.",
         stella_autonomy::ESCALATION_LABEL
     );
-    comment(provider, key, &body, signature).await
+    comment(provider, key, &note, signature).await?;
+    Ok(record)
 }
 
 /// Close an issue with a receipt naming the evidence, signed.
@@ -756,18 +798,28 @@ mod tests {
     struct FixtureProvider {
         open: Vec<Issue>,
         filed: std::sync::Mutex<Vec<IssueDraft>>,
+        edited: std::sync::Mutex<Vec<String>>,
+        labelled: std::sync::Mutex<Vec<String>>,
     }
 
     impl FixtureProvider {
         fn with(open: Vec<Issue>) -> Self {
             Self {
                 open,
-                filed: std::sync::Mutex::new(Vec::new()),
+                ..Self::default()
             }
         }
 
         fn filed(&self) -> Vec<IssueDraft> {
             self.filed.lock().expect("fixture lock").clone()
+        }
+
+        fn edited(&self) -> Vec<String> {
+            self.edited.lock().expect("fixture lock").clone()
+        }
+
+        fn labelled(&self) -> Vec<String> {
+            self.labelled.lock().expect("fixture lock").clone()
         }
     }
 
@@ -803,9 +855,13 @@ mod tests {
         async fn relabel(
             &self,
             _key: &IssueKey,
-            _add: &[String],
+            add: &[String],
             _remove: &[String],
         ) -> Result<(), IssueError> {
+            self.labelled
+                .lock()
+                .expect("fixture lock")
+                .extend(add.iter().cloned());
             Ok(())
         }
 
@@ -813,8 +869,14 @@ mod tests {
             &self,
             _key: &IssueKey,
             _title: Option<&str>,
-            _body: Option<&str>,
+            body: Option<&str>,
         ) -> Result<(), IssueError> {
+            if let Some(body) = body {
+                self.edited
+                    .lock()
+                    .expect("fixture lock")
+                    .push(body.to_owned());
+            }
             Ok(())
         }
     }
@@ -1310,6 +1372,67 @@ mod tests {
             &stella_autonomy::Attribution::default(),
         );
         assert!(outcome.is_err(), "{outcome:?}");
+    }
+
+    /// **The escalation-record witness.** Escalating writes the label a
+    /// person reads *and* a record the next run reads: the count,
+    /// the reason, and the moment. A second escalation on the stamped body
+    /// carries the count forward rather than starting over, which is what
+    /// makes parking reachable.
+    #[test]
+    fn escalating_stamps_a_record_the_next_run_can_read() {
+        let provider = FixtureProvider::default();
+        let policy = stella_autonomy::escalation::EscalationPolicy::default();
+
+        let first = escalate_blocking(
+            &provider,
+            "17",
+            "the turn exited 1 — the same `bash` call with identical arguments \
+             produced byte-identical output every time",
+            "## What happens\nThe environment was stale.\n",
+            &policy,
+            "created by stella*",
+        )
+        .expect("the fixture accepts writes");
+
+        assert_eq!(first.attempts, 1);
+        assert_eq!(
+            first.last_reason,
+            stella_autonomy::escalation::EscalationReason::Environmental(
+                stella_autonomy::escalation::EnvCause::StuckLoop
+            ),
+            "a stuck-loop abort is a broken machine, and it is retried eagerly"
+        );
+        assert_eq!(
+            provider.labelled(),
+            vec![stella_autonomy::ESCALATION_LABEL.to_owned()],
+            "the label stays as the marker a person scans for"
+        );
+
+        let stamped = provider.edited().pop().expect("the body was stamped");
+        assert!(
+            stamped.starts_with("## What happens"),
+            "the issue's own text is kept: {stamped}"
+        );
+        assert_eq!(
+            stella_autonomy::escalation::parse(&stamped).as_ref(),
+            Some(&first),
+            "the record must survive a read of the body it was written into"
+        );
+
+        let second = escalate_blocking(
+            &provider,
+            "17",
+            "the turn ran and could not work out what the issue asks for",
+            &stamped,
+            &policy,
+            "created by stella*",
+        )
+        .expect("the fixture accepts writes");
+        assert_eq!(
+            second.attempts, 2,
+            "the count carries forward, or parking is never reached"
+        );
     }
 
     /// The limit bounds what crosses the port, not what the ranker discards

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -27,6 +27,7 @@ use stella_protocol::issue::{IssueDraft, IssueError, IssueKey, IssueLabel, Issue
 
 use crate::query_format::{QueryFormat, Rows};
 
+use super::config::LoopConfig;
 use super::state::LoopState;
 
 /// How many open issues cross the port to produce one cycle's batch.
@@ -77,7 +78,7 @@ fn truncation_notice(total: usize, provider: &str) -> Option<String> {
 /// a single awaited call.
 pub(super) fn ranked(
     provider: &dyn IssueProvider,
-    policy: &stella_autonomy::priority::TriagePolicy,
+    cfg: &LoopConfig,
 ) -> Result<(stella_autonomy::priority::Queue, usize), String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -95,7 +96,9 @@ pub(super) fn ranked(
             .iter()
             .map(crate::issue_provider::to_queue_issue)
             .collect(),
-        policy,
+        &cfg.triage,
+        &cfg.escalation,
+        crate::timefmt::now_unix(),
     );
 
     // Escalated issues, excluded kinds and the unassessed split all happen
@@ -109,11 +112,11 @@ pub(super) fn ranked(
 pub(super) fn render_queue(
     _st: &LoopState,
     provider: &dyn IssueProvider,
-    policy: &stella_autonomy::priority::TriagePolicy,
+    cfg: &LoopConfig,
     limit: usize,
     format: QueryFormat,
 ) -> Result<(), String> {
-    let (queue, total_issues) = ranked(provider, policy)?;
+    let (queue, total_issues) = ranked(provider, cfg)?;
     let defects = queue.ranked;
     let picked = &defects[..limit.min(defects.len())];
 
@@ -127,7 +130,8 @@ pub(super) fn render_queue(
     for i in picked {
         // The operator's rungs, not a built-in list — a tracker spelling
         // urgency `Sev1` must render its own word.
-        let prio = policy
+        let prio = cfg
+            .triage
             .ladder
             .rungs
             .iter()
@@ -166,7 +170,7 @@ pub(super) fn render_queue(
 /// reason to wake.
 pub(super) fn demand_from(
     provider: &dyn IssueProvider,
-    policy: &stella_autonomy::priority::TriagePolicy,
+    cfg: &LoopConfig,
 ) -> Result<Demand, String> {
     // The read's failure is reported, not flattened. `Demand::default()` is
     // zero open defects, which is the *answer to a different question* — an
@@ -174,9 +178,9 @@ pub(super) fn demand_from(
     // arrive here as the same number. `watch` then printed
     // `✓ defect queue empty` and stood the loop down, and the governor planned
     // a cycle against a demand nobody had measured.
-    let (queue, _) = ranked(provider, policy)?;
+    let (queue, _) = ranked(provider, cfg)?;
     // The most urgent rung the operator declared, whatever they call it.
-    let urgent = policy.ladder.most_urgent().unwrap_or_default();
+    let urgent = cfg.triage.ladder.most_urgent().unwrap_or_default();
     let p0 = queue
         .ranked
         .iter()
@@ -280,14 +284,14 @@ pub(super) async fn file_finding(
 pub(super) fn ranked_keys(
     st: &super::state::LoopState,
     provider: &dyn IssueProvider,
-    policy: &stella_autonomy::priority::TriagePolicy,
+    cfg: &LoopConfig,
 ) -> Result<Vec<String>, String> {
-    let (queue, total) = ranked(provider, policy)?;
+    let (queue, total) = ranked(provider, cfg)?;
     // The driver's claim pass is the one place the queue is read on a
     // cadence, so it is the one place a snapshot stays current for the
     // observatory — still the single `ranked` read: the keys the loop claims
     // from and the items the dashboard shows are one list, folded twice.
-    st.write_queue_snapshot(&queue, &policy.ladder, total);
+    st.write_queue_snapshot(&queue, &cfg.triage.ladder, total);
     Ok(queue
         .ranked
         .into_iter()
@@ -302,9 +306,9 @@ pub(super) fn ranked_keys(
 /// its own read would be the second definition this module exists to prevent.
 pub(super) fn unassessed(
     provider: &dyn IssueProvider,
-    policy: &stella_autonomy::priority::TriagePolicy,
+    cfg: &LoopConfig,
 ) -> Result<Vec<stella_autonomy::priority::Unassessed>, String> {
-    let (queue, _) = ranked(provider, policy)?;
+    let (queue, _) = ranked(provider, cfg)?;
     Ok(queue.unassessed)
 }
 
@@ -1165,8 +1169,8 @@ mod tests {
     /// ranking no longer requires GitHub to exist.
     #[test]
     fn a_ranked_queue_needs_no_github_at_all() {
-        let policy = stella_autonomy::priority::TriagePolicy::default();
-        let (queue, total) = ranked(&backlog(), &policy).expect("fixture read");
+        let cfg = LoopConfig::default();
+        let (queue, total) = ranked(&backlog(), &cfg).expect("fixture read");
         let order: Vec<u64> = queue.ranked.iter().map(|issue| issue.number).collect();
         assert_eq!(
             order,
@@ -1207,8 +1211,8 @@ mod tests {
         open.push(issue("7", &["bug", "P0"], "2020-01-01T00:00:00Z"));
 
         let provider = FixtureProvider::with(open);
-        let policy = stella_autonomy::priority::TriagePolicy::default();
-        let (queue, total) = ranked(&provider, &policy).expect("fixture read");
+        let cfg = LoopConfig::default();
+        let (queue, total) = ranked(&provider, &cfg).expect("fixture read");
 
         assert_eq!(
             queue.ranked.first().map(|issue| issue.number),
@@ -1260,8 +1264,8 @@ mod tests {
     /// and place it instead of burying it.
     #[test]
     fn a_defect_with_no_rung_surfaces_as_a_question() {
-        let policy = stella_autonomy::priority::TriagePolicy::default();
-        let (queue, _) = ranked(&backlog(), &policy).expect("fixture read");
+        let cfg = LoopConfig::default();
+        let (queue, _) = ranked(&backlog(), &cfg).expect("fixture read");
         assert_eq!(
             queue
                 .unassessed
@@ -1281,8 +1285,8 @@ mod tests {
     /// disagree with the batch the same cycle draws.
     #[test]
     fn demand_is_a_fold_of_the_same_ranking() {
-        let policy = stella_autonomy::priority::TriagePolicy::default();
-        let demand = demand_from(&backlog(), &policy).expect("the fake backlog reads");
+        let cfg = LoopConfig::default();
+        let demand = demand_from(&backlog(), &cfg).expect("the fake backlog reads");
         assert_eq!(
             demand.open_defects, 3,
             "the feature is not a defect, and the unranked one is not yet work"
@@ -1307,10 +1311,7 @@ mod tests {
     /// read.
     #[test]
     fn an_unreachable_tracker_is_not_a_measured_zero() {
-        let answer = demand_from(
-            &DeadProvider,
-            &stella_autonomy::priority::TriagePolicy::default(),
-        );
+        let answer = demand_from(&DeadProvider, &LoopConfig::default());
         assert!(
             answer.is_err(),
             "a tracker that could not be read reports so: {answer:?}"

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -51,6 +51,9 @@ pub(crate) struct LoopConfig {
     pub triage: stella_autonomy::priority::TriagePolicy,
     /// How the loop decides where two operators would decide differently.
     pub doctrine: stella_autonomy::Doctrine,
+    /// How long an escalated issue waits before the loop may take it again,
+    /// and how many escalations end in it being parked for good.
+    pub escalation: stella_autonomy::escalation::EscalationPolicy,
     /// Which checks are allowed to block a merge.
     pub merge: stella_autonomy::BlockingPolicy,
     /// The command that proves a change when CI cannot, and its ceiling.
@@ -74,6 +77,7 @@ impl Default for LoopConfig {
             vocabulary: Vocabulary::default(),
             triage: stella_autonomy::priority::TriagePolicy::default(),
             doctrine: stella_autonomy::Doctrine::default(),
+            escalation: stella_autonomy::escalation::EscalationPolicy::default(),
             merge: stella_autonomy::BlockingPolicy::default(),
             verify_command: None,
             verify_timeout_secs: 1800,
@@ -101,6 +105,7 @@ pub(crate) fn load(root: &Path) -> LoopConfig {
         vocabulary: vocabulary_for(root, &parsed.issues),
         triage: parsed.self_driving.triage.policy(),
         doctrine: parsed.self_driving.doctrine,
+        escalation: parsed.self_driving.escalation,
         merge: parsed.self_driving.merge.policy(),
         verify_command: parsed.self_driving.verify.command.clone(),
         verify_timeout_secs: parsed.self_driving.verify.timeout_secs.unwrap_or(1800),

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -513,7 +513,7 @@ pub(super) fn drive(
                 // A queue read is a network call. Failing it is a reason to
                 // wait, never a reason to end a run meant to be perpetual.
                 let read = if backlog {
-                    super::ready::ready_keys(&provider, &cfg.triage.ladder)
+                    super::ready::ready_keys(&provider, &cfg)
                 } else {
                     super::backlog::ranked_keys(durable, &provider, &cfg.triage)
                 };
@@ -840,14 +840,7 @@ pub(super) fn drive(
                             Some(&issue.0),
                             &format!("the turn did not complete: {reason}"),
                         );
-                        triage::escalate(
-                            durable,
-                            &settings,
-                            &provider,
-                            &cfg,
-                            &resolved.key,
-                            &reason,
-                        );
+                        triage::escalate(durable, &settings, &provider, &cfg, &resolved, &reason);
                     }
                 }
             }

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -515,7 +515,7 @@ pub(super) fn drive(
                 let read = if backlog {
                     super::ready::ready_keys(&provider, &cfg)
                 } else {
-                    super::backlog::ranked_keys(durable, &provider, &cfg.triage)
+                    super::backlog::ranked_keys(durable, &provider, &cfg)
                 };
                 let ranked = match read {
                     Ok(ranked) => ranked,

--- a/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
@@ -98,7 +98,7 @@ pub(super) fn assess_one(
     budget: &mut crate::self_driving_cmd::budget::RunBudget,
     triaged: &mut std::collections::HashSet<String>,
 ) -> Result<(), String> {
-    let unassessed = crate::self_driving_cmd::backlog::unassessed(provider, &cfg.triage)?;
+    let unassessed = crate::self_driving_cmd::backlog::unassessed(provider, cfg)?;
     let Some(issue) = unassessed.into_iter().find(|u| !triaged.contains(&u.key)) else {
         return Ok(());
     };

--- a/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
@@ -17,29 +17,49 @@
 use super::{Audit, Durable, audit, runtime};
 
 /// Mark an issue the loop tried and could not resolve.
+///
+/// The whole issue rather than its key, because the escalation record is
+/// stamped into the body and the count in the body it already has is what
+/// says whether this is the first attempt or the last.
 pub(super) fn escalate(
     durable: &Durable,
     settings: &crate::settings::Settings,
     provider: &crate::issue_provider::GhIssueProvider,
     cfg: &crate::self_driving_cmd::config::LoopConfig,
-    key: &stella_protocol::issue::IssueKey,
+    issue: &stella_protocol::issue::Issue,
     why: &str,
 ) {
+    let key = &issue.key;
     match runtime().block_on(crate::self_driving_cmd::backlog::escalate(
         provider,
         key,
         why,
+        &issue.body,
+        &cfg.escalation,
         &cfg.attribution.issue_comment,
     )) {
-        Ok(()) => {
-            durable.update_stats(|s| s.issues_escalated += 1);
+        Ok(record) => {
+            let parked = stella_autonomy::escalation::parked(&record, &cfg.escalation);
+            durable.update_stats(|s| {
+                s.issues_escalated += 1;
+                if parked {
+                    s.issues_parked += 1;
+                }
+            });
             audit::record(
                 durable,
                 Audit::Escalated,
                 Some(key.as_str()),
                 &format!(
-                    "labelled `{}` — unresolved, later runs will skip it",
-                    stella_autonomy::ESCALATION_LABEL
+                    "labelled `{}` — attempt {} of {}; {}",
+                    stella_autonomy::ESCALATION_LABEL,
+                    record.attempts,
+                    cfg.escalation.park_after,
+                    if parked {
+                        "parked, the loop will not take it again"
+                    } else {
+                        "the loop takes it again once its cooldown is over"
+                    }
                 ),
             );
             super::notify::escalated(&durable.repo_root, settings, key.as_str(), why);
@@ -65,9 +85,11 @@ pub(super) fn escalate(
 /// at all, has told us it cannot place this issue. Leaving it unplaced would
 /// mean meeting it again on the very next pass, paying for the same turn, and
 /// getting the same refusal — forever, and at the cost of never claiming any
-/// work. So it gets the escalation label, which takes it out of the queue and
-/// puts it in front of a human. `triaged` is the process-local half of the
-/// same guard, covering the window before the label lands.
+/// work. So it escalates, which takes it out of the queue for a cooldown and
+/// puts it in front of a human. A refusal is not an environmental fault, so
+/// it takes the long cooldown and is parked after a few tries
+/// (`stella_autonomy::escalation`). `triaged` is the process-local half of
+/// the same guard, covering the window before the label lands.
 pub(super) fn assess_one(
     durable: &Durable,
     root: &std::path::Path,
@@ -114,8 +136,9 @@ pub(super) fn assess_one(
             "this loop placed the issue, and the triage guard stripped the \
              priority it wrote — the drive runner's login is not on the \
              guard's list. Add it to TRIAGE_LOGINS in the guard workflow, or \
-             set the priority from an allowed login. Then remove the \
-             escalation label to requeue",
+             set the priority from an allowed login",
+            &full.body,
+            &cfg.escalation,
             &cfg.attribution.issue_comment,
         )?;
         audit::record(
@@ -137,6 +160,8 @@ pub(super) fn assess_one(
             &issue.key,
             "triage could not place this issue in the configured vocabulary — \
              it needs a human to label it",
+            &body,
+            &cfg.escalation,
             &cfg.attribution.issue_comment,
         )?;
         audit::record(

--- a/crates/stella-cli/src/self_driving_cmd/parallel.rs
+++ b/crates/stella-cli/src/self_driving_cmd/parallel.rs
@@ -89,7 +89,7 @@ pub(super) fn wave(
     super::work::refuse_if_unsteered(root)?;
     refuse_unsupported_worker(&cfg.worker)?;
 
-    let ready = super::ready::ready_full(provider, &cfg.triage.ladder)?;
+    let ready = super::ready::ready_full(provider, cfg)?;
     let bound = (max_issues.max(width)) as usize;
 
     let session_id = audit::begin_session();

--- a/crates/stella-cli/src/self_driving_cmd/query.rs
+++ b/crates/stella-cli/src/self_driving_cmd/query.rs
@@ -123,7 +123,7 @@ pub(super) fn queue(st: &LoopState, limit: usize, format: QueryFormat) -> Result
     backlog::render_queue(
         st,
         &crate::issue_provider::GhIssueProvider,
-        &config::load(&st.repo_root).triage,
+        &config::load(&st.repo_root),
         limit,
         format,
     )

--- a/crates/stella-cli/src/self_driving_cmd/ready.rs
+++ b/crates/stella-cli/src/self_driving_cmd/ready.rs
@@ -86,10 +86,9 @@ fn open_page(provider: &dyn IssueProvider) -> Result<Vec<stella_protocol::issue:
 
 /// The readiness fold over one read's records.
 ///
-/// The escalation record sits in the body, so this read carries it too.
-/// The queue can hold a cooldown with no second call to the tracker. The
-/// clock is read here: `stella-autonomy` does no I/O and takes the time as
-/// an argument.
+/// The clock is read here: `stella-autonomy` does no I/O and takes the time
+/// as an argument. The escalation record rides on the issue itself, put
+/// there by `to_queue_issue` out of the body this read already carried.
 fn fold_ready(
     issues: &[stella_protocol::issue::Issue],
     cfg: &LoopConfig,
@@ -103,7 +102,6 @@ fn fold_ready(
         .map(|issue| stella_autonomy::ready::BacklogItem {
             issue: crate::issue_provider::to_queue_issue(issue),
             blocked_by: stella_autonomy::ready::blocker_refs(&issue.body),
-            escalation: stella_autonomy::escalation::parse(&issue.body),
         })
         .collect();
     stella_autonomy::ready::ready_queue(
@@ -143,7 +141,7 @@ pub(super) fn dry_run(
     let queue = if backlog {
         ready_issues(provider, cfg)?
     } else {
-        super::backlog::ranked(provider, &cfg.triage)?.0.ranked
+        super::backlog::ranked(provider, cfg)?.0.ranked
     };
 
     println!("dry run — nothing was claimed, branched, filed, or labelled");

--- a/crates/stella-cli/src/self_driving_cmd/ready.rs
+++ b/crates/stella-cli/src/self_driving_cmd/ready.rs
@@ -10,7 +10,6 @@
 use std::collections::BTreeSet;
 
 use stella_autonomy::CycleRecord;
-use stella_autonomy::priority::PriorityLadder;
 use stella_protocol::issue::IssueProvider;
 
 use crate::timefmt::{now_unix, rfc3339_utc_now};
@@ -32,10 +31,10 @@ use super::state::LoopState;
 /// a hit on the ceiling fails loud instead of guessing.
 fn ready_issues(
     provider: &dyn IssueProvider,
-    ladder: &PriorityLadder,
+    cfg: &LoopConfig,
 ) -> Result<Vec<stella_autonomy::QueueIssue>, String> {
     let issues = open_page(provider)?;
-    Ok(fold_ready(&issues, ladder))
+    Ok(fold_ready(&issues, cfg))
 }
 
 /// The ready backlog with the tracker's full records attached, in the order
@@ -49,10 +48,10 @@ fn ready_issues(
 /// another moment's body.
 pub(super) fn ready_full(
     provider: &dyn IssueProvider,
-    ladder: &PriorityLadder,
+    cfg: &LoopConfig,
 ) -> Result<Vec<stella_protocol::issue::Issue>, String> {
     let issues = open_page(provider)?;
-    let ready = fold_ready(&issues, ladder);
+    let ready = fold_ready(&issues, cfg);
     Ok(ready
         .iter()
         .filter_map(|queued| {
@@ -86,9 +85,14 @@ fn open_page(provider: &dyn IssueProvider) -> Result<Vec<stella_protocol::issue:
 }
 
 /// The readiness fold over one read's records.
+///
+/// The escalation record sits in the body, so this read carries it too.
+/// The queue can hold a cooldown with no second call to the tracker. The
+/// clock is read here: `stella-autonomy` does no I/O and takes the time as
+/// an argument.
 fn fold_ready(
     issues: &[stella_protocol::issue::Issue],
-    ladder: &PriorityLadder,
+    cfg: &LoopConfig,
 ) -> Vec<stella_autonomy::QueueIssue> {
     let open: BTreeSet<u64> = issues
         .iter()
@@ -99,9 +103,16 @@ fn fold_ready(
         .map(|issue| stella_autonomy::ready::BacklogItem {
             issue: crate::issue_provider::to_queue_issue(issue),
             blocked_by: stella_autonomy::ready::blocker_refs(&issue.body),
+            escalation: stella_autonomy::escalation::parse(&issue.body),
         })
         .collect();
-    stella_autonomy::ready::ready_queue(items, &open, ladder)
+    stella_autonomy::ready::ready_queue(
+        items,
+        &open,
+        &cfg.triage.ladder,
+        &cfg.escalation,
+        now_unix(),
+    )
 }
 
 /// The ready backlog as bare keys, in the order the loop takes them.
@@ -110,9 +121,9 @@ fn fold_ready(
 /// shape, a different meaning of "next" — ready, not defect rank.
 pub(super) fn ready_keys(
     provider: &dyn IssueProvider,
-    ladder: &PriorityLadder,
+    cfg: &LoopConfig,
 ) -> Result<Vec<String>, String> {
-    Ok(ready_issues(provider, ladder)?
+    Ok(ready_issues(provider, cfg)?
         .into_iter()
         .map(|issue| issue.number.to_string())
         .collect())
@@ -130,7 +141,7 @@ pub(super) fn dry_run(
     bound: u32,
 ) -> Result<(), String> {
     let queue = if backlog {
-        ready_issues(provider, &cfg.triage.ladder)?
+        ready_issues(provider, cfg)?
     } else {
         super::backlog::ranked(provider, &cfg.triage)?.0.ranked
     };
@@ -322,7 +333,7 @@ mod tests {
             issue("6", &["feature", "P0"], "Blocked by: #9"),
         ]);
 
-        let keys = ready_keys(&provider, &PriorityLadder::default()).expect("fixture read");
+        let keys = ready_keys(&provider, &LoopConfig::default()).expect("fixture read");
         assert_eq!(
             keys,
             vec!["6".to_owned(), "4".to_owned()],
@@ -378,10 +389,63 @@ mod tests {
             .collect();
         let provider = FixtureProvider::with(issues);
 
-        let result = ready_keys(&provider, &PriorityLadder::default());
+        let result = ready_keys(&provider, &LoopConfig::default());
         assert!(
             result.is_err(),
             "a page-bounded read must refuse rather than guess at readiness"
+        );
+    }
+
+    /// **The end-to-end cooldown witness.** An issue escalated because the
+    /// box broke keeps its record in its body. The generator reads that
+    /// body, sees the wait is over, and offers the issue again. The
+    /// `agent-escalated` label is still on it. Nothing was written.
+    ///
+    /// An issue that used up its tries is offered by nothing.
+    #[test]
+    fn the_backlog_generator_offers_an_escalated_issue_again_once_its_cooldown_is_over() {
+        use stella_autonomy::escalation::{
+            EnvCause, EscalationPolicy, EscalationReason, EscalationRecord, stamp,
+        };
+
+        let policy = EscalationPolicy::default();
+        let long_ago =
+            now_unix() - i64::try_from(policy.environmental_cooldown_secs).expect("fits") - 60;
+        let cooled = EscalationRecord {
+            attempts: 1,
+            last_reason: EscalationReason::Environmental(EnvCause::StuckLoop),
+            last_at: "2026-09-02T00:00:00Z".to_owned(),
+            last_at_unix: long_ago,
+        };
+        let spent = EscalationRecord {
+            attempts: policy.park_after,
+            ..cooled.clone()
+        };
+
+        let body = "## What happens\nThe environment was stale.\n";
+        let provider = FixtureProvider::with(vec![
+            issue(
+                "17",
+                &["feature", "P1", stella_autonomy::ESCALATION_LABEL],
+                &stamp(body, &cooled),
+            ),
+            issue(
+                "18",
+                &["feature", "P1", stella_autonomy::ESCALATION_LABEL],
+                &stamp(body, &spent),
+            ),
+        ]);
+
+        let keys = ready_keys(&provider, &LoopConfig::default()).expect("fixture read");
+        assert_eq!(
+            keys,
+            vec!["17".to_owned()],
+            "a cooled environmental escalation returns; one out of attempts stays parked"
+        );
+        assert_eq!(
+            provider.writes(),
+            0,
+            "requeueing must cost no label surgery and no tracker write"
         );
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -990,6 +990,7 @@ mod tests {
             labels,
             created_at: "2026-08-01T00:00:00Z".to_owned(),
             url: format!("https://example.test/issues/{number}"),
+            escalation: None,
         };
         let policy = TriagePolicy::default();
         let queue = triage(
@@ -999,6 +1000,8 @@ mod tests {
                 issue(3, "nobody placed this", vec![]),
             ],
             &policy,
+            &stella_autonomy::escalation::EscalationPolicy::default(),
+            0,
         );
 
         st.write_queue_snapshot(&queue, &policy.ladder, 3);

--- a/crates/stella-cli/src/self_driving_cmd/stats.rs
+++ b/crates/stella-cli/src/self_driving_cmd/stats.rs
@@ -99,6 +99,10 @@ pub(super) fn session_stats(st: &LoopState, format: QueryFormat) -> Result<(), S
     println!("  no change       {:>5}", stats.issues_no_change);
     println!("  failed          {:>5}", stats.issues_failed);
     println!("  escalated       {:>5}", stats.issues_escalated);
+    println!(
+        "  parked          {:>5}   out of attempts; the loop will not take them again",
+        stats.issues_parked
+    );
     println!("  deferred        {:>5}", stats.issues_deferred);
 
     println!("\nfiled");
@@ -290,6 +294,7 @@ mod tests {
         assert_eq!(stats.issues_claimed, 0);
         assert_eq!(stats.issues_deferred, 0);
         assert_eq!(stats.issues_escalated, 0);
+        assert_eq!(stats.issues_parked, 0);
         assert_eq!(stats.verified_locally, 0);
         assert_eq!(stats.prs_opened, 0);
     }

--- a/crates/stella-cli/src/self_driving_cmd/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/triage.rs
@@ -757,8 +757,11 @@ mod tests {
                     })
                     .collect(),
                 url: String::new(),
+                escalation: None,
             }],
             &policy,
+            &stella_autonomy::escalation::EscalationPolicy::default(),
+            i64::MAX,
         );
         assert!(
             escalated.is_empty(),

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -396,6 +396,15 @@ pub struct SelfDrivingSection {
     /// about the code, which is why they are declared rather than compiled in.
     #[serde(default)]
     pub doctrine: stella_autonomy::Doctrine,
+    /// `[self_driving.escalation]` — how long an issue the loop could not
+    /// finish waits before it may be taken again, and how many tries end in
+    /// it being parked.
+    ///
+    /// A judgement call about this operator's tolerance, like the doctrine
+    /// above: a team paying for a fast model wants an issue back in
+    /// minutes, and a team on a small budget wants fewer repeat attempts.
+    #[serde(default)]
+    pub escalation: stella_autonomy::escalation::EscalationPolicy,
     /// `[self_driving.triage]` — the vocabulary the loop places issues in.
     ///
     /// Here rather than in the tracker manifest because these are *this

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -418,6 +418,12 @@ ones beside the escalated ones, so a backlog the loop has given up on
 cannot read as one it is still working through. All three numbers are
 operator settings under `[self_driving.escalation]` in `stella.toml`.
 
+Both work generators ask the same question, through
+`QueueIssue::escalation_holds`: the ready backlog (`ready::ready_queue`,
+behind `drive --backlog`) and the defect queue (`priority::triage`, the
+default `drive` path). One rule, two readers, so the two cannot start
+disagreeing about when an escalated issue comes back.
+
 An escalated issue with no record stays out of the queue. The label alone
 says nothing about what went wrong or when, and a person who applied it by
 hand meant it.

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -396,8 +396,31 @@ still judges correctly, but the guard undoes its priority writes. The loop
 detects that shape — an issue carrying its own `size/` label with no rung —
 as *placed, then stripped*. It escalates the issue once to a human instead
 of re-triaging forever. The fix is operational, not code: add the runner's
-login to `TRIAGE_LOGINS`, or run the loop under a login already there. Then
-remove the escalation label to requeue.
+login to `TRIAGE_LOGINS`, or run the loop under a login already there.
+
+**Escalation is a cooldown, not a tombstone.** A flat label that only a
+person can remove costs the backlog every issue a bad hour touches. A turn
+aborts because the machine broke — a stale checkout returning the same bytes
+to every command, a provider outage, a failed install — and the issue, which
+was never the problem, leaves the queue for good. An unattended week ends
+with a queue full of parked work and no memory of why.
+
+So an escalation now writes a record into the issue body, inside an HTML
+comment (`<!-- stella-escalation {…} -->`): how many attempts there have
+been, why the last one happened, and when. The label stays as the marker a
+person scans for; the record is what the next run reads.
+`stella_autonomy::escalation` classifies the abort message and decides how
+long to wait. A broken machine waits ten minutes by default; a turn that
+ran and could not do the work waits six hours, because that one needs
+something to change first. After three attempts the issue is parked and the
+loop never takes it again. `stella self-driving stats` counts the parked
+ones beside the escalated ones, so a backlog the loop has given up on
+cannot read as one it is still working through. All three numbers are
+operator settings under `[self_driving.escalation]` in `stella.toml`.
+
+An escalated issue with no record stays out of the queue. The label alone
+says nothing about what went wrong or when, and a person who applied it by
+hand meant it.
 
 **The deploy watch.** Beside the base watch, each poll may also read the
 release workflow's latest completed run, through the same forge pathway. On

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -688,6 +688,28 @@ contention = "defer"
 # stop making more of them.
 abandon_escalated = false
 
+[self_driving.escalation]
+# What happens to an issue the loop tried and could not finish. It is labelled
+# `agent-escalated` and a record goes into its body: how many tries there have
+# been, why the last one stopped, and when. The label stays for a person to
+# see; the record is what the next run reads. Nobody has to remove anything.
+
+# Seconds to wait when the machine was what broke — a stale checkout returning
+# the same bytes to every command, a provider outage, a failed install. These
+# clear on their own in minutes, and the issue itself was never the problem.
+environmental_cooldown_secs = 600
+
+# Seconds to wait when the turn ran and could not do the work. That one needs
+# something to change first — a comment, a different model, a blocker that
+# lands — so retrying in minutes would buy the same failure at full price.
+beyond_loop_cooldown_secs = 21600
+
+# Tries after which the issue is parked and the loop never takes it again.
+# `stella self-driving stats` counts the parked ones apart from the escalated
+# ones. Two would park work on one bad afternoon; ten would spend ten turns
+# proving the same thing.
+park_after = 3
+
 [self_driving.triage]
 # The vocabulary the loop places issues in. Here rather than in the tracker
 # manifest because these are YOUR judgements about your own backlog — which

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -163,7 +163,9 @@ Asking a loop to stop when it's already stopping is not an error. The output tel
 
 ### stats
 
-`stella self-driving stats` shows what a session has done so far: issues claimed, attempted, changed, failed, escalated, and deferred; issues created, refused, and marked as duplicates; issues closed, broken down by how they were closed; pull requests opened, merged, and escalated; fixes, rebases, and time spent waiting on a broken base branch; reflections, memories, and proposals written; and turns run, including turns stopped by their limit.
+`stella self-driving stats` shows what a session has done so far: issues claimed, attempted, changed, failed, escalated, parked, and deferred; issues created, refused, and marked as duplicates; issues closed, broken down by how they were closed; pull requests opened, merged, and escalated; fixes, rebases, and time spent waiting on a broken base branch; reflections, memories, and proposals written; and turns run, including turns stopped by their limit.
+
+**Escalated and parked are different news.** An escalated issue is on a cooldown: the loop could not finish it this time, wrote down why, and will take it again by itself once enough time has passed. Nobody has to remove the `agent-escalated` label. A parked issue has used up its attempts, and the loop will never take it again — that one is waiting on a person. A break in the machine (a stale checkout, a provider outage, a failed install) comes back in minutes; work the loop genuinely could not do waits hours. Set all three numbers under `[self_driving.escalation]` in `stella.toml`.
 
 stella writes these stats after **every step**, not just at the end. Since the loop never stops on its own, a report written only on exit would never get written at all — the point is a record you can read while the loop is still running. Each write is atomic, so a dashboard reading the file mid-write always sees the last complete version, never a half-written one.
 

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -638,6 +638,31 @@ it.
   </OptionCard>
 </CardGrid>
 
+#### `[self_driving.escalation]`
+
+What happens to an issue the loop tried and could not finish. It gets the
+`agent-escalated` label and a record in its body saying how many tries there have been,
+why the last one stopped, and when. The label is what a person scans for; the record is
+what the next run reads. Nobody has to remove anything to put the issue back in the
+queue — the cooldown does that.
+
+<CardGrid size="sm">
+  <OptionCard name="self_driving.escalation.environmental_cooldown_secs" defaultValue="600">
+    Seconds to wait when the machine was what broke: a stale checkout returning the same
+    bytes to every command, a provider outage, a failed install. These clear on their own
+    in minutes, and the issue itself was never the problem.
+  </OptionCard>
+  <OptionCard name="self_driving.escalation.beyond_loop_cooldown_secs" defaultValue="21600">
+    Seconds to wait when the turn ran and could not do the work. That needs something to
+    change first — a comment, a different model, a blocker that lands — so retrying in
+    minutes would buy the same failure at full price.
+  </OptionCard>
+  <OptionCard name="self_driving.escalation.park_after" defaultValue="3">
+    Tries after which the issue is parked and the loop never takes it again.
+    `stella self-driving stats` counts the parked ones apart from the escalated ones.
+  </OptionCard>
+</CardGrid>
+
 #### `[self_driving.triage]`
 
 The vocabulary the loop places issues in: which labels mean urgent, which mean "this is


### PR DESCRIPTION
## What and why

An escalated issue left the backlog for good. `triage.rs::escalate()` applied a flat `agent-escalated` label and every later run skipped it; only a person removing that label could put it back. A turn that aborted because the machine broke — a stale checkout making every `bash` call return byte-identical output, a provider outage, a failed install — cost the backlog an issue that was never the problem. Over an unattended week that is a slow leak: the queue fills with parked work and nothing remembers why.

Escalation is now a cooldown with an end.

**Decision logic, pure, in `stella-autonomy`** (`crates/stella-autonomy/src/escalation.rs`, no I/O, per AGENTS.md invariant #2):

- `EscalationReason { Environmental(EnvCause) | BeyondLoop }`, with `EnvCause` naming the stuck loop, the provider error, and the install failure.
- `classify(why)` reads the abort message against a fixed phrase list — the same shape as the residue gate's detector, and every phrase is text this tree actually writes (`byte-identical` from the loop guard, `could not start` from a failed spawn, the HTTP words providers spell out). Anything unmatched is `BeyondLoop`, the **longer** wait, so an unrecognised message can only make the loop slower, never more eager.
- `EscalationRecord { attempts, last_reason, last_at, last_at_unix }`, `retry_after(record, policy) -> Option<Duration>` (`None` = parked), `parked`, `may_retry(record, policy, now_unix)`, and `next` for the count that carries forward.
- `EscalationPolicy` defaults: 600s environmental, 21600s beyond-loop, `park_after = 3`. Settable as `[self_driving.escalation]` in `stella.toml`.

**I/O in `stella-cli`'s `self_driving_cmd`:**

- `backlog::escalate` writes three things for three readers — the label a person scans for, the comment a person reads, and the record the next run reads. It returns the record so the caller can count a parked issue.
- `ready::fold_ready` parses the record out of the body it already read and hands it to `ready_queue`; the clock is read here, and `stella-autonomy` takes the moment as an argument.
- `drive/triage.rs` and `drive.rs` are call-throughs only. `drive.rs` got **shorter** (1495 → 1488 lines).
- `stats.rs` prints `parked` beside `escalated`; `SessionStats::issues_parked` is declared in `PRODUCERS` like every other counter.

### Two departures from the design pointer, and why

1. **The record lives in the issue body, not in a comment.** `stella_protocol::issue::IssueProvider` has `comment()` (write) and no comment **read** — so the readback the design needs does not exist, and adding it means a new required trait method plus edits to all nine implementors, eight of which are test fixtures. The body is already carried by the read `ready::fold_ready` makes (`list_open`), so a cooldown costs zero extra tracker calls; the comment form would cost one API read per escalated issue per cycle. It also reuses the exact readback path readiness already uses for `Blocked by:` lines. The marker is an HTML comment (`<!-- stella-escalation {json} -->`), invisible in the rendered issue, and `stamp` replaces the old one rather than stacking.
2. **`retry_after` returns a wall-clock `Duration`, not "N cycles."** `stella-autonomy` takes no date-parsing dependency (serde/serde_json/sha2 only), so the record stores `last_at_unix` beside the human-readable `last_at` — the convention `CycleRecord` already uses (`ended_at` + `ended_at_unix`). "Environmental after 1 cycle" is honoured as *the shorter of two cooldowns*, ten minutes by default, rather than by plumbing a cycle counter into a queue read that has none.

3. **Both work generators consult the cooldown, not just `ready.rs`.** The pointer scoped the consult to `ready.rs`; Sourcery's first review then flagged, correctly, that the *default* `drive` path is the defect queue (`priority::triage` / `rank_defects`), where the tombstone would have survived. `QueueIssue` now carries the record itself — put there by `to_queue_issue` out of the body the queue read already returned — and both generators ask one shared rule, `QueueIssue::escalation_holds`. `BacklogItem` lost its own copy for the same reason. The `ranked`/`ranked_keys`/`unassessed`/`render_queue`/`demand_from` family takes the whole `LoopConfig` instead of the triage policy alone, which is what carries the escalation policy and the clock down to the fold.

## Exemplar followed

`stella_autonomy::doctrine::Doctrine` — a pure policy struct in the leaf crate, serde-derived with `#[serde(default)]`, plugged straight into `SelfDrivingSection` as its own `stella.toml` table. `EscalationPolicy` is the same shape, which is why the config surface costs six lines instead of a new section type.

## Witness tests and their mechanism

I cannot run tests on this machine (CLAUDE.md, "CI builds and tests; this laptop does not"), so here is why each fails on `main` by construction:

1. `an_environmental_escalation_leaves_the_queue_and_returns_when_its_cooldown_is_over` (`crates/stella-autonomy/src/ready.rs`) — the rainforest#17 shape. An issue labelled `agent-escalated` whose record says the abort was a stuck loop is absent from `ready_queue` at the moment it was escalated and **present** once the cooldown has passed, with the label untouched. **Fails on old code by construction:** `ready_queue`'s old body was `if item.issue.has_label(ESCALATION_LABEL) { continue; }` with no cooldown and no `escalation` field on `BacklogItem` — the test does not compile against it, and the queue it asserts on is unconditionally empty.
2. `the_backlog_generator_offers_an_escalated_issue_again_once_its_cooldown_is_over` (`crates/stella-cli/src/self_driving_cmd/ready.rs`) — the same shape end to end, through the real generator and a fixture tracker: a cooled escalation comes back, one at `park_after` stays parked, and the fixture's write counter is 0, so nothing removed a label.
3. `an_environmental_escalation_returns_to_the_defect_queue_once_its_cooldown_is_over` (`crates/stella-autonomy/src/priority.rs`) — the same three states through the **default** `drive` path. **Fails on old code:** `triage`'s escalated arm was `if issue.has_label(ESCALATION_LABEL) { continue; }`, with no policy argument and no record on `QueueIssue` to consult.
4. `escalating_stamps_a_record_the_next_run_can_read` (`crates/stella-cli/src/self_driving_cmd/backlog.rs`) — the write half. `escalate_blocking` applies the label **and** edits the body; the stamped body round-trips back through `escalation::parse`; a second escalation on that body reports `attempts == 2`. **Fails on old code:** `escalate` returned `Result<(), IssueError>` and never called `provider.edit`.
5. `an_issue_escalated_to_the_ceiling_stays_out_of_the_ready_queue` and `an_issue_escalated_park_after_times_is_never_taken_again` — the cooldown has an end; `i64::MAX` does not make a parked issue takeable.
6. `an_escalated_issue_with_no_record_never_enters_the_ready_queue` and `an_escalated_issue_is_not_re_asked` — a label a person applied by hand still means what it meant.
7. `escalation.rs` unit tests cover classification both ways, the two cooldown lengths, the marker round-trip, damaged markers, and the carried count.

Guards run locally: `make guards-fast` green (prose, line-citations, dead-code-allows, module-reachability, lockfile-sync, fmt), `./scripts/check-file-size.sh` green — `drive.rs` 1488/1500, `backlog.rs` 1449/1500, nothing grandfathered, no baseline touched.

## Docs

- `docs/spec/backlog-self-driving.md` — a new "Escalation is a cooldown, not a tombstone" section.
- `website/content/docs/commands/self-driving.mdx` — what `escalated` vs `parked` mean in `stats`.
- `website/content/docs/configuration/stella-toml.mdx` and `stella.example.toml` — `[self_driving.escalation]`.
- `crates/stella-autonomy/README.md` — rows for `escalation.rs` and for `ready.rs`, which the table had been missing.
- `SelfDrivingCmd::Stats` clap help.

## Tests deleted

`an_escalated_issue_never_enters_the_ready_queue` (`crates/stella-autonomy/src/ready.rs`) was **renamed** to `an_escalated_issue_with_no_record_never_enters_the_ready_queue`. Its body and assertion are unchanged; the old name asserted a claim that is no longer true in general, and the new one names the case it actually covers.

## Sourcery

The first review raised two ❌ rows, both saying the defect queue was left as a tombstone. Both are now **fixed**, not answered — see departure 3 above and the new `priority.rs` witness. The residue issue filed for that gap (5663) is closed as superseded rather than left open.

## Remaining work filed

None. The gap this PR's first push left is closed inside it.

Closes #5621

## Summary by Sourcery

Make issue escalation recoverable with reason-aware cooldowns while parking issues permanently only after repeated failed attempts.

New Features:
- Replace permanent escalation tombstones with configurable cooldowns that automatically return issues to both the ready and defect queues.
- Persist escalation attempts, reasons, and timestamps in issue bodies and classify environmental failures separately from unresolved work.
- Report permanently parked issues separately from temporary escalations in self-driving statistics.

Bug Fixes:
- Prevent transient machine, provider, and installation failures from permanently removing valid backlog issues.

Enhancements:
- Centralize escalation eligibility decisions in the autonomy policy layer and preserve manually escalated issues without records as excluded.
- Add configurable environmental and beyond-loop cooldowns plus an escalation attempt ceiling.

Documentation:
- Document escalation cooldown behavior, parked issues, statistics, and the new self-driving escalation configuration.

Tests:
- Add coverage for escalation classification, record persistence, cooldown expiry, queue re-entry, parking, and missing or damaged records.