### PR TITLE
fix(scripts): state the issue priority scheme once, in SCR-005

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,16 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-gate-parity.sh
 
+      # Also toolchain-free. Four documents and one workflow regex each named
+      # a priority scheme, and no two agreed; the regex is code, so a `P4`
+      # issue read as triaged to a person and as unprioritised to the guard
+      # (#5216). SCR-005 is the home now, the regex is the one derived copy,
+      # and this holds it there. It runs in docs-guards.yml too, because a
+      # diff confined to prose is exactly the diff this job is skipped for.
+      - name: the priority scheme is stated once
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-priority-scheme.py
+
       # The five below were in `GATE_GUARDS_FAST` and in no workflow at all
       # (#4089). `gate-parity` above holds AGENTS.md and CONTRIBUTING.md to
       # `GATE_STEPS`, which is a question about the prose — it says nothing

--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -89,6 +89,14 @@ name: docs-guards
 #     PR that edits only it is the diff ci.yml's Rust job is skipped for. The
 #     in-repo reference is generated and could not drift; the website copy is
 #     hand-picked prose and could, which is the whole gap this closes.
+# 12. priority-scheme (scripts/check-priority-scheme.py): the issue priority
+#     scheme is stated once, in SCR-005, and the regex in triage-guard.yml
+#     covers exactly the levels it names (#5216). Four documents each named a
+#     scheme of their own and no two agreed. The regex is code, so the gap had
+#     teeth: an issue labelled `P4` read as triaged to a person and as
+#     unprioritised to the guard. It runs in ci.yml too; it runs here because
+#     the home and every former copy are markdown, which is the diff ci.yml's
+#     Rust job is skipped for.
 #
 # Rust sources are in the path filter because the first three read them: a
 # citation added to a .rs comment is exactly how one goes stale, and the
@@ -107,6 +115,8 @@ on:
       - "scripts/check-brand-case.sh"
       - "scripts/check-gate-parity.sh"
       - "scripts/check-god-files.sh"
+      - "scripts/check-priority-scheme.py"
+      - ".github/workflows/triage-guard.yml"
       - "scripts/check-design-refs.sh"
       - "scripts/check-website-inputs.sh"
       - "scripts/website-rust-inputs.txt"
@@ -140,6 +150,8 @@ on:
       - "scripts/check-brand-case.sh"
       - "scripts/check-gate-parity.sh"
       - "scripts/check-god-files.sh"
+      - "scripts/check-priority-scheme.py"
+      - ".github/workflows/triage-guard.yml"
       - "scripts/check-design-refs.sh"
       - "scripts/check-website-inputs.sh"
       - "scripts/website-rust-inputs.txt"
@@ -269,6 +281,14 @@ jobs:
       - name: the god-file prose matches the baseline
         if: ${{ !cancelled() }}
         run: bash scripts/check-god-files.sh
+
+      # The docs-only direction again: the scheme's home is a markdown
+      # document, and the four sources that used to restate it were markdown
+      # too, so the diff that reopens this is one ci.yml's Rust job skips
+      # (#5216).
+      - name: the priority scheme is stated once
+        if: ${{ !cancelled() }}
+        run: python3 scripts/check-priority-scheme.py
 
       # The direction that bites is the docs-only one: a document moved into
       # the scratchpad turns every Rust comment citing it into a violation,

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -207,6 +207,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 ./scripts/test-guard-trigger-coverage.py
 
+      - name: priority-scheme guard failure directions
+        if: ${{ !cancelled() }}
+        run: python3 ./scripts/test-priority-scheme.py
+
       - name: the zsh completion installer
         if: ${{ !cancelled() }}
         run: ./scripts/test-install-zsh-completions.sh

--- a/.github/workflows/triage-guard.yml
+++ b/.github/workflows/triage-guard.yml
@@ -33,7 +33,12 @@ jobs:
             // directions: the guard never strips it from a non-triage login,
             // and an issue carrying only that label reads as unprioritised to
             // every query built on this pattern while reading as triaged to a
-            // human (#5216). Keep this in step with SCR-005's scheme.
+            // human (#5216).
+            //
+            // SCR-005 states the scheme; this is the one copy of it, because a
+            // workflow cannot read a document as it runs. The two are held
+            // together by scripts/check-priority-scheme.py, so editing one
+            // without the other fails the gate rather than the backlog.
             const P = /^P[0-4]$/;
             const allowed = process.env.TRIAGE_LOGINS.split(/\s+/);
             const names = issue.labels.map(l => (typeof l === 'string' ? l : l.name));

--- a/.stella/commands/triage-sweep.md
+++ b/.stella/commands/triage-sweep.md
@@ -84,7 +84,7 @@ Do all of this before touching a single issue.
    env -u CLICOLOR_FORCE gh label list -R "$REPO" --limit 300 --json name,description > "$WORK/labels.json"
    ```
    Classify what exists into five buckets and record the result:
-   - **priority** — `P0`…`P4` (some repos stop at `P3`)
+   - **priority** — the `P` levels SCR-005 names.
    - **type** — `bug`, `feature`, `chore`, `epic`, `documentation`, `duplicate`,
      `invalid`, `wontfix`, `tech-debt`
    - **area** — `area:*` (and `@package/*` / `@app/*` where the repo uses them)

--- a/.stella/commands/triage-sweep.toml
+++ b/.stella/commands/triage-sweep.toml
@@ -104,7 +104,7 @@ Do all of this before touching a single issue.
    env -u CLICOLOR_FORCE gh label list -R "$REPO" --limit 300 --json name,description > "$WORK/labels.json"
    ```
    Classify what exists into five buckets and record the result:
-   - **priority** — `P0`…`P4` (some repos stop at `P3`)
+   - **priority** — the `P` levels SCR-005 names.
    - **type** — `bug`, `feature`, `chore`, `epic`, `documentation`, `duplicate`,
      `invalid`, `wontfix`, `tech-debt`
    - **area** — `area:*` (and `@package/*` / `@app/*` where the repo uses them)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,9 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + guard-trigger-coverage (prose, hue-separation
                          #     and transcript-surfaces each run with no
                          #     paths: filter in at least one workflow)
+                         #   + priority-scheme (the issue priority scheme is
+                         #     stated once, in SCR-005, and the triage guard's
+                         #     regex covers exactly the levels it names)
                          #   + left-behind + role-names
                          #   + stat-portability + module-reachability
                          #   + core-reachability (a stella-core module is
@@ -1435,6 +1438,6 @@ macanderson org repos.
   follow-up, tech-debt item, or logical next step you noticed. Apply ONLY
   the `triage` label.
 - **[SCR-005](docs/scr/SCR-005-triage-separation-of-duties.md) — Triage
-  separation of duties:** Never apply priority (`P0`–`P4`) or size labels —
+  separation of duties:** Never apply a priority or size label —
   a dedicated triage agent owns sizing and priority; a guard workflow
   strips creator-applied priorities.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,8 +215,8 @@
   priority — so a `P2` you add is both a rule break and a label that does not
   survive. The taxonomy below is what **triage** applies; read it to
   understand what the labels on an issue mean, not as a list to add yourself.
-- **The taxonomy, in this order.** First a priority (`P0`–`P4`),
-  then the `area:*` tag — several when the work genuinely spans areas — then
+- **The taxonomy, in this order.** First a priority (SCR-005's Directive names
+  the levels, and is the only place that does), then the `area:*` tag — several when the work genuinely spans areas — then
   exactly one `use-model:*` tag (`cheap` / `balanced` / `pro` / `ultra`)
   naming the cheapest model class that can do the work without sacrificing
   quality, then the `pain:*` tags for the pains the issue relieves

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ python3 ./scripts/check-adr-numbering.py
 ./scripts/check-god-files.sh
 ./scripts/check-gate-parity.sh
 python3 ./scripts/check-guard-trigger-coverage.py
+python3 ./scripts/check-priority-scheme.py
 ./scripts/check-left-behind.sh
 ./scripts/check-role-names.sh
 ./scripts/check-stat-portability.sh
@@ -371,7 +372,8 @@ normal part of the loop here, not a rejection.
 - **[Bug report](https://github.com/macanderson/stella/issues/new?template=bug_report.yml)** — include `stella --version`, OS, provider/model, and a repro.
 - **[Feature request](https://github.com/macanderson/stella/issues/new?template=feature_request.yml)** — say what you're trying to do, not just what to add.
 
-Labels you'll see: `area:*` routes an issue to a crate; `P0`–`P2` is priority;
+Labels you'll see: `area:*` routes an issue to a crate; a `P` label is priority,
+and [SCR-005](docs/scr/SCR-005-triage-separation-of-duties.md) names the levels;
 `good first issue` and `help wanted` mean what they say; `needs-witness` means
 a PR is waiting on its witness test.
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
                     adr-numbering \
                     command-docs website-inputs brand-case file-size god-files gate-parity \
-                    guard-trigger-coverage left-behind \
+                    guard-trigger-coverage priority-scheme left-behind \
                     role-names stat-portability module-reachability core-reachability \
                     typed-errors \
                     tool-error-class \
@@ -750,6 +750,14 @@ guard-trigger-coverage: ## Assert prose/hue-separation/transcript-surfaces each 
 .PHONY: guard-trigger-coverage-test
 guard-trigger-coverage-test: ## Test the guard-trigger-coverage guard's failure directions (hermetic; not part of `gate`)
 	@python3 ./scripts/test-guard-trigger-coverage.py
+
+.PHONY: priority-scheme
+priority-scheme: ## Assert the issue priority scheme is stated once, in SCR-005 (#5216)
+	@python3 ./scripts/check-priority-scheme.py
+
+.PHONY: priority-scheme-test
+priority-scheme-test: ## Test the priority-scheme guard's failure directions (hermetic; not part of `gate`)
+	@python3 ./scripts/test-priority-scheme.py
 
 .PHONY: bench-suites
 bench-suites: ## Assert `make bench-test` runs every suite bench.yml runs, by derivation (#2847)

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -165,6 +165,7 @@ step_command() {
   light-clamp) echo 'check-light-clamp' ;;
   transcript-surfaces) echo 'check-transcript-surfaces' ;;
   guard-trigger-coverage) echo 'check-guard-trigger-coverage' ;;
+  priority-scheme) echo 'check-priority-scheme' ;;
   prose) echo 'check-prose' ;;
   line-citations) echo 'check-line-citations' ;;
   deck-paths) echo 'check-deck-paths' ;;

--- a/scripts/check-priority-scheme.py
+++ b/scripts/check-priority-scheme.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Guard: the issue priority scheme is written down once.
+
+`docs/scr/SCR-005-triage-separation-of-duties.md` is the home. Its Directive
+names the levels and what each one means. Everything else cites it.
+
+Four documents each named a scheme of their own and no two agreed: five levels
+in two of them, three in a third, and a hedge in the fourth about repositories
+that stop earlier. The regex in `.github/workflows/triage-guard.yml` is code,
+so a gap there has teeth. An issue labelled with a level the regex misses
+looks triaged to a person and unprioritised to the guard, which then never
+strips it from a login SCR-005 says may not set it. Making the copies agree
+fixes the day. Reading them fixes the shape.
+
+Two rules:
+
+1. The regex in the triage guard covers every level SCR-005 names, and no
+   more. It is the one derived copy, because a workflow cannot read a
+   document at the moment it runs.
+2. No other file in the tree states the scheme. A span from the first level
+   to the last one, or a character class over them, is a second copy waiting
+   to drift. Cite SCR-005 there instead.
+
+Run it with `make priority-scheme`. `scripts/test-priority-scheme.py` runs it
+against throwaway trees to show it can still fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SCR = "docs/scr/SCR-005-triage-separation-of-duties.md"
+WORKFLOW = ".github/workflows/triage-guard.yml"
+
+# Where the scheme is declared inside the SCR, and the token it declares each
+# level as.
+SCHEME_HEADING = "Priority scheme:"
+LEVEL = re.compile(r"`P(\d)`")
+
+# The two shapes that state a scheme rather than use one level of it. A
+# character class is how a regex spells the range; a span is how prose spells
+# it. "`P0` and `P2`" is neither, so a sentence naming two levels as examples
+# is left alone.
+CLASS = re.compile(r"P\[0-(\d)\]")
+SPAN = re.compile(r"`P\d`\s*(?:-|–|—|\.\.\.|…|to|through)\s*`P\d`")
+
+# Files worth reading. The rest of a checkout is build output, an image, or a
+# lockfile.
+SUFFIXES = (
+    ".md",
+    ".mdx",
+    ".rs",
+    ".py",
+    ".sh",
+    ".toml",
+    ".yml",
+    ".yaml",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".mjs",
+    ".json",
+)
+
+SKIP_DIRS = {".git", "target", "node_modules", ".next", "dist", "out", "vendor"}
+
+
+def scan_files(root: Path) -> list[Path]:
+    """Every text file under `root`, minus the directories nobody edits."""
+    found: list[Path] = []
+    stack = [root]
+    while stack:
+        for entry in sorted(stack.pop().iterdir()):
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                if entry.name not in SKIP_DIRS:
+                    stack.append(entry)
+            elif entry.suffix in SUFFIXES:
+                found.append(entry)
+    return found
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def declared_levels(text: str) -> tuple[list[int], str]:
+    """The levels SCR-005 declares, or no levels and the reason why not."""
+    start = text.find(SCHEME_HEADING)
+    if start < 0:
+        return [], f"{SCR} has no `{SCHEME_HEADING}` line"
+    # The declaration runs to the end of its paragraph, so a wrapped list is
+    # read whole.
+    end = text.find("\n\n", start)
+    block = text[start:] if end < 0 else text[start:end]
+    levels = [int(n) for n in LEVEL.findall(block)]
+    if not levels:
+        return [], f"{SCR} has a `{SCHEME_HEADING}` line with no levels under it"
+    if levels != list(range(len(levels))):
+        return [], (
+            f"{SCR} declares the levels {levels}, which do not run from 0 up "
+            "with no gaps"
+        )
+    return levels, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check the priority scheme.")
+    parser.add_argument(
+        "--manifest-dir",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="tree to check (default: this repository)",
+    )
+    args = parser.parse_args()
+    root = Path(args.manifest_dir).resolve()
+
+    report: list[str] = []
+
+    def note(line: str) -> None:
+        report.append(f"check-priority-scheme: {line}")
+
+    def verdict() -> int:
+        print("\n".join(report), file=sys.stderr)
+        return 1
+
+    scr = root / SCR
+    if not scr.is_file():
+        note(f"FAIL - {SCR} is missing, so nothing declares the scheme.")
+        return verdict()
+
+    levels, why = declared_levels(read(scr))
+    if not levels:
+        note(f"FAIL - {why}.")
+        note("     Write the scheme as one paragraph of `P0` `P1` ... tokens.")
+        return verdict()
+    top = levels[-1]
+
+    workflow = root / WORKFLOW
+    if not workflow.is_file():
+        note(f"FAIL - {WORKFLOW} is missing, so no guard holds the scheme.")
+        return verdict()
+
+    ceilings = CLASS.findall(read(workflow))
+    if not ceilings:
+        note(f"FAIL - {WORKFLOW} has no `P[0-N]` pattern in it.")
+        note(f"     It is the one copy of the scheme, and {SCR} says `P0`-`P{top}`.")
+        return verdict()
+    for ceiling in ceilings:
+        if int(ceiling) != top:
+            note(f"FAIL - {WORKFLOW} matches up to `P{ceiling}`.")
+            note(f"     {SCR} names {len(levels)} levels, up to `P{top}`.")
+            note("     A level the labels have and this regex does not is a")
+            note("     hole in both directions: the guard never strips it, and")
+            note("     an issue carrying only it reads as unprioritised.")
+            return verdict()
+
+    fail = False
+    for path in scan_files(root):
+        rel = path.relative_to(root).as_posix()
+        if rel == SCR:
+            continue
+        for number, line in enumerate(read(path).splitlines(), 1):
+            second_class = rel != WORKFLOW and CLASS.search(line)
+            if second_class or SPAN.search(line):
+                note(f"FAIL - {rel}:{number} states the priority scheme.")
+                note(f"     {line.strip()}")
+                fail = True
+
+    if fail:
+        note(f"     The scheme lives in {SCR}. {WORKFLOW} copies it, because")
+        note("     code cannot read a document as it runs. Every other mention")
+        note("     cites SCR-005 rather than naming the levels again.")
+        return verdict()
+
+    print(f"check-priority-scheme: ok - {len(levels)} levels, `P0` up to `P{top}`.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-priority-scheme.py
+++ b/scripts/test-priority-scheme.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Directions `scripts/check-priority-scheme.py` must fail in.
+
+Each case builds a throwaway tree under `--manifest-dir` and runs the real
+guard against it as a subprocess, the posture
+`scripts/test-guard-trigger-coverage.py` uses: nothing here reads or writes
+this repository. Not part of `make gate`; run it with
+`make priority-scheme-test`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+GUARD = HERE / "check-priority-scheme.py"
+
+SCR = "docs/scr/SCR-005-triage-separation-of-duties.md"
+WORKFLOW = ".github/workflows/triage-guard.yml"
+
+pass_count = 0
+fail_count = 0
+
+
+def scr_body(scheme: str) -> str:
+    return (
+        "---\nid: scr/005-triage-separation-of-duties\n---\n\n"
+        "## Directive\n\n"
+        "Issue creators may apply exactly one label.\n\n"
+        f"{scheme}\n"
+    )
+
+
+FOUR_LEVELS = (
+    "Priority scheme: `P0` drop everything - `P1` this cycle - `P2` next\n"
+    "cycle - `P3` backlog. Rule: every open issue carries one of them or\n"
+    "`triage`."
+)
+
+FIVE_LEVELS = (
+    "Priority scheme: `P0` drop everything - `P1` this cycle - `P2` next\n"
+    "cycle - `P3` backlog - `P4` someday. Rule: every open issue carries one\n"
+    "of them or `triage`."
+)
+
+
+def workflow_body(ceiling: int | None) -> str:
+    pattern = "/^P$/" if ceiling is None else f"/^P[0-{ceiling}]$/"
+    return (
+        "name: triage-guard\n"
+        "on:\n  issues:\n    types: [opened, labeled]\n"
+        "jobs:\n  guard:\n    runs-on: ubuntu-latest\n    steps:\n"
+        "      - uses: actions/github-script@v9\n"
+        "        with:\n"
+        "          script: |\n"
+        f"            const P = {pattern};\n"
+    )
+
+
+# The two shapes the guard rejects, built rather than typed. Typed out, each
+# would be a second copy of the scheme, and the guard would report this file.
+# It would be right to.
+def span_line(top: int) -> str:
+    return f"Priority runs `P0`-`P{top}`.\n"
+
+
+def class_line(top: int) -> str:
+    return f"const p = /^P[0-{top}]$/;\n"
+
+
+def fixture(name: str, files: dict[str, str]) -> Path:
+    root = Path(tempfile.mkdtemp(prefix=f"priority-scheme-{name}-"))
+    for rel, body in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return root
+
+
+def tree(scheme: str, ceiling: int | None, extra: dict[str, str] | None = None) -> dict:
+    files = {SCR: scr_body(scheme), WORKFLOW: workflow_body(ceiling)}
+    files.update(extra or {})
+    return files
+
+
+def expect(name: str, files: dict[str, str], want_rc: int, needle: str = "") -> None:
+    global pass_count, fail_count
+    root = fixture(name, files)
+    proc = subprocess.run(
+        [sys.executable, str(GUARD), "--manifest-dir", str(root)],
+        capture_output=True,
+        text=True,
+    )
+    out = proc.stdout + proc.stderr
+    if proc.returncode != want_rc:
+        print(f"FAIL  {name} -- exit {proc.returncode}, wanted {want_rc}")
+        print(f"      {out.strip()}")
+        fail_count += 1
+        return
+    if needle and needle not in out:
+        print(f"FAIL  {name} -- output never says {needle!r}")
+        print(f"      {out.strip()}")
+        fail_count += 1
+        return
+    print(f"ok    {name}")
+    pass_count += 1
+
+
+# C1 — the shape that must pass, or every case below proves nothing.
+expect("C1 a tree whose regex matches the scheme", tree(FIVE_LEVELS, 4), 0)
+
+# C2 — the defect this guard was written for: the label set and the SCR grow a
+# level and the regex does not.
+expect(
+    "C2 a regex one level short fails",
+    tree(FIVE_LEVELS, 3),
+    1,
+    "triage-guard.yml matches up to `P3`",
+)
+
+# C3 — the other way round. A regex may not match a level nobody declared: it
+# would strip a label that is not a priority.
+expect("C3 a regex one level long fails", tree(FOUR_LEVELS, 4), 1)
+
+# C4 — a second statement of the scheme is what drifts, whoever writes it.
+expect(
+    "C4 a second file stating the scheme fails",
+    tree(FIVE_LEVELS, 4, {"HANDBOOK.md": span_line(4)}),
+    1,
+    "HANDBOOK.md:1 states the priority scheme",
+)
+
+# C5 — the same, spelled as a regex rather than as prose.
+expect(
+    "C5 a second character class fails",
+    tree(FIVE_LEVELS, 4, {"tools/rank.js": class_line(4)}),
+    1,
+    "tools/rank.js:1 states the priority scheme",
+)
+
+# C6 — naming two levels as examples is a use of the scheme, not a copy of it.
+# A guard that cannot tell them apart gets switched off.
+expect(
+    "C6 a sentence naming two levels passes",
+    tree(FIVE_LEVELS, 4, {"docs/queue.md": "Choosing `P0` and `P2` takes\n"}),
+    0,
+)
+
+# C7 — with no declaration there is nothing to hold the regex to, and silence
+# must not read as agreement.
+expect(
+    "C7 an SCR with no scheme line fails",
+    tree("The triage agent sizes the work.", 4),
+    1,
+    "no `Priority scheme:` line",
+)
+
+# C8 — a gap in the levels means the guard read something that is not a
+# scheme, and its ceiling would be a guess.
+expect(
+    "C8 levels with a gap fail",
+    tree("Priority scheme: `P0` now - `P1` soon - `P3` later.", 3),
+    1,
+    "do not run from 0 up",
+)
+
+# C9 — the two files the guard reads are the two it cannot do without.
+expect("C9 a missing SCR fails", {WORKFLOW: workflow_body(4)}, 1, "is missing")
+expect("C10 a missing workflow fails", {SCR: scr_body(FIVE_LEVELS)}, 1, "is missing")
+expect(
+    "C11 a workflow with no pattern fails",
+    tree(FIVE_LEVELS, None),
+    1,
+    "has no `P[0-N]` pattern",
+)
+
+print(f"\n{pass_count} passed, {fail_count} failed")
+sys.exit(1 if fail_count else 0)


### PR DESCRIPTION
## What

SCR-005's Directive is the only place the issue priority scheme is written
down. Every other mention cites it, and a new gate step keeps it that way.

Four documents and one workflow regex each named a scheme, and no two agreed:

| Source | Said |
| --- | --- |
| `CLAUDE.md` | five levels |
| `AGENTS.md` | five levels |
| `CONTRIBUTING.md` | three levels |
| `.stella/commands/triage-sweep.{md,toml}` | five, hedged with "some repos stop" earlier |
| `.github/workflows/triage-guard.yml` | five, since #5246 |

#5246 made the copies it knew about agree. That fixed the day, not the shape,
and it found two of the five copies. All five now cite SCR-005 instead of
restating it.

## Why a guard

The regex is code, and it is the one copy that cannot be a citation — a
workflow cannot read a document at the moment it runs. That copy is where the
defect had teeth: an issue carrying only a level the regex missed read as
triaged to a person and as unprioritised to the guard, which then never
stripped it from a login SCR-005 says may not set it.

`scripts/check-priority-scheme.py` (gate step `priority-scheme`, in
`GATE_GUARDS_FAST`) reads the levels out of SCR-005 and then:

1. holds the triage guard's regex to exactly those levels, in both directions;
2. fails on any other file in the tree that states a scheme — a span from the
   first level to the last, or a character class over them.

Rule 2 is what makes "stated in one place" a property rather than a promise.
It is deliberately narrow: a sentence naming two levels as examples is a use,
not a copy, and a list of label names an operator ranks by (the self-driving
ladder) is a policy, not a statement of the scheme. Case C6 pins the first;
the second is #5927.

**SCR-005 itself is not edited**, so this adds no new drift to the org corpus
on top of #5246's.

## Witness mechanism

`scripts/test-priority-scheme.py` builds a throwaway tree per case and runs the
real guard against it as a subprocess — the posture
`scripts/test-guard-trigger-coverage.py` uses, which is the exemplar for both
files. Eleven cases, and every one of them fails on the old code by
construction: there is no `scripts/check-priority-scheme.py` on `main` to run.

The two that matter beyond "it can fail at all":

- **C2** — a regex one level short of the SCR fails. That is this issue's
  defect, reproduced.
- **C6** — a document naming two levels as examples passes. A guard that
  cannot tell a use from a copy gets switched off, and then it guards nothing.

Run locally: `make priority-scheme` (green on this tree) and
`make priority-scheme-test` (11 passed, 0 failed). `./scripts/check-gate-parity.sh`
is green with the new step in `GATE_STEPS`, AGENTS.md, CONTRIBUTING.md's fence
and two workflows; `python3 scripts/check-prose.py` and
`python3 scripts/check-doc-links.py check` are green. No cargo ran on this
machine — CI is the compiler here.

## Where it runs

`ci.yml`'s guards job and `docs-guards.yml` both run the guard: the home and
every former copy are markdown, which is the diff `ci.yml`'s job is skipped
for. `guard-self-tests.yml` runs the self-test, so the guard's ability to fail
is checked server-side rather than only when someone types the target.

## Definition of done

- [x] One scheme, stated in one place, with the other two citing it — SCR-005
      is the home; `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md` and both
      spellings of `/triage-sweep` cite it
- [x] The guard's regex matches the scheme exactly — checked by the new gate
      step, in both directions (C2, C3)
- [x] Every open issue carrying a label outside the scheme is re-scored — the
      scheme covers every label that exists, so this is vacuous, as #5246 said
- [x] Nothing else in the tree can state a second scheme without failing the
      gate — rule 2, witnessed by C4 and C5

Tests deleted: None.

#5216's checklist is fully ticked, with the evidence for each box named in a
comment there.

Residue filed:

- #5926 — SCR-005's copies in the four other org repos still say four levels.
  Cross-repo, so it cannot be shown done from here; split out of this issue's
  checklist with a comment saying why.
- #5927 — the self-driving loop's default ladder stops one level short, so an
  issue on the lowest level reads to the loop as one nobody has judged.

Closes #5216
Refs #5926
