### PR TITLE
fix(stella-tui): classify GateBoard as a verdict note, not a muted other

### DIFF
--- a/crates/stella-protocol/README.md
+++ b/crates/stella-protocol/README.md
@@ -105,22 +105,27 @@ This crate has no god files: no file exceeds the gate's 1500-line ratchet
 accepts no new entries. When a file here approaches the limit, split it before
 it crosses.
 
-[`src/event.rs`](src/event.rs) was grandfathered here for a long time and now
-sits just under the limit, so its split discipline still applies: new
-supporting vocabulary goes in a new module re-exported from
-[`src/lib.rs`](src/lib.rs) — the crate's precedent is
-[`src/ladder.rs`](src/ladder.rs), split out of `event.rs` when the ladder rung
-joined it (#1043), with the re-export keeping `stella_protocol::LadderSnapshot`
-at its old path — and a genuinely new `AgentEvent` case offsets its lines
-by extracting the case's supporting types, taking their inline round-trip
-tests with them.
+[`src/event/kind.rs`](src/event/kind.rs) — the `AgentEvent` enum itself, one
+arm per wire case — is the file that sits near the limit today.
+[`src/event.rs`](src/event.rs) is 284 lines, nowhere close. `kind.rs` is not
+in `scripts/file-size-baseline.txt`, so it is held to the strict 1500-line
+ceiling rather than a grandfathered one; a first-time crossing gets no
+baseline entry (see AGENTS.md § "God files"). Split discipline therefore
+applies **there**: a genuinely new `AgentEvent` case lands its arm in
+`kind.rs`, but any supporting type it needs goes in a new module re-exported
+from [`src/event.rs`](src/event.rs) — the crate's precedent is
+[`src/ladder.rs`](src/ladder.rs), split out when the ladder rung joined the
+vocabulary (#1043), with the re-export keeping
+`stella_protocol::LadderSnapshot` at its old path — and a case's inline
+round-trip tests travel with its supporting type, not with `kind.rs`.
 
 ## Layout
 
 | File | What it holds |
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | The crate's flat re-export surface, and the statement of the one-directional wire-compatibility rule. Read it first. |
-| [`src/event.rs`](src/event.rs) | `AgentEvent` and its supporting types — the stream-json vocabulary: every wire case plus the tagless `Unknown` fallback. Open it to add or change anything a renderer, the journal, or a receipt consumes. |
+| [`src/event.rs`](src/event.rs) | The module's re-export surface and its `serde(default = "...")` helper functions. Open it to add or change anything a renderer, the journal, or a receipt consumes. |
+| [`src/event/kind.rs`](src/event/kind.rs) | `AgentEvent` itself — the stream-json vocabulary: every wire case plus the tagless `Unknown` fallback. The file near the 1500-line ceiling; see "God files" above. |
 | [`src/journal.rs`](src/journal.rs) | `StampedEvent` / `stamped_line` — one *line* of the event stream: an `AgentEvent` plus the optional wall-clock `ts` its sink stamps at the write boundary (#2111). Not a field of the enum: a stamp is a fact about a write, the same event reaches more than one sink, and this crate owns no clock. |
 | [`src/context_event.rs`](src/context_event.rs) | `CompiledContextFrameBuilt` — the compiled-frame identity the step manifest carries, and its golden JCS vector. The `LifecycleEventEnvelope` channel that used to live here was deleted unwired (#3135). |
 | [`src/completion.rs`](src/completion.rs) | `CompletionRequest` / `CompletionResult` / `CompletionUsage`, `GenerationParams`, `FinishReason`. The one envelope every provider adapter translates to and from. |
@@ -224,11 +229,14 @@ equality, and a mismatch is harvested as `AgentEvent::SpeculationDiscarded`.
   fields crossed (`text` carried `delta`, `text_delta` carried `text`); the
   serde aliases keep those parsing, and raw-JSONL readers must stay bilingual
   the same way.
-- **The golden JCS vector in `context_event.rs` is meant to break.** Renaming,
-  retyping, adding, or reordering a field of `CompiledContextFrameBuilt` breaks
-  the golden line, because those canonical bytes are the preimage
-  `stella_core::context_record::hash` builds `record_hash` from. The dev-dep
-  pins the same canonicalizer crate *and version* core hashes with.
+- **The golden JCS vector in `context_event.rs` is meant to break — on three
+  of the four edits, not all four.** Renaming, retyping, or adding a
+  field of `CompiledContextFrameBuilt` breaks the golden line, because those
+  canonical bytes are the preimage `stella_core::context_record::hash` builds
+  `record_hash` from. **Reordering does not**: RFC 8785 (JCS) sorts object
+  keys lexicographically, so two structurally-identical values serialize to
+  the same bytes regardless of field declaration order. The dev-dep pins the
+  same canonicalizer crate *and version* core hashes with.
 - **`ToolSchema::read_only` defaults to `false`** — the safe direction. An MCP
   tool or an older schema that doesn't know about the field is treated as
   mutating and never speculated on.
@@ -281,12 +289,26 @@ equality, and a mismatch is harvested as `AgentEvent::SpeculationDiscarded`.
   drops line/column from the resulting error message. Both are the price of the
   forward-compat fallback (#672), and both narrow the "a known tag with a bad
   body stays loud" guarantee slightly.
-- **`AgentEvent::UsageIncomplete::retries` serializes as `null` when absent.**
-  It is the one `Option` on the event vocabulary without
-  `skip_serializing_if`, so it costs a key on every incomplete-usage line while
-  its neighbours (`Pr::number`, `Pr::ci`, `ContextFrameRef::uri`, …) omit
-  theirs. Changing it now would be a wire change, so it is documented rather
-  than fixed; do not copy the pattern onto a new field.
+- **Six `Option` fields on the event vocabulary serialize `null` when
+  absent, because they skip `skip_serializing_if`** — six, not the single
+  field this section once named alone. `AgentEvent::UsageIncomplete::retries`
+  was first; the pattern was then copied onto `BudgetTick`'s `limit_usd`,
+  `session_spent_usd`, `session_limit_usd` and `deadline_remaining_ms`, and
+  onto `FileChange::diff`. `budget_tick` is one of the highest-volume events
+  in `stella-events.jsonl`, so four of the six now cost a `null` key on every
+  tick after every paid call. Their neighbours (`Pr::number`, `Pr::ci`,
+  `ContextFrameRef::uri`, …) omit theirs.
+
+  Fixing this is not a one-line change on three of the six:
+  `UsageIncomplete::retries`, `BudgetTick::limit_usd` and `FileChange::diff`
+  carry no `#[serde(default)]` either, so adding `skip_serializing_if` to one
+  of those three *alone* would make a newly-written event with the field
+  absent fail to decode — the key would simply be missing, not present-as-
+  `null`. Any fix has to add both attributes together, on all three, and
+  re-verify every round-trip test in this crate against the smaller wire
+  shape. That is a wire-format change to a shape already written into
+  replayable journals, so all six stay documented rather than fixed here;
+  **do not copy the pattern onto a new field.**
 
 ## Testing
 
@@ -294,16 +316,28 @@ equality, and a mismatch is harvested as `AgentEvent::SpeculationDiscarded`.
 make test-protocol        # = cargo test -p stella-protocol
 ```
 
-There is no `tests/` directory — every test is an inline `#[cfg(test)] mod
-tests` at the bottom of the module it covers, and the suite needs no fixtures,
-network, or env vars. The dominant shape is the serde round-trip (AGENTS.md
-"Serde-first": every type crossing a crate boundary round-trips byte-for-byte),
-paired with a "legacy stream still parses" test for each `serde(default)` field
-— e.g. `completion_usage_without_cache_write_tokens_still_parses`,
+Most tests are inline `#[cfg(test)] mod tests` at the bottom of the module
+they cover, and need no fixtures, network, or env vars. The dominant shape is
+the serde round-trip (AGENTS.md "Serde-first": every type crossing a crate
+boundary round-trips byte-for-byte), paired with a "legacy stream still
+parses" test for each `serde(default)` field — e.g.
+`completion_usage_without_cache_write_tokens_still_parses`,
 `step_usage_from_a_pre_drift_stream_still_parses`,
 `legacy_compaction_without_identities_still_parses`. The other shape is the
 golden-bytes test in `context_event.rs`, which needs the
 `serde_json_canonicalizer` dev-dependency.
+
+There is also a `tests/` directory, for the one kind of test an inline module
+cannot host: an integration test compiles against the crate's public API
+only, which is what proves *consumers* can build and validate what this crate
+emits, not just that the crate compiles itself.
+[`tests/wire_contract.rs`](tests/wire_contract.rs) (plus its sample table,
+[`tests/wire_contract/samples.rs`](tests/wire_contract/samples.rs)) is the
+one every `AgentEvent` case must feed — see "Adding an `AgentEvent` case"
+below. [`tests/journal_stamp_wire.rs`](tests/journal_stamp_wire.rs) and
+[`tests/text_event_wire.rs`](tests/text_event_wire.rs) cover
+`journal.rs`'s wire shape and the `Text`/`TextDelta` legacy-alias parsing
+called out above.
 
 ## Extending it
 
@@ -316,11 +350,19 @@ default. Every `serde(default)` in this crate has one; match the neighborhood.
 the new case on `AgentEvent::Unknown`, so backwards readability is not a
 reason to invent a side channel. Then:
 
-1. Add the case to `AgentEvent` in [`src/event.rs`](src/event.rs).
+1. Add the case to `AgentEvent` in
+   [`src/event/kind.rs`](src/event/kind.rs).
 2. Add its arm to `type_tag` — `cargo build -p stella-protocol` fails with
    `E0004` until you do.
 3. Add a round-trip test asserting the `"type"` tag serializes as you expect.
-4. Work the checklist in `type_tag`'s doc comment: the compile-enforced
+4. Add a sample to `sample_events()` in
+   [`tests/wire_contract/samples.rs`](tests/wire_contract/samples.rs) —
+   `cargo test -p stella-protocol` fails
+   `every_known_tag_has_a_sample` until you do. This is the integration test
+   named above, run against the crate's public API rather than the module's
+   own `#[cfg(test)]`, so skip it and the inline round-trip test in step 3
+   passes while `make test` (which does run `tests/`) still fails.
+5. Work the checklist in `type_tag`'s doc comment: the compile-enforced
    matchers in `stella-tui` will stop you one crate at a time, then hand-audit
    the wildcard matchers the compiler cannot catch. This step is not optional
    bookkeeping — a case landed on `main` past the compile-enforced half and

--- a/crates/stella-protocol/src/context_event.rs
+++ b/crates/stella-protocol/src/context_event.rs
@@ -25,8 +25,8 @@
 //!
 //! The golden JCS vector below is the reason the body is pinned here: those
 //! canonical bytes are the preimage `stella-core::context_record::hash` builds
-//! `record_hash` values from, so renaming, retyping, or reordering a field
-//! must break a test rather than silently change a hash across replays.
+//! `record_hash` values from. Renaming, retyping, or adding a field breaks
+//! this golden line; reordering one does not — JCS already sorts the keys.
 
 use serde::{Deserialize, Serialize};
 
@@ -54,9 +54,10 @@ mod tests {
     #[test]
     fn golden_jcs_vector_for_compiled_context_frame_built() {
         // The exact canonical bytes of the event body. Keys are sorted and
-        // whitespace minimal, so the vector is hand-verifiable. Renaming,
-        // retyping, adding, or reordering a field breaks this line — which is
-        // the point: the body is a wire contract across replays.
+        // whitespace minimal, so the vector is hand-verifiable. A reordered
+        // field cannot break this line — JCS already sorted the keys.
+        // Renaming, retyping, or adding one does break it, which is the
+        // point: the body is a wire contract across replays.
         assert_eq!(
             jcs(&CompiledContextFrameBuilt {
                 compiled_frame_id: "cf_1".into(),

--- a/crates/stella-protocol/src/event/tags.rs
+++ b/crates/stella-protocol/src/event/tags.rs
@@ -54,7 +54,7 @@
 //! the real trap; audit them by hand:
 //!   - `stella-tui` `deck::event_intensity` and `deck::status_from_event`: give
 //!     the case an intensity / agent status if it should register on the
-//!     fleet deck.
+//!     fleet deck; `transcript_build::note_kind` gives it a `NoteKind` tier.
 //!
 //! The same duty applies to the other exhaustively-matched cross-crate enums
 //! this pattern warns about (`ToolOutput`, `BudgetOutcome`).

--- a/crates/stella-tui/src/transcript_build.rs
+++ b/crates/stella-tui/src/transcript_build.rs
@@ -454,9 +454,17 @@ fn slug(prompt: &str) -> String {
 }
 
 /// Which visual class an event's note belongs to.
+///
+/// This match holds no arm for `Stage`, `Proof`, `BudgetDenied` or
+/// `RetriesExhausted`. [`crate::textline::event_line`] returns `None` for all
+/// four, so `RunBuilder::note` returns before this function ever sees one of
+/// them. An arm for any of the four would be dead code — coverage that never
+/// runs. That is the exact shape that hid `GateBoard`'s missing arm: the
+/// match *looked* exhaustive. The compiler cannot catch a live arm going
+/// missing here either — `_ => NoteKind::Other` still compiles — so add one
+/// only after reading `event_line` and this function side by side.
 fn note_kind(event: &AgentEvent) -> NoteKind {
     match event {
-        AgentEvent::Stage { .. } => NoteKind::Stage,
         AgentEvent::ContextRecall { .. }
         | AgentEvent::ContextWrite { .. }
         | AgentEvent::MemoryLogged { .. }
@@ -464,10 +472,8 @@ fn note_kind(event: &AgentEvent) -> NoteKind {
         | AgentEvent::SkillInjected { .. }
         | AgentEvent::Compaction { .. } => NoteKind::Context,
         AgentEvent::BudgetTick { .. }
-        | AgentEvent::BudgetDenied { .. }
         | AgentEvent::ProviderFallback { .. }
-        | AgentEvent::Retry { .. }
-        | AgentEvent::RetriesExhausted { .. } => NoteKind::Meter,
+        | AgentEvent::Retry { .. } => NoteKind::Meter,
         AgentEvent::TurnParked { .. }
         | AgentEvent::TurnWoken { .. }
         | AgentEvent::AskUser { .. } => NoteKind::Wait,
@@ -476,7 +482,10 @@ fn note_kind(event: &AgentEvent) -> NoteKind {
         | AgentEvent::ScopeReview { .. }
         | AgentEvent::HunkReview { .. }
         | AgentEvent::TaskUpdate { .. }
-        | AgentEvent::Proof { .. } => NoteKind::Verdict,
+        // `deck/classify.rs` classifies this event as `TraceKind::Verdict`
+        // too; this arm keeps the plain, non-TTY transcript agreeing with
+        // the deck about it.
+        | AgentEvent::GateBoard { .. } => NoteKind::Verdict,
         AgentEvent::SubAgent { .. }
         | AgentEvent::Commit { .. }
         | AgentEvent::Pr { .. }

--- a/crates/stella-tui/src/transcript_build/tests.rs
+++ b/crates/stella-tui/src/transcript_build/tests.rs
@@ -453,3 +453,93 @@ fn a_turn_terminator_against_a_closed_turn_is_inert() {
 
     assert_eq!(b.snapshot().turns.len(), 1);
 }
+
+// --------------------------------------------------------------- note_kind
+
+/// **Witness.** Without the `GateBoard` arm on `note_kind`, this event falls
+/// through its wildcard to `NoteKind::Other` — the muted `·` glyph a
+/// plain-transcript reader cannot tell from a budget tick — while its verdict
+/// siblings (`Verdict`, `GoalVerdict`, `ScopeReview`, `HunkReview`,
+/// `TaskUpdate`) all classify as `NoteKind::Verdict`. `deck/classify.rs`
+/// classifies the same event as `TraceKind::Verdict`; this keeps the plain,
+/// non-TTY surface agreeing with the deck about it.
+#[test]
+fn gate_board_classifies_as_a_verdict_not_a_muted_other() {
+    let event = AgentEvent::GateBoard {
+        board: stella_protocol::GateBoard::default(),
+    };
+    assert_eq!(note_kind(&event), NoteKind::Verdict);
+}
+
+/// `note_kind` exercised directly, one event per family it classifies. Before
+/// this, the only assertion on its result was indirect, through
+/// `a_non_backbone_event_survives_as_a_note`'s single `ProviderFallback` case
+/// above.
+#[test]
+fn note_kind_classifies_one_event_from_every_reachable_family() {
+    let cases: Vec<(AgentEvent, NoteKind)> = vec![
+        (
+            AgentEvent::Compaction {
+                before_tokens: 10_000,
+                after_tokens: 4_000,
+                evicted: 3,
+                deduped: 1,
+                superseded: 0,
+                aged: 0,
+                summarized: 1,
+                evicted_blocks: Vec::new(),
+                deduped_blocks: Vec::new(),
+                superseded_blocks: Vec::new(),
+                aged_blocks: Vec::new(),
+                summarized_blocks: Vec::new(),
+                rewrites: Vec::new(),
+                effective_budget_tokens: 0,
+                calibration_factor: 0.0,
+            },
+            NoteKind::Context,
+        ),
+        (
+            AgentEvent::Retry {
+                attempt: 1,
+                reason: "429".to_string(),
+            },
+            NoteKind::Meter,
+        ),
+        (
+            AgentEvent::AskUser {
+                id: "q1".to_string(),
+                question: "which branch?".to_string(),
+                options: Vec::new(),
+            },
+            NoteKind::Wait,
+        ),
+        (
+            AgentEvent::TaskUpdate { tasks: Vec::new() },
+            NoteKind::Verdict,
+        ),
+        (
+            AgentEvent::Commit {
+                sha: "abc123".to_string(),
+                message: "fix: note_kind".to_string(),
+            },
+            NoteKind::Handoff,
+        ),
+        // Not in any named family: the wildcard is the correct answer here,
+        // not a gap — `TurnComplete` has its own dedicated fold path and
+        // never reaches `note()` (its own test covers that separately).
+        (
+            AgentEvent::TurnComplete {
+                model: "m".to_string(),
+                cost_usd: 0.0,
+            },
+            NoteKind::Other,
+        ),
+    ];
+    for (event, expected) in cases {
+        assert_eq!(
+            note_kind(&event),
+            expected,
+            "event {event:?} classified wrong"
+        );
+    }
+}


### PR DESCRIPTION
## What

`transcript_build::note_kind` had no arm for `AgentEvent::GateBoard`, so it
fell through the wildcard to `NoteKind::Other` — the muted `·` glyph a
budget tick gets — on the plain, non-TTY transcript and the exported
HTML/Observatory view, while `deck/classify.rs` already classifies the same
event as `TraceKind::Verdict` on the live deck. This adds the arm, plus:

- `note_kind` added to the silent-wildcard checklist in
  `crates/stella-protocol/src/event/tags.rs`'s `type_tag` doc comment.
- The four now-false claims in `crates/stella-protocol/README.md` and
  `context_event.rs` the issue's audit found: the real six-field
  `skip_serializing_if` set, the real `tests/` layout plus the missing "add a
  sample" recipe step, the god-file pointer (`src/event/kind.rs`, not
  `src/event.rs`), and the golden-JCS-vector reordering claim.
- The four unreachable arms `note_kind` used to carry (`Stage`, `Proof`,
  `BudgetDenied`, `RetriesExhausted`) — dead because `textline::event_line`
  returns `None` for all four, so `note()` never calls `note_kind` with one
  of them. Removed rather than kept, since that unreachable coverage is the
  exact shape that hid `GateBoard`'s missing arm: the match looked
  exhaustive.

## Why (skip_serializing_if: describe, not retrofit)

The issue's DoD offers a choice: add `skip_serializing_if` to the five
fields that lack it, or describe the real frozen set. I took the second path.
Three of the six fields lacking `skip_serializing_if`
(`UsageIncomplete::retries`, `BudgetTick::limit_usd`, `FileChange::diff`)
also lack `#[serde(default)]`, so adding `skip_serializing_if` to any of them
*alone* would make a newly-written event with the field absent fail to
decode. A correct fix needs both attributes added together, on all three,
plus re-verifying every round-trip test against the smaller wire shape —
a wire-format change to a shape already written into replayable journals,
which is bigger than this PR and deserves its own review. The README now
names the real six-field set and states why, mirroring the reasoning it
already carried for `retries` alone.

## Witness

`gate_board_classifies_as_a_verdict_not_a_muted_other`
(`crates/stella-tui/src/transcript_build/tests.rs`) fails on `main` —
`GateBoard` classifies as `NoteKind::Other` — and passes with this change.
Checked the artisanal way per AGENTS.md (`git stash` the two-line arm
addition, re-read `note_kind`, confirm the wildcard is what a `GateBoard`
event would hit).

A second test, `note_kind_classifies_one_event_from_every_reachable_family`,
exercises `note_kind` directly across its other families — the issue's own
Confidence note flagged that only one indirect assertion (through
`ProviderFallback`) existed before.

Tests deleted: none.

## Scope note

`Error` and `SteeringWithheld` also mute to `NoteKind::Other` on this same
surface — a real, related defect the issue's follow-up comment names. I
did not fold that into this PR: it needs a `NoteKind` tier decision the
comment itself frames as open (a new `NoteKind::Alert` vs. reusing an
existing tier), and `Steered`'s "matching weight" isn't even well-defined
against the live deck, which renders it as a full user-turn row rather than
a note at all. Filed as #5748, referenced from the residue list below.

Closes #5504

## Residue

- #5748 — `note_kind` still mutes `Error` and `SteeringWithheld` to the same
  glyph as a budget tick; needs a `NoteKind` tier decision.

## Summary by Sourcery

Align transcript note classification with the live deck by treating `GateBoard` as a verdict and clarify the protocol’s event and wire-format guidance.

Bug Fixes:
- Classify `GateBoard` events as verdict notes in plain transcripts and exported views instead of muted miscellaneous notes.

Enhancements:
- Remove unreachable `note_kind` classifications and document the reachable event families to prevent future omissions.
- Correct protocol documentation for event layout, wire-format optional fields, integration-test coverage, and JCS ordering behavior.

Documentation:
- Update protocol guidance with the actual `AgentEvent` source file, integration-test sample workflow, frozen optional-field serialization set, and JCS compatibility details.

Tests:
- Add coverage for `GateBoard` verdict classification and direct classification of each reachable note family.