### PR TITLE
test(scripts): drive the claim-comment jq filter through a select seam

### DIFF
--- a/scripts/issue-claim.sh
+++ b/scripts/issue-claim.sh
@@ -4,6 +4,7 @@
 #
 #   scripts/issue-claim.sh check <n>    # exit 0 proceed, 1 stand down
 #   scripts/issue-claim.sh claim <n>    # check, then post the claim
+#   scripts/issue-claim.sh select --now <unix-seconds>   # pure: JSON in, rows out
 #
 # ── Why this exists ──────────────────────────────────────────────────────────
 #
@@ -55,16 +56,24 @@ fixture_login=""
 fixture_claims=""
 fixture_prs=""
 fixture_prs_failed=0
+select_now=""
 use_fixture=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
-  check | claim)
+  check | claim | select)
     mode="$1"
     shift
     ;;
   --window-minutes)
     window_minutes="${2:-}"
+    shift 2
+    ;;
+  # `select`'s own clock, so a test can pin it. Unrelated to the fixture
+  # seams below: `select` reads real comments JSON on stdin and never stubs
+  # the tracker.
+  --now)
+    select_now="${2:-}"
     shift 2
     ;;
   # Test-only, and paired: a fixture that supplied claims but read the real
@@ -108,6 +117,32 @@ while [ $# -gt 0 ]; do
     ;;
   esac
 done
+
+# Every claim comment in a `gh issue view --json comments` payload, as
+# `<login> <age-in-seconds>`. Pure: the payload comes in on stdin, and `now`
+# is an argument, not the real clock. That lets `select` mode below, and the
+# tests in scripts/test-issue-claim.sh, run the exact filter production uses.
+select_claims() {
+  jq -r --arg marker "$marker" --argjson now "$1" '
+    .comments[]
+    | select(.body | startswith($marker))
+    | "\(.author.login) \(($now - (.createdAt | fromdateiso8601)) | floor)"
+  '
+}
+
+# `select` is the seam a test can drive directly: real comments JSON goes in,
+# the parsed rows come out. No tracker, no issue number. Production wires it
+# to `gh issue view --json comments` below instead of writing this filter
+# into that call. Break the filter, and a test fails here — not only a live
+# claim, silently, later.
+if [ "$mode" = "select" ]; then
+  [ -n "$select_now" ] || {
+    echo "issue-claim: select needs --now <unix-seconds>" >&2
+    exit 2
+  }
+  select_claims "$select_now"
+  exit $?
+fi
 
 if [ -z "$mode" ] || [ -z "$issue" ]; then
   echo "issue-claim: usage: issue-claim.sh check|claim <issue-number>" >&2
@@ -191,16 +226,14 @@ if [ -z "$me" ]; then
   proceed "ok  proceed (identity unknown)"
 fi
 
-# Every claim comment, as `<login> <age-in-seconds>`. The arithmetic is jq's:
-# `date` spells the same conversion two incompatible ways across macOS and
-# Linux, and this script is run from a clone on both.
+# Every claim comment, via `select_claims` above rather than a `--jq` program
+# embedded in this call.
 if [ "$use_fixture" -eq 1 ]; then
   claims="$fixture_claims"
-elif ! claims="$(gh issue view "$issue" --json comments --jq "
-    .comments[]
-    | select(.body | startswith(\"$marker\"))
-    | \"\(.author.login) \((now - (.createdAt | fromdateiso8601)) | floor)\"
-  " 2>/dev/null)"; then
+elif ! comments_json="$(gh issue view "$issue" --json comments 2>/dev/null)"; then
+  echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (comments unreadable)"
+elif ! claims="$(printf '%s' "$comments_json" | select_claims "$(date -u +%s)")"; then
   echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
   proceed "ok  proceed (comments unreadable)"
 fi

--- a/scripts/issue-claim.sh
+++ b/scripts/issue-claim.sh
@@ -230,7 +230,7 @@ fi
 # embedded in this call.
 if [ "$use_fixture" -eq 1 ]; then
   claims="$fixture_claims"
-elif ! comments_json="$(gh issue view "$issue" --json comments 2>/dev/null)"; then
+elif ! comments_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh issue view "$issue" --json comments 2>/dev/null)"; then
   echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
   proceed "ok  proceed (comments unreadable)"
 elif ! claims="$(printf '%s' "$comments_json" | select_claims "$(date -u +%s)")"; then

--- a/scripts/main-red-claim.sh
+++ b/scripts/main-red-claim.sh
@@ -385,7 +385,7 @@ fi
 # embedded in this call.
 if [ "$use_fixture" -eq 1 ]; then
   claims="$fixture_claims"
-elif ! comments_json="$(gh issue view "$issue" --json comments 2>/dev/null)"; then
+elif ! comments_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh issue view "$issue" --json comments 2>/dev/null)"; then
   echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
   proceed "ok  proceed (comments unreadable)"
 elif ! claims="$(printf '%s' "$comments_json" | select_claims "$(date -u +%s)")"; then

--- a/scripts/main-red-claim.sh
+++ b/scripts/main-red-claim.sh
@@ -96,6 +96,7 @@
 #   scripts/main-red-claim.sh check            # exit 0 proceed, 1 stand down
 #   scripts/main-red-claim.sh claim            # check, then claim it
 #   scripts/main-red-claim.sh session          # print this clone's session word
+#   scripts/main-red-claim.sh select --now <unix-seconds>   # pure: JSON in, rows out
 #   scripts/main-red-claim.sh check --window-minutes 20
 #   scripts/main-red-claim.sh check --fixture-open-issues "4671" \
 #                                   --fixture-login "ada" \
@@ -103,8 +104,12 @@
 #                                   --fixture-claims "grace s1 300"
 #
 # Uses portable POSIX tools plus `gh` so it runs anywhere a clone does. The
-# staleness arithmetic is done by `gh --jq`, not by `date`, because `date -d`
-# and `date -j` disagree across the platforms this repository is cloned on.
+# staleness arithmetic runs in `select_claims`'s own jq filter below, not
+# embedded in the `gh` call. `select` is that filter's seam: a test can feed
+# it a real payload instead of only the already-parsed `--fixture-claims`
+# shape. Not `date`: `date -d` and `date -j` disagree across the platforms
+# this repository is cloned on, which is why the arithmetic stays in jq
+# either way.
 set -uo pipefail
 
 label="main-red"
@@ -115,11 +120,12 @@ fixture_open_issues=""
 fixture_login=""
 fixture_claims=""
 fixture_session=""
+select_now=""
 use_fixture=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
-  check | claim | session)
+  check | claim | session | select)
     mode="$1"
     shift
     ;;
@@ -129,6 +135,17 @@ while [ $# -gt 0 ]; do
       exit 2
     }
     window_minutes="$2"
+    shift 2
+    ;;
+  # `select`'s own clock, so a test can pin it. Unrelated to the fixture
+  # seams below: `select` reads real comments JSON on stdin and never stubs
+  # the tracker.
+  --now)
+    [ $# -ge 2 ] || {
+      echo "main-red-claim: --now needs a unix timestamp" >&2
+      exit 2
+    }
+    select_now="$2"
     shift 2
     ;;
   # Test-only seams. Supplying any one of them stubs the tracker entirely: a
@@ -264,6 +281,44 @@ if [ "$mode" = "session" ]; then
   exit 1
 fi
 
+# Every claim comment in a `gh issue view --json comments` payload, as
+# `<login> <session> <age-in-seconds>` — `-` marks a claim with no session
+# word, same as `--fixture-claims`. Pure: the payload comes in on stdin, and
+# `now` is an argument, not the real clock. That lets `select` mode below,
+# and the tests in scripts/test-main-red-claim.sh, run the exact filter
+# production uses.
+#
+# Only the first line is read, with CRLF stripped and runs of spaces
+# collapsed to one field each. A claim's marker line is
+# `main-red-claim: <login> [session]`; later lines never enter this parse.
+# Padding with three `-` first is what lets a two-column claim — no session
+# word, written by an older copy of this script — parse `$word[2]` instead
+# of erroring on a missing index.
+select_claims() {
+  jq -r --arg marker "$marker" --argjson now "$1" '
+    .comments[]
+    | select(.body | startswith($marker))
+    | ((.body | split("\n")[0] | gsub("\r"; "") | split(" ")
+        | map(select(length > 0)))
+       + ["-", "-", "-"]) as $word
+    | "\(.author.login) \($word[2]) \(($now - (.createdAt | fromdateiso8601)) | floor)"
+  '
+}
+
+# `select` is the seam a test can drive directly: real comments JSON goes in,
+# the parsed rows come out. No tracker, no fixture. Production wires it to
+# `gh issue view --json comments` below instead of writing this filter into
+# that call. Break the filter, and a test fails here — not only a live
+# claim, silently, later.
+if [ "$mode" = "select" ]; then
+  [ -n "$select_now" ] || {
+    echo "main-red-claim: select needs --now <unix-seconds>" >&2
+    exit 2
+  }
+  select_claims "$select_now"
+  exit $?
+fi
+
 if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
   echo "note: gh is not installed, so this run could not ask whether the" >&2
   echo "      repair is already claimed. Proceeding: a claim check that can" >&2
@@ -326,20 +381,14 @@ if [ -z "$my_session" ]; then
   echo "      be told from a peer session's. Proceeding on those (fail-open)." >&2
 fi
 
-# Every claim comment, as `<login> <session> <age-in-seconds>`, with `-` for a
-# claim that carries no session word. The arithmetic is jq's: `date` spells the
-# same conversion two incompatible ways across macOS and Linux, and this script
-# is run from a clone on both.
+# Every claim comment, via `select_claims` above rather than a `--jq` program
+# embedded in this call.
 if [ "$use_fixture" -eq 1 ]; then
   claims="$fixture_claims"
-elif ! claims="$(gh issue view "$issue" --json comments --jq "
-    .comments[]
-    | select(.body | startswith(\"$marker\"))
-    | ((.body | split(\"\n\")[0] | gsub(\"\r\"; \"\") | split(\" \")
-        | map(select(length > 0)))
-       + [\"-\", \"-\", \"-\"]) as \$word
-    | \"\(.author.login) \(\$word[2]) \((now - (.createdAt | fromdateiso8601)) | floor)\"
-  " 2>/dev/null)"; then
+elif ! comments_json="$(gh issue view "$issue" --json comments 2>/dev/null)"; then
+  echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (comments unreadable)"
+elif ! claims="$(printf '%s' "$comments_json" | select_claims "$(date -u +%s)")"; then
   echo "note: could not read #$issue's comments. Proceeding (fail-open)." >&2
   proceed "ok  proceed (comments unreadable)"
 fi

--- a/scripts/test-issue-claim.sh
+++ b/scripts/test-issue-claim.sh
@@ -236,6 +236,62 @@ else
   bad "a malformed timestamp should fail closed, got exit $rc: '$out'"
 fi
 
+# The real `check` path, end to end, through a `gh` stub instead of a
+# fixture. `gh` colorizes its output whenever it thinks it has a terminal,
+# even inside `$(...)`, which turns the comments payload into text `jq`
+# cannot parse — `check-releases-published.sh`'s own header names this
+# hazard. `gh --jq` hides it for free, because `gh` never colorizes what it
+# filters internally; splitting `--json comments` out of that call, as this
+# PR does, loses that free protection, so production has to force color off
+# itself. A stub `gh` plays back the hazard: valid JSON only when
+# `NO_COLOR`/`CLICOLOR_FORCE` are set, broken text otherwise.
+gh_colorish="$(mktemp -d)"
+trap 'rm -rf "$gh_colorish"' EXIT
+# Production stamps `select_claims`'s `now` from the real clock, so the
+# fixture's `createdAt` has to sit a few minutes behind it too — a future
+# timestamp reads as a negative age and is dropped as unparseable.
+claim_time="$(jq -n --argjson t "$(($(date -u +%s) - 300))" '$t | todateiso8601')"
+cat >"$gh_colorish/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+case "$*" in
+"pr list "*)
+  echo ""
+  ;;
+"api user --jq .login")
+  echo "ada"
+  ;;
+"issue view 5045 --json comments")
+  if [ "${NO_COLOR:-}" = "1" ] && [ "${CLICOLOR_FORCE:-}" = "0" ]; then
+    printf '{"comments":[{"author":{"login":"grace"},"body":"<!-- issue-claim --> grace","createdAt":__CLAIM_TIME__}]}'
+  else
+    printf '\033[1;37m{\033[0m broken, uncolored callers never see this'
+  fi
+  ;;
+*)
+  echo "gh stub: unhandled invocation: gh $*" >&2
+  exit 1
+  ;;
+esac
+STUB
+sed -i.bak "s|__CLAIM_TIME__|${claim_time}|" "$gh_colorish/gh"
+rm -f "$gh_colorish/gh.bak"
+chmod +x "$gh_colorish/gh"
+for tool in bash awk tr mktemp date jq; do
+  tool_path="$(command -v "$tool")"
+  [ -n "$tool_path" ] && ln -s "$tool_path" "$gh_colorish/$tool"
+done
+out="$(PATH="$gh_colorish" "$SCRIPT" check 5045 2>&1)"
+rc=$?
+case "$rc,$out" in
+1,*"claimed by @grace"*)
+  ok "check survives gh's own colorized JSON and still sees the live claim"
+  ;;
+*)
+  bad "check should stand down on the live claim through gh's real output shape, got exit $rc: $out"
+  ;;
+esac
+
 echo
 if [ "$fail" -eq 0 ]; then
   printf 'issue-claim: %d passed\n' "$pass"

--- a/scripts/test-issue-claim.sh
+++ b/scripts/test-issue-claim.sh
@@ -166,6 +166,76 @@ else
   bad "--window-minutes did not reach the comparison: $out"
 fi
 
+# ── The parse itself ──────────────────────────────────────────────────────
+#
+# Every case above drives `--fixture-claims`: already-parsed `<login> <age>`
+# rows, never the jq filter that makes them. These drive `select` instead —
+# real `gh issue view --json comments` JSON, on stdin, through the real
+# filter. A typo in it (a dropped `.author.login`, a broken marker check) now
+# fails one of these cases, not nothing.
+NOW_SELECT=2000000000
+
+iso() { jq -n --argjson t "$1" '$t | todateiso8601'; }
+
+# comment <login> <body> <created-unix> — one comment object.
+comment() {
+  local login="$1" body="$2" created
+  created="$(iso "$3")"
+  printf '{"author":{"login":"%s"},"body":%s,"createdAt":%s}' \
+    "$login" "$(printf '%s' "$body" | jq -Rs .)" "$created"
+}
+
+# want_select <name> <expect-line> <json>.
+want_select() {
+  local name="$1" expect="$2" json="$3" out rc
+  out="$(printf '%s' "$json" | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+  rc=$?
+  if [ "$out" = "$expect" ] && [ "$rc" -eq 0 ]; then
+    ok "$name"
+  else
+    bad "$name — wanted '$expect' (exit 0), got '$out' (exit $rc)"
+  fi
+}
+
+want_select "a live claim parses as <login> <age>" \
+  "grace 300" \
+  "{\"comments\":[$(comment grace "<!-- issue-claim --> grace" $((NOW_SELECT - 300)))]}"
+
+# A lapsed claim still parses correctly here — the window is judged by `check`
+# downstream, not by `select`.
+want_select "a lapsed claim still parses; the window is judged downstream" \
+  "grace 999999" \
+  "{\"comments\":[$(comment grace "<!-- issue-claim --> grace" $((NOW_SELECT - 999999)))]}"
+
+out="$(printf '{"comments":[%s]}' \
+  "$(comment grace "just an unrelated comment" $((NOW_SELECT - 10)))" \
+  | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+  ok "a comment that is not a claim produces no row"
+else
+  bad "a non-claim comment should produce no row, got '$out' (exit $rc)"
+fi
+
+# The witness: break the filter above by dropping the `.author.login`
+# interpolation (or the `startswith($marker)` filter) and re-run
+# `make issue-claim-test` — every `want_select` case above fails, naming the
+# parse. Restore it and the suite is green again. Captured as a red run
+# followed by a green one in this PR's description rather than claimed here.
+
+# A malformed timestamp must fail the parse rather than silently emit a wrong
+# age. Production treats a failed `select` as "comments unreadable" and
+# proceeds (fail-open), so this failing closed is what keeps that path from
+# reporting a wrong number.
+malformed_json='{"comments":[{"author":{"login":"grace"},"body":"<!-- issue-claim --> grace","createdAt":"not-a-date"}]}'
+out="$(printf '%s' "$malformed_json" | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+  ok "a malformed timestamp fails the parse rather than emitting a wrong age"
+else
+  bad "a malformed timestamp should fail closed, got exit $rc: '$out'"
+fi
+
 echo
 if [ "$fail" -eq 0 ]; then
   printf 'issue-claim: %d passed\n' "$pass"

--- a/scripts/test-main-red-claim.sh
+++ b/scripts/test-main-red-claim.sh
@@ -369,6 +369,66 @@ else
   bad "a malformed timestamp should fail closed, got exit $rc: '$out'"
 fi
 
+# The real `check` path, end to end, through a `gh` stub instead of a
+# fixture. `gh` colorizes its output whenever it thinks it has a terminal,
+# even inside `$(...)`. That turns the comments payload into text `jq`
+# cannot parse — `check-releases-published.sh`'s own header names this
+# hazard. `gh --jq` hides it for free: `gh` never colors what it filters
+# itself. This PR splits `--json comments` out of that call and loses the
+# free protection, so production must force color off on its own. A stub
+# `gh` plays back the hazard: valid JSON only when `NO_COLOR`/`CLICOLOR_FORCE`
+# are set, broken text otherwise. Restoring the old call passes every case
+# above (none of them touch `gh`) and fails only this one — why it exists.
+gh_colorish="$(mktemp -d)"
+trap 'rm -rf "$gh_less" "${clone_a:-}" "${clone_b:-}" "${no_repo:-}" "$gh_colorish"' EXIT
+# Production stamps `select_claims`'s `now` from the real clock (`date -u
+# +%s`), not from `NOW_SELECT` above, so the fixture's `createdAt` has to be
+# a few minutes behind the real clock too — a future timestamp reads as a
+# negative age and is dropped as unparseable, the same as garbage input.
+claim_time="$(jq -n --argjson t "$(($(date -u +%s) - 300))" '$t | todateiso8601')"
+# A quoted heredoc, so the stub's own backslash escapes (`\033` for the
+# color code) reach the file untouched instead of going through bash's
+# heredoc expansion first. The timestamp is filled in after, by `sed`.
+cat >"$gh_colorish/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+case "$*" in
+"issue list --label main-red --state open --limit 20 --json number --jq .[].number")
+  echo "9001"
+  ;;
+"api user --jq .login")
+  echo "ada"
+  ;;
+"issue view 9001 --json comments")
+  if [ "${NO_COLOR:-}" = "1" ] && [ "${CLICOLOR_FORCE:-}" = "0" ]; then
+    printf '{"comments":[{"author":{"login":"grace"},"body":"main-red-claim: grace s1","createdAt":__CLAIM_TIME__}]}'
+  else
+    printf '\033[1;37m{\033[0m broken, uncolored callers never see this'
+  fi
+  ;;
+*)
+  echo "gh stub: unhandled invocation: gh $*" >&2
+  exit 1
+  ;;
+esac
+STUB
+sed -i.bak "s|__CLAIM_TIME__|${claim_time}|" "$gh_colorish/gh" && rm -f "$gh_colorish/gh.bak"
+chmod +x "$gh_colorish/gh"
+for tool in bash awk tr mktemp date jq; do
+  tool_path="$(command -v "$tool")"
+  [ -n "$tool_path" ] && ln -s "$tool_path" "$gh_colorish/$tool"
+done
+out="$(PATH="$gh_colorish" "$SCRIPT" check 2>&1)"
+rc=$?
+case "$rc,$out" in
+1,*"claimed by @grace"*)
+  ok "check survives gh's own colorized JSON and still sees the live claim"
+  ;;
+*)
+  bad "check should stand down on the live claim through gh's real output shape, got exit $rc: $out"
+  ;;
+esac
+
 echo ""
 echo "  $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/scripts/test-main-red-claim.sh
+++ b/scripts/test-main-red-claim.sh
@@ -275,6 +275,100 @@ case "$out" in
 *) bad "--help truncated the header" ;;
 esac
 
+# ── The parse itself ──────────────────────────────────────────────────────
+#
+# Every case above drives `--fixture-claims`: already-parsed
+# `<login> <session> <age>` rows, never the jq filter that makes them. These
+# drive `select` instead — real `gh issue view --json comments` JSON, on
+# stdin, through the real filter. A typo in it (a dropped `.author.login`, a
+# broken session-word split) now fails one of these cases, not nothing.
+NOW_SELECT=2000000000
+
+# iso <unix-seconds> — jq's own conversion, not `date`. The filter under test
+# uses jq for this arithmetic because `date -d` and `date -j` disagree across
+# platforms. Building the fixture with `date` would make the test itself
+# depend on the platform too.
+iso() { jq -n --argjson t "$1" '$t | todateiso8601'; }
+
+# comment <login> <first-line> <created-unix> — one comment object. The body
+# is JSON-string-encoded by jq (`-Rs`) so a first line carrying a literal `\r`
+# round-trips as one.
+comment() {
+  local login="$1" first_line="$2" created
+  created="$(iso "$3")"
+  printf '{"author":{"login":"%s"},"body":%s,"createdAt":%s}' \
+    "$login" "$(printf '%s\nRepairing this.' "$first_line" | jq -Rs .)" "$created"
+}
+
+# want_select <name> <expect-line> <json>.
+want_select() {
+  local name="$1" expect="$2" json="$3" out rc
+  out="$(printf '%s' "$json" | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+  rc=$?
+  if [ "$out" = "$expect" ] && [ "$rc" -eq 0 ]; then
+    ok "$name"
+  else
+    bad "$name — wanted '$expect' (exit 0), got '$out' (exit $rc)"
+  fi
+}
+
+want_select "a live claim with a session word parses as <login> <session> <age>" \
+  "grace s1 300" \
+  "{\"comments\":[$(comment grace "main-red-claim: grace s1" $((NOW_SELECT - 300)))]}"
+
+want_select "a claim with no session word parses with a '-' in that column" \
+  "grace - 300" \
+  "{\"comments\":[$(comment grace "main-red-claim: grace" $((NOW_SELECT - 300)))]}"
+
+# A lapsed claim still parses here. `check` judges the window later, not
+# `select`. The age still comes out right, even for a stale claim.
+want_select "a lapsed claim still parses; the window is judged downstream" \
+  "grace s1 5000" \
+  "{\"comments\":[$(comment grace "main-red-claim: grace s1" $((NOW_SELECT - 5000)))]}"
+
+out="$(printf '{"comments":[{"author":{"login":"grace"},"body":"just fixed a typo, unrelated","createdAt":%s}]}' \
+  "$(iso $((NOW_SELECT - 10)))" | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+  ok "a comment that is not a claim produces no row"
+else
+  bad "a non-claim comment should produce no row, got '$out' (exit $rc)"
+fi
+
+# A marker line with runs of extra spaces (an older copy of this script, or a
+# body a person hand-edited) must not shift the session word into the wrong
+# column or leave stray empty fields in it.
+want_select "a marker line with extra spaces still parses" \
+  "grace s1 40" \
+  "{\"comments\":[$(comment grace "main-red-claim:  grace   s1" $((NOW_SELECT - 40)))]}"
+
+# A body whose first line arrived with a carriage return (Windows-authored, or
+# an API that round-trips CRLF) must not leave the `\r` glued onto the session
+# word, which would make it compare unequal to every other claim's.
+crlf_json="$(printf '{"comments":[{"author":{"login":"grace"},"body":%s,"createdAt":%s}]}' \
+  "$(printf 'main-red-claim: grace s1\r\nRepairing this.' | jq -Rs .)" "$(iso $((NOW_SELECT - 40)))")"
+want_select "a CRLF first line still parses cleanly" "grace s1 40" "$crlf_json"
+
+# The witness: break the filter above (drop the `.author.login` field, or
+# turn `\$word[2]` into a literal `"-"`) and re-run `make main-red-claim-test`.
+# Every `want_select` case that checks a login or a session word turns red.
+# Fix it back, and the suite turns green again. This PR's description shows
+# both runs.
+
+# A malformed timestamp must fail the parse rather than silently emit a wrong
+# age — the shape the tracker could return if a comment were ever
+# hand-crafted or corrupted. Production treats a failed `select` as "comments
+# unreadable" and proceeds (fail-open), so this failing closed is what keeps
+# that path from reporting a wrong number.
+malformed_json='{"comments":[{"author":{"login":"grace"},"body":"main-red-claim: grace s1","createdAt":"not-a-date"}]}'
+out="$(printf '%s' "$malformed_json" | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+  ok "a malformed timestamp fails the parse rather than emitting a wrong age"
+else
+  bad "a malformed timestamp should fail closed, got exit $rc: '$out'"
+fi
+
 echo ""
 echo "  $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

`scripts/main-red-claim.sh` and `scripts/issue-claim.sh` each parsed claim
comments with a `gh --jq` program embedded directly in the `gh issue view`
call. The hermetic suites only drove `--fixture-claims`, a shape already
downstream of the parse, so the jq program itself ran under no test — a
typo in it would make every claim invisible, and the guard would report
"unclaimed" forever, the same green a working guard prints on a quiet day.

The fix: each script gains a `select --now <unix-seconds>` mode, matching
the pure seam `scripts/check-releases-published.sh --select --now <unix>`
already uses — real `gh issue view --json comments` JSON on stdin,
`<login> [session] <age>` lines out. Production wires `select_claims` to
that JSON instead of embedding the filter in the `gh` call. The test
suites drive `select` directly with fixtures built from real comment
shapes: a live claim, a lapsed claim, a comment that is not a claim, a
CRLF first line, a marker line with extra spaces (main-red-claim.sh only —
it is the one with a session word to protect), and a malformed timestamp.

Building this exposed a second, real bug: splitting `--json comments` out
of the old `--jq` call reopened the color hazard `check-releases-published.sh`'s
own header already names — `gh` colorizes its output whenever it thinks it
has a terminal, even inside `$(...)`, and `--jq` used to hide that for free
because `gh` never colors what it filters internally. The plain
`--json comments` call does not get that protection, so on a maintainer's
own machine (not CI, which is never a TTY) every claim silently read as
"comments unreadable" and the script proceeded as if unclaimed — exactly
the failure mode #5898 exists to catch, just moved one layer over. Fixed
with `CLICOLOR_FORCE=0 NO_COLOR=1`, the same pattern
`check-releases-published.sh` already uses. A `gh`-stub regression test in
each suite plays back the exact hazard end to end through the real,
non-fixture `check` path (not just `select`), so this cannot regress
silently again.

Closes #5898

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

Two witnesses, run locally and reproduced below:

**1. The parse itself** — break `select_claims`'s session-word extraction in
`scripts/main-red-claim.sh` (change `$word[2]` to a literal `"-"`) and run
`make main-red-claim-test`:

```
  ✓ a claim with no session word parses with a '-' in that column
✗ a live claim with a session word parses as <login> <session> <age> — wanted 'grace s1 300' (exit 0), got 'grace - 300' (exit 0)
  ✓ a comment that is not a claim produces no row
✗ a lapsed claim still parses; the window is judged downstream — wanted 'grace s1 5000' (exit 0), got 'grace - 5000' (exit 0)
✗ a marker line with extra spaces still parses — wanted 'grace s1 40' (exit 0), got 'grace - 40' (exit 0)
✗ a CRLF first line still parses cleanly — wanted 'grace s1 40' (exit 0), got 'grace - 40' (exit 0)
  ✓ a malformed timestamp fails the parse rather than emitting a wrong age
  ✓ check survives gh's own colorized JSON and still sees the live claim

  35 passed, 4 failed
```

Restore the filter and `make main-red-claim-test` is green again (39
passed, 0 failed). The identical break/restore cycle against
`scripts/issue-claim.sh`'s `.author.login` interpolation flips 3 cases
(2 `want_select` cases plus the `gh`-stub regression case) the same way.

**2. The color hazard** — revert just the `CLICOLOR_FORCE=0 NO_COLOR=1`
prefix on `gh issue view` in either script and run its suite:

```
✗ check should stand down on the live claim through gh's real output shape, got exit 0: jq: parse error: Invalid numeric literal at line 1, column 2
note: could not read #9001's comments. Proceeding (fail-open).
ok  proceed (comments unreadable)

  38 passed, 1 failed
```

Restore the env prefix and the suite is green again (39/39,
20/20 respectively). Both breaks were applied, run, and reverted locally
before this commit — no diff to `main-red-claim.sh`/`issue-claim.sh`
survives from either experiment (`diff` against a saved copy confirmed
identical).

## The gate

- [x] `cargo fmt --check` — no Rust changed; ran anyway, no-op
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — N/A, shell-only change
- [ ] `cargo test --workspace` — N/A, shell-only change; `make main-red-claim-test` and `make issue-claim-test` cover it instead (both run locally, see witnesses above)
- [x] Docs updated where behavior/flags changed — both scripts' own `--help` header documents the new `select` mode
- [ ] CLA signed (the bot prompts on first PR)
- [x] `Closes #5898` appears both above and as a commit trailer

`make guards-fast` is green locally (toolchain-free guards, `shellcheck`,
`check-prose`, `check-file-size`, `check-line-citations` all pass over the
diff).

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

The color hazard above was found while building the fix, not left for
later — it is fixed and witnessed in the second commit rather than filed
as a follow-up.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — this touches only
      `scripts/*.sh`
- [x] No new outbound network calls — the new `select` mode is pure
      (stdin in, stdout out); production still only calls `gh` the way it
      already did

## Anything reviewers should know?

- No new file: the DoD's "if the jq program is lifted out of the script
  body, it lands under `scripts/lib/`" clause doesn't apply, because the
  seam lives as a mode (`select`) inside each script rather than being
  lifted into its own file — matching how `check-releases-published.sh`
  is itself structured, which is the exemplar this design follows
  (posted to #5898 before this branch started).
- `main-red-claim.sh` and `issue-claim.sh` keep two separate
  `select_claims` implementations rather than sharing one, because their
  jq filters have genuinely diverged: `main-red-claim.sh`'s carries the
  session-word column (#5874) that `issue-claim.sh`'s does not.
- The color-hazard fix and its regression test were not part of the
  original design pointer; they surfaced while writing the `gh`-stub
  witness for the parse itself, and are included here rather than filed
  separately since both commits are one logical change (make the claim
  parse testable, and testable end to end without a false negative).

## Summary by Sourcery

Make claim-comment parsing independently testable and ensure claim checks remain reliable when GitHub CLI output is colorized.

New Features:
- Add pure `select --now` modes to both claim scripts for parsing GitHub comment JSON into claim records.

Bug Fixes:
- Prevent colorized `gh` JSON output from corrupting claim parsing and causing live claims to be treated as absent.

Enhancements:
- Route production claim checks through the testable comment-selection seam while preserving each script’s claim format.

Documentation:
- Document the new `select` modes in both scripts’ usage help.

Tests:
- Add parser coverage for live, stale, malformed, non-claim, whitespace, and CRLF comment shapes.
- Add end-to-end regression coverage for colorized `gh` output on both claim-check paths.