### PR TITLE
fix(stella-tui): keep a panel's combining marks, and record what a cell counts

### DIFF
--- a/crates/stella-plugin/src/panel.rs
+++ b/crates/stella-plugin/src/panel.rs
@@ -879,14 +879,21 @@ impl PanelPatch {
 ///
 /// # What a cell is here, and what it is not
 ///
-/// [`PanelText::cells`] counts `char`s. A double-width glyph therefore draws
-/// wider than this contract counts, and the frame that carries it misaligns
-/// **its own interior** — never anything outside it, because the host clips
-/// every blit at the leased rectangle whatever a frame claims. Measuring
-/// display width would mean a Unicode width table, and this crate is a
-/// near-leaf that takes one workspace dependency on argument (see its
-/// `Cargo.toml`); the host already owns the clip that makes the difference
-/// safe.
+/// [`PanelText::cells`] counts `char`s, so a cell here is a glyph and not a
+/// terminal column. `あ` is one glyph and two columns; `e` followed by a
+/// combining acute is two glyphs and one column. A frame this contract admits
+/// can therefore need more columns than its lease has, or fewer.
+///
+/// The host measures the columns. `stella_tui::plugin_panel`'s `write_run`
+/// places a glyph only when every column it needs is inside the lease, so a
+/// row of wide glyphs is cut at that edge rather than drawn over the border.
+/// Two tests in that module hold it: `a_wide_glyph_cannot_reach_past_the_lease_into_the_border`
+/// draws the chrome first and asserts the border cell survives, and
+/// `a_frame_the_contract_admits_by_glyph_count_is_cut_at_the_lease` pins the
+/// seam between the two counts.
+///
+/// Keeping the `char` count is a recorded decision, with its costs and what
+/// would reopen it: `doc:adr/0028-panel-cells-are-glyphs-in-the-contract`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PanelText(String);
 
@@ -921,8 +928,8 @@ impl PanelText {
         &self.0
     }
 
-    /// How many cells these glyphs occupy — see the type docs on what a cell
-    /// counts as here.
+    /// How many glyphs these are — the count this contract calls cells. See
+    /// the type docs for what it does and does not measure.
     #[must_use]
     pub fn cells(&self) -> usize {
         self.0.chars().count()

--- a/crates/stella-tui/src/plugin_panel.rs
+++ b/crates/stella-tui/src/plugin_panel.rs
@@ -30,8 +30,17 @@
 //! repainted, so the border stays overwritten. That is a plugin painting a
 //! cell it was not leased, through a path a `chars()`-counting bounds check
 //! calls in-bounds. So a glyph whose width would cross the lease's right edge
-//! is refused rather than truncated, and a zero-width glyph is refused at the
-//! left edge, where the terminal would attach it to the border instead.
+//! is refused rather than truncated, and a combining mark rides the cell the
+//! glyph before it took rather than claiming one of its own — a mark in its own
+//! cell would attach to whatever the host drew there.
+//!
+//! The two counts still differ, and the difference is decided rather than
+//! overlooked: `stella_plugin::PanelText::cells` counts `char`s, so a row of
+//! wide glyphs the wire contract admits is cut here at the lease's edge. See
+//! `doc:adr/0028-panel-cells-are-glyphs-in-the-contract`, and this module's
+//! `a_frame_the_contract_admits_by_glyph_count_is_cut_at_the_lease` for the
+//! seam itself. That test is not linked: it is a `#[cfg(test)]` item, and a
+//! rustdoc link to one is an unresolved link in the run that ships.
 //!
 //! **The palette.** [`PanelInk`] names a token, never an RGB triple, and
 //! [`ink`] resolves it against the shipped theme — so a panel degrades with
@@ -196,22 +205,41 @@ fn blit_patches(patches: &[PanelPatch], rect: Rect, buf: &mut Buffer) {
     }
 }
 
+/// The most combining marks one cell keeps.
+///
+/// A mark takes no column of its own, so nothing else here bounds how many of
+/// them a plugin can hang on one glyph, and every one of them is bytes the
+/// terminal redraws on each repaint. Unicode's stream-safe format caps a
+/// sequence at 30 non-starters, so text that follows it loses no mark to this
+/// limit.
+const MARKS_PER_CELL: usize = 30;
+
 /// Write `text` rightwards from `x`, in display cells, stopping at the lease's
 /// right edge. Returns the column after the last glyph written.
 ///
 /// A glyph is placed only when **all** of its columns are inside the lease, so
 /// the last leased column refuses a double-width glyph rather than letting the
-/// terminal paint its second half over the host's border. A zero-width glyph —
-/// a combining mark that arrived without the character it modifies — is
-/// dropped at the left edge, where the terminal would otherwise attach it to
-/// the border cell.
+/// terminal paint its second half over the host's border.
+///
+/// A zero-width glyph rides the cell the glyph before it took, which is how
+/// ratatui writes one itself: `Buffer::set_stringn` splits into grapheme
+/// clusters and puts a whole cluster in one cell. A mark with no glyph to ride
+/// — one opening a run, or arriving after the lease's edge cut the run short —
+/// is dropped, because its own cell would attach it to whatever the host drew
+/// there.
 fn write_run(buf: &mut Buffer, mut x: u16, y: u16, rect: Rect, text: &str, style: Style) -> u16 {
     let right = rect.x.saturating_add(rect.width);
+    // The cell this run last wrote a glyph into, and how many marks it carries.
+    let mut carrier: Option<(u16, u16)> = None;
+    let mut marks = 0usize;
     for ch in text.chars() {
         let width = ch.width().unwrap_or(0);
         if width == 0 {
-            // Nothing to advance past, and nowhere safe to put it: at the
-            // lease's left edge it would modify the host's border.
+            if let Some(at) = carrier
+                && marks < MARKS_PER_CELL
+            {
+                marks += usize::from(attach_mark(buf, at, ch));
+            }
             continue;
         }
         let Ok(width) = u16::try_from(width) else {
@@ -221,6 +249,8 @@ fn write_run(buf: &mut Buffer, mut x: u16, y: u16, rect: Rect, text: &str, style
             break;
         }
         write_cell(buf, x, y, ch, style);
+        carrier = Some((x, y));
+        marks = 0;
         // The columns a wide glyph occupies beyond its first are the
         // terminal's to fill; the buffer must not leave a stale symbol in
         // them, or the diff emits a cell that overlaps the glyph.
@@ -233,6 +263,21 @@ fn write_run(buf: &mut Buffer, mut x: u16, y: u16, rect: Rect, text: &str, style
         x += width;
     }
     x
+}
+
+/// Hang one combining mark on the glyph already in `(x, y)`.
+///
+/// Returns whether it landed: a cell the buffer does not hold takes nothing,
+/// for the reason [`write_cell`] gives.
+fn attach_mark(buf: &mut Buffer, (x, y): (u16, u16), mark: char) -> bool {
+    let Some(cell) = buf.cell_mut((x, y)) else {
+        return false;
+    };
+    let mut symbol = String::with_capacity(cell.symbol().len() + mark.len_utf8());
+    symbol.push_str(cell.symbol());
+    symbol.push(mark);
+    cell.set_symbol(&symbol);
+    true
 }
 
 /// Write one glyph, if the buffer actually has that cell.
@@ -440,11 +485,11 @@ mod tests {
         assert_eq!(buf.cell((2, 0)).expect("cell").symbol(), "b");
     }
 
-    /// A lone combining mark is dropped rather than placed: it has no column of
-    /// its own, and at the lease's left edge the terminal would attach it to
-    /// the host's border glyph.
+    /// A combining mark that opens a run is dropped: it has no glyph to ride,
+    /// and a cell of its own at the lease's left edge would attach it to the
+    /// host's border glyph.
     #[test]
-    fn a_zero_width_glyph_is_never_placed() {
+    fn a_combining_mark_with_no_glyph_to_ride_is_dropped() {
         let area = Rect::new(0, 0, 4, 1);
         let mut buf = Buffer::empty(area);
         let frame = lines(vec![vec![span("\u{301}x", PanelStyle::plain())]]);
@@ -453,6 +498,90 @@ mod tests {
             buf.cell((0, 0)).expect("cell").symbol(),
             "x",
             "the mark was dropped and the real glyph took the first column"
+        );
+    }
+
+    /// A combining mark that *does* have a glyph rides it, in one cell, as
+    /// ratatui's own `Buffer::set_stringn` writes a grapheme cluster.
+    ///
+    /// Dropping every zero-width `char` instead paints `e` where the plugin
+    /// wrote `é`, and the accent goes with nothing to say it went.
+    #[test]
+    fn a_combining_mark_rides_the_glyph_it_modifies() {
+        let area = Rect::new(0, 0, 4, 1);
+        let mut buf = Buffer::empty(area);
+        let frame = lines(vec![vec![span("e\u{301}x", PanelStyle::plain())]]);
+        blit(&frame, area, &mut buf);
+        assert_eq!(
+            buf.cell((0, 0)).expect("cell").symbol(),
+            "e\u{301}",
+            "the accent stayed on the glyph it modifies"
+        );
+        assert_eq!(
+            buf.cell((1, 0)).expect("cell").symbol(),
+            "x",
+            "and it took no column of its own"
+        );
+    }
+
+    /// A mark costs no column, so the lease cannot bound how many of them one
+    /// cell collects. [`MARKS_PER_CELL`] does.
+    #[test]
+    fn one_cell_keeps_no_more_marks_than_the_stream_safe_limit() {
+        let area = Rect::new(0, 0, 2, 1);
+        let mut buf = Buffer::empty(area);
+        let mut text = String::from("e");
+        for _ in 0..MARKS_PER_CELL + 5 {
+            text.push('\u{301}');
+        }
+        let frame = lines(vec![vec![span(&text, PanelStyle::plain())]]);
+        blit(&frame, area, &mut buf);
+        assert_eq!(
+            buf.cell((0, 0)).expect("cell").symbol().chars().count(),
+            MARKS_PER_CELL + 1,
+            "the glyph, and the marks it is allowed to carry"
+        );
+    }
+
+    /// **The seam.** The wire contract counts glyphs and the host counts
+    /// columns, and this is the frame where the two disagree: four ideographs
+    /// measure four cells against a four-column lease, so `PanelFrame::fits`
+    /// admits them, and they need eight columns to draw.
+    ///
+    /// The host cuts the row at the lease's edge and the border survives. That
+    /// is the decision `doc:adr/0028-panel-cells-are-glyphs-in-the-contract`
+    /// records: changing either half alone breaks this test.
+    #[test]
+    fn a_frame_the_contract_admits_by_glyph_count_is_cut_at_the_lease() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 3));
+        let lease = chrome(Rect::new(0, 0, 6, 3), "seam", &mut buf);
+        assert_eq!(lease, Rect::new(1, 1, 4, 1));
+        let border_x = lease.x + lease.width;
+        let before = buf
+            .cell((border_x, lease.y))
+            .expect("a border cell")
+            .symbol()
+            .to_string();
+
+        let frame = lines(vec![vec![span("日本語だ", PanelStyle::plain())]]);
+        assert_eq!(
+            frame.fits(lease_rect(lease)),
+            Ok(()),
+            "the contract counts four glyphs against four columns"
+        );
+
+        blit(&frame, lease, &mut buf);
+
+        let row: String = (lease.x..lease.x + lease.width)
+            .map(|x| buf.cell((x, lease.y)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect();
+        assert_eq!(row, "日 本 ", "two of the four glyphs fit the four columns");
+        assert_eq!(
+            buf.cell((border_x, lease.y))
+                .expect("a border cell")
+                .symbol(),
+            before,
+            "the host's border survived the frame the contract admitted"
         );
     }
 

--- a/docs/adr/0028-panel-cells-are-glyphs-in-the-contract.md
+++ b/docs/adr/0028-panel-cells-are-glyphs-in-the-contract.md
@@ -1,0 +1,68 @@
+---
+id: adr/0028-panel-cells-are-glyphs-in-the-contract
+title: "ADR 0028: A panel cell is a glyph in the contract and a column in the host"
+status: implemented
+---
+
+# ADR 0028: A panel cell is a glyph in the contract and a column in the host
+
+- Status: accepted
+- Date: 2026-09-05
+- Decides: `#5185`
+
+## Context
+
+A plugin may draw a panel. The host leases it a box. The plugin sends back a
+frame of text.
+
+`PanelText::cells` counts `char`s. It lives in
+`crates/stella-plugin/src/panel.rs`. `PanelFrame::fits` is built on that count.
+A host calls `fits` to refuse a frame that runs past the lease.
+
+A `char` is not a column. `あ` is one `char` and two columns. An `e` with a
+combining acute is two `char`s and one column.
+
+So the two counts differ. `fits` can admit a row that needs more columns than
+the lease has. It can also refuse a row that would have fit.
+
+When `#5185` was filed, nothing else measured columns. There was no panel
+host at all. The type's docs said the host clipped every blit, and no host
+did. The host landed with `#5223`. Its `write_run` advances by display width.
+It places a glyph only when every column that glyph needs is inside the lease.
+
+## Decision
+
+`cells()` keeps counting `char`s. The host keeps the column count.
+
+`stella-plugin` is a near-leaf. It argues each workspace edge in its own
+`Cargo.toml`, and a width table would be a new one. The host already links
+`unicode-width`.
+
+A cell is also a wire term. Change what it means and you change which frames
+are legal. That is a wire-contract change, with a corpus to remeasure and
+`make wire-schema-update` to run.
+
+And two exact counts would still not agree. A width table has a version. The
+terminal has its own. Only the clip has to be right, so only the host should
+try.
+
+## Consequences
+
+`fits` returning `Ok` is not a promise that a row is drawn whole. A row of
+wide glyphs is cut at the lease's edge. Nothing paints outside the box.
+`a_wide_glyph_cannot_reach_past_the_lease_into_the_border` proves that, and
+`a_frame_the_contract_admits_by_glyph_count_is_cut_at_the_lease` pins the seam
+itself. Both live in `crates/stella-tui/src/plugin_panel.rs`.
+
+A mark that follows a glyph counts as a second cell here. So a frame of
+decomposed text can be refused for room it does not use. A plugin that wants
+its whole row drawn should send precomposed text, and should keep a glyph and
+its marks in one span.
+
+The host draws such a mark on the glyph before it, in one cell, as ratatui
+does. A mark with no glyph to ride is dropped. One cell keeps at most thirty
+marks, which is the cap Unicode's stream-safe format uses.
+
+What would reopen this: a panel API that has to tell a plugin how much room a
+string takes. A plugin cannot ask that question of a glyph count. If we add
+one, the contract measures width and this record is amended.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -94,6 +94,7 @@ open; nothing before Phase 3 forces it.
 | [0025](0025-nested-frontmatter-refusal-scope.md) | Refuse a Nested Key Where It Widens a Grant | Accepted |
 | [0026](0026-context-editing-ships-off-until-measured.md) | Context Editing Ships Off Until Its Trigger Is Measured | Accepted |
 | [0027](0027-a-fleet-worker-gets-its-own-worktree.md) | A Fleet Worker Gets Its Own Worktree | Accepted |
+| [0028](0028-panel-cells-are-glyphs-in-the-contract.md) | A Panel Cell Is a Glyph in the Contract and a Column in the Host | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -140,3 +141,8 @@ git restores every tracked file in the tree, and the other's edits are gone
 with no error printed. The shared root and its cooperative file claims stay,
 as something a plan names — a claim guards one path, and a branch switch
 rewrites all of them.
+
+ADR 0028 settles what a panel frame's cell count measures. The wire contract
+counts glyphs; the host counts terminal columns. A row of wide glyphs the
+contract admits is cut at the lease's edge, and the two tests named in the
+record hold both halves of that.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -140,6 +140,11 @@
       "status": "implemented",
       "title": "ADR 0027: A fleet worker gets its own worktree"
     },
+    "adr/0028-panel-cells-are-glyphs-in-the-contract": {
+      "path": "docs/adr/0028-panel-cells-are-glyphs-in-the-contract.md",
+      "status": "implemented",
+      "title": "ADR 0028: A panel cell is a glyph in the contract and a column in the host"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",


### PR DESCRIPTION
## What and why

`PanelText::cells` counts `char`s, `PanelFrame::fits` is built on that count,
and the type's docs argued the difference was safe "because the host clips
every blit at the leased rectangle". When #5185 was filed no such host
existed. It does now: #5223 shipped `crates/stella-tui/src/plugin_panel.rs`,
whose `write_run` advances by display width and refuses a glyph whose columns
would cross the lease's edge, with
`a_wide_glyph_cannot_reach_past_the_lease_into_the_border` drawing the chrome
first so the assertion is against the host's real border cell. That is boxes 1
and 2 of the issue's Definition of done, already landed.

This PR settles the rest, and fixes the other half of the defect the issue's
Problem section names.

**The combining mark (host, a real fix).** `write_run` dropped every
zero-width `char`, so a plugin sending decomposed text lost its marks: `e` +
U+0301 painted as `e`, with nothing to say the accent had gone. A mark now
rides the cell the glyph before it took. That is how ratatui writes one itself
— `Buffer::set_stringn` splits into grapheme clusters and puts a whole cluster
in one cell (`ratatui-core-0.1.2/src/buffer/buffer.rs`), which is the exemplar
followed here. A mark with no glyph to ride is still dropped, because its own
cell would attach it to whatever the host drew there. One cell keeps at most
`MARKS_PER_CELL` marks: a mark costs no column, so the lease cannot bound how
many a frame hangs on one glyph, and every one is bytes the terminal redraws.
30 is the cap Unicode's stream-safe format uses, so conforming text loses
nothing. No new dependency.

**The decision (contract).** `cells()` keeps counting `char`s and the host
keeps the column count, recorded as
`docs/adr/0028-panel-cells-are-glyphs-in-the-contract.md` per SCR-002. The
reasons are the issue's own — `stella-plugin` is a near-leaf that argues each
workspace edge, and changing what a cell means changes which frames are legal,
which is a wire-contract change — plus one the issue does not make: two exact
counts would still disagree, because a width table has a version and the
terminal has its own, so only the clip has to be right.

**The prose.** `PanelText`'s "what a cell is here" paragraph now names the two
tests that hold the property and cites the ADR, instead of asserting the clip.
Nothing in the wire contract changed, so no `make wire-schema-update`.

## Witness mechanism

`a_combining_mark_rides_the_glyph_it_modifies` fails on the old code by
construction: the old `write_run` hit `if width == 0 { continue; }` for U+0301,
so cell (0,0) held `e` and the assertion asks for `e\u{301}`. It passes on the
new code because the mark is appended to that cell's symbol.

`one_cell_keeps_no_more_marks_than_the_stream_safe_limit` fails without the
cap (the symbol would carry all 35 marks sent).

`a_frame_the_contract_admits_by_glyph_count_is_cut_at_the_lease` passes before
and after, and that is its job: it asserts `fits` admits four ideographs
against a four-column lease *and* that the host cuts them at two with the
border untouched, so changing either half alone breaks it. It is the seam ADR
0028 records, pinned in the one crate that can see both sides.

## Tests deleted

None. One rename: `a_zero_width_glyph_is_never_placed` →
`a_combining_mark_with_no_glyph_to_ride_is_dropped`. Same body, same
assertion; the old name claimed more than the code now does, since a mark with
a glyph to ride *is* placed.

## Definition of done

- [x] The host clips every panel blit at the leased rectangle — `write_run`,
      landed #5223, unchanged here.
- [x] A test proves a frame of wide glyphs measuring within its lease still
      paints nothing outside it —
      `a_wide_glyph_cannot_reach_past_the_lease_into_the_border` (#5223), and
      `a_frame_the_contract_admits_by_glyph_count_is_cut_at_the_lease` (this
      PR) starts from a frame `fits` admits.
- [x] `panel.rs`'s "what a cell is here" paragraph names those tests rather
      than asserting the clip.
- [x] A decision is recorded on whether `cells()` should measure display
      width — ADR 0028 says no, with the costs and what would reopen it.

## One correction to the issue

Its Verify section offers `"日本語テキスト"` against `PanelRect::new(4, 1)` as a
frame `fits` accepts today. It does not: that is seven `char`s against four
columns, so `fits` refuses it on the glyph count. The seam needs a string whose
glyph count fits and whose column count does not, so the test uses `"日本語だ"`
— four glyphs, eight columns.

## Remaining work filed

- #5922 — `crates/stella-plugin/src/panel.rs` is 11 lines under the 1500-line
  ceiling and takes no baseline entry, so the next change there has no room to
  design a seam.


## Note on the branch's history

#5823 landed ADR 0027 while this was open, so this record is **0028**: the file,
its id, its heading, the README row and the three `doc:adr` citations all moved
together. The branch was also flattened onto a fresh base after main's
`Cargo.lock` repair (#5940) made this branch's copy of that line an
edit-and-undo pair, which `no edit is undone inside the branch` correctly
caught. Both are settled on the current head; #5954 files the self-test case
that was missing for the rename half.

Closes #5185

---

## DoD re-check, and an ADR number claimed twice (appended 2026-09-05 by the PR sweep)

`dod / dod` failed at 09:49:52 against four unticked boxes on #5185. The boxes
were ticked at 09:52:49 — three minutes after that read — so the check is
stale rather than wrong. This edit is the `pull_request` event `dod-check.yml`
needs to read them again; the edit is the trigger, never the fix. It changes
no code.

The three items credited to this PR were checked against the diff at
`4d5c8ba` rather than against the description above:

- `a_frame_the_contract_admits_by_glyph_count_is_cut_at_the_lease` is in
  `crates/stella-tui/src/plugin_panel.rs` and asserts `frame.fits(...)` is
  `Ok(())` before it blits, so it does start from a frame the contract admits,
  and then asserts the border cell is byte-identical afterwards.
- `PanelText`'s "what a cell is here" paragraph names that test and
  `a_wide_glyph_cannot_reach_past_the_lease_into_the_border`, and cites the
  ADR instead of asserting the clip.
- `docs/adr/0028-panel-cells-are-glyphs-in-the-contract.md` is added and
  registered in both `docs/adr/README.md` and `docs/manifest.json`.

The first two boxes are #5223's and already landed.

### ADR 0027 is claimed by two open PRs

#5823 adds `docs/adr/0027-a-fleet-worker-gets-its-own-worktree.md` and
registers 0027 in the same two indexes this PR does. Both are open against
`main`, so `docs/adr/README.md` and `docs/manifest.json` are one shared cell
two branches write — the composition hazard AGENTS.md describes under the
file-size baseline: each branch is correct on its own, and the second to land
either collides in those indexes or ships a duplicate ADR number.

**Settled:** #5823 landed first and keeps 0027. This record is 0028, and the
file, its id, its heading, the README row and the three `doc:adr` citations
moved together.

## Summary by Sourcery

Preserve combining marks in panel output and document the glyph-count contract while relying on host-side column clipping.

New Features:
- Preserve combining marks by attaching them to the preceding glyph during panel rendering, with a stream-safe limit per cell.

Bug Fixes:
- Prevent combining marks from being silently lost while maintaining safe clipping of wide glyphs at panel lease boundaries.

Enhancements:
- Clarify that panel contract cells count glyphs while the host enforces terminal-column boundaries.
- Record the panel cell-count decision and its consequences in ADR 0028.

Documentation:
- Update panel and host documentation to describe glyph-versus-column semantics and link the boundary tests.
- Register ADR 0028 in the documentation indexes.

Tests:
- Add coverage for combining-mark preservation, marks without a carrier, the per-cell mark limit, and frames admitted by glyph count being clipped at the lease edge.
