### PR TITLE
feat(stella-tui): `>>> @agents` with a bang stops every session and keeps the rule

### DIFF
--- a/crates/stella-cli/src/agent/goal/tests.rs
+++ b/crates/stella-cli/src/agent/goal/tests.rs
@@ -76,6 +76,7 @@ async fn whistle_over_the_socket(socket: &std::path::Path, message: &str) {
         &crate::whistle::wire::WhistleRequest {
             text: message.to_string(),
             deep: false,
+            interrupt: false,
         },
     )
     .await

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -716,7 +716,7 @@ pub async fn run_deck_session(
         let _ = deck_tx.send(system_notice(notice));
     }
     steering::announce_withheld(cfg, &in_tx);
-    let whistle = whistle::DeckWhistle::spawn(&session_record.id);
+    let whistle = whistle::DeckWhistle::spawn(&session_record.id, sub_tx.clone());
     // An idle lead is waiting on the human, not queued behind a supervisor —
     // asserted outright, since the startup chrome above no longer folds it to
     // `Running` (see `system_notice`).
@@ -1110,15 +1110,10 @@ pub async fn run_deck_session(
                     }
                     // The composer's broadcast address — other sessions'
                     // whistle sockets, reported as one note (`whistle`).
-                    Some(WorkspaceInput::Whistle {
-                        message,
-                        session,
-                        deep,
-                    }) => {
+                    Some(WorkspaceInput::Whistle(broadcast)) => {
                         whistle::broadcast_from_deck(
-                            message,
-                            session,
-                            deep,
+                            broadcast,
+                            &whistle,
                             &session_record.id,
                             &in_tx,
                         );
@@ -2019,8 +2014,8 @@ pub async fn run_deck_session(
                         }
                         // A broadcast never waits on the lead's turn: it is
                         // about other sessions (`whistle`).
-                        Some(WorkspaceInput::Whistle { message, session, deep }) => {
-                            whistle::broadcast_from_deck(message, session, deep, &session_record.id, &in_tx);
+                        Some(WorkspaceInput::Whistle(broadcast)) => {
+                            whistle::broadcast_from_deck(broadcast, &whistle, &session_record.id, &in_tx);
                         }
                         // The agents page's new-task prompt: a lane now,
                         // exactly as at idle — the lead's turn is untouched.

--- a/crates/stella-cli/src/command_deck/keep_record.rs
+++ b/crates/stella-cli/src/command_deck/keep_record.rs
@@ -7,6 +7,11 @@
 //! deck cuts the mark off, sends the usual [`WorkspaceInput::Interrupt`], and
 //! tags it with the strength it was asked for. The tag is spent here.
 //!
+//! The room form is the same mark with an address in front (`>>> @agents !!!
+//! …`). It is written here too, and only here: the sessions it stops
+//! are handed the words with the mark spent, so a rule meant for one
+//! workspace is one file rather than one per session.
+//!
 //! `intercept` runs in front of both read points in the driver. It does not
 //! sit in the arms that take an interrupt:
 //!
@@ -53,6 +58,16 @@ pub(super) fn intercept(
                 texts,
                 keep: None,
             })
+        }
+        // A broadcast (`>>> @agents !!! …`) is the same mark aimed at the
+        // room. The write happens here, once, for this workspace — targets
+        // are handed the stop with the mark already spent, so one sentence
+        // cannot become a copy per session.
+        Some(WorkspaceInput::Whistle(mut broadcast)) => {
+            if let Some(keep) = broadcast.keep.take() {
+                save(root, keep, std::slice::from_ref(&broadcast.message), in_tx);
+            }
+            Some(WorkspaceInput::Whistle(broadcast))
         }
         other => other,
     }

--- a/crates/stella-cli/src/command_deck/keep_record/tests.rs
+++ b/crates/stella-cli/src/command_deck/keep_record/tests.rs
@@ -103,6 +103,46 @@ fn a_write_that_fails_still_hands_back_the_stop_and_says_so() {
     );
 }
 
+/// **The witness for the room's record.** A broadcast at every live
+/// session writes one record for this workspace, and hands the broadcast on
+/// with the mark spent — so the fan-out cannot ask a target to write it
+/// again.
+#[test]
+fn a_broadcast_writes_one_record_for_the_workspace() {
+    let root = tempfile::tempdir().unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let room = |keep| {
+        Some(WorkspaceInput::Whistle(stella_tui::Broadcast {
+            message: "Never force-push to main.".into(),
+            session: None,
+            deep: true,
+            interrupt: true,
+            keep,
+        }))
+    };
+
+    let passed = intercept(room(Some(KeepStrength::Rule)), root.path(), &tx);
+
+    assert_eq!(passed, room(None), "the mark is spent, the stop travels");
+    let registry = crate::context_records::load_registry(root.path());
+    let kept: Vec<_> = registry
+        .entries
+        .iter()
+        .filter(|entry| entry.record.record.statement == "Never force-push to main.")
+        .collect();
+    assert_eq!(kept.len(), 1, "one workspace, one record");
+    assert!(notes(&mut rx).iter().any(|n| n.contains("a rule (must)")));
+
+    // The fan-out hands each target this same message. Reading it again must
+    // write nothing.
+    let again = intercept(passed, root.path(), &tx);
+    assert_eq!(again, room(None));
+    assert!(
+        notes(&mut rx).is_empty(),
+        "a spent mark writes nothing on a second read"
+    );
+}
+
 /// An unmarked message is not this file's job. It passes as it came.
 #[test]
 fn an_unmarked_message_passes_straight_through() {

--- a/crates/stella-cli/src/command_deck/whistle.rs
+++ b/crates/stella-cli/src/command_deck/whistle.rs
@@ -18,6 +18,11 @@
 //! deck is delivered rather than refused, and lands in front of the model the
 //! moment the next turn opens.
 //!
+//! A whistle can also carry a stop (`>>> @agents ! …`). That one does
+//! not go into a tap here: it leaves as `WorkspaceInput::Interrupt` down the
+//! driver's own input channel, so a whistled stop and a typed `!` take one
+//! path through the backlog and the pause gate rather than two.
+//!
 //! # Why this is a sibling module
 //!
 //! `command_deck.rs` is a grandfathered god file closed to growth (AGENTS.md
@@ -28,15 +33,17 @@
 
 use std::sync::{Arc, Mutex, Weak};
 
+use tokio::sync::mpsc::UnboundedSender;
+
 use crate::subsession::SteeringTap;
 use crate::whistle::tap::Whistleable;
+use stella_tui::WorkspaceInput;
 
 /// The publication point a deck session's whistle socket writes into.
 ///
 /// Held by the driver loop for the session's lifetime. Steers reach the
 /// running turn's tap when there is one and it can still act on them, and are
 /// held for the next turn otherwise.
-#[derive(Default)]
 pub(super) struct DeckWhistle {
     /// The turn currently able to drain a steer.
     ///
@@ -57,13 +64,30 @@ pub(super) struct DeckWhistle {
     /// This session's bound socket. Replaced when the deck switches sessions;
     /// dropping it unbinds and removes the socket file.
     listener: Mutex<Option<crate::whistle::SessionListener>>,
+    /// The driver's own input channel — the one the deck sends keystrokes
+    /// down. A delivered interrupt leaves by it as
+    /// [`WorkspaceInput::Interrupt`], so the stop, the front insert and the
+    /// resume are the path a typed `!` already takes
+    /// (`command_deck::steer::interrupt_lead`) rather than a second one.
+    input: UnboundedSender<WorkspaceInput>,
 }
 
 impl DeckWhistle {
+    /// A relay bound to no socket, writing interrupts into `input`.
+    fn new(input: UnboundedSender<WorkspaceInput>) -> Self {
+        Self {
+            live: Mutex::default(),
+            pending: Mutex::default(),
+            lanes: Mutex::default(),
+            listener: Mutex::default(),
+            input,
+        }
+    }
+
     /// Bind `session_id`'s whistle socket and keep it for as long as the
     /// returned relay is held.
-    pub(super) fn spawn(session_id: &str) -> Arc<Self> {
-        let relay = Arc::new(Self::default());
+    pub(super) fn spawn(session_id: &str, input: UnboundedSender<WorkspaceInput>) -> Arc<Self> {
+        let relay = Arc::new(Self::new(input));
         relay.rebind(session_id);
         relay
     }
@@ -120,11 +144,17 @@ impl DeckWhistle {
         }
     }
 
-    /// [`Self::deliver`] to the lead, and the same text into every worker
-    /// lane still able to drain one. Lanes that ended are dropped from the
-    /// list on the way past, so it never grows with a session's history.
+    /// [`Self::deliver`] to the lead, then [`Self::deliver_lanes`] to the
+    /// workers it drives.
     fn deliver_deep(&self, text: String) {
         self.deliver(text.clone());
+        self.deliver_lanes(text);
+    }
+
+    /// The same text into every worker lane still able to drain one. Lanes
+    /// that ended are dropped from the list on the way past, so it never
+    /// grows with a session's history.
+    fn deliver_lanes(&self, text: String) {
         let mut lanes = self.lanes.lock().unwrap_or_else(|p| p.into_inner());
         lanes.retain(|lane| lane.upgrade().is_some());
         for tap in lanes.iter().filter_map(Weak::upgrade) {
@@ -132,6 +162,31 @@ impl DeckWhistle {
                 tap.push(text.clone());
             }
         }
+    }
+
+    /// Stop the lead's turn and run `text` next — the room form of the
+    /// composer's bang (`>>> @agents ! …`).
+    ///
+    /// The words leave as [`WorkspaceInput::Interrupt`] rather than going
+    /// into a tap here. The driver owns the backlog and the pause gate, and
+    /// its arms already know how to stop a running turn, run the words at
+    /// rest, and hand a lane a steer instead. `keep` is `None`: the record
+    /// was written once by the session that sent the line, so a target that
+    /// wrote another would give one sentence a copy per machine.
+    ///
+    /// A deep interrupt also reaches the live lanes, as words rather than as
+    /// a stop. A lane's next prompt is the lead's, so a stop there would have
+    /// nothing to run next. The envelope's `Interrupt` doc reads a worker
+    /// lane the same way.
+    fn interrupt_lead(&self, text: String, deep: bool) {
+        if deep {
+            self.deliver_lanes(text.clone());
+        }
+        let _ = self.input.send(WorkspaceInput::Interrupt {
+            agent: super::LEAD.to_string(),
+            texts: vec![text],
+            keep: None,
+        });
     }
 }
 
@@ -145,26 +200,50 @@ impl crate::subsession::LaneTapSink for DeckWhistle {
 }
 
 /// The deck's half of the composer's broadcast address (`>@all …`,
-/// `>@<session-id> …`): send `message` to the other live sessions on this
-/// machine over their whistle sockets, off the driver's event pump, and
-/// report every outcome as one chrome note. This session is never a target
-/// of its own broadcast — a steer meant for the room lands here through the
-/// composer's ordinary route, not through its own socket.
+/// `>>> @agents !!! …`): send the words to the live sessions on this machine
+/// over their whistle sockets, off the driver's event pump, and report every
+/// outcome as one chrome note.
+///
+/// A steer never reaches this session over its own socket — words meant for
+/// the room land here through the composer's ordinary route. **A stop does.**
+/// A person who tells every agent on the machine to stop means their own one
+/// too, so an interrupt addressed to the room is delivered here in process,
+/// through the relay's own [`DeckWhistle::interrupt_lead`], while the socket
+/// fan-out still skips this session. An interrupt addressed to one other id
+/// leaves this session alone.
 pub(super) fn broadcast_from_deck(
-    message: String,
-    session: Option<String>,
-    deep: bool,
+    broadcast: stella_tui::Broadcast,
+    relay: &Arc<DeckWhistle>,
     own_session: &str,
     in_tx: &tokio::sync::mpsc::UnboundedSender<stella_tui::Inbound>,
 ) {
     let own = own_session.to_string();
     let in_tx = in_tx.clone();
+    let here = broadcast.interrupt
+        && broadcast
+            .session
+            .as_deref()
+            .is_none_or(|id| id == own_session);
+    if here {
+        relay.interrupt_lead(broadcast.message.clone(), broadcast.deep);
+    }
     tokio::spawn(async move {
         let registry = stella_store::SessionRegistry::open_default();
-        let ids: Vec<String> = session.into_iter().collect();
-        let outcomes =
-            crate::whistle::cmd::broadcast(&registry, &message, &ids, deep, Some(&own)).await;
-        let _ = in_tx.send(super::chrome_note(crate::whistle::cmd::summary(&outcomes)));
+        let ids: Vec<String> = broadcast.session.into_iter().collect();
+        let outcomes = crate::whistle::cmd::broadcast(
+            &registry,
+            &broadcast.message,
+            &ids,
+            broadcast.deep,
+            broadcast.interrupt,
+            Some(&own),
+        )
+        .await;
+        let mut note = crate::whistle::cmd::summary(&outcomes);
+        if here {
+            note.push_str("\nstopping this session too — the room includes you");
+        }
+        let _ = in_tx.send(super::chrome_note(note));
     });
 }
 
@@ -189,12 +268,26 @@ impl Whistleable for RelayHandle {
             relay.deliver_deep(text);
         }
     }
+
+    fn interrupt(&self, text: String, deep: bool) {
+        if let Some(relay) = self.0.upgrade() {
+            relay.interrupt_lead(text, deep);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use stella_core::ports::TurnSteering;
+    use tokio::sync::mpsc::UnboundedReceiver;
+
+    /// A relay bound to no socket, with the driver channel an interrupt
+    /// leaves by.
+    fn relay() -> (Arc<DeckWhistle>, UnboundedReceiver<WorkspaceInput>) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (Arc::new(DeckWhistle::new(tx)), rx)
+    }
 
     /// **The witness (#4768).** A whistle delivered while the deck sits idle
     /// is in the next turn's tap the moment that turn opens.
@@ -205,7 +298,7 @@ mod tests {
     /// go at all.
     #[test]
     fn a_steer_that_arrives_between_turns_opens_the_next_one() {
-        let relay = Arc::new(DeckWhistle::default());
+        let (relay, _driver) = relay();
         RelayHandle(Arc::downgrade(&relay)).push("read the failing test".to_string());
 
         let tap = relay.mint_turn_tap();
@@ -216,7 +309,7 @@ mod tests {
     /// the whole point of the socket being reachable mid-turn.
     #[test]
     fn a_steer_during_a_turn_reaches_the_turn_that_is_running() {
-        let relay = Arc::new(DeckWhistle::default());
+        let (relay, _driver) = relay();
         let tap = relay.mint_turn_tap();
         RelayHandle(Arc::downgrade(&relay)).push("stop the compile".to_string());
 
@@ -232,7 +325,7 @@ mod tests {
     /// rule `steer_lead` already applies to a typed `>`.
     #[test]
     fn a_steer_at_a_settling_turn_waits_for_the_next_one() {
-        let relay = Arc::new(DeckWhistle::default());
+        let (relay, _driver) = relay();
         let settling = relay.mint_turn_tap();
         settling.mark_settling();
         RelayHandle(Arc::downgrade(&relay)).push("next time, run the tests".to_string());
@@ -273,7 +366,8 @@ mod tests {
             .build()
             .expect("runtime")
             .block_on(async {
-                let relay = DeckWhistle::spawn("dw1");
+                let (tx, _driver) = tokio::sync::mpsc::unbounded_channel();
+                let relay = DeckWhistle::spawn("dw1", tx);
                 let mut stream = tokio::net::UnixStream::connect(&socket)
                     .await
                     .expect("the deck session must have bound a whistle socket");
@@ -282,6 +376,7 @@ mod tests {
                     &crate::whistle::wire::WhistleRequest {
                         text: "the deck is listening".to_string(),
                         deep: false,
+                        interrupt: false,
                     },
                 )
                 .await
@@ -309,7 +404,7 @@ mod tests {
     #[test]
     fn a_deep_whistle_reaches_the_lead_and_every_live_lane() {
         use crate::subsession::LaneTapSink as _;
-        let relay = Arc::new(DeckWhistle::default());
+        let (relay, _driver) = relay();
         let lead = relay.mint_turn_tap();
         let lane_a: Arc<SteeringTap> = Arc::default();
         let lane_b: Arc<SteeringTap> = Arc::default();
@@ -355,7 +450,7 @@ mod tests {
     /// a queue nothing will read again.
     #[test]
     fn a_finished_turns_tap_stops_receiving() {
-        let relay = Arc::new(DeckWhistle::default());
+        let (relay, _driver) = relay();
         drop(relay.mint_turn_tap());
         RelayHandle(Arc::downgrade(&relay)).push("the next turn should know".to_string());
 
@@ -363,5 +458,185 @@ mod tests {
             relay.mint_turn_tap().drain_steering(),
             vec!["the next turn should know"]
         );
+    }
+
+    /// One session with a bound socket, and the relay behind it.
+    #[cfg(unix)]
+    fn live_session(
+        registry: &stella_store::SessionRegistry,
+        id: &str,
+    ) -> (Arc<DeckWhistle>, UnboundedReceiver<WorkspaceInput>) {
+        listed(registry, id);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (DeckWhistle::spawn(id, tx), rx)
+    }
+
+    /// Put one live session in the registry. It binds no socket of its own,
+    /// so on its own it is a target `stella whistle` cannot reach.
+    #[cfg(unix)]
+    fn listed(registry: &stella_store::SessionRegistry, id: &str) {
+        let mut record = stella_store::SessionRecord::new("ws".to_string(), "name".to_string());
+        record.id = id.to_string();
+        record.status = stella_store::SessionStatus::InProgress;
+        registry.upsert(&record).expect("register the session");
+    }
+
+    /// The words of the one interrupt a driver channel was handed.
+    #[cfg(unix)]
+    fn taken(rx: &mut UnboundedReceiver<WorkspaceInput>) -> Vec<String> {
+        match rx.try_recv() {
+            Ok(WorkspaceInput::Interrupt { texts, keep, .. }) => {
+                assert!(keep.is_none(), "the record is written once, by the sender");
+                texts
+            }
+            other => panic!("expected one interrupt, got {other:?}"),
+        }
+    }
+
+    /// The chrome notes the driver was told to show.
+    #[cfg(unix)]
+    fn notes(rx: &mut tokio::sync::mpsc::UnboundedReceiver<stella_tui::Inbound>) -> String {
+        let mut out = Vec::new();
+        while let Ok(inbound) = rx.try_recv() {
+            if let stella_tui::Inbound::Event {
+                event: stella_protocol::AgentEvent::Text { text },
+                ..
+            } = inbound
+            {
+                out.push(text);
+            }
+        }
+        out.join("\n")
+    }
+
+    /// A short home under `/tmp`: a `sockaddr_un` path is capped at about a
+    /// hundred bytes, and the platform temp dir is already half of that on
+    /// macOS. The session ids are short for the same reason.
+    #[cfg(unix)]
+    fn short_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("bc")
+            .tempdir_in("/tmp")
+            .expect("home")
+    }
+
+    /// **The witness for the room broadcast.** `>>> @agents !!! …`
+    /// stops every live session on this machine, and the one that sent it.
+    /// Two fixture sessions take the stop over their real sockets, carrying
+    /// the words; the sender takes the same stop in process rather than
+    /// through its own socket; a session that bound none is reported and
+    /// costs the others nothing.
+    ///
+    /// A broadcast that carries only words gives none of the three an
+    /// interrupt to receive, which is what makes this a witness.
+    #[cfg(unix)]
+    #[test]
+    fn a_room_broadcast_stops_every_live_session_and_the_sender() {
+        let _env = crate::test_env::lock();
+        let home = short_home();
+        let _home = crate::test_env::home_sandbox(home.path());
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(async {
+                let registry = stella_store::SessionRegistry::open_default();
+                let (_one, mut one_rx) = live_session(&registry, "bc1");
+                let (_two, mut two_rx) = live_session(&registry, "bc2");
+                listed(&registry, "bc3");
+                let (sender, mut sender_rx) = live_session(&registry, "bc0");
+                let (in_tx, mut in_rx) = tokio::sync::mpsc::unbounded_channel();
+
+                broadcast_from_deck(
+                    stella_tui::Broadcast {
+                        message: "do not force-push".to_string(),
+                        session: None,
+                        deep: true,
+                        interrupt: true,
+                        keep: Some(stella_tui::KeepStrength::Rule),
+                    },
+                    &sender,
+                    "bc0",
+                    &in_tx,
+                );
+
+                // The sender's own stop is in hand before any socket is
+                // touched. The rest cross the accept loops' own tasks.
+                assert_eq!(
+                    taken(&mut sender_rx),
+                    vec!["do not force-push".to_string()],
+                    "the room includes the session that spoke"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+                for rx in [&mut one_rx, &mut two_rx] {
+                    let texts = taken(rx);
+                    assert_eq!(texts.len(), 1);
+                    assert!(
+                        texts[0].ends_with("do not force-push"),
+                        "the words ride with the stop: {texts:?}"
+                    );
+                }
+
+                let said = notes(&mut in_rx);
+                assert!(said.contains("delivered    bc1"), "{said}");
+                assert!(said.contains("delivered    bc2"), "{said}");
+                assert!(said.contains("unreachable  bc3"), "{said}");
+                assert!(
+                    !said.contains("bc0"),
+                    "the sender is no socket target: {said}"
+                );
+                assert!(said.contains("stopping this session too"), "{said}");
+            });
+    }
+
+    /// **The witness for the fan-out.** A session whose socket takes
+    /// the frame and never answers holds up its own row alone. The live
+    /// session has its stop long before the stalled one's ack timeout is
+    /// anywhere near spent.
+    #[cfg(unix)]
+    #[test]
+    fn a_stalled_session_does_not_hold_up_the_others_stop() {
+        let _env = crate::test_env::lock();
+        let home = short_home();
+        let _home = crate::test_env::home_sandbox(home.path());
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(async {
+                let registry = stella_store::SessionRegistry::open_default();
+                let (_live, mut live_rx) = live_session(&registry, "st1");
+                // A socket nobody accepts on: connecting works, the frame is
+                // written, and no ack ever comes.
+                listed(&registry, "st2");
+                registry.prepare_sidecar("st2").expect("sidecar");
+                let _stalled = tokio::net::UnixListener::bind(registry.whistle_socket_path("st2"))
+                    .expect("bind the stalled socket");
+                let (sender, _sender_rx) = live_session(&registry, "st0");
+                let (in_tx, _in_rx) = tokio::sync::mpsc::unbounded_channel();
+
+                broadcast_from_deck(
+                    stella_tui::Broadcast {
+                        message: "stop touching main".to_string(),
+                        session: None,
+                        deep: false,
+                        interrupt: true,
+                        keep: None,
+                    },
+                    &sender,
+                    "st0",
+                    &in_tx,
+                );
+
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                let texts = taken(&mut live_rx);
+                assert!(
+                    texts[0].ends_with("stop touching main"),
+                    "the live session is not made to wait: {texts:?}"
+                );
+            });
     }
 }

--- a/crates/stella-cli/src/whistle/cmd.rs
+++ b/crates/stella-cli/src/whistle/cmd.rs
@@ -35,7 +35,7 @@ pub(crate) async fn run(message: &str, session_ids: &[String], deep: bool) -> Re
         return Err("stella whistle: message must not be empty".to_string());
     }
     let registry = SessionRegistry::open_default();
-    let outcomes = broadcast(&registry, message, session_ids, deep, None).await;
+    let outcomes = broadcast(&registry, message, session_ids, deep, false, None).await;
     if outcomes.is_empty() {
         println!(
             "no {} to whistle at",
@@ -68,11 +68,14 @@ pub(crate) async fn run(message: &str, session_ids: &[String], deep: bool) -> Re
 /// among them, a sequential sweep made "broadcast" mean "wait". A stale
 /// socket now delays only its own row. `deep` asks each session to reach
 /// its worker lanes too ([`super::tap::Whistleable::push_deep`]).
+/// `interrupt` asks it to stop the turn it is running. The words then run
+/// next there ([`super::tap::Whistleable::interrupt`]).
 pub(crate) async fn broadcast(
     registry: &SessionRegistry,
     message: &str,
     session_ids: &[String],
     deep: bool,
+    interrupt: bool,
     exclude: Option<&str>,
 ) -> Vec<(SessionRecord, Delivery)> {
     let targets: Vec<SessionRecord> = targets(registry, session_ids)
@@ -87,7 +90,7 @@ pub(crate) async fn broadcast(
     let outcomes = futures_util::future::join_all(
         targets
             .iter()
-            .map(|record| deliver_one(registry, record, &wrapped, deep)),
+            .map(|record| deliver_one(registry, record, &wrapped, deep, interrupt)),
     )
     .await;
     targets.into_iter().zip(outcomes).collect()
@@ -147,6 +150,7 @@ async fn deliver_one(
     record: &SessionRecord,
     text: &str,
     deep: bool,
+    interrupt: bool,
 ) -> Delivery {
     use tokio::net::UnixStream;
     use tokio::time::timeout;
@@ -164,6 +168,7 @@ async fn deliver_one(
     let request = WhistleRequest {
         text: text.to_string(),
         deep,
+        interrupt,
     };
     if write_frame(&mut stream, &request).await.is_err() {
         return Delivery::Unreachable("failed to send".to_string());
@@ -186,6 +191,7 @@ async fn deliver_one(
     _record: &SessionRecord,
     _text: &str,
     _deep: bool,
+    _interrupt: bool,
 ) -> Delivery {
     Delivery::Unreachable(
         "agent whistle needs a Unix domain socket — not supported on this platform yet".to_string(),
@@ -249,17 +255,25 @@ mod tests {
         registry.upsert(&unreachable).unwrap();
 
         assert_eq!(
-            deliver_one(&registry, &reachable, "test", false).await,
+            deliver_one(&registry, &reachable, "test", false, false).await,
             Delivery::Delivered
         );
         assert!(matches!(
-            deliver_one(&registry, &unreachable, "test", false).await,
+            deliver_one(&registry, &unreachable, "test", false, false).await,
             Delivery::Unreachable(_)
         ));
 
         // The broadcast reaches both at once, reports each in target order,
         // and leaves out the session that is broadcasting.
-        let mut outcomes = broadcast(&registry, "test", &[], false, Some("ses-unreachable")).await;
+        let mut outcomes = broadcast(
+            &registry,
+            "test",
+            &[],
+            false,
+            false,
+            Some("ses-unreachable"),
+        )
+        .await;
         outcomes.sort_by(|a, b| a.0.id.cmp(&b.0.id));
         assert_eq!(outcomes.len(), 1, "the excluded session is not a target");
         assert_eq!(outcomes[0].0.id, "ses-reachable");
@@ -286,7 +300,7 @@ mod tests {
             r.id = id.to_string();
             registry.upsert(&r).unwrap();
         }
-        let outcomes = broadcast(&registry, "test", &[], false, None).await;
+        let outcomes = broadcast(&registry, "test", &[], false, false, None).await;
         let mut got: Vec<&str> = outcomes.iter().map(|(r, _)| r.id.as_str()).collect();
         got.sort_unstable();
         assert_eq!(got, ids, "every target is reported, none dropped");

--- a/crates/stella-cli/src/whistle/listener.rs
+++ b/crates/stella-cli/src/whistle/listener.rs
@@ -94,7 +94,9 @@ async fn accept_loop(listener: UnixListener, tap: Arc<dyn Whistleable>) {
             let Ok(request) = read_frame::<_, WhistleRequest>(&mut stream).await else {
                 return;
             };
-            if request.deep {
+            if request.interrupt {
+                tap.interrupt(request.text, request.deep);
+            } else if request.deep {
                 tap.push_deep(request.text);
             } else {
                 tap.push(request.text);
@@ -136,6 +138,7 @@ mod tests {
             &WhistleRequest {
                 text: "stop the compile".to_string(),
                 deep: false,
+                interrupt: false,
             },
         )
         .await

--- a/crates/stella-cli/src/whistle/tap.rs
+++ b/crates/stella-cli/src/whistle/tap.rs
@@ -24,6 +24,21 @@ pub(crate) trait Whistleable: Send + Sync {
     fn push_deep(&self, text: String) {
         self.push(text);
     }
+
+    /// Queue `text` and stop the running turn, so the words run next rather
+    /// than only riding along — the room form of the composer's bang
+    /// (`>>> @agents ! …`).
+    ///
+    /// The default delivers the words and stops nothing, which is all a tap
+    /// with no stop to latch can do: the text still lands, and no caller is
+    /// told a turn halted when none did.
+    fn interrupt(&self, text: String, deep: bool) {
+        if deep {
+            self.push_deep(text);
+        } else {
+            self.push(text);
+        }
+    }
 }
 
 /// A minimal steering tap for a non-interactive (non-deck) session: `stella run`
@@ -50,6 +65,20 @@ impl Whistleable for HeadlessSteerTap {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .push(text);
     }
+
+    /// The words first, then the stop. The boundary drains steering before it
+    /// reads the stop (`stella_core::driver::step_boundary::consult_hosts`),
+    /// so this order is what puts the text in the turn it halts.
+    ///
+    /// The latch holds until the run ends, as `SteeringTap`'s does. A door
+    /// with no deck is one arc: `stella run` is a turn, and a `stella goal`
+    /// round that aborts ends the arc (`stella_core::goal`). So "stop" here
+    /// means the session stops, which is what a person broadcasting a bang
+    /// asked every session to do.
+    fn interrupt(&self, text: String, _deep: bool) {
+        self.push(text);
+        self.soft_stop.store(true, Ordering::SeqCst);
+    }
 }
 
 impl stella_core::ports::TurnSteering for HeadlessSteerTap {
@@ -63,9 +92,8 @@ impl stella_core::ports::TurnSteering for HeadlessSteerTap {
     }
 
     fn soft_stop_requested(&self) -> bool {
-        // Whistle never sets this (see the module docs on scope) — it
-        // stays wired only because the port requires it, and reading
-        // `false` forever is correct for a tap nothing latches.
+        // Latched by an interrupt whistle alone (`Whistleable::interrupt`).
+        // A plain steer rides along and never stops the turn.
         self.soft_stop.load(Ordering::SeqCst)
     }
 }
@@ -84,10 +112,21 @@ mod tests {
         assert!(tap.drain_steering().is_empty());
     }
 
+    /// **The witness for the stop at a door with no deck.** A plain steer
+    /// rides along; an interrupt puts the words in the turn and then halts
+    /// it, in that order.
     #[test]
-    fn soft_stop_is_never_requested() {
+    fn only_an_interrupt_stops_a_headless_turn() {
         let tap = HeadlessSteerTap::default();
-        tap.push("anything".to_string());
-        assert!(!tap.soft_stop_requested());
+        tap.push("ride along".to_string());
+        assert!(!tap.soft_stop_requested(), "a steer stops nothing");
+
+        tap.interrupt("stop touching main".to_string(), true);
+        assert_eq!(
+            tap.drain_steering(),
+            vec!["ride along", "stop touching main"],
+            "the words are in the turn the stop halts"
+        );
+        assert!(tap.soft_stop_requested());
     }
 }

--- a/crates/stella-cli/src/whistle/wire.rs
+++ b/crates/stella-cli/src/whistle/wire.rs
@@ -25,6 +25,12 @@ pub(crate) struct WhistleRequest {
     /// as the lead-only whistle that sender meant.
     #[serde(default)]
     pub(crate) deep: bool,
+    /// Stop the session's running turn and run this text next, rather than
+    /// only adding it at the next boundary — the room form of the composer's
+    /// bang (`>>> @agents ! …`). Absent from an older sender's frame,
+    /// which decodes as the plain steer that sender meant.
+    #[serde(default)]
+    pub(crate) interrupt: bool,
 }
 
 /// The receiving session's answer: the message was queued.
@@ -83,20 +89,23 @@ mod tests {
         let sent = WhistleRequest {
             text: "stop the compile, let CI handle the gate".to_string(),
             deep: true,
+            interrupt: true,
         };
         write_frame(&mut a, &sent).await.unwrap();
         let received: WhistleRequest = read_frame(&mut b).await.unwrap();
         assert_eq!(received.text, sent.text);
         assert!(received.deep);
+        assert!(received.interrupt);
     }
 
-    /// A frame from a sender that predates `deep` carries no such key, and
-    /// decodes as the lead-only whistle that sender meant.
+    /// A frame from a sender that predates these keys carries neither, and
+    /// decodes as the lead-only steer that sender meant.
     #[test]
     fn a_frame_without_the_deep_key_is_a_lead_only_whistle() {
         let received: WhistleRequest =
             serde_json::from_str(r#"{"text":"read the failing test"}"#).unwrap();
         assert!(!received.deep);
+        assert!(!received.interrupt);
     }
 
     #[tokio::test]

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -252,7 +252,14 @@ pub static CAPABILITIES: &[Capability] = &[
                         fans the same text into the session's live worker lanes \
                         (`a_deep_whistle_reaches_the_lead_and_every_live_lane`), and the deck's \
                         `>@all` / `>@<id>` address broadcasts from inside a session \
-                        (`the_broadcast_address_parses_its_target_depth_and_message`)",
+                        (`the_broadcast_address_parses_its_target_depth_and_message`). The room \
+                        form `>>> @agents !!! <text>` carries a stop as well as the words: every \
+                        live session takes the interrupt, the sender included \
+                        (`a_room_broadcast_stops_every_live_session_and_the_sender`), a stalled \
+                        socket holds up its own row alone \
+                        (`a_stalled_session_does_not_hold_up_the_others_stop`), and the record is \
+                        written once for the workspace \
+                        (`a_broadcast_writes_one_record_for_the_workspace`)",
             witness: "a_message_sent_over_a_deck_sessions_socket_reaches_its_next_turn",
         },
         // Not "serve has POST /v1/turns/{id}/steer, so it is covered". It has
@@ -714,11 +721,14 @@ mod tests {
     /// the same trade `provider_parity` documents: a witness that moves to a
     /// file outside this list fails loudly (a false alarm to fix by extending
     /// the list), never silently (the rotted proof this exists to catch).
-    fn cli_sources() -> [&'static str; 15] {
+    fn cli_sources() -> [&'static str; 16] {
         [
             // The deck's session-scoped whistle relay (#4768) — home of the
             // `turn.whistle` witness.
             include_str!("../../stella-cli/src/command_deck/whistle.rs"),
+            // Where a bang mark is saved — home of the `turn.whistle` row's
+            // one-record-per-workspace witness.
+            include_str!("../../stella-cli/src/command_deck/keep_record/tests.rs"),
             include_str!("../../stella-cli/src/agent/tests.rs"),
             // Home of `a_piped_stdin_text_run_denies_every_consumer_of_the_human_present_fact`
             // — the `turn.run` CLI witness since the staged pipeline's own
@@ -894,6 +904,31 @@ mod tests {
             witness_exists(&api_sources(), cited),
             "the row cites {cited}, which no swept serve source defines"
         );
+    }
+
+    /// The whistle row names three more tests than its `witness` field can
+    /// hold, because the room broadcast is three claims: every live session
+    /// stops, one stalled socket costs the others nothing, and the workspace
+    /// gets one record. Each name is checked here, so a citation cannot decay
+    /// into a test nothing answers to.
+    #[test]
+    fn the_whistle_row_cites_the_room_broadcast_witnesses() {
+        let row = capability("turn.whistle").expect("the row is declared");
+        let SurfacePosture::Shipped { mechanism, .. } = row.cli else {
+            panic!("turn.whistle's CLI posture moved — a row that ships this names its witnesses");
+        };
+        let sources = cli_sources();
+        for cited in [
+            "a_room_broadcast_stops_every_live_session_and_the_sender",
+            "a_stalled_session_does_not_hold_up_the_others_stop",
+            "a_broadcast_writes_one_record_for_the_workspace",
+        ] {
+            assert!(mechanism.contains(cited), "the row stopped citing {cited}");
+            assert!(
+                witness_exists(&sources, cited),
+                "the row cites {cited}, which no swept CLI source defines"
+            );
+        }
     }
 
     /// The unwitnessed-claims ratchet: exact equality, so witnessing a row

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -136,7 +136,8 @@ async fn main() -> std::io::Result<()> {
                 // The composer's broadcast address. The demo has no other
                 // sessions to reach, so it answers the way the driver does
                 // with nothing live to whistle at — one chrome note.
-                WorkspaceInput::Whistle { message, .. } => {
+                WorkspaceInput::Whistle(broadcast) => {
+                    let message = broadcast.message;
                     let _ = react_tx.send(Inbound::Event {
                         agent: "lead".to_string(),
                         event: stella_protocol::AgentEvent::Text {

--- a/crates/stella-tui/src/deck_ui/dispatch.rs
+++ b/crates/stella-tui/src/deck_ui/dispatch.rs
@@ -74,9 +74,13 @@ impl DispatchRoute {
 /// else: prose, custom (⚡) commands (they expand into prompts driver-side),
 /// and the turn-coupled builtins (`/clear`, `/init`, `/reload`, …), which all
 /// keep their queue behavior.
+///
+/// A broadcast address (`>@all …`, `>>> @agents !!! …`) takes the same route
+/// for the same reason: it is about other sessions, so it must not wait on
+/// this one's turn. Its grammar lives in [`crate::envelope::broadcast`].
 pub(super) fn sideband(ui: &DeckUi, text: &str) -> Option<WorkspaceInput> {
-    if let Some(input) = broadcast(text) {
-        return Some(input);
+    if let Some(broadcast) = crate::envelope::broadcast::parse(text) {
+        return Some(WorkspaceInput::Whistle(broadcast));
     }
     let head = text.split_whitespace().next()?;
     if !head.starts_with('/') {
@@ -88,32 +92,6 @@ pub(super) fn sideband(ui: &DeckUi, text: &str) -> Option<WorkspaceInput> {
         .map(|_| WorkspaceInput::Command {
             text: text.trim().to_string(),
         })
-}
-
-/// The broadcast address: `>@all <message>` reaches every other live
-/// session on this machine, `>@<session-id> <message>` one of them, and
-/// `--deep` right after the address reaches their worker lanes too. Read
-/// ahead of the `>` steer marker, which it extends — a steer aimed at the
-/// room rather than at this session's turn. `None` for an
-/// address with no message: there is nothing to send, so the text keeps its
-/// ordinary route and the user sees what they typed.
-fn broadcast(text: &str) -> Option<WorkspaceInput> {
-    let rest = text.trim_start().strip_prefix(">@")?;
-    let (address, rest) = rest.split_once(char::is_whitespace)?;
-    let (deep, message) = match rest.trim_start().strip_prefix("--deep") {
-        Some(after) if after.is_empty() || after.starts_with(char::is_whitespace) => {
-            (true, after.trim())
-        }
-        _ => (false, rest.trim()),
-    };
-    if address.is_empty() || message.is_empty() {
-        return None;
-    }
-    Some(WorkspaceInput::Whistle {
-        message: message.to_string(),
-        session: (address != "all").then(|| address.to_string()),
-        deep,
-    })
 }
 
 /// Whether `text` states its own route and must not be second-guessed.
@@ -706,52 +684,21 @@ mod tests {
         );
     }
 
-    /// **The witness for the broadcast address.** `>@all` reaches every
-    /// other session, `>@<id>` one of them, `--deep` reaches their lanes, and
-    /// an address with nothing to say keeps its ordinary route.
+    /// Both broadcast addresses leave by the queue-free route, so neither
+    /// waits on this session's turn. The grammar itself is proved where it
+    /// lives (`crate::envelope::broadcast`).
     #[test]
-    fn the_broadcast_address_parses_its_target_depth_and_message() {
-        assert_eq!(
-            broadcast(">@all stop touching the release branch"),
-            Some(WorkspaceInput::Whistle {
-                message: "stop touching the release branch".into(),
-                session: None,
-                deep: false,
-            })
-        );
-        assert_eq!(
-            broadcast("  >@ses-17-9 --deep run the tests first"),
-            Some(WorkspaceInput::Whistle {
-                message: "run the tests first".into(),
-                session: Some("ses-17-9".into()),
-                deep: true,
-            })
-        );
-        assert_eq!(
-            broadcast(">@all --deeper is a word"),
-            Some(WorkspaceInput::Whistle {
-                message: "--deeper is a word".into(),
-                session: None,
-                deep: false,
-            }),
-            "only the exact flag is a flag"
-        );
-        for text in [
-            ">@all",
-            ">@all   ",
-            ">@ --deep",
-            "> @all hello",
-            "@all hello",
-        ] {
-            assert_eq!(broadcast(text), None, "{text:?} is not a broadcast");
-        }
+    fn a_broadcast_leaves_by_the_queue_free_route() {
         let ui = DeckUi::default();
+        for text in [">@all go", ">>> @agents !!! do not force-push"] {
+            assert!(
+                matches!(sideband(&ui, text), Some(WorkspaceInput::Whistle(_))),
+                "{text:?} is queue-free, like a sideband command"
+            );
+        }
         assert!(
-            matches!(
-                sideband(&ui, ">@all go"),
-                Some(WorkspaceInput::Whistle { .. })
-            ),
-            "the broadcast is queue-free, like a sideband command"
+            sideband(&ui, "and now the tests").is_none(),
+            "a plain prompt keeps its ordinary route"
         );
     }
 

--- a/crates/stella-tui/src/deck_ui/sigil.rs
+++ b/crates/stella-tui/src/deck_ui/sigil.rs
@@ -31,6 +31,7 @@
 
 use super::*;
 use crate::envelope::KeepStrength;
+use crate::envelope::broadcast::Bangs;
 
 /// The mark a line starts with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,28 +60,26 @@ enum Mark {
 /// Bangs past the third are not a fourth strength — `!!!!` is refused as a
 /// mark rather than read as the strongest one, because guessing which of two
 /// meanings a typo intended is how a stray keystroke publishes a rule.
+///
+/// The bang run itself is read by [`crate::envelope::broadcast::bangs`], which
+/// the room address (`>>> @agents !!! …`) reads too. One grammar, so the same
+/// keystrokes mean the same thing wherever they are typed.
 fn parse(text: &str) -> Option<(Mark, &str)> {
     let head = text.trim_start();
     if let Some(rest) = head.strip_prefix('$') {
         return Some((Mark::Shell, rest.trim()));
     }
-    let bangs = head.chars().take_while(|c| *c == '!').count();
-    if bangs == 0 {
-        return None;
+    match crate::envelope::broadcast::bangs(head) {
+        Bangs::Absent | Bangs::TooMany => None,
+        // The old spelling owns only the first bang: the rest of the run
+        // belongs to the command's own text.
+        Bangs::Attached => Some((Mark::LegacyShell, head[1..].trim())),
+        Bangs::Sigil { keep: None, rest } => Some((Mark::Steer, rest)),
+        Bangs::Sigil {
+            keep: Some(strength),
+            rest,
+        } => Some((Mark::Keep(strength), rest)),
     }
-    let rest = &head[bangs..];
-    if !(rest.is_empty() || rest.starts_with(char::is_whitespace)) {
-        // The old spelling, which owns only the first bang: the rest of the
-        // run belongs to the command's own text.
-        return Some((Mark::LegacyShell, head[1..].trim()));
-    }
-    let mark = match bangs {
-        1 => Mark::Steer,
-        2 => Mark::Keep(KeepStrength::Guidance),
-        3 => Mark::Keep(KeepStrength::Rule),
-        _ => return None,
-    };
-    Some((mark, rest.trim()))
 }
 
 /// Whether a marked line beats a gate that is waiting for an answer.

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -14,8 +14,10 @@ use std::collections::BTreeMap;
 
 use stella_protocol::AgentEvent;
 
+pub(crate) mod broadcast;
 mod inspect;
 
+pub use broadcast::Broadcast;
 pub use inspect::{InspectMessage, InspectSection, InspectView, JournalEra, RecordedCallInfo};
 
 use stella_tools::search::readiness::IndexReadiness;
@@ -966,19 +968,16 @@ pub enum WorkspaceInput {
         texts: Vec<String>,
         keep: Option<KeepStrength>,
     },
-    /// The composer's broadcast address (`>@all …`, `>@<session-id> …`,
-    /// optionally `--deep`): send `message` to the other live sessions on
-    /// this machine over their whistle sockets — every live one when
-    /// `session` is `None`, that one otherwise — and, with `deep`, into
-    /// their worker lanes too. Queue-free like a sideband command: it is
-    /// about other sessions, so it never waits on this one's turn. The driver
-    /// answers with a chrome note of per-session outcomes, and this session
-    /// is never a target of its own broadcast.
-    Whistle {
-        message: String,
-        session: Option<String>,
-        deep: bool,
-    },
+    /// The composer's broadcast address (`>@all …`, `>>> @agents !!! …`):
+    /// send the words to the live sessions on this machine over their
+    /// whistle sockets. [`Broadcast`] holds who hears it, how deep it
+    /// reaches, whether their turns stop, and what is kept. Queue-free like a
+    /// sideband command: it is about other sessions, so it never waits on
+    /// this one's turn. The driver answers with a chrome note of per-session
+    /// outcomes. A plain `>@all` leaves this session alone; a `>>> @agents`
+    /// interrupt reaches it too, in process, because the room includes the
+    /// person who spoke.
+    Whistle(Broadcast),
     /// Re-root the Graph tab on `file`: the deck's file picker sends this when
     /// the user selects a file, and the driver answers with a fresh
     /// [`Inbound::GraphSnapshot`] centered on it (the same out-of-band refresh

--- a/crates/stella-tui/src/envelope/broadcast.rs
+++ b/crates/stella-tui/src/envelope/broadcast.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What a broadcast line means, and to whom.
+//!
+//! Two forms in the composer speak to other sessions on this machine:
+//!
+//! | Line | Who hears it | What it does there |
+//! |---|---|---|
+//! | `>@all <text>` | every other live session | the words land at the next step boundary |
+//! | `>@<id> --deep <text>` | that session, worker lanes too | the same |
+//! | `>>> @agents <text>` | every live session, lanes too | the same |
+//! | `>>> @agents ! <text>` | the same | the turn stops, the words run next |
+//! | `>>> @agents !! <text>` | the same | and the words are kept as guidance |
+//! | `>>> @agents !!! <text>` | the same | and the words are kept as a rule |
+//!
+//! The three arrows are deep by construction, so there is no flag to
+//! remember. The bang run says how hard the words push, and it is the run
+//! [`crate::deck_ui::sigil`] reads at the head of a plain line. One grammar,
+//! so `!!!` cannot mean two things in one composer.
+//!
+//! `@agents` and `@all` both name the room. Any other word after the `@` is
+//! one session id.
+//!
+//! What is kept is written once, by the session that sent the line, and it is
+//! written for the workspace. Every target gets the stop and the words, and
+//! none of them writes a record — see `stella-cli`'s
+//! `command_deck::keep_record`.
+
+use super::KeepStrength;
+
+/// One broadcast, read from the line a person typed.
+///
+/// The stop and the save travel in one value on purpose. A save whose stop
+/// was dropped, or a stop whose save was, is a failure the person who typed
+/// the line never sees.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Broadcast {
+    /// The words to send. Never empty.
+    pub message: String,
+    /// One session id, or `None` for every live session.
+    pub session: Option<String>,
+    /// Reach each target's worker lanes as well as its lead.
+    pub deep: bool,
+    /// Stop each target's running turn and run the words next, rather than
+    /// only adding them at the next boundary.
+    pub interrupt: bool,
+    /// Keep the words for this workspace at this strength. `None` leaves
+    /// nothing behind.
+    pub keep: Option<KeepStrength>,
+}
+
+/// The bang run at the head of a line.
+///
+/// A bang run is a sigil only when a space follows it. That space is the
+/// whole difference between `! use short sentences` and `!ls`.
+pub(crate) enum Bangs<'a> {
+    /// The line opens with no bang.
+    Absent,
+    /// A bang run with text pressed against it, as in `!ls`. Not a sigil.
+    Attached,
+    /// A sigil, and the words after it. `keep` is `None` for a lone `!`,
+    /// which stops the turn and keeps nothing.
+    Sigil {
+        keep: Option<KeepStrength>,
+        rest: &'a str,
+    },
+    /// More bangs than the family has, as in `!!!!`. Refused rather than read
+    /// as the strongest one: guessing what a stray keystroke meant is how a
+    /// typo publishes a rule.
+    TooMany,
+}
+
+/// Read the bang run at the head of `text`.
+pub(crate) fn bangs(text: &str) -> Bangs<'_> {
+    let run = text.chars().take_while(|c| *c == '!').count();
+    if run == 0 {
+        return Bangs::Absent;
+    }
+    // Every counted char is one byte, so the run is also a byte offset.
+    let rest = &text[run..];
+    if !(rest.is_empty() || rest.starts_with(char::is_whitespace)) {
+        return Bangs::Attached;
+    }
+    let keep = match run {
+        1 => None,
+        2 => Some(KeepStrength::Guidance),
+        3 => Some(KeepStrength::Rule),
+        _ => return Bangs::TooMany,
+    };
+    Bangs::Sigil {
+        keep,
+        rest: rest.trim(),
+    }
+}
+
+/// Read one composer line as a broadcast.
+///
+/// `None` for every line that is not one, which includes an address with
+/// nothing to say. Those words keep their ordinary route, and the person sees
+/// what they typed.
+pub(crate) fn parse(text: &str) -> Option<Broadcast> {
+    let head = text.trim_start();
+    match head.strip_prefix(">>>") {
+        Some(rest) => deep_form(rest),
+        None => flat_form(head),
+    }
+}
+
+/// `>>> @<address> [bangs] <message>`: deep always, with the bang run saying
+/// whether the turn stops and what is kept.
+fn deep_form(text: &str) -> Option<Broadcast> {
+    let (address, rest) = address_of(text.trim_start())?;
+    let (interrupt, keep, message) = match bangs(rest.trim_start()) {
+        Bangs::Absent => (false, None, rest.trim()),
+        Bangs::Sigil { keep, rest } => (true, keep, rest),
+        // A run this form cannot read is not a weaker form of it. The line
+        // goes out as the prompt it reads as.
+        Bangs::Attached | Bangs::TooMany => return None,
+    };
+    build(address, message, true, interrupt, keep)
+}
+
+/// `>@<address> [--deep] <message>`: the older address, which never stops a
+/// turn and keeps nothing.
+fn flat_form(text: &str) -> Option<Broadcast> {
+    let (address, rest) = address_of(text.strip_prefix('>')?)?;
+    let (deep, message) = match rest.trim_start().strip_prefix("--deep") {
+        Some(after) if after.is_empty() || after.starts_with(char::is_whitespace) => {
+            (true, after.trim())
+        }
+        _ => (false, rest.trim()),
+    };
+    build(address, message, deep, false, None)
+}
+
+/// The `@name` at the head of `text`, and whatever follows it.
+fn address_of(text: &str) -> Option<(&str, &str)> {
+    text.strip_prefix('@')?.split_once(char::is_whitespace)
+}
+
+/// One broadcast, or `None` when the line names nobody or says nothing.
+fn build(
+    address: &str,
+    message: &str,
+    deep: bool,
+    interrupt: bool,
+    keep: Option<KeepStrength>,
+) -> Option<Broadcast> {
+    if address.is_empty() || message.is_empty() {
+        return None;
+    }
+    Some(Broadcast {
+        message: message.to_string(),
+        session: (address != "all" && address != "agents").then(|| address.to_string()),
+        deep,
+        interrupt,
+        keep,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn room(message: &str, deep: bool, interrupt: bool, keep: Option<KeepStrength>) -> Broadcast {
+        Broadcast {
+            message: message.to_string(),
+            session: None,
+            deep,
+            interrupt,
+            keep,
+        }
+    }
+
+    /// **The witness for the address.** `>@all` reaches every other session,
+    /// `>@<id>` one of them, `--deep` reaches their lanes, and an address
+    /// with nothing to say keeps its ordinary route.
+    #[test]
+    fn the_broadcast_address_parses_its_target_depth_and_message() {
+        assert_eq!(
+            parse(">@all stop touching the release branch"),
+            Some(room("stop touching the release branch", false, false, None))
+        );
+        assert_eq!(
+            parse("  >@ses-17-9 --deep run the tests first"),
+            Some(Broadcast {
+                message: "run the tests first".into(),
+                session: Some("ses-17-9".into()),
+                deep: true,
+                interrupt: false,
+                keep: None,
+            })
+        );
+        assert_eq!(
+            parse(">@all --deeper is a word"),
+            Some(room("--deeper is a word", false, false, None)),
+            "only the exact flag is a flag"
+        );
+        for text in [
+            ">@all",
+            ">@all   ",
+            ">@ --deep",
+            "> @all hello",
+            "@all hello",
+        ] {
+            assert_eq!(parse(text), None, "{text:?} is not a broadcast");
+        }
+    }
+
+    /// **The witness for the broadcast sigils.** Three arrows plus a
+    /// bang run stop every live session and keep the words for the workspace.
+    /// The room is `@agents` or `@all`; one id addresses one session; the
+    /// arrows are deep with no flag.
+    #[test]
+    fn three_arrows_and_a_bang_run_stop_the_room_and_keep_the_words() {
+        assert_eq!(
+            parse(">>> @agents !!! do not force-push"),
+            Some(room(
+                "do not force-push",
+                true,
+                true,
+                Some(KeepStrength::Rule)
+            ))
+        );
+        assert_eq!(
+            parse(">>> @all !! use short sentences"),
+            Some(room(
+                "use short sentences",
+                true,
+                true,
+                Some(KeepStrength::Guidance)
+            ))
+        );
+        assert_eq!(
+            parse(">>> @agents ! stop the compile"),
+            Some(room("stop the compile", true, true, None)),
+            "one bang stops the turn and keeps nothing"
+        );
+        assert_eq!(
+            parse(">>>@agents read the failing test"),
+            Some(room("read the failing test", true, false, None)),
+            "no bang is a deep steer, and the space after the arrows is optional"
+        );
+        assert_eq!(
+            parse(">>> @ses-17-9 !!! do not force-push"),
+            Some(Broadcast {
+                message: "do not force-push".into(),
+                session: Some("ses-17-9".into()),
+                deep: true,
+                interrupt: true,
+                keep: Some(KeepStrength::Rule),
+            }),
+            "one id is the same grammar aimed at one session"
+        );
+    }
+
+    /// A typo must not publish a rule. A fourth bang, and a bang with the
+    /// text pressed against it, are both refused. The line then goes out as
+    /// the prompt it reads as.
+    #[test]
+    fn a_mistyped_sigil_broadcasts_nothing() {
+        for text in [
+            ">>> @agents !!!! do not force-push",
+            ">>> @agents !!!urgent",
+            ">>> @agents !!!",
+            ">>> @agents",
+            ">>> !!! nobody is addressed",
+        ] {
+            assert_eq!(parse(text), None, "{text:?} is not a broadcast");
+        }
+    }
+}

--- a/crates/stella-tui/src/envelope/broadcast.rs
+++ b/crates/stella-tui/src/envelope/broadcast.rs
@@ -16,8 +16,8 @@
 //!
 //! The three arrows are deep by construction, so there is no flag to
 //! remember. The bang run says how hard the words push, and it is the run
-//! [`crate::deck_ui::sigil`] reads at the head of a plain line. One grammar,
-//! so `!!!` cannot mean two things in one composer.
+//! `deck_ui::sigil` reads at the head of a plain line. One grammar, so `!!!`
+//! cannot mean two things in one composer.
 //!
 //! `@agents` and `@all` both name the room. Any other word after the `@` is
 //! one session id.

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -119,12 +119,12 @@ pub use deck_ui::{
     SkillsPanel, TypeAhead, handle_deck_key, ingest_inbound,
 };
 pub use envelope::{
-    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, EngineAgentState,
-    EngineConfigState, EngineRole, EntityField, EntityHit, GRAPH_SERVER, Inbound, InspectMessage,
-    InspectSection, InspectView, InstalledAgentEntry, IssueAction, IssueRow, JournalEra,
-    KeepStrength, LearnedProvenance, LearnedSource, McpLiveIdentity, McpLookupState, McpSearchItem,
-    McpSearchOutcome, McpServerDetail, McpServerInfo, McpSignature, McpSourceTier, McpToolRow,
-    NotificationInfo, RecordedCallInfo, RejectedSkillRow, SeatRow, Secret, SessionInfo,
+    AgentControl, AgentId, AgentMeta, AgentScope, AgentStatus, AgentVersionInfo, Broadcast,
+    EngineAgentState, EngineConfigState, EngineRole, EntityField, EntityHit, GRAPH_SERVER, Inbound,
+    InspectMessage, InspectSection, InspectView, InstalledAgentEntry, IssueAction, IssueRow,
+    JournalEra, KeepStrength, LearnedProvenance, LearnedSource, McpLiveIdentity, McpLookupState,
+    McpSearchItem, McpSearchOutcome, McpServerDetail, McpServerInfo, McpSignature, McpSourceTier,
+    McpToolRow, NotificationInfo, RecordedCallInfo, RejectedSkillRow, SeatRow, Secret, SessionInfo,
     SessionPhase, SkillOp, SkillRow, SkillScope, SkillSearchHit, SkillsView, SplashCue, ToolDenial,
     ToolPolicyState, ToolRow, ToolScope, WorkspaceInput,
 };

--- a/website/content/docs/commands/whistle.mdx
+++ b/website/content/docs/commands/whistle.mdx
@@ -47,12 +47,38 @@ A session with no workers treats `--deep` exactly like a plain whistle.
 You do not need a second terminal. In [`stella chat`](/docs/commands/chat), type the message with a broadcast address in front of it:
 
 ```text
->>> >@all stop touching the release branch
->>> >@ses-1785956826121-25167 run the tests first
->>> >@all --deep stop touching the release branch
+>@all stop touching the release branch
+>@ses-1785956826121-25167 run the tests first
+>@all --deep stop touching the release branch
 ```
 
 `>@all` reaches every other live session on this machine, `>@<id>` one of them, and `--deep` right after the address reaches their worker lanes too. The outcome for every session appears as a note in your transcript, in the same rows the command prints. The message goes out at once — it never waits behind your own agent's turn — and your own session is never a target of its own broadcast.
+
+## Stopping the room, and keeping what you said
+
+The lines above steer. To stop every agent instead, put three arrows in front of the address and a bang run after it:
+
+```text
+>>> @agents ! stop the compile
+>>> @agents !! use short sentences
+>>> @agents !!! do not force-push
+```
+
+Each target's running turn stops at its next safe point, and your words run next there. The three arrows are deep, so worker lanes hear them with no flag to remember. `@agents` and `@all` both mean the room; one session id in their place aims the same line at one session.
+
+The bang run says how hard the words push, exactly as it does when you type it with no address ([`stella chat`](/docs/commands/chat)):
+
+| Line | What it does |
+|---|---|
+| `>>> @agents ! <text>` | stops every live session and runs the words there |
+| `>>> @agents !! <text>` | the same, and keeps the words as guidance for this workspace |
+| `>>> @agents !!! <text>` | the same, and keeps the words as a rule |
+
+What is kept is one context record, written once for the workspace by the session you typed in. Sessions that start later read it the ordinary way. A stop aimed at the room reaches your own session too, because you are in the room; a stop aimed at one other id leaves you alone.
+
+A fourth bang is a typo, not a stronger rule, so `>>> @agents !!!! …` broadcasts nothing and goes out as the prompt it reads as.
+
+The `stella whistle` command has no flag for this yet: the stop is a composer form today.
 
 ## What is reachable today
 


### PR DESCRIPTION
## What

`>>> @agents !!! <text>` in the deck composer now does the three things #5445 asks for in one action: it stops every live session on this machine (worker lanes included), it runs the words there next, and it keeps them as one context record for the workspace.

The grammar composes the two merged halves — #5442's interrupt (PR #5842) and #5443's `!!`/`!!!` record write (PR #5951) — with the whistle fan-out #5431 landed.

| Line | What it does |
|---|---|
| `>@all <text>` | unchanged: words at each other session's next boundary |
| `>>> @agents <text>` | the same, deep, and this session is left alone |
| `>>> @agents ! <text>` | every live session stops and runs the words next, the sender included |
| `>>> @agents !! <text>` | the same, and the words are kept as guidance |
| `>>> @agents !!! <text>` | the same, and the words are kept as a rule |
| `>>> @<id> !!! <text>` | target set × sigil: one session |

## Why this shape

- **One grammar for the bang run.** `crates/stella-tui/src/envelope/broadcast.rs` owns it, and `deck_ui/sigil.rs` reads the same function for a plain line, so `!!!` cannot mean two things in one composer and a fourth bang is refused in both places.
- **One message.** `WorkspaceInput::Whistle` carries a `Broadcast` payload (message, target, depth, interrupt, keep) so the stop and the save cannot separate on the way to the driver. It also shrinks `command_deck.rs`, a god file closed to growth.
- **The record is written once, by the sender.** `command_deck::keep_record::intercept` already spends a keep mark in front of both driver read points; it gains the `Whistle` arm. Targets receive the stop with the mark spent, so the write is workspace-scoped rather than per session.
- **One stop path.** The deck relay turns a delivered interrupt into the driver's own `WorkspaceInput::Interrupt`, which is exactly what a typed `!` sends — so the soft stop, the front insert and the auto-resume are the #5442 path rather than a second copy of it. A tap with no deck (`stella run`, `stella goal`) queues the words and then latches its soft stop, in that order, because the boundary drains steering before it reads the stop.
- **The room includes the sender.** A stop addressed to everyone is delivered to this session in process; the socket fan-out still skips it, so it cannot arrive twice. A stop addressed to one other id leaves this session alone. A plain steer keeps its old behaviour of never reaching the sender.
- **Exemplar:** the relay follows this repository's own `command_deck::steer` / `command_deck::steering` split — the driver keeps the call, the reasoning lives in the sibling module.

## Witness mechanism

Every witness names a type, field or method that does not exist on `main`, so each one fails to compile there rather than failing on an assertion.

- `a_room_broadcast_stops_every_live_session_and_the_sender` (`crates/stella-cli/src/command_deck/whistle.rs`) — two fixture sessions on real Unix sockets each take a `WorkspaceInput::Interrupt` carrying the words; the broadcasting session takes the same stop in process; a registered session that bound no socket is reported `unreachable` and costs the others nothing; the sender is not a socket target.
- `a_stalled_session_does_not_hold_up_the_others_stop` (same file) — a socket that accepts nothing and never acks holds up only its own row: the live session has its stop long before that row's ack timeout is spent.
- `a_broadcast_writes_one_record_for_the_workspace` (`crates/stella-cli/src/command_deck/keep_record/tests.rs`) — a broadcast at every session writes exactly one record, and comes back with the mark spent, so a second read of the same message writes nothing.
- `three_arrows_and_a_bang_run_stop_the_room_and_keep_the_words` and `a_mistyped_sigil_broadcasts_nothing` (`crates/stella-tui/src/envelope/broadcast.rs`) — the grammar, and the refusals that keep a typo from publishing a rule.
- `only_an_interrupt_stops_a_headless_turn` (`crates/stella-cli/src/whistle/tap.rs`) — a plain steer rides along; an interrupt puts the words in the turn and then halts it.
- `a_frame_without_the_deep_key_is_a_lead_only_whistle` (`crates/stella-cli/src/whistle/wire.rs`) — an older sender's frame still decodes as the plain steer it meant.

The `turn.whistle` parity row names the three CLI witnesses, and `the_whistle_row_cites_the_room_broadcast_witnesses` holds those citations to tests that exist (the same enforcement `tools.contracts` already gets for its prose citation). `keep_record/tests.rs` joins `cli_sources()` so the third name is sweepable.

Tests deleted: None. `the_broadcast_address_parses_its_target_depth_and_message` moved from `deck_ui/dispatch.rs` to `envelope/broadcast.rs` with the parser it covers, and keeps its name; `dispatch.rs` keeps a smaller test that both addresses still take the queue-free route. `soft_stop_is_never_requested` was renamed to `only_an_interrupt_stops_a_headless_turn`, because a whistle can now latch that stop and the old name asserted the opposite.

## Docs

`website/content/docs/commands/whistle.mdx` gains the room form, and its older broadcast examples lose the `>>> ` shell-prompt marker that now collides with real grammar.

## Remaining work filed

- The `stella whistle` command has no `--interrupt` flag: the stop is a composer form today, and the wire field is there for one. Filed as an issue and named in the docs page.

Closes #5445

## Summary by Sourcery

Enable deep composer broadcasts to stop live sessions, run the supplied text next, and optionally retain it as workspace guidance or a rule.

New Features:
- Add composer support for deep room broadcasts with `!`, `!!`, and `!!!` controls for interrupting sessions and retaining guidance or rules.
- Propagate interrupt-aware broadcasts to live sessions and worker lanes, including the originating session for room-wide stops.
- Persist broadcast records once at workspace scope while preserving existing targeted whistle behavior.

Bug Fixes:
- Prevent stalled or unreachable session sockets from delaying delivery to other broadcast targets.
- Preserve backward compatibility when decoding whistle frames from older senders.

Enhancements:
- Unify broadcast and bang-sigil parsing around a shared grammar and carry broadcast behavior in a single workspace input payload.

Documentation:
- Document room-wide interrupting broadcasts, retention levels, targeting behavior, and current CLI limitations.

Tests:
- Add coverage for room-wide interrupt fan-out, sender inclusion, stalled sessions, workspace-scoped record persistence, parsing validation, headless interrupt behavior, and wire compatibility.