### PR TITLE
fix(stella-model): refuse a tool call whose id never arrives on every dialect

### DIFF
--- a/crates/stella-model/src/bedrock.rs
+++ b/crates/stella-model/src/bedrock.rs
@@ -403,7 +403,13 @@ fn unsupported_format_note(kind: &str, media_type: &str) -> BedrockContentBlock 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 struct BedrockToolUse {
+    /// Defaulted so a block that leaves it out still parses. Without the
+    /// default, one absent id fails the whole `Converse` body and the turn
+    /// dies on a serde message that names neither the tool nor the block.
+    /// Assembly refuses an empty id by name instead.
+    #[serde(default)]
     tool_use_id: String,
+    #[serde(default)]
     name: String,
     #[serde(default)]
     input: Value,
@@ -844,11 +850,32 @@ impl Provider for BedrockProvider {
         let mut text = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         if let Some(message) = parsed.output.and_then(|o| o.message) {
-            for block in message.content {
+            for (index, block) in message.content.into_iter().enumerate() {
                 if let Some(t) = block.text {
                     text.push_str(&t);
                 }
                 if let Some(tool_use) = block.tool_use {
+                    // The id is what the next turn's `toolResult` is matched
+                    // against, and the name is the tool to run. Neither can be
+                    // invented here. Two calls in one turn both keyed `""`
+                    // pair up with the wrong results in `stella-core`'s loop
+                    // evidence, and a result sent under an empty id matches
+                    // nothing Converse holds.
+                    let mut missing = Vec::new();
+                    if tool_use.tool_use_id.is_empty() {
+                        missing.push("toolUseId");
+                    }
+                    if tool_use.name.is_empty() {
+                        missing.push("name");
+                    }
+                    if !missing.is_empty() {
+                        return Err(http::malformed_tool_call_error(
+                            "Bedrock",
+                            index,
+                            &tool_use.name,
+                            &missing,
+                        ));
+                    }
                     // A no-argument Converse tool call omits `input` on the
                     // wire, so the `#[serde(default)]` field deserializes to
                     // `Value::Null` — which is the malformed-call sentinel
@@ -1292,5 +1319,7 @@ pub(crate) mod sigv4 {
     }
 }
 
+#[cfg(test)]
+mod malformed_tool_use;
 #[cfg(test)]
 mod tests;

--- a/crates/stella-model/src/bedrock/malformed_tool_use.rs
+++ b/crates/stella-model/src/bedrock/malformed_tool_use.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! What a `toolUse` block does to a turn when its id is missing.
+//!
+//! Converse answers once, so this adapter has one delivery path and one
+//! parse. A block with no `toolUseId` fails that parse outright unless the
+//! field defaults. The whole body goes with it, and the turn dies on a serde
+//! message that names neither the tool nor the block it sat in. A reader
+//! cannot tell that failure from a truncated body or a changed schema.
+//!
+//! The field now defaults, so the block parses and assembly refuses it by
+//! name. The error says which block, which tool, and which field.
+//!
+//! Declared from `bedrock.rs`, so the suite in `bedrock/tests.rs` keeps its
+//! own subject.
+
+use super::*;
+use stella_protocol::CompletionRequest;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn request() -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![CompletionMessage::user("list the files")],
+        max_output_tokens: Some(1024),
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+fn test_provider(server_uri: &str) -> BedrockProvider {
+    BedrockProvider::new(
+        ApiKey::new("AKIDEXAMPLE"),
+        ApiKey::new("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"),
+        None,
+        "us-east-1",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    )
+    .with_base_url(server_uri.to_string())
+}
+
+/// The witness. Without the fix the error is serde's own `missing field
+/// toolUseId`, which names no tool and no block, so the assertions about
+/// `index 0` and `bash` are the ones that fail.
+#[tokio::test]
+async fn a_tool_use_block_with_no_id_names_the_call_it_lost() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [
+                {"toolUse": {"name": "bash", "input": {"command": "ls"}}}
+            ]}},
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 9, "outputTokens": 5}
+        })))
+        .mount(&server)
+        .await;
+    let provider = test_provider(&server.uri());
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a call that cannot be dispatched must not be committed");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("index 0"),
+        "the error names the block that was lost: {message}"
+    );
+    assert!(
+        message.contains("`toolUseId`"),
+        "the error names the field that never arrived: {message}"
+    );
+    assert!(
+        message.contains("bash"),
+        "the error names the tool the model asked for: {message}"
+    );
+    assert!(
+        !error.is_retryable(),
+        "the same request returns the same absent field: {error:?}"
+    );
+}
+
+/// The constraint on the fix: an ordinary call still rides through. Only a
+/// block that cannot be dispatched is fatal.
+#[tokio::test]
+async fn a_tool_use_block_with_an_id_still_completes() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output": {"message": {"role": "assistant", "content": [
+                {"toolUse": {"toolUseId": "tooluse_1", "name": "bash", "input": {"command": "ls"}}}
+            ]}},
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 9, "outputTokens": 5}
+        })))
+        .mount(&server)
+        .await;
+    let provider = test_provider(&server.uri());
+
+    let result = provider.complete(request()).await.expect("a whole call");
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].call_id, "tooluse_1");
+    assert_eq!(result.tool_calls[0].name, "bash");
+    assert_eq!(result.finish_reason, Some(FinishReason::ToolCalls));
+}

--- a/crates/stella-model/src/gemini.rs
+++ b/crates/stella-model/src/gemini.rs
@@ -246,6 +246,12 @@ fn attachment_parts(message: &CompletionMessage) -> Vec<GeminiOutboundPart> {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct GeminiFunctionCall {
+    /// Defaulted so a part that leaves it out still parses. Without the
+    /// default the whole chunk fails to deserialize, and the arm that
+    /// tolerates a keep-alive frame drops it. The call goes with the frame,
+    /// and so does any `finishReason` riding beside it. `GeminiAssembly`'s
+    /// `absorb` refuses an empty name by name instead.
+    #[serde(default)]
     pub(crate) name: String,
     #[serde(default)]
     pub(crate) args: Value,
@@ -786,6 +792,19 @@ impl GeminiAssembly {
             for part in content.parts {
                 if let Some(call) = part.function_call {
                     let ordinal = self.tool_calls.len();
+                    // The name is the tool to run, and it cannot be invented
+                    // here. The call id is minted below from the ordinal, so
+                    // the name is the one dispatch field this wire can drop.
+                    // Committing a call named `""` would send the engine
+                    // looking for a tool no registry holds.
+                    if call.name.is_empty() {
+                        return Err(http::malformed_tool_call_error(
+                            label,
+                            ordinal,
+                            "",
+                            &["name"],
+                        ));
+                    }
                     let call_id = match &part.thought_signature {
                         Some(sig) => format!("call_{ordinal}{SIGNATURE_SEPARATOR}{sig}"),
                         None => format!("call_{ordinal}"),
@@ -976,5 +995,7 @@ fn map_gemini_finish_reason(raw: Option<&str>, has_tool_calls: bool) -> Option<F
     }
 }
 
+#[cfg(test)]
+mod malformed_tool_call;
 #[cfg(test)]
 mod tests;

--- a/crates/stella-model/src/gemini/malformed_tool_call.rs
+++ b/crates/stella-model/src/gemini/malformed_tool_call.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! What a `functionCall` part does to a turn when its name is missing.
+//!
+//! This wire carries no call id, so the adapter mints one from the call's
+//! ordinal. The name is the one dispatch field a server can drop. A part that
+//! leaves it out fails the whole chunk unless the field defaults, and the arm
+//! that tolerates a keep-alive frame skips it. The call goes with the chunk,
+//! and so does any `finishReason` beside it.
+//!
+//! The field now defaults, so the part parses and assembly refuses it by
+//! name. The fold is shared with the unary path and with `vertex.rs`, so one
+//! refusal covers all three.
+//!
+//! Declared from `gemini.rs`, so the suite in `gemini/tests.rs` keeps its own
+//! subject.
+
+use super::*;
+use stella_protocol::CompletionRequest;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// One `functionCall` part with `args` and no `name`, then a clean stop.
+const A_CALL_WITH_NO_NAME: &str = concat!(
+    "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"path\":\"a.rs\"}}}]}}]}\n\n",
+    "data: {\"candidates\":[{\"finishReason\":\"STOP\",\"content\":{\"parts\":[]}}]}\n\n",
+);
+
+/// The same shape with the name present, which must still complete.
+const A_WHOLE_CALL: &str = concat!(
+    "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"read_file\",\"args\":{\"path\":\"a.rs\"}}}]}}]}\n\n",
+    "data: {\"candidates\":[{\"finishReason\":\"STOP\",\"content\":{\"parts\":[]}}]}\n\n",
+);
+
+async fn streaming_provider(body: &'static str) -> (MockServer, GeminiProvider) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+    let provider =
+        GeminiProvider::new(ApiKey::new("k"), "gemini-3-pro").with_base_url(server.uri());
+    (server, provider)
+}
+
+fn request() -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![CompletionMessage::user("read a.rs")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+/// The witness. Without the fix the first chunk is dropped, the second sets a
+/// stop reason, and the turn ends `Ok` with no text and no tool calls. A
+/// caller reading that learns the model asked for nothing.
+#[tokio::test]
+async fn a_function_call_with_no_name_ends_the_turn_instead_of_vanishing() {
+    let (_server, provider) = streaming_provider(A_CALL_WITH_NO_NAME).await;
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a call that cannot be dispatched must not read as no call");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("index 0"),
+        "the error names the call that was lost: {message}"
+    );
+    assert!(
+        message.contains("`name`"),
+        "the error names the field that never arrived: {message}"
+    );
+    assert!(
+        !error.is_retryable(),
+        "the same request re-streams the same absent field: {error:?}"
+    );
+}
+
+/// The constraint on the fix: a whole call still rides through.
+#[tokio::test]
+async fn a_function_call_with_a_name_still_completes() {
+    let (_server, provider) = streaming_provider(A_WHOLE_CALL).await;
+
+    let result = provider.complete(request()).await.expect("a whole call");
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].name, "read_file");
+    assert_eq!(result.tool_calls[0].call_id, "call_0");
+    assert_eq!(result.tool_calls[0].input["path"], "a.rs");
+}

--- a/crates/stella-model/src/openai.rs
+++ b/crates/stella-model/src/openai.rs
@@ -407,6 +407,14 @@ enum OpenAiStreamEvent {
 #[serde(tag = "type", rename_all = "snake_case")]
 enum OpenAiOutputItem {
     FunctionCall {
+        /// Defaulted so a frame that leaves it out still parses. Serde reads
+        /// the `type` tag first. It then fails the whole event when the
+        /// matched case is missing a field. That failure lands in the arm
+        /// that skips an event type this adapter does not model, and the
+        /// call goes with it. Later argument deltas find no accumulator, and
+        /// the turn ends `Ok` with no tool calls. Assembly in `stream`
+        /// refuses an empty id instead, so the loss is named.
+        #[serde(default)]
         call_id: String,
         #[serde(default)]
         name: String,
@@ -721,5 +729,7 @@ impl OpenAiProvider {
     }
 }
 
+#[cfg(test)]
+mod malformed_tool_call;
 #[cfg(test)]
 mod tests;

--- a/crates/stella-model/src/openai/malformed_tool_call.rs
+++ b/crates/stella-model/src/openai/malformed_tool_call.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! What an `output_item.added` frame does to a turn when its id is missing.
+//!
+//! Serde reads the `type` tag first. It then fails the whole event when the
+//! matched case is missing a field. So an item that names `function_call`
+//! and has no `call_id` does not parse, unless the field defaults. The frame
+//! lands in the arm that skips an event type this adapter does not model.
+//! The call goes with it. Each later argument delta then opens a fresh
+//! accumulator keyed `""`. The turn ends `Ok` holding a call nothing can
+//! match to its result.
+//!
+//! Nothing fails and the turn goes on. That is why the proof runs at the
+//! provider edge, not on the type. The claim is about what a caller gets.
+//!
+//! Declared from `openai.rs`, not from `openai/tests.rs`. That file is close
+//! to the size ratchet.
+
+use super::*;
+use crate::provider::Provider;
+use stella_protocol::CompletionRequest;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// One `function_call` item carrying `name` and no `call_id`, its arguments
+/// streamed and closed, ending on `response.completed`. Every frame after the
+/// item is well formed — the whole loss comes from the one absent field.
+const A_FUNCTION_CALL_WITH_NO_ID: &str = concat!(
+    "event: response.output_item.added\n",
+    "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"name\":\"bash\"}}\n\n",
+    "event: response.function_call_arguments.delta\n",
+    "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{\\\"command\\\":\\\"ls\\\"}\"}\n\n",
+    "event: response.function_call_arguments.done\n",
+    "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0}\n\n",
+    "event: response.completed\n",
+    "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":12,\"output_tokens\":9}}}\n\n",
+);
+
+/// Three frames this adapter does not model, around ordinary text. One is an
+/// item type it has no case for. One is an event type it has no case for.
+/// One is a data line with no `type`. All three must still be skipped.
+const AN_UNMODELLED_OUTPUT_ITEM: &str = concat!(
+    "event: response.output_item.added\n",
+    "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+    "event: something_new\n",
+    "data: {\"type\":\"response.brand_new_thing\"}\n\n",
+    "event: message\n",
+    "data: {\"unrecognised\":true}\n\n",
+    "event: response.output_text.delta\n",
+    "data: {\"type\":\"response.output_text.delta\",\"delta\":\"done\"}\n\n",
+    "event: response.completed\n",
+    "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n",
+);
+
+async fn streaming_provider(body: &'static str) -> (MockServer, OpenAiProvider) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"))
+        .mount(&server)
+        .await;
+    let provider =
+        OpenAiProvider::new(ApiKey::new("sk-test-openai"), "gpt-5.5").with_base_url(server.uri());
+    (server, provider)
+}
+
+fn request() -> CompletionRequest {
+    CompletionRequest {
+        messages: vec![CompletionMessage::user("list the files")],
+        max_output_tokens: None,
+        temperature: None,
+        effort: None,
+        tools: vec![],
+        reasoning: None,
+        params: None,
+    }
+}
+
+/// The witness. Without the fix this body completes `Ok`. The item frame is
+/// dropped. The argument delta opens an accumulator with an empty id. The
+/// turn hands back a call no tool result can answer.
+#[tokio::test]
+async fn a_function_call_with_no_id_ends_the_turn_instead_of_vanishing() {
+    let (_server, provider) = streaming_provider(A_FUNCTION_CALL_WITH_NO_ID).await;
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a tool call that cannot be dispatched must not read as a tool call");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("index 0"),
+        "the error names the item that was lost: {message}"
+    );
+    assert!(
+        message.contains("`call_id`"),
+        "the error names the field that never arrived: {message}"
+    );
+    assert!(
+        message.contains("bash"),
+        "the error names the tool the model asked for: {message}"
+    );
+    assert!(
+        !error.is_retryable(),
+        "the same request re-streams the same absent field: {error:?}"
+    );
+}
+
+/// The same item on the non-streaming path, which the session takes once its
+/// streaming path has proven broken. Here the fields already defaulted, so
+/// the item parsed and the turn committed a call keyed `""`. That call can
+/// never be matched to its result. The two delivery paths have to refuse it
+/// alike.
+#[tokio::test]
+async fn a_unary_function_call_with_no_id_ends_the_turn_as_well() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .and(body_string_contains("\"stream\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .and(body_string_contains("\"stream\":false"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"id":"resp_1","status":"completed","output":[{"type":"function_call","name":"bash","arguments":"{\"command\":\"ls\"}"}],"usage":{"input_tokens":12,"output_tokens":9}}"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+    let provider =
+        OpenAiProvider::new(ApiKey::new("sk-test-openai"), "gpt-5.5").with_base_url(server.uri());
+
+    // An empty stream arms the latch, so the retry goes out non-streaming.
+    let armed = provider
+        .complete(request())
+        .await
+        .expect_err("an empty stream is a fault, never an empty Ok");
+    assert!(armed.is_retryable(), "{armed:?}");
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a unary item with no id must not be committed either");
+    let message = error.to_string();
+    assert!(message.contains("`call_id`"), "{message}");
+    assert!(message.contains("bash"), "{message}");
+    assert!(!error.is_retryable(), "{error:?}");
+}
+
+/// The constraint on the fix: a frame whose `type` this adapter does not
+/// model stays skippable. Only an item that declares itself `function_call`
+/// and then cannot be dispatched is fatal. Widening the refusal to every
+/// unparsed frame would break on the next item type OpenAI ships.
+#[tokio::test]
+async fn an_output_item_type_this_adapter_does_not_model_is_still_skipped() {
+    let (_server, provider) = streaming_provider(AN_UNMODELLED_OUTPUT_ITEM).await;
+
+    let result = provider
+        .complete(request())
+        .await
+        .expect("an unmodelled item type is not a fault");
+    assert_eq!(result.text, "done");
+    assert!(result.tool_calls.is_empty());
+}

--- a/crates/stella-model/src/openai/stream.rs
+++ b/crates/stella-model/src/openai/stream.rs
@@ -220,6 +220,7 @@ pub(super) async fn aggregate_openai_stream(
                     if let Some(observer) = observer
                         && let Some(acc) = tool_calls.get(&output_index)
                         && !acc.call_id.is_empty()
+                        && !acc.name.is_empty()
                     {
                         // Never announce a call whose input failed to parse —
                         // speculation on a malformed call would execute
@@ -338,18 +339,37 @@ pub(super) async fn aggregate_openai_stream(
         });
     }
 
-    let tool_calls = tool_calls
-        .into_values()
-        .map(|acc| ToolCall {
+    let mut calls = Vec::with_capacity(tool_calls.len());
+    for (index, acc) in tool_calls {
+        // The id is what the next turn's `function_call_output` is matched
+        // against, and the name is the tool to run. Neither can be invented
+        // here. Two calls in one turn both keyed `""` pair up with the wrong
+        // results in `stella-core`'s loop evidence, and a result sent under
+        // an empty id matches nothing the provider holds. The announce site
+        // above already skips such a call, so committing one here would
+        // contradict it.
+        let mut missing = Vec::new();
+        if acc.call_id.is_empty() {
+            missing.push("call_id");
+        }
+        if acc.name.is_empty() {
+            missing.push("name");
+        }
+        if !missing.is_empty() {
+            return Err(
+                http::malformed_tool_call_error("OpenAI", index, &acc.name, &missing).into(),
+            );
+        }
+        calls.push(ToolCall {
             call_id: acc.call_id,
             name: acc.name,
             input: tool_call_input(&acc.arguments),
-        })
-        .collect();
+        });
+    }
 
     Ok(OpenAiStreamOutcome {
         text,
-        tool_calls,
+        tool_calls: calls,
         usage,
         truncated_at_limit,
     })

--- a/crates/stella-model/src/openai/unary.rs
+++ b/crates/stella-model/src/openai/unary.rs
@@ -180,7 +180,7 @@ impl OpenAiProvider {
 
         let mut text = String::new();
         let mut tool_calls = Vec::new();
-        for item in parsed.output {
+        for (index, item) in parsed.output.into_iter().enumerate() {
             match item {
                 OpenAiUnaryItem::Message { content } => {
                     for part in content {
@@ -193,11 +193,30 @@ impl OpenAiProvider {
                     call_id,
                     name,
                     arguments,
-                } => tool_calls.push(ToolCall {
-                    call_id,
-                    name,
-                    input: stream::tool_call_input(&arguments),
-                }),
+                } => {
+                    // The same refusal the streaming path makes, so the two
+                    // delivery paths cannot drift on it. Every field here
+                    // defaults, so an item that leaves out the id or the tool
+                    // name parses. A call committed with an empty id can never
+                    // be matched to its result.
+                    let mut missing = Vec::new();
+                    if call_id.is_empty() {
+                        missing.push("call_id");
+                    }
+                    if name.is_empty() {
+                        missing.push("name");
+                    }
+                    if !missing.is_empty() {
+                        return Err(crate::http::malformed_tool_call_error(
+                            "OpenAI", index, &name, &missing,
+                        ));
+                    }
+                    tool_calls.push(ToolCall {
+                        call_id,
+                        name,
+                        input: stream::tool_call_input(&arguments),
+                    });
+                }
                 OpenAiUnaryItem::Other => {}
             }
         }

--- a/crates/stella-model/src/zai/malformed_tool_calls.rs
+++ b/crates/stella-model/src/zai/malformed_tool_calls.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-//! Two ways a tool call is lost on this dialect while the turn still ends
-//! `Ok`.
+//! How a tool call is lost on this dialect while the turn still ends `Ok`.
 //!
-//! Both come from a server that leaves out a field the wire normally
-//! carries. So both reach us through the same gateways as the `tool_use`
+//! Each case comes from a server that leaves out a field the wire normally
+//! carries. So each reaches us through the same gateways as the `tool_use`
 //! block the sibling `anthropic` module covers.
 //!
 //! Declared from `zai.rs`, not from `zai/tests.rs`. That file is a god file
@@ -11,7 +10,7 @@
 
 use super::*;
 use stella_protocol::CompletionRequest;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_string_contains, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Two whole tool calls, one per frame, neither with an `index`. This is what
@@ -116,5 +115,47 @@ async fn a_tool_call_whose_id_never_arrives_ends_the_turn() {
         message.contains("bash"),
         "the error names the tool the model asked for: {message}"
     );
+    assert!(!error.is_retryable(), "{error:?}");
+}
+
+/// The same gap on the non-streaming path, which the session takes once its
+/// streaming path has proven broken. Here the id already defaulted, so the
+/// call parsed and the turn committed it keyed `""`. The two delivery paths
+/// have to refuse it alike.
+#[tokio::test]
+async fn a_unary_tool_call_whose_id_never_arrives_ends_the_turn_too() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains("\"stream\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(body_string_contains("\"stream\":false"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"id":"chatcmpl-1","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"index":0,"type":"function","function":{"name":"bash","arguments":"{\"command\":\"ls\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+    let provider =
+        ZaiProvider::new(ApiKey::new("sk-test-zai"), "glm-5.2").with_base_url(server.uri());
+
+    // An empty stream arms the latch, so the retry goes out non-streaming.
+    let armed = provider
+        .complete(request())
+        .await
+        .expect_err("an empty stream is a fault, never an empty Ok");
+    assert!(armed.is_retryable(), "{armed:?}");
+
+    let error = provider
+        .complete(request())
+        .await
+        .expect_err("a unary call with no id must not be committed either");
+    let message = error.to_string();
+    assert!(message.contains("`id`"), "{message}");
+    assert!(message.contains("bash"), "{message}");
     assert!(!error.is_retryable(), "{error:?}");
 }

--- a/crates/stella-model/src/zai/unary.rs
+++ b/crates/stella-model/src/zai/unary.rs
@@ -156,6 +156,19 @@ impl ZaiProvider {
             .flatten();
         let mut calls = Vec::with_capacity(unary_calls.len());
         for (index, call) in unary_calls.into_iter().enumerate() {
+            // The same refusal the streaming path makes, so the two delivery
+            // paths cannot drift on it. The id is what the next turn's
+            // `tool_result` is matched against, and it cannot be invented
+            // here. Two calls in one turn both keyed `""` pair up with the
+            // wrong results in `stella-core`'s loop evidence.
+            if call.id.is_empty() {
+                return Err(crate::http::malformed_tool_call_error(
+                    label,
+                    index,
+                    &call.function.name,
+                    &["id"],
+                ));
+            }
             let truncated = Some(index) == truncated_index;
             let input: Value = stream::tool_call_input(
                 label,


### PR DESCRIPTION
## What and why

#5667 closed "a tool call whose id never arrives" on the Messages dialect. The
same shape was still live on four more paths, and each one loses a call while
the turn still ends `Ok`.

**The OpenAI Responses stream dropped the whole call.** `openai.rs`'s streamed
`OpenAiOutputItem::FunctionCall` declared `call_id: String` with no default.
Serde matches an internally-tagged enum on its `type` first and then fails the
whole event when a field of the matched case is absent, so a frame that omits
`call_id` never deserialized at all. `aggregate_openai_stream`'s tolerant arm —
the one that exists to skip an event type the adapter does not model — dropped
it, and with it the accumulator every later `function_call_arguments.delta`
keys on.

**Three paths committed a call with an empty id** while their speculative
announce already refused one — the asymmetry #5667 closed in `zai/stream.rs`:
`openai/stream.rs`, `openai/unary.rs` and `zai/unary.rs`.

**`bedrock.rs` had the undefaulted-id shape one level up.** `BedrockToolUse`
declared `toolUseId` and `name` with no default, inside
`Option<BedrockToolUse>`, so an absent id failed the whole `Converse` body and
the turn died on `ProviderError::Malformed("missing field \`toolUseId\`")` —
naming neither the tool nor the block, and indistinguishable from a truncated
body or a changed schema.

**`gemini.rs`: the id really is unreachable, and `name` is not.** This wire
carries no call id; `GeminiAssembly::absorb` mints one from the call's ordinal,
so the empty-`call_id` shape cannot occur. Its `name` was undefaulted, which is
the same hazard on the same field set: a `functionCall` part with no `name`
failed the whole chunk, and the arm that tolerates a keep-alive frame skipped
it, taking any `finishReason` riding beside it. `vertex.rs` calls
`aggregate_gemini_stream` and shares `GeminiAssembly`, so the one refusal
covers both providers and both delivery paths.

## The fix

Every undefaulted id (and `name`) now carries `#[serde(default)]`, so the frame
parses and the loss becomes visible. Assembly then refuses an empty one with
`http::malformed_tool_call_error` — `ProviderError::Malformed`, terminal and
not retryable, naming the block index, the tool and the fields that never
arrived. The call sites follow `anthropic/stream.rs` and `anthropic/unary.rs`
verbatim so the dialects cannot drift on the rule.

`openai/stream.rs`'s announce site now guards `name` alongside `call_id`, so
what it speculates on and what it commits agree.

## Exemplar

`crates/stella-model/src/anthropic/stream.rs` and `anthropic/unary.rs` (#5667)
are the in-tree exemplar the issue names; the shared constructor in
`crates/stella-model/src/http.rs` is used unchanged.

## Witness mechanism

One wiremock witness per fixed path, at the provider edge rather than on the
type — on today's code nothing errors, so a test written against the type alone
would pass either way. Each asserts on what a caller receives.

- `crates/stella-model/src/openai/malformed_tool_call.rs`
  - `a_function_call_with_no_id_ends_the_turn_instead_of_vanishing` — an
    `output_item.added` naming `function_call` with no `call_id`, its arguments
    streamed and closed, ending on `response.completed`. Without the change the
    item frame fails to parse and is skipped, the argument delta opens an
    accumulator keyed `""`, and `complete` returns `Ok`. The `expect_err` is
    what fails.
  - `a_unary_function_call_with_no_id_ends_the_turn_as_well` — an empty stream
    arms the fallback latch, then the unary body carries the same item. Without
    the change the fields already defaulted, so the turn committed a call keyed
    `""` and returned `Ok`.
  - `an_output_item_type_this_adapter_does_not_model_is_still_skipped` — the
    constraint on the fix: an unmodelled item type, an unmodelled event type
    and a data line with no `type` all stay skippable.
- `crates/stella-model/src/zai/malformed_tool_calls.rs`
  - `a_unary_tool_call_whose_id_never_arrives_ends_the_turn_too` — same latch
    shape, unary `chat.completion` with a `tool_calls` entry carrying no `id`.
    Without the change `assemble_unary` committed it and returned `Ok`.
- `crates/stella-model/src/bedrock/malformed_tool_use.rs`
  - `a_tool_use_block_with_no_id_names_the_call_it_lost` — Converse answers
    once, so the old failure was serde's own `missing field toolUseId`. The
    assertions that fail without the change are the ones about `index 0` and
    `bash`; the error now names the block, the tool and the field.
  - `a_tool_use_block_with_an_id_still_completes` — the constraint.
- `crates/stella-model/src/gemini/malformed_tool_call.rs`
  - `a_function_call_with_no_name_ends_the_turn_instead_of_vanishing` — without
    the change the chunk carrying the part fails to parse and is skipped, the
    next chunk sets `STOP`, and the turn ends `Ok` with no text and no tool
    calls.
  - `a_function_call_with_a_name_still_completes` — the constraint, including
    the minted `call_0` id.

Both `openai/tests.rs` and `zai/tests.rs` are grandfathered or crowded, so the
new modules are declared from `openai.rs` / `bedrock.rs` / `gemini.rs` and live
under the sibling folder, the way `zai/malformed_tool_calls.rs` already does.

## Provider parity matrix

Not updated: `crates/stella-model/src/provider_parity.rs` declares six axes
(cache, reasoning, stream fallback, overflow, output budget, parallel tool
calls) and none of them is about a malformed tool call, so there is no row to
change. #5667 added none either. Whether this deserves a seventh axis is a
separate judgement — filed as #5853 rather than decided here.

## The definition of done

#5684's checklist is fully ticked, each item carrying the evidence that
establishes it. The first four were verified against this diff and recorded on
the issue earlier.

The fifth — "CI green on the pull request" — is now settled on head `b36ca04`:
`fmt + clippy + test`, the job that compiles the workspace and runs the five
new wiremock witnesses, finished `success` at 06:17:44Z
([run 33947314518](https://github.com/macanderson/stella/actions/runs/33947314518)),
alongside every other check on this head — `cargo deny + cargo audit`, the MSRV
check, `guard self-tests`, `docs guards`, `gate steps no other workflow runs`,
`file size ratchet`, `post-merge canary self-tests`, `dependency-review`,
`harbor_adapter + analyzer pytest`, `duplicate claims`, `no edit is undone
inside the branch`, `PR carries a diff`, `is this diff prose-only?` and `main
is not known-broken`. None failed or timed out.

The one check that was red is `dod / dod`, and it was red *because that box was
unticked* — the gate reads the checklist it is enforcing, so the item and the
check are circular. It settles on this run.

Tests deleted: None.

Residue issues filed: #5853 (nothing declares that an adapter must refuse a tool call it cannot dispatch).

Closes #5684

## Summary by Sourcery

Reject tool calls that lack the identifiers or names required for dispatch across all supported provider dialects and delivery paths.

Bug Fixes:
- Reject malformed tool calls with missing dispatch identifiers instead of silently committing them or dropping them while returning a successful turn.
- Return terminal, provider-specific malformed-call errors that identify the affected block or call, tool name, and missing fields across OpenAI, Zai, Bedrock, and Gemini paths.

Enhancements:
- Keep tool-call announcement and commitment validation consistent across streaming and unary delivery paths.
- Preserve tolerance for genuinely unmodelled OpenAI events while surfacing malformed calls for supported event types.

Tests:
- Add provider-edge WireMock coverage for missing OpenAI call IDs, missing Zai IDs, missing Bedrock tool-use IDs or names, and missing Gemini function names, including successful valid-call constraints.