### PR TITLE
fix(ci): stop the pagination witness pinning its fail-side to origin/main

### DIFF
--- a/scripts/test-releases-published-pagination.sh
+++ b/scripts/test-releases-published-pagination.sh
@@ -1,109 +1,115 @@
 #!/usr/bin/env bash
 #
-# Witness test. Neither release check may depend on a fixed count cap.
+# Witness test. The release check must walk every page of the list. It must
+# also refuse a list it knows it did not finish reading.
 #
 #   ./scripts/test-releases-published-pagination.sh
 #
-# scripts/test-releases-published.sh proves the RULE has no cap. It cannot
-# reach the FETCH, where the old cap actually lived. This test drives the
-# fetch end to end with a fake `gh` on PATH, so a fake list of 1001 releases
-# runs with no network at all.
+# scripts/test-releases-published.sh proves the RULE has no cap. It does not
+# reach the FETCH. This test drives the fetch with a fake `gh` on PATH, so it
+# needs no network.
 #
-# It runs two scripts against that same list: the one `main` ships today,
-# and the one in this working tree. Main's script hits its old cap and
-# errors. This branch's script pages through all 1001 and reports clean.
+# Two arms, both against the script this tree ships:
+#
+#   PAGES — 1001 releases arrive over 11 pages. All of them are walked, and
+#           nothing reports truncation. A fixed cap fails here.
+#   CEILING — a walk needs more pages than `max_pages` allows. The script
+#           refuses. Dropping that guard fails here.
+#
+# Neither arm reads a second copy of the script out of a git ref. Say the
+# fail-side asserted that the copy on `origin/main` errors. That holds until
+# the fix merges. After that, `origin/main` has the fix too. The arm then
+# watches the fixed script pass, and the guard fails on every branch while
+# the tree is clean. Driving the shipping script's own ceiling keeps the
+# fail-side on live code. It also needs no `git fetch`, so a shallow checkout
+# and a full clone run the same test.
 #
 # bash 3.2 compatible.
 
 set -uo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
-NEW_SCRIPT="$repo_root/scripts/check-releases-published.sh"
-MAIN_SCRIPT="$repo_root/scripts/.check-releases-published.main-copy.sh"
+SCRIPT="$repo_root/scripts/check-releases-published.sh"
 
 pass=0
 fail=0
 
 work="$(mktemp -d)"
-cleanup() { rm -rf "$work"; rm -f "$MAIN_SCRIPT"; }
+cleanup() { rm -rf "$work"; }
 trap cleanup EXIT
 
-# CI checks out one ref with no history, so `origin/main` may not exist yet.
-# One shallow, on-demand fetch of just that branch tip fixes that without
-# touching the shared checkout step every other guard self-test also runs
-# under. It only ever reads; nothing here can move a real branch.
-git -C "$repo_root" fetch --depth=1 -q origin main 2>/dev/null || true
-
-# `dirname "$0"` in each script must find a folder with lib/help-header.sh.
-# So main's copy is placed next to the real script, not in the scratch dir.
-# It is a sibling file, deleted by the trap above, never staged or committed.
-if ! git -C "$repo_root" show origin/main:scripts/check-releases-published.sh >"$MAIN_SCRIPT" 2>/dev/null; then
-  echo "SKIP — could not read origin/main's copy of check-releases-published.sh (no network or no origin/main ref here); the fail-side of the witness cannot run, but this branch's own fetch is still exercised below." >&2
-else
-  chmod +x "$MAIN_SCRIPT"
-fi
-
 # A grace window wide enough that every real tag in this checkout falls
-# inside it and is skipped. So the only thing either script can report is
+# inside it and is skipped. So the only thing the script can report is
 # its own truncation guard. The fixture never has to fake a real git tag.
 grace_secs=315360000 # 10 years
 now="$(date -u +%s)"
 
-# The fake `gh`. Each script makes one call:
-#   main's version: `gh release list --limit 1000 ...`
-#   this branch:    `gh api --paginate --slurp .../releases?per_page=100`
-# Both get 1001 fake releases, one past the old cap. The shape matches real
-# `gh` output: 11 pages of up to 100 each, the last one holding 1.
-cat >"$work/gh" <<'SHIM'
+# The fake `gh`. The script under test makes one call,
+# `gh api --paginate --slurp .../releases?per_page=100`, and the shim answers
+# it with `$pages` pages of `$per_page` releases each — the shape real `gh`
+# returns under `--slurp`, an array of page arrays.
+#
+# `write_shim <dir> <pages> <per_page>` builds one in its own directory, so an
+# arm's PATH holds exactly the fixture it asked for.
+write_shim() {
+  mkdir -p "$1"
+  cat >"$1/gh" <<SHIM
 #!/usr/bin/env bash
 set -euo pipefail
-n=1001
-if [ "$1" = "api" ]; then
-  jq -n --argjson n "$n" '
-    [ range(0; $n) | { tag_name: ("v0.0." + (tostring)), draft: false } ]
-    | . as $all
-    | [ range(0; ($all | length); 100) as $i | $all[$i:$i + 100] ]
+if [ "\$1" = "api" ]; then
+  jq -n --argjson pages $2 --argjson per_page $3 '
+    [ range(0; \$pages)
+      | . as \$p
+      | [ range(0; \$per_page)
+          | { tag_name: ("v0.0." + (((\$p * \$per_page) + .) | tostring)), draft: false } ]
+    ]
   '
   exit 0
 fi
-if [ "$1" = "release" ] && [ "${2:-}" = "list" ]; then
-  jq -n --argjson n "$n" '[ range(0; $n) | ("v0.0." + (tostring)) ]'
-  exit 0
-fi
-echo "test-releases-published-pagination.sh: unhandled fake gh invocation: $*" >&2
+echo "test-releases-published-pagination.sh: unhandled fake gh invocation: \$*" >&2
 exit 3
 SHIM
-chmod +x "$work/gh"
-
-run_with_fake_gh() {
-  PATH="$work:$PATH" "$@" --now "$now" --grace-secs "$grace_secs" 2>&1
+  chmod +x "$1/gh"
 }
 
-if [ -x "$MAIN_SCRIPT" ]; then
-  main_out="$(run_with_fake_gh "$MAIN_SCRIPT")"
-  main_status=$?
-  if [ "$main_status" -ne 0 ] && printf '%s' "$main_out" | grep -q "page limit"; then
-    pass=$((pass + 1)); echo "ok   MAIN main's script hits its 1000-item cap on 1001 releases and errors"
-  else
-    fail=$((fail + 1))
-    echo "FAIL MAIN main's script hits its 1000-item cap on 1001 releases and errors — exit ${main_status}, got: ${main_out}"
-  fi
-fi
+# 1001 releases over 11 pages: one past the cap the old fetch stopped at, in
+# the page shape a real `--paginate` walk produces.
+write_shim "$work/pages" 11 91
 
-new_out="$(run_with_fake_gh "$NEW_SCRIPT")"
-new_status=$?
-if [ "$new_status" -eq 0 ] && printf '%s' "$new_out" | grep -q "^check-releases-published: OK"; then
-  pass=$((pass + 1)); echo "ok   NEW this branch's script pages through all 1001 releases and reports clean"
+# `max_pages` in check-releases-published.sh is 1000, so 1001 pages is one past
+# its sanity ceiling. One release per page keeps the fixture cheap — the script
+# refuses on the page count before it ever flattens them.
+write_shim "$work/ceiling" 1001 1
+
+run_with_fake_gh() {
+  local shim="$1"
+  shift
+  PATH="$shim:$PATH" "$@" --now "$now" --grace-secs "$grace_secs" 2>&1
+}
+
+pages_out="$(run_with_fake_gh "$work/pages" "$SCRIPT")"
+pages_status=$?
+if [ "$pages_status" -eq 0 ] && printf '%s' "$pages_out" | grep -q "^check-releases-published: OK"; then
+  pass=$((pass + 1)); echo "ok   PAGES the fetch walks all 1001 releases and reports clean"
 else
   fail=$((fail + 1))
-  echo "FAIL NEW this branch's script pages through all 1001 releases and reports clean — exit ${new_status}, got: ${new_out}"
+  echo "FAIL PAGES the fetch walks all 1001 releases and reports clean — exit ${pages_status}, got: ${pages_out}"
 fi
 
-if printf '%s' "$new_out" | grep -qi "page limit\|sanity ceiling"; then
+if printf '%s' "$pages_out" | grep -qi "page limit\|sanity ceiling"; then
   fail=$((fail + 1))
-  echo "FAIL NEW must not report a truncation/sanity error on 1001 releases — got: ${new_out}"
+  echo "FAIL PAGES must not report a truncation/sanity error on 1001 releases — got: ${pages_out}"
 else
-  pass=$((pass + 1)); echo "ok   NEW reports no truncation or page-sanity error on 1001 releases"
+  pass=$((pass + 1)); echo "ok   PAGES reports no truncation or page-sanity error on 1001 releases"
+fi
+
+ceiling_out="$(run_with_fake_gh "$work/ceiling" "$SCRIPT")"
+ceiling_status=$?
+if [ "$ceiling_status" -ne 0 ] && printf '%s' "$ceiling_out" | grep -qi "sanity ceiling"; then
+  pass=$((pass + 1)); echo "ok   CEILING a walk past the page ceiling is refused, not answered from a short list"
+else
+  fail=$((fail + 1))
+  echo "FAIL CEILING a walk past the page ceiling is refused, not answered from a short list — exit ${ceiling_status}, got: ${ceiling_out}"
 fi
 
 echo


### PR DESCRIPTION
## What & why

`guard-self-tests.yml`'s `guard self-tests` job is red on `main` and on every
branch cut from it. The failing step is **"the release fetch has no fixed count
cap"** (`scripts/test-releases-published-pagination.sh`).

Reproduced on a clean `main` checkout at `bc3e671`:

```
FAIL MAIN main's script hits its 1000-item cap on 1001 releases and errors — exit 0, got: check-releases-published: OK — every v* tag older than 5256000m has a published release (0 tag(s) checked, 24 grandfathered).
ok   NEW this branch's script pages through all 1001 releases and reports clean
ok   NEW reports no truncation or page-sanity error on 1001 releases

passed 2, failed 1
```

**The cause, established rather than guessed.** The `MAIN` arm read a second
copy of the script under test out of a moving ref and asserted *that* copy
errors:

```sh
git -C "$repo_root" show origin/main:scripts/check-releases-published.sh >"$MAIN_SCRIPT"
```

That assertion held only while `origin/main` still carried the capped
`gh release list --limit 1000` fetch. It no longer does — `origin/main`'s copy
is byte-identical to the working tree's, both carrying the paginated fetch:

```
$ git diff origin/main -- scripts/check-releases-published.sh   # empty
$ git show origin/main:scripts/check-releases-published.sh | grep -n paginate
172:pages_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh api --paginate --slurp 'repos/{owner}/{repo}/releases?per_page=100')"
```

So the arm now runs the *fixed* script, the fixed script correctly reports OK,
and the arm fails — permanently, from the moment the fix merged. A witness
pinned to a moving ref stops being a witness once the ref moves past it.

**The timeline settles it.** #5648 (the paginated fetch) merged at `23:59:29Z`.
Every `guard self-tests` run before that passed — #5640 (22:36), #5646 (23:07),
#5653 (23:29), #5641 (23:32). Every run after it failed — #5658 (00:04), #5667
(00:06), #5666 (00:16), #5672 (00:17). Nothing else changed in that window.

Closes #5681

## The change

`scripts/test-releases-published-pagination.sh` only. Both arms now run the
script this tree ships; nothing reads a second copy out of a git ref.

- **PAGES** keeps the no-cap assertion — 1001 releases over 11 pages are all
  walked, and nothing reports truncation.
- **CEILING** replaces the `origin/main` arm with the shipping script's own
  `max_pages` guard: a walk needing 1001 pages is refused rather than answered
  from a list the script knows it did not finish reading.

The `git fetch --depth=1 origin main`, the `git show`, the sibling
`.check-releases-published.main-copy.sh` and its `SKIP` branch are all gone, so
a shallow CI checkout and a full clone run the same test.

The fail-side is now pointed at live code rather than at history, which is what
makes it survive its own fix landing.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The changed file *is* the witness, so the fail→pass pair is the guard's own
directions, demonstrated by mutating the script under test:

| mutation | expected | observed |
|---|---|---|
| `max_pages=5000` (ceiling cannot fire) | CEILING fails | `FAIL CEILING … exit 0, got: check-releases-published: OK` |
| `max_pages=5` (a cap returns) | both PAGES arms fail | `FAIL PAGES … the release list needed 11 pages to walk fully, past the 5-page sanity ceiling` |
| unmutated | all pass | `passed 3, failed 0` |

Each mutation was reverted and the clean run re-confirmed at `passed 3,
failed 0`. On `main` the file fails `passed 2, failed 1`, as quoted above.

## The gate

**CI is the evidence, and it is in:** `guard self-tests` on `044158f` is
[green, all 45 steps](https://github.com/macanderson/stella/actions/runs/33699611226/job/100475852002)
— the same job that is red on `main`. Step 37 ("the release fetch has no fixed
count cap") passes, and so does step 39, the shellcheck presence guard.

- [x] `guard self-tests` — green on this head (job 100475852002)
- [x] `./scripts/test-releases-published-pagination.sh` — `passed 3, failed 0`
- [x] `cargo check on the declared MSRV`, `file size ratchet`,
      `harbor_adapter + analyzer pytest`, `gate steps no other workflow runs`,
      `post-merge canary self-tests`, `dependency-review`, `duplicate claims`,
      `main is not known-broken` — all green on this head
- [x] `make prose` — `OK`, no construction added and the file is inside its
      reading-grade ceiling (the first draft of the header was over it and was
      rewritten rather than baselined)
- [x] `make line-citations` — `OK`, none added
- [x] `check-no-scratch`, `check-left-behind`, `bash -n` — clean
- [ ] `cargo fmt --check` / clippy / `cargo test --workspace` — not run locally
      (CI builds and tests; this laptop does not — CLAUDE.md). This PR adds no
      Rust; `fmt + clippy + test` is running on this head.
- [x] Docs — no behavior or flag changed
- [x] `Closes #5681` appears both above and as a commit trailer

`shellcheck` is not installed on this machine, so that step did not run
locally (#3830 tracks the image gap) — CI's guard-self-tests step 39 covers it
and is green.

## Sourcery

Sourcery reviewed this PR and posted its **Assessment against linked issues**:
all three objectives for #5681 are `✅`, no `❌` rows, so there is nothing to fix
or rebut under CLAUDE.md's Sourcery rule.

Worth recording, because it corrects an assumption I had made from the other
open PRs: Sourcery's "you've used your own review budget of 250,000 diff
characters" message appears on the large PRs (#5640, #5641, #5646, and
cgp-website#27), but it still reviewed this one. The budget throttles large
diffs rather than blocking the repo outright, so a small PR does still get its
assessment table.

## Nothing left behind

- [x] Filed: **#5681** — this PR's own issue.

One correction made to that issue while working: its fourth DoD item as first
written read *"`guard self-tests` is green on `main`"*, which no pre-merge state
can satisfy — the job only runs on `main` after this merges, so the box could
never be ticked and `dod` would stay red forever. That is the same bootstrap
shape flagged on #5589/#5672, reproduced by the same author one issue later. It
is reworded to *green on the head that carries the fix*, which is the identical
job on the identical tree `main` receives, and is verified above. The rewording
and its reason are recorded in the issue body rather than done silently.

Two further findings from the same sweep, both outside this diff and both
needing a maintainer decision rather than a patch, so neither is folded in:

- **`release-reconcile` is separately red on `main`**: 4 tags cut but never
  published (`v0.9.194` 216h, `v0.9.254` 165h, `v0.9.264` 158h, `v0.9.273`
  135h). Recent releases succeed — `v0.9.283`…`v0.9.309` are all green — so
  this is a standing backlog, not a live regression. Both remedies
  (republishing 6–9-day-old superseded versions, or deleting the orphan tags)
  are outward-facing and irreversible, which is a call for a person; noted here
  rather than filed blind.
- **#5589's DoD has the same bootstrap item** as the one corrected above; the
  audit is on #5672.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — this diff *removes* the guard's only
      network dependence
- [x] N/A — no new cross-boundary type

## Anything reviewers should know?

- The CEILING fixture uses 1001 pages of **one** release each rather than 1001
  pages of 100. The script refuses on the page count before it flattens the
  pages, so the cheap fixture exercises the same branch; 100,100 objects
  through `jq` would only make the test slower.
- The `write_shim` heredoc is unquoted so `$pages` / `$per_page` expand at
  write time, while `\$1` and `\$*` stay literal for the shim's own runtime.
- The first draft of the fixture had a `jq` precedence bug —
  `"v0.0." + (…) | tostring` parses as `("v0.0." + (…)) | tostring` — which
  surfaced as `string and number cannot be added` and is fixed by the inner
  parens. Worth a look in review, since a shim that errors would make the
  PAGES arm fail for the wrong reason.

Tests deleted: None. The `MAIN` arm was an inline assertion block inside
`test-releases-published-pagination.sh`, not a named `#[test]`; it is replaced
by the CEILING arm rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K41tjo6pTUC1XaoPCr7u37
