### PR TITLE
fix(stella-diag): give a durable home to diagnostics an ordinary run must not lose

### DIFF
--- a/crates/stella-cli/src/diag_boot.rs
+++ b/crates/stella-cli/src/diag_boot.rs
@@ -48,8 +48,8 @@ use std::sync::{Arc, OnceLock};
 
 use colored::Colorize;
 use stella_diag::{
-    Bound, Cx, Dx, Filter, JsonlSink, Level, LevelFilter, Parsed, Record, Sink, TerminalGated,
-    TextSink, diag,
+    Bound, Cx, Dx, Filter, JsonlSink, LazyJsonlSink, Level, LevelFilter, Parsed, Record, Sink,
+    TerminalGated, TextSink, diag,
 };
 
 use crate::cli::GlobalArgs;
@@ -58,6 +58,52 @@ use crate::cli::GlobalArgs;
 /// the floor. A file nobody reads until something breaks may as well contain
 /// enough to explain it; stderr stays at `warn` so a normal run is quiet.
 const FILE_FLOOR: LevelFilter = LevelFilter::Info;
+
+/// Targets that reach [`durable_sink`] on every run. `-v`, `--log-level` and
+/// `STELLA_LOG` cannot silence them and cannot raise them either. See
+/// `docs/spec/diagnostics.md` §6 "Durable targets" for why this list exists
+/// and what belongs on it.
+///
+/// Adding a target here is a design decision, not a call-site convenience.
+/// Write the reason in that document first, the same rule §5.5 sets for
+/// `Redacted::reviewed`. A target listed here writes to disk on every
+/// ordinary run with nothing switched on, so it earns the same review a new
+/// hub telemetry column gets under AGENTS.md #3. The write stays on this
+/// machine; the question is still "does a human agree this is worth it".
+///
+/// `stella::turn_files` is `agent.task.stale_lane` and the rare
+/// `agent.files.unmeasurable` warning beside it. Both fire at most once per
+/// turn, never once per tool call and never once per token.
+const DURABLE_TARGETS: &str = "off,stella::turn_files=debug";
+
+/// Where [`durable_sink`] writes: the same 0700 directory the crash ring
+/// already uses ([`crash_dir`]), so an operator who knows to look there for a
+/// crash dump finds this file beside it.
+fn durable_diagnostics_path(workspace_root: &Path) -> PathBuf {
+    crash_dir(workspace_root).join("diagnostics.jsonl")
+}
+
+/// The sink [`install`] adds on every run, no matter what filter the
+/// operator chose. A diagnostic that exists to measure an ordinary run's own
+/// rate cannot wait on `-v` or `--log-file` — both are a flag someone must
+/// decide to set in advance. Lowering the default stderr filter is not the
+/// fix either: §6 of `docs/spec/diagnostics.md` keeps a normal run quiet on
+/// purpose.
+///
+/// [`LazyJsonlSink`], not [`JsonlSink::file`]. This sink is built on every
+/// run, `stella --version` in a bare directory included. Only a run whose
+/// target actually fires — today, a turn that ends with its lead's task lane
+/// still occupied — may create `.stella/private/`.
+///
+/// Split out of [`install`] so a test can build one alone. `install` also
+/// installs the process-wide panic hook and races [`BOOTED`]; a test over
+/// sink wiring wants neither.
+pub(crate) fn durable_sink(workspace_root: &Path) -> Bound {
+    Bound::new(
+        Filter::parse(DURABLE_TARGETS).filter,
+        Arc::new(LazyJsonlSink::new(durable_diagnostics_path(workspace_root))) as Arc<dyn Sink>,
+    )
+}
 
 /// The process's diagnostic handle and the workspace it is reporting on.
 ///
@@ -142,6 +188,10 @@ pub(crate) fn install(globals: &GlobalArgs, workspace_root: &Path) -> Arc<Dx> {
             Err(error) => log_file_error = Some(error),
         }
     }
+
+    // Unconditional: durability for the targets §6's list names does not
+    // depend on `filter` at all — see `durable_sink`'s doc comment.
+    sinks.push(durable_sink(workspace_root));
 
     let dx = Arc::new(Dx::new(sinks));
     // Losing this race means another thread booted first; take that one, so
@@ -374,6 +424,88 @@ mod tests {
             crash_dir(Path::new("/w")),
             Path::new("/w/.stella/private"),
             "a crash dump must land in the 0700 directory trace.rs establishes"
+        );
+    }
+
+    /// **Sanity half of the witness below.** `agent.task.stale_lane` is a
+    /// `Debug` record and the operator's own default filter is `Warn` — the
+    /// arrangement that drops the record everywhere without `durable_sink`.
+    #[test]
+    fn the_operators_default_filter_would_drop_a_stale_lane_record() {
+        let default_filter = resolve_filter(&globals(&[])).filter;
+        assert!(!default_filter.admits("stella::turn_files", Level::Debug));
+    }
+
+    /// **Witness.** `durable_sink` keeps the record the test above shows
+    /// every other sink drops, and it does so with nothing switched on — no
+    /// `-v`, no `--log-level`, no `--log-file`. Fails without `durable_sink`:
+    /// nothing else an ordinary `install` builds admits `stella::turn_files`
+    /// at any level.
+    #[test]
+    fn durable_sink_keeps_a_stale_lane_record_an_ordinary_run_would_otherwise_drop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Through `Dx::emit`, the same door every real call site uses —
+        // proof the wiring works end to end, not just that the filter
+        // would allow it.
+        let dx = Dx::new(vec![durable_sink(dir.path())]);
+        dx.emit(Record::new(
+            Level::Debug,
+            "agent.task.stale_lane",
+            "stella::turn_files",
+            Cx::EMPTY,
+            stella_diag::Fields::new().with("files_changed", 3_u64),
+        ));
+
+        let path = dir
+            .path()
+            .join(".stella")
+            .join("private")
+            .join("diagnostics.jsonl");
+        let text = std::fs::read_to_string(&path).expect("the durable file must exist");
+        assert!(text.contains("agent.task.stale_lane"), "{text}");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o600,
+                "the durable file is owner-only, like every other sink"
+            );
+        }
+    }
+
+    /// `DURABLE_TARGETS` is a hand-written filter spec, not operator input —
+    /// a typo in it would silently widen or narrow the durable guarantee
+    /// with no `warn` record to notice it by, unlike a bad `STELLA_LOG`
+    /// clause.
+    #[test]
+    fn durable_targets_parses_with_no_bad_clauses() {
+        assert!(Filter::parse(DURABLE_TARGETS).bad.is_empty());
+    }
+
+    /// The whole reason `durable_sink` is scoped by target rather than
+    /// admitting every `Debug` record: `stella::diag_bridge` emits one
+    /// `Debug` record per tool call and per media chunk, and durably
+    /// persisting that on every ordinary run is the noise §6 refuses to
+    /// accept for stderr, now on disk instead.
+    #[test]
+    fn durable_sink_ignores_a_debug_record_from_an_unlisted_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bound = durable_sink(dir.path());
+        assert!(!bound.filter().admits("stella::diag_bridge", Level::Debug));
+    }
+
+    /// **Witness.** The durable sink is installed on every run — `stella
+    /// --version` in a directory that has never seen `.stella/` included —
+    /// so it must not itself create `.stella/private/` there. Only a run
+    /// that actually emits under a durable target may.
+    #[test]
+    fn durable_sink_creates_nothing_for_a_run_that_never_emits_under_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _bound = durable_sink(dir.path());
+        assert!(
+            !dir.path().join(".stella").exists(),
+            "building the sink alone must not touch disk"
         );
     }
 

--- a/crates/stella-cli/src/turn_files/stale_lane.rs
+++ b/crates/stella-cli/src/turn_files/stale_lane.rs
@@ -14,6 +14,20 @@
 //! Split out of [`super`] instead of grown inside it: that file sits at its
 //! own 1500-line ceiling (AGENTS.md § "God files — plan around them, never
 //! into them"). New logic here lands in this sibling instead.
+//!
+//! ## Where the record lands
+//!
+//! [`Level::Debug`] is quiet. Too quiet: the operator's own default is
+//! `Warn`, and `--log-file` floors at `Info`. Left at that, this record
+//! reaches nobody. It only shows up once someone turns `-vv` on. That
+//! defeats the point — nobody knew to look yet.
+//!
+//! `DIAG_TARGET` (`stella::turn_files`) is on `diag_boot`'s
+//! `DURABLE_TARGETS` list now. Every `install` binds a sink to that list, no
+//! matter what filter the operator chose. So the record also lands in
+//! `.stella/private/diagnostics.jsonl` on every ordinary run, nothing
+//! switched on. `docs/spec/diagnostics.md` §6 "Durable targets" explains
+//! why; this module is the diagnostic that needed it first.
 
 use stella_diag::{Cx, Dx, Fields, Level, Record};
 
@@ -202,5 +216,34 @@ mod tests {
             records.find("agent.task.stale_lane").is_none(),
             "a completed task must stay silent"
         );
+    }
+
+    /// **Witness.** The full path an ordinary run takes: a `Dx` wired the way
+    /// `main` wires it, with no `-v`, no `--log-level`, no `--log-file` —
+    /// only [`crate::diag_boot::durable_sink`]. `note_stale_lane` still puts
+    /// its record on disk, which is what fails without it: before this, a
+    /// `Dx` built the same way kept nothing at `Debug`, and the walked-past
+    /// turn this test builds left no trace anywhere.
+    #[test]
+    fn note_stale_lane_reaches_disk_through_the_durable_sink_alone() {
+        let registry = stella_tools::ToolRegistry::new(std::env::temp_dir());
+        {
+            let handle = registry.task_board();
+            let mut board = handle.lock().unwrap();
+            board.create("investigate", None, None);
+            board.set_status("1", TaskStatus::InProgress).unwrap();
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dx = stella_diag::Dx::new(vec![crate::diag_boot::durable_sink(dir.path())]);
+        note_stale_lane(&dx, &registry, STALE_LANE_FILES);
+
+        let path = dir
+            .path()
+            .join(".stella")
+            .join("private")
+            .join("diagnostics.jsonl");
+        let text = std::fs::read_to_string(&path).expect("the durable file must exist");
+        assert!(text.contains("agent.task.stale_lane"), "{text}");
     }
 }

--- a/crates/stella-diag/src/lib.rs
+++ b/crates/stella-diag/src/lib.rs
@@ -114,7 +114,8 @@ pub use ring::{
     prune_crash_files,
 };
 pub use sink::{
-    Bound, Capture, FailingSink, JsonlSink, Sink, SinkError, TerminalGated, TerminalHold, TextSink,
+    Bound, Capture, FailingSink, JsonlSink, LazyJsonlSink, Sink, SinkError, TerminalGated,
+    TerminalHold, TextSink,
 };
 
 mod redact;

--- a/crates/stella-diag/src/sink.rs
+++ b/crates/stella-diag/src/sink.rs
@@ -170,7 +170,7 @@ impl Sink for JsonlSink {
 /// `docs/spec/diagnostics.md` §6's durable-target list needs a sink like
 /// this one: a plain `stella --version` in a bare directory must not leave
 /// behind an empty `.stella/private/` it never needed. This sink calls
-/// [`private::open_append`] on the first write its [`Bound`] filter admits,
+/// `private::open_append` on the first write its [`Bound`] filter admits,
 /// and not before, so a run that never fires under a bound target never
 /// touches disk.
 pub struct LazyJsonlSink {

--- a/crates/stella-diag/src/sink.rs
+++ b/crates/stella-diag/src/sink.rs
@@ -19,7 +19,7 @@
 //! the pair down.
 
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -105,6 +105,14 @@ impl Bound {
     }
 }
 
+/// One record, serialized as a single JSON line — shared by [`JsonlSink`] and
+/// [`LazyJsonlSink`] so the two spellings of "JSONL" cannot drift apart.
+fn jsonl_line(record: &Record) -> Result<Vec<u8>, SinkError> {
+    let mut line = serde_json::to_vec(record).map_err(|_| SinkError::Encode)?;
+    line.push(b'\n');
+    Ok(line)
+}
+
 /// One JSON object per line.
 ///
 /// The machine-readable shape, and the one `--log-file` writes. The `Mutex`
@@ -140,8 +148,7 @@ impl JsonlSink {
 
 impl Sink for JsonlSink {
     fn write(&self, record: &Record) -> Result<(), SinkError> {
-        let mut line = serde_json::to_vec(record).map_err(|_| SinkError::Encode)?;
-        line.push(b'\n');
+        let line = jsonl_line(record)?;
         let mut out = self.out.lock().map_err(|_| SinkError::Poisoned)?;
         out.write_all(&line)?;
         Ok(())
@@ -149,6 +156,59 @@ impl Sink for JsonlSink {
 
     fn flush(&self) -> Result<(), SinkError> {
         self.out.lock().map_err(|_| SinkError::Poisoned)?.flush()?;
+        Ok(())
+    }
+}
+
+/// One JSON object per line, in a file this sink opens only when its first
+/// record arrives.
+///
+/// [`JsonlSink::file`] opens its file the moment the sink is built. That is
+/// right for `--log-file`: the operator asked for it, so a bad path is
+/// worth a report at boot, not a silent failure on the first write. It is
+/// wrong for a sink installed on *every* run, whether or not it ever fires.
+/// `docs/spec/diagnostics.md` §6's durable-target list needs a sink like
+/// this one: a plain `stella --version` in a bare directory must not leave
+/// behind an empty `.stella/private/` it never needed. This sink calls
+/// [`private::open_append`] on the first write its [`Bound`] filter admits,
+/// and not before, so a run that never fires under a bound target never
+/// touches disk.
+pub struct LazyJsonlSink {
+    path: PathBuf,
+    file: Mutex<Option<Box<dyn Write + Send>>>,
+}
+
+impl LazyJsonlSink {
+    #[must_use]
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            file: Mutex::new(None),
+        }
+    }
+}
+
+impl Sink for LazyJsonlSink {
+    fn write(&self, record: &Record) -> Result<(), SinkError> {
+        let line = jsonl_line(record)?;
+        let mut slot = self.file.lock().map_err(|_| SinkError::Poisoned)?;
+        if slot.is_none() {
+            *slot = Some(Box::new(private::open_append(&self.path)?) as Box<dyn Write + Send>);
+        }
+        // `slot` was just set to `Some` on the branch above if it was not
+        // already — this always matches, and an `if let` says so without
+        // reaching for `.unwrap()`/`.expect()` to state it.
+        if let Some(file) = slot.as_mut() {
+            file.write_all(&line)?;
+        }
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        let mut slot = self.file.lock().map_err(|_| SinkError::Poisoned)?;
+        if let Some(file) = slot.as_mut() {
+            file.flush()?;
+        }
         Ok(())
     }
 }
@@ -549,6 +609,58 @@ mod tests {
             !error.to_string().contains("ada"),
             "the path survived: {error}"
         );
+    }
+
+    /// **Witness.** A sink installed on every run must not touch disk on a
+    /// run whose target never fires. `JsonlSink::file` opens eagerly and
+    /// cannot make that promise; this is why a lazy sink exists.
+    #[test]
+    fn a_lazy_sink_creates_nothing_until_its_first_write() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("diagnostics.jsonl");
+        let sink = LazyJsonlSink::new(&path);
+        assert!(!path.exists(), "building the sink must not touch disk");
+
+        sink.write(&a_record()).expect("write");
+        assert!(path.exists(), "the first write must create the file");
+        let text = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(text.lines().count(), 1);
+    }
+
+    #[test]
+    fn a_lazy_sink_appends_across_writes_owner_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("diagnostics.jsonl");
+        let sink = LazyJsonlSink::new(&path);
+        sink.write(&a_record()).expect("write");
+        sink.write(&a_record()).expect("write");
+        sink.flush().expect("flush");
+
+        let text = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(
+            text.lines().count(),
+            2,
+            "the second write must append, not truncate"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "a durable diagnostics file is owner-only");
+        }
+    }
+
+    /// A flush before anything was ever written must not itself create the
+    /// file — `LazyJsonlSink`'s whole point is staying silent on disk for a
+    /// run its bound target never reaches, and `Dx::flush` runs on every
+    /// process exit.
+    #[test]
+    fn flushing_an_unwritten_lazy_sink_creates_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("diagnostics.jsonl");
+        let sink = LazyJsonlSink::new(&path);
+        sink.flush().expect("flush");
+        assert!(!path.exists());
     }
 
     #[test]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -321,6 +321,53 @@ Human-facing messages are unaffected either way: those are the presentation
 plane's `eprintln!`s, including the one naming a crash dump, and they never went
 through a sink.
 
+### 6.1 Durable targets: a record that must survive a quiet default
+
+`-v` and `--log-file` both need an operator to decide something in advance.
+They help once somebody has already gone looking. Some records exist to
+answer a different question: how often does this happen, before anyone
+knows to look? `agent.task.stale_lane` is one. It was added to measure a
+rate the task-board reinforcement question needs answered first. It is
+emitted at `Debug` so it costs nothing on a normal terminal — and that made
+it unreachable. The operator's own default is `Warn`. Even a raised
+`--log-file` floors at `Info` (§6's table). So the record only ever showed
+up in a session where `-vv` was already on. A rate nobody can observe
+without first suspecting it is not measured. It is guessed at.
+
+Lowering the default stderr filter is **not** the fix. A normal run stays
+quiet on purpose.
+
+The fix is a third kind of sink, beside stderr and `--log-file`. It is bound
+not to a *level* an operator chooses, but to a small, reviewed list of
+**targets** — `crates/stella-cli/src/diag_boot.rs`'s `DURABLE_TARGETS`, in
+the same `Filter` grammar §6 already defines
+(`"off,stella::turn_files=debug"`: everything off by default, this one
+target through at `debug`). Every `install` binds a sink to that list, on
+every run, no matter what the operator asked for. So a target on the list
+reaches disk on an ordinary run with nothing switched on — which is exactly
+what a measurement nobody thought to look for yet needs.
+
+It lands in `.stella/private/diagnostics.jsonl`, the same 0700 directory the
+crash ring (§7.4) already uses. The sink behind it is `LazyJsonlSink`, not
+the `JsonlSink` `--log-file` uses. `--log-file` opens its file the moment it
+is built, which is right: the operator asked for it, so an unwritable path
+is worth reporting at boot. A sink installed on *every* run needs the
+opposite property. `stella --version` in a directory that has never seen
+`.stella/` must not leave one behind. So `LazyJsonlSink` waits for the first
+write its bound filter actually admits before it opens anything, and a run
+that never fires under a durable target never touches disk.
+
+**Adding a target here follows the same budget §5.5 sets for
+`Redacted::reviewed`.** A target admitted at `debug` writes to disk on
+every ordinary run. That is the same question AGENTS.md #3 asks of a new hub
+telemetry column: did a human decide this is worth it? The write here stays
+on the local machine and never crosses a socket, but the review is the same
+one. A target earns a place on the list only when its record fires at most
+a handful of times per turn — never once per tool call, never once per
+token (§3.8). `stella::turn_files` carries `agent.task.stale_lane` and the
+rare `agent.files.unmeasurable` warning beside it, each at most once per
+turn boundary.
+
 ---
 
 ## 7. Correlation without spans


### PR DESCRIPTION
## What / why

`agent.task.stale_lane` (added for #4153) fires at `Level::Debug`, and every sink an ordinary run installs is quieter than that — stderr defaults to `Warn`, `--log-file` floors at `Info`. The record only ever reached anyone in a session where `-vv` was already on, so #4153's "measure before shipping" branch had no data to measure.

This gives the diagnostic plane a durable home for records like this one, per the issue's candidate 2 (candidate 1 — raising the level — doesn't satisfy the DoD's "with no flag decided in advance," since `--log-file` still has to be set first).

## Mechanism

- **`stella-diag`**: new `LazyJsonlSink` — same JSONL shape as `JsonlSink`, but defers opening its file until the first record it is offered actually arrives, instead of opening eagerly at construction. `JsonlSink::file` (used by `--log-file`) opens eagerly on purpose: the operator asked for it, so a bad path is worth reporting at boot. A sink installed on *every* run needs the opposite property — `stella --version` in a directory that has never seen `.stella/` must not leave one behind.
- **`stella-cli::diag_boot`**: `install` now binds a third sink, `durable_sink`, unconditionally — independent of `-v`/`--log-level`/`STELLA_LOG`. It is bound to a small, reviewed allowlist of `Filter` **targets** (`DURABLE_TARGETS = "off,stella::turn_files=debug"`), not a level, using the existing `Filter` grammar. It lands in `.stella/private/diagnostics.jsonl`, the same 0700 directory the crash ring already uses.
- **`stella-cli::turn_files::stale_lane`**: no behavior change — `DIAG_TARGET` (`stella::turn_files`) is what's on the allowlist, documented in the module header.
- **`docs/spec/diagnostics.md`**: new §6.1 "Durable targets" records the mechanism and its budget — adding a target here gets the same review §5.5 gives `Redacted::reviewed`, because it means writing to disk on every ordinary run.

Exemplar: the mechanism mirrors `docs/spec/diagnostics.md` §6/§7.4's existing split between "operator-chosen filter" (stderr, `--log-file`) and "unconditional, filter-independent" (the crash ring) — this is a third member of that second category, scoped by target instead of by "everything."

## Witness

Fails on `main` today because none of `durable_sink`/`LazyJsonlSink`/`DURABLE_TARGETS` exist there — a compile failure, the same shape most witness tests in this repo take for a new API.

- `stella-diag::sink`: `LazyJsonlSink` creates nothing on disk until its first admitted write (`a_lazy_sink_creates_nothing_until_its_first_write`, `flushing_an_unwritten_lazy_sink_creates_nothing`), then behaves like `JsonlSink` (append, owner-only 0600 — `a_lazy_sink_appends_across_writes_owner_only`).
- `stella-cli::diag_boot`: the operator's own default filter drops a `stella::turn_files` `Debug` record (`the_operators_default_filter_would_drop_a_stale_lane_record`); `durable_sink` keeps the same record through `Dx::emit` (`durable_sink_keeps_a_stale_lane_record_an_ordinary_run_would_otherwise_drop`); it ignores an unrelated `Debug` target so the mechanism can't turn into "capture every debug record" (`durable_sink_ignores_a_debug_record_from_an_unlisted_target`); and it creates nothing for a run that never emits under it (`durable_sink_creates_nothing_for_a_run_that_never_emits_under_it`).
- `stella-cli::turn_files::stale_lane`: `note_stale_lane`, called against a `Dx` wired the way `main` wires it (durable sink only — no `-v`, no `--log-file`), lands its record on disk (`note_stale_lane_reaches_disk_through_the_durable_sink_alone`).

Ran locally, targeted (`cargo test -p stella-diag --lib sink`, `cargo test -p stella-cli --bin stella diag_boot::` / `turn_files::stale_lane::`) — all green. `make guards-fast` is green, including `check-prose` (grade and construction ratchets) and `check-file-size`.

## Tests deleted

None.

## Not in this PR

The issue's third DoD item — "the rate reported back on #4153" — needs real ordinary-run telemetry to accumulate *after* this mechanism ships, which can't be produced inside this session. Filed as follow-up residue rather than fabricated.

Closes #5075

## Summary by Sourcery

Persist reviewed diagnostic targets across ordinary runs without changing the quiet default logging experience.

New Features:
- Persist selected low-level diagnostics from ordinary runs in `.stella/private/diagnostics.jsonl` without requiring logging flags.

Bug Fixes:
- Ensure stale-lane diagnostics are retained even when the default operator logging filters would otherwise discard them.

Enhancements:
- Add a lazy JSONL sink that creates and opens its diagnostics file only when an admitted record is written, while preserving append behavior and owner-only permissions.
- Scope unconditional durable diagnostics to a reviewed target allowlist so unrelated debug output is not captured.

Documentation:
- Document the durable-target diagnostic category, its storage behavior, and review and frequency constraints.

Tests:
- Add coverage for lazy sink creation, flushing, appending, permissions, target filtering, and end-to-end stale-lane persistence.