### PR TITLE
fix(bench): manifest-parity sweep skips ignored files

### DIFF
--- a/bench/harbor_adapter/tests/test_manifest_parity.py
+++ b/bench/harbor_adapter/tests/test_manifest_parity.py
@@ -83,6 +83,7 @@ import importlib.util
 import inspect
 import os
 import re
+import subprocess
 from pathlib import Path
 from types import ModuleType
 from typing import Any, NamedTuple
@@ -350,7 +351,8 @@ _PACKAGE_PARTS = ("bench", "harbor_adapter", "stella_harbor")
 #: Directory names never descended into. Build output and virtualenvs hold
 #: vendored copies of this adapter's own dependencies, and `.claude/` holds
 #: agent worktrees — each a second checkout of this repository, which would be
-#: swept as though its files were this one's.
+#: swept as though its files were this one's. Used even when `git` is
+#: missing; `_git_files` below covers the rest of `.gitignore`.
 _PRUNED_DIRS = frozenset(
     {
         ".git",
@@ -435,12 +437,66 @@ def _adapter_package(root: Path) -> Path:
     return package
 
 
+@functools.cache
+def _git_files(root: Path) -> tuple[str, ...] | None:
+    """Every path under `root` a pull request can actually change.
+
+    `git ls-files --cached --others --exclude-standard` asks git one
+    question: is this file tracked, or untracked-but-not-ignored? That is
+    the sweep's universe now, read straight from git instead of walked by
+    hand. A cached search result under `.stella/context/packs/`, an old
+    `build/` tree, or any other gitignored file was never a caller a rename
+    has to keep working, and this list simply does not contain it. A
+    tracked file matching a `.gitignore` pattern by name still does appear:
+    `--cached` lists every tracked file no matter what `.gitignore` says.
+    Tracked-ness decides this, not a directory name.
+
+    `None` when `root` is not a git worktree at all: a source tarball, a
+    vendored checkout with no `.git` directory, or the synthetic trees
+    `TestSweepAntiVacuity` builds under `tmp_path` without a `git init`.
+    `_walk` then falls back to a plain filesystem walk pruned only by
+    `_PRUNED_DIRS` — exactly its behaviour before this function existed.
+    """
+    try:
+        result = subprocess.run(
+            (
+                "git",
+                "-C",
+                str(root),
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                "-z",
+            ),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    return tuple(entry for entry in result.stdout.split("\0") if entry)
+
+
+def _pruned(relative: Path) -> bool:
+    """Whether any component of `relative` (its directories only) is pruned."""
+    return any(part in _PRUNED_DIRS for part in relative.parts[:-1])
+
+
 def _walk(root: Path, suffixes: frozenset[str]) -> list[Path]:
     """Every file under `root` with one of `suffixes`, pruned and sorted.
 
     Sorted so a failure list is stable across machines: the tree is walked to
     produce a diffable report, not just a boolean.
     """
+    tracked = _git_files(root)
+    if tracked is not None:
+        return sorted(
+            root / entry
+            for entry in tracked
+            if Path(entry).suffix in suffixes and not _pruned(Path(entry))
+        )
     found: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = sorted(name for name in dirnames if name not in _PRUNED_DIRS)
@@ -942,3 +998,44 @@ class TestSweepAntiVacuity:
             "arm.sh:2" in problem and "_validated_witness_author" in problem
             for problem in problems
         ), problems
+
+    def test_a_stranded_name_is_a_failure_only_when_it_is_not_gitignored(
+        self, tmp_path: Path
+    ) -> None:
+        """Tracked-ness decides this, not a directory name.
+
+        `bench/.gitignore` ignores `build/`, `dist/` and `.egg-info/`.
+        `_PRUNED_DIRS` names none of them. A stale sdist or a cached search
+        result under `.stella/context/packs/` can carry a `stella_harbor`
+        import that no rename ever has to keep working. A real caller one
+        directory over must still fail. Both trees sit side by side here,
+        in one real `git` repository — a bare `.gitignore` file with no
+        repository around it tells git nothing.
+        """
+        self._skeleton(tmp_path)
+        subprocess.run(("git", "init", "-q"), cwd=tmp_path, check=True)
+        (tmp_path / ".gitignore").write_text("ignored_stuff/\n", encoding="utf-8")
+
+        ignored = tmp_path / "ignored_stuff"
+        ignored.mkdir()
+        (ignored / "caller.py").write_text(
+            f"from {_ADAPTER}.no_such_ignored_module import thing\nthing()\n",
+            encoding="utf-8",
+        )
+
+        kept = tmp_path / "kept_stuff"
+        kept.mkdir()
+        (kept / "caller.py").write_text(
+            f"from {_ADAPTER}.no_such_tracked_module import thing\nthing()\n",
+            encoding="utf-8",
+        )
+        # `git add` stages the file, so it counts as tracked.
+        subprocess.run(("git", "add", "kept_stuff/caller.py"), cwd=tmp_path, check=True)
+
+        problems = _sweep(tmp_path).problems
+        assert not any("no_such_ignored_module" in problem for problem in problems), (
+            problems
+        )
+        assert any("no_such_tracked_module" in problem for problem in problems), (
+            problems
+        )


### PR DESCRIPTION
## What

`bench/harbor_adapter/tests/test_manifest_parity.py`'s class-level sweep (`_walk`) walked the whole filesystem tree and pruned only a hardcoded `_PRUNED_DIRS` set. It never consulted `.gitignore`, so any gitignored file that happened to quote `stella_harbor` was counted as a live caller of the adapter — most concretely, a cached search result under `.stella/context/packs/` on a box that has run Stella locally, but also a stray `build/`, `dist/`, or `.egg-info/` tree that neither `.gitignore` nor `_PRUNED_DIRS` agreed on.

## Why

CI's clean checkout never has a `.stella/context/packs/` directory, so the suite was green there and red locally — an asymmetry that makes `pytest -q` unreliable as a pre-push check and teaches a contributor to distrust a red run of the one test class that must never be ignorable (it exists to catch #2182's shape: a rename that silently strands a live caller).

## The fix

`_walk` now derives its file universe from `git ls-files --cached --others --exclude-standard` instead of walking the filesystem: tracked files, plus untracked files `.gitignore` (nested files and `!` negations included) does not name. That is exactly the set a pull request can change, and exactly the set `bench.yml`'s scope filter (`grep -Eq '^(bench/|…)'`) is already expressed over — so `test_the_bench_workflow_runs_when_a_caller_changes`'s parity assertion becomes an honest comparison instead of an approximate one, per the issue's own stated preference.

A tracked file matching a `.gitignore` pattern by name is still swept, because `--cached` lists the index unconditionally — the question this answers is tracked-ness, not a path, which is the issue's explicit constraint (do not special-case `.stella/`).

Falls back to the previous `_PRUNED_DIRS`-pruned filesystem walk when git is unavailable: a source tarball, a vendored checkout with no `.git`, or the synthetic trees `TestSweepAntiVacuity` builds under `tmp_path` without a `git init` — those tests are unaffected, since `git ls-files` there fails ("not a git repository") and `_walk` behaves exactly as before.

## Witness

`TestSweepAntiVacuity::test_a_stranded_name_is_a_failure_only_when_it_is_not_gitignored` builds a real `git` repo under `tmp_path`, places a stranded caller under a gitignored directory next to one staged (`git add`, no commit needed) as tracked, and asserts the sweep reports only the tracked one.

- Fails on `main`: both callers are reported as problems (verified by running the new test body against `origin/main`'s copy of the file).
- Passes with this change: only the tracked caller is reported.

Also reproduced the issue's own literal repro — writing a file under `.stella/context/packs/` that quotes `stella_harbor:StellaAgent` — and confirmed `pytest -q tests/test_manifest_parity.py` stays green with the fix (17/17), where it fails on `main`.

Ran the full `harbor_adapter` suite locally via `uv sync --locked --extra dev && uv run --no-sync pytest -q`: 767 passed, 2 skipped (pre-existing, unrelated).

Tests deleted: None.

Closes #2947

## Summary by Sourcery

Align manifest-parity file discovery with Git's changeable-file set to prevent local ignored artifacts from causing false failures.

Bug Fixes:
- Ensure manifest-parity sweeps ignore gitignored files while continuing to detect stranded references in tracked files.
- Preserve the previous filesystem-walk behavior when Git is unavailable.

Enhancements:
- Add coverage verifying that tracked files are reported while gitignored files are excluded from the sweep.

Tests:
- Add an anti-vacuity test covering tracked versus gitignored stranded callers.

---

## Independent DoD verification (#2947)

The `dod` gate read red on this head against #2947's four unticked boxes. They are ticked now, each checked against the diff and against a run rather than against this description — full evidence in [the verification comment on #2947](https://github.com/macanderson/stella/issues/2947#issuecomment-5530655814). This edit is also what re-arms the gate: `dod-check` fires on pull-request events, not on an issue edit, so the tick alone would have left the check red on a stale run. No code changed in this edit.

The controlling evidence is a direct reproduction of the issue's own repro, in a worktree at `af36fa9` with the issue's exact pack file planted (`git check-ignore` confirms `.gitignore:62:/.stella/*`; `git ls-files --cached --others --exclude-standard` does not list it). Holding that file constant and varying only which copy of `test_manifest_parity.py` is checked out:

| `test_manifest_parity.py` from | result |
|---|---|
| `af948768` (this PR's base) | **1 failed**, 15 passed |
| `af36fa9` (this head) | **17 passed** |

The failure on the base is the issue's reported message verbatim (`bench.yml's scope filter does not match ['.stella/context/packs/bench-eval-state.json']`), so the boxes rest on an observed fail→pass flip rather than on an inference.

1. **A gitignored file does not fail the suite.** `--exclude-standard` drops the pack before any suffix filter runs; confirmed by the green run above with the file present.
2. **A tracked file still does, witnessed on both cases.** `test_a_stranded_name_is_a_failure_only_when_it_is_not_gitignored` fixtures a gitignored caller beside a `git add`ed one in one real repo, asserting only the tracked one is reported — so it cannot degrade into a blanket exemption.
3. **The anti-vacuity guard passes for the right reason.** `test_the_sweep_reads_the_repository_before_it_judges_it` runs `_require_non_vacuous(_sweep(_REPO_ROOT))` against the real checkout, so it can only pass on a non-empty caller set git actually listed. Both it and the new witness pass when selected by name (2 passed, 15 deselected).
4. **Green on a box that has run Stella locally.** That box is the table above — a checkout carrying `.stella/context/packs/`, the state the issue says CI never reaches.

CI on this head agrees: `harbor_adapter + analyzer pytest` reports `success` ([job 100774599819](https://github.com/macanderson/stella/actions/runs/33793228166/job/100774599819)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHHM6wiGvZXkW6rLPPBT3J