### PR TITLE
feat(stella-model): re-ask OpenRouter for the upstream that served the first call

### DIFF
--- a/crates/stella-cli/src/config/providers.rs
+++ b/crates/stella-cli/src/config/providers.rs
@@ -29,9 +29,12 @@ pub struct ProviderConfig {
     /// whose models are whatever the user's endpoint actually serves.
     pub seeded: bool,
     /// Upstreams a *gateway* provider is pinned to, in preference order, from
-    /// settings.json's `upstream_pin`. Empty for every built-in row: routing
-    /// is the gateway's choice until an operator says otherwise, and only a
-    /// measured comparison needs it fixed.
+    /// settings.json's `upstream_pin`. Empty for every built-in row, which
+    /// does not mean unrouted: the shared adapter then asks for whichever
+    /// upstream served the session's first answer and still lets the gateway
+    /// fall back (`stella_model::zai`'s `upstream` module). Setting this is
+    /// the stronger ask — one upstream or a refused call — which is what a
+    /// measured comparison needs and what an interactive session does not.
     pub upstream_pin: &'static [String],
 }
 

--- a/crates/stella-cli/src/engine_config.rs
+++ b/crates/stella-cli/src/engine_config.rs
@@ -502,12 +502,16 @@ pub fn boot_notices(cfg: &crate::config::Config) -> Vec<String> {
 /// not TTL expiry: median idle before a miss was 0.3s against 0.2s before a
 /// hit, and calls alternated hit/miss inside the same second.
 ///
-/// The default stays unpinned, because routing is the gateway's choice until
-/// an operator says otherwise and only a measured comparison needs it fixed
-/// (see `config::providers::ProviderConfig::upstream_pin`). What changes is
-/// that the choice stops being invisible — the same honest-degradation
-/// contract [`unsupported_effort_notice`] applies to a dropped reasoning
-/// effort. A silent default nobody can see is not a default anyone chose.
+/// The adapter narrows this on its own: from the first answer on it asks the
+/// gateway for whichever upstream served it, with fallbacks still allowed. So
+/// this line is about what that cannot do — the first call of every session
+/// is routed by the gateway, and a fallback may still move the rest. Only
+/// `upstream_pin` refuses one (see
+/// `config::providers::ProviderConfig::upstream_pin`), which is what a
+/// measured comparison needs. What the line buys is that the choice stops
+/// being invisible — the same honest-degradation contract
+/// [`unsupported_effort_notice`] applies to a dropped reasoning effort. A
+/// silent default nobody can see is not a default anyone chose.
 ///
 /// [`CACHE_POSTURE`]: stella_model::provider_parity::CACHE_POSTURE
 pub fn unpinned_gateway_notice(
@@ -526,9 +530,10 @@ pub fn unpinned_gateway_notice(
         return None;
     }
     Some(format!(
-        "{provider_label} is a gateway and no upstream is pinned — it may route two turns of \
-         this session to different upstreams, and a prompt cached on one is a full-price miss \
-         on the next. Set `upstream_pin` in settings.json to fix the route."
+        "{provider_label} is a gateway and no upstream is pinned. Stella asks it to keep this \
+         session on whoever serves the first call, but it may still fall back, and a prompt \
+         cached on one upstream is a full-price miss on the next. Set `upstream_pin` in \
+         settings.json to refuse the fallback."
     ))
 }
 

--- a/crates/stella-model/src/provider_parity.rs
+++ b/crates/stella-model/src/provider_parity.rs
@@ -119,6 +119,7 @@ pub(crate) fn adapter_sources() -> &'static [&'static str] {
         include_str!("zai/tests/openrouter_stream.rs"),
         include_str!("zai/tests/stream_fallback.rs"),
         include_str!("zai/tests/stream_frame.rs"),
+        include_str!("zai/tests/upstream_pin.rs"),
         include_str!("zai/tests/vision.rs"),
         include_str!("zai/tests/zai_effort.rs"),
     ]
@@ -136,6 +137,17 @@ pub enum CachePosture {
         /// Name of the test function that proves the marker reaches the
         /// wire; checked for existence by this module's tests.
         witness: &'static str,
+        /// Name of the test proving this provider asks for a *particular*
+        /// cache, where sending the marker is not the whole story: a gateway
+        /// fronts several vendors holding several caches, so the marker can
+        /// reach the wire and still buy nothing.
+        ///
+        /// Two witnesses rather than one because they are two facts with two
+        /// kinds of evidence, the split `ParallelToolCallPosture` already
+        /// makes for the same reason — collapsing them would let a row claim
+        /// more than it can show. `None` for a direct vendor, which holds one
+        /// cache and has no route to choose.
+        routing_witness: Option<&'static str>,
     },
     /// The provider caches implicitly — nothing to send, but the adapter
     /// must PARSE the provider's hit telemetry or cached tokens bill at the
@@ -167,6 +179,7 @@ pub static CACHE_POSTURE: &[(&str, CachePosture)] = &[
                         the pair reaches the wire when configured, and the default window \
                         stays byte-identical",
             witness: "request_serializes_both_cache_breakpoints",
+            routing_witness: None,
         },
     ),
     (
@@ -174,6 +187,7 @@ pub static CACHE_POSTURE: &[(&str, CachePosture)] = &[
         CachePosture::OptIn {
             mechanism: "Converse cachePoint blocks, gated to supporting model families",
             witness: "complete_sends_cache_points_for_claude_models",
+            routing_witness: None,
         },
     ),
     (
@@ -186,8 +200,20 @@ pub static CACHE_POSTURE: &[(&str, CachePosture)] = &[
                         session_id is a HINT the gateway may decline, not a pin: measured \
                         over one 17-minute session it held for the last 17 calls and not \
                         the first 32, leaving 20 of 69 calls reading zero cached tokens \
-                        for 54% of the spend. Only a non-empty upstream_pin \
-                        (provider.order + allow_fallbacks:false) actually fixes the route. \
+                        for 54% of the spend; a 174-call turn on one slug in this repo's \
+                        own store was served by three vendors, the route moving 12 times, \
+                        with the id sent on every request. So the adapter reads the served \
+                        vendor off the response (top-level provider, on the stream's chunks \
+                        and on the unary body alike) and asks for it again on every later \
+                        call as provider.order with allow_fallbacks:true — a warm cache is \
+                        worth asking for and not worth failing a call over. An operator's \
+                        upstream_pin outranks it and keeps allow_fallbacks:false, which is \
+                        what a measured run needs. Whether the gateway routes on the \
+                        display name it reports, when that name is handed back in \
+                        provider.order, is a declared gap: a wiremock accepts any string, \
+                        so the round trip needs a live call to settle, and \
+                        allow_fallbacks:true is what makes an unmatched name cost the \
+                        saving rather than the call. \
                         The gateway honours the root-level placement for Anthropic routes, \
                         verified from recorded field usage rather than a live probe \
                         (#1854): of 1,684 anthropic/* calls this adapter made between \
@@ -198,6 +224,9 @@ pub static CACHE_POSTURE: &[(&str, CachePosture)] = &[
                         the gateway those reads could not occur if the root field were \
                         dropped",
             witness: "openrouter_identity_sends_root_level_cache_control",
+            routing_witness: Some(
+                "a_gateway_is_reasked_for_the_upstream_that_served_the_first_call",
+            ),
         },
     ),
     (
@@ -847,21 +876,38 @@ mod tests {
     /// Every witness named in the cache matrix must exist as a test function
     /// in the adapter sources — a row whose proof rotted (test renamed or
     /// deleted) fails here, not as a production surprise.
+    ///
+    /// A routing witness is held to the same bar. A gateway row that names
+    /// one and then loses it would keep claiming it asks for a particular
+    /// cache, which is the claim that was wrong before it was tested.
     #[test]
     fn every_witness_test_exists_in_the_adapter_sources() {
         let sources = adapter_sources();
+        let exists = |witness: &str| {
+            let needle = format!("fn {witness}(");
+            sources.iter().any(|source| source.contains(&needle))
+        };
         for (id, posture) in CACHE_POSTURE {
-            let witness = match posture {
-                CachePosture::OptIn { witness, .. } | CachePosture::Implicit { witness, .. } => {
-                    witness
-                }
+            let (witness, routing) = match posture {
+                CachePosture::OptIn {
+                    witness,
+                    routing_witness,
+                    ..
+                } => (witness, *routing_witness),
+                CachePosture::Implicit { witness, .. } => (witness, None),
                 CachePosture::NotApplicable { .. } => continue,
             };
-            let needle = format!("fn {witness}(");
             assert!(
-                sources.iter().any(|source| source.contains(&needle)),
+                exists(witness),
                 "cache-posture witness for `{id}` not found in adapter sources: {witness}"
             );
+            if let Some(routing) = routing {
+                assert!(
+                    exists(routing),
+                    "cache-posture routing witness for `{id}` not found in adapter \
+                     sources: {routing}"
+                );
+            }
         }
     }
 

--- a/crates/stella-model/src/zai.rs
+++ b/crates/stella-model/src/zai.rs
@@ -26,7 +26,9 @@ use crate::stream_recovery::StreamRecovery;
 pub(crate) mod effort;
 mod stream;
 mod unary;
+mod upstream;
 use effort::{xai_reasoning_effort, xai_supports_reasoning_effort, zai_reasoning_effort};
+use upstream::{OpenRouterProviderPin, ServedUpstream};
 // `map_zai_effort` is asserted on directly by the wire tests, which reach it
 // through this module's namespace like every other helper here. Its xAI sibling
 // is absent: nothing outside `effort.rs` calls it, and re-exporting
@@ -66,19 +68,27 @@ pub struct ZaiProvider {
     /// carries a cost, it overrides catalog list pricing — the gateway
     /// routed the call, only it knows what the call cost.
     usage_accounting: bool,
-    /// Upstreams this provider is pinned to, in preference order, sent as
-    /// OpenRouter's `provider.order` with fallbacks refused. Empty means
-    /// unpinned — the gateway routes wherever it likes, which is the shipped
-    /// default and is only safe when nobody is comparing two runs.
+    /// Upstreams the operator pinned this provider to, in preference order,
+    /// sent as OpenRouter's `provider.order` with fallbacks refused. Empty
+    /// is the shipped default and does not mean unrouted: the adapter then
+    /// asks for whichever upstream served the session's first answer, with
+    /// fallbacks allowed. See [`upstream`] for why the two shapes differ.
     upstream_pin: Vec<String>,
+    /// The upstream that served this session's first answer, learned off the
+    /// response and re-requested on every later call. Empty until an answer
+    /// names one, which is every call on a direct endpoint. See [`upstream`].
+    served_upstream: ServedUpstream,
     /// Session-stable sticky-routing key, sent as OpenRouter's top-level
     /// `session_id` (only for the `openrouter` identity — see the field on
     /// [`ZaiRequest`]). One id per provider construction = one id per agent
-    /// run, so every turn of a session pins to the same upstream provider and
-    /// reuses the prompt cache the previous turn paid to write; distinct per
-    /// construction, so fleet siblings don't serialize on one shard. Mirrors
-    /// the OpenAI adapter's `prompt_cache_key` lifecycle. Volatile by design:
-    /// it rides as a request parameter and never enters the cached bytes.
+    /// run, asking the gateway to keep the session on one upstream provider
+    /// and reuse the prompt cache the previous turn paid to write; distinct
+    /// per construction, so fleet siblings don't serialize on one shard.
+    /// Mirrors the OpenAI adapter's `prompt_cache_key` lifecycle. Volatile by
+    /// design: it rides as a request parameter and never enters the cached
+    /// bytes. The gateway treats it as a hint and drops it under load — a
+    /// 174-call turn on one slug was served by three upstreams with this id
+    /// on every request, which is why [`ServedUpstream`] exists.
     session_id: String,
     /// The streaming→non-streaming fallback latch (#2686): armed when a
     /// stream hangs before its first byte or comes back empty, consulted per
@@ -170,6 +180,7 @@ impl ZaiProvider {
             extra_headers: Vec::new(),
             usage_accounting: false,
             upstream_pin: Vec::new(),
+            served_upstream: ServedUpstream::default(),
             session_id: new_session_id(),
             recovery: StreamRecovery::default(),
             unary_client: http::unary_client(),
@@ -268,7 +279,10 @@ impl ZaiProvider {
     /// is chosen per app identity and can differ between two runs — or between
     /// two trials of the same run — while both record the same provider id, so
     /// a head-to-head silently varies the model provider it claims to hold
-    /// fixed. Empty order leaves routing to the gateway, which is the default.
+    /// fixed. An empty order is the default and leaves the choice of upstream
+    /// to the gateway for the session's first call only; from the answer on,
+    /// the adapter asks for whoever served it, and lets the gateway fall back
+    /// (the `upstream` module).
     #[must_use]
     pub fn with_upstream_pin(mut self, order: Vec<String>) -> Self {
         self.upstream_pin = order;
@@ -386,29 +400,14 @@ struct ZaiRequest<'a> {
     /// risk a hard 400. See [`xai_reasoning_effort`] for the shape rules.
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<&'static str>,
-    /// OpenRouter's routing preferences — sent only when the operator pinned
-    /// an upstream, and only when this adapter is actually addressing the
-    /// gateway. Absent means "let the gateway choose", which is the right
-    /// default for interactive use and the wrong one for a measured run.
+    /// OpenRouter's routing preferences — sent only when this adapter is
+    /// actually addressing the gateway, and only once an upstream is known:
+    /// the operator's pin, or the one that served this session's first
+    /// answer. Absent on a session's first call, which is the only call that
+    /// has nothing to ask for. [`ZaiProvider::routing_pin`] builds it and
+    /// [`upstream`] carries the reasoning.
     #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<OpenRouterProviderPin<'a>>,
-}
-
-/// OpenRouter's `provider` routing object, in the one shape this adapter
-/// sends: an explicit upstream order with fallbacks refused.
-///
-/// `allow_fallbacks: false` is the whole point and is not configurable. A pin
-/// that silently falls back to a second vendor when the first is busy is not
-/// a pin — it is a preference, and it would reintroduce exactly the
-/// uncontrolled variable the caller asked to remove, at the least convenient
-/// moment (under load, mid-run, on some trials and not others). Refusing the
-/// call is the honest failure: a 404 from the gateway is a measurable, fixable
-/// event, while a quietly re-routed trial is a corrupted data point that looks
-/// identical to a clean one.
-#[derive(Serialize)]
-struct OpenRouterProviderPin<'a> {
-    order: &'a [String],
-    allow_fallbacks: bool,
 }
 
 /// GLM's request-level thinking object: `{"type": "enabled"}` /
@@ -1181,9 +1180,15 @@ impl ZaiProvider {
         force_default_reasoning: bool,
     ) -> Result<CompletionResult, ProviderError> {
         if self.recovery.use_unary() {
-            return self
+            let result = self
                 .complete_unary_attempt(req, force_default_reasoning)
-                .await;
+                .await?;
+            // Both delivery paths learn, because the stream→unary fallback
+            // can serve part of a session through this one without anybody
+            // choosing it.
+            self.served_upstream
+                .learn(result.upstream_provider.as_deref());
+            return Ok(result);
         }
         let body = self.build_body(req, force_default_reasoning, true);
         let response = self.dispatch(&self.client, &body, false).await?;
@@ -1204,6 +1209,11 @@ impl ZaiProvider {
                 .map(|p| p.cost_usd(&outcome.usage))
                 .unwrap_or(0.0)
         });
+        // Learned from a successful answer only. A failed attempt names no
+        // upstream to ask for, and asking for one that just failed is how a
+        // pin turns a bad minute into a bad session.
+        self.served_upstream
+            .learn(outcome.upstream_provider.as_deref());
         Ok(CompletionResult {
             text: outcome.text,
             tool_calls: outcome.tool_calls,
@@ -1295,17 +1305,7 @@ impl ZaiProvider {
                 .serves_openrouter()
                 .then_some(ZaiCacheControl { kind: "ephemeral" }),
             session_id: self.serves_openrouter().then_some(self.session_id.as_str()),
-            // Same "actually talking to OpenRouter" gate as the cache opt-in,
-            // and additionally silent unless an upstream was pinned: no other
-            // Chat Completions server speaks `provider`, and an unpinned
-            // request must keep its pre-field bytes so the prompt cache is
-            // unaffected for everyone who never asked for a pin.
-            provider: (self.serves_openrouter() && !self.upstream_pin.is_empty()).then_some(
-                OpenRouterProviderPin {
-                    order: &self.upstream_pin,
-                    allow_fallbacks: false,
-                },
-            ),
+            provider: self.routing_pin(),
         }
     }
 

--- a/crates/stella-model/src/zai/tests/upstream_pin.rs
+++ b/crates/stella-model/src/zai/tests/upstream_pin.rs
@@ -23,9 +23,34 @@ async fn mock_ok(server: &MockServer) {
         .await;
 }
 
-async fn first_request_body(server: &MockServer) -> String {
+async fn request_bodies(server: &MockServer) -> Vec<String> {
     let requests = server.received_requests().await.expect("recorded requests");
-    String::from_utf8_lossy(&requests[0].body).into_owned()
+    requests
+        .iter()
+        .map(|request| String::from_utf8_lossy(&request.body).into_owned())
+        .collect()
+}
+
+async fn first_request_body(server: &MockServer) -> String {
+    request_bodies(server)
+        .await
+        .into_iter()
+        .next()
+        .expect("at least one request")
+}
+
+/// Answer every call with a stream naming `upstream` as the vendor that
+/// served it — OpenRouter's `provider` field, in the shape the gateway sends.
+async fn mock_served_by(server: &MockServer, upstream: &str) {
+    let body = format!(
+        "data: {{\"provider\":\"{upstream}\",\
+         \"choices\":[{{\"delta\":{{\"content\":\"ok\"}}}}]}}\n\ndata: [DONE]\n\n"
+    );
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(server)
+        .await;
 }
 
 fn hello() -> CompletionRequest {
@@ -113,15 +138,7 @@ async fn a_pin_never_reaches_an_endpoint_that_is_not_the_gateway() {
 #[tokio::test]
 async fn a_streamed_gateway_answer_records_the_upstream_that_served_it() {
     let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/chat/completions"))
-        .respond_with(ResponseTemplate::new(200).set_body_raw(
-            "data: {\"provider\":\"Amazon Bedrock\",\
-             \"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n",
-            "text/event-stream",
-        ))
-        .mount(&server)
-        .await;
+    mock_served_by(&server, "Amazon Bedrock").await;
 
     let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "anthropic/claude-sonnet-5")
         .with_base_url(server.uri())
@@ -129,6 +146,84 @@ async fn a_streamed_gateway_answer_records_the_upstream_that_served_it() {
     let result = provider.complete(hello()).await.expect("should succeed");
 
     assert_eq!(result.upstream_provider.as_deref(), Some("Amazon Bedrock"));
+}
+
+/// Once an answer names a vendor, every later call asks for that vendor —
+/// and lets the gateway fall back if it is down.
+///
+/// The sticky `session_id` is a hint the gateway drops under load: one
+/// 174-call turn on a single slug (execution 327 of this repo's own store)
+/// was served by three vendors, the route moved twelve times, and five calls
+/// read no cache at all for $0.97 of the turn's $4.65. Three of those five
+/// were the first call on a vendor new to the turn, which is what re-asking
+/// removes.
+///
+/// The first request still carries no `provider` field: there is nothing to
+/// ask for yet, so a session's opening bytes are unchanged.
+#[tokio::test]
+async fn a_gateway_is_reasked_for_the_upstream_that_served_the_first_call() {
+    let server = MockServer::start().await;
+    mock_served_by(&server, "Sail Research").await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "moonshotai/kimi-k3")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter");
+    provider.complete(hello()).await.expect("first call");
+    provider.complete(hello()).await.expect("second call");
+
+    let bodies = request_bodies(&server).await;
+    assert!(!bodies[0].contains("\"provider\""), "{}", bodies[0]);
+    assert!(
+        bodies[1].contains("\"provider\":{\"order\":[\"Sail Research\"],\"allow_fallbacks\":true}"),
+        "{}",
+        bodies[1]
+    );
+}
+
+/// An operator's pin outranks the learned one, fallbacks still refused.
+///
+/// The two want different things. A learned pin chases a warm cache and would
+/// rather be served late than not at all; an operator pinning by hand is
+/// holding a variable fixed for a measurement, and a quietly re-routed trial
+/// reads just like a clean one.
+#[tokio::test]
+async fn an_operator_pin_outranks_the_upstream_that_served_the_first_call() {
+    let server = MockServer::start().await;
+    mock_served_by(&server, "Sail Research").await;
+
+    let provider = ZaiProvider::new(ApiKey::new("sk-or-test"), "moonshotai/kimi-k3")
+        .with_base_url(server.uri())
+        .with_identity("openrouter", "OpenRouter")
+        .with_upstream_pin(vec!["z-ai".to_string()]);
+    provider.complete(hello()).await.expect("first call");
+    provider.complete(hello()).await.expect("second call");
+
+    let bodies = request_bodies(&server).await;
+    assert!(
+        bodies[1].contains("\"provider\":{\"order\":[\"z-ai\"],\"allow_fallbacks\":false}"),
+        "{}",
+        bodies[1]
+    );
+    assert!(!bodies[1].contains("Sail Research"), "{}", bodies[1]);
+}
+
+/// A non-gateway endpoint that names a vendor is still never sent `provider`.
+///
+/// Same gate as the cache opt-in: "does this address OpenRouter", not "did
+/// something answer with a name we recognise". Z.ai direct, a local server or
+/// a proxy that echoes the field would all reject the unknown key.
+#[tokio::test]
+async fn a_direct_endpoint_never_asks_for_the_upstream_it_was_told_about() {
+    let server = MockServer::start().await;
+    mock_served_by(&server, "Sail Research").await;
+
+    let provider =
+        ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+    provider.complete(hello()).await.expect("first call");
+    provider.complete(hello()).await.expect("second call");
+
+    let bodies = request_bodies(&server).await;
+    assert!(!bodies[1].contains("\"provider\":{"), "{}", bodies[1]);
 }
 
 /// A direct endpoint names no upstream: `None` is the honest answer, and is a

--- a/crates/stella-model/src/zai/upstream.rs
+++ b/crates/stella-model/src/zai/upstream.rs
@@ -1,0 +1,105 @@
+//! Which vendor OpenRouter routes a call to, and how to ask for it again.
+//!
+//! OpenRouter fronts many vendors and picks one per call. Each vendor holds
+//! its own prompt cache. A switch throws that cache away, so the whole
+//! prompt bills at the full rate.
+//!
+//! The sticky `session_id` this adapter sends is a hint. It is not a pin.
+//! One 174-call turn in this repo's own store (execution 327, one slug,
+//! `moonshotai/kimi-k3`) was served by three vendors and the route moved
+//! twelve times. Five calls in that turn read no cache at all. Three of the
+//! five were the first call on a vendor new to the turn. Those five calls
+//! cost $0.97 of the $4.65 the turn spent.
+//!
+//! So the adapter reads the vendor name off the first answer and asks for
+//! that vendor again on every later call. Fallbacks stay on. If the vendor
+//! is down the gateway may still serve the call: a dearer call beats a dead
+//! one, and a warm cache is a saving, not a rule.
+//!
+//! An operator who sets `upstream_pin` asked for the stronger thing — one
+//! vendor or nothing. That setting still wins, and it still bars fallbacks.
+//!
+//! One part of this is not proven. The gateway names a vendor by its display
+//! name, and this code sends that same name back. Whether the gateway routes
+//! on it is untested, and no mock can test it: a mock takes any string.
+//! Fallbacks are on, so a name the gateway cannot place costs the saving and
+//! not the call.
+
+use std::sync::OnceLock;
+
+use serde::Serialize;
+
+use super::ZaiProvider;
+
+/// OpenRouter's `provider` routing object, in the two shapes this adapter
+/// sends.
+///
+/// An operator pin bars fallbacks. A measured run has to fail out loud
+/// rather than swap vendors part way, because a swapped trial reads just
+/// like a clean one.
+///
+/// A learned pin allows them. Nobody asked for that vendor by name; the
+/// adapter only wants the cache the first call already paid to write.
+/// Killing the call to protect a saving is a bad trade.
+#[derive(Serialize)]
+pub(super) struct OpenRouterProviderPin<'a> {
+    pub(super) order: &'a [String],
+    pub(super) allow_fallbacks: bool,
+}
+
+/// The vendor that served this session's first answer.
+///
+/// Set once, then never moved. A later call the gateway routes elsewhere
+/// does not change it: the cache worth asking for is the one the first
+/// answer wrote.
+#[derive(Debug, Default)]
+pub(super) struct ServedUpstream(OnceLock<Vec<String>>);
+
+impl ServedUpstream {
+    /// Keep `served` if nothing is kept yet.
+    ///
+    /// A missing or blank name is not an answer, so it is dropped. Every
+    /// direct endpoint sends none, and a gateway may decline to say.
+    pub(super) fn learn(&self, served: Option<&str>) {
+        let Some(name) = served.map(str::trim).filter(|name| !name.is_empty()) else {
+            return;
+        };
+        if self.0.get().is_none() {
+            // Two threads can reach this at once. One wins and the other's
+            // `set` fails. Both wanted a served name in the slot, so either
+            // winner is right.
+            let _ = self.0.set(vec![name.to_string()]);
+        }
+    }
+
+    /// The order to send, or `None` while no answer has named a vendor.
+    fn order(&self) -> Option<&[String]> {
+        self.0.get().map(Vec::as_slice)
+    }
+}
+
+impl ZaiProvider {
+    /// The `provider` object for the next request body.
+    ///
+    /// It stays off the wire unless this really is OpenRouter. No other
+    /// chat-completions server knows the key, and an unknown key risks a
+    /// hard 400. It also stays off until an answer has named a vendor, so a
+    /// session's first request keeps the bytes it has always had.
+    pub(super) fn routing_pin(&self) -> Option<OpenRouterProviderPin<'_>> {
+        if !self.serves_openrouter() {
+            return None;
+        }
+        if !self.upstream_pin.is_empty() {
+            return Some(OpenRouterProviderPin {
+                order: &self.upstream_pin,
+                allow_fallbacks: false,
+            });
+        }
+        self.served_upstream
+            .order()
+            .map(|order| OpenRouterProviderPin {
+                order,
+                allow_fallbacks: true,
+            })
+    }
+}


### PR DESCRIPTION
## The decision

Option 3 from the issue, adaptive, per the maintainer's 2026-09-02 pointer:
**pin on first success, fallbacks allowed.** A static default pin is wrong for
most slugs — the vendors serving `moonshotai/kimi-k3` are not the ones serving
an Anthropic route — and leaving it unpinned costs a measured share of every
gateway session. Reading the served vendor off the response needs no vendor
knowledge and is what `session_id` was supposed to provide.

## What changes

`crates/stella-model/src/zai.rs` reads OpenRouter's top-level `provider` field
off a successful answer, remembers it for the life of the adapter (one agent
run), and sends it back on every later call as
`provider: {order: [served], allow_fallbacks: true}` when no `upstream_pin` is
configured. Both delivery paths learn, because the stream→unary fallback can
serve part of a session through the unary path without anyone choosing it.

The two pin shapes want different things, and the flag is where they differ:

| | `order` | `allow_fallbacks` |
|---|---|---|
| operator `upstream_pin` | what they typed | `false` — a measured run holds the variable or fails out loud |
| learned | who served the first answer | `true` — a warm cache is a saving, not a rule |

A session's first call still sends no `provider` field, so its bytes are
unchanged and the prompt cache is unaffected for anyone who never asked for a
pin. A non-gateway endpoint is never sent the field at all, whatever it
answers with — the same "does this actually address OpenRouter" gate the cache
opt-in uses, not a check on the id.

## Why, with the evidence

The parity matrix said `session_id` "pins every turn of a session to the same
upstream provider + cache shard". This repository's own `store.db` is the
counter-example. Execution 327 — 174 calls, one slug (`moonshotai/kimi-k3`),
`session_id` on every request:

```
0-64:    Sail Research        105-164: Together
65:      Together             165:     Sail Research
66-67:   Sail Research        166-171: Morph
68-75:   (alternating)        172-173: Sail Research
76-104:  Sail Research
```

Twelve route changes inside one turn. Five of the 174 calls read zero cached
tokens, and they carried **$0.97 of the turn's $4.65 (21%) on 2.9% of the
calls**:

| step | vendor | input | cache read | cost |
|---|---|---|---|---|
| 65 | Together | 37,187 | 0 | $0.1130 |
| 113 | Together | 63,866 | 0 | $0.1933 |
| 120 | Together | 67,663 | 0 | $0.2045 |
| 165 | Sail Research | 83,606 | 0 | $0.2191 |
| 166 | Morph | 83,563 | 0 | $0.2402 |

**Three of those five sit at a route change** (65 is Together's first call, 165
is the switch back, 166 is Morph's first) — $0.57, 12% of the turn. That is
what re-asking is aimed at. The other two are inside one vendor's run and are
cache-shard misses the re-ask cannot touch, which is precisely the caveat the
maintainer flagged on 2026-08-22 and it survives this change intact.

Derived from `.stella/private/store.db` by joining `step_receipt` to
`telemetry` on `(execution_id, turn_instance, engine_step, call_seq)`. It is a
census of recorded runs, not a rig run.

## What this PR does not prove

**Whether the change recovers the cold-call share.** That needs a live
gateway turn and is #5692, written as a handoff with the queries and the
before-figures to compare against. The maintainer's note that this must not be
assumed ("Do not close this on the reasoning that a pin must have helped") is
quoted there. #4172 closes on the decision the 2026-09-02 pointer asked for;
the measurement is tracked, not skipped.

**Whether OpenRouter routes on the display name it reports.** The gateway
answers with `Sail Research`, `Modal`, `Together`, `Amazon Bedrock`; this code
hands the same string back in `provider.order`, and no wiremock can settle
whether the gateway matches it. `allow_fallbacks: true` is what makes an
unmatched name cost the saving rather than the call. Declared as a gap in the
parity row and filed as #5693.

## Recording the served upstream

The design pointer asked for `step_usage` "if a field exists". It does:
`AgentEvent::StepUsage.upstream_provider` and `step_receipt.upstream_provider`
(store schema v34) both carry it already, filled from
`CompletionResult::upstream_provider` in `driver/settlement.rs`'s
`emit_step_usage` and `accounted_call.rs`. Nothing was added, and no debug log
was needed.

## Witnesses

`crates/stella-model/src/zai/tests/upstream_pin.rs`, wiremock, four new tests:

- `a_gateway_is_reasked_for_the_upstream_that_served_the_first_call` — first
  response carries `provider: "Sail Research"`; the second request body
  carries `"provider":{"order":["Sail Research"],"allow_fallbacks":true}`, and
  the first carries no `provider` field at all.
- `an_operator_pin_outranks_the_upstream_that_served_the_first_call` — the
  second body carries the operator's order with `allow_fallbacks:false` and
  never mentions the served vendor.
- `a_direct_endpoint_never_asks_for_the_upstream_it_was_told_about` — a
  non-gateway endpoint that names a vendor is still sent no `provider` field.
- `every_witness_test_exists_in_the_adapter_sources` now also checks a row's
  routing witness.

**Why they fail on `main`, stated rather than run** (this laptop does not
compile; CI is the evidence). On `main`, `build_body` gates the field on
`self.serves_openrouter() && !self.upstream_pin.is_empty()`, so with no
`upstream_pin` the request body has no `provider` key on any call, first or
hundredth. The first test's second assertion looks for
`"provider":{"order":["Sail Research"]...}` in a body that cannot contain the
substring `"provider"` at all. The parity test fails on `main` for a
mechanical reason too: `CachePosture::OptIn` has no `routing_witness` field
there, so the row does not compile.

The two negative tests pass on `main` — they guard against the new field
leaking where it must not, which only becomes possible with this change.

`crates/stella-model/src/zai/tests/upstream_pin.rs` was also added to
`adapter_sources()`; it had never been in that list, so a witness naming a
test in it would have failed the parity check on a rotted proof it could not
see.

## Exemplar followed

`ParallelToolCallPosture` (`provider_parity/parallel.rs`), for the
two-witness split: it records `ParallelAdmission` and `fan_in_witness`
separately because they are different facts settled by different evidence, and
AGENTS.md invariant 8 says collapsing them would let a row claim more than it
can show. Sending a cache marker and asking for a particular cache are the same
shape of pair, so `CachePosture::OptIn` gained an optional `routing_witness`
rather than overloading its one `witness`. `None` for `anthropic` and
`bedrock`: a direct vendor holds one cache and has no route to choose.

## Prose corrected in the same change

Three places said routing is left to the gateway, which this change makes
false:

- `ZaiProvider::upstream_pin` and `session_id` field docs, and
  `with_upstream_pin`.
- `config/providers.rs`'s `ProviderConfig::upstream_pin` — the comment the
  issue quotes as documenting the empty default as a deliberate choice.
- `engine_config.rs`'s `unpinned_gateway_notice` and its doc: the notice now
  says Stella asks the gateway to stay put, that it may still fall back, and
  that `upstream_pin` is how you refuse the fallback. Its existing test asserts
  on `no upstream is pinned` and `upstream_pin`, both kept.

## Layout

New logic landed in `crates/stella-model/src/zai/upstream.rs` rather than in
`zai.rs`, which is 1391 lines against a 1500 ceiling. `zai.rs` is unchanged in
length: the `OpenRouterProviderPin` struct moved out with the new code.
`crates/stella-model/src/zai/tests.rs` is a grandfathered god file and was not
touched.

## Verification run locally

`cargo fmt --all`, `make guards-fast` (green: file-size, prose including the
new file's reading grade, line-citations, doc-links, lockfile-sync,
dead-code-allows, fmt --check). No cargo build, test, clippy or doc was run on
this machine, per CLAUDE.md. CI is the evidence.

Tests deleted: None.

Residue filed: #5692 (measure the cold-call share on a live turn), #5693
(check the gateway accepts the display name it reports).

Closes #4172

## Summary by Sourcery

Keep OpenRouter sessions on the upstream that served the first successful call while preserving strict operator pins and safe fallback behavior.

New Features:
- Re-ask OpenRouter for the upstream that served the session’s first successful response on subsequent calls, while allowing fallback routing.
- Preserve explicit operator upstream pins as strict, no-fallback routing preferences.

Bug Fixes:
- Prevent gateway session routing changes from unnecessarily discarding prompt-cache benefits after the first call.

Enhancements:
- Keep learned routing limited to OpenRouter endpoints and support learning from both streaming and unary delivery paths.
- Extend provider parity metadata and witness validation to cover gateway upstream routing behavior.
- Update configuration, provider, and engine notices to describe learned routing and fallback semantics accurately.

Tests:
- Add wire-level coverage for learned upstream reuse, operator-pin precedence, and preventing routing fields from reaching direct endpoints.