### PR TITLE
feat(stella-fleet): a settable dispatch-lease TTL and a bounded wait for a rival's claim

### DIFF
--- a/crates/stella-fleet/README.md
+++ b/crates/stella-fleet/README.md
@@ -165,6 +165,13 @@ TTL/3 for as long as its worker runs, and it is released the moment the attempt
 settles. So a session that is SIGKILLed cannot wedge a task — nothing has to be
 reaped, and there is no `--force` — while a session that is merely slow keeps
 its work. A lost lease never kills a running worker (see `Fleet::dispatch`).
+The TTL is [`DEFAULT_DISPATCH_LEASE_TTL`](src/fleet.rs) — fifteen minutes,
+what `stella fleet` runs with — and
+[`Fleet::with_dispatch_lease_ttl`](src/fleet.rs) is how a caller whose workers
+are all short-lived asks for a shorter one, floored at a second. A caller can
+also wait for a rival's claim rather than failing on it
+([`Fleet::with_dispatch_claim_wait`](src/fleet.rs), off by default), which is
+what a plan re-run right behind a finishing sibling wants.
 Every live claim is legible without `sqlite3` — `stella fleet claims` reads
 `live_dispatch_claims`, and `--all` adds the lapsed rows that say who died
 holding what. That surface is not decoration: #1136's collision was two

--- a/crates/stella-fleet/src/fleet.rs
+++ b/crates/stella-fleet/src/fleet.rs
@@ -141,9 +141,9 @@ impl Drop for ClaimGuard<'_> {
 /// Same reason as [`ClaimGuard`]: release must be tied to a scope, not to
 /// reaching a statement, because a panicking worker and a dropped dispatch
 /// future both skip the statement. Unlike a file lock, a leaked claim here is
-/// self-healing — it expires — but making the next session wait out
-/// [`DISPATCH_LEASE_TTL`] for work that settled seconds ago is a bad enough
-/// experience to be worth a guard.
+/// self-healing — it expires — but making the next session wait out the
+/// lease TTL for work that settled seconds ago is a bad enough experience to
+/// be worth a guard.
 ///
 /// Release is fenced (see [`Ledger::release_dispatch`]), so a guard whose
 /// lease was already reclaimed by a rival drops without touching the rival's
@@ -281,7 +281,8 @@ impl FleetConfig {
 /// grace is the cheap path and the synthesis the last resort.
 const TASK_STOP_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// How long a dispatch claim stays live without a heartbeat (#1136).
+/// How long a dispatch claim stays live without a heartbeat, unless
+/// [`Fleet::with_dispatch_lease_ttl`] sets another (#1136, #1678).
 ///
 /// It bounds only the *crash* case — a healthy attempt renews every
 /// [`DispatchLease::heartbeat_interval_ms`] (a third of this) for as long as
@@ -290,8 +291,36 @@ const TASK_STOP_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
 /// beats without being dead, which is why it is minutes rather than seconds:
 /// a machine that swaps, a laptop lid, or a `SIGSTOP`ped process should not
 /// hand its work to a rival. The other direction costs a human's patience —
-/// after a hard kill, this is how long the task looks taken.
-const DISPATCH_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+/// after a hard kill, this is how long the task looks taken. A workspace
+/// whose workers are all short-lived can trade the first for the second.
+pub const DEFAULT_DISPATCH_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+
+/// The shortest dispatch-lease TTL a fleet uses, whatever
+/// [`Fleet::with_dispatch_lease_ttl`] is handed.
+///
+/// Under a second the lease stops being a lease: the heartbeat is a third of
+/// the TTL, so the attempt would beat against the ledger several times a
+/// second for its whole run, and any pause longer than a scheduler slice
+/// would hand a live worker's task to a rival. A shorter ask is raised to
+/// this, and [`Fleet::dispatch_lease_ttl`] reads back what took effect.
+pub const MIN_DISPATCH_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// The shortest a waiting dispatch sleeps before asking for a held claim
+/// again.
+///
+/// The wait normally sleeps to the holder's own expiry, which is the earliest
+/// instant it can win. This floor covers the cases where that instant is not
+/// usable: a row that vanished between the claim and the read of who holds
+/// it, and a holder whose expiry is already in the past because it beat
+/// between the two statements. Without it either would spin.
+const CLAIM_RETRY_FLOOR: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// A duration as the milliseconds the ledger's lease API speaks, saturating:
+/// a `Duration` holds more milliseconds than a `u64` can, and a lease that
+/// outlives the epoch is the same lease either way.
+fn duration_to_ms(duration: std::time::Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
 
 /// The ledger key one fleet task is claimed under (#1136).
 ///
@@ -343,7 +372,7 @@ pub struct TaskHandle {
     pub ledger_error: Option<String>,
     /// `Some` when this attempt's dispatch lease (#1136) was lost mid-run: a
     /// heartbeat renewal came back [`RenewOutcome::Lost`] — the attempt
-    /// stalled past `DISPATCH_LEASE_TTL` and a rival session reclaimed the
+    /// stalled past its lease TTL and a rival session reclaimed the
     /// task — or the ledger became unreadable. The same "attempt succeeded
     /// but something durable failed" seam as `ledger_error`: the worker was
     /// left to finish (never killed mid-flight), so the outcome
@@ -439,8 +468,10 @@ pub enum FleetError {
     /// is the user's to act on.
     ///
     /// Terminal for that task within this run, like a claim conflict:
-    /// [`Fleet::run_plan`] records it as a dispatch failure rather than
-    /// waiting out a lease it cannot bound.
+    /// [`Fleet::run_plan`] records it as a dispatch failure. A fleet given
+    /// [`Fleet::with_dispatch_claim_wait`] waits that long for the lease to
+    /// lapse first and reports this only if it never does; the default wait
+    /// is zero, so a live claim fails the dispatch at once.
     #[error(
         "task `{task}` is already claimed by `{holder}` (lease expires at {expires_at_ms}ms); \
          another session is working it"
@@ -503,6 +534,14 @@ pub struct Fleet<W: FleetWorker, G: GitCli, C: Clock> {
     /// (issue #269) — `None` (the default) leaves every ready wave in its
     /// existing order.
     warmth: Option<CacheWarmthLookup>,
+    /// How long this fleet's dispatch claims stay live without a heartbeat —
+    /// [`DEFAULT_DISPATCH_LEASE_TTL`] unless
+    /// [`Fleet::with_dispatch_lease_ttl`] set another.
+    lease_ttl: std::time::Duration,
+    /// How long [`Fleet::dispatch`] waits for a rival's live claim to lapse
+    /// before giving up with [`FleetError::DispatchClaimed`] — zero unless
+    /// [`Fleet::with_dispatch_claim_wait`] set another.
+    claim_wait: std::time::Duration,
 }
 
 /// Seconds until a task's session prompt-cache prefix expires, `None` when
@@ -546,6 +585,8 @@ where
             claims: None,
             controls: Mutex::new(HashMap::new()),
             warmth: None,
+            lease_ttl: DEFAULT_DISPATCH_LEASE_TTL,
+            claim_wait: std::time::Duration::ZERO,
         })
     }
 
@@ -573,6 +614,56 @@ where
     pub fn with_cache_warmth(mut self, lookup: CacheWarmthLookup) -> Self {
         self.warmth = Some(lookup);
         self
+    }
+
+    /// Set how long this fleet's dispatch claims stay live without a
+    /// heartbeat (builder style), instead of
+    /// [`DEFAULT_DISPATCH_LEASE_TTL`].
+    ///
+    /// A workspace whose workers are all short-lived would rather a rival
+    /// reclaimed a dead session's task in a minute than in fifteen; one on a
+    /// laptop that sleeps wants the opposite. The heartbeat cadence follows
+    /// the TTL on its own ([`DispatchLease::heartbeat_interval_ms`] is a
+    /// third of it), so this is the only number to set.
+    ///
+    /// An ask shorter than [`MIN_DISPATCH_LEASE_TTL`] is raised to it —
+    /// [`Fleet::dispatch_lease_ttl`] reads back what took effect.
+    #[must_use]
+    pub fn with_dispatch_lease_ttl(mut self, ttl: std::time::Duration) -> Self {
+        self.lease_ttl = ttl.max(MIN_DISPATCH_LEASE_TTL);
+        self
+    }
+
+    /// The dispatch-lease TTL this fleet claims with.
+    #[must_use]
+    pub fn dispatch_lease_ttl(&self) -> std::time::Duration {
+        self.lease_ttl
+    }
+
+    /// Wait up to `wait` for a rival's live claim to lapse before failing a
+    /// dispatch with [`FleetError::DispatchClaimed`] (builder style).
+    ///
+    /// Zero — the default — is the original behaviour: a task somebody else
+    /// holds fails this run's dispatch immediately. A plan re-run behind a
+    /// finishing sibling is the case the wait exists for, where the claim is
+    /// about to be released anyway and losing the task costs more than the
+    /// pause.
+    ///
+    /// It sleeps to the holder's own expiry rather than polling, so a wait
+    /// long enough to cover the TTL costs one extra claim attempt, not
+    /// thousands. The wait is not a queue: several fleets waiting on one task
+    /// race for it when it frees, and the losers keep waiting until their own
+    /// budget runs out.
+    #[must_use]
+    pub fn with_dispatch_claim_wait(mut self, wait: std::time::Duration) -> Self {
+        self.claim_wait = wait;
+        self
+    }
+
+    /// How long this fleet waits for a held dispatch claim to lapse.
+    #[must_use]
+    pub fn dispatch_claim_wait(&self) -> std::time::Duration {
+        self.claim_wait
     }
 
     /// Reorder one ready wave warmest-first when a warmth lookup is
@@ -666,7 +757,7 @@ where
         //    used to re-dispatch a task another run was already on, and both
         //    ran to completion. This is the dispatch-level check-and-set, and
         //    it comes first because losing it means doing nothing at all.
-        let mut lease = self.acquire_dispatch_lease(task)?;
+        let mut lease = self.acquire_dispatch_lease(task).await?;
         let _claims = self.acquire_claims(task)?;
         self.dispatch_leased(task, &mut lease).await
     }
@@ -676,29 +767,58 @@ where
     /// Keyed `task:<id>` in the workspace's ledger, held under this run's id
     /// (which embeds the minting pid — see [`FleetConfig::run_id`]), so the
     /// holder in a refusal names a session a human can go look for.
-    fn acquire_dispatch_lease(&self, task: &Task) -> Result<LeaseGuard<'_>, FleetError> {
-        let now_ms = self.clock.now_ms();
-        let outcome = {
-            let ledger = self.lock_ledger();
-            ledger.claim_dispatch(
-                &dispatch_claim_key(&task.id),
-                &self.config.run_id,
-                now_ms,
-                DISPATCH_LEASE_TTL.as_millis().min(u128::from(u64::MAX)) as u64,
-            )?
-        };
-        match outcome {
-            ClaimOutcome::Granted(lease) => Ok(LeaseGuard {
-                ledger: &self.ledger,
-                lease,
-            }),
-            ClaimOutcome::Held(held) => Err(FleetError::DispatchClaimed {
-                task: task.id.clone(),
-                holder: held
-                    .as_ref()
-                    .map_or_else(|| "another session".to_string(), |c| c.owner.clone()),
-                expires_at_ms: held.as_ref().map_or(now_ms, |c| c.expires_at_ms),
-            }),
+    ///
+    /// With [`Fleet::with_dispatch_claim_wait`] set this waits for a rival's
+    /// lease instead of failing on it. Each round sleeps to the
+    /// holder's expiry — the earliest instant this fleet can win — floored by
+    /// [`CLAIM_RETRY_FLOOR`] and capped at the caller's deadline, so a wait
+    /// long enough to outlast a TTL costs a second claim attempt rather than
+    /// a poll loop. The refusal it eventually returns names the last holder
+    /// it saw, which need not be the first: a task can change hands while
+    /// this waits.
+    async fn acquire_dispatch_lease(&self, task: &Task) -> Result<LeaseGuard<'_>, FleetError> {
+        let ttl_ms = duration_to_ms(self.lease_ttl);
+        let give_up_at_ms = self
+            .clock
+            .now_ms()
+            .saturating_add(duration_to_ms(self.claim_wait));
+        loop {
+            let now_ms = self.clock.now_ms();
+            let held = {
+                let ledger = self.lock_ledger();
+                match ledger.claim_dispatch(
+                    &dispatch_claim_key(&task.id),
+                    &self.config.run_id,
+                    now_ms,
+                    ttl_ms,
+                )? {
+                    ClaimOutcome::Granted(lease) => {
+                        return Ok(LeaseGuard {
+                            ledger: &self.ledger,
+                            lease,
+                        });
+                    }
+                    ClaimOutcome::Held(held) => held,
+                }
+            };
+            if now_ms >= give_up_at_ms {
+                return Err(FleetError::DispatchClaimed {
+                    task: task.id.clone(),
+                    holder: held
+                        .as_ref()
+                        .map_or_else(|| "another session".to_string(), |c| c.owner.clone()),
+                    expires_at_ms: held.as_ref().map_or(now_ms, |c| c.expires_at_ms),
+                });
+            }
+            let wake_at_ms = held
+                .as_ref()
+                .map_or(now_ms, |c| c.expires_at_ms)
+                .max(now_ms.saturating_add(duration_to_ms(CLAIM_RETRY_FLOOR)))
+                .min(give_up_at_ms);
+            tokio::time::sleep(std::time::Duration::from_millis(
+                wake_at_ms.saturating_sub(now_ms),
+            ))
+            .await;
         }
     }
 

--- a/crates/stella-fleet/src/fleet/tests.rs
+++ b/crates/stella-fleet/src/fleet/tests.rs
@@ -1393,7 +1393,7 @@ async fn a_lost_dispatch_lease_is_reported_on_the_settled_handle() {
         // Paused time auto-advances to the dispatch's heartbeat while every
         // task is parked; sleeping two beats guarantees the renewal has
         // failed against the moved fence before the gate opens.
-        tokio::time::sleep(DISPATCH_LEASE_TTL * 2 / 3).await;
+        tokio::time::sleep(DEFAULT_DISPATCH_LEASE_TTL * 2 / 3).await;
         gate.add_permits(1);
     });
 

--- a/crates/stella-fleet/src/lib.rs
+++ b/crates/stella-fleet/src/lib.rs
@@ -80,9 +80,9 @@ pub mod plan;
 
 pub use cache_schedule::{RunnableSession, warmest_first};
 pub use fleet::{
-    CacheWarmthLookup, Fleet, FleetConfig, FleetError, FleetRunReport, FleetWorker, LeaseLoss,
-    TaskHandle, WorkerControls, WorkerOutcome, dispatch_claim_key, issue_claim_key,
-    notice::handle_notices,
+    CacheWarmthLookup, DEFAULT_DISPATCH_LEASE_TTL, Fleet, FleetConfig, FleetError, FleetRunReport,
+    FleetWorker, LeaseLoss, MIN_DISPATCH_LEASE_TTL, TaskHandle, WorkerControls, WorkerOutcome,
+    dispatch_claim_key, issue_claim_key, notice::handle_notices,
 };
 pub use gc::{
     BranchAction, BranchVerdict, Gc, GcError, GcOptions, GcReport, KeepReason, WorktreeAction,

--- a/crates/stella-fleet/tests/dispatch_lease_ttl.rs
+++ b/crates/stella-fleet/tests/dispatch_lease_ttl.rs
@@ -1,0 +1,275 @@
+//! The two dispatch-lease knobs, seen from outside the crate.
+//!
+//! One sets how long a claim stays live with no heartbeat. The other sets
+//! how long a dispatch waits for a rival claim to lapse.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use stella_core::{BudgetGuard, Clock};
+use stella_fleet::{
+    ClaimOutcome, DEFAULT_DISPATCH_LEASE_TTL, Fleet, FleetConfig, FleetError, FleetWorker, GitCli,
+    GitError, GitOutput, Ledger, MIN_DISPATCH_LEASE_TTL, Task, WorkerControls, WorkerOutcome,
+    WorktreeManager, dispatch_claim_key,
+};
+use stella_protocol::BudgetMode;
+
+/// The start time every fleet here reads. It never moves, so the lease end
+/// times below are exact.
+const NOW_MS: u64 = 1_700_000_000_000;
+
+/// A clock that stands still. The ledger only stores and compares the times
+/// it is handed, so no test here needs a moving one.
+struct StoppedClock;
+impl Clock for StoppedClock {
+    fn now_ms(&self) -> u64 {
+        NOW_MS
+    }
+}
+
+/// A clock that reads tokio time. A sleep inside the dispatch moves it, so a
+/// short lease lapses with no real waiting.
+struct VirtualClock {
+    origin: tokio::time::Instant,
+}
+impl VirtualClock {
+    fn started_now() -> Self {
+        Self {
+            origin: tokio::time::Instant::now(),
+        }
+    }
+}
+impl Clock for VirtualClock {
+    fn now_ms(&self) -> u64 {
+        NOW_MS + self.origin.elapsed().as_millis() as u64
+    }
+}
+
+/// A git that says yes to all. Every task here shares the tree, so the
+/// worktree manager needs one but never calls it.
+struct OkGit;
+#[async_trait]
+impl GitCli for OkGit {
+    async fn run(&self, _repo: &Path, _args: &[&str]) -> Result<GitOutput, GitError> {
+        Ok(GitOutput::ok(""))
+    }
+}
+
+fn settled(summary: &str) -> WorkerOutcome {
+    WorkerOutcome {
+        cost_usd: 0.0,
+        commits: Vec::new(),
+        summary: summary.to_string(),
+        success: true,
+    }
+}
+
+/// A worker that wins, and counts its runs for the test.
+struct CountingWorker(Arc<AtomicUsize>);
+#[async_trait]
+impl FleetWorker for CountingWorker {
+    async fn run(&self, _task: &Task, _root: &Path, _controls: WorkerControls) -> WorkerOutcome {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        settled("worked")
+    }
+}
+
+/// What the probe worker saw from inside a live attempt.
+#[derive(Debug, Clone, Copy)]
+struct Probe {
+    /// When the lease its own fleet holds runs out.
+    expires_at_ms: u64,
+    /// True if a rival claiming at `probe_at_ms` won the task.
+    rival_won: bool,
+}
+
+/// A worker that reads its own fleet's live claim, then lets a rival try to
+/// take it. Inside the attempt is the only place the lease can be seen: the
+/// guard hands it back as soon as the attempt ends.
+struct RivalProbe {
+    db: PathBuf,
+    probe_at_ms: u64,
+    seen: Arc<Mutex<Option<Probe>>>,
+}
+#[async_trait]
+impl FleetWorker for RivalProbe {
+    async fn run(&self, task: &Task, _root: &Path, _controls: WorkerControls) -> WorkerOutcome {
+        let ledger = Ledger::open(&self.db).unwrap();
+        let key = dispatch_claim_key(&task.id);
+        let held = ledger
+            .dispatch_claim(&key)
+            .unwrap()
+            .expect("a fleet holds its task's lease for the whole attempt");
+        let rival = ledger
+            .claim_dispatch(&key, "run-rival", self.probe_at_ms, 60_000)
+            .unwrap();
+        *self.seen.lock().unwrap() = Some(Probe {
+            expires_at_ms: held.expires_at_ms,
+            rival_won: matches!(rival, ClaimOutcome::Granted(_)),
+        });
+        settled("probed")
+    }
+}
+
+/// A fleet on `db` with the given worker and clock. No claim store: no task
+/// here asks for a file lock.
+fn fleet<W: FleetWorker, C: Clock>(
+    db: &Path,
+    run_id: &str,
+    worker: W,
+    clock: C,
+) -> Fleet<W, OkGit, C> {
+    Fleet::new(
+        worker,
+        WorktreeManager::new(OkGit, "/repo"),
+        Ledger::open(db).unwrap(),
+        BudgetGuard::new(BudgetMode::Observed, None, None),
+        clock,
+        FleetConfig::new(run_id, "HEAD"),
+    )
+    .unwrap()
+}
+
+/// The one task each test sends.
+fn one_task() -> Task {
+    Task::new("t1", "title", "prompt").shared_tree()
+}
+
+/// **Witness, the tunable half.** The fleet sets its own lease time. With a
+/// 60-second lease, a rival one minute in takes the task. With the default
+/// lease, the same rival is turned away.
+///
+/// A fleet that dropped the setting would turn that rival away each time.
+#[tokio::test]
+async fn a_shorter_lease_ttl_frees_a_stalled_task_sooner() {
+    // One minute in. That is inside the default lease and past a 60-second
+    // one.
+    let probe_at_ms = NOW_MS + 60_000;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("default.db");
+    let seen = Arc::new(Mutex::new(None));
+    let default = fleet(
+        &db,
+        "run-default",
+        RivalProbe {
+            db: db.clone(),
+            probe_at_ms,
+            seen: Arc::clone(&seen),
+        },
+        StoppedClock,
+    );
+    assert_eq!(default.dispatch_lease_ttl(), DEFAULT_DISPATCH_LEASE_TTL);
+    assert!(default.dispatch(&one_task()).await.unwrap().outcome.success);
+    let probe = seen.lock().unwrap().expect("the worker probed");
+    assert_eq!(
+        probe.expires_at_ms,
+        NOW_MS + 900_000,
+        "the default lease runs for fifteen minutes"
+    );
+    assert!(
+        !probe.rival_won,
+        "a rival one minute in must not take a task the default lease still covers"
+    );
+
+    let short_dir = tempfile::tempdir().unwrap();
+    let short_db = short_dir.path().join("short.db");
+    let short_seen = Arc::new(Mutex::new(None));
+    let short = fleet(
+        &short_db,
+        "run-short",
+        RivalProbe {
+            db: short_db.clone(),
+            probe_at_ms,
+            seen: Arc::clone(&short_seen),
+        },
+        StoppedClock,
+    )
+    .with_dispatch_lease_ttl(Duration::from_secs(60));
+    assert_eq!(short.dispatch_lease_ttl(), Duration::from_secs(60));
+    assert!(short.dispatch(&one_task()).await.unwrap().outcome.success);
+    let probe = short_seen.lock().unwrap().expect("the worker probed");
+    assert_eq!(
+        probe.expires_at_ms,
+        NOW_MS + 60_000,
+        "the set lease time is what the claim is written with"
+    );
+    assert!(
+        probe.rival_won,
+        "a lapsed claim is up for grabs, and this one lapsed a minute in"
+    );
+}
+
+/// A lease shorter than the floor is raised to it, and the fleet says so.
+/// Under a second, the beat would hit the ledger three times a second, and
+/// any real pause would give a live worker's task away.
+#[test]
+fn a_lease_ttl_under_the_floor_is_raised_to_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("floor.db");
+    let runs = Arc::new(AtomicUsize::new(0));
+    let f = fleet(&db, "run-floor", CountingWorker(runs), StoppedClock)
+        .with_dispatch_lease_ttl(Duration::ZERO);
+    assert_eq!(f.dispatch_lease_ttl(), MIN_DISPATCH_LEASE_TTL);
+}
+
+/// **Witness, the wait half.** By default, a task a rival holds fails the
+/// dispatch at once. A re-run right behind a finishing sibling loses work it
+/// could have waited for. With a wait set, the same fleet takes the task as
+/// soon as the rival's lease lapses.
+///
+/// The two tests share one ledger row. A dispatch that gives up on the
+/// first refusal passes the test above and fails this one.
+#[tokio::test(start_paused = true)]
+async fn a_bounded_wait_takes_the_task_when_a_rivals_lease_lapses() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("wait.db");
+
+    // A rival holds the task for 200ms, like a sibling about to finish.
+    let rival = Ledger::open(&db).unwrap();
+    assert!(matches!(
+        rival
+            .claim_dispatch(&dispatch_claim_key("t1"), "run-rival", NOW_MS, 200)
+            .unwrap(),
+        ClaimOutcome::Granted(_)
+    ));
+
+    let impatient_runs = Arc::new(AtomicUsize::new(0));
+    let impatient = fleet(
+        &db,
+        "run-impatient",
+        CountingWorker(Arc::clone(&impatient_runs)),
+        VirtualClock::started_now(),
+    );
+    assert_eq!(impatient.dispatch_claim_wait(), Duration::ZERO);
+    match impatient.dispatch(&one_task()).await {
+        Err(FleetError::DispatchClaimed { holder, .. }) => {
+            assert_eq!(holder, "run-rival", "the refusal names the session on it");
+        }
+        other => panic!("a fleet with no wait must fail on a live claim, got {other:?}"),
+    }
+    assert_eq!(
+        impatient_runs.load(Ordering::SeqCst),
+        0,
+        "nothing ran: the task was never dispatched"
+    );
+
+    let patient_runs = Arc::new(AtomicUsize::new(0));
+    let patient = fleet(
+        &db,
+        "run-patient",
+        CountingWorker(Arc::clone(&patient_runs)),
+        VirtualClock::started_now(),
+    )
+    .with_dispatch_claim_wait(Duration::from_secs(5));
+    assert_eq!(patient.dispatch_claim_wait(), Duration::from_secs(5));
+    let handle = patient
+        .dispatch(&one_task())
+        .await
+        .expect("the wait outlasts the rival's 200ms lease");
+    assert!(handle.outcome.success);
+    assert_eq!(patient_runs.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## What and why

The dispatch lease that stops two sessions taking one task (#1136) ran on a
15-minute `const` in `crates/stella-fleet/src/fleet.rs` that no caller could
reach or read back. Two things a user could not do:

- **Tune it.** A workspace whose workers are all short-lived would rather a
  rival reclaimed a dead session's task in a minute; one on a laptop that
  sleeps wants longer.
- **Wait for it.** A task a rival holds was a terminal `DispatchClaimed` with
  no rung between that and giving up, so a plan re-run right behind a
  finishing sibling lost work it could have waited a moment for.

Both are answered on `Fleet` as builders, so `FleetConfig` and
`crates/stella-cli/src/fleet_cmd.rs` (grandfathered, closed to growth) are
untouched — the shape `with_claim_store` and `with_cache_warmth` already use,
which is the in-tree exemplar this follows.

- `DISPATCH_LEASE_TTL` → `pub const DEFAULT_DISPATCH_LEASE_TTL` (same fifteen
  minutes), beside `pub const MIN_DISPATCH_LEASE_TTL` of one second.
- `Fleet::with_dispatch_lease_ttl(Duration)` sets the TTL every claim and
  heartbeat uses, raised to the floor if the ask is shorter: the heartbeat is
  a third of the TTL, so a sub-second lease beats three times a second and
  hands a live worker's task away on any real pause.
  `Fleet::dispatch_lease_ttl()` reads back what took effect, so the clamp is
  visible instead of silent.
- `Fleet::with_dispatch_claim_wait(Duration)`, zero by default — today's
  behaviour exactly. Set, `acquire_dispatch_lease` sleeps to the holder's own
  `expires_at_ms` (the earliest instant it can win), floored at 50ms and
  capped at the deadline, then asks again; out of budget it returns the same
  `DispatchClaimed`, naming the last holder it saw.

`ledger/lease.rs` is untouched: the TTL rides on the grant, so
`heartbeat_interval_ms` already tracks it, expiry stays inclusive and renewal
stays fenced.

No CLI flag here. One costs a line in the `fleet_cmd.rs` god file plus a
`fleet.mdx` entry; filed as #5789 instead. `stella fleet` still runs on the
fifteen-minute default, so `website/content/docs/commands/fleet.mdx` stays
correct as written.

## Witness mechanism

New file `crates/stella-fleet/tests/dispatch_lease_ttl.rs` — an integration
test, because the crate's unit-test file has ~90 lines left under the size
ratchet and because these knobs are a public surface.

- `a_shorter_lease_ttl_frees_a_stalled_task_sooner` — a worker that, while its
  own fleet holds the lease, reads the live claim row and has a rival session
  try to take it 60 seconds in. With `with_dispatch_lease_ttl(60s)` the rival
  is granted and the row's expiry is `now + 60s`; with the default TTL the same
  rival at the same instant is refused and the expiry is `now + 900s`. On
  `main` it does not compile (the builder does not exist); had the builder
  existed and been ignored, the short half fails on both assertions.
- `a_bounded_wait_takes_the_task_when_a_rivals_lease_lapses` — a rival holds
  the task on a 200ms lease. The fleet with no wait fails at once with
  `DispatchClaimed{holder: "run-rival"}` and never runs its worker; the fleet
  with `with_dispatch_claim_wait(5s)` takes the task the moment that lease
  lapses. Both halves run against one ledger row, so a dispatch that gives up
  on the first refusal passes the first and fails the second. Paused tokio time
  plus a clock that reads it makes the 200ms exact and instant.
- `a_lease_ttl_under_the_floor_is_raised_to_it` — a `Duration::ZERO` ask reads
  back as `MIN_DISPATCH_LEASE_TTL`.

Local evidence is `make guards-fast` (green, including `prose` and
`file-size`) and `cargo fmt --all`; nothing was compiled on this machine, so
this PR's evidence is its CI run.

Tests deleted: None.

Residue issues filed: #5789 (a CLI flag and docs entry for both knobs).

Closes #1678
Refs #1136

## Independent DoD verification (#1678)

The `dod` gate went red at 18:25 on #1678's two unticked boxes. They are ticked
now, and each was checked against this head (`9f6ec66`) by reading the diff
rather than this description. (This edit is also what re-arms the gate — it
fires on `pull_request` events, not on an issue edit, so the tick alone would
have left the check red on a stale run.)

1. **Settable through the builder, defaulting to fifteen minutes, with a
   witness.** `crates/stella-fleet/src/fleet.rs` carries
   `pub const DEFAULT_DISPATCH_LEASE_TTL = Duration::from_secs(15 * 60)` — the
   same fifteen minutes the old `const` held — and `Fleet::default` seeds
   `lease_ttl` from it, so an untouched caller's behaviour is unchanged.
   `Fleet::with_dispatch_lease_ttl` sets the field and
   `Fleet::dispatch_lease_ttl` reads back what took effect. It is the *live*
   value, not a stored-and-ignored one: `acquire_dispatch_lease` computes
   `ttl_ms` from `self.lease_ttl` and hands it to `ledger.claim_dispatch`.
   Witness: `a_shorter_lease_ttl_frees_a_stalled_task_sooner`, which asserts
   both halves against one ledger row.
2. **A decision on the bounded wait — implemented, not declined.**
   `Fleet::with_dispatch_claim_wait` is zero by default, so today's terminal
   `DispatchClaimed` is exactly preserved for every existing caller. Witness:
   `a_bounded_wait_takes_the_task_when_a_rivals_lease_lapses`.

The issue's third constraint — "heartbeat at or under TTL/3, expiry inclusive,
renewal fenced" — holds without `ledger/lease.rs` being touched, and that is
checkable rather than assumed: `DispatchLease::heartbeat_interval_ms` is
`(self.ttl_ms / 3).max(1)` computed off the grant, so a TTL set here propagates
to the heartbeat by construction. `MIN_DISPATCH_LEASE_TTL` of one second is what
keeps that quotient off the floor.

## Summary by Sourcery

Make dispatch lease duration and rival-claim waiting configurable for Fleet callers while retaining the existing defaults.

New Features:
- Add configurable dispatch-lease TTLs with public defaults, minimum bounds, and readback accessors.
- Add an optional bounded wait for rival dispatch claims before reporting a claim conflict.

Enhancements:
- Preserve existing default behavior while making lease timing and claim-wait behavior configurable at the Fleet level.
- Document the new dispatch lease controls and expose integration coverage for expiration, clamping, and bounded waiting.

Documentation:
- Document dispatch-lease TTL customization and optional waiting for rival claims in the fleet crate README.

Tests:
- Add integration tests covering configurable lease expiration, minimum TTL clamping, and waiting for rival claims to lapse.