### PR TITLE
fix(stella-cli): end a deleted file's anchor at mount, not only on demand

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -601,6 +601,11 @@ impl SessionMemory {
         .map(|store| store.with_tuning(retrieval.tuning()))
         {
             Ok(store) => {
+                // Run the stale-anchor scan here too, right next to warm,
+                // on this same open store. This ends a deleted file's
+                // anchor with no manual `--end-stale` run. See
+                // `anchor_scan::scan_stale_anchors_at_mount` for the cap.
+                anchor_scan::scan_stale_anchors_at_mount(&store, workspace_root);
                 let domains = Domains::load(workspace_root)
                     .ok()
                     .flatten()

--- a/crates/stella-cli/src/memory/anchor_scan.rs
+++ b/crates/stella-cli/src/memory/anchor_scan.rs
@@ -16,8 +16,18 @@
 //! the command merely invokes, and because `memory_cmd` sits on the repo's
 //! 1500-line file ceiling.
 
+use std::path::Path;
+use std::time::{Duration, Instant};
+
 use colored::Colorize;
 use stella_context::{Clock, ContextStore, SystemClock};
+
+/// Time cap for the auto sweep at mount. Each anchor costs one file
+/// check, and a slow disk — not a long list — is what could make that
+/// slow. So the cap is time, not a row count. Anything left unchecked
+/// just waits for the next mount; an ended anchor drops off the list,
+/// so no anchor can wait forever.
+const MOUNT_SCAN_BUDGET: Duration = Duration::from_millis(200);
 
 /// One anchor the scan found pointing at a file that is no longer there.
 struct StaleAnchor {
@@ -26,6 +36,22 @@ struct StaleAnchor {
     /// The anchoring record's text — a memory's content or an episode's
     /// summary — so the report can name what goes stale.
     source: String,
+}
+
+/// Open this workspace's context store, if it has one yet. `Ok(None)` is not
+/// an error; it means there is no `context.db` yet. Both callers below treat
+/// that the same as "a store with nothing stale" — a workspace with no
+/// memories has no anchors to end.
+fn open_context_store(workspace_root: &Path) -> Result<Option<ContextStore>, String> {
+    let Some(context_db) =
+        stella_store::existing_workspace_private_sqlite_path(workspace_root, "context.db")
+            .map_err(|e| format!("cannot resolve context store: {e}"))?
+    else {
+        return Ok(None);
+    };
+    ContextStore::open(&context_db)
+        .map(Some)
+        .map_err(|e| format!("cannot open context store: {e}"))
 }
 
 /// Walk the open `observed_in` anchors and report — or end — the ones whose
@@ -39,18 +65,10 @@ struct StaleAnchor {
 /// Read-only unless `end_stale`. Ending an anchor is a write to history, and
 /// the default for a command named `validate` must be to tell you what it
 /// found, not to change the store because you ran an inspection.
-pub(crate) fn scan_stale_anchors(
-    workspace_root: &std::path::Path,
-    end_stale: bool,
-) -> Result<(), String> {
-    let Some(context_db) =
-        stella_store::existing_workspace_private_sqlite_path(workspace_root, "context.db")
-            .map_err(|e| format!("cannot resolve context store: {e}"))?
-    else {
+pub(crate) fn scan_stale_anchors(workspace_root: &Path, end_stale: bool) -> Result<(), String> {
+    let Some(context) = open_context_store(workspace_root)? else {
         return Ok(());
     };
-    let context =
-        ContextStore::open(&context_db).map_err(|e| format!("cannot open context store: {e}"))?;
     let anchors = context
         .open_anchors()
         .map_err(|e| format!("cannot read anchors: {e}"))?;
@@ -122,6 +140,61 @@ pub(crate) fn scan_stale_anchors(
     Ok(())
 }
 
+/// Runs [`scan_stale_anchors`] on its own, at every session mount, right
+/// next to warm. It uses the store warm already opened. So a deleted
+/// file's anchor stops feeding graph links, with no need to run
+/// `stella memory validate --end-stale` by hand.
+///
+/// Stays quiet on failure and on success — this is upkeep the session
+/// does for itself, not a report. `stella memory validate` is the
+/// command for that.
+pub(crate) fn scan_stale_anchors_at_mount(context: &ContextStore, workspace_root: &Path) {
+    let deadline = Instant::now() + MOUNT_SCAN_BUDGET;
+    let _ = end_stale_anchors_within_deadline(context, workspace_root, deadline);
+}
+
+/// The bound at work: ends world validity for each open anchor whose
+/// file is gone, checked before `deadline`. Split out so a test can
+/// pass a deadline already past, and prove the cap really stops the
+/// walk.
+fn end_stale_anchors_within_deadline(
+    context: &ContextStore,
+    workspace_root: &Path,
+    deadline: Instant,
+) -> Result<usize, String> {
+    let anchors = context
+        .open_anchors()
+        .map_err(|e| format!("cannot read anchors: {e}"))?;
+    if anchors.is_empty() {
+        return Ok(0);
+    }
+
+    let stale: Vec<StaleAnchor> = anchors
+        .into_iter()
+        .take_while(|_| Instant::now() < deadline)
+        .filter(|a| !workspace_root.join(&a.path).exists())
+        .map(|a| StaleAnchor {
+            edge_id: a.edge_id,
+            path: a.path,
+            source: a.source,
+        })
+        .collect();
+    if stale.is_empty() {
+        return Ok(0);
+    }
+
+    let now = SystemClock.now_rfc3339();
+    let mut ended = 0usize;
+    for a in &stale {
+        match context.end_anchor_validity(a.edge_id, &now) {
+            Ok(true) => ended += 1,
+            Ok(false) => {}
+            Err(e) => return Err(format!("cannot end anchor {}: {e}", a.edge_id)),
+        }
+    }
+    Ok(ended)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -185,6 +258,80 @@ mod tests {
                 .count()
                 == 2,
             "both anchors remain believed; only one stopped holding"
+        );
+    }
+
+    /// The mount sweep alone — no `--end-stale` command — ends world
+    /// validity for an anchor whose file is gone, using the real time
+    /// cap.
+    #[test]
+    fn mount_scan_ends_a_stale_anchor_under_the_production_budget() {
+        let root = tempdir().unwrap();
+        let context_db =
+            stella_store::workspace_private_sqlite_path(root.path(), "context.db").unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        rt.block_on(async {
+            use stella_context::{ContextDelta, MemoryInput};
+            context
+                .upsert(ContextDelta {
+                    memories: vec![
+                        MemoryInput::reflection("about a file since deleted", Vec::<String>::new())
+                            .with_anchors(["src/gone.rs"]),
+                    ],
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+        });
+        assert_eq!(context.open_anchors().unwrap().len(), 1);
+
+        scan_stale_anchors_at_mount(&context, root.path());
+
+        assert_eq!(
+            context.open_anchors().unwrap().len(),
+            0,
+            "the mount sweep ends world validity for the gone file's anchor, unasked"
+        );
+    }
+
+    /// The time cap is real, not just assumed. A deadline already past
+    /// must stop the walk before it checks the one anchor there is. It
+    /// stays open for the next pass.
+    #[test]
+    fn mount_scan_stops_at_an_already_expired_deadline() {
+        let root = tempdir().unwrap();
+        let context_db =
+            stella_store::workspace_private_sqlite_path(root.path(), "context.db").unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        rt.block_on(async {
+            use stella_context::{ContextDelta, MemoryInput};
+            context
+                .upsert(ContextDelta {
+                    memories: vec![
+                        MemoryInput::reflection("about a file since deleted", Vec::<String>::new())
+                            .with_anchors(["src/gone.rs"]),
+                    ],
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+        });
+
+        // Sleep past a saved `Instant` so the deadline is already past.
+        // Subtracting from `Instant::now()` could panic this early on.
+        let deadline = Instant::now();
+        std::thread::sleep(Duration::from_millis(5));
+
+        let ended = end_stale_anchors_within_deadline(&context, root.path(), deadline).unwrap();
+        assert_eq!(ended, 0, "an expired deadline must not process any anchor");
+        assert_eq!(
+            context.open_anchors().unwrap().len(),
+            1,
+            "the anchor is untouched when the budget is already spent"
         );
     }
 }

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -12,6 +12,12 @@ mod determinism;
 // #3349: the assembled volatile block's bytes, pinned — the evidence that the
 // steering-plane migration changed the wiring and not the prompt.
 mod golden_block;
+// Session mount runs the anchor staleness scan on its own already-open
+// store, so a deleted file's anchor ends world validity with no manual
+// `stella memory validate --end-stale`. `anchor_scan`'s own tests cover the
+// bounded walk directly; this is the wiring witness through the real mount
+// path (`SessionMemory::open`).
+mod mount_anchor_scan;
 mod path_token;
 mod quarantine;
 // Which sessions actually receive the volatile record channel — a separate

--- a/crates/stella-cli/src/memory/tests/mount_anchor_scan.rs
+++ b/crates/stella-cli/src/memory/tests/mount_anchor_scan.rs
@@ -1,0 +1,54 @@
+//! The witness for the real mount path. Just opening a session — no
+//! `stella memory validate --end-stale` call — ends world validity for
+//! an anchor whose file is gone.
+
+use crate::memory::*;
+
+#[tokio::test]
+async fn mount_ends_world_validity_for_an_anchor_whose_file_is_gone() {
+    let dir = tempfile::tempdir().unwrap();
+    let context_db = stella_store::workspace_private_sqlite_path(dir.path(), "context.db").unwrap();
+
+    // Seed the anchor first, the way an older session's reflection
+    // would have. The open call below is the thing under test, so it
+    // must not be what makes the anchor too.
+    {
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        context
+            .upsert(ContextDelta {
+                memories: vec![
+                    MemoryInput::reflection("about a file since deleted", Vec::<String>::new())
+                        .with_anchors(["gone.rs"]),
+                ],
+                ..ContextDelta::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(context.open_anchors().unwrap().len(), 1);
+    }
+    // `gone.rs` is never written. The anchor points at a path that was
+    // never in this workspace — the same as a file that got deleted.
+
+    // The real mount path. No `--end-stale` call anywhere in this test.
+    drop(SessionMemory::open(dir.path(), false).expect("session memory opens"));
+
+    let context = stella_context::ContextStore::open(&context_db).unwrap();
+    assert_eq!(
+        context.open_anchors().unwrap().len(),
+        0,
+        "mounting the session alone ended world validity for the gone file's anchor"
+    );
+
+    // The memory itself is still true. Ending an anchor does not
+    // retract the lesson it came from.
+    assert_eq!(
+        context
+            .facts_as_of(None)
+            .unwrap()
+            .iter()
+            .filter(|f| f.predicate == stella_context::ANCHOR_REL)
+            .count(),
+        1,
+        "the anchor remains believed; only its world validity ended"
+    );
+}


### PR DESCRIPTION
## What & why

Deleted files kept feeding graph adjacency until someone ran `stella memory validate --end-stale` by hand: `end_anchor_validity` (the write that stops an anchor counting) only ran from that command. This wires the same scan into session mount, right next to warm, so it runs on its own.

`SessionMemory::open_inner` (`crates/stella-cli/src/memory.rs`) already opens the workspace's `ContextStore` via `ContextStore::open_and_warm` before wrapping it for the session. The scan now runs on that same open store, right after — so it inherits every opt-out warm already has (the `filesystem_settings_disabled()` gate above it, and simply not running when the store fails to open), with no separate flag to remember.

`crates/stella-cli/src/memory/anchor_scan.rs` gets `scan_stale_anchors_at_mount(&ContextStore, &Path)`. It reuses the same walk `scan_stale_anchors` (the `stella memory validate` command) does — open anchors, check which files are gone, end world validity for those — but:

- takes the mount's own store instead of opening a second connection,
- stays quiet on both success and failure, matching this subsystem's contract that memory upkeep must never fail or slow a user's turn (`crate::memory`'s module doc),
- is bounded by a wall-clock budget (`MOUNT_SCAN_BUDGET`, 200ms) checked before each anchor's file check — the cost that can run away is a slow filesystem, not a large anchor count, so the guard is time rather than a row limit. Whatever the deadline leaves unchecked just waits: an ended anchor drops off `open_anchors()`'s list, so a later mount (or a manual `--end-stale` run) picks up past everything already done.

`scan_stale_anchors` itself (the `stella memory validate` command body) keeps its exact behavior; it only shares a small "open the store" helper with the new function now.

## The witness

`crates/stella-cli/src/memory/tests/mount_anchor_scan.rs` seeds an anchor pointing at a path that was never in the workspace (the same shape as a file that got deleted), then calls `SessionMemory::open` — the real mount path — with no `--end-stale` call anywhere in the test, and checks the anchor's world validity ended anyway.

I confirmed the fail→pass flip by hand: commenting out the new `anchor_scan::scan_stale_anchors_at_mount(&store, workspace_root)` call site and rerunning that test fails it (`left: 1, right: 0` — the anchor stayed open); restoring the line passes it.

`crates/stella-cli/src/memory/anchor_scan.rs` also gets two direct tests on the bounded core (`end_stale_anchors_within_deadline`):
- `mount_scan_ends_a_stale_anchor_under_the_production_budget` — the public wrapper, under the real 200ms budget, ends a stale anchor.
- `mount_scan_stops_at_an_already_expired_deadline` — a deadline already past processes nothing, proving the time guard is wired rather than assumed.

Ran locally, scoped to the crate (never the workspace, per this repo's own rule):

```
cargo test -p stella-cli --bin stella "memory::anchor_scan"   # 3 passed
cargo test -p stella-cli --bin stella mount_anchor_scan       # 1 passed
cargo test -p stella-cli --bin stella "memory::"               # 328 passed
cargo test -p stella-cli --bin stella "memory_cmd::"            # 15 passed
```

Tests deleted: none.

## The gate

- [x] `cargo fmt --check` (ran locally)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI
- [ ] `cargo test --workspace` — CI (ran the affected crate/tests locally, see above)
- [x] No docs/flags changed
- [x] `Closes #5340` appears above and as a commit trailer

## Nothing left behind

- [x] Filed: #5782 — the mount sweep's time budget has no signal when a workspace's anchor backlog outruns it (silent by design today, same as the rest of this subsystem).

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

The design comment I posted on the issue before starting (see issue #5340) proposed exactly this shape and I followed it as written — no deviations found once I read the code.

## Summary by Sourcery

Automatically clean up stale file anchors during session mounting without affecting session startup behavior.

New Features:
- Automatically end the world validity of anchors whose files are missing when a session mounts.

Bug Fixes:
- Prevent deleted files from continuing to contribute graph adjacency until manual stale-anchor validation is run.

Enhancements:
- Bound mount-time stale-anchor cleanup to a 200 ms budget and keep it silent so memory maintenance cannot disrupt sessions.
- Reuse the session's already-open context store for mount cleanup and share store-opening logic with manual validation.

Tests:
- Add coverage for mount-triggered cleanup and deadline enforcement, including end-to-end session mount behavior.