### PR TITLE
fix(stella-observatory): redact userinfo in a URL-shaped settings value

### DIFF
--- a/crates/stella-observatory/README.md
+++ b/crates/stella-observatory/README.md
@@ -289,12 +289,15 @@ naming it (`{"api_keys": ["sk-live-…"]}`), and redacting only the direct strin
 child leaked that. Keys ending `_env` are exempt — they name a variable, not
 its value. `mcp_servers` never reads env or header *values* at all.
 
-The one hole left in that claim is `mcp_servers`' `target`: it is `cmd` plus
-`args` for a stdio server and `url` for an HTTP one, both served verbatim and
-neither routed through `redact`. A token passed on the command line
-(`--token=…`) or in a query string (`https://mcp.example/sse?key=…`) is a
-credential sitting in a field the scrubber does not look at. Anything new that
-reaches the browser must be audited the same way before it lands.
+`mcp_servers`' `target` uses a narrower rule than `redact`. A stdio server's
+args (`--token=…`) and an HTTP server's query string
+(`https://mcp.example/sse?key=…`) often carry credentials, in fields
+`sensitive_key` never checks. So a stdio target shows only its command name
+and an argument count. An HTTP target's `url` goes through `redacted_url`,
+which strips userinfo, query, and fragment. `redact` applies that same rule
+to any `_url`/`_uri` key in settings — `base_url`, say — so a value like
+`https://user:secret@host/v1` never reaches the browser whole. Anything new
+that reaches the browser must be audited the same way before it lands.
 
 ### The palette is a mirror, and one data-mark step is unused
 

--- a/crates/stella-observatory/src/fsview.rs
+++ b/crates/stella-observatory/src/fsview.rs
@@ -11,8 +11,8 @@
 //!    ledger rows are states, rendered as empty sections.
 //! 2. **Secrets never reach the browser.** `settings.json` and `mcp.toml`
 //!    may carry credentials; [`redact`] scrubs any value under a
-//!    sensitive-looking key (and every value under `env`/`headers` maps)
-//!    before the JSON is serialized into a response.
+//!    sensitive-looking key or a URL-shaped one (`base_url`), and every
+//!    value under `env`/`headers` maps, before the JSON is serialized.
 
 mod contributions;
 
@@ -761,10 +761,24 @@ fn sensitive_key(key: &str) -> bool {
         || k == "authorization"
 }
 
+/// Does this (lowercased) key name a URL-valued field — `base_url`,
+/// `proxy_uri`, and so on? `ProviderSettings::base_url` can hold an
+/// authenticating proxy's URL, so its value can carry userinfo
+/// (`https://user:secret@host/v1`). That is a credential in the value, and
+/// [`sensitive_key`] never matches a key named like this.
+fn url_like_key(key: &str) -> bool {
+    let k = key.to_ascii_lowercase();
+    k.ends_with("_url") || k.ends_with("_uri")
+}
+
 /// Recursively scrub credentials from parsed settings before serving them.
 /// A sensitive key — or an `env`/`headers` map, whose values are credentials
 /// by position — opens a *credential scope*, and every string at or below it
-/// is replaced.
+/// is replaced. A URL-shaped key outside that scope is not wiped out — its
+/// host and path help tell providers apart — but it still goes through
+/// [`redacted_url`], because the credential in a URL lives in its userinfo
+/// or query, not under a key name `sensitive_key` would ever match
+/// (`base_url: "https://user:secret@host/v1"`).
 ///
 /// The scope has to be inherited, not recomputed per level: settings are
 /// arbitrary user JSON, so a secret can sit one container deeper than the
@@ -781,6 +795,12 @@ fn redact(value: &mut Value, in_credential_scope: bool) {
                     || matches!(key.as_str(), "env" | "headers");
                 if scoped && v.is_string() {
                     *v = Value::String("<redacted>".into());
+                } else if !scoped && url_like_key(key) {
+                    if let Value::String(s) = v {
+                        *s = redacted_url(s);
+                    } else {
+                        redact(v, scoped);
+                    }
                 } else {
                     redact(v, scoped);
                 }
@@ -1277,6 +1297,40 @@ tags       = ["testing", "pins"]
             "STELLA_HOME does move the loader's root (#2178), so a dashboard \
              that ignored it would name a settings file the CLI never opens"
         );
+    }
+
+    /// A `base_url` carrying userinfo — the shape an authenticating proxy
+    /// needs — holds a credential in the value, under a key name
+    /// `sensitive_key` never matches. Before this fix `redact` left the
+    /// string alone, so the password reached `/api/config`'s response body.
+    #[test]
+    fn redact_strips_userinfo_from_a_url_shaped_key() {
+        let mut v = serde_json::json!({
+            "providers": {
+                "custom": { "base_url": "https://svc:s3cr3t@proxy.internal/v1" }
+            },
+        });
+        redact(&mut v, false);
+        let s = v.to_string();
+        assert!(
+            !s.contains("s3cr3t"),
+            "password must not reach the browser: {s}"
+        );
+        assert!(
+            s.contains("proxy.internal/v1"),
+            "host and path stay, so providers stay distinguishable: {s}"
+        );
+    }
+
+    /// A URL-shaped key already inside a credential scope (nested under a
+    /// key `sensitive_key` matches, like `api_key_url`) still gets the
+    /// blunt `<redacted>` treatment, not the narrower [`redacted_url`] one.
+    /// The stricter rule wins.
+    #[test]
+    fn a_sensitive_key_wins_over_the_narrower_url_redaction() {
+        let mut v = serde_json::json!({ "secret_url": "https://user:pw@host/v1?x=1" });
+        redact(&mut v, false);
+        assert_eq!(v["secret_url"], "<redacted>");
     }
 
     /// A secret one container below the key that names it used to survive:


### PR DESCRIPTION
## What

`redact` (`crates/stella-observatory/src/fsview.rs`) decides what to scrub
by key name — `api_key`, `token`, `secret`, … A URL-valued field like
`ProviderSettings::base_url` never matches any of those markers, so a
credential carried in the URL itself (`https://user:pass@host/v1`, the
shape an authenticating proxy needs) reached the dashboard's
`/api/config` response unredacted.

## Why

The crate already has `redacted_url`, which strips userinfo, query, and
fragment from a URL string. It was wired into exactly one caller
(`mcp_servers`' HTTP `target`) and never into the general settings
scrubber. This PR routes any value under a key ending `_url` or `_uri`
through `redacted_url` inside `redact`, before the plain-string
redaction path runs, so `base_url` (and any future `*_url`/`*_uri`
field) gets the same treatment.

A key already inside a credential scope keeps the blunter
`<redacted>` behavior rather than the narrower URL scrub — a
`secret_url` field is still fully redacted, not host-and-path-revealing.

## Witness

`redact_strips_userinfo_from_a_url_shaped_key` (new,
`crates/stella-observatory/src/fsview.rs`): builds a settings object with
`providers.custom.base_url` carrying `user:s3cr3t@`, calls `redact`, and
asserts the password does not appear in the serialized output while the
host/path do.

Checked the artisanal way per AGENTS.md: patched a copy of `main`'s
`fsview.rs` (outside the working tree) with just this test and ran it —
it fails, because the old `redact` leaves a `base_url` string untouched.
Swapping back to this branch's `fsview.rs` (fix + test), the same test
passes.

`a_sensitive_key_wins_over_the_narrower_url_redaction` (new) pins the
scope-priority rule above.

## Also in this PR

The README's "Secrets never reach the browser" section described
`mcp_servers`' `target` routing as a live gap (`"both served verbatim
and neither routed through redact"`). The code already closed that —
stdio args are reduced to a count and an HTTP `url` goes through
`redacted_url` — so the paragraph was stale and taught the next reviewer
to skip the path. Rewritten to describe current behavior and to name the
new `redact`-level `_url`/`_uri` rule.

## Tests deleted

None.

Closes #5495

## Summary by Sourcery

Prevent credentials embedded in URL-valued settings from being exposed through the observatory configuration response.

Bug Fixes:
- Redact credentials embedded in values of settings keys ending in `_url` or `_uri` before configuration reaches the browser.
- Preserve full redaction for URL-shaped fields that are already within a sensitive credential scope.

Documentation:
- Update the secrets-handling documentation to describe current MCP target redaction and the new URL-shaped settings rule.

Tests:
- Add coverage for removing URL userinfo while retaining host and path, and for sensitive-scope redaction taking precedence.