### PR TITLE
fix(stella-protocol): budget_usd omits null on unbounded children

### DIFF
--- a/crates/stella-protocol/src/subagent_event.rs
+++ b/crates/stella-protocol/src/subagent_event.rs
@@ -103,6 +103,7 @@ pub enum SubAgentPhase {
         /// The USD ceiling actually carved for this child, after clamping
         /// the request against the parent's remaining headroom. `None` when
         /// no axis anywhere bounds it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         budget_usd: Option<f64>,
         /// Whether the child may mutate the workspace. `false` (the
         /// default) means it ran behind a read-only view of the parent's
@@ -196,6 +197,34 @@ mod tests {
         assert!(!json.contains("effort"), "{json}");
         assert_eq!(
             serde_json::from_str::<SubAgentPhase>(&json).unwrap(),
+            started
+        );
+    }
+
+    #[test]
+    fn an_unbounded_child_omits_budget_usd_and_old_journals_with_a_null_still_parse() {
+        // `budget_usd` is `None` for the ordinary unbounded-child case, so
+        // this fires routinely. An unbounded child must not write a null,
+        // and a journal line from before this fix, which does carry the
+        // literal `null`, must still parse.
+        let started = SubAgentPhase::Started {
+            agent_id: "search-1".into(),
+            instruction_preview: String::new(),
+            budget_usd: None,
+            write_access: false,
+            depth: 1,
+            effort: None,
+        };
+        let json = serde_json::to_string(&started).unwrap();
+        assert!(!json.contains("budget_usd"), "{json}");
+        assert_eq!(
+            serde_json::from_str::<SubAgentPhase>(&json).unwrap(),
+            started
+        );
+
+        let legacy = r#"{"phase":"started","agent_id":"search-1","instruction_preview":"","budget_usd":null,"write_access":false,"depth":1}"#;
+        assert_eq!(
+            serde_json::from_str::<SubAgentPhase>(legacy).unwrap(),
             started
         );
     }


### PR DESCRIPTION
## What / why

`SubAgentPhase::Started::budget_usd` (`crates/stella-protocol/src/subagent_event.rs`)
had no serde attribute, so every unbounded child (`budget_usd: None`, the
routine case) wrote a literal `"budget_usd": null` into the event journal.
Its sibling `effort`, twelve lines below in the same variant, already
carries `#[serde(default, skip_serializing_if = "Option::is_none")]`.

This PR takes **route 1** from the issue: add that same attribute pair to
`budget_usd`, matching `effort`.

## Wire schema

`budget_usd` was already absent from `required` in
`docs/wire/agentevent.schema.json` (schemars derives `required` from the
type, and an `Option<f64>` is already optional there regardless of the
serde attribute). Regenerated via `bash scripts/export-agentevent-schema.sh`
— the diff is empty, exactly as the issue predicted.

## Witness

`an_unbounded_child_omits_budget_usd_and_old_journals_with_a_null_still_parse`
(same shape as the existing `a_started_with_no_pinned_effort_omits_the_field_and_old_journals_parse`):

- builds a `Started` with `budget_usd: None`, serializes it, asserts the
  JSON contains no `budget_usd` key, and asserts it round-trips.
- asserts a legacy journal line that still carries the literal
  `"budget_usd":null` still parses into the same value.

Confirmed the fail-to-pass flip by hand: temporarily removed the new
attribute, re-ran the narrow crate test — the test panics on the first
assertion (the serialized JSON still contains the key). Restored the
attribute — all six tests in the module pass.

## Checks run locally (SCR-001, narrow scope only)

- Narrow `stella-protocol` crate test run, `subagent_event` module — 6 passed.
- `cargo fmt` check — clean.
- `make guards-fast` — all toolchain-free guards green, including
  `check-file-size` (subagent_event.rs is nowhere near the ceiling) and
  `check-prose` (no new prose added).

Tests deleted: None.

Closes #5769

## Summary by Sourcery

Prevent unbounded child events from writing redundant null budget values while preserving compatibility with existing journals.

Bug Fixes:
- Omit `budget_usd` from serialized started events when an unbounded child has no budget, while continuing to parse legacy journals containing `budget_usd: null`.

Tests:
- Add coverage for omission of unbounded-child budgets and backward compatibility with legacy journal entries.