### PR TITLE
fix(release): record the four orphan tags and stop discarding built releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,21 @@ jobs:
           echo "asset=${stem}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "sums=${stem}.sha256" >> "$GITHUB_OUTPUT"
 
+      # Uploaded twice, because one unlucky DNS lookup used to throw away a
+      # finished release. v0.9.273 compiled for seven minutes, packaged its
+      # tarball, and then died here on `Failed to CreateArtifact: Unable to
+      # make request: ENOTFOUND` — an Actions endpoint the runner could not
+      # resolve. Every downstream job needs all four artifacts, so that one
+      # step took the whole tag with it (#5629).
+      #
+      # `continue-on-error` on the first step is what lets a second one run;
+      # the retry itself is a plain step, so a real upload failure still fails
+      # the job. No retry action is added: a third-party action would owe
+      # `action-pins` a pinned SHA and the licence allowlist a review, to buy
+      # one `if:` condition.
       - name: Upload build artifact
+        id: upload
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stella-${{ matrix.target }}
@@ -167,6 +181,21 @@ jobs:
             ${{ steps.package.outputs.sums }}
           if-no-files-found: error
           retention-days: 7
+
+      # `overwrite` covers the narrower failure where the first attempt got far
+      # enough to reserve the name before it broke; without it the retry would
+      # fail on a name conflict of its own making.
+      - name: Upload build artifact (retry)
+        if: steps.upload.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: stella-${{ matrix.target }}
+          path: |
+            ${{ steps.package.outputs.asset }}
+            ${{ steps.package.outputs.sums }}
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
 
   # Rebuild one target on a second runner and refuse to publish if the bytes
   # differ (#910, acceptance clause). This is the check that keeps
@@ -444,6 +473,37 @@ jobs:
           } > notes.md
           echo "----- notes.md -----"; cat notes.md
 
+      # A draft release is not attached to its tag, so `GET /releases/tags/{tag}`
+      # answers 404 for one and the publish step below creates a second release
+      # instead of finishing the first. That is how v0.9.254 and v0.9.264 ended
+      # up as drafts nothing would ever touch again: the step created the
+      # release, uploaded its assets, then hit a GitHub 5xx before publishing,
+      # and a re-run would have left the half-built draft sitting beside a new
+      # one (#5629). Deleting it first is what makes a re-run finish the job.
+      #
+      # Only a draft is ever deleted. A published release for this tag is a
+      # release users can already download, and this step must never touch it.
+      - name: Delete a stale draft release for this tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          # `--slurp` cannot be combined with `--jq` (gh rejects that), so the
+          # filter runs in a plain jq after the fetch.
+          ids="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh api --paginate --slurp \
+            'repos/{owner}/{repo}/releases?per_page=100' \
+            | jq -r --arg tag "$tag" '.[][] | select(.draft == true and .tag_name == $tag) | .id')"
+          if [ -z "$ids" ]; then
+            echo "no draft release for ${tag}; nothing to clear."
+            exit 0
+          fi
+          for id in $ids; do
+            echo "::notice::deleting stale draft release ${id} for ${tag} so this run can publish."
+            gh api -X DELETE "repos/{owner}/{repo}/releases/${id}"
+          done
+
       - name: Create / update GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
@@ -494,6 +554,41 @@ jobs:
 
           version="${GITHUB_REF_NAME#v}"
 
+          if [ -n "${HOMEBREW_TAP_DEPLOY_KEY:-}" ]; then
+            # SSH with the tap-scoped deploy key. The key file lives outside
+            # the workspace and is chmod 600, as ssh requires.
+            keyfile="${RUNNER_TEMP}/tap_deploy_key"
+            printf '%s\n' "${HOMEBREW_TAP_DEPLOY_KEY}" > "${keyfile}"
+            chmod 600 "${keyfile}"
+            export GIT_SSH_COMMAND="ssh -i ${keyfile} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+            git clone --depth 1 "git@github.com:macanderson/homebrew-tap.git" tap
+          else
+            git clone --depth 1 \
+              "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/macanderson/homebrew-tap.git" tap
+          fi
+
+          # The tap is cloned before anything is rendered so this job can read
+          # the version it currently serves and refuse to go backwards.
+          #
+          # Re-running release.yml on an old tag checks out the workflow AS OF
+          # THAT TAG and renders the formula for that version unconditionally,
+          # so retrying a months-old failed release would hand every `brew
+          # upgrade` an older stella than the one it has (#5629). The formula
+          # is the one artifact here that is a pointer rather than an addition:
+          # a stale GitHub Release is harmless beside the newer ones, and a
+          # stale Formula/stella.rb is what everybody installs.
+          tap_version=""
+          if [ -f tap/Formula/stella.rb ]; then
+            tap_version="$(sed -n 's/^[[:space:]]*version "\([^"]*\)".*/\1/p' tap/Formula/stella.rb | head -n1)"
+          fi
+          if [ -n "${tap_version}" ] && [ "${tap_version}" != "${version}" ]; then
+            older="$(printf '%s\n%s\n' "${version}" "${tap_version}" | sort -V | head -n1)"
+            if [ "${older}" = "${version}" ]; then
+              echo "::notice::the tap serves ${tap_version}; not rendering the older ${version} over it."
+              exit 0
+            fi
+          fi
+
           # SHA-256 of a given target's release tarball (same bytes uploaded to
           # the GitHub Release in the `release` job).
           sha_for() {
@@ -522,19 +617,6 @@ jobs:
 
           echo "----- rendered Formula/stella.rb -----"
           cat rendered/stella.rb
-
-          if [ -n "${HOMEBREW_TAP_DEPLOY_KEY:-}" ]; then
-            # SSH with the tap-scoped deploy key. The key file lives outside
-            # the workspace and is chmod 600, as ssh requires.
-            keyfile="${RUNNER_TEMP}/tap_deploy_key"
-            printf '%s\n' "${HOMEBREW_TAP_DEPLOY_KEY}" > "${keyfile}"
-            chmod 600 "${keyfile}"
-            export GIT_SSH_COMMAND="ssh -i ${keyfile} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-            git clone --depth 1 "git@github.com:macanderson/homebrew-tap.git" tap
-          else
-            git clone --depth 1 \
-              "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/macanderson/homebrew-tap.git" tap
-          fi
 
           mkdir -p tap/Formula
           cp rendered/stella.rb tap/Formula/stella.rb

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -237,6 +237,41 @@ diff:
 make releases-baseline-update    # then read the diff
 ```
 
+Write the reason above the tag as a comment line. Regeneration keeps those
+notes, and the reason is what a reviewer needs to judge the entry.
+
+### The three shapes a failed release takes
+
+`make releases-published` names the state of every reported tag, because the
+work each one needs is different. Four orphan tags once turned out to be three
+different failures:
+
+| State | What happened | What to do |
+|---|---|---|
+| `draft` | The build ran and the assets are attached, but a `5xx` killed the publish step before the release left draft. | List the draft's assets. Publish it if the set is complete; delete it and re-run the tag if it is not. |
+| `absent` | No release object exists — a build job died, often in `actions/upload-artifact`. | Re-run `release.yml` on the tag, but read the version guard below first. |
+| gone | The build finished, and the run itself was killed after the fact. Build artifacts expire after 7 days, so an old one has nothing left to publish. | Grandfather the tag with a note. Rebuilding a version a hundred releases behind buys nothing. |
+
+Find a draft and see what it holds:
+
+```bash
+gh api repos/{owner}/{repo}/releases \
+  --jq '.[] | select(.draft) | {id, tag_name, assets: [.assets[].name]}'
+```
+
+A complete set is four tarballs plus `SHA256SUMS` and `SHA256SUMS.bin`.
+`install.sh` and the Homebrew formula both read `SHA256SUMS`, so a draft
+missing it is not publishable — delete it (`gh api -X DELETE
+repos/{owner}/{repo}/releases/<id>`) rather than shipping a release whose
+checksum file is absent.
+
+**Re-running an old tag runs the workflow as it stood at that tag.** That
+matters most for the `homebrew` job, which renders `Formula/stella.rb` for
+whatever version it is building. Today's job refuses to render a version lower
+than the one the tap already serves, so a re-run cannot downgrade `brew
+upgrade`. A tag old enough to predate that guard has no such protection: check
+what its own `release.yml` does before dispatching it.
+
 ## Verify a published binary yourself
 
 Release builds are reproducible: the same tag, built on the pinned toolchain,

--- a/scripts/check-releases-published.sh
+++ b/scripts/check-releases-published.sh
@@ -4,6 +4,7 @@
 #
 #   ./scripts/check-releases-published.sh [--grace-secs N]
 #   ./scripts/check-releases-published.sh --select --now <unix> --grace-secs <n>   # pure: JSON on stdin
+#   ./scripts/check-releases-published.sh --carry-notes [--baseline PATH]          # pure: tags on stdin
 # --help text ends here.
 #
 # ── The silence ──────────────────────────────────────────────────────────────
@@ -41,6 +42,22 @@
 # is skipped. Too short and this cries wolf on every release; too long and the
 # silence it exists to break lasts that much longer.
 #
+# ── Draft or absent: two findings with two remedies ──────────────────────────
+#
+# A tag with no published release is in one of two states, and they cost
+# different things to fix:
+#
+#   draft    the build ran and its assets are attached to a release object
+#            that was never flipped out of draft. Nothing has to be rebuilt.
+#            Check the asset list, then publish or delete the draft.
+#   absent   there is no release object at all. The tag has to be built again.
+#
+# Telling them apart needs `GET /releases`, which lists drafts. The by-tag
+# endpoint cannot answer it: `GET /releases/tags/{tag}` returns 404 for a draft
+# too, because a draft is not attached to its tag. That 404 is consistent with
+# both states, so reading it as "absent" is a guess. Four orphan tags were read
+# that way once, and two of them already had their assets built.
+#
 # ── Why the release list has no fixed cap ────────────────────────────────────
 #
 # A fixed `--limit` is a trap that reopens itself. A cap of 200 once reported
@@ -60,6 +77,7 @@ set -euo pipefail
 
 grace_secs=$((90 * 60))
 select_only=0
+carry_only=0
 update=0
 now=""
 
@@ -76,6 +94,8 @@ while [ $# -gt 0 ]; do
     --grace-secs) grace_secs="${2:?--grace-secs needs a number}"; shift 2 ;;
     --now) now="${2:?--now needs a unix timestamp}"; shift 2 ;;
     --select) select_only=1; shift ;;
+    --carry-notes) carry_only=1; shift ;;
+    --baseline) baseline="${2:?--baseline needs a path}"; shift 2 ;;
     --update) update=1; shift ;;
     -h|--help) print_help_header "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
@@ -89,8 +109,9 @@ done
 #   { "tags":     [ { "name": "v0.6.75", "created_unix": 1234567890 }, … ],
 #     "releases": [ { "name": "v0.6.74", "draft": false }, … ] }
 #
-# and prints one `<tag>\t<age-in-seconds>` line per tag that should have been
-# published and was not, oldest first. Kept free of I/O so
+# and prints one `<tag>\t<age-in-seconds>\t<state>` line per tag that should
+# have been published and was not, oldest first. `state` is `draft` or
+# `absent`, the two remedies described in the header. Kept free of I/O so
 # scripts/test-releases-published.sh can drive every rule from a fixture rather
 # than from the live repository — a suite that asked GitHub would pass or fail
 # for reasons that have nothing to do with the rule under test.
@@ -99,7 +120,8 @@ done
 # one and it can sit open indefinitely, so a tag with only a draft release
 # must still be reported. `draft` rides on each release object rather than
 # being filtered out before this function sees the data, so a fixture can
-# cover the rule directly instead of trusting the wrapper below got it right.
+# cover both the reporting rule and the state directly, instead of trusting
+# the wrapper below got them right.
 #
 # Note what is NOT consulted: the outcome of any workflow run. A `release`/
 # `homebrew` job is gated on `startsWith(github.ref, 'refs/tags/')`, so
@@ -114,6 +136,7 @@ done
 select_unpublished() {
   jq -r --argjson now "$now" --argjson grace "$grace_secs" '
     ( [ .releases[] | select(.draft != true) | { (.name): true } ] | add // {} ) as $published
+    | ( [ .releases[] | select(.draft == true) | { (.name): true } ] | add // {} ) as $drafted
     | ( [ (.known // [])[] | { (.): true } ] | add // {} ) as $known
     | [ .tags[]
         | select($published[.name] | not)
@@ -122,7 +145,7 @@ select_unpublished() {
       ]
     | sort_by(.created_unix)
     | .[]
-    | "\(.name)\t\($now - .created_unix)"
+    | "\(.name)\t\($now - .created_unix)\t\(if $drafted[.name] then "draft" else "absent" end)"
   '
 }
 
@@ -135,9 +158,42 @@ known_json() {
   fi
 }
 
+# Re-attach each tag's note to it. Reads a tag per line on stdin and prints the
+# comment lines that sat directly above that tag in the current baseline, then
+# the tag. Without this, `--update` erases the reason every entry was added —
+# and the reason is the only thing that makes an entry reviewable.
+#
+# A comment block starting on line 1 is the file's own header, not a note, so
+# it is dropped rather than pinned onto whichever tag happens to be first.
+carry_notes() {
+  awk -v old="$baseline" '
+    BEGIN {
+      n = 0; block = ""; block_start = 0
+      while ((getline line < old) > 0) {
+        n++
+        if (line ~ /^[ \t]*#/) {
+          if (block == "") block_start = n
+          block = block line "\n"
+          continue
+        }
+        if (line ~ /^[ \t]*$/) { block = ""; block_start = 0; continue }
+        if (block_start != 1) note[line] = block
+        block = ""; block_start = 0
+      }
+      close(old)
+    }
+    { printf "%s%s\n", note[$0], $0 }
+  '
+}
+
 if [ "$select_only" -eq 1 ]; then
   [ -n "$now" ] || { echo "--select needs --now" >&2; exit 2; }
   select_unpublished
+  exit 0
+fi
+
+if [ "$carry_only" -eq 1 ]; then
+  carry_notes
   exit 0
 fi
 
@@ -191,13 +247,17 @@ if [ "$update" -eq 1 ]; then
     echo "# alarm about NEW silence. A tag added here is a release that will never"
     echo "# exist, so every addition should be a decision someone made, visible in"
     echo "# review — not a way to quiet the check."
+    echo "#"
+    echo "# A comment line right above a tag is that tag's note: why it shipped"
+    echo "# nothing. Regeneration keeps those notes, so writing one is safe."
+    echo ""
     printf '%s' "$doc" | jq -r --argjson now "$now" --argjson grace "$grace_secs" '
       ( [ .releases[] | select(.draft != true) | { (.name): true } ] | add // {} ) as $published
       | [ .tags[] | select($published[.name] | not) | select(($now - .created_unix) > $grace) ]
-      | sort_by(.created_unix) | .[] | .name'
+      | sort_by(.created_unix) | .[] | .name' | carry_notes
   } >"$baseline.tmp"
   mv "$baseline.tmp" "$baseline"
-  echo "check-releases-published: baseline updated — $(grep -cv '^#' "$baseline") grandfathered tag(s)."
+  echo "check-releases-published: baseline updated — $(known_json | jq 'length') grandfathered tag(s)."
   exit 0
 fi
 
@@ -213,11 +273,16 @@ fi
 count="$(printf '%s\n' "$report" | wc -l | tr -d ' ')"
 echo "::error::${count} tag(s) were cut but never published. The repository is stamping version numbers while shipping no binaries — this is the #1464 silence, live."
 echo ""
-echo "Tag                  Age"
-printf '%s\n' "$report" | while IFS="$(printf '\t')" read -r tag age; do
-  printf '  %-18s %sh\n' "$tag" "$((age / 3600))"
+echo "Tag                  Age     State"
+printf '%s\n' "$report" | while IFS="$(printf '\t')" read -r tag age state; do
+  printf '  %-18s %-6s %s\n' "$tag" "$((age / 3600))h" "$state"
 done
 echo ""
+echo "draft   the build ran and its assets are attached. Check the asset list,"
+echo "        then publish or delete the draft — nothing has to be rebuilt."
+echo "absent  no release object exists. The tag has to be built again."
+echo ""
 echo "Check what happened:  gh run list --workflow=release.yml --limit 40 --json conclusion,headBranch"
+echo "List a draft's files: gh api repos/{owner}/{repo}/releases --jq '.[] | select(.draft) | {id, tag_name, assets: [.assets[].name]}'"
 echo "Re-run one by hand:   see RELEASING.md § When a release fails"
 exit 1

--- a/scripts/test-releases-published.sh
+++ b/scripts/test-releases-published.sh
@@ -119,6 +119,97 @@ want "D2 a draft does not hide a real gap among the published releases" \
   "v0.6.76" \
   "{\"tags\":[$(tag v0.6.75 $((3 * day))),$(tag v0.6.76 $((2 * day)))],\"releases\":[$(rel v0.6.75),$(rel v0.6.76 draft)]}"
 
+# ── Draft or absent ──────────────────────────────────────────────────────────
+# The two states cost different things to fix: a draft is built and one API
+# call from done, an absent release has to be rebuilt from the tag. Reporting
+# both as "cut but never published" sent a maintainer looking for four rebuilds
+# when two of the four already had their assets attached.
+#
+# want_state reads the third field, so both cases below fail against a report
+# that carries only a tag and an age.
+want_state() {
+  local name="$1" expect="$2" json="$3" got
+  got="$(printf '%s' "$json" | "$SCRIPT" --select --now "$NOW" --grace-secs "$GRACE" 2>&1 | cut -f3 | tr '\n' ' ')"
+  got="${got% }"
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1)); echo "ok   $name"
+  else
+    fail=$((fail + 1)); echo "FAIL $name — wanted '${expect}', got '${got}'"
+  fi
+}
+
+want_state "D3 a tag whose release sits in draft is reported as draft" \
+  "draft" \
+  "{\"tags\":[$(tag v0.6.80 $((5 * day)))],\"releases\":[$(rel v0.6.80 draft)]}"
+
+want_state "D4 a tag with no release object at all is reported as absent" \
+  "absent" \
+  "{\"tags\":[$(tag v0.6.80 $((5 * day)))],\"releases\":[]}"
+
+want_state "D5 the state is read per tag, not for the whole report" \
+  "absent draft" \
+  "{\"tags\":[$(tag v0.6.80 $((5 * day))),$(tag v0.6.81 $((4 * day)))],\"releases\":[$(rel v0.6.81 draft)]}"
+
+# ── Notes on a baseline entry ────────────────────────────────────────────────
+# The reason a tag was grandfathered is the only thing that makes the entry
+# reviewable, and `--update` rewrites the file from scratch. These drive the
+# rewrite's note handling against a fixture rather than the live baseline.
+notes_dir="$(mktemp -d)"
+trap 'rm -rf "$notes_dir"' EXIT
+
+# No blank line under the header, which is the shape that traps a naive read:
+# the header would otherwise be carried onto v0.1.1 as its note.
+tight="$notes_dir/tight.txt"
+cat >"$tight" <<'FIXTURE'
+# Header line one.
+# Header line two.
+v0.1.1
+# The upload never reached GitHub.
+v0.9.273
+FIXTURE
+
+# The shape the shipped baseline uses: a blank line closes the header.
+spaced="$notes_dir/spaced.txt"
+cat >"$spaced" <<'FIXTURE'
+# Header line one.
+
+v0.1.1
+# The upload never reached GitHub.
+v0.9.273
+FIXTURE
+
+# carried <name> <baseline-file> <expected-output> <tags-one-per-line>
+carried() {
+  local name="$1" file="$2" expect="$3" input="$4" got
+  got="$(printf '%s' "$input" | "$SCRIPT" --carry-notes --baseline "$file" 2>&1)"
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1)); echo "ok   $name"
+  else
+    fail=$((fail + 1)); echo "FAIL $name — wanted '${expect}', got '${got}'"
+  fi
+}
+
+carried "B1 a tag's note is written back above it" "$tight" \
+  "$(printf '# The upload never reached GitHub.\nv0.9.273')" \
+  "$(printf 'v0.9.273\n')"
+
+carried "B2 the file header is not pinned onto the first tag" "$tight" \
+  "v0.1.1" \
+  "$(printf 'v0.1.1\n')"
+
+carried "B3 a blank line under the header works the same way" "$spaced" \
+  "$(printf 'v0.1.1\n# The upload never reached GitHub.\nv0.9.273')" \
+  "$(printf 'v0.1.1\nv0.9.273\n')"
+
+carried "B4 a tag the baseline never held gets no note" "$tight" \
+  "v0.9.999" \
+  "$(printf 'v0.9.999\n')"
+
+carried "B5 a missing baseline carries nothing and drops no tag" \
+  "$notes_dir/absent.txt" \
+  "$(printf 'v0.1.1\nv0.9.273')" \
+  "$(printf 'v0.1.1\nv0.9.273\n')"
+
 # ── Grandfathering ───────────────────────────────────────────────────────────
 # The baseline is what lets this be an alarm about NEW silence instead of a
 # daily recital of a backlog nobody is going to republish (#1463). An exemption

--- a/scripts/unpublished-tags-baseline.txt
+++ b/scripts/unpublished-tags-baseline.txt
@@ -7,6 +7,10 @@
 # alarm about NEW silence. A tag added here is a release that will never
 # exist, so every addition should be a decision someone made, visible in
 # review — not a way to quiet the check.
+#
+# A comment line right above a tag is that tag's note: why it shipped
+# nothing. Regeneration keeps those notes, so writing one is safe.
+
 v0.1.1
 v0.1.2
 v0.1.3
@@ -31,3 +35,21 @@ v0.4.7
 v0.4.8
 v0.4.9
 v0.4.29
+# Run 32789294637 stopped the whole run. All four build jobs uploaded their
+# artifacts, wrote clean logs, and were then marked failed at one identical
+# second, 48 minutes later. No job log carries an error. The artifacts
+# expired on 2026-08-31, so there is nothing left to publish (#5629).
+v0.9.194
+# Run 33035688879, job 98400786154. Every build passed. The publish step
+# created the release and uploaded five of six assets, then GitHub answered
+# a 5xx and the release was left as draft 377549233 with no SHA256SUMS.
+# That draft was deleted (#5629).
+v0.9.254
+# Run 33059553973, job 98479799232. Same 5xx in the same step. Draft
+# 377720633 was left behind, missing the aarch64-apple-darwin tarball.
+# That draft was deleted (#5629).
+v0.9.264
+# Run 33157096458. The aarch64-apple-darwin build finished and packaged its
+# tarball, then actions/upload-artifact failed to reach GitHub:
+# "Failed to CreateArtifact: Unable to make request: ENOTFOUND" (#5629).
+v0.9.273


### PR DESCRIPTION
## What this changes

Four tags cut between 2026-08-24 and 2026-08-28 shipped no binaries, and
`release-reconcile` has been red on `main` ever since. They failed three
different ways, not one:

| Tag | Failure | Evidence |
|---|---|---|
| `v0.9.194` | Run-level kill. All four build jobs uploaded their artifacts and wrote clean logs, then were marked failed at one identical second 48 minutes later. | [run 32789294637](https://github.com/macanderson/stella/actions/runs/32789294637) |
| `v0.9.254` | The publish step created the release and uploaded assets, then GitHub answered a 5xx. Draft 377549233 was left behind with no `SHA256SUMS`. | [job 98400786154](https://github.com/macanderson/stella/actions/runs/33035688879/job/98400786154) |
| `v0.9.264` | Same 5xx in the same step. Draft 377720633 was left behind, missing the `aarch64-apple-darwin` tarball. | [job 98479799232](https://github.com/macanderson/stella/actions/runs/33059553973/job/98479799232) |
| `v0.9.273` | `actions/upload-artifact` failed with `ENOTFOUND` after a seven-minute build had already packaged its tarball. | [run 33157096458](https://github.com/macanderson/stella/actions/runs/33157096458) |

I confirmed both drafts' asset lists directly (`gh api
repos/macanderson/stella/releases/<id> --jq '.assets[].name'`): five assets
each, and each set is missing a different required file. Neither was
publishable as it stood.

**The four tags stay unpublished**, per the maintainer's design note on the
issue. Re-running `release.yml` on an old tag runs the workflow *as it stood at
that tag*, whose `homebrew` job renders the formula for that version
unconditionally and would downgrade the tap. `v0.9.194`'s artifacts expired on
2026-08-31, so a rebuild is the only path there, and rebuilding a version a
hundred releases behind buys nothing. Each tag is recorded in
`scripts/unpublished-tags-baseline.txt` with a comment line naming its cause
and run id.

The two incomplete drafts are deleted (release ids 377549233 and 377720633),
noted on the issue.

## Why the path stops discarding built releases

Three changes in `.github/workflows/release.yml`, one per failure shape:

- **`upload-artifact` runs twice.** The first step carries
  `continue-on-error: true` and an `id`; the second runs on
  `steps.upload.outcome == 'failure'` with `overwrite: true`. No third-party
  retry action, so `action-pins` and the licence allowlist are untouched, and a
  genuine upload failure still fails the job because the retry step is plain.
- **The `release` job deletes a stale draft for its own tag** before
  `softprops/action-gh-release` runs. A draft is not attached to its tag, so
  the action's by-tag lookup 404s and it creates a *second* release beside the
  first — which is exactly how two half-built drafts accumulated. Only a draft
  is ever deleted; a published release for the tag is never touched.
- **The `homebrew` job clones the tap first** and refuses to render a version
  lower than the formula already there (`sort -V` comparison, `::notice::` and
  exit 0). The formula is the one artifact here that is a pointer rather than
  an addition: a stale GitHub Release sits harmlessly beside newer ones, a
  stale `Formula/stella.rb` is what everybody installs.

## Draft versus absent

`scripts/check-releases-published.sh` reported all four as "cut but never
published", which sent readers looking for four rebuilds when two already had
their assets built. It now reports a state per tag, read from `GET /releases`:

```
Tag                  Age    State
  v0.9.254           126h   draft
  v0.9.273           97h    absent
```

`GET /releases/tags/{tag}` cannot answer this — it returns 404 for a draft too,
because a draft is not attached to its tag. That 404 is consistent with both
answers, which is why the issue's own "the releases are genuinely absent, not
drafts" was wrong for half the set. The script's header says so, and the report
prints the remedy for each state.

The baseline's `--update` also keeps the comment line above each tag now.
Without that, the next regeneration would erase the reason every entry exists,
which is the only thing that makes an entry reviewable.

## The witness, and why it fails on `main`

`scripts/test-releases-published.sh` gains nine cases in two groups. Run
`make releases-published-test`.

**D3/D4/D5** read the *third* field of a `--select` line. On `main` that line
carries only `<tag>\t<age>`, so `cut -f3` returns the empty string and all
three fail with `wanted 'draft', got ''`. Verified against `main`'s copy of the
script directly:

```
$ printf '{"tags":[{"name":"v0.6.80","created_unix":568000}],
           "releases":[{"name":"v0.6.80","draft":true}]}' \
    | <origin/main copy> --select --now 1000000 --grace-secs 5400 | cut -f3
(empty)
```

**B1–B5** drive the note-carrying rule through a new pure mode
(`--carry-notes --baseline PATH`) against temp fixtures. On `main` that mode
does not exist: the argument parser answers `unknown argument: --carry-notes`
and exits 2, so every case fails. Verified the same way.

Both groups pass on this branch — all 25 cases green locally
(`./scripts/test-releases-published.sh`).

The workflow changes carry no witness test: a `run:` block cannot be exercised
without a release, and the DoD asked for no new script. `release-reconcile`
going green on `main` after merge is their fail→pass flip, and I will trigger
it and cite the run before ticking that box.

## Exemplar followed

`--carry-notes` copies `--select`'s own shape in the same file: a pure mode
with the I/O taken out, so a fixture is a complete input and no live repository
or API is involved. That is what makes the reconciliation rule testable today,
and it is why the note-carrying awk is not shipped untested.

## Evidence

- `make guards-fast` green, including `prose`, `line-citations`, `shellcheck`,
  `action-pins` and `file-size`.
- `./scripts/test-releases-published.sh` — passed 25, failed 0.
- Draft asset lists read from the API before deleting either one.

Tests deleted: None

Closes #5629
Closes #5244

## Summary by Sourcery

Harden release recovery so transient failures do not discard built artifacts or downgrade downstream packaging, while recording and accurately reporting unreleased tags.

New Features:
- Distinguish draft and absent releases in reconciliation reports and preserve explanatory notes when updating the unpublished-tag baseline.

Bug Fixes:
- Prevent transient artifact-upload failures and stale draft releases from discarding otherwise completed release builds.
- Prevent release retries from overwriting a newer Homebrew formula with an older version.

Enhancements:
- Document recovery guidance for draft, absent, and permanently unpublished releases.

Documentation:
- Document release failure states, draft asset validation, and safeguards for rerunning older tags.

Tests:
- Add coverage for draft-versus-absent reporting and baseline note preservation.

Chores:
- Record the four historically unpublished tags and their failure reasons in the baseline.