### PR TITLE
fix(stella-observatory): stop five dashboard numbers picking the reassuring state

### DIFF
--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -2535,8 +2535,11 @@ function sentContextVerdictHtml(c) {
   }
   const bad = (c.digest_mismatches ?? []).length;
   const gaps = (c.unresolved ?? []).length;
+  const local = (c.local_content_anomalies ?? []).length;
   return `${bad ? `<div class="ctx-verdict" style="color:var(--bad)">✕ ${fmtInt(bad)} block(s)
       did NOT re-hash to their recorded digest — the journal is torn or was altered</div>` : ""}
+    ${local ? `<div class="ctx-verdict" style="color:var(--bad)">✕ ${fmtInt(local)} block(s) were read
+      from the store instead of the journal, so nothing independent checked them</div>` : ""}
     ${gaps ? `<div class="ctx-verdict" style="color:var(--warn)">◌ ${fmtInt(gaps)} block(s) could not
       be resolved (synthetic results, discarded speculation, or attachments)</div>` : ""}`;
 }

--- a/crates/stella-observatory/src/self_driving_sessions.rs
+++ b/crates/stella-observatory/src/self_driving_sessions.rs
@@ -784,11 +784,29 @@ fn execution_costs(root: &Path) -> Vec<(i64, f64)> {
 /// expires on its own if the holder dies (#4300). So this table — not any one
 /// journal — is the machine-wide answer to "what is being worked this
 /// second, and by whom", including a second drive against the same clone.
-fn live_claims(root: &Path, now: i64) -> Vec<Value> {
+///
+/// `None` is a third answer, not a spelling of the empty list. An empty table
+/// says nobody holds an issue right now. An unreadable one says nothing at
+/// all. A workspace that never ran the fleet or the drive verb has no
+/// `fleet.db`. Reading that as "every issue is free" would let this page
+/// contradict a journal it has no evidence against.
+fn live_claims(root: &Path, now: i64) -> Option<Vec<Value>> {
     let db = root.join(".stella").join("private").join("fleet.db");
-    let Some(conn) = open_read_only(&db) else {
-        return Vec::new();
-    };
+    let conn = open_read_only(&db)?;
+    // `collect_rows` turns a missing table into an empty result. That is the
+    // collapse this signature undoes, so ask for the table by name first. A
+    // `fleet.db` older than the lease table cannot answer either.
+    let claims_table: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master
+             WHERE type = 'table' AND name = 'dispatch_claims'",
+            [],
+            |r| r.get(0),
+        )
+        .ok()?;
+    if claims_table == 0 {
+        return None;
+    }
     let now_ms = now * 1000;
     let rows = collect_rows(
         &conn,
@@ -809,22 +827,55 @@ fn live_claims(root: &Path, now: i64) -> Vec<Value> {
             }))
         },
     );
-    match rows {
-        Ok(v) => v,
-        Err(crate::db::DbError::Query(e)) if is_missing_schema(&e) => Vec::new(),
-        Err(_) => Vec::new(),
+    rows.ok()
+}
+
+/// Whether one queued issue is being worked this second.
+///
+/// The journal proposes and the lease table disposes. The lease covers a
+/// narrow window. `stella self-driving drive` takes `issue:<n>` when it starts
+/// a turn and drops it on the way out of that arm. `drive.rs`'s
+/// `LoopStep::Work` calls that arm "the window where a turn is in flight and
+/// no pull request exists yet".
+///
+/// So the lease may contradict the journal, but only inside that window. An
+/// issue parked on a pull request holds no lease, because the loop is polling
+/// CI. There the journal is the only witness.
+///
+/// Everywhere else a turn should be in flight. A lease table that names no
+/// holder is saying nobody is running one. A driver that died without a stop
+/// record leaves exactly that state, and its journal keeps the issue open
+/// until it goes stale.
+///
+/// `leased: None` means there was no lease table to ask. It contradicts
+/// nothing.
+fn in_progress(
+    number: &str,
+    open_now: &BTreeMap<String, String>,
+    leased: Option<&BTreeSet<String>>,
+) -> bool {
+    let Some(stage) = open_now.get(number) else {
+        return false;
+    };
+    match leased {
+        Some(held) if stage != "pr open" => held.contains(number),
+        _ => true,
     }
 }
 
 fn issue_json(i: &Issue, learning: &Learning) -> Value {
     let (lo, hi) = (i.claimed_unix, i.last_unix.max(i.claimed_unix));
     let in_window = |u: i64| u >= lo && u <= hi + 60;
+    // An episode that names an issue belongs to that issue alone. The time
+    // window is the fallback for an episode that names none. OR'd with the
+    // tag, it pulled one issue's episode into another as well, whenever the
+    // two windows overlapped.
     let episodes: Vec<&Value> = learning
         .episodes
         .iter()
-        .filter(|e| {
-            e.get("issue").and_then(Value::as_str) == Some(i.number.as_str())
-                || in_window(e.get("started_unix").and_then(Value::as_i64).unwrap_or(-1))
+        .filter(|e| match e.get("issue").and_then(Value::as_str) {
+            Some(tag) => tag == i.number,
+            None => in_window(e.get("started_unix").and_then(Value::as_i64).unwrap_or(-1)),
         })
         .collect();
     let lessons: Vec<&Value> = learning
@@ -879,6 +930,11 @@ fn session_json(
     } else {
         now
     };
+    // What the workspace spent while this session was open. It is a window
+    // sum, not a split. No cost row names the session that spent it. So a
+    // dollar spent while two sessions overlap is counted by both. That is as
+    // much as one row can claim. It is also why the machine-wide total in
+    // `sessions_from` adds up the daily series instead of these figures.
     let spend: f64 = costs
         .iter()
         .filter(|(u, _)| *u >= s.started_unix && *u <= end)
@@ -981,15 +1037,21 @@ fn sessions_from(roots: &[PathBuf], workspace_root: &Path, now: i64) -> Value {
         });
         let costs = root.as_deref().map(execution_costs).unwrap_or_default();
         let spend_days = root.as_deref().map(spend_rows).unwrap_or_default();
-        let claims = root
-            .as_deref()
-            .map(|r| live_claims(r, now))
-            .unwrap_or_default();
-        for c in &claims {
+        let claims = root.as_deref().and_then(|r| live_claims(r, now));
+        for c in claims.iter().flatten() {
             if let Some(o) = c.get("owner").and_then(Value::as_str) {
                 holders.insert(o.to_string());
             }
         }
+        // The issues a live lease names, or `None` where there was no lease
+        // table to ask.
+        let leased: Option<BTreeSet<String>> = claims.as_ref().map(|rows| {
+            rows.iter()
+                .filter_map(|c| c.get("key").and_then(Value::as_str))
+                .filter_map(|k| k.strip_prefix("issue:"))
+                .map(str::to_string)
+                .collect()
+        });
 
         // Journal → daily.
         for s in &l.sessions {
@@ -1046,9 +1108,11 @@ fn sessions_from(roots: &[PathBuf], workspace_root: &Path, now: i64) -> Value {
         }
 
         // Overlay the live claims on the queue so "in the queue" and "being
-        // worked right now" are one picture.
+        // worked right now" are one picture. Each open issue a running session
+        // holds, keyed to the stage its journal last reached — which is what
+        // decides whether a missing lease may contradict the journal.
         let mut queue = l.queue.clone();
-        let open_now: BTreeSet<String> = session_rows
+        let open_now: BTreeMap<String, String> = session_rows
             .iter()
             .filter(|s| str_at(s, "status") == "running")
             .flat_map(|s| {
@@ -1057,7 +1121,7 @@ fn sessions_from(roots: &[PathBuf], workspace_root: &Path, now: i64) -> Value {
                     .map(|a| {
                         a.iter()
                             .filter(|i| i.get("open").and_then(Value::as_bool).unwrap_or(false))
-                            .map(|i| str_at(i, "number"))
+                            .map(|i| (str_at(i, "number"), str_at(i, "outcome")))
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default()
@@ -1079,7 +1143,10 @@ fn sessions_from(roots: &[PathBuf], workspace_root: &Path, now: i64) -> Value {
                     })
                     .or_insert(0) += 1;
                 if let Some(o) = item.as_object_mut() {
-                    o.insert("in_progress".into(), json!(open_now.contains(&n)));
+                    o.insert(
+                        "in_progress".into(),
+                        json!(in_progress(&n, &open_now, leased.as_ref())),
+                    );
                 }
             }
         }
@@ -1121,10 +1188,13 @@ fn sessions_from(roots: &[PathBuf], workspace_root: &Path, now: i64) -> Value {
         .iter()
         .map(|s| s.get("claimed").and_then(Value::as_i64).unwrap_or(0))
         .sum();
-    let spend: f64 = all_sessions
-        .iter()
-        .map(|s| s.get("spend_usd").and_then(Value::as_f64).unwrap_or(0.0))
-        .sum();
+    // From the daily series, which counts each execution once. A session's
+    // own figure is a window sum over the loop's whole cost vector. Nothing
+    // links a cost row to the session that spent it. So two drives running at
+    // once each count the overlap in full. Adding those figures up billed the
+    // machine twice for one dollar. Two at once is supported: the
+    // `dispatch_claims` lease table exists for it.
+    let spend: f64 = days.values().map(|d| d.spend_usd).sum();
     let lessons: i64 = days.values().map(|d| d.lessons).sum();
     let applied: i64 = days.values().map(|d| d.applied).sum();
 
@@ -1194,238 +1264,4 @@ pub fn session_detail(id: &str) -> Value {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn line(at: &str, action: &str, subject: Option<&str>, outcome: &str) -> String {
-        let subj = subject.map_or("null".to_string(), |s| format!("\"{s}\""));
-        format!(
-            r#"{{"at":"{at}","run_id":"unassigned","action":"{action}","subject":{subj},"outcome":"{outcome}"}}"#
-        )
-    }
-
-    fn seed(root: &Path, slug: &str, lines: &[String], queue: Option<&str>) -> PathBuf {
-        let dir = root.join("self-driving").join(slug);
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("audit.jsonl"), lines.join("\n") + "\n").unwrap();
-        std::fs::write(
-            dir.join("workspace.json"),
-            format!(r#"{{"roots":["/nowhere/{slug}"],"slug":"{slug}"}}"#),
-        )
-        .unwrap();
-        if let Some(q) = queue {
-            std::fs::write(dir.join("queue.json"), q).unwrap();
-        }
-        dir
-    }
-
-    #[test]
-    fn timestamps_in_both_dialects_parse_to_the_same_instant() {
-        assert_eq!(
-            parse_unix("2026-08-23T04:32:50Z"),
-            parse_unix("2026-08-23 04:32:50")
-        );
-        assert_eq!(parse_unix("1970-01-01T00:00:00Z"), Some(0));
-        assert_eq!(parse_unix("1970-01-02T00:00:01Z"), Some(86_401));
-        assert_eq!(parse_unix("not a date"), None);
-    }
-
-    /// The journal that exists today: `run_id: "unassigned"` on every line and
-    /// no session id. Two `session_started` lines in the same second are one
-    /// launch; the next `session_started` is a new session.
-    #[test]
-    fn legacy_records_fold_into_sessions_by_session_started() {
-        let lines = [
-            line(
-                "2026-08-23T04:20:02Z",
-                "session_started",
-                None,
-                "session began — up to 10 issue(s)",
-            ),
-            line(
-                "2026-08-23T04:20:02Z",
-                "session_started",
-                None,
-                "changes will be proved here",
-            ),
-            line(
-                "2026-08-23T04:22:38Z",
-                "claimed",
-                Some("1180"),
-                "taken off the ranked queue",
-            ),
-            line(
-                "2026-08-23T04:22:40Z",
-                "work_started",
-                Some("1180"),
-                "began work — P1: drizzle mock",
-            ),
-            line(
-                "2026-08-23T04:26:28Z",
-                "session_started",
-                None,
-                "session began — up to 10 issue(s)",
-            ),
-            line(
-                "2026-08-23T04:32:43Z",
-                "claimed",
-                Some("1180"),
-                "taken off the ranked queue",
-            ),
-            line(
-                "2026-08-23T04:46:41Z",
-                "work_changed",
-                Some("1180"),
-                "the turn left changes",
-            ),
-            line(
-                "2026-08-23T04:48:04Z",
-                "pr_opened",
-                Some("1186"),
-                "opened for #1180 — ci in progress",
-            ),
-            line(
-                "2026-08-23T04:48:55Z",
-                "pr_observed",
-                Some("1186"),
-                "ci=Green -> Wait",
-            ),
-            line(
-                "2026-08-23T04:49:40Z",
-                "pr_observed",
-                Some("1186"),
-                "ci=Green -> Wait",
-            ),
-            line("2026-08-23T05:00:00Z", "pr_merged", Some("1186"), "merged"),
-            line(
-                "2026-08-23T05:00:01Z",
-                "session_stopped",
-                None,
-                "reached the bound",
-            ),
-        ];
-        let tmp = tempfile::tempdir().unwrap();
-        seed(tmp.path(), "demo", &lines, None);
-
-        let out = sessions_from(
-            &[tmp.path().join("self-driving")],
-            Path::new("/nowhere/demo"),
-            parse_unix("2026-08-23T05:01:00Z").unwrap(),
-        );
-        let s = out["sessions"].as_array().unwrap();
-        assert_eq!(s.len(), 2, "two launches, two sessions: {s:?}");
-        // Newest first.
-        assert_eq!(s[0]["status"], "stopped");
-        assert_eq!(s[0]["prs_merged"], 1);
-        assert_eq!(s[0]["claimed"], 1);
-        let issue = &s[0]["issues"][0];
-        assert_eq!(issue["number"], "1180");
-        assert_eq!(
-            issue["pr"], "1186",
-            "pr_opened's outcome links the PR to its issue"
-        );
-        assert_eq!(issue["outcome"], "merged");
-        assert_eq!(issue["polls"], 2, "pr_observed polls collapse to a count");
-        assert_eq!(issue["title"], "P1: drizzle mock");
-        // The first launch never stopped and its journal is stale.
-        assert_eq!(s[1]["status"], "lost");
-        assert_eq!(s[1]["issues"][0]["outcome"], "working");
-        assert_eq!(out["totals"]["merged"], 1);
-        assert_eq!(out["loops"][0]["is_current_workspace"], true);
-    }
-
-    /// A session-stamped journal (the writer after this change) groups by id,
-    /// and a recorded pid decides liveness rather than the journal's age.
-    #[test]
-    fn stamped_records_group_by_session_id_and_a_dead_pid_reads_crashed() {
-        let stamped = |at: &str, action: &str, sid: &str, pid: u32| {
-            format!(
-                r#"{{"at":"{at}","run_id":"{sid}","session_id":"{sid}","pid":{pid},"action":"{action}","subject":null,"outcome":""}}"#
-            )
-        };
-        // Interleaved: two drives against one repo at once.
-        let lines = [
-            stamped(
-                "2026-08-23T04:20:02Z",
-                "session_started",
-                "sd-a",
-                4_000_000_000,
-            ),
-            stamped(
-                "2026-08-23T04:20:03Z",
-                "session_started",
-                "sd-b",
-                4_000_000_001,
-            ),
-            stamped("2026-08-23T04:21:00Z", "claimed", "sd-b", 4_000_000_001),
-            stamped("2026-08-23T04:22:00Z", "claimed", "sd-a", 4_000_000_000),
-        ];
-        let tmp = tempfile::tempdir().unwrap();
-        seed(tmp.path(), "demo", &lines, None);
-        let out = sessions_from(
-            &[tmp.path().join("self-driving")],
-            Path::new("/x"),
-            parse_unix("2026-08-23T04:23:00Z").unwrap(),
-        );
-        let s = out["sessions"].as_array().unwrap();
-        assert_eq!(s.len(), 2);
-        for row in s {
-            // A pid past pid_t cannot be alive, so both read crashed even though
-            // their journals are seconds old — the pid is the witness now.
-            assert_eq!(row["status"], "crashed", "{row}");
-            assert_eq!(row["liveness"], "pid gone, no stop record");
-        }
-        assert_eq!(out["totals"]["running"], 0);
-    }
-
-    /// The queue is the loop's own snapshot, ranked, with the issues a running
-    /// session holds marked in progress.
-    #[test]
-    fn queue_snapshot_is_ranked_and_overlaid_with_live_claims() {
-        let lines = [
-            line(
-                "2026-08-23T04:20:02Z",
-                "session_started",
-                None,
-                "session began",
-            ),
-            line(
-                "2026-08-23T04:22:38Z",
-                "claimed",
-                Some("1180"),
-                "taken off the ranked queue",
-            ),
-            line(
-                "2026-08-23T04:22:40Z",
-                "work_started",
-                Some("1180"),
-                "began work — P1: x",
-            ),
-        ];
-        let queue = r#"{"at":"2026-08-23T04:22:00Z","open_total":7,"untriaged":2,
-            "items":[{"number":1180,"title":"x","rank":"P1"},{"number":1182,"title":"y","rank":"P1"},
-                     {"number":1190,"title":"z","rank":"untriaged"}]}"#;
-        let tmp = tempfile::tempdir().unwrap();
-        seed(tmp.path(), "demo", &lines, Some(queue));
-        let out = sessions_from(
-            &[tmp.path().join("self-driving")],
-            Path::new("/x"),
-            parse_unix("2026-08-23T04:23:00Z").unwrap(),
-        );
-        assert_eq!(
-            out["totals"]["running"], 1,
-            "a recent legacy journal reads running"
-        );
-        assert_eq!(out["totals"]["busy"], 1);
-        let items = out["loops"][0]["queue"]["items"].as_array().unwrap();
-        assert_eq!(items[0]["in_progress"], true);
-        assert_eq!(items[1]["in_progress"], false);
-        assert_eq!(out["queue_by_rank"]["P1"], 2);
-        assert_eq!(out["queue_by_rank"]["untriaged"], 1);
-    }
-
-    #[test]
-    fn an_unknown_session_is_an_empty_object() {
-        assert_eq!(session_detail("no-such-session"), json!({}));
-    }
-}
+mod tests;

--- a/crates/stella-observatory/src/self_driving_sessions/tests.rs
+++ b/crates/stella-observatory/src/self_driving_sessions/tests.rs
@@ -1,0 +1,502 @@
+//! The fold's tests. Each one seeds a journal on disk. Each one reads it back
+//! through [`sessions_from`], the way the route does.
+
+use super::*;
+
+fn line(at: &str, action: &str, subject: Option<&str>, outcome: &str) -> String {
+    let subj = subject.map_or("null".to_string(), |s| format!("\"{s}\""));
+    format!(
+        r#"{{"at":"{at}","run_id":"unassigned","action":"{action}","subject":{subj},"outcome":"{outcome}"}}"#
+    )
+}
+
+fn seed(root: &Path, slug: &str, lines: &[String], queue: Option<&str>) -> PathBuf {
+    let workspace = PathBuf::from(format!("/nowhere/{slug}"));
+    seed_for(root, slug, lines, queue, &workspace)
+}
+
+/// [`seed`], with the loop pointed at a real directory. The fold then reads
+/// that workspace's `store.db`, `context.db` and `fleet.db` too.
+fn seed_for(
+    root: &Path,
+    slug: &str,
+    lines: &[String],
+    queue: Option<&str>,
+    workspace: &Path,
+) -> PathBuf {
+    let dir = root.join("self-driving").join(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("audit.jsonl"), lines.join("\n") + "\n").unwrap();
+    std::fs::write(
+        dir.join("workspace.json"),
+        json!({ "roots": [workspace.to_string_lossy()], "slug": slug }).to_string(),
+    )
+    .unwrap();
+    if let Some(q) = queue {
+        std::fs::write(dir.join("queue.json"), q).unwrap();
+    }
+    dir
+}
+
+/// One of the workspace's private databases. It carries just the columns the
+/// fold reads. The DDL is written by hand for the same reason the queries are:
+/// this crate links none of the crates that own these files. See the crate
+/// README. `tests/schema_conformance.rs` is what checks the queries against
+/// the real migration path.
+fn private_db(workspace: &Path, name: &str, ddl: &str) -> Connection {
+    let dir = workspace.join(".stella").join("private");
+    std::fs::create_dir_all(&dir).unwrap();
+    let conn = Connection::open(dir.join(name)).unwrap();
+    conn.execute_batch(ddl).unwrap();
+    conn
+}
+
+/// A `pr_opened` outcome. The fold reads the issue number out of it. Built
+/// rather than spelled, so the file itself carries no issue number.
+fn pr_opened_for(issue: &str) -> String {
+    format!("opened for #{issue} — ci in progress")
+}
+
+/// An episode summary that names its issue. This is the shape the fold reads
+/// a tag out of.
+fn episode_naming(issue: &str) -> String {
+    format!("Issue #{issue}: name the tagged one")
+}
+
+#[test]
+fn timestamps_in_both_dialects_parse_to_the_same_instant() {
+    assert_eq!(
+        parse_unix("2026-08-23T04:32:50Z"),
+        parse_unix("2026-08-23 04:32:50")
+    );
+    assert_eq!(parse_unix("1970-01-01T00:00:00Z"), Some(0));
+    assert_eq!(parse_unix("1970-01-02T00:00:01Z"), Some(86_401));
+    assert_eq!(parse_unix("not a date"), None);
+}
+
+/// The journal that exists today: `run_id: "unassigned"` on every line and
+/// no session id. Two `session_started` lines in the same second are one
+/// launch; the next `session_started` is a new session.
+#[test]
+fn legacy_records_fold_into_sessions_by_session_started() {
+    let lines = [
+        line(
+            "2026-08-23T04:20:02Z",
+            "session_started",
+            None,
+            "session began — up to 10 issue(s)",
+        ),
+        line(
+            "2026-08-23T04:20:02Z",
+            "session_started",
+            None,
+            "changes will be proved here",
+        ),
+        line(
+            "2026-08-23T04:22:38Z",
+            "claimed",
+            Some("1180"),
+            "taken off the ranked queue",
+        ),
+        line(
+            "2026-08-23T04:22:40Z",
+            "work_started",
+            Some("1180"),
+            "began work — P1: drizzle mock",
+        ),
+        line(
+            "2026-08-23T04:26:28Z",
+            "session_started",
+            None,
+            "session began — up to 10 issue(s)",
+        ),
+        line(
+            "2026-08-23T04:32:43Z",
+            "claimed",
+            Some("1180"),
+            "taken off the ranked queue",
+        ),
+        line(
+            "2026-08-23T04:46:41Z",
+            "work_changed",
+            Some("1180"),
+            "the turn left changes",
+        ),
+        line(
+            "2026-08-23T04:48:04Z",
+            "pr_opened",
+            Some("1186"),
+            &pr_opened_for("1180"),
+        ),
+        line(
+            "2026-08-23T04:48:55Z",
+            "pr_observed",
+            Some("1186"),
+            "ci=Green -> Wait",
+        ),
+        line(
+            "2026-08-23T04:49:40Z",
+            "pr_observed",
+            Some("1186"),
+            "ci=Green -> Wait",
+        ),
+        line("2026-08-23T05:00:00Z", "pr_merged", Some("1186"), "merged"),
+        line(
+            "2026-08-23T05:00:01Z",
+            "session_stopped",
+            None,
+            "reached the bound",
+        ),
+    ];
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path(), "demo", &lines, None);
+
+    let out = sessions_from(
+        &[tmp.path().join("self-driving")],
+        Path::new("/nowhere/demo"),
+        parse_unix("2026-08-23T05:01:00Z").unwrap(),
+    );
+    let s = out["sessions"].as_array().unwrap();
+    assert_eq!(s.len(), 2, "two launches, two sessions: {s:?}");
+    // Newest first.
+    assert_eq!(s[0]["status"], "stopped");
+    assert_eq!(s[0]["prs_merged"], 1);
+    assert_eq!(s[0]["claimed"], 1);
+    let issue = &s[0]["issues"][0];
+    assert_eq!(issue["number"], "1180");
+    assert_eq!(
+        issue["pr"], "1186",
+        "pr_opened's outcome links the PR to its issue"
+    );
+    assert_eq!(issue["outcome"], "merged");
+    assert_eq!(issue["polls"], 2, "pr_observed polls collapse to a count");
+    assert_eq!(issue["title"], "P1: drizzle mock");
+    // The first launch never stopped and its journal is stale.
+    assert_eq!(s[1]["status"], "lost");
+    assert_eq!(s[1]["issues"][0]["outcome"], "working");
+    assert_eq!(out["totals"]["merged"], 1);
+    assert_eq!(out["loops"][0]["is_current_workspace"], true);
+}
+
+/// A session-stamped journal (the writer after this change) groups by id,
+/// and a recorded pid decides liveness rather than the journal's age.
+#[test]
+fn stamped_records_group_by_session_id_and_a_dead_pid_reads_crashed() {
+    let stamped = |at: &str, action: &str, sid: &str, pid: u32| {
+        format!(
+            r#"{{"at":"{at}","run_id":"{sid}","session_id":"{sid}","pid":{pid},"action":"{action}","subject":null,"outcome":""}}"#
+        )
+    };
+    // Interleaved: two drives against one repo at once.
+    let lines = [
+        stamped(
+            "2026-08-23T04:20:02Z",
+            "session_started",
+            "sd-a",
+            4_000_000_000,
+        ),
+        stamped(
+            "2026-08-23T04:20:03Z",
+            "session_started",
+            "sd-b",
+            4_000_000_001,
+        ),
+        stamped("2026-08-23T04:21:00Z", "claimed", "sd-b", 4_000_000_001),
+        stamped("2026-08-23T04:22:00Z", "claimed", "sd-a", 4_000_000_000),
+    ];
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path(), "demo", &lines, None);
+    let out = sessions_from(
+        &[tmp.path().join("self-driving")],
+        Path::new("/x"),
+        parse_unix("2026-08-23T04:23:00Z").unwrap(),
+    );
+    let s = out["sessions"].as_array().unwrap();
+    assert_eq!(s.len(), 2);
+    for row in s {
+        // A pid past pid_t cannot be alive, so both read crashed even though
+        // their journals are seconds old — the pid is the witness now.
+        assert_eq!(row["status"], "crashed", "{row}");
+        assert_eq!(row["liveness"], "pid gone, no stop record");
+    }
+    assert_eq!(out["totals"]["running"], 0);
+}
+
+/// The queue is the loop's own snapshot, ranked, with the issues a running
+/// session holds marked in progress.
+#[test]
+fn queue_snapshot_is_ranked_and_overlaid_with_live_claims() {
+    let lines = [
+        line(
+            "2026-08-23T04:20:02Z",
+            "session_started",
+            None,
+            "session began",
+        ),
+        line(
+            "2026-08-23T04:22:38Z",
+            "claimed",
+            Some("1180"),
+            "taken off the ranked queue",
+        ),
+        line(
+            "2026-08-23T04:22:40Z",
+            "work_started",
+            Some("1180"),
+            "began work — P1: x",
+        ),
+    ];
+    let queue = r#"{"at":"2026-08-23T04:22:00Z","open_total":7,"untriaged":2,
+        "items":[{"number":1180,"title":"x","rank":"P1"},{"number":1182,"title":"y","rank":"P1"},
+                 {"number":1190,"title":"z","rank":"untriaged"}]}"#;
+    let tmp = tempfile::tempdir().unwrap();
+    seed(tmp.path(), "demo", &lines, Some(queue));
+    let out = sessions_from(
+        &[tmp.path().join("self-driving")],
+        Path::new("/x"),
+        parse_unix("2026-08-23T04:23:00Z").unwrap(),
+    );
+    assert_eq!(
+        out["totals"]["running"], 1,
+        "a recent legacy journal reads running"
+    );
+    assert_eq!(out["totals"]["busy"], 1);
+    let items = out["loops"][0]["queue"]["items"].as_array().unwrap();
+    assert_eq!(items[0]["in_progress"], true);
+    assert_eq!(items[1]["in_progress"], false);
+    assert_eq!(out["queue_by_rank"]["P1"], 2);
+    assert_eq!(out["queue_by_rank"]["untriaged"], 1);
+}
+
+#[test]
+fn an_unknown_session_is_an_empty_object() {
+    assert_eq!(session_detail("no-such-session"), json!({}));
+}
+
+/// Two drives against one repo at once is a case the loop supports. Spend per
+/// session is a window sum over a cost vector nothing splits. So both sessions
+/// count the whole overlap. Adding those two figures up billed the machine
+/// twice for one dollar. The tile read $20; the chart under it read $10.
+#[test]
+fn overlapping_sessions_do_not_bill_one_dollar_twice() {
+    let workspace = tempfile::tempdir().unwrap();
+    let store = private_db(
+        workspace.path(),
+        "store.db",
+        "CREATE TABLE executions (id INTEGER PRIMARY KEY, started_at TEXT, cost_usd REAL);",
+    );
+    store
+        .execute(
+            "INSERT INTO executions VALUES (1, '2026-08-23 04:22:00', 10.0)",
+            [],
+        )
+        .unwrap();
+
+    let lines = [
+        line("2026-08-23T04:20:02Z", "session_started", None, "first"),
+        line("2026-08-23T04:21:00Z", "session_started", None, "second"),
+    ];
+    let tmp = tempfile::tempdir().unwrap();
+    seed_for(tmp.path(), "demo", &lines, None, workspace.path());
+    let out = sessions_from(
+        &[tmp.path().join("self-driving")],
+        Path::new("/x"),
+        parse_unix("2026-08-23T04:23:00Z").unwrap(),
+    );
+
+    let sessions = out["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 2, "{out}");
+    for s in sessions {
+        assert_eq!(
+            s["spend_usd"], 10.0,
+            "each session's window covers the whole execution: {s}"
+        );
+    }
+    assert_eq!(out["daily"][0]["spend_usd"], 10.0, "{out}");
+    assert_eq!(
+        out["totals"]["spend_usd"], 10.0,
+        "the machine spent ten dollars, once: {out}"
+    );
+}
+
+/// An episode that named the second issue was counted against the first as
+/// well. The tag and the time window were OR'd, and the first issue's window
+/// was still open. One session claiming two issues in a row is the plain
+/// case.
+#[test]
+fn an_episode_tagged_to_one_issue_is_not_counted_against_another() {
+    let workspace = tempfile::tempdir().unwrap();
+    let context = private_db(
+        workspace.path(),
+        "context.db",
+        "CREATE TABLE episode (public_id TEXT, summary TEXT, outcome TEXT,
+                               started_at TEXT, ended_at TEXT);",
+    );
+    let tagged = episode_naming("101");
+    for (id, summary, at) in [
+        ("ep-1", tagged.as_str(), "2026-08-23 04:10:30"),
+        (
+            "ep-2",
+            "a turn that named no issue at all",
+            "2026-08-23 04:05:00",
+        ),
+    ] {
+        context
+            .execute(
+                "INSERT INTO episode VALUES (?1, ?2, 'ok', ?3, ?3)",
+                rusqlite::params![id, summary, at],
+            )
+            .unwrap();
+    }
+
+    let lines = [
+        line("2026-08-23T04:00:00Z", "session_started", None, "began"),
+        line("2026-08-23T04:00:02Z", "claimed", Some("100"), "taken"),
+        line("2026-08-23T04:10:00Z", "claimed", Some("101"), "taken"),
+        line(
+            "2026-08-23T04:10:40Z",
+            "work_changed",
+            Some("101"),
+            "changed",
+        ),
+        // Keeps the first issue's window open past the second's episode.
+        line(
+            "2026-08-23T04:20:00Z",
+            "work_changed",
+            Some("100"),
+            "changed",
+        ),
+    ];
+    let tmp = tempfile::tempdir().unwrap();
+    seed_for(tmp.path(), "demo", &lines, None, workspace.path());
+    let out = sessions_from(
+        &[tmp.path().join("self-driving")],
+        Path::new("/x"),
+        parse_unix("2026-08-23T04:21:00Z").unwrap(),
+    );
+
+    let issues = out["sessions"][0]["issues"].as_array().unwrap();
+    let episodes_of = |number: &str| {
+        issues
+            .iter()
+            .find(|i| i["number"] == number)
+            .unwrap_or_else(|| panic!("issue {number} missing from {out}"))["episodes"]
+            .clone()
+    };
+    assert_eq!(episodes_of("101"), 1, "the tag names its own issue: {out}");
+    assert_eq!(
+        episodes_of("100"),
+        1,
+        "only the untagged episode falls back to the window: {out}"
+    );
+}
+
+/// The lease table is what says an issue is being worked right now, and
+/// `in_progress` never read it. A driver that dies without a stop record
+/// leaves its lease to run out. Its journal still reads open. So the page told
+/// an operator someone was on an issue that was free.
+#[test]
+fn a_working_issue_with_no_live_lease_is_not_in_progress() {
+    let workspace = tempfile::tempdir().unwrap();
+    let now = parse_unix("2026-08-23T04:23:00Z").unwrap();
+    let fleet = private_db(
+        workspace.path(),
+        "fleet.db",
+        "CREATE TABLE dispatch_claims (claim_key TEXT PRIMARY KEY, owner TEXT NOT NULL,
+             fence INTEGER NOT NULL, acquired_at_ms INTEGER NOT NULL,
+             renewed_at_ms INTEGER NOT NULL, expires_at_ms INTEGER NOT NULL);",
+    );
+    // The first is held. The second's holder died, and its lease ran out a
+    // minute ago.
+    for (key, expires) in [("issue:1180", now + 300), ("issue:1182", now - 60)] {
+        fleet
+            .execute(
+                "INSERT INTO dispatch_claims VALUES (?1, 'self-driving:4242', 1, ?2, ?2, ?3)",
+                rusqlite::params![key, (now - 600) * 1000, expires * 1000],
+            )
+            .unwrap();
+    }
+
+    let mut lines = vec![line(
+        "2026-08-23T04:20:02Z",
+        "session_started",
+        None,
+        "began",
+    )];
+    for issue in ["1180", "1182"] {
+        lines.push(line(
+            "2026-08-23T04:22:38Z",
+            "claimed",
+            Some(issue),
+            "taken",
+        ));
+        lines.push(line(
+            "2026-08-23T04:22:40Z",
+            "work_started",
+            Some(issue),
+            "began work — P1: x",
+        ));
+    }
+    let queue = r#"{"at":"2026-08-23T04:22:00Z","items":[
+        {"number":1180,"title":"x","rank":"P1"},{"number":1182,"title":"y","rank":"P1"}]}"#;
+    let tmp = tempfile::tempdir().unwrap();
+    seed_for(tmp.path(), "demo", &lines, Some(queue), workspace.path());
+    let out = sessions_from(&[tmp.path().join("self-driving")], Path::new("/x"), now);
+
+    let items = out["loops"][0]["queue"]["items"].as_array().unwrap();
+    assert_eq!(items[0]["in_progress"], true, "the lease holds it: {out}");
+    assert_eq!(
+        items[1]["in_progress"], false,
+        "the lease expired, so nobody is running a turn on it: {out}"
+    );
+    assert_eq!(out["totals"]["holders"], 1, "{out}");
+}
+
+/// The other half of the rule. The loop drops the lease once the pull request
+/// exists, then polls for as long as CI takes. A missing lease says nothing
+/// about a parked issue, so the journal stands.
+#[test]
+fn an_issue_parked_on_a_pull_request_stays_in_progress_without_a_lease() {
+    let workspace = tempfile::tempdir().unwrap();
+    private_db(
+        workspace.path(),
+        "fleet.db",
+        "CREATE TABLE dispatch_claims (claim_key TEXT PRIMARY KEY, owner TEXT NOT NULL,
+             fence INTEGER NOT NULL, acquired_at_ms INTEGER NOT NULL,
+             renewed_at_ms INTEGER NOT NULL, expires_at_ms INTEGER NOT NULL);",
+    );
+    let lines = [
+        line("2026-08-23T04:20:02Z", "session_started", None, "began"),
+        line("2026-08-23T04:22:38Z", "claimed", Some("1180"), "taken"),
+        line(
+            "2026-08-23T04:22:40Z",
+            "work_started",
+            Some("1180"),
+            "began work — P1: x",
+        ),
+        line(
+            "2026-08-23T04:22:50Z",
+            "pr_opened",
+            Some("1186"),
+            &pr_opened_for("1180"),
+        ),
+    ];
+    let queue =
+        r#"{"at":"2026-08-23T04:22:00Z","items":[{"number":1180,"title":"x","rank":"P1"}]}"#;
+    let tmp = tempfile::tempdir().unwrap();
+    seed_for(tmp.path(), "demo", &lines, Some(queue), workspace.path());
+    let out = sessions_from(
+        &[tmp.path().join("self-driving")],
+        Path::new("/x"),
+        parse_unix("2026-08-23T04:23:00Z").unwrap(),
+    );
+
+    assert_eq!(
+        out["sessions"][0]["issues"][0]["outcome"], "pr open",
+        "{out}"
+    );
+    assert_eq!(
+        out["loops"][0]["queue"]["items"][0]["in_progress"], true,
+        "an empty lease table cannot contradict a parked issue: {out}"
+    );
+}

--- a/crates/stella-observatory/src/sent_context.rs
+++ b/crates/stella-observatory/src/sent_context.rs
@@ -24,10 +24,16 @@
 //! Every block whose preimage came from the journal is re-hashed and compared
 //! against the digest the receipt recorded at emission, so a torn journal or a
 //! fabricated block surfaces as a mismatch instead of a plausible-looking lie.
-//! The two gap kinds — the system prefix and the assembled user/recall message
-//! — are stored as local bytes in `context_blocks.content`, so their check is
-//! tautological and is deliberately **not** counted as evidence: they report
-//! `digest_verified: null`, not `true`.
+//! The gap kinds ([`GAP_KINDS`]) are stored as local bytes in
+//! `context_blocks.content`, so their check is tautological and is **not**
+//! counted as evidence: they report `digest_verified: null`, not `true`.
+//!
+//! The skip is keyed on the block's **kind**, never on whether it happens to
+//! carry local bytes. A `tool_result` row with content in it contradicts the
+//! producer, and skipping its digest on that basis is how a tampered store
+//! would buy itself a `verified: true` — the exact lie this fold exists to
+//! prevent. Such a block is checked like any other and named in
+//! `local_content_anomalies`.
 //!
 //! # Reconstructable boundary
 //!
@@ -264,8 +270,8 @@ pub(crate) struct ManifestEntry {
     pub(crate) token_cost: Option<i64>,
     /// `sha256:<64 hex>` over the block's preimage, recorded at emission.
     pub(crate) content_digest: Option<String>,
-    /// Local-only preimage, present for the gap kinds the journal cannot
-    /// resolve (the system prefix and the assembled user/recall message).
+    /// Local-only preimage, present for the [`GAP_KINDS`] the journal cannot
+    /// resolve.
     pub(crate) content: Option<String>,
     /// The block's birth provenance (`context_blocks.call_id`).
     pub(crate) birth_call_id: Option<String>,
@@ -433,6 +439,23 @@ pub(crate) fn journal_era(conn: &Connection, id: i64) -> JournalEra {
     }
 }
 
+/// The block kinds whose preimage is captured locally at emission because the
+/// event journal never carries it: the system prefix, and every message the
+/// engine assembles rather than receives.
+///
+/// The producer's own list is `stella_core::receipts`'s `is_gap_kind`, which
+/// is private, so this is an acknowledged copy like the rest of the fold (see
+/// this module's header). A kind that drifts out of one list and not the other
+/// shows up as a `local_content_anomalies` entry rather than as silence.
+const GAP_KINDS: [&str; 6] = [
+    "system_prefix",
+    "user_goal",
+    "recalled_frame",
+    "steered",
+    "summary",
+    "attachment",
+];
+
 /// One message under construction — the regrouping target for every block
 /// sharing a `message_index`.
 struct Message {
@@ -456,6 +479,7 @@ pub(crate) fn reconstruct(
     let mut messages: Vec<Message> = Vec::new();
     let mut unresolved: Vec<String> = Vec::new();
     let mut mismatches: Vec<String> = Vec::new();
+    let mut local_anomalies: Vec<String> = Vec::new();
     let mut current: Option<i64> = None;
     // The effective system prompt this call was sent, gathered while folding:
     // the `system_prefix` blocks' exact bytes in manifest order, sectioned by
@@ -479,11 +503,19 @@ pub(crate) fn reconstruct(
                 .get_or_insert_with(String::new)
                 .push_str(&content);
         }
-        // Local gap content is stored bytes, so re-hashing it proves nothing;
-        // `None` says "not evidence" where `true` would claim it was.
-        let digest_verified = match &entry.content {
-            Some(_) => None,
-            None => Some(digest_matches(entry.content_digest.as_deref(), &content)),
+        // A gap kind's stored bytes re-hash to themselves, so the check proves
+        // nothing; `None` says "not evidence" where `true` would claim it was.
+        // Every other kind is checked, local bytes or not — bytes on one of
+        // those came from somewhere they should not have, which makes the
+        // digest the only thing left that can contradict them.
+        let is_gap = GAP_KINDS.contains(&kind);
+        if entry.content.is_some() && !is_gap {
+            local_anomalies.push(entry.block_id.clone());
+        }
+        let digest_verified = if is_gap {
+            None
+        } else {
+            Some(digest_matches(entry.content_digest.as_deref(), &content))
         };
         if digest_verified == Some(false) {
             mismatches.push(entry.block_id.clone());
@@ -549,9 +581,15 @@ pub(crate) fn reconstruct(
         }),
     };
     json!({
-        "verified": unresolved.is_empty() && mismatches.is_empty(),
+        "verified": unresolved.is_empty() && mismatches.is_empty() && local_anomalies.is_empty(),
         "unresolved": unresolved,
         "digest_mismatches": mismatches,
+        // Blocks carrying local bytes for a kind whose preimage belongs in the
+        // journal. Their digest still decides `digest_verified`; being here at
+        // all is the separate fact, and it withholds `verified` on its own
+        // because a block resolved from the row it is being checked against
+        // was never checked by anything.
+        "local_content_anomalies": local_anomalies,
         "journal_era": era.tag(),
         "digest_mismatch_severity": severity,
         "system_prompt": system_prompt,
@@ -771,6 +809,48 @@ mod tests {
         assert_eq!(out["messages"][1]["blocks"][0]["digest_verified"], true);
         assert_eq!(out["messages"][2]["role"], "tool");
         assert_eq!(out["messages"][2]["body"], "← tool_result c1\nfn a() {}");
+    }
+
+    /// The digest skip is keyed on the block's kind, so a `tool_result` row
+    /// carrying local bytes that contradict its recorded digest is caught.
+    /// Keyed on "does this row have content" — the old rule — the same block
+    /// reported `digest_verified: null`, stayed out of `digest_mismatches`,
+    /// and left the whole call reading `verified`.
+    #[test]
+    fn local_bytes_on_a_journal_kind_are_checked_rather_than_trusted() {
+        let tampered = r#"{"ok":{"content":"whatever the operator wanted to read"}}"#;
+        let entries = vec![ManifestEntry {
+            content_digest: Some(format!("sha256:{}", sha256_hex("the bytes actually sent"))),
+            content: Some(tampered.to_owned()),
+            ..entry("blk_res", "tool_result", 0)
+        }];
+
+        let out = reconstruct(
+            &entries,
+            &Preimages::index(&[]),
+            JournalEra::CompactionJournaled,
+            false,
+        );
+        assert_eq!(out["verified"], false, "{out}");
+        assert_eq!(out["digest_mismatches"], json!(["blk_res"]), "{out}");
+        assert_eq!(out["local_content_anomalies"], json!(["blk_res"]), "{out}");
+        assert_eq!(out["messages"][0]["blocks"][0]["digest_verified"], false);
+    }
+
+    /// The other half of the same rule: a gap kind's local bytes stay
+    /// unchecked, because re-hashing what the row itself stored proves
+    /// nothing, and it is not an anomaly to find them there.
+    #[test]
+    fn a_gap_kind_keeps_its_null_verdict_and_raises_no_anomaly() {
+        let out = reconstruct(
+            &[gap("blk_goal", "user_goal", 0, "fix the parser")],
+            &Preimages::index(&[]),
+            JournalEra::CompactionJournaled,
+            false,
+        );
+        assert_eq!(out["verified"], true, "{out}");
+        assert_eq!(out["local_content_anomalies"], json!([]), "{out}");
+        assert!(out["messages"][0]["blocks"][0]["digest_verified"].is_null());
     }
 
     /// **Witness for the "System prompt" view.** A reconstruction carries the

--- a/crates/stella-observatory/src/sessions.rs
+++ b/crates/stella-observatory/src/sessions.rs
@@ -904,11 +904,22 @@ fn fold_turn_extras(conn: &Connection, id: &str, turns: &mut [Value]) -> Result<
         }
     }
     let mut reflections: BTreeMap<i64, Value> = BTreeMap::new();
+    // `execution_reflection` gets a row for every finalized turn, graded or
+    // not, so the row's existence answers a different question from "did the
+    // model grade this turn". `HAS_SELF_REVIEW` is the predicate that tells
+    // them apart, and every other reader of this table applies it — without it
+    // here, `/api/session` returned an all-null verdict object for a turn that
+    // `/api/execution` reported as `reflection: null`.
     for row in session_group(
         conn,
         id,
-        "SELECT execution_id, delivered, self_rating FROM execution_reflection
-         WHERE execution_id IN (SELECT id FROM executions WHERE session_id = ?1)",
+        &format!(
+            "SELECT er.execution_id, er.delivered, er.self_rating
+             FROM execution_reflection er
+             WHERE er.execution_id IN (SELECT id FROM executions WHERE session_id = ?1)
+               AND {}",
+            crate::db::HAS_SELF_REVIEW
+        ),
         |r| {
             Ok(json!([
                 r.get::<_, i64>(0)?,
@@ -1110,6 +1121,42 @@ mod tests {
             json!(false),
             "with no registry record and no turns there is nothing to show: {theirs}"
         );
+    }
+
+    /// `execution_reflection` gets a row for every finalized turn, so a turn
+    /// nothing graded has one too. Keyed on the row's existence — the old
+    /// rule — this route handed the page an all-null verdict object for that
+    /// turn while `/api/execution` reported `reflection: null` for the very
+    /// same turn.
+    #[test]
+    fn a_turn_the_model_never_graded_carries_no_reflection() {
+        let conn = Connection::open_in_memory().expect("memory db");
+        conn.execute_batch(
+            "CREATE TABLE executions (id INTEGER PRIMARY KEY, session_id TEXT);
+             CREATE TABLE execution_reflection (
+               execution_id INTEGER PRIMARY KEY,
+               delivered INTEGER, self_rating INTEGER,
+               what_went_well TEXT NOT NULL DEFAULT '',
+               what_to_improve TEXT NOT NULL DEFAULT '',
+               critique TEXT NOT NULL DEFAULT '');
+             INSERT INTO executions VALUES (1, 'ses-1'), (2, 'ses-1');
+             -- The finalize row: a turn ended, nothing graded it.
+             INSERT INTO execution_reflection
+               (execution_id, delivered, self_rating) VALUES (1, NULL, NULL);
+             INSERT INTO execution_reflection
+               (execution_id, delivered, self_rating) VALUES (2, 1, 4);",
+        )
+        .expect("seed");
+
+        let mut turns = vec![json!({ "id": 1 }), json!({ "id": 2 })];
+        fold_turn_extras(&conn, "ses-1", &mut turns).expect("fold");
+        assert_eq!(
+            turns[0]["reflection"],
+            Value::Null,
+            "an ungraded turn owes the page nothing: {}",
+            turns[0]
+        );
+        assert_eq!(turns[1]["reflection"]["self_rating"], 4, "{}", turns[1]);
     }
 
     #[test]


### PR DESCRIPTION
## What and why

Five projections in `stella-observatory` could not tell two states apart, and
each reported the kinder one. All five are fixed here, each with a witness.

**1 — self-driving spend double-counted across overlapping sessions.**
`sessions_from` re-summed every session's `spend_usd`. A session's figure is a
time-window sum over `execution_costs`, and nothing links a cost row to the
session that spent it, so two drives running at once each count the whole
overlap. The tile read $20 while the `daily` chart under it, computed once,
read $10. The total now comes from the daily series. The per-session figure
stays a window sum, and its comment now says so.

**2 — an episode tagged to one issue was counted against another.**
`issue_json` OR'd the explicit `issue` tag with the time-window fallback, so an
episode carrying `Issue #101` matched issue 100 whenever 100's claim window was
still open. The tag wins where it exists; the window is the fallback for an
episode that names none.

**3 — the queue's `in_progress` ignored the live claims its comment said it
overlaid.** Fixed, but not by the plain intersection the issue proposes — the
code says that would be wrong, so here is why.

`crates/stella-cli/src/self_driving_cmd/drive.rs`'s `LoopStep::Work` arm takes
the `issue:<n>` lease and drops it on the way out, in its own words "the window
where a turn is in flight and no pull request exists yet". An issue parked on a
pull request holds no lease for as long as CI takes, so a bare intersection
would flip every parked issue to "not in progress" — which is the loop's normal
steady state. So the lease may contradict the journal only inside the window
the lease covers (`in_progress`), and a parked issue is left to the journal.

The second half of that fix is `live_claims` returning `Option<Vec<Value>>`.
It collapsed "the table says nobody holds anything" into "there is no table to
ask" — the same two-state confusion this issue is about, one layer down — and
with the intersection added, a workspace that never ran the fleet would have
reported every issue free. `collect_rows` also degrades a missing table to an
empty result, so the table is now asked for by name before the query.

**4 — `/api/session` reported an ungraded reflection as graded.**
`fold_turn_extras` was the third reader of `execution_reflection` and the only
one not applying `db::HAS_SELF_REVIEW`, so it inserted
`{"delivered": null, "self_rating": null}` for any row at all. It now reuses
that predicate.

**5 — digest verification was skipped for any block carrying local content.**
The skip is keyed on the block's kind now. Two notes on scope:

- The issue says "the two gap kinds", quoting this module's own header. The
  producer's list (`stella_core::receipts`'s `is_gap_kind`) names six:
  `system_prefix`, `user_goal`, `recalled_frame`, `steered`, `summary`,
  `attachment`. `GAP_KINDS` follows the producer, and the stale header is
  fixed in the same change. `is_gap_kind` is private, so this is an
  acknowledged copy like the rest of the fold.
- "A reportable anomaly" is `local_content_anomalies` in the payload. It
  withholds `verified` on its own, because a block resolved from the very row
  it is checked against was never checked by anything. The page renders it —
  without that, a call unverified for this reason alone drew no verdict line at
  all, which is the silence the fix exists to end.

## Witness mechanism

Each witness fails on `main` by construction, not by luck:

| Witness | Fails before because |
|---|---|
| `overlapping_sessions_do_not_bill_one_dollar_twice` | one $10 execution, two overlapping sessions; the old sum is 20.0, the assert is 10.0 |
| `an_episode_tagged_to_one_issue_is_not_counted_against_another` | the tagged episode falls inside the other issue's window, so the OR counts 2 there; the assert is 1 |
| `a_working_issue_with_no_live_lease_is_not_in_progress` | `in_progress` read no lease at all before, so the expired-lease issue asserted `false` was `true` |
| `an_issue_parked_on_a_pull_request_stays_in_progress_without_a_lease` | passes before and after — it pins the non-regression the plain intersection would have caused |
| `a_turn_the_model_never_graded_carries_no_reflection` | the finalize row exists, so the old query returned an object where `null` is asserted |
| `local_bytes_on_a_journal_kind_are_checked_rather_than_trusted` | local content skipped the digest, so the block was absent from `digest_mismatches` and `verified` was `true` |
| `a_gap_kind_keeps_its_null_verdict_and_raises_no_anomaly` | passes before and after — it pins that the skip still applies where it belongs |

## Exemplar

No new shape: `live_claims`'s `Option` return is `std`'s own distinction
between "absent" and "empty", the one `HashMap::get` makes; `GAP_KINDS` follows
the producer's `is_gap_kind` rather than inventing a second list.

## File layout

`self_driving_sessions.rs` was 1501 lines with the three new witnesses' worth of
room needed on top. Its `#[cfg(test)] mod tests` moves verbatim to
`self_driving_sessions/tests.rs` (the `foo.rs` beside `foo/` layout the
workspace uses), leaving the parent at 1267. The fixtures that spelled an issue
number in a string literal are now built by `pr_opened_for` / `episode_naming`,
because the new file gets no prose baseline and those strings trip the
`issue-reference` guard.

## Tests deleted

None. Every test in `self_driving_sessions.rs` survives under the same name in
`self_driving_sessions/tests.rs`.

## Residue filed

- #5824 — `stella_store::reconstruct`'s `content_matches_digest` has the same
  shape as item 5 and is unfixed: it returns `true` for any block with local
  content, whatever its kind, so `stella inspect` can report `verified` where
  this crate now reports an anomaly.

Closes #5500

---

## Verification by the PR sweep (appended 2026-09-05)

The witness table above was checked rather than taken on trust, and #5500's two
DoD boxes are ticked against the result. Each fix was reverted in turn with its
witness kept, and the named witness re-run alone: all five **FAILED**, items 1
and 4 reproducing the exact `20.0`-vs-`10.0` and all-null-verdict symptoms
#5500 describes; both non-regression pins passed on both sides of every
ablation. `cargo test -p stella-observatory` on `a8d1a4c` is **205 tests, 0
failed, exit 0**, worktree clean afterwards. Detail and command output are in
[this comment](https://github.com/macanderson/stella/pull/5825#issuecomment-5548274401).

This edit is what fires the `pull_request` event `dod-check.yml` needs to
re-read the boxes — the edit is the trigger, never the fix.

## Summary by Sourcery

Correct observatory projections so dashboard totals, issue activity, queue status, reflections, and context verification distinguish trustworthy states from merely reassuring ones.

Bug Fixes:
- Prevent overlapping self-driving sessions from double-counting workspace spend totals.
- Ensure issue tags take precedence over time-window matching when attributing episodes.
- Align queue in-progress status with live leases while preserving journal-based status for pull requests and unavailable lease tables.
- Return no reflection for turns that were finalized without a self-review.
- Verify digests based on block kind rather than the presence of local content, and surface anomalous local content explicitly.

Enhancements:
- Distinguish unavailable lease data from an empty lease table when deriving observatory state.
- Expose local-content anomalies in context verdicts and update gap-kind coverage to match the producer.

Tests:
- Add regression coverage for spend attribution, issue episode matching, lease-aware queue status, reflection grading, and digest verification.

Chores:
- Move self-driving session tests into a dedicated tests module while retaining the existing test coverage.