### PR TITLE
fix(workspace): move the lock entry for stella-learn to 0.9.330

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,7 +3383,7 @@ version = "0.9.330"
 
 [[package]]
 name = "stella-learn"
-version = "0.9.329"
+version = "0.9.330"
 dependencies = [
  "proptest",
  "serde",


### PR DESCRIPTION
`main` is red because `Cargo.lock` records `stella-learn` at `0.9.329` while every manifest is at `0.9.330`: the release sync (#5915) was cut before the crate landed (#5899), so its lock entry stayed behind. `cargo metadata --locked` refused the tree and every open PR inherited the red.

One line: the lock entry moves to `0.9.330`. `./scripts/check-lockfile-sync.sh` reports OK on this branch (it compiles nothing).

No witness test: this is a lockfile repair, and `lockfile-sync` is the gate that judges it.

Tests deleted: None

Closes #5939

## Summary by Sourcery

Bug Fixes:
- Update the Cargo.lock entry for stella-learn to version 0.9.330 so locked dependency metadata matches the workspace manifests.