### PR TITLE
fix(ci): unblock the two Dependabot updaters that never proposed anything

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 # Automated dependency + security updates.
 # https://docs.github.com/code-security/dependabot
+#
+# Coverage (#3459): what is tracked automatically, and what is not.
+#   - cargo (workspace root): automatic for every direct/transitive
+#     dependency except `futures-util`, ignored below.
+#   - github-actions: automatic for every pinned action.
+#   - pip in /bench/harbor_adapter and /bench/terminal_bench_analysis: the
+#     only two directories under /bench with a Python manifest, automatic
+#     except `harbor`, ignored in both for the reason given below.
 version: 2
 updates:
   # Rust workspace.
@@ -11,6 +19,39 @@ updates:
     groups:
       cargo:
         update-types: [minor, patch]
+    ignore:
+      # `futures-util` is this workspace's only *direct* dependency from the
+      # `futures` 0.3 family ([workspace.dependencies]); `futures`,
+      # `futures-channel`, `futures-core`, `futures-executor`, `futures-io`,
+      # `futures-macro`, `futures-sink` and `futures-task` all ride along as
+      # transitives locked to the same 0.3.x line (Cargo.lock). Dependabot's
+      # cargo `LockfileUpdater` moves a family member with
+      # `cargo update -p futures-util`, and when that leaves the line
+      # unmoved it retries with `--precise` to force the sibling crates to
+      # cascade -- its own source names this exact shape ("the futures
+      # family: 0.3.34 needs futures-* at ^0.3.34",
+      # cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb,
+      # `force_precise_update`). For this workspace both attempts still
+      # leave futures-util unmoved, so `validate_dependency_update` raises
+      # `RuntimeError: Failed to update futures-util!` and the whole grouped
+      # cargo update job exits non-zero -- reproduced on three consecutive
+      # weekly runs (2026-08-16 run 31946407960, 2026-08-23 run
+      # 32638709216, 2026-08-30 run 33310879038; every one names
+      # futures-util in the job's own "Dependencies failed to update"
+      # table). `serde` hit the same validator once, on the 2026-08-16 run
+      # only, most likely for the same reason (it now splits into `serde`
+      # + `serde_core`); it is not ignored here because no run since has had
+      # a serde update to test the validator against, so there is nothing
+      # to reproduce -- if it recurs, extend this list the same way.
+      #
+      # This ignore is a deliberate decision to hand-track futures-util
+      # rather than block every other cargo update on an upstream bug. To
+      # bump it: `cargo update -p futures-util --precise <version>` (which
+      # cascades the sibling futures-* crates the same way Dependabot's own
+      # retry tries and fails to), then `cargo test -p <affected crates>`.
+      # Remove this entry once dependabot-core stops hitting the family
+      # lockstep case here, and re-track automatically.
+      - dependency-name: futures-util
 
   # GitHub Actions are pinned to full commit SHAs in every workflow, with the
   # human-readable tag kept as a trailing comment. Dependabot reads that
@@ -35,7 +76,7 @@ updates:
   # path unlaunchable until #909 caught it. Moving the pin means re-auditing
   # the launcher against the new release and updating every site together.
   - package-ecosystem: pip
-    directory: /bench
+    directory: /bench/terminal_bench_analysis
     schedule:
       interval: weekly
     ignore:

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -187,6 +187,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-deleted-tests.sh
 
+      - name: dependabot pip directory guard catches an empty directory (#3459)
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-dependabot-pip-dirs.sh
+
       # Was in UNHOSTED_SELF_TESTS until #4443: 14 of its 38 cases failed
       # everywhere, not just outside a Linux dev box as first suspected — the
       # fixture built a synthetic repo shaped `stella-core/src/`, and

--- a/Makefile
+++ b/Makefile
@@ -933,6 +933,20 @@ issue-claim: ## Ask whether somebody is already implementing an issue: make issu
 issue-claim-test: ## Test the issue-claim pre-flight, standing-down branch included (hermetic; not part of `gate`)
 	./scripts/test-issue-claim.sh
 
+# Not a GATE_STEPS member -- one file, one narrow shape (#3459). The real
+# enforcement is its self-test's own live-tree case (F in
+# test-dependabot-pip-dirs.sh, "this repository's real dependabot.yml
+# passes"), which runs in guard-self-tests.yml on every PR: a future edit
+# that repoints a pip directory: at an empty one fails that case the same
+# way it would fail this target run by hand.
+.PHONY: dependabot-pip-dirs
+dependabot-pip-dirs: ## Assert every pip directory: in .github/dependabot.yml holds a manifest
+	@./scripts/check-dependabot-pip-dirs.sh
+
+.PHONY: dependabot-pip-dirs-test
+dependabot-pip-dirs-test: ## Test the dependabot pip-directory guard (hermetic; not part of `gate`)
+	./scripts/test-dependabot-pip-dirs.sh
+
 .PHONY: check
 check: $(CHECK_STEPS) ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy (default and schema features), no rustdoc and no tests
 	@./scripts/check-hooks-installed.sh

--- a/scripts/check-dependabot-pip-dirs.sh
+++ b/scripts/check-dependabot-pip-dirs.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Guard: every pip `directory:` in .github/dependabot.yml must hold a real
+# Python manifest.
+#
+# Dependabot's pip updater does not look inside subfolders. A `directory:`
+# line finds files only in that exact folder. `pip in /bench` named a
+# folder with no manifest in it at all. Every weekly run failed fast, with
+# "No files found in /bench". Two real manifests sat close by and were
+# never checked. bench/harbor_adapter/pyproject.toml had its own correct
+# entry. bench/terminal_bench_analysis/pyproject.toml had none. Nothing
+# caught this. The failure happens on Dependabot's own servers. This
+# repo's CI never sees it.
+#
+# This guard is a small, mechanical check. It cannot tell a wrong folder
+# from a stale one left behind by a rename. It can catch a folder with
+# nothing in it, which is the exact shape of the bug above.
+#
+# Not a full YAML parser. dependabot.yml's shape is simple: a flat list of
+# entries, each indented the same way. A line-by-line scan is enough, and
+# it avoids adding a YAML library dependency for one script.
+# scripts/test-dependabot-pip-dirs.sh checks that this scan still matches
+# the real file's shape.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# A test seam. The test suite points this at a fixture folder instead of
+# the real repo (same pattern as scripts/check-action-pins.sh). The
+# fixture must carry its own .github/dependabot.yml. That way directory:
+# paths resolve inside the fixture, not inside the real bench/ tree.
+if [ "${1:-}" = "--fixture-root" ]; then
+  repo_root="$2"
+fi
+
+config="$repo_root/.github/dependabot.yml"
+if [ ! -f "$config" ]; then
+  echo "check-dependabot-pip-dirs: no such file: $config" >&2
+  exit 1
+fi
+
+config_dir="$repo_root"
+
+manifest_present() {
+  # $1 = a directory: value from dependabot.yml, such as "/bench". These
+  # are always relative to the repository root, not to this script.
+  local dir="$config_dir${1%/}"
+  [ -f "$dir/pyproject.toml" ] && return 0
+  [ -f "$dir/setup.py" ] && return 0
+  [ -f "$dir/setup.cfg" ] && return 0
+  [ -f "$dir/Pipfile" ] && return 0
+  compgen -G "$dir/requirements*.txt" >/dev/null 2>&1 && return 0
+  return 1
+}
+
+fail=0
+ecosystem=""
+directory=""
+
+check_pending() {
+  if [ "$ecosystem" = "pip" ] && [ -n "$directory" ]; then
+    if ! manifest_present "$directory"; then
+      echo "check-dependabot-pip-dirs: pip entry 'directory: $directory' has no" \
+        "pyproject.toml/setup.py/setup.cfg/Pipfile/requirements*.txt in it" >&2
+      fail=1
+    fi
+  fi
+}
+
+while IFS= read -r line; do
+  case "$line" in
+    '  - package-ecosystem:'*)
+      # A new update entry starts: flush the previous one, then reset.
+      check_pending
+      ecosystem="$(printf '%s' "$line" | sed -E 's/^[^:]+:[[:space:]]*//')"
+      directory=""
+      ;;
+    '    directory:'*)
+      directory="$(printf '%s' "$line" | sed -E 's/^[^:]+:[[:space:]]*//')"
+      ;;
+  esac
+done < "$config"
+check_pending
+
+if [ "$fail" -ne 0 ]; then
+  echo "check-dependabot-pip-dirs: FAILED" >&2
+  exit 1
+fi
+
+echo "check-dependabot-pip-dirs: OK — every pip directory: has a manifest"

--- a/scripts/test-dependabot-pip-dirs.sh
+++ b/scripts/test-dependabot-pip-dirs.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/check-dependabot-pip-dirs.sh.
+#
+#   ./scripts/test-dependabot-pip-dirs.sh
+#
+# Not part of `make gate`. It builds throwaway fixture folders, the same
+# way scripts/test-no-scratch.sh does.
+#
+# The witness: case B is the real bug this repo shipped. `pip in /bench`
+# named a folder with no manifest in it, and every weekly run failed with
+# "No files found in /bench". The guard fails on that fixture. It passes
+# once the entry points at a folder that holds a pyproject.toml. Fail,
+# then pass: that pair is what this repo calls a witness.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+guard="$repo_root/scripts/check-dependabot-pip-dirs.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+ok() { pass=$((pass + 1)); echo "ok   $1"; }
+no() { fail=$((fail + 1)); echo "FAIL $1"; shift; [ $# -gt 0 ] && printf '%s\n' "$@"; }
+
+# A fresh fixture tree with just a .github/dependabot.yml. $1 = fixture name,
+# $2 = dependabot.yml body. Echoes the tree's root.
+fixture() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/.github"
+  printf '%s\n' "$2" > "$dir/.github/dependabot.yml"
+  echo "$dir"
+}
+
+# A: no pip entries. Nothing to check. Must pass.
+dir=$(fixture "a-no-pip" '
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+')
+if "$guard" --fixture-root "$dir" >/dev/null 2>&1; then
+  ok "A: no pip entries passes"
+else
+  no "A: no pip entries should pass"
+fi
+
+# B: the real bug. directory: /bench, empty.
+dir=$(fixture "b-empty-dir" '
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /bench
+    schedule:
+      interval: weekly
+')
+if "$guard" --fixture-root "$dir" >/dev/null 2>&1; then
+  no "B: empty pip directory should fail (the shipped defect's shape)"
+else
+  ok "B: empty pip directory fails"
+fi
+
+# C: same shape as B, but the folder holds a pyproject.toml.
+dir=$(fixture "c-pyproject" '
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /bench/terminal_bench_analysis
+    schedule:
+      interval: weekly
+')
+mkdir -p "$dir/bench/terminal_bench_analysis"
+touch "$dir/bench/terminal_bench_analysis/pyproject.toml"
+if "$guard" --fixture-root "$dir" >/dev/null 2>&1; then
+  ok "C: pip directory with pyproject.toml passes"
+else
+  no "C: pip directory with pyproject.toml should pass"
+fi
+
+# D: a requirements.txt file counts too, not just pyproject.toml.
+dir=$(fixture "d-requirements" '
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /tools
+    schedule:
+      interval: weekly
+')
+mkdir -p "$dir/tools"
+touch "$dir/tools/requirements-dev.txt"
+if "$guard" --fixture-root "$dir" >/dev/null 2>&1; then
+  ok "D: pip directory with requirements*.txt passes"
+else
+  no "D: pip directory with requirements*.txt should pass"
+fi
+
+# E: two pip entries. Only the second is broken. Both must be checked.
+dir=$(fixture "e-second-broken" '
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /good
+    schedule:
+      interval: weekly
+  - package-ecosystem: pip
+    directory: /bad
+    schedule:
+      interval: weekly
+')
+mkdir -p "$dir/good" "$dir/bad"
+touch "$dir/good/setup.py"
+if "$guard" --fixture-root "$dir" >/dev/null 2>&1; then
+  no "E: second broken pip entry should still fail"
+else
+  ok "E: second broken pip entry fails"
+fi
+
+# F: this repo's own real config passes today.
+if "$guard" >/dev/null 2>&1; then
+  ok "F: this repository's real dependabot.yml passes"
+else
+  no "F: this repository's real dependabot.yml should pass"
+fi
+
+echo
+echo "pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

Two of the four `Dependabot Updates` jobs have failed on every recent weekly run:

- **`cargo in /.`** — Dependabot's own cargo `LockfileUpdater` cannot move
  `futures-util` past a family-lockstep case its own source names (the
  `futures` 0.3 crates must all move together; the workspace's only direct
  member of that family is `futures-util`, and Dependabot's own `--precise`
  retry still leaves it unmoved). Reproduced on 3 consecutive runs
  (2026-08-16, 2026-08-23, 2026-08-30 — see the linked issue comment for the
  run ids and log excerpts). `serde` hit the same validator once, on
  2026-08-16, most likely for the same reason (its own `serde`/`serde_core`
  split); it is not preemptively ignored since nothing since has reproduced
  it.
- **`pip in /bench`** — `directory: /bench` has never had a Python manifest
  in it, since the commit that first added Dependabot to this repository.
  Every run fails immediately with `No files found in /bench`. The real
  manifest sits at `bench/terminal_bench_analysis/pyproject.toml`, which had
  no `dependabot.yml` entry at all — a repo misconfiguration, not an
  upstream bug.

Fix:

- `.github/dependabot.yml`: scoped `ignore` for `futures-util` under the
  cargo ecosystem, with a comment naming the upstream mechanism, the three
  reproducing runs, and the manual-bump procedure. Repoint the `pip` entry
  at `/bench/terminal_bench_analysis` (its real manifest), carrying the same
  `harbor` ignore its sibling `harbor_adapter` entry already has. A
  top-of-file comment states what's auto-tracked vs. hand-tracked, per the
  issue's DoD.
- `scripts/check-dependabot-pip-dirs.sh` (+
  `scripts/test-dependabot-pip-dirs.sh`): a small guard against the pip
  misconfiguration recurring — every pip `directory:` must hold a real
  manifest.

Closes #3459

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`scripts/test-dependabot-pip-dirs.sh` case B builds a fixture reproducing
the shipped defect (a pip `directory:` with nothing in it) and asserts
`check-dependabot-pip-dirs.sh` fails on it; cases C/F assert it passes once
the directory holds a manifest, including against this repository's own
real `.github/dependabot.yml`. Run locally: `make dependabot-pip-dirs-test`
(6/6 passing).

The **cargo-side `futures-util` ignore has no witness** — it configures
Dependabot's own infrastructure, which this repository's CI cannot exercise
or reproduce. Verified instead by reading three consecutive weekly run logs
(`gh run view --log-failed` on runs 31946407960, 32638709216, 33310879038,
all naming `futures-util` in the job's own "Dependencies failed to update"
table) and `dependabot/dependabot-core`'s own
`cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb`, whose
`force_precise_update` comment names this exact family-lockstep shape.

## The gate

- [ ] `cargo fmt --check` — n/a, no Rust changed; ran anyway via `make guards-fast` (passing)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — n/a, no Rust changed
- [ ] `cargo test --workspace` — n/a, no Rust changed
- [x] Docs updated where behavior/flags changed — the config's own top-of-file comment is the documentation here
- [ ] CLA signed
- [x] `Closes #N` appears **both** above and as a commit trailer

`make guards-fast` passes locally (shellcheck, prose, line-citations,
gate-parity, file-size, and everything else that rung runs). No Rust was
touched, so the compiling rungs don't apply; CI's required checks
(fmt/clippy/test, deny/audit, etc.) are expected to be no-ops on this diff
and are still the source of truth per CI polling below.

## Nothing left behind

- [ ] Filed: #___, #___ — **or**
- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

`serde` is deliberately *not* added to the cargo `ignore` list. It failed
the same validator once (2026-08-16) but every run since reports "No update
needed for serde" — there's been nothing to reproduce it against since. The
comment above the ignore entry says so, so if it recurs the fix is obvious
(extend the list the same way).

I could not trigger a fresh on-demand Dependabot run to confirm the cargo
job goes green post-merge — there's no public API for that, only the
weekly schedule (next run: the following Sunday) or the repo UI's manual
"Check for updates" button. The DoD's second bullet ("confirmed upstream
and linked, with a scoped ignore/config change carrying a comment") doesn't
require a fresh green run to close, but it'd be worth someone checking that
next scheduled run once it lands.

## DoD verification — #3459

Each DoD item on #3459 was re-verified against this branch rather than
against the PR description, then ticked. What was checked, and how:

1. **`cargo in /.` cause confirmed upstream + scoped `futures-util` ignore
   with a comment.** The `ignore` entry and its comment are in the diff; the
   upstream mechanism, the three reproducing run ids, and the log excerpts
   are linked on the issue in
   https://github.com/macanderson/stella/issues/3459#issuecomment-5552531081.
2. **`pip in /bench` repointed at its real manifest, keeping the `harbor`
   ignore.** `bench/terminal_bench_analysis/pyproject.toml` exists on this
   branch, and both pip entries now read `ignore: [- dependency-name: harbor]`
   — the repointed one and its `harbor_adapter` sibling. The pin the ignore
   protects is real: that manifest's `dependencies = ["harbor==0.6.1"]`.
3. **Coverage statement lives in `.github/dependabot.yml` itself.** The
   top-of-file comment is in the diff, and its one checkable claim holds —
   `find bench -maxdepth 2` for Python manifests returns exactly
   `bench/harbor_adapter/pyproject.toml` and
   `bench/terminal_bench_analysis/pyproject.toml`, the two directories it
   names.

The new guard and its self-test were run on this branch:
`check-dependabot-pip-dirs.sh` exits 0 against the real config, and
`test-dependabot-pip-dirs.sh` reports `pass=6 fail=0` (case B is the
fail-side witness).

The caveat in the section above stands and is not covered by the DoD: no
fresh Dependabot run has exercised the cargo job since this change, so the
`futures-util` ignore is verified by upstream log evidence rather than by a
green run. Worth checking the next scheduled run after this lands.

## Summary by Sourcery

Unblock Dependabot update jobs by handling the recurring cargo lockstep failure, correcting pip manifest discovery, and adding regression coverage for pip directory configuration.

Bug Fixes:
- Prevent the cargo Dependabot job from failing on the repeatedly unupdatable `futures-util` dependency by scoping an explicit ignore for that upstream lockstep case.
- Correct the pip Dependabot target to monitor the repository's actual Python manifest instead of the empty `/bench` directory.

Enhancements:
- Document Dependabot coverage and identify which dependencies require manual tracking.
- Add a guard that verifies every configured pip directory contains a supported Python manifest.

Build:
- Add Makefile targets for validating and testing Dependabot pip-directory configuration.

CI:
- Run the Dependabot pip-directory guard self-test in the guard workflow.

Documentation:
- Document automatic versus manual Dependabot tracking and the procedure for manually updating the ignored cargo dependency.

Tests:
- Add fixture-based tests covering empty, valid, multiple, and real-repository pip Dependabot directories.