### PR TITLE
fix(stella-cli): ask the child after it has exec'd, not the parent before

### DIFF
--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -415,77 +415,20 @@ mod tests {
     /// `fd`, as `/proc` names it — `pipe:[12345]` for a pipe — or `None` when
     /// that number is not open.
     ///
-    /// Names the object, not the number, which is what the predecessor
-    /// `read_link(...).is_ok()` could not do: it answered "held" for any
-    /// descriptor the child had at that number, including one the child opened
-    /// itself. Comparing targets rules that reading out.
+    /// Names the object, not the number, so a descriptor that merely sits at
+    /// the same number reads as what it is. Used on `"self"` to record what
+    /// this process's two ends name, which is the yardstick the child's own
+    /// report is compared against.
     ///
-    /// It did not make the test pass. On CI the comparison still trips, with
-    /// this pipe's own inode on **both** sides — so the child holds a real copy
-    /// of this pipe and fd-number reuse was never the explanation. Why a copy
-    /// survives an `execve` with `FD_CLOEXEC` set — the flag assertions above
-    /// pass on the same run — is unexplained. It is also rare: it has tripped
-    /// once locally, in an unrecorded run, against dozens of clean ones alone
-    /// and under induced process churn.
-    /// So `child_fd_report` is attached to both assertions to capture the
-    /// child's state the next time rather than reason about it from here.
+    /// Pointing it at a *child* is what does not work, and the reason is the
+    /// timing rather than the identity: `/proc/<pid>/fd` read from the parent
+    /// can catch the child forked but not yet through `execve`, holding a copy
+    /// of this process's whole table — both pipe ends included, whatever
+    /// `FD_CLOEXEC` says, because the flag acts at `exec` and the `exec` has
+    /// not happened. See the test below for the run that established it.
     #[cfg(target_os = "linux")]
     fn fd_target(proc_entry: &str, fd: i32) -> Option<std::path::PathBuf> {
         std::fs::read_link(format!("/proc/{proc_entry}/fd/{fd}")).ok()
-    }
-
-    /// Everything about the child that bears on why the probe above tripped:
-    /// the binary it is running, and its whole descriptor table with targets,
-    /// beside the two targets the parent recorded.
-    ///
-    /// `/proc/<pid>/exe` still naming this test binary rather than a shell says
-    /// the child had not reached `execve` when the probe read it, which would
-    /// make the probe's timing the defect rather than `CLOEXEC`. A table where
-    /// the pipe sits at some *other* number says a descriptor was duplicated.
-    /// Attempts to trip it on demand — this test alone, and under induced
-    /// process churn — come back clean, so a report it prints when the failure
-    /// does arrive is the way to tell those apart.
-    #[cfg(target_os = "linux")]
-    fn child_fd_report(
-        proc_entry: &str,
-        read_fd: i32,
-        write_fd: i32,
-        read_names: &std::path::Path,
-        write_names: &std::path::Path,
-    ) -> String {
-        use std::fmt::Write as _;
-
-        let mut report = String::from("--- child fd report ---\n");
-        let _ = writeln!(
-            report,
-            "parent: read_fd {read_fd} -> {} | write_fd {write_fd} -> {}",
-            read_names.display(),
-            write_names.display()
-        );
-        let exe = std::fs::read_link(format!("/proc/{proc_entry}/exe")).map_or_else(
-            |e| format!("<unreadable: {e}>"),
-            |p| p.display().to_string(),
-        );
-        let _ = writeln!(report, "child {proc_entry}: exe -> {exe}");
-        match std::fs::read_dir(format!("/proc/{proc_entry}/fd")) {
-            Ok(entries) => {
-                let mut rows: Vec<String> = entries
-                    .filter_map(Result::ok)
-                    .map(|e| {
-                        let name = e.file_name().to_string_lossy().into_owned();
-                        let target = std::fs::read_link(e.path())
-                            .map_or_else(|_| "<gone>".to_string(), |p| p.display().to_string());
-                        format!("  fd {name} -> {target}")
-                    })
-                    .collect();
-                rows.sort();
-                let _ = writeln!(report, "child open descriptors:\n{}", rows.join("\n"));
-            }
-            Err(e) => {
-                let _ = writeln!(report, "child fd table unreadable: {e}");
-            }
-        }
-        report
     }
 
     /// A child `std::process::Command` spawns while the pipe is open must not
@@ -505,23 +448,29 @@ mod tests {
     /// `b29e934f` after passing on its own branch at `6f6e4d84` — the same
     /// code, decided by which thread was mid-spawn.
     ///
-    /// `fd_target` compares what the child's descriptor **names** against what
-    /// the parent's names, the parent holding the pipe open throughout so the
-    /// target it reads is this pipe's and no other. That is strictly sharper
-    /// than the `read_link(...).is_ok()` it replaces, which counted any
-    /// descriptor at that number as a hit.
+    /// **The child answers for itself, and the parent waits for it to exit.**
+    /// Three earlier versions asked `/proc/<child>/fd` from the parent right
+    /// after `spawn()` returned, on the premise that a returned `spawn()` means
+    /// a completed `execve`. It does not, and that premise took `main` red
+    /// three times: the parent can catch the child forked and not yet through
+    /// `execve`, still carrying a copy of this process's whole descriptor
+    /// table. `FD_CLOEXEC` is set on both ends the whole time and is simply not
+    /// due to act yet.
     ///
-    /// **It is not yet a passing test, and the reason is unknown.** The
-    /// comparison trips on CI with this pipe's inode on both sides, on a run
-    /// whose `FD_CLOEXEC` assertions above pass — a real copy of this pipe in a
-    /// child that has exec'd with the flag set. Three rewrites have now offered
-    /// three mechanisms for this failure and none of them survived contact with
-    /// a run, so this one names none: `child_fd_report` prints the child's `exe`
-    /// link and full descriptor table on failure so the next occurrence carries
-    /// its own evidence.
+    /// A captured failure is what settled it, rather than a fourth argument.
+    /// The child the probe accused had `/proc/<pid>/exe` still naming this test
+    /// binary rather than a shell, and a table holding this process's sockets,
+    /// SQLite files and event descriptors alongside both pipe ends. Nothing
+    /// about `CLOEXEC` was broken; the question was asked too early.
     ///
-    /// The witness property is intact regardless: on a plain `libc::pipe()` the
-    /// flag assertions fail first, before either comparison is reached.
+    /// `output()` removes the window rather than narrowing it: the child has
+    /// exited before its answer is read, so there is no pre-`exec` state left
+    /// to observe. Comparing what it reports against what the parent recorded
+    /// keeps the identity property too — a descriptor the child opened at the
+    /// same number names something else and reads as a pass.
+    ///
+    /// The witness is intact: on a plain `libc::pipe()` the flag assertions
+    /// fail first, before the child is ever consulted.
     #[test]
     fn cloexec_pipe_closes_a_concurrent_childs_inherited_copy() {
         let fds = cloexec_pipe();
@@ -547,44 +496,61 @@ mod tests {
             fd_target("self", write_fd).expect("the write end is open in this process"),
         );
 
-        // `sleep 5` keeps the child alive past the probe below, so a copy it
-        // kept cannot exit early and read as absent.
+        // The child reports its own descriptors, and `output()` waits for it to
+        // exit, so the answer is necessarily post-`exec`. Reading
+        // `/proc/<pid>/fd` from the parent instead races `execve`: it sees the
+        // forked-but-not-yet-exec'd table, which is a copy of this process's
+        // and therefore holds both ends whatever the flag says. That race is
+        // what took `main` red three times, and the run that proved it printed
+        // a child whose `/proc/<pid>/exe` was still this test binary and whose
+        // table carried this process's sockets and databases.
         //
-        // Reading the child's table from the outside assumes it has reached
-        // `execve` by the time `spawn()` returns. Treat that as unestablished:
-        // the probe trips intermittently on CI naming this pipe's own inode on
-        // both sides, which no offered explanation accounts for.
-        // `child_fd_report` is attached to both assertions so the next such
-        // failure says what the child held and whether it had exec'd.
-        let mut child = std::process::Command::new("/bin/sh")
-            .args(["-c", "sleep 5"])
-            .spawn()
-            .expect("spawn a child while the pipe is open");
+        // The parent holds both ends open across the call, so the targets it
+        // recorded name this pipe and the child's report is comparable to them.
+        #[cfg(target_os = "linux")]
+        let probe = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!(
+                "printf 'read=%s\\n' \"$(readlink /proc/self/fd/{read_fd} || true)\"; \
+                 printf 'write=%s\\n' \"$(readlink /proc/self/fd/{write_fd} || true)\""
+            ))
+            .output()
+            .expect("run the in-child descriptor probe");
 
         #[cfg(target_os = "linux")]
         {
-            let child_pid = child.id().to_string();
+            assert!(
+                probe.status.success(),
+                "the in-child probe did not run, so its silence proves nothing: {probe:?}"
+            );
+            let reported = String::from_utf8_lossy(&probe.stdout);
+            let named = |key: &str| {
+                reported
+                    .lines()
+                    .find_map(|line| line.strip_prefix(key))
+                    .map(str::to_owned)
+            };
             assert_ne!(
-                fd_target(&child_pid, read_fd).as_ref(),
-                Some(&read_names),
-                "a child spawned while the pipe was open still held a live \
-                 copy of the read end\n{}",
-                child_fd_report(&child_pid, read_fd, write_fd, &read_names, &write_names)
+                named("read="),
+                Some(read_names.to_string_lossy().into_owned()),
+                "a child that exec'd while the pipe was open still held the \
+                 read end\nchild reported:\n{reported}parent: read_fd \
+                 {read_fd} -> {}",
+                read_names.display()
             );
             assert_ne!(
-                fd_target(&child_pid, write_fd).as_ref(),
-                Some(&write_names),
-                "a child spawned while the pipe was open still held a live \
-                 copy of the write end\n{}",
-                child_fd_report(&child_pid, read_fd, write_fd, &read_names, &write_names)
+                named("write="),
+                Some(write_names.to_string_lossy().into_owned()),
+                "a child that exec'd while the pipe was open still held the \
+                 write end\nchild reported:\n{reported}parent: write_fd \
+                 {write_fd} -> {}",
+                write_names.display()
             );
         }
 
         // SAFETY: both ends are still owned by this test.
         assert_eq!(unsafe { libc::close(read_fd) }, 0);
         assert_eq!(unsafe { libc::close(write_fd) }, 0);
-        let _ = child.kill();
-        let _ = child.wait();
     }
 
     #[test]

--- a/crates/stella-cli/src/credential_handoff.rs
+++ b/crates/stella-cli/src/credential_handoff.rs
@@ -411,13 +411,81 @@ mod tests {
         fds
     }
 
-    /// Whether `pid` holds `fd` open, read from its `/proc` fd directory.
+    /// What the process at `/proc/<proc_entry>` has open at descriptor number
+    /// `fd`, as `/proc` names it — `pipe:[12345]` for a pipe — or `None` when
+    /// that number is not open.
     ///
-    /// Scoped to the child this test spawned, so it answers a question about
-    /// one known process rather than about the whole machine.
+    /// Names the object, not the number, which is what the predecessor
+    /// `read_link(...).is_ok()` could not do: it answered "held" for any
+    /// descriptor the child had at that number, including one the child opened
+    /// itself. Comparing targets rules that reading out.
+    ///
+    /// It did not make the test pass. On CI the comparison still trips, with
+    /// this pipe's own inode on **both** sides — so the child holds a real copy
+    /// of this pipe and fd-number reuse was never the explanation. Why a copy
+    /// survives an `execve` with `FD_CLOEXEC` set — the flag assertions above
+    /// pass on the same run — is unexplained. It is also rare: it has tripped
+    /// once locally, in an unrecorded run, against dozens of clean ones alone
+    /// and under induced process churn.
+    /// So `child_fd_report` is attached to both assertions to capture the
+    /// child's state the next time rather than reason about it from here.
     #[cfg(target_os = "linux")]
-    fn process_holds_fd(pid: u32, fd: i32) -> bool {
-        std::fs::read_link(format!("/proc/{pid}/fd/{fd}")).is_ok()
+    fn fd_target(proc_entry: &str, fd: i32) -> Option<std::path::PathBuf> {
+        std::fs::read_link(format!("/proc/{proc_entry}/fd/{fd}")).ok()
+    }
+
+    /// Everything about the child that bears on why the probe above tripped:
+    /// the binary it is running, and its whole descriptor table with targets,
+    /// beside the two targets the parent recorded.
+    ///
+    /// `/proc/<pid>/exe` still naming this test binary rather than a shell says
+    /// the child had not reached `execve` when the probe read it, which would
+    /// make the probe's timing the defect rather than `CLOEXEC`. A table where
+    /// the pipe sits at some *other* number says a descriptor was duplicated.
+    /// Attempts to trip it on demand — this test alone, and under induced
+    /// process churn — come back clean, so a report it prints when the failure
+    /// does arrive is the way to tell those apart.
+    #[cfg(target_os = "linux")]
+    fn child_fd_report(
+        proc_entry: &str,
+        read_fd: i32,
+        write_fd: i32,
+        read_names: &std::path::Path,
+        write_names: &std::path::Path,
+    ) -> String {
+        use std::fmt::Write as _;
+
+        let mut report = String::from("--- child fd report ---\n");
+        let _ = writeln!(
+            report,
+            "parent: read_fd {read_fd} -> {} | write_fd {write_fd} -> {}",
+            read_names.display(),
+            write_names.display()
+        );
+        let exe = std::fs::read_link(format!("/proc/{proc_entry}/exe")).map_or_else(
+            |e| format!("<unreadable: {e}>"),
+            |p| p.display().to_string(),
+        );
+        let _ = writeln!(report, "child {proc_entry}: exe -> {exe}");
+        match std::fs::read_dir(format!("/proc/{proc_entry}/fd")) {
+            Ok(entries) => {
+                let mut rows: Vec<String> = entries
+                    .filter_map(Result::ok)
+                    .map(|e| {
+                        let name = e.file_name().to_string_lossy().into_owned();
+                        let target = std::fs::read_link(e.path())
+                            .map_or_else(|_| "<gone>".to_string(), |p| p.display().to_string());
+                        format!("  fd {name} -> {target}")
+                    })
+                    .collect();
+                rows.sort();
+                let _ = writeln!(report, "child open descriptors:\n{}", rows.join("\n"));
+            }
+            Err(e) => {
+                let _ = writeln!(report, "child fd table unreadable: {e}");
+            }
+        }
+        report
     }
 
     /// A child `std::process::Command` spawns while the pipe is open must not
@@ -437,10 +505,23 @@ mod tests {
     /// `b29e934f` after passing on its own branch at `6f6e4d84` — the same
     /// code, decided by which thread was mid-spawn.
     ///
-    /// `process_holds_fd` asks the question the fix is actually about: after
-    /// `exec`, does *this* child hold the read end? Nothing another thread
-    /// does can change that answer. Both assertions still fail on a plain
-    /// `libc::pipe()`: the flag is absent, and the child keeps the fd.
+    /// `fd_target` compares what the child's descriptor **names** against what
+    /// the parent's names, the parent holding the pipe open throughout so the
+    /// target it reads is this pipe's and no other. That is strictly sharper
+    /// than the `read_link(...).is_ok()` it replaces, which counted any
+    /// descriptor at that number as a hit.
+    ///
+    /// **It is not yet a passing test, and the reason is unknown.** The
+    /// comparison trips on CI with this pipe's inode on both sides, on a run
+    /// whose `FD_CLOEXEC` assertions above pass — a real copy of this pipe in a
+    /// child that has exec'd with the flag set. Three rewrites have now offered
+    /// three mechanisms for this failure and none of them survived contact with
+    /// a run, so this one names none: `child_fd_report` prints the child's `exe`
+    /// link and full descriptor table on failure so the next occurrence carries
+    /// its own evidence.
+    ///
+    /// The witness property is intact regardless: on a plain `libc::pipe()` the
+    /// flag assertions fail first, before either comparison is reached.
     #[test]
     fn cloexec_pipe_closes_a_concurrent_childs_inherited_copy() {
         let fds = cloexec_pipe();
@@ -458,12 +539,23 @@ mod tests {
             );
         }
 
-        // `Command::spawn()` returns only once the child's `execve()` has
-        // finished: Rust blocks on its own close-on-exec pipe, which the exec
-        // is what closes. So by the time this returns, `/bin/sh` has already
-        // either kept `read_fd` (no `CLOEXEC`) or lost it. `sleep 5` keeps it
-        // alive past the probe below, so a kept copy cannot exit early and
-        // read as absent.
+        // Read what each end names while this process still owns both, so the
+        // comparison below is against this pipe rather than against a number.
+        #[cfg(target_os = "linux")]
+        let (read_names, write_names) = (
+            fd_target("self", read_fd).expect("the read end is open in this process"),
+            fd_target("self", write_fd).expect("the write end is open in this process"),
+        );
+
+        // `sleep 5` keeps the child alive past the probe below, so a copy it
+        // kept cannot exit early and read as absent.
+        //
+        // Reading the child's table from the outside assumes it has reached
+        // `execve` by the time `spawn()` returns. Treat that as unestablished:
+        // the probe trips intermittently on CI naming this pipe's own inode on
+        // both sides, which no offered explanation accounts for.
+        // `child_fd_report` is attached to both assertions so the next such
+        // failure says what the child held and whether it had exec'd.
         let mut child = std::process::Command::new("/bin/sh")
             .args(["-c", "sleep 5"])
             .spawn()
@@ -471,15 +563,20 @@ mod tests {
 
         #[cfg(target_os = "linux")]
         {
-            assert!(
-                !process_holds_fd(child.id(), read_fd),
+            let child_pid = child.id().to_string();
+            assert_ne!(
+                fd_target(&child_pid, read_fd).as_ref(),
+                Some(&read_names),
                 "a child spawned while the pipe was open still held a live \
-                 copy of the read end"
+                 copy of the read end\n{}",
+                child_fd_report(&child_pid, read_fd, write_fd, &read_names, &write_names)
             );
-            assert!(
-                !process_holds_fd(child.id(), write_fd),
+            assert_ne!(
+                fd_target(&child_pid, write_fd).as_ref(),
+                Some(&write_names),
                 "a child spawned while the pipe was open still held a live \
-                 copy of the write end"
+                 copy of the write end\n{}",
+                child_fd_report(&child_pid, read_fd, write_fd, &read_names, &write_names)
             );
         }
 


### PR DESCRIPTION
## What & why

`cloexec_pipe_closes_a_concurrent_childs_inherited_copy` has taken `main` red
three times. Every repair so far changed *what* the probe compared and left
*when* it asked alone — and the timing was the defect.

The parent read `/proc/<child>/fd` immediately after `spawn()` returned, on a
premise written into the test's comment by #5793 and carried unchanged through
#5808 and this PR's first revision: that a returned `spawn()` means a completed
`execve`. It does not.

**A captured failure settles it.** The first commit here added instrumentation;
it fired on its first run —
[run 33826500237](https://github.com/macanderson/stella/actions/runs/33826500237/job/100880292160):

```
child 23019: exe -> /home/runner/work/stella/stella/target/debug/deps/stella-1c2174eab2f256df
child open descriptors:
  fd 4 -> pipe:[38517]
  fd 5 -> pipe:[38517]
  fd 25 -> /tmp/.tmpgOJS59/context.db
  fd 28 -> /tmp/.tmpkrKMdr/.stella/private/codegraph.db-wal
  fd 14 -> socket:[37377]
  ... eventfds, eventpolls, more sockets and SQLite files ...
parent: read_fd 4 -> pipe:[38517] | write_fd 5 -> pipe:[38517]
```

`/proc/<pid>/exe` still names **this test binary**, not `/bin/sh`, and the table
is *this process's own*. The child was forked and not yet through `execve`, so it
held a copy of every descriptor we had — both pipe ends included. `FD_CLOEXEC`
was set on both the whole time and simply not due to act yet, which is why the
`fcntl(F_GETFD)` assertions passed on every one of these runs.

Nothing was ever wrong with `cloexec_pipe`.

## The fix

The child answers for itself, and `output()` waits for it to exit — so there is
no pre-`exec` state left to observe. The window is removed rather than narrowed.

It reports what `/proc/self/fd/<n>` names for each end; the test compares that
against what the parent recorded while holding both ends open. That keeps the
identity property from the previous revision: a descriptor the child opened at
the same number names something else and reads as a pass.

`fd_target` stays, on `"self"`, as the parent's yardstick. `child_fd_report` goes
with the parent-side probe it served.

Closes #5812, Closes #5813

## The witness

- [x] Witness test (fails on the old behaviour, passes here)

Isolated by ablation, because the flag assertions run first and would otherwise
absorb it. Plain `libc::pipe()` **and** the `FD_CLOEXEC` assertions removed, so
only the child probe can decide:

```
assertion `left != right` failed: a child that exec'd while the pipe was open still held the read end
child reported:
read=pipe:[35844]
write=pipe:[35844]
parent: read_fd 3 -> pipe:[35844]
```

The exec'd child reports holding this exact pipe. Both restored afterwards;
unablated the suite is 14/14 over five consecutive runs.

Note what this ablation shows that the earlier ones could not: the child is
consulted *after* `exec`, so a report naming our pipe is a real `CLOEXEC`
failure rather than a race.

## The gate

Targeted per CLAUDE.md's laptop-build ban; the workspace suite is CI's.

- [x] `cargo test -p stella-cli --bin stella credential_handoff::` — 14/14, x5
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p stella-cli -- --check` — clean
- [x] `check-prose`, `check-line-citations`, `check-file-size`,
      `check-left-behind`, `check-stat-portability`, `check-dead-code-allows`,
      `check-deleted-tests` — pass
- [ ] `fmt + clippy + test` on the PR head — in flight on `dc96697`

Tests deleted: none. The test keeps its name.

## How this PR got here

Worth reading before trusting it, because the diff is small and the history is
not. This PR opened claiming a fix on a root cause (child-side fd-number reuse)
that its own CI falsified within the hour; it then claimed the failure was
CI-only, which one local trip falsified; and one commit went out carrying a
message describing code that a `git reset --soft` had left unstaged. Each is
corrected in place, on #5812 and in the commit log.

The through-line: every conclusion I reached by reasoning about this test was
wrong, and the one that holds came from instrumenting it and reading what it
printed. That is the argument for the current diff, and it is also the argument
for not taking my word on the next one.

## Relationship to #5810 and #5809

#5810 was narrowed at `eacac36` to the sibling hardener test
(`memory_hardening_precedes_read_and_closes_fd_on_failure`); this touches the
other test and the helper above it. Different regions, no conflict.

#5809's position — keep the `fcntl` flag assertions, drop the child-spawn probe —
is no longer the safer option now the child probe has a defensible shape and a
real witness. Recording that only because I argued the other way earlier tonight.

## Nothing left behind

- #5806 — `main-canary.yml` runs `cargo check`, not the suite, so a **test**
  failure on `main` files no `main-red` issue and blocks nothing. That is why
  `main` sat red repeatedly with every surface green. Untouched here, still open
  in substance, and the reason this class of failure kept reaching `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLjWhtD9KtCuJ2CQLTfr2J