### PR TITLE
fix(stella-cli): assert the cloexec pipe's mechanism, not a racy global write

### DIFF
--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -377,8 +377,9 @@ mod tests {
     /// spawn child processes. A plain `libc::pipe()` fd is open to any child.
     /// A child forked and exec'd on another thread, while a test here still
     /// holds the pipe open, can keep it alive past this thread's own close.
-    /// `cloexec_pipe_closes_a_concurrent_childs_inherited_copy` below
-    /// reproduces that exact shape on demand.
+    /// `cloexec_pipe_closes_a_concurrent_childs_inherited_copy` below holds
+    /// this function to its side of that: the flag is set, and a child it
+    /// spawns loses its copy at `exec`.
     ///
     /// `pipe2(O_CLOEXEC)` sets the flag in the same call that makes the
     /// pipe, so there is no gap where a fork could see it unset. Linux is
@@ -410,47 +411,80 @@ mod tests {
         fds
     }
 
-    /// Reproduces the fd-inheritance race on demand, instead of waiting for
-    /// the parallel test harness to hit it. Rust marks `CLOEXEC` only on fds
-    /// it made itself. A raw `libc` fd is invisible to that bookkeeping. So
-    /// a plain `libc::pipe()` fd is open to any child `std::process::Command`
-    /// spawns while the pipe is open. This test's write, after it closes its
-    /// own read end, then finds the child's copy still open and succeeds —
-    /// returning `1` rather than `-1`. `cloexec_pipe` makes the child's
-    /// `exec` close its copy too, so the write reliably has no reader left.
+    /// Whether `pid` holds `fd` open, read from its `/proc` fd directory.
+    ///
+    /// Scoped to the child this test spawned, so it answers a question about
+    /// one known process rather than about the whole machine.
+    #[cfg(target_os = "linux")]
+    fn process_holds_fd(pid: u32, fd: i32) -> bool {
+        std::fs::read_link(format!("/proc/{pid}/fd/{fd}")).is_ok()
+    }
+
+    /// A child `std::process::Command` spawns while the pipe is open must not
+    /// keep the read end alive. Rust marks `CLOEXEC` only on fds it made
+    /// itself; a raw `libc` fd is invisible to that bookkeeping, so a plain
+    /// `libc::pipe()` fd survives into any child. `cloexec_pipe` sets the flag
+    /// so the child's `exec` drops its copy.
+    ///
+    /// **Asserted on the child, not on the pipe's readability.** The obvious
+    /// probe — close the read end, write, expect `EPIPE` — asks whether *any*
+    /// process anywhere still holds the read end, and no per-fd flag can
+    /// settle that. `FD_CLOEXEC` acts at `exec`; `fork` copies the fd table
+    /// whatever the flag says. So any of the sibling tests spawning a process
+    /// on another harness thread owns a copy for the width of its own
+    /// fork→exec window, and a write landing inside that window finds a reader
+    /// and returns `1`. That is what turned this test red on `main` at
+    /// `b29e934f` after passing on its own branch at `6f6e4d84` — the same
+    /// code, decided by which thread was mid-spawn.
+    ///
+    /// `process_holds_fd` asks the question the fix is actually about: after
+    /// `exec`, does *this* child hold the read end? Nothing another thread
+    /// does can change that answer. Both assertions still fail on a plain
+    /// `libc::pipe()`: the flag is absent, and the child keeps the fd.
     #[test]
     fn cloexec_pipe_closes_a_concurrent_childs_inherited_copy() {
         let fds = cloexec_pipe();
         let (read_fd, write_fd) = (fds[0], fds[1]);
 
-        // `Command::spawn()` waits for the child's `execve()` to finish
-        // before it returns. Rust does this with its own close-on-exec pipe:
-        // the parent blocks on a read that only ends when that pipe closes,
-        // which only happens once exec succeeds. So by the time `spawn()`
-        // returns, `/bin/sh` already either kept a copy of `read_fd` (no
-        // `CLOEXEC`) or lost it (`CLOEXEC`, from `cloexec_pipe`). `sleep 5`
-        // then keeps `sh` alive well past the probe below, so a kept copy
-        // cannot exit early and hide the race.
+        for fd in [read_fd, write_fd] {
+            // SAFETY: `fd` is one of the two descriptors this test owns.
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            assert_ne!(flags, -1, "reading the descriptor flags failed");
+            assert_ne!(
+                flags & libc::FD_CLOEXEC,
+                0,
+                "cloexec_pipe returned a descriptor without FD_CLOEXEC, so an \
+                 exec'd child keeps its copy"
+            );
+        }
+
+        // `Command::spawn()` returns only once the child's `execve()` has
+        // finished: Rust blocks on its own close-on-exec pipe, which the exec
+        // is what closes. So by the time this returns, `/bin/sh` has already
+        // either kept `read_fd` (no `CLOEXEC`) or lost it. `sleep 5` keeps it
+        // alive past the probe below, so a kept copy cannot exit early and
+        // read as absent.
         let mut child = std::process::Command::new("/bin/sh")
             .args(["-c", "sleep 5"])
             .spawn()
             .expect("spawn a child while the pipe is open");
 
-        // SAFETY: `read_fd` is still owned by this test.
-        assert_eq!(unsafe { libc::close(read_fd) }, 0);
-        // SAFETY: one-byte source buffer, matching count, still-owned fd.
-        assert_eq!(
-            unsafe { libc::write(write_fd, [0_u8].as_ptr().cast(), 1) },
-            -1,
-            "a child spawned while the pipe was open still held a live copy \
-             of the read end"
-        );
-        assert_eq!(
-            std::io::Error::last_os_error().raw_os_error(),
-            Some(libc::EPIPE)
-        );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(
+                !process_holds_fd(child.id(), read_fd),
+                "a child spawned while the pipe was open still held a live \
+                 copy of the read end"
+            );
+            assert!(
+                !process_holds_fd(child.id(), write_fd),
+                "a child spawned while the pipe was open still held a live \
+                 copy of the write end"
+            );
+        }
 
-        // SAFETY: still-owned write fd.
+        // SAFETY: both ends are still owned by this test.
+        assert_eq!(unsafe { libc::close(read_fd) }, 0);
         assert_eq!(unsafe { libc::close(write_fd) }, 0);
         let _ = child.kill();
         let _ = child.wait();


### PR DESCRIPTION
## What

`main` is red. `ci` run `33796308644` on `b29e934f` failed `cargo test`:

```
---- credential_handoff::tests::cloexec_pipe_closes_a_concurrent_childs_inherited_copy stdout ----
panicked at crates/stella-cli/src/credential_handoff.rs:442:9:
assertion `left == right` failed: a child spawned while the pipe was open still
held a live copy of the read end
  left: 1
 right: -1
test result: FAILED. 2660 passed; 1 failed
```

**Flaky, not deterministically broken.** The same change passed on its own
branch — `6f6e4d84`, `fmt + clippy + test` success at 19:00 — and failed as
`b29e934f` on `main` at 19:25. Same code, opposite outcomes. That control is
what says this is a race rather than a wrong fix in #5793.

## Why it raced

The test closed the read end and asserted the following `write` returned `EPIPE`.
That asks whether **any process on the machine** still holds the read end, and no
per-descriptor flag can settle that question.

`FD_CLOEXEC` acts at `exec`. `fork` copies the fd table regardless of it. So every
sibling test spawning a process on another harness thread owns a copy of this pipe
for the width of its own fork→exec window, and a write landing inside that window
finds a reader and returns `1`. 2660 tests run in parallel over ~28s, many of them
spawning processes, so the window gets hit occasionally.

`pipe2(O_CLOEXEC)` — the Linux path CI takes — closes the *flag-setting* gap and
cannot close this one. The copy exists because of `fork`, not because the flag was
late. The assertion was never satisfiable by the code it was testing.

## The change

Assert the mechanism rather than a global side effect:

- both ends carry `FD_CLOEXEC` (`fcntl(fd, F_GETFD)`);
- the child *this test spawns* holds neither end after its `exec`, read from
  `/proc/<pid>/fd` (`process_holds_fd`, Linux — the target CI runs; `macos-check.yml`
  compiles this crate but does not run its tests).

Neither depends on what another thread is doing. `Command::spawn()` returns only
once the child's `execve` has finished, so the probe is deterministic.

**The witness is preserved, not weakened.** Both assertions still fail on a plain
`libc::pipe()`: the flag is absent, and the child keeps the fd. What is gone is only
the part whose outcome another thread could decide.

`cloexec_pipe`'s own doc comment described the old behaviour and is updated in the
same change.

## Verification

**CI is green on `b20cdff7`.** Every check has completed and passed — including
`fmt + clippy + test`, which is the job that failed on `main` — alongside
`cargo check on the declared MSRV`, `cargo deny + cargo audit`, `docs guards`,
`guard self-tests`, `gate steps no other workflow runs`, `file size ratchet`, and
`the macOS-only dependency table still compiles`. Nothing pending; no failure
outside `dod` itself, which reads #5806's checklist rather than the code. That
green `fmt + clippy + test` is the fix's own proof: the flake is gone with the
full suite running in parallel, which is the condition that produced it.

Locally, targeted per CLAUDE.md:

- `cargo test -p stella-cli --bin stella credential_handoff` — **14 passed**.
- **Witness.** Swapping `cloexec_pipe`'s Linux body from `pipe2(O_CLOEXEC)` to a
  plain `libc::pipe()` fails the test (`test result: FAILED`, exit 101); restored
  afterwards, `git diff --stat` confirming only the intended file changed.
- `cargo fmt --check -p stella-cli` — clean.
- `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean.
- `scripts/check-prose.py` — OK, none added. `scripts/check-line-citations.py` — OK.

Tests deleted: none. The test keeps its name, so `check-deleted-tests` sees no
removal; its assertions changed.

Closes #5806

## Nothing left behind

`main-canary.yml` runs `cargo check --workspace --all-targets --locked` and
`cargo metadata` — compilation and composition, by its own contract. A **test**
failure is outside what it asks, so it reported success on `b29e934f`, filed no
`main-red` issue, and `main-red-hold.yml` consequently blocks nothing. `main` has
been red with every surface reading green — which is the shape AGENTS.md's own
account of 2026-08-19 describes, where four PRs merged onto a broken tree in 35
minutes.

I have not changed that here: widening the canary to run the suite is a judgement
about post-merge cost that belongs to whoever owns `main-canary.sh`, and AGENTS.md
is explicit that a red-`main` repair edits only what it must — this PR is the one
racing every other merge. It is written up in the "Why nothing reported it" section
of #5806 so it is not lost.

I could not run `./scripts/main-red-claim.sh check` before starting — this
container has no `gh`, and the script fails open by design in exactly that case.
I checked by hand instead: no open `main-red` issue, and no open PR touching
`credential_handoff`. A peer session could still have been on this; nothing I can
read says so.

## Review

Sourcery's assessment against #5806 carries **no `❌` rows** — all three objectives
`✅`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qpp8L9tB3iP9VrCpPtkc2