### PR TITLE
feat(stella-cli): route the export archive's transcript through stella-transcript

### DIFF
--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -256,7 +256,7 @@ fn redact_dump(json: &str) -> String {
 
 /// Recursively replace every string value in `value` with its redacted
 /// form. Returns whether anything was actually masked. [`redact_dump`]
-/// ignores that return value; [`transcript::redact_run`] uses it to say, on
+/// ignores that return value; `transcript::redact_run` uses it to say, on
 /// the dashboard, whether the transcript needed masking at all.
 fn redact_json_strings(value: &mut serde_json::Value) -> bool {
     match value {

--- a/crates/stella-cli/src/export.rs
+++ b/crates/stella-cli/src/export.rs
@@ -1,16 +1,22 @@
 //! `/export` — export **one session's** telemetry as a ZIP archive of raw
-//! JSON dumps plus a self-contained HTML dashboard.
+//! JSON dumps plus two self-contained HTML documents: a metrics dashboard and
+//! the session transcript.
 //!
 //! The archive lives at `.stella/exports/` and is named with the microsecond
 //! timestamp of the **last log entry** included (the data's own clock, not the
-//! user's submission time). The HTML is fully static — no external CSS/JS,
-//! everything inlined — so it can be opened offline, emailed, or committed
-//! alongside a PR as evidence.
+//! user's submission time). Both documents are fully static — no external
+//! CSS/JS, everything inlined — so either can be opened offline, emailed, or
+//! committed alongside a PR as evidence.
 //!
-//! The dashboard surfaces the metrics that actually change software quality:
-//! resolve rate, cost-per-resolved-task, token efficiency, tool-call
-//! frequency, retry patterns, and file-edit heat — the same data `stella
-//! stats` summarizes in a table, but visually and interactively.
+//! `dashboard.html` surfaces the metrics that actually change software
+//! quality: resolve rate, cost-per-resolved-task, token efficiency,
+//! tool-call frequency, retry patterns, and file-edit heat — the same data
+//! `stella stats` summarizes in a table, but visually and interactively.
+//!
+//! It links to `transcript.html` rather than embedding it. That document is
+//! [`transcript::render`]'s own [`stella_transcript::html::render_page`]
+//! output — the same renderer `stella observe` uses. Both draw one row
+//! grammar, and each keeps its own CSS.
 //!
 //! **Scope is a safety property here, not a convenience** (#2558). Until the
 //! session argument existed, this module dumped the entire workspace store:
@@ -102,9 +108,11 @@ pub fn export_session(workspace_root: &Path, session_id: &str) -> Result<PathBuf
     // the dashboard are still worth having, and an empty transcript reports
     // itself on the page rather than pretending the session was silent.
     let journal = store.session_events(session_id).unwrap_or_default();
-    let transcript = transcript::render(&journal, &execution_prompts(&dumps));
+    let transcript = transcript::render(&journal, &execution_prompts(&dumps), session_id);
 
-    // Build the self-contained HTML dashboard.
+    // Build the self-contained HTML dashboard. It links to the transcript
+    // rather than embedding it — see `transcript::render`'s doc for why the
+    // two are separate documents.
     let html = render_dashboard(
         &usage_stats,
         &dumps,
@@ -136,6 +144,12 @@ pub fn export_session(workspace_root: &Path, session_id: &str) -> Result<PathBuf
     }
     // The dashboard.
     zip.add_file(&format!("{folder}/dashboard.html"), html.as_bytes())?;
+    // The session transcript. A complete page on its own, so it reads fine
+    // even if nobody opens `dashboard.html` first.
+    zip.add_file(
+        &format!("{folder}/transcript.html"),
+        transcript.html.as_bytes(),
+    )?;
     // A manifest with the watermark, the scope, and the table list.
     //
     // `session` and `excluded` are the archive's provenance: without them a
@@ -184,10 +198,10 @@ pub async fn export_command(workspace_root: &Path, session_id: &str) -> String {
             "Export Session Telemetry — archive written to {}\n\
              Scope: this session ({session_id}) only — the archive is safe to attach to a \
              PR or email without disclosing your other runs in this workspace. The ZIP \
-             holds a `dashboard.html` (open in any browser), raw JSON dumps of this \
-             session's telemetry tables, and a `manifest.json` naming the session and \
-             what was excluded. The timestamped folder name matches the last log entry's \
-             timestamp.",
+             holds a `dashboard.html` (metrics — open in any browser), a `transcript.html` \
+             (the replayed session), raw JSON dumps of this session's telemetry tables, \
+             and a `manifest.json` naming the session and what was excluded. The \
+             timestamped folder name matches the last log entry's timestamp.",
             path.display()
         ),
         Ok(Err(e)) | Err(e) => format!("export failed: {e}"),
@@ -240,18 +254,38 @@ fn redact_dump(json: &str) -> String {
     }
 }
 
-/// Recursively replace every string value in `value` with its redacted form.
-fn redact_json_strings(value: &mut serde_json::Value) {
+/// Recursively replace every string value in `value` with its redacted
+/// form. Returns whether anything was actually masked. [`redact_dump`]
+/// ignores that return value; [`transcript::redact_run`] uses it to say, on
+/// the dashboard, whether the transcript needed masking at all.
+fn redact_json_strings(value: &mut serde_json::Value) -> bool {
     match value {
         serde_json::Value::String(text) => {
             let redaction = stella_learn::redact::redact_secrets(text);
             if redaction.redacted {
                 *text = redaction.text;
+                true
+            } else {
+                false
             }
         }
-        serde_json::Value::Array(items) => items.iter_mut().for_each(redact_json_strings),
-        serde_json::Value::Object(map) => map.values_mut().for_each(redact_json_strings),
-        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
+        serde_json::Value::Array(items) => {
+            let mut any = false;
+            for item in items.iter_mut() {
+                any |= redact_json_strings(item);
+            }
+            any
+        }
+        serde_json::Value::Object(map) => {
+            let mut any = false;
+            for v in map.values_mut() {
+                any |= redact_json_strings(v);
+            }
+            any
+        }
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {
+            false
+        }
     }
 }
 
@@ -448,18 +482,15 @@ fn render_dashboard(
     let stats_json =
         script_json(&serde_json::to_string(usage_stats).unwrap_or_else(|_| "[]".into()));
 
-    // What the transcript panel says about itself, above its first row.
-    let transcript_provenance = transcript.provenance();
-    let transcript_rows = comma(transcript.rendered as i64);
-    // An empty transcript is a real state, not a bug: a session whose events
-    // were never persisted, or one recorded by a build old enough that none of
-    // them replay. Say which, rather than rendering a blank panel that reads
-    // as a broken page.
-    let transcript_body = if transcript.rendered > 0 {
-        transcript.body.clone()
+    // The caption under the link to `transcript.html`: what it does and
+    // does not hold, so a reader can check the claim before opening it.
+    // An empty transcript is a real state, not a bug.
+    let transcript_caption = escape_html(&transcript.provenance());
+    let transcript_note = if transcript.rendered > 0 {
+        String::new()
     } else {
-        "<p class=\"empty\">No replayable events were recorded for this session. \
-         The metrics tab and the archive's <code>raw/</code> dumps are unaffected.</p>"
+        " No replayable events were recorded for this session; the metrics \
+         below and the archive's <code>raw/</code> dumps are unaffected."
             .to_string()
     };
 
@@ -716,109 +747,21 @@ fn render_dashboard(
      --text-3 body is the intended contrast: the name is the one thing in that
      line a reader is meant to see. */
 
-  /* ── The transcript ─────────────────────────────────────────────────────
-     Every entry is `.ev` with three parts: a timestamp, a kind label, and
-     content. Kept identical across kinds so the eye scans the left two
-     columns once and never re-learns the row.
-
-     It takes the tokens above rather than a palette of its own — the rule
-     this page runs on is that colour is meaning, so `--ok`/`--bad` mark a
-     verdict and nothing else takes a hue. A transcript is the densest thing
-     here and would have been the easiest place to break that. */
-  .tabs {{ display: flex; gap: var(--sp1); margin-bottom: var(--sp2); flex-wrap: wrap;
-          position: sticky; top: 0; background: var(--ground); padding: var(--sp1) 0; z-index: 5;
-          border-bottom: 1px solid var(--hairline); }}
-  .tab {{ font: inherit; cursor: pointer; background: var(--surface); color: var(--text-2);
-         border: 1px solid var(--hairline-strong); border-radius: var(--radius);
-         padding: 6px var(--sp2); }}
-  .tab[aria-selected="true"] {{ color: var(--text); border-color: var(--control-edge); }}
-  .tab .n {{ color: var(--text-3); font-size: var(--fs-micro); }}
-  .tab:focus-visible {{ outline: 2px solid var(--accent-edge); outline-offset: 2px; }}
-  .panel {{ display: none; }} .panel.on {{ display: block; }}
-
-  .ev {{ margin: 0 0 3px; padding: 5px var(--sp1); border-left: 2px solid transparent;
-        background: var(--surface); border-radius: var(--radius); }}
-  .t {{ color: var(--text-3); font-variant-numeric: tabular-nums; margin-right: 10px;
-       font-size: var(--fs-micro); white-space: pre; }}
-  .lbl {{ display: inline-block; min-width: 74px; color: var(--text-3);
-         font-size: var(--fs-micro); letter-spacing: .14em; margin-right: var(--sp1); }}
-  .meta {{ color: var(--text-2); font-size: var(--fs-micro); margin-left: 92px; }}
-  .ev.stage {{ background: transparent; border-left-color: var(--control-edge);
-              margin: var(--sp2) 0 6px; padding-top: var(--sp1);
-              border-top: 1px solid var(--hairline); }}
-  .ev.stage b {{ letter-spacing: .14em; text-transform: uppercase; font-size: var(--fs-sm); }}
-  .ev.step {{ background: var(--sunken); }}
-  .ev.say .prose, .ev.user .prose, .ev.think .prose {{
-    margin-left: 92px; white-space: pre-wrap; word-break: break-word; max-width: 78ch; }}
-  .ev.say {{ border-left-color: var(--accent-edge); }}
-  .ev.user {{ border-left-color: var(--control-edge); }}
-  .ev.think .prose {{ color: var(--text-2); font-style: italic; }}
-  /* The two places a hue is earned: a verdict passed, or something failed. */
-  .ev.verdict {{ border-left-color: var(--ok); }}
-  .ev.proof {{ border-left-color: var(--accent-edge); }}
-  .ev.err, .ev.tool.err, .ev.verdict.err {{ border-left-color: var(--bad); }}
-  details.ev {{ padding: 0; border-left-color: var(--hairline-strong); }}
-  details.ev summary {{ cursor: pointer; padding: 5px var(--sp1); list-style: none; }}
-  details.ev summary::-webkit-details-marker {{ display: none; }}
-  details.ev summary:hover {{ background: var(--sunken); }}
-  details.ev[open] summary {{ border-bottom: 1px solid var(--hairline); }}
-  .ev pre {{ margin: 0; padding: var(--sp1) 10px var(--sp1) 100px; white-space: pre-wrap;
-            word-break: break-word; font: inherit; overflow-x: auto; }}
-  pre.in {{ color: var(--text); background: var(--sunken); }}
-  pre.out {{ color: var(--text-2); border-top: 1px dashed var(--hairline);
-            max-height: 340px; overflow: auto; }}
-  pre.out.err {{ color: var(--bad); }}
-  pre.out.pending {{ color: var(--text-3); font-style: italic; }}
-  /* Only the fallback for diff text that parses to no hunks at all. */
-  pre.diff {{ color: var(--text-2); max-height: 300px; overflow: auto; }}
-
-  /* Unified diff — git's shape, drawn the way a reviewer reads it and
-     byte-for-byte the component the Observatory uses
-     (`crates/stella-observatory/src/assets/index.html`). This archive is
-     attached to a pull request as evidence and read beside that dashboard, so
-     the two must not render one edit two ways. Old and new line numbers get
-     their own gutters, the sigil gets a third, and the change is carried by a
-     tinted ROW rather than by a coloured glyph — hue is never the only signal
-     (BRAND.md), and it is the only signal that survives a monochrome print. */
-  /* Square, like everything else on this page: a rounded corner says
-     "surface" where a hairline says "boundary", and this page is boundaries
-     (`the_dashboard_is_monospace_and_square` enforces it). */
-  .dx {{ overflow-x: auto; border: 1px solid var(--hairline);
-        background: var(--sunken); margin: var(--sp1) 10px var(--sp1) 100px; }}
-  .dx-hunk {{ min-width: 100%; }}
-  .dx-hunk + .dx-hunk {{ border-top: 1px solid var(--hairline); }}
-  .dx-at {{ color: var(--text-3); background: var(--raised); padding: 3px 12px;
-           white-space: pre; border-bottom: 1px solid var(--hairline); }}
-  .dx-line {{ display: grid; grid-template-columns: 52px 52px 22px minmax(max-content, 1fr);
-             color: var(--text-2); }}
-  .dx-line > span {{ padding: 0 6px; white-space: pre; }}
-  .dx-line .no, .dx-line .nn {{ color: var(--text-3); text-align: right;
-    font-variant-numeric: tabular-nums; -webkit-user-select: none; user-select: none; }}
-  .dx-line .sg {{ text-align: center; -webkit-user-select: none; user-select: none; }}
-  .dx-line.add {{ background: rgba(116, 201, 145, .10); color: var(--text); }}
-  .dx-line.add .sg {{ color: var(--ok); }}
-  .dx-line.rem {{ background: rgba(224, 104, 122, .10); color: var(--text); }}
-  .dx-line.rem .sg {{ color: var(--bad); }}
-  /* Word-level highlight: the exact changed tokens inside a paired
-     removal/addition, a stronger wash of the same hue the row already
-     carries — never a third colour, so the rule stays "the row's tint says
-     which side, the token's tint says which part". */
-  .dx-line.add .ww {{ background: rgba(116, 201, 145, .34); }}
-  .dx-line.rem .ww {{ background: rgba(224, 104, 122, .34); }}
-  /* The elision sits between the hunks it replaces, so it has to read as
-     unmistakably not a line of the file: raised ground, centred, no gutter. */
-  .dx-fold {{ color: var(--text-3); background: var(--raised); text-align: center;
-             padding: 2px 12px; -webkit-user-select: none; user-select: none; }}
-  .dx-hunk + .dx-fold, .dx-fold + .dx-hunk {{ border-top: 1px solid var(--hairline); }}
-  .empty {{ color: var(--text-2); padding: 10px 0; }}
-
-  /* Under 720px the 92px indent costs more than it buys — the label becomes a
-     row of its own and every indent collapses to the gutter. */
-  @media (max-width: 720px) {{
-    .lbl {{ min-width: 0; display: block; margin: 0 0 2px; }}
-    .meta, .ev .prose {{ margin-left: 0; }}
-    .ev pre {{ padding-left: 10px; }}
-  }}
+  /* ── The transcript link ───────────────────────────────────────────────
+     The session transcript is its own document, `transcript.html`, rendered
+     by `stella_transcript::html::render_page` — the same renderer `stella
+     observe` draws through. Kept as a separate document rather than an
+     embedded fragment: the shared renderer's stylesheet and this one define
+     six of the same class names differently (`.dot`, `.step`, `.t`, …) and
+     neither is namespaced, so embedding the fragment here would cross-talk
+     both directions. Two documents, one link between them, is what lets both
+     keep their own CSS closed. */
+  .transcript-link {{ background: var(--surface); border: 1px solid var(--hairline);
+                     border-radius: var(--radius); padding: var(--sp2); margin-bottom: var(--sp2); }}
+  .transcript-link a {{ color: var(--text); font-weight: 600; text-decoration: none;
+                       border-bottom: 1px solid var(--accent-edge); }}
+  .transcript-link a:hover {{ border-bottom-color: var(--text); }}
+  .transcript-link .watermark {{ margin: var(--sp1) 0 0; }}
 
   /* A stated preference for less motion wins. Every transition on this page
      reports a state change rather than carrying information, so removing them
@@ -829,9 +772,7 @@ fn render_dashboard(
 
   /* Print. The module doc tells you to attach this to a PR or email it, and a
      dark instrument printed on paper is a black rectangle that empties a
-     cartridge. The panels are forced open because `display:none` cannot be
-     paged: without this, printing the report gives you whichever single tab
-     happened to be selected. */
+     cartridge. */
   @media print {{
     :root {{
       --ground: #FFFFFF; --surface: #FFFFFF; --raised: #FFFFFF; --sunken: #FFFFFF;
@@ -841,9 +782,7 @@ fn render_dashboard(
       --accent-wash: transparent;
     }}
     body {{ padding: 0; }}
-    .tabs {{ display: none; }}
-    .panel {{ display: block !important; }}
-    .ev, table, .chart-container {{ break-inside: avoid; }}
+    table, .chart-container {{ break-inside: avoid; }}
   }}
 </style>
 </head>
@@ -861,22 +800,11 @@ fn render_dashboard(
   <div class="kpi"><div class="label">Tokens Out</div><div class="value">{total_output_fmt}</div><div class="sub">generated</div></div>
 </div>
 
-<div class="tabs" role="tablist">
-  <button class="tab" data-target="transcript" role="tab" aria-selected="true">Transcript <span class="n">{transcript_rows}</span></button>
-  <button class="tab" data-target="metrics" role="tab" aria-selected="false">Metrics</button>
+<div class="transcript-link">
+  <a href="transcript.html">Open the session transcript →</a>
+  <div class="watermark">{transcript_caption}</div>{transcript_note}
 </div>
 
-<!-- `on` is set HERE, not by the script. The tabs are a convenience; the
-     archive is evidence, and a reader with scripts disabled must not open it
-     to a blank page — which is exactly what a JS-assigned initial class gives
-     them, since the CSP already forbids the page every other resource. The
-     script re-asserts this class on load and then owns it. -->
-<section id="transcript" class="panel on" role="tabpanel">
-  <div class="watermark">{transcript_provenance}</div>
-  {transcript_body}
-</section>
-
-<section id="metrics" class="panel" role="tabpanel">
 <div id="insights"></div>
 
 <h2>Cost &amp; Efficiency by Model</h2>
@@ -901,7 +829,6 @@ fn render_dashboard(
 <div class="chart-container">
   <div id="outcome-chart" class="bar-chart"></div>
 </div>
-</section>
 
 <div class="footer">
   Exported by <span class="wordmark">stella<span class="star">*</span></span> <code>/export</code> · {total_runs} executions ·
@@ -925,22 +852,6 @@ const FILES = {files_json};
 // the sink, which is the only place that knows the value is about to
 // become markup.
 const esc = s => String(s).replace(/[&<>"']/g, c => ({{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}}[c]));
-
-// ── Tabs ────────────────────────────────────────────────────────────────
-// The transcript opens first: it is what the archive is for, and the metrics
-// are the summary of it. Everything is in the document either way — the tabs
-// only choose what is displayed, so Ctrl-F still finds a tool call on the tab
-// you are not looking at.
-(function tabs() {{
-  const buttons = [...document.querySelectorAll('.tab')];
-  const panels = [...document.querySelectorAll('.panel')];
-  const show = id => {{
-    panels.forEach(p => p.classList.toggle('on', p.id === id));
-    buttons.forEach(b => b.setAttribute('aria-selected', String(b.dataset.target === id)));
-  }};
-  buttons.forEach(b => b.addEventListener('click', () => show(b.dataset.target)));
-  if (buttons.length) show(buttons[0].dataset.target);
-}})();
 
 // ── KPI insights — surface the patterns that change quality ─────────────
 (function insights() {{

--- a/crates/stella-cli/src/export/tests.rs
+++ b/crates/stella-cli/src/export/tests.rs
@@ -184,7 +184,7 @@ fn the_cache_insight_reads_per_call_rows_not_a_token_average() {
         "now",
         "ses-x",
         &ExportExclusions::default(),
-        &transcript::render(&Default::default(), &Default::default()),
+        &transcript::render(&Default::default(), &Default::default(), "ses-x"),
     );
 
     assert!(
@@ -232,7 +232,7 @@ fn dashboard_escapes_untrusted_text_at_every_innerhtml_sink() {
         "now",
         "ses-x",
         &ExportExclusions::default(),
-        &transcript::render(&Default::default(), &Default::default()),
+        &transcript::render(&Default::default(), &Default::default(), "ses-x"),
     );
 
     // The payload does reach the page — escaping at the sink, not
@@ -271,29 +271,26 @@ fn dashboard_escapes_untrusted_text_at_every_innerhtml_sink() {
 }
 
 #[test]
-fn the_transcript_is_readable_with_scripts_disabled() {
-    // The tabs hide inactive panels with `display:none` and the script adds
-    // the `on` class — so a JS-assigned initial class opens the archive to a
-    // blank page for any reader with scripts off. That is a nuisance in a live
-    // dashboard and a failure in an artifact whose stated job is to be
-    // attached to a PR as evidence, which is why the class is emitted here and
-    // the script only takes over afterwards.
+fn the_dashboard_links_to_the_transcript_document() {
+    // The transcript is its own self-contained `transcript.html`, rendered
+    // by `stella_transcript::html::render_page`. A plain link needs no
+    // script to reach it, which a tabbed panel would.
     let html = render_dashboard(
         &[],
         &[],
         "now",
         "ses-x",
         &ExportExclusions::default(),
-        &transcript::render(&Default::default(), &Default::default()),
+        &transcript::render(&Default::default(), &Default::default(), "ses-x"),
     );
 
     assert!(
-        html.contains(r#"<section id="transcript" class="panel on""#),
-        "the transcript panel is visible before any script runs"
+        html.contains(r#"href="transcript.html""#),
+        "the dashboard links to the transcript document"
     );
     assert!(
-        html.contains(r#"data-target="transcript" role="tab" aria-selected="true""#),
-        "and its tab reads as selected without JS"
+        !html.contains("class=\"panel"),
+        "no script-gated panel remains for the transcript"
     );
 }
 
@@ -675,8 +672,8 @@ fn the_archive_carries_the_session_transcript_and_only_that_session() {
         "another session's tool call reached the transcript"
     );
     assert!(
-        find_subsequence(&bytes, br#"class="ev tool""#).is_some(),
-        "the transcript rendered in the dashboard's row grammar"
+        find_subsequence(&bytes, br#"<details class="step""#).is_some(),
+        "the transcript rendered through the shared renderer's row grammar"
     );
 }
 
@@ -723,7 +720,7 @@ fn the_dashboard_palette_is_generated_from_the_live_theme() {
         "2026-01-01 00:00:00",
         "ses-x",
         &ExportExclusions::default(),
-        &transcript::render(&Default::default(), &Default::default()),
+        &transcript::render(&Default::default(), &Default::default(), "ses-x"),
     );
 
     // Dark: the instrument ramp, achromatic chrome, the brand hue only as
@@ -820,7 +817,7 @@ fn the_dashboard_is_monospace_and_square() {
         "2026-01-01 00:00:00",
         "ses-x",
         &ExportExclusions::default(),
-        &transcript::render(&Default::default(), &Default::default()),
+        &transcript::render(&Default::default(), &Default::default(), "ses-x"),
     );
 
     // The face comes from the `--mono` token, not a hardcoded shorthand. This
@@ -879,7 +876,7 @@ fn the_dashboard_spells_the_wordmark_lowercase() {
         "2026-01-01 00:00:00",
         "ses-x",
         &ExportExclusions::default(),
-        &transcript::render(&Default::default(), &Default::default()),
+        &transcript::render(&Default::default(), &Default::default(), "ses-x"),
     );
 
     assert!(

--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -36,8 +36,8 @@
 //! **3. Drop nothing.** The shared run model has no slot for most of the
 //! wire's event kinds: a stage boundary, a provider fallback, a verdict, and
 //! more. Each of those becomes a [`Note`] — its wire tag as the summary, its
-//! whole payload as the fold-out detail ([`push_note`]). A reader can read
-//! what happened even for a kind this crate has never named, and can grep
+//! whole payload as the fold-out detail ([`Fold::push_note`]). A reader can
+//! read what happened even for a kind this crate has never named, and can grep
 //! `raw/` for the tag. A transcript that quietly skipped what it did not
 //! recognize would be a summary pretending to be a replay.
 

--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -225,8 +225,12 @@ impl<'a> Fold<'a> {
         // A call still in flight when the turn ends never resolved. Rendered
         // as `Running` rather than dropped: a tool that hung is exactly what
         // a reader is looking for.
+        //
+        // Taken rather than drained in place: `admit` charges the row budget
+        // once per call, and a live `drain` would still hold the `&mut self`
+        // that charge needs.
         let elapsed = self.elapsed_ms;
-        for (_, call) in self.pending.drain(..) {
+        for (_, call) in std::mem::take(&mut self.pending) {
             if self.admit() {
                 turn.steps.push(Step {
                     call: Some(call),

--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -1,113 +1,110 @@
 //! The session transcript — the replayable half of the `/export` archive.
 //!
-//! [`super::export_session`] bundles telemetry *tables*: what the session
-//! cost, which tools it called, which files it touched, what was sent to the
-//! model. None of that is the session. The session is the ordered stream of
-//! what the model said, what it ran, and what came back — and that lives in
-//! `events`, which the tables do not summarize and the dumps do not contain.
+//! [`super::export_session`] bundles telemetry *tables*: cost, tools called,
+//! files touched, what was sent to the model. None of that is the session
+//! itself. The session is the ordered stream of what the model said, what it
+//! ran, and what came back. That stream lives in `events`, not in the tables.
 //!
 //! This module folds [`Store::session_events`](stella_store::Store::session_events)
-//! into that stream and renders it as the archive's readable half.
+//! into a [`stella_transcript::model::Run`] and renders it with
+//! [`stella_transcript::html::render_page`] — the same renderer `stella
+//! observe` uses. Both surfaces draw one row grammar for one session.
+//! Everything below this line builds and redacts that run; the call to the
+//! renderer is [`render`]'s last line.
 //!
-//! # Four properties this fold has to get right
+//! # Three rules this fold has to keep
 //!
-//! **1. It is a third egress sink, and #817's masking did not cover it.**
-//! `redact_dump` runs over the table dumps, and the dashboard embeds those
-//! same redacted dumps — two sinks, one masking pass. The event journal is
-//! read straight from the store and reaches neither. Prompts, tool arguments
-//! and tool output are exactly the places #817 masks credentials out of, so
-//! **every string this module takes off an event goes through
-//! [`redact`](stella_learn::redact::redact_secrets) before it is escaped** (see
-//! [`Fold::clean`]). An unredacted transcript would have quietly reopened #817 in an
-//! artifact whose whole purpose is to be mailed to someone.
+//! **1. Redact everything, once, at the end.** The table dumps go through
+//! `redact_dump` before the dashboard embeds them. This event journal never
+//! passes through that path, so every string this fold takes off an event
+//! must be masked before [`render`] hands the run to the renderer. Rather
+//! than clean each string as it is read, [`redact_run`] does it once: it
+//! serializes the finished [`stella_transcript::model::Run`] to JSON, masks
+//! every string value in the tree, and reads the run back. Every model type
+//! round-trips through `serde_json` byte for byte, so this one pass cannot
+//! miss a field the way a scattered set of `clean()` calls could.
 //!
-//! **2. The elapsed clock has one-second resolution and may not pretend
-//! otherwise.** `events.ts` takes SQLite's `DEFAULT CURRENT_TIMESTAMP` at every
-//! writer, which carries no sub-second component
-//! ([`SessionEventRecord::ts`](stella_store::SessionEventRecord::ts)). So the
-//! `.t` column prints whole seconds. Per-call durations are *not* derived from
-//! it — `ToolResult::duration_ms` and `StepUsage::duration_ms` are measured,
-//! millisecond-precise, and printed as they are. A tenth of a second in the
-//! elapsed column would be a measurement artifact invented by the renderer.
+//! **2. Never invent a clock reading finer than what was measured.**
+//! `events.ts` is a plain SQLite timestamp with no sub-second part
+//! ([`SessionEventRecord::ts`](stella_store::SessionEventRecord::ts)), so
+//! this fold never reads it. [`Step::offset_ms`] is summed instead from the
+//! real, millisecond-precise durations on `ToolResult` and `StepUsage` — the
+//! same durations the shared renderer already draws for `stella observe`,
+//! and the same sum [`stella_tui::transcript_build::RunBuilder`] already
+//! keeps for the live surface.
 //!
-//! **3. One model message renders once.** The engine streams prose as
-//! [`AgentEvent::TextDelta`] fragments and then emits one consolidated
-//! [`AgentEvent::Text`] carrying the same prose. A renderer that coalesces the
-//! delta run *and* renders the `Text` event draws every assistant message
-//! twice — and the duplicate looks like a second paid model call to anyone
-//! reading the artifact rather than the stream. `Text`'s own protocol doc
-//! settles it: consumers "must REPLACE any accumulated preview with this
-//! value, never append". [`Fold::flush_prose`] implements exactly that, so a
-//! delta run followed by its `Text` emits one row.
-//!
-//! **4. A tool result knows neither its name nor its arguments.**
-//! `ToolResult` carries `call_id`, a typed [`ToolOutput`] and a duration —
-//! the name and the arguments are on the `ToolStart` sharing that `call_id`.
-//! The correlation map is built across the whole journal, never per batch.
-//! Failure is read off the `ToolOutput::Error` tag, never sniffed out of the
-//! text.
+//! **3. Drop nothing.** The shared run model has no slot for most of the
+//! wire's event kinds: a stage boundary, a provider fallback, a verdict, and
+//! more. Each of those becomes a [`Note`] — its wire tag as the summary, its
+//! whole payload as the fold-out detail ([`push_note`]). A reader can read
+//! what happened even for a kind this crate has never named, and can grep
+//! `raw/` for the tag. A transcript that quietly skipped what it did not
+//! recognize would be a summary pretending to be a replay.
 
 use std::collections::HashMap;
-use std::fmt::Write as _;
 
 use serde::Serialize;
 use stella_protocol::{AgentEvent, ToolOutput};
 use stella_store::{SessionEventRecord, SessionJournal};
+use stella_transcript::fold::FoldState;
+use stella_transcript::html;
+use stella_transcript::model::{
+    Accounting, ArgRow, Call, Extent, FileChange, FileStatus, Note, NoteKind, Output, Patch, Prose,
+    Run, Status, Step, ToolKind, Turn,
+};
 
 /// Cap on a single embedded tool result, file diff, or structured payload.
 ///
 /// The archive is a file someone opens in a browser; one `bash` call that cats
 /// a build log can carry tens of megabytes, and a handful of them make the
 /// dashboard slower to open than the run took to execute. The cut is stated
-/// inline (`… N bytes truncated`) rather than silent — an elided transcript
-/// that looks complete is worse evidence than a short one that says so — and
-/// the untruncated rows remain in `raw/` beside it.
+/// inline (`… N bytes truncated`) rather than silent, and the untruncated
+/// rows remain in `raw/` beside it.
 const MAX_EMBEDDED_BYTES: usize = 64 * 1024;
 
-/// Cap on the number of rendered rows.
+/// Cap on the number of steps and notes committed to the run.
 ///
-/// Same reasoning one level up: a long-running session can hold six figures of
-/// events, and past a point the page stops being readable at all. Overflow is
-/// reported in the transcript header, never dropped quietly.
+/// A long-running session can hold six figures of events, and past a point
+/// the page stops being readable at all. Overflow is reported in the
+/// transcript's [`Transcript::provenance`] line, never dropped quietly. Turn
+/// openings (the prompt row) are never capped — a prompt is cheap and the
+/// reader needs to see which turns exist even once their content is elided.
 const MAX_ROWS: usize = 5_000;
 
-/// One rendered transcript row, already escaped and ready to concatenate.
-struct Row {
-    html: String,
-}
-
-/// The rendered transcript plus what the render had to leave out.
+/// The rendered transcript document, plus what the render had to leave out.
 pub(crate) struct Transcript {
-    /// The `<div class="ev …">` rows, in stream order.
-    pub(crate) body: String,
-    /// How many rows were rendered.
+    /// A complete, self-contained HTML page — [`stella_transcript::html::render_page`]'s
+    /// output, written to the archive as its own `transcript.html` member.
+    pub(crate) html: String,
+    /// How many steps and notes were committed to the run.
     pub(crate) rendered: usize,
     /// Events the store could not parse back into an `AgentEvent`
     /// ([`SessionJournal::skipped`]) — a stream recorded before a variant
-    /// existed. Stated so a reader can tell a quiet session from a lossy read.
+    /// existed. Stated so a reader can tell a quiet session from a lossy
+    /// read.
     pub(crate) unparseable: usize,
-    /// Rows dropped by [`MAX_ROWS`].
+    /// Steps/notes dropped by [`MAX_ROWS`].
     pub(crate) overflow: usize,
-    /// Whether any string in the transcript had a credential masked out of it.
+    /// Whether any string in the transcript had a credential masked out of
+    /// it.
     pub(crate) redacted: bool,
 }
 
 impl Transcript {
-    /// The one-line provenance note the transcript panel prints under its
-    /// heading — what this rendering does and does not contain.
+    /// The one-line provenance note the dashboard prints beside the link to
+    /// `transcript.html` — what this rendering does and does not contain.
     pub(crate) fn provenance(&self) -> String {
-        let mut parts = vec![format!("{} entries", comma_usize(self.rendered))];
+        let mut parts = vec![format!("{} entries", super::comma(self.rendered as i64))];
         if self.overflow > 0 {
             parts.push(format!(
-                "{} further entries not rendered (the archive's <code>raw/</code> \
-                 dumps are complete)",
-                comma_usize(self.overflow)
+                "{} further entries not rendered (the archive's raw/ dumps are complete)",
+                super::comma(self.overflow as i64)
             ));
         }
         if self.unparseable > 0 {
             parts.push(format!(
                 "{} event(s) could not be replayed (recorded by an older build)",
-                comma_usize(self.unparseable)
+                super::comma(self.unparseable as i64)
             ));
         }
         if self.redacted {
@@ -117,212 +114,148 @@ impl Transcript {
     }
 }
 
-/// Fold a session's journal into transcript rows.
+/// Fold a session's journal into a transcript document.
 ///
-/// `prompts` maps `execution_id` to that execution's prompt, so the transcript
-/// opens each turn with what was actually asked. It comes from the already
-/// redacted `executions` dump rather than from the journal, because the prompt
-/// is a column, not an event.
-pub(crate) fn render(journal: &SessionJournal, prompts: &HashMap<i64, String>) -> Transcript {
-    let mut fold = Fold::new(prompts);
+/// `prompts` maps `execution_id` to that execution's prompt, so the
+/// transcript opens each turn with what was actually asked. It comes from
+/// the already redacted `executions` dump rather than from the journal,
+/// because the prompt is a column, not an event. `session_id` names the
+/// document — the shared renderer's identity bar has nowhere else to read a
+/// title from, since this fold performs no I/O of its own.
+pub(crate) fn render(
+    journal: &SessionJournal,
+    prompts: &HashMap<i64, String>,
+    session_id: &str,
+) -> Transcript {
+    let mut fold = Fold::new(prompts, session_id);
     for record in &journal.events {
         fold.push(record);
     }
     fold.finish(journal.skipped)
 }
 
-/// Accumulator for [`render`].
+/// Accumulator for [`render`]. Builds a [`Run`] much the way
+/// [`stella_tui::transcript_build::RunBuilder`] builds one from a live
+/// `AgentEvent` stream, with three differences. A turn opens on an
+/// `execution_id` change, not an explicit call. An orphaned
+/// [`AgentEvent::ToolResult`] — no matching `ToolStart` in this journal —
+/// still renders instead of being dropped. And the fallback for an event
+/// kind the backbone does not name carries the whole payload, not a
+/// narrated line.
 struct Fold<'a> {
-    rows: Vec<Row>,
-    prompts: &'a HashMap<i64, String>,
-    /// Epoch seconds of the first event that carried a parseable timestamp —
-    /// the origin the `.t` column counts from.
-    origin: Option<i64>,
-    /// Elapsed seconds for the row currently being built.
-    now: i64,
-    /// The execution whose prompt has already been printed.
-    current_execution: Option<i64>,
-    /// Accumulated `TextDelta` fragments awaiting either their consolidated
-    /// `Text` (which replaces them) or any other event (which flushes them).
-    pending_text: String,
-    /// Accumulated `Reasoning` fragments. Unlike prose these have no
-    /// consolidated counterpart, so a run always flushes to a row.
-    pending_reasoning: String,
-    /// `call_id` → the index in `rows` of the tool row awaiting its result.
-    open_tools: HashMap<String, usize>,
-    /// `call_id` → (tool name, delegate id), for a result whose call was
-    /// never recorded, or whose own `ToolResult` did not repeat the
-    /// attribution its `ToolStart` already carried (#4699).
+    run: Run,
+    /// The turn currently accumulating, opened by [`Fold::open_execution`].
+    turn: Option<Turn>,
+    /// Calls dispatched but not yet resolved, oldest first.
+    pending: Vec<(String, Call)>,
+    /// `call_id` → (tool name, delegate id), kept for every call this fold
+    /// has ever seen started — the fallback name for a `ToolResult` whose
+    /// own `ToolStart` this journal never recorded, or recorded and already
+    /// closed (a duplicate or late result).
     tool_names: HashMap<String, (String, Option<String>)>,
-    redacted: bool,
+    /// Wall time attributed to the open turn so far, summed from the
+    /// measured durations the events themselves report (module doc,
+    /// property 2).
+    elapsed_ms: u64,
+    /// The execution whose turn is currently open.
+    current_execution: Option<i64>,
+    prompts: &'a HashMap<i64, String>,
+    /// Steps and notes committed so far, against [`MAX_ROWS`].
+    emitted: usize,
     overflow: usize,
 }
 
 impl<'a> Fold<'a> {
-    fn new(prompts: &'a HashMap<i64, String>) -> Self {
+    fn new(prompts: &'a HashMap<i64, String>, session_id: &str) -> Self {
         Self {
-            rows: Vec::new(),
-            prompts,
-            origin: None,
-            now: 0,
-            current_execution: None,
-            pending_text: String::new(),
-            pending_reasoning: String::new(),
-            open_tools: HashMap::new(),
+            run: Run {
+                name: format!("session {session_id}"),
+                model: String::new(),
+                started_at: String::new(),
+                turns: Vec::new(),
+            },
+            turn: None,
+            pending: Vec::new(),
             tool_names: HashMap::new(),
-            redacted: false,
+            elapsed_ms: 0,
+            current_execution: None,
+            prompts,
+            emitted: 0,
             overflow: 0,
         }
     }
 
     /// Absorb one journal record.
     fn push(&mut self, record: &SessionEventRecord) {
-        self.now = self.elapsed(&record.ts);
-
-        // A `Text` event REPLACES the delta run it consolidates (see the
-        // module doc, property 3), so it must not flush the buffer first —
-        // every other event must.
-        if !matches!(
-            record.event,
-            AgentEvent::TextDelta { .. } | AgentEvent::Text { .. }
-        ) {
-            self.flush_prose();
-        }
-        if !matches!(record.event, AgentEvent::Reasoning { .. }) {
-            self.flush_reasoning();
-        }
-
         self.open_execution(record.execution_id);
-        self.event(&record.event);
+        self.push_event(&record.event);
     }
 
-    /// Elapsed whole seconds since the first timestamped event.
-    ///
-    /// An unparseable or absent `ts` holds the previous reading rather than
-    /// resetting to zero: the row's position in the stream is authoritative
-    /// and a jump to `0.0s` mid-transcript would read as a new run.
-    fn elapsed(&mut self, ts: &str) -> i64 {
-        let Some(secs) = parse_sql_timestamp(ts) else {
-            return self.now;
-        };
-        match self.origin {
-            Some(origin) => (secs - origin).max(0),
-            None => {
-                self.origin = Some(secs);
-                0
-            }
-        }
-    }
-
-    /// Open a new turn when the execution changes, printing its prompt.
+    /// Open a new turn when the execution changes, carrying its prompt.
     fn open_execution(&mut self, execution_id: i64) {
         if self.current_execution == Some(execution_id) {
             return;
         }
         self.current_execution = Some(execution_id);
-        let Some(prompt) = self.prompts.get(&execution_id) else {
-            return;
-        };
-        let prompt = prompt.trim();
-        if prompt.is_empty() {
-            return;
-        }
-        // Already redacted: this came off the `executions` dump, which
-        // `redact_dump` has run over. `clean` again anyway — masking twice is
-        // free and a change of source upstream must not silently unmask.
-        let prose = self.clean(prompt);
-        self.prose_row("user", "USER", &prose);
+        let prompt = self.prompts.get(&execution_id).cloned().unwrap_or_default();
+        self.start_turn(prompt);
     }
 
-    /// Render one event.
-    fn event(&mut self, event: &AgentEvent) {
+    /// Open a new turn around a prompt. Any turn still open is closed first.
+    fn start_turn(&mut self, prompt: String) {
+        self.finish_turn(Status::Ok);
+        self.elapsed_ms = 0;
+        self.turn = Some(Turn {
+            name: slug(&prompt),
+            prompt,
+            prose: Vec::new(),
+            notes: Vec::new(),
+            steps: Vec::new(),
+            answer: None,
+            status: Status::Running,
+            duration_ms: 0,
+        });
+    }
+
+    /// Close the open turn, if any.
+    fn finish_turn(&mut self, status: Status) {
+        let Some(mut turn) = self.turn.take() else {
+            return;
+        };
+        // A call still in flight when the turn ends never resolved. Rendered
+        // as `Running` rather than dropped: a tool that hung is exactly what
+        // a reader is looking for.
+        let elapsed = self.elapsed_ms;
+        for (_, call) in self.pending.drain(..) {
+            if self.admit() {
+                turn.steps.push(Step {
+                    call: Some(call),
+                    accounting: Accounting::default(),
+                    offset_ms: elapsed,
+                });
+            }
+        }
+        turn.duration_ms = self.elapsed_ms;
+        self.elapsed_ms = 0;
+        if turn.status == Status::Running {
+            turn.status = if turn.steps.iter().any(|s| s.status() == Status::Error) {
+                Status::Error
+            } else {
+                status
+            };
+        }
+        self.run.turns.push(turn);
+    }
+
+    /// Render one event onto the open turn.
+    fn push_event(&mut self, event: &AgentEvent) {
         match event {
-            AgentEvent::Stage { name, .. } => {
-                let name = wire_token(name);
-                self.row(format!(
-                    r#"<div class="ev stage">{t}<span class="lbl">STAGE</span><b>{name}</b></div>"#,
-                    t = self.stamp(),
-                    name = escape(&name),
-                ));
-            }
-
-            // Prose. The delta run is a preview of the `Text` that follows it;
-            // whichever arrives is rendered, never both.
-            AgentEvent::TextDelta { delta } => self.pending_text.push_str(delta),
-            AgentEvent::Text { text } => {
-                self.pending_text.clear();
-                let prose = self.clean(text);
-                if !prose.trim().is_empty() {
-                    self.prose_row("say", "ASSISTANT", &prose);
-                }
-            }
-            AgentEvent::Reasoning { delta } => self.pending_reasoning.push_str(delta),
-
-            AgentEvent::StepUsage {
-                step,
-                role,
-                provider,
-                model,
-                input_tokens,
-                output_tokens,
-                cached_input_tokens,
-                cost_usd,
-                duration_ms,
-                tool_calls,
-                finish_reason,
-                ..
-            } => {
-                let role = wire_token(role);
-                let route = if provider.is_empty() {
-                    model.clone()
-                } else {
-                    format!("{provider}/{model}")
-                };
-                let finish = finish_reason
-                    .as_ref()
-                    .map_or_else(|| "-".to_string(), wire_token);
-                let meta = format!(
-                    "out {out} tok · in {input} (cached {cached}) · ${cost:.4} · {secs:.1}s · \
-                     finish={finish} · tools={tools}",
-                    out = comma_u64(*output_tokens),
-                    input = comma_u64(*input_tokens),
-                    cached = comma_u64(*cached_input_tokens),
-                    cost = cost_usd,
-                    secs = *duration_ms as f64 / 1000.0,
-                    finish = escape(&finish),
-                    tools = tool_calls,
-                );
-                self.row(format!(
-                    r#"<div class="ev step" data-role="{role_attr}">{t}<span class="lbl">STEP</span><b>step {step} · {role} · {route}</b><div class="meta">{meta}</div></div>"#,
-                    role_attr = escape(&role),
-                    t = self.stamp(),
-                    role = escape(&role),
-                    route = escape(&route),
-                ));
-            }
-
+            AgentEvent::TextDelta { delta } => self.append_answer(delta),
+            AgentEvent::Text { text } => self.set_answer(text),
+            AgentEvent::Reasoning { delta } => self.append_prose(delta),
             AgentEvent::ToolStart {
                 call, sub_agent_id, ..
-            } => {
-                let args = self.clean(&pretty(&call.input));
-                let name = self.clean(&call.name);
-                self.tool_names
-                    .insert(call.call_id.clone(), (name.clone(), sub_agent_id.clone()));
-                let index = self.rows.len();
-                let stamp = self.stamp();
-                let agent = agent_suffix(sub_agent_id.as_deref());
-                // The result arrives later in the stream and is patched into
-                // this row; until then it is honestly marked pending, because
-                // a killed run leaves calls that genuinely never returned.
-                self.row(format!(
-                    r#"<details class="ev tool" open><summary>{stamp}<span class="lbl">TOOL</span><b>{name}{agent}</b></summary><pre class="in">{args}</pre><pre class="out pending">(no result recorded — the run ended before this call returned)</pre></details>"#,
-                    name = escape(&name),
-                    args = escape(&clip(&args)),
-                ));
-                if self.rows.len() > index {
-                    self.open_tools.insert(call.call_id.clone(), index);
-                }
-            }
+            } => self.open_call(call, sub_agent_id.clone()),
             AgentEvent::ToolResult {
                 call_id,
                 output,
@@ -330,119 +263,105 @@ impl<'a> Fold<'a> {
                 speculated,
                 sub_agent_id,
                 ..
-            } => self.close_tool(
+            } => self.close_call(
                 call_id,
                 output,
                 *duration_ms,
                 *speculated,
                 sub_agent_id.as_deref(),
             ),
-
+            AgentEvent::StepUsage {
+                input_tokens,
+                output_tokens,
+                cached_input_tokens,
+                cost_usd,
+                duration_ms,
+                ..
+            } => self.charge(
+                *input_tokens,
+                *output_tokens,
+                *cached_input_tokens,
+                *cost_usd,
+                *duration_ms,
+            ),
             AgentEvent::FileChange {
                 path,
-                kind,
                 added,
                 removed,
                 diff,
+                minimal,
                 ..
-            } => {
-                let kind = wire_token(kind);
-                let path = self.clean(path);
-                let diff = self.clean(diff.as_deref().unwrap_or_default());
-                self.row(format!(
-                    r#"<details class="ev file"><summary>{t}<span class="lbl">FILE</span><b>{kind} {path} (+{added}/-{removed})</b></summary>{body}</details>"#,
-                    t = self.stamp(),
-                    kind = escape(&kind),
-                    path = escape(&path),
-                    body = diff_html(&diff),
-                ));
+            } => self.attach_file(path, *added, *removed, diff.as_deref(), *minimal),
+            // A terminator closes work that already exists; `push_note` would
+            // have nothing to attribute it to once the turn it describes is
+            // gone, and the cost/model it carries is already in the turn's
+            // own accounting rollup.
+            AgentEvent::TurnComplete { .. } | AgentEvent::RunComplete { .. } => {
+                self.finish_turn(Status::Ok);
             }
-
-            AgentEvent::Verdict { passed, evidence } => {
-                let label = if *passed { "PASS" } else { "FAIL" };
-                self.structured_row(
-                    if *passed { "verdict" } else { "verdict err" },
-                    "VERDICT",
-                    &format!("verdict · {label}"),
-                    evidence,
-                );
+            AgentEvent::Error { .. } => {
+                self.push_note(event);
+                if let Some(turn) = self.turn.as_mut() {
+                    turn.status = Status::Error;
+                }
             }
-            AgentEvent::GoalVerdict {
-                round,
-                met,
-                reasoning,
-                cost_usd,
-            } => {
-                let prose = self.clean(reasoning);
-                let title = format!(
-                    "goal round {round} · {} · ${cost_usd:.4}",
-                    if *met { "met" } else { "not met" }
-                );
-                self.note_row(
-                    if *met { "verdict" } else { "verdict err" },
-                    "GOAL",
-                    &title,
-                    Some(&prose),
-                );
-            }
-
-            // The proof stream is the one place a full reason string survives:
-            // every other surface truncates it, and the truncated half is
-            // routinely the half that explains the run. An offline document has
-            // no width budget, so it prints whole.
-            AgentEvent::Proof { step } => self.structured_row("proof", "PROOF", "proof step", step),
-
-            AgentEvent::Error { message, retryable } => {
-                let prose = self.clean(message);
-                let title = if *retryable {
-                    "error (retryable)"
-                } else {
-                    "error"
-                };
-                self.note_row("err", "ERROR", title, Some(&prose));
-            }
-            AgentEvent::Retry { attempt, reason } => {
-                let prose = self.clean(reason);
-                self.note_row("err", "RETRY", &format!("attempt {attempt}"), Some(&prose));
-            }
-            AgentEvent::Steered { text, .. } => {
-                let prose = self.clean(text);
-                self.prose_row("user", "STEER", &prose);
-            }
-            AgentEvent::Commit { sha, message } => {
-                let sha = self.clean(sha);
-                let message = self.clean(message);
-                let short = sha.chars().take(12).collect::<String>();
-                self.note_row("note", "COMMIT", &short, Some(&message));
-            }
-            AgentEvent::TurnComplete { model, cost_usd } => {
-                let model = self.clean(model);
-                self.note_row(
-                    "note",
-                    "COMPLETE",
-                    &format!("{model} · ${cost_usd:.4}"),
-                    None,
-                );
-            }
-
-            // Everything else in the ~40-variant stream. A transcript that
-            // silently dropped the rest would be a summary claiming to be a
-            // replay, so each one renders as its wire tag plus its complete
-            // payload — legible without this module having to grow an opinion
-            // about a variant it has never seen.
-            other => {
-                let tag = event_tag(other);
-                self.structured_row("note", "EVENT", &tag, other);
-            }
+            other => self.push_note(other),
         }
     }
 
-    /// Attach a result to the tool row its `call_id` opened.
-    ///
-    /// `sub_agent_id` is the result's own field — read only as the fallback
-    /// for a call whose `ToolStart` was never recorded, since the row the
-    /// common path patches already carries the announcement's badge (#4699).
-    fn close_tool(
+    fn set_answer(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(turn) = self.turn.as_mut() {
+            turn.answer = Some(text.to_string());
+        }
+    }
+
+    fn append_answer(&mut self, delta: &str) {
+        if let Some(turn) = self.turn.as_mut() {
+            turn.answer.get_or_insert_with(String::new).push_str(delta);
+        }
+    }
+
+    fn append_prose(&mut self, delta: &str) {
+        let step = self.turn.as_ref().map_or(0, |t| t.steps.len());
+        let Some(turn) = self.turn.as_mut() else {
+            return;
+        };
+        match turn.prose.last_mut() {
+            Some(last) if last.before_step == step => last.text.push_str(delta),
+            _ => turn.prose.push(Prose {
+                text: delta.to_string(),
+                before_step: step,
+            }),
+        }
+    }
+
+    fn open_call(&mut self, call: &stella_protocol::ToolCall, sub_agent_id: Option<String>) {
+        let tool = ToolKind::from_name(&call.name);
+        self.tool_names.insert(
+            call.call_id.clone(),
+            (call.name.clone(), sub_agent_id.clone()),
+        );
+        let entry = Call {
+            header_object: header_object(&tool, &call.input),
+            args: arg_rows(&call.input),
+            tool,
+            output: Output::default(),
+            files: Vec::new(),
+            status: Status::Running,
+            duration_ms: 0,
+            speculated: false,
+            sub_agent_id,
+        };
+        self.pending.push((call.call_id.clone(), entry));
+    }
+
+    /// Attach a result to the call its `call_id` opened — or, when this
+    /// journal never recorded that call's start (module doc, property 3),
+    /// render the result on its own rather than dropping it.
+    fn close_call(
         &mut self,
         call_id: &str,
         output: &ToolOutput,
@@ -450,166 +369,337 @@ impl<'a> Fold<'a> {
         spec: bool,
         sub_agent_id: Option<&str>,
     ) {
-        // The tag is the whole verdict — `ToolResult` has no `error` field and
-        // never has, so branching on the enum is the only correct read.
-        let failed = output.is_error();
-        let body = match output {
-            ToolOutput::Ok { content, .. } => content.clone(),
-            ToolOutput::Error { message, .. } => message.clone(),
+        let (status, text) = match output {
+            ToolOutput::Ok { content, .. } => (Status::Ok, content.as_str()),
+            ToolOutput::Error { message, .. } => (Status::Error, message.as_str()),
         };
-        let body = self.clean(&body);
+        let offset_ms = self.elapsed_ms;
+        self.elapsed_ms += duration_ms;
+
+        if let Some(index) = self.pending.iter().position(|(id, _)| id == call_id) {
+            let (_, mut call) = self.pending.remove(index);
+            call.status = status;
+            call.duration_ms = duration_ms;
+            call.speculated = spec;
+            call.output = Output::from_text(&clip(text));
+            self.commit_step(Step {
+                call: Some(call),
+                accounting: Accounting::default(),
+                offset_ms,
+            });
+            return;
+        }
+
         let (name, started_agent) = self
             .tool_names
             .get(call_id)
             .cloned()
             .unwrap_or_else(|| ("tool".to_string(), None));
-        let meta = format!(
-            " · {:.2}s{}",
-            duration_ms as f64 / 1000.0,
-            if spec { " · speculative" } else { "" }
-        );
-
-        let Some(index) = self.open_tools.remove(call_id) else {
-            // A result with no recorded call — an older stream, or a journal
-            // read that began mid-turn. Render it rather than drop it.
-            let agent = agent_suffix(started_agent.as_deref().or(sub_agent_id));
-            self.row(format!(
-                r#"<details class="ev tool{err} open"><summary>{t}<span class="lbl">TOOL</span><b>{name}{agent}</b><span class="meta">{meta}</span></summary><pre class="out{outerr}">{body}</pre></details>"#,
-                err = if failed { " err" } else { "" },
-                t = self.stamp(),
-                name = escape(&name),
-                meta = escape(&meta),
-                outerr = if failed { " err" } else { "" },
-                body = escape(&clip(&body)),
-            ));
-            return;
+        let call = Call {
+            header_object: String::new(),
+            args: Vec::new(),
+            tool: ToolKind::from_name(&name),
+            output: Output::from_text(&clip(text)),
+            files: Vec::new(),
+            status,
+            duration_ms,
+            speculated: spec,
+            sub_agent_id: sub_agent_id.map(str::to_string).or(started_agent),
         };
-        let Some(row) = self.rows.get_mut(index) else {
-            return;
+        self.commit_step(Step {
+            call: Some(call),
+            accounting: Accounting::default(),
+            offset_ms,
+        });
+    }
+
+    /// Bill a model call to the step it paid for — the last completed step,
+    /// or a call-less step of its own when the turn has none yet (a plain
+    /// answer with no tool calls still costs tokens).
+    fn charge(&mut self, input: u64, output: u64, cached: u64, cost_usd: f64, duration_ms: u64) {
+        let accounting = Accounting {
+            tokens_in: input,
+            tokens_out: output,
+            cached_in: cached,
+            micros: (cost_usd * 1_000_000.0).round().max(0.0) as u64,
         };
-        if failed {
-            row.html = row
-                .html
-                .replacen(r#"class="ev tool""#, r#"class="ev tool err""#, 1);
+        let offset_ms = self.elapsed_ms;
+        self.elapsed_ms += duration_ms;
+        let has_step = matches!(&self.turn, Some(t) if !t.steps.is_empty());
+        if has_step {
+            if let Some(step) = self.turn.as_mut().and_then(|t| t.steps.last_mut()) {
+                step.accounting = step.accounting.merged(accounting);
+            }
+        } else {
+            self.commit_step(Step {
+                call: None,
+                accounting,
+                offset_ms,
+            });
         }
-        row.html = row.html.replacen(
-            "</b></summary>",
-            &format!(
-                "</b><span class=\"meta\">{}</span></summary>",
-                escape(&meta)
-            ),
-            1,
-        );
-        row.html = row.html.replacen(
-            r#"<pre class="out pending">(no result recorded — the run ended before this call returned)</pre>"#,
-            &format!(
-                r#"<pre class="out{err}">{body}</pre>"#,
-                err = if failed { " err" } else { "" },
-                body = escape(&clip(&body)),
-            ),
-            1,
-        );
     }
 
-    /// Flush an accumulated `TextDelta` run that never received its
-    /// consolidating `Text` — a stream cut short mid-message.
-    fn flush_prose(&mut self) {
-        if self.pending_text.trim().is_empty() {
-            self.pending_text.clear();
-            return;
+    /// Hang a file change on the step that produced it — the engine emits it
+    /// as its own event, correlated only by coming right after the call that
+    /// made it.
+    fn attach_file(
+        &mut self,
+        path: &str,
+        added: u32,
+        removed: u32,
+        diff: Option<&str>,
+        minimal: bool,
+    ) {
+        let status = if removed > 0 && added == 0 {
+            FileStatus::Deleted
+        } else if removed == 0 && added > 0 {
+            FileStatus::New
+        } else {
+            FileStatus::Modified
+        };
+        let change = FileChange {
+            path: path.to_string(),
+            before: String::new(),
+            after: String::new(),
+            status,
+            extent: Extent::delta(added as usize, removed as usize),
+            patch: diff.map(|text| Patch {
+                text: clip(text),
+                minimal,
+            }),
+        };
+        if let Some(turn) = self.turn.as_mut()
+            && let Some(call) = turn.steps.last_mut().and_then(|s| s.call.as_mut())
+        {
+            call.files.push(change);
         }
-        let text = std::mem::take(&mut self.pending_text);
-        let prose = self.clean(&text);
-        self.prose_row("say", "ASSISTANT", &prose);
     }
 
-    /// Flush an accumulated `Reasoning` run.
-    fn flush_reasoning(&mut self) {
-        if self.pending_reasoning.trim().is_empty() {
-            self.pending_reasoning.clear();
-            return;
-        }
-        let text = std::mem::take(&mut self.pending_reasoning);
-        let prose = self.clean(&text);
-        self.prose_row("think", "THINKING", &prose);
+    /// Record an event the backbone has no slot for as a [`Note`] carrying
+    /// its wire tag and its whole payload (module doc, property 3).
+    fn push_note(&mut self, event: &AgentEvent) {
+        let tag = event_tag(event);
+        let kind = note_kind(event);
+        let detail = detail_lines(event);
+        let step = self.turn.as_ref().map_or(0, |t| t.steps.len());
+        self.commit_note(Note {
+            kind,
+            summary: tag,
+            detail,
+            before_step: step,
+            inspect: None,
+        });
     }
 
-    /// A prose row (`user` / `say` / `think`).
-    fn prose_row(&mut self, class: &str, label: &str, prose: &str) {
-        self.row(format!(
-            r#"<div class="ev {class}">{t}<span class="lbl">{label}</span><div class="prose">{prose}</div></div>"#,
-            t = self.stamp(),
-            prose = escape(&clip(prose)),
-        ));
-    }
-
-    /// A one-line row with an optional prose body.
-    fn note_row(&mut self, class: &str, label: &str, title: &str, body: Option<&str>) {
-        let meta = body
-            .map(|b| format!(r#"<div class="meta">{}</div>"#, escape(&clip(b.trim()))))
-            .unwrap_or_default();
-        self.row(format!(
-            r#"<div class="ev {class}">{t}<span class="lbl">{label}</span><b>{title}</b>{meta}</div>"#,
-            t = self.stamp(),
-            title = escape(title),
-        ));
-    }
-
-    /// A row whose payload is a structured protocol value, rendered whole in a
-    /// collapsible. See the `Proof` arm for why "whole" is the point.
-    fn structured_row<T: Serialize>(&mut self, class: &str, label: &str, title: &str, value: &T) {
-        let json = serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".into());
-        let json = self.clean(&json);
-        self.row(format!(
-            r#"<details class="ev {class}"><summary>{t}<span class="lbl">{label}</span><b>{title}</b></summary><pre class="out">{json}</pre></details>"#,
-            t = self.stamp(),
-            title = escape(title),
-            json = escape(&clip(&json)),
-        ));
-    }
-
-    /// The `.t` timestamp cell. Whole seconds — see the module doc, property 2.
-    fn stamp(&self) -> String {
-        format!(r#"<span class="t">{:>6}</span>"#, format!("{}s", self.now))
-    }
-
-    /// Mask any credential in an event-derived string (module doc, property 1).
-    fn clean(&mut self, raw: &str) -> String {
-        let redaction = stella_learn::redact::redact_secrets(raw);
-        if redaction.redacted {
-            self.redacted = true;
-        }
-        redaction.text
-    }
-
-    /// Append a row, respecting [`MAX_ROWS`].
-    fn row(&mut self, html: String) {
-        if self.rows.len() >= MAX_ROWS {
+    /// Increment the row budget, or count the overflow. Never mutates a turn
+    /// itself — callers commit only after this returns `true`.
+    fn admit(&mut self) -> bool {
+        if self.emitted >= MAX_ROWS {
             self.overflow += 1;
+            false
+        } else {
+            self.emitted += 1;
+            true
+        }
+    }
+
+    fn commit_step(&mut self, step: Step) {
+        if !self.admit() {
             return;
         }
-        self.rows.push(Row { html });
+        if let Some(turn) = self.turn.as_mut() {
+            turn.steps.push(step);
+        }
+    }
+
+    fn commit_note(&mut self, note: Note) {
+        if !self.admit() {
+            return;
+        }
+        if let Some(turn) = self.turn.as_mut() {
+            turn.notes.push(note);
+        }
     }
 
     fn finish(mut self, unparseable: usize) -> Transcript {
-        self.flush_prose();
-        self.flush_reasoning();
-        let mut body = String::new();
-        for row in &self.rows {
-            let _ = writeln!(body, "{}", row.html);
-        }
+        self.finish_turn(Status::Ok);
+        let mut run = self.run;
+        let redacted = redact_run(&mut run);
+        let page = html::render_page(&run, &FoldState::new());
         Transcript {
-            body,
-            rendered: self.rows.len(),
+            html: page,
+            rendered: self.emitted,
             unparseable,
             overflow: self.overflow,
-            redacted: self.redacted,
+            redacted,
         }
     }
 }
 
-/// The `type` tag an event serializes under — the same token the raw stream
-/// carries, so a reader can grep `raw/` for a row they saw on the page.
+/// Mask any credential anywhere in the built run (module doc, property 1).
+///
+/// Every [`stella_transcript::model`] type round-trips through `serde_json`
+/// byte for byte (invariant #4), so this serializes the whole tree, redacts
+/// every string value in it, and deserializes back — the same shape
+/// [`super::redact_json_strings`] already applies to a table dump, over a
+/// [`Run`] instead of a raw JSON array. A round trip that fails (this struct
+/// carries no float, map, or other value `serde_json` could refuse) must not
+/// ship an unverified document, so the run is replaced with a note stating
+/// the withholding rather than guessed at.
+fn redact_run(run: &mut Run) -> bool {
+    let Ok(mut value) = serde_json::to_value(&*run) else {
+        *run = withheld_run(run.name.clone());
+        return true;
+    };
+    let redacted = super::redact_json_strings(&mut value);
+    if redacted {
+        match serde_json::from_value::<Run>(value) {
+            Ok(cleaned) => *run = cleaned,
+            Err(_) => *run = withheld_run(run.name.clone()),
+        }
+    }
+    redacted
+}
+
+/// The run substituted when [`redact_run`] cannot verify its own redaction —
+/// safe because it carries none of the session's own content.
+fn withheld_run(name: String) -> Run {
+    Run {
+        name,
+        model: String::new(),
+        started_at: String::new(),
+        turns: vec![Turn {
+            name: "redaction-failed".into(),
+            prompt: String::new(),
+            prose: Vec::new(),
+            notes: vec![Note {
+                kind: NoteKind::Other,
+                summary: "the transcript could not be verified as redacted, so it was withheld"
+                    .into(),
+                detail: Vec::new(),
+                before_step: 0,
+                inspect: None,
+            }],
+            steps: Vec::new(),
+            answer: None,
+            status: Status::Error,
+            duration_ms: 0,
+        }],
+    }
+}
+
+/// Which class of thing a [`Note`] records.
+///
+/// [`stella_tui::transcript_build`] maps events the same way for the live
+/// surface, but its fallback narrates through
+/// [`stella_tui::textline::event_line`] and drops what that returns `None`
+/// for. This one keeps every kind. `NoteKind` only picks a glyph and a
+/// colour here — the two fallbacks are kept apart on purpose.
+fn note_kind(event: &AgentEvent) -> NoteKind {
+    match event {
+        AgentEvent::Stage { .. } => NoteKind::Stage,
+        AgentEvent::ContextRecall { .. }
+        | AgentEvent::ContextWrite { .. }
+        | AgentEvent::MemoryLogged { .. }
+        | AgentEvent::MemoryPromoted { .. }
+        | AgentEvent::SkillInjected { .. }
+        | AgentEvent::Compaction { .. } => NoteKind::Context,
+        AgentEvent::BudgetTick { .. }
+        | AgentEvent::ProviderFallback { .. }
+        | AgentEvent::Retry { .. } => NoteKind::Meter,
+        AgentEvent::TurnParked { .. }
+        | AgentEvent::TurnWoken { .. }
+        | AgentEvent::AskUser { .. }
+        | AgentEvent::Steered { .. } => NoteKind::Wait,
+        AgentEvent::Verdict { .. }
+        | AgentEvent::GoalVerdict { .. }
+        | AgentEvent::ScopeReview { .. }
+        | AgentEvent::HunkReview { .. }
+        | AgentEvent::TaskUpdate { .. }
+        | AgentEvent::GateBoard { .. }
+        | AgentEvent::Proof { .. } => NoteKind::Verdict,
+        AgentEvent::SubAgent { .. }
+        | AgentEvent::Commit { .. }
+        | AgentEvent::Pr { .. }
+        | AgentEvent::MediaProgress { .. }
+        | AgentEvent::MediaComplete { .. } => NoteKind::Handoff,
+        _ => NoteKind::Other,
+    }
+}
+
+/// A short turn name from its prompt. Mirrors
+/// [`stella_tui::transcript_build`]'s own `slug` (private to that crate, so
+/// duplicated rather than shared — the same reasoning `diff_hunk_rows` used
+/// to give for its own small duplication before this module's diff rendering
+/// moved to the shared renderer entirely).
+fn slug(prompt: &str) -> String {
+    const MAX_WORDS: usize = 4;
+    const MAX_CHARS: usize = 28;
+    let mut out = String::new();
+    for word in prompt.split_whitespace().take(MAX_WORDS) {
+        let word: String = word
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+            .collect();
+        if word.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('-');
+        }
+        out.push_str(&word.to_lowercase());
+        if out.chars().count() >= MAX_CHARS {
+            break;
+        }
+    }
+    out.chars().take(MAX_CHARS).collect()
+}
+
+/// The object of the verb: the command line for `bash`, the path for a file
+/// tool, the query for a search. Falls back to the first string argument for
+/// a tool this crate has never seen — an MCP tool must render as a useful
+/// one-liner, not as a bare name. Mirrors
+/// `crates/stella-observatory/src/transcript_view.rs::header_object`, the
+/// worked example of a store-backed fold into this model.
+fn header_object(tool: &ToolKind, input: &serde_json::Value) -> String {
+    let key = match tool {
+        ToolKind::Bash => "command",
+        ToolKind::ReadFile | ToolKind::WriteFile | ToolKind::EditFile | ToolKind::DeleteFile => {
+            "path"
+        }
+        ToolKind::Search => "query",
+        ToolKind::Other(_) => "",
+    };
+    if let Some(found) = input.get(key).and_then(serde_json::Value::as_str) {
+        return found.to_string();
+    }
+    input
+        .as_object()
+        .and_then(|map| map.values().find_map(serde_json::Value::as_str))
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Every argument as a display row. Whichever one [`header_object`] already
+/// printed is dropped later by [`Call::extra_args`], so this does not have
+/// to know which key that was.
+fn arg_rows(input: &serde_json::Value) -> Vec<ArgRow> {
+    let Some(map) = input.as_object() else {
+        return Vec::new();
+    };
+    map.iter()
+        .map(|(key, value)| ArgRow {
+            key: key.clone(),
+            value: match value {
+                serde_json::Value::String(text) => text.clone(),
+                other => other.to_string(),
+            },
+        })
+        .collect()
+}
+
+/// The wire tag an event serializes under — the same token the raw stream
+/// carries, so a reader can grep `raw/` for a note they saw on the page.
 fn event_tag(event: &AgentEvent) -> String {
     match serde_json::to_value(event) {
         Ok(serde_json::Value::Object(map)) => map
@@ -621,25 +711,19 @@ fn event_tag(event: &AgentEvent) -> String {
     }
 }
 
-/// A protocol enum's wire token (its `snake_case` serde name), so the page and
-/// the raw dumps beside it use one vocabulary.
-fn wire_token<T: Serialize>(value: &T) -> String {
-    match serde_json::to_value(value) {
-        Ok(serde_json::Value::String(s)) => s,
-        _ => "unknown".to_string(),
-    }
-}
-
-/// Pretty-print tool arguments; fall back to the compact form.
-fn pretty(value: &serde_json::Value) -> String {
-    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+/// An event's whole payload, pretty-printed and capped, one line per
+/// [`Note::detail`] row.
+fn detail_lines<T: Serialize>(value: &T) -> Vec<String> {
+    let json = serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".into());
+    clip(&json).lines().map(str::to_string).collect()
 }
 
 /// Truncate to [`MAX_EMBEDDED_BYTES`], stating the cut.
 ///
-/// Cuts on a character boundary — the byte budget is a size limit, and slicing
-/// a UTF-8 sequence in half would panic on exactly the multi-byte output
-/// (a tree-drawing tool, a non-English file) least likely to appear in a test.
+/// Cuts on a character boundary — the byte budget is a size limit, and
+/// slicing a UTF-8 sequence in half would panic on exactly the multi-byte
+/// output (a tree-drawing tool, a non-English file) least likely to appear
+/// in a test.
 fn clip(text: &str) -> String {
     if text.len() <= MAX_EMBEDDED_BYTES {
         return text.to_string();
@@ -652,261 +736,8 @@ fn clip(text: &str) -> String {
     format!(
         "{}\n… {} bytes truncated — the complete row is in this archive's raw/ dumps",
         &text[..end],
-        comma_usize(dropped)
+        super::comma(dropped as i64)
     )
-}
-
-/// Escape a string for HTML markup. Mirrors [`super::escape_html`]; kept as a
-/// one-line alias so every interpolation in this module reads the same.
-fn escape(raw: &str) -> String {
-    super::escape_html(raw)
-}
-
-/// The ` · agent d:1` suffix a tool row's label carries when a delegate made
-/// the call — empty for the lead's own, which is the ordinary case (#4699).
-/// Escaped here rather than through [`Fold::clean`]: the id is an opaque
-/// handle the engine stamps, not model- or user-authored text, so it needs no
-/// redaction — only the same HTML-escaping every other interpolation gets.
-fn agent_suffix(sub_agent_id: Option<&str>) -> String {
-    match sub_agent_id {
-        Some(id) => format!(" · agent {}", escape(id)),
-        None => String::new(),
-    }
-}
-
-/// One file change's diff as the archive's `.dx` block: both line-number
-/// gutters, a sigil column, a tinted row per change, and — within a modified
-/// line pair — a second, stronger tint over the exact tokens that changed.
-/// The same shape the Observatory draws and the deck draws, because this
-/// archive is read side by side with them as evidence on a pull request.
-///
-/// Word-level highlighting is [`stella_transcript::word::highlight`], the
-/// same LCS-over-tokens pass the transcript surfaces use, reused rather than
-/// re-implemented: two copies of a diff tokenizer drift exactly the way two
-/// copies of a diff renderer did before this module existed. It paints with
-/// this page's own `--ok`/`--bad` tokens, not a new hue — this page's colour
-/// system is closed to categorical hues until #3630 settles that question for
-/// the transcript surfaces generally.
-///
-/// Only the changed lines and their context, never a file listing, and never
-/// more than [`stella_diff::view::VIEW_CAP`] of them: the elided middle is
-/// stated in place as a `⋯ n lines not shown` row. That cap replaces a byte
-/// clip that cut mid-hunk, so a rewritten file no longer contributes 64 KiB
-/// of `+` lines to a file someone is expected to open in a browser.
-///
-/// Diff text that parses to no hunks at all — a headerless pseudo-diff, or
-/// something that is not a diff — falls back to preformatted text rather than
-/// rendering nothing: an unrecognised shape must still be readable.
-fn diff_html(diff: &str) -> String {
-    if diff.trim().is_empty() {
-        return String::new();
-    }
-    let view = stella_diff::view::elide(
-        &stella_diff::parse::hunks(diff),
-        stella_diff::view::VIEW_CAP,
-    );
-    if view.hunks.is_empty() {
-        return format!(r#"<pre class="diff">{}</pre>"#, escape(&clip(diff)));
-    }
-    let fold = format!(
-        r#"<div class="dx-fold">⋯ {} line{} not shown</div>"#,
-        view.hidden,
-        if view.hidden == 1 { "" } else { "s" }
-    );
-    let mut out = String::from(r#"<div class="dx">"#);
-    for (i, hunk) in view.hunks.iter().enumerate() {
-        if view.fold_before == Some(i) {
-            out.push_str(&fold);
-        }
-        let _ = write!(
-            out,
-            r#"<div class="dx-hunk"><div class="dx-at">{}</div>"#,
-            escape(&hunk.header())
-        );
-        // Line numbers are walked from this hunk's own header, which is why
-        // `elide` re-headers a hunk it splits: the tail's gutter has to name
-        // the file's real lines, not restart from the head's.
-        let (mut old_no, mut new_no) = (hunk.old_start, hunk.new_start);
-        diff_hunk_rows(&hunk.lines, &mut old_no, &mut new_no, &mut out);
-        out.push_str("</div>");
-    }
-    if view.fold_before == Some(view.hunks.len()) {
-        out.push_str(&fold);
-    }
-    out.push_str("</div>");
-    out
-}
-
-/// Emit one hunk's rows, pairing each run of removals with the run of
-/// additions that follows it — positional, the `k`th removal against the
-/// `k`th addition — so a modified line gets word-level spans. Mirrors
-/// `stella_transcript::file_diff::render_hunk`'s block-pairing exactly;
-/// duplicated here rather than shared because that function consumes a
-/// `FileChange`'s raw before/after text, and this page already holds a
-/// parsed, elided `stella_diff::Hunk` with no text to rebuild it from.
-fn diff_hunk_rows(
-    lines: &[stella_diff::DiffLine],
-    old_no: &mut usize,
-    new_no: &mut usize,
-    out: &mut String,
-) {
-    let mut i = 0;
-    while i < lines.len() {
-        match lines[i].op {
-            stella_diff::Op::Equal => {
-                diff_row(
-                    " ",
-                    "",
-                    *old_no,
-                    *new_no,
-                    &[stella_transcript::word::Span {
-                        text: lines[i].text.clone(),
-                        changed: false,
-                    }],
-                    out,
-                );
-                *old_no += 1;
-                *new_no += 1;
-                i += 1;
-            }
-            stella_diff::Op::Remove | stella_diff::Op::Add => {
-                let start = i;
-                while i < lines.len() && lines[i].op == stella_diff::Op::Remove {
-                    i += 1;
-                }
-                let removals = &lines[start..i];
-                let add_start = i;
-                while i < lines.len() && lines[i].op == stella_diff::Op::Add {
-                    i += 1;
-                }
-                let additions = &lines[add_start..i];
-                diff_change_block(removals, additions, old_no, new_no, out);
-            }
-        }
-    }
-}
-
-/// One run of removals followed by its run of additions, word-highlighted
-/// where they pair. See [`diff_hunk_rows`] for why this duplicates
-/// `stella_transcript::file_diff::emit_change_block` rather than calling it.
-fn diff_change_block(
-    removals: &[stella_diff::DiffLine],
-    additions: &[stella_diff::DiffLine],
-    old_no: &mut usize,
-    new_no: &mut usize,
-    out: &mut String,
-) {
-    let paired = removals.len().min(additions.len());
-    let mut old_spans = Vec::with_capacity(removals.len());
-    let mut new_spans = Vec::with_capacity(additions.len());
-
-    for k in 0..paired {
-        let (o, n) = stella_transcript::word::highlight(&removals[k].text, &additions[k].text);
-        old_spans.push(o);
-        new_spans.push(n);
-    }
-    for line in &removals[paired..] {
-        old_spans.push(vec![stella_transcript::word::Span {
-            text: line.text.clone(),
-            changed: false,
-        }]);
-    }
-    for line in &additions[paired..] {
-        new_spans.push(vec![stella_transcript::word::Span {
-            text: line.text.clone(),
-            changed: false,
-        }]);
-    }
-
-    for spans in &old_spans {
-        diff_row("−", " rem", *old_no, 0, spans, out);
-        *old_no += 1;
-    }
-    for spans in &new_spans {
-        diff_row("+", " add", 0, *new_no, spans, out);
-        *new_no += 1;
-    }
-}
-
-/// One `.dx-line` row. `old_no`/`new_no` of `0` renders as the empty gutter
-/// cell — the same convention the old flat loop used, now driven by which
-/// side actually has a line number rather than by `line.op` directly.
-fn diff_row(
-    sigil: &str,
-    class: &str,
-    old_no: usize,
-    new_no: usize,
-    spans: &[stella_transcript::word::Span],
-    out: &mut String,
-) {
-    let old_cell = if old_no == 0 {
-        String::new()
-    } else {
-        old_no.to_string()
-    };
-    let new_cell = if new_no == 0 {
-        String::new()
-    } else {
-        new_no.to_string()
-    };
-    let _ = write!(
-        out,
-        r#"<div class="dx-line{class}"><span class="no">{old_cell}</span>"#,
-    );
-    let _ = write!(
-        out,
-        r#"<span class="nn">{new_cell}</span><span class="sg">{sigil}</span>"#,
-    );
-    out.push_str(r#"<span class="tx">"#);
-    for span in spans {
-        if span.changed {
-            let _ = write!(out, r#"<span class="ww">{}</span>"#, escape(&span.text));
-        } else {
-            out.push_str(&escape(&span.text));
-        }
-    }
-    out.push_str("</span></div>");
-}
-
-/// Parse `events.ts` (`YYYY-MM-DD HH:MM:SS`) to Unix seconds.
-///
-/// Positional, on the fixed width SQLite's `CURRENT_TIMESTAMP` writes; the
-/// separator between date and time is not inspected, so an RFC-3339 `T` parses
-/// identically. Anything shorter or non-numeric returns `None` and the caller
-/// holds the previous reading — a wrong elapsed time is worse than a repeated
-/// one, because the whole column is relative.
-fn parse_sql_timestamp(text: &str) -> Option<i64> {
-    if text.len() < 19 {
-        return None;
-    }
-    let num = |from: usize, to: usize| text.get(from..to)?.parse::<i64>().ok();
-    let (year, month, day) = (num(0, 4)?, num(5, 7)?, num(8, 10)?);
-    let (hour, minute, second) = (num(11, 13)?, num(14, 16)?, num(17, 19)?);
-    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
-        return None;
-    }
-    Some(days_from_civil(year, month, day) * 86_400 + hour * 3_600 + minute * 60 + second)
-}
-
-/// Days since 1970-01-01, by Howard Hinnant's `days_from_civil`.
-fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
-    let year = if month <= 2 { year - 1 } else { year };
-    let era = if year >= 0 { year } else { year - 399 } / 400;
-    let yoe = year - era * 400;
-    let mp = (month + 9) % 12;
-    let doy = (153 * mp + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    era * 146_097 + doe - 719_468
-}
-
-/// `1234567` → `1,234,567`.
-fn comma_u64(n: u64) -> String {
-    super::comma(n.min(i64::MAX as u64) as i64)
-}
-
-/// `1234567` → `1,234,567`.
-fn comma_usize(n: usize) -> String {
-    super::comma(n.min(i64::MAX as usize) as i64)
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/export/transcript/tests.rs
+++ b/crates/stella-cli/src/export/transcript/tests.rs
@@ -1,18 +1,27 @@
-//! Tests for [`crate::export::transcript`] — the fold from a session's event
-//! journal to the archive's readable half.
+//! Tests for [`crate::export::transcript`] — the redacting fold from a
+//! session's event journal to a [`stella_transcript::model::Run`], plus the
+//! call into [`stella_transcript::html::render_page`].
 //!
-//! Four of these are witnesses for properties stated in the module doc, and
-//! each is written so that removing the property it guards turns it red rather
-//! than merely reducing coverage — see the comment on each.
+//! Most of these check the **run**, not the rendered HTML. Rendering itself
+//! is `stella-transcript`'s own job, and it owns its own tests for what a
+//! `Run` looks like. This crate still owns what the fold puts *into* the
+//! run: one message per turn, a measured (not invented) elapsed clock, no
+//! event dropped, and no credential anywhere in the tree. Break any of
+//! those and these tests go red no matter how well `html::render_page`
+//! draws the result. A few tests at the bottom check the rendered document
+//! directly, for the properties that only show up once the two are wired
+//! together.
 
 use std::collections::HashMap;
 
-use stella_protocol::{AgentEvent, StageKind, ToolCall, ToolOutput};
+use stella_protocol::{AgentEvent, ToolCall, ToolOutput};
 use stella_store::{SessionEventRecord, SessionJournal};
 
 use super::*;
 
-/// A journal from `(ts, event)` pairs, all in one execution.
+/// A journal from `(ts, event)` pairs, all in one execution. The timestamp is
+/// never read by this fold (module doc, property 2) — it exists only because
+/// [`SessionEventRecord`] carries one.
 fn journal(events: Vec<(&str, AgentEvent)>) -> SessionJournal {
     SessionJournal {
         events: events
@@ -51,53 +60,72 @@ fn delta(s: &str) -> AgentEvent {
     AgentEvent::TextDelta { delta: s.into() }
 }
 
-/// How many times `needle` occurs in `haystack`.
-fn count(haystack: &str, needle: &str) -> usize {
-    haystack.matches(needle).count()
+/// Fold `journal` the same way [`render`] does, stopping short of redaction
+/// and the call into `html::render_page` — the seam these tests assert
+/// against, so a rendering change in `stella-transcript` cannot turn one of
+/// them red.
+fn fold_run(journal: &SessionJournal, prompts: &HashMap<i64, String>, session_id: &str) -> Run {
+    let mut fold = Fold::new(prompts, session_id);
+    for record in &journal.events {
+        fold.push(record);
+    }
+    fold.finish_turn(Status::Ok);
+    fold.run
 }
 
+fn tool_start(call_id: &str, name: &str, input: serde_json::Value) -> AgentEvent {
+    AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: call_id.into(),
+            name: name.into(),
+            input,
+        },
+        sub_agent_id: None,
+        task_id: None,
+    }
+}
+
+fn tool_result(call_id: &str, output: ToolOutput, duration_ms: u64) -> AgentEvent {
+    AgentEvent::ToolResult {
+        call_id: call_id.into(),
+        output,
+        duration_ms,
+        speculated: false,
+        sub_agent_id: None,
+        task_id: None,
+    }
+}
+
+// ── One message, one clock, nothing dropped ─────────────────────────────
+
 #[test]
-fn an_assistant_message_streamed_as_deltas_renders_exactly_once() {
-    // THE witness for module-doc property 3. The engine streams prose as
-    // `text_delta` fragments and then emits one consolidated `text` carrying
-    // the same prose. A fold that coalesces the delta run AND renders the
-    // `text` draws the message twice — and the duplicate reads, to anyone
-    // holding the artifact rather than the stream, as a second paid model
-    // call that never happened.
-    //
-    // Delete the `pending_text.clear()` in the `Text` arm and this goes red
-    // with two `ev say` rows: that line IS the property.
-    let out = render(
+fn a_streamed_message_collapses_to_the_turns_answer_once() {
+    // `AgentEvent::Text`'s own contract says a consumer must REPLACE any
+    // accumulated preview, never append to it. `set_answer` overwrites
+    // `turn.answer` rather than appending, which is what this checks.
+    // Change it to an append and the prose shows up twice.
+    let run = fold_run(
         &at(vec![
             delta("Step 1 done: "),
             delta("the tree is clean."),
             text("Step 1 done: the tree is clean."),
         ]),
         &no_prompts(),
+        "s",
     );
-
-    assert_eq!(out.rendered, 1, "one message is one row:\n{}", out.body);
+    assert_eq!(run.turns.len(), 1);
     assert_eq!(
-        count(&out.body, r#"class="ev say""#),
-        1,
-        "exactly one assistant row:\n{}",
-        out.body
-    );
-    assert_eq!(
-        count(&out.body, "Step 1 done: the tree is clean."),
-        1,
-        "the prose appears once, not twice:\n{}",
-        out.body
+        run.turns[0].answer.as_deref(),
+        Some("Step 1 done: the tree is clean.")
     );
 }
 
 #[test]
-fn a_delta_run_with_no_consolidating_text_is_still_rendered() {
-    // The other half of the same property, and the reason the fix cannot be
-    // "always drop the deltas": a killed or errored turn leaves a delta run
-    // whose `Text` never arrives. Dropping it silently would lose the last
-    // thing the model said — usually the most interesting row in the file.
-    let out = render(
+fn an_unconsolidated_delta_run_still_reaches_the_answer() {
+    // A killed or errored turn leaves a delta run whose `Text` never
+    // arrives. `append_answer` writes straight into `turn.answer` as each
+    // delta lands, so nothing needs an explicit flush to survive this case.
+    let run = fold_run(
         &at(vec![
             delta("I am about to "),
             delta("run the tests"),
@@ -107,22 +135,18 @@ fn a_delta_run_with_no_consolidating_text_is_still_rendered() {
             },
         ]),
         &no_prompts(),
+        "s",
     );
-
-    assert!(
-        out.body.contains("I am about to run the tests"),
-        "an unconsolidated delta run survives:\n{}",
-        out.body
+    assert_eq!(
+        run.turns[0].answer.as_deref(),
+        Some("I am about to run the tests")
     );
-    assert_eq!(count(&out.body, r#"class="ev say""#), 1, "as one row");
+    assert_eq!(run.turns[0].status, Status::Error, "the error flips it");
 }
 
 #[test]
-fn a_reasoning_run_coalesces_into_one_thinking_row() {
-    // `Reasoning` really is a fragment stream with no consolidated sibling, so
-    // unlike prose it always flushes — the opposite handling from the test
-    // above, which is exactly why they are separate buffers.
-    let out = render(
+fn a_reasoning_run_coalesces_into_one_prose_block() {
+    let run = fold_run(
         &at(vec![
             AgentEvent::Reasoning {
                 delta: "The commit is ".into(),
@@ -133,346 +157,17 @@ fn a_reasoning_run_coalesces_into_one_thinking_row() {
             text("Found it."),
         ]),
         &no_prompts(),
+        "s",
     );
-
-    assert_eq!(count(&out.body, r#"class="ev think""#), 1, "{}", out.body);
-    assert!(
-        out.body.contains("The commit is not on master."),
-        "{}",
-        out.body
-    );
+    assert_eq!(run.turns[0].prose.len(), 1, "{:?}", run.turns[0].prose);
+    assert_eq!(run.turns[0].prose[0].text, "The commit is not on master.");
 }
 
 #[test]
-fn a_tool_result_is_named_by_its_call_and_takes_its_verdict_from_the_tag() {
-    // Witness for module-doc property 4, and for the trap recorded in the
-    // tool-event wire notes: `ToolResult` carries NO error field and never
-    // has, so a consumer that looks for one renders every failed call as a
-    // success. The name and arguments live on the `ToolStart` sharing the
-    // `call_id`; the `ToolOutput::Error` tag is the only verdict.
-    let out = render(
-        &at(vec![
-            AgentEvent::ToolStart {
-                call: ToolCall {
-                    call_id: "c1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({"command": "git status"}),
-                },
-                sub_agent_id: None,
-                task_id: None,
-            },
-            AgentEvent::ToolResult {
-                call_id: "c1".into(),
-                output: ToolOutput::error("fatal: not a git repository"),
-                duration_ms: 40,
-                speculated: false,
-                sub_agent_id: None,
-                task_id: None,
-            },
-        ]),
-        &no_prompts(),
-    );
-
-    assert_eq!(
-        out.rendered, 1,
-        "call and result are one row:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains(r#"class="ev tool err""#),
-        "the Error tag flips the row to failed:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains("<b>bash</b>"),
-        "named from its call:\n{}",
-        out.body
-    );
-    // And named ONCE. `rendered == 1` counts rows; this counts headers, which
-    // is what a reader actually sees — a result patched into its call's row but
-    // carrying a second `<b>bash</b>` would satisfy the row count and still
-    // print the tool's name twice per call all the way down the document. That
-    // is the defect the arena's transcript shipped
-    // (`arenabench/ui/lib/transcript-view.ts::mergeToolRows`), and the reason to
-    // pin the property here rather than trust the row count to imply it.
-    assert_eq!(
-        count(&out.body, "<b>bash</b>"),
-        1,
-        "the tool is named once per call:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains("git status"),
-        "arguments come from ToolCall::input:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains("fatal: not a git repository"),
-        "the failure text is shown:\n{}",
-        out.body
-    );
-    assert!(
-        !out.body.contains("no result recorded"),
-        "the pending placeholder was replaced:\n{}",
-        out.body
-    );
-}
-
-/// The witness for #4699: a delegate's call is named apart from the lead's in
-/// the archive, and the lead's own carries no attribution at all.
-#[test]
-fn a_delegates_call_is_named_apart_from_the_leads() {
-    let out = render(
-        &at(vec![
-            AgentEvent::ToolStart {
-                call: ToolCall {
-                    call_id: "lead".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({"command": "git status"}),
-                },
-                sub_agent_id: None,
-                task_id: None,
-            },
-            AgentEvent::ToolResult {
-                call_id: "lead".into(),
-                output: ToolOutput::Ok {
-                    content: "clean".into(),
-                    data: None,
-                },
-                duration_ms: 10,
-                speculated: false,
-                sub_agent_id: None,
-                task_id: None,
-            },
-            AgentEvent::ToolStart {
-                call: ToolCall {
-                    call_id: "child".into(),
-                    name: "search".into(),
-                    input: serde_json::json!({"query": "retry"}),
-                },
-                sub_agent_id: Some("d:1".into()),
-                task_id: None,
-            },
-            AgentEvent::ToolResult {
-                call_id: "child".into(),
-                output: ToolOutput::Ok {
-                    content: "retry.rs".into(),
-                    data: None,
-                },
-                duration_ms: 20,
-                speculated: false,
-                sub_agent_id: Some("d:1".into()),
-                task_id: None,
-            },
-        ]),
-        &no_prompts(),
-    );
-
-    assert!(
-        out.body.contains("<b>search · agent d:1</b>"),
-        "the delegate's own call did not name it:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains("<b>bash</b>"),
-        "the lead's own call must carry no delegate tag:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn a_call_that_never_returned_says_so_rather_than_looking_successful() {
-    // A killed run leaves `tool_start` with no `tool_result`. The row must
-    // read as unfinished; an empty output pane would read as a tool that ran
-    // and printed nothing.
-    let out = render(
-        &at(vec![AgentEvent::ToolStart {
-            call: ToolCall {
-                call_id: "c9".into(),
-                name: "bash".into(),
-                input: serde_json::json!({"command": "sleep 600"}),
-            },
-            sub_agent_id: None,
-            task_id: None,
-        }]),
-        &no_prompts(),
-    );
-
-    assert!(
-        out.body.contains("no result recorded"),
-        "an unreturned call is marked:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn a_credential_in_the_event_stream_never_reaches_the_transcript() {
-    // THE witness for module-doc property 1, and the one with teeth: the
-    // transcript is a THIRD egress sink that #817's `redact_dump` does not
-    // reach, because it is folded from `session_events` rather than from the
-    // dumps. Remove the `clean` call on either the tool arguments or the
-    // prose and this goes red — which is the point, since the archive exists
-    // to be mailed to someone.
-    let secret = "ghp_016C7e4a9b2d3f5081726354ABCDabcd1234";
-    let out = render(
-        &at(vec![
-            AgentEvent::ToolStart {
-                call: ToolCall {
-                    call_id: "c1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({"command": format!("curl -H 'token: {secret}'")}),
-                },
-                sub_agent_id: None,
-                task_id: None,
-            },
-            AgentEvent::ToolResult {
-                call_id: "c1".into(),
-                output: ToolOutput::Ok {
-                    content: format!("echoed {secret}"),
-                    data: None,
-                },
-                duration_ms: 10,
-                speculated: false,
-                sub_agent_id: None,
-                task_id: None,
-            },
-            text(&format!("I used {secret} to authenticate.")),
-        ]),
-        &no_prompts(),
-    );
-
-    assert!(
-        !out.body.contains("ghp_016C7e4a9b2d3f5081726354"),
-        "a credential reached the transcript:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains("[redacted]"),
-        "and it was masked rather than dropped:\n{}",
-        out.body
-    );
-    assert!(out.redacted, "the page reports that masking happened");
-}
-
-#[test]
-fn the_elapsed_column_counts_whole_seconds_and_invents_no_precision() {
-    // Witness for module-doc property 2. `events.ts` takes SQLite's
-    // second-resolution `CURRENT_TIMESTAMP` at every writer, so a tenth of a
-    // second in this column would be a number the renderer made up. The
-    // per-call duration below IS millisecond-precise and is printed as such —
-    // the two must not be confused, which is why both are asserted here.
-    let out = render(
-        &journal(vec![
-            (
-                "2026-08-09 12:00:00",
-                AgentEvent::Stage {
-                    name: StageKind::Triage.into(),
-                    scope: stella_protocol::StageScope::Run,
-                },
-            ),
-            ("2026-08-09 12:00:34", text("thirty-four seconds later")),
-            ("2026-08-09 12:02:14", text("two minutes fourteen")),
-        ]),
-        &no_prompts(),
-    );
-
-    assert!(
-        out.body.contains(r#"<span class="t">    0s</span>"#),
-        "{}",
-        out.body
-    );
-    assert!(
-        out.body.contains(r#"<span class="t">   34s</span>"#),
-        "{}",
-        out.body
-    );
-    assert!(
-        out.body.contains(r#"<span class="t">  134s</span>"#),
-        "{}",
-        out.body
-    );
-    assert!(
-        !out.body.contains(".0s</span>"),
-        "no fabricated decisecond in the elapsed column:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn the_elapsed_clock_crosses_a_day_boundary() {
-    // The reason the column goes through a civil-date conversion at all
-    // rather than subtracting the HH:MM:SS fields: a session running over
-    // midnight would otherwise report a large negative elapsed time.
-    let out = render(
-        &journal(vec![
-            ("2026-08-09 23:59:50", text("before midnight")),
-            ("2026-08-10 00:00:10", text("after midnight")),
-        ]),
-        &no_prompts(),
-    );
-
-    assert!(
-        out.body.contains(r#"<span class="t">   20s</span>"#),
-        "{}",
-        out.body
-    );
-}
-
-#[test]
-fn an_unreadable_timestamp_holds_the_previous_reading() {
-    // A row's position in the stream is authoritative; a jump back to 0s
-    // mid-transcript would read as the start of a second run.
-    let out = render(
-        &journal(vec![
-            ("2026-08-09 12:00:00", text("first")),
-            ("2026-08-09 12:00:12", text("twelve")),
-            ("", text("no timestamp")),
-        ]),
-        &no_prompts(),
-    );
-
-    assert_eq!(
-        count(&out.body, r#"<span class="t">   12s</span>"#),
-        2,
-        "the unreadable row holds 12s rather than resetting:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn each_turn_opens_with_the_prompt_that_started_it() {
-    // The prompt is a column on `executions`, not an event, so it reaches the
-    // transcript from the (already redacted) dump. A transcript that opened
-    // with the model's answer would be missing the question.
-    let mut prompts = HashMap::new();
-    prompts.insert(1, "find my lost commit".to_string());
-    prompts.insert(2, "now merge it to master".to_string());
-
-    let mut events = at(vec![text("looking")]).events;
-    events.push(SessionEventRecord {
-        execution_id: 2,
-        seq: 0,
-        ts: "2026-08-09 12:00:05".into(),
-        event: text("merging"),
-    });
-    let out = render(&SessionJournal { events, skipped: 0 }, &prompts);
-
-    assert!(out.body.contains("find my lost commit"), "{}", out.body);
-    assert!(out.body.contains("now merge it to master"), "{}", out.body);
-    assert_eq!(
-        count(&out.body, r#"class="ev user""#),
-        2,
-        "one prompt row per turn, not per event:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn every_event_kind_renders_rather_than_being_silently_dropped() {
-    // A transcript that quietly skipped the variants it has no bespoke arm
-    // for would be a summary claiming to be a replay — and the reader could
-    // not tell. The catch-all renders the wire tag plus the whole payload.
-    let out = render(
+fn every_event_kind_becomes_a_note_rather_than_being_silently_dropped() {
+    // The catch-all this fold's completeness rests on: an event kind with no
+    // backbone arm still carries its wire tag and its whole payload.
+    let run = fold_run(
         &at(vec![
             AgentEvent::ProviderFallback {
                 from: "anthropic".into(),
@@ -485,267 +180,359 @@ fn every_event_kind_renders_rather_than_being_silently_dropped() {
             },
         ]),
         &no_prompts(),
+        "s",
     );
-
-    assert_eq!(out.rendered, 2, "both rendered:\n{}", out.body);
-    assert!(
-        out.body.contains("provider_fallback"),
-        "the wire tag is shown, so a reader can grep raw/ for it:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains("529 overloaded"),
-        "and the whole payload with it:\n{}",
-        out.body
-    );
-    assert!(out.body.contains("fix: the thing"), "{}", out.body);
-}
-
-#[test]
-fn an_oversized_payload_is_cut_and_says_that_it_was() {
-    // Truncation is fine; silent truncation is not. An elided transcript that
-    // looks complete is worse evidence than a short one that states the cut.
-    let huge = "x".repeat(MAX_EMBEDDED_BYTES + 5_000);
-    let out = render(
-        &at(vec![
-            AgentEvent::ToolStart {
-                call: ToolCall {
-                    call_id: "c1".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({"command": "cat build.log"}),
-                },
-                sub_agent_id: None,
-                task_id: None,
-            },
-            AgentEvent::ToolResult {
-                call_id: "c1".into(),
-                output: ToolOutput::Ok {
-                    content: huge,
-                    data: None,
-                },
-                duration_ms: 10,
-                speculated: false,
-                sub_agent_id: None,
-                task_id: None,
-            },
-        ]),
-        &no_prompts(),
-    );
-
-    assert!(
-        out.body.contains("bytes truncated"),
-        "the cut is stated:\n{}",
-        &out.body[..out.body.len().min(400)]
-    );
-}
-
-#[test]
-fn truncation_never_splits_a_utf8_character() {
-    // The byte budget is a size limit, and slicing a multi-byte sequence in
-    // half panics — on exactly the output (a tree-drawing tool, a non-English
-    // file) that a fixture of ASCII would never produce.
-    let multibyte = "é".repeat(MAX_EMBEDDED_BYTES);
-    let clipped = clip(&multibyte);
-    assert!(clipped.contains("bytes truncated"));
-    assert!(clipped.chars().count() > 0);
-}
-
-#[test]
-fn markup_in_the_event_stream_cannot_escape_its_row() {
-    // Every string here is chosen by a model, an MCP server or a repository.
-    // The page has a `default-src 'none'` CSP, but escaping at the sink is
-    // what keeps the row structure intact rather than relying on it.
-    let out = render(
-        &at(vec![text("</pre><img src=x onerror=alert(1)>")]),
-        &no_prompts(),
-    );
-
-    assert!(
-        !out.body.contains("<img"),
-        "markup neutralized:\n{}",
-        out.body
+    let notes = &run.turns[0].notes;
+    assert_eq!(notes.len(), 2, "both became notes: {notes:?}");
+    assert_eq!(
+        notes[0].summary, "provider_fallback",
+        "the wire tag is shown"
     );
     assert!(
-        out.body.contains("&lt;img"),
-        "and shown as text:\n{}",
-        out.body
+        notes[0].detail.iter().any(|l| l.contains("529 overloaded")),
+        "and the whole payload with it: {:?}",
+        notes[0].detail
     );
+    assert_eq!(notes[1].summary, "commit");
+    assert!(notes[1].detail.iter().any(|l| l.contains("fix: the thing")));
 }
 
 #[test]
 fn an_unreplayable_event_is_counted_rather_than_hidden() {
     // `SessionJournal::skipped` is the store's count of rows that no longer
-    // parse as an `AgentEvent` (a stream recorded before a variant existed).
-    // A reader must be able to tell a quiet session from a lossy read.
+    // parse as an `AgentEvent`. A reader must be able to tell a quiet
+    // session from a lossy read.
     let out = render(
         &SessionJournal {
             events: Vec::new(),
             skipped: 3,
         },
         &no_prompts(),
+        "s",
     );
-
     assert_eq!(out.unparseable, 3);
     assert!(
         out.provenance().contains("older build"),
-        "stated on the page: {}",
+        "{}",
         out.provenance()
+    );
+}
+
+// ── Tool calls ────────────────────────────────────────────────────────────
+
+#[test]
+fn a_tool_result_is_named_by_its_call_and_takes_its_verdict_from_the_tag() {
+    // `ToolResult` carries no `error` field and never has — the `ToolOutput`
+    // tag is the only verdict, and the name/arguments live on the matching
+    // `ToolStart`.
+    let run = fold_run(
+        &at(vec![
+            tool_start("c1", "bash", serde_json::json!({"command": "git status"})),
+            tool_result("c1", ToolOutput::error("fatal: not a git repository"), 40),
+        ]),
+        &no_prompts(),
+        "s",
+    );
+    let steps = &run.turns[0].steps;
+    assert_eq!(steps.len(), 1, "call and result are one step");
+    let call = steps[0].call.as_ref().expect("the step carries its call");
+    assert_eq!(call.tool, ToolKind::Bash);
+    assert_eq!(
+        call.status,
+        Status::Error,
+        "the Error tag flips the call to failed"
+    );
+    assert_eq!(call.header_object, "git status");
+    assert!(
+        call.output
+            .lines
+            .iter()
+            .any(|l| l.contains("fatal: not a git repository")),
+        "{:?}",
+        call.output.lines
+    );
+}
+
+#[test]
+fn a_delegates_call_is_named_apart_from_the_leads() {
+    // The witness for #4699: a delegate's call carries `sub_agent_id`; the
+    // lead's own carries none.
+    let child_start = AgentEvent::ToolStart {
+        call: ToolCall {
+            call_id: "child".into(),
+            name: "search".into(),
+            input: serde_json::json!({"query": "retry"}),
+        },
+        sub_agent_id: Some("d:1".into()),
+        task_id: None,
+    };
+    let child_result = AgentEvent::ToolResult {
+        call_id: "child".into(),
+        output: ToolOutput::ok("retry.rs"),
+        duration_ms: 20,
+        speculated: false,
+        sub_agent_id: Some("d:1".into()),
+        task_id: None,
+    };
+    let run = fold_run(
+        &at(vec![
+            tool_start("lead", "bash", serde_json::json!({"command": "git status"})),
+            tool_result("lead", ToolOutput::ok("clean"), 10),
+            child_start,
+            child_result,
+        ]),
+        &no_prompts(),
+        "s",
+    );
+    let steps = &run.turns[0].steps;
+    assert_eq!(steps[0].call.as_ref().unwrap().sub_agent_id, None);
+    assert_eq!(
+        steps[1].call.as_ref().unwrap().sub_agent_id.as_deref(),
+        Some("d:1")
+    );
+}
+
+#[test]
+fn a_call_that_never_returned_stays_running_rather_than_looking_successful() {
+    // A killed run leaves `tool_start` with no `tool_result`. The step must
+    // read as unfinished — an empty, `Ok`-status output would read as a tool
+    // that ran and printed nothing.
+    let run = fold_run(
+        &at(vec![tool_start(
+            "c9",
+            "bash",
+            serde_json::json!({"command": "sleep 600"}),
+        )]),
+        &no_prompts(),
+        "s",
+    );
+    let call = run.turns[0].steps[0].call.as_ref().unwrap();
+    assert_eq!(call.status, Status::Running);
+}
+
+#[test]
+fn a_result_whose_call_was_never_recorded_still_renders() {
+    // This journal never saw the matching `tool_start` — a `?after_seq` page,
+    // or a store whose early rows were pruned. The completeness contract
+    // this fold exists to hold forbids treating the correlation miss as a
+    // reason to drop the result.
+    let run = fold_run(
+        &at(vec![tool_result("ghost", ToolOutput::ok("survived"), 5)]),
+        &no_prompts(),
+        "s",
+    );
+    let steps = &run.turns[0].steps;
+    assert_eq!(steps.len(), 1, "the orphan result still becomes a step");
+    let call = steps[0].call.as_ref().unwrap();
+    assert!(call.output.lines.iter().any(|l| l == "survived"));
+}
+
+#[test]
+fn an_oversized_tool_output_is_clipped_and_says_so() {
+    let huge = "x".repeat(MAX_EMBEDDED_BYTES + 5_000);
+    let run = fold_run(
+        &at(vec![
+            tool_start(
+                "c1",
+                "bash",
+                serde_json::json!({"command": "cat build.log"}),
+            ),
+            tool_result("c1", ToolOutput::ok(huge), 10),
+        ]),
+        &no_prompts(),
+        "s",
+    );
+    let call = run.turns[0].steps[0].call.as_ref().unwrap();
+    let joined = call.output.lines.join("\n");
+    assert!(joined.contains("bytes truncated"), "{joined}");
+    assert!(
+        joined.len() < MAX_EMBEDDED_BYTES + 200,
+        "the output was actually cut, not just labelled"
     );
 }
 
 // ── File diffs ──────────────────────────────────────────────────────────
 
-/// A `FileChange` carrying a unified diff of `adds` single-line additions.
-fn a_rewrite(adds: usize) -> AgentEvent {
-    let body: String = (1..=adds).map(|i| format!("+line {i}\n")).collect();
-    AgentEvent::FileChange {
-        path: "src/big.rs".into(),
-        kind: stella_protocol::FileChangeKind::Modified,
-        added: adds as u32,
-        removed: 0,
-        diff: Some(format!(
-            "--- a/src/big.rs\n+++ b/src/big.rs\n@@ -0,0 +1,{adds} @@\n{body}"
-        )),
-        minimal: true,
-        task_id: None,
-    }
-}
-
 #[test]
-fn a_file_diff_renders_as_a_gutter_diff_rather_than_a_wall_of_text() {
-    // The archive is attached to a pull request as evidence and read beside
-    // the Observatory. This row used to be a `<pre>` of raw diff text — no
-    // line numbers, no row tint, nothing a reviewer could scan — so the same
-    // edit read two different ways in two artifacts of one run.
-    let out = render(&at(vec![a_rewrite(4)]), &no_prompts());
-    assert!(out.body.contains(r#"<div class="dx">"#), "{}", out.body);
-    assert!(
-        out.body.contains(r#"<span class="nn">1</span>"#),
-        "the new-side gutter numbers the added lines:\n{}",
-        out.body
-    );
-    assert!(
-        count(&out.body, r#"class="dx-line add"#) == 4,
-        "one tinted row per addition:\n{}",
-        out.body
-    );
-    assert!(
-        !out.body.contains(r#"<pre class="diff">"#),
-        "the raw-text fallback is for unparseable diffs only:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn a_modified_line_pair_highlights_only_the_changed_token() {
-    // A whole-line tint answers "did this line change"; a reviewer's real
-    // question is "what in it changed". Reuses
-    // `stella_transcript::word::highlight` — the same pass the transcript
-    // surfaces use — rather than a second tokenizer that could drift from it.
-    let event = AgentEvent::FileChange {
-        path: "app/main.tex".into(),
-        kind: stella_protocol::FileChangeKind::Modified,
-        added: 1,
-        removed: 1,
-        diff: Some(
-            "--- a/app/main.tex\n+++ b/app/main.tex\n\
-             @@ -1,1 +1,1 @@\n\
-             -\\setlength{\\parindent}{15pt}\n\
-             +\\setlength{\\parindent}{12pt}\n"
-                .to_string(),
-        ),
-        minimal: true,
-        task_id: None,
-    };
-    let out = render(&at(vec![event]), &no_prompts());
-    assert!(
-        out.body.contains(r#"<span class="ww">15pt</span>"#),
-        "the removed token should carry the word tint:\n{}",
-        out.body
-    );
-    assert!(
-        out.body.contains(r#"<span class="ww">12pt</span>"#),
-        "the added token should carry the word tint:\n{}",
-        out.body
-    );
-    assert!(
-        !out.body
-            .contains(r#"<span class="ww">\setlength{\parindent}{</span>"#),
-        "the unchanged prefix must not be tinted:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn an_unpaired_addition_carries_no_word_tint() {
-    // `a_rewrite` below is additions with no matching removals — there is
-    // nothing to compare each line against, so the honest answer is a plain
-    // line tint and zero word spans.
-    let out = render(&at(vec![a_rewrite(4)]), &no_prompts());
-    assert!(
-        !out.body.contains(r#"class="ww""#),
-        "an unpaired line has nothing to diff against:\n{}",
-        out.body
-    );
-}
-
-#[test]
-fn a_long_file_diff_shows_its_beginning_and_its_end_and_marks_the_middle() {
-    // Only the changed lines, never the whole file, and never more of them
-    // than the shared cap — with the elision stated where it happened. A
-    // rewrite used to contribute up to 64 KiB of `+` lines to a file someone
-    // opens in a browser, cut at a byte boundary that could land mid-hunk.
-    let adds = stella_diff::view::VIEW_CAP * 3;
-    let out = render(&at(vec![a_rewrite(adds)]), &no_prompts());
-    // The sigil lives in its own gutter column, so the text cell is the bare
-    // line — which is exactly what makes the rendering copy-pasteable.
-    assert!(
-        out.body.contains(r#"<span class="tx">line 1</span>"#),
-        "the change's first line survives"
-    );
-    assert!(
-        out.body
-            .contains(&format!(r#"<span class="tx">line {adds}</span>"#)),
-        "and so does its last — the point of showing both ends"
-    );
-    assert!(
-        out.body.contains(r#"class="dx-fold""#) && out.body.contains("not shown"),
-        "with the elision stated rather than silent"
-    );
-    let drawn = count(&out.body, r#"class="dx-line"#);
-    assert!(
-        drawn <= stella_diff::view::VIEW_CAP,
-        "{drawn} rows drawn against a cap of {}",
-        stella_diff::view::VIEW_CAP
-    );
-    // The gutter on the far side of the elision names the file's real lines.
-    assert!(
-        out.body
-            .contains(&format!(r#"<span class="nn">{adds}</span>"#)),
-        "the tail's line numbers are not restarted from 1"
-    );
-}
-
-#[test]
-fn a_diff_that_parses_to_no_hunks_still_renders_as_readable_text() {
-    // A headerless pseudo-diff carries no coordinates, so it has no hunks to
-    // draw. Rendering nothing at all would be the worst outcome: the row
-    // would claim a file changed and then show nothing of the change.
-    let out = render(
-        &at(vec![AgentEvent::FileChange {
-            path: "notes.txt".into(),
-            kind: stella_protocol::FileChangeKind::Modified,
-            added: 1,
-            removed: 0,
-            diff: Some("+just a bare line".into()),
-            minimal: true,
-            task_id: None,
-        }]),
+fn a_file_change_attaches_to_the_call_that_produced_it() {
+    let run = fold_run(
+        &at(vec![
+            tool_start("c1", "edit_file", serde_json::json!({"path": "src/big.rs"})),
+            tool_result("c1", ToolOutput::ok("ok"), 5),
+            AgentEvent::FileChange {
+                path: "src/big.rs".into(),
+                kind: stella_protocol::FileChangeKind::Modified,
+                added: 3,
+                removed: 1,
+                diff: Some(
+                    "--- a/src/big.rs\n+++ b/src/big.rs\n@@ -1,1 +1,3 @@\n-old\n+new1\n+new2\n+new3\n"
+                        .into(),
+                ),
+                minimal: true,
+                task_id: None,
+            },
+        ]),
         &no_prompts(),
+        "s",
+    );
+    let call = run.turns[0].steps[0].call.as_ref().unwrap();
+    assert_eq!(call.files.len(), 1);
+    assert_eq!(call.files[0].extent.added, Some(3));
+    assert_eq!(call.files[0].extent.removed, Some(1));
+    assert!(
+        call.files[0]
+            .patch
+            .as_ref()
+            .expect("a diff was supplied")
+            .text
+            .contains("+new1")
+    );
+}
+
+// ── Elapsed clock ─────────────────────────────────────────────────────────
+
+#[test]
+fn step_offsets_sum_from_measured_durations_not_from_the_journal_clock() {
+    // Module-doc property 2, made structural: this fold never reads
+    // `events.ts`, so every event in this journal shares one timestamp and
+    // the offsets below can only have come from `duration_ms`.
+    let run = fold_run(
+        &at(vec![
+            tool_start("a", "bash", serde_json::json!({"command": "one"})),
+            tool_result("a", ToolOutput::ok(""), 1500),
+            tool_start("b", "bash", serde_json::json!({"command": "two"})),
+            tool_result("b", ToolOutput::ok(""), 2500),
+        ]),
+        &no_prompts(),
+        "s",
+    );
+    let steps = &run.turns[0].steps;
+    assert_eq!(steps[0].offset_ms, 0);
+    assert_eq!(steps[1].offset_ms, 1500);
+    assert_eq!(run.turns[0].duration_ms, 4000);
+}
+
+// ── Turns ───────────────────────────────────────────────────────────────
+
+#[test]
+fn each_turn_opens_with_the_prompt_that_started_it() {
+    let mut prompts = HashMap::new();
+    prompts.insert(1, "find my lost commit".to_string());
+    prompts.insert(2, "now merge it to master".to_string());
+
+    let mut events = at(vec![text("looking")]).events;
+    events.push(SessionEventRecord {
+        execution_id: 2,
+        seq: 0,
+        ts: "2026-08-09 12:00:05".into(),
+        event: text("merging"),
+    });
+    let run = fold_run(&SessionJournal { events, skipped: 0 }, &prompts, "s");
+
+    assert_eq!(run.turns.len(), 2);
+    assert_eq!(run.turns[0].prompt, "find my lost commit");
+    assert_eq!(run.turns[1].prompt, "now merge it to master");
+}
+
+#[test]
+fn the_row_budget_caps_steps_and_notes_and_reports_the_overflow() {
+    let events: Vec<AgentEvent> = (0..MAX_ROWS + 5)
+        .map(|i| AgentEvent::Commit {
+            sha: format!("sha{i}"),
+            message: format!("m{i}"),
+        })
+        .collect();
+    let out = render(&at(events), &no_prompts(), "s");
+    assert_eq!(out.rendered, MAX_ROWS);
+    assert_eq!(out.overflow, 5);
+}
+
+// ── Redaction ──────────────────────────────────────────────────────────
+
+#[test]
+fn a_credential_anywhere_in_the_run_is_masked_by_the_whole_tree_pass() {
+    // THE witness for module-doc property 1: `redact_run` serializes the
+    // whole built run and redacts every string in it, so a credential in the
+    // prompt, a tool argument, a tool result, and the answer are all caught
+    // by the same pass rather than by four separate call sites.
+    let secret = "ghp_016C7e4a9b2d3f5081726354ABCDabcd1234";
+    let mut prompts = HashMap::new();
+    prompts.insert(1, format!("use {secret} to auth"));
+
+    let mut run = fold_run(
+        &at(vec![
+            tool_start(
+                "c1",
+                "bash",
+                serde_json::json!({"command": format!("curl -H 'token: {secret}'")}),
+            ),
+            tool_result("c1", ToolOutput::ok(format!("echoed {secret}")), 10),
+            text(&format!("I used {secret} to authenticate.")),
+        ]),
+        &prompts,
+        "s",
+    );
+
+    let redacted = redact_run(&mut run);
+    assert!(redacted, "the pass reports that masking happened");
+    let json = serde_json::to_string(&run).unwrap();
+    assert!(!json.contains(secret), "a credential survived redaction");
+    assert!(json.contains("[redacted]"), "masked, not dropped");
+}
+
+#[test]
+fn a_run_with_no_credential_reports_no_redaction() {
+    let mut run = fold_run(
+        &at(vec![text("nothing sensitive here")]),
+        &no_prompts(),
+        "s",
+    );
+    assert!(!redact_run(&mut run));
+}
+
+// ── End to end: the rendered document ────────────────────────────────────
+
+#[test]
+fn the_rendered_document_needs_no_script_to_read() {
+    let out = render(&SessionJournal::default(), &no_prompts(), "s");
+    assert!(
+        !out.html.contains("<script"),
+        "the transcript is pure markup and CSS:\n{}",
+        out.html
+    );
+    assert!(out.html.starts_with("<!DOCTYPE html>"));
+}
+
+#[test]
+fn a_credential_never_reaches_the_rendered_document() {
+    let secret = "ghp_016C7e4a9b2d3f5081726354ABCDabcd1234";
+    let out = render(
+        &at(vec![text(&format!("I used {secret} to authenticate."))]),
+        &no_prompts(),
+        "s",
     );
     assert!(
-        out.body.contains("just a bare line"),
-        "the change is still shown:\n{}",
-        out.body
+        !out.html.contains(secret),
+        "a credential reached the rendered document"
+    );
+    assert!(out.html.contains("[redacted]"));
+    assert!(out.redacted);
+}
+
+#[test]
+fn markup_in_the_event_stream_cannot_escape_its_row() {
+    // Every string here is chosen by a model, an MCP server or a repository.
+    // `stella_transcript::html::escape` is what neutralizes it; this checks
+    // the fold actually hands the text to the renderer rather than
+    // pre-formatting it into markup of its own.
+    let out = render(
+        &at(vec![text("</pre><img src=x onerror=alert(1)>")]),
+        &no_prompts(),
+        "s",
+    );
+    assert!(
+        !out.html.contains("<img"),
+        "markup neutralized:\n{}",
+        out.html
     );
 }

--- a/scripts/check-transcript-surfaces.py
+++ b/scripts/check-transcript-surfaces.py
@@ -152,11 +152,13 @@ SURFACES: list[Surface] = [
         ident="export-html",
         path="crates/stella-cli/src/export/transcript.rs",
         entry=HTML,
-        shared=False,
-        issue=4270,
+        shared=True,
+        issue=None,
         note="The `/export` archive's readable half. Folds "
-        "`Store::session_events` itself and emits its own HTML; carries the "
-        "#817 redaction pass the shared renderer cannot host.",
+        "`Store::session_events` into a `stella_transcript::model::Run`, "
+        "redacts the whole tree (the #817 pass the shared renderer cannot "
+        "host itself), and renders it via `html::render_page` into its own "
+        "`transcript.html` archive member.",
     ),
 ]
 

--- a/website/content/docs/telemetry/dashboard.mdx
+++ b/website/content/docs/telemetry/dashboard.mdx
@@ -189,7 +189,11 @@ matching `<timestamp>/` folder:
   model, token usage, tool usage, files touched, and run outcomes. Open it
   offline, email it, or attach it to a PR as a receipt for what an agent
   run did and cost. Its totals cover only the exported session, and it
-  names that session and what was left out at the top of the page
+  names that session and what was left out at the top of the page. It
+  links to `transcript.html` rather than embedding it
+- `<timestamp>/transcript.html`: the session **replayed** — every prompt,
+  model message, tool call, and file diff, in order. A second
+  self-contained page, drawn by the same renderer `stella observe` uses
 - `<timestamp>/manifest.json`: the watermark (as `exported_at`), the
   exported `session` id, row counts per table, and an `excluded` count of
   what was left out

--- a/website/content/docs/telemetry/index.mdx
+++ b/website/content/docs/telemetry/index.mdx
@@ -458,7 +458,7 @@ locally.
   and file leaderboards, memory, MCP traffic, and the fleet log.
 - **[`stella stats`](/docs/commands/stats)**: the same per-provider and
   per-model numbers, right in the terminal, as a table, JSON, or CSV.
-- **`/export`** (in the Command Deck): a portable ZIP with raw JSON dumps
-  and a self-contained `dashboard.html` report, scoped to the session
-  you're in so it's safe to share. See
-  [the dashboard page](/docs/telemetry/dashboard).
+- **`/export`** (in the Command Deck): a portable ZIP, scoped to the
+  session you're in so it's safe to share. Holds raw JSON dumps, a
+  self-contained `dashboard.html` report, and a `transcript.html` replay
+  of the session. See [the dashboard page](/docs/telemetry/dashboard).


### PR DESCRIPTION
## What & why

`crates/stella-cli/src/export/transcript.rs` folded a session's event
journal into its own hand-written HTML rows. `stella_transcript::html::render_page`
had exactly one production caller (the Observatory), so the same session
rendered by `stella export` and `stella observe` produced two different
documents.

This PR routes the archive's transcript through the shared renderer:
`export/transcript.rs` now folds `Store::session_events` into a
`stella_transcript::model::Run` and calls `html::render_page` — the same
call the Observatory already makes.

## Design

The issue's own investigation comment named three routes for a CSS/geometry
collision the migration runs into and left the choice to whoever picked it
up. Full reasoning is in [the issue thread](https://github.com/macanderson/stella/issues/4270#issuecomment-5551750031)
— short version: the transcript now ships as its own `transcript.html`
archive member rather than an embedded fragment, because the dashboard's
stylesheet and the shared renderer's define six class names differently
with neither namespaced. Two self-contained documents cannot cross-talk;
one merged page could. `dashboard.html` links to it instead.

Three properties the old fold carried survive the move:

- **Redaction** is now one whole-tree pass in `redact_run`: serialize the
  built `Run` to JSON, mask every string, deserialize back. Every
  `stella_transcript::model` type round-trips through `serde_json` byte for
  byte (AGENTS.md invariant #4), so this can't miss a field the way the old
  fold's per-call-site `clean()` calls could.
- **The elapsed clock** is summed from real per-call `duration_ms` on
  `ToolResult`/`StepUsage`, the same way
  `stella_tui::transcript_build::RunBuilder` already does for the live
  surface. `events.ts` (second-resolution) is never read.
- **Nothing is dropped.** Every event kind the shared model has no slot for
  becomes a `Note` carrying its wire tag and full JSON payload — including
  several kinds (`SpeculationDiscarded`, `BlockRegistered`, `StepManifest`,
  `CandidateDelivery`, the typed decision events) the old fold's own
  `RunBuilder`-style narration path would have silently dropped.

## Tests

`crates/stella-cli/src/export/transcript/tests.rs` is a fresh suite that
mostly asserts on the folded `Run` directly rather than on rendered HTML —
`stella-transcript` owns its own tests for what a `Run` renders as, and this
crate owns what the fold puts *into* the run. Covers: one message per turn
(the `TextDelta`+`Text` collapse), an unconsolidated delta run surviving, a
reasoning run coalescing to one prose block, every event kind becoming a
note, tool-result correlation (including an orphaned result with no
recorded `ToolStart`), a call that never returned staying `Running`, file
diffs attaching to the call that produced them, measured (not invented)
step offsets, per-execution turn prompts, the row budget's overflow
counter, and the whole-tree redaction pass. A handful of end-to-end tests
at the bottom check the rendered document directly (no `<script>` tag, a
credential never reaching the HTML, markup escaped).

`export/tests.rs`'s row-grammar witness
(`the_archive_carries_the_session_transcript_and_only_that_session`) is
re-pointed from the old `class="ev tool"` marker to the shared renderer's
`<details class="step">` — same property (the exported session's tool call
is present, another session's is not), checked against the new markup.

**Tests deleted.** Every one named below, as `check-deleted-tests` asks. This
PR rewrites `crates/stella-cli/src/export/transcript/tests.rs` wholesale,
because the hand-written HTML fold those tests pinned is exactly what is being
retired. Grouped by what happened to the property each covered.

*Renamed — same property, asserted against the new shape:*

- `a_call_that_never_returned_says_so_rather_than_looking_successful` →
  `a_call_that_never_returned_stays_running_rather_than_looking_successful`
- `a_credential_in_the_event_stream_never_reaches_the_transcript` →
  `a_credential_never_reaches_the_rendered_document`, plus
  `a_credential_anywhere_in_the_run_is_masked_by_the_whole_tree_pass` — the
  whole-tree pass is strictly wider than the old per-call-site `clean()`
- `a_delta_run_with_no_consolidating_text_is_still_rendered` →
  `an_unconsolidated_delta_run_still_reaches_the_answer`
- `an_assistant_message_streamed_as_deltas_renders_exactly_once` →
  `a_streamed_message_collapses_to_the_turns_answer_once`
- `a_reasoning_run_coalesces_into_one_thinking_row` →
  `a_reasoning_run_coalesces_into_one_prose_block`
- `an_oversized_payload_is_cut_and_says_that_it_was` →
  `an_oversized_tool_output_is_clipped_and_says_so`
- `every_event_kind_renders_rather_than_being_silently_dropped` →
  `every_event_kind_becomes_a_note_rather_than_being_silently_dropped`
- `the_transcript_is_readable_with_scripts_disabled` →
  `the_rendered_document_needs_no_script_to_read`, plus
  `the_dashboard_links_to_the_transcript_document` in `export/tests.rs`. Its
  tab/panel markup no longer exists — the transcript is a separate document
  now, not a script-gated panel — so the same "no script needed" property is
  checked against the new shape.

*Dropped because the code they covered is `stella-transcript`'s, and that
crate tests it directly.* This crate now owns what the fold puts **into** a
`Run`; what a `Run` renders as is the shared renderer's own suite:

- `a_modified_line_pair_highlights_only_the_changed_token` →
  `acceptance_word_diff_highlights_only_the_changed_token`
- `an_unpaired_addition_carries_no_word_tint` →
  `a_wholly_rewritten_line_drops_word_highlights_as_noise` and
  `a_long_line_under_the_cap_still_gets_word_highlights`, plus the dedicated
  `crates/stella-transcript/tests/word_highlight_matrix.rs`
- `a_file_diff_renders_as_a_gutter_diff_rather_than_a_wall_of_text` and
  `a_diff_that_parses_to_no_hunks_still_renders_as_readable_text` →
  `a_new_file_renders_as_an_all_green_diff`,
  `a_deleted_file_renders_as_an_all_red_diff` and
  `the_exported_gutter_is_not_lexed_as_source`
- `a_long_file_diff_shows_its_beginning_and_its_end_and_marks_the_middle` →
  `a_long_output_folds_head_and_tail_so_errors_at_the_end_stay_visible`
  (`FileDiff::is_large`, which both `html.rs` and `grid.rs` consult)
- `truncation_never_splits_a_utf8_character` → the shared renderer cuts on
  `char_indices`/`len_utf8` (`digest.rs`, `grid.rs`), with
  `a_digest_is_a_summary_not_truncated_content` pinning the policy

*Dropped because the behaviour is gone rather than moved.* The fold no longer
reads `events.ts` at all — elapsed is summed from measured `duration_ms`, per
the "elapsed clock" note above — so there is no journal clock left to test:

- `the_elapsed_clock_crosses_a_day_boundary`
- `the_elapsed_column_counts_whole_seconds_and_invents_no_precision`
- `an_unreadable_timestamp_holds_the_previous_reading`

What replaces all three is
`step_offsets_sum_from_measured_durations_not_from_the_journal_clock`.

## `make transcript-surfaces`

`scripts/check-transcript-surfaces.py`'s `export-html` row flips from `OWN`
(#4270) to `SHARED`, with no issue citation — the ledger's own contract for
a closed gap.

```
transcript-surfaces: 3 shared, 2 declared gaps, 0 foreign port(s) — ledger matches the tree.
    gap: deck-body -> #3578 (crates/stella-tui/src/render/entry.rs)
    gap: deck-spec6 -> #4289 (crates/stella-tui/src/views/transcript.rs)
```

## Definition of done

- [x] `stella_transcript::html::render_page` has two production callers.
- [x] `crates/stella-cli/src/export/transcript.rs` is reduced to the
      redacting fold plus the call.
- [x] `make transcript-surfaces` shows the `export-html` row as `Shared`
      with no issue citation.

## Residue

Filed a follow-up for a gap the issue's own investigation didn't surface:
`stella_transcript::html::render_page` emits no CSP meta tag, so the
standalone `transcript.html` carries none of the page-level backstop the
old embedded-fragment dashboard had (`default-src 'none'; …`). The new
document has no `<script>` tag at all, so there's no inline-script surface,
but it's still a real reduction in defense-in-depth worth closing
separately from this wiring change. Filed as #6009.

Closes #4270

## Summary by Sourcery

Use the shared transcript renderer for exported sessions and ship the replay as a standalone, redacted transcript document alongside the metrics dashboard.

New Features:
- Route exported session transcripts through the shared stella-transcript renderer used by the Observatory.
- Add a standalone, self-contained transcript.html document to export archives and link to it from the metrics dashboard.
- Preserve complete event coverage by representing unsupported event types as detailed transcript notes.

Bug Fixes:
- Prevent transcript redaction gaps by masking credentials across the fully constructed transcript model.
- Use measured tool and model durations for transcript timing instead of deriving elapsed time from journal timestamps.
- Preserve orphaned and unfinished tool calls rather than silently dropping or misrepresenting them.

Enhancements:
- Refactor the export transcript fold to build a shared Run model with prompts, tool calls, file changes, notes, accounting, and overflow reporting.
- Remove the dashboard's embedded transcript panel, duplicate row rendering, transcript-specific styling, and tab behavior.
- Keep transcript rendering and dashboard styling isolated in separate documents to avoid CSS collisions.

Documentation:
- Document the separate transcript.html archive member and its role as a replay rendered with the same component used by stella observe.
- Update telemetry documentation to describe export archives as containing both dashboard and transcript documents.

Tests:
- Replace transcript HTML-fold assertions with direct tests of the constructed Run model and shared-renderer integration.
- Add coverage for event preservation, tool correlation, unfinished calls, file attachments, measured offsets, row limits, redaction, script-free rendering, escaping, and archive linking.

Chores:
- Mark the export HTML surface as shared in the transcript-surfaces ledger and remove its resolved issue gap.

---
_Generated by [Claude Code](https://claude.ai/code)_