### PR TITLE
fix(stella-model): probe the terminal rpassword actually opens, not stdio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,6 +3421,7 @@ dependencies = [
  "base64 0.23.1",
  "futures-util",
  "hmac",
+ "libc",
  "reqwest",
  "rpassword",
  "serde",

--- a/crates/stella-cli/src/auth_cmd.rs
+++ b/crates/stella-cli/src/auth_cmd.rs
@@ -19,7 +19,7 @@
 //! next run failed on a value the command had no way to accept.
 
 use colored::Colorize as _;
-use stella_model::credential::{ApiKey, CredentialsFile};
+use stella_model::credential::{ApiKey, CredentialPrompt, CredentialsFile, TerminalPrompt};
 use zeroize::Zeroizing;
 
 use crate::config::{AuxField, ProviderConfig, settable_aux_fields};
@@ -94,6 +94,18 @@ fn read_key_value(provider: &str, key: Option<&str>, use_stdin: bool) -> Result<
             return Err("empty key read from stdin".to_string());
         }
         return Ok(trimmed);
+    }
+    // `TerminalPrompt` is `stella_model::credential`'s own gate on this exact
+    // question: it probes what `rpassword` actually opens — `/dev/tty` on
+    // Unix, `CONIN$`/`CONOUT$` on Windows — rather than `stdin`/`stdout`.
+    // Reused here rather than re-derived so this command and the provider
+    // credential chain can never disagree about whether a human is there to
+    // answer.
+    if !TerminalPrompt.can_prompt(true) {
+        return Err(format!(
+            "no terminal available to prompt for `{provider}`'s API key — pass \
+             `stella auth set {provider} --stdin` (pipe the key) or `--key` instead"
+        ));
     }
     let value = Zeroizing::new(
         rpassword::prompt_password(format!("  API key for `{provider}`: "))
@@ -171,6 +183,14 @@ fn prompt_for_fields(
         };
         let label = format!("  {}{suffix}: ", field.prompt);
         let entered = if field.secret {
+            // Same gate as `read_key_value` above — see its comment.
+            if !TerminalPrompt.can_prompt(true) {
+                return Err(format!(
+                    "no terminal available to prompt for `{}` — pass \
+                     --field {}=VALUE instead",
+                    field.prompt, field.name
+                ));
+            }
             Zeroizing::new(
                 rpassword::prompt_password(&label)
                     .map_err(|e| format!("cannot read secret from terminal: {e}"))?,

--- a/crates/stella-model/Cargo.toml
+++ b/crates/stella-model/Cargo.toml
@@ -40,6 +40,25 @@ sha2.workspace = true
 # what this crate already does correctly.
 tempfile.workspace = true
 
+# `tests/credential_prompt_dev_tty.rs`'s fixture binary — prints
+# `TerminalPrompt.can_prompt(true)` from inside a real pseudo-terminal the
+# test harness constructs, which is the only way to observe `/dev/tty`
+# reachability (rather than `stdin`/`stdout`) without risking the whole
+# suite blocking on a real keystroke. `tests/` locate it with
+# `env!("CARGO_BIN_EXE_tty-probe")`; cargo builds it for them.
+[[bin]]
+name = "tty-probe"
+path = "tests/fixtures/tty_probe.rs"
+
+# A test fixture, never a shipped surface — keep it out of dist.
+[package.metadata.dist]
+dist = false
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 wiremock.workspace = true
+# `tests/credential_prompt_dev_tty.rs` hand-rolls its pty harness on
+# `libc::openpty`/`setsid`/`TIOCSCTTY` — the same construction
+# `stella-tui`'s `tests/deck_pty_smoke.rs` uses, already a workspace
+# dependency; integration tests only see dev-dependencies.
+libc.workspace = true

--- a/crates/stella-model/src/credential.rs
+++ b/crates/stella-model/src/credential.rs
@@ -178,10 +178,14 @@ impl ApiKey {
     /// A host that already knows how it talks to its user — a GUI, a daemon
     /// with its own secret store, a test — injects that here instead of
     /// inheriting `rpassword` on the controlling terminal. It is also the only
-    /// way to reach the swallow below deterministically: the shipping
-    /// [`TerminalPrompt`] declines under `cargo test`, where stdout is not a
-    /// terminal, so a test driving `resolve` alone exercises the gate and
-    /// never the arm underneath it (#4576).
+    /// safe way to reach the swallow below deterministically:
+    /// [`TerminalPrompt::can_prompt`] genuinely probes `/dev/tty` (Unix) or
+    /// `CONIN$`/`CONOUT$` (Windows) rather than asking whether `stdout` is
+    /// captured, so a test that drives `resolve` (not this function) with
+    /// `interactive: true` is not guaranteed to decline — on a machine with a
+    /// controlling terminal attached to the test process, it would actually
+    /// call `rpassword` and block on a keystroke. Every test exercising the
+    /// interactive step calls this function with a fake instead (#4576).
     pub fn resolve_with_prompt(
         provider_id: &str,
         env_var: &str,

--- a/crates/stella-model/src/credential/prompt.rs
+++ b/crates/stella-model/src/credential/prompt.rs
@@ -133,8 +133,11 @@ impl TerminalPrompt {
     /// only adds the check that was missing: a redirected stdout must decline
     /// exactly as a redirected stdin does, not just print a prompt nobody
     /// reads before blocking on an answer nobody can give. `can_prompt` feeds
-    /// this the [`rpassword_tty`] probes (#3052), so `can_answer`/
+    /// this the `rpassword_tty` probes (#3052), so `can_answer`/
     /// `prompt_is_visible` are the exact condition rather than a stand-in.
+    /// That module is private, so this names it without linking it: a public
+    /// item's intra-doc link to a private one resolves only under
+    /// `--document-private-items` and is a `-D warnings` error without it.
     pub fn decide(interactive: bool, can_answer: bool, prompt_is_visible: bool) -> bool {
         stella_tty::human_can_answer(interactive, can_answer, prompt_is_visible)
     }

--- a/crates/stella-model/src/credential/prompt.rs
+++ b/crates/stella-model/src/credential/prompt.rs
@@ -8,24 +8,85 @@
 //! zero-argument [`ApiKey::resolve`](super::ApiKey::resolve) uses.
 //!
 //! The seam exists because the alternative could not be tested. Under `cargo
-//! test`, `stdout().is_terminal()` is false, so [`TerminalPrompt::can_prompt`]
-//! declines and the arm below it — the one that swallows a failed prompt and
-//! degrades to [`CredentialError::NotFound`] — was never reached by the test
-//! that claimed to cover it. It was green because of the gate, not because of
-//! the swallow (#4576).
+//! test`, neither probe below finds a controlling terminal, so
+//! [`TerminalPrompt::can_prompt`] declines and the arm below it — the one
+//! that swallows a failed prompt and degrades to
+//! [`CredentialError::NotFound`] — was never reached by the test that
+//! claimed to cover it. It was green because of the gate, not because of the
+//! swallow (#4576).
 //!
-//! It is also where #3052 lands. `rpassword` opens `/dev/tty` directly on
-//! Unix rather than writing to stdout, so [`TerminalPrompt::decide`]'s
-//! `stdout_is_terminal` is a proxy for "the prompt is visible" rather than the
-//! exact condition. Probing what `rpassword` actually opens changes one
-//! function here — and a real `prompt_password` on a machine with a
-//! controlling terminal would then block the suite forever if the tests still
-//! had to reach it through the shipping implementation, which is why that fix
-//! waits on this one.
+//! `rpassword` never touches `stdin`/`stdout` on Unix or Windows — see
+//! [`rpassword_tty`]'s doc for the exact device it opens instead, and why
+//! [`TerminalPrompt::can_prompt`] probes that device directly rather than
+//! asking whether `stdout` is a terminal. A `stella config > out.txt` run
+//! from a real terminal shows the prompt correctly (it lives on `/dev/tty`,
+//! not stdout); a `stdout` that merely *looks* like a terminal, with no
+//! controlling terminal behind it, correctly declines.
 
 use zeroize::Zeroizing;
 
 use super::CredentialError;
+
+/// What `rpassword::prompt_password` actually opens to show its prompt and
+/// read the answer, probed the same way it probes it — open, then drop —
+/// rather than asking whether `stdin`/`stdout` are terminals.
+///
+/// `rpassword-7.5.4/src/unix.rs`'s `DEFAULT_INPUT_PATH`/`DEFAULT_OUTPUT_PATH`
+/// are both `/dev/tty`; `windows.rs`'s twin constants are `CONIN$`/`CONOUT$`.
+/// Neither is `std::io::Stdin`/`std::io::Stdout`, so checking `stdin`/`stdout`
+/// instead would decline a redirected-stdout run — an ordinary
+/// `stella config > out.txt` — even with a live controlling terminal that
+/// `rpassword` could show the prompt on fine. `wasm.rs`'s pair is
+/// `/dev/stdin`/`/dev/stdout`, which *is* what `IsTerminal` on
+/// `std::io::stdin`/`std::io::stdout` answers for, so that stays the fallback
+/// on every target this crate does not name below.
+mod rpassword_tty {
+    /// Can `rpassword` read the typed answer right now?
+    #[cfg(unix)]
+    pub(super) fn input_is_open() -> bool {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .open("/dev/tty")
+            .is_ok()
+    }
+
+    #[cfg(windows)]
+    pub(super) fn input_is_open() -> bool {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .open("CONIN$")
+            .is_ok()
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    pub(super) fn input_is_open() -> bool {
+        use std::io::IsTerminal;
+        std::io::stdin().is_terminal()
+    }
+
+    /// Can `rpassword` show the prompt text right now?
+    #[cfg(unix)]
+    pub(super) fn output_is_open() -> bool {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/tty")
+            .is_ok()
+    }
+
+    #[cfg(windows)]
+    pub(super) fn output_is_open() -> bool {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open("CONOUT$")
+            .is_ok()
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    pub(super) fn output_is_open() -> bool {
+        use std::io::IsTerminal;
+        std::io::stdout().is_terminal()
+    }
+}
 
 /// Asking a human for a provider's API key.
 ///
@@ -71,23 +132,20 @@ impl TerminalPrompt {
     /// [`stella_tty::human_can_answer`]'s `interactive_output` role, so this
     /// only adds the check that was missing: a redirected stdout must decline
     /// exactly as a redirected stdin does, not just print a prompt nobody
-    /// reads before blocking on an answer nobody can give.
-    /// `stdout_is_terminal` is a proxy for whether `rpassword`'s prompt is
-    /// actually visible rather than an exact match — it writes to `/dev/tty`
-    /// directly on Unix, not stdout — tracked separately as #3052 rather than
-    /// folded into that fix.
-    pub fn decide(interactive: bool, stdin_is_terminal: bool, stdout_is_terminal: bool) -> bool {
-        stella_tty::human_can_answer(interactive, stdin_is_terminal, stdout_is_terminal)
+    /// reads before blocking on an answer nobody can give. `can_prompt` feeds
+    /// this the [`rpassword_tty`] probes (#3052), so `can_answer`/
+    /// `prompt_is_visible` are the exact condition rather than a stand-in.
+    pub fn decide(interactive: bool, can_answer: bool, prompt_is_visible: bool) -> bool {
+        stella_tty::human_can_answer(interactive, can_answer, prompt_is_visible)
     }
 }
 
 impl CredentialPrompt for TerminalPrompt {
     fn can_prompt(&self, interactive: bool) -> bool {
-        use std::io::IsTerminal;
         Self::decide(
             interactive,
-            std::io::stdin().is_terminal(),
-            std::io::stdout().is_terminal(),
+            rpassword_tty::input_is_open(),
+            rpassword_tty::output_is_open(),
         )
     }
 

--- a/crates/stella-model/src/credential/tests.rs
+++ b/crates/stella-model/src/credential/tests.rs
@@ -515,15 +515,34 @@ fn resolve_with_nothing_configured_and_non_interactive_is_a_named_not_found() {
     );
 }
 
+/// A prompt that always says no, and panics if asked anyway. Mirrors
+/// `ScriptedPrompt` in `tests/credential_prompt_degrade.rs`, which lives
+/// in a different binary and cannot be shared here.
+struct NoTerminal;
+
+impl CredentialPrompt for NoTerminal {
+    fn can_prompt(&self, _interactive: bool) -> bool {
+        false
+    }
+
+    fn ask(&self, _provider_id: &str, _env_var: &str) -> Result<String, CredentialError> {
+        panic!("can_prompt returned false — ask must never be called")
+    }
+}
+
 #[test]
-fn resolve_never_prompts_when_interactive_is_true_but_stdin_is_not_a_terminal() {
-    // Test harnesses never run with a real TTY on stdin, so this also
-    // guards against the suite hanging on a read that would otherwise
-    // block forever waiting for input that will never arrive.
+fn resolve_never_prompts_when_interactive_is_true_but_no_prompt_is_available() {
+    // This uses `resolve_with_prompt` with the fake, not the real
+    // `TerminalPrompt`. The real one opens `/dev/tty`. It only says no
+    // when the test has no controlling terminal — true in CI, but not
+    // on every machine. The fake pins the same rule everywhere: no
+    // prompt available means no prompt shown.
     unsafe {
         std::env::remove_var("STELLA_TEST_R5_KEY");
     }
-    let err = ApiKey::resolve("r5", "STELLA_TEST_R5_KEY", None, None, true).unwrap_err();
+    let err =
+        ApiKey::resolve_with_prompt("r5", "STELLA_TEST_R5_KEY", None, None, true, &NoTerminal)
+            .unwrap_err();
     assert_eq!(
         err,
         CredentialError::NotFound {

--- a/crates/stella-model/tests/credential_prompt_dev_tty.rs
+++ b/crates/stella-model/tests/credential_prompt_dev_tty.rs
@@ -1,0 +1,141 @@
+//! Pty coverage for `TerminalPrompt::can_prompt`.
+//!
+//! `rpassword` reads and writes `/dev/tty` on Unix. It never touches
+//! `stdin` or `stdout`. So `can_prompt` must check `/dev/tty` too, not
+//! `stdin`/`stdout`.
+//!
+//! The check here: redirect stdout to a plain file, but keep a real
+//! terminal attached. That is what `stella config > out.txt` looks
+//! like from a real shell. `stdout().is_terminal()` says no. The
+//! right answer is yes, because `rpassword` never reads stdout.
+//!
+//! Only a real pseudo-terminal can show this. The harness builds one
+//! with `libc::openpty`, `setsid`, and `TIOCSCTTY` — the same tools
+//! `stella-tui`'s `tests/deck_pty_smoke.rs` uses. It runs the
+//! `tty-probe` fixture binary as a child process, because the test
+//! needs a real controlling terminal on that child, not on this test
+//! binary's own session.
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io::Read;
+use std::os::unix::io::FromRawFd;
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+
+fn tty_probe_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_tty-probe"))
+}
+
+/// Open a pseudo-terminal. Returns the raw `(master, slave)` fds.
+fn open_pty() -> (libc::c_int, libc::c_int) {
+    let mut master: libc::c_int = -1;
+    let mut slave: libc::c_int = -1;
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            // One null works on both Linux and macOS here, even
+            // though the two declare this parameter with different
+            // pointer types.
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty: {}", std::io::Error::last_os_error());
+    (master, slave)
+}
+
+/// Run `tty-probe` with the pty slave as its stdin and controlling
+/// terminal. Stdout goes to a plain file, not the pty. Returns the line
+/// the probe printed.
+fn probe_with_redirected_stdout() -> String {
+    let (master, slave) = open_pty();
+    let out_file = tempfile::NamedTempFile::new().expect("temp file for stdout");
+
+    let mut cmd = Command::new(tty_probe_bin());
+    cmd.stdin(unsafe { Stdio::from_raw_fd(libc::dup(slave)) })
+        .stdout(Stdio::from(
+            out_file.reopen().expect("independent handle on temp file"),
+        ))
+        .stderr(Stdio::null());
+    unsafe {
+        cmd.pre_exec(move || {
+            // Start a new session with the pty as its controlling
+            // terminal. Now `/dev/tty` finds this pty no matter what
+            // fd 1 (stdout) points at.
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(0, libc::TIOCSCTTY as _, 0) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let child = cmd.spawn().expect("spawn tty-probe");
+    unsafe {
+        libc::close(slave);
+    }
+    let status = child.wait_with_output().expect("wait for tty-probe").status;
+    unsafe {
+        libc::close(master);
+    }
+    assert!(status.success(), "tty-probe exited with {status:?}");
+
+    let mut out = String::new();
+    File::open(out_file.path())
+        .expect("open probe output")
+        .read_to_string(&mut out)
+        .expect("read probe output");
+    out.trim().to_string()
+}
+
+/// Run `tty-probe` with no terminal at all: its own session, every
+/// stdio handle `/dev/null`. This is the control: it proves the probe
+/// does not just always say `true`.
+fn probe_with_no_terminal_at_all() -> String {
+    let mut cmd = Command::new(tty_probe_bin());
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    unsafe {
+        cmd.pre_exec(|| {
+            // Start a new session. Skip `TIOCSCTTY`, so it gets no
+            // controlling terminal at all.
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let output = cmd.output().expect("spawn tty-probe");
+    assert!(
+        output.status.success(),
+        "tty-probe exited with {:?}",
+        output.status
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// A check that only asks `std::io::stdout().is_terminal()` would print
+/// `false` here, since stdout is a plain file. `can_prompt` checks
+/// `/dev/tty` instead, which this pty makes reachable. So it must
+/// print `true`.
+#[test]
+fn can_prompt_reaches_dev_tty_even_when_stdout_is_redirected_away() {
+    assert_eq!(
+        probe_with_redirected_stdout(),
+        "true",
+        "a redirected stdout must not hide a live controlling terminal from rpassword"
+    );
+}
+
+/// With no controlling terminal anywhere, `can_prompt` still says no.
+/// The probe checks the real terminal; it does not just always say
+/// yes.
+#[test]
+fn can_prompt_declines_with_no_controlling_terminal_at_all() {
+    assert_eq!(probe_with_no_terminal_at_all(), "false");
+}

--- a/crates/stella-model/tests/fixtures/tty_probe.rs
+++ b/crates/stella-model/tests/fixtures/tty_probe.rs
@@ -1,0 +1,11 @@
+//! Fixture binary for `tests/credential_prompt_dev_tty.rs`.
+//!
+//! Prints `TerminalPrompt.can_prompt(true)`, then exits. It runs as its
+//! own process so the test harness can give it a real controlling
+//! terminal, one `cargo test`'s own process does not have.
+
+use stella_model::credential::{CredentialPrompt, TerminalPrompt};
+
+fn main() {
+    println!("{}", TerminalPrompt.can_prompt(true));
+}


### PR DESCRIPTION
## What & why

`TerminalPrompt::can_prompt` (the gate in front of every `rpassword` prompt)
checked `std::io::stdin().is_terminal()`/`std::io::stdout().is_terminal()`.
`rpassword` never reads or writes either on Unix or Windows — it opens
`/dev/tty` (Unix) or `CONIN$`/`CONOUT$` (Windows) directly. So the check was
a stand-in, not the exact condition, in both directions the issue names:

- **False negative:** `stella config > out.txt` from a real terminal has a
  redirected stdout but a live controlling terminal — `rpassword` would show
  the prompt fine on `/dev/tty`, but the old check declined.
- **False positive:** a `stdout` that merely looks like a terminal with no
  controlling terminal behind it could wrongly pass.

`can_prompt` now probes exactly what `rpassword` opens (open, then drop) —
`crates/stella-model/src/credential/prompt.rs`'s private `rpassword_tty`
module, cfg-gated per platform, with the old `stdin()`/`stdout()` check kept
only as the fallback on a target that is neither Unix nor Windows (where
`rpassword`'s own fallback is `/dev/stdin`/`/dev/stdout` — the one case the
old check was already exact for).

`stella-cli`'s `auth set` prompts (`crates/stella-cli/src/auth_cmd.rs`, two
`rpassword::prompt_password` call sites) had no visibility gate at all — per
the issue thread's own follow-up comment, both now share `TerminalPrompt`'s
fixed gate instead of re-deriving one, so the command and the provider
credential chain can never disagree about whether a human is there to
answer.

## The witness

`crates/stella-model/tests/credential_prompt_dev_tty.rs` drives a new
`tty-probe` fixture binary (`crates/stella-model/tests/fixtures/tty_probe.rs`)
inside a real pseudo-terminal built with `libc::openpty`/`setsid`/`TIOCSCTTY`
— the same construction `stella-tui`'s `tests/deck_pty_smoke.rs` already
uses. With the pty as the child's controlling terminal but its stdout
redirected to a plain file, a check based on `stdout().is_terminal()` prints
`false`; `can_prompt` probes `/dev/tty` directly and prints `true`. A second
scenario with no controlling terminal at all pins that the probe still
declines correctly (the fix is a more accurate probe, not one that always
says yes).

This has to run as a real subprocess rather than an in-process call: the
property is about *that process's own* controlling terminal, which nothing
running inside the test binary's own session can fake.

**A pre-existing test needed rewriting alongside the fix, not just a new
one.** `resolve_never_prompts_when_interactive_is_true_but_stdin_is_not_a_terminal`
drove the real `TerminalPrompt` through `ApiKey::resolve(..., true)`, relying
on the test harness capturing stdout to stay safe. Since `can_prompt` now
probes `/dev/tty` independent of stdout, that reliance breaks: on a machine
with a controlling terminal attached to the test process, it would call
`rpassword` for real and block on a keystroke that never arrives — exactly
the hazard the issue's first comment flagged as blocking this fix until the
prompt decision became injectable (#4576, already landed). It's rewritten as
`resolve_never_prompts_when_interactive_is_true_but_no_prompt_is_available`,
driving `resolve_with_prompt` with a fake `CredentialPrompt` instead, the
same shape every other interactive-path test in the file already uses.

Exemplar: `stella-tui`'s `tests/deck_pty_smoke.rs` for the pty harness
construction (`libc::openpty`/`setsid`/`TIOCSCTTY`); `stella-runtime`'s
`tests/fixtures/wrapper-plugin-fixture.rs` for the `[[bin]]`-under-`tests/`
fixture pattern (`CARGO_BIN_EXE_<name>`).

## The gate

- [x] fmt check
- [ ] clippy across the workspace, all targets, warnings denied — CI (this
      session does not build/test on the maintainer's machine)
- [ ] the workspace test suite — CI
- [x] Docs updated where behavior/flags changed (doc comments on
      `TerminalPrompt::can_prompt`/`decide`, `ApiKey::resolve_with_prompt`)
- [ ] CLA signed
- [x] `Closes #3052` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR. (The
      Windows `CONIN$`/`CONOUT$` arm is mirrored code, structurally the same
      shape as the Unix arm already witnessed here — no separate follow-up
      filed, matching how the rest of this tree treats Windows-only
      behavior: `windows-check.yml`'s compile-only check, not a full
      Windows pty behavioral harness, is the existing bar.)

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- New dev-dependency: `libc` in `crates/stella-model/Cargo.toml`, already a
  workspace dependency used the same way by `stella-tui`'s
  `deck_pty_smoke.rs` and `stella-runtime`'s pty-adjacent tests — justified
  by the witness test needing a real pseudo-terminal, which nothing else in
  the workspace dependency set provides.

## Anything reviewers should know?

- `crates/stella-model/src/credential.rs`'s `resolve`/`resolve_with_prompt`
  doc comments are updated to say plainly that driving the real
  `TerminalPrompt` through a test is no longer implicitly safe — it depends
  on the *test process's* terminal state, not on test-harness stdout
  capture. Every test in the tree already goes through `resolve_with_prompt`
  with a fake now; grepped for other callers of `ApiKey::resolve(..., true)`
  under test and found none.

Closes #3052

## Summary by Sourcery

Probe rpassword's actual terminal endpoints before prompting and apply the shared gate to all interactive credential requests.

Bug Fixes:
- Make credential prompting detect the actual terminal devices used by rpassword, allowing prompts with redirected standard output while rejecting environments without a controlling terminal.
- Guard all stella-cli auth secret prompts with the shared terminal-availability check so command-line and provider credential prompting behave consistently.

Enhancements:
- Clarify credential-resolution guidance and use injected prompts for deterministic interactive-path testing.

Build:
- Add the tty-probe test fixture binary and libc development dependency for pseudo-terminal integration coverage.

Documentation:
- Update credential prompting documentation to describe terminal-device probing and safe prompt injection in tests.

Tests:
- Add Unix pseudo-terminal coverage for redirected-output and no-controlling-terminal scenarios, and revise an existing test to avoid depending on the test process terminal state.

---

### DoD verification (SCR-003)

#3052's last open item — "`make gate` green; no new god-file lines, no baseline
raised" — is now settled and ticked, so the `dod / dod` gate should clear on
this re-read.

The item was waiting on one job. On `f5e5acd`, `fmt + clippy + test` reported
`success`; it carries fmt, clippy, rustdoc, the toolchain-free guards and the
test suite. Every other check on that head is green as well —
`file size ratchet`, `the platform split still compiles on Windows`,
`docs guards`, `guard self-tests`, `cargo check on the declared MSRV` and the
rest — with `dod / dod` the only red, which is the checklist itself.

The other two halves of the item hold as the issue already recorded: the eight
changed paths do not include `scripts/file-size-baseline.txt`, and none of them
is a grandfathered god file.


---
_Generated by [Claude Code](https://claude.ai/code)_