### PR TITLE
fix(stella-tui): spend width budgets in display columns, not chars

### DIFF
--- a/crates/stella-tui/src/deck/classify.rs
+++ b/crates/stella-tui/src/deck/classify.rs
@@ -388,17 +388,16 @@ pub(super) fn trace_of(ev: &AgentEvent) -> (TraceKind, String) {
     }
 }
 
-/// A one-line, length-capped snip of free text for a trace row.
+/// A one-line, column-capped snip of free text for a trace row.
+///
+/// The cap is display columns. Almost everything this snips is model output —
+/// assistant text, reasoning, an error message, a commit subject — so it is
+/// not ASCII by construction, and a `char` cap let a CJK message reach the
+/// trace row at twice the width the row budgets for it.
 pub(super) fn snip(text: &str) -> String {
     const MAX: usize = 80;
     let flat = text.replace(['\n', '\r'], " ");
-    let flat = flat.trim();
-    if flat.chars().count() <= MAX {
-        flat.to_string()
-    } else {
-        let head: String = flat.chars().take(MAX - 1).collect();
-        format!("{head}…")
-    }
+    crate::render::columns::head(flat.trim(), MAX)
 }
 
 /// One-line trace summary of a gate board — `4/5 green · failed: tests`.

--- a/crates/stella-tui/src/deck/tests.rs
+++ b/crates/stella-tui/src/deck/tests.rs
@@ -1212,3 +1212,24 @@ fn a_stale_park_stamp_cannot_resurrect_a_settled_park() {
         "and it is inert, because `live_park` gates on the pure fold"
     );
 }
+
+/// A trace snip is capped in display columns, not code points.
+///
+/// Almost everything `snip` cuts is model output, so it is not ASCII by
+/// construction; capped by `char` count, a CJK message reached the trace row
+/// at 160 columns against an 80-column cap. Measured with `unicode_width`
+/// directly rather than through the helper under test.
+#[test]
+fn a_wide_character_trace_snip_is_capped_in_columns() {
+    use unicode_width::UnicodeWidthStr;
+
+    let flat = super::classify::snip(&"重构鉴权模块".repeat(30));
+    assert!(
+        UnicodeWidthStr::width(flat.as_str()) <= 80,
+        "{flat:?} is wider than the 80-column cap"
+    );
+    assert!(flat.ends_with('…'), "a cut snip says it was cut: {flat:?}");
+
+    // A newline still flattens, and short ASCII passes through untouched.
+    assert_eq!(super::classify::snip("one\ntwo"), "one two");
+}

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -15,14 +15,13 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 
-use unicode_width::UnicodeWidthChar;
-
 use crate::cache_panel;
 use crate::composer::{ComposerLayout, PaletteState, layout as composer_layout, split_row_at};
 use crate::deck::{DeckTab, WorkspaceModel};
 use crate::deck_ui::composer_mode::ComposerMode;
 use crate::deck_ui::{DeckUi, InstalledMode, IssuesMode};
 use crate::panel_guard::{guarded_band, guarded_overlay};
+use crate::render::columns;
 use crate::render::{render_arg_popup, render_slash_popup, scroll_window_start, slash_popup_area};
 use crate::views::frame::{PROMPT_PREFIX, PROMPT_PREFIX_W};
 use crate::{notice, splash, theme};
@@ -506,7 +505,7 @@ fn render_inbox_overlay(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &m
             Span::raw(marker),
             Span::styled(dot, dot_style),
             Span::styled(
-                truncate_chars(&n.title, (w as usize).saturating_sub(10)),
+                columns::head(&n.title, (w as usize).saturating_sub(10)),
                 title_style,
             ),
         ];
@@ -523,12 +522,12 @@ fn render_inbox_overlay(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &m
         };
         let detail = format!(
             "      {}{} · {}",
-            truncate_chars(&n.body, (w as usize).saturating_sub(24)),
+            columns::head(&n.body, (w as usize).saturating_sub(24)),
             source,
             fmt_age(model.now_ms.saturating_sub(n.created_ms)),
         );
         lines.push(Line::from(Span::styled(
-            truncate_chars(&detail, (w as usize).saturating_sub(4)),
+            columns::head(&detail, (w as usize).saturating_sub(4)),
             theme::text_secondary(),
         )));
     }
@@ -579,7 +578,7 @@ fn render_context_overlay(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, b
         } else {
             ("○", theme::text_secondary())
         };
-        let desc = truncate_chars(&skill.description, (w as usize).saturating_sub(30));
+        let desc = columns::head(&skill.description, (w as usize).saturating_sub(30));
         lines.push(Line::from(vec![
             Span::raw("  "),
             Span::styled(glyph, glyph_style),
@@ -841,9 +840,9 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
                     call.turn_instance,
                     call.step,
                     call.call_seq,
-                    truncate_chars(&call.call_role, 14),
-                    truncate_chars(&call.provider, 10),
-                    truncate_chars(&call.model, 22),
+                    columns::head(&call.call_role, 14),
+                    columns::head(&call.provider, 10),
+                    columns::head(&call.model, 22),
                 ),
                 style,
             )));
@@ -915,37 +914,6 @@ fn wrap_chars(s: &str, width: usize) -> Vec<String> {
         .collect()
 }
 
-/// Display-width-safe prefix truncation with an ellipsis. `max_cols` is a
-/// terminal column budget, not a character count — a char-counting truncation
-/// would under-truncate double-width glyphs (CJK, emoji) by up to 2×,
-/// overflowing the caller's fixed-width row. Content here (session titles,
-/// notification bodies, skill descriptions) is agent- or user-authored text,
-/// not guaranteed ASCII.
-fn truncate_chars(s: &str, max_cols: usize) -> String {
-    if display_width(s) <= max_cols {
-        return s.to_string();
-    }
-    // Leave one column for the ellipsis glyph itself.
-    let budget = max_cols.saturating_sub(1);
-    let mut head = String::new();
-    let mut w = 0usize;
-    for ch in s.chars() {
-        let cw = ch.width().unwrap_or(0);
-        if w + cw > budget {
-            break;
-        }
-        head.push(ch);
-        w += cw;
-    }
-    format!("{head}…")
-}
-
-/// Terminal column width of `s` (unicode-width aware — CJK and most emoji are
-/// two columns wide, unlike a plain `chars().count()`).
-fn display_width(s: &str) -> usize {
-    s.chars().map(|c| c.width().unwrap_or(0)).sum()
-}
-
 /// A compact "3m ago"-style age from a millisecond delta.
 fn fmt_age(delta_ms: u64) -> String {
     let secs = delta_ms / 1000;
@@ -963,12 +931,13 @@ fn fmt_age(delta_ms: u64) -> String {
     format!("{}d ago", hours / 24)
 }
 
-/// The Graph tab's file picker: a centered overlay listing every indexed file,
-/// narrowed by a filter-as-you-type query, with the selection highlighted and
-/// windowed so it stays in view on long lists (the shared
-/// [`scroll_window_start`] the slash popup uses). Selecting a row re-roots the
-/// neighborhood on that file; the current focus opens pre-selected as the
-/// sensible default.
+/// The Graph tab's file picker. A centered overlay lists every indexed file.
+/// Typing narrows the list. The chosen row is lit, and the view scrolls to
+/// keep it in sight on long lists. That scroll is the shared
+/// [`scroll_window_start`], the one the slash popup uses.
+///
+/// Picking a row re-roots the neighborhood on that file. The file in focus
+/// opens picked, since that is the one you most likely want.
 fn render_graph_picker(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
     let Some(graph) = ui.graph.as_ref() else {
         return;

--- a/crates/stella-tui/src/deck_render/help.rs
+++ b/crates/stella-tui/src/deck_render/help.rs
@@ -33,7 +33,7 @@
 //! whichever pin is answering — so with the AGENTS tab's per-row model column
 //! gone, "which pin serves each role" is answered here or nowhere.
 
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::*;
 use crate::keymap::{self, Scope};

--- a/crates/stella-tui/src/diff.rs
+++ b/crates/stella-tui/src/diff.rs
@@ -28,6 +28,7 @@ use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use stella_diff::view;
 
+use crate::render::columns;
 use crate::syntax::{Lang, lang_from_path, tok_style, tokenize};
 use crate::theme;
 
@@ -75,8 +76,10 @@ pub fn count_diff_lines(diff: &str) -> (u32, u32) {
 /// the panel is narrower than the path.
 pub fn header_line(path: &str, width: usize) -> Line<'static> {
     let lead = "── ";
-    let path = elide_left(path, width.saturating_sub(lead.chars().count() + 4));
-    let used = lead.chars().count() + path.chars().count() + 1; // trailing space before the fill join
+    // Columns, not chars: a path is whatever the repository calls its files,
+    // and the fill that follows it has to know how much rule is left.
+    let path = columns::tail(path, width.saturating_sub(columns::width(lead) + 4));
+    let used = columns::width(lead) + columns::width(&path) + 1; // trailing space before the fill join
     Line::from(vec![
         Span::styled(lead.to_string(), theme::rule()),
         Span::styled(path, theme::heading()),
@@ -91,12 +94,12 @@ pub fn footer_line(added: u32, removed: u32, width: usize) -> Line<'static> {
     let add_txt = format!("+{added} {}", plural(added, "addition"));
     let sep = " · ";
     let rem_txt = format!("-{removed} {}", plural(removed, "removal"));
-    // trailing space before the fill join; `sep` is measured in chars (not
-    // `.len()` bytes) since it contains the multi-byte `·` glyph.
-    let used = lead.chars().count()
-        + add_txt.chars().count()
-        + sep.chars().count()
-        + rem_txt.chars().count()
+    // trailing space before the fill join; measured in columns (not `.len()`
+    // bytes) since `sep` carries the multi-byte `·` glyph.
+    let used = columns::width(lead)
+        + columns::width(&add_txt)
+        + columns::width(sep)
+        + columns::width(&rem_txt)
         + 1;
     Line::from(vec![
         Span::styled(lead.to_string(), theme::rule()),
@@ -712,23 +715,6 @@ fn rule_fill(used: usize, width: usize) -> String {
     "─".repeat(width.saturating_sub(used))
 }
 
-/// Left-elide `text` to at most `max` chars, keeping the tail (the meaningful
-/// end of a path) and marking the cut with `…`.
-fn elide_left(text: &str, max: usize) -> String {
-    if max == 0 {
-        return String::new();
-    }
-    let chars: Vec<char> = text.chars().collect();
-    if chars.len() <= max {
-        return text.to_string();
-    }
-    if max == 1 {
-        return "…".to_string();
-    }
-    let tail: String = chars[chars.len() - (max - 1)..].iter().collect();
-    format!("…{tail}")
-}
-
 // ── Diff-header language inference ──────────────────────────────────────────
 //
 // The lexer itself lives in [`crate::syntax`], shared with the markdown
@@ -797,6 +783,24 @@ mod tests {
         let text = line_text(&header_line("a/very/long/path/that/wont/fit.rs", 24));
         assert!(text.contains('…'), "{text}");
         assert!(text.contains("fit.rs"), "the tail survives: {text}");
+    }
+
+    /// A wide-character path must not push the rule past the panel edge.
+    ///
+    /// The lead, the path and the fill were counted in `char`s, so a CJK path
+    /// was measured at half the width it draws and the rule ran over the pane
+    /// it was given. `Line::width` is ratatui's measurement, not the helper
+    /// under test.
+    #[test]
+    fn a_wide_character_path_keeps_the_rule_inside_the_panel() {
+        let width = 60;
+        let line = header_line("源码/驱动器/上下文回忆表格渲染实现.rs", width);
+        assert_eq!(
+            line.width(),
+            width,
+            "the rule should reach the panel's right edge and stop: {}",
+            line_text(&line)
+        );
     }
 
     #[test]
@@ -1073,11 +1077,11 @@ mod tests {
     }
 
     #[test]
-    fn header_uses_char_count_not_byte_length_for_the_lead_when_eliding() {
-        // 70 chars: longer than the old byte-length-based cap (80 - 7 - 4 =
+    fn header_measures_the_lead_in_columns_not_bytes() {
+        // 70 columns: longer than the old byte-length-based cap (80 - 7 - 4 =
         // 69, since "── " is 7 bytes) but shorter than the correct
-        // char-count-based cap (80 - 3 - 4 = 73). Only survives un-elided
-        // once the lead is measured in chars, not bytes.
+        // column-based cap (80 - 3 - 4 = 73). Only survives un-elided once the
+        // lead is measured in columns, not bytes.
         let path = "a".repeat(70);
         let text = line_text(&header_line(&path, 80));
         assert!(!text.contains('…'), "path elided too early: {text}");

--- a/crates/stella-tui/src/fleet_dashboard.rs
+++ b/crates/stella-tui/src/fleet_dashboard.rs
@@ -1336,18 +1336,13 @@ fn first_line(text: &str) -> String {
         .to_string()
 }
 
-/// Truncate to `max` chars with a trailing ellipsis, never splitting a
-/// codepoint.
+/// Cut to `max` display columns, with a trailing `…`.
+///
+/// Columns, not `char`s. Every budget here is a table cell or a pane width.
+/// The text is a task title, a path, or a line of tool output. None of those
+/// is ASCII by rule. A `char` budget let any of them overrun its cell.
 fn truncate(s: &str, max: usize) -> String {
-    if max == 0 {
-        return String::new();
-    }
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let head: String = s.chars().take(max.saturating_sub(1)).collect();
-        format!("{head}…")
-    }
+    crate::render::columns::head(s, max)
 }
 
 #[cfg(test)]

--- a/crates/stella-tui/src/fleet_dashboard/tests.rs
+++ b/crates/stella-tui/src/fleet_dashboard/tests.rs
@@ -577,3 +577,24 @@ fn the_header_row_carries_the_wordmark_on_its_right_edge() {
         "the wordmark holds the upper right (SPEC 3.3):\n{frame}"
     );
 }
+
+/// A wide title must not overrun the cell it was cut to fit.
+///
+/// Every budget here is a column count. It is a table column, or the pane's
+/// own width. Spent in `char`s, a CJK title draws twice as wide as its cell
+/// and pushes the rest of the row aside. The width here is `unicode_width`'s
+/// own, not the helper under test.
+#[test]
+fn a_wide_character_title_fits_the_column_it_is_cut_to() {
+    use unicode_width::UnicodeWidthStr;
+
+    let title = "重构鉴权模块并补上失败的见证测试";
+    for max in [1usize, 8, 22, 48] {
+        let cut = truncate(title, max);
+        assert!(
+            UnicodeWidthStr::width(cut.as_str()) <= max,
+            "{cut:?} is wider than its {max}-column cell"
+        );
+    }
+    assert_eq!(truncate(title, 0), "", "a zero-column cell draws nothing");
+}

--- a/crates/stella-tui/src/render.rs
+++ b/crates/stella-tui/src/render.rs
@@ -26,6 +26,12 @@ use crate::composer::SlashMenu;
 use crate::model::{AskUserPrompt, FileState, InlineDiffRef};
 
 mod entry;
+// The crate's display-column vocabulary, beside `row` because it is the same
+// vocabulary for plain strings that `row` already speaks for styled spans.
+// `pub(crate)` because the surfaces that lay out fixed columns — the settings
+// panels, the deck overlays, the diff rules, the fleet table — live outside
+// `render`, and each had grown a private copy of it.
+pub(crate) mod columns;
 // `pub(crate)` for `wrap_one_indent` alone: the startup-notice dialog
 // (`crate::notice`) wraps its detail clauses with the same hanging indent the
 // transcript uses, rather than growing a second wrapper beside it.
@@ -456,15 +462,16 @@ pub(crate) fn render_slash_popup(
             for (hot, run) in highlight_runs(&name, &m.highlights) {
                 spans.push(Span::styled(run, if hot { lit } else { gold }));
             }
-            let pad = 16usize.saturating_sub(name.chars().count());
+            // Columns here, to match the `Span::width` below. A workspace
+            // names its own commands. A live value can be a model slug.
+            let pad = 16usize.saturating_sub(columns::width(&name));
             spans.push(Span::styled(" ".repeat(pad), gold));
             spans.push(Span::styled(format!(" {description}"), dim));
             if let Some(value) = live_value {
                 let used: usize = spans.iter().map(Span::width).sum();
-                if used + value.chars().count() + 1 < inner_w {
-                    spans.push(Span::raw(
-                        " ".repeat(inner_w - used - value.chars().count() - 1),
-                    ));
+                let value_w = columns::width(&value);
+                if used + value_w + 1 < inner_w {
+                    spans.push(Span::raw(" ".repeat(inner_w - used - value_w - 1)));
                     spans.push(Span::styled(value, muted));
                 }
             }

--- a/crates/stella-tui/src/render/columns.rs
+++ b/crates/stella-tui/src/render/columns.rs
@@ -111,7 +111,7 @@ mod tests {
     fn head_spends_its_budget_in_columns() {
         // Eight columns of CJK cut to five. Two glyphs fit, plus the `…`.
         // A char count would keep four glyphs and draw nine columns.
-        assert_eq!(head("符号符号", 5), "符符…");
+        assert_eq!(head("符号符号", 5), "符号…");
         assert_eq!(width(&head("符号符号", 5)), 5);
         assert_eq!(head("符号", 4), "符号");
         assert_eq!(head("abcdef", 4), "abc…");

--- a/crates/stella-tui/src/render/columns.rs
+++ b/crates/stella-tui/src/render/columns.rs
@@ -1,0 +1,160 @@
+//! Widths here are counted in **terminal columns**.
+//!
+//! A terminal draws text in columns. `str::chars().count()` counts code
+//! points. The two agree for ASCII. They do not agree for CJK text or for most
+//! emoji, which draw two columns wide.
+//!
+//! So a budget read off a [`Rect`] and then spent in `char`s fits every ASCII
+//! test. It fails on the first real name, path or prompt. It can be off by
+//! half. That is enough to shove the next cell off the row.
+//!
+//! [`super::row`] already counts columns for styled spans. This is the same
+//! job for plain strings. Three copies of the cut grew here before it existed.
+//! Two of them counted chars.
+//!
+//! [`Rect`]: ratatui::layout::Rect
+
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Columns `text` occupies on a terminal.
+pub(crate) fn width(text: &str) -> usize {
+    UnicodeWidthStr::width(text)
+}
+
+/// The start of `text`, in at most `cols` columns. Ends in `…` when it was
+/// cut.
+///
+/// The `…` takes one column. So the kept text gets `cols - 1`. A cut can land
+/// inside a wide glyph. Then the glyph is dropped and the result is one column
+/// short. Short is safe. Long would shove the next cell aside.
+///
+/// A budget of zero draws nothing. Even a lone `…` is one column too many.
+pub(crate) fn head(text: &str, cols: usize) -> String {
+    if width(text) <= cols {
+        return text.to_string();
+    }
+    if cols == 0 {
+        return String::new();
+    }
+    format!("{}…", take_left(text, cols - 1))
+}
+
+/// The end of `text`, in at most `cols` columns. Opens with `…` when the
+/// start was cut.
+///
+/// This is what a live edit buffer needs. The caret sits at the end, and that
+/// is the part the typist is watching.
+pub(crate) fn tail(text: &str, cols: usize) -> String {
+    if width(text) <= cols {
+        return text.to_string();
+    }
+    if cols == 0 {
+        return String::new();
+    }
+    format!("…{}", take_right(text, cols - 1))
+}
+
+/// `text` padded with spaces out to `cols` columns. Text that already fills
+/// them is left alone.
+///
+/// Rust's own `{:<width$}` pads to a **`char`** count. A fixed column laid out
+/// that way still shifts under wide text, even after a correct cut.
+pub(crate) fn pad(text: &str, cols: usize) -> String {
+    let used = width(text);
+    format!("{text}{}", " ".repeat(cols.saturating_sub(used)))
+}
+
+/// The longest prefix of `text` that fits in `cols` display columns.
+pub(crate) fn take_left(text: &str, cols: usize) -> String {
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > cols {
+            break;
+        }
+        used += w;
+        out.push(ch);
+    }
+    out
+}
+
+/// The longest suffix of `text` that fits in `cols` display columns.
+pub(crate) fn take_right(text: &str, cols: usize) -> String {
+    let mut kept: Vec<char> = Vec::new();
+    let mut used = 0usize;
+    for ch in text.chars().rev() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > cols {
+            break;
+        }
+        used += w;
+        kept.push(ch);
+    }
+    kept.iter().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One CJK glyph is one char and two columns. That gap is the whole
+    /// point of this file.
+    #[test]
+    fn a_wide_glyph_is_two_columns_and_one_char() {
+        assert_eq!(width("abc"), 3);
+        assert_eq!("符号".chars().count(), 2);
+        assert_eq!(width("符号"), 4);
+    }
+
+    #[test]
+    fn head_spends_its_budget_in_columns() {
+        // Eight columns of CJK cut to five. Two glyphs fit, plus the `…`.
+        // A char count would keep four glyphs and draw nine columns.
+        assert_eq!(head("符号符号", 5), "符符…");
+        assert_eq!(width(&head("符号符号", 5)), 5);
+        assert_eq!(head("符号", 4), "符号");
+        assert_eq!(head("abcdef", 4), "abc…");
+        assert_eq!(head("abc", 9), "abc");
+    }
+
+    /// A cut inside a wide glyph lands under budget, never over it.
+    #[test]
+    fn head_under_runs_rather_than_over_runs_an_odd_budget() {
+        let cut = head("符号符号", 4);
+        assert_eq!(cut, "符…");
+        assert_eq!(width(&cut), 3);
+    }
+
+    #[test]
+    fn tail_keeps_the_end_and_spends_columns() {
+        assert_eq!(tail("符号符号", 5), "…符号");
+        assert_eq!(width(&tail("符号符号", 5)), 5);
+        assert_eq!(tail("abcdef", 4), "…def");
+        assert_eq!(tail("abc", 9), "abc");
+    }
+
+    /// A `…` is one column. A budget of zero cannot pay for it.
+    #[test]
+    fn a_zero_budget_draws_nothing() {
+        assert_eq!(head("符号", 0), "");
+        assert_eq!(tail("符号", 0), "");
+        assert_eq!(head("", 0), "");
+    }
+
+    #[test]
+    fn pad_fills_to_columns_not_to_chars() {
+        assert_eq!(width(&pad("符号", 6)), 6);
+        assert_eq!(pad("符号", 6), "符号  ");
+        assert_eq!(pad("abc", 5), "abc  ");
+        assert_eq!(pad("abcdef", 3), "abcdef");
+    }
+
+    #[test]
+    fn take_left_and_take_right_never_split_a_glyph() {
+        assert_eq!(take_left("符号符", 3), "符");
+        assert_eq!(take_right("符号符", 3), "符");
+        assert_eq!(take_left("符号符", 4), "符号");
+        assert_eq!(take_right("符号符", 4), "号符");
+    }
+}

--- a/crates/stella-tui/src/views/engine_panel/paint.rs
+++ b/crates/stella-tui/src/views/engine_panel/paint.rs
@@ -25,6 +25,7 @@ use super::tabs::{EngineTab, GLOBAL_ROWS, GlobalRow};
 use super::{AgentField, EngineOverlay, NO_SNAPSHOT_HINT, picker_matches};
 use crate::deck_ui::DeckUi;
 use crate::envelope::{EngineConfigState, EngineRole};
+use crate::render::columns;
 use crate::render::scroll_window_start;
 
 /// Label column width — fits the longest key (`repetition_penalty`, 18).
@@ -159,16 +160,17 @@ fn row(
 
     if let Some(edit) = e.edit.as_ref().filter(|edit| edit.row == i) {
         // The live buffer, tail-windowed so the caret end stays visible on
-        // long values (a prompt), with the gold caret the composer uses.
+        // long values (a prompt), with the gold caret the composer uses. One
+        // column is held back for that caret.
         spans.push(Span::styled(
-            tail_chars(&edit.buffer, value_w.saturating_sub(1)),
+            columns::tail(&edit.buffer, value_w.saturating_sub(1)),
             Style::new().fg(token::TEXT),
         ));
         spans.push(Span::styled("▏", Style::new().fg(token::GOLD)));
     } else {
         match value {
             Some(v) => spans.push(Span::styled(
-                truncate_chars(&v, value_w),
+                columns::head(&v, value_w),
                 Style::new().fg(token::TEXT),
             )),
             None => spans.push(Span::styled(
@@ -300,7 +302,7 @@ fn render_model_picker(e: &EngineOverlay, area: Rect, buf: &mut Buffer) {
                 Style::new().fg(token::GOLD),
             ),
             Span::styled(
-                truncate_chars(slug, (w as usize).saturating_sub(6)),
+                columns::head(slug, (w as usize).saturating_sub(6)),
                 Style::new().fg(token::TEXT),
             ),
         ];
@@ -341,34 +343,10 @@ fn render_model_picker(e: &EngineOverlay, area: Rect, buf: &mut Buffer) {
     Paragraph::new(lines).block(block).render(popup, buf);
 }
 
-/// Char-safe prefix truncation with an ellipsis (long prompts, long model
-/// lists must never wrap the row).
-fn truncate_chars(s: &str, max_chars: usize) -> String {
-    if s.chars().count() <= max_chars {
-        return s.to_string();
-    }
-    let head: String = s.chars().take(max_chars.saturating_sub(1)).collect();
-    format!("{head}…")
-}
-
-/// The last `max_chars` of a buffer (edit rendering keeps the caret end in
-/// view), with a leading ellipsis when the head is cut.
-fn tail_chars(s: &str, max_chars: usize) -> String {
-    let count = s.chars().count();
-    if count <= max_chars {
-        return s.to_string();
-    }
-    let tail: String = s
-        .chars()
-        .skip(count - max_chars.saturating_sub(1))
-        .collect();
-    format!("…{tail}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::fixtures::open_ui;
-    use super::super::{EngineTab, ModelPicker};
+    use super::super::{EngineEdit, EngineTab, ModelPicker};
     use super::*;
 
     fn text(buf: &Buffer) -> String {
@@ -454,5 +432,62 @@ mod tests {
         let dirty = text(&buf);
         let strip = dirty.lines().next().unwrap_or_default();
         assert!(strip.trim_end().ends_with("modified"), "{strip:?}");
+    }
+
+    /// A wide-character value must stay inside the row it is drawn on.
+    ///
+    /// The value field is budgeted in display columns and was spent in
+    /// `char`s, so a CJK prompt composed a row twice the width of the pane.
+    /// The row is measured before it is drawn, because the buffer clips at its
+    /// own edge and so reports every overrun as a row that exactly fits — the
+    /// oracle would agree with the bug. `Line::width` is ratatui's own
+    /// measurement, not the helper under test.
+    #[test]
+    fn a_wide_character_value_stays_inside_the_row() {
+        let (_model, mut ui) = open_ui();
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        let prompt = "回忆一个符号并计算其令牌成本以便对齐列宽".repeat(4);
+        ui.engine.state.as_mut().unwrap().agents[0].prompt = Some(prompt);
+
+        // The prompt row of the agent page.
+        let i = AgentField::ALL
+            .iter()
+            .position(|f| *f == AgentField::Prompt)
+            .unwrap();
+        let width = 80usize;
+        let e = &ui.engine;
+        let state = e.state.as_ref().unwrap();
+        let line = row(e, state, i, false, width);
+        assert!(
+            line.width() <= width,
+            "the row is {} columns wide in an {width}-column pane: {:?}",
+            line.width(),
+            line
+        );
+    }
+
+    /// A wide-character edit buffer must not push the caret off the row.
+    ///
+    /// The tail window is budgeted one column short of the field so the caret
+    /// fits after it. Spent in `char`s, a CJK buffer filled the field twice
+    /// over and the caret clipped at the pane edge — it did not draw at all.
+    #[test]
+    fn a_wide_character_edit_keeps_the_caret_on_the_row() {
+        let (_model, mut ui) = open_ui();
+        ui.engine.tab = EngineTab::Agent(EngineRole::Default);
+        ui.engine.row = 0;
+        ui.engine.edit = Some(EngineEdit {
+            row: 0,
+            buffer: "回忆一个符号并计算其令牌成本以便对齐列宽".repeat(4),
+        });
+
+        let area = Rect::new(0, 0, 80, 30);
+        let mut buf = Buffer::empty(area);
+        render(&ui, area, &mut buf);
+        let frame = text(&buf);
+        assert!(
+            frame.contains('▏'),
+            "the caret was pushed off the row:\n{frame}"
+        );
     }
 }

--- a/crates/stella-tui/src/views/tools.rs
+++ b/crates/stella-tui/src/views/tools.rs
@@ -69,6 +69,7 @@ use stella_tui_theme::{glyph, token};
 use crate::deck::DeckTab;
 use crate::deck_ui::{DeckAction, DeckUi, list_nav};
 use crate::envelope::{AgentScope, ToolPolicyState, ToolRow, ToolScope, WorkspaceInput};
+use crate::render::columns;
 use crate::render::scroll_window_start;
 use crate::theme;
 use crate::views::settings::SettingsPane;
@@ -588,7 +589,10 @@ fn render_row(
             let mut spans = vec![
                 caret,
                 Span::styled(
-                    format!("{:<width$}", group.to_uppercase(), width = NAME_W),
+                    // Padded in columns: an MCP server names its own group,
+                    // and `{:<width$}` pads to a `char` count, which moves the
+                    // state column under any wide glyph.
+                    columns::pad(&group.to_uppercase(), NAME_W),
                     Style::new().fg(token::TEXT).add_modifier(Modifier::BOLD),
                 ),
                 state_span(on),
@@ -606,12 +610,14 @@ fn render_row(
             let mut spans = vec![
                 caret,
                 Span::styled(
-                    // Truncated one char shorter than the column so a long
-                    // namespaced MCP name always keeps a gap before its state.
+                    // Elided one column shorter than the field so a long
+                    // namespaced MCP name always keeps a gap before its state,
+                    // then padded back out to the field so the state column
+                    // holds. Elide and pad are both in display columns: an MCP
+                    // name is whatever the server calls itself.
                     format!(
-                        "  {:<width$}",
-                        truncate_chars(&tool.name, NAME_W - 3),
-                        width = NAME_W - 2
+                        "  {}",
+                        columns::pad(&columns::head(&tool.name, NAME_W - 3), NAME_W - 2)
                     ),
                     Style::new().fg(token::SILVER),
                 ),
@@ -627,7 +633,7 @@ fn render_row(
             if let Some(tail) = tail {
                 let room = panel_w.saturating_sub(3 + 2 + NAME_W + 5 + 1).max(8);
                 spans.push(Span::styled(
-                    truncate_chars(&tail, room),
+                    columns::head(&tail, room),
                     Style::new().fg(token::DIM),
                 ));
             }
@@ -724,16 +730,6 @@ fn row_record(
             )
         }
     }
-}
-
-/// Char-safe prefix truncation with an ellipsis — a namespaced MCP tool name
-/// must never wrap the row.
-fn truncate_chars(s: &str, max_chars: usize) -> String {
-    if s.chars().count() <= max_chars {
-        return s.to_string();
-    }
-    let head: String = s.chars().take(max_chars.saturating_sub(1)).collect();
-    format!("{head}…")
 }
 
 #[cfg(test)]
@@ -1176,6 +1172,40 @@ mod tests {
         );
         assert!(text.contains("locked"), "an org-denied row says so");
         assert!(text.contains("org-locked"), "the header counts locked rows");
+    }
+
+    /// The state column holds under a wide-character tool name.
+    ///
+    /// An MCP server names its own tools, so the name is not ASCII by
+    /// construction. The field was elided by `char` count and padded by
+    /// `{:<width$}`, which is also a `char` count — so a CJK name rendered at
+    /// twice its budget and pushed `on`/`off` and everything after it right,
+    /// on that row alone. Measured with ratatui's own `Span::width`, not with
+    /// the helper under test.
+    #[test]
+    fn a_wide_character_tool_name_does_not_move_the_state_column() {
+        let (_model, ui) = open_ui();
+        let mut state = sample_state();
+        state
+            .tools
+            .push(tool("mcp__仓库__创建议题并附上一段很长的说明", "mcp"));
+        let ascii = state
+            .tools
+            .iter()
+            .position(|t| t.name == "mcp__gh__create_issue")
+            .unwrap();
+        let wide = state.tools.len() - 1;
+
+        // The caret and the name field are what precede the state cell.
+        let field = |i: usize| -> usize {
+            let line = render_row(&ui.tools, &state, &ToolsRow::Tool(i), false, 96);
+            line.spans[..2].iter().map(Span::width).sum()
+        };
+        assert_eq!(
+            field(ascii),
+            field(wide),
+            "a wide name moved the state column"
+        );
     }
 
     /// **The witness for the port.** The pane fills the body the frame carved

--- a/crates/stella-tui/src/views/traces.rs
+++ b/crates/stella-tui/src/views/traces.rs
@@ -39,6 +39,7 @@ use stella_tui_theme::token;
 
 use crate::deck::{TraceRow, WorkspaceModel};
 use crate::deck_ui::DeckUi;
+use crate::render::columns;
 use crate::theme;
 
 /// Columns of air down the left edge, shared by the header and every row so
@@ -169,14 +170,16 @@ fn header_line(
 fn row_line(row: &TraceRow, now_ms: u64, width: usize) -> Line<'static> {
     let mmss = format_mmss(now_ms.saturating_sub(row.ts));
     let kind_chip = format!("[{}]", row.kind.label());
+    // Columns throughout: the summary is model text, and the agent name is a
+    // sub-agent's, so neither is ASCII by construction.
     let prefix_width = GUTTER_W
-        + mmss.chars().count()
+        + columns::width(&mmss)
         + 2
-        + row.agent.chars().count()
+        + columns::width(&row.agent)
         + 2
-        + kind_chip.chars().count()
+        + columns::width(&kind_chip)
         + 1;
-    let summary = truncate_to_width(&row.summary, width.saturating_sub(prefix_width));
+    let summary = columns::head(&row.summary, width.saturating_sub(prefix_width));
 
     Line::from(vec![
         Span::raw(" ".repeat(GUTTER_W)),
@@ -228,23 +231,6 @@ fn row_record(row: &TraceRow, now_ms: u64, width: usize) -> Line<'static> {
 fn format_mmss(elapsed_ms: u64) -> String {
     let total_secs = elapsed_ms / 1000;
     format!("{:02}:{:02}", total_secs / 60, total_secs % 60)
-}
-
-/// Truncate to at most `width` chars, adding an ellipsis when clipped. Robust
-/// to `width == 0` (empty string) — never panics on a too-narrow terminal.
-fn truncate_to_width(text: &str, width: usize) -> String {
-    let count = text.chars().count();
-    if count <= width {
-        return text.to_string();
-    }
-    if width == 0 {
-        return String::new();
-    }
-    if width == 1 {
-        return "…".to_string();
-    }
-    let head: String = text.chars().take(width - 1).collect();
-    format!("{head}…")
 }
 
 /// Centered muted hint shown when the (possibly filtered) timeline is empty.
@@ -445,9 +431,47 @@ mod tests {
     }
 
     #[test]
-    fn truncate_to_width_adds_an_ellipsis_only_when_clipped() {
-        assert_eq!(truncate_to_width("short", 10), "short");
-        assert_eq!(truncate_to_width("a very long summary line", 8), "a very …");
-        assert_eq!(truncate_to_width("anything", 0), "");
+    fn a_row_summary_gets_an_ellipsis_only_when_it_is_clipped() {
+        let row = |summary: &str| TraceRow {
+            ts: 0,
+            agent: "a".into(),
+            kind: crate::deck::TraceKind::Text,
+            summary: summary.into(),
+        };
+        assert!(!line_text(&row_line(&row("short"), 0, 60)).contains('…'));
+        assert!(
+            line_text(&row_line(&row(&"long ".repeat(40)), 0, 60)).contains('…'),
+            "a summary wider than the pane is clipped"
+        );
+    }
+
+    /// A wide-character summary must not push the row past the pane.
+    ///
+    /// The summary is model text and the budget it is cut to is the pane's own
+    /// width. Spent in `char`s, a CJK summary composed a row twice that wide —
+    /// which the transcript's line-exact scroll math (L-T4) assumes cannot
+    /// happen. `Line::width` is ratatui's measurement, not the helper under
+    /// test.
+    #[test]
+    fn a_wide_character_summary_stays_inside_the_pane() {
+        let width = 60;
+        let row = TraceRow {
+            ts: 0,
+            agent: "a".into(),
+            kind: crate::deck::TraceKind::Text,
+            summary: "重构鉴权模块并补上失败的见证测试".repeat(4),
+        };
+        let line = row_line(&row, 0, width);
+        assert!(
+            line.width() <= width,
+            "the row is {} columns wide in a {width}-column pane: {}",
+            line.width(),
+            line_text(&line)
+        );
+    }
+
+    /// Flatten one styled line back to its text.
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.clone()).collect()
     }
 }


### PR DESCRIPTION
## What

`crates/stella-tui` measured text in two units and mixed them. A terminal
draws in **display columns**; `str::chars().count()` counts **code points**.
The two agree for ASCII and disagree for CJK text and most emoji, which draw
two columns wide. A budget read off a `Rect` and then spent in `char`s
therefore fits every ASCII fixture in the suite and overruns the first time
real text arrives — by up to half, which is enough to shove the next cell off
the row. Much of the text on these surfaces is model- or user-authored:
prompts, MCP tool names, commit subjects, file paths.

## Why this shape

One module, `crates/stella-tui/src/render/columns.rs` — `width`, `head`
(prefix elide), `tail` (suffix elide), `pad`, `take_left`, `take_right`. It
sits beside `render/row.rs`, which the issue names as the crate's existing
column vocabulary for *styled spans* (`truncate_spans`, `justify`); this is
the same vocabulary for plain strings, so a surface laying out `String`s does
not have to grow a second one. Three private copies of the elide had already
appeared before it existed, and two of them counted chars.

Exemplar: `render/entry/recall.rs`'s `elide`/`take_left`/`take_right`, the
column-correct pair #2593 introduced for the recall table. `columns::head`
and `columns::tail` are those, generalised and shared. Folding `recall.rs`'s
own copies into the module is left to the follow-up issue, because its `cell`
(elide **then** pad) is the table's own contract and moving it would move a
golden.

Repointed at the new module:

| Site | Was |
|---|---|
| `views/engine_panel/paint.rs` (the moved `views/engine.rs`) | `truncate_chars` + `tail_chars`, both in chars |
| `views/tools.rs` | `truncate_chars` in chars, **and** a `{:<width$}` pad |
| `deck_render.rs` | its own column-correct copy + `display_width` |
| `deck/classify.rs` (`snip`) | 80-char cap on model text |
| `views/traces.rs` (`row_line`, `truncate_to_width`) | chars, named for width |
| `fleet_dashboard.rs` (`truncate`) | chars, against table cells and `area.width` |
| `diff.rs` (`header_line`, `footer_line`, `elide_left`) | chars, against the rule fill |
| `render.rs` (slash palette) | chars, against a `Span::width` fill |

`views/tools.rs` needed both halves: Rust's `{:<width$}` pads to a **char**
count, so a column-correct cut alone would have moved the state column
instead of holding it. `columns::pad` is why that row still lines up.

`progress.rs`, `model.rs` and `statline.rs` carry no `chars().count()` at
all any more, as the triage note on the issue says; the list is annotated,
not shortened.

**No golden frame moves.** Every conversion is byte-identical for ASCII
input: `width == chars().count()` there, and `pad` fills the same spaces
`{:<width$}` did. The one deliberate behaviour change is at a **zero**-column
budget, where the old copies returned a lone `…` — one column more than the
caller said it had — and `columns::head` now returns nothing.

## Witness mechanism

Each witness fails on the old code by construction: it feeds a CJK string
whose column width is twice its char count into a budget the old arithmetic
could not see, and measures the result with an oracle the implementation does
not share (`unicode_width::UnicodeWidthStr`, or ratatui's own `Line::width` /
`Span::width`) — importing the helper under test would make the test agree
with the bug.

- `views/engine_panel/paint.rs::a_wide_character_edit_keeps_the_caret_on_the_row`
  — the edit tail is budgeted one column short of the field so the caret fits
  after it. Spent in chars, a CJK buffer fills 114 columns of a 58-column
  field, so the caret lands at column 136 of an 80-column pane and is clipped
  away entirely. The assertion is that `▏` is on the screen at all.
- `..::a_wide_character_value_stays_inside_the_row` — the composed `Line` is
  measured *before* it is drawn, because the buffer clips at its own edge and
  so reports every overrun as a row that exactly fits. Old: 138 columns in an
  80-column pane.
- `views/tools.rs::a_wide_character_tool_name_does_not_move_the_state_column`
  — the caret plus name field is 24 columns for an ASCII name and 47 for a
  CJK one under the old cut-and-pad, so `on`/`off` and everything after it
  moved on that row alone.
- `diff.rs::a_wide_character_path_keeps_the_rule_inside_the_panel` — a CJK
  path measured at half its drawn width let the fill run the rule to 76
  columns of a 60-column panel.
- `views/traces.rs::a_wide_character_summary_stays_inside_the_pane` — the
  same, for the row the transcript's line-exact scroll math (L-T4) assumes
  cannot wrap.
- `fleet_dashboard/tests.rs::a_wide_character_title_fits_the_column_it_is_cut_to`
  and `deck/tests.rs::a_wide_character_trace_snip_is_capped_in_columns` —
  direct on the helpers, across several budgets including 0 and 1.
- `render/columns.rs`'s own unit tests pin the arithmetic: the two-columns-
  one-char premise, the under-run on a cut that lands mid-glyph, and the
  zero budget.

## Tests deleted

`views/traces.rs::truncate_to_width_adds_an_ellipsis_only_when_clipped` —
its subject, the private `truncate_to_width`, is gone. Replaced by
`a_row_summary_gets_an_ellipsis_only_when_it_is_clipped`, which asserts the
same two facts one level up, through `row_line`.

`diff.rs::header_uses_char_count_not_byte_length_for_the_lead_when_eliding`
is **renamed** to `header_measures_the_lead_in_columns_not_bytes`. Same body,
same 70-column fixture; the old name states a rule this PR replaces.

## Prose

`deck_render.rs`'s `render_graph_picker` doc comment was split into short
sentences — deleting the char-counting elide's own doc raised the file's mean
reading grade past its ratchet, and that paragraph was the file's hardest.

## Residue

- #5761 — the sites outside this issue's list that share the shape
  (`views/skills.rs`, `views/graph_tab.rs`, `views/seats.rs`,
  `views/record.rs`, `views/start_work.rs`, `views/approval.rs`,
  `views/queue.rs`, `views/files_tab.rs`, `composer.rs`,
  `model/summarize.rs`, `transcript_build.rs`), plus folding
  `render/entry/recall.rs`'s and `views/files_tab.rs`'s private copies into
  `render::columns`.

Closes #2598

## Summary by Sourcery

Use terminal display columns consistently when laying out and truncating TUI text so wide Unicode content remains within its allocated space.

New Features:
- Add shared Unicode-aware string column utilities for measuring, truncating, suffix-eliding, padding, and taking text without exceeding terminal display-width budgets.

Bug Fixes:
- Prevent wide characters in prompts, tool names, paths, trace summaries, dashboard titles, and other TUI content from overflowing rows, cells, panels, or rule fills.
- Keep fixed-position state columns and edit carets aligned when rendered text contains CJK characters or other double-width glyphs.
- Ensure zero-column truncation produces no visible ellipsis.

Enhancements:
- Standardize affected TUI surfaces on terminal display-column measurements instead of code-point counts and character-based formatting.

Documentation:
- Clarify that trace snippets and graph picker rendering use display-column budgets.

Tests:
- Add Unicode-width regression coverage for shared column arithmetic and affected engine, tools, traces, diff, dashboard, and deck rendering paths.