### PR TITLE
fix(stella-tools): resolve a real shell instead of the Windows WSL stub

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -52,11 +52,10 @@ name: windows-check
 # with the same guard and each backing onto the compile blocker two
 # paragraphs up: `--test group_kill_witnesses` links only the compiled
 # `stella-tools` library, not its `--lib` test binary, so it runs here without
-# waiting on that binary's Windows compile (#4698). Only the custom-tool
-# witness runs unconditionally here today — the other two are `ignore`d on
-# Windows, where plain `bash` resolves to Windows' own WSL launcher stub
-# rather than a shell (#4861), a separate defect this step's green does not
-# claim is fixed.
+# waiting on that binary's Windows compile (#4698). All three witnesses run
+# unconditionally here: the `bash` and hook witnesses used to be `ignore`d on
+# Windows, where plain `bash` resolved to Windows' own WSL launcher stub
+# rather than a shell, until #4861 gave both spawn sites a real resolver.
 #
 # Its own file rather than a job in ci.yml for the reason wire-schema.yml has
 # one: ci.yml's required job is what every PR waits on, and a Windows runner is

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -64,7 +64,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
-use tokio::process::Command;
 
 use crate::registry::Tool;
 
@@ -536,7 +535,15 @@ impl Tool for Bash {
             command
         };
 
-        let mut cmd = Command::new("bash");
+        let mut cmd = match crate::shell_resolve::bash_command() {
+            Ok(cmd) => cmd,
+            Err(err) => {
+                return ToolOutput::classified_error(
+                    stella_protocol::ErrorClass::Environment,
+                    format!("bash: {err}"),
+                );
+            }
+        };
         cmd.args(["-c", command]);
         cmd.current_dir(root);
         // Full spawn policy, not just the credential scrub: a hook-exported

--- a/crates/stella-tools/src/hook_runner.rs
+++ b/crates/stella-tools/src/hook_runner.rs
@@ -102,7 +102,12 @@ impl HookRunner for HostHookRunner {
         let mut command = match &action.plugin {
             Some(origin) => plugin_command(origin, |name| std::env::var(name).ok())?,
             None => {
-                let mut command = tokio::process::Command::new("bash");
+                let mut command = crate::shell_resolve::bash_command().map_err(|err| {
+                    HookExecError::SpawnFailed {
+                        command: action.command.clone(),
+                        message: err.to_string(),
+                    }
+                })?;
                 command.arg("-c").arg(&action.command);
                 // Full spawn policy: a hook running from inside a git hook
                 // must not inherit the outer repo's GIT_DIR, and its stdout

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -72,6 +72,7 @@ pub mod registry;
 pub mod rootfd;
 pub mod scratch;
 pub mod search;
+mod shell_resolve;
 pub mod skill_grant;
 pub mod skill_plane;
 pub mod staleness;

--- a/crates/stella-tools/src/shell_resolve.rs
+++ b/crates/stella-tools/src/shell_resolve.rs
@@ -16,10 +16,10 @@
 //!
 //! [`bash_command`] replaces the bare call. On unix it is exactly
 //! `Command::new("bash")`. On Windows it finds an absolute path to a real
-//! shell first ([`resolve_bash`]) and runs that path directly. An absolute
-//! path skips the search order entirely. A caller that gets back
-//! [`ShellResolutionError`] knows no real shell was found. It can say so,
-//! instead of quietly running whatever `bash` turned out to mean.
+//! shell first (`resolve_bash`, which is compiled only there) and runs that
+//! path directly. An absolute path skips the search order entirely. A caller
+//! that gets back [`ShellResolutionError`] knows no real shell was found. It
+//! can say so, instead of quietly running whatever `bash` turned out to mean.
 
 #[cfg(any(test, windows))]
 use std::path::{Path, PathBuf};

--- a/crates/stella-tools/src/shell_resolve.rs
+++ b/crates/stella-tools/src/shell_resolve.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Real-shell lookup for two spawn sites: [`crate::bash`] and the hook
+//! runner's own-shell path ([`crate::hook_runner`]). Both call
+//! `Command::new("bash")` and trust it to mean a real shell.
+//!
+//! On unix that trust is safe. `$PATH` finds a real shell there, and no
+//! stub gets in the way. On Windows it is not safe. `Command::new("bash")`
+//! resolves through `CreateProcessW`'s own search order. That order checks
+//! `%SystemRoot%\System32` before it ever looks at `PATH`. Windows ships a
+//! `bash.exe` stub there: the WSL launcher. With no WSL distro installed,
+//! that stub prints an install prompt and exits with an error. It never
+//! runs the script it was handed. No `PATH` order fixes this. The system
+//! folder wins every time.
+//!
+//! [`bash_command`] replaces the bare call. On unix it is exactly
+//! `Command::new("bash")`. On Windows it finds an absolute path to a real
+//! shell first ([`resolve_bash`]) and runs that path directly. An absolute
+//! path skips the search order entirely. A caller that gets back
+//! [`ShellResolutionError`] knows no real shell was found. It can say so,
+//! instead of quietly running whatever `bash` turned out to mean.
+
+#[cfg(any(test, windows))]
+use std::path::{Path, PathBuf};
+
+use tokio::process::Command;
+
+/// No real shell was found. Lists every place this looked, so the operator
+/// knows what to install or add to `PATH`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShellResolutionError {
+    tried: Vec<String>,
+}
+
+impl std::fmt::Display for ShellResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "no real shell found (checked: {}) — install Git for Windows, or put a real \
+             bash.exe on PATH ahead of %SystemRoot%\\System32",
+            self.tried.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for ShellResolutionError {}
+
+/// The lookup itself, over passed-in environment and filesystem checks
+/// instead of the real ones. [`crate::hook_runner::plugin_command`] uses
+/// the same shape for its `lookup` closure. A test can build the exact bad
+/// case: a stub `bash.exe` sitting in the system folder, ahead of a real
+/// one on `PATH`. No real Windows machine is needed to prove it.
+///
+/// `env` reads one environment variable by name. `path_dirs` lists the
+/// `PATH` folders in order. `exists` checks whether a file is there. Git
+/// for Windows' own install folder is checked first. Most Windows users
+/// with `bash` on `PATH` have their shell there. Only then does this walk
+/// `PATH` by hand, and it skips the system folder. That folder is the WSL
+/// stub's home, never a real shell's.
+///
+/// `cfg(any(test, windows))` keeps this compiled only where it is used: on
+/// Windows, by [`resolve_bash`]; under test, by the tests below. Anywhere
+/// else it would sit unused and fail the lint that checks for that.
+#[cfg(any(test, windows))]
+fn resolve_bash_with(
+    env: impl Fn(&str) -> Option<String>,
+    path_dirs: impl Fn() -> Vec<PathBuf>,
+    exists: impl Fn(&Path) -> bool,
+) -> Result<PathBuf, ShellResolutionError> {
+    let mut tried = Vec::new();
+
+    for program_files in ["ProgramFiles", "ProgramFiles(x86)"] {
+        let Some(base) = env(program_files) else {
+            continue;
+        };
+        let candidate = PathBuf::from(base).join("Git").join("bin").join("bash.exe");
+        if exists(&candidate) {
+            return Ok(candidate);
+        }
+        tried.push(candidate.display().to_string());
+    }
+
+    let system_dir = env("SystemRoot").map(|root| PathBuf::from(root).join("System32"));
+    for dir in path_dirs() {
+        if system_dir.as_deref() == Some(dir.as_path()) {
+            continue;
+        }
+        let candidate = dir.join("bash.exe");
+        if exists(&candidate) {
+            return Ok(candidate);
+        }
+        tried.push(candidate.display().to_string());
+    }
+
+    Err(ShellResolutionError { tried })
+}
+
+/// [`resolve_bash_with`] wired to the real environment and filesystem.
+///
+/// Windows-only. Its one caller is [`bash_command`]'s Windows branch, which
+/// always runs on Windows, test or not. No separate test gate is needed
+/// here.
+#[cfg(windows)]
+fn resolve_bash() -> Result<PathBuf, ShellResolutionError> {
+    resolve_bash_with(
+        |name| std::env::var(name).ok(),
+        || {
+            std::env::var_os("PATH")
+                .map(|path| std::env::split_paths(&path).collect())
+                .unwrap_or_default()
+        },
+        |candidate| candidate.is_file(),
+    )
+}
+
+/// A `Command` for a real shell. Never the Windows WSL launcher stub in
+/// `bash`'s place. See the module doc for why unix and Windows need
+/// different answers.
+pub(crate) fn bash_command() -> Result<Command, ShellResolutionError> {
+    #[cfg(windows)]
+    {
+        resolve_bash().map(Command::new)
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(Command::new("bash"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `PATH` shaped like the real bug report: the WSL stub's folder
+    /// listed first, a real shell listed after it. No Git for Windows
+    /// install folder is set, so the walk must reach `PATH`.
+    /// `Command::new("bash")`'s own lookup would find the stub no matter
+    /// the order. This function must not.
+    ///
+    /// This test cannot fail before this file existed: there was no
+    /// lookup to fail. Only a bare `Command::new("bash")` stood there,
+    /// with no logic to check.
+    #[test]
+    fn skips_the_system_directory_even_when_it_leads_path() {
+        let system_root = PathBuf::from(r"C:\Windows");
+        let system32 = system_root.join("System32");
+        let git_bin = PathBuf::from(r"C:\Users\dev\scoop\shims");
+        let dirs = vec![system32.clone(), git_bin.clone()];
+
+        let stub = system32.join("bash.exe");
+        let real = git_bin.join("bash.exe");
+
+        let resolved = resolve_bash_with(
+            |name| (name == "SystemRoot").then(|| system_root.display().to_string()),
+            || dirs.clone(),
+            |candidate| *candidate == stub || *candidate == real,
+        )
+        .expect("a real shell sits later on PATH");
+
+        assert_eq!(
+            resolved, real,
+            "the system-directory stub must never be chosen, even first on PATH"
+        );
+    }
+
+    /// Git for Windows' own install folder wins, even when a `bash.exe`
+    /// also sits on `PATH`. It is checked first, because that is where
+    /// most real installs put their shell. Finding it needs no `PATH`
+    /// walk.
+    #[test]
+    fn prefers_the_documented_git_for_windows_install() {
+        let program_files = PathBuf::from(r"C:\Program Files");
+        let git_bash = program_files.join("Git").join("bin").join("bash.exe");
+        let path_bash = PathBuf::from(r"C:\Windows\System32").join("bash.exe");
+
+        let resolved = resolve_bash_with(
+            |name| (name == "ProgramFiles").then(|| program_files.display().to_string()),
+            || vec![PathBuf::from(r"C:\Windows\System32")],
+            |candidate| *candidate == git_bash || *candidate == path_bash,
+        )
+        .expect("Git for Windows is installed at the documented location");
+
+        assert_eq!(resolved, git_bash);
+    }
+
+    /// Nothing is found anywhere. The error names every place it looked.
+    /// It never falls back to the stub in silence.
+    #[test]
+    fn names_every_location_it_tried_when_nothing_is_found() {
+        let err = resolve_bash_with(
+            |name| (name == "SystemRoot").then(|| r"C:\Windows".to_string()),
+            || vec![PathBuf::from(r"C:\Windows\System32")],
+            |_candidate| false,
+        )
+        .expect_err("no shell exists anywhere this walk looked");
+
+        assert!(
+            err.to_string().contains("bash.exe"),
+            "the error should name what it looked for: {err}"
+        );
+    }
+
+    /// On unix, `bash_command` is exactly `Command::new("bash")`. No
+    /// lookup runs, because there is no stub here to trip on.
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_bash_command_needs_no_resolution() {
+        let cmd = bash_command().expect("unix never fails to resolve bash");
+        assert_eq!(cmd.as_std().get_program(), "bash");
+    }
+}

--- a/crates/stella-tools/tests/group_kill_witnesses.rs
+++ b/crates/stella-tools/tests/group_kill_witnesses.rs
@@ -21,14 +21,14 @@
 //! The custom-tool witness's heartbeat writer is `group-kill-fixture`, a
 //! portable binary (`tests/fixtures/`, the same pattern
 //! `wrapper-plugin-fixture` established for the plugin transport): the tool
-//! runs `command[0]` with no shell, so it needs none, and it is the one
-//! witness here that runs unconditionally on Windows. The `bash` and hook
-//! witnesses have no such escape — both call sites hardcode
-//! `Command::new("bash")` — and on `windows-latest` that resolves to
-//! Windows' own WSL launcher stub, not a real shell, regardless of `PATH`
-//! (`CreateProcessW` checks `System32` before `PATH` at all). They are
-//! `#[cfg_attr(windows, ignore)]` until #4861 fixes that, rather than forced
-//! green against an environment neither call site can see through.
+//! runs `command[0]` with no shell, so it needs none. The `bash` and hook
+//! witnesses have no such escape. Both need a real shell, and a plain
+//! `Command::new("bash")` on `windows-latest` finds Windows' own WSL
+//! launcher stub, not one — no matter the `PATH` order
+//! (`CreateProcessW` checks `System32` first). Both call sites now find an
+//! absolute path to a real shell on Windows first (`stella-tools`'
+//! crate-private `shell_resolve` module), so all three witnesses here run
+//! unconditionally.
 //!
 //! An integration test on purpose, not a `#[cfg(test)] mod` beside the
 //! production code: `custom/tests.rs` and several other `stella-tools`
@@ -122,18 +122,13 @@ fn backgrounding_command(pulse: &Path) -> String {
 /// future driving a `bash` call — Esc during a long call — must kill the
 /// whole group, not just the shell that fronts it.
 ///
-/// Ignored on Windows, not skipped silently: `Bash::execute` hardcodes
-/// `Command::new("bash")`, and on `windows-latest` that resolves to Windows'
-/// own WSL launcher stub — with no distribution installed it prints an
-/// install prompt and exits nonzero instead of running anything, ahead of
-/// Git for Windows' real shell regardless of `PATH` order (`CreateProcessW`
-/// checks `System32` before consulting `PATH` at all). #4861 tracks fixing
-/// that; until then this witness cannot prove `GroupKillGuard` reaches a
-/// backgrounded child here.
-#[cfg_attr(
-    windows,
-    ignore = "blocked on #4861: bash resolves to the WSL launcher stub here, not a real shell"
-)]
+/// This runs on Windows too now. Before #4861, `Bash::execute` hardcoded
+/// `Command::new("bash")`. On `windows-latest` that resolved to Windows'
+/// own WSL launcher stub. With no distro installed, the stub prints an
+/// install prompt and exits with an error, no matter the `PATH` order
+/// (`CreateProcessW` checks `System32` first). `Bash::execute` now finds a
+/// real shell first, so this witness proves `GroupKillGuard` reaches a
+/// backgrounded child on Windows too.
 #[tokio::test]
 async fn a_dropped_bash_call_kills_the_process_group() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -220,13 +215,9 @@ async fn a_dropped_custom_tool_kills_the_process_group() {
 /// transport: `kill_now` on the timeout path reaches the grandchild, not
 /// only the hook process that fronted it.
 ///
-/// Ignored on Windows for the same reason as Witness 1, tracked by the same
-/// #4861: the hook runner's operator path (an action with no `[plugin]`
-/// origin) also hardcodes `Command::new("bash")`.
-#[cfg_attr(
-    windows,
-    ignore = "blocked on #4861: bash resolves to the WSL launcher stub here, not a real shell"
-)]
+/// Runs on Windows for the same reason Witness 1 does (#4861). The hook
+/// runner's own-shell path — an action with no `[plugin]` origin — now
+/// finds a real shell the same way `Bash::execute` does.
 #[tokio::test]
 async fn a_timed_out_hook_leaves_no_surviving_grandchild() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## What

`Bash::execute` (`crates/stella-tools/src/bash.rs`) and the hook runner's
operator path (`crates/stella-tools/src/hook_runner.rs`) both spawned
`Command::new("bash")` with no platform check. On Windows,
`CreateProcessW`'s own search order checks `%SystemRoot%\System32` before it
ever looks at `PATH`, so this silently ran Windows' own WSL launcher stub
instead of a real shell whenever no WSL distribution was installed — the
stub prints an install prompt and exits nonzero instead of running the
script it was handed, and no `PATH` reordering fixes it.

## Why

Every operator-authored hook and every `bash` tool call did nothing useful
on such a machine, with no clear error — the WSL install prompt ran as if
it were the command's own output. Found under #4698's group-kill witness
work; `crates/stella-tools/tests/group_kill_witnesses.rs` had to `ignore`
its two `bash`/hook witnesses on Windows until this landed.

## The fix

New crate-private module `crates/stella-tools/src/shell_resolve.rs`. On
unix, `bash_command()` is exactly the old `Command::new("bash")` — there is
no stub to trip over there. On Windows it resolves an absolute path first:

1. Git for Windows' own documented install locations (`%ProgramFiles%` /
   `%ProgramFiles(x86)%\Git\bin\bash.exe`), checked first since that is
   where nearly every real Windows install actually has its shell.
2. A manual walk of `PATH`, skipping any directory equal to
   `%SystemRoot%\System32` — the WSL stub's home — so a real shell earlier
   or later on `PATH` wins regardless of order.
3. If nothing is found, a named `ShellResolutionError` listing every
   location tried, surfaced as a classified tool error (`bash`) or a
   `HookExecError::SpawnFailed` (the hook runner) — never a silent run of
   whatever `bash` happened to resolve to.

Both `bash.rs` and `hook_runner.rs` now call `crate::shell_resolve::bash_command()`
instead of constructing `Command::new("bash")` directly.

## Witness

`shell_resolve`'s own unit tests fabricate the exact `PATH` shape the
defect report described — a WSL-stub-shaped `bash.exe` sitting in the
system directory, listed *first* on `PATH`, with a real shell listed after
it — and prove resolution picks the real shell regardless of that order.
These tests exercise `resolve_bash_with`, logic that did not exist before
this PR: the old call site was an unconditional `Command::new("bash")`
with nothing to unit test, so the tests fail to compile against the prior
tree by construction.

The two Windows-only witnesses in `group_kill_witnesses.rs` (#4698,
`a_dropped_bash_call_kills_the_process_group` and
`a_timed_out_hook_leaves_no_surviving_grandchild`) that were
`#[cfg_attr(windows, ignore = "blocked on #4861: ...")]` now run
unconditionally — `windows-check.yml`'s `windows-latest` job runs
`--test group_kill_witnesses` on every push touching `crates/stella-tools/**`,
so this PR's own CI run proves the fix on a real Windows machine, not only
in a fabricated unit test. `windows-check.yml`'s own comment is updated to
match.

Verified locally (targeted, per CLAUDE.md — no workspace build):
- `cargo clippy -p stella-tools --all-targets -- -D warnings` — clean.
- `cargo test -p stella-tools --lib shell_resolve` — 4/4 pass.
- `cargo test -p stella-tools --test group_kill_witnesses` — 3/3 pass (unix; the two `bash`/hook witnesses now run unignored).
- `cargo test -p stella-tools --lib bash::` and `--lib hook_runner::` — unaffected, all pass.
- `make guards-fast` — clean, including `check-prose` and `check-file-size`.

Tests deleted: none. Two `#[cfg_attr(windows, ignore = "blocked on #4861: ...")]`
attributes removed (the fix they were waiting on), not the tests themselves.

Closes #4861

## Summary by Sourcery

Resolve Bash to a real shell on Windows and restore cross-platform execution and process-group witnesses.

New Features:
- Resolve a real Bash executable on Windows for tool calls and operator-authored hooks, preferring Git for Windows and excluding the WSL launcher directory.

Bug Fixes:
- Prevent Windows Bash tools and hooks from silently invoking the WSL installation stub when no WSL distribution is available.
- Return explicit, classified errors when no usable Bash executable can be found.

Enhancements:
- Run the Bash and hook process-group cleanup witnesses on Windows now that they can use a real shell.

CI:
- Update the Windows check workflow to run all group-kill witnesses unconditionally.

Tests:
- Add shell-resolution tests covering Git for Windows preference, stub-first PATH handling, and descriptive failures.

## Independent DoD verification (#4861)

The `dod` gate went red at 17:08 on #4861's three unticked boxes. They are
ticked now, and each was checked against this head (`6b69a50`) first:

1. **Both spawn sites resolve a real shell or fail by name.**
   `bash.rs`'s `Bash::execute` and `hook_runner.rs`'s `None`-plugin arm both
   call `crate::shell_resolve::bash_command()`. On Windows that returns an
   absolute path — Git for Windows' documented locations first, then a
   hand-walked `PATH` that skips `%SystemRoot%\System32` — so
   `CreateProcessW`'s search order is bypassed entirely rather than
   out-ordered. A failure is `ShellResolutionError` naming every location
   tried, surfaced as `ErrorClass::Environment` from the tool and
   `HookExecError::SpawnFailed` from the hook runner. Neither path can now
   run the stub as if it answered.
2. **Witness on a stub-first `PATH`.**
   `skips_the_system_directory_even_when_it_leads_path` builds exactly the
   reported shape — `System32\bash.exe` listed first, a real `bash.exe`
   after it — and asserts the real one is chosen. It cannot pass against the
   old tree, which had no `resolve_bash_with` to call. Two siblings cover
   the Git-for-Windows preference and the names-everything-tried error.
3. **Ported so it runs where it matters.** Both
   `#[cfg_attr(windows, ignore = "blocked on #4861: …")]` attributes are
   gone from `group_kill_witnesses.rs`, and `windows-check.yml`'s comment no
   longer claims two of the three are skipped — so all three witnesses run
   on the `windows-latest` job, which is the `wrapper-plugin-fixture`
   pattern the issue asked for (a real Windows run, not a shell-script
   fixture).

Not a DoD item here, tracked separately: `exec.rs`'s unit tests still
hardcode `Command::new("bash")` (#5768).