### PR TITLE
docs(agents): document a stacked PR's CI evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,40 @@ partitioning by crate, directory or owner, ask whether anything in the set has
 to change atomically. `rg -l 'INTENTIONALLY DUPLICATED'` names today's only
 such twin.
 
+**A stacked PR's evidence is the same CI run — but confirm it started.** No
+workflow's `pull_request:` trigger carries a `branches:` filter (`push:`
+triggers do, and only for the workflows above's own post-merge behavior), so a
+PR whose base is another branch rather than `main` is meant to start the same
+required contexts as a `main`-based one, and normally does: a throwaway PR
+opened against a fresh non-`main` base on 2026-09-05 started `ci`, `msrv`,
+`docs-guards`, `file-size`, `guard-self-tests`, `dependency-review`,
+`duplicate-claims`, `rebase-replay`, `main-red-hold`, `bench`, `empty-diff` and
+`dod-check` within 20 seconds of opening.
+
+It did not always. A PR based on `fix/4917-observatory-plugin-skills` once
+started only `cla` (`pull_request_target`) — every `pull_request`-triggered
+workflow never ran at all, nine days before the throwaway PR above proved the
+opposite. `gh api repos/<repo>/commits/<sha>/check-suites` is what tells the
+two apart: for that PR's head commit, across its whole time on a non-`main`
+base, GitHub created exactly three `github-actions` check suites (two `cla`
+runs and one manually dispatched `ci`) and none for `ci`/`msrv`/`file-size`/the
+rest — the `pull_request` event was never delivered for those workflow files,
+so there was nothing to fail or even skip. Closing and reopening the PR did
+not recover it. No repository setting explains it: `actions/permissions`
+allows every action, and this repository's one ruleset targets only the
+`main` branch — so treat it as a rare platform gap rather than a policy, and
+use the check-suites query above to tell the two apart if it recurs.
+
+**If `gh pr checks` on a stacked PR shows only `cla`/`Sourcery review`, its CI
+evidence has not started yet — a hand-run `workflow_dispatch` of the missing
+workflow is not a substitute**, because it runs the branch head rather than
+the merge commit that would actually land, which is exactly the gap a
+hand-dispatched stand-in left open the day this was first observed. Push a
+new commit (a fresh
+`synchronize` event is a second attempt) or wait for the branch this PR is
+stacked on to merge and retarget it at `main`, which is what produces a real
+run.
+
 **Cite a document by its id, not its path.** Every document under `docs/` that
 anything cites carries frontmatter with a stable `id`, and a citation names that
 id — `doc:context-reuse §4`. Moving the file cannot break it. A document with no


### PR DESCRIPTION
## What & why

#5008 reported that a stacked PR (base != `main`) got no gate run at all — only
`cla` fired. I checked the repository settings that could cause that
(`actions/permissions`, rulesets, branch protection) and found nothing that
would scope `pull_request` runs to the default branch, then reproduced live:
a throwaway PR based on a fresh non-`main` branch started `ci`, `msrv`,
`docs-guards`, `file-size`, `guard-self-tests`, `dependency-review`,
`duplicate-claims`, `rebase-replay`, `main-red-hold`, `bench`, `empty-diff`
and `dod-check` within 20 seconds of opening. The bug does not reproduce
today.

For the original PR (#5003), `gh api repos/.../commits/<sha>/check-suites`
shows GitHub created exactly three `github-actions` check suites for that
commit's whole time on a non-`main` base — two `cla` runs and one manual
`workflow_dispatch` — and none for the `pull_request`-triggered workflows.
The event was never delivered for them; nothing filtered or failed. That
rules out both hypotheses the issue itself raises (trigger filter, missed
webhook) and everything I could check in repository settings. It reads as a
one-off GitHub platform gap, not a standing policy.

Since there's no reproducible bug and no setting to change, this documents
the mechanism in AGENTS.md's gate section, per the issue's own step 3: what a
stacked PR's evidence looks like when it works, how to distinguish a genuine
miss from a normal run with the check-suites query above, and why a
hand-dispatched `workflow_dispatch` isn't an equivalent substitute (it runs
the branch head, not the merge commit that would land).

Full investigation, including the live throwaway-PR repro and the settings
checked, is posted on the issue.

Closes #5008

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this is a
      documentation-only change (AGENTS.md prose). The empirical evidence for
      the finding is the throwaway PR repro and the check-suites query, both
      posted on the issue; nothing here changes runtime behavior.

## The gate

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

No Rust changed, so fmt/clippy/test are N/A for this diff; the required CI
gate steps still run and are the evidence.

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

This is a docs-only PR that documents a transient, non-reproducing GitHub
platform gap rather than fixing code. If the same shape recurs (a stacked PR
showing only `cla`/`Sourcery review` in `gh pr checks`), the new AGENTS.md
paragraph names the diagnostic (`check-suites` on the head commit) and the
correct-but-imperfect workaround (`workflow_dispatch`, with its caveat).

### DoD verification (2026-09-05)

`dod-check` failed against #5008 because its three DoD boxes were still
unticked. Each was re-verified against primary sources before ticking, rather
than taken from this PR's own prose:

1. **Settings checked** — the investigation comment on #5008 reports
   `actions/permissions` (`allowed_actions: all`), the single ruleset
   (targets `main`, rule `deletion`), `branches/main/protection`, and that
   `macanderson` is a User account so no org required-workflow policy exists.
2. **Live non-`main`-based PR starts the same contexts** — verified
   independently on #5969 (`test-5008-head` → `test-5008-base`): the GitHub
   check-runs API for its head commit `452ff91` lists 18 check runs, among
   them `ci` (`fmt + clippy + test`, `cargo deny + cargo audit`),
   `docs guards`, `file size ratchet`, `guard self-tests`,
   `dependency-review`, `duplicate claims`, `main is not known-broken`,
   `PR carries a diff` and `dod / dod` — all created within ~5 seconds of the
   PR opening at 11:22:19Z, and cancelled only because the PR was closed at
   11:23:49Z. The claim is therefore demonstrated, not asserted.
3. **AGENTS.md documents it** — satisfied by this diff, which adds the gate
   section's stacked-PR paragraphs including the `check-suites` diagnostic.

## Summary by Sourcery

Document how to diagnose and recover missing CI evidence on stacked pull requests without changing repository behavior.

Enhancements:
- Document how to verify that CI has started for stacked pull requests and distinguish normal runs from a rare GitHub Actions delivery gap.
- Document the limitations of manually dispatched workflows and recommended recovery options for missing stacked-PR CI evidence.

Documentation:
- Expand AGENTS.md with stacked pull-request CI evidence, diagnosis, and recovery guidance based on observed GitHub behavior.