### PR TITLE
test(stella-core): price the paths that buy an extra model call

### DIFF
--- a/crates/stella-core/tests/spend_gate.rs
+++ b/crates/stella-core/tests/spend_gate.rs
@@ -17,6 +17,10 @@
 //! The ports are scripted, so the engine does no I/O (architecture rule 2).
 //! An answered model call costs a flat quarter dollar here. That price is a
 //! round binary number, so a sum of them is exact and a pin can be too.
+//!
+//! The first four scenarios are plain: each step buys one model call. The
+//! rest buy a call no step asked for. Each one names the module it prices,
+//! so a red run says which recovery got dearer.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -24,7 +28,10 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_core::budget::BudgetGuard;
-use stella_core::ports::ToolExecutor;
+use stella_core::hooks::{
+    HookAction, HookExecError, HookExecResult, HookMatcher, HookRunner, Hooks,
+};
+use stella_core::ports::{FallbackResolver, ResolvedFallback, ToolExecutor};
 use stella_core::retry::Sleeper;
 use stella_core::{Engine, EngineConfig, TurnOutcome};
 use stella_protocol::{
@@ -59,15 +66,33 @@ impl Sleeper for NoopSleeper {
 
 /// A scripted `Provider`: one entry per call, repeating the last entry once
 /// the script runs out. Counts every attempt it is handed.
+///
+/// The id is set per instance. A fallback that resolves back to the failed
+/// provider's id is refused, so the replacement needs a name of its own.
 struct ScriptedProvider {
+    id: &'static str,
     script: TokioMutex<Vec<Result<CompletionResult, ProviderError>>>,
     calls: Arc<AtomicU32>,
+}
+
+impl ScriptedProvider {
+    fn new(
+        id: &'static str,
+        script: Vec<Result<CompletionResult, ProviderError>>,
+        calls: Arc<AtomicU32>,
+    ) -> Self {
+        Self {
+            id,
+            script: TokioMutex::new(script),
+            calls,
+        }
+    }
 }
 
 #[async_trait]
 impl Provider for ScriptedProvider {
     fn id(&self) -> &str {
-        "scripted"
+        self.id
     }
     async fn complete_ref(
         &self,
@@ -151,38 +176,146 @@ fn tool_step(commands: &[(&str, &str)]) -> CompletionResult {
     }
 }
 
+/// Hands out one replacement provider on every ask. The engine's set-once
+/// latch is the bound, so this can answer freely.
+struct OneReplacement<'p> {
+    to: &'p dyn Provider,
+}
+
+impl FallbackResolver for OneReplacement<'_> {
+    fn resolve_fallback(&self, failed_provider_id: &str) -> Option<ResolvedFallback<'_>> {
+        Some(ResolvedFallback {
+            provider: self.to,
+            reason: format!("scripted re-resolution away from `{failed_provider_id}`"),
+        })
+    }
+}
+
+/// A `HookRunner` that prints one decision, whatever it is asked. Exit code
+/// 0: a non-zero exit is a failure, not a decision, and the Stop gate then
+/// fails open.
+struct DecidingRunner {
+    stdout: String,
+}
+
+#[async_trait]
+impl HookRunner for DecidingRunner {
+    async fn run(
+        &self,
+        _action: &HookAction,
+        _payload_json: &str,
+        _cwd: &str,
+    ) -> Result<HookExecResult, HookExecError> {
+        Ok(HookExecResult {
+            exit_code: 0,
+            stdout: self.stdout.clone(),
+            stderr: String::new(),
+        })
+    }
+}
+
+/// One scenario: the scripted ports it runs over, and the turn it drives.
+struct Turn {
+    script: Vec<Result<CompletionResult, ProviderError>>,
+    config: EngineConfig,
+    messages: Vec<CompletionMessage>,
+    /// The replacement's script, when the scenario attaches a fallback.
+    replacement: Option<Vec<Result<CompletionResult, ProviderError>>>,
+    /// The document a `Stop` hook prints, when the scenario attaches one.
+    stop_decision: Option<String>,
+}
+
+impl Turn {
+    fn new(script: Vec<Result<CompletionResult, ProviderError>>) -> Self {
+        Self {
+            script,
+            config: EngineConfig::default(),
+            messages: vec![
+                CompletionMessage::system("sys"),
+                CompletionMessage::user("do the thing"),
+            ],
+            replacement: None,
+            stop_decision: None,
+        }
+    }
+
+    fn config(mut self, edit: impl FnOnce(&mut EngineConfig)) -> Self {
+        edit(&mut self.config);
+        self
+    }
+
+    fn messages(mut self, messages: Vec<CompletionMessage>) -> Self {
+        self.messages = messages;
+        self
+    }
+
+    fn replacement(mut self, script: Vec<Result<CompletionResult, ProviderError>>) -> Self {
+        self.replacement = Some(script);
+        self
+    }
+
+    /// Attach a `Stop` hook that denies every completion.
+    fn stop_hook_denies(mut self, reason: &str) -> Self {
+        self.stop_decision =
+            Some(serde_json::json!({ "action": "deny", "reason": reason }).to_string());
+        self
+    }
+
+    /// Drive the turn and report what it bought. Both providers share one
+    /// counter, so `model_calls` is the turn's total.
+    async fn run(self) -> (TurnOutcome, Spend) {
+        let model_calls = Arc::new(AtomicU32::new(0));
+        let tool_calls = Arc::new(AtomicU32::new(0));
+        let provider = ScriptedProvider::new("primary", self.script, model_calls.clone());
+        let replacement = self
+            .replacement
+            .map(|script| ScriptedProvider::new("replacement", script, model_calls.clone()));
+        let tools = CountingTools {
+            calls: tool_calls.clone(),
+        };
+        let sleeper = NoopSleeper;
+        let resolver = replacement.as_ref().map(|to| OneReplacement {
+            to: to as &dyn Provider,
+        });
+        let hooks = self.stop_decision.as_ref().map(|_| Hooks {
+            stop: Some(vec![HookMatcher {
+                matcher: None,
+                hooks: vec![HookAction::new("stop-gate")],
+            }]),
+            ..Hooks::default()
+        });
+        let runner = self.stop_decision.map(|stdout| DecidingRunner { stdout });
+
+        let mut engine = Engine::with_sleeper(&provider, &tools, self.config, &sleeper);
+        if let Some(resolver) = &resolver {
+            engine = engine.with_fallback_resolver(resolver);
+        }
+        if let (Some(hooks), Some(runner)) = (&hooks, &runner) {
+            engine = engine.with_hooks(hooks, runner);
+        }
+
+        let mut messages = self.messages;
+        let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+        let cost_usd = match &outcome {
+            TurnOutcome::Completed { cost_usd, .. } | TurnOutcome::Aborted { cost_usd, .. } => {
+                *cost_usd
+            }
+        };
+        let spend = Spend {
+            model_calls: model_calls.load(Ordering::SeqCst),
+            tool_calls: tool_calls.load(Ordering::SeqCst),
+            cost_usd,
+        };
+        (outcome, spend)
+    }
+}
+
 /// Drive one turn over the scripted ports and report what it bought.
 async fn run_turn(script: Vec<Result<CompletionResult, ProviderError>>) -> (TurnOutcome, Spend) {
-    let model_calls = Arc::new(AtomicU32::new(0));
-    let tool_calls = Arc::new(AtomicU32::new(0));
-    let provider = ScriptedProvider {
-        script: TokioMutex::new(script),
-        calls: model_calls.clone(),
-    };
-    let tools = CountingTools {
-        calls: tool_calls.clone(),
-    };
-    let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
-    let mut messages = vec![
-        CompletionMessage::system("sys"),
-        CompletionMessage::user("do the thing"),
-    ];
-    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
-    let (tx, _rx) = mpsc::unbounded_channel();
-
-    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
-    let cost_usd = match &outcome {
-        TurnOutcome::Completed { cost_usd, .. } | TurnOutcome::Aborted { cost_usd, .. } => {
-            *cost_usd
-        }
-    };
-    let spend = Spend {
-        model_calls: model_calls.load(Ordering::SeqCst),
-        tool_calls: tool_calls.load(Ordering::SeqCst),
-        cost_usd,
-    };
-    (outcome, spend)
+    Turn::new(script).run().await
 }
 
 /// Fail with the scenario named, the pin, and what the loop just bought.
@@ -288,6 +421,328 @@ async fn a_stuck_loop_is_steered_once_and_then_stopped() {
         &Spend {
             model_calls: 4,
             tool_calls: 4,
+            cost_usd: 4.0 * CALL_COST_USD,
+        },
+    );
+}
+
+// The paths that buy a model call no step asked for. Each scenario below
+// drives one arm and pins what it costs. A change that makes one of them
+// fire more often is the cost regression this file exists to catch.
+
+/// A transcript with a span the summarizer can fold. The middle has to be
+/// long enough to clear the four-message floor once the kept tail is set
+/// aside.
+fn long_transcript() -> Vec<CompletionMessage> {
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do the thing"),
+    ];
+    for note in 0..19 {
+        messages.push(CompletionMessage::user(format!("earlier note {note}")));
+    }
+    messages
+}
+
+/// The summarizer buys a second call at this step. The pure passes cannot
+/// get under the budget, so a model writes the summary before the worker
+/// call goes out.
+///
+/// A budget of one token forces the arm. The shipped default is 150k, and a
+/// scripted port should not have to build a transcript that large.
+#[tokio::test]
+async fn the_overflow_summarizer_buys_one_extra_model_call() {
+    let (outcome, spend) = Turn::new(vec![Ok(answer("SUMMARY")), Ok(answer("done"))])
+        .messages(long_transcript())
+        .config(|config| config.compaction_budget_tokens = 1)
+        .run()
+        .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: 2.0 * CALL_COST_USD,
+        },
+        "the summarizer's spend folds into the turn total"
+    );
+    assert_spend(
+        "overflow summarizer (driver::restore's summarize_overflow_span)",
+        &spend,
+        &Spend {
+            model_calls: 2,
+            tool_calls: 0,
+            cost_usd: 2.0 * CALL_COST_USD,
+        },
+    );
+}
+
+/// A mid-turn provider fallback. The ladder ends on the first attempt,
+/// because the failure is not retryable. The resolver hands over a
+/// replacement and the step re-runs there.
+#[tokio::test]
+async fn a_provider_fallback_buys_one_call_on_the_replacement() {
+    let (outcome, spend) = Turn::new(vec![Err(ProviderError::Terminal("wedged".into()))])
+        .replacement(vec![Ok(answer("rescued"))])
+        .run()
+        .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "rescued".into(),
+            cost_usd: CALL_COST_USD,
+        },
+        "the turn finishes on the replacement, and only its call bills"
+    );
+    assert_spend(
+        "provider fallback after an exhausted ladder (driver::model_fallback)",
+        &spend,
+        &Spend {
+            model_calls: 2,
+            tool_calls: 0,
+            cost_usd: CALL_COST_USD,
+        },
+    );
+}
+
+/// The same failure with nothing to fall back on. The swap is what buys the
+/// extra call, so the turn ends on the refused attempt.
+#[tokio::test]
+async fn an_exhausted_ladder_with_no_fallback_buys_nothing_further() {
+    let (outcome, spend) = run_turn(vec![Err(ProviderError::Terminal("wedged".into()))]).await;
+
+    match &outcome {
+        TurnOutcome::Aborted { reason, .. } => {
+            assert!(reason.contains("wedged"), "unexpected reason: {reason}");
+        }
+        other => panic!("expected a failed model call, got {other:?}"),
+    }
+    assert_spend(
+        "exhausted ladder with no fallback (driver::model_fallback declining)",
+        &spend,
+        &Spend {
+            model_calls: 1,
+            tool_calls: 0,
+            cost_usd: 0.0,
+        },
+    );
+}
+
+/// The provider refuses the ceiling this turn asked for and names one it
+/// can fund. The step re-runs under the clamp. The refused call bills
+/// nothing, so the added spend is one attempt.
+#[tokio::test]
+async fn an_output_budget_clamp_re_asks_the_same_step_once() {
+    let refused = ProviderError::OutputBudgetExceeded {
+        message: "can only afford 8000".into(),
+        affordable_output_tokens: Some(8_000),
+    };
+    let (outcome, spend) = run_turn(vec![Err(refused), Ok(answer("done"))]).await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: CALL_COST_USD,
+        }
+    );
+    assert_spend(
+        "output-budget clamp re-ask (driver::output_budget_recovery)",
+        &spend,
+        &Spend {
+            model_calls: 2,
+            tool_calls: 0,
+            cost_usd: CALL_COST_USD,
+        },
+    );
+}
+
+/// The bound on that ladder. A ceiling under the floor an answer needs arms
+/// no rung, so the refusal is terminal on the first attempt.
+#[tokio::test]
+async fn an_unfundable_output_ceiling_arms_no_rung() {
+    let refused = ProviderError::OutputBudgetExceeded {
+        message: "can only afford 500".into(),
+        affordable_output_tokens: Some(500),
+    };
+    let (outcome, spend) = run_turn(vec![Err(refused)]).await;
+
+    match &outcome {
+        TurnOutcome::Aborted { reason, .. } => {
+            assert!(
+                reason.contains("output budget"),
+                "unexpected reason: {reason}"
+            );
+        }
+        other => panic!("expected an unrecovered output-budget failure, got {other:?}"),
+    }
+    assert_spend(
+        "output-budget ladder refusing to arm (driver::output_budget_recovery)",
+        &spend,
+        &Spend {
+            model_calls: 1,
+            tool_calls: 0,
+            cost_usd: 0.0,
+        },
+    );
+}
+
+/// A parked wait for a 429 that will not clear. The inline ladder spends
+/// its retries, then one park buys one more attempt, which answers. Seven
+/// refused calls: the first try plus the six retries the default policy
+/// allows. The park adds one call.
+#[tokio::test]
+async fn a_parked_rate_limit_buys_one_attempt_per_park() {
+    let refused = || -> Result<CompletionResult, ProviderError> {
+        Err(ProviderError::RateLimited {
+            message: "429, no stated window".into(),
+            retry_after_ms: None,
+        })
+    };
+    let mut script: Vec<Result<CompletionResult, ProviderError>> =
+        (0..7).map(|_| refused()).collect();
+    script.push(Ok(answer("done")));
+
+    let (outcome, spend) = run_turn(script).await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: CALL_COST_USD,
+        }
+    );
+    assert_spend(
+        "parked wait after an exhausted inline ladder (driver::rate_limit)",
+        &spend,
+        &Spend {
+            model_calls: 8,
+            tool_calls: 0,
+            cost_usd: CALL_COST_USD,
+        },
+    );
+}
+
+/// The bound on the park. A stated backoff no park can afford fails fast on
+/// the first attempt. A shorter wait earns the same refusal, so it would
+/// spend wall clock and buy nothing. The inline ladder never runs either: a
+/// hint past its ceiling cannot be slept inline.
+#[tokio::test]
+async fn a_stated_backoff_no_park_can_afford_buys_one_attempt() {
+    let refused = ProviderError::RateLimited {
+        message: "429, come back tomorrow".into(),
+        retry_after_ms: Some(24 * 60 * 60 * 1000),
+    };
+    let (outcome, spend) = run_turn(vec![Err(refused)]).await;
+
+    match &outcome {
+        TurnOutcome::Aborted { reason, .. } => {
+            assert!(
+                reason.contains("failing fast instead of waiting past the budget"),
+                "unexpected reason: {reason}"
+            );
+        }
+        other => panic!("expected a fast failure, got {other:?}"),
+    }
+    assert_spend(
+        "unaffordable stated backoff (driver::rate_limit declining to park)",
+        &spend,
+        &Spend {
+            model_calls: 1,
+            tool_calls: 0,
+            cost_usd: 0.0,
+        },
+    );
+}
+
+/// The loop steer priced on its own, apart from the abort above. Three
+/// no-progress calls earn one warning. A model that obeys it answers on the
+/// next call, and the steer buys that call.
+#[tokio::test]
+async fn a_loop_steer_the_model_obeys_buys_one_more_call() {
+    let (outcome, spend) = run_turn(vec![
+        Ok(tool_step(&[("call_1", "ls")])),
+        Ok(tool_step(&[("call_2", "ls")])),
+        Ok(tool_step(&[("call_3", "ls")])),
+        Ok(answer("done")),
+    ])
+    .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: 4.0 * CALL_COST_USD,
+        }
+    );
+    assert_spend(
+        "loop steer obeyed (driver::loop_escalation)",
+        &spend,
+        &Spend {
+            model_calls: 4,
+            tool_calls: 3,
+            cost_usd: 4.0 * CALL_COST_USD,
+        },
+    );
+}
+
+/// The prove-it re-ask. A gated turn that changed the workspace and
+/// declares done is sent back once. One extra call, and one only: the nudge
+/// is on the transcript, so the next declaration stands.
+#[tokio::test]
+async fn the_prove_it_re_ask_buys_one_more_call() {
+    let (outcome, spend) = Turn::new(vec![
+        Ok(tool_step(&[("call_1", "ls")])),
+        Ok(answer("done")),
+        Ok(answer("checked, and done")),
+    ])
+    .config(|config| config.completion_gate = true)
+    .run()
+    .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "checked, and done".into(),
+            cost_usd: 3.0 * CALL_COST_USD,
+        }
+    );
+    assert_spend(
+        "prove-it re-ask under the completion gate (driver::confident_zero)",
+        &spend,
+        &Spend {
+            model_calls: 3,
+            tool_calls: 1,
+            cost_usd: 3.0 * CALL_COST_USD,
+        },
+    );
+}
+
+/// A Stop hook that denies every completion. The turn is held open for the
+/// hook's whole allowance and then finishes. Four calls: the declaration,
+/// one per held round, and the one that stands.
+#[tokio::test]
+async fn a_denying_stop_hook_buys_one_call_per_held_round() {
+    let (outcome, spend) = Turn::new(vec![Ok(answer("done"))])
+        .stop_hook_denies("the work is unproven")
+        .run()
+        .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: 4.0 * CALL_COST_USD,
+        },
+        "the allowance is spent and the last declaration stands"
+    );
+    assert_spend(
+        "Stop hook denying and continuing (driver::user_hooks)",
+        &spend,
+        &Spend {
+            model_calls: 4,
+            tool_calls: 0,
             cost_usd: 4.0 * CALL_COST_USD,
         },
     );

--- a/docs/spec/verification-gate.md
+++ b/docs/spec/verification-gate.md
@@ -64,8 +64,15 @@ re-checks the evidence (#3511) cannot gate on either.
 `crates/stella-core/tests/spend_gate.rs` drives the raw step loop over a
 scripted `Provider` and a scripted `ToolExecutor`, one turn per scenario, and
 pins what the turn bought: the model calls, the tool runs, and the reported
-cost. The scenarios are a one-step answer, a two-tool step, a retry after a
-429, and a turn the loop detector stops. A failure names the scenario, the
+cost. Four scenarios are plain, one model call per step: a one-step answer, a
+two-tool step, a retry after a 429, and a turn the loop detector stops.
+
+The rest are the paths that buy a call no step asked for, and each names the
+module it prices: the overflow summarizer, a mid-turn provider fallback, an
+output-budget clamp, a parked wait for a 429 that will not clear, a loop
+steer the model obeys, the prove-it re-ask, and a Stop hook that denies and
+holds the turn open. Several are pinned from both sides: what the arm buys,
+and the bound that stops it buying more. A failure names the scenario, the
 pinned numbers and the new ones.
 
 It needs no verification machinery, which is why it could be rebuilt here at


### PR DESCRIPTION
## What & why

`crates/stella-core/tests/spend_gate.rs` pinned four scenarios, and every one
of them took exactly one model call per step. The step loop's recovery arms
buy calls a step never asked for, and nothing priced them — so a change that
made one of them fire more often was a cost regression the gate could not
see.

Seven more scenarios, each naming the module it prices:

| Scenario | Path | Pin (model / tool / cost) |
| --- | --- | --- |
| overflow summarizer | `driver::restore`'s `summarize_overflow_span` | 2 / 0 / $0.50 |
| provider fallback | `driver::model_fallback` | 2 / 0 / $0.25 |
| exhausted ladder, no fallback | the same seam declining | 1 / 0 / $0.00 |
| output-budget clamp re-ask | `driver::output_budget_recovery` | 2 / 0 / $0.25 |
| the clamp ladder refusing to arm | the same seam's floor | 1 / 0 / $0.00 |
| parked wait after the inline ladder | `driver::rate_limit` | 8 / 0 / $0.25 |
| an unaffordable stated backoff | the same seam declining to park | 1 / 0 / $0.00 |
| loop steer the model obeys | `driver::loop_escalation` | 4 / 3 / $1.00 |
| prove-it re-ask | `driver::confident_zero` | 3 / 1 / $0.75 |
| Stop hook denying and holding | `driver::user_hooks` | 4 / 0 / $1.00 |

Four of the recoveries are pinned from both sides: what the arm buys, and the
bound that stops it buying more. The bound rows are what fail if
`MAX_RECOVERY_RUNGS`, `FLOOR_TOKENS`, `MAX_PARKED_WAIT_MS` or the set-once
fallback latch move.

Scripted `Provider` / `ToolExecutor` ports only, so the engine still does no
I/O (AGENTS.md architecture rule 2). No new dependencies.

The harness grows a `Turn` builder so a scenario can attach a second
provider, a fallback resolver, a Stop hook, its own transcript or its own
`EngineConfig`. `run_turn` stays as the thin wrapper the four existing
scenarios call, so their pins are byte-identical.

`docs/spec/verification-gate.md` listed the four scenarios by name; it now
describes both halves of the file.

Closes #5706

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Every scenario is its own witness, and the mechanism is that the pins do not
exist on `main`: the ten `assert_spend` calls and the seven `#[tokio::test]`
functions are new, so `main` cannot pass them — there is nothing to run.

What each one witnesses is the *reachability* of the arm it prices, which is
what makes the pin more than a tautology:

- the summarizer scenario's provider is called **twice** for a single step,
  and the turn's reported cost is 2 × the per-call price, which only holds if
  `run_compaction_pass` bought a summarizer call and folded its spend in;
- the fallback scenario completes on text only the replacement provider can
  produce (`"rescued"`), so the swap happened;
- the two output-budget scenarios differ only in the ceiling the provider
  says it can afford — 8000 arms a rung and re-asks, 500 is under
  `FLOOR_TOKENS` and is terminal on the first attempt;
- the park scenario's eight calls are the first try, the six retries the
  default `RetryPolicy` allows, and one more the park bought; the
  unaffordable-hint scenario asserts the fast-failure message
  (`failing fast instead of waiting past the budget`), which only the
  give-up branch of `plan_park` produces;
- the loop-steer, prove-it and Stop-hook scenarios each answer with a
  completion the engine refuses to accept, and their counts are exactly the
  extra calls those refusals buy.

## The gate

- [x] `cargo fmt --check` (run locally; nothing else compiled here — CI is
      the compiler for this repository)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — CI, green
- [x] `cargo test --workspace` — CI, green
- [x] Docs updated where behavior changed (`doc:verification-gate`)
- [x] `Closes #5706` appears both here and as a commit trailer

Tests deleted: None.

## Nothing left behind

Three paths the scripted harness could not reach, or could not pin honestly,
are filed as handoffs rather than left unsaid:

- [x] Filed: #5746 — the *total* number of attempts a deadline-less parked
  wait can buy is still unpinned. `MAX_PARKED_WAIT_MS` is `pub(super)` and
  `retry.rs`'s two park-backoff constants are private, so an integration test
  could only hardcode the count instead of deriving it from the constants
  that produce it. Hardcoding it would be a magic number, which is the
  opposite of what a pin is for.
- [x] Filed: #5747 — the **second** loop steering warning
  (`MAX_LOOP_STEERS`) is unpriced. Reaching it needs a detection whose
  `LoopIdentity` differs from the warned one, and arranging that from a
  scripted script means arranging the detector's window from an integration
  test.
- [x] Filed: #5749 — the summarizer's head-dropping re-asks, the summarizer's
  starved retry, and the length-continuation ladder each buy calls and are
  priced by nothing.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

The summarizer scenario forces its arm with `compaction_budget_tokens = 1`.
The shipped default is 150k, and building a transcript that large in a
scripted test would be slower and no more truthful about the price — the arm
either fires or it does not, and the pin is about what it costs when it does.

`guard-self-tests` may be red for the pre-existing reason in #5683; this diff
touches no guard script.

## Summary by Sourcery

Price and pin previously untracked model calls across Stella Core recovery and verification paths.

Enhancements:
- Expand the spend-gate coverage to price model calls purchased by recovery, fallback, retry, steering, completion, and hook paths, including the limits that prevent additional calls.
- Extend the spend-gate harness to support customized engine configurations, transcripts, fallback providers, and Stop-hook decisions while preserving the existing scenarios.

Documentation:
- Update the verification-gate specification to document both ordinary per-step spending scenarios and recovery paths that incur additional model calls.

Tests:
- Add witness scenarios that pin model calls, tool calls, and reported costs for overflow summarization, provider fallback, output-budget recovery, parked rate limits, loop steering, prove-it re-asks, and denying Stop hooks, along with their terminal bounds.

## DoD re-check

#5706's seven boxes are now ticked, each verified against this diff rather than
against this description — six by reading the code (every scenario cited by
symbol; the record is on the issue), and `CI green` last, on the job:
`fmt + clippy + test` at `a164492` (job `100728883659`, run `33779198699`)
concluded **`success`** at 16:55:08Z, carrying `cargo clippy -D warnings`,
`cargo test`, `cargo doc -D warnings`, `docs/wire/ still matches the types` and
the release smoke build. That is what ticks the two gate boxes above, which the
original description had left to CI.

The `dod` check last ran at 16:33Z against the then-unticked checklist and was
red on that stale reading. This edit re-asks it — `dod-check.yml` fires on
`pull_request: edited`, and a re-run would not have worked here: I lack
permission to re-run workflows on this repo.

`guard self-tests` is green on this head, so the #5683 caveat above did not
bite.