### PR TITLE
fix(stella-records): move the published-records test to the crate that owns it

### DIFF
--- a/crates/stella-records/tests/published_records_do_not_collide.rs
+++ b/crates/stella-records/tests/published_records_do_not_collide.rs
@@ -15,8 +15,8 @@
 
 use std::path::PathBuf;
 
-use stella_core::ingest::record::EnforcementMode;
-use stella_core::records::{
+use stella_records::ingest::record::EnforcementMode;
+use stella_records::records::{
     LoadedRecord, assign_handles, detect_conflicts, is_suspended, load_context_file,
 };
 


### PR DESCRIPTION
## What and why

`main` does not compile, and every open PR is red behind it.

`crates/stella-core/tests/published_records_do_not_collide.rs` still imports
`stella_core::ingest::record::EnforcementMode` and `stella_core::records`. Both
modules moved to `stella-records` when the record plane was extracted, so the
test's crate no longer has them:

```
error[E0433]: cannot find `ingest` in `stella_core`
error[E0432]: unresolved import `stella_core::records`
```

This is the shared-cell shape the canary exists for: the extraction was correct
about the code it moved, and nothing in either tree was wrong on its own.

## The fix

The test moves with the code it tests, into `crates/stella-records/tests/`.
Nothing inside it changes except the two import paths:

- It reads `.stella/rules/` through `CARGO_MANIFEST_DIR/../..`, which resolves
  to the repository root from `crates/stella-records` exactly as it did from
  `crates/stella-core`.
- The `toml` parse it does is already a dev-dependency of `stella-records`.

The alternative — giving `stella-records` a dev-dependency on `stella-core` —
would point the edge the wrong way and pull the record plane back toward the
crate it just left.

## Verification

The failing build is the witness: `cargo check --workspace --all-targets` on
`main` fails on those two imports and passes here. Nothing else in the tree
names `stella_core::records` or `stella_core::ingest`.

Tests deleted: none. `published_records_do_not_collide.rs` is renamed, and
every test function in it survives the move — git reports it as a 97% rename.

Closes #5901

## Summary by Sourcery

Move the published-record collision test into `stella-records` and point it at the relocated record APIs.

Bug Fixes:
- Move the published-record collision integration test to `stella-records` and update its imports so workspace all-target checks compile again.

Tests:
- Keep the published-record collision coverage with the crate that owns the tested record functionality.