### PR TITLE
ci(main-red-hold): clear the stale hold once main recovers

### DIFF
--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -63,6 +63,12 @@ permissions:
   # To open, comment on, and close the one tracking issue, and to provision its
   # label on first use.
   issues: write
+  # To find the open pull requests whose hold this run has just made stale,
+  # and to re-run it for them (#5913). Closing the issue is what ends the
+  # outage; the hold that failed during it is still the last word on each of
+  # those commits until something re-runs it.
+  pull-requests: read
+  actions: write
 
 # Deliberately cancel-in-progress: this reconciles state rather than reacting to
 # an event, so under a burst of merges the only tree worth judging is the last
@@ -88,6 +94,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/main-canary.sh --announce
+
+      # Recovery has to clear the holds the outage caused, or every pull
+      # request that was blocked stays blocked with no push to it (#5913).
+      # This does nothing while a `main-red` issue is open, so a run that
+      # found the tree still broken pays one tracker query for it.
+      - name: Clear the hold on every open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/clear-main-red-holds.sh
 
       # The other half of the same question, and the one nothing asked: is
       # there a commit on `main` that nothing VERIFIED — as distinct from one

--- a/.github/workflows/main-red-clear.yml
+++ b/.github/workflows/main-red-clear.yml
@@ -1,0 +1,60 @@
+name: main-red-clear
+
+# Clear the merge hold once `main` is not known-broken any more (#5913).
+#
+# `main-red-hold.yml` reports the required check `main is not known-broken` on
+# every pull request. Branch protection reads the last check run for that name
+# on that commit, so a hold that failed during an outage is still the answer
+# after the outage ends. On 2026-09-05, ten pull requests stayed unmergeable
+# on a check whose own question had already changed its answer.
+#
+# `scripts/clear-main-red-holds.sh` re-runs those holds. This workflow is one
+# of its two callers, and covers the recovery a person performs by hand:
+# closing the `main-red` issue, or taking the label off it.
+#
+# ── Why the canary calls the script too ──────────────────────────────────────
+#
+# The other caller is `main-canary.yml`, on the run that closes the issue
+# itself — which is the ordinary path, and one this workflow cannot see. The
+# canary closes with `GITHUB_TOKEN`, and GitHub starts no workflow from an
+# event raised by that token. Both callers run the same script, and running it
+# twice re-runs nothing the first pass already cleared.
+
+on:
+  issues:
+    types: [closed, unlabeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  # To re-run the stale hold. This is the one job in the repository that
+  # needs it, which is why the clean-up lives here rather than in a workflow
+  # that already does something else.
+  actions: write
+
+# One sweep at a time. A cancelled sweep costs nothing: the next one asks the
+# same questions and re-runs whatever is still stale.
+concurrency:
+  group: main-red-clear
+  cancel-in-progress: true
+
+jobs:
+  clear:
+    name: clear the hold a recovered main left behind
+    # `closed` still carries the label on the issue; `unlabeled` no longer
+    # does, and names the removed label instead.
+    if: >-
+      github.event_name != 'issues'
+      || contains(github.event.issue.labels.*.name, 'main-red')
+      || github.event.label.name == 'main-red'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Re-run the hold on every open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/clear-main-red-holds.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,25 @@ required status checks: a throwaway PR went red and unmergeable while a
 hand-filed, `main-red`-labelled issue stood, and green again once
 `unblocks-main` landed on it.
 
+**A hold outlives the outage unless something clears it.** Branch protection
+reads the last check run for that name on that commit, and the hold fires on
+`pull_request` — so a pull request that is finished and waiting has no event
+left to correct it. On 2026-09-05 `main` broke, a repair landed, the canary
+closed the issue, and ten open pull requests stayed unmergeable on a check
+whose own question now answered the other way. A push to each branch clears
+it; the two moves a session reaches for first, an empty commit and
+close-and-reopen, are the two this repository forbids.
+`scripts/clear-main-red-holds.sh` is what clears them: it asks whether any
+`main-red` issue is still open, and if none is, re-runs the failed hold on
+every open pull request, which reports under the same name on the same commit.
+It has two callers because neither sees every recovery — `main-canary.yml`, on
+the run that closes the issue, since GitHub starts no workflow from an event
+`GITHUB_TOKEN` raised; and `main-red-clear.yml`, when a person closes the issue
+or takes the label off it. Both fail open, and running it twice re-runs nothing
+the first pass cleared. `make clear-main-red-holds` prints what a sweep would
+re-run without re-running it; `make main-red-hold-test` covers the clearing
+half beside the blocking one.
+
 The chain has a third link, and it is not a workflow: **before you repair a
 red `main`, check whether somebody already is.** On 2026-08-24 three sessions
 each wrote the same two-line fix for the same break and merged them 95 seconds

--- a/Makefile
+++ b/Makefile
@@ -910,8 +910,15 @@ main-red-hold: ## Ask whether an open `main-red` issue should hold a PR (reads t
 	@./scripts/check-main-red-hold.sh
 
 .PHONY: main-red-hold-test
-main-red-hold-test: ## Test the red-main hold, blocking branch included (hermetic; not part of `gate`)
+main-red-hold-test: ## Test the red-main hold and its clean-up (hermetic; not part of `gate`)
 	./scripts/test-main-red-hold.sh
+
+# What the hold leaves behind once main recovers: a failed check run that is
+# still the last word on every blocked PR's head (#5913). CI re-runs those
+# holds; this prints what it would re-run, and changes nothing.
+.PHONY: clear-main-red-holds
+clear-main-red-holds: ## List the stale `main is not known-broken` failures a recovery left behind
+	@./scripts/clear-main-red-holds.sh --dry-run
 
 # The third signal in the red-main chain: the canary detects, the hold stops
 # a merge, and this stops a second session writing the same patch (#4680).

--- a/scripts/check-main-red-hold.sh
+++ b/scripts/check-main-red-hold.sh
@@ -186,6 +186,7 @@ echo "     What to do:" >&2
 echo "       - Fixing main? Add the \`$escape_label\` label to this PR and" >&2
 echo "         re-run. That is the designed way through, not a workaround." >&2
 echo "       - Otherwise: wait. The canary closes its issue by itself the" >&2
-echo "         moment main composes again, and this check goes green with no" >&2
+echo "         moment main composes again, and re-runs this check on every" >&2
+echo "         open PR as it does, so it goes green with no push and no" >&2
 echo "         action from you." >&2
 exit 1

--- a/scripts/clear-main-red-holds.sh
+++ b/scripts/clear-main-red-holds.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Clear the merge hold a fixed `main` leaves behind. Filed as `#5913`.
+#
+# `main-red-hold.yml` reports the check `main is not known-broken` on every
+# pull request. It is right when it runs. But the branch rules read the last
+# check run on that commit, and nothing runs it again.
+#
+# So the hold outlives the outage. On 2026-09-05 a fix landed and the canary
+# closed its issue. Ten open pull requests stayed stuck. Each was held by a
+# check that would now pass.
+#
+# A push to the branch clears it. A finished pull request has no reason to
+# push. The two moves a session tries first — an empty commit, and close and
+# reopen — are the two AGENTS.md bans.
+#
+# So the fix has to clear the holds it caused. This script is that step. It
+# asks whether `main` is still known-broken. If it is not, it runs the failed
+# hold again on every open pull request. The new run lands under the same
+# name on the same commit. That is all the branch rules read.
+#
+# ## Why run it again, and not post a new status
+#
+# The other way is to post a commit status with the same name. Then two
+# things wear one name: a failed check run, and a passing status. Which one
+# the branch rules trust is not a thing this repo can learn, short of
+# breaking `main` to see. Running the old run again leaves one verdict.
+#
+# ## Who calls it
+#
+# Two callers, since neither one sees every fix.
+#
+#   - `main-canary.yml`, on the run that closes the `main-red` issue. That is
+#     the normal path, and a workflow on the issue event cannot see it. The
+#     canary closes with `GITHUB_TOKEN`, and no event from that token starts
+#     a workflow.
+#   - `main-red-clear.yml`, when a person closes the issue by hand, or takes
+#     the `main-red` label off it.
+#
+# Two runs cost nothing. The second finds the holds green and runs nothing.
+#
+# ## Fails open, out loud
+#
+# Every unknown prints a note and exits 0. This runs inside the canary. A
+# canary turned red by a `gh` blip would say `main` is broken when it is not.
+# That is the one lie this machinery must not tell.
+#
+# Usage:
+#   scripts/clear-main-red-holds.sh
+#   scripts/clear-main-red-holds.sh --dry-run
+#
+# Needs `gh` and a POSIX shell, so it runs on a bare CI runner.
+set -uo pipefail
+
+label="main-red"
+workflow="main-red-hold.yml"
+limit=100
+dry_run=0
+fixture_open_issues=""
+fixture_open_prs=""
+fixture_stale_runs=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --dry-run)
+    dry_run=1
+    shift
+    ;;
+  --limit)
+    [ $# -ge 2 ] || {
+      echo "clear-main-red-holds: --limit needs a number" >&2
+      exit 2
+    }
+    limit="$2"
+    shift 2
+    ;;
+  # Test-only seams. Any one of them stubs every lookup, and stops the re-run
+  # from being sent. So a case cannot half-reach the network, and cannot pass
+  # or fail for a reason it did not pick. Same rule as the paired fixtures in
+  # `check-main-red-hold.sh`.
+  --fixture-open-issues)
+    [ $# -ge 2 ] || {
+      echo "clear-main-red-holds: --fixture-open-issues needs a value" >&2
+      exit 2
+    }
+    fixture_open_issues="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-open-prs)
+    [ $# -ge 2 ] || {
+      echo "clear-main-red-holds: --fixture-open-prs needs a value" >&2
+      exit 2
+    }
+    fixture_open_prs="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-stale-runs)
+    [ $# -ge 2 ] || {
+      echo "clear-main-red-holds: --fixture-stale-runs needs a value" >&2
+      exit 2
+    }
+    fixture_stale_runs="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  -h | --help)
+    # The whole block after the shebang, cut off at its first line of code.
+    # A line number here goes stale the first time the header grows. Same
+    # reader as the one in `main-canary.sh`.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    echo "clear-main-red-holds: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+[ "$use_fixture" -eq 1 ] && dry_run=1
+
+note() { printf 'clear-main-red-holds: %s\n' "$*" >&2 || true; }
+say() {
+  # Ignore SIGPIPE and drop the write. A reader that closes the pipe must not
+  # turn this into a failure — the `#1815` shape.
+  trap '' PIPE
+  printf 'clear-main-red-holds: %s\n' "$*" || true
+}
+
+if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  note "gh is not installed, so no hold could be cleared. A push to each"
+  note "branch still clears its own hold."
+  exit 0
+fi
+
+# ── Is main still known-broken? ──────────────────────────────────────────────
+#
+# This one question decides whether there is anything to clear. While an issue
+# is open the holds are right, and they must stay red.
+
+if [ "$use_fixture" -eq 1 ]; then
+  open_issues="$fixture_open_issues"
+elif ! open_issues="$(gh issue list --label "$label" --state open \
+  --limit 20 --json number --jq '.[].number' 2>/dev/null)"; then
+  note "could not reach the issue tracker, so this run could not ask whether"
+  note "main has recovered. Clearing nothing."
+  exit 0
+fi
+
+open_issues="$(printf '%s' "$open_issues" | tr -d ' ' | tr '\n' ' ')"
+open_issues="${open_issues% }"
+
+if [ -n "$open_issues" ]; then
+  say "main is still known-broken ($open_issues) — the holds are correct."
+  exit 0
+fi
+
+# ── Run the hold again on every open pull request ────────────────────────────
+
+if [ "$use_fixture" -eq 1 ]; then
+  open_prs="$fixture_open_prs"
+elif ! open_prs="$(gh pr list --state open --limit "$limit" \
+  --json number,headRefOid --jq '.[] | "\(.number) \(.headRefOid)"' 2>/dev/null)"; then
+  note "could not list the open pull requests, so no hold was cleared."
+  exit 0
+fi
+
+# The last hold run on this head, and only if it is a failure right now. A
+# re-run updates the run in place, so `[0]` is that run, and its conclusion is
+# the verdict the branch rules read.
+stale_run_for() {
+  head="$1"
+  if [ "$use_fixture" -eq 1 ]; then
+    printf '%s\n' "$fixture_stale_runs" |
+      awk -v head="$head" '$1 == head { print $2; exit }'
+    return 0
+  fi
+  gh api "repos/{owner}/{repo}/actions/workflows/$workflow/runs?head_sha=$head&per_page=20" \
+    --jq '.workflow_runs[0] | select(.conclusion == "failure") | .id' 2>/dev/null || true
+}
+
+cleared=0
+seen=0
+
+while read -r pr head; do
+  [ -n "$pr" ] || continue
+  seen=$((seen + 1))
+  run="$(stale_run_for "$head")"
+  if [ -z "$run" ]; then
+    continue
+  fi
+  if [ "$dry_run" -eq 1 ]; then
+    say "would re-run the hold on PR #$pr (head $head, run $run)"
+    cleared=$((cleared + 1))
+    continue
+  fi
+  if gh api -X POST --silent \
+    "repos/{owner}/{repo}/actions/runs/$run/rerun-failed-jobs" 2>/dev/null; then
+    say "re-ran the hold on PR #$pr (head $head, run $run)"
+    cleared=$((cleared + 1))
+  else
+    # This needs `actions: write`. A job without it must say so, rather than
+    # report a clean sweep it did not do.
+    note "could not re-run run $run for PR #$pr — does this job have"
+    note "\`actions: write\`? That hold stays red until the branch is pushed."
+  fi
+done <<EOF
+$open_prs
+EOF
+
+say "main has recovered — cleared the hold on $cleared of $seen open pull request(s)."
+exit 0

--- a/scripts/test-main-red-hold.sh
+++ b/scripts/test-main-red-hold.sh
@@ -180,6 +180,29 @@ if [ $? -eq 2 ]; then ok "clearing: a flag missing its value exits 2, not 0"; el
 out="$("$CLEAR" --nonsense 2>&1)"
 if [ $? -eq 2 ]; then ok "clearing: an unknown flag exits 2, not 0"; else bad "clearing: an unknown flag did not exit 2"; fi
 
+# A sweep nothing calls clears nothing, so the wiring is part of the fix. The
+# three cases below read the workflow files. On a tree where recovery does not
+# call the sweep, they fail.
+holds_text() { # holds_text <name> <file> <pattern>
+  local name="$1" file="$repo_root/.github/workflows/$2" pattern="$3"
+  if [ -f "$file" ] && grep -q -- "$pattern" "$file"; then
+    ok "$name"
+  else
+    bad "$name — $2 does not carry '$pattern'"
+  fi
+}
+
+holds_text "the canary sweeps on the run that closes the issue" \
+  main-canary.yml "clear-main-red-holds.sh"
+
+holds_text "...and holds the write scope that a re-run needs" \
+  main-canary.yml "actions: write"
+
+# The canary closes with `GITHUB_TOKEN`, and no event from that token starts a
+# workflow. So the issue event is the second path, not the only one.
+holds_text "a person closing the issue by hand starts a sweep too" \
+  main-red-clear.yml "types: \[closed, unlabeled\]"
+
 printf '\n'
 if [ "$fail" -eq 0 ]; then
   printf '\033[32mmain-red-hold-test: OK\033[0m — %d checks passed\n' "$pass"

--- a/scripts/test-main-red-hold.sh
+++ b/scripts/test-main-red-hold.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# Hermetic tests for scripts/check-main-red-hold.sh.
+# Hermetic tests for the two halves of the red-main hold.
+# `check-main-red-hold.sh` blocks a merge while `main` is broken.
+# `clear-main-red-holds.sh` clears those blocks once it is not.
 #
 #   ./scripts/test-main-red-hold.sh     (or: make main-red-hold-test)
 #
@@ -12,6 +14,10 @@
 # life passing, because main is usually green, so nothing else would ever
 # exercise the branch it exists for.
 #
+# The clearing half has the same gap. It is built for the moment `main` gets
+# fixed. Nothing else reaches that moment, since a green `main` leaves no
+# stale hold to clear.
+#
 # Not a `make gate` step, matching `main-canary-test`: the thing
 # under test is a CI-only guard that asks the issue tracker a question, and
 # the gate is hermetic and offline by contract.
@@ -21,6 +27,7 @@ set -uo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
 SCRIPT="$repo_root/scripts/check-main-red-hold.sh"
+CLEAR="$repo_root/scripts/clear-main-red-holds.sh"
 
 pass=0
 fail=0
@@ -28,10 +35,10 @@ fail=0
 ok()  { printf '  \033[32m✓\033[0m %s\n' "$*"; pass=$((pass + 1)); }
 bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=$((fail + 1)); }
 
-# One assertion shape: run with both fixture seams pinned and compare the exit
-# code. An expected failure must also name its reason, because "exit 1" is
-# satisfied by a typo in the script just as well as by the defect the case is
-# about — the same discipline test-install-zsh-completions.sh applies.
+# One shape for every case: pin both fixture seams, then check the exit code.
+# A case that expects a failure names its reason too. A typo in the script
+# exits 1 just as well as the defect does. `test-install-zsh-completions.sh`
+# holds the same line.
 want() { # want <name> <expect-pass|expect-block> <want-substring> <issues> <labels>
   local name="$1" expect="$2" want_text="$3" issues="$4" labels="$5"
   local out rc
@@ -93,6 +100,85 @@ if [ $? -eq 2 ]; then ok "a flag missing its value exits 2, not 0"; else bad "a 
 
 out="$("$SCRIPT" --nonsense 2>&1)"
 if [ $? -eq 2 ]; then ok "an unknown flag exits 2, not 0"; else bad "an unknown flag did not exit 2"; fi
+
+printf '\n\033[1mclearing — a recovered main un-blocks the pull requests it stopped\033[0m\n'
+
+# The stale-hold state, as fixtures. `main` is fixed, so no issue is open.
+# Three pull requests are open. Two still carry a failed hold on the head
+# they have now. That is the shape of 2026-09-05, when ten pull requests
+# were stuck on a check that would have passed.
+recovered_prs="5903 aaaaaaa
+5899 bbbbbbb
+5894 ccccccc"
+stale_runs="aaaaaaa 33951700124
+ccccccc 33950666389"
+
+# Every case checks the exit code too. This script runs inside the canary. A
+# non-zero exit there would say `main` is broken when it builds.
+clear_says() { # clear_says <name> <want-substring> <issues> <prs> <runs>
+  local name="$1" want_text="$2" issues="$3" prs="$4" runs="$5"
+  local out rc
+  out="$("$CLEAR" --fixture-open-issues "$issues" --fixture-open-prs "$prs" \
+    --fixture-stale-runs "$runs" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    bad "$name — expected exit 0 (fail-open), got $rc: $out"
+    return
+  fi
+  case "$out" in
+  *"$want_text"*) ok "$name" ;;
+  *) bad "$name — wanted '$want_text': $out" ;;
+  esac
+}
+
+clear_lacks() { # clear_lacks <name> <unwanted-substring> <issues> <prs> <runs>
+  local name="$1" unwanted="$2" issues="$3" prs="$4" runs="$5"
+  local out
+  out="$("$CLEAR" --fixture-open-issues "$issues" --fixture-open-prs "$prs" \
+    --fixture-stale-runs "$runs" 2>&1)"
+  case "$out" in
+  *"$unwanted"*) bad "$name — said '$unwanted' when it should not: $out" ;;
+  *) ok "$name" ;;
+  esac
+}
+
+# The witness. Before this fix, nothing ran the hold again. The failure from
+# the outage stayed the last word on that commit. The pull request could not
+# merge until someone pushed to it.
+#
+# Each case names the run as well as the pull request. Running the wrong run
+# would still look like a sweep, and would clear nothing.
+clear_says "a recovered main re-runs the hold on the first stale PR" \
+  "5903 (head aaaaaaa, run 33951700124)" "" "$recovered_prs" "$stale_runs"
+
+clear_says "...and on every other PR still carrying a stale failure" \
+  "5894 (head ccccccc, run 33950666389)" "" "$recovered_prs" "$stale_runs"
+
+# A green hold is already the right answer. Running it again would spend a
+# job to change nothing.
+clear_lacks "a PR whose hold already passes is left alone" \
+  "5899" "" "$recovered_prs" "$stale_runs"
+
+clear_says "the summary counts what it swept" \
+  "cleared the hold on 2 of 3 open pull request" "" "$recovered_prs" "$stale_runs"
+
+# The negative control, and the worse direction. Clearing a hold while `main`
+# is still broken would drop the signal, not the leftovers.
+clear_says "an open main-red issue keeps every hold in place" \
+  "main is still known-broken (5901)" "5901" "$recovered_prs" "$stale_runs"
+
+clear_lacks "...and re-runs nothing at all while it stands" \
+  "re-run the hold" "5901" "$recovered_prs" "$stale_runs"
+
+# No open pull request is a state, not an error.
+clear_says "a repository with no open pull request says so and stops" \
+  "cleared the hold on 0 of 0 open pull request" "" "" ""
+
+out="$("$CLEAR" --limit 2>&1)"
+if [ $? -eq 2 ]; then ok "clearing: a flag missing its value exits 2, not 0"; else bad "clearing: a flag missing its value did not exit 2"; fi
+
+out="$("$CLEAR" --nonsense 2>&1)"
+if [ $? -eq 2 ]; then ok "clearing: an unknown flag exits 2, not 0"; else bad "clearing: an unknown flag did not exit 2"; fi
 
 printf '\n'
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
## What and why

`main is not known-broken` is a required check. It fires on `pull_request`, and branch protection reads the **last** check run for that name on the head commit — so a hold that failed during an outage stays the answer after the outage ends. On 2026-09-05 `main` broke, a repair landed, the canary closed its issue, and ten open pull requests were still unmergeable on a check whose own question now answered the other way. A push to each branch clears it; a finished PR waiting for review has no reason to push, and the two moves a session reaches for first (an empty commit, close-and-reopen) are the two AGENTS.md forbids.

`scripts/clear-main-red-holds.sh` is the missing step. It asks whether any `main-red` issue is still open. If none is, it lists the open PRs, finds each head's failed `main-red-hold` run, and re-runs it. The re-run reports under the same check-run name on the same commit — the only thing branch protection reads.

**Two callers, because neither sees every recovery.**

- `main-canary.yml`, on the run that closes the issue. This is the ordinary path, and an `issues:`-triggered workflow **cannot** see it: the canary closes with `GITHUB_TOKEN`, and GitHub starts no workflow from an event that token raised. This is why the maintainer pointer's `issues`-only trigger could not stand alone.
- `.github/workflows/main-red-clear.yml`, on `issues: [closed, unlabeled]` filtered to the `main-red` label, for a person closing or unlabelling by hand.

Running it twice re-runs nothing the first pass cleared, and every unknown prints a note and exits 0 — a canary reddened by a `gh` blip in its clean-up step would report "main is broken" about a tree that composes.

**Deviation from the design pointer, stated for review.** The pointer suggested `workflow_dispatch` plus a commit status carrying the context name. That leaves a failed check run and a passing status wearing one name, and which of them branch protection believes is not something this repository can establish without breaking `main` to find out. Re-running the original run leaves one check run with one verdict, so that is what shipped.

**API evidence** (the mechanism, verified by hand rather than asserted): `GET /repos/macanderson/stella/actions/workflows/main-red-hold.yml/runs?head_sha=3a33516755b8689517c1b51f5bacc70b0405b1ec` returns `total_count 1`, run `33968280706`, and that SHA is PR #6008's `headRefOid`. So the head-SHA filter the script uses does find a PR's own hold run.

## Witness mechanism

New cases in `scripts/test-main-red-hold.sh` (`make main-red-hold-test`), driving the script's fixture seams — no network, no `gh`. They fail on the old code **by construction**: the script they exercise does not exist there, so every positive case exits 127 and the suite is red.

- With `scripts/clear-main-red-holds.sh` removed: `main-red-hold-test: FAILED — 12 passed, 7 failed`, each failure reading `expected exit 0 (fail-open), got 127: … No such file or directory`.
- With it present: `main-red-hold-test: OK — 19 checks passed`.

The cases cover the recovery sweep (both stale PRs re-run, named with the exact run id), the PR whose hold already passes being left alone, the sweep summary, the negative control (an open `main-red` issue clears nothing), an empty PR list, and both argument errors.

## Also in this PR

- `check-main-red-hold.sh`'s failure text told the reader to wait for a green check that nothing would ever produce; it now says the canary re-runs the check as it closes its issue.
- AGENTS.md's `main-red-hold.yml` paragraph said the hold "passes when no issue is open", which was true only at event time. It now names what clears it.
- `make clear-main-red-holds` prints what a sweep would re-run, changing nothing.

Exemplar followed: `scripts/main-canary.sh` and `scripts/check-main-red-hold.sh` — same fixture-seam shape, same fail-open discipline, same `--help` header reader.

Tests deleted: None.

Residue issues filed: none — see the final comment on #5913 for the one judgement left open (whether agent sessions should hold `actions: write`, which the issue itself flags as a separate call and which this PR does not need: CI holds the permission, not a session).

Closes #5913

## Summary by Sourcery

Automatically clear stale main-red merge holds when main recovers by re-running failed checks on affected pull requests through both canary and manual recovery workflows.

New Features:
- Add automatic recovery of stale main-red merge holds by re-running failed hold checks on affected open pull requests.
- Add a manual recovery workflow for closing or removing the main-red issue label.

Bug Fixes:
- Ensure pull requests become mergeable after main recovers without requiring a new push or other branch changes.
- Update hold failure guidance to accurately describe the automatic recovery behavior.

Enhancements:
- Document the lifecycle and recovery behavior of main-red holds, including the two recovery paths and dry-run command.

CI:
- Grant the canary and recovery workflows the permissions required to inspect pull requests and re-run check workflows.
- Add hermetic coverage for stale-hold recovery, negative controls, summaries, and workflow wiring.

Documentation:
- Update repository guidance for clearing stale main-red holds after recovery.

Tests:
- Extend the main-red hold test suite with recovery scenarios and argument validation.

Chores:
- Add a dry-run Make target for listing stale holds that would be re-run.

---
_Generated by [Claude Code](https://claude.ai/code)_