### PR TITLE
docs(spec): record the shipped search tool design

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -674,6 +674,18 @@
       "status": "living",
       "title": "Steering Context Records"
     },
+    "search-tool": {
+      "path": "docs/spec/search-tool.md",
+      "sections": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "status": "implemented",
+      "title": "search \u2014 one tool that replaces six, ranked and budget-bound"
+    },
     "self-driving-foundry": {
       "path": "docs/spec/self-driving-foundry.md",
       "sections": [

--- a/docs/spec/search-tool.md
+++ b/docs/spec/search-tool.md
@@ -1,0 +1,106 @@
+---
+id: search-tool
+title: "search — one tool that replaces six, ranked and budget-bound"
+status: implemented
+---
+
+# search — one tool that replaces six, ranked and budget-bound
+
+**Status:** Implemented. This document records what shipped. A design record
+carries the measurement and the reasoning behind it. An epic tracks the rest
+of the search work.
+
+## 1. What replaced what
+
+Six old tools are gone: `grep`, `glob`, `graph_query`, `read_symbol`,
+`project_overview`, and `gather_context`. One tool does their job now:
+`search(query)`.
+
+Their old names still live in `crates/stella-tools/src/catalog.rs`, marked as
+retired. `grep` and `glob` sit in a second list, because both are also plain
+English words. Nothing was deleted. The code each old tool ran — the code
+graph, the embedding index, the file scan — still runs. It just runs inside
+`search` now, not behind six separate names.
+
+`search` takes one thing: the query. Nothing else. A parameter can narrow a
+job. It must never pick a different job. `search(query, mode="regex")` would
+put the same six-way choice back behind one schema. `search` picks its own
+method. The caller never does.
+
+## 2. The four rungs
+
+`crates/stella-tools/src/search/engine.rs` holds a function called
+`dispatch`. It runs rungs in cost order. It stops at the first rung that
+finds something. One rung breaks that rule, on purpose.
+
+1. **Exact symbol.** The code graph checks whether the query names a real
+   symbol. This is not a ranking. It is a fact: the symbol exists here, or it
+   does not. A hit here goes first, ahead of anything the next rung finds. It
+   never gets pushed aside by a guess. Early on, this rung sat dead: the next
+   rung almost always found something, so nothing below it ever ran.
+2. **Meaning.** The query and the indexed files get turned into vectors and
+   ranked by how close they are. This runs whenever an embedder is set up. If
+   it fails partway, the next rung runs instead, and the failure is named.
+3. **Names.** The code graph's paths and symbol names get matched by word.
+   This is the answer when no embedder is set up.
+4. **File scan.** The whole workspace gets searched directly, by path and by
+   text. No index needed. This is the only rung that works on a workspace
+   with no code-graph support at all — which is common, not rare, on a bare
+   test container.
+
+Every search runs rung 1. Every search runs rung 2, if an embedder is set up.
+So both the code graph and the embedding index get used on every call, not
+just the calls where the model happens to reach for them. The answer lists
+which rungs ran, in a `via:` line. A reader can tell a ranked answer from a
+plain name match.
+
+**A gap.** Rungs 3 and 4 still only run when everything above them finds
+nothing. A hit from rung 1, followed by any hit from rung 2, means rung 4
+never runs. So `search` does not yet return every plain-text match in the
+workspace. A follow-up issue tracks fixing this: run rung 4 every time, and
+merge its hits in the same way rung 1's hits already get merged.
+
+## 3. How much detail, and who pays for it
+
+Ranking picks which files matter. A second question follows: how much to
+say about each one. Just the name? Or the name, the doc comment, who calls
+it, and its full body? `crates/stella-core/src/search.rs` answers this — from
+what got found and what fits, never from a guess at what the query meant.
+Guessing was ruled out on purpose: `search` has no mode flag, so a wrong
+guess could never be corrected. The model would just go back to the old
+tools.
+
+Two plain, side-effect-free pieces make this work:
+
+- **A depth dial**, set once by configuration
+  (`STELLA_SEARCH_DEPTH`), never by the model. It runs 1 to 10. Each step up
+  adds more detail; it never removes any. So two runs at different depths can
+  be compared fairly — the higher one is a strict superset of the lower one.
+  The default is the top: every detail, with the budget below in charge of
+  what actually fits. A lower default was tried first and cut too soon: a
+  three-hit answer often spent under a tenth of its budget, and the model
+  then paid for a separate file read to get the rest.
+- **A character budget**
+  (`STELLA_SEARCH_BUDGET`, 9,000 characters by default), spent across the
+  ranked hits. The top hit gets the most detail; each hit after it gets less,
+  roughly half as much as the one before. Once that pass is done, any budget
+  left over goes back to the best hits first, so nothing sits unspent while
+  a top hit could still use more room. The answer always says which hits it
+  could not afford — never a silent cut.
+
+## 4. What has not shipped
+
+A design record asked for one more step this build does not take: split the
+answer into labelled groups — code, meaning, structure, what got skipped —
+and spend the budget across those groups, not just down one ranked list.
+Each group would get a small floor, so a schema table or a doc page could
+never be crowded out entirely by code hits. `search` does not do this yet.
+It returns one ranked list with one `via:` line. A follow-up issue tracks the
+grouped answer and its per-group count of what got left out.
+
+## 5. Related
+
+A GitHub design issue proposed this tool and carries the measurement behind
+it, including the argument behind §4's gap. This document replaces that
+issue as the normative record. A GitHub epic tracks the rest of the search
+work. Two follow-up issues track the gaps named in §2 and §4.


### PR DESCRIPTION
## What & why

Issue #3063 was a design record for the `search` tool, not a document. It
argued for the tool the codebase now ships (`crates/stella-tools/src/search/`,
`crates/stella-core/src/search.rs`), but nothing under `docs/spec/` describes
what actually shipped, and the issue's own last comment (2026-09-01) says
this should close as superseded by a real spec once one exists, not as a
finished task.

This PR adds that spec: `docs/spec/search-tool.md` (id `search-tool`,
status `implemented`), describing the four-rung dispatch ladder, the
depth/budget enrichment split, and the two gaps the design record itself
flagged as never shipped (the file-scan rung not always running to
completion, and no role-grouped/dossier answer). No code changes.

`docs/manifest.json` is regenerated by `make doc-links-fix` to register the
new document.

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this is a
      documentation-only change with no behavior to flip. Verified instead
      by `make guards-fast` locally (prose, doc-links, line-citations,
      design-refs, invariants, file-size all green) and by CI's
      `docs-guards.yml` run, which re-runs `command-docs`, `website-inputs`,
      `brand-case`, `gate-parity`, `god-files` and `design-refs` on a
      `docs/**` diff.

## The gate

- [ ] fmt check
- [ ] clippy over the workspace
- [ ] the full workspace test suite
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments) — this PR *is* the doc update
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer

No Rust changed, so the compiled checks are N/A for this diff; CI still runs
them over the unchanged workspace.

## Nothing left behind

- [x] Filed: #5843 (the file-scan rung never runs once semantic returns
      anything), #5844 (no role-grouped dossier, no per-role budget floor) —
      both are the two gaps §2 and §4 of the new spec name, both were
      already argued for in #3063's own comments and had no tracking issue
      before this PR.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [ ] New cross-boundary types round-trip through serde (test included) — N/A, no types

## Anything reviewers should know?

The issue's own last comment explicitly asked for this outcome ("If it
becomes a task, it wants the task template. If it stays a design record, the
right shape is probably a document under `docs/` with an id... at which
point this closes as superseded rather than as done."). I added a small
"Definition of done" section to #3063 restating exactly that resolution path
so the DoD gate has something mechanical to check, without contradicting the
issue's own deliberate omission — see the issue for the full note.

Closes #3063

## Summary by Sourcery

Record the shipped search tool design and its remaining gaps in the specification documentation.

Enhancements:
- Document the implemented `search` tool as the replacement for six retired search tools, including its ranked dispatch behavior and depth- and budget-based result enrichment.
- Record the two known limitations of the shipped design and link them to follow-up work.

Documentation:
- Register the new implemented `search-tool` specification in the documentation manifest.