### PR TITLE
fix(stella-core): report task- and keyword-scoped record conflicts

### DIFF
--- a/crates/stella-core/src/records/select.rs
+++ b/crates/stella-core/src/records/select.rs
@@ -42,6 +42,11 @@
 //!   when a labelled task plane exists it belongs in [`TurnFacts`].
 //! - Multi-word **keywords** (`"docker compose"`) match as case-insensitive
 //!   substrings, because word-splitting would never reassemble them.
+//!
+//! [`super::validate`] asks the same rules a second question — can one turn
+//! select both of these records? — through [`shared_triggers`], so a conflict
+//! between two task-scoped records is judged by the matcher that will decide
+//! whether they both fire.
 
 use super::super::glob::match_glob;
 use super::super::ingest::record::AppliesTo;
@@ -79,6 +84,36 @@ pub fn applies_this_turn(applies_to: Option<&AppliesTo>, facts: &TurnFacts<'_>) 
                 word_in_text(facts.text, keyword)
             }
         })
+}
+
+/// The tasks and keywords of `scope` that also select `other`.
+///
+/// [`super::validate`] asks this to decide whether two records can steer the
+/// same turn once their paths have told it nothing. A turn whose text is one of
+/// `scope`'s own triggers is a turn `scope` selects, so all that is left to ask
+/// is whether [`applies_this_turn`] admits `other` for it — one matcher, and a
+/// list of the terms a conflict report can name.
+///
+/// Asymmetric, so a caller wanting every shared term asks both ways: a
+/// single-word keyword matches inside a multi-word one, and the reverse cannot.
+/// A path-only scope shares nothing here, because a glob is not a turn path;
+/// globs are compared to each other by `validate`.
+pub fn shared_triggers(scope: &AppliesTo, other: &AppliesTo) -> Vec<String> {
+    scope
+        .tasks
+        .iter()
+        .chain(scope.keywords.iter())
+        .filter(|term| {
+            applies_this_turn(
+                Some(other),
+                &TurnFacts {
+                    text: term.as_str(),
+                    paths: &[],
+                },
+            )
+        })
+        .cloned()
+        .collect()
 }
 
 /// Any pattern matching any turn path. A pattern with no literal part (`*`,
@@ -235,6 +270,36 @@ mod tests {
             Some(&phrase),
             &facts("compose a docker image name", &[])
         ));
+    }
+
+    #[test]
+    fn shared_triggers_names_the_terms_that_select_both_scopes() {
+        let task = scoped(&[], &["deploy"], &[]);
+        let keyword = scoped(&[], &[], &["deploy"]);
+        assert_eq!(shared_triggers(&task, &keyword), vec!["deploy".to_string()]);
+        assert_eq!(shared_triggers(&keyword, &task), vec!["deploy".to_string()]);
+        assert!(shared_triggers(&task, &scoped(&[], &["docs"], &[])).is_empty());
+    }
+
+    #[test]
+    fn shared_triggers_is_asymmetric_across_a_multi_word_keyword() {
+        // "docker" is a whole word of "docker compose", so a turn written for
+        // the phrase also selects the single word. A turn that says only
+        // "docker" does not select the phrase, so the caller asks both ways.
+        let phrase = scoped(&[], &[], &["docker compose"]);
+        let word = scoped(&[], &[], &["docker"]);
+        assert_eq!(
+            shared_triggers(&phrase, &word),
+            vec!["docker compose".to_string()]
+        );
+        assert!(shared_triggers(&word, &phrase).is_empty());
+    }
+
+    #[test]
+    fn a_path_only_scope_shares_no_trigger() {
+        // A glob is not a turn path, so path overlap is `validate`'s question.
+        let paths = scoped(&["src/**"], &[], &[]);
+        assert!(shared_triggers(&paths, &paths).is_empty());
     }
 
     #[test]

--- a/crates/stella-core/src/records/validate.rs
+++ b/crates/stella-core/src/records/validate.rs
@@ -30,10 +30,18 @@
 //! seconds. So [`globs_overlap`] compares literal prefixes and reports on
 //! containment, accepting the cheap false positive to make the expensive false
 //! negative impossible.
+//!
+//! Paths are half a scope. A record can also be scoped by `tasks` and
+//! `keywords`, and two records scoped that way collide on every turn that names
+//! a trigger they share — a `hard` record and an advisory one over the same
+//! task, with no path anywhere between them. So overlap falls back to
+//! [`super::select::shared_triggers`] rather than growing a second matcher, and
+//! the conflict is judged by the code that decides whether both records fire.
 
 use super::super::ingest::gate::atomicity_validation;
 use super::super::ingest::record::{AppliesTo, EnforcementMode, Record};
 use super::super::redact::redact_secrets;
+use super::select::shared_triggers;
 use super::{KNOWN_TASKS, LoadedRecord, RecordFinding};
 
 /// Glob metacharacters that are **literals** in this engine's matcher. A guard
@@ -307,7 +315,7 @@ fn conflict_between(left: &LoadedRecord, right: &LoadedRecord) -> Option<Conflic
     if left_mode == right_mode {
         return None;
     }
-    let shared = overlapping_paths(applies_to(&left.record), applies_to(&right.record))?;
+    let shared = overlapping_scope(applies_to(&left.record), applies_to(&right.record))?;
     // The less restrictive behavior wins until an owner resolves it, so the record
     // asking for more restriction is the one suspended.
     let (suspended, kept) = if restrictiveness(left_mode) > restrictiveness(right_mode) {
@@ -359,7 +367,12 @@ fn restrictiveness(mode: EnforcementMode) -> u8 {
 /// An empty `applies_to` matches everything, so a record with no scope overlaps
 /// every other record — which is correct, and is why an unscoped `hard` record
 /// beside an unscoped advisory one is a conflict worth reporting.
-fn overlapping_paths(left: Option<&AppliesTo>, right: Option<&AppliesTo>) -> Option<String> {
+///
+/// Two scoped records overlap when their path globs can reach a common path, or
+/// when they share a task or keyword trigger. The trigger half only runs when
+/// the path half found nothing, so a pair that already collides on a path keeps
+/// the more specific report.
+fn overlapping_scope(left: Option<&AppliesTo>, right: Option<&AppliesTo>) -> Option<String> {
     let unscoped = |applies: Option<&AppliesTo>| applies.is_none_or(AppliesTo::is_empty);
     if unscoped(left) && unscoped(right) {
         return Some("every path (neither record is scoped)".to_string());
@@ -374,6 +387,11 @@ fn overlapping_paths(left: Option<&AppliesTo>, right: Option<&AppliesTo>) -> Opt
         });
     }
     let (left, right) = (left?, right?);
+    overlapping_paths(left, right).or_else(|| overlapping_triggers(left, right))
+}
+
+/// The path globs two scoped records can both reach.
+fn overlapping_paths(left: &AppliesTo, right: &AppliesTo) -> Option<String> {
     let shared: Vec<String> = left
         .paths
         .iter()
@@ -392,6 +410,23 @@ fn overlapping_paths(left: Option<&AppliesTo>, right: Option<&AppliesTo>) -> Opt
         })
         .collect();
     (!shared.is_empty()).then(|| shared.join(", "))
+}
+
+/// The task and keyword triggers two scoped records share — the turns on which
+/// both of them fire, when no path connects them.
+///
+/// Asked in both directions and unioned, because
+/// [`super::select::shared_triggers`] is asymmetric: a single-word keyword
+/// matches inside a multi-word one and the reverse does not, so one direction
+/// alone would miss the pair.
+fn overlapping_triggers(left: &AppliesTo, right: &AppliesTo) -> Option<String> {
+    let mut shared = shared_triggers(left, right);
+    for term in shared_triggers(right, left) {
+        if !shared.iter().any(|seen| seen.eq_ignore_ascii_case(&term)) {
+            shared.push(term);
+        }
+    }
+    (!shared.is_empty()).then(|| format!("the triggers {}", shared.join(", ")))
 }
 
 /// Whether two globs can match a common value.
@@ -416,17 +451,59 @@ mod tests {
     use super::*;
 
     fn at(handle: &str, mode: EnforcementMode, paths: &[&str], precedence: u32) -> LoadedRecord {
-        let mut record = with_scope(
-            record_named(&format!("ctx.a.b.{handle}")),
-            paths,
+        scoped_by(
+            handle,
+            mode,
+            AppliesTo {
+                paths: paths.iter().map(|path| path.to_string()).collect(),
+                ..AppliesTo::default()
+            },
             precedence,
-        );
+        )
+    }
+
+    /// A record scoped by tasks and keywords and by no path at all — the shape
+    /// a path-only comparison cannot see.
+    fn triggered(
+        handle: &str,
+        mode: EnforcementMode,
+        tasks: &[&str],
+        keywords: &[&str],
+        precedence: u32,
+    ) -> LoadedRecord {
+        scoped_by(
+            handle,
+            mode,
+            AppliesTo {
+                paths: Vec::new(),
+                tasks: tasks.iter().map(|task| task.to_string()).collect(),
+                keywords: keywords.iter().map(|word| word.to_string()).collect(),
+            },
+            precedence,
+        )
+    }
+
+    fn scoped_by(
+        handle: &str,
+        mode: EnforcementMode,
+        applies_to: AppliesTo,
+        precedence: u32,
+    ) -> LoadedRecord {
+        let deny_path = applies_to
+            .paths
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "**".to_string());
+        let mut record = with_scope(record_named(&format!("ctx.a.b.{handle}")), &[], precedence);
+        if let Some(steering) = record.steering.as_mut() {
+            steering.applies_to = Some(applies_to);
+        }
         record.enforcement = Some(Enforcement {
             mode,
             guard_tool: Some("Edit".to_string()),
             guard_deny_command: None,
             guard_allow_command: None,
-            guard_deny_path: Some(paths.first().copied().unwrap_or("**").to_string()),
+            guard_deny_path: Some(deny_path),
             severity: None,
             on_violation: None,
             check: None,
@@ -536,6 +613,78 @@ mod tests {
         assert_eq!(conflicts.len(), 1);
         assert!(
             conflicts[0].detail.contains("unscoped"),
+            "{}",
+            conflicts[0].detail
+        );
+    }
+
+    #[test]
+    fn two_records_scoped_to_one_task_conflict_with_no_path_between_them() {
+        // Neither record names a path, so the glob comparison has nothing to
+        // compare and the trigger fallback is the only thing that can see the
+        // collision. Without it a hard record and an advisory one over the same
+        // task resolve silently.
+        let mut records = vec![
+            triggered(
+                "release-checklist",
+                EnforcementMode::Hard,
+                &["release"],
+                &[],
+                50,
+            ),
+            triggered(
+                "release-exemption",
+                EnforcementMode::None,
+                &["release"],
+                &[],
+                50,
+            ),
+        ];
+        records.iter_mut().for_each(check_record);
+        let conflicts = detect_conflicts(&mut records);
+        assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+        let conflict = &conflicts[0];
+        assert!(conflict.detail.contains("release"), "{}", conflict.detail);
+        assert_eq!(
+            conflict.suspended, "release-checklist",
+            "enforcement falls back to the LESS restrictive behavior"
+        );
+        for loaded in &records {
+            assert!(
+                loaded
+                    .findings
+                    .iter()
+                    .any(|f| matches!(f, RecordFinding::Conflict { .. })),
+                "^{} carries no conflict finding",
+                loaded.handle
+            );
+        }
+    }
+
+    #[test]
+    fn disjoint_task_scopes_do_not_conflict_however_the_enforcement_differs() {
+        let mut records = vec![
+            triggered("deploys", EnforcementMode::Hard, &["deploy"], &[], 50),
+            triggered("documentation", EnforcementMode::None, &["docs"], &[], 50),
+        ];
+        records.iter_mut().for_each(check_record);
+        assert!(detect_conflicts(&mut records).is_empty());
+    }
+
+    #[test]
+    fn a_task_on_one_record_and_the_same_word_as_a_keyword_on_the_other_conflict() {
+        // Selection matches tasks and single-word keywords the same way, so a
+        // turn that says "deploy" fires both records whichever field carries
+        // the word.
+        let mut records = vec![
+            triggered("deploy-guard", EnforcementMode::Hard, &["deploy"], &[], 50),
+            triggered("deploy-notes", EnforcementMode::None, &[], &["deploy"], 50),
+        ];
+        records.iter_mut().for_each(check_record);
+        let conflicts = detect_conflicts(&mut records);
+        assert_eq!(conflicts.len(), 1, "{conflicts:?}");
+        assert!(
+            conflicts[0].detail.contains("deploy"),
             "{}",
             conflicts[0].detail
         );


### PR DESCRIPTION
## What

Record conflict detection compared path globs and nothing else. Two records whose `applies_to` carries only `tasks` or `keywords` have no paths to cross, so `overlapping_paths` reported no overlap and `conflict_between` gave up — an equal-precedence `hard`-vs-advisory pair scoped to the same task resolved silently, which is the false negative `validate.rs`'s own header calls impossible.

## Why this shape

Overlap now falls back to trigger comparison when the glob comparison finds nothing, and the fallback shares `select.rs` rather than growing a second matcher:

- `select::shared_triggers(scope, other)` — for each of `scope`'s own tasks and keywords, build `TurnFacts { text: term, paths: &[] }` and ask `applies_this_turn(Some(other), &facts)`. A turn whose text is one record's own trigger is a turn that record selects by construction, so the only question left is whether the other record selects it too, and that is answered by the code that will decide at run time whether both records fire.
- `validate::overlapping_triggers` asks both directions and unions them, because the matcher is asymmetric: `docker` is a whole word of `docker compose`, and `docker compose` is not a substring of `docker`.
- The `Conflict::detail` names the shared terms, so §12's "what overlaps, and what to do" stays actionable.

Path overlap keeps `globs_overlap` exactly as it was, and runs first, so a pair that already collides on a path keeps the more specific report.

Exemplar: none borrowed — this follows the file's own established shape (a small private helper per question, `Option<String>` carrying the human-readable description).

## Witness mechanism

`two_records_scoped_to_one_task_conflict_with_no_path_between_them` (in `validate.rs`'s test module) builds two records at precedence 50, both scoped `tasks = ["release"]` and nothing else, one `hard` and one `none`. On `main` `overlapping_paths` iterates two empty path vectors, `shared` is empty, it returns `None`, and `detect_conflicts` returns zero — the test's `assert_eq!(conflicts.len(), 1)` fails by construction. With the fallback it returns one conflict naming `release`, suspends the `hard` record, and attaches the finding to both sides.

Its pair holds the other direction: `disjoint_task_scopes_do_not_conflict_however_the_enforcement_differs` (`deploy` vs `docs`) stays empty. `a_task_on_one_record_and_the_same_word_as_a_keyword_on_the_other_conflict` covers the cross-field case, and three unit tests in `select.rs` pin `shared_triggers` itself, including the multi-word asymmetry and the path-only scope that shares nothing.

## What this surfaces in this repository's own records — read this before merging

Running the new comparison over `.stella/rules/` finds **four** equal-precedence collisions that were silent before, all of them meeting on the multi-word keyword `"witness test"` at precedence 100: `correctness-needs-proof` (soft) and `witness-definition` (soft) each against `deleted-test-named-in-pr` (hard) and `inv8-posture-every-axis` (hard). `deleted-test-named-in-pr` joins through its task `test`, a whole word of that phrase.

They are real §12 conflicts, and the consequence is live: `registry.rs`'s `resolve_guard` refuses to arm a suspended record's guard, so those two `hard` guards stop arming in this workspace until an owner resolves the corpus. `stella context validate` reports each as a warning and exits 0 (only blocking findings drive its exit code), so CI stays green. I did not repair the records here — a record carries a canonical hash, `promotions.jsonl` is hash-chained, AGENTS.md says these are edited through `stella context keep` / `promote` rather than by hand, and which resolution to take is a policy decision. Filed as #5779.

## Remaining work filed

- #5779 — the four `witness test` collisions in this repo's own corpus, and the two hard guards they suspend.
- #5780 — conflict detection still never crosses a *path* scope against a *task* scope, so those collisions stay silent. Left out on purpose: nearly every such pair can co-apply, so reporting them all would drown the useful conflicts and disarm real guards.

Tests deleted: None.

Closes #5330

## Summary by Sourcery

Report equal-precedence enforcement conflicts when records can apply to the same task or keyword-triggered turn without sharing a path.

Bug Fixes:
- Detect conflicts between equal-precedence records that share task or keyword triggers even when their path scopes do not overlap.
- Include shared task and keyword terms in conflict details so reported conflicts identify the triggering scope.

Enhancements:
- Reuse runtime record-selection matching to determine shared triggers, including task/keyword cross-field matches and asymmetric multi-word keyword matching.
- Preserve path-based overlap reporting as the preferred, more specific conflict description.

Tests:
- Add coverage for task-only conflicts, disjoint task scopes, task/keyword cross-field conflicts, asymmetric keyword matching, and path-only scopes.