### PR TITLE
fix(stella-serve): report failed checkpoint discards and truncated replays

### DIFF
--- a/crates/stella-serve/src/observe/event.rs
+++ b/crates/stella-serve/src/observe/event.rs
@@ -403,6 +403,15 @@ pub enum SettledOutcome {
 pub enum StreamEndReason {
     /// The terminal `turn_complete` frame was written. The healthy ending.
     TurnComplete,
+    /// A reconnect asked for frames older than the retention window keeps.
+    /// The server wrote a `replay_truncated` error frame and stopped there.
+    /// The turn is still live. It gets parked for resume right after this
+    /// event, by the same call that reports it — not through
+    /// [`Self::leaves_the_turn_resumable`], which only covers a subscriber
+    /// that hangs up. [`Self::TurnComplete`] is the healthy ending; this is
+    /// not that. A dashboard built on that field would wrongly count this
+    /// live turn as done.
+    ReplayTruncated,
     /// The subscriber hung up. The turn is parked for the resume window rather
     /// than cancelled outright — see `ServerState::park_for_resume`.
     PeerDisconnected,
@@ -1007,6 +1016,11 @@ mod tests {
             // The peer is emphatically still there — it is talking, just
             // wrongly. Nothing to wait for.
             StreamEndReason::StrayBytes,
+            // Not a hang-up either — the peer is still there and the turn is
+            // still live, but this predicate is not what parks it: its one
+            // call site does that itself, unconditionally, right after
+            // emitting the event — see `ReplayTruncated`'s own doc comment.
+            StreamEndReason::ReplayTruncated,
         ] {
             assert!(
                 !reason.leaves_the_turn_resumable(),

--- a/crates/stella-serve/src/routes.rs
+++ b/crates/stella-serve/src/routes.rs
@@ -677,7 +677,7 @@ async fn write_replay(
                 Ok(written) => {
                     *frames_sent += 1;
                     *bytes_out = bytes_out.saturating_add(written);
-                    Some(StreamEndReason::TurnComplete)
+                    Some(StreamEndReason::ReplayTruncated)
                 }
                 Err(_) => Some(StreamEndReason::WriteFailed),
             };
@@ -1274,5 +1274,53 @@ mod tests {
         assert_eq!(contracts[1].name(), "peek");
         assert_eq!(contracts[1].risk, stella_protocol::RiskLevel::Low);
         assert_eq!(contracts[1].version, 1);
+    }
+
+    /// A reconnect whose resume point has fallen out of the retention ring
+    /// is `Replay::Truncated`, for a turn that has not ended. Reporting
+    /// that as `StreamEndReason::TurnComplete` reads, in the log, as a turn
+    /// that finished — it did not. A ring of size one always evicts, so it
+    /// drives this path without a real race.
+    #[tokio::test]
+    async fn a_truncated_replay_reports_a_reason_distinct_from_a_healthy_completion() {
+        // A ring of one: recording a second frame evicts the first, so a
+        // reconnect asking for everything after 0 finds its resume point
+        // already gone.
+        let history = FrameHistory::with_capacity(1);
+        history.record(|seq| format!(r#"{{"seq":{seq}}}"#));
+        history.record(|seq| format!(r#"{{"seq":{seq}}}"#));
+
+        // `Responder` writes to a real `TcpStream` by construction — see
+        // `observe::record` — so the seam under test needs a loopback pair
+        // rather than an in-memory buffer.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("loopback bind");
+        let addr = listener.local_addr().expect("bound address");
+        let client = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("loopback connect");
+        let (mut server_stream, _) = listener.accept().await.expect("loopback accept");
+        let mut res = Responder::new(
+            &mut server_stream,
+            crate::observe::event::RequestId::generate(),
+        );
+
+        let mut frames_sent = 0_u64;
+        let mut bytes_out = 0_u64;
+        let reason = write_replay(&mut res, &history, 0, &mut frames_sent, &mut bytes_out).await;
+
+        assert_eq!(
+            reason,
+            Some(StreamEndReason::ReplayTruncated),
+            "a still-live turn whose reconnect fell out of the retention \
+             window must not read, in the operator's log, as indistinguishable \
+             from one that actually finished"
+        );
+        assert_eq!(
+            frames_sent, 1,
+            "the replay_truncated error frame was written"
+        );
+        drop(client);
     }
 }

--- a/crates/stella-serve/src/routes/sessions.rs
+++ b/crates/stella-serve/src/routes/sessions.rs
@@ -14,12 +14,6 @@
 
 use super::*;
 
-// `handle_session_delete`'s only use of the checkpoint port beyond the wire
-// types `super::*` already carries. It routes a failed discard through the
-// same sink the engine's own persist and discard calls use, so the failure
-// gets reported instead of dropped.
-use stella_engine::CheckpointSink;
-
 // ── /v1/sessions: server-owned conversations (#931) ──────────────────────────
 //
 // The handlers are the thin part; the state machine (checkout, settle-back,

--- a/crates/stella-serve/src/routes/sessions.rs
+++ b/crates/stella-serve/src/routes/sessions.rs
@@ -14,6 +14,12 @@
 
 use super::*;
 
+// `handle_session_delete`'s only use of the checkpoint port beyond the wire
+// types `super::*` already carries. It routes a failed discard through the
+// same sink the engine's own persist and discard calls use, so the failure
+// gets reported instead of dropped.
+use stella_engine::CheckpointSink;
+
 // ── /v1/sessions: server-owned conversations (#931) ──────────────────────────
 //
 // The handlers are the thin part; the state machine (checkout, settle-back,
@@ -357,10 +363,11 @@ pub(crate) async fn handle_session_delete(
             .json("404 Not Found", &error_body("unknown session"))
             .await;
     };
-    if let Some(turn_id) = sess.live_turn_id() {
+    let live_turn_id = sess.live_turn_id();
+    if let Some(turn_id) = &live_turn_id {
         // Scoped so the registry guard drops before the awaits below; the
         // session's own locks are not held here (`live_turn_id` returned).
-        let removed = { state.turns().remove(&turn_id) };
+        let removed = { state.turns().remove(turn_id) };
         if let Some(entry) = removed {
             // Same three signals as `handle_cancel`: without the step-boundary
             // latch (#1129), a turn deleted mid-compaction kept computing until
@@ -374,10 +381,22 @@ pub(crate) async fn handle_session_delete(
     // The conversation is gone, so its resume point is unreachable work: the
     // key is the session id, and that id now answers `404` everywhere else.
     // Leaving it would make `DELETE` the one operation that grows the store.
-    if let Some(store) = state.checkpoints()
-        && let Ok(key) = crate::checkpoint::CheckpointKey::new(id)
-    {
-        let _ = store.remove(&key);
+    //
+    // This routes the discard through the same `TurnCheckpoint::sink` the
+    // engine's own persist and discard calls use, instead of dropping the
+    // `Result` on the floor. A failing store now reports itself the same
+    // way any other checkpoint failure does: a `CheckpointFailed` event and
+    // a `checkpoints_failed_total` bump. The response still says
+    // `"deleted"`, because the session itself is gone either way. The
+    // reference id is the turn that was live at delete time, if any —
+    // otherwise the session id, stripped of its prefix.
+    if let Some(checkpoint) = state.checkpoint_for(id) {
+        let reference = live_turn_id
+            .as_deref()
+            .unwrap_or_else(|| id.strip_prefix("session-").unwrap_or(id));
+        checkpoint
+            .sink(state.observer().clone(), TurnRef::new(reference))
+            .discard();
     }
     res.json("200 OK", br#"{"status":"deleted"}"#).await
 }

--- a/crates/stella-serve/tests/checkpoint.rs
+++ b/crates/stella-serve/tests/checkpoint.rs
@@ -30,7 +30,8 @@ use std::time::Duration;
 
 use common::{TOKEN, model_result, model_wants_echo, next_event, open_sse, post_json};
 use serde_json::json;
-use stella_serve::{CheckpointKey, CheckpointStore, MemoryCheckpointStore};
+use stella_serve::observe::ServeEvent;
+use stella_serve::{CheckpointKey, CheckpointStore, CheckpointStoreError, MemoryCheckpointStore};
 
 /// A server whose checkpoints land in a store the test can also read directly.
 ///
@@ -409,6 +410,65 @@ async fn deleting_a_session_takes_its_resume_point_with_it() {
         store.get(&key).unwrap(),
         None,
         "a destroyed conversation must not leave its resume point behind"
+    );
+}
+
+/// A store whose every operation fails. It covers the one failure mode
+/// `deleting_a_session_takes_its_resume_point_with_it` cannot: what a
+/// caller and an operator are told when a removal does not succeed.
+#[derive(Debug)]
+struct BrokenStore;
+
+impl CheckpointStore for BrokenStore {
+    fn put(&self, _key: &CheckpointKey, _json: &str) -> Result<(), CheckpointStoreError> {
+        Err(CheckpointStoreError::Backend("no room".to_string()))
+    }
+    fn get(&self, _key: &CheckpointKey) -> Result<Option<String>, CheckpointStoreError> {
+        Err(CheckpointStoreError::Backend("no room".to_string()))
+    }
+    fn remove(&self, _key: &CheckpointKey) -> Result<(), CheckpointStoreError> {
+        Err(CheckpointStoreError::Backend("no room".to_string()))
+    }
+}
+
+/// A bare `let _ = store.remove(&key);` drops the error on the floor. The
+/// response still says `{"status":"deleted"}`. Nothing else — not a
+/// `CheckpointFailed` event, not `checkpoints_failed_total` — hears about
+/// it. This test fails on that discarded `Result` by construction: a store
+/// whose `remove` always errs leaves `Capture` holding no `CheckpointFailed`
+/// event, because the error never reached anything that could observe it.
+///
+/// The session itself is gone either way, so the response staying `200` is
+/// correct. What changes is that the failing discard now gets reported the
+/// same way a failing persist already does.
+#[tokio::test]
+async fn a_failed_checkpoint_removal_at_session_delete_is_reported() {
+    let store: Arc<dyn CheckpointStore> = Arc::new(BrokenStore);
+    let (addr, capture, shutdown) = common::start_drainable_server_with_checkpoints(
+        common::TEST_RESUME_GRACE,
+        stella_serve::DEFAULT_SHUTDOWN_GRACE,
+        Some(store),
+    )
+    .await;
+    drop(shutdown);
+
+    let session_id = create_session(addr).await;
+
+    let (status, body) = delete_checkpoint(addr, &format!("/v1/sessions/{session_id}")).await;
+    assert!(
+        status.contains("200"),
+        "the session itself is genuinely gone: {status} {body}"
+    );
+
+    assert!(
+        capture
+            .events()
+            .iter()
+            .any(|event| matches!(event, ServeEvent::CheckpointFailed { .. })),
+        "a discard failure at session-delete time must be reported like \
+         every other checkpoint-store failure, not swallowed behind a \
+         response that says nothing about whether the checkpoint was \
+         actually cleared"
     );
 }
 


### PR DESCRIPTION
## What

Two `stella-serve` paths reported a better outcome than actually happened:

1. **`handle_session_delete`** dropped a failed checkpoint-store `remove()`
   with `let _ = store.remove(&key)`. A crashed-mid-turn session with a live
   checkpoint, deleted while the store is failing (disk full, revoked
   permission, unmounted volume), left the checkpoint stranded with no
   `CheckpointFailed` event, no `checkpoints_failed_total` bump, and a `200
   {"status":"deleted"}` response that told the caller nothing was wrong.
2. **`write_replay`**'s `Replay::Truncated` arm reported
   `StreamEndReason::TurnComplete` — documented as "the healthy ending" — for
   a reconnect whose resume point had already fallen out of the retention
   ring. The turn was still live and about to be parked for resume by the
   very next call in `handle_events`; the operator's JSONL log recorded it as
   a finished turn.

## Why

Both paths make a durability feature and an operator's diagnostic log lie
quietly, which is exactly what `checkpoint.rs`'s own module doc warns
against.

## Fix

1. `handle_session_delete` now routes the discard through
   `TurnCheckpoint::sink(...).discard()` — the same seam the engine's own
   persist/discard calls use — so a failing store reports itself exactly
   like every other checkpoint failure in this crate. The response stays
   `200 {"status":"deleted"}` on purpose: the session registry entry is
   removed either way, so that part of the response is still true; what
   changes is that the failure is no longer invisible to the operator.
2. Added `StreamEndReason::ReplayTruncated` and pointed the truncated-replay
   arm at it instead of `TurnComplete`. The wire behaviour toward the host
   (the `replay_truncated` SSE frame, then `park_for_resume`) is unchanged —
   only the server-side diagnostic event fed to the operator's log is
   corrected.

## Witness

- `a_failed_checkpoint_removal_at_session_delete_is_reported`
  (`crates/stella-serve/tests/checkpoint.rs`) wires a `BrokenStore` (every
  operation errs) into a live server, deletes a session, and asserts a
  `CheckpointFailed` event landed in `Capture`. Fails on the old
  `let _ = store.remove(&key)` by construction: a discarded `Result` reaches
  no observer, so `Capture` holds nothing regardless of how the store fails.
- `a_truncated_replay_reports_a_reason_distinct_from_a_healthy_completion`
  (`crates/stella-serve/src/routes.rs`) drives `write_replay` against a
  `FrameHistory` of capacity one — which always evicts on a second record,
  so the truncated arm fires deterministically rather than racing a real
  eviction — and asserts the returned reason is `ReplayTruncated`, not
  `TurnComplete`. Fails on the old unconditional `Some(StreamEndReason::TurnComplete)`
  in that arm.

Both were checked the artisanal way: reverting the two production edits
(`git stash` the non-test hunks) reproduces the pre-fix behaviour and both
new tests fail; restoring them passes.

## Tests deleted

None.

## Residue

None noticed beyond the issue's own scope.

Closes #5503

## Summary by Sourcery

Make session deletion and replay diagnostics accurately reflect checkpoint and stream outcomes.

Bug Fixes:
- Report checkpoint discard failures during session deletion through the normal checkpoint failure observability path while preserving the successful session-deletion response.
- Distinguish truncated replay diagnostics from healthy turn completion so live turns are not recorded as finished.

Tests:
- Add coverage for failed checkpoint removal reporting and truncated replay end-reason classification.