### PR TITLE
fix(stella-store): stamp events.ts to the millisecond

### DIFF
--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -25,13 +25,17 @@
 //! miss a field the way a scattered set of `clean()` calls could.
 //!
 //! **2. Never invent a clock reading finer than what was measured.**
-//! `events.ts` is a plain SQLite timestamp with no sub-second part
-//! ([`SessionEventRecord::ts`](stella_store::SessionEventRecord::ts)), so
-//! this fold never reads it. [`Step::offset_ms`] is summed instead from the
-//! real, millisecond-precise durations on `ToolResult` and `StepUsage` — the
-//! same durations the shared renderer already draws for `stella observe`,
-//! and the same sum [`stella_tui::transcript_build::RunBuilder`] already
-//! keeps for the live surface.
+//! [`Step::offset_ms`] is summed from the real, millisecond-precise durations
+//! on `ToolResult` and `StepUsage` — the same durations the shared renderer
+//! already draws for `stella observe`, and the same sum
+//! [`stella_tui::transcript_build::RunBuilder`] already keeps for the live
+//! surface. This fold does not read `events.ts`. Since #2604 that column is
+//! stamped to the millisecond
+//! ([`SessionEventRecord::ts`](stella_store::SessionEventRecord::ts)), so the
+//! old reason — nothing sub-second to read — has gone. Rows written before
+//! #2604 still hold whole seconds, a session's journal spans executions, and
+//! wall-clock does not survive a clock adjustment; whether those make `ts` the
+//! better source here is #6037.
 //!
 //! **3. Drop nothing.** The shared run model has no slot for most of the
 //! wire's event kinds: a stage boundary, a provider fallback, a verdict, and

--- a/crates/stella-store/src/ddl.rs
+++ b/crates/stella-store/src/ddl.rs
@@ -162,6 +162,12 @@ pub(crate) const UNCHANGED_TABLES: &str = "CREATE TABLE IF NOT EXISTS file_locks
 /// is exactly the replay access path (superseding the pre-v1 non-unique
 /// `events_by_execution` index, which is why no separate index exists).
 ///
+/// The `ts` default is not what a new row gets. `Store::record_event` writes
+/// the column itself, to the millisecond (`crate::event_clock`). The default
+/// is only what older rows carry, and they keep it. A migrated file and a
+/// fresh one therefore hold the same second-resolution default and the same
+/// millisecond rows.
+///
 /// `task_id` (v39, #5039) is the board task this event is evidence for, `NULL`
 /// when it is in no task's ledger — either nothing was running when it was
 /// dispatched, or the case carries no tag at all. It is a projection of the

--- a/crates/stella-store/src/event_clock.rs
+++ b/crates/stella-store/src/event_clock.rs
@@ -1,0 +1,75 @@
+//! The clock stamped on `events.ts`, and the insert that stamps it.
+//!
+//! The `events` table declares `ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP`
+//! (`ddl::events_ddl`). That default holds whole seconds and nothing finer.
+//! A fast turn writes many events inside one second. Left to the default,
+//! they all share one reading, and a timeline drawn from them can show
+//! seconds and no more.
+//!
+//! `INSERT_EVENT` stamps the column rather than leaving it to the default.
+//! `strftime('%Y-%m-%d %H:%M:%f', 'now')` reads the same UTC clock that
+//! `CURRENT_TIMESTAMP` reads, and adds a field of milliseconds on the end.
+//! The first 19 characters do not change. A reader that slices that prefix
+//! still works, and no stored row has to move.
+//!
+//! Older rows hold whole seconds and stay that way, so a reader of `ts` has
+//! to take both widths.
+//!
+//! The default in the DDL stays as it is. A change there would leave a fresh
+//! file and a migrated file with two shapes at one schema version. To agree
+//! them costs a rebuild of the largest table in the store, and the default it
+//! would install is one this writer always overrides.
+
+/// The `events` insert, with `ts` stamped to the millisecond.
+///
+/// The five placeholders bind `execution_id`, `seq`, `event_type`, `payload`
+/// and `task_id`, in that order. `ts` is SQL, not a bound value, so a row is
+/// dated by the database that stores it and never by a caller's clock.
+pub(crate) const INSERT_EVENT: &str = "INSERT INTO events \
+     (execution_id, seq, ts, event_type, payload, task_id) \
+     VALUES (?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'), ?, ?, ?)";
+
+#[cfg(test)]
+mod tests {
+    use stella_protocol::AgentEvent;
+
+    use crate::Store;
+
+    /// **The witness.** Every recorded event carries a millisecond field.
+    ///
+    /// A row that took the DDL default would be 19 characters wide and hold
+    /// no `.`, so it fails every check below. This asks the shape of one
+    /// stamp. It does not compare two, so a machine fast enough to write both
+    /// rows inside one millisecond cannot make it flap.
+    #[test]
+    fn a_recorded_event_is_stamped_to_the_millisecond() {
+        let store = Store::in_memory().unwrap();
+        let id = store
+            .begin_execution("run", "goal", "zai", "glm-5.2")
+            .unwrap();
+        store
+            .record_event(id, 0, &AgentEvent::Text { text: "a".into() })
+            .unwrap();
+        store
+            .record_event(id, 1, &AgentEvent::Text { text: "b".into() })
+            .unwrap();
+
+        let journal = store.execution_events(id).unwrap();
+        assert_eq!(journal.events.len(), 2, "both events landed");
+        for row in &journal.events {
+            let ts = &row.ts;
+            assert_eq!(ts.len(), 23, "expected YYYY-MM-DD HH:MM:SS.sss, got {ts:?}");
+            assert_eq!(&ts[19..20], ".", "no millisecond field in {ts:?}");
+            assert!(
+                ts[20..].chars().all(|c| c.is_ascii_digit()),
+                "millisecond field is not three digits: {ts:?}"
+            );
+            assert!(
+                ts[..19]
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || matches!(c, '-' | ' ' | ':')),
+                "the 19-character prefix a reader slices changed shape: {ts:?}"
+            );
+        }
+    }
+}

--- a/crates/stella-store/src/lib.rs
+++ b/crates/stella-store/src/lib.rs
@@ -114,6 +114,8 @@ use stella_protocol::{AgentEvent, TaskStatus};
 //               spool, and the per-store export ledger
 //   error       (crate-private module, `StoreError` re-exported) every
 //               failure this crate returns, as named cases
+//   event_clock (crate-private) the millisecond stamp on `events.ts`, and
+//               the insert that writes it
 //   export      the `/export` telemetry dump and `stella stats`' usage
 //               aggregate, plus the `ExportScope` that decides whether either
 //               covers one session or the whole workspace (#2558)
@@ -135,6 +137,7 @@ use stella_protocol::{AgentEvent, TaskStatus};
 mod ddl;
 mod dispatch;
 mod error;
+mod event_clock;
 mod git_env;
 mod migrations;
 mod private;
@@ -479,20 +482,21 @@ pub struct PullRequestRecord {
 pub struct SessionEventRecord {
     pub execution_id: i64,
     pub seq: i64,
-    /// The `events.ts` column: wall-clock, `YYYY-MM-DD HH:MM:SS`.
+    /// The `events.ts` column: wall-clock UTC, `YYYY-MM-DD HH:MM:SS.sss`.
     ///
-    /// **Second resolution, and that is the whole precision available.**
-    /// Every writer omits the column and takes SQLite's
-    /// `DEFAULT CURRENT_TIMESTAMP`, which has no sub-second component, so a
-    /// consumer rendering an elapsed clock from this may print whole seconds
-    /// and nothing finer. A tenth of a second here would be invented, not
-    /// measured — per-call durations live on the payloads
-    /// ([`AgentEvent::ToolResult::duration_ms`],
-    /// [`AgentEvent::StepUsage::duration_ms`]) and are the millisecond-precise
-    /// figures.
+    /// **Two widths, and a reader has to take both.** [`Store::record_event`]
+    /// stamps the millisecond field itself (`event_clock::INSERT_EVENT`).
+    /// Older rows took SQLite's `DEFAULT CURRENT_TIMESTAMP`. They are 19
+    /// characters wide, with no fractional part, and they stay that way. The
+    /// first 19 characters mean the same thing in both widths, so a reader
+    /// that slices that prefix is safe.
     ///
     /// Ordering still comes from `(execution_id, seq)`, never from this: it is
     /// wall-clock, so it neither ties-break nor survives a clock adjustment.
+    /// Per-call durations still live on the payloads
+    /// ([`AgentEvent::ToolResult::duration_ms`],
+    /// [`AgentEvent::StepUsage::duration_ms`]) and remain the figures to sum
+    /// when the question is how long one call took.
     pub ts: String,
     pub event: AgentEvent,
 }
@@ -890,8 +894,7 @@ impl Store {
         let tx = conn.transaction()?;
         let task_id = event.task_id().map(stella_protocol::TaskId::as_str);
         tx.execute(
-            "INSERT INTO events (execution_id, seq, event_type, payload, task_id) \
-             VALUES (?, ?, ?, ?, ?)",
+            event_clock::INSERT_EVENT,
             params![execution_id, seq, event_type, payload, task_id],
         )?;
         tool_calls::project_event(&tx, execution_id, seq, event)?;


### PR DESCRIPTION
## What

`Store::record_event` now writes `events.ts` itself, to the millisecond,
instead of leaving the column to SQLite's `DEFAULT CURRENT_TIMESTAMP`.

## Why

`events.ts` is declared `TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP`
(`crates/stella-store/src/ddl.rs`, `events_ddl`) and the one production writer
of the table omitted the column. That default holds whole seconds. A fast turn
wrote every one of its events under a single reading, and any consumer drawing
a timeline off the column could show seconds and no more — the Observatory's
journal projection included.

The stamp is `strftime('%Y-%m-%d %H:%M:%f', 'now')`: SQLite's own UTC clock,
the same one `CURRENT_TIMESTAMP` reads, with a millisecond field on the end.
`YYYY-MM-DD HH:MM:SS.sss`, so the first 19 characters are byte for byte what
they were. No reader changes, no stored row moves, no new dependency, no
schema migration.

The statement lives in a new `crates/stella-store/src/event_clock.rs` rather
than in `lib.rs`, which is a god file closed to growth (AGENTS.md § God
files). It follows `receipts.rs`'s shape: a sibling module owning one part of
the store's contract, with its reasoning and its tests beside it. `lib.rs` is
1673 lines against a 1719 ceiling, and the insert itself came out of it.

## Witness mechanism

`crates/stella-store/src/event_clock.rs`'s
`a_recorded_event_is_stamped_to_the_millisecond` records two events and
asserts each `ts` is 23 characters, with `.` at index 19 and three digits
after it. On `main` the writer omits the column, so every row is the DDL
default's 19 characters with no `.` in it and all three assertions fail. It
fails by construction, not by racing two clock reads: it asks the *shape* of
one stamp rather than comparing two, so a machine fast enough to write both
rows inside one millisecond cannot make it flap. It also asserts the
19-character prefix still has the old shape, which is what lets existing
readers stay untouched.

## The issue's premises, re-verified

The reopen note asks for this, and two of them had gone stale:

- **Still true.** One production writer, `Store::record_event`, omitting `ts`.
- **Stale.** The receipts-plane insert named as a second writer is now
  test-only (`crates/stella-store/src/receipts.rs`, inside `mod tests`).
- **Stale.** `parse_sql_timestamp` and
  `the_elapsed_column_counts_whole_seconds_and_invents_no_precision` no longer
  exist. `/export`'s transcript was rewritten to sum the millisecond durations
  on `ToolResult`/`StepUsage` and never reads `events.ts`, so nothing there
  needed updating beyond the module header, whose stated reason ("no
  sub-second part to read") stops being true with this change.

## Deliberately not done

**The DDL default stays at `CURRENT_TIMESTAMP`.** Changing `events_ddl` alone
would leave a fresh database and a migrated one holding two shapes at one
schema version; agreeing them means a schema bump plus a `lang_altertable` §7
rebuild of `events`, the largest table in the file, to install a default the
writer always overrides. Said out loud rather than left implicit, per
CLAUDE.md: nothing now stops a *future* writer omitting the column and
regressing this, and that gap is #6038.

**The transcript's elapsed column is not repointed at `ts`.** Rows written
before this change are second-resolution forever, a session's journal spans
executions, and wall-clock does not survive a clock adjustment. That is a
judgement with its own evidence and it is #6037. The column already shows
millisecond timing for a fast session today, by summing measured durations.

## Docs corrected in the same PR

`SessionEventRecord::ts` (`crates/stella-store/src/lib.rs`), which stated
second resolution as a fact; the `events` DDL, which now says the default is
not what a new row gets; and rule 2 of
`crates/stella-cli/src/export/transcript.rs`'s module header.

## Exemplar

`crates/stella-store/src/receipts.rs` — a sibling module holding one slice of
the store's write contract, its argument, and its tests.

Tests deleted: None

Residue filed: #6037, #6038

Closes #2604

## DoD reconciliation (#2604)

`dod / dod` was red on `1113a2d` because #2604's five boxes were unticked at the
time that run fired (15:19 UTC); they were ticked at 15:27, after it. Each was
checked against the tree rather than against this description:

1. **Sub-second precision at every production writer.** `Store::record_event`
   (`crates/stella-store/src/lib.rs`) is the only one. `receipts.rs`'s insert and
   `stella-observatory/src/turn_agents.rs`'s are both inside `#[cfg(test)]`
   blocks; the `migrations/*` inserts rewrite historic rows and keep their
   original `ts` by design.
2. **A witness that fails on the old code by construction.**
   `a_recorded_event_is_stamped_to_the_millisecond` asserts the shape of a single
   stamp — 23 characters, `.` at index 19, three digits after it. A
   default-stamped row is 19 characters with no `.`, so it fails on `main`
   without comparing two clock reads, and cannot flap on a fast machine.
3. **The 19-character prefix still slices.** `strftime('%Y-%m-%d %H:%M:%f',
   'now')` appends `.sss` to the same UTC reading `CURRENT_TIMESTAMP` gives; the
   prefix is asserted unchanged in the same test, and `SessionEventRecord::ts`
   documents both widths.
4. **The transcript's elapsed column** is split to #6037 under SCR-004 (`triage`
   label only), not dropped — this is also the one row Sourcery's assessment
   marks ❌, answered in a comment on this PR.
5. **Docs updated** in the three places that asserted second resolution:
   `SessionEventRecord::ts`, the `events` DDL comment, and rule 2 of the export
   transcript's module header.

## Summary by Sourcery

Stamp newly recorded events to the millisecond while preserving compatibility with existing second-resolution rows and duration-based transcript timing.

Bug Fixes:
- Stamp newly recorded store events with millisecond precision instead of relying on SQLite's second-resolution default timestamp.

Enhancements:
- Document the mixed timestamp precision of existing and newly written rows while preserving reader compatibility.
- Move event timestamp insertion logic into a dedicated store module with coverage for the timestamp format.

Documentation:
- Update store and transcript documentation to reflect millisecond event timestamps and the continued use of measured durations for elapsed timing.

Tests:
- Add a regression test verifying recorded event timestamps include a three-digit millisecond component and retain the existing prefix format.

---
_Generated by [Claude Code](https://claude.ai/code)_