### PR TITLE
fix(stella-core): make a gated probe answer to the trust tier

### DIFF
--- a/crates/stella-cli/src/context_cmd/review.rs
+++ b/crates/stella-cli/src/context_cmd/review.rs
@@ -164,15 +164,16 @@ fn rank(verdict: Option<&str>) -> u8 {
 ///
 /// **A gated probe is never run here, whatever the record says about itself.**
 /// The sweep's rule ([`stella_core::records::honored_probe`]) admits a
-/// `command_succeeds` or `http_ok` on a human-decreed record, and it can,
-/// because it reads a *published* file that a reviewer has already accepted.
-/// This reads a **proposal**, whose `origin` may sit in the file's `[defaults]`
-/// header rather than on the record — so the trust question this side of the
-/// review cannot be answered from the record alone, and the safe answer to a
-/// question you cannot answer is no. Review is a read of the tree; it does not
-/// become the place a document nobody has reviewed yet gets to run a command or
-/// reach a host. The remaining kinds are filesystem reads, which is what makes
-/// re-asking on every review cheap enough to be unconditional.
+/// `command_succeeds` or `http_ok` only on a record the loader stamped
+/// [`stella_core::records::Trust::User`] — a *published* file in the user's own
+/// `~/.stella/rules`, which nobody else can write. This reads a **proposal**,
+/// which has no tier at all: it is sitting in the tree awaiting a decision, and
+/// its `origin` may live in the file's `[defaults]` header rather than on the
+/// record. The safe answer to a question you cannot answer is no. Review is a
+/// read of the tree; it does not become the place a document nobody has reviewed
+/// yet gets to run a command or reach a host. The remaining kinds are filesystem
+/// reads, which is what makes re-asking on every review cheap enough to be
+/// unconditional.
 fn reprobe(root: &Path, found: &FoundProposal, now: &str) -> Probed {
     use stella_core::ingest::record::ProbeKind;
 

--- a/crates/stella-cli/src/context_cmd/validate.rs
+++ b/crates/stella-cli/src/context_cmd/validate.rs
@@ -121,7 +121,7 @@ pub fn run_validate(root: &Path, format: QueryFormat) -> Result<(), String> {
 
     let files = rule_files(root, true, true);
     let now = now_rfc3339();
-    let cache = probe_everything(root, &files.all(), &now);
+    let cache = probe_everything(root, &files, &now);
     let registry = registry_with_cache(root, &files, &cache, &now);
 
     // Regulated tier: a project record armed to block must hold a ledger

--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -549,12 +549,25 @@ pub(crate) struct TieredFiles {
 }
 
 impl TieredFiles {
-    /// Every file, tier forgotten — for the passes that only ask what is on disk,
-    /// like running due probes.
+    /// Every file, tier forgotten — for the passes that only ask what is on disk.
+    ///
+    /// Not for the probe pass. Running a due probe asks whether a gated probe may
+    /// run, which `stella_core::records::honored_probe` answers from the tier, so
+    /// the sweep reads `tiered` instead. Flattening there let a repository
+    /// record be swept as if the user had published it.
     pub(crate) fn all(&self) -> Vec<RuleFile> {
         let mut all = self.user.clone();
         all.extend(self.project.iter().cloned());
         all
+    }
+
+    /// Every file with the tier it was read out of, user first — the shape a pass
+    /// needs when the answer depends on who published the record.
+    fn tiered(&self) -> [(&[RuleFile], Trust); 2] {
+        [
+            (self.user.as_slice(), Trust::User),
+            (self.project.as_slice(), Trust::Project),
+        ]
     }
 }
 
@@ -595,7 +608,7 @@ fn load_registry_with(root: &Path, include_project: bool) -> Registry {
     let files = rule_files(root, true, include_project);
     let now = now_rfc3339();
     let mut cache = SweepCache::read(root);
-    let ran = run_due_probes(root, &files.all(), &mut cache, &now);
+    let ran = run_due_probes(root, &files, &mut cache, &now);
     if ran > 0 {
         cache.write(root);
     }
@@ -708,7 +721,7 @@ fn repo_owned_lineages(files: &TieredFiles) -> BTreeSet<String> {
         .filter(|file| file.contributed_by.is_none())
         .cloned()
         .collect();
-    parse_records(&repo_owned)
+    parse_records(&repo_owned, Trust::Project)
         .into_iter()
         .map(|loaded| loaded.record.lineage_id)
         .collect()
@@ -747,9 +760,9 @@ fn trust_of_published_path(path: &str) -> Trust {
 }
 
 /// Run every probe that is due, writing results into `cache`. Returns how many ran.
-fn run_due_probes(root: &Path, files: &[RuleFile], cache: &mut SweepCache, now: &str) -> usize {
+fn run_due_probes(root: &Path, files: &TieredFiles, cache: &mut SweepCache, now: &str) -> usize {
     let mut ran = 0;
-    for record in parse_records(files) {
+    for record in tiered_records(files) {
         let lineage = record.record.lineage_id.clone();
         let last = cache
             .checked
@@ -757,6 +770,7 @@ fn run_due_probes(root: &Path, files: &[RuleFile], cache: &mut SweepCache, now: 
             .map(|entry| entry.checked_at.clone());
         let input = records::SweepInput {
             record: &record.record,
+            trust: record.trust,
             verdict: None,
             last_checked: last.as_deref(),
             now,
@@ -768,7 +782,7 @@ fn run_due_probes(root: &Path, files: &[RuleFile], cache: &mut SweepCache, now: 
         if !(never_checked || records::probe_is_due(&input)) {
             continue;
         }
-        let Some(probe) = records::honored_probe(&record.record) else {
+        let Some(probe) = records::honored_probe(&record.record, record.trust) else {
             continue;
         };
         let refutation = crate::ingest_cmd::probe::evaluate(root, probe, now);
@@ -790,29 +804,48 @@ fn run_due_probes(root: &Path, files: &[RuleFile], cache: &mut SweepCache, now: 
 /// human's cadence and `none` is an admission that nothing can check the claim;
 /// firing either would produce a verdict nobody took.
 fn probe_is_runnable(record: &LoadedRecord) -> bool {
-    records::honored_probe(&record.record)
+    records::honored_probe(&record.record, record.trust)
         .is_some_and(|probe| !matches!(probe.kind, ProbeKind::Manual | ProbeKind::None))
 }
 
 /// Every `.toml` record in `files`, for the probe pass. Parse failures are ignored
 /// here — [`records::registry::load`] reports them properly, and reporting the
 /// same broken file twice reads like two problems.
-pub(crate) fn parse_records(files: &[RuleFile]) -> Vec<LoadedRecord> {
+///
+/// `trust` is the tier the caller read these files out of, and it is stamped here
+/// for the same reason [`records::registry::load`] stamps it: a record cannot
+/// establish its own publisher, and every gate that rations a capability asks who
+/// published it.
+pub(crate) fn parse_records(files: &[RuleFile], trust: Trust) -> Vec<LoadedRecord> {
     files
         .iter()
         .filter(|file| file.path.ends_with(".toml"))
         .filter_map(|file| load_context_file(&file.path, &file.contents).ok())
         .flatten()
+        .map(|mut record| {
+            record.trust = trust;
+            record
+        })
+        .collect()
+}
+
+/// Every `.toml` record in this workspace, each carrying the tier its file was
+/// read out of — the probe pass's view of the tree.
+fn tiered_records(files: &TieredFiles) -> Vec<LoadedRecord> {
+    files
+        .tiered()
+        .into_iter()
+        .flat_map(|(tier, trust)| parse_records(tier, trust))
         .collect()
 }
 
 /// Force every probe to run, ignoring cadence — what `stella context validate`
 /// does. Returns the fresh cache without writing it, so a validation run can
 /// report on demand without moving the scheduled sweep's clock forward.
-pub(crate) fn probe_everything(root: &Path, files: &[RuleFile], now: &str) -> SweepCache {
+pub(crate) fn probe_everything(root: &Path, files: &TieredFiles, now: &str) -> SweepCache {
     let mut cache = SweepCache::default();
-    for record in parse_records(files) {
-        let Some(probe) = records::honored_probe(&record.record) else {
+    for record in tiered_records(files) {
+        let Some(probe) = records::honored_probe(&record.record, record.trust) else {
             continue;
         };
         let refutation = crate::ingest_cmd::probe::evaluate(root, probe, now);

--- a/crates/stella-cli/src/context_records/tests.rs
+++ b/crates/stella-cli/src/context_records/tests.rs
@@ -92,7 +92,69 @@ pattern = "{pattern}"
     .unwrap();
 }
 
+/// A record the repository published, asserting everything a gated probe
+/// needs: a `user` origin, a `decree` basis, and a named human. Anyone who can
+/// open a pull request can write all three.
+fn write_gated_probe_record(root: &Path, lineage: &str) {
+    let dir = root.join(RULES_DIR);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join(format!("{lineage}.toml")),
+        format!(
+            r#"
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[defaults]
+origin = "user"
+status = "active"
+
+[[record]]
+lineage_id = "{lineage}"
+kind = "fact"
+statement = "The release script still builds this workspace."
+
+[record.steering]
+force = "must"
+precedence = 50
+
+[record.truth]
+basis = "decree"
+verified_by = "mac"
+review_every = "P30D"
+
+[record.truth.probe]
+kind = "command_succeeds"
+"#
+        ),
+    )
+    .unwrap();
+}
+
 // The sweep
+
+#[test]
+fn the_sweep_never_takes_up_a_repository_records_gated_probe() {
+    let root = tempfile::tempdir().unwrap();
+    write_gated_probe_record(root.path(), "ctx.acme.web.release-script");
+
+    // The project tier only. The user's own directory is the one place this
+    // record could arm a command, and this file is not in it.
+    let files = rule_files(root.path(), false, true);
+    let mut cache = SweepCache::default();
+    let ran = run_due_probes(root.path(), &files, &mut cache, "2026-07-20T00:00:00Z");
+
+    assert_eq!(
+        ran, 0,
+        "a repository can write every field this record asserts, so the sweep must \
+         not take the probe up at all"
+    );
+    assert!(
+        cache.checked.is_empty(),
+        "and it leaves no verdict behind: {:?}",
+        cache.checked
+    );
+}
 
 #[test]
 fn a_never_checked_record_is_probed_and_its_verdict_cached() {
@@ -180,7 +242,7 @@ fn probe_everything_ignores_the_cadence_and_does_not_move_the_scheduled_clock() 
 
     std::fs::write(root.path().join(".nvmrc"), "22\n").unwrap();
     let files = rule_files(root.path(), false, true);
-    let fresh = probe_everything(root.path(), &files.all(), "2026-07-20T00:00:00Z");
+    let fresh = probe_everything(root.path(), &files, "2026-07-20T00:00:00Z");
     assert_eq!(
         fresh.checked["ctx.acme.web.node-version"].verdict, "refuted",
         "validate must tell the truth about now, not about the last scheduled sweep"

--- a/crates/stella-cli/src/ingest_cmd/probe.rs
+++ b/crates/stella-cli/src/ingest_cmd/probe.rs
@@ -2,11 +2,20 @@
 //!
 //! Ingest runs a probe to catch a document that was already stale when it was
 //! read (`05` node-version example: CLAUDE.md says Node 20, `.nvmrc` has said 22
-//! for months). Only **ungated** probes reach this runner: `path_exists`,
-//! `path_absent`, `file_contains`, and `manual`. Gated probes
-//! (`command_succeeds`, `http_ok`) are stripped before we get here — they are
-//! never honored on an imported record (see [`stella_core::ingest::gate`]), so a
-//! document can never make ingest run a command or reach the network.
+//! for months). This runner reads the filesystem and nothing else: `path_exists`,
+//! `path_absent`, `file_contains`, and `manual`.
+//!
+//! # A gated probe abstains here, whatever let it through
+//!
+//! `command_succeeds` and `http_ok` return `unfalsifiable` from [`evaluate`].
+//! They are not assumed to have been filtered out upstream. Two callers reach
+//! this function and they apply different rules.
+//! [`stella_core::ingest::gate`] refuses a gated kind by the proposal's origin.
+//! `stella_core::records::honored_probe` admits one on a record the user
+//! published and a human decreed. So "stripped before we get here" was a claim
+//! about the callers, and for the second one it was already false. Running a
+//! command or reaching a host is a power this runner does not have. No caller
+//! can spend it.
 //!
 //! Every path is resolved under the workspace root and every read is bounded, so
 //! a probe cannot escape the tree or be turned into a denial-of-service by a
@@ -53,8 +62,9 @@ pub fn evaluate(root: &Path, probe: &Probe, checked_at: &str) -> Refutation {
         ProbeKind::FileContains => file_contains(root, probe, checked_at),
         // A manual probe is a scheduled human recheck; no machine judged it now.
         ProbeKind::Manual => unfalsifiable(checked_at, "manual re-verification; no machine check"),
-        // Gated kinds are stripped upstream and never reach here; `none` is the
-        // explicit "nothing could judge this" case. Both abstain.
+        // A gated kind abstains here rather than relying on a caller to have
+        // filtered it (see the module docs); `none` is the explicit "nothing
+        // could judge this" case.
         ProbeKind::CommandSucceeds | ProbeKind::HttpOk | ProbeKind::None => {
             unfalsifiable(checked_at, "no probe kind could judge this claim")
         }

--- a/crates/stella-cli/tests/context_review_cli.rs
+++ b/crates/stella-cli/tests/context_review_cli.rs
@@ -129,13 +129,13 @@ fn a_deleted_probe_target_is_not_still_reported_supported() {
 /// **This closed no live hole.** `ingest_cmd::probe::evaluate` abstains on
 /// every gated kind rather than executing it, so nothing ran before either.
 /// What the explicit refusal in `reprobe` buys is that review does not
-/// *depend* on that — a
-/// proposal's `origin` may sit in the file's `[defaults]` header rather than on
-/// the record, so the sweep's own `honored_probe` rule cannot be evaluated
-/// correctly from the record alone on this side — and that the stored verdict
-/// survives: re-running would have replaced a real recorded verdict with a
-/// fresh `unfalsifiable`, which reads as "the tree now refutes less" when
-/// nothing was checked at all.
+/// *depend* on that. The sweep's own `honored_probe` rule reads a trust tier,
+/// and a proposal has none. A proposal's `origin` can also sit in the file's
+/// `[defaults]` header rather than on the record. So that rule cannot be
+/// evaluated on this side at all. The refusal also keeps the stored verdict:
+/// re-running would have replaced a real recorded verdict with a fresh
+/// `unfalsifiable`, which reads as "the tree now refutes less" when nothing was
+/// checked at all.
 ///
 /// The canary is what makes the first half falsifiable: the probe's command
 /// writes a file, and the assertion is that the file is not there.

--- a/crates/stella-core/src/ingest/record.rs
+++ b/crates/stella-core/src/ingest/record.rs
@@ -823,8 +823,11 @@ impl TruthBasis {
     }
 }
 
-/// What a truth probe checks. Gated kinds run a command or reach the network and
-/// are never honored on imported/inferred records — see [`ProbeKind::is_gated`].
+/// What a truth probe checks. Gated kinds run a command or reach the network.
+/// One is never honored on an imported or inferred record. On a published
+/// record it is refused as well unless the user published it — see
+/// [`ProbeKind::is_gated`], [`super::gate::probe_honored`] and
+/// `crate::records::honored_probe`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProbeKind {

--- a/crates/stella-core/src/records.rs
+++ b/crates/stella-core/src/records.rs
@@ -183,8 +183,12 @@ pub enum RecordFinding {
         field: &'static str,
     },
     /// The record declared a gated probe (`command_succeeds`, `http_ok`) that
-    /// [`sweep::honored_probe`] refuses for its origin or truth basis, so the
-    /// claim will never be re-checked. Reported, not honored.
+    /// [`sweep::honored_probe`] refuses. The trust tier, the origin, or the
+    /// truth basis rules it out, so the claim is never re-checked. Reported,
+    /// not honored.
+    ///
+    /// A record the repository published is refused for its tier whatever else
+    /// it says. This finding is where its author finds out.
     GatedProbeRefused(ProbeKind),
     /// The record asked to block at the tool boundary and was refused. See
     /// [`BlockingRefusal`] for which precondition failed.
@@ -244,9 +248,9 @@ impl std::fmt::Display for RecordFinding {
             ),
             Self::GatedProbeRefused(kind) => write!(
                 f,
-                "probe kind {} runs a command or reaches the network, which is honored \
-                 only on a decreed record a named human verified — this claim will \
-                 never be re-checked",
+                "probe kind {} runs a command or reaches the network. That is honored \
+                 only in your own ~/.stella/rules, on a decreed record a named human \
+                 verified — this claim will never be re-checked",
                 kind.as_str()
             ),
             Self::BlockingRefused(refusal) => write!(f, "{refusal}"),

--- a/crates/stella-core/src/records/registry.rs
+++ b/crates/stella-core/src/records/registry.rs
@@ -310,6 +310,7 @@ pub fn load(user_files: &[RuleFile], project_files: &[RuleFile], facts: &Facts<'
     for (mut record, markdown) in records.into_iter().zip(markdown) {
         let mut disposition = super::disposition(&SweepInput {
             record: &record.record,
+            trust: record.trust,
             verdict: facts.verdicts.get(&record.record.lineage_id).copied(),
             last_checked: facts
                 .last_checked

--- a/crates/stella-core/src/records/registry/tests.rs
+++ b/crates/stella-core/src/records/registry/tests.rs
@@ -1,5 +1,6 @@
 //! The merge, over both formats, from real file contents.
 
+use super::super::super::ingest::record::ProbeKind;
 use super::*;
 
 const NOW: &str = "2026-07-20T00:00:00Z";
@@ -595,6 +596,85 @@ fn a_user_approval_does_not_transfer_to_a_project_record_of_the_same_lineage() {
     assert!(
         !registry.entries[0].is_enforced(),
         "the approval was granted to the user's record, not to this lineage as a name"
+    );
+}
+
+// Gated probes answer to the tier, not to what the file says about itself.
+
+/// A record whose own fields all argue for running a command: a `user` origin,
+/// a `decree` basis, and a named human. Only the directory it is read from
+/// tells the honored case from the refused one.
+fn gated_probe_record(lineage: &str) -> String {
+    format!(
+        r#"
+schema = "context-record/v0.1"
+set_id = "acme.web"
+
+[[record]]
+lineage_id = "{lineage}"
+kind = "rule"
+statement = "The release script still builds this workspace."
+origin = "user"
+status = "active"
+
+[record.steering]
+force = "should"
+precedence = 50
+
+[record.truth]
+basis = "decree"
+verified_by = "mac"
+
+[record.truth.probe]
+kind = "command_succeeds"
+"#
+    )
+}
+
+const PROBED: &str = "ctx.acme.web.release-script";
+
+#[test]
+fn a_repository_record_never_arms_a_gated_probe() {
+    // Anyone who can open a pull request can write every field this record
+    // asserts. So none of them may unlock a command. The refusal is said out
+    // loud: otherwise the author who wrote the probe never learns that the
+    // claim stopped being re-checked.
+    let project = vec![md(
+        ".stella/rules/release-script.toml",
+        &gated_probe_record(PROBED),
+    )];
+    let registry = load(&[], &project, &facts());
+
+    assert!(
+        registry.entries[0]
+            .record
+            .findings
+            .iter()
+            .any(|finding| matches!(
+                finding,
+                RecordFinding::GatedProbeRefused(ProbeKind::CommandSucceeds)
+            )),
+        "a repository's gated probe must be refused and reported: {:?}",
+        registry.entries[0].record.findings
+    );
+}
+
+#[test]
+fn the_same_record_in_the_users_own_directory_keeps_its_probe() {
+    let user = vec![md(
+        "/home/mac/.stella/rules/release-script.toml",
+        &gated_probe_record(PROBED),
+    )];
+    let registry = load(&user, &[], &facts());
+
+    assert!(
+        !registry.entries[0]
+            .record
+            .findings
+            .iter()
+            .any(|finding| matches!(finding, RecordFinding::GatedProbeRefused(_))),
+        "the user's own directory is the one place this record can arm a command: {:?}",
+        registry.entries[0].record.findings
     );
 }
 

--- a/crates/stella-core/src/records/sweep.rs
+++ b/crates/stella-core/src/records/sweep.rs
@@ -36,8 +36,9 @@
 //! disposition so the CLI can explain what happened rather than silently changing
 //! what the agent sees.
 
-use super::super::context_record::kind::Origin;
+use super::super::ingest::gate::origin_is_untrusted;
 use super::super::ingest::record::{Probe, Record, TruthBasis, Verdict};
+use super::Trust;
 use super::clock;
 
 /// What `truth.on_expiry` asks for when a claim stops being believed.
@@ -71,6 +72,11 @@ impl ExpiryAction {
 pub struct SweepInput<'a> {
     /// The record under review.
     pub record: &'a Record,
+    /// The tier the record was published at. The loader stamps it from the
+    /// directory the file was read out of. [`honored_probe`] needs it: whether
+    /// a gated probe may run is a question about the publisher, and the record
+    /// cannot answer that about itself.
+    pub trust: Trust,
     /// The verdict a probe produced this sweep, when one ran. `None` means no
     /// probe ran — either nothing is due, or nothing about this record is
     /// probeable.
@@ -138,29 +144,50 @@ impl Disposition {
     }
 }
 
-/// The probe this record's origin actually permits.
+/// The probe this record is allowed to have run for it.
 ///
 /// A gated probe (`command_succeeds`, `http_ok`) runs a command or reaches the
-/// network on content that may have come from a document nobody audited. An
-/// `http_ok` pointed at an attacker-chosen host is an exfiltration channel with a
-/// policy file's authority behind it. So a gated probe is honored **only** on a
-/// `decree` record with a human `verified_by`, and **never** on an `imported` or
-/// `inferred` one — the same gate `super::super::ingest::gate` applies at
-/// extraction, re-applied here because a record can be hand-edited after ingest
-/// and the file is the only thing the loader sees.
-pub fn honored_probe(record: &Record) -> Option<&Probe> {
+/// network. The claim it checks may have come from a document nobody read. An
+/// `http_ok` aimed at a host someone else chose leaks data, with a policy
+/// file's authority behind it. So three things must hold, and each one closes a
+/// way to fake the other two:
+///
+/// - **The loader stamped [`Trust::User`].** Every other field here is written
+///   inside the file being judged. A checkout can set a clean `origin` and a
+///   named `verified_by` as easily as it sets anything else. That would let
+///   anyone who can open a pull request arm a command. Where the file was read
+///   from is the one fact it cannot write, and [`super::registry::load`] stamps
+///   that from the directory. [`super::bridge`] asks the same question before
+///   it lets a record approve its own blocking guard.
+/// - **The origin is stamped, and is not `imported` or `inferred`.** A record
+///   with no origin is refused too. It has said nothing about where it came
+///   from, and saying nothing must not be the permissive answer.
+///   `origin_is_untrusted` belongs to `super::super::ingest::gate`, so
+///   extraction and the sweep read one rule rather than two copies.
+/// - **`truth.basis` is a `decree` with a non-empty `verified_by`.** What is
+///   being relied on is a person whose name is on the claim. A name nobody
+///   wrote is not one.
+///
+/// The gate runs here as well as at extraction because a record can be edited
+/// by hand afterwards. The file is all the loader sees.
+pub fn honored_probe(record: &Record, trust: Trust) -> Option<&Probe> {
     let truth = record.truth.as_ref()?;
     let probe = truth.probe.as_ref()?;
     if !probe.kind.is_gated() {
         return Some(probe);
     }
-    let untrusted_origin = matches!(record.origin, Some(Origin::Imported | Origin::Inferred));
+    if trust != Trust::User {
+        return None;
+    }
+    let trusted_origin = record
+        .origin
+        .is_some_and(|origin| !origin_is_untrusted(origin));
     let decreed_by_a_human = truth.basis == TruthBasis::Decree
         && truth
             .verified_by
             .as_deref()
             .is_some_and(|by| !by.is_empty());
-    (!untrusted_origin && decreed_by_a_human).then_some(probe)
+    (trusted_origin && decreed_by_a_human).then_some(probe)
 }
 
 /// Whether this record's probe should run now.
@@ -171,7 +198,7 @@ pub fn honored_probe(record: &Record) -> Option<&Probe> {
 /// timer: its cadence is a human's, and firing it automatically would produce a
 /// verdict nobody actually checked.
 pub fn probe_is_due(input: &SweepInput<'_>) -> bool {
-    let Some(probe) = honored_probe(input.record) else {
+    let Some(probe) = honored_probe(input.record, input.trust) else {
         return false;
     };
     if matches!(
@@ -248,6 +275,7 @@ pub fn disposition(input: &SweepInput<'_>) -> Disposition {
 
 #[cfg(test)]
 mod tests {
+    use super::super::super::context_record::kind::Origin;
     use super::super::super::ingest::record::{ProbeKind, Truth};
     use super::super::tests::{record_named, with_truth};
     use super::*;
@@ -257,10 +285,30 @@ mod tests {
     fn input<'a>(record: &'a Record, verdict: Option<Verdict>) -> SweepInput<'a> {
         SweepInput {
             record,
+            trust: Trust::User,
             verdict,
             last_checked: None,
             now: NOW,
         }
+    }
+
+    /// A record whose own fields all argue for a gated probe: a
+    /// `command_succeeds`, decreed, with a named human, from a `user` origin.
+    /// Only the tier the loader stamps tells the honored case from the refused
+    /// one.
+    fn gated_and_decreed(origin: Option<Origin>) -> Record {
+        let mut truth = measured(Some(Probe {
+            kind: ProbeKind::CommandSucceeds,
+            path: None,
+            pattern: None,
+            expect: None,
+            note: None,
+        }));
+        truth.basis = TruthBasis::Decree;
+        truth.verified_by = Some("platform-owner".to_string());
+        let mut record = with_truth(record_named("ctx.a.b.c"), truth);
+        record.origin = origin;
+        record
     }
 
     fn measured(probe: Option<Probe>) -> Truth {
@@ -416,6 +464,34 @@ mod tests {
     // The gated-probe boundary
 
     #[test]
+    fn no_gated_probe_is_honored_at_project_trust_ever() {
+        for origin in [
+            None,
+            Some(Origin::User),
+            Some(Origin::System),
+            Some(Origin::Observed),
+            Some(Origin::Inferred),
+            Some(Origin::Imported),
+        ] {
+            let record = gated_and_decreed(origin);
+            assert!(
+                honored_probe(&record, Trust::Project).is_none(),
+                "a repository can write every field this record asserts, so none of \
+                 them may unlock a command: origin {origin:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unstamped_origin_does_not_unlock_a_gated_probe() {
+        let record = gated_and_decreed(None);
+        assert!(
+            honored_probe(&record, Trust::User).is_none(),
+            "a record that said nothing about where it came from is not the trusted case"
+        );
+    }
+
+    #[test]
     fn a_gated_probe_is_refused_on_an_imported_record() {
         let mut record = with_truth(
             record_named("ctx.a.b.c"),
@@ -429,41 +505,21 @@ mod tests {
         );
         record.origin = Some(Origin::Imported);
         assert!(
-            honored_probe(&record).is_none(),
+            honored_probe(&record, Trust::User).is_none(),
             "an imported document must never get us to make a network call"
         );
     }
 
     #[test]
     fn a_gated_probe_is_refused_on_an_inferred_record_even_when_decreed() {
-        let mut truth = measured(Some(Probe {
-            kind: ProbeKind::CommandSucceeds,
-            path: None,
-            pattern: None,
-            expect: None,
-            note: None,
-        }));
-        truth.basis = TruthBasis::Decree;
-        truth.verified_by = Some("platform-owner".to_string());
-        let mut record = with_truth(record_named("ctx.a.b.c"), truth);
-        record.origin = Some(Origin::Inferred);
-        assert!(honored_probe(&record).is_none());
+        let record = gated_and_decreed(Some(Origin::Inferred));
+        assert!(honored_probe(&record, Trust::User).is_none());
     }
 
     #[test]
     fn a_gated_probe_is_honored_on_a_human_decreed_user_record() {
-        let mut truth = measured(Some(Probe {
-            kind: ProbeKind::CommandSucceeds,
-            path: None,
-            pattern: None,
-            expect: None,
-            note: None,
-        }));
-        truth.basis = TruthBasis::Decree;
-        truth.verified_by = Some("platform-owner".to_string());
-        let mut record = with_truth(record_named("ctx.a.b.c"), truth);
-        record.origin = Some(Origin::User);
-        assert!(honored_probe(&record).is_some());
+        let record = gated_and_decreed(Some(Origin::User));
+        assert!(honored_probe(&record, Trust::User).is_some());
     }
 
     #[test]
@@ -480,17 +536,17 @@ mod tests {
         let mut record = with_truth(record_named("ctx.a.b.c"), truth);
         record.origin = Some(Origin::User);
         assert!(
-            honored_probe(&record).is_none(),
+            honored_probe(&record, Trust::User).is_none(),
             "\"a human said so\" needs the human's name to mean anything"
         );
     }
 
     #[test]
-    fn an_ungated_probe_is_honored_on_an_imported_record() {
+    fn an_ungated_probe_is_honored_on_an_imported_project_record() {
         let mut record = with_truth(record_named("ctx.a.b.c"), measured(Some(path_probe())));
         record.origin = Some(Origin::Imported);
         assert!(
-            honored_probe(&record).is_some(),
+            honored_probe(&record, Trust::Project).is_some(),
             "reading .nvmrc is how an imported claim gets refuted at all"
         );
     }

--- a/crates/stella-core/src/records/tests.rs
+++ b/crates/stella-core/src/records/tests.rs
@@ -423,6 +423,7 @@ pattern = "20"
                 .then_some(super::super::ingest::record::Verdict::Refuted);
             sweep::disposition(&SweepInput {
                 record: &loaded.record,
+                trust: loaded.trust,
                 verdict,
                 last_checked: None,
                 now: "2026-07-20T00:00:00Z",

--- a/crates/stella-core/src/records/validate.rs
+++ b/crates/stella-core/src/records/validate.rs
@@ -34,7 +34,7 @@
 use super::super::ingest::gate::atomicity_validation;
 use super::super::ingest::record::{AppliesTo, EnforcementMode, Record};
 use super::super::redact::redact_secrets;
-use super::{KNOWN_TASKS, LoadedRecord, RecordFinding};
+use super::{KNOWN_TASKS, LoadedRecord, RecordFinding, Trust};
 
 /// Glob metacharacters that are **literals** in this engine's matcher. A guard
 /// written with them expresses an intent the matcher will not honor, so it silently
@@ -78,7 +78,7 @@ pub struct Conflict {
 /// months) — but it must still take part in conflict detection, because a markdown
 /// guard and a TOML record really can contradict each other.
 pub fn check_record(loaded: &mut LoadedRecord) {
-    let mut findings = check_one(&loaded.record);
+    let mut findings = check_one(&loaded.record, loaded.trust);
     loaded.findings.append(&mut findings);
 }
 
@@ -112,30 +112,34 @@ pub fn is_suspended(handle: &str, conflicts: &[Conflict]) -> bool {
 }
 
 /// Everything wrong with one record, independent of its neighbours.
-fn check_one(record: &Record) -> Vec<RecordFinding> {
+fn check_one(record: &Record, trust: Trust) -> Vec<RecordFinding> {
     let mut findings = Vec::new();
     findings.extend(forbidden_data(record));
     findings.extend(guard_lint(record));
     findings.extend(unknown_tasks(record));
     findings.extend(atomicity(record));
     findings.extend(scoped_without_trigger(record));
-    findings.extend(gated_probe_refused(record));
+    findings.extend(gated_probe_refused(record, trust));
     findings
 }
 
 /// A declared gated probe (`command_succeeds`/`http_ok`) the staleness sweep
 /// will never run: [`super::sweep::honored_probe`] refuses it for this record's
-/// origin or truth basis. Without this finding the record loads clean and its
-/// claim silently never gets re-checked — the author believes a probe is
-/// standing guard, and nothing is.
-fn gated_probe_refused(record: &Record) -> Vec<RecordFinding> {
+/// trust tier, origin or truth basis. Without this finding the record loads
+/// clean and its claim silently never gets re-checked — the author believes a
+/// probe is standing guard, and nothing is.
+///
+/// The tier is why this is the surface the refusal is said out loud on. Almost
+/// every gated probe in a repository is refused for its tier alone, and a record
+/// whose fields all look impeccable gives its author no other way to find out.
+fn gated_probe_refused(record: &Record, trust: Trust) -> Vec<RecordFinding> {
     let declared = record
         .truth
         .as_ref()
         .and_then(|truth| truth.probe.as_ref())
         .filter(|probe| probe.kind.is_gated());
     match declared {
-        Some(probe) if super::sweep::honored_probe(record).is_none() => {
+        Some(probe) if super::sweep::honored_probe(record, trust).is_none() => {
             vec![RecordFinding::GatedProbeRefused(probe.kind)]
         }
         _ => Vec::new(),
@@ -556,7 +560,7 @@ mod tests {
     fn a_glob_using_a_non_wildcard_metacharacter_is_blocking() {
         let mut record = record_named("ctx.a.b.c");
         record.enforcement = Some(hard_guard(Some("Edit"), Some("migrations/[0-9]*/**"), None));
-        let findings = check_one(&record);
+        let findings = check_one(&record, Trust::User);
         let lint = findings
             .iter()
             .find_map(|f| match f {
@@ -577,7 +581,7 @@ mod tests {
     fn a_deny_everything_guard_on_every_tool_is_refused() {
         let mut record = record_named("ctx.a.b.c");
         record.enforcement = Some(hard_guard(Some("*"), Some("**"), None));
-        let findings = check_one(&record);
+        let findings = check_one(&record, Trust::User);
         assert!(
             findings
                 .iter()
@@ -590,7 +594,7 @@ mod tests {
     fn an_unbounded_glob_on_one_tool_is_questioned_not_refused() {
         let mut record = record_named("ctx.a.b.c");
         record.enforcement = Some(hard_guard(Some("Write"), Some("*"), None));
-        let findings = check_one(&record);
+        let findings = check_one(&record, Trust::User);
         assert!(
             findings
                 .iter()
@@ -604,7 +608,7 @@ mod tests {
         let mut record = record_named("ctx.a.b.c");
         record.enforcement = Some(hard_guard(Some("Edit(migrations)"), None, None));
         assert!(
-            check_one(&record).iter().any(
+            check_one(&record, Trust::User).iter().any(
                 |f| matches!(f, RecordFinding::GuardLint(d) if d.contains("is not a tool name"))
             ),
         );
@@ -614,7 +618,11 @@ mod tests {
     fn a_well_formed_guard_lints_clean() {
         let mut record = record_named("ctx.a.b.c");
         record.enforcement = Some(hard_guard(Some("Bash"), None, Some("git push --force*")));
-        assert!(check_one(&record).is_empty(), "{:?}", check_one(&record));
+        assert!(
+            check_one(&record, Trust::User).is_empty(),
+            "{:?}",
+            check_one(&record, Trust::User)
+        );
     }
 
     // Forbidden data
@@ -625,7 +633,7 @@ mod tests {
         record.statement =
             "Authenticate with sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA."
                 .to_string();
-        let findings = check_one(&record);
+        let findings = check_one(&record, Trust::User);
         assert!(
             findings
                 .iter()
@@ -643,11 +651,11 @@ mod tests {
         let mut record = record_named("ctx.a.b.c");
         record.statement = "Run the build.\n$ pnpm build\nDone in 4.2s".to_string();
         assert!(
-            check_one(&record)
+            check_one(&record, Trust::User)
                 .iter()
                 .any(|f| matches!(f, RecordFinding::GuardLint(d) if d.contains("single \nsentence") || d.contains("single sentence"))),
             "{:?}",
-            check_one(&record)
+            check_one(&record, Trust::User)
         );
     }
 
@@ -661,7 +669,7 @@ mod tests {
         {
             applies_to.tasks = vec!["install".to_string(), "intall".to_string()];
         }
-        let findings = check_one(&record);
+        let findings = check_one(&record, Trust::User);
         assert_eq!(
             findings,
             vec![RecordFinding::UnknownTask("intall".to_string())],
@@ -701,7 +709,10 @@ mod tests {
 
     #[test]
     fn a_gated_probe_the_sweep_refuses_is_reported_not_silently_inert() {
-        let findings = check_one(&probing(ProbeKind::HttpOk, TruthBasis::Measured, None));
+        let findings = check_one(
+            &probing(ProbeKind::HttpOk, TruthBasis::Measured, None),
+            Trust::User,
+        );
         assert!(
             findings
                 .iter()
@@ -721,13 +732,36 @@ mod tests {
         // `record_named` stamps an imported origin, which the sweep refuses on
         // its own; the honored case needs the trusted one.
         record.origin = Some(super::super::super::context_record::kind::Origin::User);
-        assert!(check_one(&record).is_empty(), "{:?}", check_one(&record));
+        assert!(
+            check_one(&record, Trust::User).is_empty(),
+            "{:?}",
+            check_one(&record, Trust::User)
+        );
+    }
+
+    #[test]
+    fn the_same_record_at_project_trust_is_reported_instead() {
+        let mut record = probing(ProbeKind::CommandSucceeds, TruthBasis::Decree, Some("mac"));
+        record.origin = Some(super::super::super::context_record::kind::Origin::User);
+        let findings = check_one(&record, Trust::Project);
+        assert!(
+            findings.iter().any(|f| matches!(
+                f,
+                RecordFinding::GatedProbeRefused(ProbeKind::CommandSucceeds)
+            )),
+            "a repository record's gated probe is refused, and the author has to be \
+             told, or the claim silently stops being re-checked: {findings:?}"
+        );
     }
 
     #[test]
     fn an_ungated_probe_is_never_reported() {
         let record = probing(ProbeKind::FileContains, TruthBasis::Measured, None);
-        assert!(check_one(&record).is_empty(), "{:?}", check_one(&record));
+        assert!(
+            check_one(&record, Trust::User).is_empty(),
+            "{:?}",
+            check_one(&record, Trust::User)
+        );
     }
 
     #[test]
@@ -737,7 +771,7 @@ mod tests {
             "Deploys run from main, happen on Tuesdays, and are triggered with make ship."
                 .to_string();
         assert!(
-            check_one(&record)
+            check_one(&record, Trust::User)
                 .iter()
                 .any(|f| matches!(f, RecordFinding::GuardLint(d) if d.contains("re-extract"))),
         );

--- a/docs/spec/adaptive-context/context-record-examples/02-fact-observed.toml
+++ b/docs/spec/adaptive-context/context-record-examples/02-fact-observed.toml
@@ -2,9 +2,12 @@
 # the work. This is the class of record that makes ingest dangerous: a stale
 # fact from a two-year-old CLAUDE.md reads exactly like a fresh one.
 #
-# `http_ok` would be the natural probe here and is NOT used: this
-# record's origin is `imported`, and a gated probe is never honored on an
-# imported record. What is checked instead is the tracked infrastructure file
+# `http_ok` would be the natural probe here and is NOT used. Two rules each
+# rule it out on their own. This record's origin is `imported`, and a gated
+# probe is never honored on an imported record. It also lives in the
+# repository, and a gated probe is never honored there: anyone who can open a
+# pull request can write every field that would argue for one.
+# What is checked instead is the tracked infrastructure file
 # that would have to change if the endpoint moved — weaker, but safe and still
 # genuinely falsifying.
 

--- a/docs/spec/adaptive-context/context-record-examples/README.md
+++ b/docs/spec/adaptive-context/context-record-examples/README.md
@@ -149,11 +149,21 @@ A probe answers "does this claim still hold?" without executing arbitrary code:
 
 Gated probes are honored **only** when `basis = "decree"` and a human
 `verified_by` is recorded, and **never** on a record whose `origin` is
-`imported` or `inferred`. Ingest is the headline path here: a model extracting
-records from arbitrary markdown must not be able to mint a record that runs a
-command or fetches a URL. An `http_ok` probe pointed at an attacker-chosen host
-is an exfiltration channel — anything interesting fits in a query string. `05`
-shows a would-be shell probe quarantined rather than honored.
+`imported`, `inferred`, or missing. Ingest is the headline path here: a model
+extracting records from arbitrary markdown must not be able to mint a record
+that runs a command or fetches a URL. An `http_ok` probe pointed at an
+attacker-chosen host is an exfiltration channel — anything interesting fits in
+a query string. `05` shows a would-be shell probe quarantined rather than
+honored.
+
+Once a record is published, one more condition is added and it is the one that
+usually decides: a gated probe is honored only in the user's own
+`~/.stella/rules`. Every field above is written *inside the file being judged*,
+so in a checkout they are a stranger asserting the author's consent — which
+would make anyone who can open a pull request able to arm a command. Where the
+file was read from is the one fact it cannot claim, so that is what the sweep
+asks. A repository record that declares a gated probe still loads and still
+steers; it reports `gated probe refused` and its claim is never re-checked.
 
 ## Refutation is evidence, not a boolean
 


### PR DESCRIPTION
## What and why

`sweep::honored_probe` decided whether a gated probe — `command_succeeds` or `http_ok` — may run from three fields: `origin`, `truth.basis`, and `verified_by`. Every one of them is written *inside the file being judged*. A checkout's `.stella/rules/*.toml` can set all three, so anyone who could open a pull request could arm a command or a network call with a committed policy file's authority behind it. `records/bridge.rs` already refuses exactly this self-attestation before it will let a record approve its own blocking guard, and it refuses it by asking the loader-stamped `Trust`. The sweep never asked.

It asks now. A gated probe is honored only when all three hold:

- the loader stamped `Trust::User` — the one fact a file cannot write about itself, taken from the directory it was read out of;
- the origin is stamped and is not `imported` or `inferred` — a **missing** origin is now the untrusted case, which is the reading the deleted ingest-side accessor took (#5331 item 1 asked for this to be pinned);
- `truth.basis` is a `decree` with a non-empty `verified_by`.

`SweepInput` carries the tier, `registry::load` passes the one `parse_tier` already stamped, and `stella-cli`'s `run_due_probes` / `probe_everything` stop running over `TieredFiles::all()`. They parse each tier with its trust stamped instead — `TieredFiles::all()` was flattening the tiers at exactly the boundary where the answer depends on them.

`validate::gated_probe_refused` now reads the tier too, so a repository record that declares a gated probe reports `RecordFinding::GatedProbeRefused` rather than loading clean with a probe that will never run. (The issue said that finding is "defined and never produced" — that is stale against `main`: `check_one` has produced it for a while. What was wrong is that it could not see the tier, so it fired on the wrong set.)

**This makes nothing newly runnable, and closes no live hole on its own.** `ingest_cmd::probe::evaluate` abstains on every gated kind and still does. That is what kept this unexploitable, and it is why the issue is filed as a missing gate rather than as a vulnerability.

## The three comments that disagreed

- `ingest_cmd/probe.rs`'s header said gated kinds "are stripped before we get here". Two callers reach `evaluate` and they applied different rules, so that was a claim about the callers and was already false for the sweep's. It now says what this file does: a gated kind abstains here, whatever let it through.
- `context_cmd/review.rs` said the sweep admits a gated probe "on a human-decreed record". It now says what the sweep actually admits, and why a proposal — which has no tier at all — cannot be judged by that rule on the review side.
- `sweep.rs`, `records.rs`'s `GatedProbeRefused` doc and its `Display` text, `ingest/record.rs`'s `ProbeKind` doc, and the two `context-record-examples` documents all name the tier now.

## Witness mechanism

Three, at three levels. The first two fail on old code by construction (the signature gained an argument); the third and fourth fail on old code at **runtime**, which is the honest ones:

- `sweep.rs` `no_gated_probe_is_honored_at_project_trust_ever` — the record asserts everything a gated probe needs, across every `Origin` including `None`, and is refused at `Trust::Project` every time. `an_unstamped_origin_does_not_unlock_a_gated_probe` pins the `origin: None` case at `Trust::User`.
- `records/registry/tests.rs` `a_repository_record_never_arms_a_gated_probe` — the same record loaded as a **project** file through `registry::load` must carry `GatedProbeRefused`. On `main` `honored_probe` returns `Some` for it, no finding is emitted, and the assertion fails. Its pair, `the_same_record_in_the_users_own_directory_keeps_its_probe`, shows the finding is about the directory and not about the record.
- `context_records/tests.rs` `the_sweep_never_takes_up_a_repository_records_gated_probe` — the CLI sweep over the project tier returns `ran == 0` and writes no cache entry. On `main` `probe_is_runnable` is true for this record, `never_checked` fires, `evaluate` abstains, and an `unfalsifiable` verdict is cached: `ran == 1`. That difference is observable without making anything runnable.

## Exemplar

No new shape was invented. `records/registry.rs`'s `parse_tier` is the exemplar for stamping a tier at the boundary that knows the directory, and `records/bridge.rs`'s `self_attested` is the exemplar for the rule itself — a record's own fields cannot establish the authority they claim.

Tests renamed: `sweep.rs`'s `an_ungated_probe_is_honored_on_an_imported_record` is now
`an_ungated_probe_is_honored_on_an_imported_project_record`. Same assertion, and the new
name says the half that now matters: an ungated probe is honored on an imported record
*published by the repository*, which is how an imported claim gets refuted at all.

Tests deleted: None.

Residue issues filed: none — see the final comment on this PR if that changes.

Closes #5329

## Summary by Sourcery

Require gated probes to be published from the user's trusted rules directory and satisfy explicit origin and human-verification requirements before they are honored.

Bug Fixes:
- Prevent repository-published records from authorizing gated command or network probes based solely on self-attested fields.

Enhancements:
- Propagate loader-assigned trust tiers through sweep, validation, and registry processing so gated probes are evaluated against their publishing location.
- Report refused gated probes on records that cannot satisfy the trust, origin, and verification requirements.
- Clarify gated-probe behavior and trust requirements across code documentation and context-record examples.

Documentation:
- Update context-record documentation to describe missing origins and repository-tier restrictions for gated probes.

Tests:
- Add coverage confirming project records never arm gated probes, unstamped origins remain untrusted, and user-tier records retain eligible probes.