### PR TITLE
fix(stella-transcript): surface clip and minimal markers on both renderers

### DIFF
--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -184,7 +184,7 @@ impl Cell {
     /// reaches this constructor unsanitised. A bash `header_object` is
     /// routinely multi-line; a diff row of a Makefile carries tabs; raw ANSI
     /// colour codes reach `Output::lines` whenever a tool's own capture keeps
-    /// them. So the boundary is here. [`strip_csi`] drops a whole ANSI CSI
+    /// them. So the boundary is here. `strip_csi` drops a whole ANSI CSI
     /// sequence first — swapping only its leading `ESC` for a space would
     /// leave `[31m` behind as literal text, a different corruption than the
     /// one this constructor exists to stop. Tabs expand next, from the

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -180,17 +180,23 @@ impl Cell {
     /// A cell is one styled run of one row, so a control character in it can
     /// only corrupt the frame: a `\n` splits the row when the encoders join
     /// lines, and the rest of the class is zero columns to [`cells`] and
-    /// something real to the terminal — `\t` a stop, `\r` a return — so the
-    /// width contract breaks exactly where nothing measures it. Wire text
-    /// reaches this constructor unsanitised (a bash `header_object` is
-    /// routinely multi-line; a diff row of a Makefile carries tabs), so the
-    /// boundary is here: tabs expand from the cell's own origin — body lines
-    /// arrive already expanded against their true column
-    /// (`push_output_text`), so this is the fallback stop, not a second
-    /// opinion — and every other control character becomes a space.
+    /// something real to the terminal — `\t` a stop, `\r` a return. Wire text
+    /// reaches this constructor unsanitised. A bash `header_object` is
+    /// routinely multi-line; a diff row of a Makefile carries tabs; raw ANSI
+    /// colour codes reach `Output::lines` whenever a tool's own capture keeps
+    /// them. So the boundary is here. [`strip_csi`] drops a whole ANSI CSI
+    /// sequence first — swapping only its leading `ESC` for a space would
+    /// leave `[31m` behind as literal text, a different corruption than the
+    /// one this constructor exists to stop. Tabs expand next, from the
+    /// cell's own origin (body lines arrive already expanded against their
+    /// true column, `push_output_text`, so this is the fallback stop, not a
+    /// second opinion). Every remaining control character becomes a space.
     #[must_use]
     pub fn new(text: impl Into<String>, fg: Color) -> Self {
         let mut text = text.into();
+        if text.contains('\u{1b}') {
+            text = strip_csi(&text);
+        }
         if text.chars().any(char::is_control) {
             text = crate::tabs::expand(&text, 0)
                 .chars()
@@ -224,6 +230,35 @@ impl Cell {
     pub fn width(&self) -> usize {
         cells(&self.text)
     }
+}
+
+/// Remove every ANSI CSI sequence (`ESC '[' <parameters> <final byte>`) from
+/// `text`, dropping the whole run rather than the lone `ESC` byte.
+///
+/// `0x40..=0x7E` is CSI's final-byte range (ECMA-48 §5.4) — the range a real
+/// terminal reads to know a sequence has ended. A sequence with no final
+/// byte before the string runs out is malformed, so everything from its
+/// `ESC` onward is dropped; there is no legible text left to recover. A lone
+/// `ESC`, or any other escape kind (`ESC ']'` OSC, `ESC` alone), is left for
+/// [`Cell::new`]'s per-character fallback to turn into a space. Only a real
+/// CSI sequence is a run of otherwise-printable bytes, which is what a
+/// per-character substitution would leave behind as literal noise.
+fn strip_csi(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' || chars.peek() != Some(&'[') {
+            out.push(c);
+            continue;
+        }
+        chars.next(); // the '[' that confirmed this is CSI, not some other escape
+        for final_byte in chars.by_ref() {
+            if ('\u{40}'..='\u{7e}').contains(&final_byte) {
+                break;
+            }
+        }
+    }
+    out
 }
 
 /// One rendered row.
@@ -785,6 +820,21 @@ fn diff_lines(
     header.push(Cell::new(" ", Color::Faint));
     header.push(Cell::new(fold_mark(open), Color::Blue));
     out.push(header);
+    // `FileDiff::minimal` is false only when the producer's own differ
+    // tripped `stella_diff::LCS_AREA_CAP` and fell back to a blunt
+    // replace-everything rendering. The HTML renderer says so with a
+    // `.blunt` banner; the grid must say it too, not present the fallback
+    // hunks as a precise diff. Pushed ahead of the fold check, so a
+    // collapsed file still carries the marker.
+    if !diff.minimal {
+        out.push(vec![
+            body_gutter(),
+            Cell::new(
+                "diff exceeded the exact-comparison bound — shown as replace-everything",
+                Color::Amber,
+            ),
+        ]);
+    }
     if !open {
         return;
     }

--- a/crates/stella-transcript/src/html.rs
+++ b/crates/stella-transcript/src/html.rs
@@ -553,6 +553,20 @@ fn output_body(out: &mut String, run: &Run, state: &FoldState, call: &Call, ti: 
         emit_lines(out, &fold.tail, paint);
         out.push_str("</pre></div>");
     }
+
+    // `Output::clipped` lines never reached this crate, so no fold has
+    // anything to show for them. The `<details>` control above hides real
+    // lines this crate holds; a transport clip hides lines it never got.
+    // When every received line already fits in `head`, that hidden slice is
+    // empty even though `clipped` is not — so the marker stands outside the
+    // fold, not inside it.
+    if fold.clipped > 0 {
+        let _ = write!(
+            out,
+            "<div class=\"clip\">{}</div>",
+            escape(&fold.clip_label())
+        );
+    }
 }
 
 /// Emit result-body lines, syntax-coloured when `json`.

--- a/crates/stella-transcript/src/html/transcript.css
+++ b/crates/stella-transcript/src/html/transcript.css
@@ -467,6 +467,7 @@ details[open] > summary .chev { transform: rotate(90deg); }
 }
 .cmdbar .ps { color: var(--gold); font-weight: 700; flex: none; }
 .echo { padding: 4px 12px; color: var(--faint); font-size: 10.5px; font-style: italic; }
+.clip { padding: 4px 12px; color: var(--amber); font-size: 10.5px; font-style: italic; }
 .out { padding: 8px 12px; }
 .out.tail { border-top: 1px solid var(--hover-raised); }
 .out pre {

--- a/crates/stella-transcript/src/tests/file_kinds.rs
+++ b/crates/stella-transcript/src/tests/file_kinds.rs
@@ -51,8 +51,11 @@ fn a_producers_patch_is_drawn_at_the_files_own_line_numbers() {
 }
 
 /// **The witness for #4696.** A producer's patch that tripped
-/// `LCS_AREA_CAP` carries `minimal: false` on the wire; the build must read
-/// that flag rather than assume every patch is exact.
+/// `LCS_AREA_CAP` carries `minimal: false` on the wire. The build must read
+/// that flag, not assume every patch is exact. Each renderer must also say
+/// so to a reader, not present the blunt fallback as a precise diff — a gap
+/// a `FileDiff::minimal`-only assertion cannot see: the HTML renderer
+/// already surfaced it with its `.blunt` banner, and the grid did not.
 #[test]
 fn a_producers_blunt_fallback_patch_stays_marked_non_minimal() {
     let change = FileChange {
@@ -69,6 +72,27 @@ fn a_producers_blunt_fallback_patch_stays_marked_non_minimal() {
     assert!(
         !FileDiff::build(&change).minimal,
         "the producer's own cap trip must survive onto the rendered diff"
+    );
+
+    let call = Call {
+        tool: ToolKind::EditFile,
+        header_object: change.path.clone(),
+        args: Vec::new(),
+        output: Output::default(),
+        files: vec![change],
+        status: Status::Ok,
+        duration_ms: 12,
+        speculated: false,
+        sub_agent_id: None,
+    };
+    let (plain, markup) = rendered(call);
+    assert!(
+        plain.contains("exceeded the exact-comparison bound"),
+        "the expanded grid presented a blunt fallback diff as precise:\n{plain}"
+    );
+    assert!(
+        markup.contains("exceeded the exact-comparison bound"),
+        "the expanded HTML page presented a blunt fallback diff as precise:\n{markup}"
     );
 }
 

--- a/crates/stella-transcript/src/tests/folds.rs
+++ b/crates/stella-transcript/src/tests/folds.rs
@@ -143,20 +143,46 @@ fn control_characters_cannot_reach_a_grid_cell() {
     }
 }
 
+/// A real CSI sequence carries one control byte — `ESC` — ahead of printable
+/// parameter and final bytes (`\x1b[31m` is `ESC`, `[`, `3`, `1`, `m`).
+/// Mapping only that `ESC` to a space renders `"\x1b[31merror\x1b[0m"` as
+/// `" [31merror [0m"`. The width contract holds — nothing left is a control
+/// character — but the text still carries bracket-and-digit noise a reader
+/// would mistake for real content. `Cell::new` strips the whole sequence
+/// instead.
+#[test]
+fn a_csi_sequence_is_stripped_whole_not_left_as_bracket_noise() {
+    let cell = grid::Cell::new("\x1b[31merror\x1b[0m", grid::Color::Ink);
+    assert_eq!(cell.text, "error");
+    assert!(
+        !cell.text.contains("[31m"),
+        "the escape's parameter bytes survived as literal text: {:?}",
+        cell.text
+    );
+}
+
 /// `Output::clipped` promises a clipped marker "so a reader never
-/// mistakes a transport limit for the end of the output" — and an *expanded*
-/// grid body used to break that promise: the clip count only rode the closed
-/// fold's `▸ N more lines` control, so opening the output presented three
-/// surviving lines as the whole thing. The HTML renderer keeps its fold
-/// control visible when open, so only the grid needed the marker.
+/// mistakes a transport limit for the end of the output," on both
+/// renderers. An expanded grid body once carried the clip count only on the
+/// closed fold's `▸ N more lines` control, so opening the output presented
+/// three surviving lines as the whole thing. The HTML renderer had a
+/// matching gap on this exact case: three received lines fit entirely
+/// inside `head`, so the hidden slice its `<details>` control promises is
+/// empty, and nothing on the page said the other 24 were dropped in
+/// transport. This test's earlier body threw `markup` away before it ever
+/// looked, so it never saw that gap.
 #[test]
 fn an_expanded_output_still_admits_the_transport_clip() {
     let mut call = bash("cmd", &["a", "b", "c"], Status::Ok);
     call.output.clipped = 24;
-    let (plain, _) = rendered(call);
+    let (plain, markup) = rendered(call);
     assert!(
         plain.contains("clipped"),
         "the expanded grid presented a clipped body as complete:\n{plain}"
+    );
+    assert!(
+        markup.contains("clipped"),
+        "the expanded HTML page presented a clipped body as complete:\n{markup}"
     );
 }
 


### PR DESCRIPTION
## What & why

Each transcript renderer drops the honesty marker only the other one shows.
`stella-transcript` exists so both surfaces render from one model and cannot
disagree — but they did, on the exact fields whose whole job is to tell a
reader the content in front of them is incomplete or approximate.

1. **HTML never showed `Output::clipped`.** `html.rs::output_body` never read
   `fold.clipped`. When every received line already fits the fold's `head`,
   the hidden slice is empty even though lines were dropped in transport —
   the reader gets a `<details>` control promising N more lines and an empty
   block, with no marker saying those lines never reached this crate at all.
2. **Grid never showed `FileDiff::minimal`.** `grid.rs::diff_lines` never
   read `.minimal`. A patch whose producer tripped `LCS_AREA_CAP` and fell
   back to a blunt replace-everything diff rendered in the grid (and in
   plain `stella run` output) with no sign it is a coarse fallback, while the
   same run in `stella observe` showed the `.blunt` banner.
3. **`Cell::new` stripped only the `ESC` byte of a CSI sequence**, leaving
   the parameter bytes as literal text: `"\x1b[31merror\x1b[0m"` rendered as
   `" [31merror [0m"`. The width contract held; the text was still corrupted.

## The fix

- `html.rs::output_body` emits `escape(&fold.clip_label())` in a `.clip` div
  whenever `fold.clipped > 0`, unconditionally rather than only inside the
  `<details>` fold.
- `grid.rs::diff_lines` pushes an amber marker line
  (`"diff exceeded the exact-comparison bound — shown as replace-everything"`)
  right after the file header whenever `!diff.minimal`, ahead of the
  open/closed check so a collapsed file still carries it.
- `grid.rs::Cell::new` gains `strip_csi`, which drops a whole ANSI CSI
  sequence (`ESC '[' ... final byte in 0x40..=0x7E`, ECMA-48 §5.4) before
  falling back to the existing per-character control substitution.

Exemplar: none needed — this follows the existing per-field pattern each
renderer already uses for its own fold/diff state (`fold.has_more()`,
`diff.status`).

## Witnesses

One per finding, all fail on `main` and pass with the fix (verified by
stashing only the three production files and re-running the crate's tests):

- `an_expanded_output_still_admits_the_transport_clip` (`tests/folds.rs`) now
  asserts the HTML markup, not just the plain grid, contains `"clipped"` for
  the head-only-clipped case. Old code: the `markup` binding was discarded
  (`let (plain, _) = rendered(call);`) and the assertion never ran against
  it.
- `a_producers_blunt_fallback_patch_stays_marked_non_minimal`
  (`tests/file_kinds.rs`) now renders the `minimal: false` change through
  both renderers and asserts each contains `"exceeded the exact-comparison
  bound"`. Old code: the test only checked `FileDiff::build(&change).minimal`
  on the model, never that either renderer surfaced it.
- `a_csi_sequence_is_stripped_whole_not_left_as_bracket_noise` (new,
  `tests/folds.rs`) asserts `Cell::new("\x1b[31merror\x1b[0m", …).text` is
  exactly `"error"` and contains no `"[31m"`.

## Tests deleted

None.

Closes #5499

## Verification (added after review of #5499's DoD)

#5499's fourth DoD item asks for the crate's suite green. Run on this head,
rustc 1.97.0:

```
$ cargo test -p stella-transcript
running 139 tests
test result: ok. 139 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
running 2 tests
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
running 0 tests   (doc-tests)
test result: ok. 0 passed; 0 failed
exit code 0
```

All three named witnesses pass:

```
test tests::folds::an_expanded_output_still_admits_the_transport_clip ... ok
test tests::file_kinds::a_producers_blunt_fallback_patch_stays_marked_non_minimal ... ok
test tests::folds::a_csi_sequence_is_stripped_whole_not_left_as_bracket_noise ... ok
```

The new `.clip` rule resolves — `--amber` is defined in `transcript.css` at
both the base (`#e78d54`) and the light-scheme override (`#8a3f00`) — and
`Color::Amber` is an existing `grid.rs` variant, so neither addition introduces
an unresolved token.

All four of #5499's DoD items are now ticked. The fail side above is the PR
author's own stash-and-rerun; this pass did not independently reproduce it, and
says so on #5499 rather than restating it as observed.

## Summary by Sourcery

Keep HTML and grid transcript renderers consistent by exposing clipping and coarse-diff markers and preserving clean terminal text.

Bug Fixes:
- Surface transport clipping markers in HTML transcripts even when no hidden local lines are available.
- Mark non-minimal, replace-everything diffs in grid output, including collapsed files.
- Strip complete ANSI CSI sequences from grid cell text instead of leaving escape parameters as visible noise.

Tests:
- Add renderer-level coverage for clipped output and non-minimal diffs, plus regression coverage for ANSI CSI stripping.