### PR TITLE
test(stella-transcript,stella-cli): golden-frame snapshots for the plain transcript renderer

### DIFF
--- a/crates/stella-cli/src/plain/transcript/snapshots/scrollback.txt
+++ b/crates/stella-cli/src/plain/transcript/snapshots/scrollback.txt
@@ -1,0 +1,18 @@
+# plain scrollback golden · one turn, width 100
+# TranscriptPrinter's byte-for-byte scrollback for a fixed event
+# sequence — this crate's one shipping caller of
+# stella_transcript::grid::render_turn_lines. The grid golden that
+# pins the renderer itself lives one crate over, in
+# crates/stella-transcript/tests/grid_snapshots.rs. Styling stripped
+# via strip_ansi. Regenerate with:
+#   BLESS=1 cargo test -p stella-cli --bin stella plain::transcript::tests::the_scrollback_a_run_leaves_matches_its_golden
+
+╭─ fix-the-overfull-hbox ──────────────────────────────────────────────────────────────────────── ─╮
+│  you  fix the overfull hbox warnings
+│
+│  agent  ▸ I'll read the file first. …
+│ 0:00 ▸ read_file   app/main.tex                                                       [9ms] [1 ln]
+│      ▸ bash        latexmk main.tex                                                   [9ms] [1 ln]
+│
+│  agent  Read it.
+╰─ ✓ done ────────────────────────────────────────────────────────────────────── [2 steps] [0:00] ─╯

--- a/crates/stella-cli/src/plain/transcript/tests.rs
+++ b/crates/stella-cli/src/plain/transcript/tests.rs
@@ -344,3 +344,76 @@ fn strip_ansi(text: &str) -> String {
     }
     out
 }
+
+// --------------------------------------------------------- the golden
+
+/// The command quoted in every failure message below.
+const SCROLLBACK_BLESS_CMD: &str = "BLESS=1 cargo test -p stella-cli --lib \
+     plain::transcript::tests::the_scrollback_a_run_leaves_matches_its_golden";
+
+fn scrollback_snapshot_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/plain/transcript/snapshots/scrollback.txt")
+}
+
+/// The full golden file: a self-describing header, then the exact bytes a
+/// terminal or a log file receives.
+fn scrollback_golden_body(frame: &str) -> String {
+    format!(
+        "# plain scrollback golden · one turn, width {W}\n\
+         # TranscriptPrinter's byte-for-byte scrollback for a fixed event\n\
+         # sequence — this crate's one shipping caller of\n\
+         # stella_transcript::grid::render_turn_lines. The grid golden that\n\
+         # pins the renderer itself lives one crate over, in\n\
+         # crates/stella-transcript/tests/grid_snapshots.rs. Styling stripped\n\
+         # via strip_ansi. Regenerate with:\n\
+         #   {SCROLLBACK_BLESS_CMD}\n\
+         \n\
+         {frame}"
+    )
+}
+
+/// This pins the artifact the user sees. `grid_snapshots.rs`, in
+/// `stella-transcript`, pins the renderer. This test pins what
+/// [`TranscriptPrinter`] streams to scrollback, byte for byte, for one
+/// fixed run. No other test here checks that against a saved frame.
+///
+/// Every other test in this module checks `streamed`'s output with
+/// `contains(...)`. A substring check cannot see a row slide one column, or
+/// a gutter constant drift. A golden test can.
+#[test]
+fn the_scrollback_a_run_leaves_matches_its_golden() {
+    let live = strip_ansi(&streamed(&turn_events()));
+    let body = scrollback_golden_body(&live);
+    let path = scrollback_snapshot_path();
+
+    if std::env::var_os("BLESS").is_some() {
+        let dir = path.parent().expect("snapshot path has a parent");
+        std::fs::create_dir_all(dir)
+            .unwrap_or_else(|err| panic!("create {}: {err}", dir.display()));
+        std::fs::write(&path, &body)
+            .unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
+        return;
+    }
+
+    let Ok(expected) = std::fs::read_to_string(&path) else {
+        panic!(
+            "no golden at {}.\n\
+             Create it with:  {SCROLLBACK_BLESS_CMD}\n\
+             \n\
+             This run produced:\n{body}",
+            path.display()
+        );
+    };
+    // Normalize line endings: a Windows checkout with `core.autocrlf` on
+    // would otherwise fail this golden on the first character of every line.
+    let expected = expected.replace("\r\n", "\n");
+
+    assert_eq!(
+        expected,
+        body,
+        "the plain surface's scrollback drifted from its golden at {}.\n\
+         If the change is intended, re-bless and read the diff:  {SCROLLBACK_BLESS_CMD}",
+        path.display()
+    );
+}

--- a/crates/stella-cli/src/plain/transcript/tests.rs
+++ b/crates/stella-cli/src/plain/transcript/tests.rs
@@ -348,7 +348,7 @@ fn strip_ansi(text: &str) -> String {
 // --------------------------------------------------------- the golden
 
 /// The command quoted in every failure message below.
-const SCROLLBACK_BLESS_CMD: &str = "BLESS=1 cargo test -p stella-cli --lib \
+const SCROLLBACK_BLESS_CMD: &str = "BLESS=1 cargo test -p stella-cli --bin stella \
      plain::transcript::tests::the_scrollback_a_run_leaves_matches_its_golden";
 
 fn scrollback_snapshot_path() -> std::path::PathBuf {

--- a/crates/stella-transcript/tests/grid_snapshots.rs
+++ b/crates/stella-transcript/tests/grid_snapshots.rs
@@ -1,0 +1,680 @@
+//! Golden-frame snapshots of `stella_transcript::grid`.
+//!
+//! This is the character-grid renderer. It draws every plain `stella run`
+//! transcript. `grid::render` and `grid::render_turn_lines` had one fixture
+//! before this file. That fixture pins one function's spans, not a frame.
+//! Every other test in this crate is a plain unit test in `src/tests.rs`. A
+//! unit test proves a property. It cannot show which rows a frame has, in
+//! what order, at what column. This file adds that missing check.
+//!
+//! `grid.rs`'s whole frame is due for a rewrite. SPEC 6 swaps the
+//! `╭─ … ─╮` box for labelled rules. That change will move every row this
+//! file pins. A golden landed now gives that change something to diff
+//! against.
+//!
+//! This file follows `crates/stella-tui/tests/deck_render_snapshots.rs`'s
+//! harness shape — the pattern this workspace already uses for a golden
+//! suite. It asserts [`grid::to_plain`], never the ANSI output. A plain-grid
+//! diff is one a human can read. `grid.rs`'s own notes say to check the ANSI
+//! encoders on their own.
+//!
+//! ## Regenerating
+//!
+//! ```text
+//! BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+//! ```
+//!
+//! Read the diff before you commit it. A golden blessed without a look is a
+//! changelog, not a test.
+//!
+//! Every test here starts with `grid_snapshots_`. Keep that prefix: it lets
+//! `cargo test -p stella-transcript grid_snapshots` find them with no
+//! `--test` flag.
+
+use std::path::PathBuf;
+
+use stella_transcript::grid;
+use stella_transcript::{
+    Accounting, ArgRow, Call, Extent, FileChange, FileStatus, FoldState, NodeId, Note, NoteKind,
+    Output, Prose, Run, Status, Step, ToolKind, Turn, Zoom,
+};
+
+/// The command quoted in every failure message below.
+const BLESS_CMD: &str = "BLESS=1 cargo test -p stella-transcript --test grid_snapshots";
+
+/// The width most goldens render at. It is wide enough that a step row's
+/// verb, object and chips all fit with no cut. That way a fixture shows the
+/// column layout, not the cut rules `grid.rs` already covers on its own.
+const W: usize = 100;
+
+// ───────────────────────────── the harness ─────────────────────────────
+// This mirrors `crates/stella-tui/tests/deck_render_snapshots.rs`. It skips
+// the `TestBackend` step: `grid::render` and `render_turn_lines` already
+// return the character grid, with no terminal to render into first.
+
+fn snapshot_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/snapshots/grid")
+        .join(format!("{name}.txt"))
+}
+
+/// `BLESS=1` rewrites the goldens instead of asserting against them.
+fn blessing() -> bool {
+    std::env::var("BLESS").is_ok_and(|v| v == "1")
+}
+
+/// The full golden file: a header, then the plain frame.
+///
+/// The header names the width. A change to a gutter constant then shows up
+/// as a header diff, not as rows that re-wrapped for no clear reason. The
+/// header also names the bless command, so a reader can regenerate the file.
+fn golden_body(name: &str, description: &str, width: usize, frame: &str) -> String {
+    format!(
+        "# grid golden · {name}\n\
+         # {description}\n\
+         # width {width} · rendered through grid::to_plain, styling stripped\n\
+         # regenerate: {BLESS_CMD}\n\
+         \n\
+         {frame}\n"
+    )
+}
+
+/// Assert a rendered frame against its committed golden, or rewrite it under
+/// `BLESS=1`.
+fn assert_golden(name: &str, description: &str, width: usize, frame: &str) {
+    let body = golden_body(name, description, width, frame);
+    let path = snapshot_path(name);
+
+    if blessing() {
+        let dir = path.parent().expect("snapshot path has a parent");
+        std::fs::create_dir_all(dir)
+            .unwrap_or_else(|err| panic!("create {}: {err}", dir.display()));
+        std::fs::write(&path, &body)
+            .unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
+        println!("blessed {}", path.display());
+        return;
+    }
+
+    let Ok(expected) = std::fs::read_to_string(&path) else {
+        panic!(
+            "no golden for {name:?} at {}.\n\
+             Create it with:  {BLESS_CMD}\n\
+             \n\
+             This run rendered:\n{body}",
+            path.display()
+        );
+    };
+    // Normalize line endings: a Windows checkout with `core.autocrlf` on
+    // would otherwise fail every golden on the first character of every line.
+    let expected = expected.replace("\r\n", "\n");
+
+    assert!(
+        expected == body,
+        "the {name:?} frame drifted from its golden at {}.\n\n{}\n\
+         If the change is intended, re-bless and read the diff:  {BLESS_CMD}",
+        path.display(),
+        describe_diff(&expected, &body),
+    );
+}
+
+/// A short report of what changed: only the rows that differ, each with the
+/// column where it first differs. Two full walls of box-drawing left for a
+/// reader to eyeball would show much less.
+fn describe_diff(expected: &str, actual: &str) -> String {
+    use std::fmt::Write as _;
+
+    let expected: Vec<&str> = expected.lines().collect();
+    let actual: Vec<&str> = actual.lines().collect();
+    let mut out = String::new();
+
+    if expected.len() != actual.len() {
+        let _ = writeln!(
+            out,
+            "the frame changed height: {} lines -> {} lines",
+            expected.len(),
+            actual.len()
+        );
+    }
+
+    for i in 0..expected.len().max(actual.len()) {
+        let (e, a) = (
+            expected.get(i).copied().unwrap_or("<past end of golden>"),
+            actual.get(i).copied().unwrap_or("<past end of frame>"),
+        );
+        if e == a {
+            continue;
+        }
+        let col = e
+            .chars()
+            .zip(a.chars())
+            .position(|(x, y)| x != y)
+            .unwrap_or_else(|| e.chars().count().min(a.chars().count()));
+        let _ = writeln!(
+            out,
+            "line {}, first difference at character {}:",
+            i + 1,
+            col + 1
+        );
+        let _ = writeln!(out, "  golden │{e}│");
+        let _ = writeln!(out, "  actual │{a}│");
+    }
+    out
+}
+
+// ───────────────────────────── the fixtures ─────────────────────────────
+// These build `stella_transcript::model` values by hand, the way a real
+// caller does. This crate never touches an `AgentEvent`. It takes owned
+// data and hands back a grid — no scripted event stream needed.
+
+fn plain_output(lines: &[&str]) -> Output {
+    Output {
+        lines: lines.iter().map(|l| (*l).to_string()).collect(),
+        clipped: 0,
+    }
+}
+
+fn bash(command: &str, out: &[&str], status: Status) -> Call {
+    Call {
+        tool: ToolKind::Bash,
+        header_object: command.to_string(),
+        args: vec![ArgRow {
+            key: "command".to_string(),
+            value: command.to_string(),
+        }],
+        output: plain_output(out),
+        files: Vec::new(),
+        status,
+        duration_ms: 226,
+        speculated: false,
+        sub_agent_id: None,
+    }
+}
+
+fn read_file(path: &str, out: &[&str]) -> Call {
+    Call {
+        tool: ToolKind::ReadFile,
+        header_object: path.to_string(),
+        args: Vec::new(),
+        output: plain_output(out),
+        files: Vec::new(),
+        status: Status::Ok,
+        duration_ms: 4,
+        speculated: false,
+        sub_agent_id: None,
+    }
+}
+
+fn edit_file(path: &str, before: &str, after: &str) -> Call {
+    Call {
+        tool: ToolKind::EditFile,
+        header_object: path.to_string(),
+        args: Vec::new(),
+        output: Output::default(),
+        files: vec![FileChange {
+            path: path.to_string(),
+            before: before.to_string(),
+            after: after.to_string(),
+            status: FileStatus::Modified,
+            extent: Extent::default(),
+            patch: None,
+        }],
+        status: Status::Ok,
+        duration_ms: 9,
+        speculated: false,
+        sub_agent_id: None,
+    }
+}
+
+/// A deletion nothing measured. Both sides are empty, and there is no
+/// patch, so `FileDiff::build` returns [`Extent::default`]. It does not
+/// guess a count from a diff it never ran. The header must draw no `−N` at
+/// all — never a fake `−0`.
+fn delete_file_unmeasured(path: &str) -> Call {
+    Call {
+        tool: ToolKind::DeleteFile,
+        header_object: path.to_string(),
+        args: Vec::new(),
+        output: Output::default(),
+        files: vec![FileChange {
+            path: path.to_string(),
+            before: String::new(),
+            after: String::new(),
+            status: FileStatus::Deleted,
+            extent: Extent::default(),
+            patch: None,
+        }],
+        status: Status::Ok,
+        duration_ms: 3,
+        speculated: false,
+        sub_agent_id: None,
+    }
+}
+
+fn step(call: Call, offset_ms: u64) -> Step {
+    Step {
+        call: Some(call),
+        accounting: Accounting {
+            tokens_in: 4_000,
+            tokens_out: 120,
+            cached_in: 3_500,
+            micros: 600,
+        },
+        offset_ms,
+    }
+}
+
+fn run(name: &str, turns: Vec<Turn>) -> Run {
+    Run {
+        name: name.to_string(),
+        model: "z-ai/glm-5.2".to_string(),
+        started_at: "09:14:02".to_string(),
+        turns,
+    }
+}
+
+// ───────────────────────── a bash call, a read, a mutation ─────────────────
+// One turn that touches all three call shapes, pinned at every zoom preset.
+// That way the fold defaults are in the frame too, not just the calls.
+
+fn mixed_turn() -> Turn {
+    Turn {
+        name: "widen-offset".to_string(),
+        prompt: "widen the offset gutter so a five-digit step count still lines up".to_string(),
+        prose: vec![Prose {
+            text: "I'll check the current width, run the suite, then widen the constant."
+                .to_string(),
+            before_step: 0,
+        }],
+        notes: Vec::new(),
+        steps: vec![
+            step(
+                bash(
+                    "cargo test -p stella-transcript",
+                    &["running 12 tests", "test result: ok. 12 passed; 0 failed"],
+                    Status::Ok,
+                ),
+                0,
+            ),
+            step(
+                read_file(
+                    "crates/stella-transcript/src/grid.rs",
+                    &["pub const OFFSET_W: usize = 5;"],
+                ),
+                400,
+            ),
+            step(
+                edit_file(
+                    "crates/stella-transcript/src/grid.rs",
+                    "pub const OFFSET_W: usize = 5;\n",
+                    "pub const OFFSET_W: usize = 6;\n",
+                ),
+                900,
+            ),
+        ],
+        answer: Some("Widened OFFSET_W from 5 to 6; the suite still passes.".to_string()),
+        status: Status::Ok,
+        duration_ms: 4_200,
+    }
+}
+
+fn mixed_run() -> Run {
+    run("widen-offset-gutter", vec![mixed_turn()])
+}
+
+#[test]
+fn grid_snapshots_pin_a_mixed_turn_at_zoom_turns() {
+    let r = mixed_run();
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Turns);
+    let frame = grid::to_plain(&grid::render(&r, &state, W));
+    assert_golden(
+        "mixed_turn_zoom_turns",
+        "a bash call, a read and a file edit, at Zoom::Turns — turn headers only",
+        W,
+        &frame,
+    );
+}
+
+#[test]
+fn grid_snapshots_pin_a_mixed_turn_at_zoom_steps() {
+    let r = mixed_run();
+    let state = FoldState::new(); // Steps is the default preset
+    let frame = grid::to_plain(&grid::render(&r, &state, W));
+    assert_golden(
+        "mixed_turn_zoom_steps",
+        "the same turn at Zoom::Steps — one-line digests, bodies folded",
+        W,
+        &frame,
+    );
+}
+
+#[test]
+fn grid_snapshots_pin_a_mixed_turn_at_zoom_everything() {
+    let r = mixed_run();
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+    let frame = grid::to_plain(&grid::render(&r, &state, W));
+    assert_golden(
+        "mixed_turn_zoom_everything",
+        "the same turn at Zoom::Everything — every body and diff open",
+        W,
+        &frame,
+    );
+}
+
+// ───────────────────────────── a failed step ─────────────────────────────
+
+fn suite_run_with_a_failure() -> Run {
+    run(
+        "loop-detect-suite",
+        vec![
+            Turn {
+                name: "run-suite".to_string(),
+                prompt: "run the loop-detect suite".to_string(),
+                prose: Vec::new(),
+                notes: Vec::new(),
+                steps: vec![step(
+                    bash(
+                        "cargo test -p stella-core loop_detect",
+                        &[
+                            "running 4 tests",
+                            "test loop_detect::tests::detects_a_two_cycle_repeat ... FAILED",
+                            "failures:",
+                            "    loop_detect::tests::detects_a_two_cycle_repeat",
+                            "test result: FAILED. 3 passed; 1 failed; 0 ignored",
+                        ],
+                        Status::Error,
+                    ),
+                    0,
+                )],
+                answer: None,
+                status: Status::Error,
+                duration_ms: 6_100,
+            },
+            Turn {
+                name: "fix-suite".to_string(),
+                prompt: "fix it".to_string(),
+                prose: Vec::new(),
+                notes: Vec::new(),
+                steps: vec![step(
+                    bash(
+                        "cargo test -p stella-core loop_detect",
+                        &["running 4 tests", "test result: ok. 4 passed; 0 failed"],
+                        Status::Ok,
+                    ),
+                    0,
+                )],
+                answer: Some(
+                    "Fixed the off-by-one in the cycle window; the suite passes.".to_string(),
+                ),
+                status: Status::Ok,
+                duration_ms: 3_400,
+            },
+        ],
+    )
+}
+
+/// A failed step stays open at `Zoom::Turns`, the coarsest fold level.
+/// [`Status::pins_open`] wins over the zoom default. This holds even for
+/// the run's *first* turn, not its last — `Zoom::Turns` would leave only
+/// the last turn open by default. Renders through `render_turn_lines`, the
+/// entry point a plain `stella run` prints through.
+#[test]
+fn grid_snapshots_pin_a_failed_step_open_at_zoom_turns() {
+    let r = suite_run_with_a_failure();
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Turns);
+    let frame = grid::to_plain(&grid::render_turn_lines(&r, &state, 0, W));
+    assert_golden(
+        "failed_step_pinned_open",
+        "the first of two turns, not the last, failed — Zoom::Turns would \
+         otherwise collapse it, but the failure pins the step open",
+        W,
+        &frame,
+    );
+}
+
+// ──────────────────────── a note with detail, one without ─────────────────
+
+fn notes_run() -> Run {
+    run(
+        "recall-and-budget",
+        vec![Turn {
+            name: "recall-and-budget".to_string(),
+            prompt: "keep going".to_string(),
+            prose: Vec::new(),
+            notes: vec![
+                Note {
+                    kind: NoteKind::Context,
+                    summary: "recalled 3 memories".to_string(),
+                    detail: vec![
+                        "stella-transcript-golden-frame.md".to_string(),
+                        "grid-gutter-widths.md".to_string(),
+                        "append-only-streaming.md".to_string(),
+                    ],
+                    before_step: 0,
+                    inspect: None,
+                },
+                Note {
+                    kind: NoteKind::Meter,
+                    summary: "budget: 40% remaining".to_string(),
+                    detail: Vec::new(),
+                    before_step: 1,
+                    inspect: None,
+                },
+            ],
+            steps: vec![
+                step(
+                    bash(
+                        "cargo build -p stella-transcript",
+                        &["Compiling stella-transcript"],
+                        Status::Ok,
+                    ),
+                    0,
+                ),
+                step(
+                    bash(
+                        "cargo test -p stella-transcript",
+                        &["test result: ok. 12 passed; 0 failed"],
+                        Status::Ok,
+                    ),
+                    500,
+                ),
+            ],
+            answer: Some("Both crates build and the suite passes.".to_string()),
+            status: Status::Ok,
+            duration_ms: 2_000,
+        }],
+    )
+}
+
+/// A note with detail rows draws a fold control. One without draws none —
+/// the control never opens onto an empty body. The detailed note is opened
+/// by hand here, so its rows show in the frame, not just its marker.
+#[test]
+fn grid_snapshots_pin_notes_with_and_without_detail() {
+    let r = notes_run();
+    let mut state = FoldState::new();
+    state.open(NodeId::Note { turn: 0, note: 0 });
+    let frame = grid::to_plain(&grid::render_turn_lines(&r, &state, 0, W));
+    assert_golden(
+        "notes_with_and_without_detail",
+        "a context note with three detail rows, opened, beside a budget note \
+         with none — only the first draws a fold marker",
+        W,
+        &frame,
+    );
+}
+
+// ───────────────────────── an unmeasured deletion ─────────────────────────
+
+fn unmeasured_delete_run() -> Run {
+    run(
+        "drop-legacy-printer",
+        vec![Turn {
+            name: "drop-legacy-printer".to_string(),
+            prompt: "delete the dead legacy printer".to_string(),
+            prose: Vec::new(),
+            notes: Vec::new(),
+            steps: vec![step(
+                delete_file_unmeasured("crates/stella-cli/src/plain/legacy.rs"),
+                0,
+            )],
+            answer: Some("Removed the dead legacy printer.".to_string()),
+            status: Status::Ok,
+            duration_ms: 400,
+        }],
+    )
+}
+
+/// Pins [`stella_transcript::Extent`]'s rule as a frame, not just as a unit
+/// check: a side nothing measured draws no count at all, never a fake `−0`.
+#[test]
+fn grid_snapshots_pin_an_unmeasured_deleted_file() {
+    let r = unmeasured_delete_run();
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+    let frame = grid::to_plain(&grid::render_turn_lines(&r, &state, 0, W));
+    assert_golden(
+        "unmeasured_deleted_file",
+        "a delete_file call whose extent nothing measured — the header \
+         draws no count",
+        W,
+        &frame,
+    );
+}
+
+// ───────────────────────────── CJK and emoji ─────────────────────────────
+
+fn cjk_emoji_run() -> Run {
+    run(
+        "設定を更新",
+        vec![Turn {
+            name: "🔧 設定を更新".to_string(),
+            prompt: "設定ファイルを更新して絵文字のラベルを直してください 🎉".to_string(),
+            prose: Vec::new(),
+            notes: Vec::new(),
+            steps: vec![step(
+                edit_file(
+                    "設定/config.toml",
+                    "名前 = \"旧いラベル\"\n",
+                    "名前 = \"新しいラベル\" 🎉\n",
+                ),
+                0,
+            )],
+            answer: Some("設定を更新しました ✅".to_string()),
+            status: Status::Ok,
+            duration_ms: 900,
+        }],
+    )
+}
+
+/// `grid.rs` measures width through [`grid::cells`], never through
+/// `chars().count()`. An ASCII fixture cannot show the difference. CJK
+/// text and emoji can, because each one takes two columns, not one. A
+/// narrow width forces the turn name and the diff header to cut, so a bug
+/// in that measure shows up here as a moved column.
+#[test]
+fn grid_snapshots_pin_cjk_and_emoji_content() {
+    const NARROW: usize = 56;
+    let r = cjk_emoji_run();
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+    let frame = grid::to_plain(&grid::render_turn_lines(&r, &state, 0, NARROW));
+    assert_golden(
+        "cjk_and_emoji_content",
+        "a Japanese turn name/prompt/answer and an emoji, at a width narrow \
+         enough to force a cut",
+        NARROW,
+        &frame,
+    );
+}
+
+// ───────────────────────── append-only, made legible ─────────────────────
+
+fn growing_run(steps: usize) -> Run {
+    run(
+        "widen-fixture-matrix",
+        vec![Turn {
+            name: "widen-matrix".to_string(),
+            prompt: "widen the fixture matrix, crate by crate".to_string(),
+            prose: Vec::new(),
+            notes: Vec::new(),
+            steps: (0..steps)
+                .map(|i| {
+                    step(
+                        bash(
+                            &format!("cargo test -p crate-{i}"),
+                            &["test result: ok. 1 passed; 0 failed"],
+                            Status::Ok,
+                        ),
+                        (i * 200) as u64,
+                    )
+                })
+                .collect(),
+            answer: None,
+            status: Status::Running,
+            duration_ms: 0,
+        }],
+    )
+}
+
+/// A line the streaming surface has already printed must not change as the
+/// turn grows. That is [`grid::render_turn_lines`]'s own rule. A unit test
+/// already checks it: `render_turn_is_append_only_as_a_turn_grows`, in
+/// `src/tests/frame.rs`. This test shows the same rule as a diff. A bug
+/// that moves an already-printed line then shows up as a changed section
+/// of the golden, not just a failed check with no shape to it.
+///
+/// Every growing stage below skips the closing rail, the same way the
+/// streaming surface does (`stella-cli`'s `plain::transcript::frame`). That
+/// rail carries the status and the cost. Neither exists while the turn is
+/// still running.
+#[test]
+fn grid_snapshots_pin_the_append_only_growth_of_a_streaming_turn() {
+    let mut sections = String::new();
+    let mut previous: Vec<String> = Vec::new();
+    for steps in 0..=3 {
+        let r = growing_run(steps);
+        let state = FoldState::new();
+        let lines = grid::render_turn_lines(&r, &state, 0, W);
+        let body: Vec<String> = lines[..lines.len().saturating_sub(1)]
+            .iter()
+            .map(|l| grid::to_plain(std::slice::from_ref(l)))
+            .collect();
+        assert!(
+            body.len() >= previous.len(),
+            "the frame shrank at {steps} steps: {} -> {}",
+            previous.len(),
+            body.len()
+        );
+        for (i, (was, now)) in previous.iter().zip(&body).enumerate() {
+            assert_eq!(
+                was, now,
+                "line {i} was rewritten when the turn reached {steps} steps"
+            );
+        }
+        sections.push_str(&format!(
+            "── after {steps} step{} (running) ──\n",
+            if steps == 1 { "" } else { "s" }
+        ));
+        sections.push_str(&body.join("\n"));
+        sections.push_str("\n\n");
+        previous = body;
+    }
+
+    let mut finished = growing_run(3);
+    finished.turns[0].status = Status::Ok;
+    finished.turns[0].answer = Some("Every crate in the matrix now has a fixture.".to_string());
+    let full = grid::to_plain(&grid::render_turn_lines(&finished, &FoldState::new(), 0, W));
+    sections.push_str("── finished (3 steps + answer) ──\n");
+    sections.push_str(&full);
+
+    assert_golden(
+        "append_only_growth",
+        "render_turn_lines at 0..=3 steps while the turn runs, then \
+         finished — every earlier line survives unchanged into the next stage",
+        W,
+        &sections,
+    );
+}

--- a/crates/stella-transcript/tests/snapshots/grid/append_only_growth.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/append_only_growth.txt
@@ -1,0 +1,41 @@
+# grid golden · append_only_growth
+# render_turn_lines at 0..=3 steps while the turn runs, then finished — every earlier line survives unchanged into the next stage
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+── after 0 steps (running) ──
+╭─ widen-matrix ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the fixture matrix, crate by crate
+│
+
+── after 1 step (running) ──
+╭─ widen-matrix ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the fixture matrix, crate by crate
+│
+│ 0:00 ▸ bash        cargo test -p crate-0                                  [226ms] [1 ln] [$0.0006]
+
+── after 2 steps (running) ──
+╭─ widen-matrix ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the fixture matrix, crate by crate
+│
+│ 0:00 ▸ bash        cargo test -p crate-0                                  [226ms] [1 ln] [$0.0006]
+│      ▸ bash        cargo test -p crate-1                                  [226ms] [1 ln] [$0.0006]
+
+── after 3 steps (running) ──
+╭─ widen-matrix ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the fixture matrix, crate by crate
+│
+│ 0:00 ▸ bash        cargo test -p crate-0                                  [226ms] [1 ln] [$0.0006]
+│      ▸ bash        cargo test -p crate-1                                  [226ms] [1 ln] [$0.0006]
+│      ▸ bash        cargo test -p crate-2                                  [226ms] [1 ln] [$0.0006]
+
+── finished (3 steps + answer) ──
+╭─ widen-matrix ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the fixture matrix, crate by crate
+│
+│ 0:00 ▸ bash        cargo test -p crate-0                                  [226ms] [1 ln] [$0.0006]
+│      ▸ bash        cargo test -p crate-1                                  [226ms] [1 ln] [$0.0006]
+│      ▸ bash        cargo test -p crate-2                                  [226ms] [1 ln] [$0.0006]
+│
+│  agent  Every crate in the matrix now has a fixture.
+╰─ ✓ done ──────────────────────────────────────────────── [3 steps] [0:00] [12.0k→360] [$0.0018] ─╯

--- a/crates/stella-transcript/tests/snapshots/grid/cjk_and_emoji_content.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/cjk_and_emoji_content.txt
@@ -1,0 +1,17 @@
+# grid golden · cjk_and_emoji_content
+# a Japanese turn name/prompt/answer and an emoji, at a width narrow enough to force a cut
+# width 56 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ 🔧 設定を更新 ──────────────────────────────────── ─╮
+│  you  設定ファイルを更新して絵文字のラベルを直してく
+│       ださい 🎉
+│
+│ 0:00 ▾ edit_file   設定/config.toml  +1 −1[9ms] [$0.00
+│        │ ± 設定/config.toml +1 −1  ▾
+│        │ @@ -1,1 +1,1 @@
+│        │   1     − 名前 = "旧いラベル"
+│        │       1 + 名前 = "新しいラベル" 🎉
+│
+│  agent  設定を更新しました ✅
+╰─ ✓ done ───── [1 steps] [0:00] [4.0k→120] [$0.0006] ─╯

--- a/crates/stella-transcript/tests/snapshots/grid/failed_step_pinned_open.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/failed_step_pinned_open.txt
@@ -1,0 +1,15 @@
+# grid golden · failed_step_pinned_open
+# the first of two turns, not the last, failed — Zoom::Turns would otherwise collapse it, but the failure pins the step open
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ run-suite ──────────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  run the loop-detect suite
+│
+│ 0:00 ▾ bash        cargo test -p stella-core loop_detect  ✗ failed        [226ms] [5 ln] [$0.0006]
+│        │ running 4 tests
+│        │ test loop_detect::tests::detects_a_two_cycle_repeat ... FAILED
+│        │ failures:
+│        │     loop_detect::tests::detects_a_two_cycle_repeat
+│        │ test result: FAILED. 3 passed; 1 failed; 0 ignored
+╰─ ✗ failed ─────────────────────────────────────────────── [1 steps] [0:06] [4.0k→120] [$0.0006] ─╯

--- a/crates/stella-transcript/tests/snapshots/grid/mixed_turn_zoom_everything.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/mixed_turn_zoom_everything.txt
@@ -1,0 +1,24 @@
+# grid golden · mixed_turn_zoom_everything
+# the same turn at Zoom::Everything — every body and diff open
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ widen-offset ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the offset gutter so a five-digit step count still lines up
+│
+│  agent  ▾ I'll check the current width, run the suite, then widen the constant. …
+│
+│ 0:00 ▾ bash        cargo test -p stella-transcript                        [226ms] [2 ln] [$0.0006]
+│        │ running 12 tests
+│        │ test result: ok. 12 passed; 0 failed
+│      ▾ read_file   crates/stella-transcript/src/grid.rs                     [4ms] [1 ln] [$0.0006]
+│        │ pub const OFFSET_W: usize = 5;
+│      ▾ edit_file   crates/stella-transcript/src/grid.rs  +1 −1                     [9ms] [$0.0006]
+│        │ ± crates/stella-transcript/src/grid.rs +1 −1  ▾
+│        │ @@ -1,1 +1,1 @@
+│        │   1     − pub const OFFSET_W: usize = 5;
+│        │       1 + pub const OFFSET_W: usize = 6;
+│
+│  agent  Widened OFFSET_W from 5 to 6; the suite still passes.
+╰─ ✓ done ──────────────────────────────────────────────── [3 steps] [0:04] [12.0k→360] [$0.0018] ─╯
+1 turns · 3 steps · $0.0018               j/k step  ←/→ fold  z zoom [Everything]  e outputs  c copy

--- a/crates/stella-transcript/tests/snapshots/grid/mixed_turn_zoom_steps.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/mixed_turn_zoom_steps.txt
@@ -1,0 +1,16 @@
+# grid golden · mixed_turn_zoom_steps
+# the same turn at Zoom::Steps — one-line digests, bodies folded
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ widen-offset ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the offset gutter so a five-digit step count still lines up
+│
+│  agent  ▸ I'll check the current width, run the suite, then widen the constant. …
+│ 0:00 ▸ bash        cargo test -p stella-transcript                        [226ms] [2 ln] [$0.0006]
+│      ▸ read_file   crates/stella-transcript/src/grid.rs                     [4ms] [1 ln] [$0.0006]
+│      ▸ edit_file   crates/stella-transcript/src/grid.rs  +1 −1                     [9ms] [$0.0006]
+│
+│  agent  Widened OFFSET_W from 5 to 6; the suite still passes.
+╰─ ✓ done ──────────────────────────────────────────────── [3 steps] [0:04] [12.0k→360] [$0.0018] ─╯
+1 turns · 3 steps · $0.0018                    j/k step  ←/→ fold  z zoom [Steps]  e outputs  c copy

--- a/crates/stella-transcript/tests/snapshots/grid/mixed_turn_zoom_turns.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/mixed_turn_zoom_turns.txt
@@ -1,0 +1,16 @@
+# grid golden · mixed_turn_zoom_turns
+# a bash call, a read and a file edit, at Zoom::Turns — turn headers only
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ widen-offset ───────────────────────────────────────────────────────────────────────────────── ─╮
+│  you  widen the offset gutter so a five-digit step count still lines up
+│
+│  agent  ▸ I'll check the current width, run the suite, then widen the constant. …
+│ 0:00 ▸ bash        cargo test -p stella-transcript                        [226ms] [2 ln] [$0.0006]
+│      ▸ read_file   crates/stella-transcript/src/grid.rs                     [4ms] [1 ln] [$0.0006]
+│      ▸ edit_file   crates/stella-transcript/src/grid.rs  +1 −1                     [9ms] [$0.0006]
+│
+│  agent  Widened OFFSET_W from 5 to 6; the suite still passes.
+╰─ ✓ done ──────────────────────────────────────────────── [3 steps] [0:04] [12.0k→360] [$0.0018] ─╯
+1 turns · 3 steps · $0.0018                    j/k step  ←/→ fold  z zoom [Turns]  e outputs  c copy

--- a/crates/stella-transcript/tests/snapshots/grid/notes_with_and_without_detail.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/notes_with_and_without_detail.txt
@@ -1,0 +1,18 @@
+# grid golden · notes_with_and_without_detail
+# a context note with three detail rows, opened, beside a budget note with none — only the first draws a fold marker
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ recall-and-budget ──────────────────────────────────────────────────────────────────────────── ─╮
+│  you  keep going
+│
+│ ◆    ▾ recalled 3 memories
+│        stella-transcript-golden-frame.md
+│        grid-gutter-widths.md
+│        append-only-streaming.md
+│ 0:00 ▸ bash        cargo build -p stella-transcript                       [226ms] [1 ln] [$0.0006]
+│ $      budget: 40% remaining
+│      ▸ bash        cargo test -p stella-transcript                        [226ms] [1 ln] [$0.0006]
+│
+│  agent  Both crates build and the suite passes.
+╰─ ✓ done ───────────────────────────────────────────────── [2 steps] [0:02] [8.0k→240] [$0.0012] ─╯

--- a/crates/stella-transcript/tests/snapshots/grid/unmeasured_deleted_file.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/unmeasured_deleted_file.txt
@@ -1,0 +1,13 @@
+# grid golden · unmeasured_deleted_file
+# a delete_file call whose extent nothing measured — the header draws no count
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ drop-legacy-printer ────────────────────────────────────────────────────────────────────────── ─╮
+│  you  delete the dead legacy printer
+│
+│ 0:00 ▾ delete_file crates/stella-cli/src/plain/legacy.rs  deleted                  [3ms] [$0.0006]
+│        │ ✗ crates/stella-cli/src/plain/legacy.rs  ▾
+│
+│  agent  Removed the dead legacy printer.
+╰─ ✓ done ───────────────────────────────────────────────── [1 steps] [0:00] [4.0k→120] [$0.0006] ─╯


### PR DESCRIPTION
## What & why

`stella_transcript::grid::render` and `render_turn_lines` draw the transcript every `stella run` user reads on the plain surface. Before this PR nothing compared their output against a saved frame — only a plain unit test per property, plus one unrelated golden for word-highlight spans (`word-highlight-matrix.txt`). A unit test proves a property holds; it cannot show a reviewer which row moved, or that a gutter constant walked a column. #4289 piece 3 is about to rewrite this renderer's whole frame (SPEC 6's labelled rules in place of the `╭─ … ─╮` box), and that change needs something to diff against.

Adds two golden suites, both with their fixtures committed:

1. `crates/stella-transcript/tests/grid_snapshots.rs` — pins `grid::render` and `grid::render_turn_lines` at `grid::to_plain`, following `crates/stella-tui/tests/deck_render_snapshots.rs`'s harness shape (the pattern this workspace already uses for a golden suite over a rendered frame). Eight goldens under `crates/stella-transcript/tests/snapshots/grid/`, covering the issue's own list:
   - a turn with a `bash` call, a `read_file` call and a file edit, at `Zoom::Turns`/`Steps`/`Everything`;
   - a failed step pinned open past `Zoom::Turns`'s coarse fold, even for a turn that is not the run's last;
   - a note with detail rows (opened) beside one without any — only the first draws a fold marker;
   - a `delete_file` call whose extent nothing measured, so the header draws no count at all rather than a fabricated `−0` (#4289 piece 1's rule, pinned by a frame);
   - a CJK/emoji turn name, prompt and answer at a narrow width, exercising `grid::cells` rather than `chars().count()` (#3740);
   - the append-only growth of a streaming turn (`render_turn_lines` at 0..=3 steps while running, then finished), made legible as a diff instead of only the existing unit-test property (`render_turn_is_append_only_as_a_turn_grows`, `src/tests/frame.rs`).
2. `crates/stella-cli/src/plain/transcript/tests.rs` — one golden over `TranscriptPrinter`'s own scrollback for a fixed event sequence: the artifact a plain `stella run` user actually reads. Every other test in that module only asserts `contains(...)`, which is blind to a row sliding a column. Fixture at `crates/stella-cli/src/plain/transcript/snapshots/scrollback.txt`.

Exemplar crate: `crates/stella-tui/tests/deck_render_snapshots.rs` — its `assert_golden`/`describe_diff`/`BLESS=1` harness shape is copied nearly verbatim, cut down to a plain-text frame (no `TestBackend`, since `grid::render`/`render_turn_lines` already return the character grid).

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed

Every new test in this PR is a witness for issue #5081: none of these assertions existed on `main`, so each fails on `main` by construction (the module/function doesn't exist there) and passes here. The flip was run, not just described: with the golden directory moved aside, `cargo test -p stella-transcript --test grid_snapshots` reports `0 passed; 8 failed`; with it restored, `8 passed; 0 failed` — confirmed on this head, and again independently in CI's own run (see below).

## The gate

- [x] `cargo fmt --check` — green on [this run](https://github.com/macanderson/stella/actions/runs/33962101843/job/101297649599)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — same run
- [x] `cargo test --workspace` — same run, 8/8 new grid goldens + the scrollback golden passing
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments) — n/a, test-only change
- [ ] CLA signed
- [x] `Closes #5081` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [x] New cross-boundary types round-trip through serde (test included) — n/a, no new types

## Anything reviewers should know?

`#4289` piece 3 and `#3578` are the follow-up work this issue exists to give something to diff against — this PR does not touch `grid.rs` itself, so it introduces no rendering change, only coverage.

The three commits on this PR are the harness landing red (no goldens yet, by construction — the missing-file panic prints the exact expected bytes), then two follow-up commits blessing the goldens from that real output and fixing a bad `BLESS=1` command spelling (`--lib` on a crate with no library target) found along the way. Both are read in the commit messages themselves.

Closes #5081

---
_Generated by [Claude Code](https://claude.ai/code)_
