### PR TITLE
ci(dod-check): re-pin the SCR-003 caller stubs to oxagen#2643

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -25,4 +25,4 @@ permissions:
 
 jobs:
   dod:
-    uses: macanderson/oxagen/.github/workflows/dod-check.yml@ce08b16fabc613f465f69741672e584c9c82ead3 # oxagen main, #1323
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@84fe021ba3cf455b1d5057b04ed1111152fdceda # oxagen main, #2643

--- a/.github/workflows/dod-close-guard.yml
+++ b/.github/workflows/dod-close-guard.yml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   guard:
-    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@ce08b16fabc613f465f69741672e584c9c82ead3 # oxagen main, #1323
+    uses: macanderson/oxagen/.github/workflows/dod-close-guard.yml@84fe021ba3cf455b1d5057b04ed1111152fdceda # oxagen main, #2643


### PR DESCRIPTION
## What

Re-pins both SCR-003 caller stubs — `.github/workflows/dod-check.yml` and `.github/workflows/dod-close-guard.yml` — from `ce08b16f` (oxagen main, #1323) to `84fe021b` (oxagen main, #2643), the merge commit of oxagen#2643.

## Why

`dod-check.yml` took the pull request from `context.payload.pull_request`, a snapshot from the event that started the run. Release automation opens a PR and labels it seconds later, so the `opened` event's run sees no labels while the `labeled` event's run sees them, and whichever run finishes last decides the check's verdict. stella#5792 got stuck red on this: the PR already carried the `no-issue` waiver label, but the stale `opened`-event run finished last and published a failing check, blocking `auto-tag.yml`'s auto-merge.

oxagen#2643 fixes it at the source — reads the PR live (`github.rest.pulls.get`) instead of the event snapshot, and adds a per-repo-per-PR concurrency group so the two runs stop racing. The same commit also fixes `dod-close-guard.yml`'s `closeExemptFromDod` so a `duplicate` close is exempt (oxagen#2643's own second defect).

Both changes only reach this repo when the pin moves — that's what this PR does.

## Verified before opening this PR

- `84fe021ba3cf455b1d5057b04ed1111152fdceda` was confirmed on `macanderson/oxagen`'s `main` branch on a fresh clone (`git branch -r --contains` lists `origin/main`), and both `dod-check.yml` and `dod-close-guard.yml` exist at that commit with unchanged `workflow_call` interfaces.
- Checked the three sibling caller stubs across the org (`context-graph-protocol`, `arenabench`, `cgp-website`): all three pin `uses: macanderson/oxagen/.github/workflows/{dod-check,dod-close-guard}.yml@main` — a floating ref, not a SHA — so they already run oxagen#2643's fix and need no re-pin. Recorded per the issue's third DoD item. (Those repos' own use of a floating `@main` ref is a separate action-pins question for their own gates, out of scope here.)
- `./scripts/check-action-pins.sh` passes locally: 95 `uses:` references, all pinned to a commit SHA.
- `make guards-fast` passes locally (full output in the issue comment thread on request); this diff is workflow-only so no Rust rung applies.

## Fixed as a drive-by, same issue

While reading #5803's body to satisfy the "definition of done" template, its raw stored body (verified via `gh api repos/.../issues/5803`) turned out to contain **literal `\n`/`\"` escape sequences instead of real newlines/quotes** — the whole body was one un-rendered line. `dod-check.yml`'s own `dodStatus()` parser (`section.split("\n")` plus `^`-anchored regexes) needs real newline bytes to find the `## Definition of done` heading at all; without them it would report "no Definition of done section" regardless of what the checklist says, once this repo's dod-check starts reading the live PR body. Re-wrote the issue body with real newlines (content unchanged) via `gh issue edit --body-file`, and folded in the two demonstration items from the linked #5818 duplicate-close comment into the actual `## Definition of done` checklist (they were posted only as a comment before, which `dod-check` never reads).

## Witness

This PR is itself the dod-check witness: once this branch's diff is visible under the new pin, this PR's own `dod / dod` run exercises `84fe021b`'s implementation. Link and confirm below once the check reports.

Tests deleted: None.

Closes #5803

## Summary by Sourcery

Enhancements:
- Re-pin the reusable DOD check and close-guard workflows to the oxagen commit containing live pull-request evaluation, concurrency protection, and duplicate-close exemption fixes.

---

**Update:** all four items in #5803's own Definition of done that this PR can settle are now ticked, with evidence in the issue's comment thread. The remaining two items (dod-close-guard's duplicate-close exemption, live-demonstrated) were split into #5872 — `on: issues` events resolve a reusable workflow from `main`, never from an open PR, so they are only observable after this PR merges; leaving them on #5803 would have made its own dod-check gate unsatisfiable by construction. Confirmed live: closing a disposable test issue as `duplicate` while this PR was open still triggered the pre-#2643 script and reopened it.
