### PR TITLE
feat(stella-model): declare context editing off until its trigger is measured

### DIFF
--- a/crates/stella-model/src/anthropic.rs
+++ b/crates/stella-model/src/anthropic.rs
@@ -102,11 +102,12 @@ impl AnthropicProvider {
             pricing,
             previous_tails: std::sync::Mutex::new(Vec::new()),
             cache_ttl: CacheTtl::default(),
-            // Off by default. Context editing trades prompt cache for context
-            // room, and a session that never outgrows its window would pay the
-            // invalidation and get nothing; the caller who knows the shape of
-            // its conversation opts in.
-            context_management: None,
+            // The fleet-wide decision, read from one place rather than
+            // written as an inline `None` no test can see: context editing is
+            // declared off until its trigger is measured (ADR 0026, `#5796`). A
+            // caller that knows the shape of its own conversation still opts
+            // in with `with_context_editing`.
+            context_management: context_edit::shipped_context_management(),
             recovery: StreamRecovery::default(),
             unary_client: http::unary_client(),
             first_byte_deadline: http::FIRST_BYTE_TIMEOUT,
@@ -168,16 +169,22 @@ impl AnthropicProvider {
     /// context-management field in the chat-completions dialect first, plus a
     /// row on [`crate::provider_parity`] — neither exists.
     ///
-    /// # No caller, until the trigger is measured
+    /// # Declared off, until the trigger is measured
     ///
-    /// Nothing calls this outside its tests, because the value that decides
-    /// whether it helps or hurts — `trigger_tokens` — has not been measured.
-    /// Below the trigger nothing clears and a short conversation stays fully
-    /// cached; above it, every edit invalidates the cached prefix from the
-    /// edit point and pays a cache write. At Stella's observed cache-hit rate
-    /// that is a read at $0.30/MTok against a write at $3.75/MTok, so a
-    /// guessed trigger is a 12.5x mistake in whichever direction it is wrong.
-    /// #3756 holds the panel design that would settle it.
+    /// Nothing calls this outside its tests, and that is a decision rather
+    /// than a gap: the value that decides whether the feature helps or hurts —
+    /// `trigger_tokens` — has not been measured. Below the trigger nothing
+    /// clears and a short conversation stays fully cached; above it, every
+    /// edit invalidates the cached prefix from the edit point and pays a cache
+    /// write. At Stella's observed cache-hit rate that is a read at $0.30/MTok
+    /// against a write at $3.75/MTok, so a guessed trigger is a 12.5x mistake
+    /// in whichever direction it is wrong.
+    ///
+    /// The decision is recorded in
+    /// `doc:adr/0026-context-editing-ships-off-until-measured` and held as a
+    /// value by `context_edit::SHIPPED_TRIGGER_TOKENS`, which every fresh
+    /// provider reads. `#5796` is the panel that would replace it with a
+    /// measured number; `#3756` is where the question was raised.
     #[must_use]
     pub fn with_context_editing(
         mut self,

--- a/crates/stella-model/src/anthropic/context_edit.rs
+++ b/crates/stella-model/src/anthropic/context_edit.rs
@@ -37,6 +37,38 @@ use serde::Serialize;
 /// The beta that unlocks `context_management` on the Messages API.
 pub(crate) const CONTEXT_MANAGEMENT_BETA: &str = "context-management-2025-06-27";
 
+/// The trigger every session ships with, in input tokens, or `None` while the
+/// number is undecided.
+///
+/// It is `None`: context editing is declared **off**, and this is the one
+/// place that decides it (`doc:adr/0026-context-editing-ships-off-until-measured`).
+/// The trigger has never been measured, and both wrong answers are dear — a
+/// cache read bills at $0.30/MTok against a write at $3.75/MTok, so a trigger
+/// set low enough to fire on ordinary turns costs more than the tokens it
+/// clears, and one set high enough to be safe never fires. `#5796` is the panel
+/// that would settle it.
+///
+/// Off as a value rather than as an absence, because an absence reads as an
+/// oversight to the next author. `context_editing_ships_off_until_the_trigger_is_measured`
+/// pins this constant, so setting a number has to edit the test that says why
+/// it was `None`.
+pub(crate) const SHIPPED_TRIGGER_TOKENS: Option<u32> = None;
+
+/// The thinking policy that rides with [`SHIPPED_TRIGGER_TOKENS`] once it
+/// holds a number. `None` keeps every thinking block, which is the
+/// cache-preserving setting and what a current model does anyway.
+pub(crate) const SHIPPED_THINKING_TURNS: Option<u32> = None;
+
+/// What a fresh session puts on the wire: nothing, while
+/// [`SHIPPED_TRIGGER_TOKENS`] is undecided.
+///
+/// A caller that has measured its own conversation still opts in per session
+/// with [`crate::anthropic::AnthropicProvider::with_context_editing`]; this is
+/// the fleet-wide default underneath it.
+pub(crate) fn shipped_context_management() -> Option<ContextManagement> {
+    SHIPPED_TRIGGER_TOKENS.map(|trigger| ContextManagement::new(trigger, SHIPPED_THINKING_TURNS))
+}
+
 /// How many tool uses survive an edit. The vendor default; the most recent
 /// calls are the ones the model is actually still reasoning about, and
 /// clearing them is how an agent loses the file it just read.
@@ -161,6 +193,30 @@ impl ContextManagement {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The decision of `doc:adr/0026-context-editing-ships-off-until-measured`,
+    /// held as a test so that turning the feature on has to pass through the
+    /// record that says why it was off.
+    ///
+    /// Editing this test is the point. If a panel measures a trigger, set
+    /// [`SHIPPED_TRIGGER_TOKENS`], mark it `MEASURED:` with the run it came
+    /// from, and rewrite this assertion to pin that number. What must not
+    /// happen is a trigger appearing here with no measurement behind it: the
+    /// wrong number is a more-than-tenfold cost error, and it is silent.
+    #[test]
+    fn context_editing_ships_off_until_the_trigger_is_measured() {
+        assert!(
+            SHIPPED_TRIGGER_TOKENS.is_none(),
+            "context editing ships off (ADR 0026), and {SHIPPED_TRIGGER_TOKENS:?} \
+             is a trigger. `#5796` is the panel that would measure one; until it \
+             runs, a number here bills a cache write at $3.75/MTok to save a \
+             read at $0.30."
+        );
+        assert!(
+            shipped_context_management().is_none(),
+            "an undecided trigger must put nothing on the wire"
+        );
+    }
 
     #[test]
     fn thinking_is_listed_before_tool_uses() {

--- a/crates/stella-model/src/anthropic/tests/context_editing.rs
+++ b/crates/stella-model/src/anthropic/tests/context_editing.rs
@@ -1,12 +1,12 @@
-//! Context editing reaches the wire in the shape the API accepts — and does
-//! not reach it at all unless the session asked for it.
+//! Context editing reaches the wire in the shape the API accepts. It reaches
+//! it only when a session asks, or when the build declares a trigger in
+//! `context_edit::SHIPPED_TRIGGER_TOKENS`. Today it declares none.
 //!
-//! The off-by-default half is the one worth a test. Context editing trades
-//! prompt cache for context room: clearing invalidates the cached prefix from
-//! the point of the edit, and a cache re-write is priced an order of magnitude
-//! above a cache read. A session that quietly gained this feature would get
-//! slower and dearer with no symptom, which is exactly the failure this
-//! repository keeps finding in its own benchmarks.
+//! The off half is the one worth a test. Clearing buys context room and spends
+//! prompt cache: it throws away the cached prefix from the point of the edit,
+//! and a re-write costs about ten times a read. A session that gained this
+//! feature by accident would get slower and dearer with no sign. That is the
+//! failure this repository keeps finding in its own benchmarks.
 
 use super::*;
 
@@ -32,11 +32,16 @@ fn request() -> CompletionRequest {
     }
 }
 
-/// Nothing about a request changes until a caller opts in — no field, and no
-/// beta header. Both halves matter: the header is part of the request the
-/// prompt cache is keyed on.
+/// A session that did not opt in sends what the build declares. Today
+/// `SHIPPED_TRIGGER_TOKENS` is `None`, so it sends no field and no beta
+/// header. The header counts: the prompt cache is keyed on it.
+///
+/// The test reads the constant rather than asserting the absence. So it still
+/// means something once a panel sets a trigger: set the constant, and this
+/// asks for that trigger on the wire. Without it, the value and the request
+/// could disagree and nothing would say so.
 #[tokio::test]
-async fn a_session_that_did_not_opt_in_sends_no_context_management() {
+async fn a_session_that_did_not_opt_in_sends_the_trigger_this_build_ships() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/v1/messages"))
@@ -50,14 +55,22 @@ async fn a_session_that_did_not_opt_in_sends_no_context_management() {
 
     let sent = &server.received_requests().await.unwrap()[0];
     let body: serde_json::Value = serde_json::from_slice(&sent.body).unwrap();
-    assert!(
-        body.get("context_management").is_none(),
-        "context_management must be absent by default: {body}"
-    );
-    assert!(
-        sent.headers.get("anthropic-beta").is_none(),
-        "no beta header rides on a request carrying no beta field"
-    );
+    match crate::anthropic::context_edit::SHIPPED_TRIGGER_TOKENS {
+        None => {
+            assert!(
+                body.get("context_management").is_none(),
+                "the build ships no trigger, so no session may send one: {body}"
+            );
+            assert!(
+                sent.headers.get("anthropic-beta").is_none(),
+                "no beta header rides on a request carrying no beta field"
+            );
+        }
+        Some(trigger) => assert_eq!(
+            body["context_management"]["edits"][1]["trigger"]["value"], trigger,
+            "the wire must carry the trigger the build declares: {body}"
+        ),
+    }
 }
 
 /// The opted-in shape, asserted field by field against the documented

--- a/docs/adr/0026-context-editing-ships-off-until-measured.md
+++ b/docs/adr/0026-context-editing-ships-off-until-measured.md
@@ -1,0 +1,71 @@
+---
+id: adr/0026-context-editing-ships-off-until-measured
+title: "ADR 0026: Context editing ships off until its trigger is measured"
+status: implemented
+---
+
+# ADR 0026: Context editing ships off until its trigger is measured
+
+- Status: accepted
+- Date: 2026-09-03
+- Decides: `#3756`
+
+## Context
+
+The Anthropic Messages API can drop old tool results from a chat. It can drop
+old thinking blocks too. Stella can ask for that. The wire shape lives in
+`crates/stella-model/src/anthropic/context_edit.rs`. A mock server proves it.
+
+One number turns the feature on. It is the trigger. Below it, nothing is
+cleared. Above it, each edit throws away the cached prefix from the point of
+the edit.
+
+That number has never been measured. A cache read bills at $0.30/MTok. A cache
+write bills at $3.75/MTok. Stella runs near a 92% cache-hit rate. Set the
+trigger too low and long turns cost more, with no sign a user would see. Set
+it too high and nothing ever fires. Both ways the bill moves more than
+tenfold.
+
+Two counts on `#3756` bound the guess. Across 269,134 real model calls, only
+0.47% went past the vendor default of 100,000 input tokens. And Stella already
+trims old tool results itself, in compaction pass 0. That pass fires on a
+ratio, not a token count. Turn the server-side feature on and both would trim
+the same blocks. Each would spoil the prefix the other tries to keep.
+
+So the choice is not on or off. It is measure, or say out loud that we have
+not.
+
+## Decision
+
+Ship it off. Say so as a value, not as a gap.
+
+`SHIPPED_TRIGGER_TOKENS` in `context_edit.rs` is `None`. A fresh
+`AnthropicProvider` reads it. So no session sends `context_management`. A test
+pins the constant. Its message names this record and the panel issue. To set a
+number you must edit that test. That makes a guessed trigger a change a
+reviewer sees.
+
+`with_context_editing` stays. It is how one session opts in once its own shape
+is known. It is also how the panel will run its arms.
+
+There is no setting for this. The Anthropic page in the docs says so. A knob
+added now would only move the guess to a user.
+
+## Consequences
+
+The bill does not change. That is the point. A feature that sends nothing
+cannot make a session cost more.
+
+The measurement is still owed. It is a rig launch, not a code change: four
+arms over the same tasks, at triggers of 30k, 60k, 100k and off, on the direct
+`anthropic` route. Compare billed cost and cached tokens. It is filed as
+`#5796`. That issue carries the pass 0 question too.
+
+Gateway routes are out of reach either way. `factory::build_provider` sends
+every OpenAI-compatible provider to the shared chat-completions adapter.
+OpenRouter is one of them. That adapter has no such field. So a bench run
+through a gateway measures this feature as absent, whatever the gateway would
+have done.
+
+The panel may find no trigger that pays. Then this record is amended with the
+numbers and the constant stays `None`. That is an answer, not a failure.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -92,6 +92,7 @@ open; nothing before Phase 3 forces it.
 | [0023](0023-autonomous-tool-foundry.md) | Reconnect the Gap Detector; the Foundry Runs Autonomously Behind Standing Controls | Accepted |
 | [0024](0024-release-builds-unwind.md) | Release Builds Unwind on Panic | Accepted |
 | [0025](0025-nested-frontmatter-refusal-scope.md) | Refuse a Nested Key Where It Widens a Grant | Accepted |
+| [0026](0026-context-editing-ships-off-until-measured.md) | Context Editing Ships Off Until Its Trigger Is Measured | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -130,6 +130,11 @@
       "status": "implemented",
       "title": "ADR 0025: Refuse a nested key where it widens a grant"
     },
+    "adr/0026-context-editing-ships-off-until-measured": {
+      "path": "docs/adr/0026-context-editing-ships-off-until-measured.md",
+      "status": "implemented",
+      "title": "ADR 0026: Context editing ships off until its trigger is measured"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",

--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -194,6 +194,15 @@ headless run's calls are seconds apart and would pay the premium for a prefix th
 never going to expire. Override either default with
 [`providers.anthropic.cache_ttl`](/docs/configuration/settings) (`"5m"` or `"1h"`).
 
+**Server-side context editing is off, and there is no setting for it.** The Messages
+API can drop old tool results and thinking blocks from a chat before the model reads
+it. stella can ask for that, and does not: the trigger that decides when clearing
+starts has never been measured, and each edit throws away the cached prefix from the
+point of the edit. A cache read bills at $0.30/Mtok against a write at $3.75/Mtok, so
+a trigger picked by taste moves the bill more than tenfold in the direction you did
+not want. The decision is recorded in ADR 0026, and it holds until a panel measures
+the number.
+
 `params.max_tokens` defaults to **32000 with thinking on, 4096 with it off**. Adaptive
 thinking spends from the same output allowance as the answer, so without this, a
 max-effort verifier could get cut off mid-verdict. A value you set is used exactly as


### PR DESCRIPTION
## What and why

Server-side context editing has been written and witnessed since it landed, and inert ever since: nothing called `with_context_editing`. The reason lived only in a doc comment — the trigger that decides when the Messages API starts clearing tool results has never been measured. An absent caller reads as an oversight, so the next author can wire one with a guessed number and nothing in the tree objects.

Epic #3761's definition of done accepts either branch: a trigger justified by measurement, **or** an explicit declared-off with the reason recorded. The measurement is a rig launch and no rig has run, so this PR takes the second branch and makes the decision reviewable.

- `SHIPPED_TRIGGER_TOKENS` in `crates/stella-model/src/anthropic/context_edit.rs` holds the decision as a value. `AnthropicProvider::new` reads it, so it is the one place that decides what a fresh session sends. It is `None`.
- `context_editing_ships_off_until_the_trigger_is_measured` pins it. Setting a number has to edit the test that says why it was unset, which turns a one-line change into one a reviewer sees.
- ADR 0026 records the decision and the cost argument: a cache read bills at $0.30/MTok against a write at $3.75/MTok, so a guessed trigger moves the bill more than tenfold in the direction nobody wants.
- The Anthropic section of `website/content/docs/api-providers/index.mdx` says the feature is off and that there is no setting for it. Adding a knob before the number exists would only move the guess to a user.
- `with_context_editing` stays: it is how one session opts in once its own shape is known, and how the panel will run its arms.

The gateway half of the original issue title needs nothing further, and the answer comes from the code rather than from a status code: `factory::build_provider` routes every `Dialect::OpenaiCompatible` provider — `openrouter` among them — to the shared chat-completions adapter, which has no `context_management` field. A bench arm measured through a gateway measures this feature as absent whatever the gateway would have done. #4791 recorded that on the builder's doc; this PR leaves it where it is rather than adding a `provider_parity.rs` axis, because a row would declare a posture for a path that sends nothing on any route. The measurement issue says the axis is owed the day the feature is turned on.

## Witness mechanism

Two tests, both failing on `main` by construction — the constant they read does not exist there, so the crate does not compile without this change:

- `context_editing_ships_off_until_the_trigger_is_measured` (`anthropic/context_edit.rs`) asserts `SHIPPED_TRIGGER_TOKENS` is `None` and that `shipped_context_management()` puts nothing on the wire. It is the pin: it fails the moment someone sets a trigger without editing the record.
- `a_session_that_did_not_opt_in_sends_the_trigger_this_build_ships` (`anthropic/tests/context_editing.rs`) drives a real request through wiremock and matches the sent body against the constant. Today's arm asserts no `context_management` and no beta header; the `Some` arm asserts the declared trigger is on the wire. Reading the constant rather than asserting the absence is what keeps the test meaningful after a measured trigger is set — the declaration and the request cannot drift apart silently.

The behavioural change is small and real: `AnthropicProvider::new` no longer writes an inline `None`, it reads the declared policy, so flipping one constant changes every Anthropic session.

## Exemplar

The shape follows this repository's own `MEASURED:` discipline in reverse (AGENTS.md, "A constant set by a measurement carries `/// MEASURED:` and a test"): a number nobody measured is declared absent and pinned by a test, so the measurement has to arrive with the number.

## Tests deleted

`a_session_that_did_not_opt_in_sends_no_context_management` — renamed to `a_session_that_did_not_opt_in_sends_the_trigger_this_build_ships` and widened. Its two assertions survive inside the `None` arm of the new test; folding them in avoids a second, silent pin on the same fact.

## Residue filed

- #5796 — measure the trigger before the feature is turned on. Carries the four-arm panel, the route constraint, the census numbers from this issue's own comments, and the compaction pass 0 question that has to be answered in the same run.

Closes #3756

## Independent DoD verification (#3756)

The `dod` gate went red at 18:56 on #3756's six unticked boxes. They are ticked
now, each checked against this head (`83dd274`) by reading the diff and the tree
rather than this description. This edit is also what re-arms the gate — it fires
on `pull_request` events, not on an issue edit, so the tick alone would have left
the check red on a stale run.

1. **Declared off as a value a test can read.**
   `crates/stella-model/src/anthropic/context_edit.rs` carries
   `pub(crate) const SHIPPED_TRIGGER_TOKENS: Option<u32> = None` beside
   `shipped_context_management()`, and `AnthropicProvider::new` reads it —
   the inline `context_management: None` is gone from `anthropic.rs`. So the
   value is what a fresh session sends, not a comment beside an absence.
2. **A test pins that value.**
   `context_editing_ships_off_until_the_trigger_is_measured` asserts both
   `SHIPPED_TRIGGER_TOKENS.is_none()` and that `shipped_context_management()`
   returns `None`, and its failure message names ADR 0026 and #5796. Setting a
   trigger fails this test, so the record has to be edited alongside it.
3. **The decision and its cost argument are recorded.**
   `docs/adr/0026-context-editing-ships-off-until-measured.md` is new and
   registered in both `docs/adr/README.md`'s table and `docs/manifest.json`, so
   it is citable as `doc:adr/0026-context-editing-ships-off-until-measured`. It
   carries the $0.30 read against the $3.75 write, the ~92% cache-hit rate, and
   the census figure (0.47% of 269,134 calls above the vendor default).
4. **The user-facing surface says so.**
   `website/content/docs/api-providers/index.mdx`'s Anthropic section opens the
   paragraph "**Server-side context editing is off, and there is no setting for
   it.**" and points at ADR 0026.
5. **The gateway question is answered from evidence.**
   Checked in the tree rather than taken from the description:
   `git grep context_management -- crates/` returns hits only under
   `crates/stella-model/src/anthropic/`, and zero in `zai.rs` — the shared
   chat-completions adapter every `Dialect::OpenaiCompatible` provider
   (OpenRouter included) is routed to by `factory::build_provider`. A route that
   has no such field cannot send one, whatever a 200 from the gateway meant.
   That is a code fact, not a status code.
6. **The measurement is filed as its own issue.**
   #5796 is open, carries the `triage` label and nothing else (SCR-005), and is
   written as a handoff: the four-arm panel, the direct-`anthropic` route
   constraint, the census numbers, the compaction pass 0 question, and its own
   definition of done.

I did not re-run the suite — CI is the authority on it, and this PR's own run is
its evidence. What I verified is the code and documentation facts each box
asserts.

## Summary by Sourcery

Keep Anthropic context editing disabled by default until measurement establishes a safe trigger threshold.

Enhancements:
- Declare server-side Anthropic context editing off by default until its trigger threshold is measured, while retaining per-session opt-in support.

Documentation:
- Document the decision, rationale, and lack of a user setting in ADR 0026 and the Anthropic provider documentation.

Tests:
- Pin the disabled fleet-wide policy and verify that default requests match the declared context-editing configuration.