### PR TITLE
fix(stella-cli): add STELLA_HOME to the privileged-rollback list

### DIFF
--- a/crates/stella-cli/src/enterprise_telemetry.rs
+++ b/crates/stella-cli/src/enterprise_telemetry.rs
@@ -81,7 +81,27 @@ fn store_process_free_authority(value: u8) {
 /// The names the startup rollback restores after a project dotenv file has
 /// run. `env_files` refuses every one of them outright — the rollback is the
 /// backstop behind that deny-list, and its own test holds the two in step.
+///
+/// `HOME`, `USERPROFILE`, `STELLA_HOME` and `STELLA_DATA_DIR` are the whole
+/// user-tier redirect chain in `stella_home`. `HOME` and `USERPROFILE` set
+/// the default `~/.stella` root. `STELLA_HOME` moves that root. `STELLA_DATA_DIR`
+/// moves the data tier alone and wins over it. Each one is read fresh on
+/// every call, not snapshotted once. So a name a dotenv loader missed could
+/// point trusted settings, credentials, and skills anywhere the project
+/// chose. That is why each one belongs here, the same reason
+/// `STELLA_DATA_DIR` already did.
+///
+/// `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` are refused by
+/// `env_files` too, but they are not here. Nothing in the trusted user tier
+/// reads them. `stella_home::systemd_user_unit_dir` reads `XDG_CONFIG_HOME`
+/// only for the self-driving loop's per-user systemd unit path — not
+/// `~/.stella`, and not a privileged config or credential. Restoring it after
+/// a project dotenv load would be a no-op that costs a line and proves
+/// nothing.
 pub(crate) const PRIVILEGED_ENV_NAMES: &[&str] = &[
+    "HOME",
+    "USERPROFILE",
+    "STELLA_HOME",
     "STELLA_MANAGED_SETTINGS",
     "STELLA_DATA_DIR",
     "STELLA_TRUST_PROJECT",

--- a/crates/stella-cli/src/env_files.rs
+++ b/crates/stella-cli/src/env_files.rs
@@ -1055,6 +1055,42 @@ mod tests {
         }
     }
 
+    /// The other half of the drift guard. `every_privileged_name_is_refused`
+    /// checks one direction only: every rollback name is refused. It never
+    /// checks the other way: is every name that moves the whole user tier
+    /// also on the rollback list? `STELLA_HOME` was refused here but never
+    /// rolled back. So if any future caller ever skipped `is_refused` — a new
+    /// loader, a case-folding bug, a refactor — a cloned repository could set
+    /// `STELLA_HOME` and point the trusted user tier (settings, credentials,
+    /// skills) anywhere it liked, with nothing left to put it back.
+    ///
+    /// This checks a small named set, not the full `DENIED_EXACT` list.
+    /// `DENIED_EXACT` is much bigger (`PATH`, `LD_*`, `GIT_*`, …) and most of
+    /// those names have nothing to roll back. These four are the whole
+    /// `stella_home` user-tier chain: `HOME` and `USERPROFILE` set the
+    /// default `~/.stella` root, `STELLA_HOME` moves that root, and
+    /// `STELLA_DATA_DIR` moves the data tier alone and wins over it. Each one
+    /// must be both refused and restored.
+    #[test]
+    fn every_user_tier_anchor_is_refused_and_rolled_back() {
+        for name in [
+            stella_home::HOME_ENV,
+            stella_home::USERPROFILE_ENV,
+            stella_home::STELLA_HOME_ENV,
+            stella_home::STELLA_DATA_DIR_ENV,
+        ] {
+            assert!(
+                is_refused(name),
+                "{name} moves the stella user tier and must be in DENIED_EXACT"
+            );
+            assert!(
+                crate::enterprise_telemetry::PRIVILEGED_ENV_NAMES.contains(&name),
+                "{name} moves the stella user tier and must be in PRIVILEGED_ENV_NAMES \
+                 too — a caller that ever bypasses is_refused has nothing to roll it back"
+            );
+        }
+    }
+
     #[test]
     fn deny_list_matches_namespaces_and_case_but_spares_ordinary_names() {
         // Loader namespaces are refused wholesale, in any case.


### PR DESCRIPTION
## What / why

`env_files::DENIED_EXACT` (layer 1) already refused `STELLA_HOME` in a
project `.env`. `enterprise_telemetry::PRIVILEGED_ENV_NAMES` (layer 2, the
startup rollback that restores each privileged name's host value after the
dotenv load) never listed it — the second-loader backstop behind #553 had a
gap for exactly the name #2178 widened from moving only the data-tier anchor
to moving the whole user tier (settings, credentials, skills, rules, tools).

This is defense-in-depth: `main.rs` installs `UserPaths` before the dotenv
load runs, so the CLI's own resolved paths were never exposed. The residual
risk is a lazy reader (`stella_home::stella_home()` re-reads the live
environment on every call) or a child process inheriting an env a future
loader let through despite `is_refused` — a new loader, a case-folding hole,
a refactor.

**Fix**: add `STELLA_HOME`, and `HOME`/`USERPROFILE` alongside it, to
`PRIVILEGED_ENV_NAMES`. `HOME`/`USERPROFILE` have the identical hazard:
`stella_home::stella_home()` falls back to `home_dir()` (`HOME`, then
`USERPROFILE`) whenever `STELLA_HOME` is unset, so the same lazy-read
door exists through them. `STELLA_DATA_DIR` was already on the list.

**Decision recorded** (issue's third DoD item): `XDG_CONFIG_HOME` /
`XDG_DATA_HOME` / `XDG_STATE_HOME` stay off the rollback list, with a
comment saying why. Nothing in the trusted user tier resolves through them —
`stella_home::systemd_user_unit_dir` reads `XDG_CONFIG_HOME` only for the
self-driving loop's per-user systemd unit path, never `~/.stella` — so
restoring them would be a no-op that costs a line and proves nothing.

## Witness mechanism

`env_files::tests::every_user_tier_anchor_is_refused_and_rolled_back`
(`crates/stella-cli/src/env_files.rs`) enumerates the four named anchors the
issue specifies — `stella_home::{HOME_ENV, USERPROFILE_ENV, STELLA_HOME_ENV,
STELLA_DATA_DIR_ENV}` — and asserts each is on **both** `DENIED_EXACT` (via
`is_refused`) and `enterprise_telemetry::PRIVILEGED_ENV_NAMES`. It is the
reverse direction of the pre-existing `every_privileged_name_is_refused`,
which only checked "every rollback name is refused" and never checked
"every name broad enough to move the user tier is on the rollback."

Confirmed the test fails on old code by construction: stashed only the
`enterprise_telemetry.rs` change and ran
`cargo test -p stella-cli --bin stella env_files::tests::every_user_tier_anchor_is_refused_and_rolled_back`
— it fails on `HOME` (the first anchor in iteration order) with

```
HOME moves the stella user tier and must be in PRIVILEGED_ENV_NAMES too —
a caller that ever bypasses is_refused has nothing to roll it back
```

Restored the fix and re-ran; all 16 `env_files::` tests and all 25
`enterprise_telemetry::` tests pass.

## Design note

Posted as a comment on #2499 before implementing
(https://github.com/macanderson/stella/issues/2499#issuecomment-5552898081),
re-verifying the issue's own claims against the current tree (line numbers
had drifted since the 2026-08-12 close/reopen, the mechanism had not).

No change needed to `StartupAuthoritySnapshot::capture`/
`restore_after_project_env` themselves — they already snapshot and restore
whatever `PRIVILEGED_ENV_NAMES` names, so widening that list is the whole
fix.

## DoD status (#2499)

`dod / dod` was red on `a367cce` because #2499's three checklist boxes were
still unticked when that job ran at 15:45Z. All three were checked against
this diff and ticked afterwards, each with its evidence on the issue:

- **`STELLA_HOME` on `PRIVILEGED_ENV_NAMES`** — the `enterprise_telemetry.rs`
  hunk adds it.
- **The named-subset witness** — `every_user_tier_anchor_is_refused_and_rolled_back`
  iterates exactly the four `stella_home` constants the issue names and
  asserts each on both lists.
- **The `HOME`/`USERPROFILE`/`XDG_*` decision** — recorded in the
  `PRIVILEGED_ENV_NAMES` doc comment; the first two are added, the three
  `XDG_*` names deliberately excluded with the reason stated.

No code changed for this; the gate had read an earlier state of the issue.

## Tests deleted

None.

Closes #2499

## Summary by Sourcery

Close the privileged environment rollback gap for variables that can redirect Stella's trusted user data.

Bug Fixes:
- Restore HOME, USERPROFILE, and STELLA_HOME after project dotenv loading to close the privileged user-path rollback gap.

Enhancements:
- Document which environment variables redirect trusted user paths and why XDG path variables are intentionally excluded from rollback.
- Add a regression test ensuring all user-tier path anchors are both denied and included in the rollback list.

Tests:
- Add coverage that keeps the user-tier deny list and privileged rollback list synchronized.