### PR TITLE
feat(stella-cli): record a driver session's plugin, refusals, and ending

### DIFF
--- a/crates/stella-cli/src/driver_plugin.rs
+++ b/crates/stella-cli/src/driver_plugin.rs
@@ -37,6 +37,12 @@
 //! [`DriveNext::Sleep`] is #3599's B2 `LoopStep` machine, and inventing a
 //! sleeper here would be inventing the loop this channel exists to be driven
 //! by.
+//!
+//! # Where a session goes once it ends
+//!
+//! `plugin_cmd::drive` reads [`BoundDriver::refusals`] and the session's own
+//! result and hands both to [`session_log::record`], so a session survives
+//! its own terminal.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -48,6 +54,8 @@ use stella_runtime::wrapper::{
 };
 
 use crate::plugin_cmd::roster::PluginRoster;
+
+pub(crate) mod session_log;
 
 /// An installed driver, bound to the process the host will start.
 ///

--- a/crates/stella-cli/src/driver_plugin/session_log.rs
+++ b/crates/stella-cli/src/driver_plugin/session_log.rs
@@ -29,7 +29,7 @@
 //! If the record fails to write, that failure is reported. The session
 //! still counts as done. An operator has already seen the outcome on
 //! screen, so a disk error should not take it away. See
-//! [`crate::self_driving_cmd::audit`]'s own docs for the same rule.
+//! `self_driving_cmd::audit`'s own docs for the same rule.
 
 use std::path::Path;
 
@@ -86,7 +86,7 @@ impl DriverSessionOutcome {
 /// One driver session, as a fact on disk.
 ///
 /// Serde-first, so a test checks a value instead of parsing a sentence —
-/// the same rule [`crate::self_driving_cmd::audit::AuditEntry`] follows.
+/// the same rule `self_driving_cmd::audit::AuditEntry` follows.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct DriverSessionRecord {
     /// When the session was opened, RFC3339 UTC.

--- a/crates/stella-cli/src/driver_plugin/session_log.rs
+++ b/crates/stella-cli/src/driver_plugin/session_log.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where a driver session's record goes.
+//!
+//! `stella plugin drive` opens one session and serves whatever the grant
+//! allows. Before this module, it printed the outcome and threw it away.
+//! The session id, every refused ask, and how the session ended were all
+//! gone once the terminal scrolled.
+//!
+//! # Which ledger, and why not the other two
+//!
+//! The issue named three options. The self-driving audit ledger needs a
+//! `LoopState`. `stella plugin drive` is a bare CLI verb, not a
+//! self-driving loop, so it has no reason to open one. A `store.db` row
+//! would need a schema change for three fields nothing reads yet. An
+//! `AgentEvent` case needs a declared reader, and a driver session has
+//! none today.
+//!
+//! So this module is the fourth answer. It appends one line of JSON per
+//! session to `.stella/private/driver-sessions.jsonl`, through
+//! [`stella_store::append_workspace_private_line`] — the same primitive
+//! [`crate::memory::self_tuning`]'s own ledger uses. The file is
+//! workspace-private and stays out of git, like every other file under
+//! `.stella/private/`.
+//!
+//! # A write failure never fails the session
+//!
+//! If the record fails to write, that failure is reported. The session
+//! still counts as done. An operator has already seen the outcome on
+//! screen, so a disk error should not take it away. See
+//! [`crate::self_driving_cmd::audit`]'s own docs for the same rule.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use stella_plugin::DriveNext;
+
+/// The file every session's record is appended to, under
+/// `.stella/private/`.
+const LOG_NAME: &str = "driver-sessions.jsonl";
+
+/// How a driver session ended, as the record holds it.
+///
+/// Mirrors [`DriveNext`], plus one case it cannot hold: a session whose
+/// transport, process, or timeout failed before a `next` came back. A
+/// separate type, because a plugin-facing wire type should not also carry
+/// a host-only failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum DriverSessionOutcome {
+    /// The driver asked to be woken again after this many seconds.
+    Sleep {
+        /// The clamped duration the driver asked for.
+        secs: u32,
+    },
+    /// The driver stopped, and said why.
+    Halt {
+        /// The sentence a human reads in the record.
+        reason: String,
+    },
+    /// The session never ended: a transport failure, a spawn failure, or
+    /// a timeout.
+    Error {
+        /// [`BoundDriver::open`](super::BoundDriver::open)'s own message,
+        /// which already names the program.
+        message: String,
+    },
+}
+
+impl DriverSessionOutcome {
+    /// What a session's own result reads as, for the record.
+    pub(crate) fn from_result(result: &Result<DriveNext, String>) -> Self {
+        match result {
+            Ok(DriveNext::Sleep { secs }) => Self::Sleep { secs: *secs },
+            Ok(DriveNext::Halt { reason }) => Self::Halt {
+                reason: reason.clone(),
+            },
+            Err(error) => Self::Error {
+                message: error.clone(),
+            },
+        }
+    }
+}
+
+/// One driver session, as a fact on disk.
+///
+/// Serde-first, so a test checks a value instead of parsing a sentence —
+/// the same rule [`crate::self_driving_cmd::audit::AuditEntry`] follows.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DriverSessionRecord {
+    /// When the session was opened, RFC3339 UTC.
+    pub at: String,
+    /// The installed plugin's manifest name.
+    pub plugin: String,
+    /// The id `plugin_cmd::session_id` made and sent to the driver. This
+    /// record and the driver's own logs join on it.
+    pub session_id: String,
+    /// The program the host resolved and started.
+    pub program: String,
+    /// Every ask this session could not serve, in order —
+    /// [`DriverCallGate::refusals`](stella_runtime::wrapper::DriverCallGate::refusals)'s
+    /// own words.
+    pub refusals: Vec<String>,
+    /// How the session ended.
+    pub outcome: DriverSessionOutcome,
+}
+
+/// Append one session's record.
+///
+/// # Errors
+///
+/// A message naming what failed: the record could not be built, or the
+/// append itself failed. Never fatal to the session that produced it —
+/// see this module's docs.
+pub(crate) fn record(workspace_root: &Path, entry: &DriverSessionRecord) -> Result<(), String> {
+    let line = serde_json::to_string(entry)
+        .map_err(|error| format!("could not build this driver session's record: {error}"))?;
+    stella_store::append_workspace_private_line(workspace_root, LOG_NAME, &line)
+        .map(|_| ())
+        .map_err(|error| format!("could not record this driver session: {error}"))
+}
+
+/// Read every session record that parses (bad lines skipped), oldest
+/// first.
+///
+/// The read side of [`record`]. A record nothing reads back is a write
+/// nobody can check.
+#[cfg(test)]
+pub(crate) fn read_sessions(workspace_root: &Path) -> Vec<DriverSessionRecord> {
+    let Ok(path) = stella_store::workspace_private_state_path(workspace_root, LOG_NAME) else {
+        return Vec::new();
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<DriverSessionRecord>(line).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(label: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "stella-driver-session-log-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp root");
+        root
+    }
+
+    /// Every field comes back the same. The outcome is a tagged word, not
+    /// a sentence a reader has to parse.
+    #[test]
+    fn a_record_round_trips_through_json() {
+        let entry = DriverSessionRecord {
+            at: "2026-09-02T21:00:00Z".into(),
+            plugin: "watcher".into(),
+            session_id: "drive-1-abcd".into(),
+            program: "/opt/pkgs/watcher/drive.sh".into(),
+            refusals: vec!["backlog_next: unsupported".into()],
+            outcome: DriverSessionOutcome::Sleep { secs: 30 },
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        let back: DriverSessionRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(entry, back);
+        assert!(json.contains(r#""kind":"sleep""#), "{json}");
+        assert!(json.contains(r#""plugin":"watcher""#), "{json}");
+    }
+
+    /// Every ending a driver can send, plus the host's own failure path,
+    /// maps to the outcome the record holds.
+    #[test]
+    fn every_ending_converts_to_an_outcome() {
+        assert_eq!(
+            DriverSessionOutcome::from_result(&Ok(DriveNext::Sleep { secs: 5 })),
+            DriverSessionOutcome::Sleep { secs: 5 }
+        );
+        assert_eq!(
+            DriverSessionOutcome::from_result(&Ok(DriveNext::Halt {
+                reason: "budget spent".into()
+            })),
+            DriverSessionOutcome::Halt {
+                reason: "budget spent".into()
+            }
+        );
+        assert_eq!(
+            DriverSessionOutcome::from_result(&Err("could not start driver: enoent".into())),
+            DriverSessionOutcome::Error {
+                message: "could not start driver: enoent".into()
+            }
+        );
+    }
+
+    /// **The witness.** Before this module, nothing wrote a driver
+    /// session down anywhere. `record` is the first writer, and
+    /// `read_sessions` reads back exactly what it wrote.
+    #[test]
+    fn a_recorded_session_reads_back() {
+        let root = temp_root("roundtrip");
+        assert!(
+            read_sessions(&root).is_empty(),
+            "nothing recorded before the first append"
+        );
+
+        let entry = DriverSessionRecord {
+            at: "2026-09-02T21:00:00Z".into(),
+            plugin: "watcher".into(),
+            session_id: "drive-1-abcd".into(),
+            program: "/opt/pkgs/watcher/drive.sh".into(),
+            refusals: Vec::new(),
+            outcome: DriverSessionOutcome::Halt {
+                reason: "operator stop".into(),
+            },
+        };
+        record(&root, &entry).expect("append must succeed");
+
+        let sessions = read_sessions(&root);
+        assert_eq!(sessions, vec![entry]);
+    }
+
+    /// One bad line does not lose the rest of the file — the same rule
+    /// `self_tuning::read_ledger` gives its own log, for a file a crashed
+    /// process could half-write.
+    #[test]
+    fn a_bad_line_is_skipped_not_fatal() {
+        let root = temp_root("bad-line");
+        let good = DriverSessionRecord {
+            at: "2026-09-02T21:00:00Z".into(),
+            plugin: "watcher".into(),
+            session_id: "drive-2-efgh".into(),
+            program: "/opt/pkgs/watcher/drive.sh".into(),
+            refusals: Vec::new(),
+            outcome: DriverSessionOutcome::Sleep { secs: 60 },
+        };
+        record(&root, &good).expect("first append must succeed");
+        stella_store::append_workspace_private_line(&root, LOG_NAME, "not json")
+            .expect("second append must succeed");
+
+        let sessions = read_sessions(&root);
+        assert_eq!(sessions, vec![good]);
+    }
+}

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -183,6 +183,8 @@ fn session_id() -> String {
 ///
 /// The session's identifier is minted here and echoed into the driver's own
 /// telemetry, so a driver's records and the host's can be joined afterwards.
+/// Before this returns, the plugin, the refusals, and the ending are all
+/// written down through [`crate::driver_plugin::session_log::record`].
 ///
 /// # Errors
 ///
@@ -193,7 +195,10 @@ fn drive(workspace_root: &Path, name: &str) -> Result<(), String> {
     let name = checked_name(name)?;
     let mut warn = |line: String| eprintln!("  ! {line}");
     let resolved = crate::driver_plugin::resolve(workspace_root, name, &mut warn)?;
-    println!("driver \"{name}\": starting `{}`", resolved.program());
+    // Saved now, before `serving()` consumes `resolved`: the record below
+    // needs it once the session has closed.
+    let program = resolved.program().to_string();
+    println!("driver \"{name}\": starting `{program}`");
 
     let session = session_id();
     let bound = resolved.serving();
@@ -209,12 +214,30 @@ fn drive(workspace_root: &Path, name: &str) -> Result<(), String> {
         );
     }
     let next = bound.open(&session);
+    let refusals = bound.refusals();
 
     // Printed whichever way the session ended. A driver that asked for a
     // capability and then failed is the case where the refusals matter most:
     // they are usually why it failed.
-    for refusal in bound.refusals() {
+    for refusal in &refusals {
         eprintln!("  ! {refusal}");
+    }
+
+    // Written down whichever way the session ended. A write that fails is
+    // reported, but never fails the session — the same rule
+    // `self_driving_cmd::audit` uses for its own ledger.
+    if let Err(error) = crate::driver_plugin::session_log::record(
+        workspace_root,
+        &crate::driver_plugin::session_log::DriverSessionRecord {
+            at: crate::timefmt::rfc3339_utc_now(),
+            plugin: name.to_string(),
+            session_id: session.clone(),
+            program,
+            refusals,
+            outcome: crate::driver_plugin::session_log::DriverSessionOutcome::from_result(&next),
+        },
+    ) {
+        eprintln!("  ! {error}");
     }
 
     match next? {

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1102,6 +1102,91 @@ fn list_names_a_drivers_program_and_the_credential_it_will_not_get() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// A driver plugin's manifest, minimal enough that `install`'s reconciliation
+/// against the package's own directory listing (`tools/`, `skills/`,
+/// `records/`) has nothing to check — a bare `[driver]` grant plus the
+/// process that will hold the session.
+fn driving_manifest_text(name: &str) -> String {
+    format!(
+        "name = \"{name}\"\n\n\
+         [driver]\ncalls = [\"backlog_next\"]\nmax_calls = 4\n\
+         [driver.process]\nargv = [\"${{plugin_dir}}/drive.sh\"]\ntimeout_secs = 5\n"
+    )
+}
+
+/// A driver plugin that can actually run. `stella plugin drive` starts
+/// `drive.sh`, which reads the request and answers with a fixed `sleep`.
+/// A plain shell script, not the `stella-runtime` fixture binary: that one
+/// belongs to another crate, so its `CARGO_BIN_EXE_*` is not visible here.
+#[cfg(unix)]
+fn driving_package(dir: &Path, name: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let source = dir.join(format!("src-{name}"));
+    std::fs::create_dir_all(&source).expect("fixture dir");
+    std::fs::write(
+        source.join(roster::MANIFEST_FILE),
+        driving_manifest_text(name),
+    )
+    .expect("fixture manifest");
+    let script = source.join("drive.sh");
+    std::fs::write(
+        &script,
+        "#!/bin/sh\n\
+         read -r _line\n\
+         printf '{\"point\":\"drive\",\"body\":{\"next\":{\"sleep\":{\"secs\":9}}}}\\n'\n",
+    )
+    .expect("fixture driver script");
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+        .expect("fixture script is executable");
+    source
+}
+
+/// **The witness.** Before this change, `stella plugin drive` printed a
+/// session's outcome and dropped it. Nothing named the plugin, the session
+/// id, or how it ended. This runs the real `drive` entrypoint against an
+/// installed fixture and reads the record back off disk — the same record
+/// a person finds months later, not a value the test happens to still
+/// hold in memory.
+#[cfg(unix)]
+#[test]
+fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() {
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT"]);
+    // SAFETY: the env lock above is held for the whole mutate-read-restore
+    // window, and `EnvRestore` puts the prior value back on drop.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+
+    let root = temp_root("drive-record");
+    let source = driving_package(&root, "watcher");
+    let settings = Settings::default();
+    install(&root, &source, PluginScope::Project, true, &settings).expect("install must succeed");
+
+    assert!(
+        crate::driver_plugin::session_log::read_sessions(&root).is_empty(),
+        "nothing recorded before any session ran"
+    );
+
+    drive(&root, "watcher").expect("a session that sleeps is not an error");
+
+    let sessions = crate::driver_plugin::session_log::read_sessions(&root);
+    assert_eq!(sessions.len(), 1, "{sessions:?}");
+    let entry = &sessions[0];
+    assert_eq!(entry.plugin, "watcher");
+    assert!(!entry.session_id.is_empty(), "{entry:?}");
+    assert!(entry.program.ends_with("drive.sh"), "{entry:?}");
+    assert!(
+        entry.refusals.is_empty(),
+        "the fixture never asks for a capability: {entry:?}"
+    );
+    assert_eq!(
+        entry.outcome,
+        crate::driver_plugin::session_log::DriverSessionOutcome::Sleep { secs: 9 }
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 // A plugin is a package: the tools, skills and records it ships (#3380). Those
 // tests live in `contributions.rs`, split out when this file crossed the
 // 1500-line ceiling (#4440).


### PR DESCRIPTION
## What & why

`stella plugin drive <name>` opened one driver session and printed the
outcome to stdout. Nothing durable named the plugin, the session id, every
refused ask, or how the session ended — once the terminal scrolled, those
three facts were gone (#5109).

Adds `driver_plugin::session_log`, which appends one JSON line per session
to `.stella/private/driver-sessions.jsonl` through
`stella_store::append_workspace_private_line` — the same crash-safe,
owner-only append primitive `memory::self_tuning`'s ledger already uses. A
write failure is reported and never fails the session, the rule
`self_driving_cmd::audit::record` states for its own ledger.

**The ledger choice** (posted as a design comment on the issue before this
landed, and restated in the module's own docs): a workspace-private JSONL
file, not the three candidates the issue named. The self-driving audit
ledger needs a `LoopState`, which `stella plugin drive` — a bare CLI verb,
not a self-driving loop — has no reason to open. A `store.db` row costs a
schema migration for three fields nothing reads yet. An `AgentEvent` case
needs a declared consumer (invariant #10,
`crates/stella-protocol/src/event/consumers.rs`) and a driver session has
none today.

Closes #5109

## The witness

Stella's definition of done is a test that **fails on the old code and
passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended`
(`crates/stella-cli/src/plugin_cmd/tests.rs`) installs a real driver plugin
— a `/bin/sh` fixture that speaks the driver wire protocol directly, since
`wrapper-plugin-fixture`'s `CARGO_BIN_EXE_*` belongs to `stella-runtime`
and is not visible to `stella-cli`'s own tests — runs `drive`, and reads
the record back off disk. It fails by construction on the old code:
`driver_plugin::session_log` did not exist, so there was nothing to read
back and the test would not compile.

`crates/stella-cli/src/driver_plugin/session_log.rs` also carries unit
tests for the record's round trip, the outcome mapping from every ending a
driver can send, and the read side's tolerance of a bad line.

Exemplar followed: `crates/stella-cli/src/memory/self_tuning.rs`'s
append-only ledger under `.stella/private/` — same primitive, same
non-fatal-write rule, same read-side-exists-because-a-write-with-no-reader-
is-pointless argument.

## The gate

- [x] `cargo fmt --check`
- [ ] Workspace clippy at `-D warnings` — CI's job
- [ ] Full workspace test suite — CI's job
- [x] Docs updated where behavior/flags changed (doc comments on
      `driver_plugin`, `plugin_cmd::drive`, and the new `session_log`
      module explain the record and the ledger choice)
- [ ] CLA signed (bot prompts on first PR)
- [x] `Closes #5109` appears both above and as a commit trailer

`make guards-fast` is green locally (fmt, prose, file-size, and the rest of
the toolchain-free gate). Per SCR-001, only crate-scoped, filtered test
runs were done locally, targeted at the new `driver_plugin::session_log`
unit tests and at the new witness test — both pass. The workspace-wide
clippy and test suite are CI's job, not this laptop's.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

(Note: `main` is currently red on `Cargo.lock` drift, tracked and already
under repair in #5939 by another session under this account — unrelated to
this change, and this branch does not touch `Cargo.lock`.)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification
      below — no new dependency; `stella_store::append_workspace_private_line`
      is an existing, already-used-elsewhere primitive
- [x] No new outbound network calls (Stella never phones home)
- [x] New cross-boundary types round-trip through serde (test included) —
      `DriverSessionRecord`/`DriverSessionOutcome` round-trip is covered by
      `a_record_round_trips_through_json` and `a_recorded_session_reads_back`

## Anything reviewers should know?

The issue offered three ledger candidates and asked that the choice be
settled before code. I posted the design decision as an issue comment
first (https://github.com/macanderson/stella/issues/5109#issuecomment-5551075850),
then implemented against it — a fourth option, not one of the three named.

## Summary by Sourcery

Record durable driver-session history without changing session execution semantics.

New Features:
- Persist each driver session as a workspace-private JSONL record containing its plugin, session identity, executable, refused requests, and ending outcome.
- Provide tolerant session-record serialization and readback support for inspecting stored driver sessions.

Enhancements:
- Keep session execution successful when recording fails while reporting persistence errors to the operator.

Documentation:
- Document the driver-session ledger and its workspace-private storage choice.

Tests:
- Add unit and end-to-end witness tests covering record round trips, session outcome mapping, malformed-line tolerance, and durable records from a real driver session.

## DoD verification by the PR sweep (appended 2026-09-05)

The `dod / dod` check went red at 10:49:30Z reading #5109's three unchecked
items. All three were ticked at 10:59:02Z, after that read — so the gate
failed on a stale snapshot, not on a gap. This edit is what re-fires
`dod-check.yml`; the edit is the trigger, never the fix.

Checked against this branch's head (`e2f56395`) rather than against the
description:

- **"A driver session leaves a durable record naming the plugin, the session
  id, every refused ask, and how it ended."** `DriverSessionRecord` in
  `crates/stella-cli/src/driver_plugin/session_log.rs` carries exactly those
  four, one field each: `plugin` (the manifest name), `session_id` (the id
  `plugin_cmd::session_id` minted and sent to the driver, so the two logs
  join on it), `refusals` (every ask the gate could not serve, in order) and
  `outcome`. Appended one JSON line per session to
  `.stella/private/driver-sessions.jsonl`.
- **"A witness test reads it back."** `a_recorded_session_reads_back` reads
  the appended line back into a value, and
  `plugin_cmd::tests::a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended`
  does it end to end through the real verb.
- **"The choice of ledger is written down where the next reader finds it."**
  That module's header carries a `# Which ledger, and why not the other two`
  section, rejecting the self-driving audit ledger (needs a `LoopState` a
  bare CLI verb has no reason to open), a `store.db` row (a schema change for
  three fields nothing reads yet) and an `AgentEvent` case (invariant #10
  wants a declared reader, and a driver session has none).

Ran `cargo test -p stella-cli --bin stella -- session_log a_driver_session_leaves`
on this head — 5 passed, 0 failed, all four `session_log` tests plus the
end-to-end one.


---
_Generated by [Claude Code](https://claude.ai/code)_