### PR TITLE
fix(stella-model): let two sessions in one process name two Vertex projects

### DIFF
--- a/crates/stella-cli/src/config/aux_credentials.rs
+++ b/crates/stella-cli/src/config/aux_credentials.rs
@@ -16,17 +16,19 @@
 //!
 //! `config.rs` owns the one-key chain — CLI flag, env var (+aliases), the
 //! anonymous-FD handoff, `~/.stella/credentials.toml`, an interactive prompt.
-//! Bedrock is the only provider today that needs more than one value, and it
-//! needs four: an access key id (which *is* the one key, `AWS_ACCESS_KEY_ID`),
-//! a secret access key, an optional session token, and a region.
+//! Two providers need more than one value. Bedrock needs four: an access key
+//! id (which *is* the one key, `AWS_ACCESS_KEY_ID`), a secret access key, an
+//! optional session token, and a region. Vertex needs three: a bearer token
+//! (the one key, `VERTEX_ACCESS_TOKEN`), a GCP project, and a location.
 //!
-//! Those three extra values used to be read straight from the process
-//! environment inside the adapter's own construction, which made Bedrock work
-//! in exactly one situation — a shell with the standard AWS variables exported
-//! — and nowhere else. `stella auth set bedrock` stored the access key id and
-//! then the run failed on the missing secret; a sealed benchmark process, whose
+//! Those extra values used to be read straight from the process environment
+//! inside the adapter's own construction, which made each provider work in
+//! exactly one situation — a shell with the right variables exported — and
+//! nowhere else. `stella auth set bedrock` stored the access key id and then
+//! the run failed on the missing secret; a sealed benchmark process, whose
 //! whole design keeps provider secrets out of the environment, could not reach
-//! Bedrock at all (#1301).
+//! Bedrock at all (#1301). The environment is also one value per process, so a
+//! host assembling two sessions could not give them two GCP projects.
 //!
 //! This module walks the same chain for each of those names and hands the
 //! result to the adapter as an [`AuxCredentials`] set. One vocabulary
@@ -48,7 +50,9 @@
 //! to avoid — and, under a sealed launcher, would reach back out to host state
 //! the launcher spent its whole design excluding. Explicit credentials only.
 
-use stella_model::credential::{AuxCredentials, BedrockCredentials, CredentialsFile};
+use stella_model::credential::{
+    AuxCredentials, BedrockCredentials, CredentialsFile, VertexAddressing,
+};
 
 use super::{Dialect, ProviderConfig};
 
@@ -56,11 +60,11 @@ use super::{Dialect, ProviderConfig};
 /// order the one-key chain uses: the trusted handoff, then the environment,
 /// then the credentials file.
 ///
-/// Returns an empty set for every dialect that authenticates with one key —
-/// which is every dialect but Bedrock. An empty set is not an error and never
-/// blocks construction: a provider with nothing extra to resolve has nothing
-/// extra to fail on, and the Bedrock adapter reports its own named error for a
-/// value that resolved nowhere.
+/// Returns an empty set for every dialect that needs nothing beyond one key —
+/// which is every dialect but Bedrock and Vertex. An empty set is not an error
+/// and never blocks construction: a provider with nothing extra to resolve has
+/// nothing extra to fail on, and each of those two adapters reports its own
+/// named error for a value that resolved nowhere.
 ///
 /// `credentials_file` is passed in rather than loaded here so this shares the
 /// caller's decision about whether the filesystem store may be read at all —
@@ -73,6 +77,7 @@ pub(crate) fn provider_aux(
 ) -> AuxCredentials {
     let names: &[&str] = match provider.dialect {
         Dialect::Bedrock => BedrockCredentials::AUX_ENV_NAMES,
+        Dialect::Vertex => VertexAddressing::AUX_ENV_NAMES,
         _ => return AuxCredentials::new(),
     };
 
@@ -153,12 +158,12 @@ pub(crate) struct AuxField {
 }
 
 /// The auxiliary values `stella auth set <provider>` offers to store, in
-/// prompt order. Empty for every provider that authenticates with one key.
+/// prompt order. Empty for every provider that needs nothing beyond one key.
 ///
-/// `AWS_DEFAULT_REGION` is deliberately absent even though the chain reads it:
-/// it exists as a fallback for shells that already export it, and offering
-/// *two* places to write the same setting is how a stored region and an
-/// effective region end up disagreeing.
+/// `AWS_DEFAULT_REGION` and `GOOGLE_CLOUD_PROJECT` are absent even though the
+/// chain reads both: each is a fallback for shells that already export it, and
+/// offering *two* places to write one setting is how a stored value and an
+/// effective value end up disagreeing.
 pub(crate) fn settable_aux_fields(provider: &ProviderConfig) -> &'static [AuxField] {
     match provider.dialect {
         Dialect::Bedrock => &[
@@ -178,6 +183,20 @@ pub(crate) fn settable_aux_fields(provider: &ProviderConfig) -> &'static [AuxFie
                 prompt: "AWS region (blank for us-east-1)",
             },
         ],
+        // Neither is a secret: a project id and a location are addressing, and
+        // both are published in a run manifest.
+        Dialect::Vertex => &[
+            AuxField {
+                name: "VERTEX_PROJECT_ID",
+                secret: false,
+                prompt: "GCP project id (required — Vertex scopes every request to one)",
+            },
+            AuxField {
+                name: "VERTEX_LOCATION",
+                secret: false,
+                prompt: "Vertex location (blank for global)",
+            },
+        ],
         _ => &[],
     }
 }
@@ -191,6 +210,14 @@ mod tests {
             .iter()
             .find(|p| p.id == "bedrock")
             .expect("bedrock is a built-in provider")
+            .clone()
+    }
+
+    fn vertex() -> ProviderConfig {
+        super::super::PROVIDERS
+            .iter()
+            .find(|p| p.id == "vertex")
+            .expect("vertex is a built-in provider")
             .clone()
     }
 
@@ -261,15 +288,53 @@ mod tests {
     fn every_settable_field_is_a_name_the_chain_actually_reads() {
         // The failure this prevents is silent: `stella auth set` writes a field
         // name that `provider_aux` never looks up, so the value is stored,
-        // reported as stored, and never used.
-        for field in settable_aux_fields(&bedrock()) {
-            assert!(
-                BedrockCredentials::AUX_ENV_NAMES.contains(&field.name),
-                "{} is offered for storage but never resolved",
-                field.name
-            );
+        // reported as stored, and never used. Asked of the chain itself rather
+        // than of a list of names, so the test cannot drift the way the thing
+        // it guards can.
+        for provider in [bedrock(), vertex()] {
+            let mut file = CredentialsFile::empty();
+            for field in settable_aux_fields(&provider) {
+                file.set_field(provider.id, field.name, "a-stored-value");
+            }
+            let aux = provider_aux(&provider, &file);
+            for field in settable_aux_fields(&provider) {
+                assert!(
+                    aux.get(field.name).is_some(),
+                    "{}: {} is offered for storage but never resolved",
+                    provider.id,
+                    field.name
+                );
+            }
         }
         assert!(settable_aux_fields(&anthropic()).is_empty());
+    }
+
+    #[test]
+    fn vertex_resolves_its_project_and_location_through_the_same_chain() {
+        let _env = crate::test_env::lock();
+        let _restore = crate::test_env::EnvRestore::capture(&[
+            "VERTEX_PROJECT_ID",
+            "GOOGLE_CLOUD_PROJECT",
+            "VERTEX_LOCATION",
+        ]);
+        // Addressing, not a credential — and until it came through here it was
+        // read from the process environment inside the adapter, which is one
+        // value for every session in the process.
+        let mut file = CredentialsFile::empty();
+        file.set_field("vertex", "VERTEX_PROJECT_ID", "project-from-the-file");
+        file.set_field("vertex", "VERTEX_LOCATION", "europe-west4");
+
+        // SAFETY: guarded by test_env's process-wide lock.
+        unsafe {
+            std::env::remove_var("VERTEX_PROJECT_ID");
+            std::env::remove_var("GOOGLE_CLOUD_PROJECT");
+            std::env::remove_var("VERTEX_LOCATION");
+        }
+
+        let aux = provider_aux(&vertex(), &file);
+        assert_eq!(aux.get("VERTEX_PROJECT_ID"), Some("project-from-the-file"));
+        assert_eq!(aux.get("VERTEX_LOCATION"), Some("europe-west4"));
+        assert_eq!(aux.get("GOOGLE_CLOUD_PROJECT"), None);
     }
 
     #[test]

--- a/crates/stella-model/src/credential.rs
+++ b/crates/stella-model/src/credential.rs
@@ -14,10 +14,12 @@
 //! Most providers authenticate with exactly one secret, which is the shape
 //! [`ApiKey`] resolves. Bedrock needs a *set* — access key id, secret access
 //! key, optional session token, plus a region that is routing rather than a
-//! credential. Those extra values travel in [`AuxCredentials`] and are stored
-//! in the `[credential_fields.<provider>]` half of the credentials file, so
-//! Bedrock has a durable home for all four instead of only working when the
-//! standard AWS variables happen to be exported.
+//! credential. Vertex needs its bearer token plus a GCP project and a
+//! location, both of which are routing. Those extra values travel in
+//! [`AuxCredentials`] and are stored in the `[credential_fields.<provider>]`
+//! half of the credentials file, so each provider has a durable home for the
+//! whole set instead of only working when the right variables happen to be
+//! exported — and so a host running two sessions can address two projects.
 
 // Not `aux`: that spelling made the repository un-checkoutable on Windows.
 // `scripts/check-reserved-paths.sh` is what stops it coming back.
@@ -702,9 +704,71 @@ pub struct VertexAddressing {
 }
 
 impl VertexAddressing {
+    /// The two names that can carry the project, in fallback order. One field,
+    /// two spellings — which is why [`Self::resolve_with`] treats them as a
+    /// pair instead of falling back name by name.
+    pub const PROJECT_ENV_NAMES: &'static [&'static str] =
+        &["VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"];
+
+    /// The name that carries the location. Absent everywhere, the location is
+    /// [`Self::DEFAULT_LOCATION`].
+    pub const LOCATION_ENV_NAME: &'static str = "VERTEX_LOCATION";
+
+    /// The location a request is scoped to when nothing names one. Google's
+    /// multi-region endpoint, `aiplatform.googleapis.com`.
+    pub const DEFAULT_LOCATION: &'static str = "global";
+
+    /// Every environment-variable name this resolves, in the order a host
+    /// should offer them. Public for the reason
+    /// [`BedrockCredentials::AUX_ENV_NAMES`] is: the host walks its own chain
+    /// (an inherited descriptor, the environment, `~/.stella/credentials.toml`)
+    /// for each name and hands the results back as an [`AuxCredentials`] set,
+    /// so it must not re-spell the list.
+    ///
+    /// There is no `SECRET_ENV_NAMES` counterpart: a project id and a location
+    /// are addressing, not credentials — they are published in a run manifest.
+    /// The bearer token is the one key, and it travels through
+    /// [`ApiKey::resolve`] as `VERTEX_ACCESS_TOKEN`.
+    pub const AUX_ENV_NAMES: &'static [&'static str] = &[
+        "VERTEX_PROJECT_ID",
+        "GOOGLE_CLOUD_PROJECT",
+        "VERTEX_LOCATION",
+    ];
+
     /// Resolve from the process environment.
     pub fn resolve() -> Result<Self, CredentialError> {
         Self::resolve_from(env_non_empty)
+    }
+
+    /// Resolve from values a host already resolved through its own chain,
+    /// falling back to the process environment for anything absent.
+    ///
+    /// This is what lets one process hold two sessions scoped to two GCP
+    /// projects. The environment is process-global, so it is the same
+    /// for all N sessions a host assembles; the only way two of them can
+    /// disagree about a project is a value passed in per session. Without it a
+    /// multi-tenant host billed both tenants to whichever project it happened
+    /// to have exported, in the wrong region, with the wrong data residency.
+    ///
+    /// The fallback keeps a library-style caller — one that builds straight off
+    /// [`crate::factory::build_provider`] with no chain of its own — working
+    /// exactly as it did when this read the environment directly.
+    pub fn resolve_with(aux: &AuxCredentials) -> Result<Self, CredentialError> {
+        // Per field, not per name: a host that named either project spelling
+        // has spoken for the project, so the environment is not consulted for
+        // the other one. Falling back name by name would let a process-global
+        // `VERTEX_PROJECT_ID` outrank a host-supplied `GOOGLE_CLOUD_PROJECT`,
+        // and the two sessions would share a project again.
+        let host_named_project = Self::PROJECT_ENV_NAMES
+            .iter()
+            .any(|name| aux.get(name).is_some());
+        Self::resolve_from(|name| {
+            let from_aux = aux.get(name).map(str::to_string);
+            if host_named_project && Self::PROJECT_ENV_NAMES.contains(&name) {
+                return from_aux;
+            }
+            from_aux.or_else(|| env_non_empty(name))
+        })
     }
 
     /// The resolution itself, over an injected lookup — pure, so the
@@ -714,10 +778,12 @@ impl VertexAddressing {
     pub(crate) fn resolve_from(
         lookup: impl Fn(&str) -> Option<String>,
     ) -> Result<Self, CredentialError> {
-        let project = lookup("VERTEX_PROJECT_ID")
-            .or_else(|| lookup("GOOGLE_CLOUD_PROJECT"))
+        let project = Self::PROJECT_ENV_NAMES
+            .iter()
+            .find_map(|name| lookup(name))
             .ok_or(CredentialError::VertexProjectMissing)?;
-        let location = lookup("VERTEX_LOCATION").unwrap_or_else(|| "global".to_string());
+        let location =
+            lookup(Self::LOCATION_ENV_NAME).unwrap_or_else(|| Self::DEFAULT_LOCATION.to_string());
         Ok(Self { project, location })
     }
 }

--- a/crates/stella-model/src/credential/tests/secondary_credential.rs
+++ b/crates/stella-model/src/credential/tests/secondary_credential.rs
@@ -45,6 +45,48 @@ fn vertex_addressing_without_a_project_names_both_variables() {
     assert!(message.contains("GOOGLE_CLOUD_PROJECT"), "{message}");
 }
 
+/// Two sessions in one process, two GCP projects: the host passes each one in.
+#[test]
+fn vertex_addressing_prefers_host_resolved_values_over_the_environment() {
+    let mut first = AuxCredentials::new();
+    first.insert("VERTEX_PROJECT_ID", "tenant-a");
+    first.insert("VERTEX_LOCATION", "us-central1");
+    let mut second = AuxCredentials::new();
+    second.insert("VERTEX_PROJECT_ID", "tenant-b");
+    second.insert("VERTEX_LOCATION", "europe-west4");
+
+    let first = VertexAddressing::resolve_with(&first).unwrap();
+    let second = VertexAddressing::resolve_with(&second).unwrap();
+
+    assert_eq!(first.project, "tenant-a");
+    assert_eq!(second.project, "tenant-b");
+    assert_eq!(first.location, "us-central1");
+    assert_eq!(second.location, "europe-west4");
+}
+
+/// One field, two names. Either one sets the project, so the environment is
+/// not read for the other.
+#[test]
+fn a_host_supplied_project_wins_under_either_spelling() {
+    let mut aux = AuxCredentials::new();
+    aux.insert("GOOGLE_CLOUD_PROJECT", "tenant-a");
+    assert_eq!(
+        VertexAddressing::resolve_with(&aux).unwrap().project,
+        "tenant-a"
+    );
+}
+
+/// The names a host walks are the names resolution reads.
+#[test]
+fn vertex_aux_env_names_is_every_name_resolution_reads() {
+    let reads: Vec<&str> = VertexAddressing::PROJECT_ENV_NAMES
+        .iter()
+        .copied()
+        .chain(std::iter::once(VertexAddressing::LOCATION_ENV_NAME))
+        .collect();
+    assert_eq!(VertexAddressing::AUX_ENV_NAMES, reads.as_slice());
+}
+
 #[test]
 fn bedrock_region_falls_back_then_defaults_and_the_session_token_is_optional() {
     let resolved =

--- a/crates/stella-model/src/factory.rs
+++ b/crates/stella-model/src/factory.rs
@@ -159,11 +159,11 @@ pub fn check_seed_floor(spec: &ProviderSpec<'_>, model_id: &str) -> Result<(), S
 /// arms consume (they build region/project-scoped URLs themselves).
 ///
 /// `aux` carries the values a provider needs *beyond* `api_key`, already
-/// resolved through whatever chain the host owns — Bedrock's AWS secret
-/// access key, optional session token, and region today; empty for every
-/// other dialect. An empty set is not an error: the Bedrock arm falls back to
-/// the standard AWS environment variables, which is exactly what it did
-/// before hosts could resolve them.
+/// resolved through whatever chain the host owns — Bedrock's AWS secret access
+/// key, optional session token and region, and Vertex's GCP project and
+/// location; empty for every other dialect. An empty set is not an error: both
+/// arms fall back to the standard environment variables, which is exactly what
+/// they did before hosts could resolve them.
 ///
 /// Runs [`check_seed_floor`] first — no caller can skip the anti-phantom-slug
 /// floor by going through this function.
@@ -199,9 +199,12 @@ pub fn build_provider(
             // credential chain); project and location are Vertex-specific
             // addressing, owned by `crate::credential` so a second host of the
             // engine gets the same variable names, the same fallback order,
-            // and the same named errors without copying them.
-            let addressing =
-                crate::credential::VertexAddressing::resolve().map_err(|e| e.to_string())?;
+            // and the same named errors without copying them. They arrive in
+            // `aux` when the host resolved them through that chain and fall
+            // back to the environment when it did not, so two sessions in one
+            // process can name two GCP projects.
+            let addressing = crate::credential::VertexAddressing::resolve_with(aux)
+                .map_err(|e| e.to_string())?;
             let mut provider = crate::vertex::VertexProvider::new(
                 api_key,
                 model_id.to_string(),
@@ -274,6 +277,13 @@ pub fn build_provider(
 mod tests {
     use super::*;
     use crate::credential::AuxCredentials;
+    use stella_protocol::{CompletionMessage, CompletionRequest};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Two tenants whose project ids appear nowhere in this process's
+    /// environment, so only a host-supplied value can produce them.
+    const TENANTS: &[&str] = &["tenant-a", "tenant-b"];
 
     fn spec(id: &'static str, dialect: Dialect, seeded: bool) -> ProviderSpec<'static> {
         ProviderSpec {
@@ -402,6 +412,68 @@ mod tests {
             err.contains("AWS_SECRET_ACCESS_KEY"),
             "the error must name the missing variable, got: {err}"
         );
+    }
+
+    /// Two sessions in one process, two GCP projects.
+    ///
+    /// Which project an adapter addresses is visible only on the wire — a
+    /// `Box<dyn Provider>` reports its id and nothing about its addressing — so
+    /// each adapter is pointed at one mock that answers its own project-scoped
+    /// path and nothing else. Neither tenant name exists anywhere in this
+    /// process's environment, so an adapter reading the project from
+    /// `std::env` misses both mocks and the call fails.
+    #[tokio::test]
+    async fn two_vertex_sessions_in_one_process_address_two_projects() {
+        let server = MockServer::start().await;
+        for tenant in TENANTS {
+            let body = format!(
+                "data: {{\"candidates\":[{{\"finishReason\":\"STOP\",\
+                 \"content\":{{\"parts\":[{{\"text\":\"{tenant}\"}}]}}}}],\
+                 \"usageMetadata\":{{\"promptTokenCount\":1,\"candidatesTokenCount\":1}}}}\n\n"
+            );
+            Mock::given(method("POST"))
+                .and(path(format!(
+                    "/v1/projects/{tenant}/locations/global/publishers/google/models/\
+                     gemini-3-pro:streamGenerateContent"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+                .mount(&server)
+                .await;
+        }
+
+        for tenant in TENANTS {
+            let mut aux = AuxCredentials::new();
+            aux.insert("VERTEX_PROJECT_ID", *tenant);
+            aux.insert("VERTEX_LOCATION", "global");
+            let provider = build_provider(
+                &spec("vertex", Dialect::Vertex, true),
+                "gemini-3-pro",
+                key(),
+                server.uri(),
+                // The Vertex arm builds its own project-scoped URL, so the
+                // raw override is what it reads.
+                Some(&server.uri()),
+                &aux,
+            )
+            .unwrap_or_else(|e| panic!("vertex constructs for {tenant}: {e}"));
+
+            let result = provider
+                .complete(CompletionRequest {
+                    messages: vec![CompletionMessage::user("hi")],
+                    max_output_tokens: None,
+                    temperature: None,
+                    effort: None,
+                    tools: vec![],
+                    reasoning: None,
+                    params: None,
+                })
+                .await
+                .unwrap_or_else(|e| panic!("{tenant} must reach its own project's path: {e}"));
+            assert_eq!(
+                result.text, *tenant,
+                "the adapter answered from the wrong project's mock"
+            );
+        }
     }
 
     #[test]

--- a/crates/stella-model/src/vertex.rs
+++ b/crates/stella-model/src/vertex.rs
@@ -19,7 +19,9 @@
 //!   location and `{location}-aiplatform.googleapis.com` for a pinned
 //!   region. The project/location pair comes from
 //!   [`crate::credential::VertexAddressing`] — this crate owns the variable
-//!   names and the `global` default, so any host can construct the adapter.
+//!   names and the `global` default, so any host can construct the adapter. A
+//!   host that resolved the pair through its own chain passes it in, which is
+//!   what lets two sessions in one process address two GCP projects.
 
 use std::time::Duration;
 

--- a/crates/stella-runtime/src/panel_host.rs
+++ b/crates/stella-runtime/src/panel_host.rs
@@ -380,8 +380,10 @@ mod tests {
     /// grandchild per tick forever.
     #[tokio::test]
     async fn a_panels_grandchild_does_not_outlive_its_tick() {
-        let dir = std::env::temp_dir().join(format!("stella-panel-reap-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("a scratch directory");
+        // `TempDir`, not a name under the process temp dir: the scan in
+        // `tests/no_ambient_reads.rs` reads this file too.
+        let scratch = tempfile::TempDir::new().expect("a scratch directory");
+        let dir = scratch.path();
 
         for (label, script, answers) in [
             ("timeout", "sleep 30 & echo $! > PIDFILE; sleep 30", false),
@@ -435,7 +437,6 @@ mod tests {
                 "{label}: the panel's backgrounded helper (pid {pid}) outlived its tick"
             );
         }
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A plugin that writes rubbish is named, not silently ignored.

--- a/crates/stella-runtime/src/parts.rs
+++ b/crates/stella-runtime/src/parts.rs
@@ -97,13 +97,14 @@ pub fn seed_calibration(
 
 /// Construct the provider adapter for these parts.
 ///
-/// The per-dialect match itself lives in `stella_model::factory`, which also
-/// enforces the catalog seed floor, so a phantom model slug is a named error
-/// before any wire call. What this adds is nothing —. The
-/// *synced-catalog* escalation and its suggestions stay in `stella-cli`,
-/// because that layer owns the on-disk catalog; a caller that wants the
-/// richer diagnostic runs its own validation first and then calls this. That
-/// split is why this function takes resolved parts and not a `Config`.
+/// The per-dialect match lives in `stella_model::factory`. It also enforces
+/// the catalog seed floor, so a phantom model slug is a named error before any
+/// wire call.
+///
+/// The *synced-catalog* escalation and its suggestions stay in `stella-cli`.
+/// That layer owns the on-disk catalog. A caller that wants the richer
+/// diagnostic runs its own validation first, then calls this. That split is
+/// why this function takes resolved parts and not a `Config`.
 pub fn build_provider(parts: &ProviderParts) -> Result<Box<dyn Provider>, RuntimeError> {
     stella_model::factory::build_provider(
         &parts.factory_spec(),

--- a/crates/stella-runtime/tests/no_ambient_reads.rs
+++ b/crates/stella-runtime/tests/no_ambient_reads.rs
@@ -26,6 +26,14 @@ const FORBIDDEN: &[&str] = &[
     "current_dir",
     "std::env::vars",
     "set_current_dir",
+    // Three more ways to reach the same process-global state through a
+    // different name: the temp directory (`TMPDIR`), the home directory
+    // (`HOME`), and the `dirs` crate, which reads both. A caller that needs a
+    // scratch or config path takes it as a `RuntimeSpec` field, and a test
+    // takes a `TempDir`.
+    "std::env::temp_dir",
+    "home_dir",
+    "dirs::",
 ];
 
 fn source_files(dir: &Path, out: &mut Vec<PathBuf>) {

--- a/crates/stella-runtime/tests/runtime_build.rs
+++ b/crates/stella-runtime/tests/runtime_build.rs
@@ -16,7 +16,7 @@ use stella_core::budget::{BudgetAxis, BudgetOutcome};
 use stella_protocol::{CompletionRequestRef, CompletionResult, Provider, ProviderError};
 use stella_runtime::{
     Notice, NoticeSubject, Persistence, ProviderParts, RuntimeBuilder, RuntimeError, RuntimeSpec,
-    budget_guard, open_store, seed_calibration,
+    budget_guard, build_provider, open_store, seed_calibration,
 };
 use tempfile::TempDir;
 
@@ -98,6 +98,43 @@ async fn a_file_is_not_a_workspace_root() {
     match error {
         RuntimeError::WorkspaceRoot(path) => assert_eq!(path, file),
         other => panic!("expected WorkspaceRoot, got {other:?}"),
+    }
+}
+
+/// Two sessions, two GCP projects, one process.
+///
+/// The project rides `ProviderParts::aux`, so each spec carries its own. Read
+/// from the process environment instead, it is one value for all of them. That
+/// read sits one call below the scan in `tests/no_ambient_reads.rs`.
+///
+/// The environment is still the fallback. A shell that exports a project makes
+/// this pass whatever the adapter does, so the guard below says when the test
+/// can tell. Which project each adapter *addresses* shows up only on the wire.
+/// That assertion sits beside the adapter, in `stella-model`'s
+/// `two_vertex_sessions_in_one_process_address_two_projects`.
+#[test]
+fn two_specs_can_name_two_vertex_projects_in_one_process() {
+    if std::env::var_os("VERTEX_PROJECT_ID").is_some()
+        || std::env::var_os("GOOGLE_CLOUD_PROJECT").is_some()
+    {
+        return;
+    }
+    let root = TempDir::new().expect("temp dir");
+
+    for tenant in ["tenant-a", "tenant-b"] {
+        let mut spec = spec_at(&root);
+        let mut aux = stella_model::AuxCredentials::new();
+        aux.insert("VERTEX_PROJECT_ID", tenant);
+        spec.provider.id = "vertex".to_string();
+        spec.provider.display_name = "Vertex AI".to_string();
+        spec.provider.dialect = stella_model::factory::Dialect::Vertex;
+        spec.provider.seeded = true;
+        spec.provider.model_id = "gemini-3-pro".to_string();
+        spec.provider.aux = aux;
+
+        let provider = build_provider(&spec.provider)
+            .unwrap_or_else(|e| panic!("{tenant} must assemble from its own spec: {e}"));
+        assert_eq!(provider.id(), "vertex");
     }
 }
 

--- a/website/content/docs/configuration/credentials.mdx
+++ b/website/content/docs/configuration/credentials.mdx
@@ -142,7 +142,8 @@ and which `.env*` files loaded.
 
 ## Cloud provider credentials
 
-Some providers need more than one key. They read the extra values from the environment:
+Some providers need more than one value. The extra values go through the same chain the key
+does:
 
 <CardGrid size="md">
   <SpecCard
@@ -153,9 +154,9 @@ Some providers need more than one key. They read the extra values from the envir
       { label: "Location", value: "VERTEX_LOCATION (default: global)" },
     ]}
   >
-    The access token goes through the normal credential chain. stella reads the project id
-    and location straight from the environment. A missing project id shows a clear error
-    instead of silently falling back to a default.
+    The access token goes through the normal credential chain. So do the project id and the
+    location. Export them, or store them with `stella auth set vertex`. A missing project id
+    shows a clear error instead of silently falling back to a default.
   </SpecCard>
   <SpecCard
     title="Amazon Bedrock"


### PR DESCRIPTION
## What and why

The Vertex arm of `stella_model::factory::build_provider` called
`VertexAddressing::resolve()`, which reads `VERTEX_PROJECT_ID` /
`GOOGLE_CLOUD_PROJECT` / `VERTEX_LOCATION` straight from the process
environment — one call below `stella-runtime`'s `tests/no_ambient_reads.rs`,
which only scans that crate's own `src/`. The environment is the same for every
session a host assembles in one process, so a multi-tenant host could not give
two sessions two GCP projects: both talked to whichever project the host
happened to have exported, in the wrong region and the wrong data residency,
silently.

- `VertexAddressing::resolve_with(aux)` (new) mirrors
  `BedrockCredentials::resolve_with` — the exemplar the issue names, and the
  sibling in the same file. Host-resolved values win; the environment stays the
  fallback for anything absent, so a library-style caller that builds straight
  off `factory::build_provider` behaves exactly as before.
- The project is **one field with two spellings**, so `resolve_with` decides it
  per field rather than per name. A name-by-name fallback would let an exported
  `VERTEX_PROJECT_ID` outrank a host-supplied `GOOGLE_CLOUD_PROJECT` by winning
  the name order, and the two sessions would share a project again.
  `PROJECT_ENV_NAMES` / `LOCATION_ENV_NAME` / `AUX_ENV_NAMES` are one list read
  in both places, with a test pinning that they agree.
- `stella-cli`'s `config::aux_credentials::provider_aux` walks its chain
  (handoff → environment → `credentials.toml`) for those names, and
  `settable_aux_fields` lets `stella auth set vertex` store the project and the
  location — neither is a secret, so both are typed in the clear. Without that
  second half the credentials-file leg of the chain would be unreachable.
- The related items the issue filed alongside: `no_ambient_reads.rs` gains
  `std::env::temp_dir`, `home_dir` and `dirs::` as needles, and
  `panel_host.rs`'s reaping test takes a `TempDir` rather than a name under the
  process temp directory, so the widened guard needs no exemption.

`CandidateFanouts::adopt` (the issue's third related item) is untouched and
filed separately — see the comment on this PR.

## Witness mechanism

**`stella-model`, `factory.rs`:
`two_vertex_sessions_in_one_process_address_two_projects`.** Which project an
adapter addresses is visible only on the wire, so each of two adapters — built
in one process from two `AuxCredentials` sets — is pointed at a wiremock server
answering one project-scoped path per tenant and nothing else. Neither tenant
id exists in the process environment, so on the old code
`VertexAddressing::resolve()` cannot produce either path: it either errors on a
missing project or addresses some other one, and both calls fail. The test
asserts each adapter got its own tenant's response body.

**`stella-runtime`, `runtime_build.rs`:
`two_specs_can_name_two_vertex_projects_in_one_process`.** Two `RuntimeSpec`s
with `Dialect::Vertex` and distinct `aux` project ids assemble through
`stella_runtime::build_provider`. On the old code the aux set is ignored and
`resolve()` fails with `VertexProjectMissing` in any environment with no Vertex
project — which is CI. Its doc comment says so, and it returns early when a
project variable *is* exported rather than claiming a witness it cannot deliver
there; the wire-level distinctness assertion is the `stella-model` one above.

**`credential/tests/secondary_credential.rs`:** three unit tests over
`resolve_with` — two aux sets resolving to two projects and two locations, the
either-spelling rule, and `AUX_ENV_NAMES` matching what resolution reads.

**`stella-cli`:**
`vertex_resolves_its_project_and_location_through_the_same_chain` (the
credentials-file leg with the environment cleared), and
`every_settable_field_is_a_name_the_chain_actually_reads` rewritten to ask
`provider_aux` itself rather than compare against a hand-copied name list.

## Exemplar

`BedrockCredentials::resolve_with` / `AUX_ENV_NAMES` in the same file — same
seam, same fallback posture, same public-const contract with the host.

## Definition of done

- [x] A host can give two sessions two different Vertex projects in one process.
- [x] Witness: two specs with distinct `aux` project ids in one process, and an
      assertion that the two providers address different projects (on the wire,
      in `stella-model`).
- [x] `no_ambient_reads.rs` covers three more constructors one call below, and
      names what each one reads.
- [ ] CI green for `stella-runtime` and `stella-model` (this run).

## Tests deleted

None.

Closes #5501

## Summary by Sourcery

Enable per-session Vertex project and location resolution while retaining environment-based fallback behavior.

New Features:
- Allow Vertex sessions to resolve project and location values from per-session auxiliary credentials, enabling multiple projects in one process.
- Support storing and resolving Vertex project and location settings through the CLI credentials chain.

Bug Fixes:
- Prevent process-global Vertex environment settings from causing multi-tenant sessions to use the wrong project or region.

Enhancements:
- Define shared Vertex addressing environment-name contracts and preserve environment variables as fallbacks for library callers.
- Strengthen ambient process-state checks and update temporary-directory test isolation.

Documentation:
- Document credential-chain support for Vertex project and location values, including storage through `stella auth set vertex`.

Tests:
- Add coverage proving separate Vertex sessions can address distinct projects and locations, including wire-level provider verification.
- Add tests covering project aliases, credential-chain consistency, and Vertex auxiliary-field resolution.