### PR TITLE
fix(stella-core): restore every file a batched read_file put in context

### DIFF
--- a/crates/stella-core/src/restore.rs
+++ b/crates/stella-core/src/restore.rs
@@ -20,9 +20,9 @@
 //!
 //! - **Files read inside the summarized span** ([`collect_working_set`]):
 //!   the most recent read per path, most-recent-first, capped at
-//!   [`RESTORE_MAX_FILES`]. Content is re-read fresh from disk at restore
-//!   time —, so an external edit between read and restore
-//!   surfaces the *current* bytes rather than resurrecting a stale copy.
+//!   [`RESTORE_MAX_FILES`]. One call names one file or a list of files and
+//!   ranges ([`READ_FILES_PARAM`]), and every file counts. Content is re-read
+//!   fresh at restore time, so an edit in between surfaces the current bytes.
 //! - **The full body of any active invoked skill**
 //!   ([`crate::skills::invoke::ActiveSkillInvocations`] is the tracking
 //!   half): procedure text the model is executing must survive verbatim,
@@ -108,6 +108,42 @@ pub const READ_TOOL: &str = "read_file";
 /// span's recorded calls and to synthesize the replay input for a path
 /// re-collected from a prior restoration message.
 pub const READ_PATH_PARAM: &str = "path";
+
+/// The read tool's plural key: an array of `{path, offset?, limit?}` objects,
+/// one per file or range, sent instead of the single-target fields.
+///
+/// A batched call carries no path of its own, so [`READ_PATH_PARAM`] alone
+/// finds none of the files it read. Both keys are therefore read, or the
+/// splice destroys a batch's content with nothing to put back. Tied to the
+/// tool's own spelling by a pin test in `stella_tools::read`, the same way
+/// [`READ_TOOL`] is.
+pub const READ_FILES_PARAM: &str = "files";
+
+/// Every file one recorded read call asked for, each paired with the input
+/// that re-reads that file on its own.
+///
+/// A batched call yields one entry per element, carrying that element's own
+/// `offset`/`limit`, so the replay restores the window the model was looking
+/// at. Replaying the whole batch under each path instead would read every
+/// file once per path and render all of them under each heading.
+///
+/// Borrowed rather than owned: the tail walk only wants the paths, and the
+/// span walk clones the input it keeps.
+fn read_targets(input: &serde_json::Value) -> Vec<(&str, &serde_json::Value)> {
+    if let Some(items) = input.get(READ_FILES_PARAM).and_then(|v| v.as_array()) {
+        return items
+            .iter()
+            .filter_map(|item| {
+                let path = item.get(READ_PATH_PARAM)?.as_str()?;
+                Some((path, item))
+            })
+            .collect();
+    }
+    match input.get(READ_PATH_PARAM).and_then(|v| v.as_str()) {
+        Some(path) => vec![(path, input)],
+        None => Vec::new(),
+    }
+}
 
 /// Ceiling on restored files per round. Eight matches the workspace's
 /// standing notion of "the recent work the model is actively reasoning over"
@@ -278,23 +314,25 @@ pub fn collect_working_set(
                     if call.name != READ_TOOL || failed_calls.contains(call.call_id.as_str()) {
                         continue;
                     }
-                    let Some(path) = call.input.get(READ_PATH_PARAM).and_then(|v| v.as_str())
-                    else {
-                        continue;
-                    };
-                    seq += 1;
-                    match reads.iter_mut().find(|t| t.path == path) {
-                        // A later read of the same path is the fresher view:
-                        // its input (offset/limit included) wins outright.
-                        Some(tracked) => {
-                            tracked.input = call.input.clone();
-                            tracked.seq = seq;
+                    // One call names one file or several; a batch's elements
+                    // are ordered, so a later range of the same file inside
+                    // one call wins the same way a later call does.
+                    for (path, input) in read_targets(&call.input) {
+                        seq += 1;
+                        match reads.iter_mut().find(|t| t.path == path) {
+                            // A later read of the same path is the fresher
+                            // view: its input (offset/limit included) wins
+                            // outright.
+                            Some(tracked) => {
+                                tracked.input = input.clone();
+                                tracked.seq = seq;
+                            }
+                            None => reads.push(TrackedRead {
+                                path: path.to_string(),
+                                input: input.clone(),
+                                seq,
+                            }),
                         }
-                        None => reads.push(TrackedRead {
-                            path: path.to_string(),
-                            input: call.input.clone(),
-                            seq,
-                        }),
                     }
                 }
             }
@@ -336,10 +374,12 @@ pub fn collect_working_set(
     let mut tail_slugs: HashSet<String> = HashSet::new();
     for message in kept_tail {
         for call in &message.tool_calls {
-            if call.name == READ_TOOL
-                && let Some(path) = call.input.get(READ_PATH_PARAM).and_then(|v| v.as_str())
-            {
-                tail_paths.insert(path.to_string());
+            if call.name == READ_TOOL {
+                tail_paths.extend(
+                    read_targets(&call.input)
+                        .into_iter()
+                        .map(|(path, _)| path.to_string()),
+                );
             }
         }
         if message.role == MessageRole::User {
@@ -724,6 +764,122 @@ mod tests {
             vec!["lost.rs"],
             "an errored read produced nothing to lose, a tail re-read is still present"
         );
+    }
+
+    /// One batched read call, three ranges across two files.
+    ///
+    /// The batch key is what stops a model reaching for
+    /// `sed -n 'A,Bp'; echo ===; sed -n …`, and a batched call carries no
+    /// top-level `path`: a walk that reads only that field finds nothing in
+    /// this span, and the splice then destroys both files' content with
+    /// nothing to put back.
+    ///
+    /// Each restored file replays on its own, carrying its own window: the
+    /// second range of `a.rs` is the fresher view of that file and wins, the
+    /// way a second call would.
+    #[test]
+    fn every_file_a_batched_read_named_is_working_set() {
+        let span = vec![
+            CompletionMessage {
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    call_id: "batch".into(),
+                    name: READ_TOOL.into(),
+                    input: serde_json::json!({
+                        READ_FILES_PARAM: [
+                            { READ_PATH_PARAM: "a.rs", "offset": 1, "limit": 40 },
+                            { READ_PATH_PARAM: "b.rs", "offset": 10, "limit": 20 },
+                            { READ_PATH_PARAM: "a.rs", "offset": 200, "limit": 40 },
+                        ]
+                    }),
+                }],
+                tool_results: vec![],
+                attachments: Vec::new(),
+            },
+            read_result("batch", ok("three sections")),
+        ];
+
+        let set = collect_working_set(&span, &[], &[]);
+        assert_eq!(
+            set.reads
+                .iter()
+                .map(|r| r.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.rs", "b.rs"],
+            "both files are restored, freshest first"
+        );
+        assert_eq!(
+            set.reads[0].input,
+            serde_json::json!({ READ_PATH_PARAM: "a.rs", "offset": 200, "limit": 40 }),
+            "a batched element replays alone, carrying the window it asked for"
+        );
+        assert_eq!(
+            set.reads[1].input,
+            serde_json::json!({ READ_PATH_PARAM: "b.rs", "offset": 10, "limit": 20 })
+        );
+    }
+
+    /// A file the kept tail re-read in a batch was never lost, so restoring it
+    /// would spend headroom another file needs and hand the model a second
+    /// copy of bytes it already has.
+    #[test]
+    fn a_batched_tail_reread_is_not_restored() {
+        let span = vec![
+            read_call("c1", "kept.rs"),
+            read_result("c1", ok("kept content")),
+            read_call("c2", "lost.rs"),
+            read_result("c2", ok("lost content")),
+        ];
+        let tail = vec![CompletionMessage {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                call_id: "t1".into(),
+                name: READ_TOOL.into(),
+                input: serde_json::json!({
+                    READ_FILES_PARAM: [
+                        { READ_PATH_PARAM: "kept.rs" },
+                        { READ_PATH_PARAM: "other.rs" },
+                    ]
+                }),
+            }],
+            tool_results: vec![],
+            attachments: Vec::new(),
+        }];
+
+        let set = collect_working_set(&span, &tail, &[]);
+        assert_eq!(
+            set.reads
+                .iter()
+                .map(|r| r.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["lost.rs"],
+            "a batched tail read still counts as present"
+        );
+    }
+
+    /// A batch whose recorded result was an error produced no content for the
+    /// splice to lose — for every file it named, not just the first.
+    #[test]
+    fn a_failed_batched_read_contributes_nothing() {
+        let span = vec![
+            CompletionMessage {
+                role: MessageRole::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    call_id: "bad".into(),
+                    name: READ_TOOL.into(),
+                    input: serde_json::json!({
+                        READ_FILES_PARAM: [{ READ_PATH_PARAM: "a.rs" }, { READ_PATH_PARAM: "b.rs" }]
+                    }),
+                }],
+                tool_results: vec![],
+                attachments: Vec::new(),
+            },
+            read_result("bad", ToolOutput::error("`files` is empty")),
+        ];
+        assert!(collect_working_set(&span, &[], &[]).is_empty());
     }
 
     #[test]

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -354,6 +354,13 @@ fn normalized_key(root: &std::path::Path, path: &str) -> String {
 }
 
 /// The plural key: several files, or several ranges, in one call.
+///
+/// The engine's working-set restoration reads this key out of a recorded call
+/// to learn which files a batch put in front of the model
+/// (`stella_core::restore::READ_FILES_PARAM`), so the two spellings are pinned
+/// together by `the_read_tool_is_the_one_the_engines_restoration_replays`
+/// below. A drift there is the working set silently ceasing to restore
+/// anything a batch read.
 const FILES_KEY: &str = "files";
 
 /// One file and which slice of it — the unit both spellings of a `read_file`
@@ -392,7 +399,7 @@ impl Tool for ReadFile {
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: "read_file".into(),
-            description: "Read a file from the workspace. Returns content with 1-based line numbers. Use offset and limit for ranges. To read several files — or several ranges — read them in ONE call with `files` rather than one call each.".into(),
+            description: "Read one or more files or ranges in a single call. Returns content with 1-based line numbers. Use offset and limit for one range; use `files` to read several files — or several ranges — in ONE call rather than one call each.".into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {

--- a/crates/stella-tools/src/read/tests.rs
+++ b/crates/stella-tools/src/read/tests.rs
@@ -685,6 +685,16 @@ fn the_read_tool_is_the_one_the_engines_restoration_replays() {
             .is_some(),
         "the path parameter must keep the spelling the engine replays"
     );
+    // The batch key too: restoration reads a recorded call's elements out of
+    // it, and each element by its own path.
+    let plural = &schema.input_schema["properties"][stella_core::restore::READ_FILES_PARAM];
+    assert!(
+        plural["items"]["properties"]
+            .get(stella_core::restore::READ_PATH_PARAM)
+            .is_some(),
+        "the batch key and its per-element path must keep the spellings the \
+             engine replays; got {plural}"
+    );
 }
 
 /// A binary file used to come back as "stream did not contain valid
@@ -970,6 +980,65 @@ async fn a_failed_target_does_not_discard_the_rest_of_the_batch() {
     };
     assert!(content.contains("not read:"), "{content}");
     assert!(content.contains("fn real() {}"), "{content}");
+}
+
+/// Three ranges across two files in one call, then a failed edit against one
+/// of them.
+///
+/// A `sed -n 'A,Bp'; echo ===; sed -n …` chain reads the same bytes and
+/// records nothing, so a later failed `edit_file` is attributed "no read of
+/// this file is recorded this session" — false, and unactionable, because the
+/// model did read it. Every element of a batch earns its ledger entry, so the
+/// oracle reaches the real answer instead.
+#[tokio::test]
+async fn a_batch_read_leaves_the_drift_oracle_able_to_attribute_a_miss() {
+    let dir = tempfile::tempdir().unwrap();
+    let a: String = (1..=300).map(|i| format!("line {i}\n")).collect();
+    std::fs::write(dir.path().join("a.rs"), &a).unwrap();
+    std::fs::write(dir.path().join("b.rs"), "fn b() {}\n").unwrap();
+    let ledger = Arc::new(ReadLedger::default());
+
+    let out = ReadFile::with_ledger(ledger.clone())
+        .execute(
+            &serde_json::json!({"files": [
+                {"path": "a.rs", "offset": 1, "limit": 40},
+                {"path": "b.rs"},
+                {"path": "a.rs", "offset": 200, "limit": 40}
+            ]}),
+            &cx(dir.path()),
+        )
+        .await;
+    assert!(!out.is_error(), "{out:?}");
+
+    for (name, bytes) in [("a.rs", a.as_bytes()), ("b.rs", b"fn b() {}\n".as_slice())] {
+        assert_eq!(
+            ledger.last_seen_sha(dir.path(), name),
+            Some(crate::staleness::hex_sha256(bytes)),
+            "{name} was read in this batch and must be recorded"
+        );
+    }
+
+    // A needle that is not in the file, against bytes nothing changed.
+    let missed = crate::edit::EditFile::with_ledger(ledger)
+        .execute(
+            &serde_json::json!({
+                "path": "a.rs", "old_string": "not present anywhere", "new_string": "x"
+            }),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Error { message, .. } = missed else {
+        panic!("expected the edit to miss, got: {missed:?}");
+    };
+    assert!(
+        !message.contains("no read of this file is recorded"),
+        "a batch-read file has a baseline, so the miss must not be blamed on \
+         a missing read: {message}"
+    );
+    assert!(
+        message.contains("unchanged since you last saw it"),
+        "the file did not move, so that is what the oracle must say: {message}"
+    );
 }
 
 /// Both spellings at once is refused rather than resolved by precedence:

--- a/docs/tools/read_file.toml
+++ b/docs/tools/read_file.toml
@@ -27,7 +27,7 @@ available_for_speculation = true
 risk_level = "low"
 
 description = '''
-Read a file from the workspace. Returns content with 1-based line numbers. Use offset and limit for ranges. To read several files — or several ranges — read them in ONE call with `files` rather than one call each.
+Read one or more files or ranges in a single call. Returns content with 1-based line numbers. Use offset and limit for one range; use `files` to read several files — or several ranges — in ONE call rather than one call each.
 '''
 
 # The JSON Schema the model is handed for this tool's arguments, verbatim.

--- a/website/content/docs/agent-tools/index.mdx
+++ b/website/content/docs/agent-tools/index.mdx
@@ -45,7 +45,7 @@ All 18 tools register in every session, with no setup and no prerequisites. Here
 
 <CardGrid size="md">
   <ToolCard name="read_file" access="read">
-    Read a file from the workspace. Returns its content with 1-based line numbers. `offset` and `limit` pull a range out of a large file instead of the whole thing.
+    Read a file, or several files and ranges, in one call. Returns content with 1-based line numbers. Use `offset` and `limit` to pull one range out of a big file. Use `files` to ask for several at once.
   </ToolCard>
   <ToolCard name="write_file" access="mutating">
     Create or overwrite a file, creating parent folders as needed. Overwriting an existing file is refused unless the session has already been shown all of it. The argument is the whole file, so a model working from a partial view would silently cut off the rest. Use `edit_file` instead to change part of a file you haven't read in full.


### PR DESCRIPTION
## What

`read_file` can be asked for several files, or several ranges, in one call
(`files: [{path, offset?, limit?}]`). The engine's working-set restoration
could not see any of them.

`crates/stella-core/src/restore.rs`'s `collect_working_set` reads a recorded
read call's target out of `input["path"]`. A batched call carries no path of
its own, so every file a turn read through `files` was dropped from the
working set — and when the overflow summarizer spliced that span away, the
restoration put none of it back. The kept-tail walk had the mirror bug: a file
the tail re-read in a batch still read as lost, so it was restored on top of
bytes already in context, spending headroom another file needed.

This is the same family as the five bypassed mechanisms the issue lists. The
batch form was added to stop the model reaching for `sed`, and it quietly
reintroduced one of the losses through the front door.

## Why this shape

- `READ_FILES_PARAM` is declared beside `READ_TOOL` and `READ_PATH_PARAM`, and
  pinned to the tool's own spelling by
  `the_read_tool_is_the_one_the_engines_restoration_replays` — the tie that
  already exists for the tool name and the path parameter. A drift there is
  the working set silently ceasing to restore anything a batch read.
- A batch yields **one working-set entry per element**, carrying that
  element's own `offset`/`limit`. The engine half replays `SpanRead::input`
  verbatim once per restored path, so replaying the whole batch under each
  path would read every file once per path and render all of them under each
  heading. Per-element inputs also keep the standing contract that a windowed
  read restores the window the model was looking at.
- Order is preserved, so a later range of the same file **inside one call**
  wins the way a later call does — which is what "three ranges across two
  files" needs to mean.
- `read_targets` borrows rather than owns: the tail walk only wants paths.

Exemplar followed: none outside this tree — the shape is `restore.rs`'s own
existing `READ_TOOL` / `READ_PATH_PARAM` declaration plus its pin test in
`stella_tools::read`, extended to the second spelling rather than reinvented.

## Where this departs from the design pointer, and why

The pointer names the plural key `paths`. The tree already ships it as
`files`, landed by pull request 4166, and `write_file` and `delete_file` declare the same
`files` key through the shared `crate::batch::plural_schema`. Renaming
`read_file`'s alone would give the four file tools three different plural
spellings for one idea, for no gain — so the key stays `files` and the fix is
the consumer that never learned it. Everything else in the pointer is
implemented or was already present:

- one-item `path`/`offset`/`limit` sugar: present.
- one `ReadLedger` entry, byte caps, paging footer, one section per range with
  the path as its header: present, and now regression-covered end to end (see
  the second witness below).
- `files_touched` `R` event: there is **no live producer** of an `R` row for a
  read anywhere in the tree today — `turn_files.rs` writes only `C`/`U`/`D`,
  and `"R"` appears solely in `stella-store`'s own tests. Nothing was invented
  here; that gap is filed as residue below.
- schema description now leads with "Read one or more files or ranges in a
  single call"; `docs/tools/read_file.toml` and the website tool card follow.
- `crates/stella-cli/src/agent/prompt.rs`'s read-side sentence is already
  imperative and already names `cat`/`sed -n`/`head`/`tail` and the batch key.
  Left byte-identical.

## Witnesses

Neither could be run here (CLAUDE.md: CI builds and tests, this laptop does
not) — the mechanism by which each fails on the old code is below, and CI is
the evidence.

**`every_file_a_batched_read_named_is_working_set`**
(`crates/stella-core/src/restore.rs`). One `read_file` call with three ranges
across two files, then `collect_working_set`. On `main` the span walk asks for
`input["path"]`, a batched call has none, the `let … else { continue }` fires
for the only call in the span, and the returned `WorkingSet` is **empty** — so
`assert_eq!(paths, ["a.rs", "b.rs"])` fails on the first element of an empty
vec. With the change both files are collected, freshest first, and each one's
replay input is the single-form `{path, offset, limit}` of the element that
named it.

**`a_batched_tail_reread_is_not_restored`** (same file). The kept tail re-reads
`kept.rs` in a batch. On `main` `tail_paths` stays empty for that call, so
`kept.rs` survives the `retain` and the assertion `["lost.rs"]` sees
`["lost.rs", "kept.rs"]`.

**`a_failed_batched_read_contributes_nothing`** (same file) covers the other
direction: a batch whose recorded result was an error contributes nothing for
*every* file it named.

**`a_batch_read_leaves_the_drift_oracle_able_to_attribute_a_miss`**
(`crates/stella-tools/src/read/tests.rs`) is the issue's own DoD clause, end to
end: three ranges across two files in one call, then a failed `edit_file`
against one of them. It asserts the miss is **not** reported as "no read of
this file is recorded this session" and is attributed as an unchanged file.
This one **passes on `main`** — the ledger half shipped in pull request 4166 — so it is a
regression guard for the DoD clause, not a witness. Said plainly rather than
claimed as proof of new behaviour.

The pin test now also asserts the batch key and its per-element `path` keep
the spellings the engine replays.

## Verification

`cargo fmt --all` and `make guards-fast` are green locally. No workspace build
or test ran on this machine; CI is the evidence for the four tests above.

Tests deleted: None.

## What remains

The issue's third DoD clause is a number, not a design: re-measure the
sed-to-`read_file` ratio on a comparable wide-orientation task and report it.
That needs a real run against a real model and is not something to start
incidentally, so #4151 stays open for it — `Refs #4151`. The issue's
own SQL is still the right query, and the two extra counts a previous comment
asked for (how many `read_file` calls carry `files`, and distinct timestamps
per tool call) still distinguish "the batch key is being used" from "the
prompt sentence moved it".

## Issues

The restoration blindness this PR repairs is scoped as its own issue, filed
with the DoD this PR satisfies:

- `Closes #5701` — the working set cannot see a file a batched `read_file` put
  in context.

Residue filed and not fixed here:

- https://github.com/macanderson/stella/issues/5695 — no live producer of a `files_touched` `R` row
  for a read, so the audit ledger under-reports what a turn read whichever
  spelling it used.
- https://github.com/macanderson/stella/issues/5696 — the plural `read_file` form returns no
  structured `data`, so the deck's read head measures nothing for a batched
  read.


Closes #5701
Refs #4151

## Summary by Sourcery

Fix working-set restoration so batched `read_file` calls correctly preserve all files and ranges in context.

Bug Fixes:
- Restore every file and range named by batched `read_file` calls in the working set, including correct handling of batched reads in kept-tail tracking and failed calls.
- Preserve per-file read windows and freshness ordering when restoring batched reads.

Enhancements:
- Pin the `read_file` batch schema spelling to the restoration engine and update tool descriptions to clearly document multi-file and multi-range reads.

Documentation:
- Update the read tool documentation and website card to describe batched file and range reads.

Tests:
- Add regression coverage for working-set restoration, kept-tail handling, failed batches, schema spelling, and drift attribution for batched reads.