### PR TITLE
feat(stella-tui-theme): give WARNING a generated token, dedupe palette.rs's copy

### DIFF
--- a/crates/stella-tui-theme/src/fallback.rs
+++ b/crates/stella-tui-theme/src/fallback.rs
@@ -56,6 +56,11 @@ pub fn detect_truecolor() -> bool {
 ///   The deck's own table (`stella-tui`'s `FALLBACKS`) has always shipped
 ///   bright green and bright red. The v1 deck and a v2 surface must not
 ///   disagree about a status colour.
+/// - [`token::WARNING`] takes plain yellow, not bright: bright yellow is
+///   already gold's stand-in, and a warning that collapsed onto it at
+///   sixteen colours would read as the mark. The deck's own `FALLBACKS`
+///   table matches this pairing by 16-index (`(WARNING, 173, 3)` — ANSI 3
+///   is plain yellow, 11 is bright).
 /// - The diff tints go to black rather than to a green and a red background.
 ///   At 16 colours a tint is not available; only a wash is, and a wash on
 ///   every changed row would spend the palette's whole red budget on a healthy
@@ -75,6 +80,7 @@ pub fn ansi16(color: Color) -> Color {
         token::MUTED | token::DIM => Color::DarkGray,
         token::GREEN => Color::LightGreen,
         token::RED => Color::LightRed,
+        token::WARNING => Color::Yellow,
         // The light-theme stops. They reach the terminal only when a paper
         // theme is active, and at sixteen colours a paper ground *is* white —
         // there is no lighter tier to distinguish panel from canvas, so they

--- a/crates/stella-tui-theme/src/tests.rs
+++ b/crates/stella-tui-theme/src/tests.rs
@@ -314,6 +314,11 @@ fn the_named_fallbacks_are_what_the_spec_says() {
         Color::LightGreen,
         "green to bright green"
     );
+    assert_eq!(
+        fallback::ansi16(token::WARNING),
+        Color::Yellow,
+        "warning to plain yellow, not gold's bright yellow"
+    );
 }
 
 /// The metals must not collapse into each other, or the 16-color frame loses
@@ -334,6 +339,11 @@ fn the_two_metals_stay_apart_at_16_colors() {
         fallback::ansi16(token::BG),
         fallback::ansi16(token::BORDER),
         "the ground and its seams degrade to the same colour"
+    );
+    assert_ne!(
+        fallback::ansi16(token::WARNING),
+        fallback::ansi16(token::GOLD),
+        "a warning and the mark degrade to the same colour"
     );
 }
 

--- a/crates/stella-tui-theme/src/token.rs
+++ b/crates/stella-tui-theme/src/token.rs
@@ -146,6 +146,9 @@ pub const PAPER_PANEL: Color = Color::Rgb(0xF9, 0xF6, 0xEF);
 /// Light border. `#E6E3DD`
 pub const PAPER_BORDER: Color = Color::Rgb(0xE6, 0xE3, 0xDD);
 
+/// Warning: the one status the core palette does not name. `#E78D54`
+pub const WARNING: Color = Color::Rgb(0xE7, 0x8D, 0x54);
+
 // ── The walkable table ─────────────────────────────────────────────
 
 /// Which predicate a token's value is held to.
@@ -195,6 +198,7 @@ pub const ALL: &[(&str, Color, Clamp)] = &[
     ("paper", PAPER, Clamp::WarmPaper),
     ("paper-panel", PAPER_PANEL, Clamp::WarmPaper),
     ("paper-border", PAPER_BORDER, Clamp::WarmPaper),
+    ("amber", WARNING, Clamp::Verdict),
 ];
 
 // The predicates that read this table are in `crate::clamp`, and the

--- a/crates/stella-tui/src/palette.rs
+++ b/crates/stella-tui/src/palette.rs
@@ -5,7 +5,7 @@
 //!
 //! ## What is a hex here, and what is not
 //!
-//! Sixteen of these constants are **not values at all** -- they are the
+//! Seventeen of these constants are **not values at all** -- they are the
 //! generated tokens under another name:
 //!
 //! ```text
@@ -14,6 +14,7 @@
 //! TEXT_PRIMARY TEXT_EMPHASIS      ->  token::TEXT SILVER_TYPE
 //! TEXT_SECONDARY TEXT_TERTIARY    ->  token::SILVER MUTED
 //! TEXT_DIM SUCCESS DANGER INK     ->  token::DIM GREEN RED BG
+//! WARNING                         ->  token::WARNING
 //! ```
 //!
 //! They were hand-typed copies of `design/tokens/stella-tokens.json`,
@@ -21,21 +22,21 @@
 //! repository loses limits to -- a number in two places, with a comment
 //! asking the next author to copy carefully. They are re-exports now, so
 //! editing the JSON moves the deck and there is no second value to forget.
+//! `WARNING` is the newest one. `amber` always held the same `verdict`
+//! clamp `SUCCESS`/`DANGER` hold. It just had no `rust` name, so the
+//! generator never made it a constant.
 //!
 //! The rest still carry their own hex, and each is a colour the token system
 //! has no home for yet rather than an oversight (#4058):
 //!
 //! - **The light theme.** `PAPER`, `SNOW`, `PAPER_RAISED`, `PAPER_HAIRLINE`,
-//!   `INK_MUTED`, `INK_DIM`, `INK_EMPHASIS`, and the three ink golds
-//!   (`BRAND_INK`, `BRAND_INK_DEEP`, `GOLD_INK`). The JSON declares four
-//!   `web-light` stops and they disagree with these: its `paper` is pure
-//!   white where the deck paints `#F4F4F6`, and its `ink` is `#141413`
-//!   where this file means the dark ground. Reconciling them is a design
-//!   decision about what the paper theme *is*, not a remap.
-//! - **`WARNING` and the three status inks.** `#E78D54` fails the gold hue
-//!   clamp (`g/r = 0.61`, against `0.78`) and is not a verdict either, so it
-//!   has no clamp role to declare -- and the clamp is exactly the guard that
-//!   should be deciding whether an amber this close to the accent may exist.
+//!   `INK_MUTED`, `INK_DIM`, `INK_EMPHASIS`, the three ink golds (`BRAND_INK`,
+//!   `BRAND_INK_DEEP`, `GOLD_INK`), and the three status inks (`SUCCESS_INK`,
+//!   `WARNING_INK`, `DANGER_INK`). The JSON's `web-light` stops disagree with
+//!   these: its `paper` is pure white where the deck paints `#F4F4F6`, and
+//!   its `ink` is `#141413` where this file means the dark ground.
+//!   Reconciling them is a design call about what the paper theme *is*, not
+//!   a remap. The three status inks wait on that same call.
 //! - **`VOID` and `HAIRLINE_STRONG`,** derived steps either side of the
 //!   declared ramp.
 //!
@@ -248,7 +249,7 @@ pub const SUCCESS: Color = token::GREEN;
 /// lands 39.1 deg from gold and 38.9 deg from danger -- so a reader can tell
 /// a warning from the mark *and* from a failure by hue, not just by glyph.
 /// It carries the same cool pull as its two neighbours (chroma 0.131).
-pub const WARNING: Color = Color::Rgb(0xE7, 0x8D, 0x54);
+pub const WARNING: Color = token::WARNING;
 
 /// Error / failed / removed. 6.06:1 on ground, OKLCH hue 12.8 (78.0 deg from
 /// the gold accent).

--- a/crates/stella-tui/src/theme/tests.rs
+++ b/crates/stella-tui/src/theme/tests.rs
@@ -38,6 +38,25 @@ fn every_text_tier_resolves_to_the_token_it_names() {
     assert_ne!(TEXT_TERTIARY, TEXT_DIM);
 }
 
+/// `WARNING` is the generated token, not a second hand-typed copy of it.
+///
+/// `token::WARNING` did not exist before this: `amber` held a `verdict`
+/// clamp in `design/tokens/stella-tokens.json` from the start, the same
+/// channel-free clamp `SUCCESS`/`DANGER` hold, but carried no `rust` name for
+/// `scripts/gen-tokens.py` to emit a constant from. Referencing
+/// `stella_tui_theme::token::WARNING` fails to compile against a tree that
+/// predates that binding — this is that reference.
+#[test]
+fn warning_is_the_generated_token_not_a_second_literal() {
+    use stella_tui_theme::token;
+
+    assert_eq!(
+        palette::WARNING,
+        token::WARNING,
+        "palette::WARNING must be the generated amber token, not an independent literal"
+    );
+}
+
 #[test]
 fn agent_color_is_stable_across_calls() {
     assert_eq!(agent_color("lead"), agent_color("lead"));

--- a/design/tokens/stella-tokens.json
+++ b/design/tokens/stella-tokens.json
@@ -445,8 +445,9 @@
       "hex": "#E78D54",
       "clamp": "verdict",
       "css": "--st-amber",
+      "rust": "WARNING",
       "role": "warning: the one status the core palette does not name",
-      "surfaces": ["web-dark"],
+      "surfaces": ["tui", "web-dark"],
       "paint": "painted"
     },
     {

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -34,7 +34,7 @@ Every screen exists to make these four claims visible without saying them:
 
 All values are `Color::Rgb`. Grays are neutral or one to two points blue above red. This is what keeps the scheme from reading warm or brown on cheap panels.
 
-The table is every token `design/tokens/stella-tokens.json` declares on the `tui` surface — the deck's own ramp. The palette is wider than this: the JSON carries a light ground, the four status inks and the site's below-canvas backdrop as well, and those are not the terminal's, so they are not here. `crates/stella-tui/tests/spec_palette.rs` holds both directions of that claim — every hex below is the value the token holds, and every `tui` token has a row.
+The table is every token `design/tokens/stella-tokens.json` declares on the `tui` surface — the deck's own ramp. The palette is wider than this: the JSON carries a light ground, the three ink-on-paper status colors and the site's below-canvas backdrop as well, and those are not the terminal's, so they are not here. `crates/stella-tui/tests/spec_palette.rs` holds both directions of that claim — every hex below is the value the token holds, and every `tui` token has a row.
 
 <!-- BEGIN palette -->
 
@@ -56,6 +56,7 @@ The table is every token `design/tokens/stella-tokens.json` declares on the `tui
 | `red` | `#E0687A` | fail, `-` diff sign, delete events, destructive |
 | `diff_add_bg` | `#10201A` | added diff row background |
 | `diff_del_bg` | `#241019` | removed diff row background |
+| `amber` | `#E78D54` | warning, needs-input |
 
 <!-- END palette -->
 
@@ -109,6 +110,7 @@ The stand-in for every token, by the ANSI name rather than by ratatui's spelling
 | `paper` | bright white |
 | `paper_panel` | bright white |
 | `paper_border` | white |
+| `amber` | yellow |
 
 <!-- END degradation -->
 

--- a/scripts/gen-tokens.py
+++ b/scripts/gen-tokens.py
@@ -188,12 +188,20 @@ def check_clamp(
 def rust_tokens(doc: dict) -> list[dict]:
     """The tokens that reach the terminal, in declaration order.
 
-    A token declares a `rust` name when the TUI renders it. The web-only ones
-    -- the below-canvas backdrop, the gold-on-paper text stop, the five-step
-    light ramp and the four status inks -- do not, and must not: every entry in
-    the generated `ALL` table needs a 256-colour fallback pinned by
-    `stella-tui-theme`'s tests, and inventing an ANSI approximation of a paper
-    tint the terminal never draws would be an assertion about nothing.
+    A token declares a `rust` name when the TUI renders it. Eleven of the
+    JSON's stops still do not: `void`, `gold-ink`, the light page ramp
+    (`paper-text`, `paper-ground`, `paper-raised`, `paper-row`, `paper-seam`,
+    `ink-muted`), and the three status inks (`green-ink`, `amber-ink`,
+    `red-ink`). Every one of them sits on the decision
+    `crates/stella-tui/src/palette.rs`'s own module doc names: the deck's
+    paper theme is still a set of independently-derived hexes, not yet
+    reconciled against this ramp. Giving one a `rust` name before that lands
+    would force the generated `ALL`/`ansi16` tables to carry a value the
+    terminal does not actually paint yet, which is exactly the assertion
+    about nothing this rule exists to forbid. `amber` left this list once its
+    `verdict` clamp -- already shared with `red`/`green` -- got a `WARNING`
+    binding: it is the dark-ground stop, so it carries no part of the
+    undecided paper question the other eleven are waiting on.
 
     The alternative was to leave those values out of the system entirely, which
     is what `main` does -- and it means the only file that knows the site's


### PR DESCRIPTION
## What

`design/tokens/stella-tokens.json`'s `amber` token already carried the same `verdict` clamp `red`/`green` hold, at the exact hex `crates/stella-tui/src/palette.rs`'s `WARNING` was hand-typed with. It just had no `rust` name, so `scripts/gen-tokens.py` never emitted a `token::WARNING` constant for `palette.rs` to alias — unlike `SUCCESS`/`DANGER`, which already point at `token::GREEN`/`token::RED`. `palette.rs`'s own module doc claimed `WARNING` "fails the gold hue clamp... and is not a verdict either, so it has no clamp role to declare." That was false: it always held one, under `amber`.

This gives `amber` a `rust: "WARNING"` binding and adds `tui` to its surfaces (it renders on the dark-ground deck exactly like `red`/`green` do), regenerates `token.rs`, points `palette::WARNING` at the generated constant, adds the `ansi16` fallback (plain yellow — distinct from gold's bright yellow, matching the deck's own `FALLBACKS` table's existing `(WARNING, 173, 3)` 16-index) and the SPEC 3.1/3.5 rows the new `token::ALL` entry requires, and corrects `palette.rs`'s module doc and `gen-tokens.py`'s stale `rust_tokens()` docstring — it still claimed "the five-step light ramp" carried no `rust` name, though `paper`/`paper-panel`/`paper-border` already had one.

`WARNING_INK`/`SUCCESS_INK`/`DANGER_INK` stay literals. They are the paper-ground half of the same status colors, and #4058's history (see the issue thread) has repeatedly flagged the deck's paper theme vs. the web's `web-light` ramp as a maintainer decision — not a remap — because the two ramps disagree in both temperature and direction (deck: surface lighter than canvas; token: panel darker than canvas). Forcing that convergence for the ink variants would also force it for `PAPER`/`SNOW`, and nothing in CI can validate that visual call; it stays a design decision for a human, tracked by the two follow-up issues below.

## Why this exemplar

Follows the exact dedup shape #4135 already used for `SUCCESS = token::GREEN` / `DANGER = token::RED` — a byte-identical alias, not a recolor.

## Witness

`stella_tui_theme::token::WARNING` does not exist before this change — referencing it is a compile error against `main`. `crates/stella-tui/src/theme/tests.rs`'s new `warning_is_the_generated_token_not_a_second_literal` is that reference; it fails to compile on `main` and passes here.

All 40 tests in `deck_render_snapshots` pass **unblessed** (the value is byte-identical), which is the proof this is a dedupe and not a recolor.

## Tests

- `cargo test -p stella-tui-theme` (21/21)
- `cargo test -p stella-tui --lib theme::` (33/33, includes the new witness)
- `cargo test -p stella-tui --test spec_palette` (5/5)
- `cargo test -p stella-tui --test deck_render_snapshots` (40/40, unblessed)
- `cargo test -p stella-cli --test design_token_parity` (13/13)
- `cargo clippy -p stella-tui-theme -p stella-tui --all-targets -- -D warnings` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-tui-theme -p stella-tui --no-deps --document-private-items` clean
- `make guards-fast`, `python3 scripts/gen-tokens.py --check`, `python3 scripts/check-tokens.py`, `python3 scripts/check-prose.py`, `make line-citations`, `make dead-code-allows` all green

Tests deleted: None.

## #4058's remaining scope

Re-checked every claim in the issue thread against `main` at `b80b0c304` (see the comment I posted before starting: https://github.com/macanderson/stella/issues/4058#issuecomment-5551643569). Everything else the issue asked for is already on `main` — the dedup (#4101), the wordmark and gradient removal (#4909), `MIGRATING` (left the ledger), and three of the four painted-gap tokens the 2026-08 comments flagged (`diff-add-bg`/`diff-del-bg` are painted via `plugin_panel.rs`/`gate_board.rs`; only `paper-panel`/`paper-border` are still declared gaps, tied to the same light-theme decision).

What's left after this PR — the light-theme reconciliation, the categorical-token kind for `DATA_1`-`DATA_5`, and the derived-step-token kind for `VOID`/`HAIRLINE_STRONG` — is genuinely three separate maintainer decisions, each already narrated in `palette.rs`'s own module doc. Filed as focused issues rather than deciding unilaterally: brand/visual calls like these have a documented pattern in this repo of staying open for a maintainer's call (#4072, #2592), unlike an architecture choice SCR-002 asks me to decide alone.

- #5997 -- the light-theme reconciliation (deck vs. `web-light`)
- #5998 -- the categorical-hue clamp `DATA_1`-`DATA_5` need
- #6000 -- the derived-step-token kind `VOID`/`HAIRLINE_STRONG` need

Closes #4058

## Summary by Sourcery

Generate and use the terminal warning token consistently across the theme palette and specification.

New Features:
- Add a generated `WARNING` theme token for the terminal palette with an ANSI yellow fallback.

Bug Fixes:
- Replace the hand-maintained warning color with the generated token to eliminate duplicate palette values and correct stale token documentation.

Enhancements:
- Document the warning token in the TUI specification and strengthen tests ensuring it remains distinct from gold and aliases the generated value.

Documentation:
- Update palette and token-generator documentation to reflect warning's verdict clamp and the remaining paper-theme status inks.

Tests:
- Add coverage for the generated warning-token alias and its ANSI16 fallback behavior.
