### PR TITLE
fix(stella-fleet): consolidate WorktreeManager::remove and Gc::remove_worktree

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -646,7 +646,7 @@ pub(super) fn start(
     attribution: &stella_autonomy::Attribution,
     worker: &crate::settings::toml_config::WorkerSection,
 ) -> Result<WorkOutcome, String> {
-    use stella_fleet::git::{SystemGitCli, WorktreeManager};
+    use stella_fleet::git::{RemoveOptions, SystemGitCli, WorktreeManager};
 
     refuse_if_unsteered(root)?;
     // Asked before a worktree is cut, not after the turn refuses: a unit that
@@ -711,11 +711,12 @@ pub(super) fn start(
     // Nothing to deliver means nothing to keep. A worktree per issue that
     // changed nothing would accumulate silently until the disk noticed.
     //
-    // `remove` deletes the branch only when it carries no commits beyond its
-    // base, so this cannot discard work: a turn that committed keeps its
-    // branch even down this arm.
+    // `remove` deletes the branch only when it is already contained in its
+    // own base ref (the default `RemoveOptions::contained_in`), so this
+    // cannot discard work: a turn that committed keeps its branch even down
+    // this arm.
     if matches!(outcome, WorkOutcome::NoChange { .. })
-        && let Err(error) = runtime.block_on(manager.remove(&created))
+        && let Err(error) = runtime.block_on(manager.remove(&created, &RemoveOptions::default()))
     {
         // Reported, never swallowed. A worktree that failed to release is a
         // thing the operator has to know about — it will collide with the next

--- a/crates/stella-fleet/README.md
+++ b/crates/stella-fleet/README.md
@@ -252,20 +252,27 @@ table-tested with an injected `Clock` instead of a real wait (L-E4).
   matching `version < n` arm; `migrate` ([`migrate`](src/ledger.rs))
   stamps `PRAGMA user_version` in the same transaction as the DDL it applies,
   the way `MIGRATION_V2` rebuilt `lineage` to add its uniqueness constraint.
-- **A run never removes its own worktree or branch.** Neither `Fleet` nor
-  `fleet_cmd` calls `WorktreeManager::remove`; isolated worktrees under
-  `.stella/worktrees/<slug>` and their `fleet/<slug>-<hash>` branches are left
-  for review. The slug hashes the run scope *and* the task id, so re-running a
-  plan with the same task ids does not collide with what the last run kept.
-  Reclaiming them is an explicit, separate act: [`src/gc.rs`](src/gc.rs)'s
-  `Gc::sweep`, driven by `stella fleet clean`
+- **A `stella fleet` run never removes its own worktree or branch.** Neither
+  `Fleet` nor `fleet_cmd` calls `WorktreeManager::remove`; isolated worktrees
+  under `.stella/worktrees/<slug>` and their `fleet/<slug>-<hash>` branches are
+  left for review. The slug hashes the run scope *and* the task id, so
+  re-running a plan with the same task ids does not collide with what the
+  last run kept. Reclaiming them is an explicit, separate act:
+  [`src/gc.rs`](src/gc.rs)'s `Gc::sweep`, driven by `stella fleet clean`
   (`crates/stella-cli/src/fleet_gc.rs`) — never automatic, and it removes only
   a worktree with no unfinished attempt in the ledger, a clean tree, and a
-  branch the base ref already contains (#1217). `Gc` does its own
-  `worktree remove` rather than calling `WorktreeManager::remove`: the manager
-  judges a branch against the `base_ref` its `Worktree` value carries, which
-  the ledger does not record, and it has no `--force` rung. Consolidating the
-  two is tracked separately.
+  branch the base ref already contains (#1217).
+
+  `self_driving_cmd::work::start` is a different caller with a different
+  reason to remove: a per-issue worktree whose turn changed nothing has
+  nothing worth reviewing, so it is released right away instead of left for
+  a later sweep. `WorktreeManager::remove` and `Gc::remove_worktree` share
+  one routine — `is_contained_in` and `remove_worktree_and_branch` in
+  [`src/git.rs`](src/git.rs) — through `remove`'s own
+  `RemoveOptions { force, contained_in }`. `Gc` passes its resolved
+  integration ref as `contained_in`, since it has no `Worktree` value to
+  read a `base_ref` from. Every other caller leaves `contained_in` at its
+  default, which falls back to `Worktree::base_ref`.
 - **`WorktreeManager::commit_paths` has no product caller yet.** It is
   exercised only by this crate's own tests, and it ships anyway because it is
   the only place here that encodes the pathspec discipline — `git add --
@@ -276,10 +283,10 @@ table-tested with an injected `Clock` instead of a real wait (L-E4).
   `git worktree list --porcelain` itself, and both parse the result through the
   same `parse_worktree_list`.
 
-  `WorktreeManager::remove` has left this list: `stella-cli`'s
-  `candidate_workspaces` and `self_driving_cmd::work` both call it. So has the
-  warmest-first path — `Fleet::with_cache_warmth`, `cache_schedule` — is live
-  since #1222: `stella fleet` installs a ledger-backed warmth lookup, keyed by
+  `WorktreeManager::remove` has a production caller: `stella-cli`'s
+  `self_driving_cmd::work::start` (see above). The warmest-first path —
+  `Fleet::with_cache_warmth`, `cache_schedule` — is live since #1222: `stella
+  fleet` installs a ledger-backed warmth lookup, keyed by
   `Ledger::last_attempt_finish_ms` and projected through the provider cache TTL
   in `crates/stella-cli/src/fleet_warmth.rs`.
 - **`WatchConfig::run_list_limit` (default 50) is a truncation point.** A

--- a/crates/stella-fleet/src/gc.rs
+++ b/crates/stella-fleet/src/gc.rs
@@ -24,14 +24,17 @@
 //!   are not yet contained in the integration ref, is kept unless the caller
 //!   passes [`GcOptions::force`].
 //! - **Errors keep.** Every predicate answers "keep" when git cannot answer it
-//!   (an unresolvable range, a `merge-base` that failed for its own reasons),
-//!   the same direction [`WorktreeManager::remove`] already errs.
+//!   (a `merge-base` or `status` that failed), the same direction
+//!   [`WorktreeManager::remove`] errs, in the routine both share.
 //!
 //! [`WorktreeManager::remove`]: crate::git::WorktreeManager::remove
 
 use std::path::{Path, PathBuf};
 
-use crate::git::{GitCli, WorktreeError, ensure_ok, parse_worktree_list, path_arg};
+use crate::git::{
+    GitCli, RemoveOutcome, WorktreeError, ensure_ok, is_contained_in, parse_worktree_list,
+    remove_worktree_and_branch,
+};
 
 /// Milliseconds in a day — the unit [`GcOptions::min_age_days`] is expressed
 /// in.
@@ -346,7 +349,10 @@ impl<G: GitCli> Gc<G> {
                             branch_would_delete: !branch.is_empty(),
                         }
                     } else {
-                        match self.remove_worktree(&entry.path, &branch, opts.force).await {
+                        match self
+                            .remove_worktree(&entry.path, &branch, opts.force, base_ref)
+                            .await
+                        {
                             Ok(branch_deleted) => WorktreeAction::Removed { branch_deleted },
                             Err(e) => WorktreeAction::Failed(e.to_string()),
                         }
@@ -430,7 +436,7 @@ impl<G: GitCli> Gc<G> {
             if self.is_dirty(path).await? {
                 return Ok(Verdict::Keep(KeepReason::Dirty));
             }
-            if !self.is_contained_in(branch, base_ref).await? {
+            if !is_contained_in(&self.git, &self.repo_root, branch, base_ref).await? {
                 return Ok(Verdict::Keep(KeepReason::UnmergedCommits));
             }
         }
@@ -440,30 +446,24 @@ impl<G: GitCli> Gc<G> {
     /// `git worktree remove` then `branch -D`, in that order (git refuses to
     /// delete a branch that is still checked out somewhere). Returns whether
     /// the branch went with it.
+    ///
+    /// Calls `remove_worktree_and_branch`, the same routine
+    /// [`WorktreeManager::remove`](crate::git::WorktreeManager::remove)
+    /// calls, instead of issuing its own `git` commands.
+    /// `judge_worktree` already checked that `branch` is fleet-prefixed
+    /// before a `Reclaim` verdict is reachable, so this never sees a
+    /// foreign or absent branch.
     async fn remove_worktree(
         &self,
         path: &Path,
         branch: &str,
         force: bool,
+        base_ref: &str,
     ) -> Result<bool, WorktreeError> {
-        let path_str = path_arg(path)?;
-        let mut args = vec!["worktree", "remove"];
-        if force {
-            args.push("--force");
-        }
-        args.push(path_str);
-        let out = self.git.run(&self.repo_root, &args).await?;
-        ensure_ok(out, &format!("worktree remove {path_str}"))?;
-
-        if branch.is_empty() || !branch.starts_with(&self.branch_prefix) {
-            return Ok(false);
-        }
-        let out = self
-            .git
-            .run(&self.repo_root, &["branch", "-D", branch])
-            .await?;
-        ensure_ok(out, &format!("branch -D {branch}"))?;
-        Ok(true)
+        let RemoveOutcome { branch_deleted, .. } =
+            remove_worktree_and_branch(&self.git, &self.repo_root, path, branch, force, base_ref)
+                .await?;
+        Ok(branch_deleted)
     }
 
     /// The second half of the accumulation: a `fleet/*` branch whose worktree
@@ -501,7 +501,8 @@ impl<G: GitCli> Gc<G> {
             if !branch.starts_with(&self.branch_prefix) || attached.contains(&branch) {
                 continue;
             }
-            if !opts.force && !self.is_contained_in(branch, base_ref).await? {
+            if !opts.force && !is_contained_in(&self.git, &self.repo_root, branch, base_ref).await?
+            {
                 verdicts.push(BranchVerdict {
                     branch: branch.to_string(),
                     action: BranchAction::Kept(KeepReason::UnmergedCommits),
@@ -541,22 +542,6 @@ impl<G: GitCli> Gc<G> {
             return Ok(true);
         }
         Ok(!out.stdout.trim().is_empty())
-    }
-
-    /// Whether every commit on `branch` is already reachable from `base_ref`
-    /// (`git merge-base --is-ancestor`). Exit 1 is git's real "no"; any
-    /// other failure means git could not answer, and an unanswered question
-    /// keeps the branch.
-    async fn is_contained_in(&self, branch: &str, base_ref: &str) -> Result<bool, GcError> {
-        let out = self
-            .git
-            .run(
-                &self.repo_root,
-                &["merge-base", "--is-ancestor", branch, base_ref],
-            )
-            .await
-            .map_err(WorktreeError::from)?;
-        Ok(out.success)
     }
 
     /// The ref merged-ness is judged against when the caller names none:

--- a/crates/stella-fleet/src/gc.rs
+++ b/crates/stella-fleet/src/gc.rs
@@ -447,12 +447,11 @@ impl<G: GitCli> Gc<G> {
     /// delete a branch that is still checked out somewhere). Returns whether
     /// the branch went with it.
     ///
-    /// Calls `remove_worktree_and_branch`, the same routine
+    /// Calls `remove_worktree_and_branch`, the routine
     /// [`WorktreeManager::remove`](crate::git::WorktreeManager::remove)
-    /// calls, instead of issuing its own `git` commands.
-    /// `judge_worktree` already checked that `branch` is fleet-prefixed
-    /// before a `Reclaim` verdict is reachable, so this never sees a
-    /// foreign or absent branch.
+    /// calls too. `judge_worktree` already checked that `branch` is
+    /// fleet-prefixed. The prefix is passed again here, so the delete
+    /// itself enforces the namespace rule, not just the earlier verdict.
     async fn remove_worktree(
         &self,
         path: &Path,
@@ -460,9 +459,16 @@ impl<G: GitCli> Gc<G> {
         force: bool,
         base_ref: &str,
     ) -> Result<bool, WorktreeError> {
-        let RemoveOutcome { branch_deleted, .. } =
-            remove_worktree_and_branch(&self.git, &self.repo_root, path, branch, force, base_ref)
-                .await?;
+        let RemoveOutcome { branch_deleted, .. } = remove_worktree_and_branch(
+            &self.git,
+            &self.repo_root,
+            path,
+            branch,
+            force,
+            base_ref,
+            Some(&self.branch_prefix),
+        )
+        .await?;
         Ok(branch_deleted)
     }
 

--- a/crates/stella-fleet/src/gc/tests.rs
+++ b/crates/stella-fleet/src/gc/tests.rs
@@ -74,6 +74,27 @@ async fn the_main_checkout_and_foreign_worktrees_are_never_candidates() {
     }
 }
 
+/// `sweep` never reaches this case: `judge_worktree` refuses a foreign
+/// branch first. Drives `remove_worktree` directly to prove the extra
+/// guard `allowed_branch_prefix` adds still holds on its own.
+#[tokio::test]
+async fn remove_worktree_refuses_a_branch_outside_its_own_namespace_even_direct() {
+    let gc = scripted(|_| GitOutput::ok(""));
+    let deleted = gc
+        .remove_worktree(Path::new("/repo/hand-made"), "my-feature", true, "main")
+        .await
+        .expect("remove_worktree");
+    assert!(
+        !deleted,
+        "a branch outside fleet/ must never be deleted, force included"
+    );
+    assert!(
+        !gc.git.calls().iter().any(|c| c[0] == "branch"),
+        "no branch -D was even attempted: {:?}",
+        gc.git.calls()
+    );
+}
+
 #[tokio::test]
 async fn a_dry_run_mutates_nothing() {
     let gc = scripted(|args| match arg(args, 0) {

--- a/crates/stella-fleet/src/git.rs
+++ b/crates/stella-fleet/src/git.rs
@@ -443,6 +443,7 @@ impl<G: GitCli> WorktreeManager<G> {
             &worktree.branch,
             opts.force,
             contained_in,
+            None,
         )
         .await
     }
@@ -574,6 +575,14 @@ pub(crate) async fn is_contained_in(
 /// <path>`, then `git branch -D <branch>` when `force` or
 /// [`is_contained_in`] says it is safe. [`WorktreeManager::remove`] and
 /// [`Gc`](crate::gc::Gc)'s sweep are its only two callers.
+///
+/// `allowed_branch_prefix` is [`Gc`](crate::gc::Gc)'s namespace rule, kept
+/// here rather than trusted to the caller: even though `Gc::judge_worktree`
+/// already refuses a foreign branch before a removal is ever reached, the
+/// branch delete happens here, so the check belongs here too. `None` (what
+/// [`WorktreeManager::remove`] passes) skips it — a manager's own branch
+/// prefix is a configuration choice, not a namespace this routine can judge,
+/// so a manager may delete whatever branch its own `Worktree` value names.
 pub(crate) async fn remove_worktree_and_branch(
     git: &dyn GitCli,
     repo_root: &Path,
@@ -581,6 +590,7 @@ pub(crate) async fn remove_worktree_and_branch(
     branch: &str,
     force: bool,
     contained_in: &str,
+    allowed_branch_prefix: Option<&str>,
 ) -> Result<RemoveOutcome, WorktreeError> {
     let path_str = path_arg(path)?;
     let mut args: Vec<&str> = vec!["worktree", "remove"];
@@ -590,6 +600,17 @@ pub(crate) async fn remove_worktree_and_branch(
     args.push(path_str);
     let out = git.run(repo_root, &args).await?;
     ensure_ok(out, &args.join(" "))?;
+
+    // A branch outside the caller's own namespace is never a delete
+    // candidate, `force` included. Reported as "had commits" (kept) rather
+    // than a third outcome, so the two fields stay complementary for every
+    // caller reading them.
+    if allowed_branch_prefix.is_some_and(|prefix| !branch.starts_with(prefix)) {
+        return Ok(RemoveOutcome {
+            branch_deleted: false,
+            branch_had_commits: true,
+        });
+    }
 
     let branch_had_commits = if force {
         false

--- a/crates/stella-fleet/src/git.rs
+++ b/crates/stella-fleet/src/git.rs
@@ -158,12 +158,28 @@ pub struct WorktreeEntry {
 /// What [`WorktreeManager::remove`] did with the task's branch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RemoveOutcome {
-    /// The branch was deleted because it carried no commits beyond its base
-    /// (nothing to keep).
+    /// The branch was deleted because it was already contained in the
+    /// containment ref (nothing to keep).
     pub branch_deleted: bool,
-    /// The branch had commits beyond its base, so it was preserved (the
-    /// worker's work is not thrown away on cleanup).
+    /// The branch carried commits the containment ref does not have, so it
+    /// was preserved (the worker's work is not thrown away on cleanup).
     pub branch_had_commits: bool,
+}
+
+/// Options for [`WorktreeManager::remove`]. [`Gc`](crate::gc::Gc)'s sweep
+/// uses the same struct, so both callers judge a branch the same way.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RemoveOptions<'a> {
+    /// Skip the containment check. Force the worktree removal
+    /// (`git worktree remove --force`) and the branch delete. A caller
+    /// still owns its own in-flight or namespace rule; apply that first.
+    pub force: bool,
+    /// The ref the branch must already be an ancestor of
+    /// (`git merge-base --is-ancestor <branch> <ref>`). `None` falls back
+    /// to [`Worktree::base_ref`] — the right default for a lone task.
+    /// [`Gc`](crate::gc::Gc) passes one explicitly: it lists worktrees from
+    /// `git worktree list` and has no [`Worktree`] value to read.
+    pub contained_in: Option<&'a str>,
 }
 
 /// Typed worktree/commit failures.
@@ -405,41 +421,30 @@ impl<G: GitCli> WorktreeManager<G> {
         })
     }
 
-    /// Remove a worktree (`git worktree remove`), then clean up its branch
-    /// **only if unchanged** — a branch with commits beyond its base is
-    /// preserved so a worker's committed work is never discarded on cleanup.
-    /// Fails (does not force) if the worktree has uncommitted changes.
-    pub async fn remove(&self, worktree: &Worktree) -> Result<RemoveOutcome, WorktreeError> {
-        let path_str = path_arg(&worktree.path)?;
-        let out = self
-            .git
-            .run(&self.repo_root, &["worktree", "remove", path_str])
-            .await?;
-        ensure_ok(out, &format!("worktree remove {path_str}"))?;
-
-        let has_commits = self
-            .branch_has_commits_beyond_base(&worktree.branch, &worktree.base_ref)
-            .await?;
-        let branch_deleted = if has_commits {
-            false
-        } else {
-            // Branch is at base with no new commits → safe to delete. `-D`
-            // (not `-d`) because "merged" is judged by us via rev-list, not
-            // by git's HEAD-relative check.
-            let out = self
-                .git
-                .run(&self.repo_root, &["branch", "-D", &worktree.branch])
-                .await?;
-            // Surface a failed delete (e.g. the branch is checked out
-            // elsewhere) rather than silently reporting a clean no-delete,
-            // which would hide a leaked branch and the real git error.
-            ensure_ok(out, &format!("branch -D {}", worktree.branch))?;
-            true
-        };
-        Ok(RemoveOutcome {
-            branch_deleted,
-            branch_had_commits: has_commits,
-        })
+    /// Remove a worktree (`git worktree remove`, forced when
+    /// [`RemoveOptions::force`] is set). Then clean up its branch **only if
+    /// it is already contained in the containment ref**. A branch carrying
+    /// commits the ref does not have is kept, so a worker's committed work
+    /// is never thrown away on cleanup. Fails on a dirty worktree unless
+    /// `opts.force` is set.
+    ///
+    /// [`Gc`](crate::gc::Gc)'s sweep drives this same routine, so the
+    /// containment check lives in one place, not two.
+    pub async fn remove(
+        &self,
+        worktree: &Worktree,
+        opts: &RemoveOptions<'_>,
+    ) -> Result<RemoveOutcome, WorktreeError> {
+        let contained_in = opts.contained_in.unwrap_or(worktree.base_ref.as_str());
+        remove_worktree_and_branch(
+            &self.git,
+            &self.repo_root,
+            &worktree.path,
+            &worktree.branch,
+            opts.force,
+            contained_in,
+        )
+        .await
     }
 
     /// Throw a worktree away whether or not it is dirty: `git worktree remove
@@ -543,27 +548,70 @@ impl<G: GitCli> WorktreeManager<G> {
         let out = ensure_ok(out, "status --porcelain")?;
         Ok(out.stdout)
     }
+}
 
-    /// Whether `branch` has any commit beyond `base_ref` (`git rev-list
-    /// --count base..branch > 0`). On any error resolving the range, err
-    /// conservative — report `true` so the branch is kept, never silently
-    /// deleted.
-    async fn branch_has_commits_beyond_base(
-        &self,
-        branch: &str,
-        base_ref: &str,
-    ) -> Result<bool, WorktreeError> {
-        let range = format!("{base_ref}..{branch}");
-        let out = self
-            .git
-            .run(&self.repo_root, &["rev-list", "--count", &range])
-            .await?;
-        if !out.success {
-            return Ok(true);
-        }
-        let count: u64 = out.stdout.trim().parse().unwrap_or(1);
-        Ok(count > 0)
+/// Whether every commit on `branch` is already reachable from `ref_name`
+/// (`git merge-base --is-ancestor branch ref_name`). [`remove_worktree_and_branch`]
+/// and [`Gc`](crate::gc::Gc)'s loose-branch sweep both judge a branch this
+/// way. Exit 1 is git's real "no". Any other failure means git could not
+/// answer, and an unanswered question keeps the branch.
+pub(crate) async fn is_contained_in(
+    git: &dyn GitCli,
+    repo_root: &Path,
+    branch: &str,
+    ref_name: &str,
+) -> Result<bool, WorktreeError> {
+    let out = git
+        .run(
+            repo_root,
+            &["merge-base", "--is-ancestor", branch, ref_name],
+        )
+        .await?;
+    Ok(out.success)
+}
+
+/// The one worktree/branch removal routine: `git worktree remove [--force]
+/// <path>`, then `git branch -D <branch>` when `force` or
+/// [`is_contained_in`] says it is safe. [`WorktreeManager::remove`] and
+/// [`Gc`](crate::gc::Gc)'s sweep are its only two callers.
+pub(crate) async fn remove_worktree_and_branch(
+    git: &dyn GitCli,
+    repo_root: &Path,
+    path: &Path,
+    branch: &str,
+    force: bool,
+    contained_in: &str,
+) -> Result<RemoveOutcome, WorktreeError> {
+    let path_str = path_arg(path)?;
+    let mut args: Vec<&str> = vec!["worktree", "remove"];
+    if force {
+        args.push("--force");
     }
+    args.push(path_str);
+    let out = git.run(repo_root, &args).await?;
+    ensure_ok(out, &args.join(" "))?;
+
+    let branch_had_commits = if force {
+        false
+    } else {
+        !is_contained_in(git, repo_root, branch, contained_in).await?
+    };
+    let branch_deleted = if branch_had_commits {
+        false
+    } else {
+        // `-D` (not `-d`) because "merged" is judged by us via
+        // `is_contained_in`, not by git's HEAD-relative check.
+        let out = git.run(repo_root, &["branch", "-D", branch]).await?;
+        // Surface a failed delete (e.g. the branch is checked out elsewhere)
+        // rather than silently reporting a clean no-delete, which would hide
+        // a leaked branch and the real git error.
+        ensure_ok(out, &format!("branch -D {branch}"))?;
+        true
+    };
+    Ok(RemoveOutcome {
+        branch_deleted,
+        branch_had_commits,
+    })
 }
 
 /// Parse `git worktree list --porcelain` into entries. Records are
@@ -846,12 +894,12 @@ mod tests {
         assert!(mgr.git.calls().is_empty());
     }
 
-    // remove: branch cleanup only on unchanged
+    // remove: branch cleanup only when contained in the containment ref
 
     #[tokio::test]
-    async fn remove_deletes_the_branch_when_it_has_no_commits_beyond_base() {
+    async fn remove_deletes_the_branch_when_it_is_contained_in_the_base_ref() {
         let git = ScriptedGit::new(|args| match args.first().map(String::as_str) {
-            Some("rev-list") => GitOutput::ok("0\n"), // unchanged
+            Some("merge-base") => GitOutput::ok(""), // ancestor: contained
             _ => GitOutput::ok(""),
         });
         let mgr = manager(git);
@@ -860,7 +908,7 @@ mod tests {
             branch: "fleet/t".into(),
             base_ref: "HEAD".into(),
         };
-        let outcome = mgr.remove(&wt).await.unwrap();
+        let outcome = mgr.remove(&wt, &RemoveOptions::default()).await.unwrap();
         assert!(outcome.branch_deleted);
         assert!(!outcome.branch_had_commits);
         let calls = mgr.git.calls();
@@ -874,7 +922,7 @@ mod tests {
     #[tokio::test]
     async fn remove_preserves_a_branch_that_has_commits() {
         let git = ScriptedGit::new(|args| match args.first().map(String::as_str) {
-            Some("rev-list") => GitOutput::ok("3\n"), // three commits beyond base
+            Some("merge-base") => GitOutput::failed(1, ""), // not an ancestor: unmerged
             _ => GitOutput::ok(""),
         });
         let mgr = manager(git);
@@ -883,11 +931,78 @@ mod tests {
             branch: "fleet/t".into(),
             base_ref: "HEAD".into(),
         };
-        let outcome = mgr.remove(&wt).await.unwrap();
+        let outcome = mgr.remove(&wt, &RemoveOptions::default()).await.unwrap();
         assert!(!outcome.branch_deleted);
         assert!(outcome.branch_had_commits);
         // Never issued a branch delete.
         assert!(!mgr.git.calls().iter().any(|c| c[0] == "branch"));
+    }
+
+    #[tokio::test]
+    async fn remove_judges_against_an_explicit_contained_in_ref_over_base_ref() {
+        // `base_ref` says "unmerged" (a failed merge-base), but the caller
+        // passes an explicit `contained_in` that says "merged" — the
+        // explicit ref wins, which is the whole point of the field: `Gc`
+        // has no `Worktree::base_ref` to fall back to.
+        let git = ScriptedGit::new(|args| match args.first().map(String::as_str) {
+            Some("merge-base") if args.get(3).map(String::as_str) == Some("origin/main") => {
+                GitOutput::ok("")
+            }
+            Some("merge-base") => GitOutput::failed(1, ""),
+            _ => GitOutput::ok(""),
+        });
+        let mgr = manager(git);
+        let wt = Worktree {
+            path: PathBuf::from("/repo/.stella/worktrees/t"),
+            branch: "fleet/t".into(),
+            base_ref: "HEAD".into(),
+        };
+        let outcome = mgr
+            .remove(
+                &wt,
+                &RemoveOptions {
+                    force: false,
+                    contained_in: Some("origin/main"),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(outcome.branch_deleted);
+        assert!(!outcome.branch_had_commits);
+    }
+
+    #[tokio::test]
+    async fn remove_force_skips_the_containment_check_and_forces_both_removals() {
+        let git = ScriptedGit::new(|_| GitOutput::ok(""));
+        let mgr = manager(git);
+        let wt = Worktree {
+            path: PathBuf::from("/repo/.stella/worktrees/t"),
+            branch: "fleet/t".into(),
+            base_ref: "HEAD".into(),
+        };
+        let outcome = mgr
+            .remove(
+                &wt,
+                &RemoveOptions {
+                    force: true,
+                    contained_in: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(outcome.branch_deleted);
+        assert!(!outcome.branch_had_commits);
+        let calls = mgr.git.calls();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c[..3] == ["worktree", "remove", "--force"]),
+            "{calls:?}"
+        );
+        assert!(
+            !calls.iter().any(|c| c[0] == "merge-base"),
+            "force must skip the containment check entirely: {calls:?}"
+        );
     }
 
     // list parsing
@@ -1022,7 +1137,7 @@ detached
 
         // An untouched worktree → branch deleted on removal.
         let clean = mgr.create("clean", &base).await.unwrap();
-        let outcome = mgr.remove(&clean).await.unwrap();
+        let outcome = mgr.remove(&clean, &RemoveOptions::default()).await.unwrap();
         assert!(outcome.branch_deleted, "an unchanged branch is cleaned up");
 
         // A worktree with a commit → branch preserved on removal.
@@ -1031,7 +1146,10 @@ detached
         mgr.commit_paths(&worked.path, &[Path::new("f.txt")], "work")
             .await
             .unwrap();
-        let outcome = mgr.remove(&worked).await.unwrap();
+        let outcome = mgr
+            .remove(&worked, &RemoveOptions::default())
+            .await
+            .unwrap();
         assert!(!outcome.branch_deleted, "a committed branch is preserved");
         assert!(outcome.branch_had_commits);
     }

--- a/crates/stella-fleet/src/lib.rs
+++ b/crates/stella-fleet/src/lib.rs
@@ -89,8 +89,8 @@ pub use gc::{
     WorktreeActivity, WorktreeVerdict,
 };
 pub use git::{
-    GitCli, GitError, GitOutput, RemoveOutcome, SystemGitCli, Worktree, WorktreeEntry,
-    WorktreeError, WorktreeManager,
+    GitCli, GitError, GitOutput, RemoveOptions, RemoveOutcome, SystemGitCli, Worktree,
+    WorktreeEntry, WorktreeError, WorktreeManager,
 };
 pub use ledger::{
     AttemptFinish, AttemptId, AttemptStart, CommitRecord, Ledger, LedgerError, RunRecord,


### PR DESCRIPTION
## What / why

Two independent worktree-removal implementations lived in `stella-fleet`:

- `WorktreeManager::remove` (`git.rs`) judged a branch safe to delete by
  counting commits beyond the task's own `Worktree::base_ref`
  (`git rev-list --count`).
- `Gc::remove_worktree` (`gc.rs`) judged safety by checking the branch is
  contained in a resolved integration ref (`git merge-base --is-ancestor`).

They diverged because `Gc` discovers worktrees from `git worktree list` and
has no `Worktree` value (so no `base_ref`) to read, and had no `--force`
rung on the `WorktreeManager` side. Two removal paths judging safety two
different ways is exactly the shape where a future fix to one silently
misses the other.

## The fix

Following the issue's own triage comment (shape 1): `WorktreeManager::remove`
now takes an explicit `RemoveOptions { force, contained_in }`. Both callers
drive one routine — `is_contained_in` + `remove_worktree_and_branch`, new
free functions in `git.rs` — judged uniformly by `merge-base --is-ancestor`:

- `remove()`'s `contained_in` defaults to `Worktree::base_ref` when the
  caller passes `None`, the right answer for a lone task with no wider
  integration ref in play.
- `Gc::remove_worktree` passes its own resolved integration ref as
  `contained_in` explicitly (it has no `Worktree` value to fall back to).

**One deviation from the issue's exact framing, and why:** the issue expects
`Gc` to literally call `WorktreeManager::remove(&self, ...)`, which would
mean `Gc` composing a `WorktreeManager` instance. `Gc`'s own tests assert on
`gc.git.calls()` directly (a private field, readable only because the test
module is a descendant of `gc`) to prove the exact argv reaching git — the
issue's own "Constraints" section requires keeping this. `WorktreeManager`'s
`ScriptedGit` test fake isn't `Clone`, so composing a manager inside `Gc`
would mean either breaking those argv assertions or making the test fake
`Clone` for no other reason. Instead, the removal routine is two `pub(crate)`
free functions in `git.rs` that both `WorktreeManager::remove` and
`Gc::remove_worktree` call with their own `&self.git` — the predicate and the
mutation still live in exactly one place, and every existing test keeps its
shape.

**A premise correction, found while re-verifying against the tree** (the
issue's reopening comment asked for exactly this): it said
`WorktreeManager::remove` "still has zero production callers." That was true
when filed on 2026-08-06; it no longer is —
`crates/stella-cli/src/self_driving_cmd/work.rs`'s `start()` already calls
`manager.remove(&created)` to release a per-issue worktree whose turn changed
nothing. That call site is updated for the new signature
(`&RemoveOptions::default()`, which preserves its exact prior behavior: judge
against the worktree's own `base_ref`).

`crates/stella-fleet/README.md`'s two gotchas describing the split are
rewritten to describe the one routine, and the stale "`WorktreeManager::remove`
has left this list" paragraph (which had drifted to also being wrong) now
correctly says the one production caller.

## Exemplar

None named — this is an in-crate consolidation of two existing predicates
into a shared free-function pair, not a new pattern borrowed from elsewhere.

## Witness

`git.rs`'s existing `remove` tests are rewritten to assert the `merge-base`
predicate instead of `rev-list` (they fail on the old code by construction:
the old code never issued a `merge-base` call from `remove()` at all), plus
two new tests:

- `remove_judges_against_an_explicit_contained_in_ref_over_base_ref` — proves
  an explicit `contained_in` wins over `base_ref` (this is the exact
  capability `Gc` needs and the old `remove()` could not do).
- `remove_force_skips_the_containment_check_and_forces_both_removals` — proves
  `force` skips `merge-base` entirely and forces both removals (the old
  `remove()` had no `force` rung at all — this behavior is new).

Every pre-existing `gc.rs` test passes unchanged, including the two the issue
names by name: `real_git_gc_reclaims_a_finished_worktree_and_keeps_live_dirty_and_unmerged_ones`
and `real_git_force_reclaims_dirty_and_unmerged_but_not_in_flight`. That
proves the sweep's observable behavior held through the refactor of its
internals.

```
cargo test -p stella-fleet --lib        # 141 passed
cargo clippy -p stella-fleet --all-targets -- -D warnings   # clean
cargo clippy -p stella-cli --all-targets -- -D warnings     # clean
RUSTDOCFLAGS="-D warnings" cargo doc -p stella-fleet --no-deps   # clean
make guards-fast                        # clean
```

Tests deleted: None. Two `git.rs` tests were renamed (same assertions, new
predicate under test) rather than deleted:
`remove_deletes_the_branch_when_it_has_no_commits_beyond_base` →
`remove_deletes_the_branch_when_it_is_contained_in_the_base_ref`.

`git.rs` grew from 1038 to ~1165 lines (well under the 1500-line ratchet and
not grandfathered), so it stays a single file rather than splitting into a
submodule per the issue's "splitting is preferred to growing" constraint —
there was no natural seam that made a split clearer than the extra ~130
lines of load-bearing code (a struct, two free functions, and four new
tests).

Closes #1656

## Summary by Sourcery

Unify worktree and branch cleanup behind shared containment-aware removal behavior for task cleanup and garbage collection.

Bug Fixes:
- Consolidate worktree and branch removal safety checks so both task cleanup and garbage collection consistently use containment against an integration ref.

Enhancements:
- Add configurable removal options for forced cleanup and explicit containment refs, while preserving fallback to a worktree's base ref.
- Protect garbage collection from deleting branches outside its fleet namespace, including during forced removal.

Documentation:
- Update fleet documentation to describe the unified removal behavior and current production caller.

Tests:
- Update removal tests for merge-base containment and add coverage for explicit containment refs, forced removal, and namespace protection.