### PR TITLE
fix(deps): bump the stella-learn lock entry to 0.9.330

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,7 +3383,7 @@ version = "0.9.330"
 
 [[package]]
 name = "stella-learn"
-version = "0.9.329"
+version = "0.9.330"
 dependencies = [
  "proptest",
  "serde",


### PR DESCRIPTION
## What & why

`main` does not resolve against its own manifests. `Cargo.lock` lists
`stella-learn` at `0.9.329`; `crates/stella-learn/Cargo.toml` reads `0.9.330`,
like every other member. `cargo metadata --locked` fails on the tip, and so
does every `--locked` build — `install.sh` and the MSRV job included.

Two merges that were each correct wrote the same shared cell. #5899
(`87cc0d84e`) added the crate at `0.9.329`, the version `main` carried then.
#5915 (`ab787bed4`) synced every version to `0.9.330` from a branch cut before
that crate existed, so it moved every entry it knew about and left this one
behind. Neither tree was wrong, which is why no pre-merge check saw it — the
`Cargo.lock` shared-cell break AGENTS.md names.

One line changes.

Closes #5939

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`./scripts/check-lockfile-sync.sh` is the witness, and it is already a gate
step. Re-verified on a detached worktree at `origin/main` (`61725da`), applying
only this branch's `Cargo.lock`:

```
=== BEFORE (origin/main tree) ===
check-lockfile-sync: FAIL — Cargo.lock is out of sync with the manifests.
=== AFTER (this branch's lock) ===
check-lockfile-sync: OK — Cargo.lock resolves against the manifests.
```

Fail on the old tree, pass on the new, by the check the repository already
runs. It passes because the whole lock resolves — the check asks cargo, which
answers for every member, not just the line that was patched. No new test is
warranted for a lock entry.

## The gate

- [x] `./scripts/check-lockfile-sync.sh` — green.
- [x] `make guards-fast` — green.
- [x] `cargo check on the declared MSRV` — green in CI (a `--locked` build, so
      it exercises the repaired lock directly).
- [ ] Clippy and the workspace suite — CI's job.
- [x] `Closes #5939` appears as a bare line above **and** as a commit trailer.

Tests deleted: None.

## Definition of done

#5939's checklist is settled: the entry reads `0.9.330`, and the sync check
passes here and in CI.

## Nothing left behind

- [x] Nothing new. The composition hazard itself is already documented in
      AGENTS.md and watched by `main-canary.yml`.

## Ground-rule check

- [x] No new dependencies; no version change to any crate; only the lock entry
      that was left behind.

## Summary by Sourcery

Bug Fixes:
- Synchronize the Cargo.lock stella-learn entry with the workspace manifest at version 0.9.330 so locked metadata and builds succeed.