### PR TITLE
fix(design-system): re-cut muted and dim so every licensed pairing clears AA

### DIFF
--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -528,16 +528,16 @@ fn render_dashboard(
     --void: #050507; --ground: #0A0A0C; --surface: #0F0F12; --raised: #17171B;
     --hairline: #26262C; --hairline-strong: #35353D;
     --identity: #EFC53F; --identity-ink: #0A0A0C;
-    --text: #E8E8EC; --text-2: #A9AAB5; --text-3: #777782;
+    --text: #E8E8EC; --text-2: #A9AAB5; --text-3: #7C7C87;
     --ok: #74C991; --warn: #E78D54; --bad: #E0687A;
-    --c1: #E8E8EC; --c2: #A9AAB5; --c3: #777782; --c4: #4B4B56;
-    --neutral-mark: #4B4B56;
+    --c1: #E8E8EC; --c2: #A9AAB5; --c3: #7C7C87; --c4: #5F5F6A;
+    --neutral-mark: #5F5F6A;
     --ink: #0A0A0C;
     --accent: #E8E8EC;
     --accent-wash: rgba(232,232,236,.08);
     --accent-edge: rgba(232,232,236,.38);
     --sunken: #0A0A0C;
-    --control-edge: #777782;
+    --control-edge: #7C7C87;
 
     /* One face. The product lives in a terminal, so the brand speaks in
        monospace — and this artifact is a measurement, where a proportional
@@ -607,16 +607,16 @@ fn render_dashboard(
       --void: #E8E8EC; --ground: #FFFFFF; --surface: #F7F7FA; --raised: #FFFFFF;
       --hairline: #E9E9EE; --hairline-strong: #D0D0D8;
       --identity: #725a00; --identity-ink: #FFFFFF;
-      --text: #0A0A0C; --text-2: #4B4B56; --text-3: #777782;
+      --text: #0A0A0C; --text-2: #5F5F6A; --text-3: #7C7C87;
       --ok: #006933; --warn: #8a3f00; --bad: #96213C;
-      --c1: #0A0A0C; --c2: #4B4B56; --c3: #777782; --c4: #A9AAB5;
+      --c1: #0A0A0C; --c2: #5F5F6A; --c3: #7C7C87; --c4: #A9AAB5;
       --neutral-mark: #A9AAB5;
       --ink: #FFFFFF;
       --accent: #0A0A0C;
       --accent-wash: rgba(10,10,12,.06);
       --accent-edge: rgba(10,10,12,.28);
       --sunken: #F7F7FA;
-      --control-edge: #777782;
+      --control-edge: #7C7C87;
     }}
   }}
   :root[data-theme="light"] {{
@@ -624,16 +624,16 @@ fn render_dashboard(
     --void: #E8E8EC; --ground: #FFFFFF; --surface: #F7F7FA; --raised: #FFFFFF;
     --hairline: #E9E9EE; --hairline-strong: #D0D0D8;
     --identity: #725a00; --identity-ink: #FFFFFF;
-    --text: #0A0A0C; --text-2: #4B4B56; --text-3: #777782;
+    --text: #0A0A0C; --text-2: #5F5F6A; --text-3: #7C7C87;
     --ok: #006933; --warn: #8a3f00; --bad: #96213C;
-    --c1: #0A0A0C; --c2: #4B4B56; --c3: #777782; --c4: #A9AAB5;
+    --c1: #0A0A0C; --c2: #5F5F6A; --c3: #7C7C87; --c4: #A9AAB5;
     --neutral-mark: #A9AAB5;
     --ink: #FFFFFF;
     --accent: #0A0A0C;
     --accent-wash: rgba(10,10,12,.06);
     --accent-edge: rgba(10,10,12,.28);
     --sunken: #F7F7FA;
-    --control-edge: #777782;
+    --control-edge: #7C7C87;
   }}
   * {{ box-sizing: border-box; margin: 0; padding: 0; }}
   html {{ color-scheme: dark; }}

--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -735,7 +735,7 @@ fn the_dashboard_palette_is_generated_from_the_live_theme() {
         "--hairline: #26262C;",
         "--text: #E8E8EC;",
         "--text-2: #A9AAB5;",
-        "--text-3: #777782;",
+        "--text-3: #7C7C87;",
         "--accent: #E8E8EC;",
         "--identity: #EFC53F;",
         "--ok: #74C991;",

--- a/crates/stella-mcp/src/oauth/callback_page.css
+++ b/crates/stella-mcp/src/oauth/callback_page.css
@@ -24,7 +24,7 @@
   --ground:#0A0A0C;--text:#E8E8EC;--text-2:#A9AAB5;
   --ok:#74C991;--bad:#E0687A;--identity:#EFC53F}
 @media (prefers-color-scheme:light){:root{
-  --ground:#FFFFFF;--text:#0A0A0C;--text-2:#4B4B56;
+  --ground:#FFFFFF;--text:#0A0A0C;--text-2:#5F5F6A;
   --ok:#006933;--bad:#96213C;--identity:#725a00}}
 body{margin:0;padding:48px;background:var(--ground);color:var(--text);
   font:13px/1.55 "JetBrains Mono",ui-monospace,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace}

--- a/crates/stella-observatory/src/assets/index.html
+++ b/crates/stella-observatory/src/assets/index.html
@@ -80,10 +80,11 @@
      been a hue for two releases. */
   --mark:#E8E8EC; --mark-bright:#FFFFFF; --mark-deep:#A9AAB5;
   /* The text ramp, and the one caveat worth stating rather than rounding
-     away: --text-3 measures 4.47:1 on --ground and 4.04:1 on --raised, just
-     under the 4.5:1 AA body floor on both. It is the caption/label/UI tier —
-     anything a reader must actually read at 13px takes --text-2 (8.58:1). */
-  --text:#E8E8EC; --text-2:#A9AAB5; --text-3:#777782;
+     away: --text-3 measures 4.79:1 on --ground, clearing the 4.5:1 AA body
+     floor, and 4.33:1 on --raised, just under it. It is still the
+     caption/label/UI tier — anything a reader must actually read at 13px on
+     a raised row takes --text-2 (8.58:1). */
+  --text:#E8E8EC; --text-2:#A9AAB5; --text-3:#7C7C87;
   /* The one neutral above --text-2, and it has exactly one job: the token
      classes in a code body (see highlightCode() below). The palette names it
      for syntax types, and putting code tokens on a neutral rather than a hue
@@ -127,8 +128,8 @@
      separated by lightness alone, which is the one channel that survives
      greyscale printing, colour-vision deficiency, and a projector. Ordered
      light → dark so --c1 is the most prominent series. */
-  --c1:#E8E8EC; --c2:#A9AAB5; --c3:#777782; --c4:#4B4B56;
-  --neutral-mark:#4B4B56;          /* the "everything else" mark — recedes */
+  --c1:#E8E8EC; --c2:#A9AAB5; --c3:#7C7C87; --c4:#5F5F6A;
+  --neutral-mark:#5F5F6A;          /* the "everything else" mark — recedes */
   /* END palette */
 
   /* Semantic alias. One alias, for accent/active/focus. The accent is the
@@ -272,18 +273,21 @@
    estimated, on --ground (#FFFFFF) and on --surface (#F7F7FA — the lightest
    panel a mark can land on, so the binding constraint):
 
-     --text 19.78 / 18.50   --text-2  8.61 /  8.05   --text-3 4.43 / 4.14
+     --text 19.78 / 18.50   --text-2  6.30 /  5.89   --text-3 4.13 / 3.86
      --ok    6.84 /  6.40   --warn    7.52 /  7.04   --bad    8.14 / 7.61
      --identity 6.61 / 6.18 (#725A00)   --text-emph 10.90 / 10.19
 
    and on the dark side against --raised (#17171B):
 
-     --text 14.63   --text-2 7.75   --text-3 4.04   --text-emph 9.97
+     --text 14.63   --text-2 7.75   --text-3 4.33   --text-emph 9.97
      --ok    8.94   --warn   7.10   --bad    5.47   --identity 10.83
 
-   --text and --text-2 clear AAA (7:1) on both; the three semantics and
-   --identity clear AA (4.5:1) on both. --text-3 clears AA on neither —
-   4.43:1 light, 4.04:1 dark, stated rather than rounded up (#4070) — and is
+   --text clears AAA (7:1) on both; --text-2 clears AAA on dark (7.75:1) but
+   only AA on light (6.30 / 5.89); the three semantics and --identity clear
+   AA (4.5:1) on both. --text-3 clears AA on neither of the pairings above —
+   4.13:1 light, 4.33:1 dark, stated rather than rounded up (#4070; its
+   dark pairing against --ground instead of --raised is 4.79:1 and does
+   clear AA) — and is
    not meant to, which is the constraint to hold when editing: it carries
    non-essential labelling only, a legend key or a units suffix, never a
    value a reader must act on. The inversion pair (--ink on --accent) is
@@ -300,12 +304,12 @@
     color-scheme:light;
     --void:#E8E8EC; --ground:#FFFFFF; --surface:#F7F7FA; --raised:#FFFFFF;
     --hairline:#E9E9EE; --hairline-strong:#D0D0D8;
-    --mark:#0A0A0C; --mark-bright:#000000; --mark-deep:#4B4B56;
+    --mark:#0A0A0C; --mark-bright:#000000; --mark-deep:#5F5F6A;
     --identity:#725A00; --identity-ink:#FFFFFF;
-    --text:#0A0A0C; --text-2:#4B4B56; --text-3:#777782;
+    --text:#0A0A0C; --text-2:#5F5F6A; --text-3:#7C7C87;
     --text-emph:#3C3C46;
     --ok:#006933; --warn:#8A3F00; --bad:#96213C;
-    --c1:#0A0A0C; --c2:#4B4B56; --c3:#777782; --c4:#A9AAB5;
+    --c1:#0A0A0C; --c2:#5F5F6A; --c3:#7C7C87; --c4:#A9AAB5;
     --neutral-mark:#A9AAB5;
     --ink:#FFFFFF;
     --accent-wash:rgba(10,10,12,.06);
@@ -317,12 +321,12 @@
   color-scheme:light;
   --void:#E8E8EC; --ground:#FFFFFF; --surface:#F7F7FA; --raised:#FFFFFF;
   --hairline:#E9E9EE; --hairline-strong:#D0D0D8;
-  --mark:#0A0A0C; --mark-bright:#000000; --mark-deep:#4B4B56;
+  --mark:#0A0A0C; --mark-bright:#000000; --mark-deep:#5F5F6A;
   --identity:#725A00; --identity-ink:#FFFFFF;
-  --text:#0A0A0C; --text-2:#4B4B56; --text-3:#777782;
+  --text:#0A0A0C; --text-2:#5F5F6A; --text-3:#7C7C87;
   --text-emph:#3C3C46;
   --ok:#006933; --warn:#8A3F00; --bad:#96213C;
-  --c1:#0A0A0C; --c2:#4B4B56; --c3:#777782; --c4:#A9AAB5;
+  --c1:#0A0A0C; --c2:#5F5F6A; --c3:#7C7C87; --c4:#A9AAB5;
   --neutral-mark:#A9AAB5;
   --ink:#FFFFFF;
   --accent-wash:rgba(10,10,12,.06);

--- a/crates/stella-observatory/tests/light_mode.rs
+++ b/crates/stella-observatory/tests/light_mode.rs
@@ -62,7 +62,7 @@ fn between<'a>(css: &'a str, start: &str, end: &str) -> &'a str {
 }
 
 /// `css` with every `/* … */` comment removed. These blocks carry more prose
-/// than declarations, and that prose quotes contrast ratios (`4.43:1`) and
+/// than declarations, and that prose quotes contrast ratios (`4.13:1`) and
 /// measurements (`needs: 6.84`) — so a parser that splits on `:` before
 /// stripping comments reads a sentence as a declaration and, worse, swallows
 /// the real declaration that follows it.

--- a/crates/stella-transcript/src/html/transcript.css
+++ b/crates/stella-transcript/src/html/transcript.css
@@ -88,7 +88,7 @@
   --line2: #35353d;
   --ink: #e8e8ec;
   --dim: #a9aab5;
-  --faint: #777782;
+  --faint: #7c7c87;
   /* Categorical — see the header note; deliberately not instrument values,
      and deliberately outside the parity matrix. */
   --gold: #efc53f;
@@ -169,8 +169,8 @@
     --line: #e9e9ee;
     --line2: #d0d0d8;
     --ink: #0a0a0c;
-    --dim: #4b4b56;
-    --faint: #777782;
+    --dim: #5f5f6a;
+    --faint: #7c7c87;
     --green: #006933;
     --red: #96213c;
     --amber: #8a3f00;

--- a/crates/stella-tui-theme/src/token.rs
+++ b/crates/stella-tui-theme/src/token.rs
@@ -116,11 +116,11 @@ pub const SILVER_TYPE: Color = Color::Rgb(0xBF, 0xC1, 0xCC);
 /// Primary text on dark, in the deck. `#E8E8EC`
 pub const TEXT: Color = Color::Rgb(0xE8, 0xE8, 0xEC);
 
-/// Secondary text. `#777782`
-pub const MUTED: Color = Color::Rgb(0x77, 0x77, 0x82);
+/// Secondary text. `#7C7C87`
+pub const MUTED: Color = Color::Rgb(0x7C, 0x7C, 0x87);
 
-/// Hints, captions, line numbers. `#4B4B56`
-pub const DIM: Color = Color::Rgb(0x4B, 0x4B, 0x56);
+/// Hints, captions, line numbers. `#5F5F6A`
+pub const DIM: Color = Color::Rgb(0x5F, 0x5F, 0x6A);
 
 /// Pass, additive diff sign. `#74C991`
 pub const GREEN: Color = Color::Rgb(0x74, 0xC9, 0x91);

--- a/crates/stella-tui/src/palette.rs
+++ b/crates/stella-tui/src/palette.rs
@@ -215,17 +215,19 @@ pub const TEXT_EMPHASIS: Color = token::SILVER_TYPE;
 /// 7.75:1 on [`RAISED`] -- the safe small-text tone on every dark ground.
 pub const TEXT_SECONDARY: Color = token::SILVER;
 
-/// Labels and captions. 4.47:1 on ground, 4.32:1 on surface, 4.04:1 on
-/// raised -- **just under the 4.5:1 AA body floor on all three**, which is
-/// stated rather than rounded away: this is a UI/large-text tier and a
-/// caption tier, and anything a reader must actually read at 13px takes
+/// Labels and captions. 4.79:1 on ground, 4.64:1 on surface, 4.33:1 on
+/// raised -- clears the 4.5:1 AA body floor on the first two and sits
+/// fractionally under it on the third, which the ratchet never held as a
+/// pairing. This is still a UI/large-text tier and a caption tier by role,
+/// and anything a reader must actually read at 13px on a raised row takes
 /// [`TEXT_SECONDARY`] instead.
 pub const TEXT_TERTIARY: Color = token::MUTED;
 
-/// The dim tier -- 2.30:1 on ground, below every text floor and below the
-/// 3:1 graphical floor too. **Chrome only, never words**: the unfilled
-/// progress groove and nothing else. It is a real token rather than a fifth
-/// ground because it has to stay legible-as-texture against [`HAIRLINE`].
+/// The dim tier -- 3.14:1 on ground, clearing the 3:1 graphical/large-text
+/// floor and still under the 4.5:1 body floor. **Chrome only, never words**:
+/// the unfilled progress groove and nothing else. It is a real token rather
+/// than a fifth ground because it has to stay legible-as-texture against
+/// [`HAIRLINE`].
 pub const TEXT_DIM: Color = token::DIM;
 
 // -- Status ------------------------------------------------------
@@ -301,10 +303,10 @@ pub const INK: Color = token::BG;
 ///
 /// Named for its ground, like [`INK_DIM`] and [`INK_EMPHASIS`]. It was
 /// `MUTED` until #5001, which put it one word away from
-/// `stella_tui_theme::token::MUTED` `#777782` -- the dark ramp's tier below
-/// silver, a different colour on a different ground, with nothing at a call
-/// site to say which one a line had reached. #4966 removed the third
-/// constant of that name; this is the last of them.
+/// `stella_tui_theme::token::MUTED` -- the dark ramp's tier below silver, a
+/// different colour on a different ground, with nothing at a call site to say
+/// which one a line had reached. #4966 removed the third constant of that
+/// name; this is the last of them.
 pub const INK_MUTED: Color = Color::Rgb(0x5E, 0x5E, 0x69);
 
 /// Tertiary text on paper -- 4.72:1 on [`PAPER`], the counterpart of

--- a/crates/stella-tui/src/theme.rs
+++ b/crates/stella-tui/src/theme.rs
@@ -84,9 +84,9 @@ pub const TEXT_PRIMARY: Color = palette::TEXT_PRIMARY;
 /// This tier is `silver`, and it used to answer to a second name — `MUTED`,
 /// with [`text_secondary`] spelled `muted()`. That name was one tier off its
 /// own value: it resolved here, to `stella_tui_theme::token::SILVER` `#A9AAB5`,
-/// while `token::MUTED` `#777782` is the tier below and the paper theme's
-/// secondary ink `#5E5E69` was a third colour again — three constants, one
-/// word, until #4966 removed this one and #5001 renamed the paper stop to
+/// while `token::MUTED` is the tier below and the paper theme's secondary ink
+/// `#5E5E69` was a third colour again — three constants, one word, until
+/// #4966 removed this one and #5001 renamed the paper stop to
 /// [`crate::palette::INK_MUTED`]. A call site
 /// reaching for "the muted tier" and writing `muted()` got silver, and
 /// `crate::diff`'s `gutter` is where that happened: `design/tui-v2/SPEC.md`
@@ -96,14 +96,15 @@ pub const TEXT_PRIMARY: Color = palette::TEXT_PRIMARY;
 /// [`TEXT_TERTIARY`] (which *is* `token::MUTED`) → [`TEXT_DIM`], so the tier a
 /// call site asks for is the tier it gets.
 pub const TEXT_SECONDARY: Color = palette::TEXT_SECONDARY;
-/// Tertiary text (labels, captions). 4.47:1 on [`GROUND`] — just under the
-/// AA body floor, so this is the caption/UI tier and anything a reader must
-/// read at 13px takes [`TEXT_SECONDARY`].
+/// Tertiary text (labels, captions). 4.79:1 on [`GROUND`] — clears the AA
+/// body floor; it stays the caption/UI tier and anything a reader must read
+/// at 13px on a raised row still takes [`TEXT_SECONDARY`].
 pub const TEXT_TERTIARY: Color = palette::TEXT_TERTIARY;
-/// The dim tier — 2.30:1, below every text floor. **Chrome only, never
-/// words**: the unfilled progress groove. It has its own value now rather
-/// than aliasing [`TEXT_TERTIARY`], which is why the three progress call
-/// sites that painted *words* with it moved up a tier.
+/// The dim tier — 3.14:1, clearing the 3:1 large-text/graphical floor and
+/// still below the 4.5:1 body floor. **Chrome only, never words**: the
+/// unfilled progress groove. It has its own value now rather than aliasing
+/// [`TEXT_TERTIARY`], which is why the three progress call sites that
+/// painted *words* with it moved up a tier.
 pub const TEXT_DIM: Color = palette::TEXT_DIM;
 
 // Semantic (base + bright). The palette carries one value per status; the

--- a/design/tokens/stella-tokens.css
+++ b/design/tokens/stella-tokens.css
@@ -22,8 +22,8 @@
   --st-silver-type: #BFC1CC; /* syntax types, tertiary labels */
   --st-text: #E8E8EC; /* primary text on dark, in the deck */
   --st-paper-text: #F4F1EA; /* primary text on dark, off the deck */
-  --st-muted: #777782; /* secondary text */
-  --st-dim: #4B4B56; /* hints, captions, line numbers */
+  --st-muted: #7C7C87; /* secondary text */
+  --st-dim: #5F5F6A; /* hints, captions, line numbers */
   --st-green: #74C991; /* pass, additive diff sign */
   --st-red: #E0687A; /* fail, destructive, removal diff sign */
   --st-diff-add: #10201A; /* added diff row background */

--- a/design/tokens/stella-tokens.json
+++ b/design/tokens/stella-tokens.json
@@ -252,7 +252,7 @@
     },
     {
       "name": "muted",
-      "hex": "#777782",
+      "hex": "#7C7C87",
       "clamp": "neutral-gray",
       "css": "--st-muted",
       "rust": "MUTED",
@@ -262,7 +262,7 @@
     },
     {
       "name": "dim",
-      "hex": "#4B4B56",
+      "hex": "#5F5F6A",
       "clamp": "neutral-gray",
       "css": "--st-dim",
       "rust": "DIM",

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -50,8 +50,8 @@ The table is every token `design/tokens/stella-tokens.json` declares on the `tui
 | `silver` | `#A9AAB5` | world coming in: read, skill, memory, secondary emphasis |
 | `silver_type` | `#BFC1CC` | syntax types |
 | `text` | `#E8E8EC` | primary text |
-| `muted` | `#777782` | secondary text |
-| `dim` | `#4B4B56` | hints, keybinding rows, line numbers |
+| `muted` | `#7C7C87` | secondary text |
+| `dim` | `#5F5F6A` | hints, keybinding rows, line numbers |
 | `green` | `#74C991` | pass, `+` diff sign |
 | `red` | `#E0687A` | fail, `-` diff sign, delete events, destructive |
 | `diff_add_bg` | `#10201A` | added diff row background |
@@ -308,7 +308,7 @@ Rail metals: read silver-dim, edit gold, write gold, delete red, run gold, skill
   Stated as a constraint because the obvious mechanism violates it. `Line.style` is the one-call way to tint a row and is correct only where the row is *nothing but* diff; on any row carrying a margin it paints the whole row's area, so a green band swallows the rail whose metal says which event the diff belongs to (SPEC 6.2) — the two layers then disagree about what the row is. In the transcript every diff row carries that rail, so the tint rides a per-span `bg` on the code plus one trailing padded span to the pane edge. A surface with no margin may use `Line.style`; a surface with one must not. The reference implementation is `push_diff_line` in `crates/stella-tui/src/render/row.rs`, and `a_rust_diff_renders_add_and_remove_rows_per_spec_64` asserts both halves — the band reaches the pane edge, and the rail span's `bg` stays `None`.
 - Line number gutter in `silver`. Sign column (`+`/`-`) is mandatory and colored; color is never the only diff signal.
 
-  This line read `dim`, and the gutter has never been dim: `crates/stella-tui/src/diff.rs`'s `gutter` paints `theme::text_secondary()`, which is `token::SILVER` `#A9AAB5` — not `token::MUTED` `#777782` and not `dim` `#4B4B56` (#4946). The line is corrected to what ships rather than the gutter recoloured to what it said, because two tiers of difference in a margin is a design call. The call site used to read `theme::muted()`, spelling a tier it did not paint; #4966 removed that name, and `every_text_tier_resolves_to_the_token_it_names` now holds each rung of the ladder to the token it is.
+  This line read `dim`, and the gutter has never been dim: `crates/stella-tui/src/diff.rs`'s `gutter` paints `theme::text_secondary()`, which is `token::SILVER` `#A9AAB5` — not `token::MUTED` `#7C7C87` and not `dim` `#5F5F6A` (#4946). The line is corrected to what ships rather than the gutter recoloured to what it said, because two tiers of difference in a margin is a design call. The call site used to read `theme::muted()`, spelling a tier it did not paint; #4966 removed that name, and `every_text_tier_resolves_to_the_token_it_names` now holds each rung of the ladder to the token it is.
 
 ## 7. Plan and task contracts
 

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -293,7 +293,7 @@ Rail metals: read silver-dim, edit gold, write gold, delete red, run gold, skill
   | keyword, and a JSON object key | `SYNTAX_KEYWORD` | `#BFC1CC` |
   | string / char literal | `SYNTAX_STRING` | `#93D896` |
   | numeric literal | `SYNTAX_NUMBER` | `#8F70E8` |
-  | comment | `SYNTAX_COMMENT` | `#777782` |
+  | comment | `SYNTAX_COMMENT` | `#7C7C87` |
   | type position | `SYNTAX_TYPE` | `#2FD3C6` |
   | function or method name | `SYNTAX_FUNCTION` | `#E4408F` |
 

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -30,7 +30,7 @@
 body,h1,h2,p,ul{margin:0} ul{list-style:none;padding:0}
 :root{
   --bg:#FFFFFF; --sub:#F7F7FA; --panel:#FFFFFF;
-  --ink:#0A0A0C; --ink-2:#4B4B56; --ink-3:#777782;
+  --ink:#0A0A0C; --ink-2:#5F5F6A; --ink-3:#7C7C87;
   --rule:#E9E9EE; --rule-2:#D0D0D8; --pass:#006933;
   --wash:rgba(10,10,12,.06);
   --mono:"JetBrains Mono",ui-monospace,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
@@ -46,17 +46,17 @@ body,h1,h2,p,ul{margin:0} ul{list-style:none;padding:0}
 }
 @media (prefers-color-scheme:dark){:root{
   --bg:#0A0A0C; --sub:#0F0F12; --panel:#17171B;
-  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#777782;
+  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#7C7C87;
   --rule:#26262C; --rule-2:#35353D; --pass:#74C991;
   --wash:rgba(232,232,236,.08);}}
 :root[data-theme="dark"]{
   --bg:#0A0A0C; --sub:#0F0F12; --panel:#17171B;
-  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#777782;
+  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#7C7C87;
   --rule:#26262C; --rule-2:#35353D; --pass:#74C991;
   --wash:rgba(232,232,236,.08);}
 :root[data-theme="light"]{
   --bg:#FFFFFF; --sub:#F7F7FA; --panel:#FFFFFF;
-  --ink:#0A0A0C; --ink-2:#4B4B56; --ink-3:#777782;
+  --ink:#0A0A0C; --ink-2:#5F5F6A; --ink-3:#7C7C87;
   --rule:#E9E9EE; --rule-2:#D0D0D8; --pass:#006933;
   --wash:rgba(10,10,12,.06);}
 body{background:var(--bg); color:var(--ink);

--- a/docs/benchmarks/terminal-bench-2-1-glm-5-2.html
+++ b/docs/benchmarks/terminal-bench-2-1-glm-5-2.html
@@ -17,26 +17,26 @@ button{font:inherit;color:inherit} table{border-collapse:collapse}</style>
    The only colour on this page is semantic — a task passed or it did not. */
 :root{
   --bg:#FFFFFF; --sub:#F7F7FA; --panel:#FFFFFF;
-  --ink:#0A0A0C; --ink-2:#4B4B56; --ink-3:#777782;
+  --ink:#0A0A0C; --ink-2:#5F5F6A; --ink-3:#7C7C87;
   --rule:#E9E9EE; --rule-2:#D0D0D8;
   --pass:#006933; --fail:#96213C; --pass-bg:#EDF6F0; --fail-bg:#FBF0EE;
   --code:#F7F7FA;
 }
 @media (prefers-color-scheme:dark){:root{
   --bg:#0A0A0C; --sub:#0F0F12; --panel:#17171B;
-  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#777782;
+  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#7C7C87;
   --rule:#26262C; --rule-2:#35353D;
   --pass:#74C991; --fail:#E0687A; --pass-bg:#10201A; --fail-bg:#221312;
   --code:#0A0A0C;}}
 :root[data-theme="dark"]{
   --bg:#0A0A0C; --sub:#0F0F12; --panel:#17171B;
-  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#777782;
+  --ink:#E8E8EC; --ink-2:#A9AAB5; --ink-3:#7C7C87;
   --rule:#26262C; --rule-2:#35353D;
   --pass:#74C991; --fail:#E0687A; --pass-bg:#10201A; --fail-bg:#221312;
   --code:#0A0A0C;}
 :root[data-theme="light"]{
   --bg:#FFFFFF; --sub:#F7F7FA; --panel:#FFFFFF;
-  --ink:#0A0A0C; --ink-2:#4B4B56; --ink-3:#777782;
+  --ink:#0A0A0C; --ink-2:#5F5F6A; --ink-3:#7C7C87;
   --rule:#E9E9EE; --rule-2:#D0D0D8;
   --pass:#006933; --fail:#96213C; --pass-bg:#EDF6F0; --fail-bg:#FBF0EE;
   --code:#F7F7FA;}

--- a/docs/brand/brand-guidelines.html
+++ b/docs/brand/brand-guidelines.html
@@ -270,8 +270,8 @@ retired or is not a live token.</p>
 <tr><td>--st-silver-type</td><td>#BFC1CC</td><td>syntax types, tertiary labels</td></tr>
 <tr><td>--st-text</td><td>#E8E8EC</td><td>primary text on dark, in the deck</td></tr>
 <tr><td>--st-paper-text</td><td>#F4F1EA</td><td>primary text on dark, off the deck: the web surfaces and the cut assets — the wordmark SVGs and the OG card</td></tr>
-<tr><td>--st-muted</td><td>#777782</td><td>secondary text</td></tr>
-<tr><td>--st-dim</td><td>#4B4B56</td><td>hints, captions, line numbers</td></tr>
+<tr><td>--st-muted</td><td>#7C7C87</td><td>secondary text</td></tr>
+<tr><td>--st-dim</td><td>#5F5F6A</td><td>hints, captions, line numbers</td></tr>
 <tr><td>--st-green</td><td>#74C991</td><td>pass, additive diff sign</td></tr>
 <tr><td>--st-red</td><td>#E0687A</td><td>fail, destructive, removal diff sign</td></tr>
 <tr><td>--st-amber</td><td>#E78D54</td><td>warning</td></tr>
@@ -325,8 +325,8 @@ light mode the ground and the type swap; the gold budget stays the same.</p>
 <p>Every ratio below is printed by <code>scripts/check-contrast.py</code>, which
 states each pairing's measured number and the threshold its <em>role</em> is
 held to — 4.5:1 for body text, 3:1 for large text and graphical objects, and an
-explicit exemption for logotypes. Two of these rows are unflattering and are
-here for that reason.</p>
+explicit exemption for logotypes. Every row below clears its floor; the ratchet
+in <code>scripts/contrast-baseline.txt</code> holds no pairing today (#4063).</p>
 <table>
 <tr><th>pair</th><th>contrast</th><th>held to</th></tr>
 <tr><td>text on bg</td><td>16.19:1</td><td>pass (4.5)</td></tr>
@@ -336,21 +336,21 @@ here for that reason.</p>
 <tr><td>silver on bg</td><td>8.58:1</td><td>pass (4.5)</td></tr>
 <tr><td>green on bg</td><td>9.90:1</td><td>pass (4.5)</td></tr>
 <tr><td>red on bg</td><td>6.06:1</td><td>pass (4.5)</td></tr>
-<tr><td>muted on bg</td><td>4.47:1</td><td><b>under AA</b> (needs 4.5)</td></tr>
-<tr><td>muted on panel</td><td>4.32:1</td><td><b>under AA</b> (needs 4.5)</td></tr>
-<tr><td>dim on bg</td><td>2.30:1</td><td><b>under</b> the 3:1 decorative floor</td></tr>
-<tr><td>comment on panel</td><td>2.64:1</td><td><b>under</b> the 3:1 decorative floor</td></tr>
+<tr><td>muted on bg</td><td>4.79:1</td><td>pass (4.5)</td></tr>
+<tr><td>muted on panel</td><td>4.64:1</td><td>pass (4.5)</td></tr>
+<tr><td>dim on bg</td><td>3.14:1</td><td>pass (3.0)</td></tr>
 <tr><td>ink on paper</td><td>18.40:1</td><td>pass (4.5)</td></tr>
-<tr><td>dim on paper</td><td>8.61:1</td><td>pass (4.5)</td></tr>
+<tr><td>dim on paper</td><td>6.15:1</td><td>pass (4.5)</td></tr>
 <tr><td>gold on paper</td><td>1.65:1</td><td>exempt — the <em>mark</em> only</td></tr>
 <tr><td>border on bg</td><td>1.31:1</td><td>exempt — a divider, not information</td></tr>
 </table>
-<p class="m" style="font-size:12px;margin-top:8px"><b>muted</b> misses AA by
-0.03, and the number is stated rather than rounded up: nothing a reader must
-read at small size goes in muted, which is for a secondary label sitting beside
-its own subject. <b>dim</b> and <b>comment</b> are below the decorative floor by
-design — a line number and a code comment are furniture, and raising them would
-cost the code panel its hierarchy.</p>
+<p class="m" style="font-size:12px;margin-top:8px"><b>muted</b> and <b>dim</b>
+were re-cut to clear their floors (#4063); nothing a reader must read at small
+size still belongs in muted, which stays a secondary label sitting beside its
+own subject, and dim stays furniture — a line number, a hint, chrome rather
+than prose. A third row, <b>comment</b>, sat here below its floor too; the
+token had no paint site anywhere in the tree, so it was retired rather than
+re-cut (#4946) and the row is gone rather than fixed.</p>
 <p><b>Gold body text on paper is forbidden at 1.65:1</b>, and gold <em>text</em>
 on light is <code>--st-gold-ink #725A00</code>. The <b>mark</b> is a different
 question and takes the same full-strength gold on both grounds: v3.0 and v4.0

--- a/docs/brand/cometkit.py
+++ b/docs/brand/cometkit.py
@@ -79,13 +79,13 @@ PAPER = "#F4F1EA"  # text — primary text on dark
 # composited onto whatever page carries it, and white is the ground that makes
 # no assumption about which. It is the one value here that is not a token.
 PAPER_BG = "#FFFFFF"
-MUTED_ON_DARK = "#777782"  # muted
+MUTED_ON_DARK = "#7C7C87"  # muted
 # `dim` rather than `muted` on light. Both are tokens; this one is the pairing
-# that measures — 8.61:1 on the white above against muted's 4.43:1, which is
-# under AA. The checker reads `dim` on the `paper` token as 8.40:1 and licenses
+# that measures — 6.30:1 on the white above against muted's 4.13:1, which is
+# under AA. The checker reads `dim` on the `paper` token as 6.15:1 and licenses
 # no light pairing for `muted` at all, which is the same verdict arrived at
 # from the other side.
-MUTED_ON_LIGHT = "#4B4B56"  # dim
+MUTED_ON_LIGHT = "#5F5F6A"  # dim
 
 # JetBrains Mono advances 0.6em per glyph, which is what lets every string's
 # width be known before it is drawn.

--- a/docs/brand/css/tokens.css
+++ b/docs/brand/css/tokens.css
@@ -45,8 +45,8 @@
   --st-silver: #A9AAB5;
   --st-silver-type: #BFC1CC;
   --st-text: #E8E8EC;
-  --st-muted: #777782;
-  --st-dim: #4B4B56;
+  --st-muted: #7C7C87;
+  --st-dim: #5F5F6A;
   --st-green: #74C991;
   --st-red: #E0687A;
   --st-diff-add: #10201A;
@@ -129,7 +129,7 @@
   --stella-fg: var(--stella-ink);
   --stella-surface: #F9F6EF;
   --stella-border: #E6E3DD;
-  --stella-muted-fg: #4B4B56;
+  --stella-muted-fg: #5F5F6A;
   --stella-accent: var(--stella-brand);
   --stella-accent-text: var(--stella-brand-deep); /* gold that passes on light */
   /* The mark itself — shapes, not text. v5.0 retires the darker light cut:
@@ -152,7 +152,7 @@
   --stella-fg: var(--stella-paper);
   --stella-surface: #0F0F12;
   --stella-border: #26262C;
-  --stella-muted-fg: #777782;
+  --stella-muted-fg: #7C7C87;
   --stella-accent: var(--stella-brand);
   --stella-accent-text: var(--stella-brand);
   --stella-mark-shape: var(--stella-brand);
@@ -163,7 +163,7 @@
     --stella-fg: var(--stella-paper);
     --stella-surface: #0F0F12;
     --stella-border: #26262C;
-    --stella-muted-fg: #777782;
+    --stella-muted-fg: #7C7C87;
     --stella-accent: var(--stella-brand);
     --stella-accent-text: var(--stella-brand);
     --stella-mark-shape: var(--stella-brand);

--- a/docs/brand/prompts/stella-design-system-prompt.md
+++ b/docs/brand/prompts/stella-design-system-prompt.md
@@ -37,8 +37,8 @@ The system is **flat**. There are no 50→950 ramps: v5.0 deletes both the brand
 | `--st-silver-type` | `#BFC1CC` | syntax types, tertiary labels |
 | `--st-text` | `#E8E8EC` | primary text on dark, in the deck |
 | `--st-paper-text` | `#F4F1EA` | primary text on dark, off the deck — the web surfaces and the cut assets, so this is the one you want for a page |
-| `--st-muted` | `#777782` | secondary text |
-| `--st-dim` | `#4B4B56` | hints, captions, line numbers |
+| `--st-muted` | `#7C7C87` | secondary text |
+| `--st-dim` | `#5F5F6A` | hints, captions, line numbers |
 | `--st-green` | `#74C991` | pass, additive diff sign |
 | `--st-red` | `#E0687A` | fail, destructive, removal diff sign |
 | `--st-amber` | `#E78D54` | warning — the one status the core palette does not otherwise name |
@@ -73,8 +73,8 @@ Two clamps govern any colour work you do on top of this: gold must satisfy `g >=
 - Contrast facts to respect, all measured by `scripts/check-contrast.py`:
   - `text` on `bg` **16.19:1**; `gold` on `bg` **11.99:1**; `gold` on `panel` **11.60:1** — gold is a first-class text colour on dark.
   - `ink` on `gold` **11.15:1** — this is why a filled gold button takes ink, not white.
-  - `ink` on `paper` **18.40:1**; `dim` on `paper` **8.61:1**.
-  - `muted` on `bg` **4.47:1** — fractionally *under* the 4.5 AA floor, and stated rather than rounded. Do not put anything a reader must read at small size in `muted`; it is for secondary labels beside their own subject.
+  - `ink` on `paper` **18.40:1**; `dim` on `paper` **6.15:1**.
+  - `muted` on `bg` **4.79:1**; `muted` on `panel` **4.64:1**; `dim` on `bg` **3.14:1** — all three clear the AA and large-text floors their roles are held to. `scripts/contrast-baseline.txt` holds no pairing today.
   - `gold` on `paper` **1.65:1** — unusable for text or graphics, and licensed for the **mark alone** under the WCAG logotype exemption. Gold *text* on light is `--st-gold-ink`.
 
 ## typography

--- a/scripts/check-contrast.py
+++ b/scripts/check-contrast.py
@@ -20,14 +20,14 @@ The logotype exemption is what lets rule 6 say "gold for the mark and for icons
 at 24px and larger, never gold body text on light" without contradicting
 itself.
 
-Three pairings sit under their threshold today, and they are palette values
-rather than an oversight: `muted` is 4.47:1 on the canvas against a 4.5 floor,
-and `dim` is a decorative tier the terminal already documents as below every
-text floor. Moving them is a recolour and belongs to whoever owns the palette
-(#4063), so this guard records them in a **down-only ratchet**
-(`scripts/contrast-baseline.txt`) rather than waiting to become a gate step
-until they are fixed -- which is what it did for two releases, in no gate at
-all, while the tree carried figures that disagreed with it (#4423).
+A sub-threshold pairing is a palette value rather than an oversight, and
+moving it is a recolour that belongs to whoever owns the palette -- so this
+guard holds one in a **down-only ratchet** (`scripts/contrast-baseline.txt`)
+rather than waiting to become a gate step until it is fixed, which is what it
+did for two releases, in no gate at all, while the tree carried figures that
+disagreed with it (#4423). `muted` and `dim` were the ratchet's whole content
+from the day it was written until #4063 re-cut both values to clear their
+floor; the file holds nothing today, and is meant to stay that way.
 
 The ratchet records a **measured ratio**, not a count, which is what makes it
 strictly stronger than the threshold it stands in for: a baselined pairing is
@@ -104,9 +104,9 @@ PAIRINGS = [
     ("dim", "bg", "hints and line numbers (large/decorative floor)", 3.0),
     # `comment on panel` sat here at 2.64:1 and measured a value nothing
     # painted: `comment` was a token with no consumer on any surface, and code
-    # comments ship in `muted` — already on this list, at 4.32:1 on the same
-    # ground. It was one of the four sub-threshold rows #4063 is deciding about,
-    # so a quarter of that decision was about a colour no reader had seen.
+    # comments ship in `muted` — already on this list, on the same ground. It
+    # was one of the four sub-threshold rows #4063 was deciding about, so a
+    # quarter of that decision was about a colour no reader had seen.
     # #4946 retired the token; this row and its floor went with it.
     ("border", "bg", "hairlines — a divider, not information", None),
     ("rule", "bg", "section rules — a divider, not information", None),

--- a/scripts/contrast-baseline.txt
+++ b/scripts/contrast-baseline.txt
@@ -11,6 +11,3 @@
 # for every pairing and the ground it is measured on.
 #
 # This file records the debt #4423 found; it is meant to reach empty.
-dim bg 2.30
-muted bg 4.47
-muted panel 4.32

--- a/scripts/test-contrast.sh
+++ b/scripts/test-contrast.sh
@@ -9,10 +9,13 @@
 #
 # ── What the suite is for ────────────────────────────────────────────────────
 #
-# The guard became a gate step carrying four pre-existing failures, so its
-# ratchet is the only thing standing between "this palette has known debt" and
-# "this palette has a permission slip". Two directions have to hold at once and
-# they fail independently:
+# The guard became a gate step carrying four pre-existing failures, and its
+# ratchet was what stood between "this palette has known debt" and "this
+# palette has a permission slip" until the palette was re-cut and it emptied.
+# It is meant to stay empty, and these tests exercise its writing paths
+# against fixtures they seed themselves rather than against whatever the real
+# ratchet happens to hold. Two directions have to hold at once and they fail
+# independently:
 #
 #   * a colour that gets DARKER than its recorded ratio fails, and `--update`
 #     refuses to write the lower number;
@@ -45,13 +48,35 @@ pass=0
 fail=0
 
 # A throwaway root holding this repository's real token file, so every pairing
-# in PAIRINGS resolves, plus the baseline the guard reads and writes.
+# in PAIRINGS resolves, plus a copy of the real ratchet. Right for a case that
+# wants "whatever the repository's own baseline says today" -- N1/N2 and R1
+# below, none of which cares how many entries that is.
 # $1 = case name. Echoes the root path.
 new_root() {
   local dir="$TMP/$1"
   mkdir -p "$dir/design/tokens" "$dir/scripts"
   cp "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL"
   cp "$repo_root/$BASELINE_REL" "$dir/$BASELINE_REL"
+  echo "$dir"
+}
+
+# The other shape: a root whose baseline the case writes itself instead of
+# copying. A case that needs "an already-baselined pairing at a known ratio"
+# cannot lean on the real repository's ratchet holding one -- the palette was
+# re-cut and the ratchet emptied, and the tests below still need to exercise
+# its "already recorded" branches against something. $1 = case name, remaining
+# args = one "fg bg ratio" line per already-baselined pairing the case wants.
+# Echoes the root path.
+seeded_root() {
+  local dir="$TMP/$1"
+  shift
+  mkdir -p "$dir/design/tokens" "$dir/scripts"
+  cp "$repo_root/$TOKENS_REL" "$dir/$TOKENS_REL"
+  : >"$dir/$BASELINE_REL"
+  local line
+  for line in "$@"; do
+    printf '%s\n' "$line" >>"$dir/$BASELINE_REL"
+  done
   echo "$dir"
 }
 
@@ -125,8 +150,9 @@ want "U2 --update refuses to grandfather it" \
   expect-fail "$r" "new sub-threshold pairing: silver on bg" "--update"
 entry_is "U3 the refused --update wrote no entry" "$r" silver bg absent
 
-# The other half: a pairing that IS baselined and got darker still.
-r="$(new_root darkened)"
+# The other half: a pairing that IS baselined and got darker still. Seeded
+# rather than copied from the real ratchet, which now holds nothing.
+r="$(seeded_root darkened "muted bg 4.47")"
 repaint "$r" muted "#6E6E79"
 want "U4 a baselined pairing that got darker is flagged with both numbers" \
   expect-fail "$r" "darker than the 4.47:1 the ratchet holds it to"
@@ -140,29 +166,34 @@ entry_is "U6 the refused --update left the floor where it was" "$r" muted bg 4.4
 #
 # `dim` rather than `comment`, which carried this case until #4946 retired that
 # token — it was a colour with no paint site on any surface, so its ratchet row
-# guarded nothing. `dim` is the other pairing held to the 3.0 decorative floor,
-# and it is a live tier: hints, keybinding rows and the terminal's line numbers.
+# guarded nothing. `dim` is the other pairing held to the 3.0 decorative floor.
 # It appears in a second pairing (`dim on paper`, at 4.5), and #5A5A66 leaves
 # that one at 6.63:1 — well clear, so this case moves the pairing it is about
-# and nothing else.
-r="$(new_root lightened)"
+# and nothing else. Seeded with the one entry the case needs, since the real
+# ratchet has since retightened past it.
+r="$(seeded_root lightened "dim bg 2.30")"
 repaint "$r" dim "#5A5A66"
 want "D1 a pairing that improved but still fails passes the check" expect-pass "$r" "held by the ratchet"
-want "D2 --update raises its floor" expect-pass "$r" "retightened to 3 pairing(s)" "--update"
+want "D2 --update raises its floor" expect-pass "$r" "retightened to 1 pairing(s)" "--update"
 entry_is "D3 the floor is what was really measured" "$r" dim bg 2.91
 
 # Over the threshold: the entry must go, and the check must say so rather than
 # pass — a baselined pairing nobody needs is a standing permission slip.
-# `muted` is on the ledger twice and this clears both, so the count drops by two.
-r="$(new_root cleared)"
+# Seeded with three entries: `muted` twice, `dim` once. Repainting `muted`
+# clears both its rows. `dim` stays a hair under 3.0, just above its seeded
+# floor so `--update` does not refuse for the wrong reason. Clearing `muted`'s
+# two leaves `dim`'s row behind — proof the file emptied for the right
+# reason, not by accident.
+r="$(seeded_root cleared "muted bg 4.47" "muted panel 4.32" "dim bg 2.30")"
 repaint "$r" muted "#7A7A85"
+repaint "$r" dim "#5A5A65"
 want "D4 a pairing that cleared its threshold is reported, not passed" \
   expect-fail "$r" "clears its threshold now"
 want "D5 --update drops it" expect-pass "$r" "retightened to 1 pairing(s)" "--update"
 entry_is "D6 the cleared pairing is gone" "$r" muted bg absent
 
 # ── B: bootstrap runs once ───────────────────────────────────────────────────
-r="$(new_root bootstrap_guard)"
+r="$(seeded_root bootstrap_guard "muted bg 4.47")"
 want "B1 --bootstrap refuses when the ratchet already exists" \
   expect-fail "$r" "refusing to bootstrap" "--bootstrap"
 entry_is "B2 the refused --bootstrap left the ratchet intact" "$r" muted bg 4.47

--- a/website/src/app/tokens.css
+++ b/website/src/app/tokens.css
@@ -62,8 +62,8 @@
   --st-silver: #a9aab5; /* secondary emphasis, incoming context */
   --st-silver-type: #bfc1cc; /* syntax types, tertiary labels */
   --st-text: #e8e8ec; /* primary text on dark, in the deck */
-  --st-muted: #777782; /* secondary text */
-  --st-dim: #4b4b56; /* hints, captions, line numbers */
+  --st-muted: #7c7c87; /* secondary text */
+  --st-dim: #5f5f6a; /* hints, captions, line numbers */
   --st-green: #74c991; /* pass, additive diff sign */
   --st-red: #e0687a; /* fail, destructive, removal diff sign */
   --st-diff-add: #10201a; /* added diff row background */
@@ -151,8 +151,8 @@
   --stella-signal-ink: var(--st-gold-ink); /* gold TEXT on the paper ground, 6.02:1 */
   --stella-text: var(--st-paper-text); /* 16.19:1 on canvas */
   --stella-text-2: var(--st-silver); /* 8.58:1 — the safe small-text tone */
-  --stella-text-3: var(--st-muted); /* 4.47:1 — caption/UI tier, under AA body */
-  --stella-text-dim: var(--st-dim); /* 2.30:1 — chrome only, never words */
+  --stella-text-3: var(--st-muted); /* 4.79:1 — caption/UI tier (#4063) */
+  --stella-text-dim: var(--st-dim); /* 3.14:1 — chrome only, never words */
   --stella-paper-2: var(--st-paper-ground); /* the warm paper ground */
   --stella-paper-3: var(--st-paper-raised); /* paper surface */
   --stella-paper-row: var(--st-paper-row); /* paper hover / raised */


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

Four palette pairings the black-and-gold system licensed missed WCAG AA,
including `muted on bg` — the spec's own stated floor. `comment on panel`
was already retired (#4946, a token nothing painted). This closes the other
three by re-cutting the two live tokens rather than reassigning roles or
accepting the gap, per the maintainer's own steer on the issue: keep
identity gold `#EFC53F` on `#0A0A0C`, change the failing pairs.

```
muted #777782 -> #7C7C87   4.47:1 -> 4.79:1 on bg,  4.32:1 -> 4.64:1 on panel
dim   #4B4B56 -> #5F5F6A   2.30:1 -> 3.14:1 on bg (the 3.0 floor its role holds)
```

Both stay `neutral-gray` (`r == g`, `b >= g`) and inside the OKLCH hue/chroma
band the Observatory's own header already states for the ramp, so no clamp
or hue-separation law moves. `scripts/contrast-baseline.txt` — the
down-only ratchet #4423 built for this exact debt — is empty afterward.

**Why the diff is bigger than the token file.** Re-cutting only
`design/tokens/stella-tokens.json` would have reddened a second, unrelated
live gate: `scripts/check-light-clamp.py` (#4941/#4072) exempts a
light-scheme CSS declaration from its own family check whenever the hex
happens to equal a live token — and six web-instrument surfaces (the
Observatory, `export.rs`, `transcript.css`, both benchmark pages, the MCP
OAuth page) reuse `muted`'s and `dim`'s exact hex for their own
`text-2`/`text-3`-shaped roles. Moving the token without moving those
copies turns a passing-by-accident declaration into an unclassifiable one,
which `light-clamp` hard-fails with no ratchet escape hatch. So every
mirror moves with the token — verified by hand against
`crates/stella-cli/tests/design_token_parity.rs`'s own extraction logic
(a small Python stand-in; see below), and the Observatory's own descriptive
comment block (which states the ratios its reused values measure on light
surfaces too) is corrected in place — `text-2` no longer clears AAA on
light, and the comment now says so.

`docs/brand/cometkit.py`'s `MUTED_ON_DARK`/`MUTED_ON_LIGHT` constants
(mirroring `docs/brand/css/tokens.css` per its own header) move too. The
*generated* PNG/SVG brand assets those constants feed are not rebuilt here
— no rasteriser in this session — tracked as #6004, alongside two
unenforced brand mockup pages found carrying the old hex.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`scripts/check-contrast.py` fails on `main` today (three sub-threshold
pairings, per the issue) and passes here with zero pairings held by the
ratchet. `scripts/test-contrast.sh`'s fixtures were reworked to seed their
own baseline state (a new `seeded_root` helper) rather than lean on the real
ratchet holding entries, since this PR empties it — all 17 cases pass.
`design_token_parity.rs`'s cross-surface equality was verified by hand (a
Python stand-in reproducing its `declarations()`/`between()` extraction
logic against the actual files) rather than by running `cargo test`, since
this session runs no cargo command locally; every derived surface's dark
and light `text-2`/`text-3` matches the Observatory's canonical value
byte-for-byte.

## The gate

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally (see CI)
- [ ] `cargo test --workspace` — not run locally (see CI)
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer

`make guards-fast` (every toolchain-free step, including `tokens`,
`contrast`, `light-clamp`, `hue-separation`, `prose`, `line-citations`,
`css-vars`, `fmt --check`) is green on this branch. `make check`/`make gate`
(clippy, rustdoc, `cargo test --workspace`) are CI's job per this repo's own
rule — see the CI run on this PR.

Closes #4063

## Nothing left behind

- [x] Filed: #6004, #6005 — **or**
- [ ] There is nothing: everything I noticed is fixed in this PR

#6004 — the brand kit's generated binary assets (PNGs, icons, wallpapers,
social cards) and two unenforced mockup pages still carry the retired
muted/dim hex; rebuilding needs `rsvg-convert`/`ffmpeg`, unavailable here.

#6005 — `dim` is held to WCAG's 3.0:1 large-text floor by
`scripts/check-contrast.py`, but the raw `token::DIM` (as opposed to its
`theme::TEXT_DIM` alias, which genuinely is chrome-only) paints real UI
words at ~75 call sites across the TUI views — a role-classification
question this PR's value change does not resolve, flagged by the prior
investigation on #4063 and reproduced here as its own issue.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [x] New cross-boundary types round-trip through serde (test included) — n/a, no new types

## Anything reviewers should know?

The blast radius here — a value tune to two tokens touching 21 files — is
almost entirely `scripts/check-light-clamp.py`'s reach, not this PR's
choice: any fix to #4063 that changes `muted`/`dim`'s hex has to carry the
same six-surface propagation, because those surfaces silently rode on the
old value being a live token rather than declaring their own family. That
coupling (and the light-mode AAA regression on `text-2` it costs) is worth
a maintainer's eyes; #6004/#6005 are the two follow-ups that fell out of it
rather than being fixed here.

## Summary by Sourcery

Re-cut the muted and dim palette tiers and synchronize every live mirror to eliminate the remaining licensed contrast debt.

Bug Fixes:
- Raise the muted and dim palette values so all live licensed contrast pairings meet their WCAG AA or large-text/decorative contrast floors.

Enhancements:
- Propagate the palette changes across TUI, web, documentation, brand, Observatory, transcript, export, benchmark, and OAuth surfaces while updating their contrast guidance and measurements.
- Empty the contrast ratchet and make its test fixtures self-contained so the contrast gate verifies both the corrected palette and ratchet behavior.

Documentation:
- Update design-system specifications, brand guidelines, prompts, and inline palette documentation to reflect the revised values and contrast guarantees.

Tests:
- Update palette parity and dashboard expectations and revise contrast-ratchet tests for an empty production baseline.

Chores:
- Retire the obsolete comment contrast entry and track remaining generated brand-asset and dim-role follow-up work separately.