### PR TITLE
ci(auto-tag): approve the version-sync PR's parked runs and merge under protection

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -464,29 +464,55 @@ jobs:
             exit 0
           fi
 
-          # `gh pr checks --required` reports on exactly the contexts branch
-          # protection requires, so this waits for the real gate rather than
-          # for a run of its own choosing. Its exit codes: 0 every required
-          # context passed, 8 one is still pending, anything else one failed
-          # or none has reported yet.
+          # Two questions, because neither one answers this on its own.
           #
-          # "None has reported yet" is the normal state for the first minute
-          # or two, while the approved runs create their check runs, and it is
-          # indistinguishable from a red verdict by exit code alone. So a
-          # non-pending verdict only ends the wait once the grace window is
-          # over — before that it is treated as "not yet".
+          # `gh pr checks --required` reports on the contexts branch protection
+          # requires, and its exit code says which way: 0 every one it can see
+          # passed, 8 one is still pending, anything else one failed or none
+          # has reported yet. It is the only signal that tells a red check from
+          # a slow one, which is what stops this waiting 45 minutes on a
+          # failure. But it can only report on check runs that EXIST, and the
+          # required contexts appear at different times: measured on #5672,
+          # it returned "all clear" listing three of the five while ci.yml had
+          # not yet created the other two. Merging on that answer alone is a
+          # merge attempt against a gate that has not finished forming.
+          #
+          # `mergeStateStatus` is the gate's own verdict and counts the
+          # contexts that have not reported, so it closes that gap — at the
+          # cost of not distinguishing "pending" from "failed", both BLOCKED.
+          # It is computed lazily and reads UNKNOWN until a query provokes it,
+          # so a run of polls that never resolves must not be able to hold the
+          # write-back shut: after five minutes of clear checks the merge
+          # attempt itself becomes the authority.
+          #
+          # "Nothing has reported yet" is the normal state for the first
+          # minute or two while the approved runs spawn, and by exit code it
+          # is indistinguishable from red. So a non-pending verdict only ends
+          # the wait once the grace window is over.
           now() { date +%s; }
           grace_until=$(( $(now) + 300 ))
           deadline=$(( $(now) + 2700 ))
           checks_green=false
+          clear_polls=0
           while [ "$(now)" -lt "${deadline}" ]; do
             rc=0
             gh pr checks "${BRANCH}" --required || rc=$?
             if [ "${rc}" -eq 0 ]; then
-              checks_green=true
-              break
-            fi
-            if [ "${rc}" -ne 8 ] && [ "$(now)" -ge "${grace_until}" ]; then
+              clear_polls=$(( clear_polls + 1 ))
+              state="$(gh pr view "${BRANCH}" --json mergeStateStatus --jq '.mergeStateStatus // empty' 2>/dev/null || true)"
+              echo "required checks clear; merge state ${state:-UNKNOWN}"
+              case "${state}" in
+                CLEAN | UNSTABLE | HAS_HOOKS)
+                  checks_green=true
+                  break
+                  ;;
+              esac
+              if [ "${clear_polls}" -ge 10 ]; then
+                echo "merge state never settled; letting the merge attempt decide."
+                checks_green=true
+                break
+              fi
+            elif [ "${rc}" -ne 8 ] && [ "$(now)" -ge "${grace_until}" ]; then
               echo "::warning::a required check on ${BRANCH} is red or never reported — NOT merging. Read the PR's checks, fix the failure, and re-run auto-tag.yml."
               exit 0
             fi
@@ -613,12 +639,11 @@ jobs:
               || echo "::warning::could not close deferral issue #${open_defer_issue}"
           fi
 
-          # The ordinary merge, with the required checks green. Retried
-          # because `gh pr checks --required` reports on the contexts that
-          # have arrived, while branch protection also counts the ones that
-          # have not: a context whose run is still spawning reads as green
-          # here and as "expected" there. Ten tries over five minutes covers
-          # that gap without turning a genuine refusal into a long wait.
+          # The ordinary merge, with the required checks green. Retried for
+          # the case the wait loop hands over on: clear checks with a merge
+          # state that never settled. Ten tries over five minutes, which is
+          # long enough for a late verdict and short enough that a genuine
+          # refusal reaches the fallbacks below rather than sitting here.
           for _ in $(seq 1 10); do
             if gh pr merge "${BRANCH}" --squash; then
               exit 0

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -33,28 +33,31 @@ name: auto-tag
 # `[workspace.package].version` (every crate inherits it), the workspace-member
 # entries in Cargo.lock, and the local build-from-source Homebrew formula, then
 # lands via a tiny PR. A PR (not a direct push) because branch protection
-# requires changes to arrive by PR with the required `ci` checks green; those
-# checks are dispatched onto the branch explicitly because pushes made with
-# GITHUB_TOKEN never trigger `on: push`/`on: pull_request` workflows. Despite
-# the dispatched run going green, this same GITHUB_TOKEN-authored PR still
-# ends up permanently `mergeable_state: blocked` (#264, #275) — most likely
-# because the PR also picks up a second, unrunnable `action_required` check
-# suite from ci.yml's natural `pull_request` trigger for the same reason, but
-# rather than fully disambiguate every possible blocker (conversation
-# resolution, staleness, that phantom suite), this workflow just verifies the
-# run it dispatched itself is green and then bypasses whatever is blocking
-# with an admin-privileged token (`RELEASE_ADMIN_TOKEN`, falling back to ordinary
-# auto-merge — see the last step) rather than requiring a human `--admin`
-# merge every release. The bump commit carries `[skip release]`, so its merge
-# can never cut another release — the loop terminates after exactly one sync
-# per release.
+# requires changes to arrive by PR with the required checks green.
 #
-# Because that merge bypasses branch protection, the last step re-asks the
-# lockfile question against the MERGE RESULT before merging, not just against
-# the branch ci validated: `Cargo.lock` is a shared cell, and a sync branch cut
-# before a new crate landed composes into a lock that resolves for neither side
-# (#3336). scripts/sync-versions.sh asks the same question about its own output
-# at both call sites, so the tag cannot carry an unresolvable lock either.
+# That PR's own workflow runs are created and then parked: the repository's
+# Actions approval policy is `first_time_contributors`, and its author —
+# `github-actions[bot]` — is one, so every run sits at `action_required` until
+# somebody presses "Approve and run". Three releases in ninety minutes needed
+# that click, thirteen runs at a time (#5589). This workflow approves them
+# itself, and the PR then satisfies branch protection the ordinary way instead
+# of being merged past it. The bump commit carries `[skip release]`, so its
+# merge can never cut another release — the loop terminates after exactly one
+# sync per release.
+#
+# Merging past protection is what this used to do, with a maintainer PAT
+# (`RELEASE_ADMIN_TOKEN`). That path is dead: `enforce_admins` is on for main,
+# so the admin merge is refused like any other and the step warned while
+# reporting success. It stays only as a fallback for a repository that still
+# grants a bypass.
+#
+# Nothing required asks whether the branch and main compose, because `strict`
+# is off and every check runs on the branch rather than on the merge result. So
+# the last step re-asks the lockfile question against the MERGE RESULT before
+# merging: `Cargo.lock` is a shared cell, and a sync branch cut before a new
+# crate landed composes into a lock that resolves for neither side (#3336).
+# scripts/sync-versions.sh asks the same question about its own output at both
+# call sites, so the tag cannot carry an unresolvable lock either.
 #
 # GATED ON GREEN CI. This runs via `workflow_run` after the `ci` workflow
 # finishes on main, and only tags when that run *succeeded* — a commit that
@@ -73,17 +76,18 @@ on:
 
 concurrency:
   # Serialize so rapid merges compute their version off the previous tag.
-  # Waiting out the dispatched ci run (below) stretches each queued run from
-  # ~1 minute to the length of a full ci run (~4 minutes) — on a "shared,
+  # Waiting out the sync PR's required checks (below) stretches each queued
+  # run from ~1 minute to the length of the slowest one — on a "shared,
   # contested" main this can back the auto-tag queue up under a burst of
   # merges. Not dangerous (still serialized, every failure path warns and
-  # exits 0 rather than jamming), just slower than before.
+  # exits 0 rather than jamming), just slower than before. The wait is capped
+  # at 45 minutes so a stuck check cannot hold the queue indefinitely.
   group: auto-tag
   cancel-in-progress: false
 
 permissions:
   contents: write # push the tag + the version-sync branch
-  actions: write # dispatch release.yml + ci.yml
+  actions: write # dispatch release.yml + approve the sync PR's parked runs
   pull-requests: write # open/auto-merge the version-sync PR
   issues: write # open/comment/close the version-writeback-deferred issue (#3842)
 
@@ -314,7 +318,7 @@ jobs:
             "- \`packaging/homebrew/stella.rb\` (build-from-source formula)"
             "- \`CHANGELOG.md\` — whatever was under \`[Unreleased]\` now sits under \`[${version}]\`"
             ""
-            "The workflow dispatches the required \`ci\` checks onto this branch and merges once they're green (past GitHub's phantom \`action_required\` check suite for this GITHUB_TOKEN-authored PR — see #275); no action is needed unless the dispatched run fails."
+            "The workflow approves this PR's parked workflow runs, waits for the required checks, and merges once they are green (#5589). No action is needed unless a check fails."
           )
           body="$(printf '%s\n' "${body_lines[@]}")"
 
@@ -349,22 +353,88 @@ jobs:
             echo "::warning::could not resolve the write-back PR number; no-issue not applied"
           fi
 
-      # Merging a Cargo-only bot/version-sync PR the normal way never
-      # resolves. Confirmed live on PR #287 (chore(release): sync versions to
-      # 0.4.51): its `workflow_dispatch`-triggered ci run posted both required
-      # check-runs as green, yet `mergeable_state` stayed "blocked" — most
-      # likely because a GITHUB_TOKEN-triggered event can never trigger a
-      # *new* workflow run (recursion guard), so ci.yml's *natural*
-      # `pull_request` trigger on this same GITHUB_TOKEN-authored PR still
-      # spawns a check suite that can only ever complete as a zero-job
-      # "action_required" phantom, which branch protection's required-status-
-      # check evaluation may treat as permanently unresolved. Rather than
-      # fully disambiguate every possible blocker (that phantom suite,
-      # conversation resolution, staleness), this step just verifies the run
-      # it dispatched itself actually went green and then bypasses whatever
-      # is blocking with an admin-privileged merge — every sync PR needed a
-      # manual `--admin` merge before this (#264, #275).
-      - name: Wait for the dispatched checks, then merge past the GITHUB_TOKEN phantom check suite
+      # The write-back PR's own workflow runs are created and then parked:
+      # every one lands as `status: completed, conclusion: action_required`
+      # and never starts. The repository's Actions approval policy is
+      # `first_time_contributors`, and `github-actions[bot]` — the author of
+      # this PR — is one, so the whole suite waits for a person to press
+      # "Approve and run". Thirteen runs did that on #5571, #5576 and #5588,
+      # and a maintainer cleared each set by hand (#5589).
+      #
+      # Approving them is the whole fix. Three of main's five required
+      # contexts come from workflows this job cannot dispatch instead:
+      # `harbor_adapter + analyzer pytest` (bench.yml), `main is not
+      # known-broken` (main-red-hold.yml) and `gate steps no other workflow
+      # runs` (guard-self-tests.yml). Once the parked runs start, all five
+      # report and the PR merges under branch protection rather than past it.
+      #
+      # GITHUB_TOKEN first, RELEASE_ADMIN_TOKEN second: the narrower token is
+      # the one to spend if it is enough, and the log then says which one the
+      # repository actually needs. Never fatal — an unapproved run leaves the
+      # PR blocked, which is where it was already.
+      - name: Approve the version-sync PR's parked workflow runs
+        if: steps.ver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ADMIN_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
+          BRANCH: bot/version-sync
+        run: |
+          set -euo pipefail
+
+          head_sha="$(gh pr view "${BRANCH}" --json headRefOid --jq '.headRefOid // empty' 2>/dev/null || true)"
+          if [ -z "${head_sha}" ]; then
+            echo "no open ${BRANCH} PR — nothing to approve."
+            exit 0
+          fi
+          echo "approving parked runs on ${head_sha}"
+
+          approve_one() {
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/$1/approve" >/dev/null 2>&1 && return 0
+            [ -n "${ADMIN_TOKEN:-}" ] || return 1
+            GH_TOKEN="${ADMIN_TOKEN}" \
+              gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/$1/approve" >/dev/null 2>&1
+          }
+
+          # The runs are created by the `opened`/`synchronize` event this job
+          # just caused, so some of them do not exist yet on the first pass.
+          # Poll for two minutes and approve whatever has appeared. Polling to
+          # the end rather than stopping at the first empty pass: a straggler
+          # left parked is a required context that never reports, which is the
+          # failure this step exists to remove.
+          approved=0
+          for _ in $(seq 1 8); do
+            parked="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${head_sha}&per_page=100" \
+              --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')"
+            for run_id in ${parked}; do
+              if approve_one "${run_id}"; then
+                approved=$(( approved + 1 ))
+                echo "approved run ${run_id}"
+              else
+                echo "::warning::could not approve run ${run_id}; a required check may never report"
+              fi
+            done
+            sleep 15
+          done
+          echo "approved ${approved} parked run(s) on ${head_sha}"
+
+      # Merging a Cargo-only bot/version-sync PR used to need an admin bypass.
+      # The PR's own checks were parked (see the step above), so the required
+      # contexts never reported, and the workflow dispatched ci.yml onto the
+      # branch to watch a run of its own instead. That covered two of the five
+      # contexts main requires; the other three belong to workflows with no
+      # `workflow_dispatch` trigger, so the bypass was doing the rest of the
+      # work. On 2026-09-02 the bypass stopped working — `enforce_admins` is
+      # on, so `mergePullRequest` refused the admin merge with "5 of 5
+      # required status checks are expected", the step warned, and the job
+      # still reported success (#5589, run 33666329889).
+      #
+      # Approving the parked runs makes all five contexts report, so this step
+      # no longer dispatches anything and no longer bypasses anything: it
+      # waits for the required checks, re-asks the lockfile question against
+      # the merge result, and merges the ordinary way. The admin merge stays
+      # as a fallback for a repository whose protection still permits one.
+      - name: Wait for the required checks, then merge the version-sync PR
         if: steps.ver.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -378,48 +448,44 @@ jobs:
           # The previous step exits 0 early ("manifests already at ${version};
           # nothing to sync") when the bump was a no-op — a step exiting 0 is
           # a *success*, not a skip, so it doesn't stop this step from
-          # running. Without this guard, a no-op cycle would still dispatch a
-          # full ci run and then merge whatever bot/version-sync PR happens
-          # to be open — possibly a stale one left over from an earlier
-          # cycle. Bail out here if there's nothing open to merge.
+          # running. Without this guard, a no-op cycle would merge whatever
+          # bot/version-sync PR happens to be open — possibly a stale one left
+          # over from an earlier cycle. Bail out if there's nothing open.
           if [ -z "$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')" ]; then
             echo "no open ${BRANCH} PR — nothing to merge."
             exit 0
           fi
 
-          latest_run_id() {
-            gh run list --workflow=ci.yml --branch="${BRANCH}" \
-              --event=workflow_dispatch --limit=1 --json databaseId \
-              --jq '.[0].databaseId // empty'
-          }
-
-          # Capture whatever was already the newest workflow_dispatch run
-          # for this branch (usually the previous sync's), so the poll below
-          # can tell a genuinely new run apart from a stale one still cached
-          # at dispatch time — the required checks must be validated against
-          # *this* commit, not a leftover run id.
-          previous_run_id="$(latest_run_id)"
-
-          # Start the required checks — a GITHUB_TOKEN push doesn't trigger
-          # ci.yml's own `on: pull_request`.
-          gh workflow run ci.yml --ref "${BRANCH}"
-
-          run_id=""
-          for _ in $(seq 1 15); do
-            candidate="$(latest_run_id)"
-            if [ -n "${candidate}" ] && [ "${candidate}" != "${previous_run_id}" ]; then
-              run_id="${candidate}"
+          # `gh pr checks --required` reports on exactly the contexts branch
+          # protection requires, so this waits for the real gate rather than
+          # for a run of its own choosing. Its exit codes: 0 every required
+          # context passed, 8 one is still pending, anything else one failed
+          # or none has reported yet.
+          #
+          # "None has reported yet" is the normal state for the first minute
+          # or two, while the approved runs create their check runs, and it is
+          # indistinguishable from a red verdict by exit code alone. So a
+          # non-pending verdict only ends the wait once the grace window is
+          # over — before that it is treated as "not yet".
+          now() { date +%s; }
+          grace_until=$(( $(now) + 300 ))
+          deadline=$(( $(now) + 2700 ))
+          checks_green=false
+          while [ "$(now)" -lt "${deadline}" ]; do
+            rc=0
+            gh pr checks "${BRANCH}" --required || rc=$?
+            if [ "${rc}" -eq 0 ]; then
+              checks_green=true
               break
             fi
-            sleep 4
+            if [ "${rc}" -ne 8 ] && [ "$(now)" -ge "${grace_until}" ]; then
+              echo "::warning::a required check on ${BRANCH} is red or never reported — NOT merging. Read the PR's checks, fix the failure, and re-run auto-tag.yml."
+              exit 0
+            fi
+            sleep 30
           done
-          if [ -z "${run_id}" ]; then
-            echo "::warning::could not find the freshly dispatched ci run for ${BRANCH} — merge it manually once checks are green (see #275)."
-            exit 0
-          fi
-
-          if ! gh run watch "${run_id}" --exit-status; then
-            echo "::warning::the dispatched ci run for ${BRANCH} failed — NOT merging. Fix the failure and re-run ci.yml on the branch."
+          if [ "${checks_green}" != true ]; then
+            echo "::warning::the required checks on ${BRANCH} did not finish within 45 minutes — NOT merging. Merge it once they are green, or re-run auto-tag.yml."
             exit 0
           fi
 
@@ -434,16 +500,17 @@ jobs:
           # shape is AGENTS.md § Gotchas' shared-cell collision, and #3332's
           # post-merge canary is the backstop for when it still gets through).
           #
-          # This step merges with an admin bypass, so no required check stands
-          # between that composition and `main` — the question has to be asked
-          # here, against the actual merge result, or it is not asked at all.
+          # No required check asks it. `strict` is off on main's protection, so
+          # a sync branch is never made to catch up before it merges, and every
+          # check above ran on the branch rather than on the merge result. The
+          # question has to be asked here or it is not asked at all.
           #
           # Refusing rather than rebuilding the branch on the new tip: a rebuilt
-          # head would be merged past branch protection with ci having run on a
-          # commit that no longer exists. Refusing costs one cycle instead —
-          # whatever merge moved main starts another auto-tag run, which
-          # force-updates this same branch from the then-current tip. The
-          # version write-back is deferred, never dropped, and main stays green.
+          # head throws away every check that just reported and parks a fresh
+          # set of runs to approve. Refusing costs one cycle instead — whatever
+          # merge moved main starts another auto-tag run, which force-updates
+          # this same branch from the then-current tip. The version write-back
+          # is deferred, never dropped, and main stays green.
           git fetch origin main
           merge_verdict=0
           if git merge --no-commit --no-ff FETCH_HEAD >/dev/null 2>&1; then
@@ -538,16 +605,35 @@ jobs:
               || echo "::warning::could not close deferral issue #${open_defer_issue}"
           fi
 
+          # The ordinary merge, with the required checks green. Retried
+          # because `gh pr checks --required` reports on the contexts that
+          # have arrived, while branch protection also counts the ones that
+          # have not: a context whose run is still spawning reads as green
+          # here and as "expected" there. Ten tries over five minutes covers
+          # that gap without turning a genuine refusal into a long wait.
+          for _ in $(seq 1 10); do
+            if gh pr merge "${BRANCH}" --squash; then
+              exit 0
+            fi
+            sleep 30
+          done
+
           # RELEASE_ADMIN_TOKEN: a maintainer PAT with bypass rights on this
-          # branch's protection (documented in RELEASING.md). Without it,
-          # fall back to arming ordinary auto-merge plus a manual-merge
-          # warning — the phantom suite will still block it, but nothing
-          # regresses for a repo that hasn't set the secret up yet.
+          # branch's protection (documented in RELEASING.md). It is a fallback
+          # now, not the path: `enforce_admins` is on for main, which makes
+          # `mergePullRequest` refuse an admin merge on the same grounds it
+          # refuses any other (#5589). Kept for a repository whose protection
+          # still grants a bypass.
           if [ -n "${ADMIN_MERGE_TOKEN:-}" ]; then
             if GH_TOKEN="${ADMIN_MERGE_TOKEN}" gh pr merge "${BRANCH}" --squash --admin; then
               exit 0
             fi
             echo "::warning::admin merge of ${BRANCH} with RELEASE_ADMIN_TOKEN failed — falling back to auto-merge."
           fi
+
+          # Last resort: arm auto-merge so a context that reports late still
+          # lands the write-back with no human action, and say so, because a
+          # step that reaches here has not merged anything.
           gh pr merge "${BRANCH}" --squash --auto \
-            || echo "::warning::could not enable auto-merge — merge the ${BRANCH} PR manually once checks are green (see #275)."
+            || echo "::warning::could not enable auto-merge — merge the ${BRANCH} PR manually once checks are green."
+          echo "::warning::${BRANCH} did not merge in this run; auto-merge is armed. If it is still open, check that its workflow runs are not parked in action_required (#5589)."

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -402,13 +402,21 @@ jobs:
           # left parked is a required context that never reports, which is the
           # failure this step exists to remove.
           approved=0
+          done_ids=" "
           for _ in $(seq 1 8); do
             parked="$(gh api \
               "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${head_sha}&per_page=100" \
               --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')"
             for run_id in ${parked}; do
+              # An approved run keeps reporting `action_required` for a few
+              # seconds. Approving it twice is a 403, so skip what already
+              # went through rather than warn about it.
+              case "${done_ids}" in
+                *" ${run_id} "*) continue ;;
+              esac
               if approve_one "${run_id}"; then
                 approved=$(( approved + 1 ))
+                done_ids="${done_ids}${run_id} "
                 echo "approved run ${run_id}"
               else
                 echo "::warning::could not approve run ${run_id}; a required check may never report"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,9 +29,14 @@ main and does everything — no manual steps:
    with the newest tag: a `bot/version-sync` PR bumps
    `[workspace.package].version` in `Cargo.toml` (every crate inherits it),
    the workspace-member entries in `Cargo.lock`, and
-   `packaging/homebrew/stella.rb`, then auto-merges once the required checks
-   pass. Its commit carries `[skip release]`, so the sync itself never cuts a
-   release. If a sync PR is ever left open (red check, race with another
+   `packaging/homebrew/stella.rb`, then merges once the required checks pass.
+   Nobody has to touch it. That PR is written by `github-actions[bot]`, and
+   this repository makes a first-time contributor's workflow runs wait for a
+   person to approve them, so all thirteen of its runs open parked at
+   `action_required`. The workflow approves them itself and then waits for the
+   checks, which is what lets the PR merge under branch protection rather than
+   past it. Its commit carries `[skip release]`, so the sync itself never cuts
+   a release. If a sync PR is ever left open (red check, race with another
    merge), the next release supersedes it automatically — no cleanup needed.
    Both the stamp and the merge are checked against
    `scripts/check-lockfile-sync.sh`: the script refuses to author a stamp whose
@@ -130,21 +135,20 @@ to this repo's GitHub Releases and need no extra secrets — only the Homebrew
 tap push does. If neither secret is set, the release still succeeds and
 the `homebrew` job skips with a warning.
 
-**Optional — auto-merging the version-sync PR without a manual `--admin`.**
-`auto-tag.yml`'s `bot/version-sync` PR only carries a Cargo.toml/Cargo.lock
-diff, and branch protection's required `ci` checks never run on it the normal
-way (see #275): the workflow dispatches them itself, but the PR's own
-GITHUB_TOKEN authorship also spawns an unrunnable `pull_request`-triggered
-check suite that can leave `mergeable_state` stuck on "blocked" even once the
-dispatched run is green. The workflow verifies that dispatched run itself and
-then bypasses whatever is blocking with an admin-privileged merge — for that
-bypass to actually succeed (rather than fall back to arming ordinary
-auto-merge, which will just sit there the same way `--admin` used to be
-needed), add a **classic PAT with `repo` scope, owned by an account with
-admin/bypass rights on this repository**, as the `RELEASE_ADMIN_TOKEN` secret.
-Without it, sync PRs still get merged — just by a human running
-`gh pr merge bot/version-sync --squash --admin` once checks are green, same
-as before this workflow existed.
+**Optional — `RELEASE_ADMIN_TOKEN`.** The `bot/version-sync` PR merges on its
+own with no secret set, so this is not required. `auto-tag.yml` uses the token
+in two places, both as a second try after `GITHUB_TOKEN`:
+
+- **Approving the PR's parked workflow runs.** If `GITHUB_TOKEN` cannot
+  approve them, the runs stay parked, no required check reports, and the PR
+  waits for a person. The run log names which token did the approving.
+- **Merging past branch protection.** This no longer works on `main`, because
+  `enforce_admins` is on and GitHub refuses an admin merge on the same grounds
+  it refuses any other (#5589). It is kept for a repository that still grants
+  a bypass.
+
+To set it, add a **classic PAT with `repo` scope, owned by an account with
+admin rights on this repository**, as the `RELEASE_ADMIN_TOKEN` secret.
 
 ## Cut a release
 


### PR DESCRIPTION
## What and why

Every release version-sync pull request opened with all thirteen of its
workflow runs parked at `action_required` and stayed there until a maintainer
clicked "Approve and run" thirteen times.

**The cause, established rather than guessed.** The repository's Actions
approval policy is `first_time_contributors`
(`actions/permissions/fork-pr-contributor-approval`), and the PR's author is
`github-actions[bot]`, which counts as one. That policy is normally described
as a fork rule, but it reaches this same-repo branch too. Checked live on
#5634: all thirteen `pull_request`-event runs on its head sha
`398fd6435d` had `conclusion: action_required`.

**Why the workflow did not notice.** `auto-tag.yml` never depended on those
runs. It dispatched `ci.yml` onto the branch, watched that run, and then merged
past branch protection with `RELEASE_ADMIN_TOKEN`. The dispatch covered two of
main's five required contexts. The other three belong to workflows with no
`workflow_dispatch` trigger, so the admin bypass was doing the rest of the
work:

| required context | workflow | `workflow_dispatch`? |
|---|---|---|
| `fmt + clippy + test` | `ci.yml` | yes |
| `cargo deny + cargo audit` | `ci.yml` | yes |
| `harbor_adapter + analyzer pytest` | `bench.yml` | yes |
| `main is not known-broken` | `main-red-hold.yml` | **no** |
| `gate steps no other workflow runs` | `guard-self-tests.yml` | **no** |

**Why it broke now.** `enforce_admins` is `true` on main's protection, so
`mergePullRequest` refuses the admin merge on the same grounds it refuses any
other caller. Run
[33666329889](https://github.com/macanderson/stella/actions/runs/33666329889),
step `Wait for the dispatched checks…`:

```
GraphQL: 5 of 5 required status checks are expected. (mergePullRequest)
##[warning]admin merge of bot/version-sync with RELEASE_ADMIN_TOKEN failed — falling back to auto-merge.
```

The step then exited 0, so the job was green and the write-back had not landed.

## The change

`.github/workflows/auto-tag.yml` only, plus a `RELEASING.md` update.

1. **New step, `Approve the version-sync PR's parked workflow runs`.** After
   the PR is opened it polls the head sha for two minutes and `POST`s
   `/actions/runs/{id}/approve` for every run whose conclusion is
   `action_required`. `GITHUB_TOKEN` first, `RELEASE_ADMIN_TOKEN` second, so
   the narrower token is spent when it is enough and the log says which one the
   repository actually needs. Never fatal — an unapproved run leaves the PR
   where it already was.
2. **The merge step no longer dispatches or bypasses anything.** The
   `gh workflow run ci.yml` dispatch, the `previous_run_id`/`latest_run_id`
   bookkeeping and the `gh run watch` are deleted. It waits on
   `gh pr checks bot/version-sync --required`, which reports on exactly the
   contexts branch protection requires, then runs the existing
   lockfile-composition guard against the merge result, then merges with a
   plain `gh pr merge --squash`. The admin merge stays only as a fallback for a
   repository that still grants a bypass.

   The wait asks two questions, because neither answers this alone.
   `gh pr checks --required` is the only signal that tells a red check from a
   slow one, but it can only report on check runs that exist — measured on this
   PR, it returned all-clear listing three of the five required contexts while
   `ci.yml` had not yet created the other two. `mergeStateStatus` counts the
   contexts that have not reported, and cannot tell pending from failed. So the
   loop waits for both, and hands the decision to the merge attempt if the
   merge state never settles, which is the one way GitHub's lazy computation
   could otherwise hold the write-back shut.
3. The `no-issue` label step needed no change — it already exists and works;
   #5634 carried the label from the moment it opened and `dod / dod` passed
   unaided.

**No credential change.** No new secret, no new scope, no swap of
`GITHUB_TOKEN` for a PAT. The `actions: write` permission the job already
declares (for dispatching `release.yml`) is what the approve call needs.

## The witness, and its mechanism

This is a workflow that only runs after a merge to main, so the fail→pass
evidence is operational. I ran both halves of the new step by hand against the
live blocked PR #5634 before writing it, which is the fail-before/pass-after
pair:

**Before** — the three contexts owned by non-dispatchable workflows had never
reported, which is why `mergePullRequest` said "5 of 5 … are expected":

```
bench          pull_request  completed  action_required  33697188967
guard-self-tests pull_request completed action_required  33697188929
main-red-hold  pull_request  completed  action_required  33697188886
… (13 in all)
```

**After** approving all thirteen with the exact call the new step makes:

```
$ gh pr checks 5634 --required
fmt + clippy + test                  pending
cargo deny + cargo audit             pass
gate steps no other workflow runs    pass
harbor_adapter + analyzer pytest     pass
main is not known-broken             pass
rc=8
```

That also confirms the exit-code contract the wait loop is built on: `8` while
a required context is pending, `0` when all pass.

The remaining witness the issue asks for is the next real version-sync PR
merging with no human action. It opens on the merge of this PR, and I will link
its URL and run ids on #5589 before closing out.

## Notes

- Exemplar followed: none outside this repository. The wait/merge shape follows
  `main-canary.sh`'s discipline already cited in this file — warn, exit 0, never
  jam the release queue.
- Prose: `make guards-fast` green, including `check-prose` and
  `check-line-citations`.
- Shellcheck: both new `run:` blocks extracted and checked clean.

## Residue filed

- #5677 — watch the next version-sync pull request merge itself and record the
  evidence. This is #5589's witness item, split out because `auto-tag.yml` only
  runs on a merge to `main` and so cannot be observed before this merges. The
  gate's own message names splitting as the remedy (SCR-004).
- #5679 — decide whether the Actions approval policy should keep parking the
  release bot's own runs. Changing it would also change how genuine fork pull
  requests are treated, so it is a maintainer decision rather than part of this
  fix.
- #5673 — a version write-back that did not merge is only reported for one of
  its four failure paths. Three of the step's `exit 0` branches warn in the run
  log and nothing else, which is the shape #3842 argued against.

Already tracked, not caused by this branch: `guard self-tests` is red on every
open pull request right now (#5671). It is not a required context.

Closes #5589

Tests deleted: None

## Summary by Sourcery

Enable version-sync pull requests to approve their parked workflow runs and merge under branch protection without manual intervention.

New Features:
- Automatically approve parked workflow runs for version-sync pull requests so their required checks can execute without maintainer intervention.

Bug Fixes:
- Fix version-sync pull requests remaining blocked because bot-authored workflow runs were held at action_required.
- Fix release write-back merging by relying on the repository's required checks instead of an ineffective administrator bypass.

Enhancements:
- Update version-sync merging to wait for all required checks, validate lockfile composition against the merge result, and use ordinary protected merging with safe fallbacks.
- Add bounded polling, retry handling, and clearer warnings when checks or merging do not complete.
- Document the hands-off version-sync flow and the optional fallback role of RELEASE_ADMIN_TOKEN.

Documentation:
- Document automatic approval of parked version-sync workflow runs and the revised optional RELEASE_ADMIN_TOKEN behavior.