### PR TITLE
feat(stella-tui): `!!` keeps guidance, `!!!` keeps a rule

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -136,6 +136,9 @@ use settings_io::{apply_pending_reload, handle_engine_config_input, handle_tools
 /// Where an Esc-delivered steer lands, driver-side.
 mod steer;
 
+/// Where a `!!`/`!!!` interrupt's saved record is written.
+mod keep_record;
+
 /// ISSUES-tab requests, served by the workspace's issue provider.
 mod issues;
 
@@ -1067,7 +1070,7 @@ pub async fn run_deck_session(
                     }
                     IdleWake::Input(input) => input,
                 };
-                match input {
+                match keep_record::intercept(input, &cfg.workspace_root, &in_tx) {
                     None => break 'session,
                     Some(WorkspaceInput::Quit) => break 'session,
                     // Worker controls work between lead turns too — the
@@ -1153,7 +1156,7 @@ pub async fn run_deck_session(
                     // the same "run this now" path.
                     Some(
                         WorkspaceInput::Steer { agent, texts }
-                        | WorkspaceInput::Interrupt { agent, texts },
+                        | WorkspaceInput::Interrupt { agent, texts, .. },
                     ) if !texts.is_empty() => {
                         match steer::steer_idle(&agent, &subs, &mut queue, texts, &in_tx) {
                             Some(first) => {
@@ -1934,7 +1937,7 @@ pub async fn run_deck_session(
                             },
                         );
                     }
-                    input = sub_rx.recv() => match input {
+                    input = sub_rx.recv() => match keep_record::intercept(input, &cfg.workspace_root, &in_tx) {
                         None | Some(WorkspaceInput::Quit) => break TurnEnd::Quit,
                         // The lead is busy — the prompt does NOT wait for it.
                         // It backlogs and immediately drains to a dedicated
@@ -2028,10 +2031,10 @@ pub async fn run_deck_session(
                         // The composer's red mode: stop at the boundary, run the
                         // words next. At a worker lane it lands as a steer — see
                         // the envelope's `Interrupt` doc.
-                        Some(WorkspaceInput::Interrupt { agent, texts }) if agent == LEAD =>
+                        Some(WorkspaceInput::Interrupt { agent, texts, .. }) if agent == LEAD =>
                             steer::interrupt_lead(&steering, &lead_pause, &mut queue, texts, &in_tx),
                         Some(WorkspaceInput::Steer { agent, texts }
-                            | WorkspaceInput::Interrupt { agent, texts }) =>
+                            | WorkspaceInput::Interrupt { agent, texts, .. }) =>
                             steer::steer_worker(&subs, &mut queue, &agent, texts, &in_tx),
                         // An explicit front-insert stays a front-insert even
                         // if a turn started before it arrived — the deck's

--- a/crates/stella-cli/src/command_deck/keep_record.rs
+++ b/crates/stella-cli/src/command_deck/keep_record.rs
@@ -7,7 +7,7 @@
 //! deck cuts the mark off, sends the usual [`WorkspaceInput::Interrupt`], and
 //! tags it with the strength it was asked for. The tag is spent here.
 //!
-//! [`intercept`] runs in front of both read points in the driver. It does not
+//! `intercept` runs in front of both read points in the driver. It does not
 //! sit in the arms that take an interrupt:
 //!
 //! - **A bad write must not eat the stop.** A save that fails hands the

--- a/crates/stella-cli/src/command_deck/keep_record.rs
+++ b/crates/stella-cli/src/command_deck/keep_record.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Where a `!!` or `!!!` mark is saved.
+//!
+//! The deck cannot write the file. It is a fold, and a write is I/O. So the
+//! deck cuts the mark off, sends the usual [`WorkspaceInput::Interrupt`], and
+//! tags it with the strength it was asked for. The tag is spent here.
+//!
+//! [`intercept`] runs in front of both read points in the driver. It does not
+//! sit in the arms that take an interrupt:
+//!
+//! - **A bad write must not eat the stop.** A save that fails hands the
+//!   message back as it came. The turn still stops. The error goes on screen.
+//! - **One save, not three.** An interrupt lands in three arms: at rest, at
+//!   the lead, and at a lane. A save in each is three ways to write the file
+//!   twice, or not at all.
+//! - **`command_deck.rs` is a god file, closed to growth.** Each call site
+//!   there spends one word. The work is here.
+//!
+//! What the save reaches, and what it does not: this session picks the record
+//! up on its next load, and so does every session started after it. A session
+//! already running elsewhere does not. Those read the record set once, at
+//! start, and nothing swaps it under them yet.
+//!
+//! Split out of [`super`], on the `steer` and `settle` pattern.
+
+use std::path::Path;
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::context_records::decree;
+use stella_tui::{Inbound, KeepStrength, WorkspaceInput};
+
+/// Spend the mark on `input`. Hand the message back for the driver to route.
+///
+/// The mark is cleared on the way through. So the file is written once, even
+/// if a later arm reads the message again. All else passes as it came.
+pub(super) fn intercept(
+    input: Option<WorkspaceInput>,
+    root: &Path,
+    in_tx: &UnboundedSender<Inbound>,
+) -> Option<WorkspaceInput> {
+    match input {
+        Some(WorkspaceInput::Interrupt {
+            agent,
+            texts,
+            keep: Some(keep),
+        }) => {
+            save(root, keep, &texts, in_tx);
+            Some(WorkspaceInput::Interrupt {
+                agent,
+                texts,
+                keep: None,
+            })
+        }
+        other => other,
+    }
+}
+
+/// Write the file. Say what happened, on one line either way.
+///
+/// The mark sends one text. Joining is what makes this total. A message that
+/// somehow held two would save both, not drop one on the quiet.
+fn save(root: &Path, keep: KeepStrength, texts: &[String], in_tx: &UnboundedSender<Inbound>) {
+    let statement = texts.join(" ");
+    let note = match decree::publish(root, keep, &statement) {
+        Ok(saved) if saved.unchanged => {
+            format!(
+                "already kept — {} says this already",
+                shown(root, &saved.path)
+            )
+        }
+        Ok(saved) => match &saved.superseded {
+            Some(_) => format!(
+                "kept as {} in {} — it replaces the earlier wording",
+                strength(keep),
+                shown(root, &saved.path)
+            ),
+            None => format!("kept as {} in {}", strength(keep), shown(root, &saved.path)),
+        },
+        // The stop runs either way, since the message goes back whole. Say
+        // nothing here and a person is left trusting a rule nobody wrote.
+        Err(why) => format!("the turn stopped, but keeping that failed: {why}"),
+    };
+    let _ = in_tx.send(super::chrome_note(note));
+}
+
+/// How the note names the strength. It uses the words the file uses, so the
+/// two agree.
+fn strength(keep: KeepStrength) -> &'static str {
+    match keep {
+        KeepStrength::Guidance => "guidance (should)",
+        KeepStrength::Rule => "a rule (must)",
+    }
+}
+
+/// The path as a person reads it. Short, when the file is in the tree. Full,
+/// when it is not.
+fn shown(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/command_deck/keep_record/tests.rs
+++ b/crates/stella-cli/src/command_deck/keep_record/tests.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What the driver does with a marked interrupt. The failed write is here
+//! too. That is the case a person must still be told about.
+
+use super::*;
+
+use stella_protocol::AgentEvent;
+
+/// The notes that were sent, as plain text.
+fn notes(rx: &mut tokio::sync::mpsc::UnboundedReceiver<Inbound>) -> Vec<String> {
+    let mut out = Vec::new();
+    while let Ok(inbound) = rx.try_recv() {
+        if let Inbound::Event {
+            event: AgentEvent::Text { text },
+            ..
+        } = inbound
+        {
+            out.push(text);
+        }
+    }
+    out
+}
+
+fn marked(keep: KeepStrength, text: &str) -> Option<WorkspaceInput> {
+    Some(WorkspaceInput::Interrupt {
+        agent: "lead".into(),
+        texts: vec![text.to_string()],
+        keep: Some(keep),
+    })
+}
+
+/// **The witness for the driver's half.** A marked interrupt writes the file.
+/// It comes back as the plain interrupt the stop path already knows. The mark
+/// is spent, so nothing can write it twice.
+#[test]
+fn a_marked_interrupt_writes_the_record_and_hands_back_the_plain_stop() {
+    let root = tempfile::tempdir().unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let passed = intercept(
+        marked(KeepStrength::Rule, "Never force-push to main."),
+        root.path(),
+        &tx,
+    );
+
+    assert_eq!(
+        passed,
+        Some(WorkspaceInput::Interrupt {
+            agent: "lead".into(),
+            texts: vec!["Never force-push to main.".into()],
+            keep: None,
+        }),
+        "the stop is untouched, and the mark is spent"
+    );
+    let registry = crate::context_records::load_registry(root.path());
+    assert!(
+        registry
+            .entries
+            .iter()
+            .any(|entry| entry.record.record.statement == "Never force-push to main."),
+        "the next session loads what was kept"
+    );
+    assert!(
+        notes(&mut rx).iter().any(|n| n.contains("a rule (must)")),
+        "the driver says what it kept"
+    );
+}
+
+/// **The witness for a failed write.** The interrupt still travels. The error
+/// is on screen. The worst end here is a rule a person trusts that was never
+/// written.
+#[test]
+fn a_write_that_fails_still_hands_back_the_stop_and_says_so() {
+    let root = tempfile::tempdir().unwrap();
+    // `.stella/rules` is where the file has to land. A plain file there
+    // cannot be a folder. So the write fails on real I/O, not on a seam made
+    // up for the test.
+    std::fs::create_dir_all(root.path().join(".stella")).unwrap();
+    std::fs::write(root.path().join(".stella/rules"), "not a directory").unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let passed = intercept(
+        marked(KeepStrength::Guidance, "Use short sentences."),
+        root.path(),
+        &tx,
+    );
+
+    assert_eq!(
+        passed,
+        Some(WorkspaceInput::Interrupt {
+            agent: "lead".into(),
+            texts: vec!["Use short sentences.".into()],
+            keep: None,
+        }),
+        "a failed save must not swallow the interrupt"
+    );
+    let said = notes(&mut rx);
+    assert!(
+        said.iter().any(|n| n.contains("keeping that failed")),
+        "the failure is visible: {said:?}"
+    );
+}
+
+/// An unmarked message is not this file's job. It passes as it came.
+#[test]
+fn an_unmarked_message_passes_straight_through() {
+    let root = tempfile::tempdir().unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let plain = Some(WorkspaceInput::Enqueue {
+        text: "and now the tests".into(),
+    });
+
+    assert_eq!(intercept(plain.clone(), root.path(), &tx), plain);
+    assert!(notes(&mut rx).is_empty(), "nothing to say about a prompt");
+    assert!(
+        !root.path().join(".stella/rules").exists(),
+        "an unmarked message writes no record"
+    );
+}

--- a/crates/stella-cli/src/context_cmd.rs
+++ b/crates/stella-cli/src/context_cmd.rs
@@ -45,7 +45,7 @@ mod amend;
 mod explain;
 mod govern;
 mod propose;
-mod review;
+pub(crate) mod review;
 // `pub(crate)` for one reason: the retirement handshake spans two commands, so its
 // witness has to drive both halves. `ingest --refresh` archives a record in place and
 // `context validate` decides whether that is a finding — the bug they had (#3254) was

--- a/crates/stella-cli/src/context_cmd/review.rs
+++ b/crates/stella-cli/src/context_cmd/review.rs
@@ -535,7 +535,7 @@ pub fn run_keep(
 /// the `record_id` the file actually carries, not one recomputed today.
 /// `None` when the file cannot be read or parsed — the caller then falls back
 /// to the plain refusal rather than superseding something it cannot see.
-fn published_record_at(path: &Path) -> Option<stella_records::ingest::record::Record> {
+pub(crate) fn published_record_at(path: &Path) -> Option<stella_records::ingest::record::Record> {
     let contents = std::fs::read_to_string(path).ok()?;
     let file: stella_records::ingest::record::ContextFile = toml::from_str(&contents).ok()?;
     file.records.first().cloned()

--- a/crates/stella-cli/src/context_records.rs
+++ b/crates/stella-cli/src/context_records.rs
@@ -1064,5 +1064,7 @@ pub(crate) fn inferred_rule_record(
     Ok(record)
 }
 
+pub(crate) mod decree;
+
 #[cfg(test)]
 mod tests;

--- a/crates/stella-cli/src/context_records/decree.rs
+++ b/crates/stella-cli/src/context_records/decree.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What a `!!` or `!!!` mark saves: one context record, written the way the
+//! record plane writes every other one.
+//!
+//! [`inferred_rule_record`] is the near twin of this file. It saves what a
+//! miner *guessed*. So it is soft: `origin = inferred`, `force = should`, and
+//! no name on it. A bang mark is the other case. A person typed the words. So
+//! the record says `origin = user`, its `truth` is a `decree`, and the name of
+//! the person is on it. Those are the two things the sweep gate asks a record
+//! for before it trusts one ([`honored_probe`]).
+//!
+//! The rest is the path `stella context keep` walks now. Same folder. Same
+//! refusal to clobber. Same new draft when the words change. Same two ledgers.
+//! A save from the composer must not be a back door.
+//!
+//! [`inferred_rule_record`]: super::inferred_rule_record
+//! [`honored_probe`]: stella_records::records::sweep::honored_probe
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use stella_records::ingest::record as rec;
+use stella_records::ingest::refresh::same_statement;
+use stella_records::records::DecisionEvent;
+use stella_records::records::promotion::{LedgerAction, PromotionEvent};
+use stella_tui::KeepStrength;
+
+use crate::context_cmd::review::{actor, published_record_at};
+use crate::context_records::{
+    append_decision, append_promotion, now_rfc3339, publication_path, read_governance,
+    replace_record, separation_checked_proposer, write_record,
+};
+
+/// The `precedence` a `!!!` record is saved at.
+///
+/// A record carries no number for how hard it binds. `precedence` is the one
+/// number it has. It settles two things: which record wins a clash, and which
+/// one keeps its place when the budget runs short. A rule worth stopping a
+/// turn for should lose neither. So it is saved at the top.
+///
+/// `enforcement` is left off at both strengths. A `hard` mode with no guard to
+/// check claims a block that can never fire. A typed sentence brings no guard.
+const RULE_PRECEDENCE: u32 = 100;
+
+/// How many words of the claim go into the file name. Enough to find it by eye
+/// in `.stella/rules/`.
+const SLUG_WORDS: usize = 6;
+
+/// What one save did. The caller reports it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Saved {
+    /// The file that was written.
+    pub path: PathBuf,
+    /// The `lineage_id` the claim lives under.
+    pub lineage_id: String,
+    /// The `record_id` this draft retired. Set when the claim was already
+    /// saved, in other words or at another strength.
+    pub superseded: Option<String>,
+    /// True when the file already said this, at this strength, and nothing was
+    /// written. Saying a thing twice is not an error.
+    pub unchanged: bool,
+}
+
+/// Save `statement` as a context record, at the strength the mark asked for.
+///
+/// The `lineage_id` comes from the words. So one sentence always lands in one
+/// lineage. Say it twice and nothing happens. Change the words, or raise `!!`
+/// to `!!!`, and the new draft retires the old one. It never writes a second
+/// record that argues with the first.
+pub(crate) fn publish(root: &Path, keep: KeepStrength, statement: &str) -> Result<Saved, String> {
+    let statement = statement.trim();
+    if statement.is_empty() {
+        return Err("there was nothing after the mark to keep".to_string());
+    }
+    if stella_records::records::validate::statement_reads_as_pasted(statement) {
+        return Err(format!(
+            "a context record's statement is one sentence, and this is {} characters over {} \
+             lines — say it shorter and the mark will keep it",
+            statement.chars().count(),
+            statement.lines().count()
+        ));
+    }
+    let set_id = crate::ingest_cmd::derive_set_id(root);
+    let mut record = record(&set_id, keep, statement, &actor())?;
+    let path = publication_path(root, rec::SharingScope::Repository, &record.lineage_id)
+        .ok_or_else(|| "cannot work out where to publish this record".to_string())?;
+
+    let existing = path.exists().then(|| published_record_at(&path)).flatten();
+    let superseded = match existing {
+        Some(existing)
+            if same_statement(&existing.statement, &record.statement)
+                && force_of(&existing) == Some(force(keep)) =>
+        {
+            return Ok(Saved {
+                path,
+                lineage_id: record.lineage_id,
+                superseded: None,
+                unchanged: true,
+            });
+        }
+        Some(existing) => Some(existing.record_id.ok_or_else(|| {
+            format!(
+                "{} already holds this claim but carries no record id, so a new revision has \
+                 nothing to cite — run `stella context validate` to see the finding",
+                path.display()
+            )
+        })?),
+        None if path.exists() => {
+            return Err(format!(
+                "{} exists and does not parse as a context record — repair or delete it before \
+                 the mark can publish here",
+                path.display()
+            ));
+        }
+        None => None,
+    };
+
+    match &superseded {
+        Some(old_id) => {
+            // The link to the old draft is content. So it goes inside the new
+            // draft's hash, not beside it.
+            record.supersedes_record_id = Some(old_id.clone());
+            record
+                .stamp(&rec::Defaults::default())
+                .map_err(|e| format!("cannot canonicalize the record: {e}"))?;
+            replace_record(&path, &set_id, &record)?;
+            // File first, ledger second. A ledger error is loud: a swap nobody
+            // logged is the thing the ledger is for. The separation gate runs
+            // first, as `stella context keep` runs it. A swap clears any block
+            // grant the lineage holds. Under separation, an author may not
+            // disarm their own record alone.
+            let governance = read_governance(root)?;
+            let approver = actor();
+            let proposer = separation_checked_proposer(
+                root,
+                &record.lineage_id,
+                &approver,
+                "superseding it from the composer",
+            )?;
+            append_promotion(
+                root,
+                PromotionEvent {
+                    seq: 0,
+                    prev: String::new(),
+                    at: now_rfc3339(),
+                    lineage_id: record.lineage_id.clone(),
+                    from: "active".to_string(),
+                    to: "superseded".to_string(),
+                    approver,
+                    proposer,
+                    reason: format!(
+                        "{old_id} superseded by {} — kept from the composer",
+                        record.record_id.as_deref().unwrap_or("<unstamped>")
+                    ),
+                    mode: governance.mode.as_str().to_string(),
+                    action: LedgerAction::Superseded,
+                },
+            )?;
+        }
+        None => write_record(&path, &set_id, &record)?,
+    }
+
+    // The same event `stella context keep` writes. One log then says where
+    // every record came from. The path is short when the file is in the tree.
+    // The next person to open the repo reads this, and a full path names one
+    // machine.
+    let recorded_path = path
+        .strip_prefix(root)
+        .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|_| path.display().to_string());
+    let mut event = DecisionEvent::keep(
+        candidate_id(&record.lineage_id),
+        record.lineage_id.clone(),
+        actor(),
+        now_rfc3339(),
+        recorded_path,
+    );
+    if let Some(old_id) = &superseded {
+        event.reason = Some(format!("supersedes {old_id}"));
+    }
+    append_decision(root, &event)?;
+
+    Ok(Saved {
+        path,
+        lineage_id: record.lineage_id,
+        superseded,
+        unchanged: false,
+    })
+}
+
+/// The `force` a strength is saved at. `!!` steers, and a later order can
+/// override it. `!!!` binds. Both ride the cached prefix. That is what makes
+/// either one reach every later turn with nothing to select it.
+fn force(keep: KeepStrength) -> rec::Force {
+    match keep {
+        KeepStrength::Guidance => rec::Force::Should,
+        KeepStrength::Rule => rec::Force::Must,
+    }
+}
+
+/// The `force` a saved file names, if it names one.
+fn force_of(record: &rec::Record) -> Option<rec::Force> {
+    record.steering.as_ref().map(|steering| steering.force)
+}
+
+/// Build and stamp the record a mark saves.
+///
+/// `verified_by` is the person the `decree` rests on. The sweep gate reads it
+/// with the `origin`. A decree nobody signed is not one.
+fn record(
+    set_id: &str,
+    keep: KeepStrength,
+    statement: &str,
+    by: &str,
+) -> Result<rec::Record, String> {
+    // A folder whose name starts with a dot would leave an empty part in the
+    // lineage (`ctx..foo.bar`). Trim it rather than write a bad one.
+    let set_id = set_id.trim_matches('.');
+    let set_id = if set_id.is_empty() {
+        "workspace"
+    } else {
+        set_id
+    };
+    let mut record = rec::Record {
+        lineage_id: format!("ctx.{set_id}.{}", lineage_suffix(statement)),
+        record_id: None,
+        record_hash: None,
+        kind: rec::RecordKind::Rule,
+        statement: statement.to_string(),
+        tags: vec!["decreed".to_string()],
+        origin: Some(stella_records::context_record::Origin::User),
+        sharing_scope: Some(rec::SharingScope::Repository),
+        status: Some(stella_records::context_record::RecordStatus::Active),
+        supersedes_record_id: None,
+        provenance: Some(rec::Provenance {
+            source_kind: Some("decree".to_string()),
+            source_uri: Some("composer".to_string()),
+            // A person typed the words and stands behind them. That is
+            // `HumanReview`, not a measurement. It is the top grade a claim
+            // reaches with nothing in the world to back it up.
+            evidence_grade: Some(stella_protocol::provenance::ProvenanceGrade::HumanReview),
+            ..Default::default()
+        }),
+        steering: Some(rec::Steering {
+            force: force(keep),
+            precedence: match keep {
+                KeepStrength::Guidance => None,
+                KeepStrength::Rule => Some(RULE_PRECEDENCE),
+            },
+            tier: None,
+            applies_to: None,
+        }),
+        enforcement: None,
+        truth: Some(rec::Truth {
+            basis: rec::TruthBasis::Decree,
+            confidence: None,
+            verified_by: Some(by.to_string()),
+            verified_at: Some(now_rfc3339()),
+            valid_from: None,
+            ttl: None,
+            on_expiry: None,
+            review_every: None,
+            probe: None,
+        }),
+        links: Vec::new(),
+    };
+    record
+        .stamp(&rec::Defaults::default())
+        .map_err(|e| format!("cannot stamp the record: {e}"))?;
+    Ok(record)
+}
+
+/// The last part of the `lineage_id`: a few plain words off the claim, then a
+/// hash of the whole of it.
+///
+/// The words are for the person who opens `.stella/rules/`. The hash is what
+/// holds the lineage still, so one sentence always maps to one file however
+/// long it runs. It comes from the words alone, never the strength. That is
+/// what lets `!!!` raise a claim `!!` saved, in place of a rival record.
+fn lineage_suffix(statement: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(statement.as_bytes());
+    let hash = format!("{:x}", digest.finalize());
+    let words: Vec<String> = statement
+        .split_whitespace()
+        .take(SLUG_WORDS)
+        .map(|word| {
+            word.chars()
+                .filter(|c| c.is_ascii_alphanumeric())
+                .map(|c| c.to_ascii_lowercase())
+                .collect::<String>()
+        })
+        .filter(|word| !word.is_empty())
+        .collect();
+    let stem = words.join("-");
+    if stem.is_empty() {
+        format!("decreed-{}", &hash[..8])
+    } else {
+        format!("decreed-{stem}-{}", &hash[..8])
+    }
+}
+
+/// The ledger's `<slug>-<hash8>` id for this claim. A record kept from the
+/// composer has no proposal behind it. So the last part of the `lineage_id` is
+/// the id. One claim decided twice lands on one id, which is what the ledger's
+/// fold wants.
+fn candidate_id(lineage_id: &str) -> String {
+    lineage_id
+        .rsplit('.')
+        .next()
+        .unwrap_or(lineage_id)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/context_records/decree.rs
+++ b/crates/stella-cli/src/context_records/decree.rs
@@ -282,7 +282,11 @@ fn record(
 fn lineage_suffix(statement: &str) -> String {
     let mut digest = Sha256::new();
     digest.update(statement.as_bytes());
-    let hash = format!("{:x}", digest.finalize());
+    let hash: String = digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
     let words: Vec<String> = statement
         .split_whitespace()
         .take(SLUG_WORDS)

--- a/crates/stella-cli/src/context_records/decree/tests.rs
+++ b/crates/stella-cli/src/context_records/decree/tests.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What a bang mark leaves behind. One record the next session loads. One
+//! ledger line that says who left it.
+
+use super::*;
+
+use stella_records::records::Trust;
+
+use crate::context_records::{PROMOTION_LEDGER, load_registry, read_decisions};
+
+fn workspace() -> tempfile::TempDir {
+    tempfile::tempdir().expect("a temp workspace")
+}
+
+/// The saved record for `lineage`, as a fresh load sees it. That is the only
+/// view a later session has.
+fn loaded(root: &Path, lineage: &str) -> stella_records::ingest::record::Record {
+    let registry = load_registry(root);
+    registry
+        .entries
+        .iter()
+        .find(|entry| entry.record.record.lineage_id == lineage)
+        .unwrap_or_else(|| panic!("{lineage} is not in the registry"))
+        .record
+        .record
+        .clone()
+}
+
+/// **The witness for `!!`.** Words kept mid-turn come back at `should` in the
+/// next session. The `origin` says a person put them there.
+#[test]
+fn guidance_is_published_at_should_and_a_fresh_load_finds_it() {
+    let root = workspace();
+    let saved = publish(root.path(), KeepStrength::Guidance, "Use short sentences.")
+        .expect("the record publishes");
+    assert!(!saved.unchanged);
+    assert!(saved.path.exists(), "the mark writes a Git-tracked file");
+
+    let record = loaded(root.path(), &saved.lineage_id);
+    assert_eq!(record.statement, "Use short sentences.");
+    assert_eq!(force_of(&record), Some(rec::Force::Should));
+    assert_eq!(
+        record.origin,
+        Some(stella_records::context_record::Origin::User)
+    );
+    assert_eq!(
+        record.truth.as_ref().map(|t| t.basis),
+        Some(rec::TruthBasis::Decree),
+        "a person said so, which is what a decree means"
+    );
+}
+
+/// **The witness for `!!!`.** The rule strength is `must`. It is saved at the
+/// top `precedence`, so nothing beats it and no budget drops it first.
+#[test]
+fn a_rule_is_published_at_must_and_at_the_precedence_ceiling() {
+    let root = workspace();
+    let saved = publish(root.path(), KeepStrength::Rule, "Never force-push to main.")
+        .expect("the record publishes");
+
+    let record = loaded(root.path(), &saved.lineage_id);
+    assert_eq!(force_of(&record), Some(rec::Force::Must));
+    assert_eq!(record.precedence(), RULE_PRECEDENCE);
+    assert!(
+        record.enforcement.is_none(),
+        "a sentence carries no guard to evaluate, so it claims no blocking"
+    );
+}
+
+/// A saved record has to check out on load. If it does not, the next session
+/// reads a finding, not a rule.
+#[test]
+fn what_the_mark_writes_verifies_when_it_is_read_back() {
+    let root = workspace();
+    let saved =
+        publish(root.path(), KeepStrength::Rule, "Never force-push to main.").expect("publishes");
+    let registry = load_registry(root.path());
+    let entry = registry
+        .entries
+        .iter()
+        .find(|entry| entry.record.record.lineage_id == saved.lineage_id)
+        .expect("the record loads");
+    assert!(
+        entry.record.findings.is_empty(),
+        "a freshly kept record must verify: {:?}",
+        entry.record.findings
+    );
+}
+
+/// **The witness for the ledger.** Raise one claim from guidance to a rule.
+/// The old draft is retired. The shared ledger says so. This is the path
+/// `stella context keep` walks. It is not a side door.
+#[test]
+fn raising_guidance_to_a_rule_supersedes_it_and_the_ledger_says_so() {
+    let root = workspace();
+    let first = publish(
+        root.path(),
+        KeepStrength::Guidance,
+        "Never force-push to main.",
+    )
+    .expect("the first save publishes");
+    let second = publish(root.path(), KeepStrength::Rule, "Never force-push to main.")
+        .expect("the second save supersedes");
+
+    assert_eq!(
+        first.lineage_id, second.lineage_id,
+        "the same sentence keeps the same lineage, so the two do not argue"
+    );
+    assert!(
+        second.superseded.is_some(),
+        "the raise replaces the revision it outranks"
+    );
+    let ledger = std::fs::read_to_string(root.path().join(PROMOTION_LEDGER))
+        .expect("the promotion ledger exists");
+    let tail = ledger.lines().last().expect("it has a line");
+    assert!(
+        tail.contains("\"superseded\"") && tail.contains(&second.lineage_id),
+        "the ledger tail names the supersession: {tail}"
+    );
+    assert_eq!(
+        force_of(&loaded(root.path(), &second.lineage_id)),
+        Some(rec::Force::Must),
+        "the rule strength is what a later session now loads"
+    );
+}
+
+/// Say a thing twice. It is not an error, and it is not a second record.
+#[test]
+fn the_same_claim_at_the_same_strength_writes_nothing_new() {
+    let root = workspace();
+    publish(root.path(), KeepStrength::Guidance, "Use short sentences.").expect("publishes");
+    let again = publish(root.path(), KeepStrength::Guidance, "Use short sentences.")
+        .expect("a repeat is not a failure");
+    assert!(again.unchanged);
+    assert_eq!(
+        read_decisions(root.path()).len(),
+        1,
+        "a write that did not happen is not a decision"
+    );
+}
+
+/// Every save is on the ledger, with the file it wrote. So one log says where
+/// a record came from.
+#[test]
+fn every_save_is_on_the_decision_ledger_with_the_file_it_wrote() {
+    let root = workspace();
+    let saved =
+        publish(root.path(), KeepStrength::Rule, "Never force-push to main.").expect("publishes");
+    let decisions = read_decisions(root.path());
+    let event = decisions.first().expect("one decision");
+    assert_eq!(event.lineage_id, saved.lineage_id);
+    assert!(
+        event
+            .published_to
+            .as_deref()
+            .is_some_and(|to| to.starts_with(".stella/rules/")),
+        "the path is recorded repo-relative: {:?}",
+        event.published_to
+    );
+    assert!(
+        !event.approved_blocking,
+        "keeping a rule is not authorising it to block a tool call"
+    );
+}
+
+/// **The witness for the sweep gate.** The gate asks a record for two things.
+/// One: an `origin` that is not `imported` or `inferred`. Two: a `decree` with
+/// a name on it. What the mark builds has both. So the gate honors a gated
+/// probe on it. That is the read the live sweep makes.
+#[test]
+fn the_minted_record_clears_the_sweep_gate() {
+    let mut record = record("acme.web", KeepStrength::Rule, "Never force-push.", "mac")
+        .expect("the record builds");
+    let origin = record.origin.expect("an origin is stamped");
+    assert!(
+        !stella_records::ingest::gate::origin_is_untrusted(origin),
+        "a decree must not be read as imported or inferred"
+    );
+    if let Some(truth) = record.truth.as_mut() {
+        truth.probe = Some(rec::Probe {
+            kind: rec::ProbeKind::CommandSucceeds,
+            path: None,
+            pattern: None,
+            expect: None,
+            note: None,
+        });
+    }
+    assert!(
+        stella_records::records::sweep::honored_probe(&record, Trust::User).is_some(),
+        "origin plus a signed decree is what the gate asks of the record"
+    );
+}
+
+/// Pasted output is not a claim. Refuse it here. That is cheaper than a file
+/// the workspace's own check then flags.
+#[test]
+fn a_statement_that_reads_as_pasted_is_refused_before_anything_is_written() {
+    let root = workspace();
+    let pasted = "error: one\nerror: two\nerror: three\n".repeat(20);
+    let err = publish(root.path(), KeepStrength::Rule, &pasted).unwrap_err();
+    assert!(err.contains("one sentence"), "{err}");
+    assert!(
+        read_decisions(root.path()).is_empty(),
+        "a refused save records nothing"
+    );
+}
+
+/// The mark with nothing after it is refused. An empty claim is not a rule.
+#[test]
+fn an_empty_statement_is_refused() {
+    let root = workspace();
+    let err = publish(root.path(), KeepStrength::Guidance, "   ").unwrap_err();
+    assert!(err.contains("nothing after the mark"), "{err}");
+}
+
+/// The lineage comes from the words, not the strength. That is what lets a
+/// raise retire the old draft in place of a rival record.
+#[test]
+fn the_lineage_follows_the_sentence_and_not_the_strength() {
+    let one = record(
+        "acme.web",
+        KeepStrength::Guidance,
+        "Use short sentences.",
+        "mac",
+    )
+    .unwrap();
+    let two = record(
+        "acme.web",
+        KeepStrength::Rule,
+        "Use short sentences.",
+        "mac",
+    )
+    .unwrap();
+    assert_eq!(one.lineage_id, two.lineage_id);
+    assert!(
+        one.lineage_id.contains("use-short-sentences"),
+        "the file is findable by eye: {}",
+        one.lineage_id
+    );
+    let other = record(
+        "acme.web",
+        KeepStrength::Guidance,
+        "Use long sentences.",
+        "mac",
+    )
+    .unwrap();
+    assert_ne!(one.lineage_id, other.lineage_id);
+}

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -122,7 +122,7 @@ async fn main() -> std::io::Result<()> {
                 // soft-stop, so the interrupt degrades the way the envelope
                 // documents — the texts run next — echoed onto the lane the
                 // same way a steer is.
-                WorkspaceInput::Interrupt { agent, texts } => {
+                WorkspaceInput::Interrupt { agent, texts, .. } => {
                     for text in texts {
                         let _ = react_tx.send(Inbound::Event {
                             agent: agent.clone(),

--- a/crates/stella-tui/src/deck_ui/dispatch.rs
+++ b/crates/stella-tui/src/deck_ui/dispatch.rs
@@ -203,6 +203,7 @@ pub fn route(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> Option<Wo
                 return Some(WorkspaceInput::Interrupt {
                     agent,
                     texts: vec![text],
+                    keep: None,
                 });
             }
             ComposerMode::Dispatch => {}
@@ -461,6 +462,7 @@ mod tests {
             Some(WorkspaceInput::Interrupt {
                 agent: "lead".into(),
                 texts: vec!["stop — wrong branch".into()],
+                keep: None,
             })
         );
         assert_eq!(ui.composer_mode, None, "the override lasts one submission");

--- a/crates/stella-tui/src/deck_ui/sigil.rs
+++ b/crates/stella-tui/src/deck_ui/sigil.rs
@@ -10,13 +10,27 @@
 //! (`command_deck::steer::interrupt_lead`).
 //!
 //! The bang ran shell commands before this. The bang family takes it back:
-//! `!!` and `!!!` will mean "stop, and keep this rule". So `!ls` still runs
-//! `ls` for one more release, and it says where the shell mark went. `! ls`
-//! does not. A space after the bang is what the family shares.
+//! `!!` and `!!!` mean "stop, and keep this". So `!ls` still runs `ls` for one
+//! more release, and it says where the shell mark went. `! ls` does not. A
+//! space after the last bang is what the family shares.
+//!
+//! Counting the bangs is how hard the words push:
+//!
+//! | Input | Meaning |
+//! |---|---|
+//! | `! text` | stop the turn, run `text` next |
+//! | `!! text` | the same stop, and keep `text` as guidance the agent should follow |
+//! | `!!! text` | the same stop, and keep `text` as a rule it must follow |
+//!
+//! What "keep" writes is a context record, which every later session in this
+//! workspace loads through the ordinary record plane. The deck only says which
+//! strength was asked for; the driver owns the write
+//! (`command_deck::keep_record`).
 //!
 //! Split out of [`super`], a god file closed to growth.
 
 use super::*;
+use crate::envelope::KeepStrength;
 
 /// The mark a line starts with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,28 +42,45 @@ enum Mark {
     LegacyShell,
     /// `!` then a space: stop the running turn and run the rest next.
     Steer,
+    /// `!!` or `!!!` then a space: the same stop, and keep the rest as a
+    /// context record at this strength.
+    Keep(KeepStrength),
 }
 
 /// The mark `text` carries, and the words after it. `None` when the line
 /// carries no mark and is a plain prompt.
 ///
-/// A bang is a [`Mark::Steer`] only when a space follows it. That space is
-/// the whole difference between `! use short sentences` and `!ls`. It is also
-/// the shape the whole family shares. And it leaves the old shell spelling
-/// people's hands already type. Nobody writes `! ls` for a shell command.
+/// A bang run is a mark only when a space follows it. That space is the whole
+/// difference between `! use short sentences` and `!ls`, and it is what the
+/// whole family shares. It also leaves the old shell spelling people's hands
+/// already type: nobody writes `! ls` for a shell command, and `!!important`
+/// still reaches the shell as `!important`.
+///
+/// Bangs past the third are not a fourth strength — `!!!!` is refused as a
+/// mark rather than read as the strongest one, because guessing which of two
+/// meanings a typo intended is how a stray keystroke publishes a rule.
 fn parse(text: &str) -> Option<(Mark, &str)> {
     let head = text.trim_start();
     if let Some(rest) = head.strip_prefix('$') {
         return Some((Mark::Shell, rest.trim()));
     }
-    // Only the first bang is the mark. A command whose own text starts with a
-    // bang keeps it: `!important` is typed as `!!important`.
-    let rest = head.strip_prefix('!')?;
-    if rest.is_empty() || rest.starts_with(char::is_whitespace) {
-        Some((Mark::Steer, rest.trim()))
-    } else {
-        Some((Mark::LegacyShell, rest.trim()))
+    let bangs = head.chars().take_while(|c| *c == '!').count();
+    if bangs == 0 {
+        return None;
     }
+    let rest = &head[bangs..];
+    if !(rest.is_empty() || rest.starts_with(char::is_whitespace)) {
+        // The old spelling, which owns only the first bang: the rest of the
+        // run belongs to the command's own text.
+        return Some((Mark::LegacyShell, head[1..].trim()));
+    }
+    let mark = match bangs {
+        1 => Mark::Steer,
+        2 => Mark::Keep(KeepStrength::Guidance),
+        3 => Mark::Keep(KeepStrength::Rule),
+        _ => return None,
+    };
+    Some((mark, rest.trim()))
 }
 
 /// Whether a marked line beats a gate that is waiting for an answer.
@@ -85,6 +116,7 @@ pub(super) fn dispatch(ui: &mut DeckUi, model: &WorkspaceModel, text: String) ->
             DeckAction::Shell(rest)
         }
         Mark::Steer => steer(ui, model, rest),
+        Mark::Keep(strength) => keep(ui, model, rest, strength),
     }
 }
 
@@ -110,6 +142,50 @@ fn steer(ui: &mut DeckUi, model: &WorkspaceModel, text: String) -> DeckAction {
     DeckAction::Send(WorkspaceInput::Interrupt {
         agent: agent.meta.id.clone(),
         texts: vec![text],
+        keep: None,
+    })
+}
+
+/// `!! text` and `!!! text`: the interrupt above, with the words kept.
+///
+/// The save must not depend on what the session happens to be doing, so this
+/// sends the interrupt whether or not a turn is running. With nothing to stop,
+/// the driver reads that message as "run this now" — what a bang has always
+/// meant at rest — and writes the record either way. A deck with no agent at
+/// all has no interrupt to send and falls back to the plain prompt route; the
+/// composer is not reachable before the lead registers, so that arm is
+/// totality rather than a case anyone sees.
+///
+/// The note says what is being kept, not that it was kept: the write happens
+/// driver-side, and only the driver can report how it went.
+fn keep(
+    ui: &mut DeckUi,
+    model: &WorkspaceModel,
+    text: String,
+    strength: KeepStrength,
+) -> DeckAction {
+    let Some(agent) = model
+        .agents
+        .get(ui.focused)
+        .or_else(|| model.agents.first())
+    else {
+        return super::submit_prompt(ui, model, text);
+    };
+    let running = agent.status == crate::AgentStatus::Running;
+    let keeping = match strength {
+        KeepStrength::Guidance => "keeping that as guidance for this workspace",
+        KeepStrength::Rule => "keeping that as a rule for this workspace",
+    };
+    let tail = if running {
+        "stopping at the next step boundary"
+    } else {
+        "nothing was running, so it also went out as a prompt"
+    };
+    note(ui, &format!("{keeping} — {tail}"));
+    DeckAction::Send(WorkspaceInput::Interrupt {
+        agent: agent.meta.id.clone(),
+        texts: vec![text],
+        keep: Some(strength),
     })
 }
 
@@ -146,6 +222,30 @@ mod tests {
             Some((Mark::LegacyShell, "!important"))
         );
         assert_eq!(parse("!"), Some((Mark::Steer, "")));
+    }
+
+    /// Counting the bangs is the strength, and the space still separates the
+    /// family from the old shell spelling.
+    #[test]
+    fn the_bang_count_says_how_hard_the_words_push() {
+        assert_eq!(
+            parse("!! use short sentences"),
+            Some((Mark::Keep(KeepStrength::Guidance), "use short sentences"))
+        );
+        assert_eq!(
+            parse("!!! do not force-push"),
+            Some((Mark::Keep(KeepStrength::Rule), "do not force-push"))
+        );
+        assert_eq!(parse("!!ls"), Some((Mark::LegacyShell, "!ls")));
+        assert_eq!(parse("!!"), Some((Mark::Keep(KeepStrength::Guidance), "")));
+    }
+
+    /// A fourth bang is a typo, not a fourth strength. It carries no mark, so
+    /// the line goes out as the prompt it reads as.
+    #[test]
+    fn a_fourth_bang_is_not_a_stronger_rule() {
+        assert_eq!(parse("!!!! do not force-push"), None);
+        assert!(!claims_submission("!!!! do not force-push"));
     }
 
     #[test]

--- a/crates/stella-tui/src/deck_ui/tests/sigil.rs
+++ b/crates/stella-tui/src/deck_ui/tests/sigil.rs
@@ -1,4 +1,5 @@
-//! The composer marks: `$` runs a shell command, `!` interrupts the turn.
+//! The composer marks: `$` runs a shell command, `!` interrupts the turn, and
+//! `!!`/`!!!` interrupt it and keep the words.
 
 use super::*;
 
@@ -37,6 +38,7 @@ fn a_bang_at_a_running_lead_interrupts_the_turn_with_the_text() {
         DeckAction::Send(WorkspaceInput::Interrupt {
             agent: "lead".into(),
             texts: vec!["use short sentences".into()],
+            keep: None,
         })
     );
 }
@@ -76,6 +78,76 @@ fn the_dollar_mark_runs_a_shell_command_immediately_never_enqueued() {
     assert!(
         ui.notice.entries().is_empty(),
         "the current spelling is not deprecated"
+    );
+}
+
+/// **The witness for `!!`.** Two bangs interrupt exactly as one does, and the
+/// message carries the strength the driver saves the words at.
+///
+/// It fails on the old deck by construction. That deck owned only the first
+/// bang and read the second as part of a command, so `!! use short sentences`
+/// answered `DeckAction::Shell("! use short sentences")` and ran the sentence.
+#[test]
+fn two_bangs_interrupt_and_ask_for_the_words_to_be_kept_as_guidance() {
+    let model = lead(crate::AgentStatus::Running);
+    let mut ui = ready_ui();
+    assert_eq!(
+        submit("!! use short sentences", &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::Interrupt {
+            agent: "lead".into(),
+            texts: vec!["use short sentences".into()],
+            keep: Some(crate::envelope::KeepStrength::Guidance),
+        })
+    );
+    assert!(
+        ui.notice.entries().iter().any(|n| n.contains("guidance")),
+        "a keystroke that keeps something says what it keeps: {:?}",
+        ui.notice.entries()
+    );
+}
+
+/// **The witness for `!!!`.** Three bangs ask for the rule strength.
+#[test]
+fn three_bangs_interrupt_and_ask_for_the_words_to_be_kept_as_a_rule() {
+    let model = lead(crate::AgentStatus::Running);
+    let mut ui = ready_ui();
+    assert_eq!(
+        submit("!!! do not force-push", &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::Interrupt {
+            agent: "lead".into(),
+            texts: vec!["do not force-push".into()],
+            keep: Some(crate::envelope::KeepStrength::Rule),
+        })
+    );
+    assert!(
+        ui.notice.entries().iter().any(|n| n.contains("rule")),
+        "a keystroke that keeps a rule says so: {:?}",
+        ui.notice.entries()
+    );
+}
+
+/// The save must not depend on a turn being in flight, so a keep sigil at an
+/// idle lead still sends the message that carries it. The driver reads an
+/// interrupt with nothing to stop as "run this now".
+#[test]
+fn a_keep_sigil_at_an_idle_lead_still_carries_the_save() {
+    let model = lead(crate::AgentStatus::WaitingInput);
+    let mut ui = ready_ui();
+    assert_eq!(
+        submit("!! use short sentences", &model, &mut ui),
+        DeckAction::Send(WorkspaceInput::Interrupt {
+            agent: "lead".into(),
+            texts: vec!["use short sentences".into()],
+            keep: Some(crate::envelope::KeepStrength::Guidance),
+        })
+    );
+    assert!(
+        ui.notice
+            .entries()
+            .iter()
+            .any(|n| n.contains("nothing was running")),
+        "the deck says the words also went out as a prompt: {:?}",
+        ui.notice.entries()
     );
 }
 

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -836,6 +836,20 @@ pub struct InstalledAgentEntry {
     pub content: String,
 }
 
+/// How hard a bang-persistence sigil asks the record it saves to steer.
+///
+/// The two sigils differ by this field alone, so one write path serves both.
+/// `stella_tui::deck_ui::sigil` parses them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeepStrength {
+    /// `!!` — a `should` record. It steers, and a later explicit instruction
+    /// can still override it.
+    Guidance,
+    /// `!!!` — a `must` record at the precedence ceiling. It holds until
+    /// somebody retires it.
+    Rule,
+}
+
 /// What the deck sends back to the caller / engine. The single-session
 /// [`UserInput`] is wrapped with the target agent; new verbs cover the deck's
 /// workspace-level affordances (queueing, agent control, quit).
@@ -941,7 +955,17 @@ pub enum WorkspaceInput {
     /// the parked backlog. With no running turn it degrades to "run this
     /// now", and at a worker lane it lands as a steer — a lane's next prompt
     /// is the lead's, so there is nothing for the words to outrank there.
-    Interrupt { agent: AgentId, texts: Vec<String> },
+    ///
+    /// `keep` carries the bang-persistence sigils (`!!`, `!!!`): the same
+    /// stop, plus the words saved as a context record. It rides this message
+    /// rather than a second one so the stop and the save cannot separate — a
+    /// save whose stop was dropped, or a stop whose save was, is a failure the
+    /// person who typed it never sees. `None` at every other door.
+    Interrupt {
+        agent: AgentId,
+        texts: Vec<String>,
+        keep: Option<KeepStrength>,
+    },
     /// The composer's broadcast address (`>@all …`, `>@<session-id> …`,
     /// optionally `--deep`): send `message` to the other live sessions on
     /// this machine over their whistle sockets — every live one when

--- a/crates/stella-tui/src/keymap.rs
+++ b/crates/stella-tui/src/keymap.rs
@@ -657,11 +657,13 @@ pub const BINDINGS: &[Binding] = &[
     ),
     row(
         ">text / !text",
-        "steer at the next step boundary · ! stops there first",
+        "steer at the boundary · ! stops · !! !!! keep the words",
         Everywhere,
         &[
             "steering_sends_the_marker_the_driver_already_reads",
             "a_bang_at_a_running_lead_interrupts_the_turn_with_the_text",
+            "two_bangs_interrupt_and_ask_for_the_words_to_be_kept_as_guidance",
+            "three_bangs_interrupt_and_ask_for_the_words_to_be_kept_as_a_rule",
         ],
     ),
     row(

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -122,7 +122,7 @@ pub use envelope::{
     AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, EngineAgentState,
     EngineConfigState, EngineRole, EntityField, EntityHit, GRAPH_SERVER, Inbound, InspectMessage,
     InspectSection, InspectView, InstalledAgentEntry, IssueAction, IssueRow, JournalEra,
-    LearnedProvenance, LearnedSource, McpLiveIdentity, McpLookupState, McpSearchItem,
+    KeepStrength, LearnedProvenance, LearnedSource, McpLiveIdentity, McpLookupState, McpSearchItem,
     McpSearchOutcome, McpServerDetail, McpServerInfo, McpSignature, McpSourceTier, McpToolRow,
     NotificationInfo, RecordedCallInfo, SeatRow, Secret, SessionInfo, SessionPhase, SkillOp,
     SkillRow, SkillScope, SkillSearchHit, SkillsView, SplashCue, ToolDenial, ToolPolicyState,

--- a/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
+++ b/crates/stella-tui/tests/snapshots/deck/overlay_help_skills.txt
@@ -24,7 +24,7 @@
 │ │  ⏎               open it — a diff, a lane, a message's full text               ⏎               on PLAN: zoom the step — contract, evidence, planned vs … │ │
 │ │  ⌫               back up one level; never reaches a running turn               esc             on the zoom: back to PLAN, on the step you zoomed         │ │
 │ │  ⇞ ⇟ · Home End  a page · the ends                                             r s b i ⌥       on the zoom: re-run checks · split · hand off · promote … │ │
-│ │  tab / ⇧tab      the next / previous tab                                       >text / !text   steer at the next step boundary · ! stops there first     │ │
+│ │  tab / ⇧tab      the next / previous tab                                       >text / !text   steer at the boundary · ! stops · !! !!! keep the words   │ │
 │ │  q / esc         close any overlay                                             esc             steer: your draft + queue go INTO the running turn        │ │
 │ │                                                                                esc esc         cancel NOW & hold — nothing runs until your next prompt   │ │
 │ │                                                                                ?               this sheet                                                │ │

--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -87,6 +87,9 @@ These prefixes skip the queue:
   <SpecCard title="Interrupt — `! …`">
     A line that starts with `!` stops the running turn at its next step boundary, keeps the steps it finished, and runs your words next.
   </SpecCard>
+  <SpecCard title="Keep — `!! …` and `!!! …`">
+    The same stop, and the words are kept. `!!` writes them to `.stella/rules/` as guidance the agent should follow; `!!!` writes a rule it must. Later sessions load either one. A session already running does not see it until it restarts.
+  </SpecCard>
   <SpecCard title="Shell — `$ …`">
     A line that starts with `$` runs immediately as a shell command, inline in the transcript, and is never queued. `!cmd` still works for one release.
   </SpecCard>


### PR DESCRIPTION
## What and why

`!` interrupts the turn (#5442). This is the family's other half: `!!` and `!!!`
interrupt **and keep the words**, so a correction made once steers every later
session in the workspace.

| Input | Meaning |
|---|---|
| `! text` | stop the turn at its next step, run `text` next |
| `!! text` | the same stop, and keep `text` as **guidance** (`force = should`) |
| `!!! text` | the same stop, and keep `text` as a **rule** (`force = must`, `precedence = 100`) |
| `!ls` | still the old shell spelling, one more release |

A space after the last bang is the discriminator, the rule #5842 set. So
`!!important` still reaches the shell as `!important`, and the parse table test
that pinned that is unchanged. A fourth bang is refused as a mark rather than
read as the strongest one: guessing which of two meanings a typo intended is how
a stray keystroke publishes a rule.

## The write is the existing path, not a second one

`crates/stella-cli/src/context_records/decree.rs` is the sibling of
`inferred_rule_record`, the function that already publishes a mined rule. It
uses the same publication directory, the same `create_new` refusal to clobber,
the same supersession when the claim changes, and the same two ledgers. The
difference is what a decree may claim that a guess may not: `origin = user`,
`truth.basis = decree` with the actor as `verified_by`, and evidence graded
`HumanReview`. Those are exactly the fields `sweep::honored_probe` reads before
it trusts a record.

The `lineage_id` is derived from the sentence, never from the strength. So
saying the same thing twice is a no-op, and raising `!!` to `!!!` supersedes the
published revision instead of publishing a rival record that argues with it.

## Two readings the issue left open, and how they were settled

Posted on the issue before the work started
(https://github.com/macanderson/stella/issues/5443#issuecomment-5551134548).

- **"Enforcement 100."** The record surface has no numeric enforcement level.
  `steering.precedence` is its one numeric strength axis, and it decides both
  which record wins a conflict and which one keeps its place when the channel
  budget runs short. `!!!` publishes at `precedence = 100`, the ceiling.
  `enforcement` stays absent at both strengths: a `hard` mode with no evaluable
  guard advertises blocking that structurally cannot fire (the defect
  `stella_learn::rules` names), and a typed sentence supplies no guard.
- **"The ledger tail shows the promotion event."** There are two ledgers. Every
  save appends the same `DecisionEvent` `stella context keep` appends, and a
  save that supersedes a published revision appends the `Superseded` event to
  `.stella/rules/promotions.jsonl`. Both are witnessed. A first publication
  mints no *grant* event, because nothing was granted enforcement — writing one
  would put a false enforcement transition in a governance ledger.

## One save, in front of the arms

`crates/stella-cli/src/command_deck/keep_record.rs` holds one
`intercept(input, root, in_tx)` that both of the driver's receive sites pass
every message through. It writes the record, clears the mark, and **always
returns the message**, so a write that fails cannot cost the person the stop
they asked for; the failure comes back as a chrome note. An interrupt reaches
three arms (at rest, at the lead, at a worker lane) and a save inside each would
be three chances to write the record twice or not at all. `command_deck.rs` is a
god file: it gains no lines, only two changed call words.

Exemplar followed: `command_deck::steer` and `command_deck::settle`, the two
existing splits out of that god file.

## Witness mechanism

Deck (`crates/stella-tui/src/deck_ui/tests/sigil.rs`) — these **fail on `main` by
construction**: that parser owned only the first bang, so `!! use short
sentences` answered `DeckAction::Shell("! use short sentences")` and ran the
sentence as a command.

- `two_bangs_interrupt_and_ask_for_the_words_to_be_kept_as_guidance`
- `three_bangs_interrupt_and_ask_for_the_words_to_be_kept_as_a_rule`
- `a_keep_sigil_at_an_idle_lead_still_carries_the_save` — the save cannot depend
  on a turn being in flight
- parse-table units for the bang count and for the refused fourth bang

Driver (`crates/stella-cli/src/command_deck/keep_record/tests.rs`):

- `a_marked_interrupt_writes_the_record_and_hands_back_the_plain_stop`
- `a_write_that_fails_still_hands_back_the_stop_and_says_so` — `.stella/rules`
  is made a plain file, so the failure is real I/O rather than a seam invented
  for the test

Record (`crates/stella-cli/src/context_records/decree/tests.rs`):

- `guidance_is_published_at_should_and_a_fresh_load_finds_it` — a **fresh
  registry load**, which is the only view a later session has
- `a_rule_is_published_at_must_and_at_the_precedence_ceiling`
- `raising_guidance_to_a_rule_supersedes_it_and_the_ledger_says_so` — the
  promotion ledger tail
- `every_save_is_on_the_decision_ledger_with_the_file_it_wrote`
- `the_minted_record_clears_the_sweep_gate` — the origin is not untrusted, and a
  gated probe on the minted record is honored at `Trust::User`
- `what_the_mark_writes_verifies_when_it_is_read_back`, the pasted-text refusal,
  the empty-statement refusal, and the lineage-follows-the-sentence property

## Dependency

A record saved this way reaches **other live sessions** only once #5432's
mid-session hot reload lands. Those sessions read the record set once, at start.
This session and every session started afterwards pick it up on the next load.

## Golden frames

One line moved: the help sheet's `>text / !text` row now reads `steer at the
boundary · ! stops · !! !!! keep the words`, and
`tests/snapshots/deck/overlay_help_skills.txt` was updated by hand to match,
same rendered width, no other cell touched. The row also cites the two new
witnesses, which `every_binding_names_a_witness_that_exists` checks.

## Known-red base

`main` is red on a stale `Cargo.lock` (#5939, claimed by another session). This
branch touches no manifest; the lockfile check will stay red here until that
repair lands.

Tests deleted: None

Residue issues filed: listed in a comment below once opened.

Closes #5443

## Summary by Sourcery

Add persistent `!!` guidance and `!!!` rule interrupts while preserving existing stop and shell-command behavior.

New Features:
- Support `!!` interruptions that save the text as workspace guidance and `!!!` interruptions that save it as a workspace rule.
- Persist kept statements through the existing context-record publication and governance ledgers, including supersession when guidance is promoted to a rule.
- Document the new keep sigils in chat help and user-facing command documentation.

Bug Fixes:
- Preserve the original interrupt when saving fails so a failed record write cannot swallow the requested turn stop.
- Retain legacy `!cmd` shell parsing while rejecting four-bang inputs as keep markers.

Enhancements:
- Route marked interrupts through a single driver-side interception path so records are written once across idle, lead, and worker execution states.
- Add record validation, provenance, trust-gate compatibility, duplicate detection, and sentence-based lineage handling for composer-created records.

Documentation:
- Update chat command documentation and TUI help text to explain `!!` guidance and `!!!` rule persistence.

Tests:
- Add parser, deck, driver, and record-plane coverage for keep strengths, idle interrupts, failed writes, persistence, supersession, ledger entries, validation, and legacy bang behavior.

## DoD verification by the PR sweep (appended 2026-09-05)

The `dod / dod` check was red at 11:15:24Z on all six of #5443's items. Unlike
the sibling PRs in this sweep these were genuinely unticked, so each was
checked against this head (`0fff24a1`) before being ticked; the per-item
evidence is in
[this comment](https://github.com/macanderson/stella/issues/5443#issuecomment-5551453676),
including the one interpretation worth disagreeing with (item 2's "enforcement
100" → `precedence = 100`, `enforcement = None`).

Ran on this head: `cargo test -p stella-cli --bin stella -- context_records::decree keep_record`
— 13 passed, 0 failed.

Sourcery's single ❌ is answered separately above.

This edit is what re-fires `dod-check.yml` to re-read the boxes; the edit is
the trigger, never the fix.


---
_Generated by [Claude Code](https://claude.ai/code)_