### PR TITLE
fix(stella-cli,stella-model): report a worker's answer, and key the Anthropic tail anchor by conversation

### DIFF
--- a/crates/stella-cli/src/command_deck/session_clear.rs
+++ b/crates/stella-cli/src/command_deck/session_clear.rs
@@ -214,7 +214,7 @@ pub(super) fn settle_worker_task(
     let board = registry.task_board();
     let items: Vec<TaskItem> = {
         let mut guard = board.lock().unwrap_or_else(|p| p.into_inner());
-        if matches!(end, subsession::WorkerEnd::Done) {
+        if matches!(end, subsession::WorkerEnd::Done(_)) {
             let _ = guard.set_status(task_id, stella_protocol::TaskStatus::Completed);
         }
         guard.items().to_vec()
@@ -269,7 +269,7 @@ impl<'a> BoardMirror<'a> {
 /// as a dropped result.
 fn stale_worker_note(task_id: &str, end: &subsession::WorkerEnd) -> String {
     let outcome = match end {
-        subsession::WorkerEnd::Done => "finished",
+        subsession::WorkerEnd::Done(_) => "finished",
         _ => "ended without finishing",
     };
     format!(
@@ -593,7 +593,7 @@ mod tests {
         settle_worker_task(
             "sub:1",
             stale,
-            &subsession::WorkerEnd::Done,
+            &subsession::WorkerEnd::Done(String::new()),
             &mut subs,
             &registry,
             None,
@@ -686,7 +686,7 @@ mod tests {
         settle_worker_task(
             "sub:1",
             fresh,
-            &subsession::WorkerEnd::Done,
+            &subsession::WorkerEnd::Done(String::new()),
             &mut subs,
             &registry,
             None,
@@ -716,7 +716,7 @@ mod tests {
     /// of the bug being fixed.
     #[test]
     fn the_quarantine_note_distinguishes_a_failure_from_a_finish() {
-        let done = stale_worker_note("3", &subsession::WorkerEnd::Done);
+        let done = stale_worker_note("3", &subsession::WorkerEnd::Done(String::new()));
         assert!(done.contains("finished"), "{done}");
         let failed = stale_worker_note("3", &subsession::WorkerEnd::Failed("boom".into()));
         assert!(failed.contains("without finishing"), "{failed}");

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -23,6 +23,7 @@
 //! `task_assign` requests are reported on its lane instead of spawning.
 
 mod closeout;
+mod notify;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -35,6 +36,7 @@ use stella_tui::{AgentMeta, AgentStatus, Inbound};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::sync::{oneshot, watch};
 
+use self::notify::worker_notification;
 use crate::agent;
 use crate::command_deck::{LEAD, close_turn_stream, now_ms, prompt_line, spawn_forwarder};
 use crate::config::Config;
@@ -50,7 +52,12 @@ pub(crate) const MAX_CONCURRENT: usize = 3;
 /// failure, must not auto-complete a task, and needs no inbox notification —
 /// the user was there).
 pub(crate) enum WorkerEnd {
-    Done,
+    /// Finished, carrying the worker's final answer —
+    /// [`stella_core::TurnOutcome::Completed`]'s text. The answer rides here
+    /// because `task_assign` tells the model that a sub-agent's results land
+    /// back in this session, and [`notify`] is where a reader who looked away
+    /// finds them. Empty when the model ended the turn with no text.
+    Done(String),
     Failed(String),
     /// Stopped by the user (Agents tab `s`, or Esc on the worker's lane).
     Stopped,
@@ -839,7 +846,7 @@ pub(crate) fn spawn(
         let _ = in_tx.send(Inbound::Status {
             agent: lane.clone(),
             status: match &end {
-                WorkerEnd::Done => AgentStatus::Done,
+                WorkerEnd::Done(_) => AgentStatus::Done,
                 WorkerEnd::Failed(_) => AgentStatus::Failed,
                 WorkerEnd::Stopped => AgentStatus::Killed,
             },
@@ -854,23 +861,7 @@ pub(crate) fn spawn(
             });
         }
 
-        // The `/inbox` flow: a worker finishing (or failing) lands a
-        // persist-until-read notification linked to this session, so the
-        // user finds the result — and can open the session, replaying it if
-        // needed — without having watched the lane. A user-initiated stop
-        // lands none: the user was there.
-        let notification = match &end {
-            WorkerEnd::Done => Some((
-                format!("{workspace_name}: {}", spec.notify_title),
-                prompt_line(&spec.prompt, 160),
-            )),
-            WorkerEnd::Failed(reason) => Some((
-                format!("{workspace_name}: {} — FAILED", spec.notify_title),
-                format!("{} — {reason}", prompt_line(&spec.prompt, 80)),
-            )),
-            WorkerEnd::Stopped => None,
-        };
-        if let Some((title, body)) = notification {
+        if let Some((title, body)) = worker_notification(&workspace_name, &spec, &end) {
             let _ = stella_store::NotificationStore::open_default().push(
                 &stella_store::Notification::new(title, body, session_id.clone())
                     .with_session_id(session_id.clone()),
@@ -1183,8 +1174,10 @@ async fn run_worker(
     }
 
     let (label, cost, end) = match raced {
-        RacedTurn::Outcome(stella_core::TurnOutcome::Completed { cost_usd, .. }) => {
-            ("completed", cost_usd, WorkerEnd::Done)
+        // `text` is the worker's answer. It rides back on `Done` so the
+        // `/inbox` note can carry it — see [`notify`].
+        RacedTurn::Outcome(stella_core::TurnOutcome::Completed { text, cost_usd }) => {
+            ("completed", cost_usd, WorkerEnd::Done(text))
         }
         RacedTurn::Outcome(stella_core::TurnOutcome::Aborted {
             reason, cost_usd, ..

--- a/crates/stella-cli/src/subsession/notify.rs
+++ b/crates/stella-cli/src/subsession/notify.rs
@@ -1,0 +1,120 @@
+//! The `/inbox` note a settled worker leaves behind.
+//!
+//! A worker runs on its own lane, and the user may never watch it. The note
+//! is how the work reaches them: it is stored until read, and it is the only
+//! place a finished worker speaks to a reader who looked away.
+//!
+//! So the note carries the worker's **answer**. `task_assign` tells the
+//! model that a sub-agent's results land back in this session; this is the
+//! surface that keeps that true for a worker that finished, the way the
+//! failure arm below keeps it true for one that did not.
+//!
+//! A module of its own for the reason [`super::closeout`] is one:
+//! `subsession.rs` sits just under the file-size ceiling, and this needs a
+//! witness.
+
+use super::{SubSessionSpec, WorkerEnd};
+use crate::command_deck::prompt_line;
+
+/// How much of the worker's answer the note carries. Long enough for a real
+/// answer, short enough that the inbox stays a list.
+const BODY_CHARS: usize = 160;
+
+/// The title and body of the note, or `None` when no note is owed.
+///
+/// A user-initiated stop leaves none. The user was there; telling them what
+/// they just did is noise.
+pub(super) fn worker_notification(
+    workspace_name: &str,
+    spec: &SubSessionSpec,
+    end: &WorkerEnd,
+) -> Option<(String, String)> {
+    match end {
+        WorkerEnd::Done(answer) => Some((
+            format!("{workspace_name}: {}", spec.notify_title),
+            // A turn can end with tool work and no closing words. The prompt
+            // is the fallback then, because a blank note names nothing at all.
+            if answer.trim().is_empty() {
+                prompt_line(&spec.prompt, BODY_CHARS)
+            } else {
+                prompt_line(answer, BODY_CHARS)
+            },
+        )),
+        WorkerEnd::Failed(reason) => Some((
+            format!("{workspace_name}: {} — FAILED", spec.notify_title),
+            format!("{} — {reason}", prompt_line(&spec.prompt, 80)),
+        )),
+        WorkerEnd::Stopped => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> SubSessionSpec {
+        SubSessionSpec {
+            lane: "sub:1".into(),
+            title: "task #1".into(),
+            purpose: String::new(),
+            prompt: "count the rows in the ledger".into(),
+            notify_title: "task #1 done".into(),
+            dispatched_by: None,
+        }
+    }
+
+    /// The witness: the note carries what the worker said. Echoing the
+    /// prompt tells the reader only what they already asked, which is the
+    /// one thing they cannot have forgotten.
+    ///
+    /// Fails before this change: `WorkerEnd::Done` held no answer to report.
+    #[test]
+    fn a_finished_worker_reports_its_answer_not_a_copy_of_the_prompt() {
+        let end = WorkerEnd::Done("the ledger holds 412 rows".into());
+        let (title, body) = worker_notification("stella", &spec(), &end).expect("a note is owed");
+
+        assert!(title.contains("task #1 done"), "{title}");
+        assert!(
+            body.contains("412 rows"),
+            "the note must carry the worker's answer: {body}"
+        );
+        assert!(
+            !body.contains("count the rows"),
+            "the prompt is what was asked, not what came back: {body}"
+        );
+    }
+
+    /// A long answer is trimmed. The inbox is a list of lines.
+    #[test]
+    fn a_long_answer_is_trimmed_to_one_line() {
+        let end = WorkerEnd::Done(format!("start {}", "x".repeat(500)));
+        let (_, body) = worker_notification("stella", &spec(), &end).expect("a note is owed");
+
+        assert!(body.starts_with("start "), "{body}");
+        assert!(body.chars().count() <= BODY_CHARS, "{body}");
+    }
+
+    /// A turn that ends with no closing words still names its work.
+    #[test]
+    fn an_empty_answer_falls_back_to_the_prompt() {
+        let end = WorkerEnd::Done("   ".into());
+        let (_, body) = worker_notification("stella", &spec(), &end).expect("a note is owed");
+
+        assert!(body.contains("count the rows"), "{body}");
+    }
+
+    /// Failure keeps its reason, and a stop still says nothing.
+    #[test]
+    fn failure_names_the_reason_and_a_stop_leaves_no_note() {
+        let failed = WorkerEnd::Failed("provider refused the request".into());
+        let (title, body) =
+            worker_notification("stella", &spec(), &failed).expect("a note is owed");
+        assert!(title.contains("FAILED"), "{title}");
+        assert!(body.contains("provider refused"), "{body}");
+
+        assert!(
+            worker_notification("stella", &spec(), &WorkerEnd::Stopped).is_none(),
+            "a user-initiated stop owes no note"
+        );
+    }
+}

--- a/crates/stella-cli/src/subsession/tests.rs
+++ b/crates/stella-cli/src/subsession/tests.rs
@@ -318,10 +318,10 @@ fn a_panicking_worker_body_ends_as_failed_never_silence() {
         _ => panic!("a String panic payload must synthesize Failed too"),
     }
     // A body that returns normally passes through untouched.
-    let (id, cost, end) = run_caught(|| (Some(7), 1.25, WorkerEnd::Done));
+    let (id, cost, end) = run_caught(|| (Some(7), 1.25, WorkerEnd::Done("done".into())));
     assert_eq!(id, Some(7));
     assert_eq!(cost, 1.25);
-    assert!(matches!(end, WorkerEnd::Done));
+    assert!(matches!(end, WorkerEnd::Done(answer) if answer == "done"));
 }
 
 #[tokio::test]

--- a/crates/stella-model/src/anthropic.rs
+++ b/crates/stella-model/src/anthropic.rs
@@ -35,16 +35,17 @@ pub struct AnthropicProvider {
     /// List pricing for `model`, resolved from the catalog at construction so
     /// `cost_usd` is computed on the real request path (see `zai.rs`).
     pricing: Option<Pricing>,
-    /// Where the PREVIOUS request's conversation-tail breakpoint landed, so
-    /// this one can re-stamp it and keep an anchor at a position the cache was
-    /// actually written to (#1837). See [`stamp_remembered_tail`].
+    /// Where each conversation's PREVIOUS tail breakpoint landed, so the next
+    /// request in that conversation can re-stamp it and keep an anchor at a
+    /// position the cache was actually written to (#1837). See
+    /// [`stamp_remembered_tail`] and [`RememberedTail`].
     ///
     /// Session-scoped because the adapter is constructed once per session. A
     /// `Mutex` rather than a cell: `complete_ref` takes `&self` and concurrent
-    /// calls through one provider are ordinary (sibling sub-agents, the
-    /// pipeline's management roles). Contention is one pointer write per
-    /// request.
-    previous_tail: std::sync::Mutex<Option<TailPosition>>,
+    /// calls through one provider are ordinary — the turn's own calls and the
+    /// overflow summarizer's share this instance. Contention is one short
+    /// vector write per request.
+    previous_tails: std::sync::Mutex<Vec<RememberedTail>>,
     /// The session's context-editing policy, or `None` to send no
     /// `context_management` and behave exactly as before the feature existed.
     ///
@@ -55,7 +56,7 @@ pub struct AnthropicProvider {
     /// The prompt-cache window this session asks for (#1839): the default
     /// 5-minute window sends today's exact bytes; the 1-hour opt-in adds
     /// `ttl: "1h"` to every breakpoint plus the [`EXTENDED_CACHE_TTL_BETA`]
-    /// header. Session-scoped like `previous_tail` — mixing windows within a
+    /// header. Session-scoped like `previous_tails` — mixing windows within a
     /// session would pay the 2x write premium for a prefix the next turn
     /// re-anchors on the short window anyway.
     cache_ttl: CacheTtl,
@@ -99,7 +100,7 @@ impl AnthropicProvider {
             base_url: DEFAULT_BASE_URL.to_string(),
             model,
             pricing,
-            previous_tail: std::sync::Mutex::new(None),
+            previous_tails: std::sync::Mutex::new(Vec::new()),
             cache_ttl: CacheTtl::default(),
             // Off by default. Context editing trades prompt cache for context
             // room, and a session that never outgrows its window would pay the
@@ -450,6 +451,41 @@ const fn ephemeral_cache(ttl: CacheTtl) -> AnthropicCacheControl {
 /// Carried on the provider so the NEXT request can re-stamp it — see
 /// [`stamp_tail_cache_breakpoint`] for why one breakpoint is not enough.
 type TailPosition = (usize, usize);
+
+/// A remembered tail position, and which conversation it was taken from.
+///
+/// One adapter serves more than one conversation. A turn's own model calls
+/// and the overflow summarizer's go through the same instance, and the
+/// summarizer sends a short conversation of its own. A single shared slot
+/// therefore hands each conversation the other's position: the re-stamped
+/// anchor lands on a block this conversation never wrote the cache at, and
+/// the second breakpoint buys nothing.
+///
+/// The key is the system prefix. Anthropic keys its own cache on that same
+/// prefix, so two requests whose system blocks differ share no cached prefix
+/// at all, and a tail from one can never be a useful anchor in the other.
+/// One hash of one string per request — not the hash of every block that
+/// [`stamp_remembered_tail`] rules out on cost.
+#[derive(Clone, Copy)]
+struct RememberedTail {
+    /// [`conversation_key`] of the system prefix this position came from.
+    conversation: u64,
+    at: TailPosition,
+}
+
+/// How many conversations keep a remembered tail. Two are live today — the
+/// turn and the overflow summarizer — and the spare room means a third role
+/// arriving does not evict either of them.
+const REMEMBERED_TAILS: usize = 4;
+
+/// Which conversation a request belongs to, as far as the prompt cache is
+/// concerned.
+fn conversation_key(system: Option<&str>) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    system.hash(&mut hasher);
+    hasher.finish()
+}
 
 /// Re-stamp the position the PREVIOUS request's tail breakpoint landed on.
 ///
@@ -1014,6 +1050,35 @@ impl AnthropicProvider {
         })
     }
 
+    /// Where this conversation's last request put its tail breakpoint, if the
+    /// adapter still holds it.
+    fn remembered_tail(&self, conversation: u64) -> Option<TailPosition> {
+        let tails = self
+            .previous_tails
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        tails
+            .iter()
+            .find(|t| t.conversation == conversation)
+            .map(|t| t.at)
+    }
+
+    /// Record where this request put its tail breakpoint.
+    ///
+    /// Newest first, oldest dropped past [`REMEMBERED_TAILS`]. A dropped
+    /// entry costs one cache write on that conversation's next request and
+    /// nothing else — the same worst case [`stamp_remembered_tail`] already
+    /// accepts for a position history moved under.
+    fn remember_tail(&self, conversation: u64, at: TailPosition) {
+        let mut tails = self
+            .previous_tails
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        tails.retain(|t| t.conversation != conversation);
+        tails.insert(0, RememberedTail { conversation, at });
+        tails.truncate(REMEMBERED_TAILS);
+    }
+
     /// The one request body both delivery paths serialize — `stream` is the
     /// only field on which they differ, so the unary fallback re-issues the
     /// byte-identical payload minus the stream flag.
@@ -1031,13 +1096,18 @@ impl AnthropicProvider {
         // Previous first: `stamp_tail_cache_breakpoint` walks backward to the
         // newest stampable block, and re-stamping the old position afterwards
         // could otherwise land on the same block and spend both on one anchor.
+        //
+        // The remembered tail is read and written under this conversation's
+        // own key, so an interleaved call on another conversation — the
+        // overflow summarizer's, through this same adapter — neither steals
+        // this anchor nor leaves its own behind for this request to stamp.
         let marker = ephemeral_cache(self.cache_ttl);
-        let previous = *self.previous_tail.lock().unwrap_or_else(|p| p.into_inner());
-        if let Some(at) = previous {
-            stamp_remembered_tail(&mut messages, at, marker);
+        let conversation = conversation_key(system.as_deref());
+        if let Some(previous) = self.remembered_tail(conversation) {
+            stamp_remembered_tail(&mut messages, previous, marker);
         }
         if let Some(tail) = stamp_tail_cache_breakpoint(&mut messages, marker) {
-            *self.previous_tail.lock().unwrap_or_else(|p| p.into_inner()) = Some(tail);
+            self.remember_tail(conversation, tail);
         }
         let reasoning_on = req.reasoning == Some(true);
         let params = req.params.unwrap_or_default();

--- a/crates/stella-model/src/anthropic/tests/cache_breakpoints.rs
+++ b/crates/stella-model/src/anthropic/tests/cache_breakpoints.rs
@@ -200,3 +200,92 @@ async fn the_default_window_sends_no_ttl_field_and_no_beta_header() {
         "no ttl field on the default window: {body}"
     );
 }
+
+/// Every message-level breakpoint in a built body, as `(message, block)`.
+fn stamped_positions(body: &AnthropicRequest<'_>) -> Vec<(usize, usize)> {
+    body.messages
+        .iter()
+        .enumerate()
+        .flat_map(|(mi, m)| {
+            m.content.iter().enumerate().filter_map(move |(bi, b)| {
+                let marked = matches!(
+                    b,
+                    AnthropicContentBlock::Text {
+                        cache_control: Some(_),
+                        ..
+                    } | AnthropicContentBlock::ToolResult {
+                        cache_control: Some(_),
+                        ..
+                    }
+                );
+                marked.then_some((mi, bi))
+            })
+        })
+        .collect()
+}
+
+/// A conversation with `system` as its hoisted prefix and one exchange per
+/// entry in `turns`.
+fn conversation(system: &str, turns: &[(&str, &str)]) -> CompletionRequest {
+    let mut messages = vec![CompletionMessage::system(system)];
+    for (ask, answer) in turns {
+        messages.push(CompletionMessage::user(*ask));
+        messages.push(CompletionMessage::assistant(*answer));
+    }
+    CompletionRequest {
+        messages,
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+/// **Witness.** One adapter serves the turn and the overflow summarizer, and
+/// the summarizer sends a short conversation of its own. Under a shared slot
+/// its tail becomes the turn's remembered anchor, so the turn's next request
+/// spends its second breakpoint on a block its own cache was never written
+/// at. Keying the slot by conversation is what carries the anchor across the
+/// interleave.
+///
+/// Fails before this change: the last body's first breakpoint lands at
+/// `(0, 0)`, the summarizer's tail, instead of at the turn's own previous
+/// write position.
+#[test]
+fn an_interleaved_conversation_leaves_the_turns_anchor_alone() {
+    let provider = AnthropicProvider::new(ApiKey::new("sk-test"), "claude-fable-5");
+
+    // The turn's first request. Its tail lands on the newest block: two
+    // messages, once the system prefix is hoisted out.
+    let first = conversation("the agent system prompt", &[("ask", "answer one")]);
+    let body = provider.build_body(first.as_borrowed(), true);
+    assert_eq!(stamped_positions(&body), vec![(1, 0)], "the first tail");
+
+    // The overflow summarizer, through the same adapter: a different system
+    // prefix, and one message under it.
+    let mut summary = conversation("summarize the span below", &[]);
+    summary
+        .messages
+        .push(CompletionMessage::user("the span to summarize"));
+    let body = provider.build_body(summary.as_borrowed(), true);
+    assert_eq!(
+        stamped_positions(&body),
+        vec![(0, 0)],
+        "the summarizer's own tail, in its own conversation"
+    );
+
+    // The turn again, one exchange further on.
+    let second = conversation(
+        "the agent system prompt",
+        &[("ask", "answer one"), ("ask again", "answer two")],
+    );
+    let body = provider.build_body(second.as_borrowed(), true);
+    assert_eq!(
+        stamped_positions(&body),
+        vec![(1, 0), (3, 0)],
+        "the turn's own previous write position, plus its new tail — the \
+         summarizer's tail must not appear here"
+    );
+}


### PR DESCRIPTION
## What this is

The 2026-08-10 turn-loop architecture review listed five claimed critical
defects and five risks, with the caveat that its own citations were
agent-produced and unverified. Every one of the ten is read against today's
`main` here. The full verdict table is posted as a comment on #2725.

Two were live, and both are fixed in this PR. One is filed. Five are moot
because `crates/stella-pipeline` was deleted (commit `a6d3db4f6`, #3852) and
the tools they name are retired. Two are not defects: the code that would have
made them true was fixed by #2793 and by the skill-appraisal wiring, and the
verdict table names the file and symbol for each.

## The two fixes

### A finished worker reported its cost and nothing else

`crates/stella-cli/src/subsession.rs`'s `run_worker` destructured the turn
outcome as `TurnOutcome::Completed { cost_usd, .. }`. The answer text was
dropped right there, so `WorkerEnd::Done` carried nothing, and `spawn` built
the `/inbox` note from `prompt_line(&spec.prompt, 160)` — the prompt, echoed
back at the reader. `WorkerEnd::Failed(reason)` still carried its reason, so a
failed worker told the user more than a finished one, and `task_assign`'s
schema had told the model the opposite: "The sub-agent's results land back in
this session."

`WorkerEnd::Done` now carries the answer, and the note is built by
`crates/stella-cli/src/subsession/notify.rs` — a sibling module rather than
lines in `subsession.rs`, which sits under the file-size ceiling and whose
`closeout` sibling was split out for the same reason.

### The Anthropic tail anchor was one slot for every conversation

`AnthropicProvider` kept a single `Mutex>`. `build_body`
read it, re-stamped that position, then overwrote it — for every request
through the adapter, whichever conversation the request belonged to.

More than one conversation goes through one instance. The overflow summarizer
(`stella-core`'s `driver::restore::summarize_overflow_span` →
`dispatch_summarizer`) sends its own short conversation on the turn's
provider. Its tail became the turn's remembered anchor, and the turn's next
request then spent its second message breakpoint on a block its own cache was
never written at — losing the incremental tier #1837 bought, with no test and
no telemetry to notice.

The slot is a small keyed set now, keyed by the system prefix. Anthropic keys
its own prompt cache on that same prefix, so two requests whose system blocks
differ share no cached prefix at all and a tail from one can never be a useful
anchor in the other. One hash of one string per request — not the per-block
digest `stamp_remembered_tail`'s doc rules out on cost.

## Witnesses, and why they fail on `main`

Both are structural: the shape they assert against does not exist on `main`.

- `crates/stella-cli/src/subsession/notify.rs` —
  `a_finished_worker_reports_its_answer_not_a_copy_of_the_prompt` asserts the
  note carries `"412 rows"` and does not carry the prompt. On `main`
  `WorkerEnd::Done` is a unit variant with no answer to report and
  `worker_notification` does not exist, so the test cannot even be written
  there. Three siblings cover the trim, the empty-answer fallback, and the
  failure and stop arms.
- `crates/stella-model/src/anthropic/tests/cache_breakpoints.rs` —
  `an_interleaved_conversation_leaves_the_turns_anchor_alone` drives
  `build_body` three times through one provider: the turn, then a summarizer
  conversation with a different system prefix, then the turn again. It asserts
  the third body's breakpoints are at `(1, 0)` and `(3, 0)`. On `main` the
  single slot holds the summarizer's `(0, 0)` by then, so the first breakpoint
  lands there instead and the assertion fails on a real value — the interleave
  is the whole mechanism.

## Exemplar followed

`crates/stella-cli/src/subsession/closeout.rs` — the same seam, split out of
`subsession.rs` for the two reasons its own header gives: the file sits under
the size ceiling, and the invariant needs a witness.

## Residue filed

- #5713 — the turn deadline reserve measures only the model call, so a
  tool-heavy step overruns its deadline. This is the review's fifth claimed
  defect, confirmed live and out of scope here: fixing it moves step timing
  inside `driver.rs`, a god file, and has to be correct on every step exit.
- #5715 — a finished sub-agent's answer still never reaches the **lead
  model's** conversation. This PR makes the answer reach the reader; making it
  reach the model is a design decision about when and in what role, which the
  issue lays out.

#5493 already tracks the `panic="abort"` risk from the same list.

Tests deleted: None.

Closes #2725

## Definition of done

#2725's ten item boxes and its four DoD boxes are ticked. Each of the ten
verdicts was re-read against the tree before its box was ticked, rather than
taken from the table:

| Verdict | What was re-read |
|---|---|
| moot ×4 (items 1, 3, 6, 10) | `crates/stella-pipeline` is absent from the tree; `mcp_search` and `verify_done` are both in `stella_tools::catalog::RETIRED_TOOL_NAMES`; no file under `crates/` reads `witness_confirmed`; `[exit code:` appears only in `stella_tools::bash` and its own test, with no verdict path parsing it |
| confirmed → fixed here ×2 (items 2, 4) | this diff — `WorkerEnd::Done(String)` + `subsession::notify::worker_notification`, and `previous_tails` keyed by `conversation_key`, each with the witness named above |
| confirmed → filed ×2 (items 5, 7) | #5713 and #5493 both exist and are open; `Cargo.toml`'s `[profile.release]` still carries `panic = "abort"` |
| not a defect ×2 (items 8, 9) | `admit_dispatch` is called before dispatch in both `stella_tools::custom` and `stella_mcp::toolset`; `record_skill_trials`, `appraise_and_retire_skills` and `promote_measured_queued` all exist |

The `dod / dod` check last ran before those boxes were ticked and was red on the
stale reading — this edit re-triggers it (`dod-check.yml` fires on
`pull_request: edited`).

## Summary by Sourcery

Preserve worker results for readers and isolate Anthropic cache anchors across conversations.

Bug Fixes:
- Report completed workers' answers in inbox notifications instead of echoing their prompts.
- Keep Anthropic prompt-cache tail anchors separate for each conversation sharing a provider.

Enhancements:
- Extract worker notification construction into a dedicated subsession module with answer trimming and empty-answer fallback.

Tests:
- Add coverage for worker notification content, trimming, empty answers, failures, and stops.
- Add coverage proving interleaved Anthropic conversations preserve their independent cache anchors.