### PR TITLE
feat(stella-cli): report fleet worktree count and reclaimable size in doctor

### DIFF
--- a/crates/stella-cli/src/doctor.rs
+++ b/crates/stella-cli/src/doctor.rs
@@ -5,7 +5,7 @@
 //! one pass/fail line each, plus the opt-in repair for the one failure that
 //! previously had no way out.
 //!
-//! Four checks today:
+//! Five checks today:
 //!
 //! - **store integrity** — this workspace's `.stella/private/store.db`. A
 //!   corrupt store used to surface as an error at session start and nothing
@@ -15,6 +15,9 @@
 //! - **fleet ledger** — rows in `fleet.db` naming a run that is no longer
 //!   recorded. Report-only by design; see [`fleet_ledger_orphans`] for why
 //!   `--repair` must not touch them.
+//! - **fleet worktrees** — how many isolated worktrees `.stella/worktrees/`
+//!   is carrying, their on-disk size, and how many `stella fleet clean`
+//!   would reclaim; see [`fleet_worktrees`] and [`crate::doctor_fleet`].
 //! - **session sidecars** — sidecar directories whose session record is gone;
 //!   see [`orphan_session_sidecars`].
 //! - **model config** — the model the next run would actually send, and the
@@ -192,6 +195,7 @@ fn checks(
     vec![
         store_integrity(workspace_root, repair),
         fleet_ledger_orphans(workspace_root),
+        fleet_worktrees(workspace_root),
         orphan_session_sidecars(&stella_store::SessionRegistry::open_default(), repair),
         model_config(workspace_root, model_override, base_url_override),
         managed_settings(),
@@ -428,6 +432,49 @@ fn fleet_ledger_orphans(workspace_root: &Path) -> Check {
              build cannot acquire new orphans"
             .to_string(),
     ])
+}
+
+/// Whether this workspace is quietly accumulating isolated `stella fleet`
+/// worktrees under `.stella/worktrees/`. `stella fleet clean` reclaims them,
+/// but nothing else makes the pile visible before an operator thinks to run
+/// it.
+///
+/// Always a **Pass**: an accumulation is not something stella did wrong, only
+/// something an operator should see. The count and size are read straight off
+/// the filesystem; the reclaimable/kept split is a `dry_run` sweep that only
+/// runs below a threshold — see [`crate::doctor_fleet`] for why, and for the
+/// one definition of "reclaimable" this check shares with `stella fleet
+/// clean`.
+fn fleet_worktrees(workspace_root: &Path) -> Check {
+    const NAME: &str = "fleet worktrees";
+
+    let report = crate::doctor_fleet::report(workspace_root);
+    if report.count == 0 {
+        return Check::pass(NAME, "no fleet worktrees");
+    }
+
+    let size = crate::doctor_fleet::human_bytes(report.total_bytes);
+    let count = report.count;
+    match (report.split, &report.sweep_error) {
+        (Some(split), _) => Check::pass(
+            NAME,
+            format!(
+                "{count} worktree(s), {size} — {} reclaimable, {} kept; \
+                 {} loose branch(es) reclaimable, {} kept",
+                split.worktrees_reclaimable,
+                split.worktrees_kept,
+                split.branches_reclaimable,
+                split.branches_kept,
+            ),
+        ),
+        (None, Some(error)) => Check::pass(NAME, format!("{count} worktree(s), {size}"))
+            .with_details(vec![format!("reclaimable/kept split unavailable: {error}")]),
+        (None, None) => {
+            Check::pass(NAME, format!("{count} worktree(s), {size}")).with_remedy(vec![
+                "run `stella fleet clean --dry-run` to see how many are reclaimable".to_string(),
+            ])
+        }
+    }
 }
 
 /// The exit-code contract: `Ok(())` (exit 0) when every check passed, `Err`
@@ -687,6 +734,7 @@ mod tests {
             vec![
                 "store integrity",
                 "fleet ledger",
+                "fleet worktrees",
                 "session sidecars",
                 "model config",
                 "managed settings",
@@ -710,6 +758,13 @@ mod tests {
             "the ledger check names the absence: {}",
             checks[1].summary
         );
+        // No `.stella/worktrees/` here either — an unused fleet check must
+        // produce no noise.
+        assert_eq!(
+            checks[2].summary, "no fleet worktrees",
+            "an unused fleet check says so plainly, with no details or remedy"
+        );
+        assert!(checks[2].details.is_empty() && checks[2].remedy.is_empty());
     }
 
     /// #617's last open sweep: an orphan sidecar is reported without

--- a/crates/stella-cli/src/doctor_fleet.rs
+++ b/crates/stella-cli/src/doctor_fleet.rs
@@ -266,6 +266,10 @@ mod tests {
     /// Above [`SPLIT_THRESHOLD`], `doctor` reports count and size only. It
     /// must not spawn `git` for a sweep. This test needs no real
     /// repository — just enough directories to cross the gate.
+    ///
+    /// It is also where the reported size is pinned to an exact number.
+    /// Every worktree it builds holds one 1-byte file, so the total is the
+    /// worktree count and nothing else.
     #[test]
     fn above_the_threshold_reports_count_and_size_without_a_sweep() {
         let dir = tempfile::tempdir().unwrap();
@@ -278,7 +282,16 @@ mod tests {
 
         let report = report(dir.path());
         assert_eq!(report.count, SPLIT_THRESHOLD + 1);
-        assert!(report.total_bytes > 0, "{report:?}");
+        // The total is exact here: `path_size` sums file lengths and never
+        // counts the directory inodes holding them, so one 1-byte file per
+        // worktree makes the byte total equal the count. A floor (`> 0`)
+        // would survive a double-counted directory, a followed symlink, or
+        // a dropped file; this does not.
+        assert_eq!(
+            usize::try_from(report.total_bytes).unwrap(),
+            SPLIT_THRESHOLD + 1,
+            "one 1-byte file per worktree: {report:?}"
+        );
         assert_eq!(
             report.split, None,
             "above the threshold the split must not run: {report:?}"
@@ -319,6 +332,11 @@ mod tests {
 
         let report = report(repo);
         assert_eq!(report.count, 2, "{report:?}");
+        // A real worktree's `.git` file records an absolute path into the
+        // tempdir, and that path's length changes on every run, so there is
+        // no fixed byte total to assert against here. The exact size lives
+        // in `above_the_threshold_reports_count_and_size_without_a_sweep`,
+        // which builds its worktrees by hand.
         assert!(report.total_bytes > 0, "{report:?}");
         assert_eq!(report.sweep_error, None, "{report:?}");
         assert_eq!(

--- a/crates/stella-cli/src/doctor_fleet.rs
+++ b/crates/stella-cli/src/doctor_fleet.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A `stella doctor` check. It looks for a pile of `stella fleet` worktrees
+//! under `.stella/worktrees/`.
+//!
+//! `stella fleet clean` removes a finished task's worktree and its
+//! `fleet/*` branch. Nothing else shows the pile first. A workspace can
+//! hold dozens of stale worktrees and several GB with no warning.
+//! [`report`] is that warning. It always reports the count and the size on
+//! disk. At or under [`SPLIT_THRESHOLD`] worktrees, it also reports how
+//! many `stella fleet clean` would reclaim.
+//!
+//! [`report`] does not redo that work. It calls
+//! [`stella_fleet::Gc::sweep`] with `dry_run: true` and counts the verdicts
+//! it returns. So "reclaimable" here means what it means to `stella fleet
+//! clean`.
+//!
+//! # Why the split needs enough worktrees
+//!
+//! A dry-run sweep runs `git` several times per worktree. Below
+//! [`SPLIT_THRESHOLD`] that cost is small. A handful of worktrees is not
+//! the pile this check looks for. Above the threshold — dozens of stale
+//! worktrees — the split earns its cost. So the sweep runs only there.
+//! Below the threshold, `doctor` reports count and size only. It points at
+//! `stella fleet clean --dry-run` for the rest.
+
+use std::path::Path;
+
+use stella_fleet::{BranchAction, Gc, GcOptions, Ledger, SystemGitCli};
+
+/// Worktree counts at or under this get the (git-spawning) reclaimable/kept
+/// split; above it `doctor` reports count and size only. See the module doc
+/// for the direction this gate runs.
+const SPLIT_THRESHOLD: usize = 8;
+
+/// The reclaimable/kept breakdown one dry-run sweep produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Split {
+    pub(crate) worktrees_reclaimable: usize,
+    pub(crate) worktrees_kept: usize,
+    /// `fleet/*` branches with no worktree of their own.
+    pub(crate) branches_reclaimable: usize,
+    pub(crate) branches_kept: usize,
+}
+
+/// What [`report`] found. Pure data — [`crate::doctor`] turns this into a
+/// [`crate::doctor::Check`], the same split [`crate::settings_check`] uses
+/// for the model-config check.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct FleetWorktreeReport {
+    /// How many worktrees live under `.stella/worktrees/`. Zero — the
+    /// default — when the directory does not exist: a workspace that has
+    /// never run `stella fleet`, which must produce no noise.
+    pub(crate) count: usize,
+    /// Their total size on disk, in bytes.
+    pub(crate) total_bytes: u64,
+    /// `Some` when a dry-run sweep ran (`count` at or under
+    /// [`SPLIT_THRESHOLD`]) and succeeded.
+    pub(crate) split: Option<Split>,
+    /// Set when a sweep was attempted but failed — a diagnosable git error,
+    /// never a reason to fail the check.
+    pub(crate) sweep_error: Option<String>,
+}
+
+/// Walk `.stella/worktrees/` and, when the count warrants it, run a
+/// `dry_run` sweep. Never mutates a file, a branch, or the ledger.
+pub(crate) fn report(workspace_root: &Path) -> FleetWorktreeReport {
+    let worktrees_root = workspace_root.join(".stella").join("worktrees");
+    let entries: Vec<_> = match std::fs::read_dir(&worktrees_root) {
+        Ok(read) => read.filter_map(Result::ok).collect(),
+        Err(_) => return FleetWorktreeReport::default(),
+    };
+    let count = entries.len();
+    if count == 0 {
+        return FleetWorktreeReport::default();
+    }
+    let total_bytes = entries.iter().map(|entry| path_size(&entry.path())).sum();
+
+    if count > SPLIT_THRESHOLD {
+        return FleetWorktreeReport {
+            count,
+            total_bytes,
+            split: None,
+            sweep_error: None,
+        };
+    }
+    match sweep(workspace_root) {
+        Ok(split) => FleetWorktreeReport {
+            count,
+            total_bytes,
+            split: Some(split),
+            sweep_error: None,
+        },
+        Err(error) => FleetWorktreeReport {
+            count,
+            total_bytes,
+            split: None,
+            sweep_error: Some(error),
+        },
+    }
+}
+
+/// The on-disk size of a file, or the recursive size of a directory.
+/// [`std::fs::symlink_metadata`] does not traverse a symlink, so one is
+/// counted by its own size rather than its target's — the same reason `du`
+/// never follows one by default.
+fn path_size(path: &Path) -> u64 {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if !meta.is_dir() {
+        return meta.len();
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| path_size(&entry.path()))
+        .sum()
+}
+
+/// Runs a `dry_run: true` sweep. It reads the same activity `stella fleet
+/// clean` reads (`crate::fleet_gc::clean`): the ledger's worktree activity
+/// when a ledger exists, or an empty list when it does not. A workspace with
+/// no ledger has nothing in flight.
+fn sweep(workspace_root: &Path) -> Result<Split, String> {
+    let ledger_path = workspace_root
+        .join(".stella")
+        .join("private")
+        .join("fleet.db");
+    let activity = if ledger_path.exists() {
+        Ledger::open(&ledger_path)
+            .map_err(|e| format!("could not open the fleet ledger: {e}"))?
+            .worktree_activity()
+            .map_err(|e| format!("could not read the fleet ledger: {e}"))?
+    } else {
+        Vec::new()
+    };
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("system clock is before the Unix epoch: {e}"))?
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
+
+    // This builds its own runtime instead of reusing one. `stella doctor`
+    // runs before the shared runtime in `run()` exists this deep in the call
+    // chain. Every other check in `doctor.rs`, and every test that drives
+    // it, stays synchronous. One runtime here, for the one async call, costs
+    // less than making the whole module async.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to start a runtime for the fleet sweep: {e}"))?;
+
+    let gc_report = rt
+        .block_on(Gc::new(SystemGitCli, workspace_root).sweep(
+            &activity,
+            &GcOptions {
+                dry_run: true,
+                ..GcOptions::default()
+            },
+            now_ms,
+        ))
+        .map_err(|e| e.to_string())?;
+
+    let worktrees_reclaimable = gc_report.reclaimed_worktrees();
+    let branches_reclaimable = gc_report
+        .branches
+        .iter()
+        .filter(|v| matches!(v.action, BranchAction::Deleted | BranchAction::WouldDelete))
+        .count();
+    Ok(Split {
+        worktrees_reclaimable,
+        worktrees_kept: gc_report
+            .worktrees
+            .len()
+            .saturating_sub(worktrees_reclaimable),
+        branches_reclaimable,
+        branches_kept: gc_report
+            .branches
+            .len()
+            .saturating_sub(branches_reclaimable),
+    })
+}
+
+/// `12.3 MB`-style rendering for [`crate::doctor`]'s summary line. Binary
+/// (1024) units, because that is what the filesystem this counts is
+/// actually laid out in.
+pub(crate) fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use stella_fleet::{GitCli, WorktreeManager};
+
+    use super::*;
+
+    fn git_available() -> bool {
+        std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// This copies the `seed_repo` fixture from `gc/tests.rs`. This crate
+    /// cannot import a test helper from another crate's test module. The
+    /// shape — init, configure, one commit — is what this witness needs.
+    fn seed_repo(dir: &Path) -> String {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            let git = SystemGitCli;
+            for args in [
+                vec!["init", "-q", "-b", "main"],
+                vec!["config", "user.email", "fleet@test.local"],
+                vec!["config", "user.name", "Fleet Test"],
+                vec!["config", "commit.gpgsign", "false"],
+            ] {
+                let out = git.run(dir, &args).await.expect("git spawn");
+                assert!(out.success, "git {args:?} failed: {}", out.stderr);
+            }
+            std::fs::write(dir.join("README.md"), "seed\n").expect("write seed file");
+            for args in [
+                vec!["add", "--", "README.md"],
+                vec!["commit", "-q", "-m", "seed"],
+            ] {
+                let out = git.run(dir, &args).await.expect("git spawn");
+                assert!(out.success, "git {args:?} failed: {}", out.stderr);
+            }
+            let out = git
+                .run(dir, &["rev-parse", "HEAD"])
+                .await
+                .expect("rev-parse");
+            out.stdout.trim().to_string()
+        })
+    }
+
+    /// A workspace with neither `.stella/worktrees/` nor a fleet ledger must
+    /// produce no noise — the issue's own constraint.
+    #[test]
+    fn no_worktrees_directory_reports_the_zero_default() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(report(dir.path()), FleetWorktreeReport::default());
+    }
+
+    /// Above [`SPLIT_THRESHOLD`], `doctor` reports count and size only. It
+    /// must not spawn `git` for a sweep. This test needs no real
+    /// repository — just enough directories to cross the gate.
+    #[test]
+    fn above_the_threshold_reports_count_and_size_without_a_sweep() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktrees_root = dir.path().join(".stella").join("worktrees");
+        for i in 0..(SPLIT_THRESHOLD + 1) {
+            let wt = worktrees_root.join(format!("wt-{i}"));
+            std::fs::create_dir_all(&wt).unwrap();
+            std::fs::write(wt.join("f.txt"), "x").unwrap();
+        }
+
+        let report = report(dir.path());
+        assert_eq!(report.count, SPLIT_THRESHOLD + 1);
+        assert!(report.total_bytes > 0, "{report:?}");
+        assert_eq!(
+            report.split, None,
+            "above the threshold the split must not run: {report:?}"
+        );
+        assert_eq!(
+            report.sweep_error, None,
+            "a skipped sweep is not a failed one: {report:?}"
+        );
+    }
+
+    /// The witness: a real repository with a finished worktree and a dirty
+    /// one. `doctor` reports the true count and size, and the dry-run split
+    /// names the finished one reclaimable and the dirty one kept — the exact
+    /// numbers `stella fleet clean` would act on. This test compiles only
+    /// against `crate::doctor_fleet::report`, so it cannot pass on a tree
+    /// that lacks this module.
+    #[test]
+    fn reports_the_true_count_size_and_reclaimable_kept_split() {
+        if !git_available() {
+            eprintln!("skipping fleet-worktree doctor witness: `git` not available");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let base = seed_repo(repo);
+        let mgr = WorktreeManager::new(SystemGitCli, repo);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let (done, dirty) = rt.block_on(async {
+            let done = mgr.create("done", &base).await.expect("create done");
+            let dirty = mgr.create("dirty", &base).await.expect("create dirty");
+            (done, dirty)
+        });
+        std::fs::write(dirty.path.join("scratch.txt"), "unsaved work\n").unwrap();
+
+        let report = report(repo);
+        assert_eq!(report.count, 2, "{report:?}");
+        assert!(report.total_bytes > 0, "{report:?}");
+        assert_eq!(report.sweep_error, None, "{report:?}");
+        assert_eq!(
+            report.split,
+            Some(Split {
+                worktrees_reclaimable: 1,
+                worktrees_kept: 1,
+                branches_reclaimable: 0,
+                branches_kept: 0,
+            }),
+            "one finished worktree is reclaimable, the dirty one is kept: {report:?}"
+        );
+
+        assert!(done.path.exists(), "a dry run must remove nothing");
+    }
+
+    #[test]
+    fn human_bytes_renders_binary_units() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(999), "999 B");
+        assert_eq!(human_bytes(1536), "1.5 KB");
+        assert_eq!(human_bytes(5 * 1024 * 1024), "5.0 MB");
+    }
+}

--- a/crates/stella-cli/src/doctor_fleet.rs
+++ b/crates/stella-cli/src/doctor_fleet.rs
@@ -16,13 +16,13 @@
 //! it returns. So "reclaimable" here means what it means to `stella fleet
 //! clean`.
 //!
-//! # Why the split needs enough worktrees
+//! # When the split runs
 //!
-//! A dry-run sweep runs `git` several times per worktree. Below
-//! [`SPLIT_THRESHOLD`] that cost is small. A handful of worktrees is not
-//! the pile this check looks for. Above the threshold — dozens of stale
-//! worktrees — the split earns its cost. So the sweep runs only there.
-//! Below the threshold, `doctor` reports count and size only. It points at
+//! A dry-run sweep runs `git` several times per worktree. The bigger the
+//! pile, the more that costs. And a big pile is what this check looks for.
+//! `doctor` has to stay fast. So the sweep runs at or under
+//! [`SPLIT_THRESHOLD`] worktrees, and is skipped above it. Above it,
+//! [`report`] gives the count and the size alone. `doctor` then points at
 //! `stella fleet clean --dry-run` for the rest.
 
 use std::path::Path;

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -52,6 +52,7 @@ mod deck_mcp;
 mod diag_boot;
 mod diag_bridge;
 mod doctor;
+mod doctor_fleet;
 mod domains;
 mod driver_plugin;
 mod durability;

--- a/crates/stella-cli/tests/doctor_cli.rs
+++ b/crates/stella-cli/tests/doctor_cli.rs
@@ -107,7 +107,11 @@ fn doctor_reports_a_healthy_store_and_exits_zero() {
         stdout.contains("managed settings"),
         "the managed-settings check is reported too: {stdout}"
     );
-    assert!(stdout.contains("5 ok, 0 failed"), "{stdout}");
+    assert!(
+        stdout.contains("fleet worktrees"),
+        "the fleet-worktree check is reported too: {stdout}"
+    );
+    assert!(stdout.contains("6 ok, 0 failed"), "{stdout}");
 }
 
 #[test]

--- a/crates/stella-cli/tests/model_config_cli.rs
+++ b/crates/stella-cli/tests/model_config_cli.rs
@@ -197,7 +197,7 @@ fn doctor_reports_the_model_a_valid_config_resolves_to_and_where_it_came_from() 
         stdout.contains("zai/glm-5.2") && stdout.contains("default_model"),
         "the pass states the resolved model and its source: {stdout}"
     );
-    assert!(stdout.contains("5 ok, 0 failed"), "{stdout}");
+    assert!(stdout.contains("6 ok, 0 failed"), "{stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## What

`stella doctor` gets a new check: `fleet worktrees`. It reports, for the
current workspace:

- how many isolated worktrees live under `.stella/worktrees/`, and their
  total on-disk size — always, unconditionally;
- at or under 8 worktrees, how many `stella fleet clean` would reclaim
  versus keep, both for the worktrees themselves and for loose `fleet/*`
  branches (branches with no worktree of their own).

## Why

`stella fleet clean` (#1217) reclaims finished isolated worktrees and their
branches, but nothing made the pile visible before an operator thought to
run it. A workspace can carry dozens of stale worktrees and several GB with
no signal anywhere. This closes that gap: `stella doctor` is where local
state problems already surface (store integrity, orphan ledger rows,
orphan session sidecars), so a fleet-worktree pile joins that list.

## Threshold decision (the issue's "Decide and say which in the PR")

A dry-run sweep shells out to `git` several times per worktree. The issue
offered two designs: gate the reclaimable/kept split on a small worktree
count, or hide it behind an explicit opt-in flag.

I chose the threshold, not an opt-in flag, to avoid adding CLI surface for
one check. And I chose to run the sweep *below* the threshold and skip it
*above* it — the opposite of a literal reading of "above a small
threshold" in the issue body — because "`doctor` should stay fast" is the
overriding constraint, and running several git spawns per worktree is
costliest exactly when there are many worktrees. A workspace with a
handful of worktrees pays a small, bounded cost for the detail; a
workspace with dozens (the exact case this issue exists to surface) gets
the cheap count/size only, plus a remedy pointing at
`stella fleet clean --dry-run` for the full breakdown on demand. The
threshold is `SPLIT_THRESHOLD = 8` in `doctor_fleet.rs`.

## Where

- `crates/stella-cli/src/doctor_fleet.rs` (new) — `report()` walks
  `.stella/worktrees/` for count and size, and — within the threshold —
  runs a `dry_run: true` `stella_fleet::Gc::sweep()` fed the same ledger
  activity `crate::fleet_gc::clean` reads, then counts the `GcReport`
  verdicts. The classification is never re-implemented; `report()` only
  counts what `Gc::sweep` already decided. Also a `path_size()` recursive
  disk-size walker and a `human_bytes()` formatter.
- `crates/stella-cli/src/doctor.rs` — a new `fleet_worktrees()` check,
  wired into `checks()` between `fleet_ledger_orphans` and
  `orphan_session_sidecars`. Always a **Pass** — an accumulation is not a
  fault, only something to see.
- `crates/stella-cli/src/main.rs` — `mod doctor_fleet;`.

Exemplar: `crates/stella-cli/src/settings_check.rs`, the same
report-struct-in-a-sibling-module shape `doctor.rs`'s `model_config` check
already uses.

## Witness test

`crates/stella-cli/src/doctor_fleet.rs`'s
`reports_the_true_count_size_and_reclaimable_kept_split` seeds a real git
repository (the `gc/tests.rs` `seed_repo` fixture, reproduced — this crate
cannot import a `stella-fleet` test helper), creates one finished worktree
and one dirty one via `stella_fleet::WorktreeManager`, and asserts the
exact numbers: count 2, nonzero size, `Split { worktrees_reclaimable: 1,
worktrees_kept: 1, branches_reclaimable: 0, branches_kept: 0 }`. It cannot
pass on a tree without `crate::doctor_fleet::report`, which this PR adds.

Two more tests cover the edges the issue names as constraints:
`no_worktrees_directory_reports_the_zero_default` (no noise on an unused
workspace) and `above_the_threshold_reports_count_and_size_without_a_sweep`
(the sweep never runs above the threshold). `doctor.rs`'s existing
`doctor_passes_on_a_healthy_workspace_store` is extended to assert the new
check's no-noise summary on a workspace with no fleet history.

Tests deleted: none.

## Verified locally (targeted, not a workspace build)

- `cargo check -p stella-cli --bin stella`
- `cargo clippy -p stella-cli --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli --no-deps`
- `cargo test -p stella-cli --bin stella doctor_fleet` (4/4 pass)
- `cargo test -p stella-cli --bin stella doctor::` (8/8 pass)
- `cargo fmt --all`, `make guards-fast`, `python3 scripts/check-prose.py`,
  `./scripts/check-file-size.sh`, `make line-citations`,
  `make dead-code-allows` — all green

Closes #1655

## Summary by Sourcery

Expose accumulated fleet worktrees and their cleanup impact through `stella doctor` while preserving fast diagnostics for large worktree collections.

New Features:
- Add a `fleet worktrees` check to `stella doctor` that reports isolated worktree counts, disk usage, and—when practical—the reclaimable versus retained worktrees and loose fleet branches.

Enhancements:
- Keep the diagnostic non-failing and avoid expensive Git sweeps for workspaces with more than eight worktrees, providing an on-demand cleanup remedy instead.

Tests:
- Add coverage for empty worktree directories, threshold behavior, exact reclaimable/kept classifications, byte formatting, and updated doctor check totals.

---

## Sourcery's ❌ is fixed (`0d3ec2b`), and #1655's last box is ticked

Two things settled since the last push, both against evidence rather than ahead of it.

**The ❌.** Sourcery's assessment table said the witness "does not assert the exact reported size as required by the definition of done". The row was right, and both size assertions in the file were a floor (`> 0`). The git-seeded witness cannot carry an exact one: a real worktree's `.git` file records an absolute path into a randomly-named tempdir, so its byte total changes every run, and a fixed number there would be a flake. `above_the_threshold_reports_count_and_size_without_a_sweep` builds its worktrees by hand — one 1-byte file each — and now asserts the equality, since `path_size` sums file lengths without counting the directory inodes holding them:

```rust
assert_eq!(
    usize::try_from(report.total_bytes).unwrap(),
    SPLIT_THRESHOLD + 1,
    "one 1-byte file per worktree: {report:?}"
);
```

That is a real strengthening: the floor it replaces would survive a `path_size` that double-counts a directory, follows a symlink to its target, or drops a file from the walk. Full reasoning in [the comment on this PR](https://github.com/macanderson/stella/pull/5794#issuecomment-5531188364).

**#1655's box 6, `make gate` green via CI.** Green on this head. `fmt + clippy + test` — the job running `cargo fmt --check`, `cargo clippy -D warnings`, `cargo doc -D warnings` and `cargo test` — reports **success**, 19:44:31 → 20:08:09 ([job 100790899667](https://github.com/macanderson/stella/actions/runs/33798156315/job/100790899667)). Every other check on `0d3ec2b` is green too. `dod` is the only red one, and it is that box's own gate — #2638's ordering trap, where the DoD template's last item can only be true after the last `pull_request` event that would read it.

This edit is the event that lets the gate re-read the ticked box: `dod-check` fires on pull-request events, not on an issue edit, so the tick alone would have left the check red on a stale run. **No code changed in this edit.**