### PR TITLE
feat(stella-cli): reflect only on turns that hit something

### DIFF
--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -348,7 +348,10 @@ pub(crate) fn spawn_renderer(
                 // does, terminate before the provider loop can spend on a
                 // later unmetered call.
                 OutputFormat::StreamJson => emit_stream_json(&event, durable_pre_persisted, &clock),
-                OutputFormat::Json => outcome.events.push(event),
+                // Rendered by the envelope `run_turn` builds out of
+                // `RendererOutcome::events` below, so this arm prints nothing
+                // of its own.
+                OutputFormat::Json => {}
                 // One frame per turn, folded from the same events the cards
                 // below would each have printed. The two cannot both run: the
                 // frame restates every row, so a surface doing both prints the
@@ -412,6 +415,14 @@ pub(crate) fn spawn_renderer(
                     other => plain::render_event(other),
                 },
             }
+            // Kept for every format, not only `Json`. `run_turn` folds this
+            // vector into the turn's `TurnFriction`, and reflection reads
+            // those counts to decide whether the turn hit anything worth a
+            // model call. While the `Json` arm alone collected, that ledger
+            // came out empty in interactive mode and on every
+            // `--output-format stream-json` run — no retries, no loop firings,
+            // no failed calls, whatever the turn actually did.
+            outcome.events.push(event);
         }
         // The stream is closed, so the turn is final: print whatever frame the
         // fold accumulated. A turn that never opened prints nothing.

--- a/crates/stella-cli/src/agent/persistence/tests.rs
+++ b/crates/stella-cli/src/agent/persistence/tests.rs
@@ -1,5 +1,6 @@
 //! Suites over [`super`]'s persistence path, one topic per file.
 
+mod collected_journal;
 mod pipeline_variant;
 mod receipt_write;
 mod stream;

--- a/crates/stella-cli/src/agent/persistence/tests/collected_journal.rs
+++ b/crates/stella-cli/src/agent/persistence/tests/collected_journal.rs
@@ -1,0 +1,65 @@
+//! What `spawn_renderer` returns once the turn's stream closes.
+//!
+//! `RendererOutcome::events` is the turn's journal. `run_turn` folds it into a
+//! `TurnFriction`. Reflection reads those counts to decide if the turn is
+//! worth a model call. A journal the renderer drops is not a smaller answer.
+//! It is a wrong one: the turn reads as one that hit nothing.
+
+use crate::agent::persistence::*;
+
+/// One announced tool call and the error that closed it — the shape the
+/// friction fold counts.
+fn failed_call() -> Vec<AgentEvent> {
+    vec![
+        AgentEvent::ToolStart {
+            call: stella_protocol::ToolCall {
+                call_id: "c1".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({"path": "missing.rs"}),
+            },
+            sub_agent_id: None,
+            task_id: None,
+        },
+        AgentEvent::ToolResult {
+            call_id: "c1".into(),
+            output: stella_protocol::ToolOutput::error("no such file"),
+            duration_ms: 7,
+            speculated: false,
+            sub_agent_id: None,
+            task_id: None,
+        },
+    ]
+}
+
+/// Drive the renderer over `events` in `format` and hand back what it kept.
+async fn collected(format: OutputFormat, events: Vec<AgentEvent>) -> Vec<AgentEvent> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let renderer = spawn_renderer(rx, format, None, "anthropic".into(), false, None);
+    for event in events {
+        tx.send(event).expect("the renderer is live");
+    }
+    drop(tx);
+    renderer.await.expect("renderer").events
+}
+
+/// **The witness.** Every format keeps the turn's journal.
+///
+/// On base the `Text` and `StreamJson` arms kept none of it. Every fold over
+/// the journal then counted zero.
+#[tokio::test]
+async fn every_format_keeps_the_turns_journal() {
+    for format in [
+        OutputFormat::Text,
+        OutputFormat::Json,
+        OutputFormat::StreamJson,
+    ] {
+        let kept = collected(format, failed_call()).await;
+        let friction = crate::memory::TurnFriction::from_events(&kept);
+        assert_eq!(
+            friction.counts().tool_errors,
+            1,
+            "{format:?}: the fold must see the failed call the turn made, \
+             because the reflection gate decides on nothing else"
+        );
+    }
+}

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -788,7 +788,9 @@ fn attempt_task_boundary(task: &Task) -> String {
 ///
 /// **What it costs.** One model call per attempt that warrants one, on the same
 /// terms as every other door: gated by `turn_warrants_reflection` so a tool-free
-/// turn spends nothing, bounded by this child's remaining headroom, and settled
+/// turn spends nothing and by `reflect_routed`'s own friction gate so an
+/// attempt that went straight through spends nothing either, bounded
+/// by this child's remaining headroom, and settled
 /// back into its `BudgetGuard` — so the reflection lands inside the
 /// `--spend-limit` the fleet enforces twice (the child's own cap here, and the
 /// metered total the parent stops new waves on), rather than beside it.

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -781,6 +781,33 @@ fn mined_transcript() -> Vec<CompletionMessage> {
     ]
 }
 
+/// The ledger that goes with it: the first `make migrate` failed, so the turn
+/// carries friction and earns its reflection call. An empty ledger beside a
+/// successful turn stands for a turn that went straight through, and
+/// `reflect_routed` declines those — so a fixture that wants a lesson mined
+/// has to say what the turn ran into.
+fn mined_friction() -> crate::memory::TurnFriction {
+    crate::memory::TurnFriction::from_events(&[
+        stella_protocol::AgentEvent::ToolStart {
+            call: stella_protocol::ToolCall {
+                call_id: "c1".into(),
+                name: "bash".into(),
+                input: serde_json::json!({"command": "make migrate"}),
+            },
+            sub_agent_id: None,
+            task_id: None,
+        },
+        stella_protocol::AgentEvent::ToolResult {
+            call_id: "c1".into(),
+            output: stella_protocol::ToolOutput::error("ledger writer still running"),
+            duration_ms: 90,
+            speculated: false,
+            sub_agent_id: None,
+            task_id: None,
+        },
+    ])
+}
+
 /// **Witness (#3956).** A lesson mined by a fleet worker is readable from the
 /// primary workspace after the run — and is not written into the disposable
 /// tree the attempt ran in.
@@ -807,7 +834,7 @@ async fn a_worker_mines_its_lesson_into_the_invocation_root_not_its_worktree() {
     let cfg = steered_config(attempt_root.clone());
 
     let messages = mined_transcript();
-    let friction = crate::memory::TurnFriction::default();
+    let friction = mined_friction();
     let mut budget = agent::build_budget_guard(Some(10.0));
     budget.begin_turn();
 
@@ -1009,7 +1036,7 @@ async fn two_attempts_at_one_task_are_one_task_to_governance() {
         "run the billing migration",
     );
     let messages = mined_transcript();
-    let friction = crate::memory::TurnFriction::default();
+    let friction = mined_friction();
     let provider = ALessonPerAttempt(std::sync::atomic::AtomicUsize::new(0));
 
     // Two attempts at the SAME task — a retry wave, which is the shape the

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -13,7 +13,8 @@
 //! prompt ──> recall_block_reported(): registry-routed recall (crate::contextgraph) + select_skills()
 //!            └─ volatile message AFTER the byte-stable system prefix (L-E8)
 //! turn runs …
-//! outcome ─> reflect_routed(): one model call on the cheap (triage) tier -> 0-3 lessons
+//! outcome ─> reflect_routed(): the turn failed, or its ledger recorded friction? (#2155)
+//!            └─ if so, one model call on the cheap (triage) tier -> 0-3 lessons
 //!            ├─ MemoryInput::reflection(...) -> context.db (domain-tagged)
 //!            ├─ appended to .stella/private/reflections.jsonl (the mining log)
 //!            └─ mine_skill_candidates over the log -> decide_auto_creation

--- a/crates/stella-cli/src/memory/reflection.rs
+++ b/crates/stella-cli/src/memory/reflection.rs
@@ -40,6 +40,39 @@ pub fn turn_warrants_reflection(turn_messages: &[CompletionMessage]) -> bool {
         .any(|message| !message.tool_calls.is_empty())
 }
 
+/// Whether this turn has earned one reflection call.
+///
+/// The transcript gate above asks only whether the turn used a tool, and on
+/// its own that made every tool-using turn buy a model call, while the prompt
+/// itself tells the model that an empty list is a complete answer. Three
+/// trivial turns measured on 2026-08-08 spent 320-507 reflection
+/// output tokens each against 268 worker output tokens for all six worker
+/// steps combined, and one of them cost 8.8x the turn it described. That spend
+/// is structural rather than a routing problem: routing decides which model
+/// pays, and cannot decline a call the turn had no lesson to give.
+///
+/// A turn earns the call when it did not succeed, or when its event ledger
+/// recorded friction — a retry, a loop-detector firing, or a failed tool call.
+/// Those are where lessons live. A wrong attempt inside a turn that ended well
+/// is the surprise the success prompt asks about, so a failure-only gate would
+/// throw it away; a turn that went straight through has only its own success
+/// to report.
+///
+/// A user's soft stop never reaches here: [`should_reflect_on`] excludes it at
+/// every call site, before the evidence is built.
+///
+/// The counts come from the ledger the door already folded out of the turn's
+/// own event journal (`TurnFriction::from_events`), so nothing new is
+/// detected and no engine signal is plumbed a second time. `/goal` hands one
+/// ledger per round and any round's friction earns the arc its call.
+fn warrants_reflection(evidence: &TurnEvidence<'_>) -> bool {
+    !evidence.succeeded
+        || evidence
+            .friction
+            .iter()
+            .any(|round| round.counts().any() || round.truncated())
+}
+
 /// Whether a finished interactive turn should feed reflection at all.
 /// Failures ARE reflected on — a failed turn is a high-value learning
 /// signal, and the one-shot pipeline path has always treated it as one —
@@ -110,7 +143,11 @@ pub(crate) struct ReflectionPosture {
 /// This is the one seam all four reflecting surfaces (one-shot `run`, the
 /// REPL, `/goal`, the Command Deck) dispatch through, so the routing
 /// decision cannot be remembered by three drivers and forgotten by the
-/// fourth. Provider discovery runs per call rather than per session because
+/// fourth. It is also where [`warrants_reflection`] decides whether the turn
+/// has earned the call at all, so a clean successful turn returns an empty
+/// report and spends nothing.
+///
+/// Provider discovery runs per call rather than per session because
 /// reflection is already a post-turn, best-effort model call that opens the
 /// store — one credential scan is noise beside it, and it keeps this seam a
 /// drop-in for the call sites' previous direct dispatch.
@@ -122,6 +159,14 @@ pub(crate) async fn reflect_routed(
     quiet: bool,
     budget_limit: Option<f64>,
 ) -> ReflectionReport {
+    // Ahead of the route lookup, not after it: a turn that has earned nothing
+    // should not scan the machine's credentials either. The gate lives here
+    // rather than at the four call sites for the reason the routing decision
+    // does — one seam cannot be remembered by three drivers and forgotten by
+    // the fourth.
+    if !warrants_reflection(&evidence) {
+        return ReflectionReport::default();
+    }
     let routed =
         crate::agent::reflection_route(cfg, &crate::config::discover_configured_providers());
     // The posture travels with the route, not with the adapter: a triage pin

--- a/crates/stella-cli/src/memory/reflection/digest.rs
+++ b/crates/stella-cli/src/memory/reflection/digest.rs
@@ -120,7 +120,11 @@ const FRICTION_LIST_CAP: usize = 6;
 /// instead of growing. A turn cannot produce more friction than this and still
 /// have a summarizable shape, and an unbounded fold on a long-running turn is a
 /// leak in a best-effort path.
-const FRICTION_ENTRY_CAP: usize = 512;
+///
+/// Visible to the parent module because the reflection gate has to reason
+/// about the cap it enforces: a ledger that hit it cannot report absence, and
+/// the test that pins that has to be able to reach it.
+pub(super) const FRICTION_ENTRY_CAP: usize = 512;
 
 /// One model call's metering record, as [`AgentEvent::StepUsage`] reported it.
 #[derive(Debug, Clone)]
@@ -173,6 +177,31 @@ pub struct TurnFriction {
     /// where "this turn" is the whole answer and a round number would be a
     /// number invented to fill a field.
     round: Option<usize>,
+}
+
+/// What a turn's ledger holds, counted rather than quoted.
+///
+/// Three numbers, from the three engine signals that mean a turn did not go
+/// straight through: the model call was retried, the loop detector fired, or a
+/// tool came back with an error. Nothing here is new detection — the engine
+/// emits all three as events and [`TurnFriction`] already folds them.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FrictionCounts {
+    /// Model calls the engine retried, plus each exhausted retry budget
+    /// (`AgentEvent::Retry`, `AgentEvent::RetriesExhausted`).
+    pub retries: usize,
+    /// Times the loop detector fired, whether it steered the turn or aborted it
+    /// (`AgentEvent::LoopDetected`).
+    pub loop_trips: usize,
+    /// Tool calls whose result was `ToolOutput::Error`.
+    pub tool_errors: usize,
+}
+
+impl FrictionCounts {
+    /// Whether the turn hit any of the three.
+    pub fn any(&self) -> bool {
+        self.retries > 0 || self.loop_trips > 0 || self.tool_errors > 0
+    }
 }
 
 impl TurnFriction {
@@ -355,18 +384,45 @@ impl TurnFriction {
         Some(self.tools.len() - 1)
     }
 
-    /// Dead only *transitively*: its two call sites are both inside
-    /// [`Self::observe`], which lost its own production caller with the staged
-    /// pipeline (#3865). It comes back the moment `observe` does, and until
-    /// then `digest/tests.rs` drives it through that same method — so this is
-    /// one suppression cascading from one decision, not a second orphan.
-    #[allow(dead_code)]
+    /// Both call sites are inside [`Self::observe`], which every raw-loop door
+    /// reaches through [`Self::from_events`]. It carried an
+    /// `#[allow(dead_code)]` for the stretch when `observe` had no production
+    /// caller at all; the wiring landed and the suppression outlived it.
     fn push_retry(&mut self, entry: String) {
         if self.retries.len() >= FRICTION_ENTRY_CAP {
             self.dropped += 1;
             return;
         }
         self.retries.push(entry);
+    }
+
+    /// This ledger's friction as three plain counts.
+    ///
+    /// The ledger keeps the *text* of every retry, loop firing and failed call,
+    /// because the digest renders it. A caller deciding whether the turn is
+    /// worth a reflection call needs none of that text — only whether there was
+    /// any — so it reads this rather than the ledger's own shape.
+    pub fn counts(&self) -> FrictionCounts {
+        FrictionCounts {
+            retries: self.retries.len(),
+            loop_trips: self.loops.len(),
+            tool_errors: self
+                .tools
+                .iter()
+                .filter(|pass| pass.error.is_some())
+                .count(),
+        }
+    }
+
+    /// Whether `FRICTION_ENTRY_CAP` turned any record away.
+    ///
+    /// A ledger that overflowed cannot say it saw no errors. It can only say it
+    /// saw none among the first `FRICTION_ENTRY_CAP` records of a kind, and the
+    /// ones it refused may be the failures. So a caller reading [`Self::counts`]
+    /// to decide on *absence* has to ask this too, or a turn that made more than
+    /// five hundred tool calls reads as a turn that went smoothly.
+    pub fn truncated(&self) -> bool {
+        self.dropped > 0
     }
 
     /// Whether this ledger has anything to say. An empty one renders no section

--- a/crates/stella-cli/src/memory/reflection/tests.rs
+++ b/crates/stella-cli/src/memory/reflection/tests.rs
@@ -1006,3 +1006,223 @@ async fn the_prompt_names_where_the_turn_spent_itself() {
          can never recover it.\n\nprompt was:\n{prompt}"
     );
 }
+
+/// A turn that used a tool — everything the transcript gate asks for, and on
+/// its own the whole reason a clean turn buys a model call.
+fn tool_using_turn() -> Vec<CompletionMessage> {
+    let mut worked = CompletionMessage::assistant("reading it");
+    worked.tool_calls = vec![ToolCall {
+        call_id: "c0".into(),
+        name: "read_file".into(),
+        input: serde_json::json!({"path": "src/lib.rs"}),
+    }];
+    vec![
+        CompletionMessage::user("describe src/lib.rs"),
+        worked,
+        CompletionMessage::assistant("it declares one module"),
+    ]
+}
+
+/// The announcement of one tool call, and the result that closed it.
+fn tool_call_events(call_id: &str, output: ToolOutput) -> Vec<stella_protocol::AgentEvent> {
+    vec![
+        stella_protocol::AgentEvent::ToolStart {
+            call: ToolCall {
+                call_id: call_id.into(),
+                name: "read_file".into(),
+                input: serde_json::json!({"path": "src/lib.rs"}),
+            },
+            sub_agent_id: None,
+            task_id: None,
+        },
+        stella_protocol::AgentEvent::ToolResult {
+            call_id: call_id.into(),
+            output,
+            duration_ms: 12,
+            speculated: false,
+            sub_agent_id: None,
+            task_id: None,
+        },
+    ]
+}
+
+/// The ledger a door folds out of a turn whose one tool call worked.
+fn clean_ledger() -> super::TurnFriction {
+    super::TurnFriction::from_events(&tool_call_events("c0", ToolOutput::ok("pub mod money;")))
+}
+
+/// **The witness.** A successful turn that used a tool and hit nothing buys no
+/// reflection call.
+///
+/// Fails on base, where the only gate is [`super::turn_warrants_reflection`].
+/// The first assertion below is that base behaviour, and it still holds, which
+/// is what makes the second one a change rather than a rewrite. What the old
+/// answer cost, measured on three trivial turns: 320-507 reflection output
+/// tokens each against 268 worker output tokens for all six worker steps, and
+/// one reflection at 8.8x the price of the turn it described.
+#[test]
+fn a_clean_successful_turn_earns_no_reflection_call() {
+    let transcript = tool_using_turn();
+    let ledger = clean_ledger();
+    assert!(
+        super::turn_warrants_reflection(&transcript),
+        "control: the transcript gate still admits this turn, so the second \
+         assertion is about the friction gate and nothing else"
+    );
+    assert!(
+        !super::warrants_reflection(&super::TurnEvidence::with_friction(
+            &transcript,
+            &ledger,
+            true
+        )),
+        "a turn that went straight through has only its own success to report"
+    );
+}
+
+/// Each of the three engine signals earns the call on its own.
+#[test]
+fn any_one_friction_signal_earns_the_call() {
+    let transcript = tool_using_turn();
+    let cases: Vec<(&str, Vec<stella_protocol::AgentEvent>)> = vec![
+        (
+            "a retried model call",
+            vec![stella_protocol::AgentEvent::Retry {
+                attempt: 1,
+                reason: "429 from the provider".into(),
+            }],
+        ),
+        (
+            "a loop-detector firing",
+            vec![stella_protocol::AgentEvent::LoopDetected {
+                turn_instance: 0,
+                kind: "stagnation".into(),
+                pattern: vec!["bash".into()],
+                repeats: 4,
+                evidence: "same command, no progress".into(),
+                aborted: false,
+            }],
+        ),
+        (
+            "a failed tool call",
+            tool_call_events("c0", ToolOutput::error("no such file")),
+        ),
+    ];
+    for (signal, events) in cases {
+        let ledger = super::TurnFriction::from_events(&events);
+        assert!(
+            super::warrants_reflection(&super::TurnEvidence::with_friction(
+                &transcript,
+                &ledger,
+                true
+            )),
+            "{signal} is where a lesson lives, and it did not earn the call"
+        );
+    }
+}
+
+/// A failed turn reflects whatever its ledger says. The soft stop — the one
+/// outcome that is not a failure — never reaches here, because
+/// [`super::should_reflect_on`] drops it at every call site.
+#[test]
+fn a_failed_turn_reflects_on_an_empty_ledger() {
+    let transcript = tool_using_turn();
+    let ledger = clean_ledger();
+    assert!(
+        super::warrants_reflection(&super::TurnEvidence::with_friction(
+            &transcript,
+            &ledger,
+            false
+        )),
+        "a failure is the cheapest evidence there is about what the turn did \
+         not know going in"
+    );
+    let soft_stop: Result<(), String> =
+        Err(format!("goal aborted: {}", stella_core::SOFT_STOP_REASON));
+    assert!(
+        !super::should_reflect_on(&soft_stop),
+        "a user's soft stop is excluded before the evidence is even built"
+    );
+}
+
+/// `/goal` reflects once over an arc of several rounds, so the gate reads
+/// every round's ledger. A clean round cannot hide the round that struggled.
+#[test]
+fn one_rough_round_earns_the_whole_arc_its_call() {
+    let transcript = tool_using_turn();
+    let rounds = [
+        clean_ledger(),
+        super::TurnFriction::from_events(&tool_call_events(
+            "c1",
+            ToolOutput::error("the suite failed"),
+        )),
+    ];
+    assert!(
+        super::warrants_reflection(&super::TurnEvidence::with_rounds(
+            &transcript,
+            &rounds,
+            true
+        )),
+        "round 2 failed a tool call, and the arc reflects once for all of it"
+    );
+    let clean = [clean_ledger(), clean_ledger()];
+    assert!(
+        !super::warrants_reflection(&super::TurnEvidence::with_rounds(&transcript, &clean, true)),
+        "an arc where every round went straight through has nothing to mine"
+    );
+}
+
+/// A ledger that hit its entry cap cannot say it saw no errors — only that it
+/// saw none among the records it kept. Absence has to be earned.
+#[test]
+fn an_overflowed_ledger_is_never_read_as_a_clean_turn() {
+    let transcript = tool_using_turn();
+    let mut events = Vec::new();
+    for n in 0..=super::digest::FRICTION_ENTRY_CAP {
+        events.extend(tool_call_events(&format!("c{n}"), ToolOutput::ok("fine")));
+    }
+    let ledger = super::TurnFriction::from_events(&events);
+    assert!(
+        ledger.truncated(),
+        "control: the ledger must actually have turned a record away"
+    );
+    assert_eq!(
+        ledger.counts().tool_errors,
+        0,
+        "control: nothing it kept was an error, which is the trap"
+    );
+    assert!(
+        super::warrants_reflection(&super::TurnEvidence::with_friction(
+            &transcript,
+            &ledger,
+            true
+        )),
+        "the records it refused may be the failures, so it cannot claim the \
+         turn was clean"
+    );
+}
+
+/// The gate has to sit at the shared seam, and ahead of the route lookup.
+///
+/// Source-level for the reason `the_reflecting_doors_fold_a_ledger_and_reflect_with_it`
+/// above is: observing it otherwise means standing up a provider, a config, a
+/// store and a session memory to watch a call that does not happen. The
+/// end-to-end proof that no call is dispatched drives the real binary, in
+/// `tests/run_reflection_writes_cli.rs`.
+#[test]
+fn the_shared_seam_asks_the_gate_before_it_spends_anything() {
+    const SEAM: &str = include_str!("../reflection.rs");
+    let door = SEAM
+        .find("pub(crate) async fn reflect_routed(")
+        .expect("the shared reflection seam must still be named this");
+    let gate = SEAM[door..]
+        .find("if !warrants_reflection(&evidence)")
+        .expect("reflect_routed must ask whether the turn earned the call");
+    let route = SEAM[door..]
+        .find("crate::agent::reflection_route(")
+        .expect("reflect_routed must still resolve the reflection route");
+    assert!(
+        gate < route,
+        "a turn that earned nothing should not scan the machine's credentials \
+         either — the gate belongs ahead of the route lookup"
+    );
+}

--- a/crates/stella-cli/tests/run_reflection_writes_cli.rs
+++ b/crates/stella-cli/tests/run_reflection_writes_cli.rs
@@ -47,6 +47,17 @@
 //! answers — and because the child's environment is the thing #4362 was
 //! about.
 //!
+//! # Why the reflecting turn fails a tool call
+//!
+//! A turn reflects when it did not succeed, or when its event ledger recorded
+//! friction — a retry, a loop-detector firing, or a failed tool call. So the
+//! fixture's one tool call reads a file the seeded workspace does not have,
+//! which is the cheapest friction a turn can carry.
+//! [`a_clean_successful_turn_buys_no_reflection_call`] runs the identical
+//! shape with a call that works and asserts the opposite, and the two together
+//! are what pin the gate: neither a build that always reflects nor one that
+//! never does can pass both.
+//!
 //! # Routing by body, never by call order
 //!
 //! The three calls a passing run makes (worker tool call, worker answer,
@@ -104,25 +115,49 @@ fn sse_completion(text: &str) -> String {
 /// One SSE completion carrying a single tool call and no text, in the
 /// index-keyed fragment dialect the shared chat-completions adapter parses.
 ///
-/// The turn has to dispatch a tool for this test to mean anything:
+/// The turn has to dispatch a tool for any of this to mean anything:
 /// `memory::turn_warrants_reflection` is `true` only when some message in the
 /// turn carries a tool call, so a text-only turn would take the gate's
-/// "nothing to mine" arm and write no line — and the test would then be
+/// "nothing to mine" arm and write no line — and every test here would then be
 /// asserting the absence of a lesson in both directions.
-///
-/// `get_environment` is chosen for what it is *not*: it takes no arguments,
-/// changes nothing, and its `Always` authority means no approval gate stands
-/// between this fixture and a dispatched call — a run in non-interactive mode
-/// has no human to answer one.
-fn sse_tool_call() -> String {
-    concat!(
-        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_env\",\
-         \"function\":{\"name\":\"get_environment\",\"arguments\":\"{}\"}}]}}]}\n\n",
-        "data: {\"choices\":[{\"delta\":{}}],\"usage\":{\"prompt_tokens\":8,\
-         \"completion_tokens\":3}}\n\n",
-        "data: [DONE]\n\n",
+fn sse_tool_call(call_id: &str, name: &str, arguments: serde_json::Value) -> String {
+    let frame = serde_json::json!({
+        "choices": [{"delta": {"tool_calls": [{
+            "index": 0,
+            "id": call_id,
+            "function": {"name": name, "arguments": arguments.to_string()},
+        }]}}]
+    });
+    format!(
+        "data: {frame}\n\n\
+         data: {{\"choices\":[{{\"delta\":{{}}}}],\"usage\":{{\"prompt_tokens\":8,\
+         \"completion_tokens\":3}}}}\n\n\
+         data: [DONE]\n\n"
     )
-    .to_string()
+}
+
+/// A call that works. `get_environment` is chosen for what it is *not*: it
+/// takes no arguments, changes nothing, and its `Always` authority means no
+/// approval gate stands between this fixture and a dispatched call — a run in
+/// non-interactive mode has no human to answer one.
+fn sse_clean_tool_call() -> String {
+    sse_tool_call("call_env", "get_environment", serde_json::json!({}))
+}
+
+/// A call that fails, on a file the seeded workspace does not have.
+///
+/// `read_file` is read-only with the same `Always` authority, so it dispatches
+/// without an approval prompt and comes back a `ToolOutput::Error`. That error
+/// is the friction the reflection gate looks for: a turn that goes
+/// straight through buys no reflection call at all, which is what
+/// [`a_clean_successful_turn_buys_no_reflection_call`] pins from the other
+/// side.
+fn sse_failing_tool_call() -> String {
+    sse_tool_call(
+        "call_read",
+        "read_file",
+        serde_json::json!({"path": "missing.rs"}),
+    )
 }
 
 /// The reflection response, in the object shape
@@ -151,7 +186,7 @@ fn sse_reflection() -> String {
 
 /// The mocked provider a reflecting run talks to: a tool call, then an
 /// answer, then the reflection — each selected by request body.
-async fn mock_reflecting_provider() -> MockServer {
+async fn mock_reflecting_provider(first_call: String) -> MockServer {
     let server = MockServer::start().await;
 
     // Higher priority (a lower number) than the general worker mock below,
@@ -160,7 +195,7 @@ async fn mock_reflecting_provider() -> MockServer {
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .and(NotContains(REFLECTION_SYSTEM_PROMPT))
-        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_tool_call(), "text/event-stream"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(first_call, "text/event-stream"))
         .up_to_n_times(1)
         .with_priority(1)
         .mount(&server)
@@ -223,6 +258,7 @@ fn run_one_shot(
     data: &Path,
     server_uri: &str,
     opt_out: bool,
+    prompt: &str,
 ) -> std::process::Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_stella"));
     command
@@ -239,7 +275,7 @@ fn run_one_shot(
             "run",
             "--output-format",
             "json",
-            "read the environment, then stop",
+            prompt,
         ])
         .current_dir(workspace)
         .env("STELLA_HOME", data)
@@ -294,13 +330,13 @@ async fn a_non_interactive_json_run_writes_its_lesson_to_the_mining_log() {
     let workspace = tempfile::tempdir().expect("workspace");
     let data = tempfile::tempdir().expect("data dir");
     seed_workspace(workspace.path());
-    let server = mock_reflecting_provider().await;
+    let server = mock_reflecting_provider(sse_failing_tool_call()).await;
 
     let output = tokio::task::spawn_blocking({
         let workspace = workspace.path().to_path_buf();
         let data = data.path().to_path_buf();
         let uri = server.uri();
-        move || run_one_shot(&workspace, &data, &uri, false)
+        move || run_one_shot(&workspace, &data, &uri, false, "read missing.rs, then stop")
     })
     .await
     .expect("join");
@@ -344,13 +380,13 @@ async fn the_opt_out_stops_the_lesson_being_written() {
     let workspace = tempfile::tempdir().expect("workspace");
     let data = tempfile::tempdir().expect("data dir");
     seed_workspace(workspace.path());
-    let server = mock_reflecting_provider().await;
+    let server = mock_reflecting_provider(sse_failing_tool_call()).await;
 
     let output = tokio::task::spawn_blocking({
         let workspace = workspace.path().to_path_buf();
         let data = data.path().to_path_buf();
         let uri = server.uri();
-        move || run_one_shot(&workspace, &data, &uri, true)
+        move || run_one_shot(&workspace, &data, &uri, true, "read missing.rs, then stop")
     })
     .await
     .expect("join");
@@ -369,6 +405,62 @@ async fn the_opt_out_stops_the_lesson_being_written() {
     assert!(
         logged_lessons(workspace.path()).is_empty(),
         "the opted-out run wrote to the mining log: {:?}",
+        logged_lessons(workspace.path())
+    );
+}
+
+/// **The witness.** The same run, with a tool call that works, spends no
+/// reflection call.
+///
+/// Fails on base, where any tool-using turn reflects: the run above and this
+/// one differ only in whether the turn's one tool call succeeded, and on base
+/// both of them buy a model call. Three trivial turns measured on 2026-08-08
+/// spent 320-507 reflection output tokens each — one of them 8.8x the price of
+/// the turn it described — to be told there was nothing to learn.
+///
+/// The pairing is what makes it evidence. A build that never reflects passes
+/// this and fails the run above; a build that always reflects passes that and
+/// fails this.
+#[tokio::test]
+async fn a_clean_successful_turn_buys_no_reflection_call() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let data = tempfile::tempdir().expect("data dir");
+    seed_workspace(workspace.path());
+    let server = mock_reflecting_provider(sse_clean_tool_call()).await;
+
+    let output = tokio::task::spawn_blocking({
+        let workspace = workspace.path().to_path_buf();
+        let data = data.path().to_path_buf();
+        let uri = server.uri();
+        move || {
+            run_one_shot(
+                &workspace,
+                &data,
+                &uri,
+                false,
+                "read the environment, then stop",
+            )
+        }
+    })
+    .await
+    .expect("join");
+    assert!(
+        output.status.success(),
+        "the clean run did not exit 0 — stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert_eq!(
+        reflection_calls(&server).await,
+        0,
+        "a turn whose every tool call worked has only its own success to \
+         report, and must not pay a model to say so — stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        logged_lessons(workspace.path()).is_empty(),
+        "the clean run wrote to the mining log: {:?}",
         logged_lessons(workspace.path())
     );
 }

--- a/scripts/dead-code-allows-baseline.txt
+++ b/scripts/dead-code-allows-baseline.txt
@@ -9,5 +9,4 @@
 # The counts here are the debt #3872 left behind, not permission to add more.
 # The remedy is almost always `#[cfg(test)]` -- compiler-enforced, and honest
 # about what the item is for -- or deletion. This file is meant to reach empty.
-stella-cli 1
 stella-core 2


### PR DESCRIPTION
## What

Reflection fired after every turn that used a tool. The reflection prompt itself tells the model that an empty list is a complete answer, so most of those calls were spent discovering there was nothing to learn.

`reflect_routed` — the one seam all four reflecting doors dispatch through — now asks whether the turn earned the call before it resolves a route or opens a provider:

```rust
if !warrants_reflection(&evidence) {
    return ReflectionReport::default();
}
```

A turn earns it when it did not succeed, or when its folded event ledger recorded a retry, a loop-detector firing, or a failed tool call. A wrong attempt inside a turn that ended well is exactly the surprise the success prompt asks about, so this is not a failure-only gate. A user's soft stop never reaches the seam (`should_reflect_on` drops it at every call site) and `STELLA_DISABLE_REFLECTION` is untouched.

## Why

Measured on three live turns on 2026-08-08, from `.stella/private/store.db`'s `telemetry` table:

| call role | model | calls | in | out | cost |
|---|---|---:|---:|---:|---:|
| worker | deepseek/deepseek-v4-flash-0731 | 6 | 60,376 | 268 | $0.001957 |
| reflection | google/gemini-2.5-flash-lite | 1 | 763 | 490 | $0.000272 |
| reflection | anthropic/claude-haiku-4.5 | 1 | 907 | 507 | $0.003442 |
| reflection | deepseek/deepseek-v4-flash-0731 | 1 | 830 | 320 | $0.000128 |

Reflection emitted 320-507 output tokens per turn against the worker's 268 across all six of its steps, and one reflection cost 8.8x the turn it described. Routing (#1847) bounds which model pays; it cannot decline a call the turn had no lesson to give.

## Where the design pointer met the tree

The pointer asked for a `TurnFriction { retries, loop_trips, tool_errors }` plumbed from `stella-core` onto the turn outcome. The tree has moved since the issue was written: since #3946 every raw-loop door already folds its own `AgentEvent` journal into a `TurnFriction` and hands it to reflection as `TurnEvidence::friction`. Adding a second path from the engine would be a second source of truth for the same three numbers, so the gate reads the ledger that is already there. Consequences: no `stella-protocol` type crosses a crate boundary (no serde round-trip owed, invariant #4), and nothing rides an event (no consumers-ledger row owed, invariant #10). Everything the pointer named is present — the counts, the gate, the unchanged opt-out, net-zero lines at `agent.rs` and `command_deck.rs` (both untouched).

## The defect this uncovered

`spawn_renderer` kept the turn's events **only** for `OutputFormat::Json`:

```rust
OutputFormat::Json => outcome.events.push(event),
```

`run_turn` folds exactly that vector into the turn's `TurnFriction`, so on the interactive door and on every `--output-format stream-json` run the ledger was empty: no retries, no loop firings, no failed calls, whatever the turn did. #3946's source-level test asserts `run_turn` contains `TurnFriction::from_events(&collected)`, which is true and says nothing about whether `collected` holds anything. Gating on a signal that is structurally always zero would have switched reflection off outright for those two surfaces, so the push moved out of the match and now runs for every format. Nothing else changes: the JSON envelope is still printed only under `format == OutputFormat::Json`.

## Witnesses, and how each one fails on `main`

- `crates/stella-cli/tests/run_reflection_writes_cli.rs::a_clean_successful_turn_buys_no_reflection_call` — drives the real `stella` binary against a wiremock provider whose one tool call (`get_environment`) succeeds, and asserts **zero** requests carrying the reflection system prompt and an empty mining log. On `main` any tool-using turn reflects, so the count is 1 and the log has a line. Its pair, `a_non_interactive_json_run_writes_its_lesson_to_the_mining_log`, now fails its tool call (`read_file` on a path the seeded workspace does not have) and still asserts exactly one reflection call and one logged lesson. The two differ only in whether the turn's tool call succeeded: a build that always reflects fails the first, one that never reflects fails the second.
- `crates/stella-cli/src/memory/reflection/tests.rs` — five unit tests on the gate. `a_clean_successful_turn_earns_no_reflection_call` cannot compile on `main`, where `warrants_reflection` does not exist; it also asserts `turn_warrants_reflection` still admits the same turn, so the second assertion is about the friction gate alone. Then: each of the three engine signals earns the call on its own; a failed turn reflects on an empty ledger while a soft stop is refused; one rough round earns a whole `/goal` arc its call and an all-clean arc earns none; an overflowed ledger is never read as a clean turn. A source-level test pins the gate ahead of the route lookup, the same technique `the_reflecting_doors_fold_a_ledger_and_reflect_with_it` already uses in this file.
- `crates/stella-cli/src/agent/persistence/tests/collected_journal.rs::every_format_keeps_the_turns_journal` — drives `spawn_renderer` over one failed tool call in all three formats and folds what it returns. On `main` `Text` and `StreamJson` return nothing and `counts().tool_errors` is 0 for both.

## Exemplar followed

The gate's placement copies this crate's own `reflect_routed` argument for the routing decision — one seam rather than four call sites — and the source-level wiring assertions copy `the_reflecting_doors_fold_a_ledger_and_reflect_with_it` (`crates/stella-cli/src/memory/reflection/tests.rs`) and `a_fleet_attempt_reflects_before_its_spend_is_read` (`crates/stella-cli/src/fleet_cmd/tests.rs`).

## Fixture updates (behaviour change, not test weakening)

Two existing fixture sites built a successful turn with an empty ledger, which is now exactly the "went straight through" case:

- `crates/stella-cli/src/fleet_cmd/tests.rs` — `mined_friction()` gives the two attempt-mining tests a ledger with the failed `make migrate` their transcript already describes.
- `crates/stella-cli/tests/run_reflection_writes_cli.rs` — the reflecting run's tool call now fails, as described above.

## Also in this diff

`TurnFriction::push_retry` carried an `#[allow(dead_code)]` whose stated reason ("`observe` has no production caller") stopped being true when #3946 wired `from_events`. The attribute and its comment are gone and `scripts/dead-code-allows-baseline.txt` drops `stella-cli` to zero — a ratchet tightening, not a new entry.

Closes #2155

Tests deleted: None

Remaining work filed:

- #5720 — the Command Deck never reflects on a failed turn. Found while auditing every reflecting door against the shared rule; it predates this change and is not caused by it.
- #5721 — fold the friction as events stream rather than retaining the whole journal on formats that never print it. The cheaper shape for the collection fix this PR makes.
- #5722 — the Observatory's self-rating panels now see only turns that failed or hit friction, because the self-review rides the same call this PR gates. Three defensible answers, one of which a human should pick.

## Summary by Sourcery

Reflect only on turns that fail or record meaningful friction while retaining complete event evidence across all CLI output modes.

Bug Fixes:
- Prevent reflection calls for successful tool-using turns that recorded no retries, loop detections, or tool failures.
- Preserve turn event journals across text, JSON, and stream-JSON output modes so reflection decisions receive accurate friction data.

Enhancements:
- Gate reflection at the shared dispatch seam using turn success, friction counts, and journal truncation status before route or provider resolution.
- Expose aggregated friction counts and truncation state from turn ledgers for reflection eligibility checks.
- Tighten dead-code allowances after retry handling became production-reachable.

Tests:
- Add unit, renderer, fleet, and end-to-end CLI coverage for clean-turn suppression, friction-triggered reflection, overflowed ledgers, and journal retention across output formats.