### PR TITLE
fix(stella-model): refuse a tool call announced without an id

### DIFF
--- a/crates/stella-model/src/anthropic.rs
+++ b/crates/stella-model/src/anthropic.rs
@@ -771,8 +771,26 @@ struct AnthropicMessageStart {
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AnthropicStartBlock {
+    /// Both fields default. An empty one is a terminal error at assembly,
+    /// not a frame to skip.
+    ///
+    /// Serde reads the `type` tag first. It then fails the whole event when
+    /// the matched case is missing a field. Without these defaults, a
+    /// `tool_use` block with no `id` lands in
+    /// [`stream::aggregate_anthropic_stream`]'s `Err(_)` arm — the arm that
+    /// skips an event type this adapter does not model. The block goes with
+    /// it. Its `input_json_delta` parts miss the map. The turn ends `Ok`
+    /// with no tool calls, next to a finish reason of `ToolCalls`: the
+    /// model's own stop reason says it called a tool, and the adapter says
+    /// it called none.
+    ///
+    /// The defaults keep the frame readable, so the loss is visible.
+    /// [`stream::aggregate_anthropic_stream`] then refuses to commit a call
+    /// it cannot dispatch.
     ToolUse {
+        #[serde(default)]
         id: String,
+        #[serde(default)]
         name: String,
     },
     #[serde(other)]
@@ -1203,6 +1221,8 @@ fn map_stop_reason(stop_reason: Option<&str>) -> Option<FinishReason> {
     }
 }
 
+#[cfg(test)]
+mod malformed_tool_use;
 #[cfg(test)]
 mod parallel_tool_calls;
 #[cfg(test)]

--- a/crates/stella-model/src/anthropic/malformed_tool_use.rs
+++ b/crates/stella-model/src/anthropic/malformed_tool_use.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! What a `tool_use` start frame does to a turn when a field is missing.
+//!
+//! Serde reads the `type` tag first. It then fails the whole event when the
+//! matched case is missing a field. So a `content_block_start` that names
+//! `tool_use` and has no `id` does not parse at all, unless the fields
+//! default. The frame lands in the arm that skips an event type this adapter
+//! does not know. The block goes with it. Its `input_json_delta` parts miss
+//! the map. The turn ends `Ok` with no tool calls, next to a finish reason
+//! of `ToolCalls`.
+//!
+//! Nothing fails and the turn goes on. That is why the proof runs at the
+//! provider edge, not on the type. The claim is about what a caller gets.
+//!
+//! Declared from `anthropic.rs`, not from `anthropic/tests.rs`. That file is
+//! a god file closed to growth.
+
+use super::*;
+use stella_protocol::CompletionRequest;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A `tool_use` block carrying `name` and no `id`, its arguments streamed and
+/// closed, ending on a `stop_reason` of `tool_use`. Every frame after the
+/// start is well formed — the whole loss comes from the one absent field.
+const TOOL_USE_WITHOUT_AN_ID: &str = concat!(
+    "event: content_block_start\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"name\":\"bash\"}}\n\n",
+    "event: content_block_delta\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"ls\\\"}\"}}\n\n",
+    "event: content_block_stop\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "event: message_delta\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":10}}\n\n",
+    "event: message_stop\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+/// Three frames this adapter does not model — a block type it has no case
+/// for, an event type it has no case for, and a data line with no `type` at
+/// all — around an ordinary text block. All three must still be skipped.
+const AN_UNMODELLED_BLOCK_TYPE: &str = concat!(
+    "event: content_block_start\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"server_tool_use\",\"id\":\"srvtoolu_1\",\"name\":\"web_search\"}}\n\n",
+    "event: content_block_stop\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "event: ping\n",
+    "data: {\"type\":\"ping\"}\n\n",
+    "event: something_new\n",
+    "data: {\"unrecognised\":true}\n\n",
+    "event: content_block_start\n",
+    "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    "event: content_block_delta\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"done\"}}\n\n",
+    "event: message_delta\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n",
+    "event: message_stop\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+async fn streaming_provider(body: &'static str) -> (MockServer, AnthropicProvider) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+    let provider = AnthropicProvider::new(ApiKey::new("sk-ant-test"), "claude-fable-5")
+        .with_base_url(server.uri());
+    (server, provider)
+}
+
+fn request() -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![CompletionMessage::user("list the files")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+/// The witness. Without the fix this body completes `Ok`, so the `expect_err`
+/// is what fails: `tool_calls` comes back empty beside a `finish_reason` of
+/// `ToolCalls`, and a caller reading that result learns the model asked for
+/// nothing.
+#[tokio::test]
+async fn a_tool_use_block_with_no_id_ends_the_turn_instead_of_vanishing() {
+    let (_server, provider) = streaming_provider(TOOL_USE_WITHOUT_AN_ID).await;
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a tool call that cannot be dispatched must not read as no tool call");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("index 0"),
+        "the error names the block that was lost: {message}"
+    );
+    assert!(
+        message.contains("`id`"),
+        "the error names the field that never arrived: {message}"
+    );
+    assert!(
+        message.contains("bash"),
+        "the error names the tool the model asked for: {message}"
+    );
+    assert!(
+        !error.is_retryable(),
+        "the same request re-streams the same absent field: {error:?}"
+    );
+}
+
+/// The same block on the non-streaming path, which the session takes once its
+/// streaming path has proven broken. Here the fields already defaulted, so the
+/// block parsed and the turn committed a call keyed `""`. That call can never
+/// be matched to its result. The two delivery paths have to refuse it alike.
+#[tokio::test]
+async fn a_unary_tool_use_block_with_no_id_ends_the_turn_as_well() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(body_string_contains("\"stream\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(body_string_contains("\"stream\":false"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"id":"msg_2","type":"message","role":"assistant","content":[{"type":"tool_use","name":"bash","input":{"command":"ls"}}],"stop_reason":"tool_use","usage":{"input_tokens":12,"output_tokens":9}}"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+    let provider = AnthropicProvider::new(ApiKey::new("sk-ant-test"), "claude-fable-5")
+        .with_base_url(server.uri());
+
+    // An empty stream arms the latch, so the retry goes out non-streaming.
+    let armed = provider
+        .complete(request())
+        .await
+        .expect_err("an empty stream is a fault, never an empty Ok");
+    assert!(armed.is_retryable(), "{armed:?}");
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a unary call with no id must not be committed either");
+    let message = error.to_string();
+    assert!(message.contains("`id`"), "{message}");
+    assert!(message.contains("bash"), "{message}");
+    assert!(!error.is_retryable(), "{error:?}");
+}
+
+/// The constraint on the fix: a frame whose `type` this adapter does not model
+/// stays skippable. Only a block that declares itself `tool_use` and then
+/// cannot be dispatched is fatal — widening the refusal to every unparsed frame
+/// would break on the next block type Anthropic ships.
+#[tokio::test]
+async fn a_content_block_type_this_adapter_does_not_model_is_still_skipped() {
+    let (_server, provider) = streaming_provider(AN_UNMODELLED_BLOCK_TYPE).await;
+
+    let result = provider
+        .complete(request())
+        .await
+        .expect("an unmodelled block type is not a fault");
+    assert_eq!(result.text, "done");
+    assert!(result.tool_calls.is_empty());
+}

--- a/crates/stella-model/src/anthropic/stream.rs
+++ b/crates/stella-model/src/anthropic/stream.rs
@@ -337,6 +337,25 @@ pub(super) async fn aggregate_anthropic_stream(
 
     let mut tool_calls = Vec::with_capacity(tool_uses.len());
     for (index, acc) in tool_uses {
+        // A `content_block_start` that named itself `tool_use` and left out
+        // the id or the tool name parses, because both fields default. It
+        // arrives here, and it ends the turn. Neither field can be a
+        // casualty of the token limit: the whole start frame rides one SSE
+        // event. So this is checked ahead of the truncation arms below, and
+        // never competes with them.
+        let mut missing = Vec::new();
+        if acc.id.is_empty() {
+            missing.push("id");
+        }
+        if acc.name.is_empty() {
+            missing.push("name");
+        }
+        if !missing.is_empty() {
+            return Err(
+                http::malformed_tool_call_error("Anthropic", index, &acc.name, &missing).into(),
+            );
+        }
+
         let truncated = Some(index) == truncated_index;
         let input = if acc.input_json.is_empty() {
             if truncated {

--- a/crates/stella-model/src/anthropic/unary.rs
+++ b/crates/stella-model/src/anthropic/unary.rs
@@ -141,6 +141,27 @@ impl AnthropicProvider {
             match block {
                 AnthropicUnaryBlock::Text { text: chunk } => text.push_str(&chunk),
                 AnthropicUnaryBlock::ToolUse { id, name, input } => {
+                    // The same refusal the streaming path makes, so the two
+                    // delivery paths cannot drift on it. Every field here
+                    // defaults, so a block that leaves out the id or the tool
+                    // name parses, and a call committed with an empty id can
+                    // never be matched to its result.
+                    let mut missing = Vec::new();
+                    if id.is_empty() {
+                        missing.push("id");
+                    }
+                    if name.is_empty() {
+                        missing.push("name");
+                    }
+                    if !missing.is_empty() {
+                        return Err(crate::http::malformed_tool_call_error(
+                            "Anthropic",
+                            index,
+                            &name,
+                            &missing,
+                        ));
+                    }
+
                     let truncated = Some(index) == truncated_index;
                     // A tool call arrives with its arguments already parsed,
                     // so the streaming path's repair sentinel has no unary

--- a/crates/stella-model/src/http.rs
+++ b/crates/stella-model/src/http.rs
@@ -695,6 +695,37 @@ pub(crate) fn truncated_tool_input_error(
     ))
 }
 
+/// Build the terminal error for a streamed tool call that never carried a
+/// field it cannot be dispatched without. That is the id the next turn's tool
+/// result is matched against, or the name of the tool to run.
+///
+/// Shared by every adapter that builds tool calls from stream parts.
+/// `provider` names the backend. `index` is the block or call index the parts
+/// were keyed on. `name` is the tool, when one arrived. `missing` lists the
+/// fields that did not.
+///
+/// Terminal, not dropped. The frames announce a call the model made. Drop
+/// them and the turn reports no tool calls, next to a finish reason that says
+/// a tool was called. A missing measurement then reads as a negative one.
+pub(crate) fn malformed_tool_call_error(
+    provider: &str,
+    index: usize,
+    name: &str,
+    missing: &[&str],
+) -> ProviderError {
+    let called = if name.is_empty() {
+        String::new()
+    } else {
+        format!(" `{name}`")
+    };
+    let missing = missing.join("` and `");
+    ProviderError::Malformed(format!(
+        "{provider} streamed a tool call{called} at index {index} with no `{missing}`, \
+         so the call cannot be dispatched. The turn is aborted rather than reporting \
+         no tool call at all."
+    ))
+}
+
 /// Build the retryable error for a stream whose body never delivered a first
 /// byte inside `deadline`. One wording for every dialect: the fault is a
 /// property of the streaming *path* (a proxy buffering the SSE body), not of

--- a/crates/stella-model/src/zai.rs
+++ b/crates/stella-model/src/zai.rs
@@ -944,9 +944,13 @@ struct ZaiStreamDelta {
 /// failed to deserialize, and the frame was then dropped whole. A dropped
 /// frame carrying tool calls is indistinguishable from a turn that simply had
 /// none, and the driver ends a turn on `tool_calls.is_empty()`: the run would
-/// report a clean, successful completion having executed nothing. Falling back
-/// to the fragment's position in the chunk keeps the sequential-index contract
-/// that `announce_completed_below` relies on.
+/// report a clean, successful completion having executed nothing. A part that
+/// leaves it out is filed under a counter that runs for the whole stream (see
+/// `stream::aggregate_zai_stream`). That keeps the by-index order
+/// `announce_completed_below` needs. The counter has to span the stream. A
+/// part's place inside its own chunk starts again at 0 for every frame, so a
+/// server sending one call per chunk with no `index` would file them all
+/// under 0 and merge them into one call.
 #[derive(Deserialize, Debug)]
 struct ZaiStreamToolCallDelta {
     #[serde(default)]
@@ -1379,6 +1383,8 @@ impl ZaiProvider {
     }
 }
 
+#[cfg(test)]
+mod malformed_tool_calls;
 #[cfg(test)]
 mod parallel_tool_calls;
 #[cfg(test)]

--- a/crates/stella-model/src/zai/malformed_tool_calls.rs
+++ b/crates/stella-model/src/zai/malformed_tool_calls.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Two ways a tool call is lost on this dialect while the turn still ends
+//! `Ok`.
+//!
+//! Both come from a server that leaves out a field the wire normally
+//! carries. So both reach us through the same gateways as the `tool_use`
+//! block the sibling `anthropic` module covers.
+//!
+//! Declared from `zai.rs`, not from `zai/tests.rs`. That file is a god file
+//! sitting on its ceiling.
+
+use super::*;
+use stella_protocol::CompletionRequest;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Two whole tool calls, one per frame, neither with an `index`. This is what
+/// a server that never sends `index` puts on the wire.
+const TWO_UNINDEXED_CALLS_ONE_PER_FRAME: &str = concat!(
+    "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_a\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"a.rs\\\"}\"}}]}}]}\n\n",
+    "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_b\",\"function\":{\"name\":\"search\",\"arguments\":\"{\\\"query\\\":\\\"fn main\\\"}\"}}]}}]}\n\n",
+    "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+    "data: [DONE]\n\n",
+);
+
+/// One tool call whose `id` never arrives, streamed and finished cleanly.
+const A_CALL_WITH_NO_ID: &str = concat!(
+    "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"name\":\"bash\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}}]}}]}\n\n",
+    "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+    "data: [DONE]\n\n",
+);
+
+async fn streaming_provider(body: &'static str) -> (MockServer, ZaiProvider) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+    let provider =
+        ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+    (server, provider)
+}
+
+fn request() -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![CompletionMessage::user("read a.rs and search for fn main")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+/// The witness for the index fallback. A place inside one chunk starts again
+/// at 0 on every frame. That files both calls under 0 and merges them. The
+/// turn then holds one call named `read_filesearch`, with the two argument
+/// objects glued into JSON that will not parse. That falls back to the `Null`
+/// repair value, not to an error. Both real calls are gone, and nothing says
+/// so.
+#[tokio::test]
+async fn two_tool_calls_with_no_index_stay_two_calls() {
+    let (_server, provider) = streaming_provider(TWO_UNINDEXED_CALLS_ONE_PER_FRAME).await;
+
+    let result = provider
+        .complete(request())
+        .await
+        .expect("two index-less calls parse");
+
+    let names: Vec<&str> = result
+        .tool_calls
+        .iter()
+        .map(|call| call.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        ["read_file", "search"],
+        "each frame opens its own call: a shared accumulator concatenates the names"
+    );
+
+    let ids: Vec<&str> = result
+        .tool_calls
+        .iter()
+        .map(|call| call.call_id.as_str())
+        .collect();
+    assert_eq!(ids, ["call_a", "call_b"]);
+
+    assert_eq!(result.tool_calls[0].input["path"], "a.rs");
+    assert_eq!(
+        result.tool_calls[1].input["query"], "fn main",
+        "the second call's arguments are its own, not appended to the first's"
+    );
+}
+
+/// The witness for the empty `call_id`. `announce_completed_below` already
+/// skips such a call. Final assembly has to skip it too. If it does not, a
+/// turn can hold two calls both keyed `""`, and they pair up with the wrong
+/// results in `stella-core`'s loop evidence.
+#[tokio::test]
+async fn a_tool_call_whose_id_never_arrives_ends_the_turn() {
+    let (_server, provider) = streaming_provider(A_CALL_WITH_NO_ID).await;
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a call with no id cannot be correlated and must not be committed");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("`id`"),
+        "the error names the field that never arrived: {message}"
+    );
+    assert!(
+        message.contains("bash"),
+        "the error names the tool the model asked for: {message}"
+    );
+    assert!(!error.is_retryable(), "{error:?}");
+}

--- a/crates/stella-model/src/zai/stream.rs
+++ b/crates/stella-model/src/zai/stream.rs
@@ -240,6 +240,15 @@ pub(super) async fn aggregate_zai_stream(
     let mut reasoning = String::new();
     let mut usage = CompletionUsage::default();
     let mut tool_calls: BTreeMap<usize, ToolCallAccumulator> = BTreeMap::new();
+    // Where a part that carries no `index` is filed. It counts across the
+    // whole stream, not inside one chunk. A part's place inside its own chunk
+    // starts again at 0 for every frame. So a server that leaves out `index`
+    // and sends one call per chunk would file every call under 0 and merge
+    // them: names glued into `read_filesearch`, arguments glued into JSON
+    // that will not parse, and both real calls lost. A fresh `id` is what
+    // opens a call in this dialect, so it is what moves the counter on. A
+    // part with no id goes on filling the call the counter points at.
+    let mut unindexed_call: usize = 0;
     // Set once any choice reports `finish_reason: "length"` — the output was
     // cut off at the token limit, so a tool call whose argument JSON didn't
     // finish streaming is truncated, not merely malformed.
@@ -390,16 +399,23 @@ pub(super) async fn aggregate_zai_stream(
                     }
                     reasoning.push_str(&r);
                 }
-                for (position, tc_delta) in choice
-                    .delta
-                    .tool_calls
-                    .unwrap_or_default()
-                    .into_iter()
-                    .enumerate()
-                {
-                    // Absent `index` falls back to the fragment's position in
-                    // this chunk — see `ZaiStreamToolCallDelta`.
-                    let index = tc_delta.index.unwrap_or(position);
+                for tc_delta in choice.delta.tool_calls.unwrap_or_default() {
+                    // Absent `index` falls back to the per-stream counter —
+                    // see `ZaiStreamToolCallDelta`.
+                    let index = match tc_delta.index {
+                        Some(index) => index,
+                        None => {
+                            let opens_a_call =
+                                tc_delta.id.as_deref().is_some_and(|id| !id.is_empty());
+                            let counter_is_taken = tool_calls
+                                .get(&unindexed_call)
+                                .is_some_and(|acc| !acc.id.is_empty());
+                            if opens_a_call && counter_is_taken {
+                                unindexed_call += 1;
+                            }
+                            unindexed_call
+                        }
+                    };
                     // A delta for index N proves every lower index finished
                     // streaming (the dialect emits calls sequentially) —
                     // the moment those calls can be announced for
@@ -501,6 +517,18 @@ pub(super) async fn aggregate_zai_stream(
 
     let mut calls = Vec::with_capacity(tool_calls.len());
     for (index, acc) in tool_calls {
+        // The id never arrived, so nothing can match the result back. Two
+        // calls in one turn both keyed `""` pair up with the wrong results in
+        // `stella-core`'s loop evidence, and a `tool_result` sent under an
+        // empty id matches nothing the provider holds.
+        // `announce_completed_below` already skips such a call for
+        // speculative execution, and committing one here would contradict
+        // it. Terminal, for the reason the anthropic adapter treats the same
+        // gap as terminal: there is no id to invent.
+        if acc.id.is_empty() {
+            return Err(http::malformed_tool_call_error(label, index, &acc.name, &["id"]).into());
+        }
+
         let truncated = Some(index) == truncated_index;
         let input = tool_call_input(label, &acc.name, &acc.arguments, truncated)?;
         calls.push(ToolCall {

--- a/crates/stella-model/src/zai/tests/stream_frame.rs
+++ b/crates/stella-model/src/zai/tests/stream_frame.rs
@@ -65,7 +65,7 @@ async fn a_tool_call_fragment_without_an_index_is_not_dropped() {
     assert_eq!(
         result.tool_calls.len(),
         1,
-        "a fragment without `index` must fall back to its position, not vanish"
+        "a fragment without `index` must fall back to the per-stream counter, not vanish"
     );
     assert_eq!(result.tool_calls[0].name, "read_file");
     assert_eq!(


### PR DESCRIPTION
## What and why

A `content_block_start` naming `tool_use` with no `id` did not deserialize.
Serde matches the `type` tag first, then fails the whole event on an absent
required field — so the frame landed in `aggregate_anthropic_stream`'s
`Err(_)` arm, the arm that exists to tolerate an event *type* this adapter
does not model. The block went with it, the `input_json_delta` fragments
missed `tool_uses.get_mut`, and the turn returned `Ok` with `tool_calls: []`
beside `finish_reason: Some(ToolCalls)`. The model's own stop reason says it
called a tool; the adapter says it called none. Nothing errors, and the turn
proceeds — a missing measurement rendering as a negative one.

Fix, per the design pointer on the issue:

- `AnthropicStartBlock::ToolUse` gets `#[serde(default)]` on `id` and `name`,
  so the frame parses and the loss becomes visible.
- `aggregate_anthropic_stream` refuses an empty `id` or `name` at assembly,
  ahead of the truncation arms (neither field can be a casualty of the token
  limit — the whole start frame rides one SSE event).
- The unknown-`type` tolerance is unchanged, and is now pinned by a test.

## The named error

The pointer asked for `ProviderError::MalformedToolCall { index, missing }`.
This ships it as a named constructor —
`http::malformed_tool_call_error(provider, index, name, missing)` — returning
`ProviderError::Malformed`, rather than as a new enum case. Two reasons, both
in the code:

1. `ProviderError::Malformed`'s own doc comment already names this exact case:
   *"a response arrived but could not be decoded … a missing required field, an
   unparseable tool-call argument. Terminal."* The classification a caller acts
   on is identical — terminal, not retryable, not park-eligible, no recovery
   path — and AGENTS.md invariant 5's test for a new case is *whether a caller
   has to branch on it*. Nothing does.
2. A new `ProviderError` case forces a new `ProviderErrorWire` case in
   `crates/stella-serve/src/frame.rs` and a regenerated
   `docs/wire/serveframe.schema.json` / `serveinbound.schema.json` / `.d.ts` —
   the wire contract out-of-tree hosts parse by hand, which AGENTS.md calls
   "the single most dangerous drift in this document". A remote host can never
   emit this fault (only an in-tree SSE aggregator can), so the wire would gain
   a case nothing on the far side produces.

The constructor keeps everything the pointer asked the case to carry: the
block index, the missing field names, and the tool name, all in the message a
human reads. It sits beside `truncated_tool_input_error` in `http.rs`, the
existing shared constructor for the sibling "this tool call cannot be
dispatched" fault, and is the exemplar followed.

If the maintainer wants the distinct case anyway, say so and it lands as a
follow-up that touches the protocol crate, `stella-serve` and the generated
schemas together.

## Witnesses

Three, all wiremock at the provider boundary — the assertion has to be about
what a caller receives, because nothing on the old code errors.

`crates/stella-model/src/anthropic/malformed_tool_use.rs` (declared from
`anthropic.rs`, not from the `anthropic/tests.rs` god file):

- `a_tool_use_block_with_no_id_ends_the_turn_instead_of_vanishing` — the SSE
  body from the issue verbatim. **Mechanism:** on `main` the start frame does
  not deserialize, `tool_uses` stays empty, and `complete` returns `Ok` with
  `tool_calls: []`; the `expect_err` is what fails. With the change the fields
  default, assembly sees an empty `id`, and the error names `index 0`, `` `id` ``
  and `bash`.
- `a_unary_tool_use_block_with_no_id_ends_the_turn_as_well` — the same block on
  the non-streaming fallback path. **Mechanism:** `AnthropicUnaryBlock::ToolUse`
  already defaulted both fields, so on `main` this returns `Ok` with a
  `ToolCall` whose `call_id` is `""` — a call that can never be matched to its
  result. The `expect_err` fails on `main`. Included because AGENTS.md requires
  the two delivery paths not to drift on assembly rules.
- `a_content_block_type_this_adapter_does_not_model_is_still_skipped` — the
  constraint: an unmodelled block type, an unmodelled event type, and a data
  line with no `type` at all are all still skipped. Passes on `main` too; it
  exists to fail if the refusal is ever widened past `tool_use`.

`crates/stella-model/src/zai/malformed_tool_calls.rs` (declared from `zai.rs`,
not from the `zai/tests.rs` god file) — the two residues the issue's "Related"
section names, both under the 40-line bar the pointer set:

- `two_tool_calls_with_no_index_stay_two_calls` — `index` fell back to the
  fragment's position inside *its own chunk*, which `enumerate()` restarts per
  SSE frame. **Mechanism:** on `main` a server sending one index-less call per
  frame files both under 0; the turn comes back with one call named
  `read_filesearch` whose two argument objects are concatenated into
  unparseable JSON, degraded to the `Null` repair sentinel. The
  `assert_eq!(names, ["read_file", "search"])` fails. The fallback is now a
  counter that spans the stream, advanced by a fresh `id` (what opens a call in
  this dialect) rather than by frame position.
- `a_tool_call_whose_id_never_arrives_ends_the_turn` — `announce_completed_below`
  already skips a call with an empty `id`; final assembly committed one anyway.
  **Mechanism:** on `main` this returns `Ok` with `call_id: ""`, so the
  `expect_err` fails. Two such calls in one turn mis-pair with their results in
  `stella-core`'s loop evidence.

`crates/stella-model/src/zai/tests/stream_frame.rs`'s existing
`a_tool_call_fragment_without_an_index_is_not_dropped` still passes unchanged
(one call, id present, counter stays at 0); its assertion message was updated
to describe the counter instead of the position.

## Not verified locally

Per CLAUDE.md, nothing was compiled or run on the maintainer's machine — the
evidence for this PR is its CI run. `cargo fmt --all`, `make guards-fast`,
`check-prose` and `check-file-size` were run locally and are green.

Tests deleted: None.

Residue filed: none beyond this PR — the two Z.ai shapes the issue lists are
fixed here rather than filed, and the unary Anthropic path was the third
instance and is fixed here too.

Closes #5496

## Summary by Sourcery

Fail explicitly on malformed tool calls and maintain correct assembly of index-less Z.ai calls across streamed frames.

Bug Fixes:
- Reject malformed Anthropic tool-use blocks and unary tool calls that lack an ID or name instead of silently returning no or uncorrelatable tool calls.
- Preserve separate Z.ai tool calls when streamed fragments omit indexes.
- Reject Z.ai tool calls whose IDs never arrive instead of committing calls that cannot be correlated.

Enhancements:
- Keep unsupported Anthropic block and event types skippable while making malformed modeled tool calls terminal, non-retryable errors.
- Share consistent malformed-tool-call error reporting across provider adapters.

Tests:
- Add provider-boundary coverage for malformed Anthropic streaming and unary tool calls, unsupported event tolerance, and malformed Z.ai tool calls.