### PR TITLE
fix(gate): pair lint-schema with check, and stop doc-warnings-schema trusting a stale cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,15 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: python3 ./scripts/check-priority-scheme.py
 
+      # A `-schema` gate step and its base step have to agree on whether
+      # `check` (GATE=fast git push, and a hand-run `make check`) runs them,
+      # or the schema-gated crates can silently drop out of the rung most
+      # pushes actually use — which is how `lint` ran at `check` while
+      # `lint-schema` did not.
+      - name: a schema-tier gate step runs at the same rung as its base step
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-schema-tier-parity.sh
+
       # The five below were in `GATE_GUARDS_FAST` and in no workflow at all
       # (#4089). `gate-parity` above holds AGENTS.md and CONTRIBUTING.md to
       # `GATE_STEPS`, which is a question about the prose — it says nothing

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -203,6 +203,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-gate-parity.sh
 
+      - name: schema-tier-parity guard failure directions
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-schema-tier-parity.sh
+
       - name: guard-trigger-coverage guard failure directions
         if: ${{ !cancelled() }}
         run: python3 ./scripts/test-guard-trigger-coverage.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #     from that declaration)
                          #   + god-files
                          #   + gate-parity
+                         #   + schema-tier-parity (a -schema step runs at the
+                         #     same rung as its base step; #5139)
                          #   + guard-trigger-coverage (prose, hue-separation
                          #     and transcript-surfaces each run with no
                          #     paths: filter in at least one workflow)
@@ -434,8 +436,26 @@ Four rungs, each a superset of the one above:
 | --- | --- | --- |
 | `make guards-fast` | the toolchain-free guards + `lockfile-sync` + `fmt --check` — nothing compiles at all | — |
 | `make guards` | ...plus `wire-schema`, whose two schema exporters do compile | — |
-| `make check` | ...plus clippy | clippy |
-| `make gate` | ...plus rustdoc and the test suite | clippy, rustdoc, test |
+| `make check` | ...plus clippy — `lint` and `lint-schema`, both. No rustdoc at all | clippy |
+| `make gate` | ...plus rustdoc and the tests — `doc-warnings` and `doc-warnings-schema`, both | clippy, rustdoc, test |
+
+A `-schema` step and its base step move together across `check`. Both run
+there, or neither does. That rule went unwritten, and it broke: `lint` ran
+at `check`; `lint-schema` did not. So `GATE=fast git push`, and a hand-run
+`make check`, never reached the three `schema`-gated crates. A broken
+import there passed here and failed only in CI.
+`schema-tier-parity` (`scripts/check-schema-tier-parity.sh`) now holds every
+such pair to that rule. It reads `GATE_STEPS`/`CHECK_STEPS`, so a future pair
+that splits the same way fails here first, not in CI. `doc-warnings-schema`
+stays `gate`-only on purpose, paired with `doc-warnings`: at `check`, rustdoc
+never runs, for either feature set.
+
+`doc-warnings-schema` also wipes its own doc output before each run
+(`cargo clean --doc`, for the three schema crates only). `cargo doc`'s own
+freshness check can call a stale prior run "up to date" — and print nothing
+— even after the source changed. That let a broken doc link in
+`stella-plugin` pass a local `make doc-warnings-schema`, and show up only
+after a hand-run `rm -rf target/doc`.
 
 **Every rung needs `shellcheck` on `PATH`, and it is not vendored.** It is the
 gate's one external binary, so a machine or container image without it stops at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ python3 ./scripts/check-adr-numbering.py
 ./scripts/check-file-size.sh
 ./scripts/check-god-files.sh
 ./scripts/check-gate-parity.sh
+./scripts/check-schema-tier-parity.sh
 python3 ./scripts/check-guard-trigger-coverage.py
 python3 ./scripts/check-priority-scheme.py
 ./scripts/check-left-behind.sh

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
                     adr-numbering \
                     command-docs website-inputs brand-case file-size god-files gate-parity \
+                    schema-tier-parity \
                     guard-trigger-coverage priority-scheme left-behind \
                     role-names stat-portability module-reachability core-reachability \
                     typed-errors \
@@ -66,6 +67,16 @@ GATE_NO_BUILD := lockfile-sync format-check
 # added here and the prose kept the old count (#1437).
 GATE_STEPS := $(GATE_GUARDS) $(GATE_NO_BUILD) doc-warnings doc-warnings-schema \
                lint lint-schema test tool-docs self-driving-test
+
+# `check`'s own step list, named for the reason GATE_STEPS is: a guard that
+# re-parsed the `check:` target's prerequisites with a regex would be one more
+# hand-maintained copy of the thing it is guarding. `check` is `guards` plus
+# clippy — and clippy means BOTH feature configurations, `lint` and
+# `lint-schema`, or the schema-gated crates silently drop out of the rung
+# `GATE=fast git push` (and a hand-run `make check`) actually runs (#5139).
+# `doc-warnings`/`doc-warnings-schema` stay out on purpose: `check`'s contract
+# is "no rustdoc", for both feature configurations alike.
+CHECK_STEPS := $(GATE_GUARDS) $(GATE_NO_BUILD) lint lint-schema
 
 # The hermetic guard self-tests — `scripts/test-*.sh` — that deliberately run
 # in NO workflow, and why each one does not. Every other suite runs server-side
@@ -613,8 +624,24 @@ SCHEMA_FEATURES := stella-protocol/schema,stella-plugin/schema,stella-serve/sche
 # uncovered is exactly the modules the default run skips, and the feature is
 # additive, so this costs seconds. `--keep-going` for `doc-warnings`' reason —
 # one failing crate must not mask the ones behind it.
+# `cargo clean --doc` first: cargo's own freshness check for a `doc` unit can
+# mark it up to date — and print nothing — off a stale prior build even though
+# the source changed, which let a broken intra-doc link introduced by moving a
+# function between modules in `stella-plugin` survive a local
+# `make doc-warnings-schema` and reproduce only under a hand-run
+# `rm -rf target/doc` (#5139). `cargo clean --doc` is the package-scoped,
+# cargo-native version of that same fix: it drops the rustdoc output AND the
+# fingerprints cargo used to call the stale build fresh, for exactly the three
+# crates this recipe documents, so the two invocations below always run
+# rustdoc for real rather than trusting a cache that has already been wrong
+# once. Scoped to $(SCHEMA_CRATES) rather than the whole `target/doc` tree —
+# `doc-warnings` below has the same theoretical exposure, but cleaning its
+# workspace-wide output before every gate run would force a full rustdoc
+# rebuild every time, which is the "correct but slow" option #5139 weighed
+# against for a hole this recipe's own repro is what actually demonstrated.
 .PHONY: doc-warnings-schema
 doc-warnings-schema: ## Assert rustdoc is clean for the `schema`-gated wire-contract modules (#4584)
+	cargo clean --doc $(SCHEMA_CRATES)
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \
 	  --features $(SCHEMA_FEATURES) --no-deps --keep-going
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \
@@ -695,7 +722,9 @@ serve-image: ## Build the stella-serve image and smoke the container (needs Dock
 #   guards-fast  the toolchain-free guards + the lock resolve + rustfmt.
 #                Nothing compiles at all.
 #   guards       ...plus wire-schema, whose two schema exporters do compile.
-#   check        ...plus clippy. The graduated fallback: a reduced gate, not no gate.
+#   check        ...plus clippy, over BOTH feature configurations — `lint`
+#                and `lint-schema`. The graduated fallback: a reduced gate,
+#                not no gate.
 #   gate         ...plus rustdoc and the test suite. What CI runs, unscoped.
 #
 # `guards-fast` exists for the one push shape where `guards` is provably
@@ -730,6 +759,11 @@ gate: $(GATE_STEPS) ## Full CI gate: guards + rustdoc + fmt-check + clippy + tes
 print-gate-steps:
 	@echo $(GATE_STEPS)
 
+# Consumed by scripts/check-schema-tier-parity.sh, for the same reason.
+.PHONY: print-check-steps
+print-check-steps:
+	@echo $(CHECK_STEPS)
+
 # Consumed by the same guard, for the same reason.
 .PHONY: print-unhosted-self-tests
 print-unhosted-self-tests:
@@ -742,6 +776,14 @@ gate-parity: ## Assert AGENTS.md and CONTRIBUTING.md list the real gate steps (#
 .PHONY: gate-parity-test
 gate-parity-test: ## Test the gate-parity guard's failure directions (hermetic; not part of `gate`)
 	@./scripts/test-gate-parity.sh
+
+.PHONY: schema-tier-parity
+schema-tier-parity: ## Assert a `-schema` gate step runs at the same rung as its base step (#5139)
+	@./scripts/check-schema-tier-parity.sh
+
+.PHONY: schema-tier-parity-test
+schema-tier-parity-test: ## Test the schema-tier-parity guard's failure directions (hermetic; not part of `gate`)
+	@./scripts/test-schema-tier-parity.sh
 
 .PHONY: guard-trigger-coverage
 guard-trigger-coverage: ## Assert prose/hue-separation/transcript-surfaces each run unfiltered somewhere (#5448)
@@ -879,7 +921,7 @@ issue-claim-test: ## Test the issue-claim pre-flight, standing-down branch inclu
 	./scripts/test-issue-claim.sh
 
 .PHONY: check
-check: $(GATE_GUARDS) $(GATE_NO_BUILD) lint ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy, no rustdoc and no tests
+check: $(CHECK_STEPS) ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy (default and schema features), no rustdoc and no tests
 	@./scripts/check-hooks-installed.sh
 
 .PHONY: impacted

--- a/scripts/check-schema-tier-parity.sh
+++ b/scripts/check-schema-tier-parity.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Guard: a `-schema` gate step must run at the same rung as its base step.
+#
+# GATE_STEPS has two such pairs today: `lint`/`lint-schema` and
+# `doc-warnings`/`doc-warnings-schema`. `check` is a smaller rung than
+# `gate`. It is what `GATE=fast git push` runs. Without this guard, a
+# pair can split: `lint` runs at `check`, but `lint-schema` does not. So
+# `cargo clippy` at that rung never sees the three schema-gated crates. A
+# bad import there passes on this laptop and fails only in CI.
+#
+# This guard does not know what "clippy" or "rustdoc" means. It only knows
+# that `X-schema` is the sibling of `X`. It checks that `check` runs both,
+# or runs neither. Today `doc-warnings` and `doc-warnings-schema` are
+# correctly both left out — `check` skips rustdoc entirely. And `lint` and
+# `lint-schema` are correctly both included. A new pair that splits the
+# same way fails here, before it ever reaches CI.
+#
+# It reads GATE_STEPS and CHECK_STEPS from the Makefile, through two
+# `print-*` targets — the same way scripts/check-gate-parity.sh reads
+# GATE_STEPS. That keeps this list derived, not a second hand-copied one.
+#
+#   ./scripts/check-schema-tier-parity.sh
+#
+# Needs only `make` on PATH. No other toolchain, so it runs on a bare CI
+# runner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+fail=0
+
+# The verdict is fixed before anything prints. A reader that closes the
+# pipe early — `| head -1` — must not be able to turn a real failure into
+# a clean exit. scripts/check-gate-parity.sh uses the same shape.
+report=""
+note() { report="${report}check-schema-tier-parity: $1"$'\n'; }
+emit() {
+  trap '' PIPE
+  printf '%s' "$report" >&2 || true
+}
+
+if ! gate_steps="$(make -s print-gate-steps 2>/dev/null)"; then
+  note "FAIL — could not read GATE_STEPS (\`make -s print-gate-steps\`)."
+  note "     That target is what keeps this guard derived, not a"
+  note "     second copy of the list. Restore it in the Makefile."
+  emit
+  exit 1
+fi
+
+if ! check_steps="$(make -s print-check-steps 2>/dev/null)"; then
+  note "FAIL — could not read CHECK_STEPS (\`make -s print-check-steps\`)."
+  note "     That target is what keeps this guard derived, not a"
+  note "     second copy of the list. Restore it in the Makefile."
+  emit
+  exit 1
+fi
+
+# in_list <word> <space-separated list> — a whole-word membership test.
+in_list() {
+  case " $2 " in
+  *" $1 "*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+for step in $gate_steps; do
+  case "$step" in
+  *-schema)
+    base="${step%-schema}"
+    # A `-schema` step with no base in GATE_STEPS has no pair to check.
+    in_list "$base" "$gate_steps" || continue
+
+    schema_at_check=0
+    in_list "$step" "$check_steps" && schema_at_check=1
+    base_at_check=0
+    in_list "$base" "$check_steps" && base_at_check=1
+
+    if [ "$schema_at_check" -ne "$base_at_check" ]; then
+      if [ "$base_at_check" -eq 1 ]; then
+        note "FAIL — '$base' runs at the 'check' rung but its schema sibling"
+        note "     '$step' does not, so GATE=fast git push (and a hand-run"
+        note "     'make check') can pass with the schema-gated crates never"
+        note "     checked. Add '$step' to CHECK_STEPS in the Makefile, or"
+        note "     say in AGENTS.md's rung table why this pair is allowed to"
+        note "     split."
+      else
+        note "FAIL — '$step' runs at the 'check' rung but its base step"
+        note "     '$base' does not. Drop '$step' from CHECK_STEPS, or add"
+        note "     '$base' beside it."
+      fi
+      fail=1
+    fi
+    ;;
+  esac
+done
+
+if [ "$fail" -ne 0 ]; then
+  note ""
+  note "A -schema step and its base step are one question, asked under two"
+  note "feature configurations. 'check' must answer it the same way for"
+  note "both. See AGENTS.md's four-rung table."
+  emit
+  exit 1
+fi
+
+emit
+printf 'check-schema-tier-parity: OK — every schema-tier gate step agrees with its base step about the check rung.\n'

--- a/scripts/test-schema-tier-parity.sh
+++ b/scripts/test-schema-tier-parity.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Tests that scripts/check-schema-tier-parity.sh can still FAIL.
+#
+#   ./scripts/test-schema-tier-parity.sh
+#
+# A `-schema` step can drift out of step with its base step. One gets
+# added to CHECK_STEPS, and the other is left out. Each case below is one
+# way that drift could slip past the guard.
+#
+# Hermetic. Every case builds a throwaway tree with its own Makefile, one
+# that exposes `print-gate-steps` and `print-check-steps`. It copies the
+# real guard in, and runs it there. Nothing reads or writes this repo.
+# That is why this is not a `make gate` step, the same posture as
+# scripts/test-file-size.sh.
+#
+# Works on bash 3.2.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+guard="$repo_root/scripts/check-schema-tier-parity.sh"
+
+pass=0
+fail=0
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/stella-schema-tier-parity.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# fixture <name> <gate-steps> <check-steps>.
+# Builds a tree that exposes the two variables the guard reads.
+fixture() {
+  local dir="$tmp/$1" gate_steps="$2" check_steps="$3"
+  rm -rf "$dir"
+  mkdir -p "$dir/scripts"
+  cp "$guard" "$dir/scripts/check-schema-tier-parity.sh"
+
+  cat >"$dir/Makefile" <<EOF
+GATE_STEPS := $gate_steps
+CHECK_STEPS := $check_steps
+
+print-gate-steps:
+	@echo \$(GATE_STEPS)
+
+print-check-steps:
+	@echo \$(CHECK_STEPS)
+EOF
+
+  printf '%s' "$dir"
+}
+
+# expect <name> <wanted-exit> <dir> [needle].
+# Runs the guard and checks its exit code, and its output when asked.
+expect() {
+  local name="$1" want="$2" dir="$3" needle="${4:-}"
+  local out rc
+  out="$(cd "$dir" && ./scripts/check-schema-tier-parity.sh 2>&1)"
+  rc=$?
+  if [ "$rc" -ne "$want" ]; then
+    echo "FAIL  $name — exit $rc, wanted $want"
+    printf '%s\n' "$out" | sed 's/^/      /'
+    fail=$((fail + 1))
+    return
+  fi
+  if [ -n "$needle" ] && ! printf '%s' "$out" | grep -qF -- "$needle"; then
+    echo "FAIL  $name — report never says '$needle'"
+    printf '%s\n' "$out" | sed 's/^/      /'
+    fail=$((fail + 1))
+    return
+  fi
+  echo "ok    $name"
+  pass=$((pass + 1))
+}
+
+# S1. Both members present at check. This must pass.
+d="$(fixture both_present 'guard-a lint lint-schema doc-warnings doc-warnings-schema' \
+                          'guard-a lint lint-schema')"
+expect "S1  lint and lint-schema both at check passes" 0 "$d"
+
+# S2. Both members absent from check. This must also pass.
+d="$(fixture both_absent 'guard-a doc-warnings doc-warnings-schema' 'guard-a')"
+expect "S2  doc-warnings and doc-warnings-schema both absent from check passes" 0 "$d"
+
+# S3. The real bug. Base present, schema sibling forgotten.
+d="$(fixture schema_forgotten 'guard-a lint lint-schema' 'guard-a lint')"
+expect "S3  lint at check without lint-schema fails" 1 "$d" \
+  "'lint' runs at the 'check' rung but its schema sibling"
+
+# S4. The mirror case. Schema sibling present, base forgotten.
+d="$(fixture base_forgotten 'guard-a lint lint-schema' 'guard-a lint-schema')"
+expect "S4  lint-schema at check without lint fails" 1 "$d" \
+  "'lint-schema' runs at the 'check' rung but its base step"
+
+# S5. A schema step with no base sibling. The guard has no opinion here.
+d="$(fixture orphan_schema 'guard-a orphan-schema' 'guard-a')"
+expect "S5  a -schema step with no base in GATE_STEPS is ignored" 0 "$d"
+
+# S6. Several pairs, only one broken. Every mismatch must be named.
+d="$(fixture several_pairs 'lint lint-schema doc-warnings doc-warnings-schema' \
+                           'lint doc-warnings-schema')"
+out="$(cd "$d" && ./scripts/check-schema-tier-parity.sh 2>&1)"
+rc=$?
+if [ "$rc" -eq 1 ] \
+  && printf '%s' "$out" | grep -qF "'lint' runs at the 'check' rung but its schema sibling" \
+  && printf '%s' "$out" | grep -qF "'doc-warnings-schema' runs at the 'check' rung but its base step"; then
+  echo "ok    S6  both mismatches in a mixed fixture are reported"
+  pass=$((pass + 1))
+else
+  echo "FAIL  S6  expected both mismatches reported, got exit $rc:"
+  printf '%s\n' "$out" | sed 's/^/      /'
+  fail=$((fail + 1))
+fi
+
+# S7. No print-gate-steps target. The guard must fail, and say why.
+d="$(fixture no_gate_target '' '')"
+cat >"$d/Makefile" <<'EOF'
+print-check-steps:
+	@echo
+EOF
+expect "S7  no print-gate-steps target fails" 1 "$d" "could not read GATE_STEPS"
+
+# S8. No print-check-steps target. Same rule, other side.
+d="$(fixture no_check_target '' '')"
+cat >"$d/Makefile" <<'EOF'
+print-gate-steps:
+	@echo lint lint-schema
+EOF
+expect "S8  no print-check-steps target fails" 1 "$d" "could not read CHECK_STEPS"
+
+echo
+echo "test-schema-tier-parity: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Two holes in the local gate, both from #5139:

1. **`check` (`GATE=fast git push`, and a hand-run `make check`) ran `lint` but not `lint-schema`.** So clippy over the three `schema`-gated crates (`stella-protocol`, `stella-plugin`, `stella-serve`, under `--features schema`) never ran at that rung, and a broken import there passed locally and failed only in CI. `lint-schema` now joins `check`'s prerequisites through a new `CHECK_STEPS` Make variable (`GATE_GUARDS + GATE_NO_BUILD + lint + lint-schema`), mirroring how `GATE_STEPS` is already named and printed. `doc-warnings-schema` stays `gate`-only, correctly paired with `doc-warnings` — `check`'s contract is "no rustdoc", for either feature configuration, and that was already right.

2. **`cargo doc` can replay a cached green for `doc-warnings-schema`.** Its freshness check can call a stale prior build "up to date" — and print nothing — even after the source changed. That is exactly the issue's own repro: moving a function between modules in `stella-plugin` broke an intra-doc link, `make doc-warnings-schema` passed anyway, and only `rm -rf target/doc && make doc-warnings-schema` caught it. The recipe now runs `cargo clean --doc $(SCHEMA_CRATES)` before its two `cargo doc` invocations — the cargo-native, package-scoped version of the same fix, without paying for a full-workspace rustdoc rebuild on every `make gate` (the "correct but slow" tradeoff the issue names against doing this workspace-wide).

## New guard: `schema-tier-parity`

`scripts/check-schema-tier-parity.sh` holds fix (1) in place going forward. It reads `GATE_STEPS`/`CHECK_STEPS` through `print-gate-steps`/`print-check-steps` (the same derivation `check-gate-parity.sh` uses for `GATE_STEPS`) and asserts every `X`/`X-schema` pair in `GATE_STEPS` agrees on whether `check` runs them — both, or neither. A future pair that splits the same way fails here, locally, before it reaches CI. Wired into `GATE_GUARDS_FAST` (so every rung runs it), `ci.yml`'s guards job, and `guard-self-tests.yml` (its own hermetic self-test, `test-schema-tier-parity.sh`).

Exemplar: `scripts/check-gate-parity.sh` / `scripts/test-gate-parity.sh` — same shape, same fixture style (a throwaway tree with a synthetic Makefile exposing the `print-*` targets the guard reads).

## Design

Posted on the issue before this PR, since #5139 offered four options without picking one: https://github.com/macanderson/stella/issues/5139#issuecomment-5551159581

## Witness

**For (1):** `test-schema-tier-parity.sh` (8 cases) proves the guard's own fail/pass directions — S3/S4 are the exact `lint`/`lint-schema` split this PR fixes, reproduced against a synthetic `GATE_STEPS`/`CHECK_STEPS` pair. Beyond the hermetic test, I reproduced the real fail→pass against this repo's actual Makefile: temporarily dropped `lint-schema` from `CHECK_STEPS` — `check-schema-tier-parity.sh` FAILs, naming exactly the pair — restored it, back to OK.

**For (2):** the issue's own manual repro (`rm -rf target/doc && make doc-warnings-schema`) is the demonstrated bug; verifying the fix means running `cargo doc`, which this session cannot do locally (no cargo build/doc allowed on this machine by policy — "CI is the only compiler"). `wire-schema.yml`'s `rustdoc over the schema-gated wire-contract modules` step is where this runs for real; that is this PR's evidence for (2), not a local dynamic reproduction.

All locally-runnable guards green: `make guards-fast` (full run), `check-gate-parity.sh`, `check-schema-tier-parity.sh`, `check-prose.py`, `check-line-citations.py`, `check-file-size.sh`, `check-left-behind.sh`.

Tests deleted: None.

## Residue

Filed #5945: `doc-warnings` (the default-feature, workspace-wide rustdoc check) has the same theoretical `cargo doc` staleness exposure as `doc-warnings-schema` did, left unfixed here deliberately — cleaning it every gate run would force a full-workspace rustdoc rebuild, real CI cost, and the issue's repro only demonstrated the bug for the schema variant. #5945 asks someone to actually reproduce it against `doc-warnings` before paying that cost.

## Note: based on the red-main repair

This branch was rebased onto `main` after #5942 (Cargo.lock's `stella-learn` entry) to pick up that fix — `main` was genuinely red (issue #5939) when this session started, unrelated to this change.

Closes #5139

## Summary by Sourcery

Keep schema and default gate checks aligned while ensuring schema rustdoc validation always evaluates fresh documentation.

Bug Fixes:
- Ensure the reduced `check` gate runs both default-feature and schema-feature linting.
- Prevent schema rustdoc checks from accepting stale cached documentation after source changes.

Enhancements:
- Add schema-tier parity validation to ensure every `-schema` gate step is included or excluded alongside its base step.
- Expose the check gate steps through a dedicated Make target for derived guard validation.

CI:
- Run schema-tier parity checks in CI and add hermetic self-tests for both failure directions.

Documentation:
- Document the updated gate rung contracts, schema-tier parity rule, and schema rustdoc cache handling.

Tests:
- Add eight hermetic test cases covering schema-tier parity success, mismatch, orphan, and missing-target scenarios.

## DoD verification by the PR sweep (appended 2026-09-05)

The `dod / dod` check was red at 10:57:15Z on #5139's two unchecked items.
Unlike the sibling PRs in this sweep, these were genuinely unticked rather
than stale — so they were checked against this branch's head (`75de31a3`)
before being ticked, and the evidence is in
[this comment](https://github.com/macanderson/stella/issues/5139#issuecomment-5551340684).
In short, the PR takes **both** branches of that item's `or`, one per step:
`lint-schema` now runs at `check` (`CHECK_STEPS`, confirmed by
`make print-check-steps`), and `doc-warnings-schema` stays `gate`-only with
AGENTS.md's rung table now saying so plainly.

Ran on this head: `./scripts/check-schema-tier-parity.sh` (OK) and
`./scripts/test-schema-tier-parity.sh` (8 passed, 0 failed — negative
controls S3 and S4 included, so the guard is shown able to fail).

This edit is what re-fires `dod-check.yml` to re-read the boxes; the edit is
the trigger, never the fix.


---
_Generated by [Claude Code](https://claude.ai/code)_