### PR TITLE
fix(stella-cli): publish the deck's start-work branch so another clone can see it

### DIFF
--- a/crates/stella-cli/src/command_deck/start_work.rs
+++ b/crates/stella-cli/src/command_deck/start_work.rs
@@ -35,16 +35,36 @@
 //! layering the loop already uses: the lease closes the race (two claimants in
 //! the same instant, decided by one conditional write), and the branch carries
 //! the duration. `contention::for_issue` weighs a remote branch, an open pull
-//! request, a worktree and the ledger together — so once the branch is pushed
-//! it is the branch that says the issue is taken, and the lease never has to
-//! be held for the length of a human's afternoon.
+//! request, a worktree and the ledger together, so the branch is what says the
+//! issue is taken and the lease never has to be held for the length of a
+//! human's afternoon.
 //!
-//! What that leaves open: between the approval and the first push,
-//! the branch is local and only this clone can see it. A self-driving loop on
-//! the *same* clone still defers, because `worktrees_naming` and the ledger
-//! both see it; a loop on a different clone does not. Closing that means the
-//! deck pushing the branch on approval, which would be a network write before
-//! any work exists.
+//! # Why the branch is pushed before any work exists
+//!
+//! A branch only carries the duration for a peer that can see it, and a local
+//! branch is seen by one clone. Of the four signals `contention::gather`
+//! reads, two cross a machine boundary: a remote branch and an open pull
+//! request. So `approve` pushes the branch it opens, while the lease is still
+//! held — `--set-upstream`, the same `git push` the loop's own
+//! `deliver::open` runs.
+//!
+//! The two alternatives cannot reach a second clone at all. Holding
+//! the lease for the whole deck session does not, because `dispatch_claims`
+//! lives in this workspace's own `.stella/private/fleet.db`. Teaching the
+//! probe to read local branches does not either. Both close the same-clone
+//! case, which already defers on the worktree and the ledger.
+//!
+//! The price is an empty `stella/issue-<n>-<slug>` branch on the remote for
+//! every start-work a human abandons, removed with `git push -d origin`. What
+//! it buys is that two people on two machines cannot both start the same
+//! issue.
+//!
+//! A push that fails — no `origin`, no network, no write access — does not
+//! fail the approval: the branch and the plan exist, and refusing to start
+//! work because a network write failed is the worse failure, on the same
+//! fail-open rule every probe over this table follows. The summary line then
+//! says the branch is local only and names git's reason, because a card that
+//! stayed quiet would claim a protection this workspace does not have.
 
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -144,20 +164,23 @@ pub(super) fn draft_plan<P: IssueProvider + ?Sized>(
 }
 
 /// Approve a drafted plan: take the issue's claim, open the branch under it,
-/// and author the plan's first revision.
+/// publish that branch, and author the plan's first revision.
 ///
 /// Ordered so that nothing is left behind by a failure. The claim comes first
 /// because it is the only step a peer can lose a race on; the branch second,
-/// so a lost race leaves no branch; the plan last, because it is derived from
-/// the tasks and cannot fail for a reason the first two would not have caught.
+/// so a lost race leaves no branch; the push third, so nothing reaches the
+/// remote that a lost race would have to clean up; the plan last, because it
+/// is derived from the tasks and cannot fail for a reason the first two would
+/// not have caught.
 pub(super) fn approve(root: &Path, display_key: &str, tasks: &[String]) -> Result<String, String> {
     if tasks.is_empty() {
         return Err("nothing to approve — the plan has no tasks".to_string());
     }
     let key = display_key.trim_start_matches('#').to_string();
     let owner = format!("deck:{}", std::process::id());
-    // Held only across the branch write. The branch is what a peer's
-    // contention probe reads afterwards — see the module docs.
+    // Held across the branch write and its publication. The published branch
+    // is what a peer's contention probe reads afterwards, on this clone and on
+    // any other — see the module docs.
     let _lease = match crate::self_driving_cmd::claim::acquire_as(root, &key, &owner) {
         crate::self_driving_cmd::claim::Claim::Granted(lease) => Some(lease),
         crate::self_driving_cmd::claim::Claim::HeldBy(who) => {
@@ -170,6 +193,10 @@ pub(super) fn approve(root: &Path, display_key: &str, tasks: &[String]) -> Resul
     };
     let branch = branch_name(&key, tasks);
     create_branch(root, &branch)?;
+    let reach = match publish_branch(root, &branch) {
+        Ok(()) => "pushed to origin".to_string(),
+        Err(reason) => format!("local only — a peer on another clone cannot see it: {reason}"),
+    };
     let graph = PlanGraph::approve(
         tasks
             .iter()
@@ -179,7 +206,7 @@ pub(super) fn approve(root: &Path, display_key: &str, tasks: &[String]) -> Resul
     )
     .map_err(|error| format!("the plan could not be authored: {error}"))?;
     Ok(format!(
-        "#{key}: branch {branch} · plan r{} · {} tasks · {} [:NEXT] edges",
+        "#{key}: branch {branch} {reach} · plan r{} · {} tasks · {} [:NEXT] edges",
         graph.revision().get(),
         tasks.len(),
         graph.edges().len()
@@ -233,6 +260,48 @@ fn create_branch(root: &Path, branch: &str) -> Result<(), String> {
     } else {
         reason
     })
+}
+
+/// Push `branch` to `origin` and track it, so a peer on any clone can see
+/// that this issue is taken.
+///
+/// `--set-upstream` rather than a bare push: the human who approved this is
+/// about to work on the branch, and an upstream is what makes their next
+/// `git push` need no arguments.
+///
+/// The error is git's own first refusal, for the summary line to quote. It is
+/// never fatal to the approval — see the module docs on why a failed network
+/// write must not take the branch and the plan with it.
+fn publish_branch(root: &Path, branch: &str) -> Result<(), String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["push", "--set-upstream", "origin", branch])
+        .output()
+        .map_err(|error| format!("could not run git: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(refusal(&String::from_utf8_lossy(&output.stderr)))
+}
+
+/// The one line of a git failure worth showing a human.
+///
+/// git writes its whole conversation to stderr, so the first line is often
+/// `To <url>` and the last is a hint. The refusal is the line git marks as
+/// one — `fatal:`, `error:`, or the `!` of a rejected ref — and the first
+/// non-empty line is the fallback for a refusal git marked in some other way.
+fn refusal(stderr: &str) -> String {
+    let mut first: Option<&str> = None;
+    for line in stderr.lines().map(str::trim).filter(|l| !l.is_empty()) {
+        if line.starts_with("fatal:") || line.starts_with("error:") || line.starts_with('!') {
+            return line.to_string();
+        }
+        first.get_or_insert(line);
+    }
+    first
+        .unwrap_or("git refused the push and said nothing")
+        .to_string()
 }
 
 /// How many gate steps block a merge in this workspace, from the Makefile's

--- a/crates/stella-cli/src/command_deck/start_work/tests.rs
+++ b/crates/stella-cli/src/command_deck/start_work/tests.rs
@@ -3,12 +3,14 @@
 
 //! The start-work driver: what a draft derives, and what an approval writes.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use stella_autonomy::{Contention, ContentionPolicy, ContentionVerdict, contention_verdict};
 use stella_protocol::issue::{Issue, IssueClass, IssueKey, IssueState};
 
 use super::*;
+use crate::self_driving_cmd::contention::branches_naming;
 
 fn issue(title: &str, body: &str) -> Issue {
     Issue {
@@ -25,30 +27,101 @@ fn issue(title: &str, body: &str) -> Issue {
     }
 }
 
+/// The issue every approval test starts work on, in the browse row's own
+/// spelling. Named once so the tests below read as one fixture rather than
+/// eight repetitions of a literal.
+const KEY: &str = "#151";
+
 fn subjects(tasks: &[DraftTask]) -> Vec<&str> {
     tasks.iter().map(|task| task.subject.as_str()).collect()
 }
 
+/// `git` in `cwd`, insisting it succeeded.
+fn git_ok(cwd: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(out.status.success(), "git {args:?}: {out:?}");
+}
+
 /// A git repository with one commit, so `checkout -b` has a HEAD to branch
-/// from.
+/// from. No remote — see [`clones`] for the fixture that has one.
 fn repo() -> tempfile::TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
-    let git = |args: &[&str]| {
-        let out = Command::new("git")
-            .arg("-C")
-            .arg(dir.path())
-            .args(args)
-            .output()
-            .expect("git");
-        assert!(out.status.success(), "git {args:?}: {out:?}");
-    };
-    git(&["init", "-q", "-b", "main"]);
-    git(&["config", "user.email", "t@example.com"]);
-    git(&["config", "user.name", "t"]);
+    git_ok(dir.path(), &["init", "-q", "-b", "main"]);
+    git_ok(dir.path(), &["config", "user.email", "t@example.com"]);
+    git_ok(dir.path(), &["config", "user.name", "t"]);
     std::fs::write(dir.path().join("README.md"), "hello\n").expect("write");
-    git(&["add", "-A"]);
-    git(&["commit", "-qm", "one"]);
+    git_ok(dir.path(), &["add", "-A"]);
+    git_ok(dir.path(), &["commit", "-qm", "one"]);
     dir
+}
+
+/// Two clones of one repository: the deck's, and a peer's on another machine.
+///
+/// The remote is a bare repository on disk, so the fixture reaches no network
+/// and needs no credentials while still being a genuine second checkout — the
+/// peer learns nothing about the deck's clone except through `origin`, which
+/// is the whole question this fixture asks.
+struct Clones {
+    _dir: tempfile::TempDir,
+    deck: PathBuf,
+    peer: PathBuf,
+}
+
+fn clones() -> Clones {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let origin = dir.path().join("origin.git");
+    let deck = dir.path().join("deck");
+    let peer = dir.path().join("peer");
+
+    std::fs::create_dir(&origin).expect("mkdir");
+    git_ok(&origin, &["init", "-q", "--bare", "-b", "main"]);
+
+    std::fs::create_dir(&deck).expect("mkdir");
+    git_ok(&deck, &["init", "-q", "-b", "main"]);
+    git_ok(&deck, &["config", "user.email", "t@example.com"]);
+    git_ok(&deck, &["config", "user.name", "t"]);
+    std::fs::write(deck.join("README.md"), "hello\n").expect("write");
+    git_ok(&deck, &["add", "-A"]);
+    git_ok(&deck, &["commit", "-qm", "one"]);
+    git_ok(
+        &deck,
+        &["remote", "add", "origin", &origin.display().to_string()],
+    );
+    git_ok(&deck, &["push", "-q", "-u", "origin", "main"]);
+
+    git_ok(
+        dir.path(),
+        &[
+            "clone",
+            "-q",
+            &origin.display().to_string(),
+            &peer.display().to_string(),
+        ],
+    );
+
+    Clones {
+        _dir: dir,
+        deck,
+        peer,
+    }
+}
+
+/// The heads `root`'s `origin` publishes, exactly as `contention::gather`
+/// reads them.
+fn ls_remote(root: &Path) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-remote", "--heads", "origin"])
+        .output()
+        .expect("git");
+    assert!(out.status.success(), "git ls-remote: {out:?}");
+    String::from_utf8_lossy(&out.stdout).to_string()
 }
 
 fn current_branch(root: &Path) -> String {
@@ -212,8 +285,8 @@ fn a_workspace_with_no_measured_rate_gets_no_estimate() {
 #[test]
 fn an_approval_opens_the_branch_and_authors_the_plans_first_revision() {
     let dir = repo();
-    let line = approve(dir.path(), "#151", &["wire it".into(), "restore it".into()])
-        .expect("the approval");
+    let line =
+        approve(dir.path(), KEY, &["wire it".into(), "restore it".into()]).expect("the approval");
     assert_eq!(current_branch(dir.path()), "stella/issue-151-wire-it");
     assert!(line.contains("plan r1"), "{line}");
     assert!(
@@ -240,7 +313,7 @@ fn drafting_creates_no_branch() {
 #[test]
 fn an_approval_with_no_tasks_is_refused_before_it_touches_git() {
     let dir = repo();
-    let error = approve(dir.path(), "#151", &[]).expect_err("refused");
+    let error = approve(dir.path(), KEY, &[]).expect_err("refused");
     assert!(error.contains("no tasks"), "{error}");
     assert_eq!(current_branch(dir.path()), "main");
     assert_eq!(branches(dir.path()), vec!["main".to_string()]);
@@ -256,7 +329,7 @@ fn a_peer_holding_the_issues_claim_stops_the_approval_before_the_branch() {
         matches!(held, crate::self_driving_cmd::claim::Claim::Granted(_)),
         "the peer took the claim: {held:?}"
     );
-    let error = approve(dir.path(), "#151", &["wire it".into()]).expect_err("refused");
+    let error = approve(dir.path(), KEY, &["wire it".into()]).expect_err("refused");
     assert!(error.contains("already claimed by"), "{error}");
     assert!(error.contains("self-driving:9999"), "{error}");
     assert_eq!(current_branch(dir.path()), "main", "no branch was opened");
@@ -264,23 +337,106 @@ fn a_peer_holding_the_issues_claim_stops_the_approval_before_the_branch() {
     // Releasing the peer's lease lets the same approval through, which is what
     // proves the refusal was the claim and not something else.
     drop(held);
-    approve(dir.path(), "#151", &["wire it".into()]).expect("granted once the peer released");
+    approve(dir.path(), KEY, &["wire it".into()]).expect("granted once the peer released");
     assert_eq!(current_branch(dir.path()), "stella/issue-151-wire-it");
 }
 
 #[test]
 fn a_branch_that_already_exists_is_gits_refusal_rather_than_a_silent_reuse() {
     let dir = repo();
-    approve(dir.path(), "#151", &["wire it".into()]).expect("first");
+    approve(dir.path(), KEY, &["wire it".into()]).expect("first");
     Command::new("git")
         .arg("-C")
         .arg(dir.path())
         .args(["checkout", "-q", "main"])
         .output()
         .expect("git");
-    let error = approve(dir.path(), "#151", &["wire it".into()]).expect_err("refused");
+    let error = approve(dir.path(), KEY, &["wire it".into()]).expect_err("refused");
     assert!(error.contains("already exists"), "{error}");
     assert_eq!(current_branch(dir.path()), "main");
+}
+
+/// **Witness.** A peer on a *second clone* defers on an issue the deck
+/// has started.
+///
+/// Asserted through the peer's own probe — the `git ls-remote --heads origin`
+/// that `contention::gather` runs, through `branches_naming`, into the verdict
+/// `stella_autonomy` returns — rather than by looking for the branch by hand.
+/// A test that checked the remote directly would pass on a signal nothing
+/// reads.
+///
+/// It fails before this change by construction: the approval opened a local
+/// branch and pushed nothing, so the peer's `ls-remote` named no branch at
+/// all, `branches_naming` was empty, and the verdict was `Proceed`.
+#[test]
+fn a_peer_on_another_clone_defers_once_the_deck_starts_work() {
+    let repos = clones();
+
+    assert!(
+        branches_naming(&ls_remote(&repos.peer), "151").is_empty(),
+        "nothing on the remote names the issue before the approval"
+    );
+
+    let line = approve(&repos.deck, KEY, &["wire it".into()]).expect("the approval");
+    assert!(line.contains("pushed to origin"), "{line}");
+
+    let seen = branches_naming(&ls_remote(&repos.peer), "151");
+    assert_eq!(
+        seen,
+        vec!["stella/issue-151-wire-it".to_string()],
+        "the peer's probe reads the branch the deck opened"
+    );
+    assert!(
+        matches!(
+            contention_verdict(
+                ContentionPolicy::Defer,
+                &Contention {
+                    remote_branches: seen,
+                    ..Contention::default()
+                }
+            ),
+            ContentionVerdict::Defer { .. }
+        ),
+        "and defers on it"
+    );
+}
+
+/// A remote that will not take the branch does not take the approval with it.
+///
+/// The branch and the plan are real work a human asked for; the push is the
+/// protection over it. Losing the protection is a smaller failure than losing
+/// the work, so the approval succeeds — and says which of the two it lost, so
+/// the card cannot claim a reach it does not have.
+#[test]
+fn an_approval_with_no_reachable_remote_still_starts_the_work_and_says_so() {
+    let dir = repo();
+
+    let line = approve(dir.path(), KEY, &["wire it".into()]).expect("the approval");
+
+    assert_eq!(current_branch(dir.path()), "stella/issue-151-wire-it");
+    assert!(line.contains("plan r1"), "{line}");
+    assert!(line.contains("local only"), "{line}");
+    assert!(!line.contains("pushed to origin"), "{line}");
+}
+
+/// git writes its whole conversation to stderr; the summary line quotes the
+/// one sentence in it that says no.
+#[test]
+fn a_push_refusal_quotes_the_line_git_marked_as_one() {
+    assert_eq!(
+        refusal("fatal: 'origin' does not appear to be a git repository\nfatal: Could not read\n"),
+        "fatal: 'origin' does not appear to be a git repository"
+    );
+    assert_eq!(
+        refusal("To /tmp/o.git\n ! [rejected] a -> a (fetch first)\nerror: failed\nhint: pull\n"),
+        "! [rejected] a -> a (fetch first)",
+        "the rejected ref, not the `To` line above it or the hint below"
+    );
+    assert_eq!(
+        refusal("something git did not mark\n"),
+        "something git did not mark"
+    );
+    assert_eq!(refusal("  \n\n"), "git refused the push and said nothing");
 }
 
 #[test]

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -24,7 +24,11 @@ mod claude_worker;
 // a key written to the right path that nothing loads would pass every other
 // assertion. Read-only, so the wider visibility grants no authority.
 pub(crate) mod config;
-mod contention;
+// `pub(crate)` rather than private, for the reason `claim` is: the deck's
+// start-work approval is a third dispatcher on this issue's claim, and its
+// witness has to read what a *peer* reads rather than a copy of it.
+// Only `branches_naming` is widened inside; the rest stays `pub(super)`.
+pub(crate) mod contention;
 mod convention;
 mod deliver;
 mod drive;

--- a/crates/stella-cli/src/self_driving_cmd/contention.rs
+++ b/crates/stella-cli/src/self_driving_cmd/contention.rs
@@ -149,8 +149,11 @@ fn names_issue(text: &str, key: &str) -> bool {
 /// Remote only at both call sites: a *local* branch of the loop's own is not
 /// another actor, and the branch-collision guard in `work::start` is what
 /// speaks for those.
+///
+/// It is also the only cheap signal that reaches another machine. So the deck
+/// pushes the branch its start-work opens, and its test reads this function.
 #[must_use]
-pub(super) fn branches_naming(ls_remote: &str, key: &str) -> Vec<String> {
+pub(crate) fn branches_naming(ls_remote: &str, key: &str) -> Vec<String> {
     ls_remote
         .lines()
         // The ref first, then the test. `git ls-remote` prints

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -367,6 +367,8 @@ The single best demo moment: an issue becomes a plan while the user watches, and
 6. Action row: `a approve and start · e edit tasks · x cancel`. Footer states plainly: `nothing runs before approval`.
 7. On approval, stella creates the branch, the plan becomes r1 with `[:NEXT]` edges, and the breadcrumb strip updates.
 
+   **Amended.** The approval also pushes that branch to `origin`. A local branch is a claim only this clone can see, and the `issue:<n>` lease the approval takes lives in this workspace's own `.stella/private/fleet.db`, so nothing else it writes reaches a teammate on another machine. A remote branch is the cheapest signal `self_driving_cmd::contention` reads that crosses one. A push that fails leaves the branch and the plan standing and says on the summary line that the branch is local only. `publish_branch` in `crates/stella-cli/src/command_deck/start_work.rs` carries the argument beside the code.
+
 ### 8.3 Other specced scenarios
 
 Turn begin, turn end receipt, skill auto-trigger, memory log and promotion, compaction, delete with pre-execution graph check, and queued-steer consumption are all defined by section 6 and shown in renderings `01` and `02`.


### PR DESCRIPTION
## What and why

The ISSUES tab's start-work approval takes the issue's `issue:<n>` dispatch lease, opens a branch, and drops the lease. The lease closes the race; the branch is supposed to carry the duration. It only carried it for one clone — `self_driving_cmd::contention::gather` reads **remote** branches (`git ls-remote --heads origin`) and **local** worktrees, so between a deck approval and the human's first push a loop on the same clone deferred and a loop on a different clone saw nothing at all. That window is as long as the human takes.

`approve` now pushes the branch it opens (`git push --set-upstream origin <branch>`), while the lease is still held. Ordering is unchanged otherwise: claim, branch, push, plan — the push sits after the branch so a lost race leaves nothing on the remote to clean up.

## The option chosen, against the two rejected

The issue named three options.

- **Hold the lease for the deck session** cannot satisfy the issue's own first done item. `dispatch_claims` lives in this workspace's `.stella/private/fleet.db` — `contention::ledger_claims` resolves it through `stella_store::workspace_private_sqlite_path(root, "fleet.db")`. A lease held all afternoon in clone A is invisible in clone B however long it is held. It closes the same-clone case, which already defers.
- **Read local branches too** is stated in the issue as helping only the same clone, which also already defers.
- **Push the branch** reaches the second clone, because a remote branch is one of the two signals `gather` reads that cross a machine boundary. The other is an open pull request, which needs a commit and a forge round trip.

The cost is real and accepted: a start-work a human abandons leaves an empty `stella/issue-<n>-<slug>` branch on the remote, removed with `git push -d origin <branch>`. Set against two people on two machines working one issue, which #5224 records costing a whole implementation with no conflict to report.

A failed push does not fail the approval. The branch and the plan are the work a human asked for; the push is the protection over it, and losing the protection is the smaller failure — the same fail-open posture every probe over this table takes. The summary line then reads `branch <b> local only — a peer on another clone cannot see it: <git's refusal>`, so the card cannot claim a reach the workspace does not have.

## Witness mechanism

`crates/stella-cli/src/command_deck/start_work/tests.rs`, `a_peer_on_another_clone_defers_once_the_deck_starts_work`.

A bare `origin` on disk, a deck clone and a peer clone. `approve` runs in the deck clone. The peer clone then runs the exact read a peer runs — `git ls-remote --heads origin`, through `self_driving_cmd::contention::branches_naming`, into `stella_autonomy::contention_verdict(ContentionPolicy::Defer, …)` — and must get `Defer`.

It fails before this change **by construction**: nothing reached `origin` before the first push, so `ls-remote` listed only `main`, `branches_naming` returned nothing, and the verdict was `Proceed`. The test asserts the peer's verdict rather than the presence of a ref, because a ref nothing reads proves nothing.

Two more tests come with it: `an_approval_with_no_reachable_remote_still_starts_the_work_and_says_so` pins the fail-open decision and the notice that goes with it, and `a_push_refusal_quotes_the_line_git_marked_as_one` pins `refusal`, which picks the `fatal:` / `error:` / `!` line out of git's stderr instead of the `To <url>` line above it or the hint below.

`self_driving_cmd::contention` becomes `pub(crate) mod` and `branches_naming` `pub(crate)`, so the witness reads the peer's own probe rather than a copy of it. `claim` was widened for the same reason when the deck became the third dispatcher on that table.

## Exemplar

No new crate or dependency. `publish_branch` follows `self_driving_cmd::deliver::open`, the loop's own publish step, and `refusal` follows `create_branch`'s existing habit of quoting git's stderr rather than inventing a message.

## Notes for the reviewer

- `design/tui-v2/SPEC.md` item 8.2/7 carries the amendment. It is written as `**Amended.**` with the code cited by symbol rather than the file's usual `**Amended (#N).**`, because `make prose`'s `issue-reference` ratchet is a down-only count and that file is at its ceiling — adding an issue number there fails the gate. Filed as residue below; the pointer this line gives instead (`publish_branch` in `crates/stella-cli/src/command_deck/start_work.rs`) is the form the line-citation rule prefers anyway.
- `tests.rs` gains `const KEY: &str = "#151"` and uses it in place of eight repetitions of the literal. Same reason: `"#151"` is an issue reference as far as that guard can tell.

## Tests deleted

None.

## Residue filed

- #5786 — the SPEC's `Amended (#N)` convention cannot be extended while `make prose` holds that file at its issue-reference ceiling.
- #5787 — the deck never removes the branch it pushes when a start-work is abandoned.

Closes #5275

## Summary by Sourcery

Publish approved start-work branches while holding the issue claim so peers on other clones can see and defer on active work.

New Features:
- Publish newly created start-work branches to the remote so contention detection works across clones.

Bug Fixes:
- Prevent peers on different clones from concurrently starting work on an issue during the interval before a human's first push.

Enhancements:
- Keep approval fail-open when branch publication fails, while clearly reporting that the branch is local only and surfacing Git's refusal reason.
- Add cross-clone contention coverage and document the updated approval behavior in the TUI specification.

Documentation:
- Amend the TUI specification to describe remote branch publication during approval and its fail-open behavior.

Tests:
- Verify that a peer clone defers after approval publishes the branch.
- Verify approval continues without a reachable remote and reports the reduced protection.
- Verify Git push refusal messages select the relevant diagnostic line.

---

## Independent DoD verification (#5275)

The `dod` check failed at 18:10 on #5275's six then-unticked boxes. Two of them
(`Scoped tests added/updated and passing`, `Full CI green`) could not be ticked
at that moment because the run they depend on was still going. It has since
finished. The boxes are ticked now, and each was re-checked against this head
(`a3feed9`) before the tick, reading the diff rather than the description. This
edit is the `pull_request` event the gate needs to re-read them — it fires on
pull-request events, not on an issue edit, and touches no code.

1. **A peer on a second clone defers.**
   `a_peer_on_another_clone_defers_once_the_deck_starts_work` builds a bare
   `origin` on disk plus two real checkouts, runs `approve` in the deck clone,
   and then asks the peer clone the question a peer asks: `git ls-remote --heads
   origin` → `contention::branches_naming` → `stella_autonomy::contention_verdict`,
   asserting `Defer`. It asserts the peer's verdict rather than the presence of
   a ref, so it cannot pass on a signal nothing reads. The pre-assertion at the
   top (`branches_naming` empty before the approval) is what makes the `Defer`
   attributable to the push.
2. **The chosen option argued against the two rejected.** Both in the PR
   ("The option chosen, against the two rejected") and beside the code, in
   `start_work.rs`'s new module section "Why the branch is pushed before any
   work exists" — which names why the lease cannot cross a clone
   (`.stella/private/fleet.db` is this workspace's) and why reading local
   branches cannot either.
3. **Scoped tests added and passing.** Three new tests and a `clones()`
   fixture. `fmt + clippy + test` — the job that runs them — reports `success`
   on this head.
4. **Full CI green.** Run
   [33788884780](https://github.com/macanderson/stella/actions/runs/33788884780)
   concluded `success` at 18:32:58Z on `a3feed9`. `cargo deny + cargo audit`,
   `docs guards`, `file size ratchet`, `guard self-tests`, `gate steps no other
   workflow runs`, `post-merge canary self-tests`, `cargo check on the declared
   MSRV`, `the macOS-only dependency table still compiles`, `no edit is undone
   inside the branch`, `duplicate claims`, `main is not known-broken`,
   `harbor_adapter + analyzer pytest`, `dependency-review` and `PR carries a
   diff` all report `success`. The one check not green is `dod` itself, which is
   this checklist's own gate.
5. **Code comments and docs updated.** The `start_work.rs` module header is
   rewritten around the new decision; `approve`'s doc comment records the
   four-step ordering including the push; `contention::branches_naming` gains
   the sentence naming it the cross-machine signal; `design/tui-v2/SPEC.md`
   §8.2 item 7 carries the amendment.
6. **Residue filed, `triage` only.** #5786 (`triage`) and #5787 (`triage`,
   `area:cli`, `area:fleet`) are both open and both written as handoffs. Neither
   carries a priority or size label, per SCR-005.

I did not re-run the suite — CI is the authority on it, and the run above is
this PR's own. What I verified is the code and CI facts each box asserts.
