### PR TITLE
fix(stella-context): remove the dead salience field from episodes and memories

### DIFF
--- a/crates/stella-context/src/store/record.rs
+++ b/crates/stella-context/src/store/record.rs
@@ -19,7 +19,6 @@ pub(crate) fn insert_episode(
     summary: &str,
     files_touched: &serde_json::Value,
     outcome: &str,
-    salience: f64,
     started_at: &str,
     ended_at: &str,
     now: &str,
@@ -31,15 +30,14 @@ pub(crate) fn insert_episode(
     // column carried NULL from the moment v8 landed, which is what
     // migrate_v12 repairs.
     let id: i64 = conn.query_row(
-        "INSERT INTO episode (public_id, lineage_id, summary, files_touched, outcome, salience, started_at, ended_at, recorded_at)
-         VALUES (?1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        "INSERT INTO episode (public_id, lineage_id, summary, files_touched, outcome, started_at, ended_at, recorded_at)
+         VALUES (?1, ?1, ?2, ?3, ?4, ?5, ?6, ?7)
          ON CONFLICT(public_id) DO UPDATE SET
              summary = excluded.summary,
              files_touched = excluded.files_touched,
-             outcome = excluded.outcome,
-             salience = excluded.salience
+             outcome = excluded.outcome
          RETURNING id",
-        params![public_id, summary, files, outcome, salience, started_at, ended_at, now],
+        params![public_id, summary, files, outcome, started_at, ended_at, now],
         |r| r.get(0),
     )?;
     Ok(id)
@@ -60,7 +58,6 @@ pub(crate) fn insert_memory(
     lineage_id: &str,
     kind: &str,
     content: &str,
-    salience: f64,
     now: &str,
 ) -> Result<i64, ContextError> {
     // Two lineages cannot share one revision id. `public_id` is a hash of
@@ -94,16 +91,15 @@ pub(crate) fn insert_memory(
         params![lineage_id, public_id, now],
     )?;
     let id: i64 = conn.query_row(
-        "INSERT INTO memory (public_id, lineage_id, kind, content, salience, recorded_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        "INSERT INTO memory (public_id, lineage_id, kind, content, recorded_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)
          ON CONFLICT(public_id) DO UPDATE SET
              lineage_id = excluded.lineage_id,
              kind = excluded.kind,
              content = excluded.content,
-             salience = excluded.salience,
              superseded_at = NULL
          RETURNING id",
-        params![public_id, lineage_id, kind, content, salience, now],
+        params![public_id, lineage_id, kind, content, now],
         |r| r.get(0),
     )?;
     Ok(id)

--- a/crates/stella-context/src/store/schema.rs
+++ b/crates/stella-context/src/store/schema.rs
@@ -14,7 +14,7 @@ use crate::embed::EmbedderFingerprint;
 use crate::error::ContextError;
 
 /// The current on-disk schema version, tracked in `PRAGMA user_version`.
-pub(crate) const SCHEMA_VERSION: i64 = 12;
+pub(crate) const SCHEMA_VERSION: i64 = 13;
 
 /// The v1 schema. Applied once, inside the migration transaction. Bi-temporal
 /// columns (`valid_from`/`valid_to`/`recorded_at`/`superseded_at`) exist on both
@@ -528,6 +528,45 @@ pub(crate) const MIGRATION_V12: &str = "\
 UPDATE episode SET lineage_id = public_id WHERE lineage_id IS NULL;
 ";
 
+/// V13 — **drop `episode.salience` and `memory.salience`**.
+///
+/// Both columns held a caller-set importance hint. [`crate::retrieval`]'s
+/// fusion never read it: only vector similarity, recency, and graph
+/// adjacency feed the score. No writer ever set it either. Every
+/// constructor in [`crate::writeback`] defaulted it to `0.0`, and neither
+/// `EpisodeInput` nor `MemoryInput` offered a builder to change it — unlike
+/// `with_domains`, `with_anchors`, or `with_recall_tier`. A column nothing
+/// writes and nothing reads invites a caller to set a value that changes
+/// nothing. `stella-observatory`'s episode table showed it as a fixed
+/// `0.00`.
+///
+/// Removed, not wired in: nothing in this workspace computes a real
+/// salience score, so ranking by the column would rank by a constant.
+/// Wiring it in the right way would also mean moving it onto `node` first —
+/// see `migrate_v9`'s doc for why a ranking signal lives on the row
+/// retrieval scans, not on `episode`/`memory`. That is a bigger change than
+/// a constant earns.
+///
+/// Statement-level idempotent for the same reason `migrate_v5`, `migrate_v8`,
+/// and `migrate_v9` are. A rewound `user_version` is how the migration
+/// fixtures are built, and also what a partial restore looks like, so this
+/// must re-run without failing on a column already gone. SQLite's `DROP
+/// COLUMN` has no `IF EXISTS` form, so the check is done by hand, the same
+/// as those three.
+fn migrate_v13(tx: &Connection) -> Result<(), ContextError> {
+    for (table, column) in [("episode", "salience"), ("memory", "salience")] {
+        let existing: std::collections::HashSet<String> = {
+            let mut stmt = tx.prepare(&format!("PRAGMA table_info({table})"))?;
+            let rows = stmt.query_map([], |r| r.get::<_, String>("name"))?;
+            rows.collect::<rusqlite::Result<_>>()?
+        };
+        if existing.contains(column) {
+            tx.execute_batch(&format!("ALTER TABLE {table} DROP COLUMN {column};"))?;
+        }
+    }
+    Ok(())
+}
+
 /// Open a connection with the plane's fixed pragmas: WAL for concurrent
 /// reader/writer, `NORMAL` sync (durable enough with WAL, far cheaper than
 /// `FULL`), foreign keys on, and a busy timeout so a warm-task write never
@@ -655,6 +694,9 @@ pub(crate) fn migrate(conn: &Connection) -> Result<(), ContextError> {
     if version < 12 {
         tx.execute_batch(MIGRATION_V12)?;
     }
+    if version < 13 {
+        migrate_v13(&tx)?;
+    }
     // ── APPEND POINT — RESERVED SLOT ────────────────────────────────────
     // This is an ordered `if version < N` ladder and `SCHEMA_VERSION` is its
     // high-water mark. Two branches that each add "the next step" merge
@@ -676,7 +718,10 @@ pub(crate) fn migrate(conn: &Connection) -> Result<(), ContextError> {
     //
     //   v12: episode lineage repair (#5324) — TAKEN, see `MIGRATION_V12`.
     //
-    // The next free step is v13: take it and add your own line here.
+    //   v13: dropped `episode.salience`/`memory.salience` — TAKEN, see
+    //        `migrate_v13`.
+    //
+    // The next free step is v14: take it and add your own line here.
     tx.pragma_update(None, "user_version", SCHEMA_VERSION)?;
     tx.commit()?;
     Ok(())

--- a/crates/stella-context/src/store/tests.rs
+++ b/crates/stella-context/src/store/tests.rs
@@ -849,7 +849,6 @@ fn an_episode_is_born_with_its_own_lineage() {
         "a summary",
         &serde_json::json!([]),
         "success",
-        0.5,
         T1,
         T1,
         T1,
@@ -873,9 +872,9 @@ fn an_episode_is_born_with_its_own_lineage() {
 fn a_revision_cannot_steal_another_lineages_row() {
     let (_dir, store) = tmp_store();
     let conn = store.conn();
-    insert_memory(&conn, "mem_a", "mem_a", "reflection", "the text", 0.5, T1).unwrap();
+    insert_memory(&conn, "mem_a", "mem_a", "reflection", "the text", T1).unwrap();
 
-    let err = insert_memory(&conn, "mem_a", "mem_b", "reflection", "the text", 0.5, T2)
+    let err = insert_memory(&conn, "mem_a", "mem_b", "reflection", "the text", T2)
         .expect_err("a cross-lineage identity collision must refuse");
     assert!(
         err.to_string().contains("already belongs to lineage"),

--- a/crates/stella-context/src/store/tests/migrations.rs
+++ b/crates/stella-context/src/store/tests/migrations.rs
@@ -399,3 +399,112 @@ fn v8_creates_the_ledger_empty() {
         "a fresh ledger holds nothing — records are born, never migrated in"
     );
 }
+
+// ── v13: drop episode.salience / memory.salience ──────────────────────────
+
+/// A store still carrying both dead `salience` columns must migrate through
+/// v13 with the columns gone and every other value untouched. This is the
+/// witness: at schema version 12, before `migrate_v13` existed, both
+/// columns are still there after `ContextStore::open` and this test fails.
+/// With the migration in place it passes.
+#[test]
+fn v13_drops_salience_and_keeps_everything_else() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("context.db");
+    {
+        // v7 is the last shape before the episode lifecycle columns landed.
+        // Its `episode`/`memory` tables are exactly V1/V2, salience column
+        // included.
+        let conn = open_legacy(&path, 7);
+        conn.execute(
+            "INSERT INTO episode (public_id, summary, files_touched, outcome, salience,
+                                  started_at, ended_at, recorded_at)
+             VALUES ('epi_v13', 'renamed a module', '[\"src/lib.rs\"]', 'success',
+                     0.8, '2026-01-01T00:00:00Z', '2026-01-01T01:00:00Z',
+                     '2026-01-01T01:00:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO memory (public_id, kind, content, salience, recorded_at)
+             VALUES ('mem_v13', 'note', 'prefer fd over find', 0.9,
+                     '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        assert!(
+            table_has_column(&conn, "episode", "salience"),
+            "fixture really carries the column before open"
+        );
+        assert!(
+            table_has_column(&conn, "memory", "salience"),
+            "fixture really carries the column before open"
+        );
+    }
+
+    let store = ContextStore::open(&path).unwrap();
+    store.integrity_check().unwrap();
+    let conn = store.conn();
+
+    assert!(
+        !table_has_column(&conn, "episode", "salience"),
+        "v13 must drop episode.salience"
+    );
+    assert!(
+        !table_has_column(&conn, "memory", "salience"),
+        "v13 must drop memory.salience"
+    );
+
+    // SQLite's `DROP COLUMN` rewrites the whole table, so check that every
+    // other column on the row still holds its value.
+    let (summary, outcome): (String, String) = conn
+        .query_row(
+            "SELECT summary, outcome FROM episode WHERE public_id = 'epi_v13'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(summary, "renamed a module");
+    assert_eq!(outcome, "success");
+    let (kind, content): (String, String) = conn
+        .query_row(
+            "SELECT kind, content FROM memory WHERE public_id = 'mem_v13'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(kind, "note");
+    assert_eq!(content, "prefer fd over find");
+    drop(conn);
+
+    // Rewind `user_version` to 12 and reopen: `migrate_v13` must re-run over
+    // a column already gone without failing, the same idempotence contract
+    // every other migration in this file carries.
+    drop(store);
+    let conn = Connection::open(&path).unwrap();
+    conn.pragma_update(None, "user_version", 12i64).unwrap();
+    drop(conn);
+    let store2 = ContextStore::open(&path).unwrap();
+    let v: i64 = store2
+        .conn()
+        .query_row("PRAGMA user_version", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        v, SCHEMA_VERSION,
+        "re-running v13 over an already-dropped column must not fail"
+    );
+}
+
+/// Whether `table` currently has a column named `column`, via
+/// `PRAGMA table_info` — the same idempotence check `migrate_v13` itself runs.
+fn table_has_column(conn: &Connection, table: &str, column: &str) -> bool {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .unwrap();
+    let names: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>("name"))
+        .unwrap()
+        .collect::<rusqlite::Result<_>>()
+        .unwrap();
+    names.iter().any(|name| name == column)
+}

--- a/crates/stella-context/src/writeback.rs
+++ b/crates/stella-context/src/writeback.rs
@@ -98,10 +98,6 @@ pub struct EpisodeInput {
     /// it forms the episode's stable `epi_…` identity, so re-writing the same
     /// summary over the same window updates one row instead of appending.
     pub ended_at: String,
-    /// Caller-assigned importance, stored on the `episode` row. Recall does not
-    /// rank by it today (scoring is similarity + recency + graph adjacency);
-    /// it is a hint for consumers and for a future salience-aware ranker.
-    pub salience: f32,
     /// Workspace domain tags carried onto the episode's mirror node.
     pub domains: Vec<String>,
 }
@@ -119,7 +115,6 @@ impl EpisodeInput {
             outcome: EpisodeOutcome::Success,
             started_at: started_at.into(),
             ended_at: ended_at.into(),
-            salience: 0.0,
             domains: Vec::new(),
         }
     }
@@ -273,9 +268,9 @@ impl MemoryKind {
     }
 }
 
-/// A memory to write — content, kind, domains, salience. It becomes a `memory`
-/// record and a retrievable `Memory` node, so future turns recall it by
-/// similarity + domain overlap + recency.
+/// A memory to write — content, kind, domains. It becomes a `memory` record
+/// and a retrievable `Memory` node, so future turns recall it by similarity +
+/// domain overlap + recency.
 #[derive(Debug, Clone)]
 pub struct MemoryInput {
     /// Which sort of memory this is; stored on the `memory` row.
@@ -287,9 +282,6 @@ pub struct MemoryInput {
     /// Workspace domain tags carried onto the memory's mirror node; recall
     /// scores domain overlap against them.
     pub domains: Vec<String>,
-    /// Caller-assigned importance, stored on the `memory` row. As with
-    /// [`EpisodeInput::salience`], recall does not rank by it today.
-    pub salience: f32,
     /// The lineage this memory belongs to, when it revises an existing one.
     ///
     /// `None` — the overwhelmingly common case — means "a memory in its own
@@ -338,7 +330,6 @@ impl MemoryInput {
             kind: MemoryKind::Reflection,
             content: content.into(),
             domains: domains.into_iter().map(Into::into).collect(),
-            salience: 0.0,
             lineage: None,
             recall_tier: RecallTier::Normal,
             anchors: Vec::new(),
@@ -369,7 +360,6 @@ impl MemoryInput {
             kind,
             content: content.into(),
             domains: Vec::new(),
-            salience: 0.0,
             lineage: None,
             recall_tier: RecallTier::Normal,
             anchors: Vec::new(),
@@ -472,7 +462,7 @@ pub struct ContextDelta {
     pub domains: Vec<DomainInput>,
     /// Bare content nodes to index (docs, snippets, symbols).
     pub nodes: Vec<NodeInput>,
-    /// Episodic-memory summaries.
+    /// Summaries of past turns, one per episode.
     pub episodes: Vec<EpisodeInput>,
     /// Reflection/other memories.
     pub memories: Vec<MemoryInput>,
@@ -731,7 +721,6 @@ impl ContextStore {
                 &ep.summary,
                 &files,
                 ep.outcome.as_str(),
-                ep.salience as f64,
                 &ep.started_at,
                 &ep.ended_at,
                 &now,
@@ -753,7 +742,6 @@ impl ContextStore {
                 &memory.lineage_id(),
                 memory.kind.as_str(),
                 &memory.content,
-                memory.salience as f64,
                 &now,
             )?;
             let node = memory.as_node();

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -3730,7 +3730,7 @@ function renderLifecycle(d) {
   const episodes = d.episodes ?? [];
   $("imp-episodes").innerHTML = episodes.length
     ? `<table><thead><tr><th scope="col">episode</th><th scope="col">outcome</th>
-        <th scope="col" class="num">files</th><th scope="col" class="num">salience</th>
+        <th scope="col" class="num">files</th>
         <th scope="col" class="num">ended</th></tr></thead><tbody>` +
       episodes.map(ep => {
         const files = Array.isArray(ep.files_touched) ? ep.files_touched : [];
@@ -3739,7 +3739,6 @@ function renderLifecycle(d) {
         <td class="main">${esc(ep.summary)}</td>
         <td><span class="badge ${cls}">${esc(label)}</span></td>
         <td class="num" title="${esc(files.join("\n"))}">${fmtInt(files.length)}</td>
-        <td class="num">${num(ep.salience).toFixed(2)}</td>
         <td class="num">${ago(ep.ended_at)}</td></tr>`;
       }).join("") + `</tbody></table>`
     : `<div class="empty">No episodes recorded.<br>

--- a/crates/stella-observatory/src/context_db.rs
+++ b/crates/stella-observatory/src/context_db.rs
@@ -358,7 +358,7 @@ fn episode_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
     collect_rows(
         conn,
         &format!(
-            "SELECT summary, files_touched, outcome, salience, started_at, ended_at
+            "SELECT summary, files_touched, outcome, started_at, ended_at
              FROM episode WHERE superseded_at IS NULL
              ORDER BY ended_at DESC, id DESC LIMIT {MAX_LISTED_EPISODES}"
         ),
@@ -369,9 +369,8 @@ fn episode_rows(conn: &Connection) -> Result<Vec<Value>, DbError> {
                 "summary": truncate(&r.get::<_, String>(0)?, 240),
                 "files_touched": files,
                 "outcome": r.get::<_, String>(2)?,
-                "salience": r.get::<_, f64>(3)?,
-                "started_at": r.get::<_, String>(4)?,
-                "ended_at": r.get::<_, String>(5)?,
+                "started_at": r.get::<_, String>(3)?,
+                "ended_at": r.get::<_, String>(4)?,
             }))
         },
     )

--- a/crates/stella-observatory/src/self_driving_sessions.rs
+++ b/crates/stella-observatory/src/self_driving_sessions.rs
@@ -685,16 +685,15 @@ fn episode_rows(conn: &Connection) -> Result<Vec<Value>, crate::db::DbError> {
 fn lesson_rows(conn: &Connection) -> Result<Vec<Value>, crate::db::DbError> {
     collect_rows(
         conn,
-        "SELECT public_id, kind, content, salience, recorded_at
+        "SELECT public_id, kind, content, recorded_at
          FROM memory WHERE superseded_at IS NULL
          ORDER BY recorded_at DESC LIMIT 500",
         |r| {
-            let recorded: String = r.get(4)?;
+            let recorded: String = r.get(3)?;
             Ok(json!({
                 "id": r.get::<_, String>(0)?,
                 "kind": r.get::<_, String>(1)?,
                 "text": truncate(&r.get::<_, String>(2)?, 240),
-                "salience": r.get::<_, f64>(3)?,
                 "recorded_at": recorded,
                 "recorded_unix": parse_unix(&recorded).unwrap_or(0),
             }))


### PR DESCRIPTION
## What / why

`episode.salience` and `memory.salience` took a caller-set importance
hint that `stella-context`'s retrieval fusion never read (only vector
similarity, recency, and graph adjacency feed the score) and that no
writer in the workspace ever set to a nonzero value — neither
`EpisodeInput` nor `MemoryInput` even offered a builder for it, unlike
`with_domains`/`with_anchors`/`with_recall_tier`. `stella-observatory`'s
episode table rendered it as a permanent `0.00`.

Per epic #5374's rule (a stored fact is either used or removed, never
documented as ignored) I decided to **remove**, not wire in — see the
[design comment on the issue](https://github.com/macanderson/stella/issues/5339#issuecomment-5529394343)
for the reasoning: nothing produces a real salience score today, and
wiring it into ranking properly would mean moving it onto `node` first
(the crate's own precedent for a ranking-relevant signal, `node.recall_tier`
from `migrate_v9`), which is a bigger change than a constant earns.

## Changes

- `crates/stella-context/src/writeback.rs`: drop `EpisodeInput::salience`
  and `MemoryInput::salience`, their doc comments, and their constructor
  defaults.
- `crates/stella-context/src/store/record.rs`: drop the `salience`
  parameter and column from `insert_episode`/`insert_memory`.
- `crates/stella-context/src/store/schema.rs`: schema migration v13 drops
  `episode.salience` and `memory.salience`, idempotent across a rewound
  `user_version` the same way `migrate_v5`/`migrate_v8`/`migrate_v9` are
  (SQLite's `DROP COLUMN` has no `IF EXISTS`, so the check is manual).
- `crates/stella-observatory/src/context_db.rs`,
  `self_driving_sessions.rs`, `assets/index.html`: drop the two surfaces
  that displayed the always-zero value (the episode table's `salience`
  column, and `lesson_rows`' unused `salience` JSON key — grep confirms
  nothing in the frontend read the latter at all).

## Witness

`store::tests::migrations::v13_drops_salience_and_keeps_everything_else`
(new, in `crates/stella-context/src/store/tests/migrations.rs`): builds a
v7-schema fixture with both columns present and populated, opens it
through `ContextStore::open`, and asserts both columns are gone while
every other column's value survived. Confirmed the mechanism directly:
copied the pre-fix `schema.rs` (schema version 12, no `migrate_v13`) back
in and re-ran the test — it fails with `v13 must drop episode.salience`.
Restoring the fix makes it pass again.

## Tests

`cargo test -p stella-context` (179 passed), `cargo test -p stella-cli
--bin stella memory::` (325 passed), `cargo test -p stella-observatory
--test schema_conformance` (20 passed, including the store-older-than-
this-build compatibility test).

Tests deleted: none.

Closes #5339

## Summary by Sourcery

Remove the unused salience data from context records and observability surfaces, and migrate existing stores to the simplified schema.

Enhancements:
- Remove the unused salience fields from episode and memory inputs, persistence, and retrieval-facing observatory views.
- Add schema migration v13 to safely remove the obsolete salience columns while preserving existing data and supporting repeated migration runs.

Tests:
- Add migration coverage verifying both salience columns are removed, other record values are preserved, and the migration is idempotent.