### PR TITLE
fix(gate): drop the package filter cargo refuses on `cargo clean --doc`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,8 +514,9 @@ that splits the same way fails here first, not in CI. `doc-warnings-schema`
 stays `gate`-only on purpose, paired with `doc-warnings`: at `check`, rustdoc
 never runs, for either feature set.
 
-`doc-warnings-schema` also wipes its own doc output before each run
-(`cargo clean --doc`, for the three schema crates only). `cargo doc`'s own
+`doc-warnings-schema` also wipes the doc output before each run
+(`cargo clean --doc`, which takes no package filter — cargo refuses `--doc`
+alongside `-p`, so the whole `target/doc` tree goes). `cargo doc`'s own
 freshness check can call a stale prior run "up to date" — and print nothing
 — even after the source changed. That let a broken doc link in
 `stella-plugin` pass a local `make doc-warnings-schema`, and show up only

--- a/Makefile
+++ b/Makefile
@@ -629,19 +629,21 @@ SCHEMA_FEATURES := stella-protocol/schema,stella-plugin/schema,stella-serve/sche
 # the source changed, which let a broken intra-doc link introduced by moving a
 # function between modules in `stella-plugin` survive a local
 # `make doc-warnings-schema` and reproduce only under a hand-run
-# `rm -rf target/doc` (#5139). `cargo clean --doc` is the package-scoped,
-# cargo-native version of that same fix: it drops the rustdoc output AND the
-# fingerprints cargo used to call the stale build fresh, for exactly the three
-# crates this recipe documents, so the two invocations below always run
-# rustdoc for real rather than trusting a cache that has already been wrong
-# once. Scoped to $(SCHEMA_CRATES) rather than the whole `target/doc` tree —
-# `doc-warnings` below has the same theoretical exposure, but cleaning its
-# workspace-wide output before every gate run would force a full rustdoc
-# rebuild every time, which is the "correct but slow" option #5139 weighed
-# against for a hole this recipe's own repro is what actually demonstrated.
+# `rm -rf target/doc` (#5139). It drops the rustdoc output and the fingerprints
+# cargo called that stale build fresh from, so the two invocations below run
+# rustdoc for real.
+#
+# It takes no package filter: cargo refuses the pair outright — `--doc cannot
+# be used with -p` — so the whole `target/doc` tree goes and there is no scoped
+# spelling to reach for. #5947 shipped `cargo clean --doc $(SCHEMA_CRATES)`,
+# which made this recipe exit 2 on its first line every time it ran, and the
+# `wire-schema` job red on every PR reaching it. What the unscoped clean costs
+# is a later `doc-warnings` rebuilding rustdoc it could have cached; inside one
+# `make gate` that step has already run by the time this one cleans, and
+# `wire-schema.yml` runs this step without `doc-warnings` at all.
 .PHONY: doc-warnings-schema
 doc-warnings-schema: ## Assert rustdoc is clean for the `schema`-gated wire-contract modules (#4584)
-	cargo clean --doc $(SCHEMA_CRATES)
+	cargo clean --doc
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \
 	  --features $(SCHEMA_FEATURES) --no-deps --keep-going
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \


### PR DESCRIPTION
## What & why

`doc-warnings-schema` has not run since #5947. Its first line was
`cargo clean --doc $(SCHEMA_CRATES)`, and cargo rejects that pair outright:

```
$ cargo clean --doc -p stella-protocol
error: --doc cannot be used with -p
```

So the recipe exited 2 before either `cargo doc` invocation ever started —
`make: *** [Makefile:644: doc-warnings-schema] Error 101` — taking `make gate`
and the required `wire-schema` job (`docs/wire still matches the types`) down
with it on every PR that reached them. Found on #5963, whose diff has nothing
to do with it.

Cargo has no package-scoped doc clean, so the fix is the unscoped form.

The comment above the recipe was the premise the broken line rested on — it
claimed `cargo clean --doc` was "the package-scoped, cargo-native version" of
#5139's `rm -rf target/doc` fix, "for exactly the three crates this recipe
documents". That is not a thing cargo can do. Both that comment and AGENTS.md's
copy ("for the three schema crates only") now say what cargo actually does and
name what the unscoped clean costs.

Closes #6003
Refs #5992

## The witness

- [x] No witness needed (pure CI/build-tooling fix) — because: the change is one
      flag on a `make` recipe, and the recipe could not execute at all on the old
      code. There is no input on which the old line passed, so a test asserting
      "the recipe runs" has nothing to distinguish beyond what running it shows.
      The regression guard that *would* hold this shape is filed as #5992 rather
      than bolted on here — it needs its own `GATE_STEPS` entry, both prose
      copies, and a hermetic self-test.

Verified instead, on this branch:

```
$ make doc-warnings-schema        # exit 0
 Documenting stella-plugin v0.9.332
 Documenting stella-protocol v0.9.332
 Documenting stella-serve v0.9.332
```

against `Error 101` on the first line before the change.

The clean is there to defeat cargo's doc freshness check (#5139), so that
property had to survive dropping the filter. It does, and the evidence
separates the two answers rather than being consistent with both — a second
`cargo doc` with no clean between finishes in 0.11s and prints **no**
`Documenting` line (rustdoc skipped); one after `cargo clean --doc` prints it
(rustdoc re-ran).

**This PR's own CI cannot show any of that.** `wire-schema.yml` is not triggered
by a `Makefile` diff, and it is the only workflow that runs
`doc-warnings-schema` — which is exactly how #5947 landed green. Do not read a
green run here as evidence the recipe works. That gap is #5992.

## The gate

- [x] `make prose`, `line-citations`, `gate-parity`, `schema-tier-parity`,
      `doc-links` — all pass
- [x] `make doc-warnings-schema` — the step this PR repairs, exit 0
- [ ] `cargo test --workspace` — not run locally per CLAUDE.md ("CI builds and
      tests; this laptop does not"); CI is the evidence
- [x] Docs updated: AGENTS.md's gate section carried the same false claim and is
      corrected here, per CLAUDE.md's rule that a CLAUDE.md/AGENTS.md
      disagreement is fixed in the PR that notices it
- [x] `Closes #6003` appears both here and as a commit trailer

## Nothing left behind

- [x] Filed: #6003 (the break itself, closed by this PR) and #5992 (why no
      workflow caught it — #5947 was a Makefile-only diff, and `wire-schema.yml`'s
      `paths:` filter has no `Makefile` entry, so its CI never ran the step it
      rewrote). #5992 is kept separate because the repair is a workflow-trigger
      decision, not a one-line fix, and adding `Makefile` to that `paths:` list
      is the *wrong* repair — `scripts/wire-schema-paths.sh` re-derives it into
      `.githooks/pre-push` to answer one exact question ("can this diff
      invalidate `docs/wire/`?") that a Makefile edit cannot.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The unscoped clean drops the whole `target/doc` tree, which #5947's comment
weighed against as "correct but slow". That tradeoff was never available — the
scoped spelling does not exist — so the choice here is between the unscoped
clean and no clean at all, and no clean reopens #5139. The cost lands on a
later `doc-warnings` rebuilding rustdoc it could have cached; inside one
`make gate` that step has already run by the time this one cleans, and
`wire-schema.yml` runs this step without `doc-warnings` at all.

Note also that #4584's rustdoc coverage of the `schema`-gated wire modules has
not actually run since #5947 merged — the step was failing before it could check
anything. If this lands red on a real rustdoc warning in those modules, that is
a genuine finding that was being masked, not a regression from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BmQhWR76eqayt9kJ6e2WB