### PR TITLE
test(stella-store): let a spool claim lose the race without panicking

### DIFF
--- a/crates/stella-store/tests/enterprise_telemetry/spool.rs
+++ b/crates/stella-store/tests/enterprise_telemetry/spool.rs
@@ -845,6 +845,40 @@ fn repeated_corruption_keeps_only_a_bounded_diagnostic_sample() {
     }
 }
 
+/// What one claim did when two connections raced for the same row.
+///
+/// SQLite may refuse a write while a peer holds the lock. That is a lost
+/// race, not a fault, so it gets an answer of its own here.
+#[derive(Debug, PartialEq, Eq)]
+enum ClaimOutcome {
+    /// This caller leased that many rows.
+    Leased(usize),
+    /// The lock was held past the wait, so the write was refused.
+    Refused,
+}
+
+impl ClaimOutcome {
+    /// Rows this caller leased. A refused caller leased none.
+    fn leased(&self) -> usize {
+        match self {
+            Self::Leased(rows) => *rows,
+            Self::Refused => 0,
+        }
+    }
+}
+
+/// Claim once, and sort the answer into the two a race is allowed to give.
+///
+/// Only a held lock is a lost race. Every other error is still a failure,
+/// so bad data still fails the test that calls this.
+fn claim_racing(spool: &EnterpriseTelemetrySpool, owner: &str, now_ms: i64) -> ClaimOutcome {
+    match spool.claim_batch_at(SINK_A, owner, now_ms, 1_000, 1, 64 * 1024) {
+        Ok(rows) => ClaimOutcome::Leased(rows.len()),
+        Err(error) if error.is_busy() => ClaimOutcome::Refused,
+        Err(error) => panic!("{owner}: the claim failed, and not on a held lock: {error}"),
+    }
+}
+
 #[test]
 fn separate_connections_cannot_claim_the_same_event_concurrently() {
     use std::sync::{Arc, Barrier};
@@ -855,24 +889,66 @@ fn separate_connections_cannot_claim_the_same_event_concurrently() {
     let event = StellaOperationalEventV1::from_finalized_rollup(&context(), &rollup(1)).unwrap();
     first.enqueue(SINK_A, &event, 1).unwrap();
     let second = EnterpriseTelemetrySpool::open_at(&path, SpoolLimits::default()).unwrap();
+    let settling = EnterpriseTelemetrySpool::open_at(&path, SpoolLimits::default()).unwrap();
     let barrier = Arc::new(Barrier::new(3));
     let a_barrier = barrier.clone();
     let a = std::thread::spawn(move || {
         a_barrier.wait();
-        first
-            .claim_batch_at(SINK_A, "a", 10, 1_000, 1, 64 * 1024)
-            .unwrap()
+        claim_racing(&first, "a", 10)
     });
     let b_barrier = barrier.clone();
     let b = std::thread::spawn(move || {
         b_barrier.wait();
-        second
-            .claim_batch_at(SINK_A, "b", 10, 1_000, 1, 64 * 1024)
-            .unwrap()
+        claim_racing(&second, "b", 10)
     });
     barrier.wait();
-    let claimed = a.join().unwrap().len() + b.join().unwrap().len();
-    assert_eq!(claimed, 1);
+    let a = a.join().unwrap();
+    let b = b.join().unwrap();
+
+    let leased = a.leased() + b.leased();
+    assert!(leased <= 1, "both connections leased the row: {a:?}, {b:?}");
+    if a != ClaimOutcome::Refused && b != ClaimOutcome::Refused {
+        assert_eq!(leased, 1, "one side must win the row: {a:?}, {b:?}");
+    }
+    if leased == 0 {
+        let settled = settling
+            .claim_batch_at(SINK_A, "settling", 20, 1_000, 1, 64 * 1024)
+            .unwrap();
+        assert_eq!(
+            settled.len(),
+            1,
+            "a refused claim must leave the row: {a:?}, {b:?}"
+        );
+    }
+}
+
+/// **The witness.** A claim refused for a held lock is a lost race, and the
+/// row it did not take is still there.
+///
+/// The lock is held here on purpose, so the refusal lands on every run and
+/// not only on a busy machine. Read that refusal as a fault and the test
+/// panics on the same `DatabaseBusy` the racing test above turns into a
+/// verdict.
+#[test]
+fn a_claim_refused_for_a_held_lock_is_a_lost_race_not_a_lost_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("enterprise-telemetry.db");
+    let spool = EnterpriseTelemetrySpool::open_at(&path, SpoolLimits::default()).unwrap();
+    let event = StellaOperationalEventV1::from_finalized_rollup(&context(), &rollup(1)).unwrap();
+    spool.enqueue(SINK_A, &event, 1).unwrap();
+
+    let holder = rusqlite::Connection::open(&path).unwrap();
+    holder
+        .busy_timeout(std::time::Duration::ZERO)
+        .expect("the holder never waits");
+    holder
+        .execute_batch("BEGIN IMMEDIATE")
+        .expect("hold the write lock");
+
+    assert_eq!(claim_racing(&spool, "blocked", 10), ClaimOutcome::Refused);
+
+    holder.execute_batch("COMMIT").expect("release the lock");
+    assert_eq!(claim_racing(&spool, "settled", 10), ClaimOutcome::Leased(1));
 }
 
 #[test]


### PR DESCRIPTION
## What and why

`spool::separate_connections_cannot_claim_the_same_event_concurrently` races
two connections for one spool row, then called `.unwrap()` on both results.
SQLite is allowed to refuse the loser's write while the winner holds the lock,
so on a loaded runner a correct refusal became a panic. The test meant to
assert "not both", and it also asserted "neither was refused", which the API
never promised.

Each racing thread now returns a `ClaimOutcome` — it leased rows, or the lock
was held past the wait and the write was refused. Any other error still panics,
so a real fault still fails. The assertions say what they mean:

- the two connections never both lease the row;
- a pair where neither side was refused leases it exactly once;
- when neither side took it, a third handle claims it after the race, which
  shows the row was not lost.

The busy test is `StoreError::is_busy()`, which reads `crate::busy::is_busy`.
That module already owns the one answer to "was that the lock, or the data?",
so the test asks it rather than matching a SQLite code of its own.

## The production judgement: no `busy_timeout` change

The issue offers a second fix — make the loser wait instead of failing. Not
taken, and here is the reasoning rather than a silence:

- `EnterpriseTelemetrySpool::open_at` already sets `PRAGMA busy_timeout=100`,
  so a loser waits 100 ms before it is refused.
- A refused claim leases no row. The row stays pending, and the next flush
  takes it. `stella-cli`'s `flush_with_retry_clock` turns the refusal into a
  warning and the process carries on.
- So there is no lost work to buy with a longer block, and raising the number
  would make every drain hold its thread longer to quiet a test. That is the
  expedient CLAUDE.md forbids.

## Witness mechanism

`a_claim_refused_for_a_held_lock_is_a_lost_race_not_a_lost_row` holds the write
lock with a second connection told not to wait, then calls the same
`claim_racing` helper the racing test calls. The refusal therefore lands on
every run, not only on a busy machine. The helper must report `Refused`, and
after the lock clears the same row must still lease exactly once.

It fails on the old code by construction two ways. The helper does not exist
there, so the file does not compile with the fix reverted. And the behaviour it
pins is the exact one that was wrong: swap `claim_racing` for the old
`claim_batch_at(...).unwrap()` and the witness panics on
`SqliteFailure(DatabaseBusy, "database is locked")` — the panic in the issue,
now produced on purpose instead of by luck.

Exemplar: `crates/stella-store/src/busy.rs`'s own tests, which hold a lock with
an `impatient` connection to make contention deterministic. This copies that
shape into the spool's integration test.

## Notes

Closes #5304

Tests deleted: None. `separate_connections_cannot_claim_the_same_event_concurrently`
keeps its name and its subject; one test is added.

Residue issues filed: none. Nothing was noticed and left unfixed.

---

### DoD swept 2026-09-05 (appended by the PR sweep)

#5304's two boxes are now ticked, read from this diff rather than run — the
sweep runs off the maintainer's machine and does not execute the suite. Both
are settled by the diff alone and neither waits on `fmt + clippy + test`:

- **"distinguishes both-claimed from one-refused, and no longer panics on the
  second"** — `claim_racing` reaches `ClaimOutcome::Refused` only via
  `error.is_busy()`; every other error still panics, so the tolerance was not
  bought by going blind. `leased <= 1` keeps the real failure, and the
  `leased == 0` arm makes a refusal prove the row survived rather than pass by
  asserting nothing.
- **"if a `busy_timeout` is added, justify it"** — none is added. The diff
  touches no file under `crates/stella-store/src/`; the only `busy_timeout`
  call is `Duration::ZERO` on the new test's own holder connection. The
  production 100 ms this PR describes is pre-existing and unchanged.

This edit is also what re-fires `dod / dod`, which failed at 05:18 against the
un-ticked issue and had no other trigger. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E93U5PCGcuPxN6mtiPRQpS