### PR TITLE
docs(agents): name the per-crate rustdoc check beside the other targeted commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,24 @@ make watch-core          # re-test stella-core only (fastest loop)
 make watch-lint          # re-run clippy on every save
 ```
 
+**Rustdoc, scoped to the crate you're editing.** `make gate`'s `doc-warnings`
+step runs `cargo doc -D warnings --document-private-items` over the whole
+workspace, which is what catches a `rustdoc::private_intra_doc_links` error —
+a doc comment linking a crate-private item. Neither `make guards-fast` nor a
+scoped `cargo clippy` builds docs, so neither one catches it. `CARGO_SCOPE`
+narrows the same check to the crate at hand, the same way it narrows `lint`
+and `test` above:
+
+```bash
+make doc-warnings CARGO_SCOPE="-p stella-core"
+# equivalent to:
+RUSTDOCFLAGS="-D warnings" cargo doc -p stella-core --no-deps --document-private-items
+```
+
+It compiles, so it stays a `make gate` step rather than moving into
+`make guards-fast` — CARGO_SCOPE is what makes it seconds instead of the
+full workspace.
+
 ### The gate — what every push is held to
 
 A red gate is an automatic "not yet". CI is where it runs: on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,12 @@ Iterating on a single crate is much faster than the whole workspace:
 ```bash
 cargo test  -p stella-core       # just the engine
 cargo clippy -p stella-tools --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tools --no-deps --document-private-items
 ```
+
+That last command is `make doc-warnings CARGO_SCOPE="-p stella-tools"` — it
+catches a private intra-doc link before CI does. Neither `cargo build` nor
+`cargo clippy` compiles docs, so neither one sees it.
 
 ### The gate — run before every push
 


### PR DESCRIPTION
## What

Documents the per-crate rustdoc check that already exists in the Makefile,
next to the other single-crate commands in AGENTS.md and CONTRIBUTING.md:

```bash
make doc-warnings CARGO_SCOPE="-p <crate>"
# equivalent to:
RUSTDOCFLAGS="-D warnings" cargo doc -p <crate> --no-deps --document-private-items
```

## Why

`make gate`'s `doc-warnings` step already runs this check workspace-wide and
already honors `CARGO_SCOPE` (it has since #634/#2336, long before this
issue). What was missing was the documentation: neither AGENTS.md's "Iterate
on a single crate" block nor CONTRIBUTING.md's equivalent mentioned it, so a
contributor had no local command for the one failure mode `make guards-fast`
and a scoped `cargo clippy` both leave green — a public doc comment linking a
crate-private item (`rustdoc::private_intra_doc_links`). It surfaced only
when CI's full `cargo doc -D warnings` ran, several minutes in.

## Verifying the other two "Done means" items were already true

- **Wired into the right rung, not `guards-fast`:** `doc-warnings` is in
  `GATE_STEPS` (`Makefile`), not `GATE_GUARDS_FAST` — it only runs as part of
  `make gate`, which compiles. Unchanged by this PR.
- **`gate-parity` passes:** ran `./scripts/check-gate-parity.sh` locally —
  `OK — 53 (fifty-three) gate steps, named in AGENTS.md and CONTRIBUTING.md,
  each run by a workflow.`

## Witness

Docs-only change — no behavior to flip fail→pass. Verified locally instead
(all four are on the allowed-local list):

- `./scripts/check-gate-parity.sh` — OK, 53 steps, both docs agree.
- `python3 scripts/check-prose.py` — OK, no content-free construction added
  (my first draft cited `#5226` inline and the ratchet caught it —
  `AGENTS.md issue-reference: 97 allowed, 98 found` — rewritten to state the
  fact instead, per `docs/prose-guidelines.md` rule 7).
- `python3 scripts/check-line-citations.py` — OK, nothing added.
- `./scripts/check-file-size.sh` — OK, no file crossed.
- `make guards-fast` — full run, green.

Tests deleted: None.

## Residue

None filed. Everything the issue's "Files" section named (`Makefile`,
`AGENTS.md`, `.githooks/pre-push`) was already correct except the AGENTS.md
prose; the two follow-on comments on #5226 (a function-body-scoped rustdoc
link, and a stale `cargo clippy` cache) are already tracked by #5139 ("The
local gate misses the schema tier, and cargo doc replays a cached green"),
which is a separate, larger design question this PR does not touch.

Closes #5226

## Summary by Sourcery

Document how to run rustdoc warnings for a single crate during local development.

Enhancements:
- Document the scoped rustdoc warnings check alongside the other single-crate development commands so contributors can catch private intra-doc link errors locally before CI.

Documentation:
- Add scoped rustdoc command guidance and explain its relationship to the full gate in AGENTS.md and CONTRIBUTING.md.