### PR TITLE
fix(build): bump Cargo.lock's stella-learn entry to 0.9.330

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,7 +3383,7 @@ version = "0.9.330"
 
 [[package]]
 name = "stella-learn"
-version = "0.9.329"
+version = "0.9.330"
 dependencies = [
  "proptest",
  "serde",


### PR DESCRIPTION
## What

Bumps `Cargo.lock`'s `stella-learn` entry from `0.9.329` to `0.9.330`, matching every other workspace member.

## Why — main-red repair

This is a shared-cell composition break, the exact shape AGENTS.md's `Cargo.lock` gotcha describes: #5899 (`87cc0d84e`) added the `stella-learn` crate at `0.9.329`, the version `main` carried at the time; #5915 (`ab787bed4`), the `0.9.330` release sync, moved every member's version and lock entry it knew about — but it was cut before `stella-learn` existed, so that one entry stayed behind. Neither branch was wrong on its own, which is why no pre-merge check caught it. `install.sh` and the MSRV job both build with `--locked`, so every one of those has failed against `main`'s tip since.

Filed by the post-merge canary as #5939 (`main-red` label). Checked `./scripts/main-red-claim.sh check` before starting (unclaimed) and claimed it before pushing.

## Witness

```
./scripts/check-lockfile-sync.sh   # FAIL before this commit, OK after
```
Confirmed locally: `check-lockfile-sync: FAIL — Cargo.lock is out of sync with the manifests` on the unfixed tree, `check-lockfile-sync: OK — Cargo.lock resolves against the manifests` after the one-line bump. No other member is out of step — `cargo metadata --locked` resolves clean.

No code changes beyond `Cargo.lock`, so no other DoD items (god-file, prose, docs) apply — this is a generated-file fix.

Closes #5939

## Summary by Sourcery

Bug Fixes:
- Synchronize Cargo.lock's stella-learn version with the workspace's 0.9.330 release to restore locked builds and lockfile validation.