### PR TITLE
fix(gate): drop the -p from doc-warnings-schema's clean, which cargo refuses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,11 +515,18 @@ stays `gate`-only on purpose, paired with `doc-warnings`: at `check`, rustdoc
 never runs, for either feature set.
 
 `doc-warnings-schema` also wipes its own doc output before each run
-(`cargo clean --doc`, for the three schema crates only). `cargo doc`'s own
-freshness check can call a stale prior run "up to date" — and print nothing
-— even after the source changed. That let a broken doc link in
-`stella-plugin` pass a local `make doc-warnings-schema`, and show up only
-after a hand-run `rm -rf target/doc`.
+(`cargo clean --doc`). `cargo doc`'s own freshness check can call a stale
+prior run "up to date" — and print nothing — even after the source changed.
+That let a broken doc link in `stella-plugin` pass a local
+`make doc-warnings-schema`, and show up only after a hand-run
+`rm -rf target/doc`.
+
+The clean takes the whole `target/doc` tree, because cargo rejects `--doc`
+alongside `-p` and there is no scoped spelling. A scoped one shipped once and
+failed the recipe on its own first line for every diff that reaches
+`wire-schema.yml`. `doc-warnings` shares that tree, so it now rebuilds each
+gate run; the recipe's own comment carries what that costs and what would buy
+the scope back.
 
 **Every rung needs `shellcheck` on `PATH`, and it is not vendored.** It is the
 gate's one external binary, so a machine or container image without it stops at

--- a/Makefile
+++ b/Makefile
@@ -629,19 +629,26 @@ SCHEMA_FEATURES := stella-protocol/schema,stella-plugin/schema,stella-serve/sche
 # the source changed, which let a broken intra-doc link introduced by moving a
 # function between modules in `stella-plugin` survive a local
 # `make doc-warnings-schema` and reproduce only under a hand-run
-# `rm -rf target/doc` (#5139). `cargo clean --doc` is the package-scoped,
-# cargo-native version of that same fix: it drops the rustdoc output AND the
-# fingerprints cargo used to call the stale build fresh, for exactly the three
-# crates this recipe documents, so the two invocations below always run
-# rustdoc for real rather than trusting a cache that has already been wrong
-# once. Scoped to $(SCHEMA_CRATES) rather than the whole `target/doc` tree —
-# `doc-warnings` below has the same theoretical exposure, but cleaning its
-# workspace-wide output before every gate run would force a full rustdoc
-# rebuild every time, which is the "correct but slow" option #5139 weighed
-# against for a hole this recipe's own repro is what actually demonstrated.
+# `rm -rf target/doc` (#5139). The clean drops the rustdoc output AND the
+# fingerprints cargo used to call the stale build fresh, so the two
+# invocations below always run rustdoc for real rather than trusting a cache
+# that has already been wrong once.
+#
+# It cleans the whole `target/doc` tree because cargo offers no other shape:
+# `--doc` and `-p` are mutually exclusive, and `cargo clean --doc
+# $(SCHEMA_CRATES)` is rejected outright with `--doc cannot be used with -p`
+# (#5991). #5947 landed it in the scoped spelling, which made this recipe
+# fail on its first line for every diff that reaches wire-schema.yml.
+#
+# So the cost #5139 weighed against is paid after all: `doc-warnings` below
+# shares `target/doc`, and cleaning it means a full rustdoc rebuild on each
+# gate run. That is the "correct but slow" side of that trade, taken because
+# the alternative available today is to drop the clean and restore the stale
+# cache #5139 exists to close. #5991 holds the question of buying the scope
+# back — a separate CARGO_TARGET_DIR for this recipe is the obvious candidate.
 .PHONY: doc-warnings-schema
 doc-warnings-schema: ## Assert rustdoc is clean for the `schema`-gated wire-contract modules (#4584)
-	cargo clean --doc $(SCHEMA_CRATES)
+	cargo clean --doc
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \
 	  --features $(SCHEMA_FEATURES) --no-deps --keep-going
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \


### PR DESCRIPTION
## What and why

`doc-warnings-schema`'s first line was `cargo clean --doc $(SCHEMA_CRATES)`, and `SCHEMA_CRATES` is `-p stella-protocol -p stella-plugin -p stella-serve`. Cargo refuses that combination:

```console
$ cargo clean --doc -p stella-protocol
error: --doc cannot be used with -p
```

`cargo clean -p stella-protocol --doc` is refused identically, so **no spelling of the scoped form works** on the pinned toolchain (1.97.0).

The recipe therefore failed on its own first line, for every diff that reaches `wire-schema.yml` — `docs/wire/**`, `crates/stella-protocol/**`, `crates/stella-serve/**`, `crates/stella-plugin/**`. It landed in #5947 and merged as `a2fe819`, which is on `main` now. #5963 is where it surfaced: a diff about wrapper stage bands, failing a check named `docs/wire still matches the types` on a rustdoc clean it never asked for.

Not caught before the merge because `wire-schema.yml` triggers on `pull_request` only, and #5947's own diff (`Makefile`, `AGENTS.md`, `CONTRIBUTING.md`, `.github/workflows/**`, `scripts/**`) touches none of those paths — so the workflow that runs this recipe never ran on the PR that changed it.

## The fix

Drop the scope. The clean stays, so #5139's protection stands: cargo's doc freshness check can mark a `doc` unit up to date — printing nothing — off a stale prior build, which is what let a broken intra-doc link in `stella-plugin` survive a local run and reproduce only under a hand-run `rm -rf target/doc`.

**The cost is real, and is now written down instead of implied.** `doc-warnings` shares `target/doc`, so an unscoped clean means a full workspace rustdoc rebuild on each gate run — the "correct but slow" side of the trade #5139 weighed against. Taken because the only other option available today is to drop the clean and reopen the hole. #5991 holds whether to buy the scope back; a separate `CARGO_TARGET_DIR` for this recipe is the obvious candidate, since that is the one dimension cargo does let you scope.

`AGENTS.md`'s rung section described the clean as "for the three schema crates only", which this makes false, so it now says what the recipe does.

## Witness

The recipe is its own flip, run both ways in one tree:

```console
$ git stash && make doc-warnings-schema
cargo clean --doc -p stella-protocol -p stella-plugin -p stella-serve
error: --doc cannot be used with -p
make: *** [Makefile:644: doc-warnings-schema] Error 101        # exit 2

$ git stash pop && make doc-warnings-schema
   Generated target/doc/stella_plugin/index.html and 5 other files   # exit 0
```

A Rust witness test is not available for this one: the subject is a Makefile recipe's argument list, and what proves it is running the recipe.

Guards run locally, each exit code read directly rather than through a pipe (per AGENTS.md's own gotcha about `$?` after a filter): `check-prose`, `check-gate-parity`, `check-line-citations`, `check-god-files`, `check-file-size`, `check-left-behind` — all `0`.

`check-prose` earned its keep here: the first draft of the AGENTS.md paragraph raised that file's `issue-reference` count from 97 to 99. The prose was rewritten to state the facts rather than cite the numbers; no baseline entry was added.

## Tests deleted

None.

## Residue

- **#5991** — whether to restore the scope, and at what cost. Filed with the three options weighed (leave it and measure; a separate `CARGO_TARGET_DIR`; a hand `rm -rf` of the three doc dirs, which is suspected not to defeat the fingerprint that caused #5139 and is rejected on that suspicion rather than on measurement).

Refs #5139, #5947, #5991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2Pca8syUyEdAi7KK6LVXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2Pca8syUyEdAi7KK6LVXk)_

## Summary by Sourcery

Restore the doc-warnings-schema gate by using a cargo-compatible documentation clean while preserving protection against stale rustdoc output.

Bug Fixes:
- Fix the doc-warnings-schema gate by removing the unsupported package scoping from cargo's documentation clean command.

Enhancements:
- Document the resulting workspace-wide documentation clean and its full rustdoc rebuild cost.

Documentation:
- Update contributor guidance to accurately describe the documentation clean behavior and its trade-offs.