### PR TITLE
fix(stella-core): receipt the engine's completion nudges as steering, not the user's goal

### DIFF
--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -96,10 +96,10 @@ use crate::loop_detect::LoopDetectionConfig;
 use crate::retry::RetryPolicy;
 use lifecycle::step_outcome_label;
 
-mod confident_zero;
+pub(crate) mod confident_zero;
 mod config;
 pub mod lifecycle;
-mod live_services;
+pub(crate) mod live_services;
 pub(crate) mod loop_escalation;
 pub mod loop_evidence;
 mod truncation;

--- a/crates/stella-core/src/driver/confident_zero.rs
+++ b/crates/stella-core/src/driver/confident_zero.rs
@@ -108,7 +108,7 @@ const ONGOING_ACTIVITY_PREFIXES: &[&str] = &[
 /// The gate has no in-turn proof channel: every gated mutating turn is asked
 /// exactly once, and the model's answer — run a check through whatever tools
 /// the session carries, or say why none can exist — is the whole exchange.
-pub(super) const PROVE_IT_PREFIX: &str = "Before declaring this task complete:";
+pub(crate) const PROVE_IT_PREFIX: &str = "Before declaring this task complete:";
 const PROVE_IT_NUDGE: &str = "Before declaring this task complete: nothing in this turn proved \
      the work. Run the task's own test or check command, read what it actually says, and fix \
      anything it reveals. If no check can exist for this change, say so explicitly and why, \
@@ -194,25 +194,6 @@ fn detect(
     } else {
         None
     }
-}
-
-/// Whether a user message is one the engine wrote rather than one the user
-/// (or host) sent. Exactly the set of once-per-turn nudge prefixes; a new
-/// gate adds its own here in the same change that adds the gate.
-///
-/// Read by [`turn_start_index`] alongside the marker table: a nudge is a
-/// user-role message the engine authored, so it bounds no window. It used to
-/// be excluded only from the nudge gates' own scans, so every nudge reset the
-/// loop-detection and confident-zero windows mid-turn — the prove-it ask on
-/// an edited-then-tested turn erased the edit from the tally, and the turn
-/// could then be aborted as a confident zero for the read-only test run the
-/// nudge itself requested. Measured once already on the prove-it gate's first
-/// field trial (run `gate-ab`, task pypi-server): three nudges in one turn,
-/// each re-armed by that reset, riding a refuted `verify_done` into the 900s
-/// ceiling.
-pub(super) fn is_engine_nudge(content: &str) -> bool {
-    content.starts_with(PROVE_IT_PREFIX)
-        || content.starts_with(super::live_services::SERVICES_PREFIX)
 }
 
 /// True when this turn did mutating work and the prove-it nudge has not

--- a/crates/stella-core/src/driver/live_services.rs
+++ b/crates/stella-core/src/driver/live_services.rs
@@ -59,12 +59,11 @@ use stella_protocol::{AgentEvent, CompletionMessage};
 use crate::event_sender::EventSender;
 use crate::ports::LiveService;
 
-/// The nudge's own marker, prefix-detected on the transcript. Shares the
-/// once-per-turn window with the prove-it nudge — see
-/// [`super::confident_zero::is_engine_nudge`], which the shared turn window
-/// reads: it must skip both prefixes or each gate's message reopens the
+/// The nudge's own opening, prefix-detected on the transcript. One of
+/// [`crate::engine_markers::ENGINE_NUDGE_PREFIXES`], which the shared turn
+/// window reads: it must skip both, or each gate's message reopens the
 /// other's window (the `gate-ab` regression, #2663).
-pub(super) const SERVICES_PREFIX: &str = "Before ending this turn:";
+pub(crate) const SERVICES_PREFIX: &str = "Before ending this turn:";
 
 /// One line per still-running service, in the order the executor reported
 /// them. Named by handle first: the handle is the stable identifier the

--- a/crates/stella-core/src/driver/loop_evidence.rs
+++ b/crates/stella-core/src/driver/loop_evidence.rs
@@ -35,13 +35,15 @@ use crate::receipts::TranscriptRevision;
 /// reaching this rule, so a stuck-loop scan silently reset on the exact two
 /// injections that mean the turn is still running (#2837).
 ///
-/// The once-per-turn completion nudges (`confident_zero::is_engine_nudge` —
-/// the prove-it ask and the live-service assertion) are engine-authored
-/// user-role text too, and are excluded for the same reason: they carry no
-/// bracketed marker, so the table alone cannot recognize them, and a window
-/// that reset on one erased the turn's pre-nudge activity — a mutating turn
-/// answering the prove-it ask with a read-only test run could then be
-/// aborted as a confident zero for doing exactly what the nudge asked.
+/// The once-per-turn completion nudges — the prove-it ask and the
+/// live-service assertion — are engine-authored user-role text too, and are
+/// excluded for the same reason: they carry no bracketed marker, so the
+/// marker table alone cannot recognize them, and a window that reset on one
+/// erased the turn's pre-nudge activity — a mutating turn answering the
+/// prove-it ask with a read-only test run could then be aborted as a
+/// confident zero for doing exactly what the nudge asked. They are the second
+/// table beside the markers (`engine_markers::ENGINE_NUDGE_PREFIXES`), read
+/// here through `engine_markers::is_engine_nudge`.
 ///
 /// Shared by [`recent_call_records`] (loop-detection evidence) and
 /// `driver::confident_zero` (turn-activity evidence for #1477, and both
@@ -56,7 +58,7 @@ pub(super) fn turn_start_index(messages: &[CompletionMessage]) -> usize {
                 && !crate::engine_markers::ENGINE_MARKERS
                     .iter()
                     .any(|marker| m.content.starts_with(marker))
-                && !super::confident_zero::is_engine_nudge(&m.content)
+                && !crate::engine_markers::is_engine_nudge(&m.content)
         })
         .map(|i| i + 1)
         .unwrap_or(0)
@@ -238,13 +240,14 @@ mod tests {
     /// table loop above cannot cover them — and a window that reset on one
     /// erased the turn's pre-nudge activity from every consumer at once
     /// (loop detection and the confident-zero tally). Fails before
-    /// `turn_start_index` read `is_engine_nudge`.
+    /// `turn_start_index` read `engine_markers::is_engine_nudge`.
+    ///
+    /// Driven off the exported table rather than a hand-written pair, for the
+    /// reason the marker loop above is: a third gate's nudge that never
+    /// reached this rule fails here by name.
     #[test]
     fn an_engine_nudge_does_not_reset_the_turn_window() {
-        for nudge in [
-            super::super::confident_zero::PROVE_IT_PREFIX,
-            super::super::live_services::SERVICES_PREFIX,
-        ] {
+        for nudge in crate::engine_markers::ENGINE_NUDGE_PREFIXES {
             let messages = vec![
                 CompletionMessage::system("sys"),
                 CompletionMessage::user("fix the flaky test"),

--- a/crates/stella-core/src/driver/truncation.rs
+++ b/crates/stella-core/src/driver/truncation.rs
@@ -128,10 +128,12 @@ pub(super) const TIME_EXHAUSTED_PARTIAL: &str = "[no answer produced: this step'
 /// The history copy of a length-truncated assistant text: middle-elided when
 /// large, verbatim when small.
 ///
-/// [`plan_continuation`] applies this shape on the continuation path; this
-/// helper is the same policy for the paths that *end* the turn with a
-/// truncated partial — the spent allowance, the out-of-time stop, the
-/// budget abort, and a truncated step that still carried tool calls. All of
+/// The one producer of that shape, so what the model re-reads after a
+/// continuation and what it re-reads after a stop cannot diverge.
+/// [`plan_continuation`] calls it on the continuation path; the driver calls
+/// it on the paths that *end* the turn with a truncated partial — the spent
+/// allowance, the out-of-time stop, the budget abort, and a truncated step
+/// that still carried tool calls. All of
 /// them used to push `result.text` verbatim, so a 64k-token cut-off
 /// scratchpad landed in history as protected assistant text no compaction
 /// pass may touch, and every later step of the session re-sent it
@@ -283,8 +285,7 @@ pub(super) fn plan_continuation(
         });
     }
     ContinuationPlan::Continue(Continuation {
-        retained: crate::compaction::elide_truncated_partial(text)
-            .unwrap_or_else(|| text.to_string()),
+        retained: retained_partial(text),
         note: format!(
             "\n\n⚠ Output-token limit reached ({output_tokens} tokens) before any tool call; \
              continuing ({attempt}/{MAX_LENGTH_CONTINUATIONS})."

--- a/crates/stella-core/src/engine_markers.rs
+++ b/crates/stella-core/src/engine_markers.rs
@@ -1,11 +1,11 @@
-//! The closed table of engine-injected message markers (#2722).
+//! The closed tables of engine-injected message text (#2722).
 //!
 //! The engine and the CLI write messages that ride the wire as `User`-role
 //! turns but are not the user speaking — the overflow summary, the stuck-loop
-//! steer, an invoked skill's body, a parked wait's wake report. Each opens
-//! with a recognizable marker prefix, and [`ENGINE_MARKERS`] below is the
-//! enumeration; three independent consumers depend on knowing the complete
-//! set:
+//! steer, an invoked skill's body, a parked wait's wake report. Most open with
+//! a bracketed marker prefix, enumerated in [`ENGINE_MARKERS`]; the two
+//! completion nudges are plain English and are enumerated in
+//! [`ENGINE_NUDGE_PREFIXES`]. Three consumers depend on the complete set:
 //!
 //! - `receipts::user_block_kind` classifies `User`-role content by these
 //!   prefixes so a receipt never attributes engine text to the person;
@@ -20,9 +20,8 @@
 //!
 //! Before this table existed the prompt hand-wrote that list in prose and had
 //! already drifted: the continuation nudge — itself instruction-shaped — was
-//! absent entirely, so the engine's own steering failed the prompt's own test,
-//! and the recall marker was described but never spelled. A prose list has no
-//! failure mode; this table does.
+//! absent entirely, and the recall marker was described but never spelled. A
+//! prose list has no failure mode; a table does.
 //!
 //! # The tie, in both directions
 //!
@@ -36,8 +35,8 @@
 //! by name until it teaches the new marker, instead of silently narrowing the
 //! model's injection test.
 //!
-//! This module is a leaf: one `pub` table, no logic, declared
-//! outside `driver.rs` because that file is closed to growth
+//! This module is a leaf: two `pub` tables and one predicate over them,
+//! declared outside `driver.rs` because that file is closed to growth
 //! (`scripts/file-size-baseline.txt`).
 
 /// Every marker prefix the engine or the CLI puts on a `User`-role message it
@@ -67,9 +66,49 @@ pub const ENGINE_MARKERS: &[&str] = &[
     crate::driver::deadline_notice::DEADLINE_MARKER_PREFIX,
 ];
 
+/// The engine-authored `User`-role openings that carry **no** bracketed
+/// marker: the once-per-turn completion nudges — the prove-it ask
+/// (`driver::confident_zero`) and the live-service assertion
+/// (`driver::live_services`).
+///
+/// They are addressed to the model as plain English, so a bracketed tag would
+/// read as noise in the one message whose whole job is to be answered. That
+/// makes them invisible to [`ENGINE_MARKERS`] and to anything matching on its
+/// shape, which is why they get a table of their own instead of an entry
+/// there.
+///
+/// A new completion gate adds its prefix here in the same change that adds
+/// the gate, exactly as a new marker joins [`ENGINE_MARKERS`].
+pub const ENGINE_NUDGE_PREFIXES: &[&str] = &[
+    crate::driver::confident_zero::PROVE_IT_PREFIX,
+    crate::driver::live_services::SERVICES_PREFIX,
+];
+
+/// Whether `content` opens with one of [`ENGINE_NUDGE_PREFIXES`] — a user-role
+/// message the engine wrote rather than one the user (or host) sent.
+///
+/// Read by `driver::loop_evidence::turn_start_index` alongside
+/// [`ENGINE_MARKERS`]: a nudge bounds no turn window. A window that reset on
+/// one erased the turn's pre-nudge activity — the prove-it ask on an
+/// edited-then-tested turn erased the edit from the tally, and the turn was
+/// then abortable as a confident zero for the read-only test run the nudge
+/// itself requested. Measured on the prove-it gate's first field trial (run
+/// `gate-ab`, task pypi-server): three nudges in one turn, each re-armed by
+/// that reset, riding a refuted `verify_done` into the 900s ceiling.
+///
+/// Read by `receipts::user_block_kind` for the reason it reads
+/// [`ENGINE_MARKERS`]: a nudge is engine text, and filing it as the person's
+/// own goal is the misattribution that classifier exists to prevent.
+#[must_use]
+pub fn is_engine_nudge(content: &str) -> bool {
+    ENGINE_NUDGE_PREFIXES
+        .iter()
+        .any(|prefix| content.starts_with(prefix))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ENGINE_MARKERS;
+    use super::{ENGINE_MARKERS, ENGINE_NUDGE_PREFIXES};
 
     /// Anti-vacuity for every downstream `contains`/`starts_with` check: an
     /// empty or near-empty entry would make the prompt-parity and receipts
@@ -117,6 +156,71 @@ mod tests {
                     std::ptr::eq(a, b) || !a.starts_with(b),
                     "{a:?} starts with {b:?}: prefix-matching consumers could \
                      never distinguish them"
+                );
+            }
+        }
+    }
+
+    /// The nudge table's own anti-vacuity, and the line that keeps the two
+    /// tables apart: a bracketed opening belongs in [`ENGINE_MARKERS`], where
+    /// every consumer matching on marker shape already sees it. An entry that
+    /// drifted across would be classified twice and enumerated twice.
+    #[test]
+    fn every_nudge_is_distinctive_and_unmarked() {
+        assert!(
+            ENGINE_NUDGE_PREFIXES.len() >= 2,
+            "an entry left the table; a nudge is retired by deleting the gate \
+             that writes it, never by shrinking this list"
+        );
+        for nudge in ENGINE_NUDGE_PREFIXES {
+            assert!(
+                !nudge.starts_with('['),
+                "{nudge:?} opens a bracketed tag, so it belongs in \
+                 ENGINE_MARKERS rather than here"
+            );
+            assert!(
+                nudge.len() >= 12,
+                "{nudge:?} is too short for a `starts_with` check against it to \
+                 prove anything"
+            );
+        }
+    }
+
+    /// The nudge table is a set, and no entry shadows another — the same two
+    /// properties [`ENGINE_MARKERS`] holds, for the same reason: consumers
+    /// match with `starts_with`.
+    #[test]
+    fn no_nudge_repeats_or_shadows_another() {
+        let mut seen = std::collections::BTreeSet::new();
+        for nudge in ENGINE_NUDGE_PREFIXES {
+            assert!(seen.insert(nudge), "duplicate engine nudge {nudge:?}");
+        }
+        for a in ENGINE_NUDGE_PREFIXES {
+            for b in ENGINE_NUDGE_PREFIXES {
+                assert!(
+                    std::ptr::eq(a, b) || !a.starts_with(b),
+                    "{a:?} starts with {b:?}: prefix-matching consumers could \
+                     never distinguish them"
+                );
+            }
+        }
+    }
+
+    /// A marked message is never also a nudge, in either direction: the two
+    /// tables partition the engine's user-role writing, and an overlap would
+    /// give one message two classifications depending on which table a
+    /// consumer read first.
+    #[test]
+    fn the_two_tables_do_not_overlap() {
+        for marker in ENGINE_MARKERS {
+            assert!(
+                !super::is_engine_nudge(marker),
+                "{marker:?} is in ENGINE_MARKERS and also reads as a nudge"
+            );
+            for nudge in ENGINE_NUDGE_PREFIXES {
+                assert!(
+                    !nudge.starts_with(marker),
+                    "{nudge:?} starts with the marker {marker:?}"
                 );
             }
         }

--- a/crates/stella-core/src/receipts.rs
+++ b/crates/stella-core/src/receipts.rs
@@ -346,12 +346,20 @@ pub const RECALL_MARKER: &str = "[auto-recalled context]";
 /// Which block kind a `User`-role message actually is.
 ///
 /// Not every `User` message is the user's goal. The engine and the CLI write
-/// several of their own as `CompletionMessage::user`, and
-/// [`crate::engine_markers::ENGINE_MARKERS`] is the enumeration. Before Phase 2
-/// they all collapsed onto [`BlockKind::UserGoal`], so a receipt attributed
-/// engine-generated text to the person. Every marker is a prefix on content the
-/// engine and CLI write themselves, which is why this is a prefix match and not
-/// a heuristic.
+/// several of their own as `CompletionMessage::user`. Two tables in
+/// [`crate::engine_markers`] name them all:
+/// [`ENGINE_MARKERS`](crate::engine_markers::ENGINE_MARKERS) for the bracketed
+/// ones, and
+/// [`ENGINE_NUDGE_PREFIXES`](crate::engine_markers::ENGINE_NUDGE_PREFIXES) for
+/// the two completion nudges, which are plain English and carry no bracket.
+/// Before Phase 2 they all collapsed onto [`BlockKind::UserGoal`], so a receipt
+/// attributed engine-generated text to the person. Every marker is a prefix on
+/// content the engine and CLI write themselves, which is why this is a prefix
+/// match and not a heuristic.
+///
+/// Both tables are read here. While only the markers were, both nudges were
+/// filed as the person's goal. The turn window already read the nudge table,
+/// so one message had two answers.
 ///
 /// The continuation nudge and the Stop-hook feedback file as
 /// [`BlockKind::Steered`] rather than earning kinds of their own: each is a
@@ -415,6 +423,12 @@ fn user_block_kind(content: &str) -> BlockKind {
         || content.starts_with(crate::skills::invoke::SKILL_INVOCATION_PREFIX)
         || content.starts_with(crate::waiting::WAKE_MARKER)
         || content.starts_with(crate::driver::deadline_notice::DEADLINE_MARKER_PREFIX)
+        // Both completion nudges: each is a mid-turn injected instruction that
+        // redirects the model — run the task's own check, or account for the
+        // services this turn left running — which is what `Steered` means.
+        // Read through the table so a third gate's nudge lands here the day it
+        // is written, rather than the day someone notices.
+        || crate::engine_markers::is_engine_nudge(content)
     {
         BlockKind::Steered
     } else if content.starts_with(RECALL_MARKER) {

--- a/crates/stella-core/src/receipts/tests.rs
+++ b/crates/stella-core/src/receipts/tests.rs
@@ -392,6 +392,64 @@ fn every_exported_engine_marker_is_classified_as_engine_text() {
     }
 }
 
+/// **The witness.** Both completion nudges are text the engine wrote. A
+/// receipt filed each one as the person's own goal.
+///
+/// Spelled as literals, not through `ENGINE_NUDGE_PREFIXES`, on
+/// `driver/restore.rs`'s precedent: the fail half then runs against the base
+/// tree, which has no such table. `the_nudge_literals_are_the_constants` pins
+/// the spelling.
+#[test]
+fn the_completion_nudges_are_steering_not_the_users_goal() {
+    let prove_it = "Before declaring this task complete: nothing in this turn proved the work. \
+                    Run the task's own test or check command.";
+    assert_eq!(
+        user_block_kind(prove_it),
+        BlockKind::Steered,
+        "the prove-it ask is the engine redirecting the model, not the person \
+         restating the goal"
+    );
+
+    let services = "Before ending this turn: 2 processes you started are still running:\n  \
+                    - `srv1`: uvicorn";
+    assert_eq!(
+        user_block_kind(services),
+        BlockKind::Steered,
+        "the live-service assertion is the engine's own text too"
+    );
+}
+
+/// The literals above are the constants the gates actually write, so the
+/// witness cannot pass against a prefix nobody sends.
+#[test]
+fn the_nudge_literals_are_the_constants() {
+    assert_eq!(
+        crate::engine_markers::ENGINE_NUDGE_PREFIXES,
+        [
+            "Before declaring this task complete:",
+            "Before ending this turn:"
+        ]
+        .as_slice()
+    );
+}
+
+/// The classifier half of the `ENGINE_NUDGE_PREFIXES` tie, and the twin of
+/// `every_exported_engine_marker_is_classified_as_engine_text`. A nudge added
+/// to the table that never reaches this classifier fails here by name. The
+/// receipt would otherwise file the new engine message under the person.
+#[test]
+fn every_exported_engine_nudge_is_classified_as_engine_text() {
+    for nudge in crate::engine_markers::ENGINE_NUDGE_PREFIXES {
+        let content = format!("{nudge} engine-authored ask");
+        assert_eq!(
+            user_block_kind(&content),
+            BlockKind::Steered,
+            "{nudge:?} is in ENGINE_NUDGE_PREFIXES but user_block_kind does not \
+             read it as steering — add it in receipts.rs"
+        );
+    }
+}
+
 #[test]
 fn a_hydrated_attachment_never_puts_its_payload_on_the_event_stream() {
     // An at-rest attachment is metadata and rides as a gap kind. A hydrated

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -634,15 +634,6 @@ fn floor_char_boundary(text: &str, max: usize) -> usize {
     cut
 }
 
-/// Render the selected skills into the markdown block the CLI injects as a
-/// **volatile context message after the byte-stable system prefix** — never
-/// baked into the cached system block, so prompt-cache hits on the prefix are
-/// preserved ( L-E8). Each skill contributes its name,
-/// description, and body; bodies over `SKILL_BODY_TOKEN_BUDGET` are
-/// truncated with a marker, and once the running total exceeds
-/// `SKILLS_SECTION_TOKEN_BUDGET` the remaining (lower-ranked) skills are
-/// dropped with a note. At least the top skill always renders. Empty input ⇒
-/// empty string (inject nothing).
 /// The block ONE selected skill contributes to the section: name, description,
 /// and the (budget-truncated) body.
 ///
@@ -659,6 +650,15 @@ pub fn rendered_skill_block(sel: &SelectedSkill) -> String {
     )
 }
 
+/// Render the selected skills into the markdown block the CLI injects as a
+/// **volatile context message after the byte-stable system prefix** — never
+/// baked into the cached system block, so prompt-cache hits on the prefix are
+/// preserved (L-E8). Each skill contributes its name, description, and body;
+/// bodies over `SKILL_BODY_TOKEN_BUDGET` are truncated with a marker, and once
+/// the running total exceeds `SKILLS_SECTION_TOKEN_BUDGET` the remaining
+/// (lower-ranked) skills are dropped with a note ([`section_fit`] owns that
+/// cut). At least the top skill always renders. Empty input renders the empty
+/// string, so the caller injects nothing.
 pub fn render_skills_section(selected: &[SelectedSkill]) -> String {
     if selected.is_empty() {
         return String::new();
@@ -871,14 +871,6 @@ pub struct SkillRejection {
     pub rejected_at: u64,
 }
 
-/// The deterministic `<slug>-<hash8>` identity a lesson mines to.
-///
-/// One function rather than an expression inlined per site, because this
-/// string is three things at once: the candidate's name, the `SKILL.md`
-/// filename stem on disk, and the key a [`SkillRejection`] is recorded
-/// against. Those three must agree byte-for-byte or a rejection silently
-/// misses — and `migration_contract::candidate_identity_is_pinned_to_a_literal`
-/// is the literal all three are pinned to.
 /// The longest a mined description may be. Descriptions are one-liners —
 /// rendered into a single frontmatter field, listed in a fixed-width column,
 /// and read by the scorer as a bag of words, where every extra term the
@@ -939,6 +931,14 @@ fn candidate_description(text: &str) -> String {
     }
 }
 
+/// The deterministic `<slug>-<hash8>` identity a lesson mines to.
+///
+/// One function rather than an expression inlined per site, because this
+/// string is three things at once: the candidate's name, the `SKILL.md`
+/// filename stem on disk, and the key a [`SkillRejection`] is recorded
+/// against. Those three must agree byte-for-byte or a rejection silently
+/// misses — and `migration_contract::candidate_identity_is_pinned_to_a_literal`
+/// is the literal all three are pinned to.
 pub fn candidate_id(text: &str) -> String {
     format!(
         "{}-{}",

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -656,20 +656,6 @@ impl TurnState {
         self
     }
 
-    /// The cancellation check `run_step` runs at its safe boundaries: `None`
-    /// when the turn may proceed, otherwise the clean abort.
-    ///
-    /// Closing any open `tool_use` before returning mirrors the budget-abort
-    /// discipline in `Engine::handle_committed_result`. At a step boundary the
-    /// engine's own path never leaves one open — `dispatch_completion` appends
-    /// the results before it returns — so this only ever fires on history a
-    /// caller handed in (or appended to) mid-turn. It is cheap, and the
-    /// alternative is a resumed session whose first provider call is rejected
-    /// outright for an unanswered `tool_use`.
-    ///
-    /// No `Error` event: a cancellation is a decision, not a failure, exactly
-    /// as the soft stop is. The `Aborted` outcome carries [`CANCELLED_REASON`]
-    /// and that is what a host renders.
     /// The per-call shape of this step: which step it is, and the output
     /// ceiling it may ask for.
     ///
@@ -700,6 +686,20 @@ impl TurnState {
         self.output_budget_recovery.apply(configured)
     }
 
+    /// The cancellation check `run_step` runs at its safe boundaries: `None`
+    /// when the turn may proceed, otherwise the clean abort.
+    ///
+    /// Closing any open `tool_use` before returning mirrors the budget-abort
+    /// discipline in `Engine::handle_committed_result`. At a step boundary the
+    /// engine's own path never leaves one open — `dispatch_completion` appends
+    /// the results before it returns — so this only ever fires on history a
+    /// caller handed in (or appended to) mid-turn. It is cheap, and the
+    /// alternative is a resumed session whose first provider call is rejected
+    /// outright for an unanswered `tool_use`.
+    ///
+    /// No `Error` event: a cancellation is a decision, not a failure, exactly
+    /// as the soft stop is. The `Aborted` outcome carries [`CANCELLED_REASON`]
+    /// and that is what a host renders.
     pub(crate) fn cancel_outcome(&mut self, events: &EventSender) -> Option<StepOutcome> {
         if !self.cancel.is_cancelled() {
             return None;


### PR DESCRIPTION
## What

The full-file correctness sweep of the nine `stella-core` files #5390 names, with the confirmed defects fixed. One behavioural defect, three documentation defects, one duplicated policy.

### The behavioural defect: engine nudges receipted as the user's goal

`receipts::user_block_kind` exists so a receipt never attributes engine-written text to the person. It restated the marker list inline and knew nothing of the two once-per-turn completion nudges — the prove-it ask (`driver::confident_zero::PROVE_IT_PREFIX`) and the live-service assertion (`driver::live_services::SERVICES_PREFIX`). Both are `User`-role messages the engine writes; both are plain English with no bracketed marker, so `ENGINE_MARKERS` cannot see them.

Consequence on `main`: every turn either gate fires, the engine's own nudge is decomposed as `BlockKind::UserGoal` and registered under a `user_goal` block id. That is exactly the misattribution the classifier was introduced to fix.

This is the "paired functions that disagree" lens the issue asks for. `driver::loop_evidence::turn_start_index` already read both facts — the marker table *and* `confident_zero::is_engine_nudge` — so two rules over the same message gave two answers.

The fix follows the `ENGINE_MARKERS` precedent rather than adding a third restatement: `engine_markers.rs` gains a second table, `ENGINE_NUDGE_PREFIXES`, plus one predicate `is_engine_nudge` over it. `turn_start_index` and `user_block_kind` both read the predicate; `confident_zero`'s private copy is deleted. Two tables and not one list, because the marked half is recognisable by shape and the unmarked half only by enumeration — the module's tests hold them non-empty, duplicate-free, non-shadowing and disjoint.

### The documentation defects

Three doc blocks had been welded onto the item below them. The item they described lost its documentation and the item they landed on gained a wrong one:

| Item with no doc | Item wearing the wrong doc |
|---|---|
| `TurnState::cancel_outcome` (`step.rs`) | `TurnState::model_call_shape` — read as closing open `tool_use` calls and returning a cancellation abort |
| `render_skills_section` (`skills.rs`) | `rendered_skill_block` — read as rendering the whole section |
| `candidate_id` (`skills.rs`) | `DESCRIPTION_MAX_CHARS` — a `usize` const whose rustdoc claimed it was "the candidate's name, the `SKILL.md` filename stem on disk, and the key a `SkillRejection` is recorded against" |

Each block is moved back onto the item it describes. `candidate_id` and `render_skills_section` are `pub`, so two of the three were wrong in the crate's public API docs.

### The duplicated policy

`truncation.rs` carried the retained-partial shape twice: `retained_partial` and, inlined, the continuation arm of `plan_continuation`. They agree today. `plan_continuation` now calls the helper, so what the model re-reads after a continuation and after a stop cannot drift apart.

## The witness and its mechanism

`crates/stella-core/src/receipts/tests.rs`:

- `the_completion_nudges_are_steering_not_the_users_goal` — the fail-on-base half. It asserts `user_block_kind` returns `BlockKind::Steered` for a real prove-it ask and a real live-service assertion. On `main` this classifier has no arm for either prefix, so both fall through to the final `else` and return `BlockKind::UserGoal`; the assertion fails on the value. Spelled with string literals rather than the new constants, on `driver/restore.rs`'s stated precedent, so the fail half genuinely runs against a base tree that has no `ENGINE_NUDGE_PREFIXES`.
- `the_nudge_literals_are_the_constants` — pins those literals to the table, so the witness cannot pass against a prefix nobody sends.
- `every_exported_engine_nudge_is_classified_as_engine_text` — the durable form, the twin of the existing `every_exported_engine_marker_is_classified_as_engine_text`: a third gate's nudge added to the table without reaching the classifier fails here by name.

`crates/stella-core/src/engine_markers.rs` adds `every_nudge_is_distinctive_and_unmarked`, `no_nudge_repeats_or_shadows_another` and `the_two_tables_do_not_overlap`, mirroring the marker table's own three. `driver/loop_evidence.rs`'s `an_engine_nudge_does_not_reset_the_turn_window` now iterates the exported table instead of a hand-written pair, so it covers a nudge added later.

The three doc moves and the `truncation.rs` dedup change no behaviour and carry no witness, per CONTRIBUTING.md's carve-out for docs and pure refactors.

I did not compile or run tests locally (CLAUDE.md: CI builds and tests, this laptop does not). `make guards-fast` is green, including the prose, prose-density and line-citation ratchets.

## Exemplar followed

`engine_markers::ENGINE_MARKERS` itself — one leaf table of constants by path, read by every consumer, tied from both sides by test. The second table is the same shape applied to the half of the engine's writing that has no marker to match on.

## Verdicts for the other files

`driver/dispatch.rs`, `driver/rate_limit.rs`, `driver/restore.rs`, `tasks.rs` and `goal.rs` were read in full and are clean under the issue's lens. The per-file reasoning goes on #5390 as the comment the design pointer asks for.

## Residue

- #5716 — the two nudges are engine text the *model* cannot tell from a tool result. The prompt's injection-defence contract teaches that engine guidance carries a bracketed marker, and these two do not. Fixing it moves prompt bytes and both once-per-turn latches, so it is a prompt change with its own measurement rather than a classifier repair.

Closes #5390

Tests deleted: None

## Summary by Sourcery

Correct engine completion-nudge attribution and consolidate the shared engine-message and truncation policies.

Bug Fixes:
- Classify engine-authored completion nudges as steering instead of attributing them to the user's goal in receipts and turn-window tracking.

Enhancements:
- Centralize completion-nudge prefixes alongside engine markers and validate that the two message tables remain complete, distinct, and non-overlapping.
- Reuse the retained-partial truncation policy for continuation handling to prevent behavioral drift.
- Correct misplaced API documentation for cancellation outcomes, skill rendering, and candidate identifiers.

Tests:
- Add regression coverage for completion-nudge receipt classification and exported nudge-table consistency.