### PR TITLE
fix(stella-store): evict past an abandoned telemetry-spool lease

### DIFF
--- a/crates/stella-cli/src/memory_cmd.rs
+++ b/crates/stella-cli/src/memory_cmd.rs
@@ -70,11 +70,13 @@ pub enum MemoryCmd {
     /// Forget a memory: stop it steering the agent, and stop the reflection
     /// loop re-learning it. Reversible with `stella memory restore <id>`.
     ///
-    /// This is a tombstone, not a delete. The reflection loop re-mines
-    /// paraphrases of lessons it has already learned, so removing the row
-    /// alone does not hold — the tombstone also suppresses restatements at
-    /// the point new lessons are recorded and at the point the log is mined
-    /// into skills.
+    /// This is a tombstone, not a delete. The memory's row stays in
+    /// `.stella/private/context.db`. Its text is also copied into a second,
+    /// permanent record. Forgetting hides a memory; it does not erase the
+    /// text. The reflection loop re-mines lessons it already learned, so
+    /// removing the row alone would not hold — the tombstone also blocks
+    /// restatements, both when a new lesson is recorded and when the log
+    /// is mined into skills.
     Forget {
         /// The memory's stable id (nod_…) as shown by `stella memory list`
         id: String,

--- a/crates/stella-store/src/enterprise_telemetry.rs
+++ b/crates/stella-store/src/enterprise_telemetry.rs
@@ -772,7 +772,7 @@ impl EnterpriseTelemetrySpool {
             tx.commit()?;
             return Ok(EnqueueOutcome::Duplicate);
         }
-        enforce_limits(&tx, self.limits, sink_fingerprint)?;
+        enforce_limits(&tx, self.limits, sink_fingerprint, created_at_ms)?;
         let retained: bool = tx.query_row(
             "SELECT EXISTS(SELECT 1 FROM operational_spool
              WHERE sink_fingerprint = ?1 AND event_id = ?2)",
@@ -1284,6 +1284,7 @@ fn enforce_limits(
     tx: &rusqlite::Transaction<'_>,
     limits: SpoolLimits,
     inserting_sink: &str,
+    now_ms: i64,
 ) -> Result<()> {
     loop {
         let (rows, bytes): (i64, i64) = tx.query_row(
@@ -1296,12 +1297,16 @@ fn enforce_limits(
         if rows <= limits.max_rows && bytes <= limits.max_bytes {
             return Ok(());
         }
+        // A dead lease must not block eviction forever. If the owner dies
+        // before `ack` or `retry`, this row still counts as free once its
+        // lease expires — the same rule `claim_batch` already uses.
         let oldest: Option<i64> = tx
             .query_row(
                 "SELECT insertion_seq FROM operational_spool
-                 WHERE sink_fingerprint = ?1 AND leased_by IS NULL
+                 WHERE sink_fingerprint = ?1
+                   AND (leased_by IS NULL OR lease_until_ms <= ?2)
                  ORDER BY insertion_seq LIMIT 1",
-                params![inserting_sink],
+                params![inserting_sink, now_ms],
                 |row| row.get(0),
             )
             .optional()?;

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -999,6 +999,13 @@ impl Store {
     /// content and the reason rather than erroring, so forgetting a memory
     /// that was re-learned under a new id behaves the way a user expects.
     ///
+    /// This suppresses; it does not delete. The item's original row is left
+    /// exactly where it was, and `content` is written into a second, durable
+    /// copy in the `forgotten` table that carries no age or GC coverage of
+    /// its own — so a forgotten item ends up with two live copies of its
+    /// text, not zero. A caller that needs the text gone, not just hidden,
+    /// has to remove both rows itself.
+    ///
     /// `content` is what makes this survive re-learning — the reflection
     /// recorder and the skill miner compare candidates against it, so a
     /// paraphrase with a fresh id is still caught. Pass the item's text, not

--- a/crates/stella-store/src/usage/rekey.rs
+++ b/crates/stella-store/src/usage/rekey.rs
@@ -1,36 +1,43 @@
-//! Project re-key (#408): merge one hub project identity into another.
+//! Project re-key: merge one hub project identity into another.
 //!
 //! `project_id` began as the FNV hash of the checkout path, so a `mv` forked
 //! the identity: the cursor reset, the whole store re-replicated, and the hub
 //! showed two projects for one repo. A *registered* workspace now replicates
 //! under its stable `workspace_id`-derived id
-//! ([`crate::identity::replication_project_id`]) — and this module is the
-//! migration for rows that landed under the old path hash: registration and
-//! every sync call [`UsageStore::adopt_project_identity`], which idempotently
-//! re-keys the six tables carrying a `project_id`.
+//! ([`crate::identity::replication_project_id`]). This module moves rows
+//! that landed under the old path hash to the new id. Registration, and
+//! every sync call, run [`UsageStore::adopt_project_identity`], which
+//! idempotently re-keys every table in [`PROJECT_KEYED_TABLES`], plus the
+//! summed tool-usage tables and the replication cursor.
 //!
-//! Merge semantics, per table: rows move to the new id; a row that already
-//! exists under the new id wins and the old duplicate is dropped (`telemetry`
-//! and `cloud_quarantine` rows are identical under both ids by construction —
-//! they came from the same source rowids); the replication cursor merges by
-//! `MAX`, so it continues instead of rewinding. One transaction: the hub is
-//! never observable half-migrated.
+//! Merge rule, per table: a [`PROJECT_KEYED_TABLES`] row is identical under
+//! both ids by construction — it came from the same source row — so on a
+//! key conflict the new-id copy wins and the old duplicate is dropped. The
+//! tool-usage tables hold counts instead, so a conflict there sums both
+//! sides. The replication cursor merges by `MAX`, so it keeps going rather
+//! than starting over. One transaction: the hub is never observed half
+//! migrated.
 
 use rusqlite::params;
 
 use super::{Result, UsageStore};
 
 /// The hub tables with a `project_id` column whose rows are *identical*
-/// under both identities by construction (they came from the same source
-/// rowids), so a key conflict resolves by keeping the new-id copy. A new
-/// project-keyed table must be added here or handled explicitly like
-/// `tool_usage_rollup` — whose buckets are additive counts and merge by
-/// summing instead.
+/// under both identities by construction — they came from the same source
+/// row — so a key conflict resolves by keeping the new-id copy. A new
+/// project-keyed table goes here, unless its rows are counts like
+/// `tool_usage_rollup`, which must sum on conflict instead and is merged by
+/// hand below.
 const PROJECT_KEYED_TABLES: &[&str] = &[
     "projects",
     "execution_rollup",
     "telemetry",
     "cloud_quarantine",
+    // One claim per execution, not a count: an execution claimed under
+    // either id has claimed once, so the new-id row winning is already the
+    // right merge — the same rule as the rows above, not the summing rule
+    // below.
+    "tool_fold_ledger",
 ];
 
 impl UsageStore {
@@ -112,7 +119,8 @@ impl UsageStore {
 
 #[cfg(test)]
 mod tests {
-    use super::super::UsageStore;
+    use super::super::tests::rollup;
+    use super::super::{ToolBucket, UsageStore};
     use crate::identity::TelemetryScope;
 
     fn scope(project_id: &str) -> TelemetryScope {
@@ -236,6 +244,43 @@ mod tests {
             hub.telemetry_cursor("new").unwrap(),
             3,
             "the cursor is the MAX of the two"
+        );
+    }
+
+    /// `tool_fold_ledger` needs an entry in `PROJECT_KEYED_TABLES` too.
+    /// Without one, a re-sync after a rekey finds no claim under the new
+    /// id, folds the histogram again, and double-counts it.
+    #[test]
+    fn rekey_carries_the_tool_fold_claim_so_a_resync_does_not_double_count() {
+        let usage = UsageStore::in_memory().unwrap();
+        let mut r = rollup(
+            7,
+            vec![ToolBucket {
+                tool: "grep".into(),
+                surface: "native".into(),
+                calls: 2,
+                errors: 0,
+            }],
+        );
+        r.project_id = "old".into();
+        usage.sync_execution(&r).unwrap();
+
+        usage.adopt_project_identity("old", "new").unwrap();
+
+        // Re-sync the same execution under its new id. This is what a
+        // retry, backfill, or replay of `sync_execution` would do.
+        r.project_id = "new".into();
+        usage.sync_execution(&r).unwrap();
+
+        let grep_calls = usage
+            .tool_report()
+            .unwrap()
+            .into_iter()
+            .find(|row| row.tool == "grep")
+            .map_or(0, |row| row.calls);
+        assert_eq!(
+            grep_calls, 2,
+            "the tool-day fold must not double-count after a rekey"
         );
     }
 }

--- a/crates/stella-store/tests/enterprise_telemetry/spool.rs
+++ b/crates/stella-store/tests/enterprise_telemetry/spool.rs
@@ -276,6 +276,66 @@ fn spool_is_idempotent_bounded_and_evicts_oldest_with_durable_drop_count() {
 }
 
 #[test]
+fn abandoned_lease_does_not_block_eviction_of_stale_rows() {
+    // A worker leases a sink's whole backlog, then dies before `ack` or
+    // `retry` runs. `leased_by` never clears. A dead lease must not count
+    // as a live one: `claim_batch` already treats an expired lease as free,
+    // and eviction must agree.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("enterprise-telemetry.db");
+    let spool = EnterpriseTelemetrySpool::open_at(
+        &path,
+        SpoolLimits {
+            max_rows: 2,
+            max_bytes: 64 * 1024,
+        },
+    )
+    .unwrap();
+    let first = StellaOperationalEventV1::from_finalized_rollup(&context(), &rollup(1)).unwrap();
+    let second = StellaOperationalEventV1::from_finalized_rollup(&context(), &rollup(2)).unwrap();
+    let third = StellaOperationalEventV1::from_finalized_rollup(&context(), &rollup(3)).unwrap();
+
+    spool.enqueue(SINK_A, &first, 10).unwrap();
+    spool.enqueue(SINK_A, &second, 20).unwrap();
+
+    // Lease the whole backlog, then abandon it. The lease expires at
+    // 30 + 5 = 35, but `leased_by` stays set forever.
+    let claimed = spool
+        .claim_batch_at(SINK_A, "worker", 30, 5, 10, 64 * 1024)
+        .unwrap();
+    assert_eq!(claimed.len(), 2, "both rows are leased and then abandoned");
+
+    // The lease is long expired. A new event now arrives for this sink.
+    // It must survive. The old row gets dropped instead.
+    let outcome = spool.enqueue(SINK_A, &third, 1_000).unwrap();
+    assert_eq!(
+        outcome,
+        EnqueueOutcome::Retained,
+        "an abandoned lease must not make the fresh event the only eviction \
+         candidate and force it to be dropped in place of stale data"
+    );
+
+    let status = spool.status().unwrap();
+    assert_eq!(status.pending_rows, 2);
+    assert_eq!(status.dropped_rows, 1);
+
+    // Check which row was evicted: it must be the old one (`first`), not
+    // the new one (`third`).
+    let recovered = spool
+        .claim_batch_at(SINK_A, "worker-2", 2_000, 1_000, 10, 64 * 1024)
+        .unwrap();
+    let ids: Vec<_> = recovered.iter().map(|item| item.event.event_id()).collect();
+    assert!(
+        !ids.contains(&first.event_id()),
+        "the stale, abandoned-lease row was evicted"
+    );
+    assert!(
+        ids.contains(&third.event_id()),
+        "the fresh event was retained"
+    );
+}
+
+#[test]
 fn claims_are_transactional_retryable_and_expired_leases_recover() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("enterprise-telemetry.db");

--- a/website/content/docs/commands/memory.mdx
+++ b/website/content/docs/commands/memory.mdx
@@ -200,6 +200,13 @@ This writes a **tombstone**. It does not delete the memory, and that difference 
 
 `--reason` is optional, and `stella memory forgotten` shows it later. Write one anyway. Months from now, you'll probably be the one deciding whether to `restore` it.
 
+<Callout type="warn">
+`forget` hides a memory. It does not remove the text from your disk. The original row stays
+in `.stella/private/context.db`. `forget` also copies the full text into the tombstone
+record, and keeps that copy forever. If a memory holds something you want gone, not just
+hidden, `forget` alone will not do that. You would need to edit `context.db` by hand.
+</Callout>
+
 ### `stella memory restore <id>`
 
 Remove a tombstone. The memory can be recalled again, and stella can learn it again too.


### PR DESCRIPTION
Closes #5510

## What & why

Three findings from a workspace-wide correctness audit of `stella-store`'s
telemetry and egress layer.

**Finding 1 (fixed).** The telemetry spool's `enforce_limits` picked its
eviction candidate with `leased_by IS NULL` only, never checking
`lease_until_ms` — unlike `claim_batch`'s own reclaim query, which already
treats an expired lease as free. A host killed between `claim_batch` and
`ack`/`retry` left `leased_by` set forever, so `enforce_limits` found nothing
to evict for that sink: the spool grew past its documented hard cap
(`SpoolLimits::max_rows`/`max_bytes`) while the newest, still-useful event was
the one getting dropped in its place. `enforce_limits` now takes a `now_ms`
parameter (threaded from `enqueue`'s own `created_at_ms`, which every call
site already passes as real wall-clock time) and evicts a row that is
`leased_by IS NULL OR lease_until_ms <= ?now`, mirroring `claim_batch`
exactly.

**Finding 2 (fixed).** `tool_fold_ledger` — the per-execution claim that makes
the hub's tool-day fold idempotent — is a fifth project-keyed table and was
missing from `usage/rekey.rs`'s `PROJECT_KEYED_TABLES`. `adopt_project_identity`
runs on registration and on every `replicate_telemetry_to_usage`, and today's
only production caller of `sync_execution` invokes it once per execution at
turn finish, so no currently-wired path re-syncs an execution after its
project rekeys — the issue marked this PLAUSIBLE rather than CONFIRMED, and I
found nothing that upgrades it to a live path either. It is a real break of
`tool_fold.rs`'s own stated idempotency contract, though: the module doc says
`sync_execution` can be re-invoked safely for one execution, and a retry,
backfill, or replay path would silently double-count. Cheap and structurally
correct to close now rather than carry as a latent gap, so I added the entry
rather than downgrading. `tool_fold_ledger`'s primary key is
`(project_id, execution_id)`, and a claim is presence rather than a count, so
it merges by the same `UPDATE OR IGNORE` + delete rule as `telemetry` and
`cloud_quarantine` above it (new-id row wins on conflict) — not the summing
rule `tool_usage_rollup` needs.

**Finding 3 (documented, no code change).** `forget` is a suppression filter
by design (module doc in `crates/stella-store/src/forget.rs` gives the
re-learning reason), not a delete — but nothing told a user that plainly.
`Store::forget`'s doc comment, `stella memory forget`'s `--help` text, and
`website/content/docs/commands/memory.mdx` now all say directly that the
original row and text stay in place, and that a second permanent copy is
written into the tombstone record with no age or GC coverage of its own.

## The witness

- `crates/stella-store/tests/enterprise_telemetry/spool.rs`:
  `abandoned_lease_does_not_block_eviction_of_stale_rows` seeds a sink at
  `max_rows` (2), leases the whole backlog with a 5ms lease, lets the lease
  expire with no `ack`/`retry`, enqueues a third event, and asserts the row
  count stays at `max_rows`, the fresh event is retained, and the stale
  abandoned row (not the fresh one) is what got evicted. Fails on `main`
  (the fresh event is dropped instead), passes here.
- `crates/stella-store/src/usage/rekey.rs`:
  `rekey_carries_the_tool_fold_claim_so_a_resync_does_not_double_count` syncs
  an execution with a 2-call tool bucket under one project id, rekeys the
  project, re-syncs the same execution under the new id, and asserts the
  tool count is still 2. Fails on `main` (goes to 4), passes here.

## The gate

- [x] `cargo fmt --check` (ran locally)
- [ ] clippy across the workspace — CI
- [ ] the full workspace test suite — CI (this laptop doesn't build or test
      the whole workspace; see CLAUDE.md)
- [x] Docs updated: `Store::forget`'s doc comment, `stella memory forget`
      `--help` text, `website/content/docs/commands/memory.mdx`
- [x] CLA already on file
- [x] `Closes #5510` appears above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR (finding 3
      was explicitly marked "by design, no fix" by the issue itself; I only
      strengthened the docs it asked for)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary types

## Anything reviewers should know?

Finding 2 stayed PLAUSIBLE in the issue text — I re-checked for a live
re-invocation path (`stella usage sync --all` turned out to only call
`replicate_telemetry_to_usage`, not `sync_execution`) and found none, but
fixed it anyway rather than downgrading, since the entry is a one-line,
low-risk closure of a real contract gap the module's own tests already
assume holds.

## Summary by Sourcery

Keep telemetry spools bounded and tool usage idempotent across abandoned leases and project identity rekeys, while clarifying memory-forgetting semantics.

Bug Fixes:
- Allow telemetry spool eviction to reclaim rows whose leases have expired, preventing abandoned leases from exceeding spool limits or causing fresh events to be discarded.
- Preserve tool-fold idempotency across project identity rekeys by migrating execution claims with other project-keyed data.

Documentation:
- Clarify that forgetting a memory suppresses it without deleting its original row or text, and that the tombstone retains a permanent copy.

Tests:
- Add regression coverage for eviction past abandoned telemetry leases and for preventing tool-count duplication after project rekeying.

## Independent DoD verification (#5510)

`cargo test -p stella-store` re-run on this head (`482bb161`), rustc 1.97.0:

```
running 479 tests   -> ok. 479 passed; 0 failed
running  32 tests   -> ok.  32 passed; 0 failed   (enterprise_telemetry)
doc-tests           -> ok.   0 passed; 0 failed
exit code 0

test spool::abandoned_lease_does_not_block_eviction_of_stale_rows ... ok
test usage::rekey::tests::rekey_carries_the_tool_fold_claim_so_a_resync_does_not_double_count ... ok
```

The other three ticked items check out against the diff: `tool_fold_ledger` is
added to `PROJECT_KEYED_TABLES` (`usage/rekey.rs`), and the suppress-not-delete
wording lands in all three places the issue names — `Store::forget`'s doc
(`lib.rs`), the CLI help text (`memory_cmd.rs`), and
`website/content/docs/commands/memory.mdx`.

All four of #5510's DoD boxes were already ticked; this re-runs the `dod` check,
which had reported against the checklist as it stood before they were.

---
_Generated by [Claude Code](https://claude.ai/code)_