### PR TITLE
fix(stella-records): move the published-record collision test to its own crate

### DIFF
--- a/crates/stella-records/tests/published_records_do_not_collide.rs
+++ b/crates/stella-records/tests/published_records_do_not_collide.rs
@@ -15,8 +15,8 @@
 
 use std::path::PathBuf;
 
-use stella_core::ingest::record::EnforcementMode;
-use stella_core::records::{
+use stella_records::ingest::record::EnforcementMode;
+use stella_records::records::{
     LoadedRecord, assign_handles, detect_conflicts, is_suspended, load_context_file,
 };
 


### PR DESCRIPTION
## What and why

`main` does not compile. `cargo check --workspace --all-targets` fails on two unresolved imports:

```
error[E0433]: cannot find `ingest` in `stella_core`
  --> crates/stella-core/tests/published_records_do_not_collide.rs:18:18
error[E0432]: unresolved import `stella_core::records`
  --> crates/stella-core/tests/published_records_do_not_collide.rs:19:18
```

The record plane left `stella-core` in #5829 — `records`, `context_record` and `ingest` are `stella-records` modules now. #5855 added this integration test against the old paths at the same time. Both branches were green on their own; only the composition is wrong, which is the shape the post-merge canary exists to catch and did.

## The fix

The test moves to `crates/stella-records/tests/published_records_do_not_collide.rs` and imports `stella_records::ingest::record::EnforcementMode` and `stella_records::records::{…}`.

Moved rather than given a dev-dependency back into `stella-core`: everything it exercises — `load_context_file`, `assign_handles`, `detect_conflicts`, `is_suspended`, `EnforcementMode` — is `stella-records`'s own public surface, and pointing a core dev-dependency at the crate that already depends on core would put the edge back the way the extraction removed it.

Nothing else had to change. `stella-records` already declares the `toml` dev-dependency the test uses, and the crate sits at the same depth under `crates/`, so the `../../.stella/rules` the test reads resolves unchanged.

## Witness mechanism

The compiler. The test does not build on `main` and does build here; CI's `fmt + clippy + test` is the evidence, since the failing job is a workspace build.

`make guards-fast` is clean locally, `check-deleted-tests` sees a move rather than a deletion, and `git mv` staged it so the rename is visible to the guards that follow renames.

Tests deleted: None — `no_two_published_records_collide` and `every_published_hard_guard_arms` both move with the file and keep their names.

Closes #5901

## Summary by Sourcery

Restore workspace compilation by placing the published-record collision test alongside the record-plane APIs it exercises.

Bug Fixes:
- Move the published-record collision integration test to `stella-records` and update its imports so workspace builds no longer reference removed `stella-core` modules.

Tests:
- Preserve both published-record collision checks while relocating their test crate.