### PR TITLE
fix(stella-plugin): refuse a bidi override in a panel's glyphs

### DIFF
--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -271,10 +271,14 @@ before it crosses.
   (`PanelGrant`, `PanelDenial`, `PanelLease`, `PanelFrame`): a plugin leased a
   rectangle of the screen, returning styled lines or a cell diff each tick
   (`design/tui-v2/SPEC.md` §12). Two of that section's rules are the types
-  rather than a host's care — `PanelText` wraps a private `String` that refuses
-  every control character, so no plugin emits an escape sequence in any
-  language, and `PanelRect` carries an extent with no origin, so a frame cannot
-  name a cell of Stella's own chrome.
+  rather than a host's care — `PanelText` wraps a private `String` that turns
+  away every control `char` and every bidi one, so no plugin emits an escape
+  sequence or flips its own text, and `PanelRect` carries an extent with no
+  origin, so a frame cannot name a cell of Stella's own chrome.
+- `src/drawable.rs` — the two rules behind that first one, and the argument for
+  where each line sits: what a screen runs (`Cc`), and what reorders the text
+  after it (the bidi `char`s). `PanelText::new` asks both; a plugin's `name`
+  asks the first.
 - `src/error.rs` — `ManifestError`, typed per rule (AGENTS.md #5).
 - `tests/manifest_grades.rs` + `tests/fixtures/*.toml` — slice A's
   acceptance: one fixture per grade, round-tripped through both TOML and

--- a/crates/stella-plugin/src/drawable.rs
+++ b/crates/stella-plugin/src/drawable.rs
@@ -1,0 +1,144 @@
+//! What Stella will draw.
+//!
+//! One rule, read wherever a plugin's text reaches a screen. Two kinds of
+//! `char` are turned away, for two reasons.
+//!
+//! A control `char` is an escape. `\x1b` opens every `CSI`, `OSC` and `SGR`
+//! run. `U+009B` opens one on its own. `\n`, `\r` and `\t` set a row's shape.
+//! A screen obeys them all. Stella writes every escape byte a screen sees.
+//!
+//! A bidi `char` is a lie. `U+202E` and its kin flip the text after them. A
+//! run can then read in an order its bytes do not have. That is the Trojan
+//! Source shape (`CVE-2021-42574`). None of it leaves the leased box, since
+//! the host clips each blit. It still counts. The box is chrome a person
+//! chose to trust.
+//!
+//! The rest of `Cf` stays. `U+200D` builds each family and job emoji. `U+200C`
+//! is plain text in Persian and in `Indic` scripts. To bar them is to bar a
+//! script. `U+200B` takes a cell here and none on a screen. That is the gap a
+//! wide glyph already opens; [`crate::PanelText::cells`] says so.
+
+use crate::error::ManifestError;
+
+/// Every bidi `char`, in code point order.
+///
+/// Written out, not looked up. The set is closed and has not moved since
+/// `Unicode 6.3` added the isolates. This crate takes a new dep only on a
+/// good case, and a whole crate for the list below is not one.
+const BIDI_CONTROLS: &[char] = &[
+    '\u{061c}', // ARABIC LETTER MARK
+    '\u{200e}', // LEFT-TO-RIGHT MARK
+    '\u{200f}', // RIGHT-TO-LEFT MARK
+    '\u{202a}', // LEFT-TO-RIGHT EMBEDDING
+    '\u{202b}', // RIGHT-TO-LEFT EMBEDDING
+    '\u{202c}', // POP DIRECTIONAL FORMATTING
+    '\u{202d}', // LEFT-TO-RIGHT OVERRIDE
+    '\u{202e}', // RIGHT-TO-LEFT OVERRIDE
+    '\u{2066}', // LEFT-TO-RIGHT ISOLATE
+    '\u{2067}', // RIGHT-TO-LEFT ISOLATE
+    '\u{2068}', // FIRST STRONG ISOLATE
+    '\u{2069}', // POP DIRECTIONAL ISOLATE
+];
+
+/// The first control `char` in `text`, as `(index in chars, character)`.
+///
+/// Read in two places. [`crate::PanelText::new`] holds it for a panel's own
+/// text, and [`validate_plugin_name`] holds it for the name Stella prints. A
+/// second copy would drift. Both ask one thing: can this string reach a screen
+/// with no escape in it?
+pub(crate) fn first_control_character(text: &str) -> Option<(usize, char)> {
+    text.chars()
+        .enumerate()
+        .find(|(_, found)| found.is_control())
+}
+
+/// The first bidi `char` in `text`, as `(index in chars, character)`.
+///
+/// The index counts `char`s, as [`first_control_character`] does. A refusal
+/// then names a spot a reader can count to.
+pub(crate) fn first_bidi_control(text: &str) -> Option<(usize, char)> {
+    text.chars()
+        .enumerate()
+        .find(|(_, found)| BIDI_CONTROLS.contains(found))
+}
+
+/// Whether a plugin's name is one Stella can print in its own chrome.
+///
+/// The name is the one string Stella puts in chrome it owns: the
+/// `◳ panel · <plugin>` label, the install prompt, a popup head, the rules
+/// panel. [`crate::PanelText`] keeps a panel's own text free of escapes. That
+/// is worth nothing if the label around it is not. A plugin named `"\x1b[2J"`
+/// wipes the screen from inside Stella's own border.
+///
+/// Asked once, at load, not at each reader. Each reader is a place to forget.
+/// Here, not in `manifest.rs`, so it sits by the rule it shares with
+/// [`crate::PanelText::new`].
+///
+/// It asks [`first_control_character`] and not [`first_bidi_control`]. A name
+/// with `U+202E` is the same trick one door over. To bar it adds a case to the
+/// public [`ManifestError`], which is its own change.
+///
+/// # Errors
+///
+/// [`ManifestError::NameNotDrawable`], naming the `char` and where it sits.
+pub(crate) fn validate_plugin_name(name: &str) -> Result<(), ManifestError> {
+    match first_control_character(name) {
+        Some((index, found)) => Err(ManifestError::NameNotDrawable {
+            index,
+            code: found as u32,
+        }),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_bidi_control_is_found_and_the_joiners_are_not() {
+        for hazard in BIDI_CONTROLS {
+            assert_eq!(
+                first_bidi_control(&format!("gates {hazard} green")),
+                Some((6, *hazard)),
+                "U+{:04X} is listed and must be found",
+                *hazard as u32
+            );
+        }
+        // The chars the rule keeps. To bar one is to bar a script.
+        for kept in ['\u{200b}', '\u{200c}', '\u{200d}', '✦', '👩'] {
+            assert_eq!(first_bidi_control(&kept.to_string()), None, "{kept:?}");
+        }
+    }
+
+    #[test]
+    fn the_list_is_sorted_and_carries_no_duplicate() {
+        let mut sorted = BIDI_CONTROLS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted, BIDI_CONTROLS,
+            "the list reads in code-point order, once each"
+        );
+    }
+
+    #[test]
+    fn a_bidi_control_is_not_a_control_character() {
+        // The two rules ask different things. `char::is_control` is `Cc`, and
+        // each `char` above is `Cf`.
+        for hazard in BIDI_CONTROLS {
+            assert!(!hazard.is_control(), "U+{:04X}", *hazard as u32);
+        }
+    }
+
+    #[test]
+    fn a_name_carrying_an_escape_is_refused_by_position() {
+        // `matches!` rather than `assert_eq!`, because `ManifestError` carries
+        // no `PartialEq`.
+        assert!(matches!(
+            validate_plugin_name("✦\u{1b}[2J"),
+            Err(ManifestError::NameNotDrawable { index: 1, code: 27 })
+        ));
+        assert!(validate_plugin_name("vera").is_ok());
+    }
+}

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -104,6 +104,7 @@
 mod candidate_grant;
 mod configure;
 mod consent;
+mod drawable;
 mod driver;
 mod error;
 mod evidence;

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -552,7 +552,7 @@ impl PluginManifest {
         if self.name.trim().is_empty() {
             return Err(ManifestError::EmptyName);
         }
-        crate::panel::validate_plugin_name(&self.name)?;
+        crate::drawable::validate_plugin_name(&self.name)?;
 
         let grant = &self.loop_grant;
         let participation = grant.participation;

--- a/crates/stella-plugin/src/panel.rs
+++ b/crates/stella-plugin/src/panel.rs
@@ -6,13 +6,14 @@
 //! point, its own grant, and no rung on the [`crate::Participation`] ladder,
 //! because drawing is not influence over a turn.
 //!
-//! Two rules from that section are held by the types instead of by a host's
-//! care, and they are the reason this is a contract at all:
+//! Some of that section's rules are held by the types, not by a host's care.
+//! That is why this is a contract at all:
 //!
-//! - **A panel never emits an escape sequence.** [`PanelText`] wraps a private
-//!   `String` whose only constructor refuses every control character, so
-//!   `\x1b[2J` is a decode error on the frame that carries it. The host draws
-//!   the border, the title and every escape byte the terminal ever sees.
+//! - **A panel never emits an escape sequence, and never flips its own text.**
+//!   [`PanelText`] wraps a private `String` whose only constructor turns away
+//!   every control `char` and every bidi one, so `\x1b[2J` and `U+202E` are
+//!   both decode errors on the frame that carries them. The host draws the
+//!   border, the title and every escape byte the terminal ever sees.
 //! - **A panel cannot address a cell it was not leased.** [`PanelRect`] carries
 //!   an extent and no origin, so the coordinates a plugin writes are its own
 //!   rectangle's; there is no number it could put in a frame that names a cell
@@ -30,6 +31,7 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::drawable::{first_bidi_control, first_control_character};
 use crate::error::ManifestError;
 use crate::runtime::{ProcessBlock, Runtime};
 use crate::wire::PROTOCOL_VERSION;
@@ -788,46 +790,6 @@ impl PanelLine {
     }
 }
 
-/// The first control character in `text`, as `(index in chars, character)`.
-///
-/// One definition of "drawable", read in two places: [`PanelText::new`] holds
-/// it for a panel's own glyphs, and
-/// [`PluginManifest::validate`](crate::PluginManifest) holds it
-/// for the name Stella composes into chrome. A second copy of the predicate
-/// would drift, and the two are the same question — whether a string can reach
-/// a terminal without carrying an escape sequence into it.
-pub(crate) fn first_control_character(text: &str) -> Option<(usize, char)> {
-    text.chars()
-        .enumerate()
-        .find(|(_, found)| found.is_control())
-}
-
-/// Whether a plugin's name is one Stella can print inside its own chrome.
-///
-/// The name is the one string Stella **composes into chrome it owns**: the
-/// `◳ panel · <plugin>` label, the install prompt, a popup's heading, the rules
-/// panel. [`PanelText`] makes a plugin's own glyphs unable to carry an escape
-/// sequence, and that guarantee is worth nothing while the label around them
-/// can — a plugin named `"\x1b[2J"` clears the screen from inside Stella's own
-/// border, through a path no panel frame touches.
-///
-/// Asked once, at load, rather than at each consumer, because every consumer is
-/// a place someone can forget. Here rather than in `manifest.rs` so it sits
-/// beside the predicate it shares with [`PanelText::new`] (#5203).
-///
-/// # Errors
-///
-/// [`ManifestError::NameNotDrawable`], naming the character and where it sits.
-pub(crate) fn validate_plugin_name(name: &str) -> Result<(), ManifestError> {
-    match first_control_character(name) {
-        Some((index, found)) => Err(ManifestError::NameNotDrawable {
-            index,
-            code: found as u32,
-        }),
-        None => Ok(()),
-    }
-}
-
 /// One run of text in a row, drawn in one style.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -886,6 +848,15 @@ impl PanelPatch {
 /// and `\t` go with them: a row's structure is the frame's, and a tab's width
 /// is the terminal's rather than this contract's.
 ///
+/// **And the no-flip rule, held the same way.** The same constructor turns
+/// away the bidi `char`s — `U+061C`, `U+200E`, `U+200F`, `U+202A`–`U+202E`,
+/// `U+2066`–`U+2069`. Each one flips the text after it. A run can then read in
+/// an order its bytes do not have. That is the Trojan Source shape
+/// (`CVE-2021-42574`). None of it leaves the leased box, since the host clips
+/// each blit. It still counts. The box is chrome a person chose to trust. The
+/// rest of `Cf` is fine: `U+200D` builds the emoji runs, and `U+200C` is plain
+/// Persian and `Indic` text. This crate's `drawable.rs` has the case.
+///
 /// The privacy is what makes it a rule and not a request, exactly as
 /// [`crate::VolatileContext`]'s is. A public field would let a host write
 /// `PanelText("\x1b[2J".into())` in one line, change no type, and stay green:
@@ -903,6 +874,7 @@ impl PanelPatch {
 /// assert_eq!(text.as_str(), "gates: 3 green");
 /// assert_eq!(text.cells(), 14);
 /// assert!(PanelText::new("\u{1b}[31mred").is_err());
+/// assert!(PanelText::new("gates: 3 \u{202e}neerg").is_err());
 /// ```
 ///
 /// # What a cell is here, and what it is not
@@ -923,12 +895,19 @@ impl PanelText {
     ///
     /// # Errors
     ///
-    /// [`PanelTextError::ControlCharacter`] when the text carries a control
-    /// character, naming the character and where it sits.
+    /// [`PanelTextError::ControlCharacter`] for a control `char`, and
+    /// [`PanelTextError::BidiControl`] for a bidi one. Each names the `char`
+    /// and where it sits.
     pub fn new(text: impl Into<String>) -> Result<Self, PanelTextError> {
         let text = text.into();
         if let Some((index, found)) = first_control_character(&text) {
             return Err(PanelTextError::ControlCharacter {
+                index,
+                code: found as u32,
+            });
+        }
+        if let Some((index, found)) = first_bidi_control(&text) {
+            return Err(PanelTextError::BidiControl {
                 index,
                 code: found as u32,
             });
@@ -995,6 +974,21 @@ pub enum PanelTextError {
          the terminal sees"
     )]
     ControlCharacter {
+        /// Which character of the text, counted in `char`s from zero.
+        index: usize,
+        /// The Unicode scalar value that was refused.
+        code: u32,
+    },
+
+    /// The text carries a bidi `char`. Its own error, not a reused
+    /// [`PanelTextError::ControlCharacter`]. The two refusals ask different
+    /// things, and a host that printed the wrong one would send an author
+    /// hunting an escape that is not there.
+    #[error(
+        "panel text carries the bidi formatting character U+{code:04X} at position {index}: it \
+         reorders the glyphs after it, so the panel would read one way and mean another"
+    )]
+    BidiControl {
         /// Which character of the text, counted in `char`s from zero.
         index: usize,
         /// The Unicode scalar value that was refused.

--- a/crates/stella-plugin/tests/panel_contract.rs
+++ b/crates/stella-plugin/tests/panel_contract.rs
@@ -1,6 +1,3 @@
-//! The wrapper socket's wire contract, asserted rather than promised.
-//!
-
 //! The panel channel's wire contract — `design/tui-v2/SPEC.md` §12.
 //!
 //! Split from `wire_contract.rs` when that file met the 1500-line ceiling
@@ -11,10 +8,11 @@
 //!
 //! Held to the identical contract as every other channel here: byte-for-byte
 //! in both directions (AGENTS.md #4), every closed vocabulary pinned on both
-//! sides, and every table refusing a key it does not know. Two rules are this
-//! channel's own and are witnessed rather than asserted in prose — a frame
-//! cannot address a cell outside its lease, and cannot carry an escape
-//! sequence in any language.
+//! sides, and every table refusing a key it does not know. Three rules are
+//! this channel's own and are witnessed rather than asserted in prose — a
+//! frame cannot address a cell outside its lease, cannot carry an escape
+//! sequence in any language, and cannot reorder its own glyphs against the
+//! bytes it sent.
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -277,6 +275,67 @@ fn a_panel_frame_carrying_an_escape_sequence_does_not_decode() {
     let json = "{\"point\":\"frame\",\"body\":{\"protocol_version\":1,\"tick\":1,\
                 \"paint\":{\"lines\":[{\"spans\":[{\"text\":\"\\u001b[31mred\"}]}]}}}";
     assert!(serde_json::from_str::<PanelResponse>(json).is_err());
+}
+
+/// A panel's glyphs read in the order its bytes are in, in Rust and on the wire.
+///
+/// The test above covers the escape-sequence class. This covers the second
+/// one: `U+202E` RIGHT-TO-LEFT OVERRIDE and its siblings reorder the glyphs
+/// after them, so a frame can render text whose visual reading is not its
+/// content — the Trojan Source shape (CVE-2021-42574). Nothing escapes the
+/// leased rectangle, because the host clips every blit; the harm is that a
+/// panel is chrome a person agreed to trust, and this is text that means one
+/// thing and reads as another inside it.
+///
+/// Either half alone is a hole. [`PanelText::new`] is the only door in Rust,
+/// and `Deserialize` routes through it, so a host never holds a reordered
+/// frame to inspect.
+#[test]
+fn a_panel_frame_carrying_a_bidi_override_does_not_decode() {
+    // The whole refused set, written as the JSON escapes a plugin's own encoder
+    // would put on the pipe rather than as Rust literals.
+    for hazard in [
+        "\\u061c", "\\u200e", "\\u200f", "\\u202a", "\\u202b", "\\u202c", "\\u202d", "\\u202e",
+        "\\u2066", "\\u2067", "\\u2068", "\\u2069",
+    ] {
+        let json = format!(
+            "{{\"point\":\"frame\",\"body\":{{\"protocol_version\":1,\"tick\":1,\
+             \"paint\":{{\"diff\":[{{\"row\":0,\"col\":0,\"text\":\"gates {hazard}neerg\"}}]}}}}}}"
+        );
+        let err = serde_json::from_str::<PanelResponse>(&json)
+            .expect_err("a bidi override must not decode as drawable glyphs");
+        assert!(
+            err.to_string().contains("bidi formatting character"),
+            "the refusal must say why, got {err}"
+        );
+    }
+
+    // The same refusal on the other frame shape, so neither of them is the
+    // soft one.
+    let lines = "{\"point\":\"frame\",\"body\":{\"protocol_version\":1,\"tick\":1,\
+                 \"paint\":{\"lines\":[{\"spans\":[{\"text\":\"\\u202egates\"}]}]}}}";
+    assert!(serde_json::from_str::<PanelResponse>(lines).is_err());
+
+    // The Rust half: the constructor is the door, and it names the character
+    // and its position in `char`s rather than bytes.
+    assert!(PanelText::new("gates: 3 \u{202e}neerg").is_err());
+    let err = PanelText::new("\u{2726}\u{202e}").expect_err("a bidi override is not drawable");
+    assert!(err.to_string().contains("U+202E"), "got {err}");
+    assert!(err.to_string().contains("position 1"), "got {err}");
+
+    // What the rule keeps, and why it keeps it: `U+200D` ZWJ builds the emoji
+    // sequences and `U+200C` ZWNJ is ordinary Persian and Indic text.
+    for kept in [
+        "\u{200b}",
+        "\u{200c}",
+        "\u{200d}",
+        "\u{1f469}\u{200d}\u{1f4bb}",
+    ] {
+        assert!(
+            PanelText::new(kept).is_ok(),
+            "{kept:?} is allowed by the rule this test pins"
+        );
+    }
 }
 
 /// Every closed vocabulary the panel channel adds, on both sides.


### PR DESCRIPTION
## What & why

`PanelText::new` is the single door that makes "a panel never emits raw ANSI" a property of the type. It asked `char::is_control()` alone — Unicode `Cc`, the escape-sequence class — and left `Cf` open.

`U+202E` RIGHT-TO-LEFT OVERRIDE and its siblings reorder the glyphs after them, so a frame could render text whose visual reading is not its content: the Trojan Source shape, CVE-2021-42574. Nothing escaped the leased rectangle, because the host clips every blit, so the harm sat inside a panel's own box — which is chrome a person agreed to trust after a consent handshake (`design/tui-v2/SPEC.md` §12).

The constructor now refuses the bidi formatting characters as well: `U+061C`, `U+200E`, `U+200F`, `U+202A`–`U+202E`, `U+2066`–`U+2069`. `Deserialize` routes through the same constructor, so a frame carrying one fails to decode rather than arriving as a value the host is trusted to inspect.

Closes #5184

### The decision the issue asked for

Refuse the bidi controls; allow every other `Cf`. `U+200D` ZWJ builds every family and profession emoji and `U+200C` ZWNJ is ordinary Persian and Indic text — refusing them bans writing systems to tidy a count. `U+200B` stays for the same reason the type already accepts a double-width glyph: it costs a cell in `PanelText::cells()` and none on screen, which misaligns a panel's own interior and nothing outside it. That caveat is already written on `cells()`. The full argument is in `drawable.rs`'s module header, and the type's own doc comment names the classes it refuses and why the rest are allowed. The decision was posted on the issue before any code was written.

### A second typed error, not a reused one

`PanelTextError::BidiControl { index, code }` names the character and its position in `char`s. Not a reused `ControlCharacter`: the two refusals answer different questions, and a host printing the wrong one sends an author hunting an escape sequence that is not in their frame.

### Where the code went

`crates/stella-plugin/src/drawable.rs` is a new **flat sibling** module holding `first_control_character`, the new `first_bidi_control`, and `validate_plugin_name` — the one definition of what Stella will draw, read by both the panel channel and the manifest's `name` rule.

`panel.rs` sat 18 lines under the 1500-line ceiling, so the split had to happen. It is flat rather than a child module under `panel/` because `make module-layout` rejects a new `foo.rs` beside `foo/` (#5604), which is the layout the size ceiling would otherwise ask for. `panel.rs` ends at 1476 lines.

No new dependency. The bidi set is closed and has not moved since Unicode 6.3 added the isolates, so a `const &[char]` answers it — `stella-plugin` is a near-leaf whose `Cargo.toml` takes a workspace dependency only on argument, and a crate for that list is not one.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_panel_frame_carrying_a_bidi_override_does_not_decode`, in `crates/stella-plugin/tests/panel_contract.rs`.

**Why it fails on the old code by construction:** the test decodes a `PanelResponse` whose `text` is `"gates ‮neerg"`, written as the JSON escape a plugin's own encoder would put on the pipe. Before this change `char::is_control()` returns false for every character in `BIDI_CONTROLS` (a unit test in `drawable.rs` pins that fact), so `PanelText::new` accepted the string and the frame decoded cleanly — `expect_err` panics. It runs the whole refused set, both frame shapes (`lines` and `diff`), and the Rust half (`PanelText::new` directly, plus the position and code point in the message). It also asserts what the rule keeps: `U+200B`, `U+200C`, `U+200D` and a ZWJ emoji sequence still construct.

The issue named `tests/wire_contract.rs`. The panel half of that file was split into `tests/panel_contract.rs` when it met the ceiling, and `a_panel_frame_carrying_an_escape_sequence_does_not_decode` — the sibling this test is written beside — lives there now.

`drawable.rs` carries the unit half: every listed character is found, the joiners are not, the list is sorted and unique, and no listed character is a `Cc` control (so neither predicate can stand in for the other).

**Tests deleted: None.**

## The gate

- [x] `cargo fmt --check` (`cargo fmt --all`, then `make guards-fast` green locally)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI
- [ ] `cargo test --workspace` — CI
- [x] Docs updated: `panel.rs`'s module header and `PanelText`'s doc comment state which Unicode classes are refused and why the rest are allowed; `crates/stella-plugin/README.md` gains the new module and the widened rule
- [x] `Closes #5184` appears both here and as a commit trailer

Not built or tested on the maintainer's laptop (CLAUDE.md, "CI builds and tests; this laptop does not"). The evidence is this PR's run.

## Nothing left behind

- [x] Filed: #5917 — a plugin's `name` is composed into Stella's **own** chrome and `validate_plugin_name` still accepts `U+202E`. That is the same spoof one surface over, and worse, since a name is not clipped to a leased rectangle. Fixing it adds a public `ManifestError` variant, which is a wire-visible change this issue did not scope, so it is its own handoff. `validate_plugin_name`'s doc comment says plainly that it asks only the control-character predicate and why.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] The wire shape is unchanged — `PanelText` still serializes as a string; what changed is which strings decode, and the round-trip tests in `panel_contract.rs` cover it

## Anything reviewers should know?

Two prose fixes rode along in `tests/panel_contract.rs`, both in files this PR already touches: a stray copy of `wire_contract.rs`'s header was sitting above the real one (a leftover from the split), and the header's rule list now names the third rule this PR adds.

Exemplar for the predicate module: `stella-plugin`'s own `runtime.rs` / `consent.rs` shape — a small module of pure functions over borrowed text with the argument in the header, which is what the rest of this near-leaf crate already is.

## Summary by Sourcery

Refuse Unicode bidirectional controls in panel glyphs so decoded frames cannot visually reorder their own text.

New Features:
- Reject Unicode bidirectional formatting characters from panel text to prevent visual text reordering and Trojan Source-style spoofing.

Bug Fixes:
- Prevent panel frames containing bidi controls from decoding through either line-based or diff-based wire formats.

Enhancements:
- Introduce shared drawable-text validation helpers in a dedicated module and retain support for non-bidi format characters needed by common scripts and emoji sequences.
- Add a dedicated typed error identifying the refused bidi character and its character position.

Documentation:
- Document the panel glyph restrictions, rationale, and shared drawable-text validation module.

Tests:
- Add unit and wire-contract coverage for the complete bidi-control set, error details, both panel frame shapes, and explicitly allowed joiner characters.