### PR TITLE
fix(scripts): stop check-rebase-replay reading an upstream move as an undo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,20 @@ guards job checks out at `fetch-depth: 2` — right for `check-deleted-tests.sh`
 which compares two trees, and useless for a question about every commit on a
 branch.
 
+**A path can also leave the net diff without anyone undoing anything**, and the
+guard tells the two apart by asking who removed it. When an upstream commit
+moves or deletes a path and the branch absorbs that through a merge, the path is
+absent from the base as well, so no upstream copy exists for a replayed undo to
+revert and the branch's old commit would conflict rather than apply in silence.
+`upstream_removed` clears exactly that case and the run says which paths it
+cleared. Absence at both ends is not the test on its own: a file created and
+then deleted inside the branch is absent at both ends too, and it is the hazard
+— what separates them is a deletion in the branch's own non-merge history
+(`test-rebase-replay.sh`'s R4 against R9, with R10 holding the pair together so
+the skip stays per-path). This is not a corner: the extraction that moved three
+module trees out of `stella-core` fired the guard on two open branches the same
+morning, each time prescribing a history rewrite that would have bought nothing.
+
 **A partition can also split something atomic**, which per-pull-request CI does
 catch — each branch fails on its own — but only after the plan is already
 wrong. `crates/stella-serve/src/accept.rs` and

--- a/scripts/check-rebase-replay.sh
+++ b/scripts/check-rebase-replay.sh
@@ -165,9 +165,44 @@ if [ -z "$suspects" ]; then
   exit 0
 fi
 
+# A path can drop out of the net diff for two reasons. One is the hazard.
+#
+#   1. The branch edited the path and undid it. A rebase drops the edit as
+#      already applied and keeps the undo. That is the hazard above.
+#   2. The base does not have the path. Some commit upstream moved or deleted
+#      it, and the branch took that in through a merge. So no copy is left to
+#      revert, and the old commit conflicts instead of applying.
+#
+# Case 2 fires on any branch that edited a path a crate move relocated. Moving
+# three module trees out of `stella-core` tripped it on two branches in one
+# morning. The remedy it prints is a history rewrite that buys nothing.
+#
+# Absence at both ends does not tell the two apart. A file added and then
+# dropped inside the branch is absent at both ends too, and it IS the hazard:
+# rebase onto an upstream that added the same path, and the branch's delete is
+# what lives (R4 in scripts/test-rebase-replay.sh). What tells them apart is
+# who removed the path. A delete in the branch's own non-merge history is the
+# branch undoing its work. No such commit means the merge did it, so the base
+# did, not this branch.
+upstream_removed() {
+  local path="$1"
+  # Present at either end: an upstream copy can exist to be reverted.
+  if git_c cat-file -e "$base:$path" 2>/dev/null; then return 1; fi
+  if git_c cat-file -e "$head:$path" 2>/dev/null; then return 1; fi
+  if [ -n "$(git_c log --no-merges --diff-filter=D --format=%h "$base..$head" -- "$path")" ]; then
+    return 1
+  fi
+  return 0
+}
+
 found=0
+removed_upstream=0
 while IFS= read -r path; do
   [ -n "$path" ] || continue
+  if upstream_removed "$path"; then
+    removed_upstream=$((removed_upstream + 1))
+    continue
+  fi
   found=$((found + 1))
   note ""
   note "  $path"
@@ -183,6 +218,17 @@ COMMITS
 done <<EOF
 $suspects
 EOF
+
+# Every suspect turned out to be case 2. Say so rather than printing the bare
+# OK line the no-suspects path prints: a reader who arrived from a red run on
+# an earlier head needs to see that the paths were considered and why they were
+# cleared, not a green line that looks like the guard never saw them.
+if [ "$found" -eq 0 ]; then
+  echo "check-rebase-replay: OK — $removed_upstream path(s) left the branch's diff because the base"
+  echo "check-rebase-replay:      moved or deleted them, not because this branch undid an edit."
+  echo "check-rebase-replay:      No upstream copy exists for a rebase to revert."
+  exit 0
+fi
 
 report="check-rebase-replay: FAIL — $found path(s) edited and then undone inside this branch."$'\n'"$report"
 note ""

--- a/scripts/test-rebase-replay.sh
+++ b/scripts/test-rebase-replay.sh
@@ -208,6 +208,47 @@ git -C "$r" commit -qam "edit f"
 want "R8 an absent base ref is a failure naming the shallow checkout" \
   expect-fail "$r" origin/nonexistent "fetch-depth"
 
+# ── 9. A path the base moved out from under the branch ───────────────────────
+#
+# The branch edits a file. Upstream moves it. The branch merges that and
+# re-lands the work at the new path. The old path is absent at both ends, so
+# it lands in `suspects`. But no copy is left to revert, and the old commit
+# would conflict on rebase instead of applying in silence.
+#
+# Real, not made up: moving three module trees out of `stella-core` fired this
+# on two open branches in one morning. The fix it printed was a history
+# rewrite that would have bought nothing.
+r="$(new_repo moved_upstream)"
+mkdir -p "$r/old"
+printf 'alpha\n' >"$r/old/mod.rs"
+git -C "$r" add old/mod.rs
+git -C "$r" commit -qm "add old/mod.rs"
+git -C "$r" checkout -q -b b
+printf 'beta\n' >"$r/old/mod.rs"
+git -C "$r" commit -qam "edit old/mod.rs"
+git -C "$r" checkout -q main
+mkdir -p "$r/new"
+git -C "$r" mv old/mod.rs new/mod.rs
+git -C "$r" commit -qm "move the module upstream"
+git -C "$r" checkout -q b
+git -C "$r" merge -q --no-edit main >/dev/null 2>&1
+want "R9 a path the base moved away is not read as an undo" \
+  expect-pass "$r" main "moved or deleted them"
+
+# ── 10. The skip is per path, not a waiver ───────────────────────────────────
+#
+# The R9 branch plus a real pair (R4's shape: added and dropped inside the
+# branch, so absent at both ends too). A blanket "absent at both ends is fine"
+# was the first fix proposed. Measured against R4 it fails: this branch would
+# read green and the real hazard would ship.
+printf 'new\n' >"$r/g.txt"
+git -C "$r" add g.txt
+git -C "$r" commit -qm "add g"
+git -C "$r" rm -q g.txt
+git -C "$r" commit -qm "drop g again"
+want "R10 a real pair beside a moved path is still flagged" \
+  expect-fail "$r" main "g.txt"
+
 echo
 echo "passed ${pass}, failed ${fail}"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What &amp; why

A path leaves the branch's net diff for two reasons, and `check-rebase-replay.sh` treated both as the hazard.

1. **The branch edited the path and undid it.** A rebase drops the edit as already applied and keeps the undo — the #4979 hazard the guard exists for.
2. **The base does not carry the path.** An upstream commit moved or deleted it and the branch took that in through a merge. No copy is left upstream for a replayed undo to revert, and the old commit conflicts on rebase rather than applying in silence.

Case 2 is a false positive whose prescribed remedy is a history rewrite that buys nothing. Moving three module trees out of `stella-core` fired it on **two open branches in one morning** (#5840 and #5894), and it scales with (files moved) × (branches touching them) — this repository does crate extractions deliberately, with more queued under the re-layering epic.

`upstream_removed` clears that case. The run names the paths it cleared instead of printing the bare OK line: a reader arriving from a red run on an earlier head needs to see that the paths were considered.

Closes #5910

### The condition is narrower than the issue proposed — deliberately

#5910 proposed skipping a suspect **absent at both `$base` and `$head`**. Measured against the existing suite, that waives **R4**, which is a real hazard with exactly that signature: a file added and then dropped inside the branch is absent at both ends too, and rebasing onto an upstream that added the same path leaves the branch's delete as the survivor.

What separates the cases is *who removed the path*. A delete in the branch's own non-merge history is the branch undoing its work; no such commit means the merge did it, so the base did. The implemented condition is absent-at-both-ends **and** no non-merge deletion on the branch.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

**R9** builds the upstream-move shape (branch edits a file → upstream moves it → branch merges and re-lands at the new path) and expects OK.

```
old script, new suite:   passed 12, failed 1   ← FAIL R9 ... expected OK
new script, new suite:   passed 13, failed 0
```

**R10** puts a genuine pair on that same branch and still expects a failure, so the skip cannot degrade into a blanket waiver. **R4** is untouched and still red under both scripts.

Against the live instances, run at `origin/main`:

| | PR #5894 head | PR #5840 head |
|---|---|---|
| old guard | exit 1 (the red in CI today) | exit 1 |
| new guard | **exit 0** | **exit 0** |

No history rewrite on either branch.

## The gate

- [x] `bash -n` clean on both scripts; `scripts/test-rebase-replay.sh` 13/13
- [x] `check-prose` OK — **removes 4 grandfathered constructions** (17156 → 17152); the reading-grade and issue-reference ratchets both hold
- [x] `check-line-citations`, `check-file-size`, `check-left-behind`, `check-invariants` all exit 0
- [x] Docs updated — AGENTS.md § `rebase-replay.yml` gains the two reasons a net diff can be empty and why absence at both ends is not the test
- [x] `Closes #5910` appears above **and** as a commit trailer
- [ ] **`shellcheck` is not installed in this environment, so that gate step did not run here.** It is left to CI rather than reported as passing.

No Rust changed, so `cargo fmt` / `clippy` / `test` are not implicated by this diff; CI is the authority regardless.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

Both live instances (#5840, #5894) are cleared by this change rather than deferred.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The correction to #5910's proposed condition is the part worth a second pair of eyes — the issue's own DoD says "skips a suspect absent at both ends", and this implements something stricter on purpose. If R4's hazard is judged not worth preserving, the simpler condition is a one-line change, but I read R4 as a genuine rebase hazard and kept it.

Tests deleted: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCzBgbB8RU7FBcTJgoh5ZD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCzBgbB8RU7FBcTJgoh5ZD)_

## Summary by Sourcery

Distinguish upstream path removals from genuine branch undo operations in the rebase-replay check while preserving protection against real rebase hazards.

Bug Fixes:
- Prevent `check-rebase-replay.sh` from flagging paths removed upstream as branch edits that were undone.
- Continue detecting genuine edit-and-undo hazards, including paths absent at both branch endpoints.

Enhancements:
- Report which paths were cleared as upstream removals instead of emitting an ambiguous success message.

Documentation:
- Document how upstream removals differ from branch undo operations in the rebase-replay guard.

Tests:
- Add regression coverage for upstream path moves and for retaining failures when genuine undo hazards occur alongside them.