### PR TITLE
fix(stella-records): move the published-record test to the crate that holds the code

### DIFF
--- a/crates/stella-records/tests/published_records_do_not_collide.rs
+++ b/crates/stella-records/tests/published_records_do_not_collide.rs
@@ -15,8 +15,8 @@
 
 use std::path::PathBuf;
 
-use stella_core::ingest::record::EnforcementMode;
-use stella_core::records::{
+use stella_records::ingest::record::EnforcementMode;
+use stella_records::records::{
     LoadedRecord, assign_handles, detect_conflicts, is_suspended, load_context_file,
 };
 


### PR DESCRIPTION
## What & why

`main` does not compile, and this is the repair. Canary issue #5901.

```
error[E0433]: cannot find `ingest` in `stella_core`
  --> crates/stella-core/tests/published_records_do_not_collide.rs:18:18
error[E0432]: unresolved import `stella_core::records`
  --> crates/stella-core/tests/published_records_do_not_collide.rs:19:18
```

**The commit the canary named is not the commit that broke it.** The break is the composition of two merges, neither wrong alone:

- **#5829** (merged 05:35, `913e21a0`) moved the record plane out of `stella-core` — `records`, `ingest` and `context_record` now live in `stella-records`.
- **#5855** (merged 06:09, `ffcda37f`) **added** `crates/stella-core/tests/published_records_do_not_collide.rs`, importing `stella_core::ingest::record::EnforcementMode` and `stella_core::records::{...}`.

That the second wrote the file against a pre-extraction base is checked, not assumed: `git cat-file -e` finds the path absent at both `913e21a0` and `913e21a0^`, so it did not exist before or at the extraction and could only have been authored where those imports still resolved. Each branch was green; the tree they compose is not. That is the shared-cell hazard `main-canary.yml` exists for.

**The fix is a move, not a repoint.** `stella-records` depends on `stella-core` — its manifest says so, and says why that edge points the wrong way — so naming `stella-records` from a `stella-core` test would invert the edge rather than repair it. The test goes where the code it exercises went, which is what #5829 did with `context_record_examples.rs`. It uses nothing else from `stella-core`, `toml` is already a dev-dependency of `stella-records`, and `CARGO_MANIFEST_DIR/../../` resolves to the repository root from either crate, so `rules_dir()` still finds `.stella/rules`.

Git records it as a rename plus two import lines.

Closes #5901

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this is a build repair, and the moved file **is** the test. A witness for "the workspace compiles" is the compile itself. The two tests it carries are unchanged and still assert what they always did.

Verified rather than asserted:

- `cargo check -p stella-core -p stella-records --all-targets` — exit 0, zero errors, zero warnings (read from the exit code, not a grep over cargo's output).
- `cargo test -p stella-records --test published_records_do_not_collide` — `2 passed; 0 failed`: `no_two_published_records_collide` and `every_published_hard_guard_arms`. The gate this file exists to be still does its job from the new home, which a compile alone would not have shown.
- The failing side is CI's own output on `ffcda37fe`, quoted above from #5901.

## The gate

- [x] `cargo fmt --check` (`-p stella-records`, exit 0)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI's job; not run on this box per CLAUDE.md's "CI builds and tests; this laptop does not"
- [ ] `cargo test --workspace` — same; the targeted run above is what this change warrants
- [x] Docs updated where behavior/flags changed — none changed
- [x] `Closes #5901` appears both above and as a commit trailer
- [x] `make prose` green — a file changing crates can move a header-length ceiling, and this one moves neither: 26 units within ceiling, none added

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

Two things checked and deliberately not folded in — landing a red-`main` repair on its own is the rule this PR is following, and widening it is how #4654 held every open PR for half an hour:

- `crates/stella-protocol/README.md` still cites `stella_core::context_record::hash`. Stale on `main` already, and #5889 is repointing it.
- `crates/stella-cli/src/memory/learning/guarantees.rs` had the same stale-path shape on the #5894 branch. Fixed there, in that PR.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification — no manifest change at all; cargo auto-discovers `tests/*.rs` and `toml` was already a dev-dependency
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

Labelled `unblocks-main`, which is the designed way past `main is not known-broken` — that required check fails on every open PR while #5901 stands, this one included, so without the label the repair cannot merge past the hold it exists to lift.

No test is deleted: both survive under the same names at the new path, which `check-deleted-tests` compares across trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j1bUFSFRjeNjZDzh85Jtt

---
_Generated by [Claude Code](https://claude.ai/code/session_019j1bUFSFRjeNjZDzh85Jtt)_

## Summary by Sourcery

Move the published-record tests to stella-records and update their crate references to repair the broken workspace build.

Bug Fixes:
- Restore workspace compilation by moving the published-record collision tests to the stella-records crate, where the tested APIs now reside.

Tests:
- Keep the published-record collision and hard-guard coverage intact under the stella-records test suite.