### PR TITLE
ci(codeql): replace default setup with an advanced-setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,20 +46,22 @@
 # `.github/workflows/`). `ruby` is dropped — the repository's only `.rb` file
 # is `packaging/homebrew/stella.rb`, not worth its own CodeQL extractor pass.
 #
-# ── Why `rust` gets `build-mode: manual` and the rest get `none` ─────────────
+# ── Why every language here gets `build-mode: none` ─────────────────────────
 #
-# CodeQL's compiled-language extractors work by tracing the compiler
-# invocations a real build makes, so `rust` needs one. `python` and
-# `javascript-typescript` are interpreted and `actions` parses YAML directly —
-# none of the three need a build step, hence `build-mode: none`.
+# CodeQL's Rust extractor accepts one build mode, `none`: it extracts from
+# source with the workspace resolved by cargo, rather than tracing a compiler
+# the way the C/C++/Java extractors do. `manual` is refused outright by
+# `codeql database init` — "Rust does not support the manual build mode.
+# Please try using one of the following build modes instead: none" — so the
+# rust leg carries no build step. `python` and `javascript-typescript` are
+# interpreted and `actions` parses YAML directly, so none of those needs one
+# either.
 #
-# The build command is `cargo check --workspace --all-targets --locked` — not
-# `cargo build` — because CodeQL's Rust extractor only needs the compiler
-# front end (parsing, type-checking, MIR) that `check` already runs; skipping
-# codegen keeps this from paying for a release build it has no use for. It is
-# also the exact command `scripts/main-canary.sh`'s `compile` row already uses
-# to answer "does this workspace build", so a CodeQL-only build failure and a
-# main-canary compile failure are diagnosed the same way.
+# The rust leg still installs the toolchain `rust-toolchain.toml` pins,
+# because the extractor resolves the workspace through cargo before it
+# extracts; a runner with no toolchain hands it an unresolved dependency
+# graph. Whether this workspace *compiles* is `ci.yml`'s question, not this
+# file's.
 #
 # ── Why this stays advisory (#3260 DoD item 4) ───────────────────────────────
 #
@@ -103,7 +105,7 @@ jobs:
       matrix:
         include:
           - language: rust
-            build-mode: manual
+            build-mode: none
           - language: python
             build-mode: none
           - language: javascript-typescript
@@ -113,8 +115,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      # Only the rust leg needs a toolchain; rust-toolchain.toml pins the
-      # version cargo below picks up.
+      # Only the rust leg needs a toolchain — CodeQL's extractor resolves the
+      # workspace through cargo. The pin comes from rust-toolchain.toml.
       - name: Install Rust (rustup; the pin comes from rust-toolchain.toml)
         if: matrix.language == 'rust'
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -127,12 +129,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
-      # The manual build CodeQL's rust extractor traces. See the header above
-      # for why `check` rather than `build`.
-      - name: Build the Rust workspace for CodeQL to trace
-        if: matrix.language == 'rust'
-        run: cargo check --workspace --all-targets --locked
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,172 @@
+# Static analysis (CodeQL) — the security-scanning half of the supply-chain
+# posture AGENTS.md describes: `cargo deny` gates advisories/bans/sources/
+# licenses, `dependency-review.yml` reviews every PR's dependency diff, and
+# this is what actually reads the code.
+#
+# ── Why this file exists at all (#3260) ──────────────────────────────────────
+#
+# Until this file, CodeQL ran as GitHub's managed "default setup" — no
+# committed workflow, configured entirely through repository settings. Its
+# last successful analysis was 2026-07-13; every run after that, on
+# 2026-07-17, failed in five to nine seconds each. That is too fast to be a
+# Rust autobuild actually attempting this workspace — a real build failure
+# would cost minutes, not single digits of seconds — which points at an
+# init-time configuration error rather than a build problem, though the exact
+# cause is not recoverable: default setup's run logs are not retained the way
+# a committed workflow's are, and by the time #3260 was filed they had already
+# expired. What is verifiable is that default setup's own state is
+# `not-configured` today (`gh api repos/<repo>/code-scanning/default-setup`) —
+# GitHub disables default setup automatically after enough consecutive
+# failures — so from some point after 2026-07-17 there were not even any red
+# runs left to notice. The scanner was not merely failing; for over a month,
+# nothing invoked it at all, and nothing in this repository's own gate reads
+# CodeQL's status, so nothing said so.
+#
+# Committing this file switches CodeQL to "advanced setup": a workflow this
+# repository owns, whose logs live in this repository's own Actions history
+# with the same retention as every other workflow here, and whose language
+# list and build step are declared rather than configured through a settings
+# page nobody was watching.
+#
+# ── Why these four languages, and not default setup's seven ─────────────────
+#
+# Default setup's configured language list (readable via the same API call
+# above) was `[actions, javascript, javascript-typescript, python, ruby, rust,
+# typescript]` — `javascript`, `javascript-typescript` and `typescript` all
+# three at once. Current CodeQL does not accept that combination (the
+# consolidated `javascript-typescript` id supersedes the separate
+# `javascript`/`typescript` ones), and duplicated/overlapping language ids is
+# exactly the kind of error that would fail at init time, before any build
+# runs — consistent with the five-to-nine-second failures above, though this
+# is inference rather than something a log line confirms.
+#
+# The four kept here are the languages this repository actually has real
+# source in: `rust` (the workspace itself), `python` (`bench/`, `scripts/`),
+# `javascript-typescript` (`website/`) and `actions` (every workflow under
+# `.github/workflows/`). `ruby` is dropped — the repository's only `.rb` file
+# is `packaging/homebrew/stella.rb`, not worth its own CodeQL extractor pass.
+#
+# ── Why `rust` gets `build-mode: manual` and the rest get `none` ─────────────
+#
+# CodeQL's compiled-language extractors work by tracing the compiler
+# invocations a real build makes, so `rust` needs one. `python` and
+# `javascript-typescript` are interpreted and `actions` parses YAML directly —
+# none of the three need a build step, hence `build-mode: none`.
+#
+# The build command is `cargo check --workspace --all-targets --locked` — not
+# `cargo build` — because CodeQL's Rust extractor only needs the compiler
+# front end (parsing, type-checking, MIR) that `check` already runs; skipping
+# codegen keeps this from paying for a release build it has no use for. It is
+# also the exact command `scripts/main-canary.sh`'s `compile` row already uses
+# to answer "does this workspace build", so a CodeQL-only build failure and a
+# main-canary compile failure are diagnosed the same way.
+#
+# ── Why this stays advisory (#3260 DoD item 4) ───────────────────────────────
+#
+# Recorded on the issue: advisory, not a required check. This repository
+# already gates hard on `cargo deny` as a required check, and adding a second
+# required check before a CodeQL run is proven reliably green risks
+# reproducing the exact failure this file exists to fix — a scanner nobody can
+# get green, blocking every PR, is worse than one running silently. The
+# `report` job below is the other half of that decision: the silence itself
+# was the defect (five and a half weeks with nothing surfacing it), so a red
+# run on `main` now opens a labelled tracking issue and a green run closes it
+# — `scripts/codeql-canary.sh`, modeled on `main-canary.yml`'s pattern but
+# scoped to the one fact this workflow already knows: did the analyze job
+# conclude success or failure.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, offset from scorecard.yml's Monday 06:00 so the two scheduled
+    # security scans do not queue against each other.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: manual
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Only the rust leg needs a toolchain; rust-toolchain.toml pins the
+      # version cargo below picks up.
+      - name: Install Rust (rustup; the pin comes from rust-toolchain.toml)
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - if: matrix.language == 'rust'
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # The manual build CodeQL's rust extractor traces. See the header above
+      # for why `check` rather than `build`.
+      - name: Build the Rust workspace for CodeQL to trace
+        if: matrix.language == 'rust'
+        run: cargo check --workspace --all-targets --locked
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  # Makes a sustained red visible (#3260 DoD item 4) instead of another month
+  # of silence. Runs only outside `pull_request`: a PR's `GITHUB_TOKEN` cannot
+  # be trusted with `issues: write` the way a push-to-main or scheduled run's
+  # can, and per-PR issue noise is not what this is for — the canary is
+  # answering "is CodeQL still working on `main`", not judging any one PR's
+  # code.
+  report:
+    name: report CodeQL status
+    needs: analyze
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Open, refresh or close the codeql-red tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          conclusion=failure
+          if [ "${{ needs.analyze.result }}" = "success" ]; then
+            conclusion=success
+          fi
+          ./scripts/codeql-canary.sh \
+            --announce \
+            --conclusion "$conclusion" \
+            --sha "${{ github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -239,6 +239,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-issue-claim.sh
 
+      - name: the CodeQL canary opens, refreshes and closes a codeql-red issue
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-codeql-canary.sh
+
       - name: the retired-hex ban in every notation, and the citation check
         if: ${{ !cancelled() }}
         run: ./scripts/test-tokens.sh

--- a/Makefile
+++ b/Makefile
@@ -947,6 +947,16 @@ dependabot-pip-dirs: ## Assert every pip directory: in .github/dependabot.yml ho
 dependabot-pip-dirs-test: ## Test the dependabot pip-directory guard (hermetic; not part of `gate`)
 	./scripts/test-dependabot-pip-dirs.sh
 
+# The same shape as main-canary, scoped to one fact: did CodeQL's analyze job
+# pass or fail. A job in codeql.yml runs scripts/codeql-canary.sh directly
+# with --announce and the job's own conclusion, so a sustained red opens a
+# labelled issue instead of running silently. There is nothing for a local
+# "ask" target to check — the conclusion is not this repository's to derive,
+# only the CI job's — so only the test suite gets a target.
+.PHONY: codeql-canary-test
+codeql-canary-test: ## Test the CodeQL canary, announcing included (hermetic; not part of `gate`)
+	./scripts/test-codeql-canary.sh
+
 .PHONY: check
 check: $(CHECK_STEPS) ## Reduced pre-push gate: every guard + lock resolve + fmt + clippy (default and schema features), no rustdoc and no tests
 	@./scripts/check-hooks-installed.sh

--- a/scripts/codeql-canary.sh
+++ b/scripts/codeql-canary.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Is CodeQL still running, and is it green?
+#
+#   scripts/codeql-canary.sh --conclusion success|failure
+#
+# CodeQL's last clean scan here ran on 2026-07-13. Every run after that
+# failed in under ten seconds. That is too fast for a real Rust build to
+# fail, so a bad setting was the likely cause, not broken code.
+#
+# Nobody saw it happen. CodeQL ran as a GitHub-managed setup, not a file in
+# this repository, so no local check read its result. It stayed red until
+# GitHub turned the scan off on its own after too many failed runs. After
+# that there were no runs left to fail. Weeks passed with a dead scanner,
+# and nothing said so.
+#
+# `.github/workflows/codeql.yml` fixes the run itself: a committed workflow
+# this repository owns, in place of a setting nobody was watching. This
+# script is the other half. It makes a sustained red visible, the way
+# `main-canary.sh` does for a broken `main`. It does not add CodeQL as a
+# required check. That call stays advisory, and the tracking issue records
+# why: a required check nobody can pass is worse than one that runs quiet.
+#
+# It is much smaller than `main-canary.sh`. That script owns several checks
+# and re-runs each one. This one owns a single fact: did the CodeQL job pass
+# or fail. The caller already knows the answer and passes it in with
+# `--conclusion`. Both scripts share one shape: one label, one issue kept
+# open across every red run, closed on the next green one, with a
+# "Definition of done" box so the close guard leaves it alone.
+set -euo pipefail
+
+# Same trap as main-canary.sh, and the same reason: the exit code is the
+# verdict. A closed pipe must not turn a lost printf into a lost verdict.
+trap '' PIPE
+
+announce=0
+dry_run=0
+conclusion=""
+sha="unknown"
+run_url="<no run URL given>"
+label="codeql-red"
+fixture_open_issue=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --announce)
+    announce=1
+    shift
+    ;;
+  --dry-run)
+    dry_run=1
+    shift
+    ;;
+  --conclusion)
+    if [ $# -lt 2 ]; then
+      echo "codeql-canary: --conclusion needs a value" >&2
+      exit 2
+    fi
+    conclusion="$2"
+    shift 2
+    ;;
+  --sha)
+    if [ $# -lt 2 ]; then
+      echo "codeql-canary: --sha needs a value" >&2
+      exit 2
+    fi
+    sha="$2"
+    shift 2
+    ;;
+  --run-url)
+    if [ $# -lt 2 ]; then
+      echo "codeql-canary: --run-url needs a value" >&2
+      exit 2
+    fi
+    run_url="$2"
+    shift 2
+    ;;
+  --label)
+    if [ $# -lt 2 ]; then
+      echo "codeql-canary: --label needs a value" >&2
+      exit 2
+    fi
+    label="$2"
+    shift 2
+    ;;
+  --fixture-open-issue)
+    if [ $# -lt 2 ]; then
+      echo "codeql-canary: --fixture-open-issue needs a value" >&2
+      exit 2
+    fi
+    fixture_open_issue="$2"
+    shift 2
+    ;;
+  *)
+    echo "codeql-canary: unknown argument: $1" >&2
+    exit 2
+    ;;
+  esac
+done
+
+case "$conclusion" in
+success | failure) ;;
+*)
+  echo "codeql-canary: --conclusion must be 'success' or 'failure' (got '${conclusion:-<empty>}')" >&2
+  exit 2
+  ;;
+esac
+
+# Same rule as main-canary.sh: --dry-run alone would be a silent no-op that
+# still looks like it did something.
+if [ "$dry_run" -eq 1 ] && [ "$announce" -eq 0 ]; then
+  echo "codeql-canary: --dry-run only means something with --announce" >&2
+  exit 2
+fi
+
+gh_run() {
+  if [ "$dry_run" -eq 1 ]; then
+    printf 'codeql-canary: [dry-run] gh %s\n' "$*" || true
+    return 0
+  fi
+  # The verdict is already decided by --conclusion. A gh outage here must
+  # not turn a green run's exit status red.
+  if ! gh "$@"; then
+    printf 'codeql-canary: WARN — "gh %s" failed; the verdict is unaffected\n' "$*" >&2 || true
+  fi
+}
+
+# The open canary issue, or empty. A gh outage here must not change the exit
+# status below either.
+open_issue=""
+if [ -n "$fixture_open_issue" ]; then
+  open_issue="$fixture_open_issue"
+elif [ "$announce" -eq 1 ] && [ "$dry_run" -eq 0 ]; then
+  open_issue="$(gh issue list --label "$label" --state open --limit 1 \
+    --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+fi
+
+if [ "$announce" -eq 1 ]; then
+  if [ "$conclusion" = "success" ]; then
+    if [ -n "$open_issue" ]; then
+      body="CodeQL analysis succeeded again at \`${sha}\` (${run_url}). Closing
+automatically — reopen if you disagree.
+
+**Definition of done**
+
+- [x] CodeQL analysis completes successfully on \`main\`.
+
+<!-- codeql-canary -->"
+      gh_run issue comment "$open_issue" --body "$body"
+      gh_run issue close "$open_issue" \
+        --reason completed \
+        --comment "Closed by the CodeQL canary at ${sha}."
+      printf 'codeql-canary: CodeQL recovered — closed #%s\n' "$open_issue" || true
+    else
+      printf 'codeql-canary: green, nothing open to close\n' || true
+    fi
+  else
+    body="CodeQL's analyze job failed on \`main\` at \`${sha}\`.
+
+Run: ${run_url}
+
+**Why this matters**
+
+CodeQL went silently red for five and a half weeks before anyone found it —
+the run failed, then GitHub auto-disabled default setup after enough
+consecutive failures, and after that there were not even red runs to notice.
+This issue is the fix for the silence: it stays open for as long as CodeQL
+does, one issue with a growing comment thread rather than a new issue per
+failing run, and the canary closes it itself on the next green run.
+
+**How to investigate**
+
+\`\`\`sh
+gh run view --log-failed \\
+  \"\$(gh run list --repo macanderson/stella --workflow CodeQL --limit 1 \\
+      --json databaseId --jq '.[0].databaseId')\"
+\`\`\`
+
+**Definition of done**
+
+- [ ] CodeQL analysis completes successfully on \`main\`.
+
+The canary closes this issue itself on its next green run, so a box nobody
+ticks costs the issue nothing.
+
+<!-- codeql-canary -->"
+
+    if [ -n "$open_issue" ]; then
+      gh_run issue comment "$open_issue" --body "Still red at \`${sha}\` (${run_url})."
+      printf 'codeql-canary: still red — commented on #%s\n' "$open_issue" || true
+    else
+      # Make the label first. `gh issue create --label` fails if the label
+      # does not exist yet, and `--force` makes this safe to repeat.
+      gh_run label create "$label" \
+        --color B60205 \
+        --description "CodeQL is failing on main — filed by the CodeQL canary" \
+        --force
+      gh_run issue create \
+        --title "CodeQL is red on main" \
+        --label "$label" \
+        --body "$body"
+      printf 'codeql-canary: opened an issue for the failing scan\n' || true
+    fi
+  fi
+fi
+
+if [ "$conclusion" = "success" ]; then
+  printf 'codeql-canary: OK — CodeQL is green at %s.\n' "$sha" || true
+  exit 0
+fi
+
+printf 'codeql-canary: FAIL — CodeQL is red at %s.\n' "$sha" >&2 || true
+exit 1

--- a/scripts/test-codeql-canary.sh
+++ b/scripts/test-codeql-canary.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Hermetic tests for scripts/codeql-canary.sh.
+#
+#   ./scripts/test-codeql-canary.sh    (or: make codeql-canary-test)
+#
+# No network and no `gh`. Every announcing case runs under `--dry-run`, and
+# the issue lookup is pinned with `--fixture-open-issue` instead of a live
+# tracker read. That keeps the suite the same on a bare runner as on a dev
+# box. A monitor that files and closes issues is exactly the kind of script
+# you cannot test by running it for real.
+#
+# CodeQL itself went silently red for weeks with nothing to say so. Every
+# case below fails on the old commit. The script it runs did not exist yet.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+canary="$repo_root/scripts/codeql-canary.sh"
+
+pass=0
+fail=0
+
+ok() {
+  printf '  \033[32m✓\033[0m %s\n' "$*"
+  pass=$((pass + 1))
+}
+bad() {
+  printf '  \033[31m✗\033[0m %s\n' "$*"
+  fail=$((fail + 1))
+}
+
+# A run that must hit one exit code and print one substring.
+expect() {
+  local name="$1" want_code="$2" needle="$3"
+  shift 3
+  local out code
+  out="$("$canary" "$@" 2>&1)"
+  code=$?
+  if [ "$code" -ne "$want_code" ]; then
+    bad "$name — exit $code, wanted $want_code: $out"
+    return
+  fi
+  case "$out" in
+  *"$needle"*) ok "$name" ;;
+  *) bad "$name — output did not contain '$needle': $out" ;;
+  esac
+}
+
+# A run that must NOT print one substring.
+refute() {
+  local name="$1" needle="$2"
+  shift 2
+  local out code
+  out="$("$canary" "$@" 2>&1)"
+  code=$?
+  # The canary always exits 0, 1 or 2. Any other code means the shell
+  # crashed, not the canary. A refute against a run that never happened
+  # would pass by accident, so this catches that case first.
+  case "$code" in
+  0 | 1 | 2) ;;
+  *)
+    bad "$name — the canary did not run (exit $code): $out"
+    return
+    ;;
+  esac
+  case "$out" in
+  *"$needle"*) bad "$name — should NOT have contained '$needle': $out" ;;
+  *) ok "$name" ;;
+  esac
+}
+
+echo "codeql-canary:"
+
+# Argument validation.
+
+expect "a missing --conclusion is rejected" 2 "must be 'success' or 'failure'"
+expect "an unrecognized --conclusion is rejected" 2 "must be 'success' or 'failure'" \
+  --conclusion maybe
+expect "--dry-run without --announce is rejected" 2 "only means something with --announce" \
+  --conclusion failure --dry-run
+expect "an unknown flag is rejected" 2 "unknown argument" \
+  --conclusion failure --nonsense
+
+# The bare check, with no --announce: exit status only, no gh calls.
+
+expect "success exits 0" 0 "OK — CodeQL is green" \
+  --conclusion success
+expect "failure exits 1" 1 "FAIL — CodeQL is red" \
+  --conclusion failure
+refute "a bare check never touches gh" "gh " \
+  --conclusion failure
+
+# Red, no issue open yet: opens one.
+
+expect "a red run with nothing open creates an issue" 1 "gh issue create" \
+  --conclusion failure --announce --dry-run
+expect "the created issue is labelled so only one stays open" 1 "codeql-red" \
+  --conclusion failure --announce --dry-run
+expect "the issue carries the run URL" 1 "https://example.invalid/run/42" \
+  --conclusion failure --announce --dry-run --run-url "https://example.invalid/run/42"
+expect "the issue carries the tested commit" 1 "deadbee" \
+  --conclusion failure --announce --dry-run --sha deadbee
+expect "the issue explains why this exists" 1 "five and a half weeks" \
+  --conclusion failure --announce --dry-run
+expect "the issue carries a Definition of done section" 1 "**Definition of done**" \
+  --conclusion failure --announce --dry-run
+expect "...with an unchecked box, since CodeQL is still red" 1 "- [ ] CodeQL analysis completes successfully" \
+  --conclusion failure --announce --dry-run
+
+# Red, an issue is already open: comments, does not create a second one.
+
+expect "a red run with one already open comments instead" 1 "gh issue comment 99" \
+  --conclusion failure --announce --dry-run --fixture-open-issue 99
+refute "...and does not open a second issue" "issue create" \
+  --conclusion failure --announce --dry-run --fixture-open-issue 99
+
+# Green, an issue is open: closes it, ticking the box.
+
+expect "a green run with one open closes it" 0 "gh issue close 99" \
+  --conclusion success --announce --dry-run --fixture-open-issue 99
+expect "...and ticks the Definition of done box first" 0 "- [x] CodeQL analysis completes successfully" \
+  --conclusion success --announce --dry-run --fixture-open-issue 99
+expect "...naming the recovery commit" 0 "recovered" \
+  --conclusion success --announce --dry-run --fixture-open-issue 99
+
+# Green, nothing open: does nothing. It never leaves a stale issue open.
+
+expect "a green run with nothing open does nothing" 0 "nothing open to close" \
+  --conclusion success --announce --dry-run
+refute "...and never calls gh" "gh " \
+  --conclusion success --announce --dry-run
+
+echo
+echo "codeql-canary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

CodeQL's last clean scan on `main` ran 2026-07-13. Every run since failed in
five to nine seconds — too fast for a real Rust build to fail, which points
at a bad setting rather than broken code (inference: the run logs are gone,
so this is not confirmed by a log line). CodeQL ran as GitHub's managed
"default setup", not a committed workflow, so nothing in this repository's
own gate or dashboard read its result. It stayed red, then GitHub
auto-disabled default setup after enough consecutive failures — after that
there were no runs left to notice at all. Five and a half weeks of total
silence passed before #3260 found it.

Two changes:

1. `.github/workflows/codeql.yml` — an advanced-setup workflow this
   repository owns, replacing default setup. Scoped to the languages the
   repo actually has: `rust` (`build-mode: none` — the only mode the Rust
   extractor accepts; see `14b3880` and the comment below for why the
   original `manual` mode plus an explicit `cargo check` step was wrong and
   was removed), `python`, `javascript-typescript` and `actions`. Default
   setup's own language list (readable via
   `gh api repos/<repo>/code-scanning/default-setup`) mixed `javascript`,
   `javascript-typescript` and `typescript` all at once — a combination
   current CodeQL does not accept, and the likely cause of every init
   failing before any build ran.
2. `scripts/codeql-canary.sh`, run from a `report` job in `codeql.yml` — the
   decision recorded on #3260 is that CodeQL stays advisory (not a required
   check: a required check nobody can get green is worse than one running
   quietly), so the fix for the silence is visibility instead. Modeled on
   `main-canary.sh`'s shape (one label, one issue kept open across every red
   run, closed on the next green one) but scoped to the single fact the
   workflow already knows: did the analyze job conclude success or failure.

**Exemplar**: `scripts/main-canary.sh` / `.github/workflows/main-canary.yml`
for the announce/dry-run/fixture-open-issue shape, and
`.github/workflows/scorecard.yml` for the SARIF-upload/action-pin style —
`github/codeql-action/init` and `analyze` reuse the exact commit SHA
`upload-sarif` there already pins (same monorepo release).

Closes #3260 — its Definition of done is now fully satisfied. The three items
this PR delivers are ticked on the issue with their evidence, and the fourth
(`A green CodeQL run exists on main`), which no pre-merge state of this branch
could satisfy, is split into #6050 per SCR-004 — the same shape as #5613 →
#6024 earlier today. #6050 carries that box verbatim and says to read the
first `CodeQL` run on `main` after this merges, linking either a green run or
the `codeql-red` issue the canary opens.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`scripts/test-codeql-canary.sh` drives `scripts/codeql-canary.sh` entirely
under `--dry-run`, with the issue lookup pinned via `--fixture-open-issue` so
no case touches `gh` or the network. All 21 cases fail on `main` before this
PR — the script does not exist there — and pass here
(`./scripts/test-codeql-canary.sh`, wired into `guard-self-tests.yml`
alongside the other canary self-tests).

`.github/workflows/codeql.yml` itself has no witness in the classic
fail→pass sense (it is CI configuration, not application logic): the
evidence is this PR's own CI run of the new workflow.

## The gate

- [x] `cargo fmt --check` — no Rust changed; ran `cargo fmt --all` anyway
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no Rust changed; not run per CLAUDE.md ("CI builds and tests; this laptop does not")
- [ ] `cargo test --workspace` — same as above
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments) — n/a, no CLI surface changed
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #3260` appears in the description above. The commit trailers on
      this branch read `Refs #3260`, written before #3260's item 3 was split
      into #6050; the description's linked-issue reference is what closes the
      issue on merge. Not re-pushed for the trailer alone, which would restart
      a full CI run to change no code.

Ran locally and green: `make guards-fast` (every toolchain-free guard,
`lockfile-sync`, `fmt --check`), `shellcheck` on both new scripts,
`actionlint` on the new workflow, `./scripts/check-action-pins.sh`,
`./scripts/check-gate-parity.sh`.

## Nothing left behind

Anything you noticed and did not fix — a bug, a missing test, dead or unwired
code, the logical next step of this work — is a GitHub issue before this merges,
written as a handoff a fresh agent could execute (AGENTS.md § "Nothing left
behind"). The gate catches the residue (a `TODO` with no issue number); it
cannot catch what only you saw.

- [x] Filed: #6040, #6050 — **or**
- [ ] There is nothing: everything I noticed is fixed in this PR

#6040 tracks revisiting the advisory-vs-required call once
`.github/workflows/codeql.yml` has a track record. #6050 carries #3260's
post-merge box: read the first `CodeQL` run on `main` after this merges.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home) — `codeql-canary.sh` only calls `gh`, from CI, using the workflow's own token, the same as every other canary/claim script in this repo
- [ ] New cross-boundary types round-trip through serde (test included) — n/a

## Anything reviewers should know?

The root cause of the original default-setup failures is inference, not a
confirmed fact — GitHub does not retain default setup's run logs the way it
retains a committed workflow's, and by the time #3260 was filed they had
already expired. What's verified: `gh api
repos/macanderson/stella/code-scanning/default-setup` reports `state:
"not-configured"` today, and `code-scanning/analyses` shows CodeQL's last
successful analysis at 2026-07-13, five weeks before every subsequent
default-setup run failed in single-digit seconds. Committing an
advanced-setup workflow sidesteps root-causing the exact original error,
since GitHub Actions runs the committed file directly regardless of the
default-setup toggle.

`Analyze (rust)` was red on the first push with `build-mode: manual` —
`codeql database init` refuses that mode for Rust outright ("Rust does not
support the manual build mode"), so the `cargo check` step behind it never
ran on any attempt. `14b3880` moves that leg to `build-mode: none` and
deletes the build step; the pinned toolchain install stays, because the
extractor still resolves the workspace through cargo.

`dod / dod` was red on this PR for as long as #3260's item 3 sat unticked and
unsplit — it asked for a green run *on `main`*, which no pre-merge state can
produce. That is now split into #6050 and the remaining three boxes are ticked
with their evidence, so the gate reads a satisfiable checklist and this
description carries the closing reference it wanted.

## Summary by Sourcery

Replace GitHub-managed CodeQL default setup with a repository-owned advisory workflow and failure-monitoring canary.

New Features:
- Add a repository-owned CodeQL workflow covering Rust, Python, JavaScript/TypeScript, and GitHub Actions analysis on pushes, pull requests, schedules, and manual dispatches.
- Add an advisory CodeQL canary that tracks sustained failures through a single labeled GitHub issue and closes it after recovery.

Bug Fixes:
- Restore CodeQL scanning after the managed default setup became disabled and stopped producing visible results.

Enhancements:
- Make CodeQL execution and results visible through committed workflow history while keeping the scan advisory rather than required.

CI:
- Add hermetic self-tests for the CodeQL canary to the guard self-test workflow and expose a Makefile test target.

Tests:
- Add comprehensive dry-run coverage for CodeQL canary argument validation, failure reporting, issue creation and refresh, and recovery handling.