### PR TITLE
fix(stella-cli): stop the deck panicking on a memory edit, and hold the memories span for the session

### DIFF
--- a/crates/stella-cli/README.md
+++ b/crates/stella-cli/README.md
@@ -255,12 +255,19 @@ that prefix is what the provider's prompt cache keys on, so nondeterminism here
 is a re-billing regression, not a cosmetic one. The code enforces two rules on
 purpose:
 
-- `append_workspace_memories` reads `.stella/memories/*.md`, `files.sort()`s by
+- `workspace_memories_span` reads `.stella/memories/*.md`, `files.sort()`s by
   filename, and concatenates under a 16,000-char budget (`MEMORY_PROMPT_BUDGET_CHARS`);
-  overflow is dropped with a count, never reordered. The prompt is built **once
-  per session** and reused verbatim (including across `/clear`), so a memory
-  saved mid-session deliberately does not appear until the next session —
-  hot-injecting it would invalidate the cached prefix on every save.
+  overflow is dropped with a count, never reordered. A file that cannot be read
+  as text, and one whose canonical path escapes the workspace root, are both
+  refused and named in the span — a memory may not be a symlink out of the
+  checkout, and one that vanishes must leave a sign. The
+  prompt is built **once per session** and reused verbatim (including across
+  `/clear`), so a memory saved mid-session deliberately does not appear until
+  the next session — hot-injecting it would invalidate the cached prefix on
+  every save. `session_workspace_memories` is what holds that: it latches the
+  span per workspace root, so the deck's mid-session `/model` and `/agent`
+  rebuilds re-send the bytes the session opened with instead of re-reading the
+  directory.
 - `append_session_environment` states only session-constant facts — working
   directory, git checkout or not, platform, OS release, shell dialect (#2692).
   A process cannot change its OS mid-session, so the block is prefix-safe.

--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -514,6 +514,13 @@ pub(crate) const MEMORIES_OMITTED_PREFIX: &str =
 /// carries durable lessons, the recall block carries turn-relevant memories
 /// and skills. The rules rendered here are the same set whose Tier-2 guards
 /// `crate::rules::enforce_workspace_rules` arms at the tool boundary.
+///
+/// "Loaded once per session" is enforced rather than described:
+/// [`session_workspace_memories`] reads `.stella/memories/` the first time a
+/// prompt is assembled for a root and hands back the same bytes afterwards.
+/// The deck rebuilds `messages[0]` on a mid-session `/model` or `/agent`
+/// (`command_deck::session_override`'s `refresh_prompts`), and a rebuild that
+/// re-read the files would move the prefix this promise covers.
 pub(crate) fn assemble_system_prompt(
     base: &str,
     workspace_root: &std::path::Path,
@@ -531,7 +538,7 @@ pub(crate) fn assemble_system_prompt(
         return prompt;
     }
     if authority.project_prompts_allowed {
-        append_workspace_memories(&mut prompt, workspace_root);
+        prompt.push_str(&session_workspace_memories(workspace_root));
     }
     // The cached channel: `must` and `should` records, grouped by force, each
     // carrying its `^handle` so the model can name what it followed. Byte-stable by
@@ -696,9 +703,9 @@ fn workspace_suppression(
         .map_err(|e| format!("suppression state unavailable: {e}"))
 }
 
-/// The memories half of [`assemble_system_prompt`]: append the workspace's
-/// saved memories (filename order, budget-capped, **tombstone-filtered**) to
-/// `prompt`, or leave it untouched when there are none.
+/// The memories half of [`assemble_system_prompt`]: the workspace's saved
+/// memories (filename order, budget-capped, **tombstone-filtered**) as the
+/// bytes the prompt carries, or an empty string when there are none.
 ///
 /// # Forgetting one has to stop it shipping
 ///
@@ -718,7 +725,28 @@ fn workspace_suppression(
 /// left for the model to not notice. Shipping a memory someone forgot is worse
 /// than shipping none: the forget is the explicit instruction, and the file is
 /// still on disk for a later turn.
-fn append_workspace_memories(prompt: &mut String, workspace_root: &std::path::Path) {
+///
+/// # Every omission but a forget is named
+///
+/// A memory the budget dropped, one that could not be read, and one that
+/// resolves outside the workspace are each reported in the span, naming the
+/// files. Skipping an unreadable memory — invalid UTF-8, a directory, a
+/// permission error — in silence costs a reader the one thing they need: a
+/// file that picks up bad bytes is gone from every future prompt, and nothing
+/// says so. A forget is the one omission that stays quiet: it is an
+/// instruction that the memory is gone, and announcing it invites the
+/// asking-about-it that forgetting exists to end.
+///
+/// # A memory file may not point outside the workspace
+///
+/// `read_dir` lists symlinks and `read_to_string` follows them, and
+/// `.stella/memories/` is neither private-tier nor gitignored — so a cloned
+/// repository could ship `.stella/memories/x.md` as a symlink to any readable
+/// path and have its content pasted into the next session's system prompt and
+/// sent to the configured provider. An entry whose canonical path escapes the
+/// workspace root is refused, matching the containment the file tools already
+/// enforce.
+fn workspace_memories_span(workspace_root: &std::path::Path) -> String {
     let dir = workspace_root.join(".stella/memories");
     let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
         .map(|entries| {
@@ -729,39 +757,43 @@ fn append_workspace_memories(prompt: &mut String, workspace_root: &std::path::Pa
         })
         .unwrap_or_default();
     if files.is_empty() {
-        return;
+        return String::new();
     }
     files.sort();
 
     let suppression = match workspace_suppression(workspace_root) {
         Ok(suppression) => suppression,
         Err(error) => {
-            prompt.push_str(&format!(
+            return format!(
                 "{MEMORIES_OMITTED_PREFIX}{error}. They are still on disk in .stella/memories/ \
                  and will return once the suppression state is readable."
-            ));
-            return;
+            );
         }
     };
 
     let mut memories = String::new();
     let mut used = 0usize;
     let mut dropped = 0usize;
+    let mut unreadable: Vec<String> = Vec::new();
+    let mut outside: Vec<String> = Vec::new();
     for file in &files {
-        let Ok(body) = std::fs::read_to_string(file) else {
-            continue;
-        };
+        // The tombstone is keyed by filename stem, which is what
+        // `ContextSurface::WorkspaceMemory` records.
         let name = file
             .file_stem()
             .and_then(|n| n.to_str())
             .unwrap_or("memory");
-        // The tombstone is keyed by filename stem, which is what
-        // `ContextSurface::WorkspaceMemory` records.
-        // No count of these is reported. A budget omission is worth telling
-        // the model about, because it can be fixed by consolidating files; a
-        // forget is an instruction that this memory is gone, and announcing
-        // "three memories are being withheld" invites exactly the asking-about
-        // -it that forgetting exists to end.
+        if !resolves_inside(workspace_root, file) {
+            outside.push(name.to_string());
+            continue;
+        }
+        let body = match std::fs::read_to_string(file) {
+            Ok(body) => body,
+            Err(_) => {
+                unreadable.push(name.to_string());
+                continue;
+            }
+        };
         if suppression.suppresses(name, &body) {
             continue;
         }
@@ -780,16 +812,86 @@ fn append_workspace_memories(prompt: &mut String, workspace_root: &std::path::Pa
         used += cost;
         memories.push_str(&entry);
     }
-    if memories.is_empty() {
-        return;
-    }
-    prompt.push_str(&format!("{MEMORIES_HEADER}{memories}"));
+
+    // Deterministic for a given directory: the file list is sorted, so every
+    // note below is the same bytes on every assembly (L-E8).
+    let mut notes = String::new();
     if dropped > 0 {
-        prompt.push_str(&format!(
+        notes.push_str(&format!(
             "
 ({dropped} additional memories exceeded the prompt budget and were omitted — consolidate .stella/memories/ to bring them back)"
         ));
     }
+    if !unreadable.is_empty() {
+        notes.push_str(&format!(
+            "
+(these .stella/memories/ files could not be read and were omitted: {} — they are not readable text; nothing here saw their content)",
+            unreadable.join(", ")
+        ));
+    }
+    if !outside.is_empty() {
+        notes.push_str(&format!(
+            "
+(these .stella/memories/ files resolve outside the workspace and were omitted: {} — a memory must be a file inside the workspace, never a link out of it)",
+            outside.join(", ")
+        ));
+    }
+    if memories.is_empty() && notes.is_empty() {
+        return String::new();
+    }
+    format!("{MEMORIES_HEADER}{memories}{notes}")
+}
+
+/// Whether `file` resolves inside `workspace_root`.
+///
+/// Both sides are canonicalised, so a `..` component and a symlinked
+/// workspace root resolve the same way on either side of the comparison. A
+/// path that cannot be canonicalised — a broken link, a permission error — is
+/// not contained, because nothing here can say where it points.
+fn resolves_inside(workspace_root: &std::path::Path, file: &std::path::Path) -> bool {
+    match (workspace_root.canonicalize(), file.canonicalize()) {
+        (Ok(root), Ok(file)) => file.starts_with(&root),
+        _ => false,
+    }
+}
+
+/// The memories span this session sends: [`workspace_memories_span`] for a
+/// root, assembled on first use and reused for the life of the process.
+///
+/// A session's prefix has to be byte-stable for the whole of it (AGENTS.md's
+/// rule 7). The deck rebuilds `messages[0]` whenever `/model` or `/agent`
+/// moves the session's wiring; reading the directory again there would let a
+/// memory edited on disk change a prefix the provider is already caching,
+/// which is the one thing [`assemble_system_prompt`] promises cannot happen.
+/// The span is held for the life of the process, which covers the session: a
+/// session seeds `messages[0]` at open, and the deck only ever rewrites that
+/// one message in place.
+///
+/// Latched like the catalog [`knowledge_cutoff_for`] reads: a value fixed for
+/// the session, resolved the first time it is asked for. Keyed by root because
+/// one process assembles prompts for more than one — a fleet worker's
+/// worktree, a sub-agent's session — and those are different workspaces with
+/// different memories.
+fn session_workspace_memories(workspace_root: &std::path::Path) -> std::sync::Arc<str> {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::{Arc, LazyLock, Mutex};
+
+    static SPANS: LazyLock<Mutex<HashMap<PathBuf, Arc<str>>>> = LazyLock::new(Default::default);
+
+    // A poisoned lock means some other thread panicked while holding it, not
+    // that the map is unusable — what it holds is a cache of bytes already
+    // read. Recovering keeps a panic in one assembly from taking the next one
+    // down with it.
+    let mut spans = SPANS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(span) = spans.get(workspace_root) {
+        return span.clone();
+    }
+    let span: Arc<str> = Arc::from(workspace_memories_span(workspace_root));
+    spans.insert(workspace_root.to_path_buf(), span.clone());
+    span
 }
 
 /// The `agent_engine_config` custom prompt, when one is set — it replaces

--- a/crates/stella-cli/src/agent/prompt/tests.rs
+++ b/crates/stella-cli/src/agent/prompt/tests.rs
@@ -7,7 +7,7 @@
 //! for the reason stated there: `macro_rules!` scope is textual, so the
 //! contracts have to be in scope before either module is declared.
 
-use super::append_workspace_memories;
+use super::workspace_memories_span;
 
 // Every static prompt, labelled. Lives in `parity`, where it is
 // cross-checked against this file's own source, so a third prompt cannot
@@ -615,8 +615,7 @@ fn a_forgotten_workspace_memory_does_not_reach_the_system_prompt() {
     std::fs::write(memories.join("kept.md"), "KEEP_THIS_LESSON").unwrap();
     std::fs::write(memories.join("dropped.md"), "FORGET_THIS_LESSON").unwrap();
 
-    let mut before = String::new();
-    append_workspace_memories(&mut before, root);
+    let before = workspace_memories_span(root);
     assert!(
         before.contains("KEEP_THIS_LESSON") && before.contains("FORGET_THIS_LESSON"),
         "both ship before anything is forgotten: {before}"
@@ -632,8 +631,7 @@ fn a_forgotten_workspace_memory_does_not_reach_the_system_prompt() {
         )
         .expect("forget");
 
-    let mut after = String::new();
-    append_workspace_memories(&mut after, root);
+    let after = workspace_memories_span(root);
     assert!(
         after.contains("KEEP_THIS_LESSON"),
         "forgetting one memory must not withhold the others: {after}"
@@ -648,8 +646,7 @@ fn a_forgotten_workspace_memory_does_not_reach_the_system_prompt() {
             .restore(stella_store::ContextSurface::WorkspaceMemory, "dropped")
             .expect("restore")
     );
-    let mut restored = String::new();
-    append_workspace_memories(&mut restored, root);
+    let restored = workspace_memories_span(root);
     assert!(
         restored.contains("FORGET_THIS_LESSON"),
         "restore brings it back: {restored}"
@@ -683,8 +680,7 @@ fn forgetting_one_authored_memory_does_not_suppress_a_similar_one() {
         )
         .expect("forget");
 
-    let mut prompt = String::new();
-    append_workspace_memories(&mut prompt, root);
+    let prompt = workspace_memories_span(root);
     assert!(
         prompt.contains("### rewritten"),
         "an identical authored memory under a different name still ships: {prompt}"
@@ -743,8 +739,7 @@ fn the_provenance_markers_are_what_this_assembler_emits() {
     let memories = root.join(".stella/memories");
     std::fs::create_dir_all(&memories).expect("memories dir");
     std::fs::write(memories.join("one.md"), "A_REAL_LESSON").expect("memory file");
-    let mut appended = String::new();
-    append_workspace_memories(&mut appended, root);
+    let appended = workspace_memories_span(root);
     assert!(
         appended.starts_with(super::MEMORIES_HEADER),
         "the memories marker must be the bytes the appender pushes: {appended}"
@@ -994,4 +989,119 @@ fn a_worktree_turn_is_steered_by_this_repositorys_records() {
             "retiring one record must leave the rest steering: {statement:?}"
         );
     }
+}
+
+/// **The witness for the byte-stable prefix across a rebuild.** A prompt
+/// rebuilt mid-session carries the memories the session opened with, whatever
+/// the directory says now.
+///
+/// The deck rebuilds `messages[0]` whenever `/model` or `/agent` moves the
+/// session's wiring (`command_deck::session_override`'s `refresh_prompts`). A
+/// rebuild that reads `.stella/memories/` again lets a file edited on disk
+/// change the prefix the provider is caching, which drops the cache for every
+/// remaining call of the session and breaks the guarantee
+/// `assemble_system_prompt` states.
+///
+/// It fails against that shape by construction: a second assembly that reads
+/// the edited directory cannot produce the same bytes.
+#[test]
+fn a_rebuilt_prompt_carries_the_memories_the_session_opened_with() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    let memories = root.join(".stella/memories");
+    std::fs::create_dir_all(&memories).expect("memories dir");
+    std::fs::write(memories.join("lesson.md"), "LESSON_AT_SESSION_OPEN").expect("memory file");
+
+    let authority = crate::settings::AuthorityPolicy {
+        project_prompts_allowed: true,
+        ..Default::default()
+    };
+    let rules = crate::rules::ResolvedRules::default();
+    let opened =
+        super::assemble_system_prompt(super::SYSTEM_PROMPT, root, &authority, &rules, None);
+    assert!(
+        opened.contains("LESSON_AT_SESSION_OPEN"),
+        "the fixture must reach the prefix or this guard is vacuous: {opened}"
+    );
+
+    std::fs::write(memories.join("lesson.md"), "LESSON_EDITED_MID_SESSION").expect("edit");
+    std::fs::write(memories.join("added.md"), "MEMORY_ADDED_MID_SESSION").expect("add");
+
+    let rebuilt =
+        super::assemble_system_prompt(super::SYSTEM_PROMPT, root, &authority, &rules, None);
+    assert_eq!(
+        opened, rebuilt,
+        "a mid-session rebuild must re-send the same prefix bytes (AGENTS.md #7)"
+    );
+    for edited in ["LESSON_EDITED_MID_SESSION", "MEMORY_ADDED_MID_SESSION"] {
+        assert!(
+            !rebuilt.contains(edited),
+            "a memory written mid-session appears in the NEXT session, never this one: {edited}"
+        );
+    }
+}
+
+/// **The witness for naming an unreadable memory.** A file that cannot be
+/// read as text is named in the prompt rather than dropped in silence.
+///
+/// Every other omission from this span reports itself — the budget drop, the
+/// unreadable suppression state. A file that picks up invalid bytes must not
+/// be the exception, vanishing from every future prompt with nothing to say
+/// so.
+#[test]
+fn an_unreadable_memory_is_named_in_the_prompt() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    let memories = root.join(".stella/memories");
+    std::fs::create_dir_all(&memories).expect("memories dir");
+    std::fs::write(memories.join("good.md"), "A_READABLE_LESSON").expect("memory file");
+    // Not valid UTF-8, which is what `read_to_string` refuses.
+    std::fs::write(memories.join("corrupt.md"), [0xffu8, 0xfe, 0xfd]).expect("corrupt file");
+
+    let span = workspace_memories_span(root);
+    assert!(
+        span.contains("A_READABLE_LESSON"),
+        "one unreadable file must not withhold the others: {span}"
+    );
+    assert!(
+        span.contains("could not be read and were omitted: corrupt"),
+        "the omission must name the file: {span}"
+    );
+}
+
+/// **The witness for workspace containment.** A memory file that points
+/// outside the workspace is refused, and says so.
+///
+/// `.stella/memories/` is neither private-tier nor gitignored, so a cloned
+/// repository can ship one as a symlink to any readable path. `read_dir` lists
+/// it and `read_to_string` follows it, which is enough to paste the target's
+/// content into the next session's system prompt and send it to the configured
+/// provider.
+#[cfg(unix)]
+#[test]
+fn a_memory_symlinked_outside_the_workspace_is_refused() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let elsewhere = tempfile::tempdir().expect("elsewhere");
+    let root = workspace.path();
+    let secret = elsewhere.path().join("secret.md");
+    std::fs::write(&secret, "CONTENT_OUTSIDE_THE_WORKSPACE").expect("secret file");
+
+    let memories = root.join(".stella/memories");
+    std::fs::create_dir_all(&memories).expect("memories dir");
+    std::fs::write(memories.join("mine.md"), "A_LOCAL_LESSON").expect("memory file");
+    std::os::unix::fs::symlink(&secret, memories.join("leak.md")).expect("symlink");
+
+    let span = workspace_memories_span(root);
+    assert!(
+        !span.contains("CONTENT_OUTSIDE_THE_WORKSPACE"),
+        "a memory may not read outside the workspace root: {span}"
+    );
+    assert!(
+        span.contains("A_LOCAL_LESSON"),
+        "refusing one entry must not withhold the rest: {span}"
+    );
+    assert!(
+        span.contains("resolve outside the workspace and were omitted: leak"),
+        "the refusal must name the file: {span}"
+    );
 }

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -1588,7 +1588,7 @@ pub async fn run_deck_session(
                             )
                             && !service_undo_delete(&other, &workspace_path, &in_tx)
                             && !service_reject_memory(&other, &workspace_path, &in_tx)
-                            && !service_edit_memory(&other, &workspace_path, &in_tx)
+                            && !service_edit_memory(&other, &workspace_path, &in_tx).await
                             && !inspect_service::service_inspect_action(
                                 &other,
                                 &store,
@@ -2292,7 +2292,7 @@ pub async fn run_deck_session(
                         // edit that waited would be recalled in its old words
                         // by the very turn the reader is watching.
                         Some(input @ WorkspaceInput::EditMemory { .. }) => {
-                            service_edit_memory(&input, &workspace_path, &in_tx);
+                            service_edit_memory(&input, &workspace_path, &in_tx).await;
                         }
                         // `r rerun gate` likewise: it answers in words rather
                         // than running anything (`service_rerun_gate`), so

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -183,20 +183,7 @@ pub(super) fn service_undo_delete(
     true
 }
 
-/// Service `x reject` on a memory row: tombstone that memory so it stops
-/// being recalled and the reflection loop stops re-learning it. Returns `true`
-/// if `input` was the reject verb (so the caller skips its own dispatch). A
-/// cheap local SQLite write, serviced identically idle or mid-turn — and
-/// answered either way with an [`Inbound::Notice`], because a rejection that
-/// says nothing leaves the reader unsure whether the key registered.
-///
-/// The tombstone is written with the memory's **text** as well as its id, and
-/// that is the half that makes the rejection durable: the reflection loop
-/// re-mines paraphrases of lessons it already learned, so a tombstone keyed on
-/// the id alone would be undone by the next turn that re-learned the same
-/// lesson under a fresh one. `Store::forget` compares candidates against the
-/// content copied in here.
-/// `e edit` on a memory row: replace its words, keeping the lineage (#5231).
+/// Service `e edit` on a memory row: replace its words, keeping the lineage.
 ///
 /// Drives the same path `stella memory edit <id> <text>` does — a new revision
 /// on the same lineage, so the old words stop being served and the id does not
@@ -206,7 +193,12 @@ pub(super) fn service_undo_delete(
 /// Reports its failure for the reason `service_reject_memory` does: an edit
 /// that did not land leaves the OLD words steering later turns, and a silent
 /// failure would leave the reader believing the opposite.
-pub(super) fn service_edit_memory(
+///
+/// Alone among the services here it is async. The write goes through the
+/// context store, and that store's write is async. The loop this runs on
+/// already drives a runtime, so a `block_on` here would panic and end the
+/// session.
+pub(super) async fn service_edit_memory(
     input: &WorkspaceInput,
     workspace: &str,
     in_tx: &UnboundedSender<Inbound>,
@@ -216,6 +208,7 @@ pub(super) fn service_edit_memory(
     };
     let notice =
         match crate::memory_cmd::edit_memory_text(std::path::Path::new(workspace), memory_id, text)
+            .await
         {
             Ok(_) => format!("edited {memory_id} — later turns recall the new words"),
             Err(why) => format!("could not edit {memory_id}: {why}"),
@@ -224,6 +217,18 @@ pub(super) fn service_edit_memory(
     true
 }
 
+/// Service `x reject` on a memory row: tombstone that memory so it stops
+/// being recalled and the reflection loop stops re-learning it. Returns `true`
+/// if `input` was the reject verb (so the caller skips its own dispatch). A
+/// cheap local SQLite write, serviced identically idle or mid-turn — and
+/// answered either way with an [`Inbound::Notice`], because a rejection that
+/// says nothing leaves the reader unsure whether the key registered.
+///
+/// The tombstone carries the memory's **text** as well as its id. That is what
+/// makes a rejection stick. The reflection loop re-mines lessons it has
+/// already learned, so a tombstone keyed on the id alone would be undone by
+/// the next turn that learned the same lesson under a new id. `Store::forget`
+/// compares each candidate against the text copied in here.
 pub(super) fn service_reject_memory(
     input: &WorkspaceInput,
     workspace: &str,

--- a/crates/stella-cli/src/command_deck/session_override.rs
+++ b/crates/stella-cli/src/command_deck/session_override.rs
@@ -17,6 +17,14 @@
 //! SessionStart hook context is NOT re-run for the rewrite: the caller hands
 //! in the suffix captured at startup, so a hook's side effects happen once
 //! per session no matter how often the model changes.
+//!
+//! Everything else a rebuild re-derives has to be session-constant, or the
+//! switch moves bytes the prompt cache keys on. The rules come in as the
+//! resolved set rather than being re-read; the memories span is latched per
+//! workspace root by `agent::prompt`'s `session_workspace_memories`, so a
+//! `.stella/memories/` file edited on disk cannot change `messages[0]` under a
+//! running session. What the rebuild does move is the session-environment
+//! block, which carries the model line the switch just changed.
 
 use std::sync::Arc;
 

--- a/crates/stella-cli/src/memory_cmd.rs
+++ b/crates/stella-cli/src/memory_cmd.rs
@@ -24,8 +24,10 @@ use crate::query_format::{QueryFormat, Rows};
 use stella_core::rules::{self, PromoteStatus, RuleCandidate};
 use stella_store::{ContextSurface, MemoryCitationStats, PROMOTION_CITATIONS_REQUIRED, Store};
 
+mod edit;
 mod restore;
 
+pub use edit::{edit_memory_text, run_memory_edit};
 pub use restore::run_memory_restore;
 
 /// `stella memory` subcommands — the inspection and promotion surface of the
@@ -604,14 +606,13 @@ pub fn run_memory_forget(id: &str, reason: &str) -> Result<(), String> {
         .forget(ContextSurface::Memory, id, &content, reason)
         .map_err(|e| format!("cannot record tombstone: {e}"))?;
 
-    // Project the tombstone into the plane that owns the memory, so recall
-    // stops offering it at the SQL boundary instead of at the CLI after a
-    // budget has already been spent on it (#712 deliverable 4). The tombstone
-    // in `store.db` stays canonical — it is surface-aware, carries the reason,
-    // and outlives the row — so this is a projection, not a second source of
-    // truth, and it is written second: a failure here leaves the tombstone
-    // recorded and the memory merely still visible, which is recoverable, where
-    // the opposite order could hide a memory with no record of why.
+    // Copy the tombstone into the plane that owns the memory. Recall then
+    // stops offering it in SQL, not at the CLI after the budget is spent. The
+    // one in `store.db` is still the source of truth: it knows the surface, it
+    // carries the reason, and it outlives the row. This copy is written
+    // second, on purpose. A failure here leaves the tombstone on record and
+    // the memory merely still in view, which a rerun fixes. The other order
+    // could hide a memory with no record of why.
     if let Some(context) = open_context(&workspace_root)? {
         context
             .supersede_node(id)
@@ -631,123 +632,6 @@ pub fn run_memory_forget(id: &str, reason: &str) -> Result<(), String> {
         format!("undo: stella memory restore {id}").dimmed()
     );
     Ok(())
-}
-
-/// Entry point for `stella memory edit <id> <text>` — #712 deliverable 5.
-///
-/// Writes a new revision of the memory's lineage. The mirror node is keyed by
-/// lineage, so it is updated in place: one live record, the same `nod_…` id,
-/// and the old text kept as history rather than left competing for recall
-/// slots.
-///
-/// Before lineage, this operation did not exist and could not be built. A
-/// memory's identity was the hash of its content, so "the same memory with
-/// different words" was a contradiction — you got a second memory, and the
-/// first went on being recalled with its old text and its own vector.
-pub fn run_memory_edit(id: &str, text: &str) -> Result<(), String> {
-    let workspace_root =
-        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
-    let previous = edit_memory_text(&workspace_root, id, text)?;
-
-    println!("  {} revised {id}", "✓".green());
-    println!(
-        "    {} {}",
-        "was:".dimmed(),
-        clip(previous.trim(), 68).dimmed()
-    );
-    println!("    {} {}", "now:".dimmed(), clip(text.trim(), 68).dimmed());
-
-    // The lineage tally is this verb's reporting rather than the edit's work,
-    // so it reads the store again after the revision landed. The deck's `e`
-    // path (#5231) answers with one notice line and has no use for it.
-    let Some(context) = open_context(&workspace_root)? else {
-        return Ok(());
-    };
-    let stats = context
-        .memory_lineage_stats()
-        .map_err(|e| format!("cannot read lineage stats: {e}"))?;
-    println!(
-        "    {}",
-        format!(
-            "{} live {}, {} superseded revision{} kept as history",
-            stats.live,
-            if stats.live == 1 {
-                "memory"
-            } else {
-                "memories"
-            },
-            stats.superseded,
-            if stats.superseded == 1 { "" } else { "s" }
-        )
-        .dimmed()
-    );
-    Ok(())
-}
-
-/// [`run_memory_edit`]'s work, over an explicit root and printing nothing.
-///
-/// Split out for the deck's `e edit` (#5231), which drives the same revision
-/// from a transcript row: a reader who edits a memory from the deck and a
-/// reader who runs `stella memory edit` must get the same thing, and two
-/// implementations of "revise on the lineage" would be free to disagree about
-/// the one part that matters — carrying the classification forward.
-///
-/// Returns the text it replaced, which is what the CLI verb prints as `was:`.
-pub fn edit_memory_text(
-    workspace_root: &std::path::Path,
-    id: &str,
-    text: &str,
-) -> Result<String, String> {
-    if text.trim().is_empty() {
-        return Err(
-            "the replacement text must not be empty — use `stella memory forget` to \
-                    remove a memory"
-                .to_string(),
-        );
-    }
-    let Some(context) = open_context(workspace_root)? else {
-        return Err("this workspace has no context store yet — nothing to edit".to_string());
-    };
-    let Some(node) = context
-        .node_by_public_id(id)
-        .map_err(|e| format!("cannot read memory `{id}`: {e}"))?
-    else {
-        return Err(format!(
-            "`{id}` is not a live memory — check the id against `stella memory list`"
-        ));
-    };
-    let Some(lineage) = context
-        .memory_lineage(id)
-        .map_err(|e| format!("cannot resolve the lineage of `{id}`: {e}"))?
-    else {
-        return Err(format!(
-            "`{id}` is not a memory — only memories have revisions (episodes are a record \
-             of what happened and are not rewritten)"
-        ));
-    };
-    let previous = node.content.clone();
-    // Carry the lineage's classification forward. Defaulting here would
-    // silently reclassify a mined reflection as an authored note, which changes
-    // whether the restatement filter treats it as regenerable.
-    let kind = context
-        .memory_kind(&lineage)
-        .map_err(|e| format!("cannot read the kind of `{id}`: {e}"))?
-        .and_then(|k| stella_context::MemoryKind::parse(&k))
-        .unwrap_or(stella_context::MemoryKind::Note);
-
-    let runtime = tokio::runtime::Runtime::new()
-        .map_err(|e| format!("cannot start the async runtime: {e}"))?;
-    runtime
-        .block_on(async {
-            context
-                .upsert(stella_context::ContextDelta::new().with_memory(
-                    stella_context::MemoryInput::new(kind, text.trim()).revises(&lineage),
-                ))
-                .await
-        })
-        .map_err(|e| format!("cannot write the revision: {e}"))?;
-
-    Ok(previous)
 }
 
 /// Entry point for `stella memory forgotten` — the tombstones in this

--- a/crates/stella-cli/src/memory_cmd/edit.rs
+++ b/crates/stella-cli/src/memory_cmd/edit.rs
@@ -1,0 +1,185 @@
+//! `stella memory edit <id> <text>` — change the words of a memory.
+//!
+//! Two doors reach this code. One is the CLI verb. The other is `e` on a
+//! memory row in the deck. Both call [`edit_memory_text`], so both do the
+//! same thing: one live row on the same lineage, the old words kept as
+//! history, and the kind kept too.
+//!
+//! The write is async, since the store is. That decides who owns the runtime.
+//! The CLI verb is sync, so it blocks on the future here. The deck is already
+//! in a runtime, so it awaits. A `block_on` there would panic and end the
+//! session.
+
+use colored::Colorize;
+
+use super::{clip, open_context};
+
+/// Entry point for `stella memory edit <id> <text>`.
+///
+/// Writes a new version on the memory's lineage. The mirror row is keyed by
+/// lineage, so it moves in place: one live row, the same `nod_…` id, and the
+/// old text kept as history. It does not compete for a recall slot.
+///
+/// Before lineage this verb could not be built. A memory was named by the
+/// hash of its text. "The same memory with new words" made no sense: you got
+/// a second memory, and the first was still recalled with its old text.
+pub fn run_memory_edit(id: &str, text: &str) -> Result<(), String> {
+    let workspace_root =
+        std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
+    // The one `block_on` on this path, and it belongs here. `main::run` is
+    // sync, and the write is async because the store is. The deck awaits
+    // instead: a `block_on` on its thread would panic, since that thread
+    // already drives a runtime.
+    let previous = tokio::runtime::Runtime::new()
+        .map_err(|e| format!("cannot start the async runtime: {e}"))?
+        .block_on(edit_memory_text(&workspace_root, id, text))?;
+
+    println!("  {} revised {id}", "✓".green());
+    println!(
+        "    {} {}",
+        "was:".dimmed(),
+        clip(previous.trim(), 68).dimmed()
+    );
+    println!("    {} {}", "now:".dimmed(), clip(text.trim(), 68).dimmed());
+
+    // The tally is this verb's own reporting, not part of the edit, so it
+    // reads the store again after the write lands. The deck answers with one
+    // notice line and has no use for it.
+    let Some(context) = open_context(&workspace_root)? else {
+        return Ok(());
+    };
+    let stats = context
+        .memory_lineage_stats()
+        .map_err(|e| format!("cannot read lineage stats: {e}"))?;
+    println!(
+        "    {}",
+        format!(
+            "{} live {}, {} superseded revision{} kept as history",
+            stats.live,
+            if stats.live == 1 {
+                "memory"
+            } else {
+                "memories"
+            },
+            stats.superseded,
+            if stats.superseded == 1 { "" } else { "s" }
+        )
+        .dimmed()
+    );
+    Ok(())
+}
+
+/// [`run_memory_edit`]'s work, over a root it is handed, printing nothing.
+///
+/// Split out for the deck's `e edit`, which makes the same change from a
+/// transcript row. Both readers must get the same thing. Two copies of "write
+/// a new version on the lineage" would be free to drift on the part that
+/// matters: keeping the kind.
+///
+/// Returns the text it replaced, which the CLI verb prints as `was:`.
+///
+/// Async because the deck calls it from inside its driver loop.
+/// `tokio::runtime::Runtime::block_on` panics on a thread that already drives
+/// a runtime, so one keypress would end the session. The sync CLI verb owns
+/// the one `block_on` instead.
+pub async fn edit_memory_text(
+    workspace_root: &std::path::Path,
+    id: &str,
+    text: &str,
+) -> Result<String, String> {
+    if text.trim().is_empty() {
+        return Err(
+            "the replacement text must not be empty — use `stella memory forget` to \
+                    remove a memory"
+                .to_string(),
+        );
+    }
+    let Some(context) = open_context(workspace_root)? else {
+        return Err("this workspace has no context store yet — nothing to edit".to_string());
+    };
+    let Some(node) = context
+        .node_by_public_id(id)
+        .map_err(|e| format!("cannot read memory `{id}`: {e}"))?
+    else {
+        return Err(format!(
+            "`{id}` is not a live memory — check the id against `stella memory list`"
+        ));
+    };
+    let Some(lineage) = context
+        .memory_lineage(id)
+        .map_err(|e| format!("cannot resolve the lineage of `{id}`: {e}"))?
+    else {
+        return Err(format!(
+            "`{id}` is not a memory — only memories have revisions (episodes are a record \
+             of what happened and are not rewritten)"
+        ));
+    };
+    let previous = node.content.clone();
+    // Keep the kind the lineage already has. A default here would turn a
+    // mined lesson into a hand-written note. That changes whether the
+    // restatement filter treats it as one the loop may write again.
+    let kind = context
+        .memory_kind(&lineage)
+        .map_err(|e| format!("cannot read the kind of `{id}`: {e}"))?
+        .and_then(|k| stella_context::MemoryKind::parse(&k))
+        .unwrap_or(stella_context::MemoryKind::Note);
+
+    context
+        .upsert(
+            stella_context::ContextDelta::new()
+                .with_memory(stella_context::MemoryInput::new(kind, text.trim()).revises(&lineage)),
+        )
+        .await
+        .map_err(|e| format!("cannot write the revision: {e}"))?;
+
+    Ok(previous)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The witness: an edit must land from a thread that already drives a
+    /// runtime.
+    ///
+    /// A `#[tokio::test]` is one such thread. So is the deck's driver loop,
+    /// where `e` on a memory row is served. Code that builds a runtime of its
+    /// own and calls `block_on` panics here. So this test fails against that
+    /// shape by construction, not by an assertion someone can weaken.
+    #[tokio::test]
+    async fn a_memory_edits_from_inside_a_running_runtime() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+        let context_db = stella_store::workspace_private_sqlite_path(root, "context.db").unwrap();
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        context
+            .upsert(stella_context::ContextDelta::new().with_memory(
+                stella_context::MemoryInput::new(
+                    stella_context::MemoryKind::Note,
+                    "prefer rg over grep",
+                ),
+            ))
+            .await
+            .unwrap();
+        let id = context.memory_nodes().unwrap()[0].public_id.clone();
+        drop(context);
+
+        let previous = edit_memory_text(root, &id, "prefer rg over grep, and fd over find")
+            .await
+            .expect("the deck edits from inside the driver loop's runtime");
+        assert_eq!(previous, "prefer rg over grep");
+
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        let nodes = context.memory_nodes().unwrap();
+        assert_eq!(
+            nodes.len(),
+            1,
+            "a revision replaces; it mints no second row"
+        );
+        assert_eq!(
+            nodes[0].public_id, id,
+            "the id a reader holds still resolves"
+        );
+        assert_eq!(nodes[0].content, "prefer rg over grep, and fd over find");
+    }
+}

--- a/docs/prompts/worker.md
+++ b/docs/prompts/worker.md
@@ -37,7 +37,7 @@ runs on the worker's resolved provider.
 ```
 base persona            SYSTEM_PROMPT | PIPELINE_SYSTEM_PROMPT | agents.<kind>.prompt
 + session environment   append_session_environment
-+ workspace memories    append_workspace_memories     ≤ 16,000 chars
++ workspace memories    session_workspace_memories    ≤ 16,000 chars
 + rules section         Channel::Cached render
 ```
 


### PR DESCRIPTION
## What and why

Four defects on the path from `.stella/memories/*.md` to the bytes a provider is sent, all from #5508.

**1. Editing a memory from the deck panicked the session.** `edit_memory_text` built its own `tokio::runtime::Runtime` and called `block_on`. The deck services `e` on a memory row from inside `run_deck_session`'s driver loop, which is already driving a runtime, so the call panicked with "Cannot start a runtime from within a runtime" — an ordinary keypress on the default interactive shell. The write is now `async` and the deck awaits it; the synchronous CLI verb (`run_memory_edit`, reached from `main::run`) owns the one `block_on`.

Both functions moved to `crates/stella-cli/src/memory_cmd/edit.rs`, a sibling module beside the existing `memory_cmd/restore.rs`. `memory_cmd.rs` was 1437 lines against the 1500-line ratchet, so the witness had nowhere to land; the split takes it to 1330 and gives the new logic and its test a home. The two deck call sites in `command_deck.rs` gained `.await` on the existing lines, so the god file grew by nothing.

**2. `/model` and `/agent` re-read memories mid-session.** `refresh_prompts` rebuilds `messages[0]` through the full assembler, which called `append_workspace_memories` and re-read the directory. A memory edited on disk therefore changed the cached prefix under a running session — the exact thing `assemble_system_prompt` documents cannot happen (AGENTS.md rule 7), and a dropped prompt cache for every remaining call. `session_workspace_memories` now assembles the span once per workspace root and hands back the same bytes afterwards, latched the way `knowledge_cutoff_for` reads a catalog installed once at startup. Keyed by root, because one process assembles prompts for more than one (a fleet worker's worktree, a sub-agent's session). The latch sits inside the `project_prompts_allowed` branch, after the isolation early return, so the benchmark-isolation gate is untouched.

**3. An unreadable memory vanished with no diagnostic.** `let Ok(body) = read_to_string(file) else { continue }` skipped invalid UTF-8, a directory, or a permission error in silence, while every other omission from that span already reported itself. Unreadable files are now named in the span.

**4. A memory file could be a symlink pointing anywhere.** `read_dir` lists symlinks and `read_to_string` follows them, and `.stella/memories/` is neither private-tier nor gitignored — so a cloned repository could ship one pointing at any readable path and have its content pasted into the next session's system prompt. An entry whose canonical path escapes the workspace root is refused and named.

Also repaired while in the file: `service_reject_memory`'s doc comment sat above `service_edit_memory`, leaving the reject verb undocumented and the edit verb described by the wrong paragraph.

## Witness mechanism

- `a_memory_edits_from_inside_a_running_runtime` (`memory_cmd/edit.rs`) — a `#[tokio::test]` that calls `edit_memory_text` over a temp workspace. It fails against the old shape **by construction**, not by assertion: `block_on` on a thread a runtime already drives panics, and a `#[tokio::test]` is such a thread, exactly like the deck's driver loop. No `~/.stella` is touched — the path resolves through `existing_workspace_private_sqlite_path`, which is workspace-scoped.
- `a_rebuilt_prompt_carries_the_memories_the_session_opened_with` — assembles, edits `.stella/memories/` on disk, adds a second memory, reassembles, and asserts the two prompts are byte-identical. The old assembler re-read the directory, so the second prompt could not equal the first.
- `an_unreadable_memory_is_named_in_the_prompt` — a memory holding invalid UTF-8 beside a readable one; the readable one still ships and the omission names `corrupt`.
- `a_memory_symlinked_outside_the_workspace_is_refused` (`#[cfg(unix)]`) — a symlink to a file in another temp directory; the target's content is absent, the local memory still ships, and the refusal names `leak`.

## Exemplar

The latch follows this file's own `knowledge_cutoff_for` (a process-wide value resolved once and read from the byte-stable prefix) rather than inventing a new mechanism; the module split follows `memory_cmd/restore.rs`, and `command_deck/session_override.rs` is the pattern for keeping new lines out of `command_deck.rs`.

## Tests deleted

None.

## Follow-ups filed

See the comment on this PR after CI settles — `read_skill_files` in `crates/stella-cli/src/memory/skill_files.rs` has the identical silent-skip shape and is filed separately rather than folded in, because skills ride the volatile channel and the fix wants its own witness.

Closes #5508

## Summary by Sourcery

Keep memory edits safe in running deck sessions and make workspace memory prompts stable, observable, and workspace-contained.

Bug Fixes:
- Prevent memory edits initiated from the interactive deck from panicking an active session.
- Keep workspace memories stable for the duration of a session, including prompt rebuilds triggered by model or agent changes.
- Report unreadable memory files instead of silently omitting them.
- Reject and report memory files that resolve outside the workspace, preventing external symlink content from entering provider prompts.

Enhancements:
- Move memory edit logic into a dedicated module and share the asynchronous operation between the CLI and deck entry points.
- Correct the memory service documentation to describe the corresponding edit and reject commands accurately.

Documentation:
- Update CLI and worker prompt documentation to describe memory validation and session-scoped caching.

Tests:
- Add coverage for editing memories inside an active Tokio runtime, stable prompt rebuilds, unreadable memories, and out-of-workspace symlinks.

## Independent DoD verification (#5508)

The `dod` gate was red because #5508's five boxes were all unticked. Each was
checked against this head (`a7b5de8`) before ticking, item by item:

1. **No panic on a deck memory edit.** `edit_memory_text` is `async` in the new
   `memory_cmd/edit.rs`; `driver_support.rs`'s `service_edit_memory` is `async`
   and awaits it; `command_deck.rs`'s two call sites gained `.await` on the
   existing lines. The one surviving `block_on` is in the sync CLI verb.
   Witness `a_memory_edits_from_inside_a_running_runtime` fails against the old
   shape by construction, since `Runtime::block_on` panics on a thread already
   driving a runtime.
2. **Byte-identical memories span across a rebuild.** `session_workspace_memories`
   latches the span per workspace root (`LazyLock<Mutex<HashMap<PathBuf,
   Arc<str>>>>`, poison recovered). Witness
   `a_rebuilt_prompt_carries_the_memories_the_session_opened_with` asserts
   `opened == rebuilt` after both editing and adding a memory on disk between
   the two assemblies.
3. **An unreadable memory is named.** A `read_to_string` error pushes the stem
   onto `unreadable` and emits its own note beside the budget-drop note.
   Witness `an_unreadable_memory_is_named_in_the_prompt` uses genuine
   invalid UTF-8 (`[0xff, 0xfe, 0xfd]`).
4. **Symlink containment.** `resolves_inside` canonicalises both sides and
   requires `starts_with`; a path that cannot be canonicalised is not
   contained, so a broken link fails closed. Witness
   `a_memory_symlinked_outside_the_workspace_is_refused`.
5. **Suite green.** `cargo test` (the workspace suite, which includes
   `stella-cli`) succeeded on this head, 17:07:48 → 17:16:00, as did
   `cargo fmt --check` and `cargo clippy -D warnings`:
   https://github.com/macanderson/stella/actions/runs/33781804160

All five boxes on #5508 are now ticked, with that record on the issue. The
issue's follow-on note — `memory/skill_files.rs`'s identical silent-skip shape —
is not a DoD item here and is tracked separately (#5765).