### PR TITLE
fix(stella-tui): finish the width budgets PR #5762 started

### DIFF
--- a/crates/stella-tui/src/composer.rs
+++ b/crates/stella-tui/src/composer.rs
@@ -375,6 +375,10 @@ impl Composer {
             self.cursor = 0;
             return;
         }
+        // This is a char index, not a screen-column budget. No pane width
+        // is checked here. `byte_at_char_col` clamps to the line's own
+        // length, so a CJK line cannot crash it. It just picks a slightly
+        // different landing glyph, same as most editors do.
         let col = self.buffer[start..self.cursor].chars().count();
         let prev_start = line_start(&self.buffer, start - 1);
         let prev_line = &self.buffer[prev_start..start - 1];
@@ -389,6 +393,7 @@ impl Composer {
             return;
         };
         let start = line_start(&self.buffer, self.cursor);
+        // Same as `move_up` above: a char index, not a column budget.
         let col = self.buffer[start..self.cursor].chars().count();
         let next_start = self.cursor + newline + 1;
         let next_end = self.buffer[next_start..]

--- a/crates/stella-tui/src/model/summarize.rs
+++ b/crates/stella-tui/src/model/summarize.rs
@@ -53,6 +53,11 @@ pub(super) fn cap_middle(text: &str, budget: usize) -> String {
 /// [`cap_middle`] with a caller-chosen elision marker. Slices at
 /// `char_indices` boundaries instead of materializing a `Vec<char>`, so a
 /// multi-megabyte payload costs no allocation beyond the capped result.
+///
+/// `budget` caps how much raw text this model keeps. It is not a screen
+/// width. No `Rect` is read here. Whatever view paints this text later
+/// cuts it again, by columns, at that point. So `marker.chars().count()`
+/// is fine as written.
 pub(super) fn cap_middle_with(text: &str, budget: usize, marker: &str) -> String {
     // Byte length bounds char count, so an in-budget payload returns without
     // scanning; an over-budget one probes just past the boundary instead.
@@ -205,6 +210,11 @@ pub(super) fn format_tool_input(input: &serde_json::Value) -> String {
 /// slicing the raw text first yields the identical result without copying a
 /// multi-megabyte `content`/`old_string` argument in full (the same reason
 /// [`cap_middle_with`] walks `char_indices` instead of materializing chars).
+///
+/// Every caller passes a fixed number, never a pane width. This shapes a
+/// short **headline** string. The transcript renders it later and cuts it
+/// again, by columns, at that point. A char cap is the right unit for a
+/// headline's own length.
 pub(super) fn truncate_field(s: &str, max: usize) -> String {
     // `nth(max)` is `None` exactly when the text is `max` chars or shorter.
     if s.char_indices().nth(max).is_none() {

--- a/crates/stella-tui/src/render/entry/recall.rs
+++ b/crates/stella-tui/src/render/entry/recall.rs
@@ -51,10 +51,10 @@
 
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::{plural, quiet, value};
 use crate::model::{RecallBudget, RecalledFrameRow};
+use crate::render::columns;
 use crate::render::row::*;
 use crate::theme;
 
@@ -434,7 +434,7 @@ impl RecallColumns {
         let metric = digits + " tok".len();
         let kind = frames
             .iter()
-            .map(|f| display_width(frame_kind(f)))
+            .map(|f| columns::width(frame_kind(f)))
             .max()
             .unwrap_or(RECALL_KIND_MIN)
             .clamp(RECALL_KIND_MIN, RECALL_KIND_MAX);
@@ -449,7 +449,7 @@ impl RecallColumns {
         let widest = frames
             .iter()
             .filter_map(|f| f.uri.as_deref())
-            .map(|u| display_width(&recall_location(u, RECALL_LOCATION_MAX)))
+            .map(|u| columns::width(&recall_location(u, RECALL_LOCATION_MAX)))
             .max()
             .unwrap_or(0);
 
@@ -522,7 +522,7 @@ impl LegColumns {
         Self {
             provider: legs
                 .iter()
-                .map(|(p, ..)| display_width(p))
+                .map(|(p, ..)| columns::width(p))
                 .max()
                 .unwrap_or(0)
                 .min(RECALL_LEG_MAX),
@@ -614,7 +614,7 @@ fn short_digest(digest: &str) -> String {
 }
 
 /// The first `cap` chars of `text`, whole — the char-boundary cut
-/// [`short_digest`] needs, as [`take_right`] is for the other end.
+/// [`short_digest`] needs, as [`columns::take_right`] is for the other end.
 fn prefix_chars(text: &str, cap: usize) -> &str {
     match text.char_indices().nth(cap) {
         Some((at, _)) => &text[..at],
@@ -631,13 +631,13 @@ fn recall_location(uri: &str, cap: usize) -> String {
     // Strip a scheme so `file:///…` and a bare path render alike; the scheme
     // is never the discriminating part of a recall row.
     let path = uri.split_once("://").map_or(uri, |(_, rest)| rest);
-    if display_width(path) <= cap {
+    if columns::width(path) <= cap {
         return path.to_string();
     }
     if cap == 0 {
         return String::new();
     }
-    let tail = take_right(path, cap - 1);
+    let tail = columns::take_right(path, cap - 1);
     // Cut on a separator so the elision lands between path segments rather
     // than mid-directory-name — but only when that leaves a real path behind.
     // Snapping to a separator that sits near the end would trade a readable
@@ -649,7 +649,7 @@ fn recall_location(uri: &str, cap: usize) -> String {
     // the snap on any path with a multi-byte segment in front of the cut.
     match tail
         .find('/')
-        .filter(|cut| display_width(&tail[..*cut]) <= cap / 3)
+        .filter(|cut| columns::width(&tail[..*cut]) <= cap / 3)
     {
         Some(cut) => format!("…{}", &tail[cut..]),
         None => format!("…{tail}"),
@@ -669,57 +669,22 @@ fn cell(text: &str, col: usize) -> String {
     let text = elide(text, col);
     format!(
         "{text}{}",
-        " ".repeat(col.saturating_sub(display_width(&text)))
+        " ".repeat(col.saturating_sub(columns::width(&text)))
     )
 }
 
 /// Truncate to `cap` display columns with a trailing `…`.
 ///
-/// The `…` is one column, so the kept text is budgeted `cap - 1`. A cut that
-/// lands mid-wide-character keeps the narrower text and lets [`cell`] pad the
-/// hole, rather than emitting a cell one column over its budget.
+/// Built on [`columns::take_left`], not [`columns::head`]. A cut right
+/// after a space would leave `"ab …"`. That trailing space is this table's
+/// own quirk to fix, so it stays here and not in the shared helper.
 fn elide(text: &str, cap: usize) -> String {
-    if display_width(text) <= cap {
+    if columns::width(text) <= cap {
         return text.to_string();
     }
     if cap == 0 {
         return String::new();
     }
-    let kept = take_left(text, cap - 1);
+    let kept = columns::take_left(text, cap - 1);
     format!("{}…", kept.trim_end())
-}
-
-/// The longest prefix of `text` that fits in `cap` display columns.
-fn take_left(text: &str, cap: usize) -> String {
-    let mut out = String::new();
-    let mut used = 0;
-    for ch in text.chars() {
-        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if used + w > cap {
-            break;
-        }
-        used += w;
-        out.push(ch);
-    }
-    out
-}
-
-/// The longest suffix of `text` that fits in `cap` display columns.
-fn take_right(text: &str, cap: usize) -> String {
-    let mut kept: Vec<char> = Vec::new();
-    let mut used = 0;
-    for ch in text.chars().rev() {
-        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if used + w > cap {
-            break;
-        }
-        used += w;
-        kept.push(ch);
-    }
-    kept.iter().rev().collect()
-}
-
-/// Columns `text` occupies on a terminal — the unit every width here is in.
-fn display_width(text: &str) -> usize {
-    UnicodeWidthStr::width(text)
 }

--- a/crates/stella-tui/src/transcript_build.rs
+++ b/crates/stella-tui/src/transcript_build.rs
@@ -430,6 +430,13 @@ impl RunBuilder {
 /// frames. The header rail is one line shared with the status word and the
 /// chips, so this is deliberately terse; the prompt itself is rendered in full
 /// on the `you` row directly below and is never what this replaces.
+///
+/// `MAX_CHARS` shapes the identifier's own length, not a pane's — this is a
+/// content cap the shared [`stella_transcript`] model carries, read by both
+/// the grid and the HTML renderer, and the grid one re-elides `Turn::name`
+/// to its live column budget with its own `head_cells` (`unicode_width`
+/// aware) before drawing it. A `char` cap here is the right unit for "how
+/// much of the prompt survives into the name."
 fn slug(prompt: &str) -> String {
     const MAX_WORDS: usize = 4;
     const MAX_CHARS: usize = 28;

--- a/crates/stella-tui/src/views/approval.rs
+++ b/crates/stella-tui/src/views/approval.rs
@@ -66,6 +66,7 @@ use stella_tui_theme::{glyph, token};
 
 use stella_tools::registry::approval::{ApprovalRequest, ApprovalResponse};
 
+use crate::render::columns;
 use crate::views::cards::truncate_cols;
 
 /// Matches the question overlay's width so the two mid-turn asks read as one
@@ -390,6 +391,8 @@ fn hints(mode: ApprovalMode) -> &'static str {
 /// through JSON to reach it — these two fields are named members of a Rust
 /// struct, and the projection's row width is its own rather than the card's.
 fn field(label: &str, value: &str, inner_w: usize) -> Line<'static> {
+    // `label` is always one of this file's own words ("gate", "reason").
+    // It is always ASCII, so `chars().count()` is already its width.
     let room = inner_w.saturating_sub(label.chars().count() + 3).max(8);
     Line::from(vec![
         Span::styled(format!(" {label} "), Style::new().fg(token::MUTED)),
@@ -401,9 +404,11 @@ fn field(label: &str, value: &str, inner_w: usize) -> Line<'static> {
 fn editor_row(text: &str, inner_w: usize) -> Line<'static> {
     let room = inner_w.saturating_sub(6).max(8);
     // Show the tail: a person typing past the field's width needs to see
-    // what they are typing now.
-    let shown: String = if text.chars().count() > room {
-        text.chars().skip(text.chars().count() - room).collect()
+    // what they are typing now. The reason is free typed text, so this
+    // window is spent in columns. A `char` count can cut a glyph in half
+    // or leave the row too wide.
+    let shown = if columns::width(text) > room {
+        columns::take_right(text, room)
     } else {
         text.to_string()
     };
@@ -648,5 +653,22 @@ mod tests {
             render(&open(), false, area, &mut buf);
             render(&open(), true, area, &mut buf);
         }
+    }
+
+    /// The tail window stays inside `inner_w` for a CJK reason.
+    ///
+    /// Old code did `text.chars().skip(chars_count - room)`. With 30 CJK
+    /// glyphs (30 chars, 60 columns) and a 20-column `room`, that skip
+    /// dropped only 10 chars and kept 20 glyphs — 40 columns. Twice the
+    /// budget.
+    #[test]
+    fn a_wide_character_reason_keeps_the_editor_tail_inside_its_width() {
+        let text = "圈".repeat(30);
+        let inner_w = 26; // room = inner_w - 6 = 20
+        let line = editor_row(&text, inner_w);
+        assert!(
+            line.width() <= inner_w,
+            "editor row overran its {inner_w}-column budget: {line:?}"
+        );
     }
 }

--- a/crates/stella-tui/src/views/files_tab.rs
+++ b/crates/stella-tui/src/views/files_tab.rs
@@ -61,6 +61,7 @@ use stella_protocol::FileChangeKind;
 use crate::deck::{FileLedger, FileRecord, WorkspaceModel};
 use crate::deck_ui::DeckUi;
 use crate::diff;
+use crate::render::columns;
 
 /// The selection gutter: `▸ ` on the selected row, blank on every other.
 const GUTTER_W: usize = 2;
@@ -282,9 +283,9 @@ fn header_line(width: usize) -> Line<'static> {
 fn record_line(rec: &FileRecord, width: usize, selected: bool) -> Line<'static> {
     let muted = Style::new().fg(token::MUTED);
     let pw = path_width(width);
-    let path = elide_left(&rec.path, pw);
-    let pad = pw.saturating_sub(path.chars().count());
-    let agent = elide_left(&rec.agent, AGENT_W.saturating_sub(1));
+    let path = columns::tail(&rec.path, pw);
+    let pad = pw.saturating_sub(columns::width(&path));
+    let agent = columns::tail(&rec.agent, AGENT_W.saturating_sub(1));
     let (op_letter, op_metal) = op_style(rec.kind);
 
     let mut spans = vec![Span::styled(
@@ -300,8 +301,10 @@ fn record_line(rec: &FileRecord, width: usize, selected: bool) -> Line<'static> 
     spans.extend([
         // Padded to the full column, unlike the pre-port row, which padded to
         // one less and left every op badge sitting a column left of its own
-        // header cell.
-        Span::styled(format!("{agent:<aw$}", aw = AGENT_W), muted),
+        // header cell. `columns::pad` fills by display column, not by char.
+        // An agent tag is free text (a name, a model slug), and Rust's own
+        // `{:<aw$}` fills by char — too little space for a CJK or emoji tag.
+        Span::styled(columns::pad(&agent, AGENT_W), muted),
         Span::styled(
             format!("{op_letter:^ow$}", ow = OP_W),
             Style::new().fg(op_metal).add_modifier(Modifier::BOLD),
@@ -356,23 +359,6 @@ fn op_style(kind: FileChangeKind) -> (&'static str, Color) {
         FileChangeKind::Deleted => token::RED,
     };
     (crate::textline::crud_letter(kind), metal)
-}
-
-/// Left-elide `text` to at most `max` chars, keeping the tail (the
-/// meaningful end of a path) and marking the cut with `…`.
-fn elide_left(text: &str, max: usize) -> String {
-    if max == 0 {
-        return String::new();
-    }
-    let chars: Vec<char> = text.chars().collect();
-    if chars.len() <= max {
-        return text.to_string();
-    }
-    if max == 1 {
-        return "…".to_string();
-    }
-    let tail: String = chars[chars.len() - (max - 1)..].iter().collect();
-    format!("…{tail}")
 }
 
 // ── Diff pane ────────────────────────────────────────────────────────────
@@ -914,6 +900,33 @@ mod tests {
         render(&model, &mut ui, area, &mut buf);
         let text = buffer_text(&buf);
         assert!(text.contains("no files touched yet"));
+    }
+
+    /// A CJK path or agent tag stays inside its column, and the row it sits
+    /// on stays inside the pane.
+    ///
+    /// Old code used `elide_left` and `chars().count()`. A CJK glyph is
+    /// one char but two columns, so a char budget kept twice the width it
+    /// meant to. Measured with [`ratatui::text::Line::width`], never
+    /// through `render::columns` itself, so the test cannot agree with
+    /// the bug it checks for.
+    #[test]
+    fn a_wide_character_row_stays_inside_its_width() {
+        let width = 60;
+        let rec = FileRecord {
+            agent: "查看文件目录结构树状图代理".into(),
+            path: "crates/查看文件目录结构树状图/driver.rs".into(),
+            kind: FileChangeKind::Modified,
+            added: 4,
+            removed: 1,
+            changes: 1,
+            reads: 0,
+        };
+        let line = record_line(&rec, width, false);
+        assert!(
+            line.width() <= width,
+            "row overran its {width}-column budget: {line:?}"
+        );
     }
 
     #[test]

--- a/crates/stella-tui/src/views/graph_tab.rs
+++ b/crates/stella-tui/src/views/graph_tab.rs
@@ -49,6 +49,7 @@ use stella_tui_theme::{glyph, token};
 use crate::deck::WorkspaceModel;
 use crate::deck_ui::DeckUi;
 use crate::graph::{FileTouch, GraphSnapshot, SessionTouch};
+use crate::render::columns;
 
 /// The SPEC 4 glyph for a node kind: file, type, fn — anything else a plain
 /// bullet.
@@ -252,11 +253,11 @@ pub fn paint(
     };
     let used: usize = query.iter().map(Span::width).sum();
     let inner_w = bands[0].width.saturating_sub(2) as usize;
-    if used + right.chars().count() < inner_w {
-        query.push(Span::styled(
-            " ".repeat(inner_w - used - right.chars().count()),
-            dim,
-        ));
+    // `right` is a node count, a timing, and static ASCII words joined by
+    // `·`. Every glyph is one column, so `chars().count()` is the width.
+    let right_w = right.chars().count();
+    if used + right_w < inner_w {
+        query.push(Span::styled(" ".repeat(inner_w - used - right_w), dim));
         query.push(Span::styled(right, muted));
     }
     Paragraph::new(Line::from(query))
@@ -364,6 +365,8 @@ fn hot_mark(touch: &SessionTouch, width: usize) -> String {
     // Longest first; `width` is the pane, and a rung is affordable when the
     // label keeps its floor. The `+ 4` matches `label_w`'s own arithmetic
     // below — the glyph cell, its spaces, and the gap before this column.
+    // `rung` is `MARK` (one bullet, ASCII words) plus a turn number.
+    // Every glyph is one column wide, so `chars().count()` is the width.
     for rung in [format!("{MARK} · turn {turn}"), format!("{MARK} {turn}")] {
         if width.saturating_sub(rung.chars().count() + 4) >= MIN_LABEL_COLS {
             return rung;
@@ -410,12 +413,13 @@ fn render_list(snapshot: &GraphSnapshot, cursor: usize, area: Rect, buf: &mut Bu
             Some(touch) => hot_mark(touch, width),
             None => snapshot.degree(i).to_string(),
         };
-        let label_w = width.saturating_sub(right.chars().count() + 4);
-        let mut label = node.label.clone();
-        if label.chars().count() > label_w {
-            label = label.chars().take(label_w.saturating_sub(1)).collect();
-            label.push('…');
-        }
+        // `right` is `hot_mark`'s output or a decimal count — both one
+        // column per glyph. `node.label` is a code-graph symbol or path,
+        // and it can be any language, so its elide and this fill both
+        // spend their budget in display columns.
+        let right_w = columns::width(&right);
+        let label_w = width.saturating_sub(right_w + 4);
+        let label = columns::head(&node.label, label_w);
         let mut spans = vec![
             Span::styled(
                 format!(" {} ", kind_glyph(&node.kind)),
@@ -423,9 +427,9 @@ fn render_list(snapshot: &GraphSnapshot, cursor: usize, area: Rect, buf: &mut Bu
             ),
             Span::styled(label.clone(), Style::new().fg(token::TEXT)),
         ];
-        let used = 3 + label.chars().count();
-        if used + right.chars().count() < width {
-            spans.push(Span::raw(" ".repeat(width - used - right.chars().count())));
+        let used = 3 + columns::width(&label);
+        if used + right_w < width {
+            spans.push(Span::raw(" ".repeat(width - used - right_w)));
         }
         spans.push(Span::styled(
             right,
@@ -573,6 +577,7 @@ mod tests {
     use super::*;
 
     use crate::envelope::{AgentMeta, Inbound};
+    use crate::graph::GraphNode;
     use stella_protocol::{AgentEvent, FileChangeKind};
 
     fn touched(turn: Option<u32>) -> SessionTouch {
@@ -627,6 +632,42 @@ mod tests {
     fn a_touch_with_no_turn_names_none_however_wide_the_pane() {
         assert_eq!(hot_mark(&touched(None), 200), "● hot");
         assert_eq!(hot_mark(&touched(None), 20), "● hot");
+    }
+
+    /// A CJK node label keeps the edge count on screen, not past the pane.
+    ///
+    /// Old code checked `label.chars().count() > label_w`. `label_w` is a
+    /// **column** budget, but the check read it as a char count. A 20-glyph
+    /// CJK label is 40 columns but only 20 chars. Against a 30-column
+    /// `label_w`, `20 > 30` was false, so the old check kept the label
+    /// whole — 10 columns over budget. That is what pushes the edge count
+    /// off screen.
+    #[test]
+    fn a_wide_character_label_keeps_the_edge_count_on_screen() {
+        let snapshot = GraphSnapshot {
+            nodes: vec![GraphNode {
+                label: "圈".repeat(20),
+                kind: "function".into(),
+                location: None,
+                touch: None,
+            }],
+            ..GraphSnapshot::default()
+        };
+        // `inner.width` 35: label_w = 35 - 1 (the "0" edge count) - 4 = 30.
+        let area = Rect::new(0, 0, 37, 5);
+        let mut buf = Buffer::empty(area);
+        render_list(&snapshot, 0, area, &mut buf);
+        let last_col = area.width - 2; // one column inside the right border
+        let row_y = area.y + 1; // one row inside the top border
+        let row: String = (0..area.width)
+            .map(|x| buf.cell((x, row_y)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect();
+        assert_eq!(
+            buf.cell((last_col, row_y)).map(|c| c.symbol()),
+            Some("0"),
+            "the edge count for a node with no edges should still land on \
+             the last content column, not be clipped past the pane:\n{row:?}"
+        );
     }
 
     /// The ledger the tab reads is the lane's own `files` vector, carrying the

--- a/crates/stella-tui/src/views/queue.rs
+++ b/crates/stella-tui/src/views/queue.rs
@@ -103,6 +103,10 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, area: Rect, buf: &mut Buffer)
             row_style = row_style.bg(token::HL).add_modifier(Modifier::BOLD);
             ordinal_style = ordinal_style.bg(token::HL);
         }
+        // `ordinal` is this file's own `"{n}. "` — decimal digits and ASCII
+        // punctuation, so `chars().count()` already equals its display
+        // width. `item.text` is the queued prompt itself and is already
+        // elided by `cards::truncate_cols`, the column-correct helper.
         let room = inner_w.saturating_sub(ordinal.chars().count() + 2);
         lines.push(Line::from(vec![
             Span::raw(" "),

--- a/crates/stella-tui/src/views/record.rs
+++ b/crates/stella-tui/src/views/record.rs
@@ -29,6 +29,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use stella_tui_theme::token;
 
+use crate::render::columns;
+
 /// The separator between one labelled value and the next.
 ///
 /// Spoken, ` · ` is a pause rather than a word, which is what a field boundary
@@ -88,11 +90,12 @@ pub(crate) fn identity(
 
 /// Clip a span run to `width` display columns, marking a clip with an ellipsis.
 ///
-/// Char-counted rather than measured with `unicode-width`, matching what the
-/// grid views' own truncation already does; every label here is ASCII and the
-/// values are the same strings the tables were clipping before.
+/// Measured in display columns, same as `render::columns`. An identity can
+/// be a tool name, an issue key, or an entry's own name — text this crate
+/// did not write. The source table already clipped it by column before
+/// accessible mode turned it into this one row.
 pub(crate) fn truncate_spans(spans: Vec<Span<'static>>, width: usize) -> Vec<Span<'static>> {
-    let total: usize = spans.iter().map(|s| s.content.chars().count()).sum();
+    let total: usize = spans.iter().map(|s| columns::width(&s.content)).sum();
     if total <= width {
         return spans;
     }
@@ -103,7 +106,7 @@ pub(crate) fn truncate_spans(spans: Vec<Span<'static>>, width: usize) -> Vec<Spa
     let mut out: Vec<Span<'static>> = Vec::new();
     let mut used = 0usize;
     for span in spans {
-        let len = span.content.chars().count();
+        let len = columns::width(&span.content);
         if used + len <= budget {
             used += len;
             out.push(span);
@@ -111,7 +114,7 @@ pub(crate) fn truncate_spans(spans: Vec<Span<'static>>, width: usize) -> Vec<Spa
         }
         let take = budget - used;
         if take > 0 {
-            let head: String = span.content.chars().take(take).collect();
+            let head = columns::take_left(&span.content, take);
             out.push(Span::styled(head, span.style));
         }
         break;
@@ -170,5 +173,21 @@ mod tests {
     fn a_row_that_fits_is_left_exactly_as_it_was() {
         let spans = vec![Span::raw("abc".to_string())];
         assert_eq!(truncate_spans(spans.clone(), 3), spans);
+    }
+
+    /// A CJK identity clips to the pane by column, not by char.
+    ///
+    /// 20 CJK glyphs are 20 chars but 40 columns. Old code cut the row to
+    /// 19 *chars* of glyph plus an ellipsis — 38 columns wide plus the
+    /// 2-column prefix, well past a 20-column pane. L-T4's line-exact
+    /// scroll needs this to never happen.
+    #[test]
+    fn a_wide_character_identity_clips_to_columns_not_chars() {
+        let wide_name = "圈".repeat(20);
+        let line = record_line(identity(wide_name, false, token::GOLD), &[], 20);
+        assert!(
+            line.width() <= 20,
+            "row overran its 20-column budget: {line:?}"
+        );
     }
 }

--- a/crates/stella-tui/src/views/seats.rs
+++ b/crates/stella-tui/src/views/seats.rs
@@ -55,6 +55,7 @@ use ratatui::widgets::{Paragraph, Widget, Wrap};
 use stella_tui_theme::token;
 
 use crate::envelope::SeatRow;
+use crate::render::columns;
 
 /// Shown when the driver has not delivered an engine snapshot yet — a race
 /// right after startup, or a driver error. The same shape (and the same
@@ -173,7 +174,10 @@ pub fn render(seats: Option<&[SeatRow]>, area: Rect, buf: &mut Buffer) {
 /// already the head of every key beside it; the model next; the seat key last,
 /// down to [`MIN_KEY_CELLS`] and no further.
 fn columns(rows: &[SeatRow], width: usize) -> (usize, usize) {
-    let cells = |s: &str| s.chars().count();
+    // A seat key, a model slug, and a plugin name are all text a plugin
+    // manifest chose (`doc:roleless-core` §8.4). This pane has no say in
+    // it. So every width here is a display column, never a `char`.
+    let cells = columns::width;
     let mut key_w = rows.iter().map(|r| cells(&r.key)).max().unwrap_or(0);
     let mut model_w = rows
         .iter()
@@ -202,22 +206,15 @@ fn columns(rows: &[SeatRow], width: usize) -> (usize, usize) {
     (key_w, model_w)
 }
 
-/// `s` cut to `width` cells, with an ellipsis where it was cut.
+/// `s` cut to `width` display columns, with an ellipsis where it was cut.
 fn fit(s: &str, width: usize) -> String {
-    if s.chars().count() <= width {
-        return s.to_string();
-    }
-    let mut out: String = s.chars().take(width.saturating_sub(1)).collect();
-    out.push('…');
-    out
+    columns::head(s, width)
 }
 
-/// `s` padded to `width` cells. `format!("{s:width$}")` counts bytes, which
-/// pads a key holding a non-ASCII character short.
+/// `s` padded to `width` display columns. `format!("{s:width$}")` counts
+/// `char`s, which under-pads a key holding a CJK or emoji glyph.
 fn pad(s: &str, width: usize) -> String {
-    let mut out = s.to_string();
-    out.push_str(&" ".repeat(width.saturating_sub(s.chars().count())));
-    out
+    columns::pad(s, width)
 }
 
 /// One muted line of explanation where the rows would have been.
@@ -356,5 +353,56 @@ mod tests {
         let row = text.lines().nth(1).unwrap_or_default().to_string();
         assert!(row.contains("stella-plan/planner"), "{row}");
         assert!(!row.contains("from stella-plan"), "{row}");
+    }
+
+    /// A CJK seat key is measured in the columns it draws, not its chars.
+    /// A plugin can name a role however it likes.
+    ///
+    /// 13 CJK glyphs are 13 chars but 26 columns — the same 13 chars as the
+    /// ASCII key, whose 13 chars are also 13 columns. Old code would still
+    /// call the shared key column 13, leaving the CJK row 13 columns over
+    /// its padded budget.
+    #[test]
+    fn columns_measures_a_wide_character_key_in_display_columns() {
+        let wide_key = "圈".repeat(13);
+        let rows = [
+            seat("acme/reviewer", Some("m"), "acme"),
+            seat(&wide_key, Some("m"), "acme2"),
+        ];
+        assert_eq!(columns(&rows, 90), (26, 1));
+    }
+
+    /// The same rows, rendered: the CJK row's `from` column lands where
+    /// the ASCII row's does, because the key column was sized to the
+    /// widest key's real columns, not its char count.
+    ///
+    /// Checked by buffer column index, not by string search. A wide glyph
+    /// fills two buffer cells — the glyph, then an empty one — so a byte
+    /// offset in flattened text is not a column index once one is on
+    /// screen.
+    #[test]
+    fn a_wide_character_key_does_not_shift_a_shared_column() {
+        let wide_key = "圈".repeat(13);
+        let rows = [
+            seat("acme/reviewer", Some("m"), "acme"),
+            seat(&wide_key, Some("m"), "acme2"),
+        ];
+        let area = Rect::new(0, 0, 90, 12);
+        let mut buf = Buffer::empty(area);
+        render(Some(&rows), area, &mut buf);
+        let (key_w, model_w) = columns(&rows, area.width as usize);
+        let from_col = 1 + key_w + GAP + model_w + GAP;
+        let ascii_row_y = 1; // row 0 is the head strip
+        let wide_row_y = 2;
+        assert_eq!(
+            buf.cell((from_col as u16, ascii_row_y)).map(|c| c.symbol()),
+            Some("f"),
+            "the ascii row's `from` should start at the shared column"
+        );
+        assert_eq!(
+            buf.cell((from_col as u16, wide_row_y)).map(|c| c.symbol()),
+            Some("f"),
+            "the CJK row's `from` shifted off the shared column"
+        );
     }
 }

--- a/crates/stella-tui/src/views/skills.rs
+++ b/crates/stella-tui/src/views/skills.rs
@@ -50,6 +50,7 @@ use stella_tui_theme::token;
 use crate::deck::WorkspaceModel;
 use crate::deck_ui::{DeckUi, SkillsFocus};
 use crate::envelope::SkillRow;
+use crate::render::columns;
 
 /// Draw the tab into `area`, then float whichever dialog is open above it.
 pub fn render(model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
@@ -134,10 +135,11 @@ fn render_search_box(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
     };
     let used: usize = spans.iter().map(Span::width).sum();
     let inner_w = area.width.saturating_sub(2) as usize;
-    if used + right.chars().count() < inner_w {
-        spans.push(Span::raw(
-            " ".repeat(inner_w - used - right.chars().count()),
-        ));
+    // `right` is fixed words plus a decimal count. Every glyph in it
+    // (`·`, `…`) is one column, so `chars().count()` is already its width.
+    let right_w = right.chars().count();
+    if used + right_w < inner_w {
+        spans.push(Span::raw(" ".repeat(inner_w - used - right_w)));
         spans.push(Span::styled(right, if focused { muted } else { dim }));
     }
     Paragraph::new(Line::from(spans))
@@ -198,81 +200,6 @@ fn render_installed(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
 
     let sel = ui.skills.sel.min(rows.len() - 1);
     let width = inner.width as usize;
-    let row_line = |(i, row): &(usize, &SkillRow)| -> Line<'static> {
-        let is_sel = *i == sel && focused;
-        let marker = if is_sel { "▸ " } else { "  " };
-        let boxed = if row.enabled { "[x] " } else { "[ ] " };
-        let box_style = if row.enabled {
-            Style::new().fg(token::GOLD)
-        } else {
-            dim
-        };
-        let ver = if row.latest > row.version {
-            format!("v{}/{}", row.version, row.latest)
-        } else {
-            format!("v{}", row.version)
-        };
-        // A contributed skill names its package instead of a version and a
-        // scope: neither is a thing it has (`skill_manager::contributed_rows`),
-        // and whose it is is the column a reader of this row actually needs.
-        //
-        // A learned row names the grade of the evidence that promoted it
-        // (#4871) when the ledger still has one — the same `snake_case` token
-        // `stella proposals` prints, so a reader learns one vocabulary rather
-        // than two. Absent for a skill mined before the ledger existed, or
-        // under the shipped lexical loop, which records no proposal at all —
-        // there is no grade to name, not a missing feature.
-        let meta = match (&row.contributed_by, row.origin.as_str()) {
-            (Some(plugin), _) => format!(" via {plugin} "),
-            (None, "auto") => match &row.evidence_grade {
-                Some(grade) => format!(" learned · {grade} "),
-                None => " learned ".to_string(),
-            },
-            (None, _) => format!(" {ver} · {} ", row.scope.label()),
-        };
-        let name = format!("{:<24}", row.name);
-        let used = marker.chars().count()
-            + boxed.chars().count()
-            + name.chars().count()
-            + meta.chars().count();
-        let desc_room = width.saturating_sub(used + 3);
-        // A learned row spends its last column on **provenance** rather than
-        // on a description (SPEC 9.2), because provenance carries the turn and
-        // the identity `r rename` has to keep, and the description does not.
-        //
-        // That trade used to be free: the description a mined skill carried
-        // was `Learned from N observations.`, the trace count said less
-        // precisely. Since #5335 it is the lesson's own first sentence, so
-        // there is now a real thing on the other side of the choice — #5425
-        // is where whether this column should prefer it gets decided. The
-        // full prose is in the body either way, one `ctrl+o` away. *This*
-        // column and not a right-aligned one: the right edge of an installed
-        // row is where per-skill economics land (#4337).
-        let tail = provenance(row).unwrap_or_else(|| row.description.clone());
-        let desc = if desc_room >= 6 && !tail.is_empty() {
-            format!("  {}", truncate(&tail, desc_room))
-        } else {
-            String::new()
-        };
-        let mut line = Line::from(vec![
-            Span::styled(marker, Style::new().fg(token::GOLD)),
-            Span::styled(boxed, box_style),
-            Span::styled(name, text),
-            Span::styled(
-                meta,
-                if row.origin == "auto" {
-                    Style::new().fg(token::GOLD)
-                } else {
-                    muted
-                },
-            ),
-            Span::styled(desc, muted),
-        ]);
-        if is_sel {
-            line.style = Style::new().bg(token::HL);
-        }
-        line
-    };
 
     let mut lines: Vec<Line<'static>> = Vec::new();
     let budget = inner.height as usize;
@@ -286,8 +213,8 @@ fn render_installed(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
     let authored_budget = budget.saturating_sub(learned_rows).max(1);
     let sel_pos = authored.iter().position(|(i, _)| *i == sel).unwrap_or(0);
     let start = window_start(authored.len(), sel_pos, authored_budget);
-    for entry in authored.iter().skip(start).take(authored_budget) {
-        lines.push(row_line(entry));
+    for (i, row) in authored.iter().skip(start).take(authored_budget) {
+        lines.push(installed_row_line(row, *i == sel && focused, width));
     }
     if !learned.is_empty() && lines.len() < budget {
         lines.push(Line::from(vec![
@@ -298,11 +225,99 @@ fn render_installed(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
         let room = budget.saturating_sub(lines.len());
         let lsel = learned.iter().position(|(i, _)| *i == sel).unwrap_or(0);
         let lstart = window_start(learned.len(), lsel, room.max(1));
-        for entry in learned.iter().skip(lstart).take(room) {
-            lines.push(row_line(entry));
+        for (i, row) in learned.iter().skip(lstart).take(room) {
+            lines.push(installed_row_line(row, *i == sel && focused, width));
         }
     }
     Paragraph::new(lines).render(inner, buf);
+}
+
+/// One row of the installed list: enabled box, name, version/scope or
+/// provenance, description — fitted to `width` display columns.
+///
+/// A named function rather than a closure over `render_installed`'s locals,
+/// so a test can compose one row and measure [`Line::width`] directly against
+/// `width`, which is exactly what a CJK or emoji name, plugin id, or
+/// description needs checked: none of them are text this crate authored.
+fn installed_row_line(row: &SkillRow, is_sel: bool, width: usize) -> Line<'static> {
+    let dim = Style::new().fg(token::DIM);
+    let muted = Style::new().fg(token::MUTED);
+    let text = Style::new().fg(token::TEXT);
+    let marker = if is_sel { "▸ " } else { "  " };
+    let boxed = if row.enabled { "[x] " } else { "[ ] " };
+    let box_style = if row.enabled {
+        Style::new().fg(token::GOLD)
+    } else {
+        dim
+    };
+    let ver = if row.latest > row.version {
+        format!("v{}/{}", row.version, row.latest)
+    } else {
+        format!("v{}", row.version)
+    };
+    // A contributed skill names its package instead of a version and a
+    // scope: neither is a thing it has (`skill_manager::contributed_rows`),
+    // and whose it is is the column a reader of this row actually needs.
+    //
+    // A learned row names the grade of the evidence that promoted it
+    // (#4871) when the ledger still has one — the same `snake_case` token
+    // `stella proposals` prints, so a reader learns one vocabulary rather
+    // than two. Absent for a skill mined before the ledger existed, or
+    // under the shipped lexical loop, which records no proposal at all —
+    // there is no grade to name, not a missing feature.
+    let meta = match (&row.contributed_by, row.origin.as_str()) {
+        (Some(plugin), _) => format!(" via {plugin} "),
+        (None, "auto") => match &row.evidence_grade {
+            Some(grade) => format!(" learned · {grade} "),
+            None => " learned ".to_string(),
+        },
+        (None, _) => format!(" {ver} · {} ", row.scope.label()),
+    };
+    // `columns::pad`, not `{:<24}`. `row.name` is a skill's own name,
+    // chosen by a user or by `stella` itself. Rust's own pad fills by
+    // char, so a CJK or emoji name overshoots the 24-column target.
+    let name = columns::pad(&row.name, 24);
+    let used = columns::width(marker)
+        + columns::width(boxed)
+        + columns::width(&name)
+        + columns::width(&meta);
+    let desc_room = width.saturating_sub(used + 3);
+    // A learned row spends its last column on **provenance** rather than
+    // on a description (SPEC 9.2), because provenance carries the turn and
+    // the identity `r rename` has to keep, and the description does not.
+    //
+    // That trade used to be free: the description a mined skill carried
+    // was `Learned from N observations.`, the trace count said less
+    // precisely. Since #5335 it is the lesson's own first sentence, so
+    // there is now a real thing on the other side of the choice — #5425
+    // is where whether this column should prefer it gets decided. The
+    // full prose is in the body either way, one `ctrl+o` away. *This*
+    // column and not a right-aligned one: the right edge of an installed
+    // row is where per-skill economics land (#4337).
+    let tail = provenance(row).unwrap_or_else(|| row.description.clone());
+    let desc = if desc_room >= 6 && !tail.is_empty() {
+        format!("  {}", columns::head(&tail, desc_room))
+    } else {
+        String::new()
+    };
+    let mut line = Line::from(vec![
+        Span::styled(marker, Style::new().fg(token::GOLD)),
+        Span::styled(boxed, box_style),
+        Span::styled(name, text),
+        Span::styled(
+            meta,
+            if row.origin == "auto" {
+                Style::new().fg(token::GOLD)
+            } else {
+                muted
+            },
+        ),
+        Span::styled(desc, muted),
+    ]);
+    if is_sel {
+        line.style = Style::new().bg(token::HL);
+    }
+    line
 }
 
 /// SPEC 9.2's learned-skill provenance line — `from N traces · turn M ·
@@ -383,15 +398,20 @@ fn render_search(ui: &DeckUi, area: Rect, buf: &mut Buffer) {
         let bar = popularity_bar(hit.installs_rank, peak);
         let metric = hit.installs.clone();
         let install = if is_sel { "↵ install" } else { "" };
-        let right_w = bar.chars().count()
+        // `metric` and the id below come from a registry, not this crate.
+        // A foreign registry can format an install count or an owner/repo
+        // id however it likes. So every width here is a display column,
+        // never `marker.len()`'s byte count or a plain `.chars().count()`.
+        let right_w = columns::width(&bar)
             + usize::from(!bar.is_empty())
-            + metric.chars().count()
+            + columns::width(&metric)
             + usize::from(!metric.is_empty())
-            + install.chars().count()
+            + columns::width(install)
             + 2;
-        let name = truncate_skill_id(&hit.id, width.saturating_sub(marker.len() + right_w).max(4));
+        let marker_w = columns::width(marker);
+        let name = truncate_skill_id(&hit.id, width.saturating_sub(marker_w + right_w).max(4));
         let pad = width
-            .saturating_sub(marker.len() + name.chars().count() + right_w)
+            .saturating_sub(marker_w + columns::width(&name) + right_w)
             .max(1);
         let mut spans = vec![
             Span::styled(marker, Style::new().fg(token::GOLD)),
@@ -532,34 +552,21 @@ fn centered_row(inner: Rect) -> Rect {
 /// gives way to an ellipsis first. Falls back to a plain tail-ellipsis when
 /// even `@skill` cannot fit.
 fn truncate_skill_id(id: &str, max: usize) -> String {
-    if id.chars().count() <= max || max == 0 {
-        return truncate(id, max);
+    if columns::width(id) <= max || max == 0 {
+        return columns::head(id, max);
     }
     if let Some(at) = id.rfind('@') {
         let skill = &id[at..]; // "@skill"
-        let skill_w = skill.chars().count();
+        let skill_w = columns::width(skill);
         // Keep the whole @skill tail plus an ellipsis, filling the rest with the
         // head of owner/repo — but only when that leaves real owner context.
         if skill_w + 2 <= max {
             let owner_room = max - skill_w - 1; // room minus the ellipsis
-            let owner_head: String = id[..at].chars().take(owner_room).collect();
+            let owner_head = columns::take_left(&id[..at], owner_room);
             return format!("{owner_head}…{skill}");
         }
     }
-    truncate(id, max)
-}
-
-/// Truncate to `max` chars with a trailing ellipsis, char-safe.
-fn truncate(s: &str, max: usize) -> String {
-    if max == 0 {
-        return String::new();
-    }
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let head: String = s.chars().take(max.saturating_sub(1)).collect();
-        format!("{head}…")
-    }
+    columns::head(id, max)
 }
 
 #[cfg(test)]
@@ -1195,6 +1202,89 @@ mod tests {
         assert!(
             buffer_text(&buf).contains("fetching"),
             "loading state shown"
+        );
+    }
+
+    /// A CJK skill name stays inside the installed row's width budget.
+    ///
+    /// Old code used `{:<24}`, which fills by char. A name of 12 wide
+    /// glyphs is already 24 columns, but old code still added
+    /// `24 - 12 = 12` more chars of fill — 36 columns for a 24-column
+    /// budget. Checked with `Line::width()`, backed by [`unicode_width`]
+    /// directly, never through `render::columns` itself.
+    #[test]
+    fn a_wide_character_name_keeps_the_installed_row_inside_its_width() {
+        use unicode_width::UnicodeWidthStr;
+
+        let wide_name = "圈".repeat(12);
+        assert_eq!(
+            UnicodeWidthStr::width(wide_name.as_str()),
+            24,
+            "the fixture: 12 double-width glyphs, 24 columns, 12 chars"
+        );
+        let row = row(&wide_name, SkillScope::Project, true, 1, 1);
+        // Tight enough that the old pad's 36-column name alone overruns
+        // it, before the description even joins the row. The fixed part
+        // of the new, correct row is only 44 columns.
+        let width = 55;
+        let line = installed_row_line(&row, false, width);
+        assert!(
+            line.width() <= width,
+            "row overran its {width}-column budget: {line:?}"
+        );
+    }
+
+    /// The same fixture, but checking what a person would see: an
+    /// over-wide name pushes the row's later cells outward, so
+    /// `desc_room` comes up short. At this 55-column width, a char-spent
+    /// `desc_room` is 0 — below the 6-column floor — so no description
+    /// shows at all. Spent in columns, `desc_room` is 8, and it shows.
+    #[test]
+    fn a_wide_character_name_still_leaves_room_for_the_description() {
+        let wide_name = "圈".repeat(12);
+        let row = row(&wide_name, SkillScope::Project, true, 1, 1);
+        let line = installed_row_line(&row, false, 55);
+        let rendered: String = line
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            rendered.contains("does a thing") || rendered.contains('…'),
+            "the description column should still show something at a \
+             60-column width: {rendered:?}"
+        );
+    }
+
+    /// A registry hit's `owner/repo@skill` id can hold non-ASCII text.
+    /// This crate does not control a foreign registry. The elide must stay
+    /// inside its column budget, not its char budget.
+    ///
+    /// Old code used `id.chars().count()` and `.chars().take()`. An id can
+    /// sit well under its char budget but over its column budget, and old
+    /// code would then keep it whole.
+    #[test]
+    fn truncate_skill_id_spends_its_budget_in_columns() {
+        use unicode_width::UnicodeWidthStr;
+
+        let id = format!("acme/{}@extract", "文".repeat(5));
+        assert!(
+            id.chars().count() < 20,
+            "the fixture: well under 20 chars, comfortably over 20 columns"
+        );
+        assert!(
+            UnicodeWidthStr::width(id.as_str()) > 20,
+            "the fixture: over 20 columns"
+        );
+        let cut = truncate_skill_id(&id, 20);
+        assert!(
+            UnicodeWidthStr::width(cut.as_str()) <= 20,
+            "elided id overran its 20-column budget: {cut:?}"
+        );
+        assert!(
+            cut.ends_with("@extract"),
+            "the @skill tail is kept whole: {cut:?}"
         );
     }
 }

--- a/crates/stella-tui/src/views/skills/overlays.rs
+++ b/crates/stella-tui/src/views/skills/overlays.rs
@@ -26,9 +26,10 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wra
 use stella_tui_theme::token;
 
 use crate::deck_ui::{DeckUi, ScopeAction, SkillPrompt};
+use crate::render::columns;
 use crate::syntax::{self, HighlightSpans as _};
 
-use super::{centered_row, truncate};
+use super::centered_row;
 
 /// Widest dialog, in columns. The pin picker and the scope picker are lists of
 /// short labels; anything wider reads as a pane rather than a question.
@@ -123,7 +124,7 @@ pub fn render_prompt(ui: &DeckUi, now_ms: u64, area: Rect, buf: &mut Buffer) {
                 ]),
                 Line::default(),
                 Line::from(Span::styled(
-                    format!("“{}”", truncate(description, 70)),
+                    format!("“{}”", columns::head(description, 70)),
                     muted,
                 )),
                 Line::default(),
@@ -203,7 +204,10 @@ pub fn render_prompt(ui: &DeckUi, now_ms: u64, area: Rect, buf: &mut Buffer) {
             name, buffer, was, ..
         }) => {
             let mut lines = vec![
-                Line::from(Span::styled(format!("Rename {}", truncate(name, 44)), text)),
+                Line::from(Span::styled(
+                    format!("Rename {}", columns::head(name, 44)),
+                    text,
+                )),
                 Line::default(),
                 Line::from(vec![
                     Span::styled("> ", Style::new().fg(token::GOLD)),
@@ -288,7 +292,7 @@ pub fn render_preview(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     let h = area.height.saturating_sub(2).clamp(6, 32);
     let rect = centered(area, w, h);
     Clear.render(rect, buf);
-    let title = truncate(&preview.title, (w as usize).saturating_sub(20).max(8));
+    let title = columns::head(&preview.title, (w as usize).saturating_sub(20).max(8));
     let block = framed(title, "↑/↓ scroll · esc close");
     let inner = block.inner(rect);
     block.render(rect, buf);
@@ -299,7 +303,7 @@ pub fn render_preview(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     let bands = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(inner);
     if !preview.subtitle.is_empty() {
         Paragraph::new(Line::from(Span::styled(
-            truncate(&preview.subtitle, inner.width as usize),
+            columns::head(&preview.subtitle, inner.width as usize),
             Style::new().fg(token::MUTED),
         )))
         .render(bands[0], buf);

--- a/crates/stella-tui/src/views/start_work.rs
+++ b/crates/stella-tui/src/views/start_work.rs
@@ -51,6 +51,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 use stella_tui_theme::token;
 
+use crate::render::columns;
 use crate::start_work::{StartWork, StartWorkDraft};
 
 /// The overlay's share of the deck's width, and the two bounds on it.
@@ -63,8 +64,8 @@ const WIDTH_SHARE: u16 = 5;
 const WIDTH_MIN: u16 = 56;
 const WIDTH_MAX: u16 = 100;
 
-/// Longest a quoted RULE runs before it is cut.
-const RULE_QUOTE_CHARS: usize = 44;
+/// Longest a quoted RULE runs, in display columns, before it is cut.
+const RULE_QUOTE_COLS: usize = 44;
 
 /// Draw the overlay over `area`. Nothing here reads the panel's mode — the
 /// caller decides the overlay is open, exactly as the send-to-prompt
@@ -188,7 +189,7 @@ fn sources(draft: &StartWorkDraft, inner: usize, lines: &mut Vec<Line<'static>>)
         let quoted = format!(
             "RULE {} \"{}\"",
             applied.id,
-            truncate(&flatten(&applied.text), RULE_QUOTE_CHARS)
+            truncate(&flatten(&applied.text), RULE_QUOTE_COLS)
         );
         lines.push(Line::from(Span::styled(
             format!("          {}", truncate(&quoted, inner.saturating_sub(10))),
@@ -324,10 +325,14 @@ fn actions(panel: &StartWork) -> Line<'static> {
 /// that runs into its own tag reads as one string.
 fn row(left: &str, right: &str, left_style: Style, inner: usize) -> Line<'static> {
     let field = inner.saturating_sub(1);
-    let left = truncate(left, field.saturating_sub(right.chars().count() + 2));
+    // `left` is a task subject or the verify line, written by a model or
+    // a user. So its elide, and the fill after it, both spend `field` in
+    // display columns.
+    let right_w = columns::width(right);
+    let left = truncate(left, field.saturating_sub(right_w + 2));
     let gap = field
-        .saturating_sub(left.chars().count())
-        .saturating_sub(right.chars().count());
+        .saturating_sub(columns::width(&left))
+        .saturating_sub(right_w);
     Line::from(vec![
         Span::styled(left, left_style),
         Span::raw(" ".repeat(gap)),
@@ -358,16 +363,9 @@ fn compact(tokens: u64) -> String {
     }
 }
 
-/// Cut to `max` characters (never bytes), with an ellipsis when it cuts.
+/// Cut to `max` display columns, with an ellipsis when it cuts.
 fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    if max <= 1 {
-        return "…".to_string();
-    }
-    let head: String = s.chars().take(max - 1).collect();
-    format!("{head}…")
+    columns::head(s, max)
 }
 
 #[cfg(test)]
@@ -541,9 +539,15 @@ mod tests {
         assert!(text(&panel).contains("no tracker connected"));
     }
 
+    /// `truncate` spends `max` in display columns, never bytes or chars.
+    ///
+    /// Renamed from `truncate_cuts_on_characters_not_bytes`. That old name
+    /// kept 3 whole glyphs at `max` 4 — a char count. Here `max` is a
+    /// column budget, and a CJK glyph is 2 columns, so only one glyph
+    /// plus the ellipsis fits.
     #[test]
-    fn truncate_cuts_on_characters_not_bytes() {
-        assert_eq!(truncate("日本語のテキスト", 4), "日本語…");
+    fn truncate_spends_its_budget_in_display_columns() {
+        assert_eq!(truncate("日本語のテキスト", 4), "日…");
         assert_eq!(truncate("short", 40), "short");
     }
 
@@ -552,5 +556,28 @@ mod tests {
         assert_eq!(compact(999), "999");
         assert_eq!(compact(60_000), "60k");
         assert_eq!(compact(1_250_000), "1.2M");
+    }
+
+    /// A CJK task subject keeps its contract tag flush at the row's own
+    /// width, instead of drifting past it.
+    ///
+    /// `left` here is 20 CJK glyphs — 20 chars, 40 columns. A char-counted
+    /// gap sees "20" where the row spent 40, so old code pads with 20
+    /// extra columns it never had, and the row runs past `inner`.
+    #[test]
+    fn a_wide_character_subject_keeps_the_tag_flush_at_the_rows_width() {
+        let left = "圈".repeat(20);
+        let right = "graph · det";
+        let inner = 60;
+        let line = row(&left, right, Style::new(), inner);
+        assert!(
+            line.width() <= inner,
+            "row overran its {inner}-column budget: {line:?}"
+        );
+        assert_eq!(
+            line.spans.last().map(|s| s.content.as_ref()),
+            Some(right),
+            "the tag should render whole: {line:?}"
+        );
     }
 }


### PR DESCRIPTION
## What / why

#2598 pointed the sites it named at `render::columns`; #5762 built the
module and repointed its own list. This finishes the sweep #5761 asked
for: every remaining width budget in `crates/stella-tui` that a wide
(CJK/emoji) value can overrun is now spent in display columns, not
`char`s or bytes.

## Where

**Folded into `render::columns` (dedup, no ASCII behaviour change):**
- `render/entry/recall.rs` — deletes its private
  `take_left`/`take_right`/`display_width`, delegating to
  `columns::take_left`/`columns::take_right`/`columns::width`. Its
  `cell`/`elide` pair stays local (the table's own contract — `elide`
  trims a trailing space before the ellipsis, which `columns::head`
  deliberately does not do for every other caller), rebuilt on the
  shared primitives.
- `views/files_tab.rs` — `elide_left` (a left-elide keeping the tail)
  is exactly `columns::tail`; deleted in favour of it. The path's pad
  and the agent tag's `{:<aw$}` pad both move to `columns::pad`.

**Converted, each with its own CJK/emoji witness:**
- `views/skills.rs` — the installed row's name pad (`row_line` pulled
  out to a named `installed_row_line` so its `Line::width()` is
  directly assertable), the registry row's right-aligned fill and
  `truncate_skill_id`'s owner/repo elide (the id is foreign registry
  text).
- `views/skills/overlays.rs` — repoints its `truncate` import to
  `columns::head` (skills.rs's own char-counted copy is gone): the
  LLM-create description, the rename dialog's name, and the preview's
  title/subtitle are all user- or registry-authored text.
- `views/graph_tab.rs` — the node list's label elide and its
  right-aligned fill against the `● hot`/edge-count column (a
  code-graph symbol can be any language).
- `views/seats.rs` — its own `cells`/`fit`/`pad` trio: a plugin-declared
  seat key, model slug, and plugin name are all foreign text.
- `views/record.rs` — `truncate_spans`' per-span clip, used by the
  accessible-mode identity row (a tool name, an issue key, an
  installed entry's own name).
- `views/start_work.rs` — `truncate` and `row`'s two-sided fill; task
  subjects, contract done-means text and rule quotes are model- or
  user-authored. `RULE_QUOTE_CHARS` renamed to `RULE_QUOTE_COLS`.
- `views/approval.rs` — the reason editor's tail window (a person's
  typed denial reason).

**Annotated benign, per the issue's own instruction** ("say which in a
one-line comment"), because the value is provably ASCII or the number
is not a column budget at all:
- `views/queue.rs` — the ordinal (`"{n}. "`) is this file's own
  decimal literal; the prompt text beside it already goes through
  `cards::truncate_cols`.
- `views/graph_tab.rs`, `views/skills.rs` — two query-bar/hint strings
  built from static template words plus a decimal count.
- `views/approval.rs` — `field`'s `label` is one of two ASCII literals
  ("gate", "reason").
- `composer.rs` — `move_up`/`move_down`'s char-index `col` is a
  logical-position preservation across hard lines, not a pane-width
  check (`byte_at_char_col` clamps regardless, so no panic risk). The
  crate's actual cursor-column path, `layout()`/`split_row_at`, was
  already `unicode_width`-aware and already has a wide-char witness
  (`layout_is_wide_char_aware`).
- `model/summarize.rs` — `INPUT_BUDGET`/`OUTPUT_BUDGET`/the marker cap
  and `truncate_field`'s `max` are all **retention**/headline-shaping
  caps with no `Rect` in sight; whichever view paints the result
  elides it again, by column, at that point.
- `transcript_build.rs` — `slug`'s `MAX_CHARS` shapes the shared
  `stella_transcript::Turn::name`, which both live renderers read.
  `stella-transcript`'s own grid painter (`grid.rs::head_cells`) is
  already `unicode_width`-based and re-elides the name to its live
  column budget before drawing it.

## Witness mechanism

Every conversion carries a fixture whose CJK/emoji width fails the old
char-counted arithmetic by construction, and is measured with an
oracle independent of `render::columns` (ratatui's own `Line::width()`,
or `unicode_width::UnicodeWidthStr` directly) — importing the helper
under test would make the test agree with the bug. Two of the
witnesses check the composed row rather than a helper in isolation
(`views/graph_tab.rs`'s edge-count-stays-on-screen buffer test,
`views/seats.rs`'s shared-column-does-not-shift buffer test), per the
issue's own suggested verify method.

Golden frames are untouched: `cargo test -p stella-tui --test
deck_render_snapshots` is 40/40 green, because every conversion is
byte-identical for ASCII input (the one intentional exception, matching
#5762's own precedent, is a zero-column budget: the old private copies
in `seats.rs`/`start_work.rs` returned a lone `…` there — one column
over budget — and the shared `columns::head`/`columns::tail` now
return nothing).

## Tests deleted

None. `views/start_work.rs`'s
`truncate_cuts_on_characters_not_bytes` is **renamed** to
`truncate_spends_its_budget_in_display_columns`, with its assertion
corrected: at a 4-column budget a CJK glyph (2 columns) only leaves
room for one glyph plus the ellipsis, not the three whole glyphs the
old char-counted test pinned.

## Residue

None filed — every site named in #5761 is either converted with a
witness or annotated, and no new defect was found outside that list.

Closes #5761

## DoD verified by the PR sweep (2026-09-05)

`dod / dod` failed on this head naming seven unchecked boxes on #5761. All
seven are now ticked, checked against the diff at `25a2363` rather than
against this description, with the evidence recorded in the issue body:

- **Private copies folded.** `files_tab.rs`'s `elide_left` is gone;
  `recall.rs` loses `take_left`/`take_right`/`display_width` (−49 lines) and
  carries 12 `columns::` call sites, with `elide` rebuilt on
  `columns::take_left` and `cell` kept as the issue asked.
- **Every listed site addressed** — all 11 `char`-counting sites plus both
  fold targets, 13 files, every one under `crates/stella-tui`. Nothing
  dropped from the list silently.
- **Witnesses are per site**: 11 wide-character tests — `skills.rs` 3,
  `seats.rs` 2, `start_work.rs` 2, one each in `approval.rs`,
  `files_tab.rs`, `graph_tab.rs`, `record.rs` — with the four benign sites
  carrying the one-line reason instead.
- **No god file**: largest changed file is `views/skills.rs` at 1290 lines,
  under the 1500 ceiling; nothing baselined, no file added.
- **Prose**: `scripts/check-prose.py` and `scripts/check-line-citations.py`
  both report `OK … none added` on this head.
- **Docs**: no `*.md` on this head names any of the removed private helpers,
  so that item's own "no doc change is needed" branch applies.

This edit is what fires the `pull_request` event `dod-check.yml` needs to
re-read the boxes — the edit is the trigger, never the fix.

## Summary by Sourcery

Finish the Stella TUI width-budget sweep by making all screen-width calculations Unicode display-column aware and verifying wide-text layout safety without changing ASCII rendering.

Bug Fixes:
- Prevent wide CJK and emoji text from overrunning Stella TUI width budgets by measuring truncation, padding, alignment, and clipping in display columns.
- Preserve shared-column and edge-count placement when foreign or user-authored text contains wide characters.

Enhancements:
- Consolidate duplicated width and elision logic around the shared render::columns helpers while preserving component-specific behavior.
- Document width calculations that intentionally remain character-based because they operate on ASCII-only values, logical positions, or content-retention limits.

Tests:
- Add independent CJK and wide-character witnesses across affected views, including composed-row and rendered-buffer checks.
- Update the start-work truncation expectation to reflect display-column budgets.