### PR TITLE
fix(stella-core): the stagnation rung reads where a tool came from

### DIFF
--- a/crates/stella-cli/src/agent/tool_stack.rs
+++ b/crates/stella-cli/src/agent/tool_stack.rs
@@ -510,6 +510,71 @@ mod tests {
         );
     }
 
+    /// **The tool-origin witness, through the *shipped* composition.**
+    ///
+    /// The stagnation rung exempts a tool that came from outside the binary,
+    /// and it learns that from `ToolExecutor::tool_origin`. The answer starts
+    /// three or four layers down — the registry knows its catalog rows, the
+    /// MCP set knows its namespace, the custom set knows its manifest — and
+    /// has to survive every decorator above it. The port's default is `None`,
+    /// so a layer that forgets to forward reports "unknown" and the exemption
+    /// silently stops reaching the session that needed it.
+    ///
+    /// Asserted through `session_stack_with_gate` with the skill plane on
+    /// top, which is the chain a turn driver mounts, for the same reason the
+    /// gate witness above is: a future decorator that forgets to forward
+    /// fails here, and nowhere else.
+    #[tokio::test]
+    async fn the_production_tool_stack_forwards_tool_origin() {
+        use stella_core::loop_detect::ToolOrigin;
+        use stella_tools::skill_plane::{SkillInvocationPlane, SkillScopedTools};
+
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(stella_tools::registry::ToolRegistry::new(
+            dir.path().to_path_buf(),
+        ));
+        let mut client = stella_mcp::McpClient::new(
+            "vendor",
+            Box::new(CannedTransport {
+                called: Arc::new(std::sync::Mutex::new(false)),
+            }),
+        );
+        client.initialize().await.unwrap();
+        let mcp = stella_mcp::McpToolSet::from_clients(vec![client])
+            .wrapping(registry.clone() as Arc<dyn ToolExecutor>);
+
+        let stack = session_stack_with_gate(
+            &mcp,
+            vec![script_tool(dir.path())],
+            dir.path().to_path_buf(),
+            ToolPolicy::allow_all(),
+            session_gate(dir.path()),
+            Principal::User,
+        );
+        let view = SkillScopedTools::new(&stack, SkillInvocationPlane::new());
+
+        assert_eq!(
+            view.tool_origin("task_list"),
+            Some(ToolOrigin::Builtin),
+            "a catalog row is a built-in and the rung must keep firing for it"
+        );
+        assert_eq!(
+            view.tool_origin("mcp__vendor__deploy"),
+            Some(ToolOrigin::Mcp),
+            "a server's tool, whose constant ack is its own design"
+        );
+        assert_eq!(
+            view.tool_origin("my_tool"),
+            Some(ToolOrigin::Custom),
+            "a .stella/tools script, which may print one constant line"
+        );
+        assert_eq!(
+            view.tool_origin("no_such_tool"),
+            None,
+            "a name nothing registered is unknown, not a built-in"
+        );
+    }
+
     /// **The skill-invocation witness, through the shipped composition.**
     /// The skill invocation plane composed over the assembled session chain — the
     /// position every turn driver mounts it at — is exactly the

--- a/crates/stella-cli/src/claims.rs
+++ b/crates/stella-cli/src/claims.rs
@@ -617,6 +617,12 @@ impl ToolExecutor for ClaimTap<'_> {
     fn dispatch_gate(&self) -> Option<&dyn stella_core::ports::DispatchGate> {
         self.inner.dispatch_gate()
     }
+
+    /// Forwarded. The tap claims files. It owns no tool name of its own, so
+    /// every origin it can give back is the base's.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        self.inner.tool_origin(name)
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -187,6 +187,12 @@ impl ToolExecutor for TaskTap<'_> {
         self.inner.dispatch_gate()
     }
 
+    /// Forwarded. The tap mirrors task updates. It owns no tool name of its
+    /// own, so every origin it can give back is the base's.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        self.inner.tool_origin(name)
+    }
+
     /// Forwarded: the deck's lead lane wraps the discovery mount (which owns
     /// the invocation plane) in this tap, so a tap that let the empty default
     /// stand would silently stop active skill bodies surviving summarization

--- a/crates/stella-cli/src/fleet_commits.rs
+++ b/crates/stella-cli/src/fleet_commits.rs
@@ -167,6 +167,12 @@ impl ToolExecutor for CommitObserver<'_> {
     fn dispatch_gate(&self) -> Option<&dyn stella_core::ports::DispatchGate> {
         self.inner.dispatch_gate()
     }
+
+    /// Forwarded. This observer watches commits. It owns no tool name of its
+    /// own, so every origin it can give back is the base's.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        self.inner.tool_origin(name)
+    }
 }
 
 /// One attempt's commits, oldest first — and the two ways of knowing which

--- a/crates/stella-cli/src/tool_policy.rs
+++ b/crates/stella-cli/src/tool_policy.rs
@@ -142,6 +142,13 @@ impl ToolExecutor for PolicyToolSet<'_> {
     fn dispatch_gate(&self) -> Option<&dyn stella_core::ports::DispatchGate> {
         self.inner.get().dispatch_gate()
     }
+
+    /// Forwarded, and NOT narrowed, as the gate above is not. A tool that is
+    /// switched off cannot run again. A call it made before the switch
+    /// flipped is still in the window, and the rung still reads its origin.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        self.inner.get().tool_origin(name)
+    }
 }
 
 /// Which `"tools"` key withheld `name` — the exact name, its group, or the

--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -56,7 +56,7 @@ use crate::loop_detect::{CallRecord, LoopIdentity, LoopVerdict, detect_loop};
 use crate::ports::ToolExecutor;
 use crate::step::AbortKind;
 
-use super::loop_evidence::{recent_call_records, turn_start_index};
+use super::loop_evidence::{recent_call_records, stamp_origins, turn_start_index};
 use super::{EngineConfig, LOOP_STEER_PREFIX, TurnMemos, TurnOutcome};
 
 /// How many stuck-loop steering warnings one turn may spend.
@@ -282,7 +282,10 @@ pub(super) fn check_loop_detection(
     events: &EventSender,
 ) -> Option<TurnOutcome> {
     let turn_instance = config.turn_instance;
-    let records = recent_call_records(messages, &memos.identities);
+    let mut records = recent_call_records(messages, &memos.identities);
+    // Where each call's tool came from, which the transcript cannot say and
+    // the stagnation rung needs.
+    stamp_origins(&mut records, tools);
     // Classified on every step, not only on the arm that steers on it, and
     // recorded before any of them can return: the number is the turn's, and a
     // step that also detected a loop is exactly the one a post-hoc reader most

--- a/crates/stella-core/src/driver/loop_escalation/tests.rs
+++ b/crates/stella-core/src/driver/loop_escalation/tests.rs
@@ -628,6 +628,7 @@ mod stall {
                 }),
                 output: Some(Cow::Owned(ToolOutput::ok("done"))),
                 identity: None,
+                origin: None,
             })
             .collect()
     }

--- a/crates/stella-core/src/driver/loop_evidence.rs
+++ b/crates/stella-core/src/driver/loop_evidence.rs
@@ -333,6 +333,7 @@ pub(super) fn recent_call_records<'a>(
                     call: Cow::Borrowed(call),
                     output: None,
                     identity: None,
+                    origin: None,
                 }));
             }
             MessageRole::Tool => {
@@ -354,6 +355,27 @@ pub(super) fn recent_call_records<'a>(
         }
     }
     records
+}
+
+/// Stamp each record with where its tool came from. The answer comes from
+/// the executor that dispatches the name.
+///
+/// A second pass, not an argument to [`recent_call_records`]. That walk reads
+/// the transcript, and every caller wants it. This one needs the live tool
+/// stack, and only the loop-detection pass holds one. A caller that skips it
+/// leaves every origin `None`, and the detector reads that as "not
+/// recorded".
+///
+/// One lookup per record, not one per name. The window is a few dozen calls,
+/// and each answer is a short walk down the tool chain. A memo would cost
+/// more than it saves.
+pub(super) fn stamp_origins(
+    records: &mut [CallRecord<'_>],
+    tools: &dyn crate::ports::ToolExecutor,
+) {
+    for record in records.iter_mut() {
+        record.origin = tools.tool_origin(&record.call.name);
+    }
 }
 
 /// Identifies a tool call for the purpose of [`ResultIdentities`]: the

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -77,7 +77,9 @@ pub use extensions::{
 };
 pub use goal::{GoalAssessError, GoalConfig, GoalOutcome, GoalVerifierVerdict};
 pub use hooks::{HookEvent, HookPayload, HookRunOutcome, HookRunner, Hooks, run_hooks};
-pub use loop_detect::{CallRecord, LoopDetectionConfig, LoopIdentity, LoopVerdict, detect_loop};
+pub use loop_detect::{
+    CallRecord, LoopDetectionConfig, LoopIdentity, LoopVerdict, ToolOrigin, detect_loop,
+};
 pub use mcp_usage::{McpUsageLedger, McpUsageRecord, drain_usage, push_usage};
 pub use plan_graph::{PlanGraph, PlanGraphError, RevisionError, RevisionGate};
 pub use ports::{Clock, LiveService, ToolExecutor};

--- a/crates/stella-core/src/loop_detect.rs
+++ b/crates/stella-core/src/loop_detect.rs
@@ -92,6 +92,40 @@ mod sweep;
 /// observation with a number it did not produce.
 const MAX_CYCLE_PERIOD: usize = 4;
 
+/// Where a called tool came from, and so whether byte-identical output says
+/// anything about the turn.
+///
+/// A built-in's output is content: it reports what it read, what it matched,
+/// what it wrote. The same bytes back from different arguments therefore mean
+/// the arguments are not reaching anything new, which is what the stagnation
+/// rung claims. A tool outside the binary makes no such promise. An MCP
+/// server may answer every successful call with one ack string, and a
+/// workspace script may print one constant line, so identical output there is
+/// the tool's design and says nothing about the turn.
+///
+/// Set by the caller from the executor that dispatches the name
+/// (`crate::ports::ToolExecutor::tool_origin`), never derived here: this
+/// module is a pure function over owned data, and which names a session
+/// registered is not something it can see.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolOrigin {
+    /// Compiled into this binary and declared in the reviewed catalog.
+    Builtin,
+    /// Reached over an MCP server's wire, named `mcp__<server>__<tool>`.
+    Mcp,
+    /// A workspace's own script tool, declared in `.stella/tools/*.toml`.
+    Custom,
+}
+
+impl ToolOrigin {
+    /// Whether this tool's output was reviewed as content, which is the claim
+    /// `detect_stagnation` rests on.
+    #[must_use]
+    pub fn is_builtin(self) -> bool {
+        matches!(self, Self::Builtin)
+    }
+}
+
 /// One tool call paired with the output it produced — the unit the
 /// detector inspects. `output` is `None` while unresolved (the call never
 /// ran, or its result message is gone from the window); an unresolved
@@ -119,6 +153,15 @@ pub struct CallRecord<'a> {
     pub call: Cow<'a, ToolCall>,
     pub output: Option<Cow<'a, ToolOutput>>,
     pub identity: Option<String>,
+    /// Where the tool this call names came from, when the caller knows —
+    /// read by `detect_stagnation` and by nothing else.
+    ///
+    /// `None` means the origin was never recorded, not that the tool is a
+    /// built-in. A caller that leaves it unset gets what this module did
+    /// before origins existed, so the field cannot quietly disarm a rung for
+    /// anyone who has not opted in. [`Self::identity`] carries the same
+    /// three states, for the same reason.
+    pub origin: Option<ToolOrigin>,
 }
 
 /// Threshold configuration for [`detect_loop`] and for the stall rung beside
@@ -270,6 +313,11 @@ pub enum LoopVerdict {
     /// The weakest of the three verdicts and the last one checked: it makes
     /// no claim about the *shape* of the repetition, only that the tool
     /// stopped being informative.
+    ///
+    /// Reported for a built-in tool, or for one whose [`ToolOrigin`] the
+    /// caller did not record. A tool known to come from outside the binary
+    /// never reaches this verdict — its constant output may be a design
+    /// choice rather than a stalled turn.
     Stagnant { tool: String, count: usize },
     /// One identical call — same tool, same input, byte-identical output —
     /// recurring across the window with other work in between.
@@ -789,11 +837,26 @@ fn detect_short_cycle(records: &[CallRecord<'_>], repeats_threshold: usize) -> O
 /// other pairwise, or differ in any particular way. A run of `a, a, b, b, c`
 /// stagnates just as a run of `a, b, c, d, e` does — what makes it stagnation
 /// is that none of them moved the answer.
+///
+/// A tool the caller marked as coming outside the binary is exempt
+/// ([`ToolOrigin`]). This rung rests on one claim: the same bytes mean
+/// nothing was learned. That is false for a server that acks every call with
+/// one string, and killing a working turn over it is the bug.
+///
+/// The other four rungs still cover such a tool. An identical *input*
+/// repeated still trips `detect_exact_repeat`, which makes no claim about
+/// what the bytes mean.
 fn detect_stagnation(records: &[CallRecord<'_>], threshold: usize) -> Option<LoopVerdict> {
     if threshold < 2 {
         return None;
     }
     let last = records.last()?;
+    // Read off the trailing record, as every verdict here is. The run below
+    // shares this record's tool name, and an origin is a fact about a name,
+    // so one lookup settles the whole run.
+    if last.origin.is_some_and(|origin| !origin.is_builtin()) {
+        return None;
+    }
     // `same_output(last, last)` is false for an unresolved output, so a
     // trailing call whose result is not in the window yields a count of 0 and
     // never fires — the same "a loop can only be PROVEN by observed outputs"

--- a/crates/stella-core/src/loop_detect/tests.rs
+++ b/crates/stella-core/src/loop_detect/tests.rs
@@ -2,6 +2,7 @@ use proptest::prelude::*;
 
 use super::*;
 
+mod origin;
 mod sweep;
 
 fn record(name: &str, input: serde_json::Value, output: Option<ToolOutput>) -> CallRecord<'static> {
@@ -20,7 +21,18 @@ fn record(name: &str, input: serde_json::Value, output: Option<ToolOutput>) -> C
         // comparison. The identity path has its own witness in
         // `driver::tests::audit_fixes`.
         identity: None,
+        // Unrecorded, which is what every caller said before origins existed
+        // and what these fixtures keep saying — the origin-aware witnesses
+        // set it through `from`.
+        origin: None,
     }
+}
+
+/// The same record, marked with where its tool came from. The driver stamps
+/// this once it has asked the executor.
+fn from(mut record: CallRecord<'static>, origin: ToolOrigin) -> CallRecord<'static> {
+    record.origin = Some(origin);
+    record
 }
 
 /// The same record with a caller-supplied output identity attached —

--- a/crates/stella-core/src/loop_detect/tests/origin.rs
+++ b/crates/stella-core/src/loop_detect/tests/origin.rs
@@ -1,0 +1,172 @@
+//! Witnesses for the stagnation rung's origin exemption.
+//!
+//! A server may ack every call the same way. That is its design. A built-in
+//! that says the same thing every time is a turn that has stopped.
+
+use proptest::prelude::*;
+
+use super::*;
+
+/// One call to a server that acks every success the same way. The arguments
+/// differ. The bytes back do not. That is what the server was built to do.
+fn mcp_ack(issue: &str) -> CallRecord<'static> {
+    call(
+        "mcp__tracker__create_issue",
+        serde_json::json!({ "title": issue }),
+        "ok",
+    )
+}
+
+/// **Witness, direction one.** Six calls to an MCP tool. Six sets of
+/// arguments. One ack. This was real work, and the rung killed it.
+///
+/// The mark is the whole difference. The same records with no mark still
+/// stagnate, and the second check pins that. So this test cannot pass by
+/// the fixture missing the rung.
+#[test]
+fn an_mcp_tool_acking_every_call_the_same_way_is_not_stagnation() {
+    let unmarked: Vec<CallRecord<'static>> = (0..6)
+        .map(|i| mcp_ack(&format!("flaky test {i}")))
+        .collect();
+    let marked: Vec<CallRecord<'static>> = unmarked
+        .iter()
+        .cloned()
+        .map(|record| from(record, ToolOrigin::Mcp))
+        .collect();
+
+    assert_eq!(
+        detect_loop(&marked, LoopDetectionConfig::default()),
+        LoopVerdict::NoLoop,
+        "a constant ack is the server's design, not evidence the turn stalled"
+    );
+    assert!(
+        matches!(
+            detect_loop(&unmarked, LoopDetectionConfig::default()),
+            LoopVerdict::Stagnant { .. }
+        ),
+        "anti-vacuity: with the origin unrecorded these exact records still trip \
+         the rung, so the exemption is what the first assertion measures"
+    );
+}
+
+/// **Witness, direction two.** The exemption is only for arguments that
+/// moved. Six *identical* calls to one MCP tool are a repeat, whatever the
+/// bytes mean. Exact-repeat needs no claim about the bytes to say so.
+#[test]
+fn an_mcp_tool_called_identically_over_and_over_is_still_a_loop() {
+    let records: Vec<CallRecord<'static>> = vec![mcp_ack("one issue"); 6]
+        .into_iter()
+        .map(|record| from(record, ToolOrigin::Mcp))
+        .collect();
+
+    match detect_loop(&records, LoopDetectionConfig::default()) {
+        LoopVerdict::ExactRepeat { tool, count, .. } => {
+            assert_eq!(tool, "mcp__tracker__create_issue");
+            assert_eq!(count, 6);
+        }
+        other => panic!("expected ExactRepeat, got {other:?}"),
+    }
+}
+
+/// **Witness, direction three.** The exemption reaches only tools from
+/// outside the binary. A built-in reports what it saw. The same bytes for
+/// six sets of arguments still mean the arguments reached nothing new.
+#[test]
+fn a_builtin_answering_every_new_argument_the_same_way_still_stagnates() {
+    for origin in [None, Some(ToolOrigin::Builtin)] {
+        let records: Vec<CallRecord<'static>> = (0..6)
+            .map(|i| {
+                let record = grep_variant(&format!("cache_write|savings_{i}"));
+                match origin {
+                    Some(origin) => from(record, origin),
+                    None => record,
+                }
+            })
+            .collect();
+
+        match detect_loop(&records, LoopDetectionConfig::default()) {
+            LoopVerdict::Stagnant { tool, count } => {
+                assert_eq!(tool, "grep");
+                assert_eq!(count, 6, "origin {origin:?}");
+            }
+            other => panic!("expected Stagnant for origin {origin:?}, got {other:?}"),
+        }
+    }
+}
+
+/// A script that prints one line on success is the MCP ack one byte away.
+/// The stamp a silent success gets fires on *empty* stdout only. So
+/// `echo done` gives the same bytes every call.
+#[test]
+fn a_custom_tool_printing_a_constant_line_is_not_stagnation() {
+    let records: Vec<CallRecord<'static>> = (0..8)
+        .map(|i| {
+            from(
+                call(
+                    "deploy_preview",
+                    serde_json::json!({ "branch": format!("topic-{i}") }),
+                    "done",
+                ),
+                ToolOrigin::Custom,
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        detect_loop(&records, LoopDetectionConfig::default()),
+        LoopVerdict::NoLoop
+    );
+}
+
+proptest! {
+    /// Property: a history of records from outside the binary never
+    /// reaches `Stagnant`. Not for any arguments, outputs or thresholds.
+    ///
+    /// The rung rests on one claim: the same bytes mean nothing was
+    /// learned. That claim is false for a tool that acks by design. So the
+    /// verdict must never be reached for one.
+    ///
+    /// The other rungs stay armed. An exact repeat of a server call is
+    /// still a loop, and this says nothing against that.
+    #[test]
+    fn a_tool_from_outside_the_binary_never_stagnates(
+        records in proptest::collection::vec(arb_call_record(), 0..16),
+        exact_repeat_threshold in 0usize..8,
+        short_cycle_repeats in 0usize..8,
+        stagnation_threshold in 0usize..8,
+        interleaved_repeat_threshold in 0usize..8,
+        monotonic_sweep_threshold in 0usize..8,
+        custom in proptest::bool::ANY,
+    ) {
+        let origin = if custom { ToolOrigin::Custom } else { ToolOrigin::Mcp };
+        let records: Vec<CallRecord<'static>> = records
+            .into_iter()
+            .map(|record| from(record, origin))
+            .collect();
+        let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold, interleaved_repeat_threshold, monotonic_sweep_threshold, stall_steer_threshold_secs: 0 };
+        prop_assert!(!matches!(detect_loop(&records, config), LoopVerdict::Stagnant { .. }));
+    }
+
+    /// Property: marking every record `Builtin` changes no verdict. The
+    /// rung always assumed as much, so writing it down must change nothing.
+    ///
+    /// A record with no origin set behaves the same way. A caller that does
+    /// not stamp yet keeps the detector it has today.
+    #[test]
+    fn marking_a_history_builtin_changes_nothing(
+        records in proptest::collection::vec(arb_call_record(), 0..16),
+        exact_repeat_threshold in 0usize..8,
+        short_cycle_repeats in 0usize..8,
+        stagnation_threshold in 0usize..8,
+        interleaved_repeat_threshold in 0usize..8,
+        monotonic_sweep_threshold in 0usize..8,
+    ) {
+        let marked: Vec<CallRecord<'static>> = records
+            .iter()
+            .cloned()
+            .map(|record| from(record, ToolOrigin::Builtin))
+            .collect();
+        let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold, interleaved_repeat_threshold, monotonic_sweep_threshold, stall_steer_threshold_secs: 0 };
+        prop_assert_eq!(detect_loop(&marked, config), detect_loop(&records, config));
+    }
+}

--- a/crates/stella-core/src/loop_detect/tests/origin.rs
+++ b/crates/stella-core/src/loop_detect/tests/origin.rs
@@ -144,7 +144,10 @@ proptest! {
             .map(|record| from(record, origin))
             .collect();
         let config = LoopDetectionConfig { exact_repeat_threshold, short_cycle_repeats, stagnation_threshold, interleaved_repeat_threshold, monotonic_sweep_threshold, stall_steer_threshold_secs: 0 };
-        prop_assert!(!matches!(detect_loop(&records, config), LoopVerdict::Stagnant { .. }));
+        prop_assert!(
+            !matches!(detect_loop(&records, config), LoopVerdict::Stagnant { .. }),
+            "a tool from outside the binary reached Stagnant"
+        );
     }
 
     /// Property: marking every record `Builtin` changes no verdict. The

--- a/crates/stella-core/src/ports.rs
+++ b/crates/stella-core/src/ports.rs
@@ -221,6 +221,34 @@ pub trait ToolExecutor: Send + Sync {
     fn dispatch_gate(&self) -> Option<&dyn DispatchGate> {
         None
     }
+
+    /// Where `name` came from — a reviewed built-in, an MCP server, or a
+    /// workspace script. `None` means this executor cannot say.
+    ///
+    /// The engine's stagnation rung reads it. That rung fires on a run of
+    /// same-tool calls whose output never changed. For a built-in that is
+    /// evidence, because its output reports what it saw. For a server that
+    /// acks every call with one string it is no evidence at all. So the
+    /// answer has to come from the layer that knows which names it
+    /// registered. The transcript cannot supply it.
+    ///
+    /// The layer that **dispatches** the name answers. The registry says
+    /// [`crate::loop_detect::ToolOrigin::Builtin`] for a catalog row. The
+    /// custom-script set says `Custom` for a manifest tool. The MCP set says
+    /// `Mcp` for a namespaced one. Every other decorator forwards, and
+    /// forwards **unfiltered**: the question is about a name that has already
+    /// run, so narrowing it could only lose an answer the caller needs.
+    ///
+    /// # A decorator that forgets to forward
+    ///
+    /// The default `None` reads as "unknown", and unknown is what the rung
+    /// assumed before origins existed: it fires exactly as it always did. So
+    /// a missed forward costs the fix and causes no regression, which is what
+    /// the default buys. The shipped composition is pinned end-to-end by
+    /// `stella-cli`'s `the_production_tool_stack_forwards_tool_origin`.
+    fn tool_origin(&self, _name: &str) -> Option<crate::loop_detect::ToolOrigin> {
+        None
+    }
 }
 
 /// The one entry every tool dispatch passes through before it runs: the
@@ -380,6 +408,14 @@ impl ToolExecutor for ReadOnlyTools<'_> {
         self.inner.dispatch_gate()
     }
 
+    /// Forwarded unfiltered, unlike `contracts()` above: a call already in
+    /// the loop-detection window ran somewhere, and answering `None` for it
+    /// because this view would not admit it today only costs the rung its
+    /// evidence.
+    fn tool_origin(&self, name: &str) -> Option<crate::loop_detect::ToolOrigin> {
+        self.inner.tool_origin(name)
+    }
+
     /// Forwarded, not zeroed. A sub-agent runs behind this view, so a
     /// *grandchild* it dispatched settles here first — into the child's own
     /// carve — and only then into the parent as part of the child's total.
@@ -485,6 +521,13 @@ impl ToolExecutor for GrantedTools<'_> {
     /// view would otherwise find no gate and go ungated (#2793).
     fn dispatch_gate(&self) -> Option<&dyn DispatchGate> {
         self.inner.dispatch_gate()
+    }
+
+    /// Forwarded unfiltered, for the same reason [`ReadOnlyTools`] forwards
+    /// it unfiltered: the grant decides what may run next, and this answers
+    /// where a call already in the window came from.
+    fn tool_origin(&self, name: &str) -> Option<crate::loop_detect::ToolOrigin> {
+        self.inner.tool_origin(name)
     }
 
     /// Forwarded, not zeroed, for the same reason as [`ReadOnlyTools`]: a

--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -1046,6 +1046,26 @@ impl ToolExecutor for McpToolSet {
         self.native.as_ref().and_then(|n| n.dispatch_gate())
     }
 
+    /// A namespaced name is this set's. Its origin is
+    /// [`stella_core::loop_detect::ToolOrigin::Mcp`].
+    ///
+    /// The test is the prefix, as in `execute` above. Every name this set
+    /// answers is a [`wire_name`], the synthetic resource and needs-auth
+    /// tools included. So a new synthetic family is covered the day it lands.
+    ///
+    /// A server's output is relayed word for word, so Stella cannot stamp
+    /// it. A server that acks each success with one string gives back the
+    /// same bytes for arguments that differ. The rung reads that as a stalled
+    /// turn unless it is told where the tool came from.
+    ///
+    /// Anything else is the native layer's to answer.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        if name.starts_with(NS_PREFIX) {
+            return Some(stella_core::loop_detect::ToolOrigin::Mcp);
+        }
+        self.native.as_ref().and_then(|n| n.tool_origin(name))
+    }
+
     /// Forwarded: this is a decorator, and a decorator that let the default
     /// `0.0` stand would silently drop sub-agent spend out of the parent's
     /// budget (see the port's contract).
@@ -1154,6 +1174,19 @@ impl ToolExecutor for CandidateMcpView {
     /// through `inner`, which gates it against the session's own base.
     fn dispatch_gate(&self) -> Option<&dyn stella_core::ports::DispatchGate> {
         self.native.dispatch_gate()
+    }
+
+    /// Split the way `execute` above splits. A namespaced name reaches
+    /// `inner`. Everything else reaches the candidate's own `native` layer.
+    ///
+    /// The candidate-safe filter is left out on purpose. A withheld tool
+    /// never ran, so it never sits in a window. Filtering here could only
+    /// drop an answer for a tool that did run.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        if name.starts_with(NS_PREFIX) {
+            return self.inner.tool_origin(name);
+        }
+        self.native.tool_origin(name)
     }
 
     /// Forwarded: this is a decorator, and a decorator that let the default

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -546,6 +546,15 @@ impl ToolExecutor for DelegatingTools<'_> {
     fn dispatch_gate(&self) -> Option<&dyn stella_core::ports::DispatchGate> {
         self.inner.dispatch_gate()
     }
+
+    /// Forwarded for the same reason. This wrapper adds the `delegate` name
+    /// and dispatches nothing else, so every origin it gives back is the
+    /// base's. The base here is the remoted executor, and it reports none.
+    /// The host owns the registry. So what comes back is an unknown, not a
+    /// guess.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        self.inner.tool_origin(name)
+    }
 }
 
 /// Turn a child's outcome into a model-visible result.

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -1339,6 +1339,19 @@ impl ToolExecutor for CustomToolSet<'_> {
         self.inner.get().dispatch_gate()
     }
 
+    /// A name this set dispatches is a workspace script. Everything else is
+    /// the inner surface's to answer.
+    ///
+    /// The stamp a silent success gets covers an *empty* stdout only. A
+    /// script that prints one line still gives the same bytes every call. So
+    /// the loop detector has to be told what kind of tool it is looking at.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        if self.tools.iter().any(|tool| tool.name == name) {
+            return Some(stella_core::loop_detect::ToolOrigin::Custom);
+        }
+        self.inner.get().tool_origin(name)
+    }
+
     /// Forwarded: this is a decorator, and a decorator that let the default
     /// `0.0` stand would silently drop sub-agent spend out of the parent's
     /// budget (see the port's contract).

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -496,6 +496,14 @@ impl ToolExecutor for GatedToolSet<'_> {
     fn dispatch_gate(&self) -> Option<&dyn stella_core::ports::DispatchGate> {
         self.inner.get().dispatch_gate()
     }
+
+    /// Forwarded, and not narrowed by the grant: the loop detector asks about
+    /// a call that already ran, so refusing an answer here would only cost
+    /// the stagnation rung its evidence. This is the outermost layer of the
+    /// shipped chain, so a `None` here would strand every origin beneath it.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        self.inner.get().tool_origin(name)
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-tools/src/registry/executor.rs
+++ b/crates/stella-tools/src/registry/executor.rs
@@ -46,6 +46,19 @@ impl ToolExecutor for ToolRegistry {
         Some(self)
     }
 
+    /// A catalog row is a built-in. Nothing else is.
+    ///
+    /// This is the same name lookup `crate::contracts::contract_for` uses to
+    /// decide whether a tool's claims were reviewed. So the loop detector and
+    /// the authorization plane cannot disagree about what a built-in is.
+    ///
+    /// A name the catalog has never heard of answers `None`. Unknown is what
+    /// it is, and the detector treats unknown as it did before origins
+    /// existed.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        crate::catalog::get(name).map(|_| stella_core::loop_detect::ToolOrigin::Builtin)
+    }
+
     /// Take what the `delegate` tool's children cost since the last step
     /// boundary. Destructive by the port's contract: the engine charges
     /// whatever this returns, so reporting twice would bill twice.

--- a/crates/stella-tools/src/skill_plane.rs
+++ b/crates/stella-tools/src/skill_plane.rs
@@ -209,6 +209,12 @@ impl ToolExecutor for SkillScopedTools<'_> {
         self.inner.dispatch_gate()
     }
 
+    /// Forwarded unfiltered: a skill's allowed-tools grant says what may run
+    /// next, and the loop detector is asking about a call that already ran.
+    fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
+        self.inner.tool_origin(name)
+    }
+
     /// Forwarded, not zeroed — a grandchild dispatched behind this view
     /// still settles into the carve that bounds it (see `ReadOnlyTools`).
     fn drain_sub_agent_spend_usd(&self) -> f64 {


### PR DESCRIPTION
## What

The output-keyed stagnation rung in `crates/stella-core/src/loop_detect.rs`
now reads where the tool came from before it fires.

`detect_stagnation` takes the trailing run of same-tool calls whose output
never changed, and returns `None` when every input in the run matches — so
the only case it fires on is **arguments that differ, output that does not**.
For a built-in that is evidence: its output reports what it read, what it
matched, what it wrote, so the same bytes for new arguments mean the
arguments reached nothing new (the `grep`-alternation regression this rung
was written for). For a tool outside the binary it is no evidence at all. An
MCP server may ack every successful call with one string, and a workspace
script may print one constant line, so identical output there is the tool's
design.

`CallRecord` carries a new `origin: Option<ToolOrigin>` with three states —
`Builtin`, `Mcp`, `Custom`. The rung exempts a run whose trailing record is
marked `Mcp` or `Custom`, and behaves exactly as before for `Builtin` and for
`None`.

### Where the answer comes from

A new `ToolExecutor::tool_origin(&self, name)` port method, answered by the
layer that **dispatches** the name:

| Layer | Answers |
|---|---|
| `ToolRegistry` (`stella-tools`) | `Builtin` for a `catalog::get` row, else `None` |
| `McpToolSet` (`stella-mcp`) | `Mcp` for an `mcp__…` name, else forwards to native |
| `CustomToolSet` (`stella-tools`) | `Custom` for a `.stella/tools/*.toml` name, else forwards |

Every other decorator forwards unfiltered — `GatedToolSet`, `PolicyToolSet`,
`SkillScopedTools`, `ClaimTap`, `TaskTap`, `CommitObserver`, `ReadOnlyTools`,
`GrantedTools`, `CandidateMcpView`, `DelegatingTools`. Unfiltered on purpose:
the question is about a name that has already run, so narrowing it could only
lose an answer the rung needs.

The driver stamps the window in `driver/loop_evidence.rs::stamp_origins`, a
second pass over the records `recent_call_records` built, called from
`loop_escalation::check_loop_detection`. The port's default is `None`, which
the detector reads as "not recorded" and treats as it always did, so a
decorator that forgets to forward costs the fix and causes no regression.

Exemplar followed: `dispatch_gate` on the same trait — a defaulted accessor
answered by the base of the chain and forwarded by every decorator over it
(#2793). The forwarding sites and the doc-comment shape are copied from it.

## Witnesses, and why each fails on the old code

All in `crates/stella-core/src/loop_detect/tests/origin.rs` (a new submodule;
`tests.rs` would have crossed the 1500-line ceiling), plus one in
`crates/stella-cli/src/agent/tool_stack.rs`. **They cannot compile on the old
code** — `CallRecord` had no `origin` field and `ToolOrigin` did not exist —
so the mechanism is structural rather than a threshold that happens to move.
Beyond that, each pins its own direction:

- `an_mcp_tool_acking_every_call_the_same_way_is_not_stagnation` — six MCP
  calls, six sets of arguments, one constant ack, marked `Mcp` → `NoLoop`.
  Its second assertion runs the **same records with the mark removed** and
  requires `Stagnant`, so the test cannot pass by the fixture missing the
  rung. That assertion is what fails on old behaviour.
- `an_mcp_tool_called_identically_over_and_over_is_still_a_loop` — six
  identical MCP calls still trip `ExactRepeat` with count 6. The exemption is
  only for arguments that moved.
- `a_builtin_answering_every_new_argument_the_same_way_still_stagnates` —
  the `grep` fixture over both `Some(Builtin)` and `None`, both `Stagnant`
  count 6. The exemption reaches nothing else.
- `a_custom_tool_printing_a_constant_line_is_not_stagnation` — the
  constant-stdout script, the second population the issue names.
- Property `a_tool_from_outside_the_binary_never_stagnates` — over arbitrary
  histories and all five thresholds, a history marked `Mcp` or `Custom` never
  reaches `Stagnant`.
- Property `marking_a_history_builtin_changes_nothing` — marking every record
  `Builtin` yields verdict-for-verdict the same answer as leaving the origin
  unset, so recording the origin is invisible where it was already assumed.
- `the_production_tool_stack_forwards_tool_origin` (stella-cli) — through
  `session_stack_with_gate` with the skill plane on top, over a real
  `ToolRegistry` under a real `McpToolSet` with a real custom script tool:
  `task_list` → `Builtin`, `mcp__vendor__deploy` → `Mcp`, `my_tool` →
  `Custom`, an unknown name → `None`. A future decorator inserted into the
  shipped chain that forgets to forward fails here and nowhere else.

`Tests deleted: None.` The five origin tests were **moved** from
`loop_detect/tests.rs` into the new `loop_detect/tests/origin.rs` in the same
commit that added them, so they appear only once in the diff against `main`.

## Part B — the varied-grind study (#3292): the metric does not separate

The design pointer asked for the novelty-collapse measurement over
`~/.arenabench/matches/`, and to ship a detector only if some threshold has
**zero false positives on the working population**. No such threshold exists.
Recording the numbers here and leaving #3292 open, as the pointer directs.

**Population.** 294 local matches, 497 trials carrying both a
`verifier/reward.txt` and an `agent/stella-events.jsonl`: 264 at reward 0.0,
233 at reward 1.0. The stuck trace is `5a38720c145f` →
`extract-moves-from-video__3AqwMdY`, reward 0.0, 62 `tool_start` / 62
`tool_result` events — the trial #3292's census is drawn from. The 10-trial
working sample is the first ten reward-1.0 trials by path:
`build-cython-ext`, `reshard-c4-data`, `sparql-university`, `git-multibranch`,
`distribution-search`, `fix-git`, `compile-compcert`, `crack-7z-hash`,
`break-filter-js-from-html`, `financial-document-processor`.

**Metric A — repeated lines within a window of W tool outputs.** Non-empty
lines, stripped; a line counts as a repeat when it already appeared earlier
in the same window; collapse = repeats / total lines.

| W | stuck (n, median, max) | working-10 (n, median, max) | zero-FP threshold from the 10 | stuck windows it catches |
|---|---|---|---|---|
| 6 | 57, 0.111, 0.613 | 370, 0.143, 0.446 | &gt; 0.446 | 7 / 57 (12%) |
| 8 | 55, 0.129, 0.598 | 350, 0.157, 0.436 | &gt; 0.436 | 7 / 55 (13%) |
| 10 | 53, 0.162, 0.608 | 332, 0.175, 0.494 | &gt; 0.494 | 3 / 53 (6%) |

The stuck trial's **median is below the working median at every W**. The
populations do not separate; only the extreme tail does, and it catches one
window in eight.

**The 10-trial threshold does not survive the rest of the winners.** Against
all 230 reward-1.0 trials that score at W=6 (7,582 windows, median 0.149,
p99 0.844, max 0.939), the 0.446 threshold fires on **374 windows in 68 of
230 winning trials** — it would kill 30% of successful runs. A threshold with
zero false positives over the whole winning population is &gt; 0.939 at W=6,
&gt; 0.936 at W=8, &gt; 0.918 at W=10, and each catches **0** stuck windows.

**Metric B — the newest output against the prior W steps** (the pointer's
literal wording: fraction of an output's lines already seen in the last W
steps). Worse. At W=8 the stuck median is 0.250 against a working median of
0.168, but **128 of 221 winning trials contain a window at 1.000** — an
output made entirely of lines seen before. No threshold at or under the
ceiling has zero false positives, and the ceiling catches nothing.

**Sustained level rather than a peak.** Share of a trial's W=8 metric-B
windows at or above 0.5: the stuck trial is 0.389; across 170 winning trials
with 10+ windows the median is 0.243, p90 0.438, max 0.634, and **31 of 170
winners (18%) sit at or above the stuck trial's share**.

**Conclusion.** Novelty collapse over tool-output lines does not distinguish
grinding from work on this corpus, in three formulations. Nothing ships for
#3292 and it stays open, with these numbers posted on it along with the exact
script.

**On the fixture windows.** The pointer asked for redacted fixture windows
under the crate's test fixtures. With no detector shipping there is nothing
in the tree that would read them, and committed data no test touches is the
unwired-code shape AGENTS.md asks us not to leave behind. The script and the
per-population numbers are posted verbatim on #3292 instead, so the
measurement is reproducible from any machine holding `~/.arenabench`. Say the
word and I will land the fixtures alongside whatever detector #3292 settles
on.

## Deviation from the design pointer

None on part A. On part B the pointer's own escape clause applies — no
threshold has zero false positives, so no detector ships and #3292 stays
open. The fixture-window question above is the one judgement call.

## DoD verification (#3328)

The three DoD boxes on #3328 were ticked after checking each against this
diff, not on the strength of this description:

| DoD item | Where it is satisfied |
|---|---|
| Distinct arguments + byte-identical outputs no longer trip the rung, or trip it under a stricter joint condition | `detect_stagnation`'s origin guard in `loop_detect.rs`; witnessed by `an_mcp_tool_acking_every_call_the_same_way_is_not_stagnation` and `a_custom_tool_printing_a_constant_line_is_not_stagnation`. Tool origin is the stricter joint condition, and part B records why no #3292 detector ships beside it. |
| Identical arguments + identical outputs still trip it | `an_mcp_tool_called_identically_over_and_over_is_still_a_loop` (`ExactRepeat`, count 6) and `a_builtin_answering_every_new_argument_the_same_way_still_stagnates` (`Stagnant`, count 6, for both `Some(Builtin)` and `None`). |
| Property tests updated alongside | `a_tool_from_outside_the_binary_never_stagnates` and `marking_a_history_builtin_changes_nothing`, both in `loop_detect/tests/origin.rs`. |

Closes #3328
Refs #3292, Refs #3303, Refs #3176, Refs #3187

## Summary by Sourcery

Make stagnation detection account for tool origin so constant external-tool acknowledgements do not trigger false loop alerts while preserving existing safeguards.

New Features:
- Add tool-origin metadata to loop-detection records so calls can be identified as built-in, MCP, or custom tools.

Bug Fixes:
- Prevent constant outputs from MCP and custom tools with changing arguments from being misclassified as stagnation while preserving exact-repeat detection.
- Preserve existing stagnation behavior for built-in and unrecorded tool origins.

Enhancements:
- Extend the tool executor interface and production tool stack to resolve and forward tool origins throughout decorators.
- Stamp call records with origin information before loop detection evaluates escalation evidence.

Tests:
- Add unit and property tests covering origin-aware stagnation behavior and unchanged built-in semantics.
- Add an end-to-end tool-stack test verifying origin propagation for built-in, MCP, custom, and unknown tools.

Chores:
- Record the varied-grind novelty-collapse study results without shipping a detector because no zero-false-positive threshold was found.