### PR TITLE
throwaway: #5587 required-check witness (never merge)

### DIFF
--- a/docs/throwaway-5587-witness.md
+++ b/docs/throwaway-5587-witness.md
@@ -1,0 +1,12 @@
+---
+id: throwaway-5587-witness
+status: proposed
+---
+
+# Throwaway witness for #5587
+
+This file exists only to trip `check-prose.py` on purpose, so the
+`gate steps no other workflow runs` required check goes red and this
+witness PR is confirmed blocked from merging. This file will never be
+merged; it is deleted before the PR closes. Deliberately, deliberately,
+deliberately.


### PR DESCRIPTION
Throwaway. Witness for #5587: a diff that trips `check-prose.py` must turn `gate steps no other workflow runs` red and block the merge. Closed unmerged afterward.

## Summary by Sourcery

Verify that prose-validation failures turn the required workflow gate red and prevent merging.

Documentation:
- Add a temporary documentation witness designed to trigger prose validation and verify that the required workflow gate blocks merging.

Chores:
- Add a throwaway file for validating required-check behavior; it is intended to be removed before the PR closes.