### PR TITLE
fix(stella-cli): hold a running turn's tool calls while a plan change waits

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -128,7 +128,7 @@ use slash_commands::{DeckCommand, handle_agents_input, run_deck_command};
 use crate::memory::{SessionMemory, TurnFriction};
 use crate::subsession::{self, SubSessions, SupervisorMsg};
 use authoring::{agents_list_creating, handle_agent_create};
-pub(crate) use forwarder::{close_turn_stream, spawn_forwarder};
+pub(crate) use forwarder::{SharedRevisions, close_turn_stream, spawn_forwarder};
 use sessions_view::sessions_inbound;
 use settings_io::{apply_pending_reload, handle_engine_config_input, handle_tools_input};
 

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -322,6 +322,7 @@ mod tests {
             in_tx,
             LEAD.to_string(),
             None,
+            SharedRevisions::default(),
         );
         registry.attach_events(stella_core::EventSender::new(tx.clone()));
         tx.send(priced_step_usage(cost_usd)).expect("in flight");

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -13,6 +13,10 @@ use crate::agent;
 use crate::cache_insight::{InsightScope, cache_insight_for};
 use crate::memory::TurnFriction;
 
+/// Re-exported beside [`spawn_forwarder`], the function that takes one, so a
+/// caller of the seam picks up the type from the same place.
+pub(crate) use super::task_tap::SharedRevisions;
+
 /// What a lane's closed turn stream leaves behind for its owner.
 ///
 /// Two facts, not one, since #3962. `persistence_complete` was always the
@@ -73,6 +77,10 @@ pub(crate) fn warn_audit_record_incomplete(
 /// see [`stella_core::tasks::TaskBoard::seed_from_plan`] for why the two used
 /// to be unconnected, and what that cost. `None` for lanes with no board of
 /// their own.
+///
+/// `revisions` is the lane's plan-change gate. A failing gate board puts a
+/// change on it here, and the lane's own plan gate reads it — see
+/// `task_tap::plan_gate::revision` for why one gate serves both.
 pub(crate) fn spawn_forwarder(
     mut rx: UnboundedReceiver<AgentEvent>,
     execution: Option<(Arc<Store>, i64)>,
@@ -80,6 +88,7 @@ pub(crate) fn spawn_forwarder(
     inbound: UnboundedSender<Inbound>,
     lane: String,
     plan_board: Option<stella_tools::tasks::TaskBoardHandle>,
+    revisions: SharedRevisions,
 ) -> tokio::task::JoinHandle<LaneStreamEnd> {
     tokio::spawn(async move {
         let mut seq = 0u64;
@@ -93,12 +102,12 @@ pub(crate) fn spawn_forwarder(
         // forwarder, and a forwarder is one lane — every lane has a registry
         // and a channel of its own, so two lanes' thoughts cannot fuse.
         let mut reasoning = agent::ReasoningRun::default();
-        // The lane's standing plan revision, and the number the next one would
-        // take. Held here because this task is the one place a `GateBoard` and
-        // the lane's plan are both in view: the gate goes past on this stream
-        // and the plan is `plan_board`'s rows. Per lane and per turn, like the
-        // ledger above.
-        let mut revisions = stella_core::RevisionGate::default();
+        // The number the lane's next plan revision would take. Read off the
+        // gate's own proposals below rather than counted here. The change
+        // itself goes on `revisions`, which this task writes and the lane's
+        // plan gate reads: a gate board reaches this host on this stream and
+        // nowhere else, and the turn's plan graph lives in the plan gate and
+        // nowhere else.
         let mut plan_revision = stella_protocol::PlanRevision::FIRST;
         // Two independent latches, not one. A single shared flag meant an
         // early usage gap — the benign, self-healing condition — silenced any
@@ -242,6 +251,8 @@ pub(crate) fn spawn_forwarder(
                         super::task_tap::plan_gate::plan_tasks(guard.items())
                     });
                     revisions
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
                         .observe(plan_revision.next(), &planned, board)
                         .cloned()
                 }
@@ -467,6 +478,7 @@ mod tests {
             in_tx,
             "lead".to_string(),
             None,
+            SharedRevisions::default(),
         );
         registry.attach_events(stella_core::EventSender::new(tx.clone()));
         tx.send(AgentEvent::TurnComplete {
@@ -545,6 +557,7 @@ mod tests {
             in_tx,
             "lead".to_string(),
             None,
+            SharedRevisions::default(),
         );
         tx.send(AgentEvent::Text { text: "hi".into() }).unwrap();
         tx.send(AgentEvent::TurnComplete {
@@ -607,6 +620,7 @@ mod tests {
             in_tx,
             "lead".to_string(),
             None,
+            SharedRevisions::default(),
         );
         // Recall is the first event of the turn, queued after the forwarder
         // was spawned — exactly as `run_lead_turn` does it.
@@ -667,6 +681,7 @@ mod tests {
             in_tx,
             "lead".to_string(),
             None,
+            SharedRevisions::default(),
         );
         tx.send(AgentEvent::TurnComplete {
             model: "m".into(),
@@ -716,6 +731,7 @@ mod tests {
             in_tx,
             "lead".to_string(),
             Some(registry.task_board()),
+            SharedRevisions::default(),
         );
         tx.send(AgentEvent::GateBoard {
             board: board(vec![gate("fmt", GateState::Green)]),

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -21,7 +21,7 @@ use stella_tools::hook_runner::HostHookRunner;
 use stella_tui::{AgentStatus, Inbound};
 use tokio::sync::mpsc::{self, UnboundedSender};
 
-use super::task_tap::{PlanSetup, TaskTap};
+use super::task_tap::{PlanSetup, SharedRevisions, TaskTap};
 use super::{LEAD, agent, close_turn_stream, forwarder, lead_control, spawn_forwarder};
 use crate::claims::{ClaimTap, ShellWatch};
 use crate::config::Config;
@@ -83,6 +83,11 @@ pub(super) async fn run_lead_turn(
         tx.clone().into(),
         recall.produced,
     );
+    // This turn's plan-change gate. The forwarder writes to it, because a
+    // gate board reaches this host on that stream and nowhere else; the plan
+    // gate below reads it, because the turn's plan graph lives there and
+    // nowhere else (`task_tap::plan_gate::revision`).
+    let revisions = SharedRevisions::default();
     let forwarder = spawn_forwarder(
         rx,
         execution.clone(),
@@ -90,6 +95,7 @@ pub(super) async fn run_lead_turn(
         in_tx.clone(),
         LEAD.to_string(),
         Some(registry.task_board()),
+        Arc::clone(&revisions),
     );
     // Park it where the driver's cancel arm can reach it, and take it back on
     // the path that ends normally — whichever of the two runs, exactly one
@@ -138,7 +144,7 @@ pub(super) async fn run_lead_turn(
         // Both read before the engine borrows `messages` mutably: the plan
         // gate's setup (`task_tap::plan_gate`, #4594/#4611) and this turn's
         // id, which every lane it spawns records (#4628).
-        let plan = PlanSetup::for_turn(messages, cfg);
+        let plan = PlanSetup::for_turn(messages, cfg, Arc::clone(&revisions));
         let turn = execution.as_ref().map(|(_, id)| *id);
         let tap = TaskTap::new(&permitted, tx.clone(), registry, Some(sup_tx), plan, turn);
         // The invocation plane rides outermost: the grant narrows

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -12,7 +12,7 @@ use crate::subsession::SupervisorMsg;
 
 pub(crate) mod plan_gate;
 
-pub(crate) use plan_gate::PlanSetup;
+pub(crate) use plan_gate::{PlanSetup, SharedRevisions};
 
 /// Hands `task_assign`'s spawn requests to the driver's supervisor channel,
 /// and turns the board into a **scope**: the same board traffic is what the
@@ -312,6 +312,7 @@ mod tests {
         PlanSetup {
             goal: goal.to_string(),
             policy: crate::settings::PlanReviewPolicy::default(),
+            revisions: SharedRevisions::default(),
         }
     }
 
@@ -802,6 +803,7 @@ mod tests {
                     enabled: true,
                     min_steps: 2,
                 },
+                revisions: SharedRevisions::default(),
             },
             None,
         );
@@ -836,6 +838,7 @@ mod tests {
                     enabled: false,
                     min_steps: 3,
                 },
+                revisions: SharedRevisions::default(),
             },
             None,
         );
@@ -869,6 +872,7 @@ mod tests {
                 min_steps: 9,
             }
             .for_run(true),
+            revisions: SharedRevisions::default(),
         };
         let (registry, ran, mut rx, events) = gated(1, Some(picked("Start work", None)));
         let inner = Ran(ran.clone());

--- a/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
+++ b/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
@@ -76,6 +76,10 @@ use stella_tools::registry::question::QuestionBroker;
 use crate::settings::PlanReviewPolicy;
 use tokio::sync::mpsc::UnboundedSender;
 
+mod revision;
+
+pub(crate) use revision::SharedRevisions;
+
 /// The label whose selection means "run this plan". Matched by exact string
 /// against [`stella_protocol::Answer::chosen`], so it is named once here
 /// rather than written twice.
@@ -125,6 +129,10 @@ pub(crate) struct PlanGate {
     plan_changed: DivergenceCause,
     /// The same, for a plan put up again unchanged.
     re_proposed: DivergenceCause,
+    /// The lane's plan-change gate, shared with the forwarder that writes to
+    /// it (`revision`). A change waiting there withholds every tool call
+    /// [`Self::review`] guards.
+    revisions: SharedRevisions,
     state: Mutex<GateState>,
 }
 
@@ -141,6 +149,8 @@ pub(crate) struct PlanSetup {
     pub(crate) goal: String,
     /// The `plan_review` policy this invocation applies.
     pub(crate) policy: PlanReviewPolicy,
+    /// The lane's plan-change gate, shared with its forwarder (`revision`).
+    pub(crate) revisions: SharedRevisions,
 }
 
 impl PlanSetup {
@@ -150,10 +160,15 @@ impl PlanSetup {
     /// Both sources are joined here, once, so no caller downstream can apply
     /// only one of the two — the same discipline `Config::allowed_write_dirs`
     /// applies to its flag.
-    pub(crate) fn for_turn(messages: &[CompletionMessage], cfg: &crate::config::Config) -> Self {
+    pub(crate) fn for_turn(
+        messages: &[CompletionMessage],
+        cfg: &crate::config::Config,
+        revisions: SharedRevisions,
+    ) -> Self {
         Self {
             goal: plan_goal(messages),
             policy: cfg.plan_review.for_run(cfg.plan_mode),
+            revisions,
         }
     }
 }
@@ -218,6 +233,7 @@ impl PlanGate {
             min_steps: plan.policy.min_steps,
             plan_changed,
             re_proposed,
+            revisions: plan.revisions,
             state: Mutex::new(GateState::default()),
         })
     }
@@ -250,6 +266,12 @@ impl PlanGate {
     /// repair step), then from a plain statement of what happened. There is no
     /// fourth source, because a `DivergenceCause` cannot be blank.
     pub(crate) async fn review(&self, board: &[TaskItem]) -> Option<ToolOutput> {
+        // A waiting plan change is settled first. The plan changed under a
+        // turn that is already running, and SPEC 8.1 item 3 says nothing runs
+        // until somebody answers that (see the `revision` submodule).
+        if let Some(held) = self.settle_revision(board) {
+            return Some(held);
+        }
         let steps = plan_steps(board);
         let tasks = plan_tasks(board);
         let revision = {

--- a/crates/stella-cli/src/command_deck/task_tap/plan_gate/revision.rs
+++ b/crates/stella-cli/src/command_deck/task_tap/plan_gate/revision.rs
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A plan change can wait on a person. While it waits, this gate stops the
+//! tool calls of a turn that is already running (SPEC 8.1 item 3).
+//!
+//! # The half that was missing
+//!
+//! `RevisionGate::admits` says whether work may go on. The deck's
+//! `gates::revision_hold` holds back new prompts. Neither one can stop a tool
+//! call the model has already asked for. This gate can. It runs before the
+//! step does. It hands back a [`ToolOutput`] the tool returns in place of its
+//! work.
+//!
+//! # One gate, two tasks
+//!
+//! A [`SharedRevisions`] is the lane's plan-change gate. The lane's forwarder
+//! writes to it, because a gate board reaches this host on that stream and
+//! nowhere else. The plan gate reads it, because the turn's plan graph lives
+//! here and nowhere else. Two gates would each hold half the answer and
+//! disagree about the rest.
+//!
+//! # A yes goes through the plan graph
+//!
+//! The person driving says yes on the deck, and that verb puts the repair on
+//! the task board (`driver_support::service_approve_revision`). So a board
+//! that carries the waiting subject **is** their yes, and the next
+//! [`PlanGate::review`] writes it: [`PlanGate::approve_revision`] hands the
+//! graph to `RevisionGate::approve`. The `[:NEXT]` edge and the cause come
+//! from `PlanGraph::revise`. One writer makes them, so no second path can
+//! disagree.
+
+use std::sync::{Arc, Mutex};
+
+use stella_core::{RevisionError, RevisionGate};
+use stella_protocol::{ErrorClass, PlanRevision, RevisionProposal, TaskItem, ToolOutput};
+
+use super::PlanGate;
+
+/// One lane's plan-change gate, shared by the two tasks that need it.
+///
+/// Cheap to clone, and per lane and per turn like the forwarder's own
+/// ledgers. A lane with no plan gate still gets one, so its proposals reach
+/// the deck the way they always did.
+pub(crate) type SharedRevisions = Arc<Mutex<RevisionGate>>;
+
+/// What the model is told while a plan change waits on the person driving.
+///
+/// It says to stop, not to fix. The model has nothing to fix here: the answer
+/// is a person's to give. A retry loop on a hold would burn the whole turn on
+/// one refusal.
+const REVISION_HELD: &str = "the plan has a change waiting on the person driving, and nothing runs \
+     until they answer it. Wait for their answer; do not retry this call, and do not work around \
+     it.";
+
+/// What the model is told when the change the person agreed to cannot be
+/// written, because the plan moved while it was on the table.
+const REVISION_STALE: &str = "the plan change could not be written, so nothing runs until the \
+     person driving is asked again.";
+
+impl PlanGate {
+    /// Settle the waiting plan change against `board`, and return the refusal
+    /// a guarded tool call gets while it is still waiting.
+    ///
+    /// `None` in three cases: nothing is waiting; there is no plan to write a
+    /// yes into; or the board carries the change, so it is written and work
+    /// goes on.
+    pub(super) fn settle_revision(&self, board: &[TaskItem]) -> Option<ToolOutput> {
+        let waiting = self.pending_revision()?;
+        let planned = self
+            .state
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .graph
+            .is_some();
+        if !planned {
+            // No plan, no hold. A yes is written into this turn's plan graph,
+            // so a hold raised before one exists could never be lifted.
+            return None;
+        }
+        if !board.iter().any(|item| item.subject == waiting.subject) {
+            return Some(ToolOutput::classified_error(
+                ErrorClass::RefusedByPolicy,
+                hold_message(REVISION_HELD, &waiting),
+            ));
+        }
+        // The plan can move while a change sits on the table, and the graph
+        // then refuses it. The person is asked again rather than having some
+        // other change written under their answer, and the hold stands until
+        // they are.
+        match self.approve_revision() {
+            Ok(_) => None,
+            Err(_) => Some(ToolOutput::classified_error(
+                ErrorClass::RefusedByPolicy,
+                hold_message(REVISION_STALE, &waiting),
+            )),
+        }
+    }
+
+    /// The plan change on the table, if there is one.
+    pub(crate) fn pending_revision(&self) -> Option<RevisionProposal> {
+        self.revisions
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .pending()
+            .cloned()
+    }
+
+    /// Say yes to the waiting change: write it into this turn's plan.
+    ///
+    /// The insert goes through `RevisionGate::approve`. That adds the task
+    /// and calls `PlanGraph::revise`. So the new revision, its `[:NEXT]`
+    /// chain and the cause it carries all come from the code that writes
+    /// every other revision.
+    ///
+    /// The yes is kept as this turn's approved revision too. Without that,
+    /// the next [`PlanGate::review`] reads the longer plan as a plan that
+    /// changed. It would put it back to the person who just agreed to it.
+    ///
+    /// [`RevisionError::NothingPending`] when no plan was ever put up. A
+    /// change cannot be written into a plan that does not exist.
+    pub(crate) fn approve_revision(&self) -> Result<PlanRevision, RevisionError> {
+        let mut state = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(graph) = state.graph.as_mut() else {
+            return Err(RevisionError::NothingPending);
+        };
+        let revision = self
+            .revisions
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .approve(graph)?;
+        state.approved = Some(revision);
+        Ok(revision)
+    }
+}
+
+/// The refusal text: what waits, what it would add, and why.
+///
+/// It names the gate and the cause, so the model can tell one hold from the
+/// next. A bare "wait" would read the same on every board.
+fn hold_message(frame: &str, waiting: &RevisionProposal) -> String {
+    format!(
+        "{frame} {} would add \"{}\", because the {} gate reported: {}",
+        waiting.revision,
+        waiting.subject,
+        waiting.gate,
+        waiting.cause.as_str()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use stella_protocol::{
+        Answer, GateBoard, GateRow, GateState, QuestionOutcome, QuestionRequest, TaskStatus,
+    };
+    use stella_tools::ToolRegistry;
+    use stella_tools::registry::question::QuestionResponder;
+
+    use super::super::{APPROVE_LABEL, PlanSetup};
+    use super::*;
+    use crate::settings::PlanReviewPolicy;
+
+    /// A person who says yes to every plan they are shown.
+    struct Approving;
+
+    #[async_trait]
+    impl QuestionResponder for Approving {
+        async fn respond(&self, _request: &QuestionRequest) -> QuestionOutcome {
+            QuestionOutcome::Answered {
+                answers: vec![Answer {
+                    header: "Plan".into(),
+                    question: String::new(),
+                    chosen: vec![APPROVE_LABEL.to_string()],
+                    note: None,
+                }],
+            }
+        }
+    }
+
+    fn row(id: &str, subject: &str) -> TaskItem {
+        TaskItem {
+            id: id.to_string(),
+            subject: subject.to_string(),
+            description: None,
+            status: TaskStatus::Pending,
+            owner: None,
+            contract: None,
+        }
+    }
+
+    fn board(n: usize) -> Vec<TaskItem> {
+        (0..n)
+            .map(|i| row(&(i + 1).to_string(), &format!("step {}", i + 1)))
+            .collect()
+    }
+
+    /// What a plugin reported: one gate green, one gate failed.
+    fn failing_board() -> GateBoard {
+        GateBoard {
+            patch: Some("patch-7".into()),
+            gates: vec![
+                GateRow {
+                    name: "fmt".into(),
+                    state: GateState::Green,
+                    deterministic: true,
+                },
+                GateRow {
+                    name: "tests".into(),
+                    state: GateState::Failed {
+                        case: "stella_core::loop_detect::a_short_cycle_is_detected".into(),
+                        log: "assertion `left == right` failed\n  left: 3\n right: 2\n".into(),
+                    },
+                    deterministic: true,
+                },
+            ],
+        }
+    }
+
+    /// A gate with a person to answer it, the plan-change gate its forwarder
+    /// would write to, and the stream it puts its card on. The test holds the
+    /// receiver open.
+    fn gate(
+        registry: &ToolRegistry,
+    ) -> (
+        PlanGate,
+        SharedRevisions,
+        tokio::sync::mpsc::UnboundedReceiver<stella_protocol::AgentEvent>,
+    ) {
+        registry.attach_question_responder(Arc::new(Approving), Duration::from_secs(30));
+        let (events, rx) = tokio::sync::mpsc::unbounded_channel();
+        let revisions = SharedRevisions::default();
+        let gate = PlanGate::install(
+            registry.question_broker(),
+            events,
+            PlanSetup {
+                goal: "fix the router".into(),
+                policy: PlanReviewPolicy::default(),
+                revisions: Arc::clone(&revisions),
+            },
+        )
+        .expect("a person is attached, so the gate is installed");
+        (gate, revisions, rx)
+    }
+
+    /// What the lane's forwarder does with a failing board: put a plan change
+    /// on the shared gate at the number the reader will be shown.
+    fn observe(revisions: &SharedRevisions, gate: &PlanGate) -> RevisionProposal {
+        let graph = gate.plan_graph().expect("a plan was put up this turn");
+        let mut held = revisions.lock().expect("the gate");
+        held.observe(
+            graph.revision().next(),
+            &graph.planned(graph.revision()),
+            &failing_board(),
+        )
+        .expect("a plain gate failure puts a change up")
+        .clone()
+    }
+
+    /// **The witness.** A gate failed while the turn ran, so a plan change
+    /// waits. The next tool call is held back until somebody answers it. It
+    /// runs once they say yes, and the plan carries the gate's own cause.
+    ///
+    /// Nothing here can pass without the plan-change gate this file hangs on
+    /// the plan gate. With no gate there is nothing to read, nothing for
+    /// `review` to hold back, and no way to write the answer into the plan.
+    #[tokio::test]
+    async fn a_waiting_plan_change_stops_the_next_tool_call_until_it_is_answered() {
+        let registry = ToolRegistry::new(std::path::PathBuf::from("."));
+        let (gate, revisions, _events) = gate(&registry);
+        let mut plan = board(3);
+        assert!(
+            gate.review(&plan).await.is_none(),
+            "the person driving said start, so r1 runs"
+        );
+
+        let waiting = observe(&revisions, &gate);
+        assert_eq!(waiting.revision, PlanRevision::new(2).expect("r2"));
+        assert_eq!(waiting.gate, "tests");
+
+        let held = gate
+            .review(&plan)
+            .await
+            .expect("nothing runs while a change waits");
+        let ToolOutput::Error { message, class } = &held else {
+            panic!("a hold is a refusal, not a success: {held:?}");
+        };
+        assert_eq!(
+            *class,
+            Some(ErrorClass::RefusedByPolicy),
+            "a plane above the call held it back"
+        );
+        assert!(
+            message.contains("r2"),
+            "the hold names the change: {message}"
+        );
+        assert!(
+            message.contains(&waiting.subject),
+            "the hold says what it would add: {message}"
+        );
+        assert!(
+            message.contains("tests"),
+            "the hold names the gate that failed: {message}"
+        );
+
+        // The deck's approve verb puts the repair on the board. That row is
+        // the person's yes, and the next call reads it.
+        plan.push(row("4", &waiting.subject));
+        assert!(
+            gate.review(&plan).await.is_none(),
+            "work goes on once the change is answered"
+        );
+        assert!(
+            gate.pending_revision().is_none(),
+            "a written change stops waiting"
+        );
+
+        let graph = gate.plan_graph().expect("a plan was put up this turn");
+        assert_eq!(graph.revision(), waiting.revision, "the yes wrote r2");
+        assert!(
+            graph
+                .planned(waiting.revision)
+                .iter()
+                .any(|task| task.subject == waiting.subject),
+            "a yes writes the repair into the plan"
+        );
+        let drift = graph.divergences();
+        assert_eq!(drift.len(), 1, "one insert, from PlanGraph::revise");
+        assert_eq!(
+            drift[0].cause, waiting.cause,
+            "the revision carries the gate's own cause"
+        );
+    }
+
+    /// A change put up before any plan cannot be written, since a plan graph
+    /// is what it would be written into. It must not wedge the turn either.
+    #[tokio::test]
+    async fn a_change_with_no_plan_to_write_it_into_holds_nothing() {
+        let registry = ToolRegistry::new(std::path::PathBuf::from("."));
+        let (gate, revisions, _events) = gate(&registry);
+        revisions
+            .lock()
+            .expect("the gate")
+            .observe(PlanRevision::FIRST, &[], &failing_board())
+            .expect("a plain gate failure puts a change up");
+
+        assert_eq!(
+            gate.approve_revision(),
+            Err(RevisionError::NothingPending),
+            "there is no plan, so there is nothing to write into"
+        );
+        assert!(
+            gate.settle_revision(&board(2)).is_none(),
+            "a change nobody can write must not wedge the turn"
+        );
+    }
+}

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -38,7 +38,9 @@ use tokio::sync::{oneshot, watch};
 
 use self::notify::worker_notification;
 use crate::agent;
-use crate::command_deck::{LEAD, close_turn_stream, now_ms, prompt_line, spawn_forwarder};
+use crate::command_deck::{
+    LEAD, SharedRevisions, close_turn_stream, now_ms, prompt_line, spawn_forwarder,
+};
 use crate::config::Config;
 use crate::runtime::TokioSleeper;
 
@@ -1065,6 +1067,10 @@ async fn run_worker(
         in_tx.clone(),
         spec.lane.clone(),
         Some(registry.task_board()),
+        // A worker lane has no plan gate to read this, so its gate is its
+        // own: the proposals it authors reach the deck the way they always
+        // did, and nothing on this lane is held back by one.
+        SharedRevisions::default(),
     );
 
     /// How the raced turn resolved, before store closeout.


### PR DESCRIPTION
## What and why

SPEC 8.1 item 3 says nothing runs until a proposed plan revision is answered. #5043 shipped two of the three halves — `stella_core::plan_graph::RevisionGate::admits` answers `false` while a change waits, and `deck_ui::gates::revision_hold` holds back the prompts the deck would start. Neither can stop a tool call the model has **already** asked for, so a gate failing mid-turn parked nothing on that path.

`crates/stella-cli/src/command_deck/task_tap/plan_gate.rs`'s `PlanGate` is the one place consulted before a guarded tool call that also owns the turn's `PlanGraph`. It now reads the lane's plan-change gate and refuses while one waits.

## How

One gate, shared, rather than two that could disagree:

- `SharedRevisions` (`Arc<Mutex<RevisionGate>>`) is built per turn in `run_lead_turn`.
- `spawn_forwarder` takes it and writes to it. The forwarder's own private `RevisionGate` is deleted — a `GateBoard` reaches this host on that stream and nowhere else.
- `PlanSetup` carries it into `PlanGate`. The turn's plan graph lives there and nowhere else.
- `PlanGate::review` calls `settle_revision` first. While a change waits and the board does not carry it, the tool call gets a `RefusedByPolicy` refusal naming the revision, what it would add, the failing gate and its cause.
- The deck's `a approve` verb already puts the repair row on the board (`driver_support::service_approve_revision`), so a board carrying the waiting subject **is** the person's yes. `approve_revision` hands the graph to `RevisionGate::approve`, so the `[:NEXT]` edge and the `Divergence` carrying the gate's cause come from `PlanGraph::revise` — the issue's "the two should meet rather than both writing".
- No plan graph, no hold: a yes is written into that graph, so a hold raised before a plan exists could never be lifted. Same failure direction the plan gate already takes for a card nobody answered.

New logic lands in a sibling submodule (`plan_gate/revision.rs`), not in `plan_gate.rs` (715 lines, ungrandfathered) and not in `command_deck.rs` (a god file — the one line touched there is an existing re-export, widened by one name, so the file does not grow).

### Why this differs from the issue's wording

The issue asks for a `PlanGate` that "is handed the failing `GateBoard`". A `PlanGate` method taking a board has no production caller — only the forwarder ever sees one — and `stella-cli` is a binary crate, so a `pub(crate)` fn nothing calls is a `dead_code` failure under `-D warnings`. Sharing the gate gives the same result with nothing unwired. Recorded on the issue before the work: https://github.com/macanderson/stella/issues/5296#issuecomment-5549714457

## Witness mechanism

`a_waiting_plan_change_stops_the_next_tool_call_until_it_is_answered` (`crates/stella-cli/src/command_deck/task_tap/plan_gate/revision.rs`) approves a three-step plan, writes a failing gate board onto the shared gate the way the forwarder does, and then asserts the next `review`:

- refuses with `ErrorClass::RefusedByPolicy`, naming `r2`, the subject and the `tests` gate;
- admits once the repair row is on the board, and leaves nothing waiting;
- has written `r2` into the plan graph with exactly one insertion whose `Divergence` carries the gate's own cause.

It fails on `main` by construction: `PlanGate` had no field to read, `review` no `settle_revision` to call, and no `approve_revision` to write the answer. No terminal, no plugin, no engine.

`a_change_with_no_plan_to_write_it_into_holds_nothing` pins the other direction — a change that arrives before any plan cannot wedge the turn.

Exemplar: `stella_core::plan_graph::revision`, whose `RevisionGate` this composes rather than reimplements.

## Tests deleted

None.

## Definition of done

#5296's three boxes are ticked, each checked against this diff rather than against the description. The one mechanism difference from the issue's wording — the board reaching `PlanGate` through the shared gate instead of a method parameter — is recorded beside the box it belongs to, with the `dead_code` reason above. Working shown under "How each box was checked" on the issue.

## Residue filed

- #5867 — route the deck's `a approve` / `x dismiss` keys into the live turn's gate directly, instead of inferring the yes from a board row. `x dismiss` reaches nothing today, so a person who does not want the repair task cannot lift the hold.

Closes #5296

## Summary by Sourcery

Ensure running turns stop guarded tool calls until pending plan revisions are answered and approved changes are recorded in the active plan.

New Features:
- Hold tool calls from an already-running turn while a plan revision is awaiting approval.
- Share the per-turn revision gate between the event forwarder and plan gate so approvals update the active plan graph.

Bug Fixes:
- Prevent tool calls from bypassing plan-change holds when a gate fails mid-turn.
- Avoid wedging turns when a revision arrives before a plan graph exists.

Enhancements:
- Return classified refusal messages that identify the pending revision, proposed task, failing gate, and cause, while routing approved revisions through the plan graph.

Tests:
- Add coverage for holding and resuming tool calls around an answered plan revision.
- Add coverage ensuring pre-plan revisions do not block execution.