### PR TITLE
fix(stella-cli): assert FD_CLOEXEC directly instead of probing for EPIPE

### DIFF
--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -414,8 +414,9 @@ mod tests {
     /// Rust marks `CLOEXEC` only on fds it made itself, and a raw `libc` fd
     /// is invisible to that bookkeeping — so a plain `libc::pipe()` leaves
     /// the flag clear and hands every child a live copy of the read end.
-    /// That is the fd-inheritance race #2603 reports, and this assertion
-    /// fails against a tree whose `cloexec_pipe` is a bare `pipe()`.
+    /// That is the fd-inheritance race this helper exists to close, and the
+    /// assertion fails against a tree whose `cloexec_pipe` is a bare
+    /// `pipe()`.
     ///
     /// It asks only about this process's own descriptor table, which is what
     /// makes it reliable under `cargo test`'s parallel harness.
@@ -428,8 +429,8 @@ mod tests {
     /// descriptor, the flag included; the copy is dropped when that child
     /// reaches `execve`, so a spawner on another thread inside its own
     /// fork-to-exec window is a live reader and the write returns `1`. The
-    /// probe read that as a missing flag and turned `main` red on `b29e934`
-    /// (#5804), having passed on the 14-test filter its author ran.
+    /// probe read that as a missing flag and turned `main` red on
+    /// `b29e934`, having passed on the 14-test filter its author ran.
     #[test]
     fn cloexec_pipe_sets_close_on_exec_on_both_ends() {
         let fds = cloexec_pipe();

--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -377,8 +377,8 @@ mod tests {
     /// spawn child processes. A plain `libc::pipe()` fd is open to any child.
     /// A child forked and exec'd on another thread, while a test here still
     /// holds the pipe open, can keep it alive past this thread's own close.
-    /// `cloexec_pipe_closes_a_concurrent_childs_inherited_copy` below
-    /// reproduces that exact shape on demand.
+    /// `cloexec_pipe_sets_close_on_exec_on_both_ends` below asserts the flag
+    /// that makes the child's `exec` drop its copy.
     ///
     /// `pipe2(O_CLOEXEC)` sets the flag in the same call that makes the
     /// pipe, so there is no gap where a fork could see it unset. Linux is
@@ -410,50 +410,47 @@ mod tests {
         fds
     }
 
-    /// Reproduces the fd-inheritance race on demand, instead of waiting for
-    /// the parallel test harness to hit it. Rust marks `CLOEXEC` only on fds
-    /// it made itself. A raw `libc` fd is invisible to that bookkeeping. So
-    /// a plain `libc::pipe()` fd is open to any child `std::process::Command`
-    /// spawns while the pipe is open. This test's write, after it closes its
-    /// own read end, then finds the child's copy still open and succeeds —
-    /// returning `1` rather than `-1`. `cloexec_pipe` makes the child's
-    /// `exec` close its copy too, so the write reliably has no reader left.
+    /// `cloexec_pipe`'s promise, read back off the descriptors themselves.
+    /// Rust marks `CLOEXEC` only on fds it made itself, and a raw `libc` fd
+    /// is invisible to that bookkeeping — so a plain `libc::pipe()` leaves
+    /// the flag clear and hands every child a live copy of the read end.
+    /// That is the fd-inheritance race #2603 reports, and this assertion
+    /// fails against a tree whose `cloexec_pipe` is a bare `pipe()`.
+    ///
+    /// It asks only about this process's own descriptor table, which is what
+    /// makes it reliable under `cargo test`'s parallel harness.
+    ///
+    /// The probe this replaces asked a wider question and could not get a
+    /// stable answer: it spawned a child, closed the read end, and required
+    /// the following write to fail with `EPIPE`. That holds only if no
+    /// process anywhere holds the read end — and a concurrent test can make
+    /// it false without `FD_CLOEXEC` being wrong. `fork` copies every open
+    /// descriptor, the flag included; the copy is dropped when that child
+    /// reaches `execve`, so a spawner on another thread inside its own
+    /// fork-to-exec window is a live reader and the write returns `1`. The
+    /// probe read that as a missing flag and turned `main` red on `b29e934`
+    /// (#5804), having passed on the 14-test filter its author ran.
     #[test]
-    fn cloexec_pipe_closes_a_concurrent_childs_inherited_copy() {
+    fn cloexec_pipe_sets_close_on_exec_on_both_ends() {
         let fds = cloexec_pipe();
-        let (read_fd, write_fd) = (fds[0], fds[1]);
 
-        // `Command::spawn()` waits for the child's `execve()` to finish
-        // before it returns. Rust does this with its own close-on-exec pipe:
-        // the parent blocks on a read that only ends when that pipe closes,
-        // which only happens once exec succeeds. So by the time `spawn()`
-        // returns, `/bin/sh` already either kept a copy of `read_fd` (no
-        // `CLOEXEC`) or lost it (`CLOEXEC`, from `cloexec_pipe`). `sleep 5`
-        // then keeps `sh` alive well past the probe below, so a kept copy
-        // cannot exit early and hide the race.
-        let mut child = std::process::Command::new("/bin/sh")
-            .args(["-c", "sleep 5"])
-            .spawn()
-            .expect("spawn a child while the pipe is open");
+        for fd in fds {
+            // SAFETY: `fd` is one of the two descriptors `cloexec_pipe` just
+            // returned open and owned by this test.
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            assert_ne!(flags, -1, "F_GETFD failed on fd {fd}");
+            assert_ne!(
+                flags & libc::FD_CLOEXEC,
+                0,
+                "cloexec_pipe returned fd {fd} without FD_CLOEXEC — a child's \
+                 copy of it would survive that child's exec"
+            );
+        }
 
-        // SAFETY: `read_fd` is still owned by this test.
-        assert_eq!(unsafe { libc::close(read_fd) }, 0);
-        // SAFETY: one-byte source buffer, matching count, still-owned fd.
-        assert_eq!(
-            unsafe { libc::write(write_fd, [0_u8].as_ptr().cast(), 1) },
-            -1,
-            "a child spawned while the pipe was open still held a live copy \
-             of the read end"
-        );
-        assert_eq!(
-            std::io::Error::last_os_error().raw_os_error(),
-            Some(libc::EPIPE)
-        );
-
-        // SAFETY: still-owned write fd.
-        assert_eq!(unsafe { libc::close(write_fd) }, 0);
-        let _ = child.kill();
-        let _ = child.wait();
+        for fd in fds {
+            // SAFETY: both descriptors are still owned by this test.
+            assert_eq!(unsafe { libc::close(fd) }, 0);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What & why

**`main` is red on `b29e934`** and nothing in the repository is reporting it. `ci` run [33796308644](https://github.com/macanderson/stella/actions/runs/33796308644), step `cargo test`:

```
thread 'credential_handoff::tests::cloexec_pipe_closes_a_concurrent_childs_inherited_copy' (22661)
panicked at crates/stella-cli/src/credential_handoff.rs:442:9:
assertion `left == right` failed: a child spawned while the pipe was open still held a live copy of the read end
  left: 1
 right: -1

test result: FAILED. 2660 passed; 1 failed
```

Every other step of that job is green. `main-canary` ran on the same commit and concluded **success** at 19:27:03, six minutes before `cargo test` failed — correctly, since it re-asks the shared-cell composition questions rather than running the suite. `check-main-verified` is also right to stay quiet: a `ci` run did complete, so the commit is *verified*, red. The result is that no `main-red` issue exists, `main-red-hold` passes, and every surface reads green.

### The defect

The probe requires `write` to the write end to fail with `EPIPE` after closing the read end. **`EPIPE` means no process anywhere holds that read end** — and the test controls its own child, not the other 2660 tests in the same binary, several of which spawn processes.

`O_CLOEXEC` does not close that gap. `fork` duplicates the entire descriptor table, `FD_CLOEXEC` entries included, and the flag is acted on when the child reaches `execve`. A concurrent test inside its own fork-to-exec window is therefore a live reader of this pipe, the write returns `1`, and the assertion reads that as a missing flag. It is #2603's own race, moved onto the witness that was meant to prove it fixed.

#5793 verified with `cargo test -p stella-cli --bin stella credential_handoff::` — 14 tests, almost no concurrent spawners. The full binary runs 2661. That asymmetry is the entire difference between its green run and CI's red one, and it will keep producing intermittent reds on PR branches, not only on `main`.

### The fix

`cloexec_pipe` itself is correct and **unchanged**. It does close the steady-state inheritance that `memory_hardening_precedes_read_and_closes_fd_on_failure` was flaking on. Only the probe's question was unanswerable.

`cloexec_pipe_sets_close_on_exec_on_both_ends` reads the flag back off both descriptors with `fcntl(F_GETFD)`. That touches only this process's own descriptor table, so no other thread can perturb it, and it still fails against a bare `libc::pipe()`.

Closes #5804

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Checked the artisanal way — reverting `pipe2(O_CLOEXEC)` to a plain `pipe()` to simulate the pre-`cloexec_pipe` tree, holding the new test constant, and running only it:

| `cloexec_pipe` body | result |
|---|---|
| plain `libc::pipe()` | **`test result: FAILED. 0 passed; 1 failed`** (exit 101) |
| `libc::pipe2(O_CLOEXEC)` (this tree) | `test result: ok. 1 passed; 0 failed` (exit 0) |

An observed fail→pass flip, not an inference. Note it cannot reproduce the *reported* failure: that needs a concurrent spawner, which is the bug.

## The gate

- [x] `cargo fmt --check` — `cargo fmt -p stella-cli -- --check`, clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — scoped to `-p stella-cli` per CLAUDE.md's laptop-build ban; clean
- [x] `cargo test --workspace` — CI only; scoped locally to `cargo test -p stella-cli --bin stella credential_handoff::` → 14/14 pass
- [x] Docs updated where behavior/flags changed — `cloexec_pipe`'s doc comment pointed at the old test by name and now points at the new one
- [x] CLA signed
- [x] `Closes #N` appears **both** above and as a commit trailer

## Tests deleted

`cloexec_pipe_closes_a_concurrent_childs_inherited_copy` — replaced by `cloexec_pipe_sets_close_on_exec_on_both_ends`, which asserts the same property without depending on global process state. Named here for `check-deleted-tests`.

## Nothing left behind

- [x] Filed: #5804 (this PR closes it) — **or**
- [ ] There is nothing: everything I noticed is fixed in this PR

#5804 also records one thing this PR does **not** fix: a suite-level red on `main` is currently detected by nobody. The canary does not run the suite, and `check-main-verified` counts a red run as verified. Whether something should read the latest `ci` conclusion on `main` and file the way the canary does for composition breaks is a separate design question, and guessing at it inside a repair PR is the wrong place to decide it.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

Test-only change, confined to `#[cfg(all(test, unix))] mod tests` in one file. No production code path is touched.

## Anything reviewers should know?

**The alternative I rejected**: isolating the existing probe in its own process (`rusty_fork_test!`, already in the dep graph via `proptest`) would keep the end-to-end shape and make it deterministic. I did not take it — it adds a direct dev-dependency and a macro layer to buy an indirect proxy for a property that `fcntl(F_GETFD)` answers exactly, in this process, in two lines. If a reviewer wants the end-to-end assertion back, that is the way to do it, and it is worth a separate issue rather than a rewrite here while `main` is red.

**On the deletion**: it would be an expedient if the property went unasserted. It does not — the flip table above is the same fail→pass guarantee, off a source no other thread can move.

---

## Second push (`96926ab`), and why this description was edited

**`96926ab` is a comment-only fix.** The first push, `99d1aa0`, turned `guard self-tests` red on its "no content-free prose was added" step. `check-prose` is a down-only ratchet kept per (file, pattern), and `credential_handoff.rs` sits at 10 allowed `issue-reference` hits; the new doc comment cited `#2603` and `#5804` and took it to 12:

```
crates/stella-cli/src/credential_handoff.rs [issue-reference]: 10 allowed, 12 found
```

Both facts stay and only the numbers go, which is what the guard asks for — the race is now named as the one `cloexec_pipe` exists to close, and the red `main` is named by its commit. That was my miss: I ran `fmt`, `clippy` and the targeted test before the first push but not the toolchain-free guards, which compile nothing and would have caught it in seconds.

**CI on `96926ab` is green.** All 19 checks pass except `dod`: `fmt + clippy + test` **success**, 20:21:53 → 20:39:32 ([job 100802862329](https://github.com/macanderson/stella/actions/runs/33801777787/job/100802862329)), alongside `guard self-tests`, `gate steps no other workflow runs`, `cargo deny + cargo audit`, `cargo check on the declared MSRV`, `docs guards`, `file size ratchet`, `post-merge canary self-tests`, `the macOS-only dependency table still compiles`, `harbor_adapter + analyzer pytest`, `duplicate claims`, `no edit is undone inside the branch`, `PR carries a diff`, `dependency-review`, `main is not known-broken`, `is this diff prose-only?`.

**Sourcery's assessment table carries three ✅ rows and no ❌**, so nothing is outstanding from review.

**#5804's last DoD box is ticked**, against that completed run rather than ahead of it. One box was reworded first: it read "`ci`'s `cargo test` is green on `main` again", which no pull request can satisfy before it merges — I wrote it that way when filing the issue, and it would have held this PR's `dod` gate shut permanently (#2638's shape). It now reads "green on the fix's own head", which is the strongest statement that is true pre-merge; `main` recovering follows from merging this.

This edit is the `pull_request` event that lets `dod` re-read the ticked boxes: it fires on pull-request events, not on an issue edit. **No code changed in this edit.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACQ5Q8b594KumCiAo79ePf