### PR TITLE
fix(scripts): derive the pagination witness's failing side in-tree

### DIFF
--- a/scripts/test-releases-published-pagination.sh
+++ b/scripts/test-releases-published-pagination.sh
@@ -5,13 +5,22 @@
 #   ./scripts/test-releases-published-pagination.sh
 #
 # scripts/test-releases-published.sh proves the RULE has no cap. It cannot
-# reach the FETCH, where the old cap actually lived. This test drives the
-# fetch end to end with a fake `gh` on PATH, so a fake list of 1001 releases
-# runs with no network at all.
+# reach the FETCH, which is where a cap lives. This test drives the fetch end
+# to end with a fake `gh` on PATH, so a fake list of 1001 releases runs with
+# no network at all.
 #
-# It runs two scripts against that same list: the one `main` ships today,
-# and the one in this working tree. Main's script hits its old cap and
-# errors. This branch's script pages through all 1001 and reports clean.
+# It runs two scripts against that same list. One is the shipping script. It
+# must page through all 1001 and report clean. The other is a capped copy.
+# This file derives that copy from the shipping script. It splices in a fixed
+# `--limit` fetch and the truncation error that fetch raises. The copy must
+# fail. A fixture is evidence only while something it runs against fails on
+# it. So the failing side is derived here, not read from a branch.
+#
+# Reading the failing side from `origin/main` holds only until the fix merges.
+# From that commit on, `main` carries the paged fetch. The failing side then
+# reports clean. The arm that asserts it errors fails on every open pull
+# request. Deriving the capped copy keeps both directions demonstrated for as
+# long as the shipping script has a fetch to splice.
 #
 # bash 3.2 compatible.
 
@@ -19,40 +28,61 @@ set -uo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
 NEW_SCRIPT="$repo_root/scripts/check-releases-published.sh"
-MAIN_SCRIPT="$repo_root/scripts/.check-releases-published.main-copy.sh"
+CAPPED_SCRIPT="$repo_root/scripts/.check-releases-published.capped.sh"
 
 pass=0
 fail=0
 
 work="$(mktemp -d)"
-cleanup() { rm -rf "$work"; rm -f "$MAIN_SCRIPT"; }
+cleanup() { rm -rf "$work"; rm -f "$CAPPED_SCRIPT"; }
 trap cleanup EXIT
 
-# CI checks out one ref with no history, so `origin/main` may not exist yet.
-# One shallow, on-demand fetch of just that branch tip fixes that without
-# touching the shared checkout step every other guard self-test also runs
-# under. It only ever reads; nothing here can move a real branch.
-git -C "$repo_root" fetch --depth=1 -q origin main 2>/dev/null || true
-
-# `dirname "$0"` in each script must find a folder with lib/help-header.sh.
-# So main's copy is placed next to the real script, not in the scratch dir.
-# It is a sibling file, deleted by the trap above, never staged or committed.
-if ! git -C "$repo_root" show origin/main:scripts/check-releases-published.sh >"$MAIN_SCRIPT" 2>/dev/null; then
-  echo "SKIP — could not read origin/main's copy of check-releases-published.sh (no network or no origin/main ref here); the fail-side of the witness cannot run, but this branch's own fetch is still exercised below." >&2
-else
-  chmod +x "$MAIN_SCRIPT"
+# The capped fetch. `gh release list --limit N` asks for a fixed number of
+# releases. A full answer may be cut off. Every release past the cut then
+# reads as a tag that shipped nothing, so the fetch refuses to trust one. Its
+# result is remapped to the `{ name, draft }` shape the rest of the script
+# reads. This copy differs from the shipping script in the cap alone.
+capped_fetch='releases_limit=1000
+capped_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh release list --limit "$releases_limit" --json tagName --jq '"'"'[.[].tagName]'"'"')"
+if [ "$(printf '"'"'%s'"'"' "$capped_json" | jq '"'"'length'"'"')" -ge "$releases_limit" ]; then
+  echo "::error::the release list hit the ${releases_limit} page limit, so it may be truncated — every release past the cut would be reported as an unpublished tag." >&2
+  exit 1
 fi
+releases_json="$(printf '"'"'%s'"'"' "$capped_json" | jq '"'"'[ .[] | { name: ., draft: false } ]'"'"')"'
+
+# The splice runs between these two anchors in the shipping script: the page
+# ceiling that opens its fetch, and the assignment that closes it. Both are
+# matched at the start of a line and both must appear exactly once. A rewrite
+# of that fetch fails here rather than quietly producing a copy with no cap
+# left in it, which would pass this test while proving nothing.
+splice_start="$(grep -c '^max_pages=' "$NEW_SCRIPT")"
+splice_end="$(grep -c '^releases_json=' "$NEW_SCRIPT")"
+if [ "$splice_start" != "1" ] || [ "$splice_end" != "1" ]; then
+  echo "FAIL SPLICE check-releases-published.sh does not have exactly one '^max_pages=' line (found ${splice_start}) and one '^releases_json=' line (found ${splice_end}), so the capped copy cannot be derived. Re-derive the anchors in $0 against the current fetch." >&2
+  exit 1
+fi
+
+# `dirname "$0"` in the capped copy must find a folder with lib/help-header.sh,
+# so it is written next to the real script rather than in the scratch dir. The
+# trap above deletes it; it is never staged or committed.
+{
+  sed -n "1,$(($(grep -n '^max_pages=' "$NEW_SCRIPT" | cut -d: -f1) - 1))p" "$NEW_SCRIPT"
+  printf '%s\n' "$capped_fetch"
+  sed -n "$(($(grep -n '^releases_json=' "$NEW_SCRIPT" | cut -d: -f1) + 1)),\$p" "$NEW_SCRIPT"
+} >"$CAPPED_SCRIPT"
+chmod +x "$CAPPED_SCRIPT"
 
 # A grace window wide enough that every real tag in this checkout falls
 # inside it and is skipped. So the only thing either script can report is
 # its own truncation guard. The fixture never has to fake a real git tag.
+# A tag inside the window is skipped before the grandfather baseline is read.
 grace_secs=315360000 # 10 years
 now="$(date -u +%s)"
 
 # The fake `gh`. Each script makes one call:
-#   main's version: `gh release list --limit 1000 ...`
-#   this branch:    `gh api --paginate --slurp .../releases?per_page=100`
-# Both get 1001 fake releases, one past the old cap. The shape matches real
+#   the capped copy:     `gh release list --limit 1000 ...`
+#   the shipping script: `gh api --paginate --slurp .../releases?per_page=100`
+# Both get 1001 fake releases, one past the cap. The shape matches real
 # `gh` output: 11 pages of up to 100 each, the last one holding 1.
 cat >"$work/gh" <<'SHIM'
 #!/usr/bin/env bash
@@ -79,24 +109,22 @@ run_with_fake_gh() {
   PATH="$work:$PATH" "$@" --now "$now" --grace-secs "$grace_secs" 2>&1
 }
 
-if [ -x "$MAIN_SCRIPT" ]; then
-  main_out="$(run_with_fake_gh "$MAIN_SCRIPT")"
-  main_status=$?
-  if [ "$main_status" -ne 0 ] && printf '%s' "$main_out" | grep -q "page limit"; then
-    pass=$((pass + 1)); echo "ok   MAIN main's script hits its 1000-item cap on 1001 releases and errors"
-  else
-    fail=$((fail + 1))
-    echo "FAIL MAIN main's script hits its 1000-item cap on 1001 releases and errors — exit ${main_status}, got: ${main_out}"
-  fi
+capped_out="$(run_with_fake_gh "$CAPPED_SCRIPT")"
+capped_status=$?
+if [ "$capped_status" -ne 0 ] && printf '%s' "$capped_out" | grep -q "page limit"; then
+  pass=$((pass + 1)); echo "ok   CAPPED the capped fetch hits its 1000-item cap on 1001 releases and errors"
+else
+  fail=$((fail + 1))
+  echo "FAIL CAPPED the capped fetch hits its 1000-item cap on 1001 releases and errors — exit ${capped_status}, got: ${capped_out}"
 fi
 
 new_out="$(run_with_fake_gh "$NEW_SCRIPT")"
 new_status=$?
 if [ "$new_status" -eq 0 ] && printf '%s' "$new_out" | grep -q "^check-releases-published: OK"; then
-  pass=$((pass + 1)); echo "ok   NEW this branch's script pages through all 1001 releases and reports clean"
+  pass=$((pass + 1)); echo "ok   NEW the shipping script pages through all 1001 releases and reports clean"
 else
   fail=$((fail + 1))
-  echo "FAIL NEW this branch's script pages through all 1001 releases and reports clean — exit ${new_status}, got: ${new_out}"
+  echo "FAIL NEW the shipping script pages through all 1001 releases and reports clean — exit ${new_status}, got: ${new_out}"
 fi
 
 if printf '%s' "$new_out" | grep -qi "page limit\|sanity ceiling"; then


### PR DESCRIPTION
## What & why

`guard self-tests` is red on **every open pull request in this repository** —
#5640, #5641, #5646, #5653, #5658, #5662, #5666, #5667, #5672, #5678, #5680 —
on one arm of one script:

```
FAIL MAIN main's script hits its 1000-item cap on 1001 releases and errors — exit 0,
got: check-releases-published: OK — every v* tag older than 5256000m has a published
release (0 tag(s) checked, 24 grandfathered).
```

`scripts/test-releases-published-pagination.sh` read its failing side with
`git show origin/main:scripts/check-releases-published.sh` and asserted that copy
errors on 1001 releases. That holds only while `main` carries the cap. #5648
(commit `74c5673`) landed the paged fetch, so `origin/main`'s copy is now the
*fixed* script, the arm runs it, gets a clean answer, and fails. It cannot pass
again on any branch.

Verified rather than inferred:

```
$ git show origin/main:scripts/check-releases-published.sh > /tmp/main-copy.sh
$ diff -q /tmp/main-copy.sh scripts/check-releases-published.sh
(identical)
$ git log --oneline -1 origin/main -- scripts/check-releases-published.sh
74c5673 fix(scripts): stop release checks from depending on a fixed --limit (#5648)
```

The `24 grandfathered` in the message is incidental: the fixture's 10-year grace
window skips every real tag before the baseline is read.

**The fix.** The failing side is derived from the shipping script instead of read
from a branch. The test splices the fixed-`--limit` fetch and its truncation
error in between the `^max_pages=` and `^releases_json=` anchors, and asserts the
result errors. A witness that compares against a moving branch stops being a
witness once the branch catches up; a derived one keeps both directions
demonstrated for as long as the shipping script has a fetch to splice.

This also drops the `git fetch origin main` and the `origin/main` read, so the
test needs no network and its shallow-checkout `SKIP` path is gone — which is
what `Makefile`'s `releases-published-pagination-test` help already claimed.

Closes #5689

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The changed file *is* the witness, so it is verified by demonstrating that it
still fails in both directions rather than by a new test over it.

**The derived copy differs from the shipping script in the fetch alone** — the
whole `diff` is the fetch block and the `releases_json=` assignment, so the arm
tests the cap and not a shape change.

**It fails when the shipping fetch regresses.** Replacing the paged fetch with a
capped one (anchors left intact, so the splice still runs):

```
ok   CAPPED the capped fetch hits its 1000-item cap on 1001 releases and errors
FAIL NEW the shipping script pages through all 1001 releases and reports clean — exit 1,
     got: ::error::the release list needed 1001 pages to walk fully, past the 1000-page
     sanity ceiling.
FAIL NEW must not report a truncation/sanity error on 1001 releases
passed 1, failed 2
```

**It fails loudly when the splice anchors break**, rather than producing a copy
with no cap left in it that would pass while proving nothing:

```
FAIL SPLICE check-releases-published.sh does not have exactly one '^max_pages=' line
(found 0) and one '^releases_json=' line (found 1), so the capped copy cannot be
derived. Re-derive the anchors in ./scripts/test-releases-published-pagination.sh
against the current fetch.
```

**On this branch, unmodified:**

```
ok   CAPPED the capped fetch hits its 1000-item cap on 1001 releases and errors
ok   NEW the shipping script pages through all 1001 releases and reports clean
ok   NEW reports no truncation or page-sanity error on 1001 releases
passed 3, failed 0
```

## The gate

This diff is one shell script and touches no Rust, so the cargo tiers have
nothing to compile here — CI's run is the evidence for those. Run locally:

- [x] `make prose` — `OK`, none added (the rewrite cost three passes: `variant`,
      issue numbers in prose, and reading grade)
- [x] `make line-citations` — `OK`, none added
- [x] `make no-scratch` — `OK`
- [x] `make left-behind` — `OK`
- [x] `bash -n` parses
- [x] `Closes #5689` appears both above and as a commit trailer
- [ ] `shellcheck` — **this step did not run**: shellcheck is not installed in
      this environment. CI's `guard self-tests` job is the check for it.

No behavior, flags, or docs changed, so nothing to update there.

## Nothing left behind

- [x] Filed: #5689 — the defect this PR closes.

One thing I noticed and did **not** change, because it is a maintainer call
rather than a defect: `scripts/check-releases-published.sh` reports four tags
that were cut but never published (`v0.9.194`, `v0.9.254`, `v0.9.264`,
`v0.9.273`). That is release hygiene already tracked in #5629, and #5680 is open
against it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — this PR **removes** one (`git fetch origin main`)

## Anything reviewers should know?

**Why derive rather than delete the arm.** Dropping it would turn the file into a
one-sided test that can only ever confirm the shipping script passes, which is
what `guard-self-tests.yml` exists to prevent ("the hermetic suites that prove a
guard can still fail"). Deriving keeps the fail side.

**Why splice rather than hand-write a minimal fixture.** A standalone fixture
would prove a fixture fails, not that *this* fetch is the thing under test. The
splice keeps every other line of the shipping script identical, so the arm is
about the cap.

**The anchors are the fragile part**, and that is deliberate: they are checked for
exactly one match each and the failure names the remedy, so a fetch rewrite gets
a loud "re-derive this" instead of a silently toothless test.

This PR unblocks `guard self-tests` for every open PR listed above; each will
need a re-run or a push once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUbDs7gj6E7UzZRPtdcTJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUbDs7gj6E7UzZRPtdcTJr)_

## Summary by Sourcery

Keep the release-pagination self-test effective by deriving its failing witness from the shipping script instead of a moving main-branch copy.

Bug Fixes:
- Fix the pagination witness so it continues to validate both capped-fetch failures and shipping-script success after the pagination fix reaches the main branch.

Enhancements:
- Make the witness hermetic by deriving its capped failing copy from the shipping script and removing its dependency on fetching or reading origin/main.
- Fail loudly when the fetch splice anchors change, preventing the witness from silently becoming ineffective.

Tests:
- Update the pagination self-test to exercise a derived capped script alongside the current shipping script without network access or shallow-checkout skips.