### PR TITLE
fix(workspace): unwind on panic in the release profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,6 +633,18 @@ jobs:
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo build --workspace --release --config 'profile.release.lto="thin"' --config 'profile.release.codegen-units=16'
 
+      # The one check that can see the release panic strategy. `cargo test`
+      # always unwinds, so the panel boundary and stella-serve's per-connection
+      # isolation were both tested in a build that could not tell an aborting
+      # profile from an unwinding one. This example panics inside
+      # `stella_tui::panel_guard::guarded_band` and exits 0 only if the catch
+      # ran; set `panic = "abort"` in the root Cargo.toml again and it dies on
+      # SIGABRT instead. Same two profile overrides as the build above, so it
+      # links what that step already compiled — neither one touches `panic`.
+      - name: a panel panic is contained under the release profile
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: cargo run -p stella-tui --example panic_guard_probe --release --config 'profile.release.lto="thin"' --config 'profile.release.codegen-units=16'
+
       # Two guard self-tests that want the toolchain, so they sit here rather
       # than in guard-self-tests.yml with their twenty toolchain-free siblings
       # (#3820, #4427). This one is also a `GATE_STEPS` member that ran in no

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,5 +224,13 @@ install-updater = false
 [profile.release]
 lto = true
 codegen-units = 1
-panic = "abort"
+# Unwind, so that `catch_unwind` works in the binary a user runs. Two shipped
+# promises rest on it: a panel that panics paints an error card and the rest of
+# the screen keeps working (`stella_tui::panel_guard`), and a panic in one
+# `stella-serve` connection ends that connection rather than the server. Under
+# `panic = "abort"` a catch never runs and both promises are void. The trade is
+# code size and a little speed, and `doc:adr/0024-release-builds-unwind` records
+# it. `crates/stella-tui/examples/panic_guard_probe.rs` runs under this profile
+# in CI and fails if this line ever says "abort" again.
+panic = "unwind"
 strip = true

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -644,10 +644,9 @@ pub async fn run_deck_session(
                 .max(restored.spent_usd.unwrap_or(0.0)),
         );
     }
-    // A release-build panic aborts before any `Drop` or `catch_unwind` runs
-    // (the workers' panic catch included), so this hook is the journal's
-    // only flush point on that path — the terminal is restored by
-    // stella-tui's own hook the same way.
+    // The flush point for a build made with an aborting profile, where no
+    // `Drop` and no catch runs. Every profile here unwinds, so the journal is
+    // flushed by the sink's own drop instead; see the guard's own docs.
     let _journal_panic_guard =
         crate::session_persist::JournalPanicGuard::install(journal_sink.clone());
     let _tee = crate::session_persist::spawn_journal_tee(

--- a/crates/stella-cli/src/daemon/console.rs
+++ b/crates/stella-cli/src/daemon/console.rs
@@ -531,9 +531,10 @@ impl Drainable {
 /// past `main`'s orderly [`ConsoleGuard::drain`], the process exits without
 /// joining the pump threads, and up to a pipe buffer of output — the panic
 /// message itself, most of the time — dies in the pipe. That is the one
-/// artifact a postmortem of a supervised child actually wants. Release builds
-/// run with `panic = "abort"`, so this hook is the only cleanup such a process
-/// ever gets.
+/// artifact a postmortem of a supervised child actually wants. The drain in
+/// `main` is a call, not a `Drop`. An unwind skips it. So this hook is the
+/// only cleanup such a child gets. It asks no `cfg` about the panic strategy.
+/// It is the last chance to drain under either one.
 ///
 /// The hook chains rather than replaces: whatever hook is already installed
 /// (the diagnostics dump, or the default printer) runs FIRST, so its output

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -531,9 +531,8 @@ fn main() -> ExitCode {
     // before that boundary would race the env mutations it fences — and
     // drained as this function's last act so the final lines land.
     //
-    // A panic would unwind (or, under the release profile's
-    // `panic = "abort"`, not unwind at all) past that last act and strand up
-    // to a pipe buffer — usually including the panic message itself — so
+    // A panic unwinds past that last act — every profile here unwinds — and
+    // strands up to a pipe buffer, usually including the panic message, so
     // `arm_panic_drain` chains a hook that performs the same idempotent
     // drain (#1616). Whichever of the two arrives first does the one real
     // drain; the other finds the streams already taken.

--- a/crates/stella-cli/src/session_persist.rs
+++ b/crates/stella-cli/src/session_persist.rs
@@ -253,13 +253,19 @@ type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'sta
 
 /// Installs a layered panic hook that flushes the session journal before an
 /// abort-build panic kills the process, and puts the previous hook back on
-/// drop — the journal's only flush point on that path, since under
-/// `[profile.release] panic = "abort"` neither `catch_unwind` nor any `Drop`
-/// runs (stella-tui's own hook restores the terminal the same way). In
-/// unwind builds the sync is skipped: panics there are either caught (panel
-/// draws, worker bodies) or unwind into the orderly teardown that already
-/// syncs. Best-effort by the store's contract — `try_lock`, because the
-/// panicking process must never deadlock on a sink another thread holds.
+/// drop. Under `panic = "abort"` neither a catch nor any `Drop` runs, so this
+/// hook is the journal's only flush point on that path; stella-tui's own hook
+/// restores the terminal the same way.
+///
+/// Every profile in this workspace unwinds, so the sync branch is asleep in
+/// the binaries built here and the flush comes from elsewhere: a caught panic
+/// (panel draws, worker bodies) leaves the session running, and a panic that
+/// ends the process unwinds until the last `SharedSink` clone drops, whose
+/// `SessionJournal` fsyncs on the way out. The branch stays for a host that
+/// builds this crate with an aborting profile of its own.
+///
+/// Best-effort by the store's contract — `try_lock`, because the panicking
+/// process must never deadlock on a sink another thread holds.
 pub struct JournalPanicGuard {
     prev: Arc<PanicHook>,
 }

--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -33,9 +33,8 @@
 //! - **A child runs on a fresh OS thread with a current-thread runtime**,
 //!   because an engine turn's future is not `Send` and every tool-call path
 //!   above it requires one. `catch_unwind` around the child turn contains a
-//!   panic **only where builds unwind**: the workspace sets `panic = "abort"`,
-//!   so in release a child panic takes the process, and only a process
-//!   boundary could contain it.
+//!   panic **only where builds unwind**. Both profiles here do. So a child
+//!   panic costs the child, and its spend is settled, in a shipped build too.
 //!
 //! A hard cancel is the dropping of a future, which cannot reach a thread, so
 //! the intent cascades instead of the mechanism. [`ParentGone`] drops with the
@@ -656,10 +655,10 @@ impl SessionSubAgents {
                 // budget carve — is exactly what is read afterwards, on
                 // purpose. A partially-billed carve is the number to settle.
                 //
-                // Only unwinds are catchable. Release builds set
-                // `panic = "abort"` (workspace Cargo.toml), so there a child
-                // panic takes the process down and nothing below runs — see
-                // this module's header, which no longer claims otherwise.
+                // Only an unwind can be caught. Every profile in the
+                // workspace Cargo.toml unwinds, release too. So the settle
+                // below runs on the panic path in a shipped build, and not
+                // just under `cargo test`.
                 let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     runtime.block_on(engine.run_sub_agent_with_sender(
                         SubAgentHost::new(&*provider),

--- a/crates/stella-cli/src/subagent/tests.rs
+++ b/crates/stella-cli/src/subagent/tests.rs
@@ -1023,10 +1023,8 @@ impl Provider for PanicAfterBillingProvider {
 /// `wait.await` claimed settling happened "on every path" — a panic was the
 /// path it did not.
 ///
-/// Debug profile only by nature: `panic = "abort"` in release means there is
-/// no unwind to catch, and the module header now says so instead of implying
-/// otherwise. Tests build with unwind, which is exactly where the fix is
-/// observable.
+/// Every profile here unwinds. So what this test sees is what a release
+/// build does too.
 #[tokio::test]
 async fn a_panicking_child_still_settles_the_spend_it_incurred() {
     let registry = registry();

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -736,10 +736,9 @@ const PANIC_FAILURE_PREFIX: &str = "worker panicked: ";
 
 /// Run one worker body, converting a panic into a `Failed` ending so the
 /// supervisor ALWAYS receives `Ended` — a panicking tool must cost one
-/// failed worker, not a lane stuck "Running" and a leaked slot. Effective
-/// in unwind builds; under `panic = "abort"` (release) the process dies in
-/// the panic hook before any catch — stella-tui's hook restores the
-/// terminal there, and the deck's journal hook flushes the session journal.
+/// failed worker, not a lane stuck "Running" and a leaked slot. Effective in
+/// unwind builds, which is every profile here — the release one included, so
+/// a worker panic costs a lane rather than the session in a shipped binary.
 fn run_caught<F>(body: F) -> (Option<i64>, f64, WorkerEnd)
 where
     F: FnOnce() -> (Option<i64>, f64, WorkerEnd),

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -277,8 +277,10 @@ system message and the latest user message are never touched.
   callers that can preserve what a call really produced pass it as
   `CallRecord::identity` rather than let comparison see rewritten bytes.
 - **Bus observers must return `Err`, never panic.** `catch_unwind` contains a
-  panic only under an unwinding profile, and the workspace `release` profile sets
-  `panic = "abort"` ([`../Cargo.toml`](../Cargo.toml)).
+  panic only under an unwinding profile. The workspace `release` profile sets
+  `panic = "unwind"` ([`../Cargo.toml`](../Cargo.toml)), so the catch holds in a
+  shipped build — but a host that builds this crate with `panic = "abort"` has
+  no catch at all, and `Err` is the signal that works either way.
 - **No engine method fires `SessionStart` — it is a host obligation (#2674).**
   `SessionStart` is a session-level event and `run_turn` runs many times per
   session; the host fires [`src/hooks.rs`](src/hooks.rs)'s `run_hooks` once,

--- a/crates/stella-core/src/bus.rs
+++ b/crates/stella-core/src/bus.rs
@@ -15,9 +15,9 @@
 //!   `extension.error` event, and skipped — the emitting operation
 //!   continues unconditionally. The **supported** failure signal is
 //!   `Err(msg)`; a panic is *also* contained via [`catch_unwind`], but only
-//!   under an unwinding profile — the workspace's `release` profile sets
-//!   `panic = "abort"`, where nothing can catch a panic, so extensions must
-//!   report failure by returning `Err`, not by panicking.
+//!   under an unwinding profile. The workspace's `release` profile unwinds,
+//!   so the catch holds in a shipped build; a host that builds this crate
+//!   with `panic = "abort"` loses it, so an extension returns `Err` instead.
 //! - **Policy hooks** ([`HookBus::on_blocking`], [`HookBus::emit_blocking`])
 //!   run *sequentially in registration order* before a policy-sensitive
 //!   operation (the [`names::BLOCKING`] set: tool execution, filesystem
@@ -396,9 +396,9 @@ impl HookBus {
     /// registration order under [`HookBus::emit_blocking`]; a handler that
     /// panics fails **closed** — the chain stops with `Deny` (a broken
     /// policy extension must never silently wave operations through). The
-    /// fail-closed-on-panic net requires an unwinding profile; under
-    /// `release`'s `panic = "abort"` a panic aborts, so a policy handler
-    /// should signal refusal by returning `Deny`, not by panicking.
+    /// fail-closed-on-panic net requires an unwinding profile; the `release`
+    /// profile is one, and a host that builds with `panic = "abort"` is not,
+    /// so a policy handler signals refusal by returning `Deny` regardless.
     pub fn on_blocking<F>(&self, pattern: &str, handler: F) -> HookSubscription
     where
         F: Fn(&HookEvent) -> HookDecision + Send + Sync + 'static,

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -139,8 +139,9 @@ impl SubAgentPolicy {
         // the floor here is a literal while the ceiling is a `pub` field no
         // constructor validates. `max_child_steps: 0` — a plausible reading of
         // "cap children at nothing" — panicked on any request that named
-        // `max_steps`, and the release profile builds with `panic = "abort"`,
-        // so that ends the whole server rather than the one request.
+        // `max_steps`. The floor is the fix; the release profile unwinds, so
+        // a panic here would now cost the one connection rather than the
+        // server, which is a smaller blast radius and still the wrong answer.
         let child_ceiling = self.max_child_steps.max(1);
         Some(EffectiveSubAgents {
             pool_usd: requested
@@ -1057,10 +1058,9 @@ mod tests {
     /// `max_child_steps` is a `pub` field no constructor validates, so an
     /// operator reading it as "cap children at nothing" can set it to zero.
     /// The ceiling reached `clamp(1, 0)`, which asserts `min <= max` and
-    /// panicked on any request naming `max_steps` — and the release profile
-    /// sets `panic = "abort"`, so that ended the server rather than the
-    /// request. Both branches answer the floored ceiling, so an unasked
-    /// request and an asked one cannot disagree.
+    /// panicked on any request naming `max_steps`. Both branches answer the
+    /// floored ceiling, so an unasked request and an asked one cannot
+    /// disagree.
     #[test]
     fn a_zero_operator_ceiling_floors_at_one_instead_of_panicking() {
         let zeroed = SubAgentPolicy {

--- a/crates/stella-tui/README.md
+++ b/crates/stella-tui/README.md
@@ -254,23 +254,27 @@ enqueued as a prompt so the answer lands in the transcript.
 [`src/term.rs`](src/term.rs) before changing any of it. `TerminalGuard` is
 constructed *before* the first state is acquired and flags each one (raw, alt
 screen, bracketed paste, mouse, kitty) as it lands, so a failure partway through
-`enter` still rolls back exactly what was entered. Release builds set
-`panic = "abort"`, where destructors never run, so `PanicHookGuard::install`
+`enter` still rolls back exactly what was entered. A build made with
+`panic = "abort"` runs no destructor, so `PanicHookGuard::install`
 ([`src/term.rs`](src/term.rs)) additionally restores from inside the panic
 hook — but **only** under `cfg!(panic = "abort")`, then delegating to the
 previous hook so the panic message prints on the real screen, not the alternate
-one. In unwind builds the hook deliberately does *not* restore: it fires for
-every panic on every thread, including panel panics the session survives.
+one. In an unwinding build the hook does *not* restore: it fires for every
+panic on every thread, including panel panics the session survives. Every
+profile here unwinds, so a shipped binary restores through `TerminalGuard`'s
+`Drop`.
 
 ## Gotchas
 
-- **The panic boundary covers every band, but only in unwind builds.**
+- **The panic boundary covers every band, and the release profile unwinds so
+  it holds in a shipped binary.**
   [`src/panel_guard.rs`](src/panel_guard.rs) wraps the single-session panels,
   every deck band (tab bar, active tab, trace strip, progress bar, composer,
   footer, status band, splash, each overlay) and the fleet dashboard, so a
-  panicking view becomes an error card and the session continues. Release
-  builds set `panic = "abort"`, where `catch_unwind` never runs its handler —
-  so the shipped binary still dies on a view panic. A new draw surface is
+  panicking view becomes an error card and the session continues. A build made
+  with `panic = "abort"` loses that: no catch runs its handler there.
+  `examples/panic_guard_probe.rs`, which CI runs with `--release`, is what
+  keeps the profile from drifting back. A new draw surface is
   covered only if you route it through `guarded_band`/`guarded_overlay`, and a
   new `&mut DeckUi` write in a view has to be classified in that module's
   "what a caught panic can leave behind" list or the argument there stops

--- a/crates/stella-tui/examples/panic_guard_probe.rs
+++ b/crates/stella-tui/examples/panic_guard_probe.rs
@@ -1,0 +1,40 @@
+//! Check that a panicking panel is contained in a build made with the release
+//! panic strategy.
+//!
+//! `cargo test` always unwinds, so no test can see the strategy the shipped
+//! binary is built with. This example can: run it with `--release` and it
+//! enters the real panel boundary. If the profile unwinds, the boundary paints
+//! its error card and this exits 0. If the profile aborts, the panic kills the
+//! process here and the exit code says so.
+//!
+//! ```sh
+//! cargo run -p stella-tui --example panic_guard_probe --release
+//! ```
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+
+fn main() {
+    // A quiet hook so the one line this prints is the whole story. Under an
+    // aborting profile the hook still runs and the process still dies.
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let area = Rect::new(0, 0, 60, 10);
+    let mut frame = Buffer::empty(area);
+    stella_tui::panel_guard::guarded_band(&mut frame, area, "probe", |_| {
+        panic!("panic_guard_probe: on purpose")
+    });
+
+    let _ = std::panic::take_hook();
+
+    let painted: String = (0..area.height)
+        .flat_map(|y| (0..area.width).map(move |x| (x, y)))
+        .map(|p| frame[p].symbol().to_string())
+        .collect();
+
+    if !painted.contains("panicked") {
+        eprintln!("panic_guard_probe: FAIL — the boundary caught the panic but painted no card");
+        std::process::exit(1);
+    }
+    println!("panic_guard_probe: OK — a panel panic was contained under this profile");
+}

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -55,7 +55,7 @@ pub mod debug_log;
 pub mod input;
 pub mod keymap;
 pub mod model;
-pub(crate) mod panel_guard;
+pub mod panel_guard;
 pub mod render;
 pub mod scroll;
 pub(crate) mod term;

--- a/crates/stella-tui/src/panel_guard.rs
+++ b/crates/stella-tui/src/panel_guard.rs
@@ -81,7 +81,7 @@
 //! on the frames they are actually up — including the startup notice, whose
 //! visibility is asked at the call site rather than inside its renderer.
 //!
-//! [`crate::term::PanelBoundary`] is a `thread_local!`, and tokio tasks can
+//! `crate::term::PanelBoundary` is a `thread_local!`, and tokio tasks can
 //! migrate between workers — but `terminal.draw(..)` is fully synchronous with
 //! no `await` inside it, so the marker is entered and dropped on the same
 //! thread. Nesting is safe: the guard restores the previous flag rather than

--- a/crates/stella-tui/src/panel_guard.rs
+++ b/crates/stella-tui/src/panel_guard.rs
@@ -87,11 +87,14 @@
 //! thread. Nesting is safe: the guard restores the previous flag rather than
 //! clearing it.
 //!
-//! Release builds set `panic = "abort"` (`[profile.release]`), where
-//! `catch_unwind` never runs its handler — the process dies inside the panic
-//! hook. Everything here is therefore effective in unwind (dev/test) builds
-//! only, exactly as this boundary always has been. See
-//! `crate::term` for what the hook does on each side of that split.
+//! The release profile unwinds (`[profile.release] panic = "unwind"`, root
+//! `Cargo.toml`), so this boundary holds in a shipped build and not just in a
+//! test one. A build that sets `panic = "abort"` instead loses it: a catch
+//! never runs its handler there and the process dies inside the panic hook.
+//! See `crate::term` for what the hook does on each side of that split, and
+//! `examples/panic_guard_probe.rs` for the check that the profile still
+//! unwinds. That probe is why [`guarded_band`] and [`guarded_overlay`] are
+//! public: it has to enter this boundary rather than a copy of it.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -108,7 +111,7 @@ const CARD_H: u16 = 7;
 /// Draw one band under the panic boundary. On a panic the error card fills
 /// `area`, which is what a band wants: the band's whole rectangle is the thing
 /// that failed to render.
-pub(crate) fn guarded_band<F>(dst: &mut Buffer, area: Rect, label: &str, draw: F)
+pub fn guarded_band<F>(dst: &mut Buffer, area: Rect, label: &str, draw: F)
 where
     F: FnOnce(&mut Buffer),
 {
@@ -122,7 +125,7 @@ where
 /// underneath is preserved either way. On a panic the error card is a small
 /// centred card rather than a full-frame wipe — the overlay is what broke, and
 /// the deck behind it is still worth looking at while the user presses `esc`.
-pub(crate) fn guarded_overlay<F>(dst: &mut Buffer, area: Rect, label: &str, draw: F)
+pub fn guarded_overlay<F>(dst: &mut Buffer, area: Rect, label: &str, draw: F)
 where
     F: FnOnce(&mut Buffer),
 {

--- a/crates/stella-tui/src/term.rs
+++ b/crates/stella-tui/src/term.rs
@@ -1,16 +1,16 @@
 //! Terminal enter/restore shared by both shells (single-session and deck).
 //!
-//! Restoration must not rely on `Drop` alone: release builds abort on panic
-//! (`[profile.release] panic = "abort"`), so destructors never run on a
-//! panicking process and a Drop-only guard leaves the user's terminal
-//! stranded in raw mode on the alternate screen. The panic hook installed by
-//! [`PanicHookGuard`] therefore restores the terminal *directly* in abort
-//! builds — sharing the guard's acquired-state flags — and then delegates to
-//! the previously installed hook, so the standard panic message (and any
-//! `RUST_BACKTRACE` output) lands on the user's real screen, not the
-//! alternate one.
+//! Restoration must not rely on `Drop` alone. A build made with
+//! `panic = "abort"` runs no destructor on a panicking process, so a
+//! Drop-only guard leaves the user's terminal stranded in raw mode on the
+//! alternate screen. The panic hook installed by [`PanicHookGuard`] therefore
+//! restores the terminal *directly* in an aborting build — sharing the
+//! guard's acquired-state flags — and then delegates to the previously
+//! installed hook, so the standard panic message (and any `RUST_BACKTRACE`
+//! output) lands on the user's real screen, not the alternate one.
 //!
-//! In unwind (dev) builds the hook never restores. The hook fires for EVERY
+//! Every profile here unwinds, release included, so the branch below is what
+//! ships. In an unwinding build the hook never restores. It fires for EVERY
 //! panic on ANY thread or tokio task, and a session can outlive a panic in
 //! two ways that make hook-time restoration actively harmful: band panics are
 //! caught by [`crate::panel_guard`] and rendered as an error card in place
@@ -23,7 +23,7 @@
 //! so the unwind-build hook instead writes the debug log and STASHES the
 //! panic report (message + backtrace) on the shared state; the restore
 //! replays it on stderr once the real screen is back. Without that replay a
-//! fatal dev panic exits silently. Under abort none of that machinery gets a
+//! fatal panic exits silently. Under abort none of that machinery gets a
 //! chance to run — the process dies inside the hook — so the hook is the
 //! only restoration point and restoring (then delegating to the previous
 //! hook for the message) is always right, even mid-panel-draw.
@@ -298,8 +298,9 @@ type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'sta
 /// survives (caught band draws, background tasks), and real teardown
 /// restores via [`TerminalGuard`]'s `Drop` instead. What an unwind build
 /// does instead is stash the report (unless a [`crate::panel_guard`] catch
-/// renders it in place) so the restore can replay it on stderr — a fatal dev
-/// panic must not exit silently (see the module docs).
+/// renders it in place) so the restore can replay it on stderr — a fatal
+/// panic must not exit silently (see the module docs). Every profile in this
+/// workspace unwinds, so that is the branch a shipped binary takes.
 pub(crate) struct PanicHookGuard {
     prev: Arc<PanicHook>,
 }

--- a/docs/adr/0024-release-builds-unwind.md
+++ b/docs/adr/0024-release-builds-unwind.md
@@ -1,0 +1,67 @@
+---
+id: adr/0024-release-builds-unwind
+title: "ADR 0024: Release builds unwind on panic"
+status: implemented
+---
+
+# ADR 0024: Release builds unwind on panic
+
+- Status: accepted
+- Date: 2026-09-02
+- Decides: `#5493`
+
+## Context
+
+The release profile set `panic = "abort"`. A catch cannot catch an abort. So
+every panic guard in the tree did nothing in the build a user runs. The code
+that builds those guards is written and tested as if it works. It does work,
+in a test build. That is where the tests run.
+
+Two of those guards are promises to a person.
+
+A panel that panics paints a small red card. The rest of the screen keeps
+working. See `crates/stella-tui/src/panel_guard.rs`. Under an aborting profile
+the whole program dies instead. It leaves the terminal in raw mode.
+
+A panic in one `stella-serve` connection ends that connection. Under an
+aborting profile it ends the server. Every other live turn dies with it.
+
+Three more guards have the same shape. A child agent settles its spend on the
+panic path, in `crates/stella-cli/src/subagent.rs`. A worker panic costs one
+lane and not the session, in `crates/stella-cli/src/subsession.rs`. A hook that
+panics is skipped and not fatal, in `crates/stella-core/src/bus.rs`.
+
+## Decision
+
+Set `panic = "unwind"` in `[profile.release]`. Keep `lto`, `codegen-units` and
+`strip` as they are.
+
+The other choice was to keep `abort` and delete the guards. That is cheaper.
+It is the wrong trade here. A coding agent runs for hours on a user's
+terminal. Living through one bad draw is worth more than the code size.
+Deleting the guards would also drop the spend settle, and that one is money.
+
+## Consequences
+
+The binary grows. It loses a little speed. An unwinding build needs landing
+pads that an aborting build leaves out, and the optimiser has more edges to
+walk. Neither is measured here. Neither changes the answer.
+
+Two paths read the strategy with `cfg!(panic = "abort")`. One is the terminal
+restore in `crates/stella-tui/src/term.rs`. The other is the journal flush in
+`crates/stella-cli/src/session_persist.rs`. Both already had an unwinding
+branch. That branch is what a shipped build now takes. Neither `abort` branch
+is dropped. A host that builds these crates with an aborting profile still
+needs it.
+
+Comments all over the tree said a panic ends the program in a release build.
+They are fixed in the same change. A comment that claims more than the build
+does is worse than no comment.
+
+## How this is checked
+
+`cargo test` always unwinds. So no test can see the strategy a release build
+was made with. `crates/stella-tui/examples/panic_guard_probe.rs` can see it.
+It panics inside the real panel guard. It exits 0 only if the catch ran. CI
+runs it with `--release` next to the release smoke build. Put `abort` back and
+that step dies on a signal.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,6 +90,7 @@ open; nothing before Phase 3 forces it.
 | [0021](0021-a-memory-event-names-one-memory.md) | A Memory Event Names One Memory | Implemented — landed with #5032 |
 | [0022](0022-adopt-standing-decisions-scr-corpus.md) | Adopt Org Standing Decisions as a Steering Context Record Corpus | Accepted |
 | [0023](0023-autonomous-tool-foundry.md) | Reconnect the Gap Detector; the Foundry Runs Autonomously Behind Standing Controls | Accepted |
+| [0024](0024-release-builds-unwind.md) | Release Builds Unwind on Panic | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -122,3 +123,10 @@ editing `mcp.toml`. Only the middle one withholds, and `CapabilityGrants` then
 keeps an ungranted server out of `schemas()` and refuses its calls before the
 transport — on both hosts, so the property does not depend on which surface is
 driving.
+
+ADR 0024 sets `panic = "unwind"` for the release profile. Every panic boundary
+in the workspace was inert in shipped binaries, including the two that are
+promises to a person: a panel that panics paints an error card instead of
+killing the process, and a panic in one server connection ends that connection
+rather than the server. An example binary run with `--release` in CI is what
+holds the profile there.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -120,6 +120,11 @@
       "status": "implemented",
       "title": "ADR 0023: Reconnect the gap detector and let the foundry run autonomously behind standing controls"
     },
+    "adr/0024-release-builds-unwind": {
+      "path": "docs/adr/0024-release-builds-unwind.md",
+      "status": "implemented",
+      "title": "ADR 0024: Release builds unwind on panic"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",


### PR DESCRIPTION
## What and why

The release profile set `panic = "abort"`. A catch cannot catch an abort, so
every panic boundary in the workspace did nothing in the binaries users run.
The code that builds those boundaries is written, documented and tested as
though it works — and it does, in test builds, which is where the tests run.

Two of them are promises to a person:

- A panel that panics paints an error card and the rest of the screen keeps
  working (`crates/stella-tui/src/panel_guard.rs`). Under `abort` the process
  died instead and left the terminal in raw mode.
- A panic in one `stella-serve` connection ends that connection. Under `abort`
  it ended the server, every other live turn with it.

Three more have the same shape: a child agent's spend settles on the panic path
(`crates/stella-cli/src/subagent.rs`), a worker panic costs one lane rather than
the session (`crates/stella-cli/src/subsession.rs`), and a hook that panics is
skipped rather than fatal (`crates/stella-core/src/bus.rs`).

This sets `panic = "unwind"` in `[profile.release]` and keeps `lto`,
`codegen-units` and `strip`. The decision is recorded as
`docs/adr/0024-release-builds-unwind.md` (`doc:adr/0024-release-builds-unwind`,
cited from the profile itself), per the maintainer's design pointer on the
issue.

### No behaviour is left dangling by the flip

Two paths read the strategy with `cfg!(panic = "abort")` — the terminal restore
in `crates/stella-tui/src/term.rs` and the journal flush in
`crates/stella-cli/src/session_persist.rs`. Both already had an unwinding
branch, and that is the branch a shipped binary now takes: the terminal is
restored by `TerminalGuard`'s `Drop`, and the journal is fsynced by
`SessionJournal`'s `Drop` when the last `SharedSink` clone goes. Neither
aborting branch is deleted — a host that builds these crates with an aborting
profile of its own still needs it — and both doc comments now say which branch
ships. `crates/stella-cli/src/daemon/console.rs`'s panic drain was never
conditioned on the strategy and stays as it was; its comment claimed `abort`
was the reason it exists, and the real reason (the drain in `main` is a call,
not a `Drop`, so an unwind skips it) is now written down.

## The witness and how it fails on the old code

`cargo test` always unwinds — the harness forces it — so **no test in this
repository can see the panic strategy a release build was made with**. That is
exactly why this defect survived: `tests/render_robustness.rs` and
`panel_guard.rs`'s own unit tests all pass under `abort` too, because they never
run under it.

The witness is therefore an example binary run in the release profile:

- `crates/stella-tui/examples/panic_guard_probe.rs` panics inside
  `stella_tui::panel_guard::guarded_band`, then asserts the error card was
  painted and exits 0.
- `.github/workflows/ci.yml` runs it right after the release smoke build:
  `cargo run -p stella-tui --example panic_guard_probe --release --config 'profile.release.lto="thin"' --config 'profile.release.codegen-units=16'`
  — the same two overrides as the build above it, neither of which touches
  `panic`, so it links what that step already compiled and observes the real
  release strategy.

**Mechanism (I cannot run it locally — this repo's agents push and read CI).**
Revert `Cargo.toml` to `panic = "abort"` and the probe's `catch_unwind` never
runs its handler: the panic goes straight to `abort()`, the process dies on
SIGABRT, `cargo run` exits 134 and the step is red. With `panic = "unwind"` the
catch runs, the card is painted, and it prints
`panic_guard_probe: OK — a panel panic was contained under this profile`. The
CI log line for that step is the evidence, cited below once the run is green.

Making the probe enter the *real* boundary rather than a copy of it is why
`panel_guard::guarded_band` and `guarded_overlay` are now `pub` (the module was
`pub(crate)`); an example is a separate crate and sees only the public API. The
module doc says so at the point of the change.

## The comment sweep

`rg -n catch_unwind crates` plus `rg -n 'panic = "abort"'` found ten comments
claiming a panic ends the process in a release build. All ten are corrected, in
`stella-tui` (`panel_guard.rs`, `term.rs`, `README.md`), `stella-core`
(`bus.rs`, `README.md`), `stella-serve` (`subagents.rs`), and `stella-cli`
(`subagent.rs`, `subagent/tests.rs`, `subsession.rs`, `main.rs`,
`session_persist.rs`, `command_deck.rs`, `daemon/console.rs`). Where the
guidance behind a claim still stands regardless of profile — a bus observer
returns `Err` rather than panicking, a policy hook returns `Deny` — the guidance
is kept and re-grounded on "a host may build with `abort`" rather than on a
statement about this workspace that is no longer true.

## Exemplar followed

The probe follows `crates/stella-tui/examples/splash_frames.rs` — the crate's
existing pattern for a small example that drives a real render path and prints
its result.

## Notes

- Tests deleted: None.
- No new dependencies.
- `make guards-fast`, `make doc-links`, `make invariants` and
  `python3 scripts/check-prose.py` are green locally (they compile nothing);
  everything that compiles is CI's.
- Cost: `cargo run --example` builds `stella-tui`'s dev-dependencies in release
  once. The alternative — a `[[bin]]` target — would ship a binary in the
  release artifact set, which is worse.

## Remaining work filed

None found beyond the change itself; the two `cfg!(panic = "abort")` branches
are documented as reachable only for a host with an aborting profile rather than
left as unexplained dead code.

Closes #5493

## Summary by Sourcery

Make release builds unwind on panic so the workspace's existing recovery boundaries protect user sessions and remain verifiable in CI.

New Features:
- Add a release-mode panic guard probe that verifies panel panics are contained in the actual release profile.

Bug Fixes:
- Enable panic unwinding in release builds so existing panel, server-connection, subagent billing, worker, and hook panic boundaries work in shipped binaries instead of aborting the process.
- Preserve terminal restoration and journal flushing behavior across both unwinding and host-provided aborting profiles.

Enhancements:
- Expose the panel guard render functions needed by the release-mode probe and update panic-handling guidance throughout the workspace to reflect the release strategy.

CI:
- Run the release panic guard probe in CI alongside the release smoke build to detect regressions to the panic strategy.

Documentation:
- Document the release-build unwinding decision in ADR 0024 and register it in the ADR documentation indexes.