### PR TITLE
feat(stella-cli): publish the CI-hardening record and prove the loop is steered by it

### DIFF
--- a/.stella/rules/ctx.stella.harden-ci-from-lessons.toml
+++ b/.stella/rules/ctx.stella.harden-ci-from-lessons.toml
@@ -1,0 +1,56 @@
+# This repo's own policy, kept as a record.
+#
+# It comes from what AGENTS.md says about the gate. Most steps in the gate
+# were added after a bug slipped by. `gate-parity` came after the step list
+# drifted. `check-deleted-tests` came after a merge dropped a test.
+# `main-canary` came after two good branches broke the tree.
+#
+# So the rule is the habit, not the list. A fix with no guard behind it
+# lets the same bug come back.
+#
+# Written by hand, like the two records next to it. The id is made from
+# the text, so the loader stamps `record_id` and `record_hash` on the
+# first load. No one has to trust a typed-in hash. `stella context
+# validate` checks it on each pull request.
+#
+# It has no probe. The claim is about what a session does after a fix.
+# No file on disk can prove it wrong. A probe on a stand-in would make
+# `validate` say more than it knows.
+
+schema = "context-record/v0.1"
+set_id = "stella"
+
+[defaults]
+sharing_scope = "repository"
+status        = "active"
+origin        = "user"
+
+# `source_digest`/`commit` pin AGENTS.md at the state the claim was read
+# from, not at the current tip.
+[defaults.provenance]
+source_kind   = "document"
+source_uri    = "AGENTS.md"
+source_digest = "sha256:ccff490389b7d7537ab27c61f0ea1e08d35b7035016eeb66c4df2580f413e791"
+repo          = "git@github.com:macanderson/stella"
+commit        = "ea1dc958"
+
+
+[[record]]
+lineage_id = "ctx.stella.harden-ci-from-lessons"
+kind       = "rule"
+statement  = "When a defect is fixed, the same change adds the guard that would have caught it whenever such a guard can be written."
+tags       = ["ci", "guards", "regressions"]
+
+  [record.steering]
+  force      = "must"
+  precedence = 90
+  applies_to = { keywords = ["fix", "defect", "guard", "regression"] }
+
+  [record.enforcement]
+  mode = "none"
+
+  [record.truth]
+  basis        = "decree"
+  confidence   = 95
+  verified_at  = "2026-09-02T00:00:00Z"
+  review_every = "P180D"

--- a/crates/stella-cli/src/agent/prompt/tests.rs
+++ b/crates/stella-cli/src/agent/prompt/tests.rs
@@ -879,3 +879,111 @@ fn the_observatory_marker_copy_matches_the_emitting_constants() {
         "the rules heading moved — update the Observatory MARKERS"
     );
 }
+
+/// The three statements this repository steers its own autonomous loop by,
+/// copied from `.stella/rules/` byte for byte. A record whose wording changes
+/// has to change here too, which is the point: the loop's standards are meant
+/// to be reviewed, not drifted.
+const HARDEN_CI: &str = "When a defect is fixed, the same change adds the guard that would have caught it whenever such a guard can be written.";
+const DURABLE_DESIGN: &str = "Code in this repository must meet a reference-grade Rust quality bar rather than merely working.";
+const NOTHING_LEFT_BEHIND: &str = "Work is not finished while anything noticed during the session lives only in the author's head, a chat transcript, or a worktree about to be deleted.";
+
+/// This repository's root, two levels above the crate this test compiles in.
+fn repository_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("the crate sits under <repo>/crates/")
+        .to_path_buf()
+}
+
+/// A throwaway checkout carrying this repository's own published records.
+///
+/// A copy rather than the tree itself, because the test retires a record and
+/// must not edit the file a person reviews.
+fn worktree_with_this_repositorys_records() -> tempfile::TempDir {
+    let worktree = tempfile::tempdir().expect("worktree");
+    let rules = worktree.path().join(".stella").join("rules");
+    std::fs::create_dir_all(&rules).expect("rules directory");
+    let published = repository_root().join(".stella").join("rules");
+    for entry in std::fs::read_dir(&published).expect("this repository publishes records") {
+        let from = entry.expect("a directory entry").path();
+        if from.is_file() {
+            let name = from.file_name().expect("a file name");
+            std::fs::copy(&from, rules.join(name)).expect("copy one record");
+        }
+    }
+    worktree
+}
+
+/// The system prompt a turn in `root` is given, with the repository trusted to
+/// steer it.
+fn prompt_in(root: &std::path::Path) -> String {
+    let authority = crate::settings::AuthorityPolicy {
+        project_prompts_allowed: true,
+        ..Default::default()
+    };
+    let resolved = crate::rules::load_workspace_rules(root, &authority);
+    super::assemble_system_prompt(super::SYSTEM_PROMPT, root, &authority, &resolved, None)
+}
+
+/// **Witness.** The self-driving loop starts a turn by spawning `stella run`
+/// in a fresh worktree (`self_driving_cmd::work`'s `turn_command`), so the
+/// turn's prompt is assembled over that worktree's root. This drives that: a
+/// worktree holding this repository's own records, and the prompt a turn
+/// there is given.
+///
+/// The records reach the turn. All three the loop is meant to be steered by
+/// are asserted, because two of them already existed — a test that checked
+/// one would not show that the set arrives.
+///
+/// Retiring a record stops it steering. The retirement here is the edit a
+/// person makes in `.stella/rules/`: the record's status stops being active.
+/// No Rust changes in either direction.
+///
+/// It fails on the base commit. `ctx.stella.harden-ci-from-lessons` does not
+/// exist there, so the first assertion finds no such sentence in the prompt.
+#[test]
+fn a_worktree_turn_is_steered_by_this_repositorys_records() {
+    let worktree = worktree_with_this_repositorys_records();
+
+    let steered = prompt_in(worktree.path());
+    assert!(
+        steered.contains(stella_core::records::CACHED_HEADING.trim_start()),
+        "the records must render as the cached rules block: {steered}"
+    );
+    for statement in [HARDEN_CI, DURABLE_DESIGN, NOTHING_LEFT_BEHIND] {
+        assert!(
+            steered.contains(statement),
+            "a turn in a worktree of this repository must be steered by {statement:?}"
+        );
+    }
+
+    let record = worktree
+        .path()
+        .join(".stella")
+        .join("rules")
+        .join("ctx.stella.harden-ci-from-lessons.toml");
+    let published = std::fs::read_to_string(&record).expect("the record file");
+    let retired = published.replace(
+        r#"status        = "active""#,
+        r#"status        = "archived""#,
+    );
+    assert_ne!(
+        retired, published,
+        "the record must declare an active status for this to retire it"
+    );
+    std::fs::write(&record, retired).expect("retire the record");
+
+    let after = prompt_in(worktree.path());
+    assert!(
+        !after.contains(HARDEN_CI),
+        "a retired record must stop steering the turn: {after}"
+    );
+    for statement in [DURABLE_DESIGN, NOTHING_LEFT_BEHIND] {
+        assert!(
+            after.contains(statement),
+            "retiring one record must leave the rest steering: {statement:?}"
+        );
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -747,6 +747,16 @@ pub(super) fn start(
 /// has no steering to miss, and demanding a trust flag from it would be
 /// ceremony.
 pub(super) fn refuse_if_unsteered(root: &Path) -> Result<(), String> {
+    refuse_unless_trusted(root, crate::settings::project_code_execution_trusted())
+}
+
+/// The rule of [`refuse_if_unsteered`], with the process it reads taken out.
+///
+/// Separated for the reason [`classify`] is: `project_code_execution_trusted`
+/// answers from the process environment, which this test suite shares with
+/// every other test running beside it. A pure function takes the answer as an
+/// argument, so both directions of the rule can be pinned without a race.
+fn refuse_unless_trusted(root: &Path, trusted: bool) -> Result<(), String> {
     let records = root.join(".stella").join("rules");
     let count = std::fs::read_dir(&records)
         .map(|entries| {
@@ -761,7 +771,7 @@ pub(super) fn refuse_if_unsteered(root: &Path) -> Result<(), String> {
         })
         .unwrap_or(0);
 
-    if count == 0 || crate::settings::project_code_execution_trusted() {
+    if count == 0 || trusted {
         return Ok(());
     }
 
@@ -1313,6 +1323,62 @@ mod tests {
         assert!(
             budget.exhausted().is_some(),
             "which is the condition `drive` reports as *budget reached*"
+        );
+    }
+
+    /// **Witness.** The loop refuses to work an issue when the workspace's
+    /// records would not reach the turn, and runs when they would.
+    ///
+    /// The failure this guards is silent. An untrusted checkout loads none of
+    /// its records, so the turn writes plausible code under nobody's standards
+    /// and the pull request looks like every other one. Both directions are
+    /// asserted, because a check that only ever refused would be satisfied by
+    /// a function that always refuses.
+    ///
+    /// A workspace with no records is the third cell: there is no steering to
+    /// miss, so asking it for a trust flag would be ceremony.
+    #[test]
+    fn the_loop_will_not_work_an_issue_that_its_records_cannot_steer() {
+        let bare = tempfile::tempdir().expect("workspace");
+        assert!(
+            refuse_unless_trusted(bare.path(), false).is_ok(),
+            "a workspace with no records has no steering to miss"
+        );
+
+        let steered = tempfile::tempdir().expect("workspace");
+        let rules = steered.path().join(".stella").join("rules");
+        std::fs::create_dir_all(&rules).expect("rules directory");
+        std::fs::write(rules.join("ctx.example.one.toml"), "").expect("a record file");
+
+        let refusal = refuse_unless_trusted(steered.path(), false)
+            .expect_err("records that cannot steer must stop the work");
+        assert!(
+            refusal.contains("STELLA_TRUST_PROJECT"),
+            "the refusal must name the remedy: {refusal}"
+        );
+        assert!(
+            refuse_unless_trusted(steered.path(), true).is_ok(),
+            "a trusted workspace steers the turn, so the work proceeds"
+        );
+    }
+
+    /// **Witness.** The child turn keeps the trust that lets this repository
+    /// steer it.
+    ///
+    /// `refuse_if_unsteered` asks whether *this* process trusts the project;
+    /// the turn runs in a child. Inheriting the environment is the only thing
+    /// joining those two answers, so a later `env_remove` here would unsteer
+    /// every loop turn while the parent's check went on passing.
+    #[test]
+    fn the_turn_keeps_the_trust_that_lets_this_repository_steer_it() {
+        let removed: Vec<String> = turn_cmd(&TurnFlags::default())
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(key, _)| key.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            !removed.iter().any(|key| key == "STELLA_TRUST_PROJECT"),
+            "the child turn must inherit the project trust: {removed:?}"
         );
     }
 }


### PR DESCRIPTION
## What and why

The self-driving loop's behaviour is meant to come from context records, so a
person changes it by retiring a record rather than by editing Rust. Two of the
three records #4000 asks for already existed —
`ctx.macanderson.stella.reference-grade-bar` (prefer the durable design) and
`ctx.macanderson.stella.nothing-left-behind`. The CI-hardening one did not, and
nothing anywhere proved that any of them reach a turn the loop started.

**The premise check the design pointer asked for first.** `stella context list`
in this worktree does print `project steering in … was NOT loaded (39 context
records)` when the checkout is untrusted, so the warning is real. It no longer
means the loop runs unsteered: `self_driving_cmd::work`'s `refuse_if_unsteered`
(landed with #4001) refuses to work an issue when `.stella/rules` holds records
and the workspace is untrusted, and `turn_command` passes the parent's
environment to the child, so the trust the parent checked is the trust the turn
gets. Both of those were untested, and both are witnessed here rather than
changed — refusing is the safer of the two designs the pointer named, and
undoing it to pass trust implicitly would trade a loud stop for a silent one.

## What this adds

`.stella/rules/ctx.stella.harden-ci-from-lessons.toml` — *"When a defect is
fixed, the same change adds the guard that would have caught it whenever such a
guard can be written."*

Hand-authored with no `record_id` or `record_hash`, exactly the way the two
`ctx.stella.*` records beside it are written: identity is derived, so the loader
stamps both from the content on load and no hash is typed in. `stella context
keep` was not used because it needs an ingest run first, and the maintainer's own
investigation on the issue measured that at 20+ minutes and several hundred
candidates for one document; the reason the issue gives for "not by hand" is the
hash, and deriving it is what removes that hazard. Evidence from the installed
0.9.300 binary in this worktree:

- `stella context validate` → *Every loaded record is schema-valid and currently
  believed.* (CI runs this too.)
- `stella context list` → `^harden-ci-from-lessons  must · cached`.

Its first wording tripped the atomicity gate (`", and "` with two commas reads as
a compound claim, `stella_core::ingest::gate`'s `detect_compound`) and was
rewritten to one clause.

## Witnesses and how each one fails on the base

`crates/stella-cli/src/agent/prompt/tests.rs` —
`a_worktree_turn_is_steered_by_this_repositorys_records`. A loop-driven turn is
`stella run` spawned with its cwd set to a fresh worktree, so its prompt is
assembled over that worktree's root. The test copies this repository's own
`.stella/rules` into a temp worktree, assembles the prompt through
`load_workspace_rules` + `assemble_system_prompt` with project prompts trusted,
and asserts all three statements are in it. It then archives the CI-hardening
record — the same edit a person makes, `status` stops being `active` — reloads,
and asserts that statement is gone while the other two remain. **Fails on the
base**: `ctx.stella.harden-ci-from-lessons` does not exist there, so the first
assertion finds no such sentence.

`crates/stella-cli/src/self_driving_cmd/work.rs` —
`the_loop_will_not_work_an_issue_that_its_records_cannot_steer` covers all three
cells (records + untrusted refuses and names the remedy, records + trusted
proceeds, no records + untrusted proceeds). **Fails on the base**:
`refuse_unless_trusted` does not exist, so the file does not compile.

`the_turn_keeps_the_trust_that_lets_this_repository_steer_it` asserts the built
child command does not remove `STELLA_TRUST_PROJECT`. **Fails on the base** only
if someone adds that removal; it is a regression guard on the one link joining
the parent's trust check to the child that needs it, written in the shape the
sibling `the_turn_does_not_inherit_the_reflection_opt_out` already uses.

## The one Rust change

`refuse_if_unsteered` grew a pure seam, `refuse_unless_trusted(root, trusted)`,
because `project_code_execution_trusted` reads the process environment and this
suite runs in parallel — the same split `classify` in that file already draws
and states. No behaviour changes: the public entry point passes the same answer
it always read. Nothing about the steering itself is Rust.

Exemplar followed: the file's own neighbours — `classify`'s pure-seam comment and
`turn_command`'s "separated so the whole command is a test seam" — rather than an
outside crate.

## Verification

CI is the evidence; nothing was compiled on the maintainer's machine (CLAUDE.md,
"CI builds and tests; this laptop does not"). Run locally: `cargo fmt --all`,
`make guards-fast` (green), `python3 scripts/check-prose.py` (green — the record's
comment header was rewritten twice to clear the 6.00 reading-grade ceiling for a
new file), `./scripts/check-file-size.sh` (green), `make line-citations`,
`make dead-code-allows`, and the two `stella context` commands quoted above.

Tests deleted: None.

Residue issues filed: #5712 (`refuse_if_unsteered` counts `governance.toml` and
archived records toward its tally, so the loop refuses over files that would
never steer it) and #5714 (there is no `stella context retire`, so a retirement
lands as a hand-edit with no ledger event naming who did it).

Closes #4000

## Definition of done

#4000's three boxes are ticked, each on the evidence in this diff rather than in
this description; the reasoning per box is in the PR comment of 2026-09-03. The
`dod / dod` check last ran before those boxes were ticked and was red on the
stale reading — this edit re-triggers it (`dod-check.yml` fires on
`pull_request: edited`).

The one Sourcery ❌ — that the record is hand-authored rather than produced by
`stella context keep` / `promote` — is answered in the PR comment of the same
date, on three grounds: `keep` needs an ingest run that has no proposal to
resolve, the hazard the rule guards is a typed-in hash that this record derives
instead, and the two sibling `ctx.stella.*` records are hand-authored in exactly
this shape.

## Summary by Sourcery

Publish the CI-hardening steering record and verify that trusted self-driving turns receive active repository guidance while unsteered work is stopped safely.

New Features:
- Publish a CI-hardening context record that requires fixes to add applicable regression guards.

Enhancements:
- Add coverage proving repository context records steer turn prompts and that retiring a record removes only its guidance.
- Add coverage for refusing self-driving work when records cannot steer an untrusted workspace, while allowing trusted or record-free work.
- Add a pure trust-check seam for deterministic testing and guard inheritance of project trust by child turns.

Tests:
- Add prompt, steering, trust, and child-environment regression tests covering the repository's context-driven loop behavior.