### PR TITLE
feat(stella-cli): mirror self-driving issue claims onto GitHub

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -17,6 +17,7 @@ mod audit;
 mod backlog;
 mod budget;
 pub(crate) mod claim;
+mod claim_mirror;
 mod claude_worker;
 // `pub(crate)` rather than private: `plugin_cmd::configure` asserts against
 // this reader directly (#3999). A package that configures attribution has to

--- a/crates/stella-cli/src/self_driving_cmd/claim.rs
+++ b/crates/stella-cli/src/self_driving_cmd/claim.rs
@@ -113,6 +113,20 @@ pub(crate) struct Lease {
     beat: Option<JoinHandle<()>>,
 }
 
+impl Lease {
+    /// The grant this lease holds — owner, fence, expiry — for a caller that
+    /// wants to show a human what it is rather than only hold it.
+    ///
+    /// [`super::claim_mirror`] is the one caller today: it reads `owner` and
+    /// `ttl_ms` to build the comment it posts on the tracker when the lease
+    /// is granted. Read-only — nothing outside this module may renew or
+    /// release a lease it does not own.
+    #[must_use]
+    pub(super) fn dispatch_lease(&self) -> &DispatchLease {
+        &self.lease
+    }
+}
+
 impl Drop for Lease {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);

--- a/crates/stella-cli/src/self_driving_cmd/claim_mirror.rs
+++ b/crates/stella-cli/src/self_driving_cmd/claim_mirror.rs
@@ -41,11 +41,14 @@ use super::claim::Lease;
 /// the codebase — the end of a scope, an early `continue`, a bulk `drop` —
 /// mirrors for free. See the module docs for why the mirroring half is
 /// best-effort.
+///
+/// The wrapped lease is read again at drop time (its `owner`, off
+/// [`Lease::dispatch_lease`]) rather than copied out at construction, so
+/// there is exactly one place this type learns who it was granted to.
 pub(super) struct MirroredLease<'p> {
     lease: Lease,
     provider: &'p dyn IssueProvider,
     key: IssueKey,
-    owner: String,
     signature: String,
 }
 
@@ -61,19 +64,20 @@ impl<'p> MirroredLease<'p> {
         number: &str,
         signature: &str,
     ) -> Self {
-        let dispatch = lease.dispatch_lease().clone();
         let key = IssueKey::from(number);
-        post(
-            provider,
-            &key,
-            &claimed_body(&dispatch.owner, dispatch.ttl_ms),
-            signature,
-        );
+        {
+            let dispatch = lease.dispatch_lease();
+            post(
+                provider,
+                &key,
+                &claimed_body(&dispatch.owner, dispatch.ttl_ms),
+                signature,
+            );
+        }
         Self {
             lease,
             provider,
             key,
-            owner: dispatch.owner,
             signature: signature.to_owned(),
         }
     }
@@ -81,10 +85,11 @@ impl<'p> MirroredLease<'p> {
 
 impl Drop for MirroredLease<'_> {
     fn drop(&mut self) {
+        let owner = self.lease.dispatch_lease().owner.clone();
         post(
             self.provider,
             &self.key,
-            &released_body(&self.owner),
+            &released_body(&owner),
             &self.signature,
         );
     }

--- a/crates/stella-cli/src/self_driving_cmd/claim_mirror.rs
+++ b/crates/stella-cli/src/self_driving_cmd/claim_mirror.rs
@@ -1,0 +1,272 @@
+//! Mirrors a local dispatch claim onto the issue tracker.
+//!
+//! [`super::claim`] closes the race between two `stella self-driving drive`
+//! processes sharing one clone. It does this with a lease, kept in
+//! `.stella/private/fleet.db`. That lease works for two local processes.
+//! It does not help a human. A human deciding what to hand out next
+//! cannot see the lease without opening the ledger by hand. Neither can a
+//! session on a second clone.
+//!
+//! [`MirroredLease`] wraps a granted [`super::claim::Lease`] and posts one
+//! comment on the tracker when the lease is granted, and a second when it
+//! is given back. A human reading the issue then sees the same two events
+//! a peer reading the ledger would see.
+//!
+//! # A mirror, never an arbiter
+//!
+//! GitHub has no compare-and-set. So nothing here decides a claim. The
+//! lease still does, exactly as `lease.rs` describes. A comment that fails
+//! to post — `gh` offline, no login, a rate limit — is dropped rather than
+//! treated as a reason to stop working the issue. [`super::claim::acquire`]
+//! already takes this same stance for the ledger side. The lease this
+//! session holds stays the same lease whether or not GitHub heard about
+//! it.
+//!
+//! The mirror is a snapshot, not a live view. The claimed comment states
+//! the lease's own TTL. It does not promise to stay current. So a reader
+//! who finds it later can tell it is stale on sight, with no second look
+//! at the issue's history needed. Posting on every heartbeat would turn a
+//! lease renewed every couple of minutes into comment spam. The released
+//! comment is what actually closes the loop for a human watching.
+
+use stella_protocol::issue::{IssueKey, IssueProvider};
+
+use super::backlog;
+use super::claim::Lease;
+
+/// A granted dispatch lease, plus its tracker-visible trail.
+///
+/// Wraps [`Lease`] rather than replacing it. Dropping this drops the lease
+/// at the exact moment it always dropped. So every release site already in
+/// the codebase — the end of a scope, an early `continue`, a bulk `drop` —
+/// mirrors for free. See the module docs for why the mirroring half is
+/// best-effort.
+pub(super) struct MirroredLease<'p> {
+    lease: Lease,
+    provider: &'p dyn IssueProvider,
+    key: IssueKey,
+    owner: String,
+    signature: String,
+}
+
+impl<'p> MirroredLease<'p> {
+    /// Wrap a just-granted lease and post the claim comment.
+    ///
+    /// `number` is the bare issue number the lease was taken under — what
+    /// [`super::claim::acquire`] was called with. It is not the ledger's
+    /// `issue:<n>` claim key. The tracker has never heard that spelling.
+    pub(super) fn new(
+        lease: Lease,
+        provider: &'p dyn IssueProvider,
+        number: &str,
+        signature: &str,
+    ) -> Self {
+        let dispatch = lease.dispatch_lease().clone();
+        let key = IssueKey::from(number);
+        post(
+            provider,
+            &key,
+            &claimed_body(&dispatch.owner, dispatch.ttl_ms),
+            signature,
+        );
+        Self {
+            lease,
+            provider,
+            key,
+            owner: dispatch.owner,
+            signature: signature.to_owned(),
+        }
+    }
+}
+
+impl Drop for MirroredLease<'_> {
+    fn drop(&mut self) {
+        post(
+            self.provider,
+            &self.key,
+            &released_body(&self.owner),
+            &self.signature,
+        );
+    }
+}
+
+/// The comment posted the moment a lease is granted.
+fn claimed_body(owner: &str, ttl_ms: u64) -> String {
+    let minutes = ttl_ms.div_ceil(60_000).max(1);
+    format!(
+        "\u{1F512} Claimed by `{owner}`.\n\n\
+         This is a local dispatch lease, not a GitHub assignment. It lasts \
+         about {minutes} minute(s) and renews on its own while the run \
+         stays alive. If this comment is older than that with no new \
+         activity below, the lease has almost certainly lapsed and the \
+         issue is free again.\n\n\
+         Run `stella fleet claims --all` in the workspace for live status."
+    )
+}
+
+/// The comment posted the moment a lease is given up.
+fn released_body(owner: &str) -> String {
+    format!("\u{1F513} Released by `{owner}`. Free for the next claimant.")
+}
+
+/// Post one mirror comment, and drop whatever goes wrong.
+///
+/// See the module docs: nothing here may turn a tracker hiccup into a
+/// reason to stop working the issue. A failure here has no caller left to
+/// report it to.
+fn post(provider: &dyn IssueProvider, key: &IssueKey, body: &str, signature: &str) {
+    let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        return;
+    };
+    let _ = runtime.block_on(backlog::comment(provider, key, body, signature));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use stella_protocol::issue::{Issue, IssueDraft, IssueError};
+
+    use super::*;
+
+    /// A tracker that only records what it was told. The witness below
+    /// checks the two comments a mirrored lease posts against this record,
+    /// with no real network call.
+    #[derive(Default)]
+    struct RecordingProvider {
+        posted: Mutex<Vec<(String, String)>>,
+    }
+
+    impl RecordingProvider {
+        fn posted(&self) -> Vec<(String, String)> {
+            self.posted.lock().expect("fixture lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl IssueProvider for RecordingProvider {
+        fn id(&self) -> &str {
+            "fixture"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(Vec::new())
+        }
+
+        async fn file(&self, _draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            Ok(IssueKey::from("1"))
+        }
+
+        async fn close(
+            &self,
+            _key: &IssueKey,
+            _receipt: &str,
+            _state: &str,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, key: &IssueKey, body: &str) -> Result<(), IssueError> {
+            self.posted
+                .lock()
+                .expect("fixture lock")
+                .push((key.as_str().to_owned(), body.to_owned()));
+            Ok(())
+        }
+
+        async fn relabel(
+            &self,
+            _key: &IssueKey,
+            _add: &[String],
+            _remove: &[String],
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            _body: Option<&str>,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+    }
+
+    fn granted(root: &std::path::Path, number: &str, owner: &str) -> Lease {
+        match super::super::claim::acquire_as(root, number, owner) {
+            super::super::claim::Claim::Granted(lease) => lease,
+            other => panic!("the key was free, so the claim must be granted: {other:?}"),
+        }
+    }
+
+    /// **The witness.** Wrapping a granted lease posts the claim comment
+    /// right away. Dropping the wrapper posts a second comment giving it
+    /// back. Those are the two events a human needs to see on the issue —
+    /// the same two events the local ledger already knows.
+    ///
+    /// Fails on the parent commit by construction: `MirroredLease` does not
+    /// exist there, so nothing posts either comment.
+    #[test]
+    fn a_lease_posts_a_claim_comment_and_a_release_comment_around_its_life() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let provider = RecordingProvider::default();
+        let lease = granted(root.path(), "1675", "self-driving:4242");
+
+        let mirrored = MirroredLease::new(lease, &provider, "1675", "");
+        // `claim::acquire_as` grants under `claim::LEASE_TTL`. That
+        // constant is private to its own module, so its value — five
+        // minutes — is spelled out here in milliseconds instead.
+        let five_minutes_ms = 5 * 60 * 1000;
+        assert_eq!(
+            provider.posted(),
+            vec![(
+                "1675".to_owned(),
+                claimed_body("self-driving:4242", five_minutes_ms)
+            )],
+            "granting the wrapper posts the claim comment right away"
+        );
+
+        drop(mirrored);
+        let posted = provider.posted();
+        assert_eq!(
+            posted.len(),
+            2,
+            "dropping it posts exactly one more comment"
+        );
+        assert_eq!(posted[1].0, "1675");
+        assert_eq!(posted[1].1, released_body("self-driving:4242"));
+    }
+
+    /// The claimed comment names the owner, a whole number of minutes, and
+    /// the command a human can run for live status. It has to name all
+    /// three, or a reader has no way to judge whether the claim is still
+    /// good.
+    #[test]
+    fn the_claim_comment_names_the_owner_and_a_whole_minute_ttl() {
+        let body = claimed_body("self-driving:1", 5 * 60_000);
+        assert!(body.contains("self-driving:1"));
+        assert!(body.contains("5 minute"));
+        assert!(body.contains("stella fleet claims --all"));
+    }
+
+    /// A TTL under a minute still reads as at least one minute, not zero.
+    /// "Expires in 0 minutes" would read as already gone.
+    #[test]
+    fn a_sub_minute_ttl_rounds_up_rather_than_down_to_zero() {
+        assert!(claimed_body("owner", 1).contains("1 minute"));
+    }
+
+    /// The release comment names who released it, and nothing more. There
+    /// is no lease state left to report once it is gone.
+    #[test]
+    fn the_release_comment_names_the_owner() {
+        let body = released_body("self-driving:1");
+        assert!(body.contains("self-driving:1"));
+        assert!(body.contains("Released"));
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -346,8 +346,10 @@ pub(super) fn drive(
     // The ledger claims this run holds, one per issue taken and not yet
     // worked. Keyed by issue so the Work arm can take back the one it is
     // about to run; dropped wholesale if the run ends holding any, which
-    // releases them rather than leaving a peer to wait out the TTL.
-    let mut leases: HashMap<String, super::claim::Lease> = HashMap::new();
+    // releases them rather than leaving a peer to wait out the TTL. Each is
+    // a `MirroredLease` rather than a bare lease, so the drop that frees the
+    // ledger row also tells GitHub the issue is free again.
+    let mut leases: HashMap<String, super::claim_mirror::MirroredLease<'_>> = HashMap::new();
     // Issues this process already offered to triage. The escalation label is
     // the durable half; this covers the window before it lands, and stops a
     // provider that failed to accept the label costing a turn every pass.
@@ -612,7 +614,15 @@ pub(super) fn drive(
                 );
                 durable.update_stats(|s| s.issues_claimed += 1);
                 if let Some(lease) = lease {
-                    leases.insert(key.clone(), lease);
+                    leases.insert(
+                        key.clone(),
+                        super::claim_mirror::MirroredLease::new(
+                            lease,
+                            &provider,
+                            &key,
+                            &cfg.attribution.issue_comment,
+                        ),
+                    );
                 }
                 state.claimed.push(IssueRef(key));
             }

--- a/crates/stella-cli/src/self_driving_cmd/parallel.rs
+++ b/crates/stella-cli/src/self_driving_cmd/parallel.rs
@@ -108,7 +108,9 @@ pub(super) fn wave(
     // Take the issue leases first, in readiness order. An issue a live
     // peer holds is deferred by name, never contested. A ledger that will
     // not answer fails open, the same direction every claim probe takes.
-    let mut taken: Vec<(Issue, Option<super::claim::Lease>)> = Vec::new();
+    // Each grant is wrapped as a `MirroredLease`, so the `drop` below that
+    // frees the ledger rows also tells GitHub each issue is free again.
+    let mut taken: Vec<(Issue, Option<super::claim_mirror::MirroredLease<'_>>)> = Vec::new();
     for issue in ready {
         if taken.len() >= bound {
             break;
@@ -122,7 +124,13 @@ pub(super) fn wave(
                     "taken off the ready backlog for the wave",
                 );
                 durable.update_stats(|s| s.issues_claimed += 1);
-                taken.push((issue, Some(lease)));
+                let mirrored = super::claim_mirror::MirroredLease::new(
+                    lease,
+                    provider,
+                    issue.key.as_str(),
+                    &cfg.attribution.issue_comment,
+                );
+                taken.push((issue, Some(mirrored)));
             }
             super::claim::Claim::HeldBy(owner) => {
                 audit::record(

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -137,6 +137,8 @@ A Claude worker will not accept `--spend-limit`. Claude does not report what a r
 
 `stella self-driving drive` runs on its own, without you watching it. It keeps asking what to do next, does it, and asks again: claim the next issue from the ranked queue, run it through the turn loop, open a pull request, watch CI, and merge when it's ready.
 
+Claiming an issue posts a comment on it saying who claimed it and for how long, and a second comment when the claim is given back. This is a courtesy for a human deciding what to hand out next, or for a session on a second clone — the comment can never decide who owns an issue, since GitHub has no way to check-and-set a claim. The workspace's own lease, in `.stella/private/fleet.db`, is what actually decides that; `stella fleet claims --all` shows it live. A failure to post — no `gh`, no login, a rate limit — never stops the loop from working the issue.
+
 **When it hits a block, it parks and keeps checking — it does not exit.** Nothing stays "stuck" on purpose: every block is recalculated from scratch each time, so as soon as its cause is gone, it stops being reported. If the command exited on a block instead, nothing could resume it automatically. You never need to tell this loop it can resume — raising a limit, restoring a permission, removing a stop flag, or merging an escalated pull request already says everything that needs to be said.
 
 `--max-issues` limits one run so that it eventually stops. The loop itself never stops on its own, which is why this limit is a flag you set, not a fixed number. When the loop hits this limit, it's reported as *reached the bound*, not as *finished*.
@@ -147,7 +149,7 @@ A tracking issue never counts as ready, whatever its blockers say — an epic wh
 
 `--dry-run` prints the issue the loop would take next — the generator, the queue depth, the pick, and the branch prefix it would cut — and then stops. It reads the tracker and changes nothing: no claim, no branch, no label, no session record.
 
-`--parallel N` (with `--backlog`) works N ready issues at once instead of one after another. N defaults to the governor's number: what the machine probes and the learned calibration say this box can host right now. So a wave sizes itself to the machine, with nobody choosing a width. The ready issues go out as a single-wave fleet plan. Each worker gets its own worktree and holds its own issue lease, so a second loop on the same repository defers instead of doubling up. The run's spend cap is divided across the width before any worker starts. At `--parallel 1` the loop runs exactly the serial path described above.
+`--parallel N` (with `--backlog`) works N ready issues at once instead of one after another. N defaults to the governor's number: what the machine probes and the learned calibration say this box can host right now. So a wave sizes itself to the machine, with nobody choosing a width. The ready issues go out as a single-wave fleet plan. Each worker gets its own worktree and holds its own issue lease, mirrored on GitHub the same way, so a second loop on the same repository defers instead of doubling up. The run's spend cap is divided across the width before any worker starts. At `--parallel 1` the loop runs exactly the serial path described above.
 
 If the machine asks for a step this build can't do, like sweeping an audit lens or curating a proposal, stella reports it and stops the loop, instead of silently skipping it. A driver that silently skipped steps would always look healthy, even when it wasn't doing anything.
 


### PR DESCRIPTION
## What / why

`self_driving_cmd::claim` already takes a local dispatch lease under `issue:<n>` (`stella_fleet::Ledger::claim_dispatch`) before `stella self-driving drive` (serial or `--parallel`) works an issue. That closed the race between two loops sharing one clone (#4300), but the only way a human — or a session on a second clone — could see the claim was to open `.stella/private/fleet.db` with `sqlite3`. #1675 is the second half of #1136's "the claim is visible to a human deciding what to hand out next" acceptance bullet; the first half (`stella fleet claims`) shipped in #1680.

## What changed

A new `MirroredLease` type (`crates/stella-cli/src/self_driving_cmd/claim_mirror.rs`) wraps the existing `claim::Lease`:

- **On grant**, it posts one comment on the issue naming the owner, the lease's actual TTL, and `stella fleet claims --all` for live status.
- **On drop** — the exact moment the wrapped lease itself releases the SQL row — it posts a second comment saying the issue is free again.

This needed no new `IssueProvider` capability: it reuses the `comment` port and the `backlog::comment` helper (`stella_autonomy::sign` + `cfg.attribution.issue_comment`) the loop's escalation and closure paths already use.

Wired at the two places that grant a lease today — `drive`'s serial loop (`leases: HashMap<String, MirroredLease>`) and `parallel`'s wave dispatch (`taken: Vec<(Issue, Option<MirroredLease>)>`) — by changing the stored type from the bare `Lease` to `MirroredLease`. Every existing release site (the end of a scope, an early `continue` inside `drive`'s `Work` arm, the bulk `drop(taken)` in `parallel::wave`) already drops the lease at the right moment, so wrapping it needed no new call sites.

**GitHub is a mirror, never an arbiter.** The lease still decides who owns the work — nothing here reads GitHub to make that decision, and it offers no compare-and-set to read anyway. A comment that fails to post (`gh` offline, unauthenticated, rate-limited) is dropped rather than treated as a reason to stop working the issue, matching the fail-open posture `claim::acquire` already documents for the ledger side. The claimed comment states the lease's own TTL rather than promising to stay live (no per-heartbeat re-posting, to avoid comment spam on a lease renewed every couple of minutes) — a reader who finds it later can tell it is stale on sight.

Went with a claim comment rather than "assign self + an `in-progress` label" — the issue's other offered option — because `IssueProvider` has no assign capability today and adding one is a separate, bigger change; a comment is the DoD's own alternative and reuses machinery that already ships. Full design posted as a comment on #1675 before implementation.

## Witness

`claim_mirror::tests::a_lease_posts_a_claim_comment_and_a_release_comment_around_its_life` — a hermetic test: a real tempdir-backed dispatch lease (`claim::acquire_as`, no mock), a fixture `IssueProvider` that only records what it is told (no network), asserting the wrapper posts exactly one "claimed" comment on construction and exactly one "released" comment on drop, both bodies checked verbatim. Fails on `main` by construction — `MirroredLease` does not exist there.

Three more unit tests cover the comment bodies directly (owner + whole-minute TTL + the `stella fleet claims --all` pointer; sub-minute TTL rounds up to "1 minute" rather than "0"; the release comment names the owner).

## Docs

Two sentences added to `website/content/docs/commands/self-driving.mdx`, next to the existing paragraphs describing `drive`'s claim/work/deliver loop and the parallel wave's per-worker lease.

## Tests deleted

None.

Closes #1675
Refs #1136

## Independent DoD verification (#1675)

The `dod` gate went red at 18:27 on #1675's one remaining unticked box:

> A documented path for an issue-driven session to take `issue:<n>` and have that visible on GitHub, with the lease semantics from `lease.rs` (expiry + renewal + fence) preserved.

It is ticked now, checked against this head (`25d4ede`) in three parts:

1. **Visible on GitHub.** `claim_mirror.rs`'s `MirroredLease::new` posts the claim comment on grant and its `Drop` posts the release comment, at both grant sites — `drive.rs`'s `leases` map and `parallel.rs`'s `taken` vec. The witness asserts both bodies verbatim against a recording `IssueProvider`, with no network.
2. **A documented path.** `website/content/docs/commands/self-driving.mdx` gains a paragraph stating what the two comments are, that the workspace lease in `.stella/private/fleet.db` is what actually decides ownership, that `stella fleet claims --all` shows it live, and that a failed post never stops the loop. The `--parallel` paragraph is updated to say each worker's lease is mirrored the same way.
3. **Lease semantics preserved.** `MirroredLease` *wraps* `Lease` rather than replacing it, and adds no path that renews or releases — the new `Lease::dispatch_lease` accessor is `pub(super)` and read-only. Expiry, the heartbeat renewal, and the fence are untouched in `lease.rs`, and the inner `Lease::drop` still runs at the same moment it always did.

Also checked, since the mirror posts from a `Drop`: `post()` builds a current-thread runtime and `block_on`s it, which would panic inside an existing runtime. It cannot be. `self_driving_cmd::run` is reached synchronously from `fn main` (`main.rs`'s `fn run`), and in `parallel::wave` the `taken` vec holding the leases is declared *before* the multi-thread `runtime`, so it drops after that runtime does — never inside its `block_on`. The build-a-runtime-per-call shape is also the established idiom in the sibling `backlog.rs`.

## Summary by Sourcery

Make self-driving issue leases visible on the issue tracker without changing local lease ownership semantics.

New Features:
- Mirror self-driving issue lease claims and releases to the issue tracker with owner, lease duration, and live-status guidance.

Enhancements:
- Preserve local lease ownership, expiry, renewal, and fencing as the authoritative dispatch mechanism while making tracker comments best-effort.
- Apply lease mirroring consistently to serial and parallel self-driving execution paths.

Documentation:
- Document tracker-visible claim and release comments, local lease authority, live claim inspection, and fail-open posting behavior for self-driving workflows.

Tests:
- Add hermetic and unit coverage for claim and release comment creation, lease duration formatting, and owner attribution.