### PR TITLE
fix(stella-records): move the published-records test to the crate that owns it

### DIFF
--- a/crates/stella-records/tests/published_records_do_not_collide.rs
+++ b/crates/stella-records/tests/published_records_do_not_collide.rs
@@ -15,8 +15,8 @@
 
 use std::path::PathBuf;
 
-use stella_core::ingest::record::EnforcementMode;
-use stella_core::records::{
+use stella_records::ingest::record::EnforcementMode;
+use stella_records::records::{
     LoadedRecord, assign_handles, detect_conflicts, is_suspended, load_context_file,
 };
 


### PR DESCRIPTION
## What

`main` does not compile. The record plane's extraction moved `context_record`,
`ingest`, `records` and `adapt` out of `stella-core` into `stella-records`, and
left one integration test behind:

```
error[E0433]: cannot find `ingest` in `stella_core`
  --> crates/stella-core/tests/published_records_do_not_collide.rs:18:18
error[E0432]: unresolved import `stella_core::records`
  --> crates/stella-core/tests/published_records_do_not_collide.rs:19:18
```

`git mv` it into `crates/stella-records/tests/` and repoint the two imports.
Nothing else changes.

## Why there and not a dev-dependency edge

The test loads `.stella/rules/` through the record loader and asserts no two
published records collide. That is the record plane's own contract, so it
belongs beside the plane. Adding `stella-records` as a `stella-core`
dev-dependency would work too, and would leave the assertion in a crate that
no longer owns any of the code it exercises.

Two details that made this cheap: both crates sit one level under `crates/`, so
the test's `CARGO_MANIFEST_DIR` walk to `../../.stella/rules` names the same
directory; and `stella-records` already declares `toml` as a dev-dependency,
with the comment "an integration test links dev-dependencies, not the
library's own".

## Witness

The break is the compiler. `cargo check --workspace --all-targets` fails on
`main` and passes here — that is what the canary measured and what this PR's
own `fmt + clippy + test` job re-measures.

Both test names survive the move, so `check-deleted-tests` has nothing to
report.

## Tests deleted

None. `no_two_published_records_collide` and `every_published_hard_guard_arms`
both move with the file.

Closes #5901

## Summary by Sourcery

Restore workspace compilation by placing the published-record integration test in stella-records, its owning crate.

Bug Fixes:
- Move the published-record collision integration test to stella-records and update its imports so workspace all-target checks compile again.

Tests:
- Keep the existing published-record validation coverage while relocating it beside the crate that owns the tested record-plane functionality.