### PR TITLE
fix(scripts): pin the pagination witness fail-side to a commit

### DIFF
--- a/scripts/test-releases-published-pagination.sh
+++ b/scripts/test-releases-published-pagination.sh
@@ -9,38 +9,50 @@
 # fetch end to end with a fake `gh` on PATH, so a fake list of 1001 releases
 # runs with no network at all.
 #
-# It runs two scripts against that same list: the one `main` ships today,
-# and the one in this working tree. Main's script hits its old cap and
-# errors. This branch's script pages through all 1001 and reports clean.
+# Two scripts run against that same list. One is the capped script named by
+# CAPPED_REV below. The other is the one in this working tree. The capped one
+# hits its cap and errors. This tree's one pages through all 1001 and reports
+# clean.
+#
+# The fail-side names a commit, never `origin/main`. Point it at a moving ref
+# and it proves nothing once the fix merges there. It then asserts that the
+# fixed script still carries the bug, and fails on every open pull request at
+# once. CAPPED_REV is the last commit that carried the cap. Both halves of
+# this witness hold for as long as that commit does.
 #
 # bash 3.2 compatible.
 
 set -uo pipefail
 
+# 5096b3f — the last commit whose check-releases-published.sh still called
+# `gh release list --limit` rather than `gh api --paginate`. Its copy of that
+# script is the capped one this test drives.
+CAPPED_REV="5096b3ff7df2e12986957287fe13b03ebbeacc3e"
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
 NEW_SCRIPT="$repo_root/scripts/check-releases-published.sh"
-MAIN_SCRIPT="$repo_root/scripts/.check-releases-published.main-copy.sh"
+CAPPED_SCRIPT="$repo_root/scripts/.check-releases-published.capped-copy.sh"
 
 pass=0
 fail=0
 
 work="$(mktemp -d)"
-cleanup() { rm -rf "$work"; rm -f "$MAIN_SCRIPT"; }
+cleanup() { rm -rf "$work"; rm -f "$CAPPED_SCRIPT"; }
 trap cleanup EXIT
 
-# CI checks out one ref with no history, so `origin/main` may not exist yet.
-# One shallow, on-demand fetch of just that branch tip fixes that without
-# touching the shared checkout step every other guard self-test also runs
-# under. It only ever reads; nothing here can move a real branch.
-git -C "$repo_root" fetch --depth=1 -q origin main 2>/dev/null || true
+# CI checks out one ref with no history, so CAPPED_REV may be absent. One
+# shallow fetch of that single commit gets it. The shared checkout step every
+# other guard self-test runs under stays as it is. This only ever reads;
+# nothing here can move a real branch.
+git -C "$repo_root" fetch --depth=1 -q origin "$CAPPED_REV" 2>/dev/null || true
 
 # `dirname "$0"` in each script must find a folder with lib/help-header.sh.
-# So main's copy is placed next to the real script, not in the scratch dir.
-# It is a sibling file, deleted by the trap above, never staged or committed.
-if ! git -C "$repo_root" show origin/main:scripts/check-releases-published.sh >"$MAIN_SCRIPT" 2>/dev/null; then
-  echo "SKIP — could not read origin/main's copy of check-releases-published.sh (no network or no origin/main ref here); the fail-side of the witness cannot run, but this branch's own fetch is still exercised below." >&2
+# So the capped copy is placed next to the real script, not in the scratch
+# dir. It is a sibling file, deleted by the trap above, never staged.
+if ! git -C "$repo_root" show "$CAPPED_REV:scripts/check-releases-published.sh" >"$CAPPED_SCRIPT" 2>/dev/null; then
+  echo "SKIP — could not read ${CAPPED_REV}'s copy of check-releases-published.sh (no network, or a shallow clone that cannot reach it); the fail-side of the witness cannot run, but this tree's own fetch is still exercised below." >&2
 else
-  chmod +x "$MAIN_SCRIPT"
+  chmod +x "$CAPPED_SCRIPT"
 fi
 
 # A grace window wide enough that every real tag in this checkout falls
@@ -50,8 +62,8 @@ grace_secs=315360000 # 10 years
 now="$(date -u +%s)"
 
 # The fake `gh`. Each script makes one call:
-#   main's version: `gh release list --limit 1000 ...`
-#   this branch:    `gh api --paginate --slurp .../releases?per_page=100`
+#   the capped version: `gh release list --limit 1000 ...`
+#   this tree:          `gh api --paginate --slurp .../releases?per_page=100`
 # Both get 1001 fake releases, one past the old cap. The shape matches real
 # `gh` output: 11 pages of up to 100 each, the last one holding 1.
 cat >"$work/gh" <<'SHIM'
@@ -79,24 +91,24 @@ run_with_fake_gh() {
   PATH="$work:$PATH" "$@" --now "$now" --grace-secs "$grace_secs" 2>&1
 }
 
-if [ -x "$MAIN_SCRIPT" ]; then
-  main_out="$(run_with_fake_gh "$MAIN_SCRIPT")"
-  main_status=$?
-  if [ "$main_status" -ne 0 ] && printf '%s' "$main_out" | grep -q "page limit"; then
-    pass=$((pass + 1)); echo "ok   MAIN main's script hits its 1000-item cap on 1001 releases and errors"
+if [ -x "$CAPPED_SCRIPT" ]; then
+  capped_out="$(run_with_fake_gh "$CAPPED_SCRIPT")"
+  capped_status=$?
+  if [ "$capped_status" -ne 0 ] && printf '%s' "$capped_out" | grep -q "page limit"; then
+    pass=$((pass + 1)); echo "ok   OLD the capped script hits its 1000-item cap on 1001 releases and errors"
   else
     fail=$((fail + 1))
-    echo "FAIL MAIN main's script hits its 1000-item cap on 1001 releases and errors — exit ${main_status}, got: ${main_out}"
+    echo "FAIL OLD the capped script hits its 1000-item cap on 1001 releases and errors — exit ${capped_status}, got: ${capped_out}"
   fi
 fi
 
 new_out="$(run_with_fake_gh "$NEW_SCRIPT")"
 new_status=$?
 if [ "$new_status" -eq 0 ] && printf '%s' "$new_out" | grep -q "^check-releases-published: OK"; then
-  pass=$((pass + 1)); echo "ok   NEW this branch's script pages through all 1001 releases and reports clean"
+  pass=$((pass + 1)); echo "ok   NEW this tree's script pages through all 1001 releases and reports clean"
 else
   fail=$((fail + 1))
-  echo "FAIL NEW this branch's script pages through all 1001 releases and reports clean — exit ${new_status}, got: ${new_out}"
+  echo "FAIL NEW this tree's script pages through all 1001 releases and reports clean — exit ${new_status}, got: ${new_out}"
 fi
 
 if printf '%s' "$new_out" | grep -qi "page limit\|sanity ceiling"; then


### PR DESCRIPTION
## What & why

`guard self-tests` is red on **every open pull request** in this repository, and `main`'s own CI is green. This unblocks the queue.

`scripts/test-releases-published-pagination.sh` is a witness test whose fail-side read `origin/main`:

```sh
git show origin/main:scripts/check-releases-published.sh >"$MAIN_SCRIPT"
```

It then asserted that copy still hits its 1000-item cap. That held while the paginating rewrite was unmerged. Once it landed (`74c5673`, PR #5648, 23:59), `origin/main` carried `gh api --paginate`, the capped behaviour was gone, and the assertion could never pass again:

```
FAIL MAIN main's script hits its 1000-item cap on 1001 releases and errors — exit 0,
got: check-releases-published: OK — every v* tag older than 5256000m has a published release
```

`guard-self-tests.yml` runs on `pull_request` only, so nothing re-asked the question after the merge: `main` reads green while every PR opened against it fails. Confirmed red on #5672, #5667, #5666 and #5678 — the same single failing assertion in each.

A fail-side that reads a moving ref stops proving anything the moment the fix merges into that ref. `CAPPED_REV` pins it to `5096b3f`, the last commit whose `check-releases-published.sh` still called `gh release list --limit`. Both halves of the witness stay demonstrable for as long as that commit does, and the shallow-clone `SKIP` path is unchanged — an unreachable pinned commit skips the fail-side exactly as an unreachable `origin/main` did.

Deleting the fail-side would have cleared the red just as fast and left the guard proving only one direction, which this repository asks of no other guard.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The test is its own witness. On `main` it reports `passed 2, failed 1` and exits 1 — the exact `FAIL MAIN` line CI prints, reproduced locally before the fix. With this change:

```
ok   OLD the capped script hits its 1000-item cap on 1001 releases and errors
ok   NEW this tree's script pages through all 1001 releases and reports clean
ok   NEW reports no truncation or page-sanity error on 1001 releases

passed 3, failed 0
```

The `OLD` arm genuinely runs and genuinely proves the cap — it is not passing by being skipped.

## The gate

Shell only; nothing here compiles. Per CLAUDE.md ("CI builds and tests; this laptop does not") the cargo tiers are CI's, and this diff reaches no crate.

- [x] `./scripts/test-releases-published-pagination.sh` — 3 passed, 0 failed, exit 0
- [x] `scripts/check-prose.py` — exit 0 (grade and issue-reference violations in my first draft fixed, not baselined)
- [x] `scripts/check-line-citations.py` — exit 0
- [x] `scripts/check-left-behind.sh` — exit 0
- [x] `scripts/check-file-size.sh` — exit 0
- [ ] `shellcheck` — **not run**: not installed in this environment. It is a required gate step and CI is the evidence for it. `bash -n` parses clean.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

The general shape — a witness whose fail-side reads a moving ref, self-invalidating on merge — is worth a sweep, but `check-rebase-replay.sh`'s `MAIN`-style comparison is the only other fail-side in `scripts/` I found reading a moving ref, and it compares two trees by design rather than asserting a bug persists. No second instance to file.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — the pinned-commit fetch replaces the branch fetch that was already there

## Anything reviewers should know?

`CAPPED_REV` is a full 40-character SHA so it cannot be confused with a ref. The fetch is `git fetch --depth=1 origin <sha>`, which GitHub serves for a reachable commit; if a future checkout cannot reach it, the fail-side skips with a message rather than failing, which is how the `origin/main` version already behaved.

Rejected alternative: deleting the `MAIN`/`OLD` arm. Faster, and it would leave the guard unable to demonstrate its own failure direction — the property `guard-self-tests.yml` exists to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U91qDoJdXhCbEDeSEUSUot

---
_Generated by [Claude Code](https://claude.ai/code/session_01U91qDoJdXhCbEDeSEUSUot)_

## Summary by Sourcery

Pin the pagination witness test’s legacy comparison to a commit so it continues validating both failure and success paths across pull requests.

Bug Fixes:
- Prevent the pagination witness test from invalidating itself after the fix reaches the default branch by pinning its legacy fail-side to a known commit.

Enhancements:
- Preserve verification of both the old capped behavior and the new paginated behavior while retaining graceful skipping when the pinned commit is unavailable.

Tests:
- Update the witness assertions and messaging to compare the current script with the pinned capped version.