### PR TITLE
fix(stella-records): declare the memory-citation evidence source retired

### DIFF
--- a/crates/stella-cli/src/memory/evidence.rs
+++ b/crates/stella-cli/src/memory/evidence.rs
@@ -1,56 +1,42 @@
-//! Generalizing the citation loop — Phase 4 deliverable 2 (#715).
+//! Observation sources beyond reflection lessons — Phase 4 deliverable 2
+//! (#715).
 //!
-//! [`ObservationSource`] has always had three variants. Only one of them,
-//! `ReflectionLesson`, had a constructor: `MemoryCitation` and `ToolOutcome`
+//! [`ObservationSource`] started with three variants. Only one,
+//! `ReflectionLesson`, had a constructor — `MemoryCitation` and `ToolOutcome`
 //! were declared in Phase 1 and written by nothing, so the typed loop learned
 //! from reflection prose and from no other evidence at all. This module fills
-//! the other two, which is what turns explicit citation from *the* evidence
-//! source into *one* of them.
+//! `ToolOutcome`, the one source left standing beside `ReflectionLesson`.
 //!
-//! # What does not change
+//! # Why `MemoryCitation` is gone
 //!
-//! The deliverable is explicit that the citation loop keeps its semantics, and
-//! it does — untouched. `fold_citation_stats` still derives quarantine at
-//! [`stella_store::QUARANTINE_NEGATIVES_THRESHOLD`] untruthful citations and
-//! promotion eligibility at a streak past
-//! [`stella_store::PROMOTION_CITATIONS_REQUIRED`], still recomputed on every
-//! read, still never stored. Nothing here reads those thresholds, changes
-//! them, or adds a second path to quarantine.
-//!
-//! What changes is that a citation now *also* leaves an observation, so the
-//! same miner that learns from reflection prose can learn from what the model
-//! said about a memory while using it. Two evidence sources feeding one loop,
-//! rather than one source feeding the loop and another feeding a separate
-//! quarantine counter that nothing else can see.
-//!
-//! # Why only negative citations become observations
-//!
-//! A positive citation says "this memory was right", which the memory already
-//! claims — mining it produces an observation that restates its own evidence,
-//! and spec §7's second anti-poisoning rule is that a proposal may not cite
-//! itself. A *negative* citation says something the corpus does not already
-//! contain: that a stored belief is wrong. That is new information and is worth
-//! learning from.
+//! It shipped here too, pairing an observed retrieval with a model's
+//! usefulness judgement — and the judgement half had no producer. The
+//! `cite_memory` tool that collected it is retired, and every replacement
+//! source checked only knows a memory was *rendered* into the prompt, never
+//! that it was judged useful or truthful. Writing `truthful: true` for "the
+//! handle appeared somewhere" would fabricate a judgement no evidence
+//! earned. See [`ObservationSource`]'s own doc comment for the full account;
+//! the citation-derived quarantine loop it fed
+//! (`fold_citation_stats`/thresholds in `stella-store`) stays as declared,
+//! inert plumbing rather than being deleted with it.
 //!
 //! # Why only failed tool calls
 //!
-//! Same asymmetry. A tool that worked is the expected case; mining it would
-//! bury the signal under thousands of successes. A failure is a fact about this
-//! workspace that the next turn could use.
+//! A tool that worked is the expected case; mining it would bury the signal
+//! under thousands of successes. A failure is a fact about this workspace
+//! that the next turn could use.
 
 use stella_context::{AppendOutcome, ContextStore, LedgerAppend};
 use stella_learn::redact::redact_secrets;
 use stella_records::context_record::{
     ContextRecordKind, LIFECYCLE_SCHEMA_VERSION, ObservationRecord, ObservationSource,
 };
-use stella_store::MemoryCitationRow;
 
-/// The longest observation text either source will emit.
+/// The longest observation text this source will emit.
 ///
-/// A citation remark is at most 300 characters by the ledger's own contract,
-/// but a tool error is unbounded — a stack trace or a wall of compiler output would
-/// otherwise become one enormous "observation" that the miner cannot cluster
-/// and a person cannot read.
+/// A tool error is unbounded — a stack trace or a wall of compiler output
+/// would otherwise become one enormous "observation" that the miner cannot
+/// cluster and a person cannot read.
 const MAX_OBSERVATION_CHARS: usize = 300;
 
 /// Truncate on a character boundary, marking that it happened.
@@ -64,40 +50,6 @@ fn bounded(text: &str) -> String {
     }
     let kept: String = text.chars().take(MAX_OBSERVATION_CHARS - 1).collect();
     format!("{kept}…")
-}
-
-/// Append an observation for one negative citation. `None` if there is nothing
-/// worth recording or the write failed.
-///
-/// The candidate id is the cited memory rather than the citation, so repeated
-/// negative citations of the same memory across different tasks cluster —
-/// which is exactly the recurrence the proposal miner counts.
-pub(super) fn citation_observation(
-    store: &ContextStore,
-    citation: &MemoryCitationRow,
-    task_id: &str,
-    observed_at: &str,
-) -> Option<AppendOutcome> {
-    // Positive citations are self-confirming; see the module docs.
-    if citation.is_positive() {
-        return None;
-    }
-    if citation.remark.trim().is_empty() {
-        return None;
-    }
-    let text = format!(
-        "memory {} was cited unhelpful: {}",
-        citation.memory_id,
-        citation.remark.trim()
-    );
-    append(
-        store,
-        ObservationSource::MemoryCitation,
-        format!("citation:{}", citation.memory_id),
-        task_id,
-        &text,
-        observed_at,
-    )
 }
 
 /// Append an observation for one failed tool call.

--- a/crates/stella-cli/src/memory/evidence/tests.rs
+++ b/crates/stella-cli/src/memory/evidence/tests.rs
@@ -1,9 +1,9 @@
-//! Phase 4 deliverable 2: citations and tool outcomes are evidence sources
-//! alongside reflection lessons — without changing what citation already means.
+//! Phase 4 deliverable 2: a failed tool call is an evidence source, alongside
+//! reflection lessons. `evidence.rs`'s module doc covers the other source,
+//! `MemoryCitation`. It is retired, and this module does not test it.
 
 use stella_context::{AppendOutcome, ContextStore};
 use stella_records::context_record::{ContextRecordKind, ObservationRecord, ObservationSource};
-use stella_store::MemoryCitationRow;
 
 use super::*;
 
@@ -15,15 +15,6 @@ fn store() -> (tempfile::TempDir, ContextStore) {
     (dir, store)
 }
 
-fn citation(memory_id: &str, score: i64, truthful: bool, remark: &str) -> MemoryCitationRow {
-    MemoryCitationRow {
-        memory_id: memory_id.into(),
-        useful_score: score,
-        truthful,
-        remark: remark.into(),
-    }
-}
-
 fn observations(store: &ContextStore) -> Vec<ObservationRecord> {
     store
         .records_of_kind(ContextRecordKind::Observation.as_str(), 100)
@@ -31,48 +22,6 @@ fn observations(store: &ContextStore) -> Vec<ObservationRecord> {
         .into_iter()
         .filter_map(|row| serde_json::from_str(&row.body).ok())
         .collect()
-}
-
-#[test]
-fn a_negative_citation_becomes_a_citation_sourced_observation() {
-    let (_dir, store) = store();
-    let outcome = citation_observation(
-        &store,
-        &citation("nod_a", 1, false, "the path it names was deleted"),
-        "task1",
-        AT,
-    );
-
-    assert_eq!(outcome, Some(AppendOutcome::Appended));
-    let observations = observations(&store);
-    assert_eq!(observations.len(), 1);
-    assert_eq!(observations[0].source, ObservationSource::MemoryCitation);
-    assert!(
-        observations[0]
-            .text
-            .contains("the path it names was deleted")
-    );
-    assert_eq!(observations[0].task_id, "task1");
-}
-
-#[test]
-fn a_positive_citation_is_not_mined_because_it_would_cite_itself() {
-    let (_dir, store) = store();
-    // Spec §7: a proposal may not cite itself. "This memory was right" is the
-    // memory restating its own claim.
-    let outcome = citation_observation(&store, &citation("nod_a", 5, true, "spot on"), "task1", AT);
-
-    assert_eq!(outcome, None);
-    assert!(observations(&store).is_empty());
-}
-
-#[test]
-fn a_citation_with_no_remark_records_nothing() {
-    let (_dir, store) = store();
-    let outcome = citation_observation(&store, &citation("nod_a", 1, false, "   "), "task1", AT);
-
-    assert_eq!(outcome, None);
-    assert!(observations(&store).is_empty());
 }
 
 #[test]
@@ -116,13 +65,12 @@ fn repeated_failures_of_one_tool_cluster_under_one_candidate() {
 #[test]
 fn re_appending_the_same_evidence_is_a_replay() {
     let (_dir, store) = store();
-    let row = citation("nod_a", 1, false, "wrong");
     assert_eq!(
-        citation_observation(&store, &row, "task1", AT),
+        tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT),
         Some(AppendOutcome::Appended)
     );
     assert_eq!(
-        citation_observation(&store, &row, "task1", AT),
+        tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT),
         Some(AppendOutcome::AlreadyPresent),
         "content-derived ids must absorb a re-scan as a replay"
     );
@@ -183,8 +131,8 @@ fn bounded_never_splits_a_multibyte_character() {
 
 #[test]
 fn the_citation_loops_own_thresholds_are_untouched() {
-    // The deliverable keeps citation semantics. This module must not have
-    // introduced a second quarantine path or moved the shipped constants.
+    // Removing the citation observation source must not move these
+    // shipped constants.
     assert_eq!(stella_store::QUARANTINE_NEGATIVES_THRESHOLD, 2);
     assert_eq!(stella_store::PROMOTION_CITATIONS_REQUIRED, 10);
     assert_eq!(stella_store::POSITIVE_SCORE_MIN, 3);

--- a/crates/stella-cli/src/memory/uses.rs
+++ b/crates/stella-cli/src/memory/uses.rs
@@ -223,18 +223,12 @@ fn extract_one(store: &Store, context: &ContextStore, execution: &FinishedExecut
         }
     }
 
-    // Deliverable 2: the same citations also become observations, so the miner
-    // that learns from reflection prose learns from them too. Every citation is
-    // considered — including ones naming a record this frame never carried,
-    // which have no use to attach feedback to but are still a real remark about
-    // a real memory.
-    for citation in &citations {
-        if super::evidence::citation_observation(context, citation, &task, &at)
-            == Some(AppendOutcome::Appended)
-        {
-            appended += 1;
-        }
-    }
+    // Deliverable 2 mined the same citations into observations here too.
+    // That source, `ObservationSource::MemoryCitation`, is retired: nothing
+    // ever wrote a real citation, so this loop only ever mined test
+    // fixtures. See `evidence.rs`'s module doc for the full account; the
+    // feedback loop above is untouched — it stays declared, inert plumbing
+    // on the same empty table.
 
     // The third source. Declared in Phase 1, unwritten until now.
     if let Ok(failures) = store.failed_tool_calls_for_execution(execution.execution_id) {

--- a/crates/stella-records/src/context_record/lifecycle.rs
+++ b/crates/stella-records/src/context_record/lifecycle.rs
@@ -51,13 +51,24 @@ pub const LIFECYCLE_SCHEMA_VERSION: &str = "1.0-draft";
 /// Where an observation came from. Small: spec §1's "extend before
 /// inventing" applies to vocabularies too, and each of these names evidence the
 /// system *already captures*.
+///
+/// A third option, `MemoryCitation`, paired a memory citation with a model's
+/// usefulness judgement. It is retired. No real turn ever wrote one: the
+/// `cite_memory` tool that collected the judgement is retired
+/// (`RETIRED_TOOL_NAMES`, `crates/stella-tools/src/catalog.rs`). Every other
+/// source only knows a memory was *shown* to the model, never that the model
+/// judged it useful or true. Marking a memory `truthful: true` just because
+/// it was shown would be a guess dressed up as evidence, and `stella-cli`'s
+/// `memory::uses::extract_one` already refuses to make that guess.
+/// `stella-store`'s `memory_citations` table, `MemoryCitationRow`/
+/// `MemoryCitationStats`, `fold_citation_stats`, and the promotion/quarantine
+/// thresholds stay in place, unused, so a later shared holdout sweep can
+/// reuse them without a new migration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ObservationSource {
     /// A lesson from post-turn reflection.
     ReflectionLesson,
-    /// An explicit memory citation with its usefulness judgment.
-    MemoryCitation,
     /// The outcome of a tool call.
     ToolOutcome,
 }
@@ -67,7 +78,6 @@ impl ObservationSource {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ReflectionLesson => "reflection_lesson",
-            Self::MemoryCitation => "memory_citation",
             Self::ToolOutcome => "tool_outcome",
         }
     }

--- a/crates/stella-records/src/context_record/provenance.rs
+++ b/crates/stella-records/src/context_record/provenance.rs
@@ -45,18 +45,15 @@ use super::lifecycle::{ObservationRecord, ObservationSource};
 /// - [`ObservationSource::ReflectionLesson`] is a model's judgement about a
 ///   run it just took, which is [`ProvenanceGrade::ModelCritique`] however
 ///   confident the prose sounds.
-/// - [`ObservationSource::MemoryCitation`] pairs an observed retrieval with a
-///   model's usefulness judgement. The retrieval is observed and the judgement
-///   is not, so the pair is graded at the weaker half. Splitting the citation
-///   into its observed and judged parts would promote it; counting
-///   citations would not, and that is the door this grading closes.
+///
+/// A third source, `MemoryCitation`, paired an observed retrieval with a
+/// model's usefulness judgement here. It is retired — see
+/// [`ObservationSource`]'s own doc comment for why.
 #[must_use]
 pub fn observation_grade(source: ObservationSource) -> ProvenanceGrade {
     match source {
         ObservationSource::ToolOutcome => ProvenanceGrade::EnvironmentObservation,
-        ObservationSource::ReflectionLesson | ObservationSource::MemoryCitation => {
-            ProvenanceGrade::ModelCritique
-        }
+        ObservationSource::ReflectionLesson => ProvenanceGrade::ModelCritique,
     }
 }
 

--- a/crates/stella-records/src/context_record/provenance/tests.rs
+++ b/crates/stella-records/src/context_record/provenance/tests.rs
@@ -65,9 +65,19 @@ fn every_observation_source_grades_to_one_named_thing() {
         observation_grade(ObservationSource::ReflectionLesson),
         ProvenanceGrade::ModelCritique
     );
-    assert_eq!(
-        observation_grade(ObservationSource::MemoryCitation),
-        ProvenanceGrade::ModelCritique
+}
+
+/// `ObservationSource::MemoryCitation` is retired: this payload once
+/// deserialized to `Ok(MemoryCitation)`, the one option only tests could ever
+/// construct, since nothing wrote a real one. The same bytes are now a parse
+/// error, which states plainly that the source does not exist to name.
+#[test]
+fn memory_citation_is_retired_and_no_longer_parses() {
+    let parsed: Result<ObservationSource, _> = serde_json::from_str(r#""memory_citation""#);
+    assert!(
+        parsed.is_err(),
+        "MemoryCitation was retired, since no real turn ever produced one — \
+         the wire form must not resurrect it"
     );
 }
 

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -42,7 +42,8 @@
 //!   usefulness score, whether the memory's content still held true, and a
 //!   short remark. Aggregated by [`Store::memory_citation_stats`] into the
 //!   rule-promotion eligibility gate `stella memory` surfaces. No shipped
-//!   tool writes new rows today.
+//!   tool writes new rows today — declared, inert plumbing, see
+//!   [`MemoryCitationRow`]'s own doc comment.
 //! - **rules** — extension-authored workspace rules: one row per rule id,
 //!   holding the full rule markdown in the `.stella/rules/*.md` authoring
 //!   format (the store never parses it — `stella_learn::rules` does).
@@ -276,6 +277,21 @@ pub struct FileTouchRow {
 /// id (the `nod_…` id the recall block showed the model), the agent's
 /// usefulness score (1–5), whether the memory's content still held true this
 /// turn, and a short free-text remark.
+///
+/// **Declared, inert plumbing today.** The row shape, [`Self::is_positive`],
+/// [`fold_citation_stats`], and the promotion/quarantine thresholds below are
+/// all still here and still correct, but nothing in a real turn writes one:
+/// the `cite_memory` tool that collected the judgement is retired, and
+/// [`Store::record_memory_citations`] has no production caller — only tests
+/// construct rows to exercise this fold. `quarantined_memory_ids` and
+/// `stella memory`'s eligibility column are therefore always empty/false, and
+/// real memory retirement runs entirely on deterministic path-anchor
+/// validation (`stella-cli`'s `memory::validation`), not this table.
+/// `ObservationSource::MemoryCitation`, the source that paired a citation
+/// with a mined observation, was removed for the same reason
+/// (`stella-records`' `ObservationSource` doc comment). This stays rather
+/// than being deleted so a later shared holdout sweep can repoint memory
+/// retirement here without a second schema migration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryCitationRow {
     pub memory_id: String,
@@ -300,6 +316,10 @@ pub const POSITIVE_SCORE_MIN: i64 = 3;
 /// A memory must be cited successfully STRICTLY MORE THAN this many times to
 /// become rule-promotion eligible (spec: "more than 10 times" — exactly 10
 /// is not enough).
+///
+/// Declared, inert plumbing today — see [`MemoryCitationRow`]'s doc comment.
+/// Unreachable in practice: nothing writes a citation, so no memory's streak
+/// ever advances past zero.
 pub const PROMOTION_CITATIONS_REQUIRED: i64 = 10;
 
 /// A memory cited untruthful this many times (total, across its history) is
@@ -309,6 +329,10 @@ pub const PROMOTION_CITATIONS_REQUIRED: i64 = 10;
 /// untruthful citation counts regardless of score, and one fresh truthful
 /// citation does NOT clear quarantine — only `stella memory unquarantine`
 /// (or deleting the stale memory) does.
+///
+/// Declared, inert plumbing today — see [`MemoryCitationRow`]'s doc comment.
+/// Unreachable in practice: nothing writes an untruthful citation, so no
+/// memory is ever quarantined by this path.
 pub const QUARANTINE_NEGATIVES_THRESHOLD: i64 = 2;
 
 /// One tombstone as stored — what a person chose to forget, the text it
@@ -336,6 +360,10 @@ pub struct ForgottenRow {
 
 /// Per-memory citation aggregate — the data behind `stella memory` and the
 /// rule-promotion eligibility gate.
+///
+/// Declared, inert plumbing today — see [`MemoryCitationRow`]'s doc comment.
+/// Folded from an always-empty citation table, so every row this type ever
+/// produces has `eligible == false` and `quarantined == false`.
 ///
 /// Eligibility semantics (deliberately strict, per spec): a memory is
 /// eligible once its **positive streak** — consecutive positive citations
@@ -903,6 +931,10 @@ impl Store {
 
     /// Persist one citation row per execution/memory pair. One transaction —
     /// see [`Self::record_files_touched`].
+    ///
+    /// No production caller today — see [`MemoryCitationRow`]'s doc comment.
+    /// Callable and correct so a future producer, or a test exercising the
+    /// fold below, has a real write path.
     pub fn record_memory_citations(
         &self,
         execution_id: i64,
@@ -1574,6 +1606,11 @@ impl Store {
 /// negative one; eligibility is a STRICT `> PROMOTION_CITATIONS_REQUIRED` on
 /// that streak, so one negative remark disqualifies the memory until it
 /// re-earns more than 10 fresh all-positive citations.
+///
+/// Declared, inert plumbing today — see [`MemoryCitationRow`]'s doc comment.
+/// `Store::memory_citation_stats` always calls this with an empty slice in
+/// production, so it always folds to nothing; kept correct against a real
+/// input for the day a producer exists.
 pub fn fold_citation_stats(rows: &[MemoryCitationRow]) -> Vec<MemoryCitationStats> {
     let mut stats: Vec<MemoryCitationStats> = Vec::new();
     let mut score_sum: i64 = 0;


### PR DESCRIPTION
## What

`ObservationSource::MemoryCitation` is retired. It paired a memory citation
with a model's usefulness/truthfulness judgement, but nothing in a real turn
ever produced one: the `cite_memory` tool that collected the judgement is in
`RETIRED_TOOL_NAMES`, and every other source that touches a recalled memory
only knows it was *shown* to the model, never that the model judged it
useful or true.

This is the declared-gap half from the issue's own two options, per the
maintainer's decision already posted on the thread (and epic #5200:
"citations are display-only; retirement will read the shared holdout
sweep"). No producer is added.

## Changes

- `crates/stella-records/src/context_record/lifecycle.rs`: delete the
  `ObservationSource::MemoryCitation` option and its `as_str` arm.
- `crates/stella-records/src/context_record/provenance.rs`: drop it from
  `observation_grade`'s match.
- `crates/stella-cli/src/memory/evidence.rs`: delete the
  `citation_observation` constructor (its module doc now covers only the
  surviving `ToolOutcome` source).
- `crates/stella-cli/src/memory/uses.rs`: delete the call site that mined
  citations into observations (it only ever mined test fixtures — the
  feedback loop that reads `memory_citations` for selection health is
  untouched).
- `crates/stella-store/src/lib.rs`: doc comments on `MemoryCitationRow`,
  `MemoryCitationStats`, `fold_citation_stats`,
  `PROMOTION_CITATIONS_REQUIRED`, and `QUARANTINE_NEGATIVES_THRESHOLD` now
  say plainly that no production caller writes a row today, and why they
  stay rather than being deleted.
- `crates/stella-parity/src/evolution.rs`'s `Memory` row already states this
  posture (landed in #5246, before this PR) — left as is.

## Why not wire a producer

Writing `truthful: true` because a memory's handle appeared in the answer
would assert a judgement nothing gathered, which #2782 forbids — and
`memory::uses::extract_one` already refuses exactly that fabrication for the
sibling `ContextUse::Rendered` vs `Cited` distinction. The issue's own
investigation (posted on the thread) checked reflection, the recall path,
and the answer text for an honest signal and found none.

## Witness

`memory_citation_is_retired_and_no_longer_parses`
(`crates/stella-records/src/context_record/provenance/tests.rs`) asserts the
wire payload `"memory_citation"` fails to deserialize as
`ObservationSource`.

Checked the artisanal way: swapped `lifecycle.rs`/`provenance.rs` back to
their pre-change content, added this exact test, and ran
`cargo test -p stella-records --lib memory_citation_is_retired_and_no_longer_parses`.
It failed — the pre-change enum still parses `"memory_citation"` to
`Ok(MemoryCitation)`. Restored the new files (`git status` clean again) and
reran the same command: it passes.

Also ran, on the new code:
- `cargo test -p stella-cli memory::evidence::` — 8 passed (the tests for
  the deleted citation constructor are removed with it; the rest,
  including a rewritten `re_appending_the_same_evidence_is_a_replay`
  against the surviving `tool_outcome_observation`, pass).
- `cargo test -p stella-cli memory::uses::` — 13 passed, including
  `citations_alone_never_retire_and_a_strong_verdict_retires_restorably`,
  which exercises the citation-fed selection-health feedback loop this PR
  leaves untouched.

## Tests deleted

Three tests exercising the deleted `citation_observation` constructor
(`a_negative_citation_becomes_a_citation_sourced_observation`,
`a_positive_citation_is_not_mined_because_it_would_cite_itself`,
`a_citation_with_no_remark_records_nothing`) in
`crates/stella-cli/src/memory/evidence/tests.rs`. The replay-idempotency
property they and `re_appending_the_same_evidence_is_a_replay` covered is
kept — that one test is rewritten against the surviving
`tool_outcome_observation` source instead of deleted, so no coverage is
lost.

## Residue

None filed — the two natural follow-ups (a producer for citation-based
promotion, and the shared holdout sweep) are already tracked by #5200,
which this PR does not attempt.

Closes #4862

## DoD gate re-fired by the PR sweep (2026-09-05)

`dod / dod` read #4862's five items unchecked at 12:08:57Z; all five were
ticked at 12:10:45Z, after that read, so the gate failed on a stale snapshot.
This edit is what re-fires it.

Spot-checked on this head rather than taken on trust: `ObservationSource::MemoryCitation`
is gone from `crates/`, and the names that remain are different things —
`stella_store::MemoryCitationRow`, the `memory_citations` table, and the doc
comments in `memory/evidence.rs` and `memory/uses.rs` explaining the
retirement. `stella-parity`'s `Memory` row states that nothing writes
`memory_citations` and that path-anchor validation is the only evidence source
retiring anything today.


---
_Generated by [Claude Code](https://claude.ai/code)_