### PR TITLE
fix(stella-core): stop a ledger-retired record from steering, and drop a wordless skill candidate

### DIFF
--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -641,11 +641,25 @@ fn registry_from(root: &Path, files: &TieredFiles, cache: &SweepCache, now: &str
     // `plugin_first`) is necessary and not sufficient: it only settles the
     // collision when the workspace still *has* a record of that lineage, and a
     // grant outlives the file it was written for.
+    //
+    // The same ledger, read for the other question: which lineages it has
+    // *closed*. The engine decides whether a record steers from the record's own
+    // `status` field. The writer that retracts a record flips that field and
+    // appends the event in one step, and nothing in the engine can see whether it
+    // did both. So a `Retired` event with no `.toml` edit beside it left the
+    // record steering. Both filters above hold here too. An unverified ledger
+    // says nothing, and an entry may close only a lineage this repository owns.
+    let mut retired_lineages: BTreeSet<(Trust, String)> = BTreeSet::new();
     if let Ok(events) = read_promotions(root) {
         let repo_owned = repo_owned_lineages(files);
         for lineage in stella_core::records::promotion::blocking_grants(&events).into_keys() {
             if repo_owned.contains(&lineage) {
                 approved_blocking.insert((Trust::Project, lineage));
+            }
+        }
+        for lineage in stella_core::records::promotion::retired_lineages(&events) {
+            if repo_owned.contains(&lineage) {
+                retired_lineages.insert((Trust::Project, lineage));
             }
         }
     }
@@ -657,6 +671,7 @@ fn registry_from(root: &Path, files: &TieredFiles, cache: &SweepCache, now: &str
             verdicts,
             last_checked,
             approved_blocking,
+            retired_lineages,
             now,
         },
     )

--- a/crates/stella-core/src/extensions.rs
+++ b/crates/stella-core/src/extensions.rs
@@ -1026,6 +1026,26 @@ mod tests {
         );
     }
 
+    /// The other half of ADR 0025. A key that grants nothing may be nested, and
+    /// the file still loads. Pinned here, so a wider refusal later has to delete
+    /// a test that names the record.
+    ///
+    /// `rules.rs` refuses any record with a nested key. This loader does not.
+    /// A bad `description:` costs a label, since the first line of the body
+    /// stands in. A bad `tools:` costs the whole registry. Refusing the file
+    /// for the first would take an agent away over a key nobody reads.
+    #[test]
+    fn nesting_under_a_key_that_grants_nothing_still_loads() {
+        let raw = "---\nname: reviewer\ndescription:\n  short: s\n  long: l\n---\nReview the diff.";
+        let agent = agent_from_file("/x/reviewer.md", raw).expect("the definition still loads");
+        assert_eq!(agent.name, "reviewer");
+        assert_eq!(
+            agent.description, "Review the diff.",
+            "an unreadable description falls back to the body's first line"
+        );
+        assert_eq!(agent.tools, None, "and it asked for no restriction");
+    }
+
     #[test]
     fn toolbelt_wildcards_and_empties_mean_all_tools() {
         assert_eq!(parse_toolbelt(None), None);

--- a/crates/stella-core/src/records/promotion.rs
+++ b/crates/stella-core/src/records/promotion.rs
@@ -48,7 +48,7 @@
 //! (`advisory` | `blocking`); the four review-ladder labels are UI over it
 //! and never appear on the wire or in this ledger.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -348,6 +348,29 @@ pub fn blocking_grants(events: &[PromotionEvent]) -> BTreeMap<String, PromotionE
     latest
 }
 
+/// The lineages whose LATEST event closed their valid time. The render path
+/// reads this fold. So a retirement that reached the ledger, and not the record
+/// file, still stops the record steering.
+///
+/// The same latest-event fold [`blocking_grants`] uses, for the same reason. A
+/// lineage a later revision revived has a grant as its newest event, so it is
+/// not retired. Retired and superseded are one answer here. Each says the
+/// source has dropped the claim, and a superseding revision arrives as its own
+/// record under its own `lineage_id`.
+pub fn retired_lineages(events: &[PromotionEvent]) -> BTreeSet<String> {
+    let mut latest: BTreeMap<&str, LedgerAction> = BTreeMap::new();
+    for event in events {
+        latest.insert(&event.lineage_id, event.action);
+    }
+    latest
+        .into_iter()
+        .filter_map(|(lineage, action)| {
+            matches!(action, LedgerAction::Retired | LedgerAction::Superseded)
+                .then(|| lineage.to_string())
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -495,6 +518,37 @@ mod tests {
         ]);
         let events = parse_and_verify(&text).unwrap();
         assert!(blocking_grants(&events).is_empty());
+    }
+
+    /// The retirement fold the render path reads, for `#5509`. A grant leaves the
+    /// lineage open, a retirement closes it, and a later grant on the same
+    /// lineage reopens it — the latest event decides, as it does for grants.
+    #[test]
+    fn the_retirement_fold_follows_the_latest_event() {
+        let open = ledger(&[event("^a", "blocking", "lead@example.test")]);
+        let events = parse_and_verify(&open).unwrap();
+        assert!(retired_lineages(&events).is_empty());
+
+        let closed = ledger(&[
+            event("^a", "blocking", "lead@example.test"),
+            retirement("^a"),
+        ]);
+        let events = parse_and_verify(&closed).unwrap();
+        assert_eq!(
+            retired_lineages(&events),
+            BTreeSet::from(["^a".to_string()])
+        );
+
+        let reopened = ledger(&[
+            event("^a", "blocking", "lead@example.test"),
+            retirement("^a"),
+            event("^a", "blocking", "lead@example.test"),
+        ]);
+        let events = parse_and_verify(&reopened).unwrap();
+        assert!(
+            retired_lineages(&events).is_empty(),
+            "a revision published after the retirement reopens the lineage"
+        );
     }
 
     /// **Witness (#5327).** A truncated tail passes the hash chain, and the

--- a/crates/stella-core/src/records/promotion.rs
+++ b/crates/stella-core/src/records/promotion.rs
@@ -364,10 +364,8 @@ pub fn retired_lineages(events: &[PromotionEvent]) -> BTreeSet<String> {
     }
     latest
         .into_iter()
-        .filter_map(|(lineage, action)| {
-            matches!(action, LedgerAction::Retired | LedgerAction::Superseded)
-                .then(|| lineage.to_string())
-        })
+        .filter(|&(_, action)| matches!(action, LedgerAction::Retired | LedgerAction::Superseded))
+        .map(|(lineage, _)| lineage.to_string())
         .collect()
 }
 

--- a/crates/stella-core/src/records/registry.rs
+++ b/crates/stella-core/src/records/registry.rs
@@ -232,6 +232,20 @@ pub struct Facts<'a> {
     /// otherwise transfer, silently and automatically, to any repository record that
     /// happened to name the same lineage.
     pub approved_blocking: BTreeSet<(Trust, String)>,
+    /// Lineages the promotion ledger has retired or superseded, **qualified by the
+    /// tier the retirement was recorded against**.
+    ///
+    /// A record's own `status` field is the plain way a retirement stops it
+    /// steering. The writer that retracts a record flips that field and appends
+    /// the event. Nothing here can see whether it did both. So the status field
+    /// alone leaves a half-done retraction steering: a `Retired` event with no
+    /// `.toml` edit reads as ordinary policy. This fact is the ledger's half of
+    /// the answer, folded by the caller the way `approved_blocking` is.
+    ///
+    /// Tier-qualified for the reason `approved_blocking` is. A `lineage_id`
+    /// comes from an author, so an entry that names one tier must not reach a
+    /// record of the same name in another.
+    pub retired_lineages: BTreeSet<(Trust, String)>,
     /// Now, RFC-3339.
     pub now: &'a str,
 }
@@ -240,6 +254,12 @@ impl Facts<'_> {
     /// Whether a human approved blocking for this record — at this record's own tier.
     fn approves(&self, trust: Trust, lineage: &str) -> bool {
         self.approved_blocking
+            .contains(&(trust, lineage.to_string()))
+    }
+
+    /// Whether the ledger retired this record's lineage — at this record's own tier.
+    fn retired(&self, trust: Trust, lineage: &str) -> bool {
+        self.retired_lineages
             .contains(&(trust, lineage.to_string()))
     }
 }
@@ -303,7 +323,7 @@ pub fn load(user_files: &[RuleFile], project_files: &[RuleFile], facts: &Facts<'
         // the same thing: a dropped record is invisible to `stella context validate`
         // and `explain`, which is precisely where somebody needs to be told that the
         // policy they committed is inert. It stays visible; it stops steering.
-        if let Some(reason) = blocking_reason(&record) {
+        if let Some(reason) = blocking_reason(&record, facts) {
             disposition = Disposition::Block { reason };
         }
         let guard = resolve_guard(&record, markdown.as_ref(), facts, &conflicts);
@@ -447,7 +467,13 @@ fn merge_tiers(mut user: Vec<Parsed>, project: Vec<Parsed>) -> Vec<Parsed> {
 /// A retracted or archived record is not a defect — somebody retired it, and revert
 /// relies on that taking effect — so it reads as an ordinary status rather than a
 /// finding to fix.
-fn blocking_reason(record: &LoadedRecord) -> Option<String> {
+///
+/// Two sources say a record was retired, and either one is enough. The `status`
+/// field is the one a reader sees in the file. [`Facts::retired_lineages`] is
+/// the ledger's answer. Both are read here because the two writes are separate:
+/// a `Retired` event with no `.toml` edit beside it left a closed record
+/// steering.
+fn blocking_reason(record: &LoadedRecord, facts: &Facts<'_>) -> Option<String> {
     if !matches!(record.record.status, None | Some(RecordStatus::Active)) {
         return Some(format!(
             "its status is {}",
@@ -457,6 +483,9 @@ fn blocking_reason(record: &LoadedRecord) -> Option<String> {
                 .map(|status| status.as_str())
                 .unwrap_or("unset")
         ));
+    }
+    if facts.retired(record.trust, &record.record.lineage_id) {
+        return Some("the promotion ledger retired its lineage".to_string());
     }
     let blockers: Vec<String> = record
         .findings
@@ -481,7 +510,7 @@ fn resolve_guard(
             refusal: None,
         };
     }
-    if blocking_reason(record).is_some() {
+    if blocking_reason(record, facts).is_some() {
         // A record that must not steer must certainly not deny a tool call.
         return GuardDecision {
             guard: None,

--- a/crates/stella-core/src/records/registry/tests.rs
+++ b/crates/stella-core/src/records/registry/tests.rs
@@ -770,3 +770,74 @@ force = "info"
         requeried.dropped
     );
 }
+
+/// **Witness for `#5509`.** A record the promotion ledger retired stops steering, even
+/// while its own `status` field still reads `active`.
+///
+/// The two writes are separate. `stella context` retracts a record by flipping the
+/// `.toml`'s status and appending a `Retired` event, and nothing in the engine can
+/// see whether both landed. `blocking_reason` read the status field alone, so the
+/// ledger's half of a half-applied retraction went on steering the model as
+/// ordinary policy — and went on being able to deny a tool call.
+#[test]
+fn a_ledger_retirement_stops_a_still_active_record_from_steering() {
+    let corpus = toml_record(
+        "ctx.acme.web.retired-rule",
+        "Deploy from main only.",
+        "must",
+    );
+    let files = [md(".stella/rules/acme.web.toml", &corpus)];
+
+    // The control: with nothing retired, this record steers. Without it the
+    // assertions below could pass on a record that never rendered at all.
+    let steering = load(&[], &files, &facts()).render(Channel::Cached, None);
+    assert!(
+        steering.text.contains("Deploy from main only."),
+        "the control must steer or the witness proves nothing: {}",
+        steering.text
+    );
+
+    let mut retired = facts();
+    retired
+        .retired_lineages
+        .insert((Trust::Project, "ctx.acme.web.retired-rule".to_string()));
+    let registry = load(&[], &files, &retired);
+
+    let entry = registry.by_handle("retired-rule").expect("still loaded");
+    assert_eq!(
+        entry.disposition,
+        Disposition::Block {
+            reason: "the promotion ledger retired its lineage".to_string()
+        },
+        "a retired record stays visible to `explain` and stops steering"
+    );
+    let cached = registry.render(Channel::Cached, None);
+    assert!(cached.text.is_empty(), "{}", cached.text);
+    let volatile = registry.render(Channel::Volatile, None);
+    assert!(volatile.text.is_empty(), "{}", volatile.text);
+    assert!(
+        !entry.is_enforced(),
+        "and a record that must not steer must certainly not deny a tool call"
+    );
+}
+
+/// The retirement fact is qualified by tier for the reason approval is: a
+/// `lineage_id` is author-supplied, so an entry naming the project tier must not
+/// reach a user-tier record that happens to share the name.
+#[test]
+fn a_project_tier_retirement_leaves_a_user_record_of_the_same_lineage_steering() {
+    let corpus = toml_record("ctx.acme.web.shared-name", "Deploy from main only.", "must");
+    let mut retired = facts();
+    retired
+        .retired_lineages
+        .insert((Trust::Project, "ctx.acme.web.shared-name".to_string()));
+
+    let registry = load(&[md(".stella/rules/acme.web.toml", &corpus)], &[], &retired);
+    assert!(
+        registry
+            .render(Channel::Cached, None)
+            .text
+            .contains("Deploy from main only."),
+        "the user record is a different record, whatever it is called"
+    );
+}

--- a/crates/stella-core/src/records/tests.rs
+++ b/crates/stella-core/src/records/tests.rs
@@ -572,6 +572,7 @@ applies_to = { paths = [".git/*"], keywords = ["fsck", "reflog"] }
             verdicts: BTreeMap::new(),
             last_checked: BTreeMap::new(),
             approved_blocking: BTreeSet::new(),
+            retired_lineages: BTreeSet::new(),
             now: "2026-08-08T00:00:00Z",
         };
         registry::load(&[], &files, &facts)
@@ -800,6 +801,7 @@ expect = "present"
             verdicts,
             last_checked: checked,
             approved_blocking: BTreeSet::new(),
+            retired_lineages: BTreeSet::new(),
             now,
         };
         registry::load(&[], &files, &facts)
@@ -950,6 +952,7 @@ guard_deny_command = "git push --force*"
         verdicts: std::collections::BTreeMap::new(),
         last_checked: std::collections::BTreeMap::new(),
         approved_blocking: std::collections::BTreeSet::new(),
+        retired_lineages: std::collections::BTreeSet::new(),
         now: "2026-08-08T00:00:00Z",
     };
     let loaded = registry::load(&[], &files, &facts);

--- a/crates/stella-core/src/skills.rs
+++ b/crates/stella-core/src/skills.rs
@@ -904,6 +904,10 @@ const SENTENCE_MIN_CHARS: usize = 24;
 /// The provenance it replaced is not lost — [`render_skill_markdown`] writes
 /// it into the file, which is where a person reading the skill looks for it
 /// and where no scorer is charged for it.
+///
+/// Empty for a lesson that has no words: whitespace, or punctuation with no
+/// sentence in front of it. [`mine_skill_candidates`] drops such a cluster rather
+/// than minting a file the loader will refuse forever.
 fn candidate_description(text: &str) -> String {
     let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
     let mut end = flat.len();
@@ -1017,6 +1021,18 @@ pub fn mine_skill_candidates(
         if is_rejected(&text, rejected, config.min_similarity) {
             continue;
         }
+        // A lesson with no words describes nothing. `skill_from_file_with_origin`
+        // refuses an empty `description:` with `MissingDescription`. So this
+        // candidate would land a file that can never load, and it would hold one
+        // of the session's `max_per_session` slots. The next session would write
+        // the same dead file, since `already_captured` reads only skills that
+        // loaded. One odd note is enough to get here: a cluster of one is a
+        // candidate as soon as any note is salient, whatever `min_occurrences`
+        // says.
+        let description = candidate_description(&text);
+        if description.is_empty() {
+            continue;
+        }
 
         let domains = union_domains(&cluster);
         let mut sorted = cluster;
@@ -1037,7 +1053,7 @@ pub fn mine_skill_candidates(
             // subject matter (#5335). The occurrence count that used to sit
             // here is written into the file instead — see
             // `candidate_description` and `render_skill_markdown`.
-            description: candidate_description(&text),
+            description,
             domains,
             occurrences,
             salient,

--- a/crates/stella-core/src/skills/migration_contract.rs
+++ b/crates/stella-core/src/skills/migration_contract.rs
@@ -277,8 +277,11 @@ fn the_eval_gate_is_checked_after_the_cap_and_the_no_clobber_guard() {
 /// `reference`. So thirty repetitions inside one task mine a candidate today.
 ///
 /// This test asserts the **current, wrong** behavior on purpose. It is the
-/// baseline the typed path is measured against, and flipping it is a deliberate
-///, visible act rather than a silent fix folded into a migration commit.
+/// baseline the typed path is measured against, and flipping it is a deliberate,
+/// visible act rather than a silent fix folded into a migration commit.
+///
+/// What bounds the gap in the meantime is the *write* step, not the mine step:
+/// see `the_shipped_default_refuses_to_write_a_single_task_candidate`.
 #[test]
 fn lexical_miner_counts_events_not_distinct_tasks() {
     let thirty_in_one_task: Vec<SkillObservation> = (0..30)
@@ -293,6 +296,53 @@ fn lexical_miner_counts_events_not_distinct_tasks() {
          observation has no task identity to count"
     );
     assert_eq!(mined[0].occurrences, 30);
+}
+
+/// The gap above reaches the mine step and stops there, per `#5509`.
+///
+/// Spec §7's anti-poisoning rule is about what gets *written*, and on the shipped
+/// defaults nothing does: `require_measured_lift` is on, so a candidate nothing
+/// has appraised is held as `AwaitingEvaluation` however many times its
+/// observations recurred. Thirty repetitions inside one task therefore mint a
+/// candidate and no file.
+///
+/// Pinned against `AutoCreateConfig::default()` rather than an armed literal,
+/// because the default is the whole claim: flipping it back to `false` would let
+/// frequency alone write a `SKILL.md` from one task's repetitions, which is
+/// exactly what the distinct-task floor exists to refuse. The floor itself still
+/// belongs to the typed path — [`crate::context_record::lifecycle`]'s
+/// `ProposalRecord::is_eligible` counts distinct tasks — because
+/// [`SkillObservation`] carries no task identity to count. `#5738` is where that
+/// floor is being built.
+#[test]
+fn the_shipped_default_refuses_to_write_a_single_task_candidate() {
+    let thirty_in_one_task: Vec<SkillObservation> = (0..30)
+        .map(|i| pinned_observation("trace:the-one-and-only-task", 100 + i))
+        .collect();
+    let mined = mine_skill_candidates(thirty_in_one_task, &[], &[], &SkillMineConfig::default());
+    let candidate = mined.first().expect("the mine step still yields one");
+
+    let config = AutoCreateConfig::default();
+    assert!(
+        config.require_measured_lift,
+        "the shipped default is what holds the distinct-task gap closed"
+    );
+    assert_eq!(
+        decide_auto_creation(
+            candidate,
+            ".stella/skills",
+            &[],
+            0,
+            super::appraisal::EvalEvidence::Unevaluated,
+            &config
+        ),
+        AutoCreateDecision::Skip {
+            reason: AutoCreateSkip::AwaitingEvaluation {
+                evidence: super::appraisal::EvalEvidence::Unevaluated
+            }
+        },
+        "thirty repetitions of one task must not write a skill file"
+    );
 }
 
 /// The threshold itself, as shipped. Three occurrences, or one salient

--- a/crates/stella-core/src/skills/tests.rs
+++ b/crates/stella-core/src/skills/tests.rs
@@ -1212,3 +1212,26 @@ fn a_short_lesson_becomes_its_own_description() {
     let candidates = mine_skill_candidates(obs, &[], &[], &SkillMineConfig::default());
     assert_eq!(candidates[0].description, "use pnpm");
 }
+
+/// **Witness for `#5509`.** A lesson with no words mines no candidate.
+///
+/// One salient note clears the count floor by itself. So one bad note reached
+/// the push, and its `description` was empty. `render_skill_markdown` then
+/// writes `description: ` and nothing more.
+/// `skill_from_file_with_origin` reads that back and refuses it, with
+/// [`SkillProblem::MissingDescription`]. The file is dead, and it holds one of
+/// the two slots a session may write. The next session writes it again, because
+/// `already_captured` can only weigh a skill that loaded.
+#[test]
+fn a_wordless_lesson_mines_no_candidate() {
+    for text in ["   ", "\t\n ", "...", "?!"] {
+        let mut obs = vec![observation(text, 1)];
+        obs[0].salient = true;
+        let candidates = mine_skill_candidates(obs, &[], &[], &SkillMineConfig::default());
+        assert!(
+            candidates.is_empty(),
+            "{text:?} mined {candidates:#?}, and every one of those writes a \
+             `SKILL.md` that can never load again"
+        );
+    }
+}

--- a/docs/adr/0025-nested-frontmatter-refusal-scope.md
+++ b/docs/adr/0025-nested-frontmatter-refusal-scope.md
@@ -1,0 +1,61 @@
+---
+id: adr/0025-nested-frontmatter-refusal-scope
+title: "ADR 0025: Refuse a nested key where it widens a grant"
+status: implemented
+---
+
+# ADR 0025: Refuse a nested key where it widens a grant
+
+- Status: accepted
+- Date: 2026-09-03
+- Decides: `#5509`
+
+## Context
+
+Stella reads markdown files with a `key: value` header. The parser reads one
+line at a time. It cannot hold a key with keys under it. So it notes the
+child key names and moves on. See `Frontmatter::nested_keys` in
+`crates/stella-core/src/rules.rs`.
+
+Two loaders read that header. They answer the nested case in two ways.
+
+A rule record is refused. `rule_from_file` returns `NestedFrontmatterKeys`
+for any record that has one. A rule is policy. A mangled policy file that
+loads looks just like a sound one.
+
+A command or an agent is refused only for `tools:`. See
+`ExtensionProblem::NestedToolbelt` in `crates/stella-core/src/extensions.rs`.
+
+Should the second loader copy the first and refuse every nested header?
+
+## Decision
+
+No. Keep the narrow refusal. State it as a rule:
+
+> Refuse a nested value when reading it wrong would **widen** what the file
+> may do. Read past it everywhere else.
+
+`tools:` widens. The parser leaves the key empty. An empty `tools:` means
+every tool. So an author who named two tools gets the whole registry, and no
+message. That file is refused.
+
+`description:` and `name:` do not widen. A bad `description:` falls back to
+the first line of the body. A bad `name:` falls back to the file name. Each
+loses a label. Neither grants a thing. Refusing the file would cost an author
+their agent over a key that changes nothing.
+
+A new field that grants something joins the refusal in the change that adds
+it. The test `nesting_under_a_key_that_grants_nothing_still_loads` pins the
+other half. So a wider refusal later has to delete a test that names this
+record.
+
+## Consequences
+
+The two loaders stay apart. A reader who spots that and reaches for one rule
+should read this first.
+
+The check is weaker than the rule. `nested_keys` holds the child names, not
+the parent's. So the check asks whether `tools:` is empty and whether
+anything is nested at all. A file with a bare `tools:` and a nested
+`description:` is refused, and nothing widened. That is `#5737`. Fixing it is
+what would let the rule hold per field.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,6 +91,7 @@ open; nothing before Phase 3 forces it.
 | [0022](0022-adopt-standing-decisions-scr-corpus.md) | Adopt Org Standing Decisions as a Steering Context Record Corpus | Accepted |
 | [0023](0023-autonomous-tool-foundry.md) | Reconnect the Gap Detector; the Foundry Runs Autonomously Behind Standing Controls | Accepted |
 | [0024](0024-release-builds-unwind.md) | Release Builds Unwind on Panic | Accepted |
+| [0025](0025-nested-frontmatter-refusal-scope.md) | Refuse a Nested Key Where It Widens a Grant | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -125,6 +125,11 @@
       "status": "implemented",
       "title": "ADR 0024: Release builds unwind on panic"
     },
+    "adr/0025-nested-frontmatter-refusal-scope": {
+      "path": "docs/adr/0025-nested-frontmatter-refusal-scope.md",
+      "status": "implemented",
+      "title": "ADR 0025: Refuse a nested key where it widens a grant"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",


### PR DESCRIPTION
## What and why

#5509 filed four findings plus one open decision against `stella-core`'s context and extension surfaces. Reading the code first changed two of them.

**Finding 2 — a ledger-retired record kept steering.** `records::registry::blocking_reason` decided whether a record may steer from the record's own `status` field. The two writes that retire a record are separate: `stella context` retracts by flipping the `.toml` status *and* appending a `Retired` event, and nothing in `stella-core` can see whether both landed. A `Retired` event with no matching `.toml` edit left the record rendering as ordinary policy — and able to arm a Tier-2 guard.

`Facts` gains `retired_lineages: BTreeSet<(Trust, String)>`, tier-qualified exactly like `approved_blocking` and for the same reason (`lineage_id` is author-supplied, so an entry naming one tier must not reach a same-named record in another). `promotion::retired_lineages` is the latest-event fold, so a lineage a later revision revived is not retired. `stella-cli`'s `context_records::registry_from` folds it beside the existing `blocking_grants` fold, under the same two constraints: an unverified ledger contributes nothing, and only a `repo_owned_lineages` entry counts, so a plugin's contributed record cannot be closed by an entry it was never reviewed against.

**Finding 3 — a wordless lesson minted a dead skill file.** `candidate_description` returns `""` for whitespace, or for punctuation with no sentence in front of it. One salient observation clears the count floor by itself, so a single degenerate lesson pushed a candidate whose `description` was empty. `render_skill_markdown` writes `description: ` and nothing more; `skill_from_file_with_origin` then refuses that file with `MissingDescription` on every later session, holding one of the two `max_per_session` slots — and the next session writes it again, because `already_captured` can only weigh a skill that loaded. `mine_skill_candidates` now skips such a cluster.

**Finding 1 — already fixed on `main`; no code change.** `tool_foundry.rs`'s `render_template` searches for the three exact `ParamKind` placeholders and takes the earliest match, rather than pairing any `<` with the next `>`. `redirect_operators_survive_template_rendering` pins `render_template("sort < <path>") == "sort < {p1}"`, and `an_input_redirect_shape_is_proposed_with_its_operator` mines `sort < a.txt` / `b.txt` / `c.txt` end to end and asserts `command_template == "sort < {p1}"`. The issue's scenario is covered.

**Finding 4 — the premise was stale; deferred with the bound pinned.** `AutoCreateConfig::require_measured_lift` already defaults to `true`, not `false`, so the shipping default path cannot write a `SKILL.md` from thirty same-task repetitions: the candidate is held as `AwaitingEvaluation`. The distinct-task floor still belongs to the typed path, because `SkillObservation` carries no task identity — filed as #5738. What was missing is a test tying the two together: `the_eval_gate_is_checked_after_the_cap_and_the_no_clobber_guard` arms the flag explicitly and mentions the default only in prose. `the_shipped_default_refuses_to_write_a_single_task_candidate` now pins the default itself, so flipping it back is a red test rather than a silent widening.

**Finding 5 — decided, recorded as ADR 0025.** `extensions.rs` refuses nesting under `tools:` because an unreadable value there degrades to `None`, which means every tool: the failure widens authority. Nesting under `description:` or `name:` degrades to the body's first line or the path slug — it loses a label and grants nothing. So the durable rule is *refuse a nested value when reading it wrong would widen what the file may do, and read past it everywhere else*, not "nesting is refused". A whole-file refusal would cost an author their agent over a key nobody reads. `nesting_under_a_key_that_grants_nothing_still_loads` pins the tolerated half, so a wider refusal later has to delete a test that names the record.

## Witness mechanism

Each witness fails on `main` by construction, not by luck:

- `a_ledger_retirement_stops_a_still_active_record_from_steering` (`records/registry/tests.rs`) sets a fact that does not exist on `main` — `Facts::retired_lineages` is a new field — so the test does not compile there, and `blocking_reason` has no parameter to read it from. It opens with a control that asserts the same record *does* steer with nothing retired, so the emptiness assertions cannot pass on a record that never rendered.
- `a_project_tier_retirement_leaves_a_user_record_of_the_same_lineage_steering` holds the tier qualification, which is the half a lineage-keyed set would get wrong.
- `the_retirement_fold_follows_the_latest_event` (`records/promotion.rs`) covers the fold's three states, including a lineage a later grant reopens.
- `a_wordless_lesson_mines_no_candidate` (`skills/tests.rs`) mines one salient observation whose text is whitespace or bare punctuation. On `main` each of the four inputs mines exactly one candidate with an empty `description`; the assertion prints the candidates it found.
- `the_shipped_default_refuses_to_write_a_single_task_candidate` (`skills/migration_contract.rs`) passes today and fails the moment `require_measured_lift`'s default moves.
- `nesting_under_a_key_that_grants_nothing_still_loads` (`extensions.rs`) passes today and is the test a later broad refusal has to delete.

## Exemplar

`promotion::retired_lineages` follows its sibling `blocking_grants` — same latest-event `BTreeMap` fold, same reason stated on both. The `Facts` field follows `approved_blocking` field for field, including the tier qualification and the caller-side fold.

## Notes

`cargo fmt --all`, `make guards-fast`, `make prose`, `make line-citations`, `make dead-code-allows`, `check-file-size`, `check-adr-numbering` and `check-doc-links` are green locally. No crate was compiled locally, per this repository's CI-only build rule — the test evidence is this PR's run.

Tests deleted: None.

Residue filed:

- #5737 — `Frontmatter::nested_keys` records the child key, not the parent, so ADR 0025's rule cannot be enforced per field and a bare `tools:` beside any other nesting is refused wrongly.
- #5738 — the skill miner counts events, so thirty repetitions of one task pass a three-task bar; the eval gate bounds it, the floor is still owed.

Closes #5509

## Summary by Sourcery

Ensure retired records and malformed skill candidates cannot affect runtime behavior while documenting and testing the scoped frontmatter policy.

Bug Fixes:
- Prevent ledger-retired or superseded records from steering when their record status was not updated.
- Skip skill candidates with empty descriptions so invalid, unloadable skill files are not generated.

Enhancements:
- Preserve tier-qualified retirement handling and latest-event reopening semantics for record lineages.
- Document the scoped nested-frontmatter refusal policy and cover tolerated nesting under non-authorizing keys.
- Pin the shipped measured-lift default to prevent single-task repetition from writing a skill.

Documentation:
- Add ADR 0025 and register it in the ADR index and documentation manifest.

Tests:
- Add coverage for ledger retirement, tier isolation, latest-event retirement folding, wordless skill lessons, nested frontmatter behavior, and the shipped skill auto-creation default.