### PR TITLE
docs(website): stop chat.mdx claiming a hunk review can fire

### DIFF
--- a/website/content/docs/commands/chat.mdx
+++ b/website/content/docs/commands/chat.mdx
@@ -110,7 +110,7 @@ empty composer `Shift-Tab` keeps its usual job of cycling tabs.
 <Callout type="info">
 A bare `⏎` **always** submits, even while an agent is busy — that is what makes queueing
 possible without waiting. The one exception is a pending gate on the focused agent (a
-scope review, a hunk review, or a question the approvals plane asked you): there, the submit
+scope review, or a question the approvals plane asked you): there, the submit
 answers the gate instead of queueing or steering anything. Answer it first, then steer.
 </Callout>
 


### PR DESCRIPTION
## What / why

Per-hunk write review is documented in several places as a working feature.
It is not: no settings key reads `hunk_review`, and nothing constructs a
`HunkProposal` or emits `AgentEvent::HunkReview` outside `stella-tui`'s tests
and `stella-protocol`'s wire-contract fixtures. #3633 tracked this for a long
run of investigation sweeps, all reaching the same verified conclusion.

Per the maintainer's design pointer (SCR-002): a feature with no producer
gets its docs corrected, and the actual build gets filed as its own issue
rather than shipped half-wired here. Shipping the settings key alone would
make the feature *look* switchable while every decision path is still
dropped — `command_deck.rs` already has a `UserInput::HunkDecision` arm that
drops the deck's own answer on the floor, and that gap is real design work,
not a doc fix.

**What was already fixed, before this PR** (verified against `main`, not
assumed): `agent-engine-config.mdx` has zero `hunk` mentions,
`diagnostics.md`'s `agent.hunk.review` entry says "no run emits this record
today," and `stella.next.toml` annotates `hunk_review` as unreachable — all
landed by earlier work on #3633.

**What this PR fixes:** PR #5471 (a site-wide prose-simplification pass on
2026-08-29) deleted the "Reviewing a write hunk by hunk — not yet reachable"
section from `chat.mdx`, warn callout included, but left an earlier,
unrelated callout on the same page listing "a hunk review" as one of the
gates that can claim a bare `⏎`. That was the one overstatement left in the
docs. This PR removes it from that list.

## Witness

Docs-only change; no witness test per `CONTRIBUTING.md`'s "pure refactors,
docs, and CI changes don't need one." Verified by construction: the removed
clause is the only place on `main` that claims a hunk review can fire, per

```bash
rg -n hunk crates/stella-cli/src/settings/                 # no settings key
rg -n 'HunkProposal' crates/ --glob '!*/tests/*' --glob '!*/wire_contract/*'   # no producer
```

## Tests deleted

None.

## Residue filed

- #6019 — building the feature itself (responder port, producer, settings
  key, decline path, ledger promotion, witness test), split out of #3633 so
  this doc fix does not have to wait on a feature decision.

Closes #3633

## Summary by Sourcery

Update chat documentation to stop claiming that hunk reviews can currently fire.

Bug Fixes:
- Remove the remaining website copy that incorrectly presents hunk review as an active chat gate.

Documentation:
- Correct the chat command documentation so bare submit behavior lists only currently supported review and approval gates.