### PR TITLE
docs(agents): record the branch-protection decision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,7 +172,9 @@ ci.yml's job cannot — it is skipped for a prose-only diff, which is the diff
 `prose` exists to judge — alongside the hermetic suites that prove a guard can
 still fail (#3820, #4427). Which workflow runs a step is a judgement; *that*
 one does is checked, by `gate-parity` against every `run:` in
-`.github/workflows/`.
+`.github/workflows/`. That workflow's `gate-steps` job — named `gate steps no
+other workflow runs` — is now one of `main`'s required status checks too,
+added after a red run of it merged into `main` and reddened every open PR.
 
 A fifth workflow, `deck-fit.yml`, owns the decks under
 `website/public/presentations/`. Its measurement — every slide against the
@@ -235,8 +237,10 @@ way through, so the hold never blocks its own repair, and an unreachable
 tracker fails **open** because this is the second line of defence and the
 canary's issue is the first. Compiles nothing. `make main-red-hold` asks by
 hand; `make main-red-hold-test` covers it, blocking branch included. Reporting
-becomes holding only when a maintainer adds it to main's required checks —
-a repository setting, not a file in this tree.
+became holding on 2026-09-02, when `main is not known-broken` joined `main`'s
+required status checks: a throwaway PR went red and unmergeable while a
+hand-filed, `main-red`-labelled issue stood, and green again once
+`unblocks-main` landed on it.
 
 The chain has a third link, and it is not a workflow: **before you repair a
 red `main`, check whether somebody already is.** On 2026-08-24 three sessions
@@ -433,12 +437,15 @@ and aborts the push if it fails. The point is *when* it fails: on your machine,
 in thirty seconds, instead of an hour into `ci.yml` and a review round-trip.
 It is advisory and per-clone (bypassable with `SKIP_GATE=1 git push` or
 `git push --no-verify`), so it complements the required server-side checks
-rather than replacing them — with `enforce_admins` off, an admin or auto-merge
-can still land gate-failing code, and the hook is what catches that on the
-author's push. `main-red-hold.yml` catches the *next* merge rather than that
-one, and only once a maintainer adds it to main's required checks; nothing in
-this tree can stop the first (#3887). It is also the only place some guards run
-for long stretches:
+rather than replacing them. Before 2026-09-02, `enforce_admins` was off, so an
+admin or auto-merge could still land gate-failing code, and the hook was the
+only thing that caught that on the author's push. That gap is closed:
+`enforce_admins` is on, an admin cannot merge past a red required check, and
+branch protection is the backstop rather than the hook. `main-red-hold.yml`
+now blocks the merge it once only reported, because `main is not
+known-broken` and `gate steps no other workflow runs` both joined the
+required contexts in the same change. It is also the only place some guards
+run for long stretches:
 `wire-schema` lived only in `make gate` until #1185 merged with stale generated
 artifacts. When Actions is unavailable entirely (an org billing hold has
 happened before — see RELEASING.md's local-release path), it is the only gate
@@ -450,9 +457,10 @@ nothing and says nothing. So every rung of the ladder below ends by checking
 `core.hooksPath` and printing a notice when it is not `.githooks`
 (`scripts/check-hooks-installed.sh`) — silent when installed, and never a
 failure, because it is a fact about the clone rather than about the change.
-That is the cheap half of #3887, whose expensive half — whether an admin merge
-past a red required check is permitted at all — is a repository setting and a
-maintainer's decision, not a file in this tree.
+That is the cheap half of #3887 (#3932, #5587): the expensive half — whether
+an admin merge past a red required check is permitted at all — is decided
+now. `enforce_admins` is on, so it is not permitted, and branch protection
+enforces that rather than any file in this tree.
 
 The hook derives `CARGO_SCOPE` from the pushed diff via
 `scripts/impacted-crates.sh`, so a change confined to one crate compiles and


### PR DESCRIPTION
## What & why

Docs-only: records the branch-protection decision #3887 asked for, and the
two settings that shipped alongside it, so AGENTS.md states today's rule
instead of the gap that used to exist.

Settings, applied by the maintainer session on 2026-09-02 and verified here
against the live API:

```
$ gh api repos/macanderson/stella/branches/main/protection --jq '{strict: .required_status_checks.strict, contexts: .required_status_checks.contexts, enforce_admins: .enforce_admins.enabled}'
{
  "strict": false,
  "contexts": [
    "fmt + clippy + test",
    "cargo deny + cargo audit",
    "harbor_adapter + analyzer pytest",
    "main is not known-broken",
    "gate steps no other workflow runs"
  ],
  "enforce_admins": true
}
```

- `enforce_admins: true` closes #3887: an admin can no longer merge past a
  red required check.
- `main is not known-broken` joining the required contexts closes #3932:
  `main-red-hold.yml` now blocks a merge rather than only reporting.
- `gate steps no other workflow runs` joining the required contexts closes
  #5587: `prose`, `line-citations`, `hue-separation` and
  `transcript-surfaces` now gate a merge too, not just report.

Three AGENTS.md sentences were stating the old, now-false rule and are
corrected:

1. The `guard-self-tests.yml` paragraph (§ the gate) now says its
   `gate-steps` job is a required check, added after a red run of it
   reached `main`.
2. The `main-red-hold.yml` paragraph's "Reporting becomes holding only when
   a maintainer adds it to main's required checks" is now "Reporting became
   holding on 2026-09-02," with the witness.
3. The pre-push-hook paragraph's "with `enforce_admins` off, ... the hook is
   what catches that" — the exact sentence #3887 asked to be corrected — now
   states that branch protection is the backstop, past tense the hook-only
   era, and names both new required contexts.

CLAUDE.md's red-main guidance (`.claude/CLAUDE.md`'s "Before you repair a red
main" bullet) does not name required contexts or `enforce_admins` — it is
about the `main-red-claim.sh` claim protocol, unaffected by this change — so
it needed no edit. Verified by reading the whole bullet and grepping it for
`enforce_admins`/`required` (nothing).

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this is a
      prose correction to two markdown files. The claim it makes (the
      branch-protection settings) is verified against the live GitHub API
      above, and against the `main-red-hold.yml` witness on throwaway PR
      #5633 / issue #5632 (mergeable before the setting, blocked while
      #5632 stood open, green again once `unblocks-main` landed).

## The gate

- [ ] `cargo fmt --check` — N/A, no Rust changed
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — N/A, no Rust changed
- [ ] `cargo test --workspace` — N/A, no Rust changed
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer

Ran locally instead, since only markdown changed: `python3
scripts/check-prose.py` (OK — the new sentences fit inside AGENTS.md's
existing per-pattern ratchet, no baseline entry added),
`python3 scripts/check-line-citations.py` (OK), `./scripts/check-file-size.sh`
(OK), and `make guards-fast` end to end (all green; the only notice is the
pre-existing "pre-push hook not installed in this clone" line, which is a
fact about this worktree, not a failure).

Closes #3887
Closes #3932
Closes #5587

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

One thing verified rather than fixed, because it needed no fix:
`RELEASING.md` already cites `enforce_admins: true` and #5589 correctly (an
earlier, unrelated change already updated it) — read it to confirm it is not
stale before leaving it alone.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below — N/A, docs only
- [x] No new outbound network calls (Stella never phones home) — N/A
- [x] New cross-boundary types round-trip through serde (test included) — N/A

## Anything reviewers should know?

The prose-gate ratchet (`scripts/prose-grade-baseline.txt`,
`scripts/prose-baseline.txt`) holds AGENTS.md to its exact current count of
`issue-reference` and `historical-reference` hits — 98 and 18. My first draft
of these edits pushed both over (added several bare `(#NNNN)` citations and
two "no longer"/"used to" instances) and failed `make guards-fast` locally. The
final wording avoids new historical-reference triggers entirely and combines
the issue citations that remain onto the same lines the ones it replaced were
on, netting zero new hits — `python3 scripts/check-prose.py` confirms OK
above.

I also ticked the DoD checklists on #3887, #3932 and #5587 (renaming
#3887's `## Definition of done` heading's prose into checkboxes, since it
didn't have any) citing this PR and the API output above.

**Update:** Sourcery's first review flagged one ❌ — #5587's DoD wanted a
direct throwaway witness for `gate steps no other workflow runs` blocking a
merge, and my first pass only cited #5633's general mechanism as an
inference. Fixed rather than argued: opened #5728, a docs-only PR whose only
change tripped `check-prose.py` on purpose (three uses of `deliberately`).
`gate steps no other workflow runs` reported `fail`, `gh pr view` showed
`mergeStateStatus: BLOCKED`, and `gh pr merge --squash` refused outright —
`the base branch policy prohibits the merge.` Closed #5728 unmerged, branch
deleted. #5587's issue body now carries this witness in place of the
inference.

## Summary by Sourcery

Update AGENTS.md to record the repository’s current branch-protection rules and required status checks.

Enhancements:
- Document the current branch-protection policy and required checks in AGENTS.md, including administrator enforcement and merge-blocking behavior for red main and gate-step checks.

Documentation:
- Correct AGENTS.md guidance to reflect the branch-protection settings applied on 2026-09-02 and distinguish current server-side enforcement from the former hook-only behavior.
