### PR TITLE
fix(stella-tools): re-read a file before the write that replaces it

### DIFF
--- a/crates/stella-tools/src/edit.rs
+++ b/crates/stella-tools/src/edit.rs
@@ -12,6 +12,13 @@
 //! byte-identical outputs, so the loop detector (which requires identical
 //! outputs to flag a loop) keeps treating it as progress.
 //!
+//! The ledger is also what the write is held to. The bytes this tool reads at
+//! the top of a call are a snapshot, and the file it writes at the end is
+//! computed from that snapshot, so anything written in between would be
+//! replaced by bytes that never contained it. The crate's `recheck` module
+//! re-reads the file through the same descriptor immediately before the write
+//! and refuses rather than clobber a change nobody would ever see again.
+//!
 //! The success path holds itself to the same contract (#3176): every success
 //! string carries the match's byte offset and a short digest of the resulting
 //! file, so N distinct edits to one file produce N distinct outputs. A
@@ -147,13 +154,39 @@ const INDENT_HINT_MAX_LINES: usize = 40;
 #[derive(Default)]
 pub struct EditFile {
     ledger: Arc<ReadLedger>,
+    /// A test's window between the read and the write — see the `recheck`
+    /// module's `Seam`. Nothing outside `cfg(test)` can install one.
+    #[cfg(test)]
+    seam: Option<crate::recheck::Seam>,
 }
 
 impl EditFile {
     /// Construct sharing the registry's read-state ledger, so match failures
     /// can be attributed against what the model last saw.
     pub fn with_ledger(ledger: Arc<ReadLedger>) -> Self {
-        Self { ledger }
+        Self {
+            ledger,
+            #[cfg(test)]
+            seam: None,
+        }
+    }
+
+    /// Construct with `seam` running in the window between the read and the
+    /// write, so a test can put a concurrent writer there.
+    #[cfg(test)]
+    pub(crate) fn with_seam(ledger: Arc<ReadLedger>, seam: crate::recheck::Seam) -> Self {
+        Self {
+            ledger,
+            seam: Some(seam),
+        }
+    }
+
+    /// Hand a test its window. Compiles to nothing in a shipped build.
+    fn run_seam(&self) {
+        #[cfg(test)]
+        if let Some(seam) = &self.seam {
+            seam();
+        }
     }
 }
 
@@ -452,6 +485,38 @@ impl EditFile {
             content.replacen(old_string, new_string, 1)
         };
 
+        // The last look. `new_content` is the whole file computed from
+        // the snapshot read at the top of this call, so a write that landed in
+        // between is about to be replaced by bytes that never contained it.
+        self.run_seam();
+        let read_sha = crate::staleness::hex_sha256(content.as_bytes());
+        if let Err(drift) = crate::recheck::confirm(&handle, path, &read_sha).await {
+            let echo = match drift.fresh() {
+                Some(fresh) => {
+                    // Recorded as seen for the reason the miss path records it:
+                    // the model has now been shown these bytes, so a later
+                    // failure against them is reported as unchanged rather than
+                    // re-attributed as drift forever.
+                    self.ledger.record_known(&scope_root, path, fresh);
+                    format!(
+                        "\n\nCurrent content follows — re-issue the edit against these \
+                         bytes.\n\n--- {path} (current) ---\n{}",
+                        drift_echo(fresh)
+                    )
+                }
+                None => String::new(),
+            };
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                format!(
+                    "refusing to write `{path}` — {} between the read and the write, so this \
+                     edit was computed from bytes disk does not hold and writing it would \
+                     destroy that change. Nothing was written.{echo}",
+                    drift.because()
+                ),
+            );
+        }
+
         match crate::durable_write::write_file_durably_at(
             handle,
             path.to_string(),
@@ -619,10 +684,12 @@ impl EditFile {
             pending[slot].edits += 1;
         }
 
-        // Every edit validated against the composed content. Only now does
-        // anything reach the disk.
-        let mut report = Vec::with_capacity(pending.len());
-        let mut changes = Vec::with_capacity(pending.len());
+        // Every edit validated against the composed content. Before anything
+        // reaches the disk, confirm every file still holds the bytes this batch
+        // read — all of them first, because a batch that would clobber
+        // a concurrent write to its third file must not have written its first.
+        self.run_seam();
+        let mut handles = Vec::with_capacity(pending.len());
         for file in &pending {
             let handle = match crate::rootfd::RootHandle::open(&file.scope_root) {
                 Ok(handle) => Arc::new(handle),
@@ -633,6 +700,25 @@ impl EditFile {
                     );
                 }
             };
+            let read_sha = crate::staleness::hex_sha256(file.original.as_bytes());
+            if let Err(drift) = crate::recheck::confirm(&handle, &file.path, &read_sha).await {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    format!(
+                        "refusing to write `{}` — {} between the read and the write, so this \
+                         batch was composed from bytes disk does not hold. Nothing was \
+                         written — re-read it and re-issue the batch.",
+                        file.path,
+                        drift.because()
+                    ),
+                );
+            }
+            handles.push(handle);
+        }
+
+        let mut report = Vec::with_capacity(pending.len());
+        let mut changes = Vec::with_capacity(pending.len());
+        for (file, handle) in pending.iter().zip(handles) {
             if let Err(e) = crate::durable_write::write_file_durably_at(
                 handle,
                 file.path.clone(),

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -64,6 +64,10 @@ pub mod netdeny;
 pub mod own_change;
 pub mod policy;
 pub mod read;
+/// The last look a mutating file tool takes before it writes. Crate-internal:
+/// it is a rule the file tools hold themselves to, not a surface anything
+/// outside calls.
+mod recheck;
 pub mod registry;
 pub mod rootfd;
 pub mod scratch;

--- a/crates/stella-tools/src/recheck.rs
+++ b/crates/stella-tools/src/recheck.rs
@@ -1,0 +1,93 @@
+//! The last look before a write.
+//!
+//! `edit_file` reads a file. It works out the whole new file from that copy.
+//! Then it writes it back. Anything written in the gap is wiped out, and the
+//! call still says "replaced 1 occurrence(s)".
+//!
+//! Other writers are normal here. The agent's own `bash` runs beside its file
+//! tools. A code formatter or a git hook needs no agent at all.
+//!
+//! So a tool asks here first. It re-reads the file through the same
+//! descriptor. If disk holds other bytes, it refuses and writes nothing.
+//!
+//! This is not a compare-and-swap. No portable one exists. A write can still
+//! land between the check and the rename. The check shrinks the gap to those
+//! few microseconds.
+//!
+//! One extra read per call is the cost. Not wiping out someone else's work is
+//! worth it.
+//!
+//! A file that cannot be re-read counts as changed. It was readable a moment
+//! ago through this same descriptor. A tool that cannot see the bytes has no
+//! ground to replace them. A brief failure costs a retry, which is the safe
+//! way to fail.
+
+use std::sync::Arc;
+
+use crate::rootfd::RootHandle;
+
+/// A test's window between the read and the write.
+///
+/// The race is real. It is also rare: the two syscalls are microseconds apart.
+/// A closure the tool calls in that window makes it happen every run. Then a
+/// witness can assert what happens instead of hoping to catch it.
+#[cfg(test)]
+pub(crate) type Seam = Arc<dyn Fn() + Send + Sync>;
+
+/// What the last look found in place of the bytes the tool read.
+pub(crate) enum Drift {
+    /// Disk holds other bytes. `fresh` is the text there now, or `None` when
+    /// those bytes are not UTF-8 and cannot be echoed back.
+    Rewritten { fresh: Option<String> },
+    /// The file could not be re-read at all. It was deleted, replaced by a
+    /// directory, or is not readable. The message is the raw error.
+    Unreadable(String),
+}
+
+impl Drift {
+    /// The clause a refusal puts after the path. It names what happened.
+    pub(crate) fn because(&self) -> String {
+        match self {
+            Self::Rewritten { .. } => "the file CHANGED (out-of-band modification)".to_string(),
+            Self::Unreadable(error) => format!("the file could not be re-read ({error})"),
+        }
+    }
+
+    /// The text on disk now, when there is any to hand back.
+    pub(crate) fn fresh(&self) -> Option<&str> {
+        match self {
+            Self::Rewritten { fresh } => fresh.as_deref(),
+            Self::Unreadable(_) => None,
+        }
+    }
+}
+
+/// Confirm `path` still hashes to `expected`, reading through `handle`.
+///
+/// `expected` is a hex sha256 of the bytes the caller read, in the form
+/// [`crate::staleness::hex_sha256`] makes. [`crate::read::ReadLedger`] stores
+/// the same form. So a caller may pass its own copy's hash, or the ledger's.
+///
+/// `handle` is the descriptor the write will walk. The bytes checked here and
+/// the bytes about to go are one file. A path resolved twice can name two.
+pub(crate) async fn confirm(
+    handle: &Arc<RootHandle>,
+    path: &str,
+    expected: &str,
+) -> Result<(), Drift> {
+    let (handle, rel) = (Arc::clone(handle), path.to_string());
+    let bytes = match tokio::task::spawn_blocking(move || handle.read(&rel)).await {
+        Ok(Ok(bytes)) => bytes,
+        Ok(Err(error)) => return Err(Drift::Unreadable(error.to_string())),
+        Err(error) => return Err(Drift::Unreadable(format!("read task failed: {error}"))),
+    };
+    if crate::staleness::hex_sha256(&bytes) == expected {
+        return Ok(());
+    }
+    Err(Drift::Rewritten {
+        fresh: String::from_utf8(bytes).ok(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-tools/src/recheck/tests.rs
+++ b/crates/stella-tools/src/recheck/tests.rs
@@ -1,0 +1,230 @@
+//! The witnesses for the last look before a write.
+//!
+//! They sit beside the check, not in `edit.rs` and `write.rs`. One rule is
+//! what they prove. Both tools are just where it is applied.
+
+use std::sync::Arc;
+
+use serde_json::json;
+use stella_protocol::tool::ToolOutput;
+
+use super::{Drift, confirm};
+use crate::edit::EditFile;
+use crate::read::{ReadFile, ReadLedger};
+use crate::registry::Tool;
+use crate::write::WriteFile;
+
+/// A bare run context rooted at `root`, as every file-tool test builds.
+fn cx(root: impl AsRef<std::path::Path>) -> crate::ctx::ToolCtx {
+    crate::ctx::ToolCtx::bare(root.as_ref().to_path_buf())
+}
+
+/// A seam that writes `bytes` to `file` when the tool reaches its gap.
+fn writes(file: std::path::PathBuf, bytes: &'static str) -> super::Seam {
+    Arc::new(move || std::fs::write(&file, bytes).expect("the concurrent write"))
+}
+
+#[tokio::test]
+async fn confirm_passes_the_bytes_it_was_given_and_fails_any_other() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("f.txt"), "before\n").unwrap();
+    let handle = Arc::new(crate::rootfd::RootHandle::open(dir.path()).expect("root"));
+    let sha = crate::staleness::hex_sha256(b"before\n");
+
+    assert!(confirm(&handle, "f.txt", &sha).await.is_ok());
+
+    std::fs::write(dir.path().join("f.txt"), "after\n").unwrap();
+    match confirm(&handle, "f.txt", &sha).await {
+        Err(Drift::Rewritten { fresh }) => assert_eq!(fresh.as_deref(), Some("after\n")),
+        other => panic!("a rewritten file must read as drift: {:?}", other.is_ok()),
+    }
+
+    std::fs::remove_file(dir.path().join("f.txt")).unwrap();
+    match confirm(&handle, "f.txt", &sha).await {
+        Err(Drift::Unreadable(_)) => {}
+        other => panic!("a file that vanished must refuse: {:?}", other.is_ok()),
+    }
+}
+
+/// The witness for `edit_file`.
+///
+/// `notes.md` holds three lines. The model has read it. Another writer adds a
+/// fourth line in the gap between the read and the write. The seam puts it
+/// there every run.
+///
+/// The edit's needle is on line 2. It still matches the stale copy, so the
+/// miss path never runs. That path is the only one that ever asked the ledger.
+///
+/// Without the check the tool writes its three-line copy, `delta` goes, and
+/// the call says "replaced 1 occurrence(s)". Take the `confirm` call out of
+/// `edit_one` and the first assert below fails.
+#[tokio::test]
+async fn a_concurrent_append_survives_an_edit_that_did_not_touch_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("notes.md");
+    std::fs::write(&file, "alpha\nbeta\ngamma\n").unwrap();
+
+    let ledger = Arc::new(ReadLedger::default());
+    let seen = ReadFile::with_ledger(ledger.clone())
+        .execute(&json!({"path": "notes.md"}), &cx(dir.path()))
+        .await;
+    assert!(!seen.is_error(), "the seeding read: {seen:?}");
+
+    let out = EditFile::with_seam(ledger, writes(file.clone(), "alpha\nbeta\ngamma\ndelta\n"))
+        .execute(
+            &json!({"path": "notes.md", "old_string": "beta", "new_string": "BETA"}),
+            &cx(dir.path()),
+        )
+        .await;
+
+    let after = std::fs::read_to_string(&file).unwrap();
+    assert!(
+        after.contains("delta\n"),
+        "the concurrent write must survive; disk holds {after:?} and the tool said {out:?}"
+    );
+    let ToolOutput::Error { message, class } = out else {
+        panic!("an edit computed from bytes that are gone must not land: {out:?}");
+    };
+    assert!(message.contains("refusing to write"), "{message}");
+    assert!(
+        message.contains("delta"),
+        "the fresh content is echoed so the model can re-issue: {message}"
+    );
+    assert_eq!(class, Some(stella_protocol::ErrorClass::RefusedByPolicy));
+}
+
+/// The batch form has the same gap. It has one more rule to hold: a batch
+/// refused on its second file must not have written its first.
+#[tokio::test]
+async fn a_batch_refuses_whole_when_one_of_its_files_changed_under_it() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "let a = 1;\n").unwrap();
+    let b = dir.path().join("b.rs");
+    std::fs::write(&b, "let b = 2;\n").unwrap();
+
+    let out = EditFile::with_seam(
+        Arc::new(ReadLedger::default()),
+        writes(b.clone(), "let b = 2;\nlet c = 3;\n"),
+    )
+    .execute(
+        &json!({"edits": [
+            {"path": "a.rs", "old_string": "1", "new_string": "10"},
+            {"path": "b.rs", "old_string": "2", "new_string": "20"}
+        ]}),
+        &cx(dir.path()),
+    )
+    .await;
+
+    let ToolOutput::Error { message, .. } = out else {
+        panic!("the batch was composed from bytes that are gone: {out:?}");
+    };
+    assert!(message.contains("Nothing was written"), "{message}");
+    assert_eq!(
+        std::fs::read_to_string(&b).unwrap(),
+        "let b = 2;\nlet c = 3;\n",
+        "the concurrent write survives"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("a.rs")).unwrap(),
+        "let a = 1;\n",
+        "the file that would have succeeded must not have landed"
+    );
+}
+
+/// `write_file` has the widest gap. It does no read of its own. The content
+/// it writes comes from a `read_file` that may be many turns old.
+///
+/// Coverage says the model saw the file. It never says the file still holds
+/// what the model saw.
+///
+/// This one needs no seam. The change happens in the open, between two tool
+/// calls. Paste it onto `main` and it fails there: the write lands and `beta`
+/// is gone.
+#[tokio::test]
+async fn an_overwrite_of_a_file_that_changed_since_the_read_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("notes.md");
+    std::fs::write(&file, "alpha\n").unwrap();
+
+    let ledger = Arc::new(ReadLedger::default());
+    let seen = ReadFile::with_ledger(ledger.clone())
+        .execute(&json!({"path": "notes.md"}), &cx(dir.path()))
+        .await;
+    assert!(!seen.is_error(), "the seeding read: {seen:?}");
+
+    // Another writer, in between.
+    std::fs::write(&file, "alpha\nbeta\n").unwrap();
+
+    let out = WriteFile::with_ledger(ledger)
+        .execute(
+            &json!({"path": "notes.md", "content": "ALPHA\n"}),
+            &cx(dir.path()),
+        )
+        .await;
+
+    let ToolOutput::Error { message, class } = out else {
+        panic!("the content was composed from bytes that are gone: {out:?}");
+    };
+    assert!(message.contains("refusing to overwrite"), "{message}");
+    assert_eq!(class, Some(stella_protocol::ErrorClass::RefusedByPolicy));
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        "alpha\nbeta\n",
+        "the concurrent write survives"
+    );
+}
+
+/// The batch form of the same. It adds the all-or-nothing half: nothing is
+/// written when one file of the batch changed.
+#[tokio::test]
+async fn a_write_batch_refuses_whole_when_one_of_its_files_changed_since_the_read() {
+    let dir = tempfile::tempdir().unwrap();
+    let existing = dir.path().join("notes.md");
+    std::fs::write(&existing, "alpha\n").unwrap();
+
+    let ledger = Arc::new(ReadLedger::default());
+    let seen = ReadFile::with_ledger(ledger.clone())
+        .execute(&json!({"path": "notes.md"}), &cx(dir.path()))
+        .await;
+    assert!(!seen.is_error(), "the seeding read: {seen:?}");
+
+    std::fs::write(&existing, "alpha\nbeta\n").unwrap();
+
+    let out = WriteFile::with_ledger(ledger)
+        .execute(
+            &json!({"files": [
+                {"path": "fresh.md", "content": "new\n"},
+                {"path": "notes.md", "content": "ALPHA\n"}
+            ]}),
+            &cx(dir.path()),
+        )
+        .await;
+
+    let ToolOutput::Error { message, .. } = out else {
+        panic!("the batch was composed from bytes that are gone: {out:?}");
+    };
+    assert!(message.contains("Nothing was written"), "{message}");
+    assert!(
+        !dir.path().join("fresh.md").exists(),
+        "the file that would have succeeded must not have landed"
+    );
+    assert_eq!(std::fs::read_to_string(&existing).unwrap(), "alpha\nbeta\n");
+}
+
+/// The gate has to open. An edit with nothing racing it still lands. That is
+/// what keeps this a check and not a wall.
+#[tokio::test]
+async fn an_uncontested_edit_still_lands() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("notes.md");
+    std::fs::write(&file, "alpha\nbeta\n").unwrap();
+
+    let out = EditFile::default()
+        .execute(
+            &json!({"path": "notes.md", "old_string": "beta", "new_string": "BETA"}),
+            &cx(dir.path()),
+        )
+        .await;
+    assert!(!out.is_error(), "{out:?}");
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "alpha\nBETA\n");
+}

--- a/crates/stella-tools/src/write.rs
+++ b/crates/stella-tools/src/write.rs
@@ -30,14 +30,18 @@
 //!
 //! # The stale-snapshot guard
 //!
-//! Coverage answers "was the model shown this file", which is a fact about the
-//! session and not about the disk. The read that earned the coverage can be
-//! many turns old, and everything written to the file since is replaced by
-//! content composed before it existed. So an overwrite is also refused when
-//! the ledger's hash of what the model last saw stops matching the bytes on
-//! disk, checked through the descriptor the write is about to walk by the
-//! crate's `recheck` module. A file the ledger has no hash for is one this
-//! session never saw whole, which the coverage guard has already refused.
+//! Coverage asks whether the model was shown this file. That is a fact about
+//! the session, not about the disk.
+//!
+//! The read that earned it can be many turns old. Anything written to the file
+//! since is wiped out by content composed before it existed.
+//!
+//! So an overwrite is refused for a second reason: the ledger's hash of what
+//! the model last saw stops matching the bytes on disk. The crate's `recheck`
+//! module asks, through the descriptor the write is about to walk.
+//!
+//! A file the ledger has no hash for is one this session never saw whole. The
+//! coverage guard has already refused it.
 //!
 //! # Registering what was created (#5034)
 //!
@@ -61,10 +65,6 @@ pub struct WriteFile {
     /// The index a created file is registered in. Injected for the same
     /// reason `delete_file`'s is — see [`crate::graph_fact`]'s header.
     graph: Arc<dyn crate::graph_fact::WorkspaceGraph>,
-    /// A test's window before the overwrite — see the `recheck` module's `Seam`.
-    /// Nothing outside `cfg(test)` can install one.
-    #[cfg(test)]
-    seam: Option<crate::recheck::Seam>,
 }
 
 impl Default for WriteFile {
@@ -79,8 +79,6 @@ impl WriteFile {
         Self {
             ledger,
             graph: Arc::new(crate::graph_fact::Codegraph),
-            #[cfg(test)]
-            seam: None,
         }
     }
 
@@ -90,26 +88,6 @@ impl WriteFile {
         Self {
             ledger: Arc::default(),
             graph,
-            seam: None,
-        }
-    }
-
-    /// Construct with `seam` running in the window before the overwrite, so a
-    /// test can put a concurrent writer there.
-    #[cfg(test)]
-    pub(crate) fn with_seam(ledger: Arc<ReadLedger>, seam: crate::recheck::Seam) -> Self {
-        Self {
-            ledger,
-            graph: Arc::new(crate::graph_fact::Codegraph),
-            seam: Some(seam),
-        }
-    }
-
-    /// Hand a test its window. Compiles to nothing in a shipped build.
-    fn run_seam(&self) {
-        #[cfg(test)]
-        if let Some(seam) = &self.seam {
-            seam();
         }
     }
 
@@ -267,10 +245,9 @@ impl WriteFile {
                     ),
                 );
             }
-            // The stale-snapshot guard (module header), asked in this pass so a
-            // batch refused on its third file has written neither of the first
+            // The stale-snapshot guard (module header), in this pass. A batch
+            // refused on its third file must have written neither of the first
             // two.
-            self.run_seam();
             if exists
                 && let Some(seen) = self.ledger.last_seen_sha(&scope_root, &path)
                 && let Err(drift) = crate::recheck::confirm(&handle, &path, &seen).await
@@ -388,14 +365,13 @@ impl WriteFile {
             }
         };
 
-        // The no-clobber guard (module header). Asked through the descriptor
-        // already open for the write rather than by path, so the existence
-        // answer and the bytes that follow it name the same file; and asked
-        // *before* the write, because a refusal that arrives after the content
-        // is gone is a report, not a boundary. A `stat` that fails for any
-        // reason — absent, unreadable, an escape — is not evidence that
-        // something is there to destroy, and the write below answers it
-        // properly.
+        // The no-clobber guard (module header). It asks through the descriptor
+        // already open for the write, not by path. So the existence answer and
+        // the bytes after it name one file. It asks before the write too: a
+        // refusal that arrives after the content is gone is a report, not a
+        // boundary. A `stat` that fails for any reason — absent, unreadable,
+        // an escape — is no evidence that something is there to destroy. The
+        // write below answers that case.
         let exists = handle.stat(path).is_ok();
         if exists && !self.ledger.saw_whole_file(&scope_root, path) {
             return ToolOutput::classified_error(
@@ -409,9 +385,8 @@ impl WriteFile {
         }
 
         // The stale-snapshot guard (module header). A creation has nothing to
-        // clobber, and a path the ledger has no hash for is a file this session
-        // never saw whole — the guard above already refused it.
-        self.run_seam();
+        // clobber. A path with no hash in the ledger was never seen whole, and
+        // the guard above refused it.
         if exists
             && let Some(seen) = self.ledger.last_seen_sha(&scope_root, path)
             && let Err(drift) = crate::recheck::confirm(&handle, path, &seen).await

--- a/crates/stella-tools/src/write.rs
+++ b/crates/stella-tools/src/write.rs
@@ -28,6 +28,17 @@
 //! * **`edit_file` is untouched.** It replaces a needle it had to know to
 //!   name, and it is the escape hatch the refusal points at.
 //!
+//! # The stale-snapshot guard
+//!
+//! Coverage answers "was the model shown this file", which is a fact about the
+//! session and not about the disk. The read that earned the coverage can be
+//! many turns old, and everything written to the file since is replaced by
+//! content composed before it existed. So an overwrite is also refused when
+//! the ledger's hash of what the model last saw stops matching the bytes on
+//! disk, checked through the descriptor the write is about to walk by the
+//! crate's `recheck` module. A file the ledger has no hash for is one this
+//! session never saw whole, which the coverage guard has already refused.
+//!
 //! # Registering what was created (#5034)
 //!
 //! A write that creates a file registers it in the workspace code graph and
@@ -50,6 +61,10 @@ pub struct WriteFile {
     /// The index a created file is registered in. Injected for the same
     /// reason `delete_file`'s is — see [`crate::graph_fact`]'s header.
     graph: Arc<dyn crate::graph_fact::WorkspaceGraph>,
+    /// A test's window before the overwrite — see the `recheck` module's `Seam`.
+    /// Nothing outside `cfg(test)` can install one.
+    #[cfg(test)]
+    seam: Option<crate::recheck::Seam>,
 }
 
 impl Default for WriteFile {
@@ -64,6 +79,8 @@ impl WriteFile {
         Self {
             ledger,
             graph: Arc::new(crate::graph_fact::Codegraph),
+            #[cfg(test)]
+            seam: None,
         }
     }
 
@@ -73,6 +90,26 @@ impl WriteFile {
         Self {
             ledger: Arc::default(),
             graph,
+            seam: None,
+        }
+    }
+
+    /// Construct with `seam` running in the window before the overwrite, so a
+    /// test can put a concurrent writer there.
+    #[cfg(test)]
+    pub(crate) fn with_seam(ledger: Arc<ReadLedger>, seam: crate::recheck::Seam) -> Self {
+        Self {
+            ledger,
+            graph: Arc::new(crate::graph_fact::Codegraph),
+            seam: Some(seam),
+        }
+    }
+
+    /// Hand a test its window. Compiles to nothing in a shipped build.
+    fn run_seam(&self) {
+        #[cfg(test)]
+        if let Some(seam) = &self.seam {
+            seam();
         }
     }
 
@@ -218,7 +255,8 @@ impl WriteFile {
                     );
                 }
             };
-            if handle.stat(&path).is_ok() && !self.ledger.saw_whole_file(&scope_root, &path) {
+            let exists = handle.stat(&path).is_ok();
+            if exists && !self.ledger.saw_whole_file(&scope_root, &path) {
                 return ToolOutput::classified_error(
                     stella_protocol::ErrorClass::RefusedByPolicy,
                     format!(
@@ -226,6 +264,24 @@ impl WriteFile {
                          not been shown the whole file, and `write_file` replaces all of it. Read \
                          it first (`read_file` with no offset/limit), then write — or use \
                          `edit_file` to change part of it in place. Nothing was written."
+                    ),
+                );
+            }
+            // The stale-snapshot guard (module header), asked in this pass so a
+            // batch refused on its third file has written neither of the first
+            // two.
+            self.run_seam();
+            if exists
+                && let Some(seen) = self.ledger.last_seen_sha(&scope_root, &path)
+                && let Err(drift) = crate::recheck::confirm(&handle, &path, &seen).await
+            {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::RefusedByPolicy,
+                    format!(
+                        "`{FILES_KEY}`[{index}]: refusing to overwrite `{path}` — {} since you \
+                         read it, so this content was composed from bytes disk does not hold. \
+                         Nothing was written — read it again, then write.",
+                        drift.because()
                     ),
                 );
             }
@@ -340,13 +396,33 @@ impl WriteFile {
         // reason — absent, unreadable, an escape — is not evidence that
         // something is there to destroy, and the write below answers it
         // properly.
-        if handle.stat(path).is_ok() && !self.ledger.saw_whole_file(&scope_root, path) {
+        let exists = handle.stat(path).is_ok();
+        if exists && !self.ledger.saw_whole_file(&scope_root, path) {
             return ToolOutput::classified_error(
                 stella_protocol::ErrorClass::RefusedByPolicy,
                 format!(
                     "refusing to overwrite `{path}`: this session has not been shown the whole file, \
                  and `write_file` replaces all of it. Read it first (`read_file` with no \
                  offset/limit), then write — or use `edit_file` to change part of it in place."
+                ),
+            );
+        }
+
+        // The stale-snapshot guard (module header). A creation has nothing to
+        // clobber, and a path the ledger has no hash for is a file this session
+        // never saw whole — the guard above already refused it.
+        self.run_seam();
+        if exists
+            && let Some(seen) = self.ledger.last_seen_sha(&scope_root, path)
+            && let Err(drift) = crate::recheck::confirm(&handle, path, &seen).await
+        {
+            return ToolOutput::classified_error(
+                stella_protocol::ErrorClass::RefusedByPolicy,
+                format!(
+                    "refusing to overwrite `{path}` — {} since you read it, so this content was \
+                     composed from bytes disk does not hold and writing it would destroy that \
+                     change. Nothing was written — read it again, then write.",
+                    drift.because()
                 ),
             );
         }


### PR DESCRIPTION
## What

`edit_file` read a file, computed the whole new file from that snapshot, and
wrote it back — with nothing between the read and the write checking the file
was still what it read. A concurrent write in that window was replaced by bytes
that never contained it, and the tool answered "replaced 1 occurrence(s)".

A new crate-internal `recheck` module re-reads the file through the
already-open `RootHandle` immediately before the write and compares the sha256
against the bytes the tool read. On a mismatch the call takes the
drift-attributed refusal the miss path already produces, echoes the fresh
content so the model can re-issue, and writes nothing.

- `edit_one` — confirm between the replacement and `write_file_durably_at`.
- `edit_batch` — confirm **every** file before writing **any**, so the
  all-or-nothing guarantee survives a refusal on the third file.
- `write_one` / `write_batch` — the same check against the read ledger's hash,
  rather than a note saying coverage suffices. Coverage answers "was the model
  shown this file", which is a fact about the session and not about the disk:
  the read that earned it can be many turns old, and everything written since
  is replaced by content composed before it existed. A creation is untouched
  (nothing to clobber), and a path the ledger has no hash for is one the
  coverage guard has already refused.

This is not a compare-and-swap — no portable one exists — so a write can still
land between the check and the rename. The window shrinks from the whole call
to those microseconds, which is most of the exposure and all of it a portable
tool can close. A file that cannot be re-read counts as changed: it was
readable a moment ago through the same descriptor, and a tool that cannot see
the current bytes has no ground to replace them.

## Why the design is this shape

The maintainer's design pointer on the issue asked for exactly this: hash the
bytes read with `staleness::hex_sha256`, re-read through the open
`RootHandle` immediately before the write, take the drift refusal on mismatch,
and add a `#[cfg(test)]` fault-injection seam so the race is deterministic. The
code agreed with the pointer at every step; nothing in it argued for a
different shape.

The one judgement it left open — `write.rs` gets the same treatment, or a
comment saying why coverage suffices — is answered by doing the work. Coverage
cannot see the disk, so it cannot be the answer.

`recheck` is a sibling module rather than lines in `edit.rs`, because `edit.rs`
is 1420 lines against a 1500-line ceiling with no baseline entry
(AGENTS.md § "God files"). The witnesses live in `recheck/tests.rs` for the
same reason and because one rule is what they prove.

Exemplar: the two-pass shape (check every target, then commit) is `write.rs`'s
own `write_batch`, which already validated the whole batch before writing any
of it. `edit_batch` now does the same for the same reason.

## The witnesses and how they fail on `main`

`crates/stella-tools/src/recheck/tests.rs`:

1. **`a_concurrent_append_survives_an_edit_that_did_not_touch_it`** — the issue's
   scenario. `notes.md` holds `alpha/beta/gamma`, the model reads it whole, the
   seam appends `delta` in the window, and the edit replaces `beta`. The needle
   still matches the stale copy, so the miss path — the only path that ever
   consulted the ledger — never runs. Asserts `delta` is still on disk and the
   call refused. **Fails on `main` by construction**: `EditFile::with_seam` does
   not exist there, so it does not compile. What it guards from here on is real:
   keep the seam and delete the `confirm` call from `edit_one`, and the first
   assertion fails because `delta` is gone.
2. **`a_batch_refuses_whole_when_one_of_its_files_changed_under_it`** — same for
   `edit_batch`, plus: the file that would have succeeded must still be
   untouched.
3. **`an_overwrite_of_a_file_that_changed_since_the_read_is_refused`** —
   **this one needs no seam and can be pasted onto `main`, where it fails by
   assertion**: the drift is out in the open between two tool calls, `main`
   lands the overwrite, and the concurrent `beta` line is destroyed.
4. **`a_write_batch_refuses_whole_when_one_of_its_files_changed_since_the_read`**
   — the batch form of 3, with the all-or-nothing half.
5. **`confirm_passes_the_bytes_it_was_given_and_fails_any_other`** — the unit
   directions of the check, including the vanished-file arm.
6. **`an_uncontested_edit_still_lands`** — the gate has to open. This is what
   keeps the change a check and not a wall.

I could not run these: this repository's rule is that CI compiles and the
maintainer's laptop does not. The two constructs I was least sure of —
`#[cfg(test)]` on a struct-expression field and on an `if let` statement, and
`.await` inside a let-chain — I verified with a standalone `rustc --edition
2024` on a scratch file rather than asserting they compile.

## Cost

One extra read of the file per mutating call. That is what not silently
destroying somebody else's write is worth.

## Tests deleted

None.

## Remaining work filed

- #5664 — the Windows reserved-device-name residue the issue names in the same
  slice (`write_file({"path": "notes/AUX.txt"})` reaches the DOS device
  namespace). Out of scope here: it is a different door, on a platform this
  change does not touch.
- #5665 — `edit.rs` sits 80 lines from the file-size ceiling; its inline test
  module should move to `edit/tests.rs`. Deliberately not folded in, because a
  600-line move in this diff would bury the witness.

Closes #5502

## Summary by Sourcery

Refuse file mutations when the on-disk content no longer matches the snapshot used to compose them.

Bug Fixes:
- Prevent edit and write operations from overwriting concurrent changes made after the tool read a file.
- Refuse stale single-file and batch writes while preserving all-or-nothing behavior for batches.
- Return current file content when a concurrent edit is detected so the model can retry against fresh bytes.

Enhancements:
- Centralize last-moment file consistency checks in a crate-internal recheck module using content hashes and the existing root handles.

Tests:
- Add deterministic coverage for concurrent edits, stale overwrites, batch atomicity, successful uncontended edits, and unreadable files.