### PR TITLE
fix(rules): give each witness-test record its own trigger

### DIFF
--- a/.stella/rules/ctx.macanderson.stella.deleted-test-named-in-pr.toml
+++ b/.stella/rules/ctx.macanderson.stella.deleted-test-named-in-pr.toml
@@ -3,6 +3,8 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.deleted-test-named-in-pr"
+record_id = "rec_macanderson_stella_deleted_test_named_in_pr_3db5b98f8e84"
+record_hash = "sha256:a769e9153665fcecdeb65ece470da12fe8fcf2691dde93eb48a42b7b5ebe9559"
 kind = "rule"
 statement = "Deleting a test is permitted but must be named in the PR description so an invisible deletion becomes a sentence a reviewer reads."
 origin = "imported"
@@ -24,11 +26,19 @@ force = "must"
 precedence = 100
 
 [record.steering.applies_to]
-# Retargeted from the extractor's ["pull-request", "delete-test"], neither
-# of which is a ratified task name.
-tasks = ["test", "review"]
+# The extractor proposed tasks = ["pull-request", "delete-test"], neither of
+# which is a ratified task name. The task "test" stood in for them and was far
+# wider than this rule: it selected every turn that used the word, including
+# the phrase "witness test" that three other records carry, so this `hard`
+# record met two `soft` ones at equal precedence and its guard stayed
+# suspended. The words below name the deletion this rule is about.
+tasks = ["review"]
 keywords = [
     "deleted test",
+    "deleting a test",
+    "delete a test",
+    "test deletion",
+    "removed test",
     "PR description",
 ]
 

--- a/.stella/rules/ctx.macanderson.stella.inv8-posture-every-axis.toml
+++ b/.stella/rules/ctx.macanderson.stella.inv8-posture-every-axis.toml
@@ -3,6 +3,8 @@ set_id = "macanderson.stella"
 
 [[record]]
 lineage_id = "ctx.macanderson.stella.inv8-posture-every-axis"
+record_id = "rec_macanderson_stella_inv8_posture_every_axis_cc7ff80065b6"
+record_hash = "sha256:ab8f9e40bd4d26f0f3c2e9f9391bb43c52a8536d6bb2d8005ba6a4002d1613bd"
 kind = "rule"
 statement = "Each provider id declares a posture on every parity axis and, for a controllable/opt-in/implicit posture, names the witness test proving it on the wire."
 origin = "imported"
@@ -26,11 +28,14 @@ precedence = 100
 [record.steering.applies_to]
 paths = ["crates/stella-model/src/provider_parity.rs"]
 # The extractor proposed tasks = ["add-provider"]; no such task is in the ratified
-# applies_to.tasks vocabulary, so it matched nothing. Paths and keywords
-# carry the selection instead.
+# applies_to.tasks vocabulary, so it matched nothing. The path and the parity
+# words carry the selection. The keyword "witness test" is the whole subject of
+# two `soft` records, and sharing it at equal precedence held this `hard` guard
+# suspended, so the trigger names parity instead. The statement still names the
+# witness test it asks a provider row to cite.
 keywords = [
     "posture",
-    "witness test",
+    "provider parity",
     "axis",
 ]
 

--- a/crates/stella-core/tests/published_records_do_not_collide.rs
+++ b/crates/stella-core/tests/published_records_do_not_collide.rs
@@ -1,0 +1,108 @@
+//! No two records in `.stella/rules/` may clash.
+//!
+//! Those files steer every session run here. Two of them can share a
+//! trigger, sit at one `precedence`, and ask for different `enforcement`.
+//! The stricter one is then held back. It still loads, and its guard never
+//! arms.
+//!
+//! `stella context validate` says so in a warning and exits 0. So the build
+//! stays green while a `hard` guard is down. This test is the gate that
+//! warning is not.
+//!
+//! To clear a failure, run `stella context amend <handle> --keywords ...`.
+//! It narrows the trigger and stamps a new hash. A hand edit leaves the old
+//! hash in place.
+
+use std::path::PathBuf;
+
+use stella_core::ingest::record::EnforcementMode;
+use stella_core::records::{
+    LoadedRecord, assign_handles, detect_conflicts, is_suspended, load_context_file,
+};
+
+/// The schema tag a record carries. `governance.toml` sits in the same
+/// folder and has none, which is how it gets skipped.
+const RECORD_SCHEMA: &str = "context-record/v0.1";
+
+fn rules_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../.stella/rules")
+}
+
+/// Every record this repo ships, loaded the way the CLI loads them.
+fn published_records() -> Vec<LoadedRecord> {
+    let dir = rules_dir();
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|err| panic!("{} must be readable: {err}", dir.display()))
+        .map(|entry| entry.expect("a readable directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "toml"))
+        .collect();
+    files.sort();
+
+    let mut records = Vec::new();
+    for path in files {
+        let contents = std::fs::read_to_string(&path).expect("a readable record file");
+        let parsed = toml::from_str::<toml::Value>(&contents)
+            .unwrap_or_else(|err| panic!("{} is not valid TOML: {err}", path.display()));
+        if parsed.get("schema").and_then(|value| value.as_str()) != Some(RECORD_SCHEMA) {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .expect("a file path names a file")
+            .to_string_lossy();
+        records.extend(
+            load_context_file(&name, &contents).unwrap_or_else(|err| panic!("{name} loads: {err}")),
+        );
+    }
+    assign_handles(&mut records);
+    assert!(
+        !records.is_empty(),
+        "{} holds no published record — the test would pass over nothing",
+        dir.display()
+    );
+    records
+}
+
+#[test]
+fn no_two_published_records_collide() {
+    let mut records = published_records();
+    let conflicts = detect_conflicts(&mut records);
+    let report: String = conflicts
+        .iter()
+        .map(|conflict| {
+            format!(
+                "\n  ^{} and ^{}: {}",
+                conflict.left, conflict.right, conflict.detail
+            )
+        })
+        .collect();
+    assert!(
+        conflicts.is_empty(),
+        "{} record pair(s) collide:{report}\n\
+         Narrow one side's trigger with `stella context amend <handle> --keywords ...`",
+        conflicts.len()
+    );
+}
+
+#[test]
+fn every_published_hard_guard_arms() {
+    let mut records = published_records();
+    let conflicts = detect_conflicts(&mut records);
+    let down: Vec<&str> = records
+        .iter()
+        .filter(|loaded| {
+            loaded
+                .record
+                .enforcement
+                .as_ref()
+                .is_some_and(|enforcement| enforcement.mode == EnforcementMode::Hard)
+        })
+        .map(|loaded| loaded.handle.as_str())
+        .filter(|handle| is_suspended(handle, &conflicts))
+        .collect();
+    assert!(
+        down.is_empty(),
+        "a conflict holds these `hard` guards down, so they block nothing: {}",
+        down.join(", ")
+    );
+}


### PR DESCRIPTION
## What & why

Four of this repository's published records met on the keyword `witness test` at precedence 100, in pairs that mixed `hard` enforcement with `soft`. `crates/stella-core/src/records/validate.rs` reports each such pair and suspends the stricter side, so the `hard` guards on `deleted-test-named-in-pr` and `inv8-posture-every-axis` never armed. `stella context validate` said so in a warning and exited 0, so nothing failed while both guards were down.

Two records reached the collision through triggers wider than their own subject, and those are the two this PR narrows:

- **`deleted-test-named-in-pr`** carried `tasks = ["test", "review"]`. The matcher compares a task against whole words of the turn text (`select.rs`'s `word_in_text`), so `test` matches inside the phrase `witness test` that the other three records carry as a keyword. It is now `tasks = ["review"]` plus the deletion words this rule is actually about (`deleted test`, `deleting a test`, `delete a test`, `test deletion`, `removed test`).
- **`inv8-posture-every-axis`** carried the literal keyword `witness test`. Its subject is provider parity, and its path glob plus `posture` / `axis` already select that work; the third keyword is now `provider parity`.

The two `soft` records — `correctness-needs-proof` and `witness-definition` — keep `witness test`. Two records of the same enforcement never conflict, and both are genuinely about the witness contract.

Both files were changed through `stella context amend`, never by hand, so each carries a freshly stamped `record_id` / `record_hash`. The explanatory comments were typed back afterwards; a comment is not part of the hash preimage (`context_record/hash.rs` hashes the parsed record), and `stella context validate` reports no hash mismatch. The comment loss is a defect in `amend` itself, filed as #5852.

Closes #5779

## The witness

`crates/stella-core/tests/published_records_do_not_collide.rs` loads this repository's own `.stella/rules/*.toml` through `load_context_file` + `assign_handles`, runs `detect_conflicts`, and fails on any conflict — and, in a second test, on any `hard` record `is_suspended` holds down. Both fail on `main` and pass here, by construction:

- On `main`, `shared_triggers` returns `witness test` for all four pairs — from `deleted-test-named-in-pr`'s task `test` matching that word inside the phrase, and from `inv8-posture-every-axis`'s literal keyword. `detect_conflicts` therefore returns four `Conflict`s, `no_two_published_records_collide` fails on a non-empty list, and `every_published_hard_guard_arms` fails naming both suspended handles.
- After the amend no pair shares a task or keyword, `detect_conflicts` returns nothing, and both tests pass.

I could not run the current detector locally: the installed `stella` is 0.9.300, which predates #5330's trigger comparison. What I did run is a line-for-line Python mirror of `find_conflicts` / `overlapping_scope` / `shared_triggers` over all 39 published records — 4 conflicts before, matching the table in #5779 exactly, and 0 after. CI's `cargo test --workspace` is the real evidence, and this test is in it. `.stella/rules/**` is outside `scripts/ci-rust-scope.sh`'s prose paths, so a future record-only PR still starts the Rust gate and still runs this test.

The exemplar for the test's shape is `crates/stella-core/tests/context_record_examples.rs`, which reads repository files the same way and asserts the loader agrees with them.

- [x] This PR includes a witness test (fails on `main`, passes here)

## The gate

- [x] `cargo fmt --all` (ran locally), `make guards-fast` green, `python3 scripts/check-prose.py` green
- [ ] `cargo clippy` / `cargo test --workspace` — CI runs these; per CLAUDE.md this laptop does not
- [x] Docs updated where needed: nothing under `docs/` or `website/` names these four records or their scoping (checked with `rg`), so there is nothing to keep in step
- [x] `Closes #5779` appears here and as a commit trailer

Tests deleted: None.

## Nothing left behind

- [x] Filed: #5851 (every `hard` record here is `origin = "imported"`, so none of them clears the blocking gate — a second, independent reason these guards do not block, which this PR does not address), #5852 (`stella context amend` deletes the comments in the block it rewrites)

## Ground-rule check

- [x] No I/O added to `stella-core`'s library code; the file reading is in an integration test, as in `context_record_examples.rs`
- [x] No new dependencies

## Anything reviewers should know?

Resolving the collision un-suspends both guards; it does not make them block, because both records are `origin = "imported"` and `bridge.rs`'s `may_block` refuses that origin. That is #5851, and it is a policy decision about who owns these statements rather than a code fix.

## Summary by Sourcery

Prevent published rule trigger collisions so hard guards remain armed and enforce repository policies.

Bug Fixes:
- Narrow published rule triggers to eliminate equal-precedence conflicts that suspended two hard guards.
- Add coverage preventing published records from colliding and ensuring every hard guard remains active.

Enhancements:
- Broaden deletion-related matching with phrases specific to test removal while retaining review-based applicability.
- Retarget provider-parity matching from the generic witness-test phrase to the provider parity subject.

Tests:
- Add integration tests that load all published repository records and fail on trigger conflicts or suspended hard guards.

Chores:
- Refresh record identifiers and hashes for the amended rule records.