### PR TITLE
fix(loop-bench): gate on the loop abort, not on the warning before it

### DIFF
--- a/bench/loop-bench/README.md
+++ b/bench/loop-bench/README.md
@@ -78,7 +78,7 @@ harbor knew something the harness did not (#1299) — see
 | `solved` | reward `1.0` — a solved task did the work by definition, so reward beats every other signal | no |
 | `NOT-RUN` | requested, but harbor produced no trial dir for it | **yes** |
 | `UNREADABLE` | the stream had lines, none of them an event — plumbing, not loop evidence | no |
-| `STUCK-LOOP` | the engine's own `loop_detected` fired on a non-pass | **yes** |
+| `STUCK-LOOP` | the engine's loop ladder aborted the turn on a non-pass | **yes** |
 | `BUDGET-CAP` | `STELLA_SPEND_LIMIT` denied the turn — a cost decision, not a loop defect | no |
 | `SILENT-DEATH` | zero tool calls *and* no terminal event — it vanished with no explanation, the worst mode | **yes** |
 | `ZERO-WORK` | zero tool calls, but it said why | **yes** |
@@ -87,6 +87,13 @@ harbor knew something the harness did not (#1299) — see
 
 **The gate is loop health, not pass rate.** The process exits `1` if any trial's
 `loop_broken()` matches, even when others passed.
+
+A `loop_detected` event carrying `aborted: false` is the engine warning the
+model and letting the turn run on. That is the ladder working, so it does not
+gate: the row prints `steered off N detected loop(s)` and the JSON carries the
+warnings in `loop_detected` beside the gating `loop_aborted`. An event with no
+`aborted` field counts as an abort — a stream that does not say the turn
+recovered is not evidence that it did.
 
 `CRASHED` is the lowest-precedence verdict above `ran (unsolved)`, and that is
 the whole design. It never displaces a red verdict: a trial that did nothing and

--- a/bench/loop-bench/src/lib.rs
+++ b/bench/loop-bench/src/lib.rs
@@ -11,7 +11,7 @@
 //! | `solved` | the verifier passed it; reward wins | no |
 //! | `NOT-RUN` | the task (or one of its trials) was requested but harbor never produced a trial dir | **yes** |
 //! | `UNREADABLE` | the stream had lines but not one parsed as an event — schema drift or plumbing, not loop evidence | no |
-//! | `STUCK-LOOP` | the engine's own `loop_detected` fired and the task did not pass | **yes** |
+//! | `STUCK-LOOP` | the engine's loop ladder **aborted** the turn and the task did not pass | **yes** |
 //! | `BUDGET-CAP` | the harness's `STELLA_SPEND_LIMIT` denied the turn — a cost decision, not a loop defect | no |
 //! | `SILENT-DEATH` | zero tool calls and no terminal event: the loop vanished | **yes** |
 //! | `ZERO-WORK` | zero tool calls with a stated terminal event | **yes** |
@@ -26,6 +26,31 @@
 //! address. `STUCK-LOOP` outranks `BUDGET-CAP` because a loop that cycles
 //! until the cap trips is exactly the defect this harness exists to catch —
 //! the cap firing is a symptom there, not the cause.
+//!
+//! # A steer is not a stuck loop
+//!
+//! The engine emits `loop_detected` at both ends of its ladder. `aborted:
+//! false` says it warned the model and let the turn go on. `aborted: true`
+//! says the warning did not take and the turn ended there. Only the second is
+//! a loop the engine could not get out of, so only the second is
+//! `STUCK-LOOP`.
+//!
+//! Reading the abort alone costs the gate nothing, because the ladder
+//! escalates by itself: a turn may spend at most two warnings
+//! (`stella_core::driver::loop_escalation::MAX_LOOP_STEERS`), and every
+//! detection after that ends the turn. A model that keeps cycling always
+//! reaches `aborted: true`.
+//!
+//! A detection whose event carries no `aborted` field counts as an abort. An
+//! outcome the stream does not state must keep the gating meaning it has,
+//! rather than read as a recovery nobody recorded.
+//!
+//! The evidence is nightly run 33387694069. Its `overfull-hbox` trial fired
+//! one detection, `aborted: false`. The next call answered the warning with a
+//! different command; the turn then ran 99 more tool calls, 78 of them
+//! distinct, edited files 14 times, and died on harbor's 750-second ceiling.
+//! Across the four red nights from 2026-08-31 to 2026-09-05, 11 of 16 trials
+//! fired a detection and two of those ever aborted.
 //!
 //! # `CRASHED`, and why it sits where it does (#1299)
 //!
@@ -115,10 +140,15 @@ pub struct TrialReport {
     /// The turn ended without executing a single tool call. Paired with a
     /// non-pass, this is the "chose nothing" death the hardening work targets.
     pub zero_work: bool,
-    /// `loop_detected` events from the engine's own loop detector — the turn
-    /// was caught cycling. Any non-zero count on a non-pass is a `STUCK-LOOP`
-    /// verdict and gates red (#611).
+    /// `loop_detected` events from the engine's own loop detector — every
+    /// time the turn was caught cycling, warnings and aborts alike. This is
+    /// the count an operator reads; `loop_aborted` is the count the gate
+    /// reads.
     pub loop_detected: u32,
+    /// The share of `loop_detected` that ended the turn: `aborted: true`,
+    /// plus any detection whose event states no outcome at all. A non-zero
+    /// count on a non-pass is the `STUCK-LOOP` verdict and gates red.
+    pub loop_aborted: u32,
     /// A `budget_denied` event reached the stream: the harness's own
     /// `STELLA_SPEND_LIMIT` cap stopped the turn. `BUDGET-CAP` verdict, excluded
     /// from the gate — a cost decision is not a loop defect (#611).
@@ -204,6 +234,14 @@ impl TrialReport {
         self.parsed_lines == 0 && self.unparsable_lines > 0
     }
 
+    /// Detections the turn survived: the engine warned, the model changed
+    /// course, and the turn carried on. Reported on the row, never gated —
+    /// the ladder working is not a defect. See the crate docs.
+    #[must_use]
+    pub fn loop_steered(&self) -> u32 {
+        self.loop_detected.saturating_sub(self.loop_aborted)
+    }
+
     /// Harbor recorded this trial as having raised: it did not finish, whatever
     /// its reward says. See the crate docs for why this is read off harbor's
     /// record rather than inferred from the stream (#1299).
@@ -222,7 +260,7 @@ impl TrialReport {
             "NOT-RUN"
         } else if self.unreadable() {
             "UNREADABLE"
-        } else if self.loop_detected > 0 {
+        } else if self.loop_aborted > 0 {
             "STUCK-LOOP"
         } else if self.budget_capped {
             "BUDGET-CAP"
@@ -264,7 +302,7 @@ impl TrialReport {
         if self.unreadable() {
             return false;
         }
-        if self.loop_detected > 0 {
+        if self.loop_aborted > 0 {
             return true;
         }
         if self.budget_capped {
@@ -446,6 +484,7 @@ pub fn fold_steps(steps: &[TrialReport]) -> TrialReport {
         folded.model_calls = folded.model_calls.saturating_add(step.model_calls);
         folded.tool_calls = folded.tool_calls.saturating_add(step.tool_calls);
         folded.loop_detected = folded.loop_detected.saturating_add(step.loop_detected);
+        folded.loop_aborted = folded.loop_aborted.saturating_add(step.loop_aborted);
         folded.retries = folded.retries.saturating_add(step.retries);
         folded.parsed_lines = folded.parsed_lines.saturating_add(step.parsed_lines);
         folded.unparsable_lines = folded
@@ -510,7 +549,15 @@ pub fn distill_events(task: &str, raw: &str) -> TrialReport {
                     r.stages.push(s.to_string());
                 }
             }
-            Some("loop_detected") => r.loop_detected += 1,
+            Some("loop_detected") => {
+                r.loop_detected += 1;
+                // Only an explicit `aborted: false` buys a detection out of
+                // the gate: that is the engine saying it warned the model and
+                // the turn went on. Silence is not a recovery.
+                if ev.get("aborted").and_then(Value::as_bool) != Some(false) {
+                    r.loop_aborted += 1;
+                }
+            }
             Some("budget_denied") => r.budget_capped = true,
             Some("complete") => r.terminal_event = true,
             Some("error") => {
@@ -707,6 +754,17 @@ pub fn print_table(reports: &[TrialReport]) {
             println!(
                 "{:>26}└ vanished in stage `{stage}` (no terminal event)",
                 ""
+            );
+        }
+        // A warning the turn survived is a real thing that happened: the model
+        // did cycle, and the ladder is why it stopped. It is not the gate's
+        // business, so it rides the row as a note rather than taking the
+        // verdict column.
+        if r.loop_steered() > 0 {
+            println!(
+                "{:>26}└ steered off {} detected loop(s); the turn carried on",
+                "",
+                r.loop_steered()
             );
         }
         // The crash line prints even for a row whose verdict is something

--- a/bench/loop-bench/src/tests.rs
+++ b/bench/loop-bench/src/tests.rs
@@ -196,6 +196,9 @@ fn a_retryable_warning_is_not_a_terminal_event() {
 /// #611: the engine's own loop detector firing on a non-pass is the
 /// `STUCK-LOOP` verdict, and it gates red — a run that burns its budget
 /// cycling the same two tools must not report `ran (unsolved)` and exit 0.
+///
+/// These events state no outcome, which counts as an abort: a stream that
+/// does not say the turn recovered is not evidence that it did.
 #[test]
 fn a_detected_loop_on_a_non_pass_is_stuck_and_gates_red() {
     let stream = ev(&[
@@ -214,6 +217,70 @@ fn a_detected_loop_on_a_non_pass_is_stuck_and_gates_red() {
     solved.reward = Some(1.0);
     assert_eq!(solved.loop_verdict(), "solved");
     assert!(!solved.loop_broken());
+}
+
+/// A warning the turn survived is not a stuck loop. The engine emits
+/// `loop_detected` with `aborted: false` when it steers the model and lets the
+/// turn run on; the abort carries `aborted: true`. Only the abort gates.
+#[test]
+fn a_steer_the_turn_survived_is_not_a_stuck_loop() {
+    let steered = ev(&[
+        r#"{"type":"tool_start","call":{"name":"bash"}}"#,
+        r#"{"type":"loop_detected","kind":"exact_repeat","repeats":3,"aborted":false}"#,
+        r#"{"type":"tool_start","call":{"name":"edit_file"}}"#,
+    ]);
+    let r = distill_events("steered", &steered);
+    assert_eq!(
+        (r.loop_detected, r.loop_aborted, r.loop_steered()),
+        (1, 0, 1)
+    );
+    assert_eq!(
+        r.loop_verdict(),
+        "ran (unsolved)",
+        "the engine warned and the turn went on doing work"
+    );
+    assert!(!r.loop_broken());
+
+    // The second detection ends the turn, and that is the gate.
+    let aborted = ev(&[
+        r#"{"type":"tool_start","call":{"name":"bash"}}"#,
+        r#"{"type":"loop_detected","kind":"exact_repeat","repeats":3,"aborted":false}"#,
+        r#"{"type":"loop_detected","kind":"exact_repeat","repeats":3,"aborted":true}"#,
+    ]);
+    let a = distill_events("aborted", &aborted);
+    assert_eq!(
+        (a.loop_detected, a.loop_aborted, a.loop_steered()),
+        (2, 1, 1)
+    );
+    assert_eq!(a.loop_verdict(), "STUCK-LOOP");
+    assert!(a.loop_broken());
+}
+
+/// The trial that held `nightly-bench` red, replayed from its own stream.
+///
+/// This is the `loop_detected` line out of `events/overfull-hbox__82dbB8w.jsonl`
+/// in artifact `loop-bench-33387694069`, with the tool calls either side of it
+/// standing in for the 136 the trial made. One warning, obeyed, then a turn
+/// that worked until harbor's 750-second ceiling killed it — which the row
+/// reports as the crash it was.
+#[test]
+fn the_nightly_trial_that_obeyed_its_warning_is_not_stuck() {
+    let stream = ev(&[
+        r#"{"type":"tool_start","call":{"name":"bash","input":{"command":"grep -E \"sensitivity|knowledge\" synonyms.txt"}}}"#,
+        r#"{"type":"loop_detected","turn_instance":0,"kind":"exact_repeat","pattern":["bash"],"repeats":3,"evidence":"the same `bash` call with identical arguments repeated 3 times consecutively","aborted":false}"#,
+        r#"{"type":"tool_start","call":{"name":"bash","input":{"command":"grep -i \"parent\" synonyms.txt"}}}"#,
+        r#"{"type":"tool_start","call":{"name":"edit_file","input":{"path":"input.tex"}}}"#,
+    ]);
+    let mut r = distill_events("overfull-hbox", &stream);
+    r.reward = Some(0.0);
+    r.crash = Some("AgentTimeoutError: Agent execution timed out after 750.0 seconds".into());
+    assert_eq!(r.loop_steered(), 1);
+    assert_eq!(
+        r.loop_verdict(),
+        "CRASHED",
+        "the wall clock ended this trial; the warning did not"
+    );
+    assert!(!r.loop_broken(), "a harbor timeout is not a loop defect");
 }
 
 /// #611: the harness's own cost cap stopping the turn is `BUDGET-CAP`,


### PR DESCRIPTION
## What

`nightly-bench` has failed almost every night since 2026-08-17 on a
`STUCK-LOOP` verdict. The engine was not stuck. `bench/loop-bench` counted
every `loop_detected` event and called any of them, on a non-pass,
`STUCK-LOOP` — including the ones where the engine warned the model and the
turn carried on working.

The gate now reads the abort.

- `TrialReport::loop_aborted` counts detections that ended the turn.
  `loop_detected` stays the total, and `loop_steered()` is the difference.
- `loop_verdict()` and `loop_broken()` read `loop_aborted`.
- A detection whose event carries no `aborted` field counts as an abort, so a
  stream that does not say the turn recovered is not read as evidence that it
  did. The existing #611 tests use exactly that shape and pass unchanged.
- The table prints `steered off N detected loop(s); the turn carried on`, so
  the warning is reported rather than dropped.

Nothing is muted. No ceiling moved. `.github/workflows/nightly-bench.yml` is
untouched.

## Why — the trace

Artifact `loop-bench-33387694069`, `events/overfull-hbox__82dbB8w.jsonl`,
24,825 lines, all parseable. It holds one `loop_detected`:

```json
{"type":"loop_detected","kind":"exact_repeat","pattern":["bash"],"repeats":3,
 "evidence":"the same `bash` call with identical arguments repeated 3 times
 consecutively, producing byte-identical output every time
 (input: {\"command\":\"grep -E \\\"sensitivity|knowledge\\\" synonyms.txt\"})",
 "aborted":false}
```

`aborted: false` is `AgentEvent::LoopDetected` saying the ladder steered and
the turn continued (`crates/stella-protocol/src/event/kind.rs`;
`crates/stella-core/src/driver/loop_escalation.rs`).

Measured over that stream:

| | before the warning | after |
|---|---|---|
| tool calls | 37 | 99 |
| distinct tool calls | 31 | 78 |
| `edit_file` calls | — | 14 |

The next call after the warning is a different `grep`. The longest run of
identical consecutive calls anywhere in the trial is 3 — the detector's own
threshold, never passed again. 107 of 136 tool calls are distinct; 47
`file_change` events. Harbor's 750-second agent ceiling ended it
(`AgentTimeoutError`), which the row already printed.

Across the four most recent red nights (33387694069, 33741033194,
33859394391, 33956998843 — 16 trials): 11 trials fired a detection, and 2 of
them ever reached `aborted: true`. The other 9 were warnings the turn
survived, and all 9 were reported as stuck loops. Replayed under this change,
the two genuine aborts (`fix-git` on 33741033194, `prove-plus-comm` on
33859394391) stay red and the nine recovered warnings stop gating.

Gating on the abort is not weaker. The ladder escalates on its own: a turn may
spend at most `MAX_LOOP_STEERS` warnings, and once that budget is gone every
further detection aborts. A model that keeps cycling always reaches
`aborted: true`.

## Witness

`a_steer_the_turn_survived_is_not_a_stuck_loop` (`bench/loop-bench/src/tests.rs`)
fails on `main` by construction twice over: `loop_aborted` and
`loop_steered()` do not exist there, and the first assertion demands
`ran (unsolved)` from a stream whose single `aborted: false` detection old code
reports as `STUCK-LOOP`.

`the_nightly_trial_that_obeyed_its_warning_is_not_stuck` replays the real event
line out of that artifact, with the calls either side of it, and asserts the
row lands on `CRASHED` — the wall clock, which is what ended the trial.

The abort half of the first test keeps the red case pinned: a second detection
carrying `aborted: true` is still `STUCK-LOOP` and still gates.

## Scope

The design pointer allowed either an engine fix or a classification fix,
depending on what the trace showed. It shows the second: the rung fired, the
model obeyed it, and the trial died on a harness ceiling the engine cannot
see. There is no engine defect in this trace to fix.

Closes #5613

Tests deleted: None

Residue filed:
- #6024 — watch `nightly-bench` for ten nights after this merges. The original
  issue's last done-item asked for ten green nights, which cannot be ticked
  before the merge that produces them; it moved there and the issue body says so.
- #6025 — most nightly trials never finish (3 of 4 raised on three of the four
  runs read here) and nothing gates on that.

## DoD status (#5613)

`dod / dod` was red on `f2b7aac` because #5613's checklist still had six
unticked boxes when that job ran at 14:42Z. All six were satisfied and ticked
afterwards, the last of them by the `nightly-bench` dispatch box 5 asks for —
which is this PR's own `loop-bench (spends real money)` job, run
[33973144575](https://github.com/macanderson/stella/actions/runs/33973144575),
`workflow_dispatch` on `fix/5613-gate-on-loop-abort`, `success`,
`LOOP: 0/4 broken`. No code changed; the gate had simply read an earlier state
of the issue.

What that run does not establish is recorded on the issue rather than glossed:
no `loop_detected` fired in any of its four streams, so those four trials would
have been green on the old code too. The recorded-stream census across the four
red nights and the two unit tests above are what tell this fix apart from what
it replaced.

## Summary by Sourcery

Gate loop-bench failures on loop-abort outcomes while retaining recovered loop warnings as observable, non-gating evidence.

Bug Fixes:
- Classify non-passing trials as stuck loops only when loop detection aborts the turn, preventing recovered warnings from incorrectly failing nightly benchmarks.

Enhancements:
- Track total loop detections separately from aborted and steered detections, preserve unknown abort outcomes as aborts, and report survived warnings in the results table.

Documentation:
- Update loop-bench documentation to define STUCK-LOOP around aborted turns and explain how steered warnings are reported.

Tests:
- Add coverage for survived loop warnings, aborted detections, missing abort fields, and replay of the affected nightly trial.
