### PR TITLE
fix(stella-cli): publish the wrapper's judged verdict for stella goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,19 +629,21 @@ SCHEMA_FEATURES := stella-protocol/schema,stella-plugin/schema,stella-serve/sche
 # the source changed, which let a broken intra-doc link introduced by moving a
 # function between modules in `stella-plugin` survive a local
 # `make doc-warnings-schema` and reproduce only under a hand-run
-# `rm -rf target/doc` (#5139). `cargo clean --doc` is the package-scoped,
-# cargo-native version of that same fix: it drops the rustdoc output AND the
-# fingerprints cargo used to call the stale build fresh, for exactly the three
-# crates this recipe documents, so the two invocations below always run
-# rustdoc for real rather than trusting a cache that has already been wrong
-# once. Scoped to $(SCHEMA_CRATES) rather than the whole `target/doc` tree —
-# `doc-warnings` below has the same theoretical exposure, but cleaning its
-# workspace-wide output before every gate run would force a full rustdoc
-# rebuild every time, which is the "correct but slow" option #5139 weighed
-# against for a hole this recipe's own repro is what actually demonstrated.
+# `rm -rf target/doc` (#5139). It drops the rustdoc output and the fingerprints
+# cargo called that stale build fresh from, so the two invocations below run
+# rustdoc for real.
+#
+# It takes no package filter: cargo refuses the pair outright — `--doc cannot
+# be used with -p` — so the whole `target/doc` tree goes and there is no scoped
+# spelling to reach for. #5947 shipped `cargo clean --doc $(SCHEMA_CRATES)`,
+# which made this recipe exit 2 on its first line every time it ran, and the
+# `wire-schema` job red on every PR reaching it. What the unscoped clean costs
+# is a later `doc-warnings` rebuilding rustdoc it could have cached; inside one
+# `make gate` that step has already run by the time this one cleans, and
+# `wire-schema.yml` runs this step without `doc-warnings` at all.
 .PHONY: doc-warnings-schema
 doc-warnings-schema: ## Assert rustdoc is clean for the `schema`-gated wire-contract modules (#4584)
-	cargo clean --doc $(SCHEMA_CRATES)
+	cargo clean --doc
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \
 	  --features $(SCHEMA_FEATURES) --no-deps --keep-going
 	RUSTDOCFLAGS="-D warnings" cargo doc $(SCHEMA_CRATES) \

--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -513,12 +513,16 @@ pub(crate) async fn run_goal_wrapped_turn(
                     kind: None,
                 };
             }
-            // SPEC 8.1's board, on the stream the deck and the recorded journal
-            // both read. Emitted per round rather than once at the end: a
-            // held-open wrapper re-judges every round, so the board a reader
-            // sees beside round 2's work has to be round 2's — one board at the
-            // end would report the last round's gates over the whole run.
-            //
+            // The training label's only producer, and the board just below
+            // it. A held-open wrapper re-judges every round. So the pair a
+            // reader sees beside round 2's work has to be round 2's — sent
+            // once at the end, either one would report only the last
+            // round's verdict.
+            let _ = tx.send(AgentEvent::Verdict {
+                passed: report.met(),
+                evidence: report.verdict_evidence(),
+            });
+            // SPEC 8.1's board — the same verdict rendered per requirement.
             // Nothing was re-run to produce it (`stella_runtime::wrapper::gate_board`).
             let _ = tx.send(AgentEvent::GateBoard {
                 board: report.board.clone(),

--- a/crates/stella-cli/src/calibration.rs
+++ b/crates/stella-cli/src/calibration.rs
@@ -26,13 +26,24 @@
 //!
 //! # What produces the verdicts this reads
 //!
-//! Nothing in this workspace, any more. The built-in staged pipeline was the
-//! only in-tree emitter of [`AgentEvent::Verdict`] and was deleted in #3865;
-//! `Verdict` stays on the wire as `RecordedOnly` because it is the natural
-//! event a verification plugin re-emits (`stella-protocol`'s consumer ledger,
-//! #3790). So this instrument reads two populations and no third: sessions
-//! recorded while the built-in ladder still ran, and streams an installed
-//! verification plugin writes now.
+//! Three populations, not the two the built-in pipeline's deletion (#3865)
+//! left behind. The oldest is sessions recorded while that pipeline's own
+//! ladder still ran. The newest is this host's own: `stella goal --pipeline`
+//! keeps one event channel open across its whole round loop, so
+//! `crate::agent::goal::goal_wrapped` can publish
+//! [`stella_runtime::wrapper::DispatchReport::verdict_evidence`] as an
+//! [`AgentEvent::Verdict`] after every round `judge` decides, and land it on
+//! the run's own execution row. That call is mechanical and synchronous —
+//! never a model (`stella_runtime::wrapper::verdict`'s module doc) — so it
+//! does not blur the line this instrument measures. `stella run --pipeline`
+//! and `stella fleet --pipeline` cannot do the same today: each of their
+//! rounds opens and closes its own execution row before `judge` ever runs, so
+//! nothing they could send afterward has a live channel left to reach — a gap
+//! tracked as a follow-up issue rather than closed here. The third
+//! population, still hypothetical, is a verification plugin re-emitting its
+//! own `Verdict` some other way. `Verdict` staying `RecordedOnly` on
+//! `stella-protocol`'s consumer ledger (#3790) was always about *this*
+//! crate's own read, not about whether anything writes.
 //!
 //! That is why [`render_calibration`] says so out loud when it folds no
 //! verdict at all. A report of "0 passes, 0 false positives" reads exactly

--- a/crates/stella-cli/tests/run_require_verdict_cli.rs
+++ b/crates/stella-cli/tests/run_require_verdict_cli.rs
@@ -40,6 +40,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
 
+use stella_protocol::{AgentEvent, LadderRung};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -478,6 +479,94 @@ async fn goal_takes_the_flag_and_exits_by_the_goals_own_result() {
         Some(0),
         "a met goal whose last-round verdict is Met exits 0 under the flag: \
          {stdout}\n{stderr}"
+    );
+}
+
+/// **Witness.** Before this change, nothing in production built an
+/// `AgentEvent::Verdict`. `judge`'s answer stayed inside the
+/// `DispatchReport` this door printed to stderr, and never reached the
+/// store. `crate::dataset_cmd::reward_label` reads exactly that event and
+/// nothing else, so it found none, and `stella dataset export`'s `reward`
+/// column was null for every real run.
+///
+/// The goal door, not the plain `stella run` one: each round of a plain
+/// `stella run --pipeline` opens and closes its own execution row before
+/// the wrapper's verdict is even decided, so nothing this door's dispatch
+/// judges afterward has a live channel left to reach. That gap is tracked
+/// separately. `stella goal`'s round driver keeps one channel open across
+/// its whole loop, so its round-boundary send lands before that channel
+/// closes.
+///
+/// This test enumerates every execution the run left behind, because a
+/// wrapped goal run also opens the plugin's own child-turn row beside the
+/// worker's — and reads each one back with `Store::execution_events`, the
+/// same reader `dataset export` uses.
+#[tokio::test]
+async fn goal_wrapped_records_the_verdict_event_the_dataset_export_reads() {
+    let server = mock_one_round_goal_loop().await;
+    let ws = tempfile::tempdir().expect("workspace");
+    install_goal_fixture(ws.path());
+    std::fs::write(ws.path().join("lib.rs"), "pub fn hello() {}\n").expect("source file");
+
+    let (code, _stdout, stderr) = stella(
+        ws.path(),
+        &server.uri(),
+        &[
+            "goal",
+            "--pipeline",
+            "goal-verdict-fixture-v1",
+            "say the work is done, then stop",
+        ],
+    );
+    assert_eq!(code, Some(0), "a met goal exits 0: {stderr}");
+
+    let store = stella_store::Store::open(ws.path()).expect("open the workspace store");
+    let finished = store
+        .finished_executions_after(0, 10)
+        .expect("read finished executions");
+    assert!(!finished.is_empty(), "the run left no finished execution");
+    let mut verdicts: Vec<(bool, stella_protocol::VerdictEvidence)> = Vec::new();
+    for execution in &finished {
+        let journal = store
+            .execution_events(execution.execution_id)
+            .expect("read an execution's journal");
+        verdicts.extend(
+            journal
+                .events
+                .iter()
+                .filter_map(|record| match &record.event {
+                    AgentEvent::Verdict { passed, evidence } => Some((*passed, evidence.clone())),
+                    _ => None,
+                }),
+        );
+    }
+    assert_eq!(
+        verdicts.len(),
+        1,
+        "the fixture's single round judges exactly one verdict: {verdicts:?}"
+    );
+    let (passed, evidence) = verdicts
+        .pop()
+        .expect("the wrapper's judged verdict must reach the store as an AgentEvent::Verdict");
+    assert!(
+        passed,
+        "this door's `judge` is vacuously Met on the empty rule every steering-grade \
+         plugin declares (see GOAL_PLUGIN_TOML)"
+    );
+    let rung = evidence
+        .ladder
+        .as_deref()
+        .and_then(|snapshot| snapshot.rung);
+    assert_eq!(
+        rung,
+        Some(LadderRung::Waived),
+        "a met rule with no requirement settles on the ladder's `waived` rung — nothing \
+         was asked for, so nothing here scores a reward"
+    );
+    assert!(
+        !evidence.deterministic,
+        "waived carries no oracle evidence either way — reward_label discards it rather \
+         than crediting a check that never ran"
     );
 }
 

--- a/crates/stella-protocol/src/event/tags.rs
+++ b/crates/stella-protocol/src/event/tags.rs
@@ -471,9 +471,14 @@ agent_event_tags! {
         &[];
     // `Verdict` additionally folds the session model's verification state
     // (`stella-tui/src/model.rs`) into the one-line textline verdict — still
-    // rendering, still no branch, still no selecting surface. It stays on the
-    // wire because it is the natural event a verification plugin re-emits;
-    // #3790 confirms that assumption when the wire contract is settled.
+    // rendering, still no branch, still no selecting surface. `RecordedOnly`
+    // is about this crate's readers, not about whether anything writes.
+    // `stella-cli`'s `agent::goal::goal_wrapped` now publishes one per judged
+    // round. It converts `stella_runtime::wrapper::DispatchReport` rather
+    // than re-deriving a verdict — a different producer than the
+    // verification plugin #3790 anticipated. `run` and `fleet`'s wrapper
+    // doors cannot do the same yet: each round's execution row closes
+    // before a verdict exists to send.
     Verdict => "verdict",
         ConsumerPosture::RecordedOnly { issue: "#3790" },
         &[];

--- a/crates/stella-runtime/src/wrapper/dispatch.rs
+++ b/crates/stella-runtime/src/wrapper/dispatch.rs
@@ -79,7 +79,7 @@ use stella_plugin::{
     StageProgram, TamperFinding, TurnOutcome, Verdict, VerdictRule, WrapperPoint,
 };
 use stella_protocol::completion::CompletionMessage;
-use stella_protocol::{GateBoard, LadderSnapshot};
+use stella_protocol::{GateBoard, LadderRung, LadderSnapshot, VerdictEvidence};
 
 use super::stamp::{HostClock, StampTiming};
 use super::{
@@ -1006,6 +1006,41 @@ impl DispatchReport {
             Outcome::Undecided { reason } => {
                 format!("{}: nothing decided it either way — {reason}", self.variant)
             }
+        }
+    }
+
+    /// This report, as the evidence an `AgentEvent::Verdict` carries.
+    ///
+    /// This crate sends no events (module doc, "the dispatcher owns the
+    /// loop, the host owns the turn"). The host builds the event and sends
+    /// it. But the evidence *inside* the event comes from this report, so it
+    /// is built once, here.
+    ///
+    /// `deterministic` is [`VerdictEvidence`]'s own distinction: real oracle
+    /// checks versus a model verifier's opinion. `judge` never calls a model
+    /// (`super::judge`'s module doc), so nothing here is ever a model's
+    /// opinion. But not every rung is oracle evidence either.
+    /// [`LadderRung::SubmitFast`] and [`LadderRung::Revise`] are the two
+    /// rungs `stamp`'s `rung` reaches when the oracle's checks actually
+    /// decided every requirement, met or unmet. Every other rung — `Waived`
+    /// (nothing was declared to check), `Unverified`/`Unverifiable`/
+    /// `WitnessUnsatisfiable` (the oracle could not decide) — carries no such
+    /// evidence, and says so.
+    ///
+    /// `evidence_refs` is left empty. The oracle wire contract names no
+    /// artifact today (`stella_plugin::ObservedEvidence`), so there is
+    /// nothing here to point at.
+    #[must_use]
+    pub fn verdict_evidence(&self) -> VerdictEvidence {
+        let deterministic = matches!(
+            self.snapshot.rung,
+            Some(LadderRung::SubmitFast | LadderRung::Revise)
+        );
+        VerdictEvidence {
+            summary: self.summary(),
+            deterministic,
+            evidence_refs: Vec::new(),
+            ladder: Some(Box::new(self.snapshot.clone())),
         }
     }
 }


### PR DESCRIPTION
## What / why

`crate::dataset_cmd::reward_label` reads `AgentEvent::Verdict` and nothing
else, and nothing in production ever emitted one — `stella dataset export`'s
`reward` column was null for every real execution (#4224). This wires the
missing producer for one wrapper-driving door.

`DispatchReport` (stella-runtime) gains `verdict_evidence()`, building the
`VerdictEvidence` an `AgentEvent::Verdict` carries: `deterministic` is true
exactly when the oracle's own checks decided the requirement (rung
`SubmitFast`/`Revise`), false for `Waived`/`Unverified`/`Unverifiable`/
`WitnessUnsatisfiable`. `stella-cli`'s `agent::goal::goal_wrapped` sends the
event after every judged round, right beside the existing `AgentEvent::GateBoard`
send.

**`stella run --pipeline` and `stella fleet --pipeline` are not fixed here.**
Building the witness against a real subprocess turned up an architecture gap
the original recommendation (issue comment) didn't anticipate: each of their
rounds opens and closes its own execution row through the shared
`agent::turn::run_turn` helper *before* the wrapper's `judge()` even runs, so
by the time a dispatch's report comes back `registry.events()` is already
`None` and a send is silently dropped. I verified this is also true of the
*existing* `AgentEvent::GateBoard` send at that call site in
`wrapper_plugin::run_wrapped` — it has apparently never reached the store for
the plain `run` door either. Fixing that needs a way for the wire-stable
`TurnDriver`/`DrivenTurn` shape (shared with `stella-serve`) to report which
execution row a round used, or a different delivery path — bigger than this
issue's scope, so I left `wrapper_plugin.rs` untouched and filed the gap
separately (#6001).

`stella goal --pipeline` keeps one execution row and one event channel open
across its whole round loop, so it does not have this problem, and is the
door this PR fixes.

## Exemplar

The pattern this follows is the existing `AgentEvent::GateBoard` send in
`goal_wrapped.rs`, right above the new code — same channel, same per-round
cadence, same "no re-run, this is `judge`'s answer being reported" shape.

## Witness

`crates/stella-cli/tests/run_require_verdict_cli.rs`:
`goal_wrapped_records_the_verdict_event_the_dataset_export_reads` drives the
real `stella` binary through `stella goal --pipeline <fixture>` against a
mocked provider, then reads the workspace store back with
`Store::execution_events` — the same reader `dataset export` uses — and
asserts exactly one `AgentEvent::Verdict` landed, with the ladder rung and
`deterministic` flag `reward_label`/`crate::reward::label` actually consume.

Confirmed fail→pass by hand: `git stash` the two producer files
(`goal_wrapped.rs`, `dispatch.rs`) and the test fails with `0 Verdict events
found: []`; restoring them, it passes.

```
test goal_wrapped_records_the_verdict_event_the_dataset_export_reads ... FAILED   (old code)
test goal_wrapped_records_the_verdict_event_the_dataset_export_reads ... ok       (this change)
```

Also ran the whole file (`cargo test -p stella-cli --test run_require_verdict_cli`,
7 tests) to confirm nothing else in that file regressed.

## Notes

- `crates/stella-cli/src/calibration.rs` and
  `crates/stella-protocol/src/event/tags.rs` had prose stating "nothing in
  this workspace produces `AgentEvent::Verdict`" / "it stays `RecordedOnly`" —
  both false as of this PR, so I corrected them in the same PR rather than
  leaving stale claims (CLAUDE.md's rule on stale comments).
- `RewardSettings`/`Settings::reward_policy()` are already wired — confirmed
  by reading `dataset_cmd.rs`'s `run_export`, not just trusting the earlier
  issue comment that said so.
- Tests deleted: none.
- Local evidence: `cargo check -p stella-runtime -p stella-cli -p stella-protocol`,
  `cargo clippy -p stella-runtime -p stella-cli -p stella-protocol --all-targets -- -D warnings`,
  `cargo fmt --all`, `make guards-fast` — all clean. Full workspace build/test
  is CI's job per CLAUDE.md.

Closes #4224

## DoD gate re-fired by the autonomous PR routine (2026-09-05)

`dod / dod` failed at 12:34:29Z on #4224's three boxes being unticked. All
three are now ticked, each against the code on this head rather than against
this description:

1. The emitter — `run_goal_wrapped_turn` sends
   `AgentEvent::Verdict { passed: report.met(), evidence: report.verdict_evidence() }`,
   both fields read off the `DispatchReport`, with the conversion living in
   `crates/stella-runtime/src/wrapper/dispatch.rs`. Converted, not re-derived,
   which is what the box asks.
2. The witness — present at the exact path and name the box names, spawning
   the real binary and reading back through `Store::execution_events`. Fails
   on `main` by construction: with no emitter there, `verdicts.len()` is 0
   against an expected 1.
3. The doc and config half — re-checked rather than taken on trust.
   `doc:self-driving-foundry` §2's row now reads "Reward labelling *survives*
   … `stella dataset export` is its consumer", and `reward_policy()` has three
   production call sites (`config.rs:610`, `config/reload.rs:61`,
   `dataset_cmd.rs:496`), the last feeding `reward_label` at
   `dataset_cmd.rs:660`. So `stella.example.toml`'s `[reward]` block documents
   a knob that is consumed.

This edit is what re-fires the gate; nothing in the diff changed. Sourcery's
own "Assessment against linked issues" table independently marks all three
objectives ✅.