### PR TITLE
fix(ci): correct issue-triage.yml's TYPE_LABELS to the five real types

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -26,8 +26,11 @@ env:
   GH_TOKEN: ${{ github.token }}
   ISSUE: ${{ github.event.issue.number }}
   REPO: ${{ github.repository }}
-  # Space-separated; adding any of these counts as typing the issue.
-  TYPE_LABELS: bug feature epic documentation question
+  # Space-separated; adding any of these counts as typing the issue. Must
+  # match /backlog-triage's five valid types exactly (#2825): `question` is
+  # not one of them and `chore` was missing, so a `chore`-typed issue never
+  # counted as typed here.
+  TYPE_LABELS: bug feature chore documentation epic
 
 jobs:
   triage:

--- a/crates/stella-autonomy/src/convention.rs
+++ b/crates/stella-autonomy/src/convention.rs
@@ -14,7 +14,7 @@
 //! carries `bug` **or** `triage` — an untriaged issue is a defect nobody has
 //! classified yet. Meanwhile `.github/workflows/issue-triage.yml` adds
 //! `triage` to any issue opened without one of its `TYPE_LABELS`
-//! (`bug feature epic documentation question`), and the comment above that
+//! (`bug feature chore documentation epic`), and the comment above that
 //! rule says why: "Issues opened outside the template (`gh issue create`, the
 //! API) carry no labels at all — those are exactly the ones this catches."
 //!
@@ -499,7 +499,7 @@ mod tests {
             axes: vec![
                 LabelAxis {
                     name: "type".into(),
-                    members: ["bug", "feature", "epic", "documentation", "question"]
+                    members: ["bug", "feature", "chore", "documentation", "epic"]
                         .iter()
                         .map(|s| (*s).to_owned())
                         .collect(),
@@ -545,9 +545,9 @@ mod tests {
                 candidates: vec![
                     "bug".into(),
                     "feature".into(),
-                    "epic".into(),
+                    "chore".into(),
                     "documentation".into(),
-                    "question".into(),
+                    "epic".into(),
                 ],
             }]
         );

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -947,7 +947,7 @@ mod tests {
         BacklogConvention {
             axes: vec![LabelAxis {
                 name: "type".into(),
-                members: ["bug", "feature", "epic", "documentation", "question"]
+                members: ["bug", "feature", "chore", "documentation", "epic"]
                     .iter()
                     .map(|s| (*s).to_owned())
                     .collect(),

--- a/crates/stella-cli/src/self_driving_cmd/convention.rs
+++ b/crates/stella-cli/src/self_driving_cmd/convention.rs
@@ -190,7 +190,7 @@ mod tests {
 env:
   GH_TOKEN: ${{ github.token }}
   # Space-separated; adding any of these counts as typing the issue.
-  TYPE_LABELS: bug feature epic documentation question
+  TYPE_LABELS: bug feature chore documentation epic
 jobs:
   triage:
     steps:
@@ -213,7 +213,7 @@ jobs:
         assert_eq!(axis.source, ConventionSource::Enforced);
         assert_eq!(
             axis.members,
-            vec!["bug", "feature", "epic", "documentation", "question"]
+            vec!["bug", "feature", "chore", "documentation", "epic"]
         );
         assert_eq!(bound.convention.reserved, vec!["triage".to_owned()]);
     }
@@ -283,5 +283,30 @@ jobs:
 
         assert_eq!(bound.provenance, Provenance::Manifest);
         assert_eq!(bound.convention.axes[0].name, "kind");
+    }
+
+    /// Reads this repository's own checked-in
+    /// `.github/workflows/issue-triage.yml` — not a fixture — and checks
+    /// `TYPE_LABELS` against `/backlog-triage`'s five valid types
+    /// (`bug feature chore documentation epic`), no more and no less: a
+    /// `question` entry or a missing `chore` fails this test.
+    #[test]
+    fn the_real_workflow_type_labels_match_the_five_valid_types() {
+        // crates/stella-cli -> repository root.
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+
+        let bound = load(&repo_root);
+
+        assert_eq!(
+            bound.provenance,
+            Provenance::Discovered,
+            "expected TYPE_LABELS to be discoverable from the real workflow"
+        );
+        let mut members = bound.convention.axes[0].members.clone();
+        members.sort();
+        assert_eq!(
+            members,
+            vec!["bug", "chore", "documentation", "epic", "feature"]
+        );
     }
 }

--- a/crates/stella-cli/src/self_driving_cmd/residue.rs
+++ b/crates/stella-cli/src/self_driving_cmd/residue.rs
@@ -298,7 +298,7 @@ mod tests {
         BacklogConvention {
             axes: vec![LabelAxis {
                 name: "type".into(),
-                members: ["bug", "feature", "epic", "documentation", "question"]
+                members: ["bug", "feature", "chore", "documentation", "epic"]
                     .iter()
                     .map(|s| (*s).to_owned())
                     .collect(),


### PR DESCRIPTION
## What

`TYPE_LABELS` in `.github/workflows/issue-triage.yml` carried `question`,
which is not one of `/backlog-triage`'s five valid issue types, and was
missing `chore`, which is one of them. A `chore`-typed issue never counted
as "typed" by this workflow, and a `question`-labelled issue would have
counted even though nothing else in this repository's taxonomy recognizes
it.

`TYPE_LABELS` is now `bug feature chore documentation epic` -- exactly the
five types `/backlog-triage` names, no more and no less.

## Why the other half of #2825 is already done

#2825 reported two things: this workflow auto-stripping `triage` before
`/backlog-triage`'s other facets landed (the structural bug), and
`TYPE_LABELS` naming the wrong five types (the vocabulary bug). The issue
sat closed under the 2026-08-12 mission-scope sweep and was reopened
2026-08-27 without being re-verified against the tree.

The structural half was already fixed in #4397 (`e1886e310`, closing
#3851, merged 2026-08-23 -- four days *before* #2825 was reopened):
`.github/workflows/issue-triage.yml` no longer triggers on `labeled` and no
longer carries a "Typing an issue clears triage" step. `triage` is added
only on `opened`; the sweep is the only thing that ever removes it now. I
verified this by diffing `origin/main`'s current copy against that commit
-- unchanged since.

This PR is the remaining half: the vocabulary.

## Files touched

- `.github/workflows/issue-triage.yml` -- the fix itself.
- `crates/stella-cli/src/self_driving_cmd/convention.rs` -- the module that
  discovers this repository's issue-type convention *by reading this exact
  file at runtime*; its test fixture mirroring the real workflow is updated
  to match, and a new witness test reads the real checked-in file.
- `crates/stella-autonomy/src/convention.rs`,
  `crates/stella-cli/src/self_driving_cmd/{backlog,residue}.rs` -- three
  more test fixtures whose doc comments claim to mirror this workflow's
  `TYPE_LABELS` ("This repository's convention, as `issue-triage.yml`
  enforces it"), updated so those comments stay true. None of their test
  assertions depended on the specific label names, so this is a pure
  substitution.

## Witness

`crates/stella-cli/src/self_driving_cmd/convention.rs`'s new
`the_real_workflow_type_labels_match_the_five_valid_types` reads the actual
checked-in `.github/workflows/issue-triage.yml` (not a fixture, via
`self_driving_cmd::convention::load`) and asserts its `TYPE_LABELS` is
exactly `bug feature chore documentation epic`.

Verified failing on the pre-fix file:

```
$ git stash push -- .github/workflows/issue-triage.yml
$ cargo test -p stella-cli --bin stella \
    self_driving_cmd::convention::tests::the_real_workflow_type_labels_match_the_five_valid_types
...
left:  ["bug", "documentation", "epic", "feature", "question"]
right: ["bug", "chore", "documentation", "epic", "feature"]
test result: FAILED. 0 passed; 1 failed
$ git stash pop
```

And passing on the fixed file (6/6 in that module, plus 15/15 in
`self_driving_cmd::backlog::tests`, 8/8 in `self_driving_cmd::residue::tests`,
and 15/15 in `stella-autonomy::convention::tests`).

## Tests deleted

None.

## Guards

`make guards-fast` clean locally (no cargo compile needed for the workflow
change; the Rust changes were checked with targeted `cargo test -p stella-cli
--bin stella` / `cargo test -p stella-autonomy`, not a workspace build, per
CLAUDE.md).

Closes #2825

## Summary by Sourcery

Correct the issue-triage workflow’s type vocabulary so `chore` issues are recognized and unsupported `question` labels are excluded.

Bug Fixes:
- Align issue triage type detection with the five valid backlog types by replacing `question` with `chore`.
- Add a regression test that verifies the checked-in workflow defines exactly the supported issue types.

Enhancements:
- Update convention documentation and test fixtures to reflect the repository's corrected issue-type taxonomy.

Tests:
- Add coverage that reads the real issue-triage workflow and validates its `TYPE_LABELS` against the supported types.