### PR TITLE
test(stella-core): a per-PR spend gate over the raw step loop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,13 +287,30 @@ For a behavior change or feature, your PR should include a **witness test**:
 
 You can check this the artisanal way (`git stash && cargo test -p <crate>`),
 or let Stella verify Stella — run your task through `stella run --pipeline
-classic`, whose witness stage enforces exactly this fail→pass contract (a
-plain `stella run`, with no `--pipeline` flag, is the raw step-loop and does
-not verify on its own).
+<plugin-id>`, naming an installed verification plugin whose witness stage
+enforces this fail→pass contract. A plain `stella run` is the raw step-loop
+and does not verify on its own, and the built-in `classic` pipeline this
+flag once named is gone from the workspace, so `--pipeline classic` is
+refused.
 
 Pure refactors, docs, and CI changes don't need a witness — say so in the PR
 template and move on. If a witness is genuinely impractical (e.g. TUI
 rendering), explain how you verified the change instead.
+
+### The spend gate — pin what a turn buys
+
+A change to the agent loop can leave every answer the same and still buy an
+extra model call. `crates/stella-core/tests/spend_gate.rs` is what fails when
+it does: one turn per scenario over scripted ports, with the model calls, the
+tool runs and the reported cost pinned.
+
+Read a red run one of two ways. Either the change is a bug, and the fix is in
+the code. Or the new price is the one you meant, and you edit the pin in the
+same pull request and say in the PR why. A reviewer then reads the new price
+as a diff line. Never widen a pin to whatever the loop does now.
+
+`doc:verification-gate` covers what this layer can and cannot claim, and what
+is still unobserved beside it.
 
 ## Style
 

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -313,8 +313,8 @@ make test-core           # cargo test -p stella-core
 make watch-core          # re-run on save (needs cargo-watch)
 ```
 
-There is no `tests/` directory: every test is an inline `#[cfg(test)]` module in
-the file it covers, which is why the engine's own suite is split across
+Nearly every test is an inline `#[cfg(test)]` module in the file it covers,
+which is why the engine's own suite is split across
 [`src/driver/tests.rs`](src/driver/tests.rs) and
 [`src/driver/tests/`](src/driver/tests) (`audit_fixes.rs` holds the 2026-07
 turn-driver audit witnesses; also `budget_boundaries.rs`,
@@ -327,6 +327,13 @@ fixture server and no network — driver tests wire scripted `Provider`s, counti
 `ToolExecutor`s and no-op `Sleeper`s, so the suite runs in seconds. Keep it that
 way: a test here that needs a file or a socket means the logic under test is in
 the wrong crate.
+
+[`tests/`](tests) holds the few that have to drive the crate the way a host
+does, through the public API alone. [`tests/spend_gate.rs`](tests/spend_gate.rs)
+is the one to read first: it pins the model calls, tool runs and cost of one
+turn per scenario, so a loop change that quietly buys an extra model call fails
+here. An intended change edits the pin in the same pull request
+(`doc:verification-gate`).
 
 ## Extending it
 

--- a/crates/stella-core/tests/spend_gate.rs
+++ b/crates/stella-core/tests/spend_gate.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The spend gate: what a turn buys, pinned scenario by scenario.
+//!
+//! A change to the step loop can leave every answer the same and still buy
+//! an extra model call. This file is what fails when it does. Each test
+//! below drives one turn over scripted ports and pins three numbers: model
+//! calls, tool runs, and the cost the turn reports.
+//!
+//! Read a red run one of two ways. Either the change is a bug, and the fix
+//! is in the code. Or the new numbers are the ones you meant, and you edit
+//! the pin in this file in the same pull request. A reviewer then reads the
+//! new price as a diff line. Never widen a pin to whatever the loop does
+//! now: the worth of this file is that intent is written down.
+//!
+//! The ports are scripted, so the engine does no I/O (architecture rule 2).
+//! An answered model call costs a flat quarter dollar here. That price is a
+//! round binary number, so a sum of them is exact and a pin can be too.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_core::budget::BudgetGuard;
+use stella_core::ports::ToolExecutor;
+use stella_core::retry::Sleeper;
+use stella_core::{Engine, EngineConfig, TurnOutcome};
+use stella_protocol::{
+    BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage,
+    Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
+};
+use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::mpsc;
+
+/// What one answered model call costs the scripted provider.
+const CALL_COST_USD: f64 = 0.25;
+
+/// What a turn bought.
+///
+/// `model_calls` counts attempts, not bills: a refused call reaches the
+/// provider and takes wall clock, so it belongs in the number a reviewer
+/// reads. `cost_usd` is what the turn reported, which only answered calls
+/// add to.
+#[derive(Debug, PartialEq)]
+struct Spend {
+    model_calls: u32,
+    tool_calls: u32,
+    cost_usd: f64,
+}
+
+/// A `Sleeper` that never waits, so a retry ladder costs no test time.
+struct NoopSleeper;
+#[async_trait]
+impl Sleeper for NoopSleeper {
+    async fn sleep(&self, _duration_ms: u64) {}
+}
+
+/// A scripted `Provider`: one entry per call, repeating the last entry once
+/// the script runs out. Counts every attempt it is handed.
+struct ScriptedProvider {
+    script: TokioMutex<Vec<Result<CompletionResult, ProviderError>>>,
+    calls: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl Provider for ScriptedProvider {
+    fn id(&self) -> &str {
+        "scripted"
+    }
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let mut script = self.script.lock().await;
+        if script.len() > 1 {
+            script.remove(0)
+        } else {
+            clone_step(&script[0])
+        }
+    }
+}
+
+fn clone_step(
+    step: &Result<CompletionResult, ProviderError>,
+) -> Result<CompletionResult, ProviderError> {
+    match step {
+        Ok(result) => Ok(result.clone()),
+        Err(error) => Err(error.clone()),
+    }
+}
+
+/// A tool that always succeeds and counts the times it really ran.
+struct CountingTools {
+    calls: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl ToolExecutor for CountingTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a command".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        ToolOutput::Ok {
+            content: "ok".into(),
+            data: None,
+        }
+    }
+}
+
+fn answer(text: &str) -> CompletionResult {
+    CompletionResult {
+        upstream_provider: None,
+        text: text.into(),
+        tool_calls: vec![],
+        usage: CompletionUsage::reported_zero(),
+        model: "scripted".into(),
+        cost_usd: CALL_COST_USD,
+        finish_reason: None,
+    }
+}
+
+/// A step that asks for one run of the scripted tool per command given.
+/// Each call carries its own id and command, so the two calls of a two-tool
+/// step are two units of work rather than one call sent twice.
+fn tool_step(commands: &[(&str, &str)]) -> CompletionResult {
+    CompletionResult {
+        upstream_provider: None,
+        text: String::new(),
+        tool_calls: commands
+            .iter()
+            .map(|(call_id, command)| ToolCall {
+                call_id: (*call_id).into(),
+                name: "bash".into(),
+                input: serde_json::json!({ "cmd": command }),
+            })
+            .collect(),
+        usage: CompletionUsage::reported_zero(),
+        model: "scripted".into(),
+        cost_usd: CALL_COST_USD,
+        finish_reason: None,
+    }
+}
+
+/// Drive one turn over the scripted ports and report what it bought.
+async fn run_turn(script: Vec<Result<CompletionResult, ProviderError>>) -> (TurnOutcome, Spend) {
+    let model_calls = Arc::new(AtomicU32::new(0));
+    let tool_calls = Arc::new(AtomicU32::new(0));
+    let provider = ScriptedProvider {
+        script: TokioMutex::new(script),
+        calls: model_calls.clone(),
+    };
+    let tools = CountingTools {
+        calls: tool_calls.clone(),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do the thing"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    let cost_usd = match &outcome {
+        TurnOutcome::Completed { cost_usd, .. } | TurnOutcome::Aborted { cost_usd, .. } => {
+            *cost_usd
+        }
+    };
+    let spend = Spend {
+        model_calls: model_calls.load(Ordering::SeqCst),
+        tool_calls: tool_calls.load(Ordering::SeqCst),
+        cost_usd,
+    };
+    (outcome, spend)
+}
+
+/// Fail with the scenario named, the pin, and what the loop just bought.
+fn assert_spend(scenario: &str, got: &Spend, want: &Spend) {
+    assert_eq!(
+        got, want,
+        "spend gate: the scenario `{scenario}` changed price.\n  \
+         pinned: {want:?}\n  bought: {got:?}\n  \
+         Fix the loop, or edit this pin in the same pull request."
+    );
+}
+
+#[tokio::test]
+async fn a_one_step_answer_buys_one_model_call() {
+    let (outcome, spend) = run_turn(vec![Ok(answer("done"))]).await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: CALL_COST_USD,
+        }
+    );
+    assert_spend(
+        "one-step answer",
+        &spend,
+        &Spend {
+            model_calls: 1,
+            tool_calls: 0,
+            cost_usd: CALL_COST_USD,
+        },
+    );
+}
+
+#[tokio::test]
+async fn two_tools_in_one_step_buy_one_model_call_between_them() {
+    let (outcome, spend) = run_turn(vec![
+        Ok(tool_step(&[("call_1", "ls"), ("call_2", "pwd")])),
+        Ok(answer("done")),
+    ])
+    .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: 2.0 * CALL_COST_USD,
+        }
+    );
+    assert_spend(
+        "two-tool step",
+        &spend,
+        &Spend {
+            model_calls: 2,
+            tool_calls: 2,
+            cost_usd: 2.0 * CALL_COST_USD,
+        },
+    );
+}
+
+#[tokio::test]
+async fn a_rate_limited_call_is_retried_once_and_billed_once() {
+    let refused = ProviderError::RateLimited {
+        message: "429".into(),
+        retry_after_ms: Some(10),
+    };
+    let (outcome, spend) = run_turn(vec![Err(refused), Ok(answer("done"))]).await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: CALL_COST_USD,
+        }
+    );
+    assert_spend(
+        "retry after a 429",
+        &spend,
+        &Spend {
+            model_calls: 2,
+            tool_calls: 0,
+            cost_usd: CALL_COST_USD,
+        },
+    );
+}
+
+#[tokio::test]
+async fn a_stuck_loop_is_steered_once_and_then_stopped() {
+    // The script never runs out, so the only thing that can end this turn
+    // is loop detection. Three no-progress calls earn one warning and a
+    // fourth ends the turn, which is where the pinned four comes from.
+    let (outcome, spend) = run_turn(vec![Ok(tool_step(&[("call_1", "ls")]))]).await;
+
+    match &outcome {
+        TurnOutcome::Aborted { reason, .. } => {
+            assert!(reason.contains("stuck-loop"), "unexpected reason: {reason}");
+        }
+        other => panic!("expected a stuck-loop abort, got {other:?}"),
+    }
+    assert_spend(
+        "loop-detector trip",
+        &spend,
+        &Spend {
+            model_calls: 4,
+            tool_calls: 4,
+            cost_usd: 4.0 * CALL_COST_USD,
+        },
+    );
+}

--- a/docs/spec/verification-gate.md
+++ b/docs/spec/verification-gate.md
@@ -14,12 +14,15 @@ what each one can honestly claim, and what none of them can.
 
 > **Read this first: two of the three layers no longer exist.** Layers 1 and 2
 > were tests inside `crates/stella-pipeline`, deleted from the workspace in
-> #3865. Nothing replaced them, so **no per-PR gate observes what the agent
-> decides or spends today** — only the wire-contract half of Layer 2 survives.
-> They are described below in the past tense because they are the shape a
-> verification plugin is asked to port (`doc:pipeline-as-plugins` §8) and
-> because the hole they left is the thing a reader most needs to know about.
-> Tracked in #3901 alongside the rest of the sweep.
+> #3865. One piece of Layer 1 has been rebuilt: **the spend gate** below pins
+> what a turn buys over the raw step loop, so a per-PR check fails again when
+> a loop change moves the price. What is still missing is Layer 1's other
+> half, the decision policy, which was the staged pipeline's own and is now a
+> verification plugin's. Only the wire-contract half of Layer 2 survives.
+> Layers 1 and 2 are described below in the past tense because they are the
+> shape a verification plugin is asked to port (`doc:pipeline-as-plugins` §8)
+> and because the hole they left is the thing a reader most needs to know
+> about. Tracked in #3901 alongside the rest of the sweep.
 
 ## Layer 1 — the degradation gate (**gone**; was blocking, per-PR)
 
@@ -56,6 +59,30 @@ are its decision policy, and pinning them against scripted doubles is work on th
 plugin's own side of the wrapper socket — a host that neither runs the check nor
 re-checks the evidence (#3511) cannot gate on either.
 
+## The spend gate — Layer 1's price half, rebuilt (blocking, per-PR)
+
+`crates/stella-core/tests/spend_gate.rs` drives the raw step loop over a
+scripted `Provider` and a scripted `ToolExecutor`, one turn per scenario, and
+pins what the turn bought: the model calls, the tool runs, and the reported
+cost. The scenarios are a one-step answer, a two-tool step, a retry after a
+429, and a turn the loop detector stops. A failure names the scenario, the
+pinned numbers and the new ones.
+
+It needs no verification machinery, which is why it could be rebuilt here at
+all. The engine does no I/O, so scripted ports are the whole harness
+(architecture rule 2 in AGENTS.md), and `cargo test -p stella-core` runs it in
+the required check with every other test.
+
+Layer 1's operating rule carries over word for word. A red run means one of
+two things. Either the change is a bug, and the fix is in the code. Or the
+new price is what you meant, and you edit the pin in the same pull request,
+where a reviewer reads it as a diff line. Never widen a pin to whatever the
+loop does now.
+
+What it does not prove: that the price is *right*, or that the agent still
+decides well. It pins the scenarios above over doubles this repository wrote.
+Real capability is still Layer 3's question.
+
 ## Layer 2 — golden trajectories (**mostly gone**; the wire half survives)
 
 `pipeline/tests/golden.rs` recorded full `AgentEvent` streams from fixed runs and
@@ -90,18 +117,20 @@ per-PR. What keeps them honest is protocol, not frequency:
   from "plausibly fine"; it does not rank models or prove a 3% improvement.
   Claims must match the N.
 
-This is the only layer still standing at full strength, which raises its price:
-a change to the loop, prompts, routing or a wrapper plugin now has no cheap
-per-PR observation between it and a benchmark run.
+This is the only layer still standing at full strength. A change to the loop,
+prompts, routing or a wrapper plugin has one cheap per-PR observation between
+it and a benchmark run — the spend gate, which reads price and nothing else.
 
 ## How to read the layers together
 
 - Wire schema red → your change altered what the agent *emits*. Consumers (TUI,
   serve, store projections) are affected; review the schema diff.
+- Spend gate red → your change moved what a turn buys. Fix it, or edit the pin
+  in the same pull request and say in the PR why the new price is right.
 - Green but you touched the loop, prompts, routing, or a verification plugin:
-  the change is *unobserved*, not *safe*. With Layers 1 and 2 gone there is no
-  per-PR signal for what the agent decides or spends, so "the tests pass" now
-  carries strictly less information than this document was written to describe.
+  what the agent *decides* is still unobserved. The spend gate reads price over
+  scripted turns; nothing per-PR reads decision quality, so "the tests pass"
+  carries less than this document was first written to describe.
 - If a change claims to make the agent better, it earns a preregistered Layer 3
   run before that claim appears anywhere.
 


### PR DESCRIPTION
## What & why

A change to the agent loop can leave every answer the same and still buy an
extra model call. The check that used to fail on that was the staged
pipeline's degradation gate, deleted with `crates/stella-pipeline` in #3865.
Nothing per-PR has read price since, so the cheapest signal between "someone
changed the loop" and "we know what it cost" was a Terminal-Bench run.

This is the maintainer's option 2, taken as recorded on the issue: a scenario
matrix over the **raw step loop**, not over verification machinery. It needs
none — the engine does no I/O, so scripted ports are the whole harness
(architecture rule 2), and the raw loop already makes the model calls whose
count is the thing worth pinning. Options 1 (a verification plugin owns the
decision policy) and 3 (document the gap and stop) are not foreclosed: this
covers the cost regression, which is the failure with no other net, and the
decision-policy half stays a plugin's problem under #4029.

`crates/stella-core/tests/spend_gate.rs` drives one turn per scenario against
a scripted `Provider` and a scripted `ToolExecutor`, and pins the model calls,
the tool runs and the reported cost:

| Scenario | Model calls | Tool runs | Cost |
|---|---|---|---|
| one-step answer | 1 | 0 | one call |
| two-tool step | 2 | 2 | two calls |
| retry after a 429 | 2 | 0 | one call — the refused attempt bills nothing |
| loop-detector trip | 4 | 4 | four calls |

`model_calls` counts attempts rather than bills, so a retried 429 shows up as
the second call it is. A scripted call costs a flat `0.25`, which is exact in
binary, so a summed price is pinned rather than approximated.

The old gate's operating rule carries over, stated in the file header and in
CONTRIBUTING.md: an intended change edits the pin **in the same pull
request**, so a reviewer reads the new price as a diff line instead of
inferring it.

## The witness

The file is the witness, and its mechanism is the pin itself: each scenario
asserts an exact count, so any loop change that moves a count fails it with
the scenario named. Two one-line demonstrations, either of which turns it red
on this branch:

- In `driver/loop_escalation.rs`, `check_loop_detection`'s steer arm returning
  `Some(...)` instead of `None` (abort on first detection) drops the
  loop-detector trip from `model_calls: 4, tool_calls: 4` to `3, 3`.
- Making `retry_with_backoff_observed` give up on a `RateLimited` instead of
  retrying it turns the 429 scenario's `model_calls: 2` into `1` and its
  outcome into an abort.

It cannot fail on `main` in the usual fail→pass sense, because `main` does not
contain the file — this PR adds an observation that did not exist, which is
the issue's own definition of done. Its counts were derived from the loop's
own phase order (loop detection runs *before* the model call, and a steer
continues the same step) and cross-read against the existing driver tests that
already pin the same shapes: `stuck_loop_steers_once_then_aborts_on_re_detection`
pins the four tool calls, `retry_never_re_executes_a_tool_call` pins the
retry-does-not-re-execute rule and the cost of two answered calls.

Exemplar followed: `crates/stella-core/tests/parallel_dispatch.rs` — the same
public-API-only integration-test shape (scripted `Provider` + `ToolExecutor`,
`Engine::with_sleeper`, a `NoopSleeper`), and `driver/tests.rs`'s
`ScriptedProvider` for the script-with-repeating-tail idiom.

## The gate

- [x] `cargo fmt --all`
- [x] `make guards-fast` (prose, doc-links, line-citations, lockfile-sync, fmt)
- [ ] clippy / test — CI runs them; this laptop does not (CLAUDE.md)
- [x] Docs updated: `doc:verification-gate` gains the layer and says what it
      cannot claim; CONTRIBUTING.md names the gate and its operating rule
- [x] `Closes #4223` in this description and as a commit trailer

CONTRIBUTING.md's witness section also still told contributors to run
`stella run --pipeline classic`, which is refused outright since the same
deletion. Corrected in the paragraph this PR was already editing.

Tests deleted: None.

## Nothing left behind

- Filed: #5706 — the spend gate prices the plain scenarios only, so the arms
  that buy an *extra* model call (the overflow summarizer, provider fallback,
  output-budget recovery, the parked rate-limit wait) are still unpinned.
- Not filed, already tracked: the decision-policy half of the old Layer 1 —
  #4029 owns it, and it lands on a verification plugin's side of the wrapper
  socket rather than here.

Closes #4223

## Summary by Sourcery

Restore a lightweight per-PR observation for raw-loop cost regressions by pinning representative turn spending and documenting how to review intentional changes.

New Features:
- Add a per-PR spend gate that measures model attempts, tool executions, and reported cost across representative raw-loop scenarios.

Enhancements:
- Document the spend gate’s review rule and clarify that decision quality remains outside its scope.
- Update core testing documentation to describe public-API integration tests and correct the obsolete classic pipeline guidance.

Documentation:
- Document the spend gate in CONTRIBUTING.md, the core README, and the verification-gate specification, including its limitations and intended workflow.

Tests:
- Add scripted integration tests covering one-step answers, multi-tool turns, rate-limit retries, and stuck-loop termination with pinned spend expectations.