### PR TITLE
fix(stella-cli): apply token-drift calibration in fleet workers

### DIFF
--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -1125,9 +1125,8 @@ async fn run_task(
             .attach_turn_controls(stella_core::ports::TurnControls::none().with_gate(gate.clone()));
         let raced: Raced<Result<TurnOutcome, String>> = {
             let hook_runner = HostHookRunner;
-            // Above the operator's policy layer, the position
-            // `skill_grant`'s module docs specify: a grant selects within
-            // the surface a worker already has and can never widen it.
+            // Above the operator's policy layer, per `skill_grant`'s module
+            // docs: a grant selects within existing surface, never widens it.
             let scoped =
                 stella_tools::skill_plane::SkillScopedTools::new(&permitted, skill_plane.clone());
             let mut config = attempt_durability.engine_config(&cfg);
@@ -1135,15 +1134,16 @@ async fn run_task(
                 // The skill's `effort:` override, for this attempt.
                 config.effort = Some(effort);
             }
+            let calibration = agent::seed_calibration(&store, &cfg);
             let mut engine = Engine::with_sleeper(&*provider, &scoped, config, &TokioSleeper)
-                .with_gate(gate.as_ref());
+                .with_gate(gate.as_ref())
+                .with_calibration(&calibration);
             if let Some(hooks) = &cfg.hooks {
                 engine = engine.with_hooks(hooks, &hook_runner);
             }
-            // A fleet worker owns its lane's stage vocabulary; the engine
-            // emits no `Stage` of its own (#3416). The opener is here; the
-            // closer rides `worker_event_sender` below, ahead of the
-            // engine's `TurnComplete` (#3428).
+            // A fleet worker owns its lane's stage vocabulary — the opener is
+            // here; the closer rides `worker_event_sender` below, ahead of
+            // the engine's `TurnComplete` (#3416, #3428).
             let _ = tx.send(AgentEvent::Stage {
                 name: stella_protocol::StageKind::Execute.into(),
                 scope: stella_protocol::StageScope::Run,

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -961,6 +961,64 @@ fn a_fleet_attempt_reflects_before_its_spend_is_read() {
     );
 }
 
+/// A fleet worker must seed and apply token-drift calibration. Every other
+/// door onto `Engine` does this: `agent.rs`, `agent/goal.rs`,
+/// `agent/resume.rs`, `command_deck.rs`, `subsession.rs`. A worker that
+/// skips it starts from an uncalibrated estimate while its siblings start
+/// corrected.
+///
+/// This test reads the source instead of driving a real attempt, for the
+/// same reason `a_fleet_attempt_reflects_before_its_spend_is_read` does: a
+/// real attempt needs a live provider, a git worktree, a store, and a
+/// renderer task, just to watch one estimator call. The check is whether
+/// the seeded map reaches the engine that runs the attempt, not whether
+/// `seed_calibration` is called somewhere in the file.
+///
+/// Before this fix, `fleet_cmd.rs` never called `seed_calibration` in
+/// shipping code. Its `Engine::with_sleeper` construction never chained
+/// `.with_calibration(...)` either. This test fails on both counts against
+/// that tree.
+#[test]
+fn a_fleet_worker_seeds_and_applies_token_drift_calibration() {
+    const FLEET: &str = include_str!("../fleet_cmd.rs");
+
+    let seed = FLEET
+        .find("let calibration = agent::seed_calibration(&store, &cfg);")
+        .expect(
+            "run_task must seed calibration from this attempt's own store and \
+             resolved config, the same call every other door onto Engine makes",
+        );
+
+    // Anchored on the exact `Engine::with_sleeper` construction `run_task`
+    // builds inside its raced block, not a copy-pasted reference elsewhere in
+    // the file — a rename of this call site breaks the compile as well as
+    // this find.
+    let engine_ctor = FLEET
+        .find("Engine::with_sleeper(&*provider, &scoped, config, &TokioSleeper)")
+        .expect("run_task must still build its engine through Engine::with_sleeper");
+    assert!(
+        seed < engine_ctor,
+        "calibration must be seeded before the engine that consumes it is built"
+    );
+
+    // The chain this construction opens runs to its first `;` — `with_hooks`
+    // reassigns `engine` in a separate statement below, so bounding the
+    // search there is what keeps this from passing on a `.with_calibration(...)`
+    // written anywhere later in the function instead of on this construction.
+    let chain_end = engine_ctor
+        + FLEET[engine_ctor..]
+            .find(';')
+            .expect("the Engine::with_sleeper statement terminates");
+    let chain = &FLEET[engine_ctor..chain_end];
+    assert!(
+        chain.contains(".with_calibration(&calibration)"),
+        "run_task's own Engine::with_sleeper(...) construction must chain \
+         .with_calibration(&calibration) — every other door onto Engine does, \
+         and a fleet worker hitting the same providers needs the same \
+         output-ceiling correction. Chain was:\n{chain}"
+    );
+}
+
 /// Answers each reflection call with a lesson of its own.
 ///
 /// Two attempts saying the identical thing would derive the identical


### PR DESCRIPTION
## What / why

`stella fleet`'s `run_task` built its `Engine` through `Engine::with_sleeper(...)` but never seeded or applied token-drift calibration — unlike every other door onto `Engine` (`agent.rs`, `agent/goal.rs`, `agent/resume.rs`, `command_deck.rs`, `subsession.rs`). A fleet worker hits the same providers as those doors, so its retry/truncation math started every attempt from an uncalibrated factor of 1.0 while every sibling door started corrected — the exact silent-by-door divergence the provider-parity axes exist to catch.

## The fix

In `crates/stella-cli/src/fleet_cmd.rs`'s `run_task`, seed calibration from this attempt's own store/config (`agent::seed_calibration(&store, &cfg)`) and chain `.with_calibration(&calibration)` onto the existing `Engine::with_sleeper(...)` construction, alongside `.with_gate(...)`/`.with_hooks(...)`. Exemplar: `crates/stella-cli/src/agent/resume.rs` and `crates/stella-cli/src/command_deck.rs`, which do exactly this at their own `Engine` construction sites.

`crates/stella-core/src/driver.rs`'s `with_calibration` doc comment already names "fleet worker" as one of the intended callers, so this closes a gap in wiring rather than a gap in design.

## Witness

`a_fleet_worker_seeds_and_applies_token_drift_calibration` in `crates/stella-cli/src/fleet_cmd/tests.rs` reads `fleet_cmd.rs`'s own source — the same source-level approach the existing `a_fleet_attempt_reflects_before_its_spend_is_read` test in this file already uses, and for the same reason: standing up a live provider, a git worktree, a store and a renderer task just to observe one estimator call is disproportionate to what this checks. It finds the seed call, finds the exact `Engine::with_sleeper(...)` statement `run_task` builds, and asserts `.with_calibration(&calibration)` is chained onto that statement before its terminating `;`.

It fails on `main` today on both counts: `fleet_cmd.rs` calls `seed_calibration` nowhere in shipping code, and its `Engine::with_sleeper` construction never chains `.with_calibration(...)`.

Verified locally the artisanal way: `git stash` (or checking out `main`) removes both the seed call and the chained `.with_calibration`, at which point `FLEET.find("let calibration = agent::seed_calibration(&store, &cfg);")` returns `None` and the test panics on the first `.expect(...)`.

## God-file budget

`fleet_cmd.rs` was already sitting exactly at its 1500-line ceiling and is not a grandfathered god file for `stella-cli`, so the two lines this fix genuinely needs (the seed binding, and the new chained call) are offset by tightening two adjacent, already-existing comments in the same block by an equal number of lines — no baseline entry added, file stays at exactly 1500.

Tests deleted: None.

Closes #3869

## Summary by Sourcery

Correct fleet worker engine setup to apply token-drift calibration and prevent provider-parity regressions.

Bug Fixes:
- Apply token-drift calibration to fleet workers so retry and truncation calculations use provider-specific corrections consistently with other engine entry points.

Tests:
- Add a regression test verifying fleet workers seed calibration from their attempt store and configuration and pass it to the engine.