### PR TITLE
fix(stella-store): classify SQLite corruption wherever a read raises it

### DIFF
--- a/crates/stella-store/src/error.rs
+++ b/crates/stella-store/src/error.rs
@@ -20,7 +20,10 @@
 //! [`StoreError::NegativeSchemaVersion`] and [`StoreError::SchemaTooNew`] tell
 //! "move the file aside" from "upgrade your binary", and
 //! [`StoreError::Corrupt`] tells a malformed file (run `stella doctor`) from
-//! the plain [`StoreError::Sqlite`] failure it otherwise arrives as.
+//! the plain [`StoreError::Sqlite`] failure it otherwise arrives as. Which of
+//! those two a SQLite failure becomes is decided in one place, the
+//! `From<rusqlite::Error>` conversion below, because that is the only path
+//! every `?` in the crate takes.
 //! [`StoreError::Io`] and [`StoreError::Serde`] keep the underlying
 //! `std::io::Error` / `serde_json::Error` reachable through
 //! [`std::error::Error::source`], so a caller can branch on
@@ -75,31 +78,36 @@ pub enum StoreError {
         build_version: i64,
     },
 
-    /// SQLite cannot read the file as a database at all.
+    /// SQLite cannot read a database it was given, on page 1 or anywhere
+    /// after it.
     ///
     /// Separated from [`StoreError::Sqlite`] because the remedy is different
     /// and because it is otherwise invisible: without this the failure reaches
     /// the caller as the raw rusqlite string ("database disk image is
     /// malformed"), every later session repeats the same warning, and nothing
-    /// ever tells the user to move the file aside. See
-    /// `integrity::corrupt_store_error`.
+    /// ever tells the user to move the file aside. Reached from every `?` in
+    /// the crate — see the `From<rusqlite::Error>` conversion below.
     #[error(
-        "store.db cannot be read as a SQLite database ({source}), so it is corrupt \
-         or was overwritten. Run `stella doctor` to confirm, then `stella doctor --repair` \
-         to salvage what is readable and move {path} aside (it is renamed, never deleted) \
-         — it holds local telemetry and session replay, never your source."
+        "{subject} cannot be read as a SQLite database ({source}), so it is corrupt or \
+         was overwritten. Run `stella doctor` to confirm, then `stella doctor --repair` \
+         to salvage what is readable and move the file aside (it is renamed, never \
+         deleted) — it holds local telemetry and session replay, never your source.",
+        subject = corrupt_subject(.path)
     )]
     Corrupt {
-        /// The file named in the remedy, as the caller located it.
-        path: String,
+        /// The file named in the remedy, as the caller located it. `None` when
+        /// the failure arrived through the blanket conversion, which has no
+        /// database to ask — see `corrupt_subject`.
+        path: Option<String>,
         /// The corruption SQLite reported.
         source: rusqlite::Error,
     },
 
     /// An ordinary SQLite failure — a busy database, a constraint, a query
-    /// against a schema this build did not expect.
+    /// against a schema this build did not expect. Never corruption: the
+    /// conversion below routes that to [`StoreError::Corrupt`] instead.
     #[error("{0}")]
-    Sqlite(#[from] rusqlite::Error),
+    Sqlite(#[source] rusqlite::Error),
 
     /// A filesystem operation failed. `context` names the operation and the
     /// path in the crate's established wording ("cannot read /…"); the kind is
@@ -130,6 +138,41 @@ pub enum StoreError {
     /// in a case of its own, not here.
     #[error("{0}")]
     Other(String),
+}
+
+/// How the corruption message names the database.
+///
+/// A caller that resolved the file gets the file. The blanket conversion below
+/// has none to give: SQLite raises `SQLITE_CORRUPT` from a statement, and a
+/// statement does not carry the database it ran against. This crate opens
+/// several (`store.db`, `usage.db`, `catalog.db`, `enterprise-telemetry.db`),
+/// so a guessed name would send a user to move a healthy database aside.
+/// `stella doctor`, which the remedy points at, locates and names the file it
+/// checks.
+fn corrupt_subject(path: &Option<String>) -> &str {
+    path.as_deref().unwrap_or("a stella SQLite database")
+}
+
+/// Every `?` on a SQLite failure in this crate lands here, which is why the
+/// corruption split is made here and not at the call sites.
+///
+/// A store can take damage on any page, and the statement that walks it is
+/// whichever read reaches that table next — so the split has to hold for the
+/// whole read/write surface, not for the two statements that run while opening.
+/// Wrapping call sites cannot do that: SQLite reports the damage from
+/// `Rows::next`, so [`Store::execution_events`](crate::Store::execution_events)
+/// fails inside `for row in rows { … row? }`, where there is no
+/// connection-level result to wrap. Every fallible method in the crate would
+/// also have to remember, and a new one would not. This conversion is the one
+/// path all of them already take.
+///
+/// Anything that is not corruption passes through as
+/// [`StoreError::Sqlite`] unchanged, so `SQLITE_BUSY` keeps its own retry
+/// (see [`crate::busy`]).
+impl From<rusqlite::Error> for StoreError {
+    fn from(error: rusqlite::Error) -> Self {
+        crate::integrity::corrupt_store_error(error, None)
+    }
 }
 
 impl StoreError {
@@ -262,6 +305,63 @@ mod tests {
             matches!(ordinary, StoreError::Sqlite(_)),
             "an ordinary statement failure is not corruption: {ordinary:?}"
         );
+    }
+
+    /// Corruption reaches a caller as [`StoreError::Corrupt`] however it was
+    /// raised, not only from the two statements the open sequence runs.
+    ///
+    /// This is the wire shape SQLite hands back mid-scan, put through the
+    /// conversion every `?` in the crate takes. Flattened into
+    /// [`StoreError::Sqlite`] it says "database disk image is malformed" and
+    /// nothing else: no remedy, no file, and nothing to tell it from an
+    /// ordinary `SQLITE_BUSY`.
+    #[test]
+    fn corruption_is_classified_by_the_conversion_every_query_takes() {
+        let malformed = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CORRUPT),
+            Some("database disk image is malformed".to_string()),
+        );
+
+        let error = StoreError::from(malformed);
+        match &error {
+            StoreError::Corrupt { path, .. } => assert_eq!(
+                *path, None,
+                "the conversion has no database to name, and must not guess one"
+            ),
+            other => panic!(
+                "corruption from an ordinary statement must classify as Corrupt, \
+                 not as a bare SQLite failure: {other:?}"
+            ),
+        }
+        assert!(
+            error.to_string().contains("stella doctor"),
+            "the remedy travels with the error: {error}"
+        );
+        assert_eq!(
+            error.sqlite_code(),
+            Some(rusqlite::ErrorCode::DatabaseCorrupt),
+            "the code stays reachable through the corrupt case"
+        );
+        assert!(!error.is_busy(), "corruption is not a held lock");
+    }
+
+    /// The other half of the split: a lock that is held is still an ordinary
+    /// failure, so [`crate::busy::retry_busy`] keeps asking again for it. A
+    /// conversion that classified too eagerly would turn a retryable write
+    /// into a corrupt-database report.
+    #[test]
+    fn a_held_lock_is_not_reclassified_as_corruption() {
+        let busy = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            Some("database is locked".to_string()),
+        );
+
+        let error = StoreError::from(busy);
+        assert!(
+            matches!(error, StoreError::Sqlite(_)),
+            "a busy database is not corruption: {error:?}"
+        );
+        assert!(error.is_busy(), "and it is still retryable: {error}");
     }
 
     /// A filesystem failure keeps its `ErrorKind` reachable through

--- a/crates/stella-store/src/integrity.rs
+++ b/crates/stella-store/src/integrity.rs
@@ -67,9 +67,14 @@ pub(crate) fn is_sqlite_corruption(error: &rusqlite::Error) -> bool {
 /// string ("database disk image is malformed"), which `open_store` prints as
 /// `local store unavailable (store: …)` — and then EVERY later session repeats
 /// the warning and runs with zero persistence, because nothing ever tells the
-/// user to move the file aside. `From<rusqlite::Error>` flattens the error to a
-/// `String`, so the code has to be inspected before that conversion happens.
-/// Anything that is not corruption is passed through unchanged.
+/// user to move the file aside. Anything that is not corruption is passed
+/// through as [`StoreError::Sqlite`].
+///
+/// This is what `From<rusqlite::Error> for StoreError` calls, with no path, so
+/// the split holds for every `?` in the crate. Callers that resolved the file
+/// pass it and get it named; the conversion cannot, and must not guess (see
+/// `error::corrupt_subject`). Returning [`StoreError::Sqlite`] here rather
+/// than going back through `From` is what keeps that from recursing.
 ///
 /// The message names `stella doctor` because a diagnosis the user cannot
 /// confirm and a repair they have to invent are what made this failure a dead
@@ -77,21 +82,22 @@ pub(crate) fn is_sqlite_corruption(error: &rusqlite::Error) -> bool {
 /// place most users ever hear about them.
 pub(crate) fn corrupt_store_error(error: rusqlite::Error, db_path: Option<&Path>) -> StoreError {
     if !is_sqlite_corruption(&error) {
-        return StoreError::from(error);
+        return StoreError::Sqlite(error);
     }
-    let path = db_path.map_or_else(
-        || ".stella/private/store.db".to_string(),
-        |path| path.display().to_string(),
-    );
     StoreError::Corrupt {
-        path,
+        path: db_path.map(|path| path.display().to_string()),
         source: error,
     }
 }
 
-/// Re-classify an error raised anywhere in the open sequence, so corruption
-/// found after page 1 carries the same remedy corruption found *on* page 1
-/// already does.
+/// Name the file on an error raised anywhere in the open sequence, so
+/// corruption found after page 1 says which database it is as well as what to
+/// do about it.
+///
+/// The blanket conversion classifies the failure but has no database to name,
+/// which is the shape almost every corruption error in the crate now arrives
+/// in. The open sequence is the one place that holds the resolved path, so it
+/// re-names what the conversion left unnamed.
 ///
 /// [`corrupt_store_error`] maps the pragma batch, which is the first statement
 /// to touch page 1 — so it catches a file whose header is gone or overwritten.
@@ -110,6 +116,12 @@ pub(crate) fn corrupt_store_error(error: rusqlite::Error, db_path: Option<&Path>
 /// healthy open to learn what the failing open is already being told.
 pub(crate) fn classify_store_corruption(error: StoreError, db_path: Option<&Path>) -> StoreError {
     match error {
+        StoreError::Corrupt { source, path: None } if db_path.is_some() => {
+            corrupt_store_error(source, db_path)
+        }
+        // An error built as `StoreError::Sqlite` by hand skipped the
+        // conversion, so classify it here too rather than depending on which
+        // door it came through.
         StoreError::Sqlite(sqlite) if is_sqlite_corruption(&sqlite) => {
             corrupt_store_error(sqlite, db_path)
         }
@@ -679,10 +691,9 @@ mod tests {
     }
 
     /// A store whose `events` table spans enough pages that damage can be put
-    /// past the header without touching it, staged so that reopening rebuilds
-    /// the `events_by_task` index — the v38 → v39 step, and the full table scan
-    /// that walked the maintainer's damaged pages in #4564.
-    fn workspace_needing_an_index_rebuild(rows: usize) -> (tempfile::TempDir, PathBuf) {
+    /// past the header without touching it. Returned open, and with the
+    /// execution the rows belong to, so each caller stages the reopen it needs.
+    fn workspace_with_padded_events(rows: usize) -> (tempfile::TempDir, Store, i64) {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open(dir.path()).expect("store");
         let id = store
@@ -703,23 +714,48 @@ mod tests {
         store
             .finish_execution(id, "completed", 0.5)
             .expect("finish");
+        (dir, store, id)
+    }
+
+    /// Every row in the main file rather than in a `-wal` the corruption a test
+    /// writes next would miss, and the file closed.
+    fn checkpoint_and_close(dir: &tempfile::TempDir, store: Store) -> PathBuf {
+        store
+            .lock()
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+            .expect("checkpoint");
+        drop(store);
+        let db_path = dir.path().join(".stella/private/store.db");
+        assert!(db_path.is_file(), "fixture store exists");
+        db_path
+    }
+
+    /// A padded store staged so that reopening rebuilds the `events_by_task`
+    /// index — the v38 → v39 step, and the full table scan that walked the
+    /// maintainer's damaged pages in #4564.
+    fn workspace_needing_an_index_rebuild(rows: usize) -> (tempfile::TempDir, PathBuf) {
+        let (dir, store, _) = workspace_with_padded_events(rows);
         {
             // Drop the index and wind the stamp back, so the reopen genuinely
             // re-runs the migration rather than skipping an index that is
-            // already there. Checkpointed so every row is in the main file and
-            // not in a `-wal` the corruption below would miss.
+            // already there.
             let conn = store.lock();
             conn.execute_batch("DROP INDEX IF EXISTS events_by_task;")
                 .expect("drop the index the migration rebuilds");
             conn.pragma_update(None, "user_version", 38i64)
                 .expect("wind the schema stamp back to v38");
-            conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
-                .expect("checkpoint");
         }
-        drop(store);
-        let db_path = dir.path().join(".stella/private/store.db");
-        assert!(db_path.is_file(), "fixture store exists");
+        let db_path = checkpoint_and_close(&dir, store);
         (dir, db_path)
+    }
+
+    /// A padded store left at the schema this build already writes, so
+    /// [`Store::migrate`]'s `while version < SCHEMA_VERSION` body never runs
+    /// and no DDL walks the file while it is being opened.
+    fn workspace_at_the_current_schema(rows: usize) -> (tempfile::TempDir, PathBuf, i64) {
+        let (dir, store, id) = workspace_with_padded_events(rows);
+        let db_path = checkpoint_and_close(&dir, store);
+        (dir, db_path, id)
     }
 
     /// Overwrite a run of pages in the middle of the file, leaving page 1 — the
@@ -769,13 +805,75 @@ mod tests {
 
         match Store::open(dir.path()) {
             Ok(_) => panic!("a store with shredded pages must not open"),
-            Err(error @ StoreError::Corrupt { .. }) => assert!(
-                error.to_string().contains("stella doctor"),
-                "corruption found after page 1 carries the remedy too: {error}"
-            ),
+            Err(error @ StoreError::Corrupt { .. }) => {
+                assert!(
+                    error.to_string().contains("stella doctor"),
+                    "corruption found after page 1 carries the remedy too: {error}"
+                );
+                // The open sequence holds the resolved path, so it is the file
+                // the sentence names rather than a description of one.
+                assert!(
+                    error.to_string().contains("store.db"),
+                    "and the file it happened to: {error}"
+                );
+            }
             Err(other) => panic!(
                 "corruption below the header must classify as Corrupt, not as a \
                  bare SQLite failure: {other:?}"
+            ),
+        }
+    }
+
+    /// Corruption that no statement in the open sequence can reach must still
+    /// arrive as the error that names the repair.
+    ///
+    /// The store is already at this build's `SCHEMA_VERSION`, so `migrate`'s
+    /// step loop never runs and the pragma batch touches only page 1: opening
+    /// succeeds, which is the premise asserted below. The damage surfaces on
+    /// the first read that walks those pages, and without the split covering
+    /// that read it reaches the caller as
+    /// `Sqlite(SqliteFailure(DatabaseCorrupt, 11))` — the bare "database disk
+    /// image is malformed", with no remedy and nothing to tell it from a held
+    /// lock.
+    ///
+    /// The read is `execution_events` rather than `list_session_tasks`: the
+    /// `tasks` table is empty here and its pages sit before the damage, so
+    /// that read raises nothing. This one scans the padded `events` table, and
+    /// it fails from `Rows::next` — inside `for row in rows`, where no wrapper
+    /// around the connection could have classified it.
+    #[test]
+    fn corruption_found_by_an_ordinary_read_names_the_remedy() {
+        let (dir, db_path, execution_id) = workspace_at_the_current_schema(4_000);
+        shred_pages_past_the_header(&db_path);
+
+        // The premise: page 1 survived and the stamp already matches this
+        // build, so nothing walks the damaged pages while opening.
+        let header = Connection::open(&db_path).expect("a damaged file still opens");
+        let stamped: i64 = header
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("the header still answers its version");
+        assert_eq!(
+            stamped,
+            crate::migrations::SCHEMA_VERSION,
+            "the fixture must need no migration, or the open-time path catches this"
+        );
+        drop(header);
+
+        let store = Store::open(dir.path())
+            .expect("a store at the current schema opens even with damage past page 1");
+
+        match store.execution_events(execution_id) {
+            Ok(journal) => panic!(
+                "reading {} events off shredded pages must fail",
+                journal.events.len()
+            ),
+            Err(error @ StoreError::Corrupt { .. }) => assert!(
+                error.to_string().contains("stella doctor"),
+                "an ordinary read carries the remedy too: {error}"
+            ),
+            Err(other) => panic!(
+                "corruption raised by an ordinary read must classify as Corrupt, \
+                 not as a bare SQLite failure: {other:?}"
             ),
         }
     }

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -594,8 +594,8 @@ pub struct Store {
     /// `None` for in-memory/ephemeral stores.
     root: Option<PathBuf>,
     /// The file this connection is open on. `None` in memory. It is kept so
-    /// that a write which fails can name the file to go and look at. That is
-    /// the one part of the failure a person can act on.
+    /// that a failed open can name the file to go and look at. That is the
+    /// one part of the failure a person can act on.
     db_path: Option<PathBuf>,
 }
 
@@ -680,8 +680,8 @@ impl Store {
         // `paranoid`, which costs 180x and is therefore opt-in.
         //
         // This batch is also the first statement to touch page 1, so it is
-        // where an unreadable file announces itself — mapped here, before the
-        // blanket `From<rusqlite::Error>` flattens the error code away.
+        // where an unreadable file announces itself — mapped here with the
+        // resolved path, which the blanket conversion has none of.
         // The batch absorbs a concurrent first-open's `SQLITE_BUSY`; see
         // [`initialize_store_pragmas`].
         initialize_store_pragmas(&conn).map_err(|error| corrupt_store_error(error, db_path))?;


### PR DESCRIPTION
## What & why

Corruption found while opening a store became `StoreError::Corrupt`, which
names the file and points at `stella doctor`. Corruption found at any other
moment did not: it reached the caller as `StoreError::Sqlite` carrying
SQLite's raw "database disk image is malformed", with no remedy and nothing to
tell it from an ordinary `SQLITE_BUSY`.

The gap is reachable. A store already stamped at this build's
`SCHEMA_VERSION` opens cleanly with damaged interior pages — the pragma batch
touches only page 1, and `migrate`'s `while version < SCHEMA_VERSION` body
never runs — and the session then works normally until some read walks those
pages.

The split now lives in `impl From<rusqlite::Error> for StoreError`
(`crates/stella-store/src/error.rs`), the one conversion every `?` in the
crate takes, so it holds for the whole read and write surface and for every
method the crate grows.

Closes #5505

### Deviation from the issue's "The fix"

The issue prescribed `fn corrupt_aware<T>(&self, r: rusqlite::Result<T>)` at
the call sites. The code says that cannot cover this failure: SQLite reports
the damage from `Rows::next`, so `Store::execution_events` fails inside
`for row in rows { … row? }`, where there is no connection-level result to
wrap. It would also have to be repeated across 142 `self.lock()` sites and
169 fallible public methods, and a new method would forget. The conversion is
total by construction instead. Posted on the issue before starting:
https://github.com/macanderson/stella/issues/5505#issuecomment-5528701534

`StoreError::Corrupt`'s `path` becomes `Option<String>`. The conversion has
no database to ask, and this crate opens several (`store.db`, `usage.db`,
`catalog.db`, `enterprise-telemetry.db`), so a hardcoded default would send a
user to move a healthy database aside. The open sequence still names the file
it resolved: `classify_store_corruption` re-names what the conversion left
unnamed, and that is asserted in
`corruption_below_the_header_still_names_the_repair`. Naming the file on the
read/write surface needs a facade down to `Rows` — filed as #5745 with the
design that works and the two that do not.

`stella-cli`'s `UnmeasurableReason::classify` matches `E::Corrupt { .. }`, so
the field change reaches no other crate.

Exemplar: `thiserror`'s own guidance for a message that needs a computed
field (`#[error("…", subject = f(.field))]`), which is how the corruption
sentence names a file it may not have.

## The witness

Three tests, two of them witnesses.

- `corruption_found_by_an_ordinary_read_names_the_remedy`
  (`crates/stella-store/src/integrity.rs`) — end-to-end, and the one the
  issue asks for. A padded store left at `SCHEMA_VERSION`, WAL-checkpointed,
  pages shredded past the header; `Store::open` is asserted to **succeed**
  (the premise: no open-time statement walks the damage), then
  `Store::execution_events` is asserted to fail with `Corrupt`. On `main`
  that read returns `Sqlite(SqliteFailure(DatabaseCorrupt, 11))` and the test
  fails on its `Corrupt` arm.

  The read is `execution_events`, not the `list_session_tasks` the issue
  names: the `tasks` table is empty in the fixture and its pages sit before
  the damage, so that read raises nothing at all. `execution_events` scans
  the 4000-row `events` table the fixture pads the file with.

- `corruption_is_classified_by_the_conversion_every_query_takes`
  (`crates/stella-store/src/error.rs`) — the mechanism alone. The wire shape
  SQLite hands back mid-scan, put through `StoreError::from`. On `main` the
  derived `#[from]` yields `Sqlite`, so it fails on the `Corrupt` arm by
  construction.

- `a_held_lock_is_not_reclassified_as_corruption` — the control. A
  `SQLITE_BUSY` still yields `Sqlite` and `is_busy()`, so `busy::retry_busy`
  keeps retrying it. This one passes on `main` too; it is there so a future
  over-eager classifier fails something.

Fixture refactor: `workspace_needing_an_index_rebuild` now shares
`workspace_with_padded_events` + `checkpoint_and_close` with the new
`workspace_at_the_current_schema`. The v38 wind-back it does is unchanged.

Tests deleted: None.

## The gate

- [x] `cargo fmt --check` (run locally)
- [ ] clippy over the workspace at `-D warnings` — CI
- [ ] the workspace test suite — CI
- [x] Docs updated: `error.rs`'s module header and both case docs,
      `integrity.rs`'s two function docs, and the two stale claims in
      `lib.rs` that said the blanket conversion flattens the error code
- [x] `Closes #5505` in this description and as a commit trailer

## Nothing left behind

- [x] Filed: #5745 — a corruption error raised by an ordinary read does not
      say which file it is, with the facade design that would fix it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies
- [x] No new outbound network calls

## Anything reviewers should know?

The `Sqlite` arm of `classify_store_corruption` is now unreachable through
the conversion, which classifies first. It stays because a hand-built
`StoreError::Sqlite` skips the conversion, and the function should not depend
on which door the error came through.

`corrupt_store_error`'s non-corruption branch returns `StoreError::Sqlite`
directly rather than going through `From`. That is what keeps the conversion,
which now calls it, from recursing.

## Summary by Sourcery

Classify SQLite corruption consistently across the store error surface while preserving retryable and non-corruption SQLite failures.

Bug Fixes:
- Classify SQLite corruption raised during any store operation as `StoreError::Corrupt`, ensuring callers receive the repair guidance instead of a raw SQLite error.
- Preserve ordinary SQLite failures such as `SQLITE_BUSY` as `StoreError::Sqlite` so existing retry behavior remains intact.

Enhancements:
- Allow corruption errors to omit the database path when classification occurs without connection context, while retaining resolved paths for failures during store opening.

Documentation:
- Update store error and integrity documentation to describe centralized corruption classification and path availability.

Tests:
- Add coverage for corruption discovered during ordinary reads, centralized error conversion, and preservation of busy-database classification.
- Refactor corruption fixtures to support both migration-time and read-time corruption scenarios.