### PR TITLE
fix(stella-cli): probe the hardener's fd closure per-process, not across the whole machine

### DIFF
--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -411,13 +411,54 @@ mod tests {
         fds
     }
 
-    /// Whether `pid` holds `fd` open, read from its `/proc` fd directory.
+    /// Whether `pid` holds *this process's* `fd` — the same object, not merely
+    /// the same number — read from both `/proc` fd directories.
     ///
     /// Scoped to the child this test spawned, so it answers a question about
     /// one known process rather than about the whole machine.
+    ///
+    /// Comparing the link targets is what makes the number incidental. A child
+    /// holding some unrelated descriptor at that number is not holding the
+    /// pipe, and an occupancy test cannot tell those apart — it reports the
+    /// number, and the caller reads it as the pipe.
     #[cfg(target_os = "linux")]
     fn process_holds_fd(pid: u32, fd: i32) -> bool {
-        std::fs::read_link(format!("/proc/{pid}/fd/{fd}")).is_ok()
+        match (
+            std::fs::read_link(format!("/proc/{pid}/fd/{fd}")),
+            std::fs::read_link(format!("/proc/self/fd/{fd}")),
+        ) {
+            (Ok(theirs), Ok(ours)) => theirs == ours,
+            // The number is free in the child, so it holds nothing of ours.
+            (Err(_), _) => false,
+            // This process has closed its own copy, leaving nothing to compare
+            // the child's against and so nothing to claim.
+            (_, Err(_)) => false,
+        }
+    }
+
+    /// Every descriptor `pid` holds, as `fd -> target`, for a failure message.
+    ///
+    /// A bare assertion says a number was occupied and stops there, which is
+    /// how this test's flake survived three repairs with nobody able to say
+    /// what the child was actually holding. Putting the whole table in the
+    /// panic makes the next red run carry its own evidence.
+    #[cfg(target_os = "linux")]
+    fn fd_table(pid: u32) -> Vec<(String, String)> {
+        let Ok(entries) = std::fs::read_dir(format!("/proc/{pid}/fd")) else {
+            return Vec::new();
+        };
+        let mut table: Vec<(String, String)> = entries
+            .flatten()
+            .map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                let target = std::fs::read_link(e.path())
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_else(|e| format!("<unreadable: {e}>"));
+                (name, target)
+            })
+            .collect();
+        table.sort();
+        table
     }
 
     /// The `(device, inode)` pair naming the object `fd` refers to, or `None`
@@ -498,12 +539,14 @@ mod tests {
             assert!(
                 !process_holds_fd(child.id(), read_fd),
                 "a child spawned while the pipe was open still held a live \
-                 copy of the read end"
+                 copy of the read end; the child's table was {:?}",
+                fd_table(child.id())
             );
             assert!(
                 !process_holds_fd(child.id(), write_fd),
                 "a child spawned while the pipe was open still held a live \
-                 copy of the write end"
+                 copy of the write end; the child's table was {:?}",
+                fd_table(child.id())
             );
         }
 

--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -411,54 +411,13 @@ mod tests {
         fds
     }
 
-    /// Whether `pid` holds *this process's* `fd` — the same object, not merely
-    /// the same number — read from both `/proc` fd directories.
+    /// Whether `pid` holds `fd` open, read from its `/proc` fd directory.
     ///
     /// Scoped to the child this test spawned, so it answers a question about
     /// one known process rather than about the whole machine.
-    ///
-    /// Comparing the link targets is what makes the number incidental. A child
-    /// holding some unrelated descriptor at that number is not holding the
-    /// pipe, and an occupancy test cannot tell those apart — it reports the
-    /// number, and the caller reads it as the pipe.
     #[cfg(target_os = "linux")]
     fn process_holds_fd(pid: u32, fd: i32) -> bool {
-        match (
-            std::fs::read_link(format!("/proc/{pid}/fd/{fd}")),
-            std::fs::read_link(format!("/proc/self/fd/{fd}")),
-        ) {
-            (Ok(theirs), Ok(ours)) => theirs == ours,
-            // The number is free in the child, so it holds nothing of ours.
-            (Err(_), _) => false,
-            // This process has closed its own copy, leaving nothing to compare
-            // the child's against and so nothing to claim.
-            (_, Err(_)) => false,
-        }
-    }
-
-    /// Every descriptor `pid` holds, as `fd -> target`, for a failure message.
-    ///
-    /// A bare assertion says a number was occupied and stops there, which is
-    /// how this test's flake survived three repairs with nobody able to say
-    /// what the child was actually holding. Putting the whole table in the
-    /// panic makes the next red run carry its own evidence.
-    #[cfg(target_os = "linux")]
-    fn fd_table(pid: u32) -> Vec<(String, String)> {
-        let Ok(entries) = std::fs::read_dir(format!("/proc/{pid}/fd")) else {
-            return Vec::new();
-        };
-        let mut table: Vec<(String, String)> = entries
-            .flatten()
-            .map(|e| {
-                let name = e.file_name().to_string_lossy().into_owned();
-                let target = std::fs::read_link(e.path())
-                    .map(|p| p.to_string_lossy().into_owned())
-                    .unwrap_or_else(|e| format!("<unreadable: {e}>"));
-                (name, target)
-            })
-            .collect();
-        table.sort();
-        table
+        std::fs::read_link(format!("/proc/{pid}/fd/{fd}")).is_ok()
     }
 
     /// The `(device, inode)` pair naming the object `fd` refers to, or `None`
@@ -539,14 +498,12 @@ mod tests {
             assert!(
                 !process_holds_fd(child.id(), read_fd),
                 "a child spawned while the pipe was open still held a live \
-                 copy of the read end; the child's table was {:?}",
-                fd_table(child.id())
+                 copy of the read end"
             );
             assert!(
                 !process_holds_fd(child.id(), write_fd),
                 "a child spawned while the pipe was open still held a live \
-                 copy of the write end; the child's table was {:?}",
-                fd_table(child.id())
+                 copy of the write end"
             );
         }
 
@@ -826,9 +783,7 @@ mod tests {
         // *any* process still holds a read end, and `CLOEXEC` clears an
         // inherited copy at `exec` rather than at `fork`, so a sibling forking
         // between `cloexec_pipe` and the write keeps a live copy in flight and
-        // the write succeeds. `cloexec_pipe_closes_a_concurrent_childs_inherited_copy`
-        // above had the same defect and was repaired the same way, by asking
-        // about one known process instead of about the machine.
+        // the write succeeds.
         assert_ne!(
             fd_identity(read_fd),
             Some(pipe),

--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -411,8 +411,21 @@ mod tests {
         fds
     }
 
+    /// Whether `pid` holds `fd` open, read from its `/proc` fd directory.
+    ///
+    /// Scoped to the child this test spawned, so it answers a question about
+    /// one known process rather than about the whole machine.
+    #[cfg(target_os = "linux")]
+    fn process_holds_fd(pid: u32, fd: i32) -> bool {
+        std::fs::read_link(format!("/proc/{pid}/fd/{fd}")).is_ok()
+    }
+
     /// The `(device, inode)` pair naming the object `fd` refers to, or `None`
     /// when `fd` is not open.
+    ///
+    /// Identifies the object rather than the descriptor number, so a sibling
+    /// test taking the number the instant it is freed reads as a different
+    /// pair rather than as the same pipe.
     ///
     /// Read through `MetadataExt` rather than a raw `libc::stat`, because
     /// `dev_t` is signed on macOS and unsigned on Linux, so no single
@@ -431,57 +444,74 @@ mod tests {
         Some((stat.dev(), stat.ino()))
     }
 
-    /// Reproduces the fd-inheritance race on demand, instead of waiting for
-    /// the parallel test harness to hit it. Rust marks `CLOEXEC` only on fds
-    /// it made itself. A raw `libc` fd is invisible to that bookkeeping, so a
-    /// plain `libc::pipe()` fd survives `exec` into any child
-    /// `std::process::Command` spawns while the pipe is open, and
-    /// `cloexec_pipe` is what closes it there.
+    /// A child `std::process::Command` spawns while the pipe is open must not
+    /// keep the read end alive. Rust marks `CLOEXEC` only on fds it made
+    /// itself; a raw `libc` fd is invisible to that bookkeeping, so a plain
+    /// `libc::pipe()` fd survives into any child. `cloexec_pipe` sets the flag
+    /// so the child's `exec` drops its copy.
     ///
-    /// The child is asked over `/dev/fd`, which names one process's own open
-    /// descriptors, so the assertion covers the single process this test
-    /// controls — which is the process the assertion is about. An `EPIPE`
-    /// probe on a retained write end cannot do that: `EPIPE` asks whether
-    /// *any* process still holds a read end, and `CLOEXEC` clears an inherited
-    /// copy at `exec` rather than at `fork`, so a sibling test forking
-    /// anywhere between `cloexec_pipe` and the write holds a live copy in
-    /// flight and the write finds a reader.
+    /// **Asserted on the child, not on the pipe's readability.** The obvious
+    /// probe — close the read end, write, expect `EPIPE` — asks whether *any*
+    /// process anywhere still holds the read end, and no per-fd flag can
+    /// settle that. `FD_CLOEXEC` acts at `exec`; `fork` copies the fd table
+    /// whatever the flag says. So any of the sibling tests spawning a process
+    /// on another harness thread owns a copy for the width of its own
+    /// fork→exec window, and a write landing inside that window finds a reader
+    /// and returns `1`. That is what turned this test red on `main` at
+    /// `b29e934f` after passing on its own branch at `6f6e4d84` — the same
+    /// code, decided by which thread was mid-spawn.
+    ///
+    /// `process_holds_fd` asks the question the fix is actually about: after
+    /// `exec`, does *this* child hold the read end? Nothing another thread
+    /// does can change that answer. Both assertions still fail on a plain
+    /// `libc::pipe()`: the flag is absent, and the child keeps the fd.
     #[test]
     fn cloexec_pipe_closes_a_concurrent_childs_inherited_copy() {
         let fds = cloexec_pipe();
         let (read_fd, write_fd) = (fds[0], fds[1]);
 
-        // `/dev/fd/N` resolves inside the child exactly when the child holds
-        // fd `N`: Linux points the directory at `/proc/self/fd`, Darwin
-        // provides it directly. The shell reports which way it went instead of
-        // exiting on it, so a child that died for any other reason cannot read
-        // as a pass. `read_fd` is at least 3 — stdio holds 0 through 2 in this
-        // process — and the parent cannot hand that number to anything else
-        // while it still owns the pipe, so a hit is this pipe and nothing
-        // else.
-        let probe = std::process::Command::new("/bin/sh")
-            .args([
-                "-c",
-                &format!("if [ -e /dev/fd/{read_fd} ]; then echo held; else echo closed; fi"),
-            ])
-            .output()
+        for fd in [read_fd, write_fd] {
+            // SAFETY: `fd` is one of the two descriptors this test owns.
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+            assert_ne!(flags, -1, "reading the descriptor flags failed");
+            assert_ne!(
+                flags & libc::FD_CLOEXEC,
+                0,
+                "cloexec_pipe returned a descriptor without FD_CLOEXEC, so an \
+                 exec'd child keeps its copy"
+            );
+        }
+
+        // `Command::spawn()` returns only once the child's `execve()` has
+        // finished: Rust blocks on its own close-on-exec pipe, which the exec
+        // is what closes. So by the time this returns, `/bin/sh` has already
+        // either kept `read_fd` (no `CLOEXEC`) or lost it. `sleep 5` keeps it
+        // alive past the probe below, so a kept copy cannot exit early and
+        // read as absent.
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "sleep 5"])
+            .spawn()
             .expect("spawn a child while the pipe is open");
 
-        assert!(
-            probe.status.success(),
-            "the probe itself failed rather than answering: {probe:?}"
-        );
-        assert_eq!(
-            String::from_utf8_lossy(&probe.stdout).trim(),
-            "closed",
-            "a child exec'd while the pipe was open still held a copy of the \
-             read end"
-        );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(
+                !process_holds_fd(child.id(), read_fd),
+                "a child spawned while the pipe was open still held a live \
+                 copy of the read end"
+            );
+            assert!(
+                !process_holds_fd(child.id(), write_fd),
+                "a child spawned while the pipe was open still held a live \
+                 copy of the write end"
+            );
+        }
 
-        // SAFETY: both descriptors are still owned by this test.
+        // SAFETY: both ends are still owned by this test.
         assert_eq!(unsafe { libc::close(read_fd) }, 0);
-        // SAFETY: as above.
         assert_eq!(unsafe { libc::close(write_fd) }, 0);
+        let _ = child.kill();
+        let _ = child.wait();
     }
 
     #[test]
@@ -743,17 +773,19 @@ mod tests {
         // whether `read_fd` still names *this* pipe, rather than whether the
         // number is open at all: a sibling test can take the number the
         // instant it is freed, so `fcntl(read_fd, F_GETFD)` succeeding would
-        // report that fd's flags and prove nothing. The write end is still
-        // held here, so the pipe cannot be freed and its inode cannot be
-        // handed to anything else while this runs — the recorded pair can
-        // therefore only come back from a read end that was left open.
+        // report that fd's flags and prove nothing. The write end is held
+        // here, so the pipe cannot be freed and its inode cannot be handed to
+        // anything else while this runs — the recorded pair can only come back
+        // from a read end left open.
         //
-        // Identity is a fact about this process alone, which an `EPIPE` probe
-        // on the retained write end is not: that one asks whether any process
-        // still holds a read end, and `CLOEXEC` clears an inherited copy at
-        // `exec` rather than at `fork`, so a sibling forking between
-        // `cloexec_pipe` and the write keeps a live copy in flight and the
-        // write succeeds.
+        // Identity is a fact about this process alone, which the `EPIPE` probe
+        // this replaces is not: writing to the retained write end asks whether
+        // *any* process still holds a read end, and `CLOEXEC` clears an
+        // inherited copy at `exec` rather than at `fork`, so a sibling forking
+        // between `cloexec_pipe` and the write keeps a live copy in flight and
+        // the write succeeds. `cloexec_pipe_closes_a_concurrent_childs_inherited_copy`
+        // above had the same defect and was repaired the same way, by asking
+        // about one known process instead of about the machine.
         assert_ne!(
             fd_identity(read_fd),
             Some(pipe),

--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -410,50 +410,77 @@ mod tests {
         fds
     }
 
+    /// The `(device, inode)` pair naming the object `fd` refers to, or `None`
+    /// when `fd` is not open.
+    ///
+    /// Read through `MetadataExt` rather than a raw `libc::stat`, because
+    /// `dev_t` is signed on macOS and unsigned on Linux, so no single
+    /// conversion of `st_dev` compiles clean on both, while `dev()` and
+    /// `ino()` are `u64` on every Unix. `daemon.rs`'s `inherited_lock_fd`
+    /// reads a borrowed descriptor the same way.
+    fn fd_identity(fd: i32) -> Option<(u64, u64)> {
+        use std::os::unix::fs::MetadataExt;
+
+        // SAFETY: the descriptor is borrowed, never owned — `ManuallyDrop`
+        // keeps `File`'s destructor from closing an fd this only looks at.
+        // `metadata` is an `fstat`, which reports EBADF for a descriptor that
+        // is not open rather than doing anything with it.
+        let probe = std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(fd) });
+        let stat = probe.metadata().ok()?;
+        Some((stat.dev(), stat.ino()))
+    }
+
     /// Reproduces the fd-inheritance race on demand, instead of waiting for
     /// the parallel test harness to hit it. Rust marks `CLOEXEC` only on fds
-    /// it made itself. A raw `libc` fd is invisible to that bookkeeping. So
-    /// a plain `libc::pipe()` fd is open to any child `std::process::Command`
-    /// spawns while the pipe is open. This test's write, after it closes its
-    /// own read end, then finds the child's copy still open and succeeds —
-    /// returning `1` rather than `-1`. `cloexec_pipe` makes the child's
-    /// `exec` close its copy too, so the write reliably has no reader left.
+    /// it made itself. A raw `libc` fd is invisible to that bookkeeping, so a
+    /// plain `libc::pipe()` fd survives `exec` into any child
+    /// `std::process::Command` spawns while the pipe is open, and
+    /// `cloexec_pipe` is what closes it there.
+    ///
+    /// The child is asked over `/dev/fd`, which names one process's own open
+    /// descriptors, so the assertion covers the single process this test
+    /// controls — which is the process the assertion is about. An `EPIPE`
+    /// probe on a retained write end cannot do that: `EPIPE` asks whether
+    /// *any* process still holds a read end, and `CLOEXEC` clears an inherited
+    /// copy at `exec` rather than at `fork`, so a sibling test forking
+    /// anywhere between `cloexec_pipe` and the write holds a live copy in
+    /// flight and the write finds a reader.
     #[test]
     fn cloexec_pipe_closes_a_concurrent_childs_inherited_copy() {
         let fds = cloexec_pipe();
         let (read_fd, write_fd) = (fds[0], fds[1]);
 
-        // `Command::spawn()` waits for the child's `execve()` to finish
-        // before it returns. Rust does this with its own close-on-exec pipe:
-        // the parent blocks on a read that only ends when that pipe closes,
-        // which only happens once exec succeeds. So by the time `spawn()`
-        // returns, `/bin/sh` already either kept a copy of `read_fd` (no
-        // `CLOEXEC`) or lost it (`CLOEXEC`, from `cloexec_pipe`). `sleep 5`
-        // then keeps `sh` alive well past the probe below, so a kept copy
-        // cannot exit early and hide the race.
-        let mut child = std::process::Command::new("/bin/sh")
-            .args(["-c", "sleep 5"])
-            .spawn()
+        // `/dev/fd/N` resolves inside the child exactly when the child holds
+        // fd `N`: Linux points the directory at `/proc/self/fd`, Darwin
+        // provides it directly. The shell reports which way it went instead of
+        // exiting on it, so a child that died for any other reason cannot read
+        // as a pass. `read_fd` is at least 3 — stdio holds 0 through 2 in this
+        // process — and the parent cannot hand that number to anything else
+        // while it still owns the pipe, so a hit is this pipe and nothing
+        // else.
+        let probe = std::process::Command::new("/bin/sh")
+            .args([
+                "-c",
+                &format!("if [ -e /dev/fd/{read_fd} ]; then echo held; else echo closed; fi"),
+            ])
+            .output()
             .expect("spawn a child while the pipe is open");
 
-        // SAFETY: `read_fd` is still owned by this test.
-        assert_eq!(unsafe { libc::close(read_fd) }, 0);
-        // SAFETY: one-byte source buffer, matching count, still-owned fd.
-        assert_eq!(
-            unsafe { libc::write(write_fd, [0_u8].as_ptr().cast(), 1) },
-            -1,
-            "a child spawned while the pipe was open still held a live copy \
-             of the read end"
+        assert!(
+            probe.status.success(),
+            "the probe itself failed rather than answering: {probe:?}"
         );
         assert_eq!(
-            std::io::Error::last_os_error().raw_os_error(),
-            Some(libc::EPIPE)
+            String::from_utf8_lossy(&probe.stdout).trim(),
+            "closed",
+            "a child exec'd while the pipe was open still held a copy of the \
+             read end"
         );
 
-        // SAFETY: still-owned write fd.
+        // SAFETY: both descriptors are still owned by this test.
+        assert_eq!(unsafe { libc::close(read_fd) }, 0);
+        // SAFETY: as above.
         assert_eq!(unsafe { libc::close(write_fd) }, 0);
-        let _ = child.kill();
-        let _ = child.wait();
     }
 
     #[test]
@@ -692,6 +719,8 @@ mod tests {
         let fds = cloexec_pipe();
         let (read_fd, write_fd) = (fds[0], fds[1]);
 
+        let pipe = fd_identity(read_fd).expect("the read end is open before the call");
+
         // Invalid UTF-8 waits unread in the pipe. If a credential byte were
         // read before hardening, the error below would be the UTF-8 failure.
         // SAFETY: two-byte source buffer, matching count, valid fd.
@@ -709,31 +738,25 @@ mod tests {
         // proving no credential bytes were read first.
         assert_eq!(err, "synthetic hardening failure");
 
-        // The fail-closed path still consumed ownership of the read end. Probe
-        // the open-file description, not the freed fd *number*: with the last
-        // reader gone, writing to the retained write end fails with EPIPE.
-        // (A raw `fcntl(read_fd, F_GETFD) == -1` check would be racy under the
-        // parallel test harness — a sibling test can reuse the number the
-        // instant it is freed, and `fcntl` would then report that fd's flags.)
+        // The fail-closed path still consumed ownership of the read end. Ask
+        // whether `read_fd` still names *this* pipe, rather than whether the
+        // number is open at all: a sibling test can take the number the
+        // instant it is freed, so `fcntl(read_fd, F_GETFD)` succeeding would
+        // report that fd's flags and prove nothing. The write end is still
+        // held here, so the pipe cannot be freed and its inode cannot be
+        // handed to anything else while this runs — the recorded pair can
+        // therefore only come back from a read end that was left open.
         //
-        // The open-file-description probe carries a second race of its own:
-        // a sibling test's `fork`+`exec`, landing in the window between this
-        // pipe's creation and the hardener's close, can inherit the read end
-        // and keep a live reader around after this test dropped its own
-        // copy — the write then returns `1` instead of `-1`, not an error.
-        // `cloexec_pipe` above closes that window by marking the fd
-        // close-on-exec at creation, so a concurrently exec'd child never
-        // holds a copy to begin with.
-        // Rust ignores SIGPIPE process-wide, so the write returns EPIPE rather
-        // than raising a signal.
-        // SAFETY: one-byte source buffer, matching count, still-owned write fd.
-        assert_eq!(
-            unsafe { libc::write(write_fd, [0_u8].as_ptr().cast(), 1) },
-            -1
-        );
-        assert_eq!(
-            std::io::Error::last_os_error().raw_os_error(),
-            Some(libc::EPIPE)
+        // Identity is a fact about this process alone, which an `EPIPE` probe
+        // on the retained write end is not: that one asks whether any process
+        // still holds a read end, and `CLOEXEC` clears an inherited copy at
+        // `exec` rather than at `fork`, so a sibling forking between
+        // `cloexec_pipe` and the write keeps a live copy in flight and the
+        // write succeeds.
+        assert_ne!(
+            fd_identity(read_fd),
+            Some(pipe),
+            "the fail-closed path left the read end open"
         );
 
         // SAFETY: we still own the write end; close it to avoid leaking the fd.


### PR DESCRIPTION
## What &amp; why

**This PR was rewritten at 00:50Z after #5808 merged.** It originally fixed two
tests; #5808 landed the same diagnosis and repair for one of them while this
branch was open, so that half is gone. What remains is the half #5808 did not
cover.

`memory_hardening_precedes_read_and_closes_fd_on_failure` proves that
`read_and_close_fd_with_hardener` closed the descriptor it was handed by writing
to the retained write end and expecting `EPIPE`. `EPIPE` arrives only when **no
process anywhere** still holds a read end, so the assertion is about the whole
machine rather than about the function under test. `CLOEXEC` clears an inherited
copy at `exec`, not at `fork`, so a sibling test forking between `cloexec_pipe`
and the write keeps a live copy in flight and the write succeeds — the same
defect #5808 repaired one test over, reached the same way.

It now records the read end's `(device, inode)` before the call and asserts the
fd number no longer names that pipe. The write end is held throughout, so the
pipe cannot be freed and its inode cannot be reassigned; a hit can only be a
read end left open, and a number a sibling took the instant it was freed reads
as a different pair rather than as a pass. That is why this is not simply
`fcntl(read_fd, F_GETFD)` → `EBADF`: the fd *number* is the unreliable thing,
which the comment this replaces already said. Identity is read through
`MetadataExt` per the `stat-portability` guard, following `daemon.rs`'s
`inherited_lock_fd`.

Closes #5807

## What I removed, and why that mattered

`f3121164` merged `main` into this branch and resolved the whole test to **this
branch's** version — dropping `process_holds_fd` and the `FD_CLOEXEC` flag
assertions #5808 had just landed. Merging that would have been a silent revert
of a teammate's work, the #4979 shape. `eacac36` restores main's copy of that
test verbatim.

`git diff origin/main` is now one file, and the only lines it removes are the
old `EPIPE` probe in the hardener test. #5808's witness, its helper and its flag
assertions are untouched.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Checked by ablation rather than asserted. Leaking the descriptor on the
fail-closed path, holding everything else constant:

```rust
let file = unsafe { std::fs::File::from_raw_fd(fd) };
if let Err(e) = harden() {
    std::mem::forget(file);
    return Err(e);
}
```

```
assertion `left != right` failed: the fail-closed path left the read end open
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2664 filtered out
```

exit 101. Restoring the real close makes it pass. So the test still detects the
defect it exists for, and the identity probe is not weaker than the `EPIPE` one
on the property that matters.

**The control for the race itself**, run before any of this was written: on
`a6f93af`, `cargo test -p stella-cli --bin stella credential_handoff::` failed
on this test (`left: 1  right: -1`) as soon as a sibling in the same filter
spawned a child; run alone it passed. A concurrency defect, not a logic one.

## The gate

Targeted per CLAUDE.md's laptop-build ban; the workspace runs are CI's.

- [x] `cargo fmt -p stella-cli -- --check` — clean
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [ ] `cargo test --workspace` — CI's; locally `credential_handoff::` 14/14,
      three consecutive runs
- [x] Toolchain-free guards, including `check-rebase-replay.sh` (OK — 15 paths
      touched, every one still live in the branch diff) and
      `check-stat-portability.sh`
- [x] `Closes #N` appears both here and as a commit trailer

Tests deleted: none.

## `main` was red, the mechanism is settled, and it was not this PR's

Worth a reviewer's attention more than this diff is. `main`'s last verified
commit at the time was `f0201f75`, where `fmt + clippy + test` failed on
`credential_handoff::tests::cloexec_pipe_closes_a_concurrent_childs_inherited_copy`
([run 33821298562](https://github.com/macanderson/stella/actions/runs/33821298562)).
The same failure hit this branch's `e330eeb`
([run 33828980514](https://github.com/macanderson/stella/actions/runs/33828980514)) —
2664 passed, 1 failed, on that test and not on the one this PR changes.

**An earlier revision of this description said "I do not know the mechanism".
That is no longer true, and the answer is not mine.** #5816's instrumentation
captured it: the parent read `/proc/<child>/fd` immediately after `spawn()`
returned, on the premise that a returned `spawn()` means a completed `execve`.
It does not. The captured child's `/proc/<pid>/exe` still named the test binary
and its descriptor table was this process's own, so it held a forked copy of
both pipe ends. `FD_CLOEXEC` was set the whole time and simply not due to act
yet. Full write-up on #5812 — which supersedes #5813, my own duplicate filed
seven minutes later and now folded into it.

That also retires the theory I pushed and then reverted here: number reuse is
ruled out, because #5816's run printed the same inode on both sides.

**Not porting the fix into this branch, deliberately.** The repair exists and is
green — #5816 at `dc96697`, `fmt + clippy + test` success. Normally a
base-branch failure with a known fix gets that fix ported so it no-ops once the
base carries it. Here it must not: #5815 and #5816 took incompatible approaches
to this same test (#5815 drops the child probe and keeps the flag assertions;
#5816 keeps the probe and fixes its timing), and #5812's own checklist records
that only one may land. Porting either into a third PR would put a contested
edit to one test body in three branches at once — the #4979 shape this branch
has already come within one merge of twice tonight.

So this PR stays narrowed to `memory_hardening_precedes_read_and_closes_fd_on_failure`,
whose defect is separately established and which nobody else is touching.
`process_holds_fd` here is byte-identical to main's.

### The contested edit is settled (appended 2026-09-05 by the PR sweep)

The paragraph above said this PR's CI could not go green until the maintainer
picked between #5815 and #5816. That has happened, and the sentence is corrected
rather than left to mislead a reviewer into skipping a mergeable PR:

- **#5816 merged** and is `main`'s current head `6d5fb8f`; **#5815 is closed**.
  So the contested test body has one owner and porting is moot.
- **`main` is green.** Run
  [33934351422](https://github.com/macanderson/stella/actions/runs/33934351422)
  on `6d5fb8f` — `ci`, conclusion `success`.
- **This head is green.** On `f586d8e3`, which carries that `main`,
  `fmt + clippy + test` is
  [success](https://github.com/macanderson/stella/actions/runs/33934361636/job/101219354446),
  and every one of the 20 checks on the head is `success` or `skipped` —
  `dod / dod` included. `mergeable_state` is `clean`; there is no conflict.
- **#5807's definition of done is fully ticked**, its last box re-cited against
  this head rather than the three-heads-stale `7596f59` it named before.

No code changed in this edit; only the stale claim above it. Nothing here is an
approval — this PR still needs a reviewer's, and Sourcery's review budget is
exhausted until 2026-09-06, so its `COMMENTED` review on this PR is a
rate-limit notice and not an assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mVWJypH68S5e4andTT3D7

## Summary by Sourcery

Make the credential hardening test reliably verify per-process closure of the handed-off read descriptor.

Bug Fixes:
- Make the hardener failure test verify that the read descriptor no longer refers to its original pipe, avoiding machine-wide false failures caused by concurrent processes retaining inherited copies.

Enhancements:
- Add a portable Unix file-descriptor identity helper for checking device and inode without taking ownership of the descriptor.

Tests:
- Strengthen credential handoff coverage for per-process descriptor closure under parallel test execution.