### PR TITLE
fix(scripts): stop issue-claim.sh claiming an unread PR list is empty

### DIFF
--- a/scripts/issue-claim.sh
+++ b/scripts/issue-claim.sh
@@ -54,6 +54,7 @@ issue=""
 fixture_login=""
 fixture_claims=""
 fixture_prs=""
+fixture_prs_failed=0
 use_fixture=0
 
 while [ $# -gt 0 ]; do
@@ -83,6 +84,14 @@ while [ $# -gt 0 ]; do
     fixture_prs="${2:-}"
     use_fixture=1
     shift 2
+    ;;
+  # Test-only: simulates the `gh pr list` call itself failing, as opposed to
+  # succeeding with an empty result. --fixture-prs is meaningless paired with
+  # this — a failed query has no rows to fake.
+  --fixture-prs-failed)
+    fixture_prs_failed=1
+    use_fixture=1
+    shift
     ;;
   -h | --help)
     awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
@@ -136,13 +145,23 @@ fi
 # have caught the collisions this script was filed for: #5246 closed 44 issues
 # in one sweep, and none of them showed a thing on the issue itself.
 
+# prs_ok tracks whether this query actually ran, distinct from prs itself
+# being empty. "no PR closes it" is a claim about a list that was read; a
+# query that failed to even ask must never be reported in that shape.
+prs_ok=1
 if [ "$use_fixture" -eq 1 ]; then
-  prs="$fixture_prs"
+  if [ "$fixture_prs_failed" -eq 1 ]; then
+    prs=""
+    prs_ok=0
+  else
+    prs="$fixture_prs"
+  fi
 elif ! prs="$(gh pr list --state all --limit 100 --json number,state,body \
   --jq ".[] | select(.body | test(\"Closes #$issue\\\\b\")) | \"\(.number) \(.state)\"" 2>/dev/null)"; then
   echo "note: could not list pull requests. Proceeding (fail-open); the claim" >&2
   echo "      check below still runs." >&2
   prs=""
+  prs_ok=0
 fi
 
 if [ -n "$prs" ]; then
@@ -226,6 +245,9 @@ if [ -n "$held_by" ]; then
 fi
 
 if [ "$mode" = "check" ]; then
+  if [ "$prs_ok" -eq 0 ]; then
+    proceed "ok  proceed (PR list unreadable)"
+  fi
   proceed "ok  #$issue is unclaimed — no PR closes it and no live claim holds it."
 fi
 

--- a/scripts/test-issue-claim.sh
+++ b/scripts/test-issue-claim.sh
@@ -107,6 +107,30 @@ want "an unknown identity proceeds" \
 want "a claim with an unreadable age is ignored" \
   expect-proceed "is unclaimed" check "ada" "grace notanumber" ""
 
+# A query that never ran is not proof the list was empty. The unfixed script
+# prints "no PR closes it" whether it read the list or failed to ask. That
+# let a duplicate start while a real pull request already closed the issue
+# and sat open, green and ready to merge. This case is the fail→pass witness:
+# it fails on the unfixed script, because the printed line is false, and it
+# passes on the fixed script, because the line names the failure instead.
+out="$("$SCRIPT" check 5045 \
+  --fixture-login ada --fixture-claims "" --fixture-prs-failed 2>&1)"
+rc=$?
+case "$rc,$out" in
+0,*"no PR closes it"*)
+  bad "a failed PR-list query claimed to have read the list: $out"
+  ;;
+0,*"PR list unreadable"*)
+  ok "a failed PR-list query proceeds without claiming no PR closes it"
+  ;;
+0,*)
+  bad "a failed PR-list query proceeded with unexpected wording: $out"
+  ;;
+*)
+  bad "a failed PR-list query blocked — expected exit 0, got $rc: $out"
+  ;;
+esac
+
 # ── claim mode ───────────────────────────────────────────────────────────────
 
 want "claim posts when the issue is free" \


### PR DESCRIPTION
## What / why

`scripts/issue-claim.sh check` printed the same success sentence —
`ok  #N is unclaimed — no PR closes it and no live claim holds it.` —
whether it actually read the pull request list or the `gh pr list` call
failed. On #5117 a session read that line, trusted it, and started
duplicate work while PR #5829 was open, green, and said `Closes #5117` in
its body. The check that exists to catch exactly that gave the all-clear.

Fail-open stays right (a claim check that can block work is worse than the
duplication it prevents). The bug is the wording: the script already has an
honest shape for its other two unknowns (`ok  proceed (could not ask)`,
`ok  proceed (comments unreadable)`); the PR query was the only one that
fell through to a sentence asserting an answer it never got.

## Fix

`scripts/issue-claim.sh` tracks `prs_ok` alongside `prs` — set to 0 both on
a real `gh pr list` failure and on a new `--fixture-prs-failed` test seam
(fixture mode had no way to fake a failed query before this, only an empty
successful one). `check` mode's success branch checks `prs_ok` first and
prints `ok  proceed (PR list unreadable)` instead of the false sentence
whenever the query never actually ran; a run that did read the list keeps
today's sentence unchanged.

## Witness mechanism

`scripts/test-issue-claim.sh` gets a case driving the new
`--fixture-prs-failed` flag. It is the fail→pass witness this PR proves
itself with:

- **On the unfixed script**: the flag does not exist, so the case fails
  (exit 2, `unknown argument '--fixture-prs-failed'`) rather than reaching
  exit 0 at all — there was no way to make the old script simulate a failed
  query without actually breaking `gh`, which is the reason the flag is new.
- **On the fixed script**: the case passes, asserting the honest
  `ok  proceed (PR list unreadable)` line and rejecting the old false
  sentence outright.

Verified locally (this repo forbids `cargo`/`make gate` on the maintainer's
machine, but these are hermetic shell scripts, not Rust — no code compiles
either way):

```
$ git stash push -- scripts/issue-claim.sh && ./scripts/test-issue-claim.sh
...
  ✗ a failed PR-list query blocked — expected exit 0, got 2: issue-claim: unknown argument '--fixture-prs-failed'
issue-claim: 14 passed, 1 FAILED
$ git stash pop && ./scripts/test-issue-claim.sh
...
  ✓ a failed PR-list query proceeds without claiming no PR closes it
issue-claim: 15 passed
```

`shellcheck`, `make line-citations`, `python3 scripts/check-prose.py`, and
`./scripts/check-file-size.sh` all pass on the changed files.

## Tests deleted

None.

## Residue

None — the fix is contained to the two named files, matching the issue's
"File placement" DoD item.

Closes #5834

---

## Verification by the PR sweep (appended 2026-09-05)

`dod / dod` was the only red check on this head, blocking on #5834's nine
unticked DoD boxes. All nine are now ticked, each **run** rather than read,
and the flip was reproduced independently of the description above:

- On `b4232ed`, `bash scripts/test-issue-claim.sh` — **15 passed, exit 0**.
- The same test file against `origin/main`'s `scripts/issue-claim.sh`, all
  else held constant — **14 passed, 1 FAILED, exit 1**, on the new case.

That reproduction confirms this description's own account of the failure
mode, including the part worth keeping visible: the old script fails the
case on `unknown argument '--fixture-prs-failed'`, not by printing the false
sentence, because the fixture seam is itself part of the fix. #5834's box 5
predicted the latter; the PR was right and the checklist's parenthetical was
stale. Noted on the issue rather than quietly ticked past.

Also re-derived: `proceed()` is `exit 0` so the check still cannot block;
`grep -rn "no PR closes it"` finds no doc quoting the line verbatim; the diff
is the two named files; and `check-prose.py` exits 0 with *"none added"*.
Detail and command output are in
[this comment](https://github.com/macanderson/stella/issues/5834#issuecomment-5549636840).

This edit is what fires the `pull_request` event `dod-check.yml` needs to
re-read the boxes — the edit is the trigger, never the fix. **No code changed
in this edit.**

## Summary by Sourcery

Prevent issue checks from falsely asserting that no pull request closes an issue when the pull-request list could not be read.

Bug Fixes:
- Report pull-request list failures honestly in issue checks instead of treating an unreadable list as proof that no pull request closes the issue.

Enhancements:
- Track whether the pull-request query succeeded independently of whether it returned results.
- Add a fixture option and regression coverage for failed pull-request queries.

Tests:
- Add a regression test verifying failed pull-request queries proceed with explicit unreadable-list wording and never emit the empty-list claim.