### PR TITLE
fix(stella-context): six recall and writeback defects, each with a witness

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -957,6 +957,16 @@ impl SessionMemory {
             format_rfc3339(now_secs),
         )
         .with_domains(domains);
+        // The turn's own execution row is what separates two turns that share a
+        // prompt and land in the same second — both timestamps are
+        // second-resolution, so without it the second write lands on top of the
+        // first and the earlier turn's outcome and files are gone. A turn that
+        // is recorded twice passes the same id and still updates one row. A
+        // path that never adopted `set_execution_id` keeps the older identity
+        // and the collision with it, which is tracked on its own issue.
+        if let Some(execution) = self.execution_id {
+            episode = episode.with_occurrence(execution.to_string());
+        }
         episode.outcome = outcome;
         episode.files_touched = files_touched.iter().map(|(path, _)| path.clone()).collect();
 
@@ -964,6 +974,12 @@ impl SessionMemory {
             episodes: vec![episode],
             ..Default::default()
         };
+        // Ignored on purpose, and it is the weakest link on this path: a
+        // failed episode must not fail the turn it describes, the deck calls
+        // this while it owns the terminal so stderr is not available, and the
+        // workspace has no logger to route the failure to. Reporting it is
+        // tracked on its own issue. The delta holds one record, so nothing
+        // else is lost with it.
         let _ = self.store.upsert(delta).await;
     }
 

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -48,6 +48,30 @@ mod skill_lifecycle;
 #[cfg(test)]
 mod dedupe;
 
+/// Drop the lessons the store cannot write, keeping every one it can.
+///
+/// A memory's mirror node takes its display name from the memory's own text,
+/// and a node with a blank name is refused — a node has to be humanly citable
+/// (`L-C4`). A lesson with no words in either half is therefore unwritable, and
+/// the whole delta is one transaction, so handing the store one of them throws
+/// away every good lesson of the same turn. The model writes the text, so an
+/// empty one is model output like any other rather than a case that cannot
+/// arise.
+///
+/// The check is `recall_text`'s output, not the lesson alone: a lesson with no
+/// body but a real trigger still has words, and it is that composed string the
+/// store labels the node from.
+fn writable_lessons(lessons: Vec<ReflectionLesson>) -> Vec<ReflectionLesson> {
+    lessons
+        .into_iter()
+        .filter(|l| {
+            !applicability::recall_text(&l.lesson, &l.trigger)
+                .trim()
+                .is_empty()
+        })
+        .collect()
+}
+
 /// One SPEC 6.3 `memory` (log) event per lesson the store just wrote.
 ///
 /// Paired positionally with [`stella_context::UpsertReceipt::memory_node_ids`],
@@ -74,30 +98,6 @@ mod dedupe;
 ///   evidently of the next; a domain lesson is still true on a task the agent
 ///   has never seen. That is the distinction [`LessonKind`] draws, and the one
 ///   [`LessonKind::recall_tier`] already spends the recall budget on.
-/// Drop the lessons the store cannot write, keeping every one it can.
-///
-/// A memory's mirror node takes its display name from the memory's own text,
-/// and a node with a blank name is refused — a node has to be humanly citable
-/// (`L-C4`). A lesson with no words in either half is therefore unwritable, and
-/// the whole delta is one transaction, so handing the store one of them throws
-/// away every good lesson of the same turn. The model writes the text, so an
-/// empty one is model output like any other rather than a case that cannot
-/// arise.
-///
-/// The check is `recall_text`'s output, not the lesson alone: a lesson with no
-/// body but a real trigger still has words, and it is that composed string the
-/// store labels the node from.
-fn writable_lessons(lessons: Vec<ReflectionLesson>) -> Vec<ReflectionLesson> {
-    lessons
-        .into_iter()
-        .filter(|l| {
-            !applicability::recall_text(&l.lesson, &l.trigger)
-                .trim()
-                .is_empty()
-        })
-        .collect()
-}
-
 fn memory_logged_events(
     novel: &[ReflectionLesson],
     memory_node_ids: &[String],

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -74,6 +74,30 @@ mod dedupe;
 ///   evidently of the next; a domain lesson is still true on a task the agent
 ///   has never seen. That is the distinction [`LessonKind`] draws, and the one
 ///   [`LessonKind::recall_tier`] already spends the recall budget on.
+/// Drop the lessons the store cannot write, keeping every one it can.
+///
+/// A memory's mirror node takes its display name from the memory's own text,
+/// and a node with a blank name is refused — a node has to be humanly citable
+/// (`L-C4`). A lesson with no words in either half is therefore unwritable, and
+/// the whole delta is one transaction, so handing the store one of them throws
+/// away every good lesson of the same turn. The model writes the text, so an
+/// empty one is model output like any other rather than a case that cannot
+/// arise.
+///
+/// The check is `recall_text`'s output, not the lesson alone: a lesson with no
+/// body but a real trigger still has words, and it is that composed string the
+/// store labels the node from.
+fn writable_lessons(lessons: Vec<ReflectionLesson>) -> Vec<ReflectionLesson> {
+    lessons
+        .into_iter()
+        .filter(|l| {
+            !applicability::recall_text(&l.lesson, &l.trigger)
+                .trim()
+                .is_empty()
+        })
+        .collect()
+}
+
 fn memory_logged_events(
     novel: &[ReflectionLesson],
     memory_node_ids: &[String],
@@ -240,6 +264,7 @@ impl SessionMemory {
         // at recall is what makes forgetting durable — an unsuppressed lesson
         // would land in the log and stay re-mineable forever.
         let lessons = self.retain_unforgotten(turn_store.as_ref(), lessons);
+        let lessons = writable_lessons(lessons);
         // Then split what survives into lessons the store should learn and
         // restatements of what it already holds. The split — rather than the
         // filter this used to be — is the #2358 fix: a restatement must skip

--- a/crates/stella-cli/src/memory/learning/dedupe.rs
+++ b/crates/stella-cli/src/memory/learning/dedupe.rs
@@ -168,3 +168,37 @@ async fn a_batch_repeat_of_a_diverted_restatement_is_dropped_not_double_counted(
          evidence of anything but verbosity"
     );
 }
+
+/// A lesson with no words costs itself and nothing else.
+///
+/// The store labels a memory's mirror node from the memory's own text and
+/// refuses a blank label, and the whole batch is one transaction — so a
+/// whitespace-only lesson handed to the store takes every good lesson of the
+/// same turn down with it, and the caller sees only a failed write. The turn's
+/// other lessons have to survive it.
+#[test]
+fn a_blank_lesson_is_dropped_and_its_siblings_are_kept() {
+    let mut blank = lesson("   \n\t ");
+    blank.trigger = "  ".to_string();
+    let writable = super::writable_lessons(vec![
+        lesson("commands are registered in registry.py"),
+        blank,
+        lesson("the deck reads its own snapshot"),
+    ]);
+    assert_eq!(
+        texts(&writable),
+        vec![
+            "commands are registered in registry.py",
+            "the deck reads its own snapshot",
+        ]
+    );
+}
+
+/// A lesson that is blank only in its body still has words, and is kept: the
+/// store labels the node from the composed string, not from the body alone.
+#[test]
+fn a_lesson_with_only_a_trigger_is_still_writable() {
+    let mut only_trigger = lesson("");
+    only_trigger.trigger = "editing a provider adapter".to_string();
+    assert_eq!(super::writable_lessons(vec![only_trigger]).len(), 1);
+}

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -9,6 +9,9 @@ mod ab_control;
 // source rather than the wall clock is the property replay rests on, and it is
 // what makes the truth sweep's TTL branch reachable from a test at all.
 mod determinism;
+// What keeps two turns' episodes apart when their prompt and their second are
+// the same — the case the timestamps alone cannot answer.
+mod episode_identity;
 // #3349: the assembled volatile block's bytes, pinned — the evidence that the
 // steering-plane migration changed the wiring and not the prompt.
 mod golden_block;

--- a/crates/stella-cli/src/memory/tests/episode_identity.rs
+++ b/crates/stella-cli/src/memory/tests/episode_identity.rs
@@ -1,0 +1,76 @@
+//! Two turns in one second are two episodes.
+//!
+//! An episode is keyed by its text and its time window. Both are cut to whole
+//! seconds. So two turns on the same prompt in one second get the same key.
+//! The second write then lands on the row the first turn wrote. What is left
+//! holds one turn's result under the other turn's name, and no one is told.
+//!
+//! The turn's own row id in the store keeps them apart. The chat path sets it
+//! in `stamp_and_record_skill_usage`. A path that sets none can still clash,
+//! and that gap has its own issue.
+
+use std::sync::Arc;
+
+use stella_context::{Clock, EpisodeOutcome, FixedClock};
+
+use crate::memory::SessionMemory;
+
+const PROMPT: &str = "run the failing test again";
+
+/// A session on a fixed clock, so both turns land in one second. A real clock
+/// would hit that case only by luck.
+fn session(root: &std::path::Path) -> SessionMemory {
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock::new(1_700_000_000));
+    SessionMemory::open_with_clock(root, false, false, clock).expect("session memory")
+}
+
+/// The text of each episode in this store.
+fn episodes(memory: &SessionMemory) -> Vec<String> {
+    memory
+        .store
+        .recallable_nodes()
+        .expect("nodes readable")
+        .into_iter()
+        .filter(|n| n.kind == stella_context::NodeKind::Episode)
+        .map(|n| n.content)
+        .collect()
+}
+
+/// Same prompt, same second, two turns. Both must be kept.
+#[tokio::test]
+async fn two_executions_in_one_second_keep_their_own_episodes() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut memory = session(dir.path());
+
+    memory.set_execution_id(41);
+    memory
+        .record_episode(PROMPT, EpisodeOutcome::Success, &[], 1_700_000_000, None)
+        .await;
+    memory.set_execution_id(42);
+    memory
+        .record_episode(PROMPT, EpisodeOutcome::Failure, &[], 1_700_000_000, None)
+        .await;
+
+    assert_eq!(
+        episodes(&memory).len(),
+        2,
+        "the second turn wrote over the first turn's row"
+    );
+}
+
+/// One turn, written twice, is still one episode. A key that does not hold
+/// still would double each row a retry writes again.
+#[tokio::test]
+async fn one_execution_recorded_twice_keeps_one_episode() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut memory = session(dir.path());
+
+    memory.set_execution_id(41);
+    for _ in 0..2 {
+        memory
+            .record_episode(PROMPT, EpisodeOutcome::Success, &[], 1_700_000_000, None)
+            .await;
+    }
+
+    assert_eq!(episodes(&memory).len(), 1);
+}

--- a/crates/stella-context/src/retrieval/outcome.rs
+++ b/crates/stella-context/src/retrieval/outcome.rs
@@ -96,13 +96,16 @@ impl SelectionReason {
 /// only when, something has to be dropped. Within a tier the ranking still
 /// decides everything.
 ///
-/// The vocabulary has exactly two entries, and the asymmetry is the point.
+/// The asymmetry between the entries is the point.
 /// [`Normal`](RecallTier::Normal) is the default for every node the store has
 /// ever written, so adding this changes nothing for code symbols, episodes, or
 /// ordinary memories. [`Deferred`](RecallTier::Deferred) has to be asked for.
 /// Nothing is *promoted* by a tier — a frame can only volunteer to yield first
 /// — which is what keeps a writer from buying rank by relabeling its own
 /// content.
+///
+/// [`RecallTier::ALL`] is the whole vocabulary, in the order the budget admits
+/// it, and it is what the packer walks.
 ///
 /// Its one caller today is the reflection lifecycle: a lesson about how the
 /// agent went about its work (`LessonKind::Process`) is written `Deferred`, so
@@ -155,6 +158,51 @@ impl RecallTier {
             _ => RecallTier::Normal,
         }
     }
+}
+
+/// Declares the tier family once and derives [`RecallTier::ALL`] from it.
+///
+/// The same token list builds `ALL` and an exhaustive `match`, so a tier added
+/// to the enum but not named here fails that match with `E0004`. That matters
+/// more here than for most enumerations: `pack_to_budget` walks `ALL` one band
+/// at a time, and a band it never walks holds candidates that reach neither the
+/// kept set nor the dropped one — the partition `L-C5` forbids, and invisible
+/// until a store starts writing the new tier.
+///
+/// Modelled on `model_call_roles!` in `stella-protocol`'s
+/// `event::call_role`, which binds `ModelCallRole::ALL` to its enum the same
+/// way.
+macro_rules! recall_tiers {
+    ($($tier:ident),* $(,)?) => {
+        impl RecallTier {
+            /// Every tier, in the order the budget admits them: a later entry
+            /// is offered only what the earlier ones left.
+            ///
+            /// Unlike most `ALL` lists this order is a contract, because
+            /// `pack_to_budget` reads it as the precedence order. It is the
+            /// enum's declaration order, which is also what `Ord` gives.
+            pub const ALL: &'static [Self] = &[$(Self::$tier,)*];
+
+            /// Compile-time proof that [`Self::ALL`] names every tier.
+            ///
+            /// Never called at runtime and does nothing: its body is an
+            /// exhaustive `match`, and that is the assertion. The `const` item
+            /// below forces it to be evaluated, so it cannot rot into dead
+            /// code.
+            const fn every_tier_is_in_all(self) {
+                match self {
+                    $(Self::$tier => (),)*
+                }
+            }
+        }
+
+        const _: () = RecallTier::Normal.every_tier_is_in_all();
+    };
+}
+
+recall_tiers! {
+    Normal,
+    Deferred,
 }
 
 /// Why a candidate frame did not make it into the assembled context.

--- a/crates/stella-context/src/retrieval/ranking.rs
+++ b/crates/stella-context/src/retrieval/ranking.rs
@@ -292,11 +292,15 @@ pub(crate) fn pack_to_budget(
     // deferred candidate is admitted only out of what the normal ones left. The
     // walk within a band is still strict rank order, and a band is not a score:
     // with budget to spare every candidate is admitted exactly as before, and
-    // the tier decides nothing until something has to be dropped. Two passes
-    // over a shortlist that `max_frames * mmr_candidate_multiple` already
-    // bounded, so the extra walk is not a cost worth avoiding.
+    // the tier decides nothing until something has to be dropped. One pass per
+    // band over a shortlist that `max_frames * mmr_candidate_multiple` already
+    // bounded, so the extra walks are not a cost worth avoiding.
+    //
+    // `RecallTier::ALL` rather than a literal band list: a tier missing from
+    // the walk is a tier whose candidates land in neither `kept` nor `dropped`,
+    // and `ALL` is derived from a total match so a new tier cannot go missing.
     let mut ranked_kept = 0usize;
-    for band in [RecallTier::Normal, RecallTier::Deferred] {
+    for &band in RecallTier::ALL {
         for (index, candidate) in candidates.iter().enumerate() {
             if candidate.is_required() || candidate.meta.recall_tier != band {
                 continue;

--- a/crates/stella-context/src/retrieval/tests.rs
+++ b/crates/stella-context/src/retrieval/tests.rs
@@ -329,6 +329,67 @@ fn a_deferred_item_cannot_displace_a_required_one() {
     assert_eq!(dropped[0].id, "process_note");
 }
 
+/// A knob that is not a number takes the default.
+///
+/// `f32::clamp` passes NaN straight through — it answers "is this in range",
+/// and NaN is neither in nor out — so a clamp alone leaves both float knobs
+/// NaN. A NaN `mmr_lambda` makes every MMR comparison false, and a NaN
+/// `min_coverage` never compares below the coverage score, which turns off the
+/// lexical fallback the coverage floor exists to trigger.
+#[test]
+fn a_knob_that_is_not_a_number_falls_back_to_its_default() {
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let sane = RecallTuning {
+            mmr_lambda: bad,
+            min_coverage: bad,
+            ..RecallTuning::default()
+        }
+        .sanitized();
+        assert_eq!(sane.mmr_lambda, DEFAULT_MMR_LAMBDA, "mmr_lambda from {bad}");
+        assert_eq!(
+            sane.min_coverage, DEFAULT_MIN_COVERAGE,
+            "min_coverage from {bad}"
+        );
+    }
+    // A number outside the range is still clamped, not defaulted: the guard
+    // added a validity check, it did not replace the range check.
+    let clamped = RecallTuning {
+        mmr_lambda: 5.0,
+        min_coverage: -1.0,
+        ..RecallTuning::default()
+    }
+    .sanitized();
+    assert_eq!(clamped.mmr_lambda, 1.0);
+    assert_eq!(clamped.min_coverage, 0.0);
+}
+
+/// Every tier the vocabulary holds is a tier the packer walks.
+///
+/// One candidate per entry of [`RecallTier::ALL`], with room for none of them,
+/// so a tier the band walk skips shows up as a candidate in neither `kept` nor
+/// `dropped` — the partition failure `L-C5` forbids. A hand-written band list
+/// is right today and silently wrong the day a third tier is written by
+/// anything; this test cannot be compiled against one, because
+/// [`RecallTier::ALL`] is what the fix adds.
+#[test]
+fn every_tier_reaches_the_packer() {
+    let frames: Vec<Ranked> = RecallTier::ALL
+        .iter()
+        .enumerate()
+        .map(|(i, tier)| {
+            let mut c = candidate(tier.as_str(), 1);
+            c.meta.id = i as i64;
+            c.meta.recall_tier = *tier;
+            c
+        })
+        .collect();
+    let total = frames.len();
+    // No slots at all, so every candidate must be reported as dropped.
+    let (kept, dropped) = pack_to_budget(frames, 1000, 0);
+    assert!(kept.is_empty(), "kept: {kept:?}");
+    assert_eq!(dropped.len(), total, "dropped: {dropped:?}");
+}
+
 // ── Required items survive ranking pressure (#713 deliverable 5) ────────────
 
 #[test]

--- a/crates/stella-context/src/retrieval/tuning.rs
+++ b/crates/stella-context/src/retrieval/tuning.rs
@@ -197,8 +197,23 @@ impl RecallTuning {
             } else {
                 DEFAULT_RECENCY_WEIGHT
             },
-            mmr_lambda: self.mmr_lambda.clamp(0.0, 1.0),
-            min_coverage: self.min_coverage.clamp(0.0, 1.0),
+            // `clamp` asks if a value is in range, not if it is a number, so
+            // NaN goes straight through it. Both knobs take the `is_finite`
+            // guard the two `f64` knobs above have. A NaN `mmr_lambda` makes
+            // every MMR test false. A NaN `min_coverage` never falls under
+            // the coverage score, so the lexical fallback stops firing. An
+            // infinity takes the default too, as `rrf_k` does. JSON can spell
+            // neither value, so no settings file reaches this today.
+            mmr_lambda: if self.mmr_lambda.is_finite() {
+                self.mmr_lambda.clamp(0.0, 1.0)
+            } else {
+                DEFAULT_MMR_LAMBDA
+            },
+            min_coverage: if self.min_coverage.is_finite() {
+                self.min_coverage.clamp(0.0, 1.0)
+            } else {
+                DEFAULT_MIN_COVERAGE
+            },
             coverage_topk: self.coverage_topk.max(1),
             max_vector_seeds: self.max_vector_seeds,
             lexical_limit: self.lexical_limit.max(1),

--- a/crates/stella-context/src/writeback.rs
+++ b/crates/stella-context/src/writeback.rs
@@ -94,10 +94,22 @@ pub struct EpisodeInput {
     pub outcome: EpisodeOutcome,
     /// RFC-3339 start of the episode's window.
     pub started_at: String,
-    /// RFC-3339 end of the episode's window. With `summary` and `started_at`
-    /// it forms the episode's stable `epi_…` identity, so re-writing the same
-    /// summary over the same window updates one row instead of appending.
+    /// RFC-3339 end of the episode's window. With `summary`, `started_at` and
+    /// `occurrence` it forms the episode's stable `epi_…` identity, so
+    /// re-writing the same episode updates one row instead of appending.
     pub ended_at: String,
+    /// What tells two episodes apart when their summary and window are equal.
+    ///
+    /// Both timestamps are second-resolution, so two turns on the same prompt
+    /// inside one second hash to one id and the second write silently replaces
+    /// the first — a different outcome and a different file list, over the top
+    /// of the record they belong to. A caller that holds a per-turn identity
+    /// passes it here and the two stay separate; passing the same key again is
+    /// still the update it was, which is what a retry of one turn wants.
+    ///
+    /// `None` hashes exactly as before this field existed, so every `epi_` id
+    /// already on disk is unchanged.
+    pub occurrence: Option<String>,
     /// Caller-assigned importance, stored on the `episode` row. Recall does not
     /// rank by it today (scoring is similarity + recency + graph adjacency);
     /// it is a hint for consumers and for a future salience-aware ranker.
@@ -119,9 +131,18 @@ impl EpisodeInput {
             outcome: EpisodeOutcome::Success,
             started_at: started_at.into(),
             ended_at: ended_at.into(),
+            occurrence: None,
             salience: 0.0,
             domains: Vec::new(),
         }
+    }
+
+    /// Set the key that separates this episode from another with the same
+    /// summary and window. See [`Self::occurrence`].
+    #[must_use]
+    pub fn with_occurrence(mut self, occurrence: impl Into<String>) -> Self {
+        self.occurrence = Some(occurrence.into());
+        self
     }
 
     /// Tag with one or more workspace domains.
@@ -146,7 +167,11 @@ impl EpisodeInput {
         self
     }
 
-    /// Stable identity: the summary plus its time window.
+    /// Stable identity: the summary, its time window, and the occurrence key
+    /// when the caller supplied one.
+    ///
+    /// An absent key adds no bytes, so an episode written without one keeps
+    /// the id it has always had.
     fn public_id(&self) -> String {
         let mut h = Sha256::new();
         h.update(self.summary.as_bytes());
@@ -154,6 +179,10 @@ impl EpisodeInput {
         h.update(self.started_at.as_bytes());
         h.update([0u8]);
         h.update(self.ended_at.as_bytes());
+        if let Some(occurrence) = &self.occurrence {
+            h.update([0u8]);
+            h.update(occurrence.as_bytes());
+        }
         format!("epi_{}", &to_hex(&h.finalize())[..24])
     }
 
@@ -626,14 +655,106 @@ fn truncate_label(s: &str) -> String {
     format!("{truncated}…")
 }
 
+/// How many times [`ContextStore::upsert`] re-embeds and retries when a vector
+/// it planned to reuse is gone by the time it writes.
+///
+/// Each retry embeds what went, so the reusable set only shrinks. Two reclaims
+/// in a row are already unlikely. The last try writes what it has: the other
+/// choice is to fail a write over a race the next warm index would repair.
+const REUSE_RACE_ATTEMPTS: usize = 3;
+
+/// What one attempt at a delta did.
+enum UpsertAttempt {
+    /// The transaction committed.
+    Committed(UpsertReceipt),
+    /// A vector the attempt planned to reuse was gone by the time the
+    /// transaction could see it, so nothing was written. Carries the content
+    /// hashes to embed on the retry.
+    Raced(Vec<String>),
+}
+
+/// The record in this delta that cannot be written, named for the error.
+///
+/// Every record here mints a node, and a node needs a name a person can cite
+/// (`L-C4`). An episode and a memory take that name from their own text. So a
+/// blank summary, or a lesson that is all spaces, is a record the store will
+/// not take. Left to the transaction, it says so half way through: the delta
+/// has paid for its embeddings and the whole batch rolls back. Asked first,
+/// the answer names the record. A caller that builds a batch can then drop
+/// the one bad entry and keep the rest.
+fn unwritable_record(delta: &ContextDelta) -> Option<String> {
+    if delta.domains.iter().any(|d| d.name.trim().is_empty()) {
+        return Some("a domain with a blank name".into());
+    }
+    if delta.nodes.iter().any(|n| n.display_name.trim().is_empty()) {
+        return Some("a node with a blank display name".into());
+    }
+    if delta.episodes.iter().any(|e| e.summary.trim().is_empty()) {
+        return Some("an episode with a blank summary".into());
+    }
+    if delta.memories.iter().any(|m| m.content.trim().is_empty()) {
+        return Some("a memory with blank content".into());
+    }
+    if delta.facts.iter().any(|f| {
+        f.subject.display_name.trim().is_empty() || f.object.display_name.trim().is_empty()
+    }) {
+        return Some("a fact whose subject or object has a blank display name".into());
+    }
+    None
+}
+
 impl ContextStore {
     /// Apply a delta atomically, returning a receipt. Embedding decisions
     /// happen before the transaction (async), then all node/episode/fact/vector
     /// writes commit together (`L-L1`).
+    ///
+    /// A record that cannot be written is rejected before anything is embedded
+    /// or written — see [`unwritable_record`] for why the whole batch is the
+    /// thing at stake.
     pub async fn upsert(&self, delta: ContextDelta) -> Result<UpsertReceipt, ContextError> {
+        if let Some(what) = unwritable_record(&delta) {
+            return Err(ContextError::InvalidInput(format!(
+                "delta holds {what}; every record must mint a humanly citable node (L-C4)"
+            )));
+        }
         let now = self.clock().now_rfc3339();
         let fingerprint = self.fingerprint().id();
+        // Content this delta must embed even though a vector for it exists:
+        // an earlier attempt found that vector gone once it opened the write
+        // transaction. Empty on the first attempt, which is every ordinary one.
+        let mut force_embed: HashSet<String> = HashSet::new();
+        let mut attempts = 0usize;
+        loop {
+            attempts += 1;
+            // The last attempt commits without re-checking, so this terminates.
+            let recheck = attempts < REUSE_RACE_ATTEMPTS;
+            match self
+                .upsert_attempt(&delta, &now, &fingerprint, &force_embed, recheck)
+                .await?
+            {
+                UpsertAttempt::Committed(receipt) => return Ok(receipt),
+                UpsertAttempt::Raced(vanished) => force_embed.extend(vanished),
+            }
+        }
+    }
 
+    /// One pass of [`Self::upsert`]: embed what is missing, then write.
+    ///
+    /// `recheck` asks the write transaction to confirm that every vector the
+    /// embedding pass decided to reuse is still there. It cannot be assumed:
+    /// the store holds no lock while it embeds, and until this delta's nodes
+    /// exist those vectors belong to no node, which is exactly what
+    /// [`ContextStore::compact`] reclaims. Losing that race left the new node
+    /// with no vector — invisible to similarity recall until the next mount's
+    /// warm indexer noticed.
+    async fn upsert_attempt(
+        &self,
+        delta: &ContextDelta,
+        now: &str,
+        fingerprint: &str,
+        force_embed: &HashSet<String>,
+        recheck: bool,
+    ) -> Result<UpsertAttempt, ContextError> {
         // Phase A: decide what to embed (async, no lock held).
         // Gather every distinct piece of embeddable content in this delta.
         let mut contents: Vec<(String, String)> = Vec::new();
@@ -663,12 +784,14 @@ impl ContextStore {
         }
 
         // Partition into already-embedded (reused) vs missing (`L-C2`).
+        // `force_embed` holds content an earlier attempt watched disappear, so
+        // it is embedded again rather than trusted a second time.
         let (missing, reused): (Vec<_>, Vec<_>) = {
             let conn = self.conn();
             let mut missing = Vec::new();
             let mut reused = Vec::new();
             for (hash, content) in contents {
-                if embedding_exists(&conn, &hash, &fingerprint)? {
+                if !force_embed.contains(&hash) && embedding_exists(&conn, &hash, fingerprint)? {
                     reused.push(hash);
                 } else {
                     missing.push((hash, content));
@@ -711,15 +834,32 @@ impl ContextStore {
         let conn = self.conn();
         let tx = conn.unchecked_transaction()?;
 
+        // Ask the transaction, not the earlier read, whether the reusable
+        // vectors are still there. A vector this delta plans to lean on belongs
+        // to no node until the delta lands, so `compact` may have reclaimed it
+        // as an orphan while the embedder was working. Dropping `tx` rolls the
+        // attempt back and nothing has been written yet.
+        if recheck {
+            let mut vanished = Vec::new();
+            for hash in &reused {
+                if !embedding_exists(&tx, hash, fingerprint)? {
+                    vanished.push(hash.clone());
+                }
+            }
+            if !vanished.is_empty() {
+                return Ok(UpsertAttempt::Raced(vanished));
+            }
+        }
+
         // Explicit domain definitions first, so descriptions land even if the
         // same names are also referenced as bare tags below.
         for domain in &delta.domains {
-            upsert_domain(&tx, &domain.name, domain.description.as_deref(), &now)?;
+            upsert_domain(&tx, &domain.name, domain.description.as_deref(), now)?;
         }
 
         for node in &delta.nodes {
-            let id = upsert_node(&tx, node, &now)?;
-            receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, &now)?;
+            let id = upsert_node(&tx, node, now)?;
+            receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, now)?;
             receipt.nodes_upserted += 1;
         }
 
@@ -734,16 +874,16 @@ impl ContextStore {
                 ep.salience as f64,
                 &ep.started_at,
                 &ep.ended_at,
-                &now,
+                now,
             )?;
             let node = ep.as_node();
-            let id = upsert_node(&tx, &node, &now)?;
-            receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, &now)?;
+            let id = upsert_node(&tx, &node, now)?;
+            receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, now)?;
             receipt.nodes_upserted += 1;
             receipt.episodes_written += 1;
             // The files this turn touched, as edges rather than only as the
             // JSON column written above (#5338).
-            anchor_to_files(&tx, id, &ep.files_touched, &ep.domains, &now, &mut receipt)?;
+            anchor_to_files(&tx, id, &ep.files_touched, &ep.domains, now, &mut receipt)?;
         }
 
         for memory in &delta.memories {
@@ -754,11 +894,11 @@ impl ContextStore {
                 memory.kind.as_str(),
                 &memory.content,
                 memory.salience as f64,
-                &now,
+                now,
             )?;
             let node = memory.as_node();
-            let id = upsert_node(&tx, &node, &now)?;
-            receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, &now)?;
+            let id = upsert_node(&tx, &node, now)?;
+            receipt.domain_tags_added += tag_node_domains(&tx, id, &node.domains, now)?;
             receipt.nodes_upserted += 1;
             receipt.memories_written += 1;
             receipt.memory_node_ids.push(node.public_id());
@@ -768,31 +908,24 @@ impl ContextStore {
             // node's identity is minted in this loop — a caller would have to
             // reconstruct `memory://{lineage}` by hand and would silently
             // anchor to nothing the day that spelling changed.
-            anchor_to_files(
-                &tx,
-                id,
-                &memory.anchors,
-                &memory.domains,
-                &now,
-                &mut receipt,
-            )?;
+            anchor_to_files(&tx, id, &memory.anchors, &memory.domains, now, &mut receipt)?;
         }
 
         for fact in &delta.facts {
-            let src = upsert_node(&tx, &fact.subject, &now)?;
-            let dst = upsert_node(&tx, &fact.object, &now)?;
-            receipt.domain_tags_added += tag_node_domains(&tx, src, &fact.subject.domains, &now)?;
-            receipt.domain_tags_added += tag_node_domains(&tx, dst, &fact.object.domains, &now)?;
+            let src = upsert_node(&tx, &fact.subject, now)?;
+            let dst = upsert_node(&tx, &fact.object, now)?;
+            receipt.domain_tags_added += tag_node_domains(&tx, src, &fact.subject.domains, now)?;
+            receipt.domain_tags_added += tag_node_domains(&tx, dst, &fact.object.domains, now)?;
             receipt.nodes_upserted += 2;
-            apply_fact(&tx, fact, src, dst, &now, &mut receipt)?;
+            apply_fact(&tx, fact, src, dst, now, &mut receipt)?;
         }
 
         for (hash, vector) in &new_vectors {
-            store_embedding(&tx, hash, &fingerprint, vector, &now)?;
+            store_embedding(&tx, hash, fingerprint, vector, now)?;
         }
 
         tx.commit()?;
-        Ok(receipt)
+        Ok(UpsertAttempt::Committed(receipt))
     }
 
     /// Every record→file anchor still believed and still holding in the world.

--- a/crates/stella-context/src/writeback.rs
+++ b/crates/stella-context/src/writeback.rs
@@ -709,8 +709,9 @@ impl ContextStore {
     /// writes commit together (`L-L1`).
     ///
     /// A record that cannot be written is rejected before anything is embedded
-    /// or written — see [`unwritable_record`] for why the whole batch is the
-    /// thing at stake.
+    /// or written. The whole batch is what is at stake: a refusal from inside
+    /// the transaction rolls every good record back with the bad one, and says
+    /// nothing about which one was at fault.
     pub async fn upsert(&self, delta: ContextDelta) -> Result<UpsertReceipt, ContextError> {
         if let Some(what) = unwritable_record(&delta) {
             return Err(ContextError::InvalidInput(format!(

--- a/crates/stella-context/src/writeback/tests.rs
+++ b/crates/stella-context/src/writeback/tests.rs
@@ -8,7 +8,7 @@
 
 use super::*;
 use crate::clock::FixedClock;
-use crate::embed::HashEmbedder;
+use crate::embed::{Embedder, HashEmbedder};
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -543,4 +543,260 @@ async fn ending_an_anchor_twice_keeps_the_first_date() {
         !store.end_anchor_validity(anchor.edge_id, &later).unwrap(),
         "a second scan reports no change rather than re-dating the deletion"
     );
+}
+
+// ── Identity, validation, and the reuse race ────────────────────────────────
+
+/// How many `episode` rows the store holds.
+fn episode_count(store: &ContextStore) -> i64 {
+    store
+        .conn()
+        .query_row("SELECT COUNT(*) FROM episode", [], |r| r.get(0))
+        .unwrap()
+}
+
+/// Two turns that share a prompt and a second are two episodes.
+///
+/// Both timestamps are second-resolution, so the summary and the window come
+/// out equal for two distinct turns often enough to matter — and the second
+/// write then landed on the first turn's row, replacing its outcome and its
+/// file list with another turn's. The occurrence key is how a caller says the
+/// two are different; without it this test writes one row.
+#[tokio::test]
+async fn two_turns_in_one_second_write_two_episodes() {
+    let clock = FixedClock::shared(1_000);
+    let (_dir, store) = store_at(clock);
+    for occurrence in ["execution:41", "execution:42"] {
+        store
+            .upsert(
+                ContextDelta::new().with_episode(
+                    EpisodeInput::new(
+                        "run the failing test",
+                        "2026-07-01T10:00:00Z",
+                        "2026-07-01T10:00:00Z",
+                    )
+                    .with_occurrence(occurrence),
+                ),
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(episode_count(&store), 2, "one turn overwrote the other");
+
+    // The same key again is still the update it always was — a turn recorded
+    // twice must not double its row.
+    store
+        .upsert(
+            ContextDelta::new().with_episode(
+                EpisodeInput::new(
+                    "run the failing test",
+                    "2026-07-01T10:00:00Z",
+                    "2026-07-01T10:00:00Z",
+                )
+                .with_occurrence("execution:42"),
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        episode_count(&store),
+        2,
+        "re-recording one turn added a row"
+    );
+}
+
+/// An episode written with no occurrence key keeps the identity it always had.
+#[tokio::test]
+async fn an_episode_without_an_occurrence_keeps_its_old_identity() {
+    let clock = FixedClock::shared(1_000);
+    let (_dir, store) = store_at(clock);
+    for _ in 0..2 {
+        store
+            .upsert(ContextDelta::new().with_episode(EpisodeInput::new(
+                "the same turn, recorded twice",
+                "2026-07-01T10:00:00Z",
+                "2026-07-01T10:05:00Z",
+            )))
+            .await
+            .unwrap();
+    }
+    assert_eq!(episode_count(&store), 1);
+}
+
+/// An embedder that reclaims one stored vector while it is embedding.
+///
+/// This is the `compact` race, made deterministic and single-threaded: the
+/// store holds no lock while it embeds, so anything may delete a row in that
+/// window, and the row this deletes is one the same delta was about to reuse.
+/// A real reclaim is legitimate — until this delta's nodes exist, that vector
+/// belongs to no node and is exactly what `compact` collects.
+struct ReclaimingEmbedder {
+    inner: HashEmbedder,
+    /// The store's own connection, attached after the store is built.
+    conn: std::sync::Mutex<Option<Arc<std::sync::Mutex<rusqlite::Connection>>>>,
+    /// The content hash to reclaim.
+    victim: String,
+    /// Which call reclaims it. Only one, so the retry can settle.
+    reclaim_on_call: usize,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl ReclaimingEmbedder {
+    fn new(victim: &str, reclaim_on_call: usize) -> Self {
+        Self {
+            inner: HashEmbedder::default(),
+            conn: std::sync::Mutex::new(None),
+            victim: victim.to_string(),
+            reclaim_on_call,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn attach(&self, conn: Arc<std::sync::Mutex<rusqlite::Connection>>) {
+        *self.conn.lock().expect("attach") = Some(conn);
+    }
+}
+
+impl ReclaimingEmbedder {
+    /// Delete the victim row through the store's own connection. Nothing holds
+    /// that lock while the store is embedding.
+    fn reclaim(&self) {
+        let handle = self.conn.lock().expect("reclaim").clone();
+        let Some(conn) = handle else {
+            return;
+        };
+        conn.lock()
+            .expect("reclaim conn")
+            .execute(
+                "DELETE FROM embedding WHERE content_hash = ?1",
+                [self.victim.as_str()],
+            )
+            .expect("reclaim the orphan");
+    }
+}
+
+#[async_trait::async_trait]
+impl Embedder for ReclaimingEmbedder {
+    fn fingerprint(&self) -> crate::embed::EmbedderFingerprint {
+        self.inner.fingerprint()
+    }
+
+    fn similarity_posture(&self) -> crate::embed::SimilarityPosture {
+        self.inner.similarity_posture()
+    }
+
+    async fn embed(
+        &self,
+        texts: &[String],
+    ) -> Result<Vec<crate::embed::Embedding>, crate::embed::EmbedError> {
+        let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        if call == self.reclaim_on_call {
+            self.reclaim();
+        }
+        self.inner.embed(texts).await
+    }
+}
+
+/// A vector reclaimed mid-write is embedded again, not assumed.
+///
+/// The reuse decision is made before the embedder runs and the write happens
+/// after it, so a `compact` in that window can leave the new node with no
+/// vector at all — invisible to similarity recall until the next mount's warm
+/// indexer finds it. The write transaction re-asks, and retries the delta with
+/// the lost content in the embed set.
+#[tokio::test]
+async fn a_vector_reclaimed_while_embedding_is_written_again() {
+    let clock = FixedClock::shared(1_000);
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("context.db");
+    let reused_hash = crate::store::sha256_hex("alpha content");
+    // Reclaim on the second call: the first embeds "alpha content" itself, and
+    // the second serves the delta that plans to reuse it.
+    let embedder = Arc::new(ReclaimingEmbedder::new(&reused_hash, 2));
+    let store = ContextStore::open_with(&path, embedder.clone(), clock).unwrap();
+    embedder.attach(store.conn_handle());
+    let fingerprint = store.fingerprint().id();
+
+    store
+        .upsert(
+            ContextDelta::new().with_node(
+                NodeInput::new(NodeKind::Concept, "alpha").with_content("alpha content"),
+            ),
+        )
+        .await
+        .unwrap();
+    assert!(embedding_exists(&store.conn(), &reused_hash, &fingerprint).unwrap());
+
+    // This delta reuses "alpha content" and embeds "beta content"; the vector
+    // it plans to reuse is reclaimed while that embedding is computed.
+    store
+        .upsert(
+            ContextDelta::new()
+                .with_node(
+                    NodeInput::new(NodeKind::Concept, "alpha again").with_content("alpha content"),
+                )
+                .with_node(NodeInput::new(NodeKind::Concept, "beta").with_content("beta content")),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        embedding_exists(&store.conn(), &reused_hash, &fingerprint).unwrap(),
+        "the reclaimed vector was never written back, so its node is unembedded"
+    );
+    assert!(
+        embedding_exists(
+            &store.conn(),
+            &crate::store::sha256_hex("beta content"),
+            &fingerprint
+        )
+        .unwrap()
+    );
+}
+
+/// One unwritable record is named before anything is written.
+///
+/// A memory's mirror node takes its label from the memory's own text, so a
+/// whitespace-only lesson mints a node with no citable name and the store
+/// refuses it (`L-C4`). A refusal half way through the transaction costs the
+/// delta its embeddings and rolls the whole batch back, so one blank lesson
+/// discards every good lesson written beside it with nothing saying which
+/// record was at fault.
+#[tokio::test]
+async fn a_blank_record_is_named_before_anything_is_written() {
+    let clock = FixedClock::shared(1_000);
+    let (_dir, store) = store_at(clock);
+    let err = store
+        .upsert(
+            ContextDelta::new()
+                .with_memory(MemoryInput::reflection(
+                    "a real lesson",
+                    Vec::<String>::new(),
+                ))
+                .with_memory(MemoryInput::reflection("   \n ", Vec::<String>::new())),
+        )
+        .await
+        .unwrap_err();
+    match err {
+        ContextError::InvalidInput(message) => {
+            assert!(message.contains("memory"), "unhelpful message: {message}");
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+    assert_eq!(
+        store.node_count().unwrap(),
+        0,
+        "a rejected delta wrote rows"
+    );
+
+    // The good half of that batch is perfectly writable on its own, which is
+    // what makes dropping the blank record at the caller the right repair.
+    store
+        .upsert(ContextDelta::new().with_memory(MemoryInput::reflection(
+            "a real lesson",
+            Vec::<String>::new(),
+        )))
+        .await
+        .unwrap();
+    assert_eq!(store.node_count().unwrap(), 1);
 }

--- a/crates/stella-store/src/private.rs
+++ b/crates/stella-store/src/private.rs
@@ -426,17 +426,40 @@ pub fn workspace_private_state_path(workspace_root: &Path, name: &str) -> Result
 
 /// Append one line to a workspace-private log through the same no-follow,
 /// owner-only file primitive used by session state.
+///
+/// A file that does not end in a newline gets one before the new record goes
+/// down. These logs are read a line at a time, and a process killed part way
+/// through a write leaves a record with no terminator; appending straight onto
+/// it would join the fragment and the new record into one line that parses as
+/// neither, losing both instead of one. The repair costs a one-byte read per
+/// append and only ever fires after a crash.
 pub fn append_workspace_private_line(
     workspace_root: &Path,
     name: &str,
     line: &str,
 ) -> Result<PathBuf> {
-    use std::io::Write as _;
+    use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 
     let path = workspace_private_state_path(workspace_root, name)?;
     let mut options = std::fs::OpenOptions::new();
-    options.create(true).append(true);
+    // `read` so the last byte can be inspected. Appending is unaffected: every
+    // write on an `O_APPEND` handle lands at the end whatever the read offset.
+    options.create(true).append(true).read(true);
     let mut file = open_private_file(&path, options)?;
+    let len = file
+        .metadata()
+        .map_err(|e| StoreError::io(format!("cannot inspect {}", path.display()), e))?
+        .len();
+    if len > 0 {
+        let mut last = [0u8; 1];
+        file.seek(SeekFrom::Start(len - 1))
+            .and_then(|_| file.read_exact(&mut last))
+            .map_err(|e| StoreError::io(format!("cannot read {}", path.display()), e))?;
+        if last[0] != b'\n' {
+            file.write_all(b"\n")
+                .map_err(|e| StoreError::io(format!("cannot terminate {}", path.display()), e))?;
+        }
+    }
     writeln!(file, "{line}")
         .map_err(|e| StoreError::io(format!("cannot append {}", path.display()), e))?;
     Ok(path)

--- a/crates/stella-store/src/private/tests.rs
+++ b/crates/stella-store/src/private/tests.rs
@@ -136,6 +136,38 @@ fn an_empty_ignore_with_no_writer_is_still_given_the_private_entry() {
     );
 }
 
+/// A record a crash left without its newline costs itself, not its neighbour.
+///
+/// The log is read one line at a time. Writing onto a fragment glues the two
+/// records into one line, and that line parses as neither. So a crash that
+/// damaged one record took out the next one too. Nothing said so: a reader
+/// cannot tell a glued line from a bad one.
+#[test]
+fn an_unterminated_record_does_not_swallow_the_next_one() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    // What a process killed mid-append leaves behind: a whole record, then a
+    // fragment with no terminator.
+    let path = append_workspace_private_line(workspace.path(), "reflections.jsonl", "{\"a\":1}")
+        .expect("first append");
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("reopen")
+        .write_all(b"{\"partial\"")
+        .expect("plant the fragment");
+
+    append_workspace_private_line(workspace.path(), "reflections.jsonl", "{\"b\":2}")
+        .expect("append after a crash");
+
+    let settled = std::fs::read_to_string(&path).expect("read");
+    let lines: Vec<&str> = settled.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["{\"a\":1}", "{\"partial\"", "{\"b\":2}"],
+        "the new record must be a line of its own, not glued to the fragment"
+    );
+}
+
 use std::io::Write as _;
 
 #[cfg(unix)]


### PR DESCRIPTION
Six traced defects in `stella-context`, plus the two callers in `stella-cli`
and `stella-store` that the last two need. Each has its own test. The design
was posted on the issue before implementation and is followed.

## 1. A tier the packer never walks

`pack_to_budget` walked a hand-written `[Normal, Deferred]`. A third
`RecallTier` compiles clean, and its candidates land in neither `kept` nor
`dropped` — the partition `L-C5` forbids, invisible until something writes the
new tier.

`RecallTier::ALL` is now derived from a `recall_tiers!` table, modelled on
`model_call_roles!` in `stella-protocol`'s `event::call_role` (the exemplar the
issue names): one token list builds `ALL` and an exhaustive `match`, and a
`const _: ()` forces that match to be evaluated. A tier not named there is
`E0004`. `pack_to_budget` walks `ALL`.

**Witness:** `every_tier_reaches_the_packer` builds one candidate per entry of
`ALL` with no slots at all and asserts every one is reported as dropped. It
cannot compile against the old code, which has no `ALL`.

## 2. NaN survives `RecallTuning::sanitized`

`f32::clamp` asks whether a value is in range, not whether it is a number, so a
NaN went straight through the function whose job is to make a misconfiguration
safe. A NaN `mmr_lambda` makes every MMR comparison false; a NaN `min_coverage`
never falls under the coverage score, so the lexical fallback stops firing.
Both knobs now take the `is_finite` guard `rrf_k` already had.

**Witness:** `a_knob_that_is_not_a_number_falls_back_to_its_default` over NaN
and both infinities, plus an in-range case proving the clamp still clamps.

## 3. A torn log line swallows the next record

`append_workspace_private_line` wrote onto whatever was there. A process killed
mid-append leaves a record with no terminator, and the next append glued the
two into one line that parses as neither. It now reads the last byte and writes
a newline first when one is missing.

**Witness:** `an_unterminated_record_does_not_swallow_the_next_one` plants the
fragment, appends, and asserts three whole lines.

## 4. Two turns in one second are one episode

An episode is keyed by its summary and its window, both at second resolution,
so two turns on one prompt inside a second hashed to one id and the second
write replaced the first turn's outcome and file list. `EpisodeInput` gains
`occurrence`, folded into `public_id` only when set — every `epi_` id already
on disk is unchanged — and `record_episode` passes the turn's `execution_id`.

**Witness:** `two_turns_in_one_second_write_two_episodes` and
`an_episode_without_an_occurrence_keeps_its_old_identity` in `stella-context`,
and `two_executions_in_one_second_keep_their_own_episodes` plus
`one_execution_recorded_twice_keeps_one_episode` on the CLI side. Without the
key each pair writes one row.

## 5. A reused vector reclaimed mid-write

`upsert`'s reuse decision was made before the embedder ran and the write
happened after it. Until the delta's nodes exist those vectors belong to no
node, which is exactly what `compact` reclaims — so the new node landed
unembedded until the next mount's warm index. The write transaction now
re-asks, and on a loss rolls back and retries with that content forced into the
embed set (`REUSE_RACE_ATTEMPTS`).

**Witness:** `a_vector_reclaimed_while_embedding_is_written_again` uses an
embedder that deletes the row it is about to reuse, through the store's own
connection, on the call that serves the delta. The store holds no lock while it
embeds, so this is the real race, single-threaded and deterministic.

## 6. A blank lesson discards its siblings

A memory's mirror node takes its label from its own text, so a whitespace-only
lesson mints a node with no citable name and the store refuses it (`L-C4`) —
half way through the transaction, after the delta paid for its embeddings, with
the whole batch rolled back. `upsert` now names the bad record before anything
is embedded or written, and the reflection writer drops a lesson with no words
(`writable_lessons`) so a blank one costs only itself.

**Witness:** `a_blank_record_is_named_before_anything_is_written` in
`stella-context`, and `a_blank_lesson_is_dropped_and_its_siblings_are_kept`
plus `a_lesson_with_only_a_trigger_is_still_writable` in `stella-cli`.

## Remaining work filed

- #5776 — episode ids still collide on the paths that set no execution id
  (`goal.rs`, `agent.rs`, the deck's authoring door).
- #5777 — a best-effort store write that fails leaves no trace anywhere. The
  `let _ = ... upsert` in `record_episode` stays a swallow in this PR and says
  why: the deck calls it while it owns the terminal, and the workspace has no
  logger.

Tests deleted: None.

Closes #5326

## Summary by Sourcery

Fix six recall and writeback defects across context storage, episode recording, reflection handling, and workspace logs while adding witness tests for each failure mode.

Bug Fixes:
- Prevent recall packing from losing candidates when additional recall tiers are introduced.
- Treat non-finite recall tuning values as invalid and restore safe defaults.
- Preserve record boundaries when appending to truncated workspace-private logs.
- Disambiguate episodes from separate executions occurring in the same second while preserving retry idempotency and legacy identities.
- Retry writes when reusable embeddings are reclaimed during an upsert.
- Reject blank records with actionable validation errors and allow reflection batches to retain valid lessons alongside blank ones.

Enhancements:
- Make recall-tier enumeration exhaustive and drive packer precedence from the complete tier vocabulary.

Tests:
- Add regression coverage for recall-tier packing, non-finite tuning values, truncated log recovery, episode identity collisions, embedding reuse races, and blank-record handling across context, CLI, and store.