### PR TITLE
fix(stella-serve): widen the streaming-deadline test's wall-clock margin

### DIFF
--- a/crates/stella-serve/tests/bridge.rs
+++ b/crates/stella-serve/tests/bridge.rs
@@ -514,20 +514,35 @@ async fn a_host_that_never_streams_is_unchanged() {
 /// Fragments count as progress against the reverse-request deadline: a host
 /// that keeps streaming past the configured window must not have its turn cut
 /// as "unanswered" — the deadline measures silence, not elapsed time.
+///
+/// This test races two real clocks against each other. `Session::start`
+/// drives the turn on its own OS thread with its own `tokio` runtime (see
+/// that fn's doc comment for why). So a paused clock in this test cannot
+/// reach the deadline's sleep, which ticks on the other thread. The margin
+/// below only needs to survive scheduler delay, not the whole deadline, so a
+/// generous margin is enough.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_streaming_host_resets_the_reverse_request_deadline() {
-    let deadline = Duration::from_millis(120);
+    // 300ms gaps against a 1s deadline: 3.3x slack per gap. A loaded CI
+    // runner delaying either side of a gap by a few tens of milliseconds
+    // must not false-fail this test — a 60ms gap against a 120ms deadline
+    // gave that delay only 60ms to hide in; 300ms against 1s gives it 700ms.
+    // `gap < deadline` still holds, so a single gap can never trip the
+    // deadline on its own; `6 * gap` (1.8s) still clears `deadline` (1s), so
+    // the turn only survives past the deadline if resetting it on progress
+    // is real.
+    let deadline = Duration::from_millis(1000);
     let mut session = Session::start(spec_with_deadline("keep streaming", deadline));
 
     let mut outcome = None;
     while let Some(frame) = session.next_frame().await {
         match frame {
             ServerFrame::ProviderRequest { request_id, .. } => {
-                // Stream fragments for ~3x the deadline, each gap well inside
-                // it, then answer. Under a fixed total window this turn would
-                // have been killed after `deadline`.
+                // Stream fragments for ~1.8x the deadline, each gap well
+                // inside it, then answer. Under a fixed total window this
+                // turn would have been killed after `deadline`.
                 for n in 0..6 {
-                    tokio::time::sleep(Duration::from_millis(60)).await;
+                    tokio::time::sleep(Duration::from_millis(300)).await;
                     session
                         .resolve_provider_delta(
                             &request_id,


### PR DESCRIPTION
## What

Widens `a_streaming_host_resets_the_reverse_request_deadline`'s wall-clock
margin from 2x to 3.3x (300ms gaps against a 1s deadline, up from 60ms
against 120ms) — the fallback fix this issue names, since the preferred one
(a paused clock) needs new production-facing surface (see below).

## Why — the mechanism

The test streams six fragments, each after a real `tokio::time::sleep`, and
asserts each one resets the reverse-request deadline instead of letting it
fire. With a 60ms gap against a 120ms deadline, a single scheduler delay of
more than 60ms on either side of a gap — routine when the full workspace
test suite saturates every core — pushes the gap past the deadline. The
pending request is then abandoned server-side, and the next
`resolve_provider_delta` panics on `.expect(...)`, even though the property
under test (a streaming host keeps its request in flight) was never
actually violated. That is exactly the shape the issue describes and
reproduces (`UnknownRequest("prov-2-0")` under a full-suite run, 3/3 pass
alone).

## Why not the preferred fix (paused clock)

Investigated first, and posted as a comment on the issue before starting.
`Session::start` (`crates/stella-serve/src/session.rs`) spawns the turn on
its own dedicated OS thread, in its own `tokio::runtime::Builder`
current-thread runtime — the turn future is `!Send` (holds provider futures
and the retry-jitter RNG across awaits) and cannot share the caller's
runtime at all. The reverse-request deadline's `tokio::time::sleep`
(`crates/stella-serve/src/remote.rs::complete_remoted`) runs inside that
dedicated runtime, not the test's own.

`tokio::time::pause`/`start_paused` pauses one runtime's clock. Since the
deadline ticks on a different runtime than the test does, pausing the
test's runtime does nothing for it, and pausing both independently doesn't
help either: paused-time auto-advance only works within a closed system —
here, progress arrives from another OS thread over a channel the paused
runtime can't see, so it would auto-advance straight past the fragments to
the deadline.

Making the two share a clock needs the turn actually driven on the test's
runtime — a `tokio::task::LocalSet` + `spawn_local` alternate entry point,
reachable from an integration test (which only sees the public API, so this
also needs a new Cargo feature; this crate has no existing self-referential
`[dev-dependencies]` test-support pattern to build on). That is new
production-facing surface sized to fix one test's flakiness, not a
same-size refactor, so per the issue's own fallback I widened the margin
instead and filed #6021 for the deterministic version.

## Witness

This is a flakiness fix, not a feature — the failure is a probabilistic
race under load, so there is no deterministic fail-old/pass-new witness to
construct (AGENTS.md's exception for a genuinely impractical witness). The
old numbers (`gap = 60ms`, `deadline = 120ms`) are unchanged in the code
history and reproduce the exact issue traceback when the whole workspace
suite runs on a loaded machine; the new numbers keep the same inequalities
(`gap < deadline`, `6 * gap > deadline`) with far more absolute slack
(700ms vs 60ms) per gap, so the same property is asserted with much less
exposure to scheduler jitter. CI's own full-suite test step is the run this
fix has to survive, alongside every other test in the workspace rather than
alone — see the CI run on this PR.

## Tests deleted

None.

## DoD reconciliation (#3799)

`dod / dod` was red on `daacc04` because #3799's two DoD boxes were both
unchecked, and the first of them — *"The test's outcome does not depend on
how loaded the machine is"* — is **not** satisfied by this PR: widening a
margin lowers a flake rate, it does not remove a wall-clock dependence.
That box was not ticked on that wording.

Resolved instead by the second remedy the gate's own failure text names —
*"split the remainder into a new issue (`triage` label only, SCR-004)"*.
That split already existed as **#6021** (filed before this PR opened,
`triage` label only, carrying the literal box verbatim as its own DoD); it
had simply never reached #3799's checklist. #3799's DoD now records the
split, so the requirement is **moved, not dropped**, and #3799 closes on
the fallback its own **Fix guidance** authorises to the digit — "a 1 s
deadline with 300 ms gaps ... 3.3x of slack per gap instead of 2x", which
is precisely this diff. Full audit trail, including what was verified
against the tree rather than against a description, is in
[the comment on #3799](https://github.com/macanderson/stella/issues/3799#issuecomment-5552557271).

**Landed 2026-09-05:** #3799's checklist now carries that split — box 2
ticked, wall-clock independence recorded as moved to #6021 rather than
ticked. Until then the edit this section describes had never actually
reached the issue, which is why `dod / dod` stayed red. See the sweep
comments on this PR for what was verified against the tree.

Refs #6021
Closes #3799

## Summary by Sourcery

Widen the streaming deadline test's timing margin to make it reliable on heavily loaded test runners.

Bug Fixes:
- Reduce flakiness in the streaming reverse-request deadline integration test by increasing its timing margin under scheduler load.

Tests:
- Adjust the streaming deadline test to use 300 ms fragment intervals and a 1 s deadline while preserving coverage that streaming progress resets the deadline.