### PR TITLE
fix(stella-store): reap a session's lane records with the session

### DIFF
--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -898,17 +898,15 @@ pub(crate) fn spawn(
 /// embedded in `session` there is parsed as a path separator into a
 /// subdirectory nothing creates — so `record_checkpoint` fails, and
 /// `JournalCheckpointSink::persist`'s best-effort contract swallows that
-/// error silently. `__` is neither a filesystem nor a git-ref special
-/// character, so it is safe on both axes at once.
+/// error silently.
 ///
-/// `:` is replaced too, for the ref-name half of the same contract: every
-/// lane id this file mints carries one (`req:<n>`, `sub:<task-id>`), so
-/// this is not a defensive edge case — every lane hits both bytes, and an
-/// unsanitized key would make `bind_session` fail silently on every single
-/// one, defeating the whole feature with no visible symptom short of a kill
-/// actually losing a transcript.
+/// The shape itself is [`stella_store::work_journal::lane`]'s, not this
+/// file's: retention has to know which keys a session owns before it can drop
+/// them, and the same rule written down in two crates is the drift this
+/// repository files bugs about. What stays here is which lanes exist and what
+/// they are called.
 fn lane_journal_key(session_id: &str, lane: &str) -> String {
-    format!("{session_id}__{}", lane.replace(':', "-"))
+    stella_store::work_journal::lane::lane_key(session_id, lane)
 }
 
 /// A worker's initial messages: restored from a prior interrupted attempt on
@@ -1015,6 +1013,13 @@ async fn run_worker(
     // killed worker's transcript survives independently of the lead's, and a
     // later spawn on the SAME lane id (a task re-assigned after a crash, or
     // the Restart verb) can find it.
+    //
+    // It lives exactly as long as this deck session: nothing retires it when
+    // the lane ends, and `WorkJournal::prune` drops it with the session
+    // rather than ageing it out on a clock of its own
+    // (`stella_store::work_journal::lane`). A lane that dies and is never
+    // re-attempted therefore keeps its terminal frame for the lead to read,
+    // and stops costing anything once the session it belonged to is pruned.
     let lane_durability = crate::durability::SessionDurability::default();
     let lane_key = lane_journal_key(session_id, &spec.lane);
     if let Some(warning) =

--- a/crates/stella-store/src/work_journal.rs
+++ b/crates/stella-store/src/work_journal.rs
@@ -45,6 +45,11 @@
 //! path, built to the same shape as `store.db`'s [`crate::prune`]: an age
 //! cutoff plus a ceiling, both opt-in, run when a command asks rather than on
 //! every exit.
+//!
+//! A session's worker lanes each keep a record of their own. Those records
+//! belong to the session. They are dropped with it, in one batch, and are
+//! never counted or aged on their own. [`lane`] holds the key shape and the
+//! reasons.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -52,6 +57,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::{Result, StoreError};
 
+pub mod lane;
 pub mod snapshot;
 
 pub use snapshot::{JournalChange, JournalChangeKind};
@@ -112,6 +118,30 @@ fn journal_key_of(refname: &str) -> Option<&str> {
     (!key.is_empty() && !key.contains('/')).then_some(key)
 }
 
+/// The journal key a refname sits under: the first path segment after
+/// `refs/stella/`.
+///
+/// Unlike [`journal_key_of`] this takes a turn mark as well as a tip.
+/// Retention deletes every ref a key owns, so it has to name the key a turn
+/// mark sits under. The tip-only reading cannot do that.
+fn key_of_ref(refname: &str) -> Option<&str> {
+    let key = refname.strip_prefix("refs/stella/")?.split('/').next()?;
+    (!key.is_empty()).then_some(key)
+}
+
+/// Every journal key the given refs sit under, sorted, each listed once — one
+/// session's own key plus one per lane it dispatched.
+fn keys_of_refs(refs: &[String]) -> Vec<String> {
+    let mut keys: Vec<String> = refs
+        .iter()
+        .filter_map(|refname| key_of_ref(refname.as_str()))
+        .map(str::to_string)
+        .collect();
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
 /// The reserved directory stella's own records live under, so a blob can
 /// never collide with a real workspace path — and so a per-turn diff can
 /// filter the records back out ([`WorkJournal::changed_paths_at_turn`]).
@@ -144,10 +174,15 @@ const LARGE_PRUNE_REFS: u64 = 100;
 /// the same shape: an age cutoff, a hard ceiling, both opt-in, and a policy
 /// carrying neither is a no-op that deletes nothing.
 ///
-/// The unit of retention is the **session**, because that is what the ref
-/// namespace is keyed on: a session owns `refs/stella/<session>/head` plus one
+/// The unit of retention is the **session**, because that is the lifetime the
+/// records share: a session owns `refs/stella/<session>/head` plus one
 /// `refs/stella/<session>/turn/<n>` per turn, and dropping some of a session's
 /// turns would leave a truncated history that reads as a complete one.
+///
+/// A worker lane's record sits under a name of its own
+/// (`refs/stella/<session>__<lane>/…`). It is still part of the session, not
+/// a unit beside it. It has no age of its own. It takes no line against
+/// `max_sessions`. [`lane`] holds the reasons.
 #[derive(Debug, Clone, Default)]
 pub struct JournalPrunePolicy {
     /// Sessions whose last commit is at least this old are dropped; `None`
@@ -183,11 +218,17 @@ pub struct JournalPruneReport {
     pub aged_out: u64,
     /// Sessions evicted to satisfy the ceiling.
     pub ceiling_evicted: u64,
-    /// Refs deleted across both phases — one `head` per session plus its turn
-    /// marks. This is the number that matters: a session's objects stay
-    /// reachable, and so unreclaimable, until its last ref is gone.
+    /// Worker-lane records dropped with the sessions that started them.
+    /// Counted apart from [`Self::total_sessions`] because a lane is not a
+    /// session. Folding the two together would report more sessions removed
+    /// than a prune removed.
+    pub lanes_removed: u64,
+    /// Refs deleted across both phases: every ref a pruned session owns, its
+    /// lanes' included. This is the number that matters. A session's objects
+    /// stay reachable, and so stay on disk, until its last ref is gone.
     pub refs_deleted: u64,
-    /// Sidecar index files removed, one per pruned session that had one.
+    /// Sidecar index files removed, one per pruned record that had one — a
+    /// session's own and each of its lanes'.
     pub indexes_removed: u64,
     /// Sessions still above the ceiling afterwards, because the only ones left
     /// to evict were protected (the running session is never pruned).
@@ -705,7 +746,9 @@ impl WorkJournal {
     /// including the automatic one [`Self::compact`] runs, can collect them.
     /// A session's refs go in one transactional batch: half a namespace left
     /// standing keeps the whole history reachable, which would report a prune
-    /// that reclaimed nothing.
+    /// that reclaimed nothing. The batch covers the session's worker lanes
+    /// too. A lane left behind by its own session is the half-deleted
+    /// namespace this rule exists to prevent; [`lane`] gives the reasons.
     ///
     /// **The running session is never pruned**, whatever the policy says —
     /// this is the analogue of `store.db`'s un-replicated-telemetry guard, and
@@ -723,11 +766,15 @@ impl WorkJournal {
         }
         let mut retained = self.recorded_sessions()?;
         let mut doomed: Vec<String> = Vec::new();
+        // A lane's handle protects the session it hangs off, not just its
+        // own key. Pruning the lead out from under a live lane would delete
+        // the resume point that lane is about to read.
+        let running = lane::owning_session(&self.session);
 
         if let Some(older_than) = policy.older_than {
             let cutoff = unix_now().saturating_sub(older_than.as_secs() as i64);
             retained.retain(|(session, at)| {
-                if *at <= cutoff && *session != self.session {
+                if *at <= cutoff && session.as_str() != running {
                     doomed.push(session.clone());
                     return false;
                 }
@@ -743,7 +790,7 @@ impl WorkJournal {
             // `recorded_sessions` is oldest-first, so this evicts in the same
             // order `store.db`'s ceiling does.
             retained.retain(|(session, _)| {
-                if excess > 0 && *session != self.session {
+                if excess > 0 && session.as_str() != running {
                     excess -= 1;
                     doomed.push(session.clone());
                     report.ceiling_evicted += 1;
@@ -757,22 +804,27 @@ impl WorkJournal {
         for session in &doomed {
             let refs = self.session_refs(session)?;
             report.refs_deleted += refs.len() as u64;
+            let keys = keys_of_refs(&refs);
+            report.lanes_removed += keys.iter().filter(|key| *key != session).count() as u64;
             if policy.dry_run {
                 continue;
             }
             self.delete_refs(&refs)?;
-            let index = index_file_path(&self.store_root, &self.workspace_id, session);
-            if std::fs::remove_file(&index).is_ok() {
-                report.indexes_removed += 1;
-            }
-            // The snapshot lineage's sidecar, removed on the same terms. A
-            // session can have one without the other (a turn that snapshotted
-            // but never checkpointed, or the reverse), so neither removal may
-            // be conditioned on the other having succeeded.
-            let snapshot_index =
-                snapshot_index_file_path(&self.store_root, &self.workspace_id, session);
-            if std::fs::remove_file(&snapshot_index).is_ok() {
-                report.indexes_removed += 1;
+            for key in &keys {
+                let index = index_file_path(&self.store_root, &self.workspace_id, key);
+                if std::fs::remove_file(&index).is_ok() {
+                    report.indexes_removed += 1;
+                }
+                // The snapshot lineage's sidecar, removed on the same terms. A
+                // record can have one without the other (a turn that
+                // snapshotted but never checkpointed, or the reverse), so
+                // neither removal may be conditioned on the other having
+                // succeeded.
+                let snapshot_index =
+                    snapshot_index_file_path(&self.store_root, &self.workspace_id, key);
+                if std::fs::remove_file(&snapshot_index).is_ok() {
+                    report.indexes_removed += 1;
+                }
             }
         }
 
@@ -797,9 +849,10 @@ impl WorkJournal {
     /// retention half of the same question and stays private, because an age
     /// cutoff is [`Self::prune`]'s business alone.
     ///
-    /// This module learns no composition rule. A prefix is whatever the caller
-    /// says it is, so the convention that separates a session from a lane
-    /// stays in the crate that mints it.
+    /// A prefix is whatever the caller says it is. This reader applies no key
+    /// shape of its own. The shape lives in [`lane`]: retention has to know
+    /// which keys a session owns before it can drop them. The caller still
+    /// picks which lanes exist and what they are called.
     ///
     /// An empty result is a real answer — nothing recorded under that prefix —
     /// and is not distinguished from a store with no history at all.
@@ -831,6 +884,12 @@ impl WorkJournal {
     /// resume point to write a checkpoint) has a `tree` ref and no `head`, and
     /// reading `head` alone would leave it permanently unreachable by
     /// retention. A session with both is listed once, at its later tip.
+    ///
+    /// A worker lane's tips fold into the session that started it
+    /// ([`lane::owning_session`]). A lane is not a session. It gets no clock
+    /// of its own and no line against the ceiling. A deck session with ten
+    /// lanes is one session here, and its age is the latest moment any of its
+    /// eleven records moved.
     fn recorded_sessions(&self) -> Result<Vec<(String, i64)>> {
         let listing = self.git(&[
             "for-each-ref",
@@ -842,7 +901,7 @@ impl WorkJournal {
             let Some((at, refname)) = line.trim().split_once(' ') else {
                 continue;
             };
-            let Some(session) = journal_key_of(refname) else {
+            let Some(session) = journal_key_of(refname).map(lane::owning_session) else {
                 continue;
             };
             let Ok(at) = at.parse::<i64>() else {
@@ -850,7 +909,7 @@ impl WorkJournal {
             };
             // Later tip wins: the session's most recent moment is what an age
             // cutoff must judge, so a stale `head` must never age out a
-            // session whose snapshots are current.
+            // session whose snapshots — or whose lanes — are current.
             match sessions.iter_mut().find(|(name, _)| name == session) {
                 Some((_, seen)) => *seen = (*seen).max(at),
                 None => sessions.push((session.to_string(), at)),
@@ -860,18 +919,23 @@ impl WorkJournal {
         Ok(sessions)
     }
 
-    /// Every ref in one session's namespace — its head and all of its turn
-    /// marks.
+    /// Every ref one session owns — its head, its snapshot tip and all of its
+    /// turn marks, plus the same for every worker lane it dispatched
+    /// ([`lane`]).
+    ///
+    /// One listing of `refs/stella/`, filtered here, rather than a glob
+    /// handed to git. `for-each-ref` matches with wildmatch, whose `*` stops
+    /// at a `/`. A glob would then have to obey git's rules as well as this
+    /// module's. Reading the key off each refname asks the question directly.
     fn session_refs(&self, session: &str) -> Result<Vec<String>> {
-        let listing = self.git(&[
-            "for-each-ref",
-            "--format=%(refname)",
-            &format!("refs/stella/{session}/"),
-        ])?;
+        let listing = self.git(&["for-each-ref", "--format=%(refname)", "refs/stella/"])?;
         Ok(listing
             .lines()
-            .map(|line| line.trim().to_string())
-            .filter(|line| !line.is_empty())
+            .filter_map(|line| {
+                let refname = line.trim();
+                let key = key_of_ref(refname)?;
+                (lane::owning_session(key) == session).then(|| refname.to_string())
+            })
             .collect())
     }
 
@@ -949,13 +1013,16 @@ fn run(cmd: &mut Command) -> Result<String> {
 }
 
 #[cfg(test)]
+mod retention_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
     /// A scratch workspace and its own store root. No environment variable
     /// is touched, so these run correctly in parallel with everything else —
     /// an earlier version set `STELLA_HOME` and the tests raced each other.
-    fn scratch() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    pub(super) fn scratch() -> (tempfile::TempDir, PathBuf, PathBuf) {
         let guard = tempfile::tempdir().unwrap();
         let ws = guard.path().join("ws");
         std::fs::create_dir_all(&ws).unwrap();
@@ -997,7 +1064,7 @@ mod tests {
     /// Both lineages count. A key that only ever checkpointed has a `head` and
     /// no `tree`; one that only ever snapshotted has the reverse; reading
     /// either alone would report a live key as absent, and a caller avoiding a
-    /// name it must not reuse (#3233) would then reuse it. A key with both is
+    /// name it must not reuse would then reuse it. A key with both is
     /// listed once. Turn marks name no key of their own.
     #[test]
     fn a_prefix_finds_every_key_recorded_under_it_and_nothing_else() {
@@ -1201,7 +1268,7 @@ mod tests {
 
     #[test]
     fn changed_paths_name_exactly_what_moved_between_turns() {
-        // The #1870 name half: turn 2 changed a.txt and created c.txt, so
+        // The naming half: turn 2 changed a.txt and created c.txt, so
         // those two — and only those two — are its changed paths. b.txt was
         // recorded in turn 1 and untouched since; the checkpoint blob rides
         // in the same commits and must never surface as a workspace path.
@@ -1250,7 +1317,7 @@ mod tests {
 
     #[test]
     fn computing_a_diff_neither_blocks_nor_mutates_a_live_writer() {
-        // The #1870 no-lock constraint, made a test instead of a sentence:
+        // The no-lock constraint, made a test instead of a sentence:
         // the diff reads are tree-to-tree plumbing against refs, so another
         // session committing into the same shared store is not blocked, and
         // the reader leaves every ref of both sessions exactly where it was.
@@ -1304,140 +1371,6 @@ mod tests {
 
         assert_eq!(journal.read_at_turn(2, "first.txt").unwrap(), "one\n");
         assert_eq!(journal.read_at_turn(2, "second.txt").unwrap(), "two\n");
-    }
-
-    /// Whether the store still holds `oid` at all — `cat-file -e` is the
-    /// cheapest way to ask, and the only assertion that distinguishes "the ref
-    /// is gone" from "the bytes are gone".
-    fn object_exists(journal: &WorkJournal, oid: &str) -> bool {
-        journal.git(&["cat-file", "-e", oid]).is_ok()
-    }
-
-    #[test]
-    fn pruning_a_session_unreaches_its_objects_so_gc_can_reclaim_them() {
-        // The whole point of retention here: deleting the ref is what makes
-        // the objects collectable. `gc` on its own is required to KEEP
-        // anything a ref reaches, so a store with no ref deletion grows
-        // forever no matter how often it compacts.
-        let (_guard, ws, store) = scratch();
-        std::fs::write(ws.join("a.txt"), "theirs\n").unwrap();
-        let theirs = WorkJournal::open_in(&store, &ws, "ses-old").unwrap();
-        let dropped = theirs.record(&["a.txt".into()], &[], "their work").unwrap();
-        theirs.mark_turn(1, &dropped).unwrap();
-
-        std::fs::write(ws.join("b.txt"), "mine\n").unwrap();
-        let mine = WorkJournal::open_in(&store, &ws, "ses-live").unwrap();
-        let kept = mine.record(&["b.txt".into()], &[], "my work").unwrap();
-
-        let report = mine
-            .prune(&JournalPrunePolicy {
-                older_than: Some(Duration::ZERO),
-                gc: true,
-                ..Default::default()
-            })
-            .unwrap();
-
-        assert_eq!(report.aged_out, 1, "the running session is never pruned");
-        assert_eq!(report.total_sessions(), 1);
-        assert_eq!(report.refs_deleted, 2, "the head plus its one turn mark");
-        assert_eq!(report.indexes_removed, 1, "and the sidecar index with it");
-        assert!(report.gc_ran);
-
-        assert!(
-            theirs.session_tip().is_none(),
-            "the pruned session's head is gone"
-        );
-        assert!(
-            theirs.read_at_turn(1, "a.txt").is_err(),
-            "and so is its turn mark"
-        );
-        assert!(
-            !index_file_path(&mine.store_root, &mine.workspace_id, "ses-old").exists(),
-            "the pruned session's index file is gone"
-        );
-        assert_eq!(
-            mine.session_tip().as_deref(),
-            Some(kept.as_str()),
-            "the live session is untouched"
-        );
-
-        assert!(object_exists(&mine, &kept), "a retained commit stays");
-        assert!(
-            !object_exists(&mine, &dropped),
-            "the pruned commit's objects were actually reclaimed"
-        );
-    }
-
-    #[test]
-    fn the_session_ceiling_evicts_the_oldest_and_reports_what_the_guard_blocks() {
-        let (_guard, ws, store) = scratch();
-        std::fs::write(ws.join("a.txt"), "shared\n").unwrap();
-        // Same second for all three, so the tiebreak is the session name and
-        // the eviction order is deterministic: ses-1 (this handle's, and
-        // therefore protected), then ses-2, then ses-3.
-        for session in ["ses-1", "ses-2", "ses-3"] {
-            let journal = WorkJournal::open_in(&store, &ws, session).unwrap();
-            journal.record(&["a.txt".into()], &[], session).unwrap();
-        }
-        let mine = WorkJournal::open_in(&store, &ws, "ses-1").unwrap();
-
-        let report = mine
-            .prune(&JournalPrunePolicy {
-                max_sessions: Some(1),
-                ..Default::default()
-            })
-            .unwrap();
-        assert_eq!(report.aged_out, 0, "no age window means no age phase");
-        assert_eq!(report.ceiling_evicted, 2);
-        assert_eq!(report.still_over_ceiling, 0);
-        assert_eq!(mine.recorded_sessions().unwrap().len(), 1);
-
-        // A ceiling the guard cannot satisfy is reported, never forced: the
-        // running session outranks any policy.
-        let report = mine
-            .prune(&JournalPrunePolicy {
-                max_sessions: Some(0),
-                ..Default::default()
-            })
-            .unwrap();
-        assert_eq!(report.ceiling_evicted, 0);
-        assert_eq!(report.still_over_ceiling, 1);
-        assert!(mine.session_tip().is_some());
-    }
-
-    #[test]
-    fn an_empty_policy_is_a_no_op_and_a_dry_run_deletes_nothing() {
-        let (_guard, ws, store) = scratch();
-        std::fs::write(ws.join("a.txt"), "theirs\n").unwrap();
-        let theirs = WorkJournal::open_in(&store, &ws, "ses-old").unwrap();
-        let tip = theirs.record(&["a.txt".into()], &[], "their work").unwrap();
-        theirs.mark_turn(1, &tip).unwrap();
-        let mine = WorkJournal::open_in(&store, &ws, "ses-live").unwrap();
-        mine.record(&["a.txt".into()], &[], "my work").unwrap();
-
-        assert_eq!(
-            mine.prune(&JournalPrunePolicy::default()).unwrap(),
-            JournalPruneReport::default(),
-            "a policy with neither knob set deletes nothing"
-        );
-
-        let report = mine
-            .prune(&JournalPrunePolicy {
-                older_than: Some(Duration::ZERO),
-                gc: true,
-                dry_run: true,
-                ..Default::default()
-            })
-            .unwrap();
-        assert_eq!(report.aged_out, 1, "a dry run reports what it would drop");
-        assert_eq!(report.refs_deleted, 2);
-        assert_eq!(report.indexes_removed, 0);
-        assert!(!report.gc_ran, "and never reclaims");
-        assert_eq!(
-            theirs.session_tip().as_deref(),
-            Some(tip.as_str()),
-            "the session it named is still there"
-        );
     }
 
     #[test]

--- a/crates/stella-store/src/work_journal/lane.rs
+++ b/crates/stella-store/src/work_journal/lane.rs
@@ -1,0 +1,89 @@
+//! How a worker lane's record is named, and how long it lives.
+//!
+//! A deck session can start worker lanes. Each lane keeps a record of its
+//! own. It does not write into the lead's. So a lane that is killed still has
+//! a transcript, and a later spawn on the same lane id can pick it up. A
+//! lane's key is the session id, then [`LANE_SEPARATOR`], then the lane id.
+//!
+//! # How long a lane record lives
+//!
+//! Just as long as the session that started it. A lane is not a session, so
+//! it is not a unit of retention. It has no clock of its own. It takes no
+//! line against the ceiling. When
+//! [`crate::work_journal::WorkJournal::prune`] drops a session it drops that
+//! session's lanes too, in the same batch. The age cutoff reads the whole
+//! group by its newest tip.
+//!
+//! Left to age out alone, a lane outlives the session it belongs to. Its
+//! objects stay reachable, and `gc` must keep whatever a ref reaches.
+//!
+//! Lane ids are not capped. A deck session can hand out `req:1` … `req:n`
+//! all day. Each lane that wrote a record leaves a name under
+//! `refs/stella/`. Counted as sessions, one busy session fills a ceiling
+//! meant to hold many, and pushes real sessions out.
+//!
+//! Nothing drops a lane record when the lane ends. `prune` runs when a
+//! command asks for it, never on exit. A lane that dies leaves a terminal
+//! frame ([`crate::lane_frame`]). The frame stands until that lane finishes
+//! a later try. Dropping it on exit would take it away before the lead read
+//! it.
+//!
+//! # Where the key shape lives
+//!
+//! Here, in the store. `prune` has to know which keys a session owns before
+//! it can drop them. The crate that starts lanes still picks which lanes
+//! exist and what they are called. It builds their keys with [`lane_key`].
+
+/// What sits between a session id and a lane id in a lane's journal key.
+///
+/// Not `/`. A key is part of a file name too
+/// (`<workspace-id>.<key>.index`), and a `/` there reads as a path, into a
+/// folder nothing makes. Git refs take `/` happily, so only one of the two
+/// axes would break, and it would break in silence. `__` is plain to git and
+/// to a file system alike.
+pub const LANE_SEPARATOR: &str = "__";
+
+/// The journal key one lane of `session` writes its record under.
+///
+/// The lane id is made ref-safe on the way in. Every lane id the deck mints
+/// holds a `:` (`req:<n>`, `sub:<task-id>`), and `:` is not legal in a ref
+/// name. So this is the normal case, not an edge one.
+pub fn lane_key(session: &str, lane: &str) -> String {
+    format!("{session}{LANE_SEPARATOR}{}", lane.replace(':', "-"))
+}
+
+/// The session a journal key belongs to. For a session's own record that is
+/// the key itself. For a lane's it is the part before [`LANE_SEPARATOR`].
+///
+/// A session id (`ses-<ms>-<pid>`) holds no `__`, so the split is exact for
+/// every key this workspace mints. A key that does hold one, and names no
+/// session that ever wrote a record, still groups under its prefix. That is
+/// the right answer: such keys are lanes of a lead that wrote nothing, and
+/// they belong together.
+pub fn owning_session(key: &str) -> &str {
+    match key.split_once(LANE_SEPARATOR) {
+        Some((session, _)) => session,
+        None => key,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_lane_key_names_its_session_and_survives_the_round_trip() {
+        let key = lane_key("ses-17-42", "req:3");
+        assert_eq!(key, "ses-17-42__req-3");
+        assert_eq!(owning_session(&key), "ses-17-42");
+        assert!(
+            !key.contains(':') && !key.contains('/'),
+            "a key is part of a ref name and part of a file name: {key}"
+        );
+    }
+
+    #[test]
+    fn a_session_key_owns_itself() {
+        assert_eq!(owning_session("ses-17-42"), "ses-17-42");
+    }
+}

--- a/crates/stella-store/src/work_journal/retention_tests.rs
+++ b/crates/stella-store/src/work_journal/retention_tests.rs
@@ -1,0 +1,249 @@
+//! What `prune` keeps and what it drops.
+//!
+//! Its own file because `work_journal.rs` sits at the size ceiling and is
+//! closed to growth.
+
+use super::tests::scratch;
+use super::*;
+
+/// Whether the store still holds `oid` at all. `cat-file -e` is the
+/// cheapest way to ask. It is also the only check that tells "the ref is
+/// gone" from "the bytes are gone".
+fn object_exists(journal: &WorkJournal, oid: &str) -> bool {
+    journal.git(&["cat-file", "-e", oid]).is_ok()
+}
+
+#[test]
+fn pruning_a_session_unreaches_its_objects_so_gc_can_reclaim_them() {
+    // Deleting the ref is what frees the objects. `gc` must KEEP
+    // whatever a ref reaches. A store that deletes no refs grows
+    // forever, however often it packs.
+    let (_guard, ws, store) = scratch();
+    std::fs::write(ws.join("a.txt"), "theirs\n").unwrap();
+    let theirs = WorkJournal::open_in(&store, &ws, "ses-old").unwrap();
+    let dropped = theirs.record(&["a.txt".into()], &[], "their work").unwrap();
+    theirs.mark_turn(1, &dropped).unwrap();
+
+    std::fs::write(ws.join("b.txt"), "mine\n").unwrap();
+    let mine = WorkJournal::open_in(&store, &ws, "ses-live").unwrap();
+    let kept = mine.record(&["b.txt".into()], &[], "my work").unwrap();
+
+    let report = mine
+        .prune(&JournalPrunePolicy {
+            older_than: Some(Duration::ZERO),
+            gc: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(report.aged_out, 1, "the running session is never pruned");
+    assert_eq!(report.total_sessions(), 1);
+    assert_eq!(report.refs_deleted, 2, "the head plus its one turn mark");
+    assert_eq!(report.indexes_removed, 1, "and the sidecar index with it");
+    assert!(report.gc_ran);
+
+    assert!(
+        theirs.session_tip().is_none(),
+        "the pruned session's head is gone"
+    );
+    assert!(
+        theirs.read_at_turn(1, "a.txt").is_err(),
+        "and so is its turn mark"
+    );
+    assert!(
+        !index_file_path(&mine.store_root, &mine.workspace_id, "ses-old").exists(),
+        "the pruned session's index file is gone"
+    );
+    assert_eq!(
+        mine.session_tip().as_deref(),
+        Some(kept.as_str()),
+        "the live session is untouched"
+    );
+
+    assert!(object_exists(&mine, &kept), "a retained commit stays");
+    assert!(
+        !object_exists(&mine, &dropped),
+        "the pruned commit's objects were actually reclaimed"
+    );
+}
+
+#[test]
+fn the_session_ceiling_evicts_the_oldest_and_reports_what_the_guard_blocks() {
+    let (_guard, ws, store) = scratch();
+    std::fs::write(ws.join("a.txt"), "shared\n").unwrap();
+    // All three land in the same second. The tiebreak is then the
+    // session name, so the order is fixed: ses-1 first (this handle's
+    // own, and so protected), then ses-2, then ses-3.
+    for session in ["ses-1", "ses-2", "ses-3"] {
+        let journal = WorkJournal::open_in(&store, &ws, session).unwrap();
+        journal.record(&["a.txt".into()], &[], session).unwrap();
+    }
+    let mine = WorkJournal::open_in(&store, &ws, "ses-1").unwrap();
+
+    let report = mine
+        .prune(&JournalPrunePolicy {
+            max_sessions: Some(1),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(report.aged_out, 0, "no age window means no age phase");
+    assert_eq!(report.ceiling_evicted, 2);
+    assert_eq!(report.still_over_ceiling, 0);
+    assert_eq!(mine.recorded_sessions().unwrap().len(), 1);
+
+    // A ceiling the guard cannot meet is reported, never forced. The
+    // running session outranks any policy.
+    let report = mine
+        .prune(&JournalPrunePolicy {
+            max_sessions: Some(0),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(report.ceiling_evicted, 0);
+    assert_eq!(report.still_over_ceiling, 1);
+    assert!(mine.session_tip().is_some());
+}
+
+#[test]
+fn an_empty_policy_is_a_no_op_and_a_dry_run_deletes_nothing() {
+    let (_guard, ws, store) = scratch();
+    std::fs::write(ws.join("a.txt"), "theirs\n").unwrap();
+    let theirs = WorkJournal::open_in(&store, &ws, "ses-old").unwrap();
+    let tip = theirs.record(&["a.txt".into()], &[], "their work").unwrap();
+    theirs.mark_turn(1, &tip).unwrap();
+    let mine = WorkJournal::open_in(&store, &ws, "ses-live").unwrap();
+    mine.record(&["a.txt".into()], &[], "my work").unwrap();
+
+    assert_eq!(
+        mine.prune(&JournalPrunePolicy::default()).unwrap(),
+        JournalPruneReport::default(),
+        "a policy with neither knob set deletes nothing"
+    );
+
+    let report = mine
+        .prune(&JournalPrunePolicy {
+            older_than: Some(Duration::ZERO),
+            gc: true,
+            dry_run: true,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(report.aged_out, 1, "a dry run reports what it would drop");
+    assert_eq!(report.refs_deleted, 2);
+    assert_eq!(report.indexes_removed, 0);
+    assert!(!report.gc_ran, "and never reclaims");
+    assert_eq!(
+        theirs.session_tip().as_deref(),
+        Some(tip.as_str()),
+        "the session it named is still there"
+    );
+}
+
+/// The tip of `key`'s own record, read through a fresh handle.
+fn tip_of(store: &Path, ws: &Path, key: &str) -> Option<String> {
+    WorkJournal::open_in(store, ws, key).unwrap().session_tip()
+}
+
+#[test]
+fn a_sessions_lanes_are_reaped_with_it_and_are_never_counted_as_sessions() {
+    let (_guard, ws, store) = scratch();
+    std::fs::write(ws.join("a.txt"), "shared\n").unwrap();
+
+    // One lead with two worker lanes, plus two sessions with none. All
+    // five land in the same second. The tiebreak is then the key, so the
+    // order is fixed: `ses-1` and its lanes sort ahead of `ses-2` and
+    // `ses-3`.
+    let lane_a = lane::lane_key("ses-1", "req:1");
+    let lane_b = lane::lane_key("ses-1", "req:2");
+    for key in ["ses-1", lane_a.as_str(), lane_b.as_str(), "ses-2", "ses-3"] {
+        let journal = WorkJournal::open_in(&store, &ws, key).unwrap();
+        journal.record(&["a.txt".into()], &[], key).unwrap();
+    }
+    // A handle on none of them. The guard protects nothing here, so the
+    // ceiling alone decides.
+    let mine = WorkJournal::open_in(&store, &ws, "ses-9").unwrap();
+
+    assert_eq!(
+        mine.recorded_sessions().unwrap().len(),
+        3,
+        "five records, three sessions: a lane is part of the session that \
+         dispatched it"
+    );
+    assert_eq!(
+        mine.prune(&JournalPrunePolicy {
+            max_sessions: Some(3),
+            ..Default::default()
+        })
+        .unwrap(),
+        JournalPruneReport::default(),
+        "three sessions already fit under a ceiling of three — counting the \
+         lanes would evict real sessions to make room for one session's lanes"
+    );
+    assert!(
+        tip_of(&store, &ws, &lane_a).is_some(),
+        "and deletes nothing"
+    );
+
+    let report = mine
+        .prune(&JournalPrunePolicy {
+            max_sessions: Some(2),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(report.ceiling_evicted, 1, "one session over, one evicted");
+    assert_eq!(report.lanes_removed, 2, "and its two lanes go with it");
+    assert_eq!(
+        report.refs_deleted, 3,
+        "the lead's head plus one per lane — a lane left standing would keep \
+         its own objects reachable forever"
+    );
+    assert_eq!(report.indexes_removed, 3, "each record's sidecar index too");
+    assert_eq!(report.still_over_ceiling, 0);
+
+    assert!(
+        tip_of(&store, &ws, "ses-1").is_none(),
+        "the lead's record is gone"
+    );
+    assert!(
+        tip_of(&store, &ws, &lane_a).is_none(),
+        "and its first lane's"
+    );
+    assert!(
+        tip_of(&store, &ws, &lane_b).is_none(),
+        "and its second lane's"
+    );
+    assert!(
+        !index_file_path(&mine.store_root, &mine.workspace_id, &lane_a).exists(),
+        "a reaped lane leaves no sidecar index behind"
+    );
+    assert!(
+        tip_of(&store, &ws, "ses-2").is_some() && tip_of(&store, &ws, "ses-3").is_some(),
+        "the sessions under the ceiling are untouched"
+    );
+}
+
+#[test]
+fn a_lane_handle_never_prunes_the_session_it_hangs_off() {
+    // The guard protects the session, not just the key. A prune run from
+    // a lane's own handle must not delete the lead it hangs off.
+    let (_guard, ws, store) = scratch();
+    std::fs::write(ws.join("a.txt"), "shared\n").unwrap();
+    let lead = WorkJournal::open_in(&store, &ws, "ses-1").unwrap();
+    let tip = lead.record(&["a.txt".into()], &[], "lead").unwrap();
+    let worker = WorkJournal::open_in(&store, &ws, &lane::lane_key("ses-1", "req:1")).unwrap();
+    worker.record(&["a.txt".into()], &[], "lane").unwrap();
+
+    let report = worker
+        .prune(&JournalPrunePolicy {
+            older_than: Some(Duration::ZERO),
+            ..Default::default()
+        })
+        .unwrap();
+
+    assert_eq!(report.total_sessions(), 0, "nothing here is prunable");
+    assert_eq!(
+        lead.session_tip().as_deref(),
+        Some(tip.as_str()),
+        "the lead this lane hangs off is still there"
+    );
+}


### PR DESCRIPTION
## What and why

A deck session's worker lanes each bind a work-journal record of their own, keyed `{session}__{lane}` (#4725). Retention read those keys as sessions. Two consequences, both live today:

- **A ceiling counts lanes.** A session that dispatched ten lanes is eleven units against `JournalPrunePolicy::max_sessions`, so a ceiling of five evicts real sessions to make room for one session's lanes. Lane ids are uncapped — `MAX_CONCURRENT` bounds how many run at once, not how many are minted — so the multiplier is per session, not per workspace.
- **A lane outlives the session that was pruned.** `session_refs` globbed `refs/stella/<session>/`, so pruning a session left every one of its lanes' namespaces standing, keeping their objects reachable and so unreclaimable by `gc`. Only the age cutoff ever reached them, on a policy written for sessions.

The issue's three open questions are answered in one move, posted as a design comment before the work started: **a lane record is not a retention unit. It is part of its session, and it is reaped with it, in the same transaction.** `JournalPrunePolicy`'s unit stays "the session" and now actually is one. Nothing deletes on exit; retention stays opt-in.

## What changed

New sibling module `crates/stella-store/src/work_journal/lane.rs` — `LANE_SEPARATOR`, `lane_key`, `owning_session`, and the written-down lifetime. `stella-cli`'s `subsession::lane_journal_key` composes through it and keeps its own doc. The shape moved into the store because retention cannot be correct without knowing it, and the same rule written in two crates with only a comment linking them is the drift this repo files bugs about; `recorded_keys`'s "this module learns no composition rule" paragraph is rewritten to match. The lifetime is also written at `run_worker`'s bind site, which is where the record is created.

In `prune`:

- `recorded_sessions` groups every key under `owning_session`, taking the latest tip across the lead and its lanes.
- `session_refs` returns every ref whose first segment resolves to that session. Filtered in Rust off one `for-each-ref refs/stella/` rather than a git glob: `for-each-ref` matches with wildmatch, whose `*` stops at a `/`, so a glob would have to obey git's rules as well as this module's.
- One `update-ref --stdin` transaction over the whole set, unchanged, so a session and its lanes go together or not at all.
- Each removed key's two sidecar index files go with it.
- The running-session guard compares `owning_session(self.session)`, so a lane's own handle cannot prune the lead it hangs off.
- `JournalPruneReport` gains `lanes_removed`, counted apart from `total_sessions` so a report cannot claim more sessions removed than it removed.

The terminal frame a dead lane leaves (#5878, raised in the issue's comment) needs no special case: it is a commit on `refs/stella/{session}__{lane}/head`, so it is retired with the lane's refs. `lane_frame::clear` stays the finished-lane path, not the retention one.

## Witness

`a_sessions_lanes_are_reaped_with_it_and_are_never_counted_as_sessions` — one lead with two lanes plus two bare sessions, five records in all.

- On old code `recorded_sessions` returns five units, so the first assertion (three sessions) fails, and the `max_sessions: Some(3)` prune evicts two records rather than reporting a default no-op — a ceiling three sessions already fit under.
- The second phase pins the reaping: `max_sessions: Some(2)` drops the lead **and** both its lanes in one prune, three refs and three sidecar indexes, with the two other sessions untouched. On old code `session_refs`'s `refs/stella/<session>/` glob reaches none of the lane refs.

`a_lane_handle_never_prunes_the_session_it_hangs_off` — a prune run from a lane's handle under `older_than: ZERO`. On old code the guard compares the lane's own key, so the lead is not equal to it and is deleted; the test fails. On new code the lead is protected and the report is empty.

`lane.rs` carries its own round-trip tests for the key shape, and `subsession::tests::the_lane_journal_key_is_filesystem_and_git_ref_safe` still pins the exact bytes.

## File split

`work_journal.rs` was 1470 lines and closed to growth, so the prune suite moved to `work_journal/retention_tests.rs` (the sibling layout `work_journal/snapshot.rs` already uses) and its prose was rewritten to the reading-grade gate. `work_journal.rs` is 1407 lines after the change. No test was deleted — every one moved.

Exemplar: `stella-store`'s own `prune.rs`, whose age-cutoff-then-ceiling shape `JournalPrunePolicy` was already built to.

Tests deleted: None.

Residue issues filed: None — nothing was noticed and left unfixed.

Closes #5104

## DoD verified by the PR sweep (2026-09-05)

`dod / dod` was failing on this head with both of #5104's boxes unticked. Both are now ticked, checked against the diff at `f272d7e` rather than against this description, with the evidence recorded in the issue body.

- **"A lane record's lifetime is written down where the record is created."** Stated at the creation site — `subsession.rs`'s `run_worker`, directly above the `SessionDurability` bind — and again at the store end in `work_journal/lane.rs`'s `# How long a lane record lives`, which also carries the reasoning for both failure modes the issue raised. `lane_journal_key` delegates to `lane::lane_key`, so the shape is stated once rather than in two crates.
- **"Whatever policy is chosen has a test that fails if it changes."** `retention_tests.rs`, wired in at `work_journal.rs:1016`. `a_sessions_lanes_are_reaped_with_it_and_are_never_counted_as_sessions` pins both halves of the decision; `a_lane_handle_never_prunes_the_session_it_hangs_off` pins the direction that must not hold. Run targeted on this head: `cargo test -p stella-store --lib retention_tests` → `5 passed; 0 failed`.

This edit is what fires the `pull_request` event `dod-check.yml` needs to re-read the boxes — the edit is the trigger, never the fix.

## Summary by Sourcery

Make journal retention treat worker-lane records as part of their owning session and remove them together during pruning.

Bug Fixes:
- Reap worker-lane journal records together with their owning session so pruned lanes no longer remain reachable or consume retention capacity independently.
- Protect a lead session when pruning from one of its lane handles.

Enhancements:
- Centralize lane-key ownership and parsing in the store and report lane removals separately from removed sessions.
- Move retention tests into a dedicated module while preserving and expanding coverage for session and lane pruning.

Documentation:
- Document worker-lane journal lifetime and its treatment as part of the owning session.

Tests:
- Add coverage confirming lanes are excluded from session counts, removed atomically with their session, sidecar indexes are cleaned up, and lane handles protect their lead session.

## DoD verification by the PR sweep (appended 2026-09-05)

The `dod / dod` check went red at 10:45:47Z reading #5104's two unchecked
items. Both boxes were ticked at 10:51:26Z, after that read — so the gate
failed on a stale snapshot, not on a gap. This edit is what re-fires
`dod-check.yml`; the edit is the trigger, never the fix.

Checked against this branch's head (`f272d7e5`) rather than against the
description:

- **"A lane record's lifetime is written down where the record is created."**
  `crates/stella-store/src/work_journal/lane.rs` opens with *How a worker
  lane's record is named, and how long it lives*, and carries a
  `# How long a lane record lives` section stating the policy — a lane lives
  exactly as long as its session, is not a unit of retention, and is dropped
  in the same batch by `prune`. It sits in the same file as `lane_key`, which
  is what builds the key the record is created under, so the lifetime is
  written where the record is named rather than a crate away.
- **"Whatever policy is chosen has a test that fails if it changes."**
  `work_journal/retention_tests.rs` pins both directions:
  `a_sessions_lanes_are_reaped_with_it_and_are_never_counted_as_sessions`
  (reaped with the session, and never counted against the session ceiling)
  and `a_lane_handle_never_prunes_the_session_it_hangs_off` (the inverse).

Ran `cargo test -p stella-store --lib -- work_journal` on this head — green,
both named tests included.


---
_Generated by [Claude Code](https://claude.ai/code)_