### PR TITLE
fix(stella-tui,stella-graph): keep the keyboard alive while the graph pass runs

### DIFF
--- a/crates/stella-cli/src/agent/graph.rs
+++ b/crates/stella-cli/src/agent/graph.rs
@@ -703,8 +703,17 @@ async fn backfill_vectors_quietly(
 
     // Settled, whatever happened — including a failure. A gate that outlives
     // the pass behind it is a wedge: a workspace whose embedder is down must
-    // still take prompts (`search_cmd::readiness`).
-    readiness(settled_readiness(root, embedder.as_ref()));
+    // still take prompts (`search_cmd::readiness`). The report opens the
+    // graph store. That is SQLite, so it runs on the blocking pool and not
+    // on this task's worker. A report that could not run settles as unknown,
+    // and unknown holds nothing. That is how `measure` fails too.
+    let fingerprint = stella_embed::Embedder::fingerprint(embedder.as_ref()).id();
+    let report_root = root.to_path_buf();
+    let measured =
+        tokio::task::spawn_blocking(move || settled_readiness(&report_root, &fingerprint))
+            .await
+            .unwrap_or_else(|_| IndexReadiness::unknown());
+    readiness(measured);
 }
 
 /// The workspace's index coverage, marked settled — what the prompt gate
@@ -714,18 +723,14 @@ async fn backfill_vectors_quietly(
 /// have failed before it opened one at all, and this report is owed either
 /// way. An unopenable graph reports [`IndexReadiness::unknown`], which holds
 /// nothing — the direction `readiness::measure` argues for.
-fn settled_readiness(
-    root: &std::path::Path,
-    embedder: &dyn stella_embed::Embedder,
-) -> IndexReadiness {
+fn settled_readiness(root: &std::path::Path, fingerprint: &str) -> IndexReadiness {
     let Ok(db_path) = stella_store::workspace_private_sqlite_path(root, "codegraph.db") else {
         return IndexReadiness::unknown();
     };
     let Ok(graph) = stella_graph::CodeGraph::open(root, &db_path) else {
         return IndexReadiness::unknown();
     };
-    let measured =
-        crate::search_cmd::readiness::measure(&graph, &embedder.fingerprint().id(), true);
+    let measured = crate::search_cmd::readiness::measure(&graph, fingerprint, true);
     graph.shutdown();
     measured
 }

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -78,7 +78,7 @@ use stella_tools::ToolRegistry;
 use stella_tools::registry::approval::ApprovalResponse;
 use stella_tui::{
     AgentMeta, AgentScope, AgentStatus, DeckOptions, Inbound, SkillOp, SkillScope, SkillSearchHit,
-    SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput, run_deck,
+    SkillsView, SlashCommand, SplashCue, UserInput, WorkspaceInput,
 };
 use tokio::sync::mpsc::{self, UnboundedSender};
 
@@ -89,6 +89,7 @@ use crate::{agent, rules};
 mod add_dir;
 mod authoring;
 mod command_side;
+mod deck_thread;
 mod driver_support;
 mod dropped_turn;
 pub(crate) mod forwarder;
@@ -117,9 +118,9 @@ mod voice_cmd;
 mod whistle;
 mod worker_control;
 use driver_support::{
-    handle_supervisor_msg, service_approve_revision, service_edit_memory, service_registry_action,
-    service_reject_memory, service_rerun_gate, service_undo_delete, spawn_mcp_connect,
-    spawn_notification_poller, spawn_pr_monitor,
+    graph_ready_callback, handle_supervisor_msg, service_approve_revision, service_edit_memory,
+    service_registry_action, service_reject_memory, service_rerun_gate, service_undo_delete,
+    spawn_mcp_connect, spawn_notification_poller, spawn_pr_monitor,
 };
 use lead_turn::run_lead_turn;
 use panel_snapshots::{engine_config_inbound, tool_policy_inbound};
@@ -808,9 +809,10 @@ pub async fn run_deck_session(
         voice_enabled: voice::enabled(cfg),
         voice_mode: voice::mode(cfg),
     };
-    // The deck owns its channel ends and runs on its own task so rendering
-    // never waits on the driver (and vice versa).
-    let deck = tokio::spawn(run_deck(opts, deck_rx, sub_tx));
+    // The deck owns its channel ends and runs on its own thread, so nothing
+    // the driver blocks on can hold a keystroke (`deck_thread`).
+    let deck =
+        deck_thread::spawn(opts, deck_rx, sub_tx).map_err(|e| format!("deck thread: {e}"))?;
 
     // The launch cinematic: hold the splash's battle loop open over session
     // init and release it once BOTH async legs — the background code-graph
@@ -841,25 +843,14 @@ pub async fn run_deck_session(
     // every boot, so journaling it would replay stale "indexing…" lines on
     // top of every resumed transcript.
     let status_tx = deck_tx.clone();
-    let ready_tx = deck_tx.clone();
-    let ready_root = cfg.workspace_root.clone();
     let (_session_graph, _graph_build) = agent::spawn_session_graph(
         &cfg.workspace_root,
         Box::new(agent::deck_notice_narrator(status_tx, LEAD)),
-        Box::new(move || {
-            // Populate the Graph tab now the index exists (it opened on the
-            // "run stella init" hint), and assert the lead is idle — the
-            // index progress above no longer folds it to `Running`.
-            if let Some(snapshot) = agent::graph_snapshot(&ready_root) {
-                let _ = ready_tx.send(Inbound::GraphSnapshot(snapshot));
-            }
-            let _ = ready_tx.send(Inbound::Status {
-                agent: LEAD.to_string(),
-                status: AgentStatus::WaitingInput,
-            });
-            // One of the two init legs the launch splash waits on.
-            release_on_graph_ready();
-        }),
+        Box::new(graph_ready_callback(
+            cfg.workspace_root.clone(),
+            deck_tx.clone(),
+            release_on_graph_ready,
+        )),
         Box::new(agent::deck_readiness_reporter(deck_tx.clone())),
     );
 
@@ -2753,14 +2744,14 @@ pub async fn run_deck_session(
     // already quit (the journal tee drains, fsyncs, and forwards the close);
     // then wait for it to restore the terminal.
     drop(in_tx);
-    let deck_result = deck.await;
+    let deck_result = deck.join().await;
     if let Some(set) = mcp_slot.get() {
         set.close_all().await;
     }
     match deck_result {
         Ok(Ok(())) => Ok(()),
         Ok(Err(e)) => Err(format!("deck terminal error: {e}")),
-        Err(e) => Err(format!("deck task failed: {e}")),
+        Err(e) => Err(format!("deck thread failed: {e}")),
     }
 }
 

--- a/crates/stella-cli/src/command_deck/deck_thread.rs
+++ b/crates/stella-cli/src/command_deck/deck_thread.rs
@@ -1,0 +1,174 @@
+//! The deck's own thread.
+//!
+//! A task on the shared runtime cannot promise that the screen never waits
+//! on the driver. Tokio parks a task woken from a worker in that worker's
+//! LIFO slot, and no other worker steals from that slot. So a driver task
+//! that wakes the deck and then blocks its worker holds the deck for as long
+//! as it blocks. On 2026-09-05 the block was a count over the code graph. It
+//! took eleven seconds, and the embedding pass asked for it after every
+//! batch. The keyboard was dead for six minutes. The reader thread was alive
+//! and queueing keys the whole time, and nothing drained them.
+//!
+//! A thread keeps the promise. The deck runs its loop under a runtime of its
+//! own, on a thread of its own. The driver cannot block that thread. The
+//! deck's channels cross runtimes as any channel does. The tasks the deck
+//! spawns for `!` shell commands and the clipboard live on its runtime and
+//! end with it. The driver still waits for the deck through
+//! [`DeckThread::join`], so a quit restores the terminal before the session's
+//! own teardown runs.
+//!
+//! The driver's blocking call is a defect on its own (AGENTS.md architecture
+//! rule 2 bans it), and it is fixed apart from this. This module is what lets
+//! the keyboard survive the next one.
+
+use std::future::Future;
+use std::io;
+
+use stella_tui::{DeckOptions, Inbound, WorkspaceInput, run_deck};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::oneshot;
+
+/// The deck, running on its own thread. Dropping this does not stop the deck.
+/// Closing its inbound channel does, as before.
+pub(super) struct DeckThread {
+    done: oneshot::Receiver<io::Result<()>>,
+}
+
+/// Start the deck on its own thread. This fails only when the OS refuses the
+/// thread. Then there is no deck, and the session cannot start.
+pub(super) fn spawn(
+    opts: DeckOptions,
+    inbound: UnboundedReceiver<Inbound>,
+    submissions: UnboundedSender<WorkspaceInput>,
+) -> io::Result<DeckThread> {
+    let done = run_on_own_thread("stella-deck", run_deck(opts, inbound, submissions))?;
+    Ok(DeckThread { done })
+}
+
+impl DeckThread {
+    /// Wait for the deck to finish. `Err` means the thread ended without a
+    /// report. Only a panic in the deck does that, and the terminal guard's
+    /// panic hook has restored the screen by then.
+    pub(super) async fn join(self) -> Result<io::Result<()>, DeckThreadGone> {
+        self.done.await.map_err(|_| DeckThreadGone)
+    }
+}
+
+/// The deck thread ended without a report.
+#[derive(Debug)]
+pub(super) struct DeckThreadGone;
+
+impl std::fmt::Display for DeckThreadGone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("the deck thread ended without reporting")
+    }
+}
+
+/// Drive `future` to its end on a new thread, under a current-thread runtime.
+/// The output comes back on a channel. The receiver resolves when the future
+/// finishes, and errors if the thread dies first.
+fn run_on_own_thread<F>(name: &str, future: F) -> io::Result<oneshot::Receiver<F::Output>>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let (done_tx, done_rx) = oneshot::channel();
+    std::thread::Builder::new()
+        .name(name.to_owned())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build();
+            match runtime {
+                Ok(runtime) => {
+                    let output = runtime.block_on(future);
+                    let _ = done_tx.send(output);
+                }
+                // The receiver reads the drop as the thread ending. The
+                // caller reports it the way it reports a panic.
+                Err(_) => drop(done_tx),
+            }
+        })?;
+    Ok(done_rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use tokio::sync::{mpsc, oneshot};
+
+    use super::run_on_own_thread;
+
+    /// How long the driver-shaped task holds its worker.
+    const HOLD: Duration = Duration::from_millis(500);
+
+    /// One worker, so the task that wakes the probe and then blocks is the
+    /// only worker there is. Returns how long the probe took to see the
+    /// wake, measured from the moment it was sent.
+    async fn probe_latency(host: impl FnOnce(ProbeFuture) -> ProbeHandle) -> Duration {
+        let (wake_tx, mut wake_rx) = mpsc::unbounded_channel::<()>();
+        let (seen_tx, seen_rx) = oneshot::channel::<Instant>();
+        let probe: ProbeFuture = Box::pin(async move {
+            wake_rx.recv().await;
+            let _ = seen_tx.send(Instant::now());
+        });
+        let handle = host(probe);
+        let sent = Instant::now();
+        let blocker = tokio::spawn(async move {
+            wake_tx.send(()).expect("probe is listening");
+            std::thread::sleep(HOLD);
+        });
+        let seen = seen_rx.await.expect("probe reports");
+        blocker.await.expect("blocker ends");
+        handle.await;
+        seen.duration_since(sent)
+    }
+
+    type ProbeFuture = std::pin::Pin<Box<dyn Future<Output = ()> + Send>>;
+    type ProbeHandle = std::pin::Pin<Box<dyn Future<Output = ()> + Send>>;
+
+    fn one_worker() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime")
+    }
+
+    /// **The witness for the thread.** A driver-shaped task wakes the deck
+    /// and then blocks its worker. A deck on its own thread answers the wake
+    /// at once, however long the worker stays blocked.
+    #[test]
+    fn a_blocked_runtime_worker_cannot_hold_a_deck_on_its_own_thread() {
+        let latency = one_worker().block_on(probe_latency(|probe| {
+            let done = run_on_own_thread("probe", probe).expect("thread");
+            Box::pin(async move {
+                let _ = done.await;
+            })
+        }));
+        assert!(
+            latency < HOLD / 2,
+            "the deck waited {latency:?} on a worker it does not run on"
+        );
+    }
+
+    /// The hazard the witness above guards against. It stays so the harness
+    /// is shown to tell the two apart. The same probe, hosted as a task on
+    /// the shared runtime, sits in the blocked worker's LIFO slot for the
+    /// whole hold. This is the shape the keyboard freeze had.
+    #[test]
+    fn the_same_deck_as_a_runtime_task_waits_out_the_whole_hold() {
+        let latency = one_worker().block_on(probe_latency(|probe| {
+            let task = tokio::spawn(probe);
+            Box::pin(async move {
+                let _ = task.await;
+            })
+        }));
+        assert!(
+            latency >= HOLD,
+            "a task-hosted deck answered in {latency:?}; the LIFO slot does not park it and \
+             this test's premise has changed"
+        );
+    }
+}

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -769,6 +769,35 @@ pub(super) fn spawn_notification_poller(in_tx: mpsc::UnboundedSender<Inbound>) {
     });
 }
 
+/// The session graph's on-ready callback: fill the Graph tab now the index
+/// exists (it opened on the "run stella init" hint), mark the lead idle, and
+/// release the splash leg that waited on the index.
+///
+/// The snapshot opens the graph store and reads a file neighbourhood, which is
+/// SQLite on whichever thread calls it. The callback fires on the graph task,
+/// a task on the shared runtime, so the read runs on the blocking pool rather
+/// than holding a worker. The three sends follow the read on that same
+/// thread: the tab must not be told the lead is idle before the snapshot it
+/// idles over has arrived.
+pub(super) fn graph_ready_callback(
+    root: PathBuf,
+    deck_tx: UnboundedSender<Inbound>,
+    release_splash: impl FnOnce() + Send + 'static,
+) -> impl FnOnce() + Send + 'static {
+    move || {
+        tokio::task::spawn_blocking(move || {
+            if let Some(snapshot) = agent::graph_snapshot(&root) {
+                let _ = deck_tx.send(Inbound::GraphSnapshot(snapshot));
+            }
+            let _ = deck_tx.send(Inbound::Status {
+                agent: LEAD.to_string(),
+                status: AgentStatus::WaitingInput,
+            });
+            release_splash();
+        });
+    }
+}
+
 #[cfg(test)]
 mod undo_delete_tests {
     use super::*;

--- a/crates/stella-graph/src/store.rs
+++ b/crates/stella-graph/src/store.rs
@@ -239,6 +239,16 @@ CREATE TABLE IF NOT EXISTS code_graph_chunk_vectors (
 -- pass does.
 CREATE INDEX IF NOT EXISTS code_graph_chunk_vectors_fp
     ON code_graph_chunk_vectors(fingerprint);
+-- The coverage question (`vectors::chunks::NEEDS_CHUNK_PASS`) asks, per file,
+-- whether any chunk row exists under one fingerprint for the file's current
+-- hash. Without this index the planner answers it from the fingerprint index
+-- above, which walks every chunk row of that fingerprint, vector blob
+-- included, once per file: on a workspace of two thousand files and thirty
+-- thousand chunks one count took eleven seconds, and the readiness gate asks
+-- for that count after every embedding batch. Three equality columns, and
+-- covering, so the answer is an index probe that never reads a vector.
+CREATE INDEX IF NOT EXISTS code_graph_chunk_vectors_coverage
+    ON code_graph_chunk_vectors(file_id, fingerprint, file_sha256);
 -- The commit this store last reconciled against (see `crate::reconcile`).
 -- Exactly one row, enforced by the CHECK rather than by every writer
 -- remembering to: this is a singleton, and a second row would silently make

--- a/crates/stella-graph/src/vectors/chunks/tests.rs
+++ b/crates/stella-graph/src/vectors/chunks/tests.rs
@@ -170,3 +170,35 @@ fn a_different_fingerprint_still_counts_as_pending() {
         "a fingerprint that has embedded nothing must still see the file as pending"
     );
 }
+
+/// **The witness for `code_graph_chunk_vectors_coverage`.** The coverage
+/// predicate asks, per file, whether a chunk row exists under the fingerprint
+/// for the file's current hash. Before the index existed the planner answered
+/// from `code_graph_chunk_vectors_fp` and walked every chunk row of the
+/// fingerprint, vector blob included, once per file. On one workspace that
+/// made a single count eleven seconds, and the readiness gate asks for it
+/// after every embedding batch. The plan is the fact this test pins: the
+/// chunk-table step of the count must probe the coverage index, never scan
+/// the fingerprint one.
+#[test]
+fn the_coverage_predicate_probes_its_own_index_not_the_fingerprint_scan() {
+    let (_ws, conn) = indexed_workspace(&[("a.rs", "fn alpha() {}\n")]);
+    let mut stmt = conn
+        .prepare(&format!(
+            "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM code_graph_files f WHERE {NEEDS_CHUNK_PASS}"
+        ))
+        .expect("prepare");
+    let plan: Vec<String> = stmt
+        .query_map([FP], |row| row.get::<_, String>(3))
+        .expect("plan")
+        .collect::<Result<_, _>>()
+        .expect("rows");
+    let chunk_step = plan
+        .iter()
+        .find(|step| step.contains("code_graph_chunk_vectors"))
+        .unwrap_or_else(|| panic!("no chunk-table step in the plan: {plan:?}"));
+    assert!(
+        chunk_step.contains("code_graph_chunk_vectors_coverage"),
+        "the coverage check must probe its covering index; the plan chose {chunk_step:?}"
+    );
+}


### PR DESCRIPTION
## What & why

Typing in the Command Deck froze for minutes in this repo, and a session had to be killed to get the terminal back (#5981). A `sample` of the frozen process showed one runtime worker inside SQLite for four minutes of CPU, the crossterm reader alive and queueing keys, and every other worker parked. Three defects stacked to make that:

1. **The coverage count scanned every chunk vector once per file.** `pending_chunk_file_count`'s `NOT EXISTS` over `code_graph_chunk_vectors` had only the fingerprint index to use, so the planner walked all 33,677 chunk rows, 4 KB blob each, for each of 2,061 files. Measured on a copy of this repo's graph: 7.6 s per count before, under 10 ms after, with the plan moving from `SEARCH v USING INDEX code_graph_chunk_vectors_fp` to `SEARCH v USING COVERING INDEX code_graph_chunk_vectors_coverage`. The backfill asks for that count before the pass and after every embedding batch.
2. **The count ran on a runtime worker,** from the session-graph task (`backfill_opened` → `measure`).
3. **The deck was a task on the same runtime.** Tokio parks a task woken from a worker in that worker's LIFO slot, and the slot is not stolen. The backfill task woke the deck with a progress line and then blocked in the count, so the deck sat in the slot until the count returned.

The change:

- `stella-graph`: `code_graph_chunk_vectors_coverage`, a covering index on `(file_id, fingerprint, file_sha256)`. Convergent DDL, no version bump, as `store.rs`'s own header prescribes for an additive index. It reached this repo's real graph file on the first open of the fixed build.
- `stella-cli`: the deck runs on its own thread under a runtime of its own (`command_deck/deck_thread.rs`). The driver still waits for it through `DeckThread::join`, so a quit restores the terminal before teardown, as before. `command_deck.rs` shrinks by nine lines.
- `stella-cli`: the two session-start graph reads that stay on the runtime, the settled readiness report and the graph-ready snapshot, run on the blocking pool (`agent/graph.rs`, `command_deck/driver_support.rs::graph_ready_callback`).

Exemplar for the thread: tokio's own guidance that a blocking loop gets a thread, not a task; the shape is `std::thread::Builder` plus `Builder::new_current_thread().block_on`, the same one `drive_index_blocking` already uses for the index walk one layer down.

Closes #5981
Refs #4048

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, one per mechanism:

- `stella-graph`: `the_coverage_predicate_probes_its_own_index_not_the_fingerprint_scan` runs `EXPLAIN QUERY PLAN` over the coverage count and asserts the chunk-table step names the covering index. Run against the `HEAD` copy of `store.rs` it fails with `the plan chose "SEARCH v USING INDEX code_graph_chunk_vectors_fp (fingerprint=?)"`; with the index it passes.
- `stella-cli`: `deck_thread::tests::a_blocked_runtime_worker_cannot_hold_a_deck_on_its_own_thread`. One worker; a task wakes the probe and then blocks the worker for 500 ms; a probe on its own thread answers in under half that. Its twin `the_same_deck_as_a_runtime_task_waits_out_the_whole_hold` hosts the identical probe as a runtime task and asserts it waits the whole hold, so the harness is shown to tell the two apart. On `main` the module does not exist.

Live check: the fixed debug build run in this workspace under tmux echoed a line typed 12 s into boot and another at 50 s; `sample` lists a `stella-deck` thread beside the ten workers.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-graph --all-targets -- -D warnings` (targeted; CI runs the workspace)
- [x] `cargo test -p stella-graph --lib chunks::tests`, `cargo test -p stella-cli --bin stella deck_thread` (targeted; CI runs the workspace)
- [x] Docs updated where behavior/flags changed (module docs and the DDL comment)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #5982 (the backfill's remaining SQLite and file reads on the runtime), #5983 (the deck's key reader ends silently on a crossterm error), #5984 (`codegraph.db` never runs `ANALYZE`)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- The keyboard freeze is fixed twice over: the count is now instant, and the deck no longer shares a runtime with anything that can block. Either alone would have hidden the symptom; the second is what makes the next blocking call survivable.
- The old `tokio::spawn` comment at the deck's spawn site promised "rendering never waits on the driver". A task cannot keep that promise on a work-stealing runtime; the module doc in `deck_thread.rs` says why.
- The tests deleted: none.

## Summary by Sourcery

Keep the command deck responsive during graph backfill by isolating it from blocking work and optimizing repeated coverage checks.

Bug Fixes:
- Prevent keyboard input from freezing while graph backfill work performs slow SQLite operations.
- Speed up graph coverage checks by adding a covering index for current file and embedding data.
- Move graph readiness and snapshot reads off shared runtime workers to avoid blocking interactive tasks.

Enhancements:
- Run the command deck on a dedicated thread and runtime while preserving orderly shutdown and terminal restoration.

Documentation:
- Document the dedicated deck thread and graph coverage index behavior.

Tests:
- Add witness tests verifying the coverage query uses its covering index and demonstrating the deck remains responsive when a runtime worker is blocked.