### PR TITLE
fix(stella-observatory): release the live stream's connection permit at its head

### DIFF
--- a/crates/stella-observatory/src/lib.rs
+++ b/crates/stella-observatory/src/lib.rs
@@ -112,12 +112,14 @@ const READ_TIMEOUT: Duration = Duration::from_secs(10);
 /// deadlock a protocol against itself. 64 is far past what one dashboard page
 /// opens while keeping the blocking-pool fan-out bounded.
 ///
-/// That reasoning is exactly why the live SSE stream is **not** counted here.
-/// An SSE connection is held open for as long as a tab is, so a handful of
-/// them on this semaphore would hold permits indefinitely and starve every
-/// one-shot route behind them — the page would hang while its own stream was
-/// perfectly healthy. Streams carry their own separate, smaller budget in
-/// the `live` module. Do not merge the two.
+/// That reasoning is exactly why the live SSE stream must not stay on this
+/// semaphore past its request head. An SSE connection is held open for as
+/// long as a tab is, so a handful of them holding a permit for that whole
+/// life would starve every one-shot route behind them — the page would hang
+/// while its own stream was perfectly healthy. `respond_to_head` drops the
+/// permit the moment a request routes to `/api/v1/live`, before handing the
+/// socket to a long-lived stream; streams carry their own separate, smaller
+/// budget in the `live` module from that point on. Do not merge the two.
 const MAX_LIVE_CONNECTIONS: usize = 64;
 
 /// Sent on every response, making the dashboard's zero-external-reference
@@ -682,12 +684,34 @@ pub async fn serve(
     plugins: Arc<dyn PluginContributions>,
     on_ready: impl FnOnce(SocketAddr),
 ) -> Result<(), ServeError> {
+    serve_with_capacity(
+        workspace_root,
+        port,
+        plugins,
+        on_ready,
+        MAX_LIVE_CONNECTIONS,
+    )
+    .await
+}
+
+/// [`serve`]'s body, with the one-shot pool's size pulled out as a
+/// parameter. [`serve`] always passes [`MAX_LIVE_CONNECTIONS`]; a test asks
+/// for a single permit instead, because proving a live stream does not hold
+/// its permit for its whole life needs one stream and one ordinary request
+/// past it, not sixty-four sockets.
+async fn serve_with_capacity(
+    workspace_root: PathBuf,
+    port: u16,
+    plugins: Arc<dyn PluginContributions>,
+    on_ready: impl FnOnce(SocketAddr),
+    max_live_connections: usize,
+) -> Result<(), ServeError> {
     let listener = TcpListener::bind(("127.0.0.1", port))
         .await
         .map_err(|source| ServeError::Bind { port, source })?;
     let addr = listener.local_addr().map_err(ServeError::Accept)?;
     on_ready(addr);
-    let connections = Arc::new(tokio::sync::Semaphore::new(MAX_LIVE_CONNECTIONS));
+    let connections = Arc::new(tokio::sync::Semaphore::new(max_live_connections));
     let mut backoff = AcceptBackoff::new();
     loop {
         let stream = match listener.accept().await {
@@ -714,12 +738,18 @@ pub async fn serve(
                 AcceptAction::Fatal => return Err(ServeError::Accept(err)),
             },
         };
-        // Bounded concurrency. Unlike `stella-serve`, nothing here is a
-        // long-lived stream — every response is one shot and closes — so a
-        // permit is held for a single request and a semaphore cannot starve a
-        // protocol against itself. A connection that cannot get a permit waits
-        // rather than being refused: the dashboard is a local tool, and a brief
-        // queue is a better answer than an error the page has to render.
+        // Bounded concurrency. A permit is held for the one-shot portion of a
+        // connection — reading the request head and, for every route but the
+        // live stream, writing that route's single answer — so bounding
+        // connections cannot starve a protocol against itself the way it
+        // would in `stella-serve`. The one route that is not one-shot,
+        // `/api/v1/live`, has `respond_to_head` drop its permit the moment
+        // that route is known, before the socket is handed to a long-lived
+        // stream (see `live`'s module doc for the separate, smaller budget
+        // that governs a stream from that point on). A connection that
+        // cannot get a permit waits rather than being refused: the dashboard
+        // is a local tool, and a brief queue is a better answer than an
+        // error the page has to render.
         let permit = Arc::clone(&connections)
             .acquire_owned()
             .await
@@ -728,9 +758,11 @@ pub async fn serve(
         let plugins = Arc::clone(&plugins);
         tokio::spawn(async move {
             // Per-connection errors (bad request line, client hangup) only
-            // affect that connection; the accept loop keeps serving.
-            let _ = handle(stream, &root, plugins).await;
-            drop(permit);
+            // affect that connection; the accept loop keeps serving. `permit`
+            // travels into `handle` and is dropped there — either by
+            // `respond_to_head` early, for a live stream, or on this task's
+            // return for every other route.
+            let _ = handle(stream, &root, plugins, permit).await;
         });
     }
 }
@@ -780,15 +812,17 @@ async fn handle(
     mut stream: TcpStream,
     workspace_root: &Path,
     plugins: Arc<dyn PluginContributions>,
+    permit: tokio::sync::OwnedSemaphorePermit,
 ) -> std::io::Result<()> {
     let head = match tokio::time::timeout(READ_TIMEOUT, read_head(&mut stream)).await {
         Ok(result) => result?,
         // The peer never finished its head. Dropping the connection is the whole
         // remedy: there is nobody to tell, because a client that cannot send a
         // request head in ten seconds is not waiting for a status code.
+        // `permit` drops with the rest of this frame.
         Err(_elapsed) => return Ok(()),
     };
-    respond_to_head(stream, workspace_root, head, plugins).await
+    respond_to_head(stream, workspace_root, head, plugins, permit).await
 }
 
 /// One request head, and whether its terminator arrived inside the cap.
@@ -832,6 +866,7 @@ async fn respond_to_head(
     workspace_root: &Path,
     head: RequestHead,
     plugins: Arc<dyn PluginContributions>,
+    permit: tokio::sync::OwnedSemaphorePermit,
 ) -> std::io::Result<()> {
     let RequestHead {
         text: head,
@@ -851,6 +886,11 @@ async fn respond_to_head(
         let root = query_param(path.split_once('?').map(|(_, query)| query), "project")
             .and_then(|id| global::resolve_project_root(&id))
             .unwrap_or_else(|| workspace_root.to_path_buf());
+        // The one-shot budget above bounds reading this head, not the stream
+        // that follows: dropped here, before the socket is handed to
+        // `live::serve_stream`, so an open tab never counts against it. A
+        // stream's own admission is `live`'s separate `MAX_LIVE_STREAMS`.
+        drop(permit);
         return live::serve_stream(stream, Arc::new(Observatory::new(&root)), CSP).await;
     }
     let response = if !head_complete {

--- a/crates/stella-observatory/src/live.rs
+++ b/crates/stella-observatory/src/live.rs
@@ -31,20 +31,18 @@
 //!
 //! # Why this needs its own connection budget
 //!
-//! `lib.rs` bounds concurrent connections with a semaphore, and the comment
-//! there is an explicit warning: it is only safe because "nothing here is a
-//! long-lived stream — every response is one shot and closes". An SSE
-//! connection is exactly the long-lived stream that warning is about. Left on
-//! the same semaphore, a handful of open dashboard tabs would hold permits
-//! indefinitely and starve every one-shot route behind them, and the page
-//! would hang while its own stream was healthy.
+//! `lib.rs` bounds concurrent connections with a semaphore, sized for
+//! requests that answer once and close. An SSE connection stays open for as
+//! long as a tab is, so `respond_to_head` drops its one-shot permit the
+//! moment a request is known to be this route, before the socket ever
+//! reaches [`serve_stream`] — left on that semaphore for its whole life, a
+//! handful of open tabs would starve every one-shot route behind them.
 //!
-//! So streams get a separate, smaller budget ([`MAX_LIVE_STREAMS`]) and the
-//! one-shot semaphore is left exactly as it was. A stream that cannot get a
-//! slot is **refused** rather than queued — the opposite of the one-shot
-//! policy, and: a queued one-shot request arrives a moment late,
-//! but a queued stream would hang forever behind connections that never
-//! close, and a client told "no" can fall back to polling immediately.
+//! Streams instead get their own, smaller budget ([`MAX_LIVE_STREAMS`]). A
+//! stream past that budget is **refused** rather than queued: a queued
+//! one-shot request just arrives late, but a queued stream would hang
+//! behind connections that never close, and a refused client can fall back
+//! to polling right away.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/stella-observatory/src/tests/http_surface.rs
+++ b/crates/stella-observatory/src/tests/http_surface.rs
@@ -428,3 +428,89 @@ async fn unterminated_request_head_is_refused_not_routed() {
     assert!(!body.contains("\"runs\""), "no telemetry may leak");
     server.abort();
 }
+
+/// A live stream must release its one-shot connection permit the moment its
+/// route is known. It must not hold that permit until the tab closes.
+///
+/// `serve_with_capacity` shrinks the pool to a single permit. That keeps the
+/// proof cheap: one live connection and one ordinary request, not the
+/// `MAX_LIVE_CONNECTIONS` sockets the real pool would need. With the bug,
+/// the live stream below holds that lone permit for as long as its socket
+/// stays open. The accept loop then wedges at the second connection's
+/// `acquire_owned`, so an ordinary `GET /api/meta` — which would otherwise
+/// answer in microseconds — never gets a response. The bounded read below
+/// turns that hang into a failing assertion instead of a stuck test.
+#[tokio::test]
+async fn a_live_stream_releases_its_permit_before_its_long_life_begins() {
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+    let ws = TempDir::new().unwrap();
+    let root = ws.path().to_path_buf();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let _ = serve_with_capacity(
+            root,
+            0,
+            std::sync::Arc::new(crate::NoContributions),
+            move |addr| {
+                let _ = tx.send(addr);
+            },
+            1, // one permit: a single leaked one is enough to wedge the loop
+        )
+        .await;
+    });
+    let addr = rx.await.unwrap();
+
+    // Open the live stream and read its response head. By the time that
+    // head arrives, `respond_to_head` has already dropped the permit — it
+    // does so before ever calling `live::serve_stream`, which is what
+    // writes this head. The socket is then left open, unread, for the rest
+    // of the test: what matters is that the *server* still treats it as a
+    // live subscription, not that this client does anything with it.
+    let live_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let mut live_reader = BufReader::new(live_stream);
+    live_reader
+        .get_mut()
+        .write_all(b"GET /api/v1/live HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .await
+        .unwrap();
+    let mut status = String::new();
+    live_reader.read_line(&mut status).await.unwrap();
+    assert!(
+        status.starts_with("HTTP/1.1 200"),
+        "stream refused: {status}"
+    );
+    loop {
+        let mut line = String::new();
+        live_reader.read_line(&mut line).await.unwrap();
+        if line.trim().is_empty() {
+            break; // end of the response head; the stream body follows
+        }
+    }
+
+    // The single permit is now either free (fixed) or gone for good (bug).
+    // This connection is reachable at all only if the accept loop is still
+    // calling `accept()`, and answered only if a permit was free to take —
+    // both fail together the moment the live stream above leaks its own.
+    let mut plain = tokio::net::TcpStream::connect(addr).await.unwrap();
+    plain
+        .write_all(b"GET /api/meta HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .await
+        .unwrap();
+    let mut response = String::new();
+    let answered =
+        tokio::time::timeout(Duration::from_secs(2), plain.read_to_string(&mut response)).await;
+    assert!(
+        answered.is_ok(),
+        "an ordinary request hung behind the live stream's permit, which \
+         must be released before the stream's long life begins rather than \
+         held for it"
+    );
+    assert!(
+        response.starts_with("HTTP/1.1 200 OK"),
+        "head was: {response}"
+    );
+
+    drop(live_reader);
+    server.abort();
+}


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

`stella observe`'s one-shot semaphore bounded ordinary requests at 64
concurrent permits, and the live SSE stream (`/api/v1/live`) was documented
as exempt from it. It was not: `serve` took the permit before the route was
known and only released it when the spawned task's `handle(...).await`
returned — for a live stream, that is when the browser tab closes. Eight
open dashboard tabs (the documented max for `live.rs`'s own separate
budget) silently held eight of the 64 one-shot slots forever, and once the
pool was exhausted the accept loop blocked at `acquire_owned` with a socket
already accepted, so it stopped calling `accept()` at all — a fresh page
load, or any ordinary request, could hang behind it.

`serve`, `handle` and `respond_to_head` now thread the
`OwnedSemaphorePermit` through instead of holding it in `serve`'s spawned
task. `respond_to_head` drops it the instant a request is known to route to
`/api/v1/live`, before the socket is ever handed to `live::serve_stream` —
so the permit only ever covers the one-shot part of the connection (the
bounded head read, and for every other route, writing the single answer).
Corrected the three comments the issue names (`MAX_LIVE_CONNECTIONS`'s doc,
the `acquire_owned` comment in `serve`, and `live.rs`'s module doc), which
all described the fixed invariant as already holding.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-observatory/src/tests/http_surface.rs`'s
`a_live_stream_releases_its_permit_before_its_long_life_begins` opens one
live stream against a one-shot pool shrunk to a single permit
(`serve_with_capacity`, a private wrapper `serve` calls with
`MAX_LIVE_CONNECTIONS`), then issues an ordinary `GET /api/meta` behind it
and asserts the response arrives within 2 seconds. Real `MAX_LIVE_CONNECTIONS`/
`MAX_LIVE_STREAMS` untouched — the pool is shrunk only for the test, per the
issue's own suggested design, so the proof costs one live connection and one
ordinary request instead of ~65 sockets.

Verified the fail→pass flip by hand: temporarily reverted `lib.rs` to
`origin/main` and re-added only the `serve_with_capacity` plumbing (no
permit threading) — the test panics at the 2-second timeout with "an
ordinary request hung behind the live stream's permit". With the real fix
restored it passes in under a millisecond (`finished in 0.00s`). All 154
existing `stella-observatory` lib tests plus the 4 `tests/live_stream.rs`
integration tests still pass.

Closes #5491

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — CI, green
- [x] `cargo test --workspace` — CI, green
- [x] Docs updated where behavior/flags changed (doc comments corrected on `MAX_LIVE_CONNECTIONS`, `serve`, `live.rs`'s module doc)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [ ] N/A — no new cross-boundary types

## Anything reviewers should know?

`serve_with_capacity` is a plain refactor of `serve`'s body with the pool
size pulled out as a parameter; `serve` itself is unchanged in behavior and
still always passes `MAX_LIVE_CONNECTIONS`. Only a test calls the new
function with a smaller number.

## Summary by Sourcery

Prevent live SSE connections from exhausting the observatory's one-shot request capacity by releasing their permit before the stream begins.

Bug Fixes:
- Release the one-shot connection permit as soon as a request is identified as a long-lived live stream, preventing open SSE connections from blocking ordinary requests and the accept loop.

Enhancements:
- Keep live streams governed by their dedicated connection budget while limiting the general semaphore to each connection's one-shot request work.

Documentation:
- Correct documentation to describe the live stream permit-release behavior and its separate connection budget.

Tests:
- Add a regression test using a single-permit pool to verify ordinary requests remain responsive while a live stream stays open.

## DoD re-check (#5491)

#5491's last open box was `cargo test -p stella-observatory` green, and the
evidence for it did not exist when `dod` last ran at 16:39Z — the required job
was still running. It has since concluded.

The required `fmt + clippy + test` job on this head
(`6e0d339b53942eecaa10a7a9e77fb2c03adc5581`, run `33779702029`, job
`100730418543`) concluded **`success`** at 2026-09-03T17:01:27Z. That job
carries `cargo clippy -D warnings`, `cargo test --workspace` — which is where
this crate's own suite runs — `cargo doc -D warnings` and the release smoke
build, and it is the authoritative gate per AGENTS.md rather than a local run.
That is what ticks the two gate boxes above, which the original description had
left to CI, and the matching box on #5491.

All four of #5491's DoD boxes are now ticked. This edit re-asks the `dod` check,
which fires on `pull_request: edited`; a workflow re-run was not available
(`403 Resource not accessible by integration`).

The remaining unticked boxes above are the CLA line (handled by the bot, not
per commit) and an explicit N/A, both unchanged.
