### PR TITLE
fix(stella-tools): say whose payload cap stopped a batched read

### DIFF
--- a/crates/stella-cli/src/agent/prompt/tests.rs
+++ b/crates/stella-cli/src/agent/prompt/tests.rs
@@ -75,6 +75,14 @@ fn both_prompts_keep_the_steering_the_schemas_cannot_carry() {
             // other one", and reaching for grep when `search` would answer
             // is the round trip the steering exists to prevent.
             "To find code, call search first",
+            // The read side, which leaked for as long as it was only a
+            // suggestion: one execution ran 24 `sed -n` range reads against 2
+            // `read_file` calls, and a shell read leaves the ledger no
+            // baseline for the drift oracle to attribute a later edit against.
+            "To read a file, use read_file rather than the shell",
+            // The round trip that made the shell cheaper. No schema can say
+            // "several files are still one call".
+            "pass files to ONE read_file call",
             // The file tools are not interchangeable with shell equivalents:
             // their edits are what the diff and verification are computed from.
             "use the file tools rather than the shell",

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -363,6 +363,23 @@ fn normalized_key(root: &std::path::Path, path: &str) -> String {
 /// anything a batch read.
 const FILES_KEY: &str = "files";
 
+/// How many bytes one section may render, and whether the call it belongs to
+/// spends that ceiling across several files.
+///
+/// `shared` exists for the footer alone. A batch spends one
+/// [`MAX_RENDER_BYTES`] budget across every section, so a later section can
+/// stop after a few hundred bytes of it; told only "stopped at the 64 KB
+/// payload cap", a model reads that as a file too big to show and narrows its
+/// range, when the move that works is to ask for that file in a call of its
+/// own.
+#[derive(Clone, Copy)]
+struct RenderBudget {
+    /// Bytes this section may render into.
+    bytes: usize,
+    /// Whether the ceiling belongs to the whole call rather than to this file.
+    shared: bool,
+}
+
 /// One file and which slice of it — the unit both spellings of a `read_file`
 /// call reduce to.
 struct ReadTarget {
@@ -434,7 +451,11 @@ impl Tool for ReadFile {
             // Byte-identical to what the single form has always emitted. The
             // footer is what loop comparison strips and what this module's
             // tests assert verbatim, so the batch path must not reshape it.
-            return self.read_one(&targets[0], ctx, MAX_RENDER_BYTES).await.0;
+            let budget = RenderBudget {
+                bytes: MAX_RENDER_BYTES,
+                shared: false,
+            };
+            return self.read_one(&targets[0], ctx, budget).await.0;
         }
 
         // The payload cap is a BATCH budget, not a per-file one. Ten files at
@@ -449,7 +470,11 @@ impl Tool for ReadFile {
                 unread.push(target.path.as_str());
                 continue;
             }
-            let (out, used) = self.read_one(target, ctx, MAX_RENDER_BYTES - spent).await;
+            let budget = RenderBudget {
+                bytes: MAX_RENDER_BYTES - spent,
+                shared: true,
+            };
+            let (out, used) = self.read_one(target, ctx, budget).await;
             spent += used;
             if !rendered.is_empty() {
                 rendered.push_str("\n\n");
@@ -496,7 +521,7 @@ impl ReadFile {
         &self,
         target: &ReadTarget,
         ctx: &crate::ctx::ToolCtx,
-        budget: usize,
+        budget: RenderBudget,
     ) -> (ToolOutput, usize) {
         let out = self.read_section(target, ctx, budget).await;
         // A refusal costs the batch nothing: it is a sentence, and charging
@@ -514,7 +539,7 @@ impl ReadFile {
         &self,
         target: &ReadTarget,
         ctx: &crate::ctx::ToolCtx,
-        budget: usize,
+        budget: RenderBudget,
     ) -> ToolOutput {
         let root = ctx.root();
         let path = target.path.as_str();
@@ -721,14 +746,14 @@ impl ReadFile {
                         .iter()
                         .map(|l| l.len().min(MAX_LINE_BYTES) + 32)
                         .sum::<usize>()
-                        .min(budget + 1024)
+                        .min(budget.bytes + 1024)
                         + 64,
                 );
                 let mut clipped_lines = 0usize;
                 let mut shown = 0usize;
                 let mut payload_capped = false;
                 for (i, line) in lines[start..end].iter().enumerate() {
-                    if numbered.len() >= budget {
+                    if numbered.len() >= budget.bytes {
                         payload_capped = true;
                         break;
                     }
@@ -767,13 +792,28 @@ impl ReadFile {
                     // line count it can see, because `start` may be non-zero
                     // and clipped lines still count as shown. A paging note
                     // that costs a guess is a note that costs another read.
-                    let _ = write!(
-                        numbered,
-                        "{READ_FOOTER_CLAUSE_SEP}stopped at the {} KB payload cap — \
-                         continue with offset={}",
-                        MAX_RENDER_BYTES / 1024,
-                        start + shown + 1
-                    );
+                    //
+                    // Name whose cap it was, too. A batch section can stop
+                    // after a fraction of the ceiling because its siblings
+                    // already spent the rest, and the single form's sentence
+                    // points such a read at the wrong repair: narrowing the
+                    // range does not buy back budget another file is holding.
+                    let cap_kb = MAX_RENDER_BYTES / 1024;
+                    let resume = start + shown + 1;
+                    let _ = if budget.shared {
+                        write!(
+                            numbered,
+                            "{READ_FOOTER_CLAUSE_SEP}stopped at the {cap_kb} KB payload cap \
+                             this call shares across its files — continue with \
+                             offset={resume}, asking for this file on its own"
+                        )
+                    } else {
+                        write!(
+                            numbered,
+                            "{READ_FOOTER_CLAUSE_SEP}stopped at the {cap_kb} KB payload cap — \
+                             continue with offset={resume}"
+                        )
+                    };
                 }
                 numbered.push_str(READ_FOOTER_CLOSE);
                 // Every line, and every line whole. `shown == total` alone is

--- a/crates/stella-tools/src/read/tests.rs
+++ b/crates/stella-tools/src/read/tests.rs
@@ -1041,6 +1041,67 @@ async fn a_batch_read_leaves_the_drift_oracle_able_to_attribute_a_miss() {
     );
 }
 
+/// A capped batch section says whose cap stopped it.
+///
+/// One `MAX_RENDER_BYTES` budget is spent across every section of a batch, so
+/// a section can stop after a fraction of it. The single form's sentence is
+/// then true about the number and wrong about the cause, and it points the
+/// model at a repair that cannot work: narrowing the range does not buy back
+/// budget another file in the same call is holding. The batch says the cap is
+/// shared and names the call that gets the file back.
+#[tokio::test]
+async fn a_capped_batch_section_names_the_cap_as_the_calls_own() {
+    let dir = tempfile::tempdir().unwrap();
+    // One file is already past the whole-call budget on its own.
+    let body = std::iter::repeat_n("y".repeat(4096), 800)
+        .collect::<Vec<_>>()
+        .join("\n");
+    for name in ["one.sql", "two.sql"] {
+        std::fs::write(dir.path().join(name), &body).unwrap();
+    }
+
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"files": [{"path": "one.sql"}, {"path": "two.sql"}]}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok { content, .. } = out else {
+        panic!("expected ok, got: {out:?}");
+    };
+    assert!(
+        content.contains("payload cap this call shares across its files"),
+        "a batch section's cap belongs to the call, not to the file: {content}"
+    );
+    assert!(
+        content.contains("asking for this file on its own"),
+        "the remedy for a shared cap is a call of its own: {content}"
+    );
+
+    // The single form's footer is what loop comparison strips and what the
+    // tests above assert verbatim, so it must stay exactly what it was.
+    let single = ReadFile::default()
+        .execute(&serde_json::json!({"path": "one.sql"}), &cx(dir.path()))
+        .await;
+    let ToolOutput::Ok {
+        content: single, ..
+    } = single
+    else {
+        panic!("expected ok, got: {single:?}");
+    };
+    assert!(
+        single.contains(&format!(
+            "stopped at the {} KB payload cap — continue with offset=",
+            MAX_RENDER_BYTES / 1024
+        )),
+        "the single form keeps its wording: {single}"
+    );
+    assert!(
+        !single.contains("shares across its files"),
+        "one file spends the whole budget, so nothing is shared: {single}"
+    );
+}
+
 /// Both spellings at once is refused rather than resolved by precedence:
 /// either choice silently drops work, and the model cannot tell which half
 /// ran.


### PR DESCRIPTION
## What

A `read_file` call can name several files or ranges, and every section of one
call spends from a single 64 KB render budget (`MAX_RENDER_BYTES`). When a
section ran out of room the footer said:

```
stopped at the 64 KB payload cap — continue with offset=1401
```

That sentence is written for a call that reads one file, where 64 KB is what
the reader actually got. Inside a batch the section may have stopped after a
few hundred bytes, because the files ahead of it already spent the budget. The
number then describes nothing the model saw, and the repair it implies — ask
for a narrower range — cannot work, because the missing room is held by another
file in the same call. The move that does work, a second call for that file
alone, was named nowhere.

A batch section now says the cap belongs to the call and names that follow-up.
The single-file footer is byte for byte what it was: loop comparison strips
that footer (`stella_core::driver::loop_evidence`) and
`the_total_payload_cap_stops_the_render_and_reports_it` asserts its wording, so
the two spellings are told apart by a `RenderBudget` the call passes down
rather than by reshaping the shared text.

The read-side steering sentence is pinned in the same change. "To read a file,
use read_file rather than the shell" and "pass files to ONE read_file call" are
the prompt half of the sed-over-read_file defect, and
`both_prompts_keep_the_steering_the_schemas_cannot_carry` listed only the write
side — a later trim of either sentence failed nothing.

## Why this shape

`RenderBudget { bytes, shared }` rather than comparing the budget against
`MAX_RENDER_BYTES` to guess which spelling asked: the first section of a batch
gets the whole ceiling and its cap is still the call's, so the fact belongs to
the call and not to the arithmetic. Exemplar followed: none outside this tree —
it is the same "carry the fact the callee cannot re-derive" shape `ReadTarget`
already uses in this module.

## Witness

`a_capped_batch_section_names_the_cap_as_the_calls_own`
(`crates/stella-tools/src/read/tests.rs`). It reads two files that each render
past the ceiling in one call and requires the footer to say
`payload cap this call shares across its files` and
`asking for this file on its own`. Neither string exists on `main`, so the
assertion fails there by construction. The second half of the same test reads
one of those files through the single form and requires the old wording
verbatim; that half passes on both sides, and is what would catch a fix that
moved the single form's bytes.

The prompt claims are a regression guard rather than a witness: both sentences
are in `tool_steering!()` today, and the test fails only once someone removes
one.

## Scope, and what remains on 4151

The batch mechanism itself already shipped: the `files` key and the
per-element ledger entries landed earlier, and the schema description, the docs
card and the drift-oracle witness landed in pull request 5697. This is the one
defect left in that surface that a reader of the footer can hit.

What issue 4151 still waits on is its own third clause, unchanged: re-measure
the sed-to-`read_file` ratio on a comparable wide-orientation task and report
the number. That needs a real run against a real model, so the issue stays
open.

Tests deleted: None.

## Issues

Residue already tracked, not fixed here:

- https://github.com/macanderson/stella/issues/5695 — nothing writes an `R` row
  to `files_touched`, so the audit ledger under-reports what a turn read,
  whichever spelling it used.
- https://github.com/macanderson/stella/issues/5696 — the plural `read_file`
  form returns no structured `data`, so the deck's read head measures nothing
  for a batched read.

Closes #5707
Refs #4151

## Summary by Sourcery

Clarify payload-cap guidance for batched reads and preserve compatible single-file behavior.

Bug Fixes:
- Clarify batched read payload-cap footers so they identify the shared call budget and recommend requesting the affected file separately, while preserving the existing single-file wording.

Enhancements:
- Carry render-budget ownership through read rendering to distinguish shared batch caps from per-file caps.

Tests:
- Add regression coverage for shared-cap batch footer guidance and preservation of the single-file footer wording.
- Strengthen prompt steering tests for using read_file instead of shell reads and grouping files in one read_file call.