### PR TITLE
fix(stella-serve): report a retained checkpoint in the session-delete body

### DIFF
--- a/crates/stella-serve/src/checkpoint.rs
+++ b/crates/stella-serve/src/checkpoint.rs
@@ -375,6 +375,32 @@ impl TurnCheckpoint {
             reported: AtomicBool::new(false),
         })
     }
+
+    /// Discard this resume point outside the engine's step loop. Unlike the
+    /// engine's own discard, this one tells the caller whether it worked.
+    ///
+    /// [`CheckpointSink::discard`] stays void on purpose: the engine never
+    /// branches on an I/O result. A session-delete route is not the step
+    /// loop. It discards this key exactly once, right before it answers a
+    /// caller, so it can afford to know the answer.
+    ///
+    /// A failure is still reported the same way [`StoreSink::discard`]
+    /// reports one: one [`ServeEvent::CheckpointFailed`], which feeds
+    /// `checkpoints_failed_total`. An operator sees it either way. The
+    /// return value here is only for the caller's own response.
+    pub(crate) fn discard_now(&self, observer: &SharedObserver, turn: TurnRef) -> bool {
+        match self.store.remove(&self.key) {
+            Ok(()) => true,
+            Err(err) => {
+                observer.emit(&ServeEvent::CheckpointFailed {
+                    turn,
+                    op: CheckpointOp::Discard,
+                    error: err.to_string(),
+                });
+                false
+            }
+        }
+    }
 }
 
 /// One key of a [`CheckpointStore`], seen by the engine as a

--- a/crates/stella-serve/src/routes.rs
+++ b/crates/stella-serve/src/routes.rs
@@ -1133,6 +1133,13 @@ pub(crate) async fn handle_checkpoint_get(
 /// deleting what is not there is a `200`, because a host recovering from a
 /// crash cannot be expected to know which of its turns got far enough to write
 /// one.
+///
+/// A store error here is a genuine `500`, unlike `handle_session_delete`'s
+/// `200 {"checkpoint":"retained"}` on the same failure. This route's only
+/// job is the checkpoint, so a failure to remove it *is* the whole outcome.
+/// `handle_session_delete`'s discard is a side effect of ending a session
+/// that is already gone by the time the discard runs; a `500` there would
+/// ask a caller to retry a delete that already happened.
 pub(crate) async fn handle_checkpoint_delete(
     res: &mut Responder<'_>,
     state: &Arc<ServerState>,

--- a/crates/stella-serve/src/routes/sessions.rs
+++ b/crates/stella-serve/src/routes/sessions.rs
@@ -308,6 +308,19 @@ pub(crate) async fn handle_session_turn(
     res.json("200 OK", &body).await
 }
 
+/// Response to `DELETE /v1/sessions/{id}`.
+///
+/// `checkpoint` is present only when the discard failed — see
+/// `handle_session_delete`'s own comment for why `status` never varies. A
+/// caller that never reads `checkpoint` parses the same
+/// `{"status":"deleted"}` every existing integration already expects.
+#[derive(Debug, Serialize)]
+struct SessionDeleted {
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    checkpoint: Option<&'static str>,
+}
+
 /// `GET /v1/sessions/{id}` — history, cost to date, and the live turn if any.
 pub(crate) async fn handle_session_get(
     res: &mut Responder<'_>,
@@ -376,21 +389,29 @@ pub(crate) async fn handle_session_delete(
     // key is the session id, and that id now answers `404` everywhere else.
     // Leaving it would make `DELETE` the one operation that grows the store.
     //
-    // This routes the discard through the same `TurnCheckpoint::sink` the
-    // engine's own persist and discard calls use, instead of dropping the
-    // `Result` on the floor. A failing store now reports itself the same
-    // way any other checkpoint failure does: a `CheckpointFailed` event and
-    // a `checkpoints_failed_total` bump. The response still says
-    // `"deleted"`, because the session itself is gone either way. The
-    // reference id is the turn that was live at delete time, if any —
-    // otherwise the session id, stripped of its prefix.
+    // `status` stays `"deleted"` no matter what happens next. The registry
+    // entry is gone. A `500` here would only make a caller retry a delete
+    // that already worked.
+    //
+    // A failed discard is still reported: one `CheckpointFailed` event, one
+    // `checkpoints_failed_total` bump, same as any other checkpoint
+    // failure. The body also carries a new field on that failure —
+    // `"checkpoint":"retained"` — so a host that just ended a session is
+    // told its checkpoint outlived it, not just that the session is gone.
+    //
+    // The reference id is the live turn at delete time, if any. Otherwise
+    // it is the session id with its prefix stripped.
+    let mut checkpoint_retained = false;
     if let Some(checkpoint) = state.checkpoint_for(id) {
         let reference = live_turn_id
             .as_deref()
             .unwrap_or_else(|| id.strip_prefix("session-").unwrap_or(id));
-        checkpoint
-            .sink(state.observer().clone(), TurnRef::new(reference))
-            .discard();
+        checkpoint_retained = !checkpoint.discard_now(state.observer(), TurnRef::new(reference));
     }
-    res.json("200 OK", br#"{"status":"deleted"}"#).await
+    let body = serde_json::to_vec(&SessionDeleted {
+        status: "deleted",
+        checkpoint: checkpoint_retained.then_some("retained"),
+    })
+    .unwrap_or_default();
+    res.json("200 OK", &body).await
 }

--- a/crates/stella-serve/tests/checkpoint.rs
+++ b/crates/stella-serve/tests/checkpoint.rs
@@ -397,6 +397,9 @@ async fn a_host_can_reclaim_a_resume_point_it_has_recovered() {
 
 /// Ending a conversation takes its resume point with it — otherwise `DELETE`
 /// would be the one operation that grows the store.
+///
+/// This also checks the body, not just the status. A successful discard
+/// keeps the same shape it has always had.
 #[tokio::test]
 async fn deleting_a_session_takes_its_resume_point_with_it() {
     let (addr, store) = start_durable_server().await;
@@ -406,6 +409,10 @@ async fn deleting_a_session_takes_its_resume_point_with_it() {
 
     let (status, body) = delete_checkpoint(addr, &format!("/v1/sessions/{session_id}")).await;
     assert!(status.contains("200"), "delete session: {status} {body}");
+    assert_eq!(
+        body, r#"{"status":"deleted"}"#,
+        "a discard that succeeds must not mention the checkpoint at all"
+    );
     assert_eq!(
         store.get(&key).unwrap(),
         None,
@@ -431,16 +438,13 @@ impl CheckpointStore for BrokenStore {
     }
 }
 
-/// A bare `let _ = store.remove(&key);` drops the error on the floor. The
-/// response still says `{"status":"deleted"}`. Nothing else — not a
-/// `CheckpointFailed` event, not `checkpoints_failed_total` — hears about
-/// it. This test fails on that discarded `Result` by construction: a store
-/// whose `remove` always errs leaves `Capture` holding no `CheckpointFailed`
-/// event, because the error never reached anything that could observe it.
-///
-/// The session itself is gone either way, so the response staying `200` is
-/// correct. What changes is that the failing discard now gets reported the
-/// same way a failing persist already does.
+/// A bare `let _ = store.remove(&key);` drops the error on the floor. This
+/// test guards against that: a discard failure at session-delete time must
+/// show up two ways. One `CheckpointFailed` event, which feeds
+/// `checkpoints_failed_total`. And `"checkpoint":"retained"` in the
+/// response body. `status` stays `"deleted"` either way: the session is
+/// gone, and a `500` would only make a caller retry a delete that already
+/// worked.
 #[tokio::test]
 async fn a_failed_checkpoint_removal_at_session_delete_is_reported() {
     let store: Arc<dyn CheckpointStore> = Arc::new(BrokenStore);
@@ -458,6 +462,11 @@ async fn a_failed_checkpoint_removal_at_session_delete_is_reported() {
     assert!(
         status.contains("200"),
         "the session itself is genuinely gone: {status} {body}"
+    );
+    assert_eq!(
+        body, r#"{"status":"deleted","checkpoint":"retained"}"#,
+        "a caller that cleaned up this session must be told the checkpoint \
+         outlived it, not just that the session is gone"
     );
 
     assert!(


### PR DESCRIPTION
## What & why

`DELETE /v1/sessions/{id}` answered `200 {"status":"deleted"}` even when the
checkpoint discard failed. A caller had no way to tell "deleted, and its
checkpoint is gone too" from "deleted, but the checkpoint is stuck in the
store forever."

#5503 found the failure was swallowed entirely; #5736 fixed the reporting
half (a `CheckpointFailed` event and a `checkpoints_failed_total` bump) and
left the response shape as a stated open question. #5766 is that question,
and the answer is SCR-002: keep `200` — the session registry entry really is
gone by the time this runs, and a `500` would only make a caller retry a
delete that already worked — but tell the caller about the checkpoint. A
discard failure now adds `"checkpoint":"retained"` to the body; a
successful discard's body is exactly what it was before,
`{"status":"deleted"}`.

The decision and its reasoning are recorded on the issue before this PR:
https://github.com/macanderson/stella/issues/5766#issuecomment-5549625708

### How

`TurnCheckpoint::discard_now` (new, `crates/stella-serve/src/checkpoint.rs`)
removes the key directly and reports a failure the same way
`StoreSink::discard` does — one `CheckpointFailed` event — but returns
whether it worked. The engine-facing `CheckpointSink::discard` stays void on
purpose (the step loop never branches on an I/O result); this is a
session-delete route, not the step loop, and it discards exactly once, so it
can afford to know the answer.

`handle_session_delete` (`crates/stella-serve/src/routes/sessions.rs`) uses
that to fill a new `SessionDeleted` response struct's `checkpoint` field,
present only on failure (`#[serde(skip_serializing_if)]`) so an existing
integration that never reads it keeps parsing the same body.

The dedicated `DELETE /v1/{turns,sessions}/{id}/checkpoint` route
(`handle_checkpoint_delete`) keeps answering `500` on the same store error —
its whole job is the checkpoint, so a failed removal is its whole outcome.
That divergence is documented at both call sites.

Closes #5766

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`crates/stella-serve/tests/checkpoint.rs`:

- `a_failed_checkpoint_removal_at_session_delete_is_reported` now asserts
  the exact failure body, `{"status":"deleted","checkpoint":"retained"}`.
  Checked by hand (`git stash` the three `src/` files, keep the test): it
  fails against the prior `200 {"status":"deleted"}` shape with
  ```
  left: "{\"status\":\"deleted\"}"
  right: "{\"status\":\"deleted\",\"checkpoint\":\"retained\"}"
  ```
  and passes once the `src/` change is restored.
- `deleting_a_session_takes_its_resume_point_with_it` now asserts the
  success body is unchanged, guarding the other shape.

Both test files pass locally, scoped to `stella-serve` per SCR-001 (9/9 and
10/10 respectively).

## The gate

- [x] `cargo fmt --check` (`cargo fmt --all` run locally)
- [ ] clippy across the workspace, `-D warnings` — CI's job, per CLAUDE.md
      ("CI builds and tests; this laptop does not")
- [ ] the full workspace test suite — CI's job, same reason; the scoped
      `stella-serve` run is green locally (see above)
- [x] Docs updated where behavior/flags changed — no `docs/wire/` change:
      that directory tracks `AgentEvent`, `ServerFrame`, and the wrapper
      socket, none of which this response is; the body is hand-built JSON,
      not a `stella-protocol` type, so invariant #4's round-trip
      requirement doesn't apply. Said explicitly on the issue's DoD.
- [ ] CLA signed (bot prompts automatically)
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [x] New cross-boundary types round-trip through serde (test included) —
      N/A: `SessionDeleted` is a private, serve-local response struct; it
      never crosses a crate boundary, so invariant #4 doesn't apply (see
      above)

## Anything reviewers should know?

The two session-delete paths — `handle_session_delete` and the dedicated
checkpoint-delete route — now intentionally disagree on the status code for
the same store failure (`200` + body flag vs. `500`). That divergence is the
issue's own explicit allowance ("either... consistent, or the difference is
documented at both") and is documented in both handlers' doc comments.

Tests deleted: None.

## Summary by Sourcery

Tell callers when session deletion succeeds but its checkpoint remains retained.

New Features:
- Report retained checkpoints in session deletion responses when checkpoint cleanup fails.

Bug Fixes:
- Prevent checkpoint discard failures during session deletion from being invisible to API callers while preserving the successful deletion response.

Enhancements:
- Preserve HTTP 200 for session deletion regardless of checkpoint cleanup outcome and continue emitting checkpoint failure telemetry.
- Keep dedicated checkpoint deletion failures as HTTP 500 responses while documenting the intentional distinction.

Tests:
- Verify unchanged successful session deletion responses and the retained-checkpoint response on discard failure.