### PR TITLE
fix(stella-core): reserve the whole step against the turn deadline

### DIFF
--- a/crates/stella-core/src/accounted_call.rs
+++ b/crates/stella-core/src/accounted_call.rs
@@ -172,7 +172,7 @@ pub async fn run_accounted_call(
     // estimate to anticipate with, and inventing one here would be a second,
     // invisible policy on top of the operator's — so the anticipatory rung
     // lives wherever a basis for one does. The engine's step loop forecasts
-    // from `TurnState::last_step`, which it measures; the staged pipeline's
+    // from `TurnState::pace`, which it measures; the staged pipeline's
     // `dispatch_raw` reserved each management call's own declared `timeout`
     // and refused ahead of this seam (#2432) until that crate was deleted
     // (#3865). A caller holding no such basis

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -151,6 +151,7 @@ mod restore;
 // The step boundary's host consults (steering, soft stop, #3243 re-query).
 mod settlement;
 mod step_boundary;
+pub(crate) mod step_pace;
 pub(crate) mod usage_anchor;
 pub(crate) mod user_hooks;
 mod waiting;
@@ -892,7 +893,7 @@ impl<'a> Engine<'a> {
         self.emit_lifecycle(bus::names::MODEL_REQUEST_COMPLETED, || {
             lifecycle::model_request_completed_payload(state.step, &committed.result)
         });
-        state.last_step = Some(step_started.elapsed());
+        state.pace.observe_model(step_started.elapsed());
         state.calibration_model = Some(committed.result.model.clone());
         // Anchor the context measure to what the provider just attested for
         // this exact prefix — before dispatch appends the reply to it.
@@ -921,12 +922,13 @@ impl<'a> Engine<'a> {
             return aborted.into();
         }
 
-        // Only meaningful once a step has been timed and a budget configured:
-        // the forecast for one more continuation is what the last one cost.
+        // Only meaningful once a call has been timed and a budget configured:
+        // a continuation re-runs a tool-less step, so the model call is the
+        // whole forecast (`step_pace::StepPace::model`).
         let continuation_budget =
             self.config
                 .turn_budget
-                .zip(state.last_step)
+                .zip(state.pace.model())
                 .map(|(budget, last_step)| ContinuationBudget {
                     remaining: budget.saturating_sub(state.started_at.elapsed()),
                     last_step,
@@ -953,6 +955,9 @@ impl<'a> Engine<'a> {
         if let Some(cancelled) = self.maybe_park(state, events).await {
             return cancelled;
         }
+
+        // The whole step, tools and park included: the reserve (`step_pace`).
+        state.pace.observe_step(step_started.elapsed());
 
         // Advanced only by a step that committed and continued, so the index
         // a checkpoint carries is always "the step that runs next".

--- a/crates/stella-core/src/driver/settlement.rs
+++ b/crates/stella-core/src/driver/settlement.rs
@@ -125,7 +125,7 @@ impl super::Engine<'_> {
     /// exactly that amount.
     ///
     /// Takes the whole [`TurnState`] rather than three of its fields because
-    /// the deadline question needs a fourth — `last_step`, the pace estimate —
+    /// the deadline question needs a fourth — `pace`, the step estimate —
     /// and threading each one through by hand is what makes a call site grow
     /// every time this learns to consider something else.
     pub(super) fn check_budget(
@@ -157,7 +157,7 @@ impl super::Engine<'_> {
             &mut state.messages,
             &state.budget,
             state.total_cost_usd,
-            state.last_step,
+            state.pace.reserve(),
             &mut state.memos.warnings,
             events,
             now,
@@ -184,23 +184,26 @@ fn check_budget(
     messages: &mut Vec<CompletionMessage>,
     budget: &BudgetGuard,
     total_cost_usd: f64,
-    last_step: Option<std::time::Duration>,
+    reserve: std::time::Duration,
     warnings: &mut BudgetWarnings,
     events: &EventSender,
     now: std::time::Instant,
 ) -> Option<TurnOutcome> {
-    // The forecast for one more step is what the last one cost. Same rule,
-    // same words, as `truncation::ContinuationBudget::affords_another` — and
-    // no safety margin invented here either: the caller owns the deadline
+    // `reserve` is what one more WHOLE step needs: the model call plus the
+    // tools it asks for, measured by `driver::step_pace` and read off the
+    // turn by the wrapper above. A reserve read off the call alone keeps 8s
+    // for a step that thought for 8s and then ran `bash` for 4 minutes, and
+    // the turn then opens a step it cannot finish.
+    //
+    // No safety margin is invented here: the caller owns the deadline
     // (`runtime::one_shot_budget_guard` derives it from `--turn-timeout`, which
     // the bench adapter already sets to Harbor's timeout minus a teardown
     // reserve). A margin baked in at this level would be a second, invisible
     // policy on top of the one the operator configured.
     //
-    // `None` before any step has been timed, which reads as a zero reserve and
-    // so reproduces the reactive check exactly — there is nothing to forecast
-    // from yet, and inventing a number would be guessing at the model.
-    let reserve = last_step.unwrap_or_default();
+    // Zero before any step has been timed, which reproduces the reactive
+    // check exactly — there is nothing to forecast from yet, and inventing a
+    // number would be guessing at the model.
     let reason = match budget.check_deadline_with_reserve(now, reserve) {
         DeadlineOutcome::Exceeded { overrun } => Some(format!(
             "task deadline exceeded by {:.1}s — stopping with partial work",
@@ -414,7 +417,7 @@ mod tests {
     /// `check_budget` was split out of the `&self` wrapper in the first place.
     fn decide(
         deadline_in: Option<Duration>,
-        last_step: Option<Duration>,
+        reserve: Duration,
     ) -> (Option<TurnOutcome>, Vec<String>) {
         let now = std::time::Instant::now();
         let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
@@ -429,7 +432,7 @@ mod tests {
             &mut transcript,
             &budget,
             0.0,
-            last_step,
+            reserve,
             &mut warnings,
             &events,
             now,
@@ -448,8 +451,7 @@ mod tests {
         // #2278's witness. 20s of wall clock left and the last step took 30s:
         // starting another buys a harness SIGKILL with the work discarded,
         // which is what `sqlite-with-gcov__egbgJmd` bought at step 77.
-        let (outcome, messages) =
-            decide(Some(Duration::from_secs(20)), Some(Duration::from_secs(30)));
+        let (outcome, messages) = decide(Some(Duration::from_secs(20)), Duration::from_secs(30));
 
         let Some(TurnOutcome::Aborted { reason, kind, .. }) = outcome else {
             panic!("expected an anticipatory stop, got {outcome:?}");
@@ -474,10 +476,7 @@ mod tests {
 
     #[test]
     fn room_for_another_step_starts_it() {
-        let (outcome, messages) = decide(
-            Some(Duration::from_secs(300)),
-            Some(Duration::from_secs(30)),
-        );
+        let (outcome, messages) = decide(Some(Duration::from_secs(300)), Duration::from_secs(30));
         assert!(outcome.is_none(), "300s left, 30s steps: keep working");
         assert!(messages.is_empty(), "and say nothing");
     }
@@ -486,7 +485,7 @@ mod tests {
     fn before_the_first_timed_step_the_check_stays_reactive() {
         // No pace to forecast from yet. Inventing one would be guessing at the
         // model, so an unmeasured turn behaves exactly as it did before #2278.
-        let (outcome, _) = decide(Some(Duration::from_millis(1)), None);
+        let (outcome, _) = decide(Some(Duration::from_millis(1)), Duration::ZERO);
         assert!(
             outcome.is_none(),
             "a 1ms-from-deadline turn with no measured step must not stop early"
@@ -496,7 +495,7 @@ mod tests {
     #[test]
     fn a_crossed_deadline_still_reports_the_overrun() {
         // The anticipatory rung must not swallow the hard one.
-        let (outcome, _) = decide(None, Some(Duration::from_secs(30)));
+        let (outcome, _) = decide(None, Duration::from_secs(30));
         assert!(outcome.is_none(), "no deadline configured: never stops");
 
         let now = std::time::Instant::now();
@@ -508,7 +507,7 @@ mod tests {
             &mut Vec::new(),
             &budget,
             0.0,
-            Some(Duration::from_secs(600)),
+            Duration::from_secs(600),
             &mut warnings,
             &EventSender::new(tx),
             now,

--- a/crates/stella-core/src/driver/step_pace.rs
+++ b/crates/stella-core/src/driver/step_pace.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! How long a step took, as the guess for what the next one needs.
+//!
+//! The engine stops a turn early when the clock left is less than one more
+//! step needs. A step is not just its model call. It is the call plus every
+//! tool the call asked for. A reserve read off the call alone keeps 8
+//! seconds for a step that thought for 8 seconds and then ran `bash` for 4
+//! minutes, and the turn then starts a step it cannot finish.
+//!
+//! [`StepPace`] keeps both times. `model` is the model call by itself.
+//! `step` is the whole step: the same call, its tools, and any wait a tool
+//! asked for. The reserve is the larger of the two.
+//!
+//! # Why the larger, and not the sum
+//!
+//! `step` already holds `model` inside it, so on a step that ran to the
+//! boundary it is the bigger number and it wins. `model` is the floor for a
+//! step that ends sooner. A budget abort or a cut-off reply leaves the model
+//! time timed and no tool time to time. The larger of the two covers both,
+//! and the caller never has to say which kind of step it just saw.
+//!
+//! # Why the last step, and not a mean
+//!
+//! [`crate::driver::settlement`] adds no safety margin of its own, because
+//! the caller owns the deadline. A weight for a rolling mean would be such a
+//! margin, picked by taste, with nothing to measure it against. It would
+//! also read low right after the slow step this exists to catch, which is
+//! the one moment the reserve has to be right.
+//!
+//! Pure data and pure sums. The driver reads the clock and hands the
+//! numbers in (AGENTS.md #2).
+
+use std::time::Duration;
+
+/// The pace of this turn's steps: the last model call, and the last whole
+/// step. Lives on [`crate::step::TurnState`] and dies with the turn.
+///
+/// Not part of a checkpoint, for the reason the other turn latches are not:
+/// a turn that resumes has a new caller with a new deadline, so it times its
+/// own first step and forecasts from that.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct StepPace {
+    model: Option<Duration>,
+    step: Option<Duration>,
+}
+
+impl StepPace {
+    /// Record how long one model call took, retries and all. That is what
+    /// the same call would cost again, not the one try that worked.
+    pub(crate) fn observe_model(&mut self, took: Duration) {
+        self.model = Some(took);
+    }
+
+    /// Record how long one whole step took: the model call, the tools it
+    /// asked for, and any wait a tool asked the turn to take.
+    pub(crate) fn observe_step(&mut self, took: Duration) {
+        self.step = Some(took);
+    }
+
+    /// The last model call by itself, or `None` before the first one.
+    ///
+    /// Read by one caller only:
+    /// [`ContinuationBudget`](crate::driver::truncation::ContinuationBudget).
+    /// A length continuation re-runs a step that made no tool call, so tool
+    /// time is not part of what it will cost.
+    pub(crate) fn model(&self) -> Option<Duration> {
+        self.model
+    }
+
+    /// How much clock to keep for one more step. Zero until a step has been
+    /// timed, which leaves the deadline check reactive — there is nothing to
+    /// forecast from yet, and a made-up number would be a guess at the model.
+    pub(crate) fn reserve(&self) -> Duration {
+        self.model
+            .unwrap_or_default()
+            .max(self.step.unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The witness for the whole module. A step whose tools ran far longer
+    /// than its model call must keep the whole step, not the call.
+    #[test]
+    fn tool_time_is_part_of_the_reserve() {
+        let mut pace = StepPace::default();
+        pace.observe_model(Duration::from_secs(8));
+        pace.observe_step(Duration::from_secs(248));
+
+        assert_eq!(
+            pace.reserve(),
+            Duration::from_secs(248),
+            "a step that thought for 8s and then ran a tool for 4 minutes \
+             must not reserve 8s"
+        );
+    }
+
+    /// A step that ends before its tools run leaves the model time as the
+    /// floor, so the reserve never drops to zero after a real call.
+    #[test]
+    fn a_step_that_never_dispatched_keeps_the_model_time() {
+        let mut pace = StepPace::default();
+        pace.observe_model(Duration::from_secs(30));
+
+        assert_eq!(pace.reserve(), Duration::from_secs(30));
+        assert_eq!(
+            pace.model(),
+            Some(Duration::from_secs(30)),
+            "and the continuation forecast is that same call"
+        );
+    }
+
+    /// Nothing timed yet means no forecast. The deadline check then behaves
+    /// as it did before the reserve existed.
+    #[test]
+    fn an_untimed_turn_reserves_nothing() {
+        let pace = StepPace::default();
+
+        assert_eq!(pace.reserve(), Duration::ZERO);
+        assert_eq!(pace.model(), None);
+    }
+
+    /// The continuation forecast stays the model call alone even after a
+    /// slow step. A continuation re-runs a step that called no tool.
+    #[test]
+    fn the_continuation_forecast_leaves_tool_time_out() {
+        let mut pace = StepPace::default();
+        pace.observe_model(Duration::from_secs(5));
+        pace.observe_step(Duration::from_secs(200));
+
+        assert_eq!(pace.model(), Some(Duration::from_secs(5)));
+    }
+
+    /// Each step replaces the last. A fast step after a slow one lowers the
+    /// reserve, so one long tool call cannot hold the turn back all turn.
+    #[test]
+    fn the_newest_step_is_the_one_that_counts() {
+        let mut pace = StepPace::default();
+        pace.observe_model(Duration::from_secs(1));
+        pace.observe_step(Duration::from_secs(240));
+        pace.observe_model(Duration::from_secs(1));
+        pace.observe_step(Duration::from_secs(2));
+
+        assert_eq!(pace.reserve(), Duration::from_secs(2));
+    }
+}

--- a/crates/stella-core/src/driver/tests/budget_boundaries.rs
+++ b/crates/stella-core/src/driver/tests/budget_boundaries.rs
@@ -1,8 +1,9 @@
 //! Budget-boundary witnesses: an over-cap call is settled spend but the next
 //! provider call never starts, an already-breached turn never pays for
 //! compaction, a billed completion and its usage envelope land exactly once
-//! even when a speculation is still in flight, and both top-of-step aborts
-//! hand back a transcript the next provider call still accepts.
+//! even when a speculation is still in flight, both top-of-step aborts
+//! hand back a transcript the next provider call still accepts, and a step
+//! with a slow tool stops the turn before the deadline instead of after it.
 
 use super::*;
 
@@ -419,5 +420,87 @@ async fn a_normal_completion_charges_the_budget_exactly_once() {
             .count(),
         1,
         "the normal path must not re-emit the success envelope"
+    );
+}
+
+/// A `ToolExecutor` whose one tool sleeps, so the step around it costs far
+/// more than the model call inside it.
+///
+/// Real time, because the reserve is real time: the driver reads
+/// `Instant::now`, and a paused tokio clock would leave every step measured
+/// at zero.
+struct SlowTool {
+    took: std::time::Duration,
+}
+
+#[async_trait]
+impl ToolExecutor for SlowTool {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a command".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        tokio::time::sleep(self.took).await;
+        ToolOutput::Ok {
+            content: "ok".into(),
+            data: None,
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_slow_tool_stops_the_turn_before_the_deadline() {
+    // The scripted model answers at once and its tool then runs for a
+    // second, so the step costs a second and the call inside it costs
+    // nothing. With 600ms left after that step, a reserve measured on the
+    // model call alone reads about zero and opens step two, which runs the
+    // same slow tool and crosses the deadline. A reserve measured on the
+    // whole step reads about a second, and the turn stops with what it has.
+    let tool_time = std::time::Duration::from_millis(1_000);
+    let deadline_in = std::time::Duration::from_millis(1_600);
+
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(vec![Ok(tool_call_result("slow-call", "bash"))]),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let provider_calls = provider.calls.clone();
+    let tools = SlowTool { took: tool_time };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("the task"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    budget.set_task_deadline(Some(std::time::Instant::now() + deadline_in));
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+
+    let TurnOutcome::Aborted { reason, kind, .. } = outcome else {
+        panic!("expected the deadline stop, got {outcome:?}");
+    };
+    assert_eq!(
+        kind,
+        AbortKind::DeliberateStop,
+        "stopping early is the engine's own policy, not a crash"
+    );
+    assert_eq!(
+        provider_calls.load(Ordering::SeqCst),
+        1,
+        "step two must never start: its tool alone takes {tool_time:?} of a \
+         {deadline_in:?} deadline"
+    );
+    assert!(
+        reason.contains("cannot finish"),
+        "the turn must stop while the deadline is still ahead, not report an \
+         overrun after crossing it: {reason}"
     );
 }

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -58,6 +58,7 @@ use crate::driver::deadline_notice::DeadlineNotices;
 use crate::driver::loop_escalation::LoopSteerBudget;
 use crate::driver::output_budget_recovery::OutputBudgetRecovery;
 use crate::driver::overflow_recovery::OverflowRecovery;
+use crate::driver::step_pace::StepPace;
 use crate::driver::usage_anchor::UsageAnchor;
 use crate::driver::{EngineConfig, SPECULATION_DISCARD_ATTEMPT_FAILED, TurnMemos, TurnOutcome};
 use crate::event_sender::EventSender;
@@ -394,11 +395,11 @@ pub struct TurnState {
     /// the original start would make the budget read as long spent before any
     /// work happened. Same reasoning as `length_continuations` starting over.
     pub(crate) started_at: std::time::Instant,
-    /// How long the most recent model call took, as the estimate of what one
-    /// more continuation would cost. A continuation re-runs the work that just
-    /// truncated, so its predecessor's duration is the honest forecast — and
-    /// the only one available without predicting the model.
-    pub(crate) last_step: Option<std::time::Duration>,
+    /// How long this turn's steps have been taking: the last model call, and
+    /// the last whole step. The deadline reserve reads the whole step, and
+    /// the length-continuation forecast reads the call
+    /// ([`StepPace`](crate::driver::step_pace::StepPace)).
+    pub(crate) pace: StepPace,
     /// Steps since the [`SteeringRequery`](crate::ports::SteeringRequery)
     /// port last answered — the `since_last_query` half of the hysteresis
     /// input (#3243 Phase 3). Reset when the port returns a block. Not
@@ -451,7 +452,7 @@ impl TurnState {
             length_continuations: 0,
             stop_hook_consults: 0,
             started_at: std::time::Instant::now(),
-            last_step: None,
+            pace: StepPace::default(),
             steps_since_requery: 0,
             cancel: CancelToken::new(),
         }
@@ -498,7 +499,7 @@ impl TurnState {
             // the same bounded-allowance reasoning as `length_continuations`.
             stop_hook_consults: 0,
             started_at: std::time::Instant::now(),
-            last_step: None,
+            pace: StepPace::default(),
             steps_since_requery: 0,
             cancel: CancelToken::new(),
         }

--- a/crates/stella-core/src/step.rs
+++ b/crates/stella-core/src/step.rs
@@ -398,7 +398,7 @@ pub struct TurnState {
     /// How long this turn's steps have been taking: the last model call, and
     /// the last whole step. The deadline reserve reads the whole step, and
     /// the length-continuation forecast reads the call
-    /// ([`StepPace`](crate::driver::step_pace::StepPace)).
+    /// ([`StepPace`]).
     pub(crate) pace: StepPace,
     /// Steps since the [`SteeringRequery`](crate::ports::SteeringRequery)
     /// port last answered — the `since_last_query` half of the hysteresis


### PR DESCRIPTION
## What & why

The anticipatory stop asks whether one more step fits in the wall clock a
turn has left. It answered from the last **model call**'s duration alone,
and a step is that call plus every tool it asked for. So a step that
thought for 8s and then ran `bash` for 4 minutes reserved 8s: the turn
opened a step it could not finish, and died past its deadline with the work
uncommitted instead of stopping one step early with partial work.

`crates/stella-core/src/driver/step_pace.rs` (new sibling module of the
`driver.rs` god file) keeps both times:

- `model` — the last model call, retries included. Still the only term the
  length-continuation forecast reads, because a continuation re-runs a
  tool-less step (`truncation::ContinuationBudget`).
- `step` — the last whole step, from before the call to the step boundary
  after tool dispatch and any park a tool asked for.
- `reserve()` — the larger of the two. `step` contains `model`, so it wins
  on a step that ran to the boundary; `model` is the floor for a step that
  ended sooner (a budget abort, a truncated reply), where there is no tool
  time to measure.

`driver.rs` grows three lines: the module declaration, `observe_model`
where `state.last_step` was set, and `observe_step` after the park, reusing
the `step_started` clock already in scope. `settlement.rs`'s `check_budget`
now takes the reserve as a `Duration` and its comment says what the reserve
forecasts. `TurnState::last_step` becomes `TurnState::pace`.

Pure arithmetic in `stella-core`, no I/O (ground rule 2). Ground rule 6
holds unchanged: the check still runs between model calls only, never
mid-tool — this changes the estimate the boundary uses, not where the
boundary is.

One deviation from the design pointer, which asked for an EWMA of each
term. The reserve keeps the last observation instead. `settlement.rs`
states that no safety margin is invented at that level because the operator
owns the deadline, and a smoothing weight is exactly such an invented
number with nothing to measure it against (and `MEASURED:` is not for a
constant chosen by taste). Smoothing also reads low right after the slow
step the stop exists to catch. `max(model, step)` gives the pointer's
`max(model, model + tool)` and keeps the model term as the floor. Design
comment posted on the issue before the work started.

Exemplar for the module shape: `driver/usage_anchor.rs` — the same
pattern of a small pure estimator on `TurnState`, read by the driver at one
boundary.

Closes #5713

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_slow_tool_stops_the_turn_before_the_deadline` in
`crates/stella-core/src/driver/tests/budget_boundaries.rs` drives a real
turn: a scripted provider that answers at once with one `bash` call, a tool
executor that sleeps 1s, and a 1.6s task deadline.

- On `main` the reserve after step one is the model call, about 0ms, so
  600ms of remaining clock reads as room. Step two starts, runs the same
  1s tool, and the turn ends with `deadline exceeded by …` after two
  provider calls.
- Here the reserve is the whole step, about 1s, so 600ms is not enough. The
  turn stops with `… cannot finish` after exactly one provider call.

The test asserts both the provider-call count and the abort wording, so it
fails on the old code on two independent axes. `step_pace.rs`'s unit tests
pin the arithmetic (tool time is in the reserve, the model call is the
floor, an untimed turn reserves nothing, the continuation forecast excludes
tool time, and the newest step replaces the last).

## The gate

- [x] `cargo fmt --all` (and `cargo fmt --check` via `make guards-fast`)
- [x] `make guards-fast` green locally, including `check-prose`,
      `check-file-size`, `check-core-reachability`, `check-invariants`
- [ ] clippy / `cargo test --workspace` — CI runs them; this laptop does not
      (CLAUDE.md, "CI builds and tests; this laptop does not")
- [x] Doc comments updated where the name or the meaning changed:
      `step.rs`'s field, `settlement.rs`'s two comments,
      `accounted_call.rs`'s citation of `TurnState::last_step`, and
      `budget_boundaries.rs`'s module header
- [x] `Closes #5713` appears here and as a commit trailer

`driver.rs` lands at exactly its baseline ceiling of 1678 lines, so the
`file-size` ratchet passes without a baseline edit.

Tests deleted: None.

## Nothing left behind

- [x] Filed: #5740 — a parked tool inflates the next step's reserve. The
      park is real wall clock, so counting it is the safe direction, but it
      is not work the next step repeats.
- [x] Filed: #5741 — the wall clock a failed model call spends is invisible
      to the reserve, including on the overflow re-run path where the turn
      keeps going.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Summary by Sourcery

Prevent deadline overruns by forecasting the next turn step from the latest measured whole-step duration while retaining model-call timing for continuations.

Bug Fixes:
- Reserve the duration of the latest complete step, including tool execution and tool-requested waits, when deciding whether another step can meet the turn deadline.
- Preserve the model-call duration as the fallback reserve for steps that end before tool dispatch and as the forecast for tool-less continuations.

Enhancements:
- Add a dedicated step-pace estimator that tracks model-call and whole-step durations and uses the larger value as the deadline reserve.

Tests:
- Add unit coverage for step-pace reserve arithmetic and continuation behavior.
- Add an integration witness verifying that a slow tool causes the turn to stop before starting another provider call.

## Independent DoD verification (#5713)

`cargo test -p stella-core` on this head (`1170d09`), rustc 1.97.0: exit 0,
**1573 passed / 0 failed** on the lib target plus every other target green. Both
witnesses pass by name — `budget_boundaries::a_slow_tool_stops_the_turn_before_the_deadline`
and `step_pace::tests::tool_time_is_part_of_the_reserve`.

`driver.rs` moves by `9 4` (net +5): the `mod` line, the two `observe_*` call
sites replacing one assignment, and their comments — the 150 lines of logic land
in the new `driver/step_pace.rs`, so the god file does not grow.

Worth naming for a reviewer, because it is the part a careless fix would have got
wrong: `reserve()` is `max(model, step)` rather than the whole-step number alone,
so the exits the issue warned about — an abort, the overflow re-run that returns
`Continue` before dispatch — still forecast from the timed model call exactly as
`main` did, and the reserve is zero before anything is timed, unchanged from
`last_step.unwrap_or_default()`. `ContinuationBudget` keeps reading `pace.model()`,
not the reserve, since a length continuation re-runs a tool-less step.

All four of #5713's DoD boxes are now ticked. Full record: the verification
comment on #5713.

---
_Generated by [Claude Code](https://claude.ai/code)_