### PR TITLE
docs(records): repoint six citations at the crate that holds the code

### DIFF
--- a/crates/stella-protocol/README.md
+++ b/crates/stella-protocol/README.md
@@ -232,7 +232,7 @@ equality, and a mismatch is harvested as `AgentEvent::SpeculationDiscarded`.
 - **The golden JCS vector in `context_event.rs` is meant to break — on three
   of the four edits, not all four.** Renaming, retyping, or adding a
   field of `CompiledContextFrameBuilt` breaks the golden line, because those
-  canonical bytes are the preimage `stella_core::context_record::hash` builds
+  canonical bytes are the preimage `stella_protocol::hash` builds
   `record_hash` from. **Reordering does not**: RFC 8785 (JCS) sorts object
   keys lexicographically, so two structurally-identical values serialize to
   the same bytes regardless of field declaration order. The dev-dep pins the

--- a/docs/adr/0012-context-record-field-schema.md
+++ b/docs/adr/0012-context-record-field-schema.md
@@ -58,7 +58,7 @@ a Context PR at all: the provider-hosted record is authoritative for workspace
 scope and is never materialized into a rule file unless a separate repository
 publication is approved (`docs/spec/adaptive-context/context-pr.md` §2). That channel remains deferred.
 
-Implemented as `stella_core::records::publication_dir`.
+Implemented as `stella_records::records::publication_dir`.
 
 ## Decision 2 — The surface keeps `personal`, and maps to the ledger's `user`
 
@@ -80,7 +80,7 @@ ADR 0009 froze the *ledger* vocabulary, not the file surface, and the file
 surface is what humans hand-edit. Two vocabularies with one documented mapping
 beats one vocabulary that reads wrong in one of its two homes.
 
-Implemented as `stella_core::ingest::record::SharingScope`, with the mapping
+Implemented as `stella_records::ingest::record::SharingScope`, with the mapping
 documented on the type.
 
 ## Decision 3 — `set_id` is a citation *namespace*, not a citation
@@ -118,7 +118,7 @@ Two properties this has to have, and does:
   break the prompt cache on an unrelated rename. The final tiebreak is the
   content-derived `record_id`.
 
-Implemented as `stella_core::records::handle::assign_handles`.
+Implemented as `stella_records::records::handle::assign_handles`.
 
 ## Decision 5 — `applies_to.tasks` is a closed vocabulary with a loud warning
 
@@ -149,7 +149,7 @@ outright would be worse — the statement is still policy, and a `must` record
 injects regardless of task matching — so the record loads and carries a
 `RecordFinding::UnknownTask`.
 
-Adding a task name is an edit to `stella_core::records::KNOWN_TASKS` and a line
+Adding a task name is an edit to `stella_records::records::KNOWN_TASKS` and a line
 in this ADR: a vocabulary that grows without a decision is an open
 vocabulary with extra steps.
 
@@ -174,7 +174,7 @@ deadline:
 | `review_every` | re-probe on this cadence | probe runs; verdict decides |
 | `ttl` | this claim's shelf life | `on_expiry`, default demote-to-stale |
 
-Implemented in `stella_core::records::sweep`.
+Implemented in `stella_records::records::sweep`.
 
 ## Decision 7 — `tags` is kept, for human browsing only
 


### PR DESCRIPTION
## What & why

#5829 moved the record plane out of `stella-core` into `stella-records`, and the
canonical hash primitive into `stella-protocol`. Six prose citations were left
naming the old homes. AGENTS.md § "Code style and conventions" asks that a
rename be chased through comments and docs in the same PR — *"stale comments are
treated as bugs in review"* — so these are that PR's residue, found by an
automated open-PR sweep.

Every target was verified against `origin/main` rather than inferred from the
move commit's message:

| Citation | Now | Verified by |
|---|---|---|
| `crates/stella-protocol/README.md` — `stella_core::context_record::hash` | `stella_protocol::hash` | `record_hash` and `RecordHashError` are both in `crates/stella-protocol/src/hash.rs`; no `hash` module remains under `stella-records`' `context_record/` |
| ADR 0012 — `stella_core::records::publication_dir` | `stella_records::records::publication_dir` | `crates/stella-records/src/records.rs` |
| ADR 0012 — `stella_core::ingest::record::SharingScope` | `stella_records::ingest::record::SharingScope` | `crates/stella-records/src/ingest/record.rs` |
| ADR 0012 — `stella_core::records::handle::assign_handles` | `stella_records::records::handle::assign_handles` | `crates/stella-records/src/records/handle.rs` |
| ADR 0012 — `stella_core::records::KNOWN_TASKS` | `stella_records::records::KNOWN_TASKS` | `crates/stella-records/src/records.rs` |
| ADR 0012 — `stella_core::records::sweep` | `stella_records::records::sweep` | `crates/stella-records/src/records/sweep.rs` |

The README line sits in `stella-protocol`'s own README and now names that
crate's own module, which is why it reads `stella_protocol::hash` rather than
a `stella_records` path like the other five.

**This is the whole of the drift.** `git grep` for
`stella_core::{context_record,records,ingest}` over `*.rs` returns nothing — no
Rust file named any of these paths, so nothing compiled was affected and there
is no code change here. After this diff the same grep over `*.rs` and `*.md`
returns nothing at all.

An ADR that names a crate which no longer holds the code sends the next reader
to an empty grep. That is the failure this repository treats as a bug rather
than a nit, and it is cheap to fix now and expensive to notice later.

Refs #5829

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: prose-only. Six
      markdown citations; no Rust file changes, no behavior, nothing to assert.
      The verification that matters is that each new path resolves to real code,
      which is the table above — each row checked against `origin/main` with
      `git grep` for the symbol's definition, not against the move commit's
      claim about where it went.

## The gate

Per CLAUDE.md's "CI builds and tests; this laptop does not", nothing was
compiled here; CI is the evidence. The toolchain-free guards that govern a
docs diff were run:

- [x] `make prose` — OK, none added
- [x] `make line-citations` — OK, none added (every citation here is by symbol, not line number)
- [x] `make adr-numbering` — OK, 26 records, every heading and id in agreement
- [x] `make doc-links` — exit 0, and confirmed identical on clean `main` (the five uncited documents it lists are pre-existing and untouched by this diff)
- [x] `make design-refs`, `make brand-case` — OK
- [ ] `cargo fmt --check` / `clippy` / `test --workspace` — CI's; no Rust file is in the diff
- [x] `Refs #5829` appears both here and as a commit trailer

**One guard did not run and is not being reported as passing:** `shellcheck` is
not installed on this machine (#3830), so `make guards-fast` stops there. This
diff touches no shell script, and CI runs the lint on a runner that has it.

Tests deleted: none.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

The sweep that found this also checked whether the move left any *code* behind —
it did not — and the five uncited documents `doc-links` lists are pre-existing
drift unrelated to #5829, already visible in that guard's own advisory output on
`main`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No cross-boundary types touched

## Anything reviewers should know?

Found by an automated sweep over the open PRs, not by working on #5829 — so the
reviewer worth asking is whoever owns that refactor, in case any of the six was
left pointing at the old crate deliberately. I do not believe any was: all five
ADR citations read "Implemented as …", which is a claim about where the code is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWFU92RqDBoXgW8TBnVgNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWFU92RqDBoXgW8TBnVgNa)_

## Summary by Sourcery

Correct documentation references to reflect the record-plane and hashing code moves.

Bug Fixes:
- Update six documentation citations to reference the crates and modules that now contain the record and hashing implementations.

Documentation:
- Correct stale crate paths in the protocol README and context-record ADR.