### PR TITLE
fix(stella-cli): read the issue before writing the escalation record

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -30,6 +30,8 @@ use crate::query_format::{QueryFormat, Rows};
 use super::config::LoopConfig;
 use super::state::LoopState;
 
+mod record;
+
 /// How many open issues cross the port to produce one cycle's batch.
 ///
 /// This is a page size, and a page the backlog outgrows silently changes the
@@ -521,7 +523,6 @@ pub(super) fn escalate_blocking(
     provider: &dyn IssueProvider,
     key: &str,
     why: &str,
-    body: &str,
     policy: &EscalationPolicy,
     signature: &str,
 ) -> Result<EscalationRecord, String> {
@@ -534,7 +535,6 @@ pub(super) fn escalate_blocking(
             provider,
             &IssueKey::from(key),
             why,
-            body,
             policy,
             signature,
         ))
@@ -554,29 +554,32 @@ pub(super) fn escalate_blocking(
 /// costs no extra call to the tracker. It is an HTML comment, so nobody
 /// reading the rendered issue sees it.
 ///
+/// **No body is passed in.** A turn runs for minutes, and the text a person
+/// is looking at can change in that time. [`record::write`] reads the issue
+/// itself, right before it writes, and that module carries the rest of the
+/// rule — what happens to an edit that lands in the gap, and how wide the gap
+/// can be.
+///
 /// Returns the record it wrote, so the caller can count an issue that has
 /// just used up its last attempt.
 pub(super) async fn escalate(
     provider: &dyn IssueProvider,
     key: &IssueKey,
     why: &str,
-    body: &str,
     policy: &EscalationPolicy,
     signature: &str,
 ) -> Result<EscalationRecord, IssueError> {
-    let record = escalation::next(
-        escalation::parse(body).as_ref(),
-        escalation::classify(why),
-        &crate::timefmt::rfc3339_utc_now(),
-        crate::timefmt::now_unix(),
-    );
-
     provider
         .relabel(key, &[stella_autonomy::ESCALATION_LABEL.to_owned()], &[])
         .await?;
-    provider
-        .edit(key, None, Some(&escalation::stamp(body, &record)))
-        .await?;
+    let record = record::write(
+        provider,
+        key,
+        escalation::classify(why),
+        &crate::timefmt::rfc3339_utc_now(),
+        crate::timefmt::now_unix(),
+    )
+    .await?;
 
     let next_step = match escalation::retry_after(&record, policy) {
         Some(wait) => format!(
@@ -794,16 +797,14 @@ mod tests {
 
     /// A tracker that is not GitHub and is not a process.
     ///
-    /// Records what it was asked to write, so a test can assert not only what
-    /// was filed but that nothing **was** — which is the half that matters for
-    /// a refusal, since a conformance check that ran after the write would pass
-    /// the same assertions on the returned value.
+    /// It keeps every draft it was asked to file. So a test can assert that
+    /// nothing was filed at all, which is what a refusal has to show: a check
+    /// that ran after the write would pass the same assertions on the value it
+    /// returned.
     #[derive(Default)]
     struct FixtureProvider {
         open: Vec<Issue>,
         filed: std::sync::Mutex<Vec<IssueDraft>>,
-        edited: std::sync::Mutex<Vec<String>>,
-        labelled: std::sync::Mutex<Vec<String>>,
     }
 
     impl FixtureProvider {
@@ -816,14 +817,6 @@ mod tests {
 
         fn filed(&self) -> Vec<IssueDraft> {
             self.filed.lock().expect("fixture lock").clone()
-        }
-
-        fn edited(&self) -> Vec<String> {
-            self.edited.lock().expect("fixture lock").clone()
-        }
-
-        fn labelled(&self) -> Vec<String> {
-            self.labelled.lock().expect("fixture lock").clone()
         }
     }
 
@@ -859,13 +852,9 @@ mod tests {
         async fn relabel(
             &self,
             _key: &IssueKey,
-            add: &[String],
+            _add: &[String],
             _remove: &[String],
         ) -> Result<(), IssueError> {
-            self.labelled
-                .lock()
-                .expect("fixture lock")
-                .extend(add.iter().cloned());
             Ok(())
         }
 
@@ -873,14 +862,8 @@ mod tests {
             &self,
             _key: &IssueKey,
             _title: Option<&str>,
-            body: Option<&str>,
+            _body: Option<&str>,
         ) -> Result<(), IssueError> {
-            if let Some(body) = body {
-                self.edited
-                    .lock()
-                    .expect("fixture lock")
-                    .push(body.to_owned());
-            }
             Ok(())
         }
     }
@@ -1373,67 +1356,6 @@ mod tests {
             &stella_autonomy::Attribution::default(),
         );
         assert!(outcome.is_err(), "{outcome:?}");
-    }
-
-    /// **The escalation-record witness.** Escalating writes the label a
-    /// person reads *and* a record the next run reads: the count,
-    /// the reason, and the moment. A second escalation on the stamped body
-    /// carries the count forward rather than starting over, which is what
-    /// makes parking reachable.
-    #[test]
-    fn escalating_stamps_a_record_the_next_run_can_read() {
-        let provider = FixtureProvider::default();
-        let policy = stella_autonomy::escalation::EscalationPolicy::default();
-
-        let first = escalate_blocking(
-            &provider,
-            "17",
-            "the turn exited 1 — the same `bash` call with identical arguments \
-             produced byte-identical output every time",
-            "## What happens\nThe environment was stale.\n",
-            &policy,
-            "created by stella*",
-        )
-        .expect("the fixture accepts writes");
-
-        assert_eq!(first.attempts, 1);
-        assert_eq!(
-            first.last_reason,
-            stella_autonomy::escalation::EscalationReason::Environmental(
-                stella_autonomy::escalation::EnvCause::StuckLoop
-            ),
-            "a stuck-loop abort is a broken machine, and it is retried eagerly"
-        );
-        assert_eq!(
-            provider.labelled(),
-            vec![stella_autonomy::ESCALATION_LABEL.to_owned()],
-            "the label stays as the marker a person scans for"
-        );
-
-        let stamped = provider.edited().pop().expect("the body was stamped");
-        assert!(
-            stamped.starts_with("## What happens"),
-            "the issue's own text is kept: {stamped}"
-        );
-        assert_eq!(
-            stella_autonomy::escalation::parse(&stamped).as_ref(),
-            Some(&first),
-            "the record must survive a read of the body it was written into"
-        );
-
-        let second = escalate_blocking(
-            &provider,
-            "17",
-            "the turn ran and could not work out what the issue asks for",
-            &stamped,
-            &policy,
-            "created by stella*",
-        )
-        .expect("the fixture accepts writes");
-        assert_eq!(
-            second.attempts, 2,
-            "the count carries forward, or parking is never reached"
-        );
     }
 
     /// The limit bounds what crosses the port, not what the ranker discards

--- a/crates/stella-cli/src/self_driving_cmd/backlog/record.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog/record.rs
@@ -7,7 +7,7 @@
 //! read at the start of a turn is minutes old. Sending it back would wipe out
 //! any note a person added while the turn ran.
 //!
-//! [`write`] reads the issue just before it writes. It builds the record from
+//! [`write()`] reads the issue just before it writes. It builds the record from
 //! that read. If the read fails it writes nothing. A body nobody can see is a
 //! body nobody may replace.
 //!

--- a/crates/stella-cli/src/self_driving_cmd/backlog/record.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog/record.rs
@@ -1,0 +1,407 @@
+//! Where the escalation record gets written.
+//!
+//! The record lives in the issue body. To write it, the loop has to send a
+//! whole body. That is the only shape a tracker edit takes.
+//!
+//! So the body it sends must be the body the tracker holds right then. A body
+//! read at the start of a turn is minutes old. Sending it back would wipe out
+//! any note a person added while the turn ran.
+//!
+//! [`write`] reads the issue just before it writes. It builds the record from
+//! that read. If the read fails it writes nothing. A body nobody can see is a
+//! body nobody may replace.
+//!
+//! Then it reads once more. If the record is gone, a person saved their own
+//! text in the gap. Theirs is the newer text, so the same record goes back on
+//! top of it. Once only. The loop must not fight a person over one body.
+//!
+//! GitHub has no compare-and-set on an issue body. One round trip between the
+//! read and the write is the floor. An edit saved inside that gap is lost.
+
+use stella_autonomy::escalation::{self, EscalationReason, EscalationRecord};
+use stella_protocol::issue::{IssueError, IssueKey, IssueProvider};
+
+/// Stamp one escalation record into the issue's own current body.
+///
+/// `at` and `at_unix` are one moment in two spellings. One is for a person to
+/// read. The other is for the cooldown math. Both come from the caller, so
+/// these rules can be tested against a fixed clock.
+pub(super) async fn write(
+    provider: &dyn IssueProvider,
+    key: &IssueKey,
+    reason: EscalationReason,
+    at: &str,
+    at_unix: i64,
+) -> Result<EscalationRecord, IssueError> {
+    let before = provider.get(key).await?.body;
+    let record = escalation::next(escalation::parse(&before).as_ref(), reason, at, at_unix);
+    provider
+        .edit(key, None, Some(&escalation::stamp(&before, &record)))
+        .await?;
+
+    // The second read and the repair are best effort. The record is already
+    // written. Both can only add to what the issue holds. Failing here would
+    // drop the comment that tells a person what went wrong.
+    let Ok(settled) = provider.get(key).await else {
+        return Ok(record);
+    };
+    if escalation::parse(&settled.body).as_ref() != Some(&record) {
+        let _ = provider
+            .edit(key, None, Some(&escalation::stamp(&settled.body, &record)))
+            .await;
+    }
+    Ok(record)
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use stella_protocol::issue::{
+        Issue, IssueClass, IssueDraft, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState,
+    };
+
+    use super::*;
+
+    /// A tracker that stores one issue body and hands back what it holds.
+    ///
+    /// `get` reads the stored body. `edit` replaces it. So a test can watch a
+    /// write land the way a person would.
+    ///
+    /// `person_writes_after` is the race. When it holds text, a person saves
+    /// that text right after the first `edit`. A tracker with no
+    /// compare-and-set allows that.
+    #[derive(Default)]
+    struct BodyTracker {
+        body: std::sync::Mutex<String>,
+        person_writes_after: std::sync::Mutex<Option<String>>,
+        labelled: std::sync::Mutex<Vec<String>>,
+        comments: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl BodyTracker {
+        fn holding(body: &str) -> Self {
+            Self {
+                body: std::sync::Mutex::new(body.to_owned()),
+                ..Self::default()
+            }
+        }
+
+        fn body(&self) -> String {
+            self.body.lock().expect("fixture lock").clone()
+        }
+
+        fn labelled(&self) -> Vec<String> {
+            self.labelled.lock().expect("fixture lock").clone()
+        }
+
+        fn comments(&self) -> Vec<String> {
+            self.comments.lock().expect("fixture lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl IssueProvider for BodyTracker {
+        fn id(&self) -> &str {
+            "body-tracker"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(Vec::new())
+        }
+
+        async fn file(&self, _draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            Ok(IssueKey::from("1"))
+        }
+
+        async fn close(
+            &self,
+            _key: &IssueKey,
+            _receipt: &str,
+            _state: &str,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, _key: &IssueKey, body: &str) -> Result<(), IssueError> {
+            self.comments
+                .lock()
+                .expect("fixture lock")
+                .push(body.to_owned());
+            Ok(())
+        }
+
+        async fn relabel(
+            &self,
+            _key: &IssueKey,
+            add: &[String],
+            _remove: &[String],
+        ) -> Result<(), IssueError> {
+            self.labelled
+                .lock()
+                .expect("fixture lock")
+                .extend(add.iter().cloned());
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            body: Option<&str>,
+        ) -> Result<(), IssueError> {
+            if let Some(body) = body {
+                *self.body.lock().expect("fixture lock") = body.to_owned();
+            }
+            if let Some(theirs) = self
+                .person_writes_after
+                .lock()
+                .expect("fixture lock")
+                .take()
+            {
+                *self.body.lock().expect("fixture lock") = theirs;
+            }
+            Ok(())
+        }
+
+        async fn get(&self, key: &IssueKey) -> Result<Issue, IssueError> {
+            Ok(Issue {
+                key: key.clone(),
+                title: "an issue somebody is reading".into(),
+                body: self.body(),
+                state: IssueState::Open,
+                class: IssueClass::Bug,
+                labels: self
+                    .labelled()
+                    .into_iter()
+                    .map(|name| IssueLabel { name })
+                    .collect(),
+                created_at: "2026-09-02T00:00:00Z".into(),
+                updated_at: "2026-09-02T00:00:00Z".into(),
+                url: String::new(),
+                parent: None,
+            })
+        }
+    }
+
+    /// A tracker nobody can read. Its writes still work. That is what makes
+    /// it worth a test: a body nobody can read is left alone.
+    struct BlindTracker {
+        writes: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl IssueProvider for BlindTracker {
+        fn id(&self) -> &str {
+            "blind"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(Vec::new())
+        }
+
+        async fn file(&self, _draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            Ok(IssueKey::from("1"))
+        }
+
+        async fn close(
+            &self,
+            _key: &IssueKey,
+            _receipt: &str,
+            _state: &str,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn relabel(
+            &self,
+            _key: &IssueKey,
+            _add: &[String],
+            _remove: &[String],
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            body: Option<&str>,
+        ) -> Result<(), IssueError> {
+            self.writes
+                .lock()
+                .expect("fixture lock")
+                .push(body.unwrap_or_default().to_owned());
+            Ok(())
+        }
+
+        async fn get(&self, _key: &IssueKey) -> Result<Issue, IssueError> {
+            Err(IssueError::Unavailable {
+                provider: "blind".into(),
+                reason: "the tracker cannot be read".into(),
+            })
+        }
+    }
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+    }
+
+    fn stuck() -> EscalationReason {
+        escalation::classify("byte-identical output every time")
+    }
+
+    /// **The witness.** A note a person adds while the turn runs is still
+    /// there after the escalation lands.
+    ///
+    /// The tracker holds the note. The loop holds nothing. So the record has
+    /// to come from a read taken at write time, or the note goes.
+    #[test]
+    fn a_note_added_during_the_turn_survives_the_escalation() {
+        let tracker = BodyTracker::holding(
+            "## What happens\nThe queue never gets it back.\n\n\
+             somebody's note: this needs the 0.9.3 client\n",
+        );
+
+        let record = runtime()
+            .block_on(crate::self_driving_cmd::backlog::escalate(
+                &tracker,
+                &IssueKey::from("17"),
+                "the turn exited 1 — byte-identical output every time",
+                &stella_autonomy::escalation::EscalationPolicy::default(),
+                "created by stella*",
+            ))
+            .expect("the tracker accepts writes");
+
+        let landed = tracker.body();
+        assert!(
+            landed.contains("somebody's note: this needs the 0.9.3 client"),
+            "the note a person added is gone: {landed}"
+        );
+        assert!(
+            landed.starts_with("## What happens"),
+            "the issue's own text is kept: {landed}"
+        );
+        assert_eq!(
+            escalation::parse(&landed).as_ref(),
+            Some(&record),
+            "the record must survive a read of the body it was written into"
+        );
+        assert_eq!(
+            tracker.labelled(),
+            vec![stella_autonomy::ESCALATION_LABEL.to_owned()],
+            "the label stays as the marker a person scans for"
+        );
+        assert_eq!(
+            tracker.comments().len(),
+            1,
+            "one comment says what went wrong"
+        );
+    }
+
+    /// A save that lands in the gap keeps its text. The record goes back on
+    /// top of it.
+    #[test]
+    fn a_write_that_lands_in_the_gap_keeps_its_text_and_gets_the_record_back() {
+        let tracker = BodyTracker::holding("## What happens\nThe queue never gets it back.\n");
+        *tracker.person_writes_after.lock().expect("fixture lock") =
+            Some("## What happens\nRewritten by hand.\n".to_owned());
+
+        let record = runtime()
+            .block_on(write(
+                &tracker,
+                &IssueKey::from("17"),
+                stuck(),
+                "2026-09-02T00:00:00Z",
+                1_000,
+            ))
+            .expect("the tracker accepts writes");
+
+        let landed = tracker.body();
+        assert!(
+            landed.starts_with("## What happens\nRewritten by hand."),
+            "the newer text is kept: {landed}"
+        );
+        assert_eq!(
+            escalation::parse(&landed).as_ref(),
+            Some(&record),
+            "an issue with the label and no record is parked for good"
+        );
+    }
+
+    /// A body the loop cannot read is a body it cannot replace.
+    #[test]
+    fn an_unreadable_body_is_never_written_over() {
+        let tracker = BlindTracker {
+            writes: std::sync::Mutex::new(Vec::new()),
+        };
+
+        let outcome = runtime().block_on(write(
+            &tracker,
+            &IssueKey::from("17"),
+            stuck(),
+            "2026-09-02T00:00:00Z",
+            1_000,
+        ));
+
+        assert!(outcome.is_err(), "{outcome:?}");
+        assert!(
+            tracker.writes.lock().expect("fixture lock").is_empty(),
+            "nothing may be sent when the current text is unknown"
+        );
+    }
+
+    /// The count carries forward, so parking can be reached. The second
+    /// escalation reads the record the first one left in the body.
+    #[test]
+    fn escalating_stamps_a_record_the_next_run_can_read() {
+        let tracker = BodyTracker::holding("## What happens\nThe environment was stale.\n");
+        let policy = stella_autonomy::escalation::EscalationPolicy::default();
+        let key = IssueKey::from("17");
+
+        let first = runtime()
+            .block_on(crate::self_driving_cmd::backlog::escalate(
+                &tracker,
+                &key,
+                "the turn exited 1 — the same `bash` call with identical \
+                 arguments produced byte-identical output every time",
+                &policy,
+                "created by stella*",
+            ))
+            .expect("the tracker accepts writes");
+
+        assert_eq!(first.attempts, 1);
+        assert_eq!(
+            first.last_reason,
+            stella_autonomy::escalation::EscalationReason::Environmental(
+                stella_autonomy::escalation::EnvCause::StuckLoop
+            ),
+            "a stuck-loop abort is a broken machine, and it is retried eagerly"
+        );
+
+        let second = runtime()
+            .block_on(crate::self_driving_cmd::backlog::escalate(
+                &tracker,
+                &key,
+                "the turn ran and could not work out what the issue asks for",
+                &policy,
+                "created by stella*",
+            ))
+            .expect("the tracker accepts writes");
+        assert_eq!(
+            second.attempts, 2,
+            "the count carries forward, or parking is never reached"
+        );
+        assert_eq!(
+            tracker.body().matches(escalation::MARKER_OPEN).count(),
+            1,
+            "a body escalated twice carries one record"
+        );
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive/triage.rs
@@ -18,9 +18,9 @@ use super::{Audit, Durable, audit, runtime};
 
 /// Mark an issue the loop tried and could not resolve.
 ///
-/// The whole issue rather than its key, because the escalation record is
-/// stamped into the body and the count in the body it already has is what
-/// says whether this is the first attempt or the last.
+/// The whole issue rather than its key, because the caller already holds it
+/// and a later reader of this signature should not have to guess which half
+/// of it is wanted.
 pub(super) fn escalate(
     durable: &Durable,
     settings: &crate::settings::Settings,
@@ -34,7 +34,6 @@ pub(super) fn escalate(
         provider,
         key,
         why,
-        &issue.body,
         &cfg.escalation,
         &cfg.attribution.issue_comment,
     )) {
@@ -137,7 +136,6 @@ pub(super) fn assess_one(
              priority it wrote — the drive runner's login is not on the \
              guard's list. Add it to TRIAGE_LOGINS in the guard workflow, or \
              set the priority from an allowed login",
-            &full.body,
             &cfg.escalation,
             &cfg.attribution.issue_comment,
         )?;
@@ -160,7 +158,6 @@ pub(super) fn assess_one(
             &issue.key,
             "triage could not place this issue in the configured vocabulary — \
              it needs a human to label it",
-            &body,
             &cfg.escalation,
             &cfg.attribution.issue_comment,
         )?;

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -428,6 +428,18 @@ An escalated issue with no record stays out of the queue. The label alone
 says nothing about what went wrong or when, and a person who applied it by
 hand meant it.
 
+**The record write never carries a stale body.** Writing the record means
+sending a whole issue body, because that is the only shape a tracker edit
+takes. A work turn runs for minutes, and the text a person is reading can
+change while it does. So `backlog::record::write` reads the issue itself,
+right before it writes, and builds the record from that read. A body it
+cannot read is one it will not replace: the read failing aborts the write and
+the loop reports it as a transient tracker failure. After the write it reads
+once more, and if the record is gone it stamps the same record onto the newer
+text, once. GitHub offers no compare-and-set on an issue body, so an edit
+saved inside that one round trip is still lost; the gap is one call wide
+rather than one turn wide.
+
 **The deploy watch.** Beside the base watch, each poll may also read the
 release workflow's latest completed run, through the same forge pathway. On
 a red conclusion with no open report, the loop files one and adopts it. The


### PR DESCRIPTION
## What and why

Writing the escalation record means sending a whole issue body — `gh issue
edit --body` takes no other shape. `backlog::escalate` took the body the loop
had read earlier in the same turn and sent that back. A work turn runs for
minutes, so a note a person added while it ran was carried away, with nothing
to report it and the loop showing as the last editor.

`escalate` no longer accepts a body at all, so the stale snapshot is not
representable. The new `crates/stella-cli/src/self_driving_cmd/backlog/record.rs`
does the write:

- It reads the issue right before it writes, and builds the record from that
  read, so the attempt count is the tracker's own rather than a stale copy's.
- A failed read aborts the write. A body nobody can see is a body nobody may
  replace. The caller already reports that as a transient tracker failure.
- After the write it reads once more. If the record is gone, a person saved
  their own text in the gap; theirs is the newer text, so the same record is
  stamped on top of it, once. The loop cannot fight a person over one body.

GitHub offers no compare-and-set on an issue body, so an edit saved inside one
round trip is still lost. That is written down in the module docs and in
`doc:backlog-self-driving` rather than left for the next reader to re-derive.

The record stays in the body rather than moving to a comment: `to_queue_issue`
parses the cooldown out of the body every queue read already carries, and a
comment would cost a read per escalated issue. #5662 weighed that and declined
it; nothing here changes the arithmetic.

## Witness

`a_note_added_during_the_turn_survives_the_escalation` in
`crates/stella-cli/src/self_driving_cmd/backlog/record.rs`. A fixture tracker
stores a body that already carries `somebody's note: this needs the 0.9.3
client`, and the loop holds no body at all. The test asserts the note is still
there after the escalation lands, alongside the record and the label.

It fails on the old code by construction twice over: `escalate` took the body
to write as a parameter, so the tracker's own text was never read, and the
note was replaced by whatever the caller passed. The signature no longer has
that parameter, so the old code cannot even express the call.

Two more tests cover the rest of the rule:

- `a_write_that_lands_in_the_gap_keeps_its_text_and_gets_the_record_back` —
  the fixture saves a person's text right after the first `edit`, and the
  single repair puts the record back on their text.
- `an_unreadable_body_is_never_written_over` — a tracker whose reads fail and
  whose writes would succeed sees no write at all.

Exemplar: the fixture-tracker shape is the one already in
`backlog.rs`'s test module, extended to store a body so `get` and `edit` talk
to each other.

## Tests deleted

None. `escalating_stamps_a_record_the_next_run_can_read` moved from
`backlog.rs` to `backlog/record.rs`, where the fixture that stores a body
lives, and asserts the same thing plus the single-marker property.

`FixtureProvider`'s `edited` and `labelled` recorders in `backlog.rs` went with
it — no test read them any more.

## Residue

None found beyond what this change fixes.

Closes #5702

## Verification by the PR sweep (appended 2026-09-05)

#5702's four DoD boxes are ticked, checked against the diff at `9a03228` rather
than against this description.

- **The stale body is not representable.** `body: &str` is gone from `escalate`
  and `escalate_blocking`, and from all three call sites in `drive/triage.rs`
  (`escalate`, plus the two `assess_one` paths that passed `&full.body` and
  `&body`). `record::write` opens with `provider.get(key).await?.body`.
- **The witness fails on the old code.** Both new race tests call
  `backlog::escalate` with five arguments against a signature that took six, so
  they cannot compile on `main`; semantically,
  `a_note_added_during_the_turn_survives_the_escalation` asserts text the loop
  never held, which `stamp(body, record)` could not have contained.
  `an_unreadable_body_is_never_written_over` pins the fail-closed direction.
- **The choice is recorded where the next reader lands.** `escalate`'s doc
  comment names it ("**No body is passed in.**") and `record.rs`'s module header
  carries the remainder.
- **The spec states the residual gap honestly.** `doc:backlog-self-driving`'s
  new paragraph says the round-trip gap is narrowed, not closed.

Detail is in [this comment](https://github.com/macanderson/stella/issues/5702#issuecomment-5549750291).

This edit is what fires the `pull_request` event `dod-check.yml` needs to
re-read the boxes — the edit is the trigger, never the fix.

## Summary by Sourcery

Make escalation recording read the current issue body immediately before writing so stale turn snapshots cannot erase human updates.

Bug Fixes:
- Prevent escalation records from overwriting issue text added or changed by people during a self-driving work turn.
- Fail closed when the current issue body cannot be read before recording an escalation.
- Repair a record lost to an edit race by restoring it once on the newer issue text.

Enhancements:
- Centralize escalation-record writes so attempt counts are derived from the tracker's current issue body.
- Document the unavoidable race window caused by trackers lacking compare-and-set body updates.

Documentation:
- Document the current-body read, fail-closed behavior, and residual edit race in the backlog self-driving specification.

Tests:
- Add coverage for preserving concurrent notes, repairing edits that land during recording, and avoiding writes when issue reads fail.
- Move and expand escalation record persistence coverage around the body-aware fixture.