### PR TITLE
test(stella-cli): hold the shipped self-driving grant to the gate that enforces it

### DIFF
--- a/crates/stella-cli/src/plugin_authz.rs
+++ b/crates/stella-cli/src/plugin_authz.rs
@@ -26,7 +26,7 @@
 //!
 //! # What it decides, and what it deliberately does not
 //!
-//! Two rules, and they are the two #3482's definition of done names:
+//! The rules it applies:
 //!
 //! - a tool **absent** from the accepted list is denied;
 //! - a tool graded **above** what was accepted is denied.
@@ -65,8 +65,9 @@
 //! The rule is therefore *undeclared-within-a-declared-grant is denied*, not
 //! *silence is denial*. Declaring a list is a plugin opting into being bounded
 //! by it. The residual hole — a plugin that declares nothing is not narrowed
-//! here at all — is real and is tracked separately: closing it needs a default
-//! grant a user accepts, which is a decision, not an implementation.
+//! here at all — is real, and #6060 is where it is being decided: closing it
+//! needs a default grant a user accepts, which is a decision, not an
+//! implementation.
 //!
 //! # It answers about one plugin
 //!

--- a/crates/stella-cli/src/plugin_authz/tests.rs
+++ b/crates/stella-cli/src/plugin_authz/tests.rs
@@ -451,3 +451,151 @@ async fn a_plugin_is_refused_through_the_assembled_stack_and_the_user_is_not() {
     );
     assert_eq!(leaf.reached.lock().unwrap().len(), 1);
 }
+
+/// The repository root, derived from the crate this test lives in.
+///
+/// `CARGO_MANIFEST_DIR` is `<repo>/crates/stella-cli`, so the root is two
+/// levels up — the same derivation `crates/stella-cli/tests/self_driving_consent.rs`
+/// uses to reach the shipped manifest.
+fn repo_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("the crate sits two levels under the repository root")
+        .to_path_buf()
+}
+
+/// **The shipped grant, against the shipped gate.** Every test above writes
+/// its own fixture manifest, so until this one no manifest this repository
+/// actually ships had ever been put in front of the rule that enforces it —
+/// and the widest grant in the tree is `plugins/stella-selfdriving`, which
+/// asks for `bash` and `write_file` at destructive and `process_spawn` at
+/// high.
+///
+/// `crates/stella-cli/tests/self_driving_consent.rs` is where the hole was
+/// named. That test pairs each declared power with the file that performs it,
+/// and its module doc says the pairing is an enumeration: a driver that grew a
+/// power nobody listed would still pass. Closing that needs the loader binding
+/// a declaration to a gate under `Principal::Plugin`, which is what
+/// [`super::PluginGates`] does. This is the check that binding made writable.
+///
+/// The grades are read out of the manifest rather than restated here, so an
+/// entry added later is covered the day it is added.
+///
+/// What it does not claim: that a self-driving run is held to this grant.
+/// Nothing in that package is a program Stella starts, so no call is ever
+/// attributed to the plugin and the rule is built without being asked —
+/// `scripts/self-driving.sh` runs as you. Closing that needs the loop to
+/// become a program Stella drives.
+#[test]
+fn the_shipped_selfdriving_grant_is_exactly_what_the_gate_enforces() {
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT"]);
+    let root = std::env::temp_dir().join(format!(
+        "stella-selfdriving-authz-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("temp root");
+    let _paths = crate::paths::test_user_home(root.join("home"));
+    // SAFETY: the env lock is held for the whole mutate-read-restore window.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+
+    let text = std::fs::read_to_string(repo_root().join("plugins/stella-selfdriving/plugin.toml"))
+        .expect("the shipped self-driving manifest");
+    let manifest = stella_plugin::PluginManifest::from_toml_str(&text)
+        .expect("the shipped manifest must parse");
+    let dir = stella_home::resolve_project_plugins_dir(&root).join(&manifest.name);
+    std::fs::create_dir_all(&dir).expect("plugin dir");
+    std::fs::write(dir.join("plugin.toml"), &text).expect("install the shipped manifest");
+
+    let gate = crate::agent::tool_stack::session_gate(&root);
+    let plugin = Principal::Plugin(manifest.name.clone());
+
+    // An empty list installs no rule at all, which would make every assertion
+    // below pass by allowing everything.
+    assert!(
+        !manifest.capabilities.is_empty(),
+        "this manifest is a grant; a copy of it declaring nothing is a different document"
+    );
+
+    // Every declared entry binds, at exactly the grade a human was shown.
+    for capability in &manifest.capabilities {
+        assert_eq!(
+            gate.check(
+                &contract(&capability.tool, capability.risk),
+                &plugin,
+                &json!({})
+            )
+            .expect("a decision"),
+            AuthzDecision::Allow,
+            "`{}` is declared at {} and must bind",
+            capability.tool,
+            capability.risk.as_str()
+        );
+    }
+
+    // Asked for above the grade that was accepted, a declared tool is refused.
+    let mut below_the_top = 0;
+    for capability in &manifest.capabilities {
+        if capability.risk == RiskLevel::Destructive {
+            continue;
+        }
+        below_the_top += 1;
+        let refused = gate
+            .check(
+                &contract(&capability.tool, RiskLevel::Destructive),
+                &plugin,
+                &json!({}),
+            )
+            .expect("a decision");
+        assert!(
+            matches!(&refused, AuthzDecision::Deny { reason } if reason.contains(&capability.tool)),
+            "`{}` was accepted at {} and must be refused at destructive: {refused:?}",
+            capability.tool,
+            capability.risk.as_str()
+        );
+    }
+    assert!(
+        below_the_top > 0,
+        "every declared entry sits at destructive, so the over-grade check proved nothing"
+    );
+
+    // A tool nobody asked for is refused, and the refusal names both sides so
+    // an author fixes the manifest instead of guessing.
+    let undeclared = "delete_file";
+    assert!(
+        !manifest
+            .capabilities
+            .iter()
+            .any(|capability| capability.tool == undeclared),
+        "this manifest now declares `{undeclared}`; pick a tool it does not ask for"
+    );
+    let refused = gate
+        .check(
+            &contract(undeclared, RiskLevel::Destructive),
+            &plugin,
+            &json!({}),
+        )
+        .expect("a decision");
+    assert!(
+        matches!(&refused, AuthzDecision::Deny { reason } if reason.contains(&manifest.name)
+            && reason.contains(undeclared)),
+        "the shipped grant does not include `{undeclared}`: {refused:?}"
+    );
+
+    // Anti-vacuity: the call the plugin was refused is the operator's to make,
+    // and this gate does not touch it.
+    assert_eq!(
+        gate.check(
+            &contract(undeclared, RiskLevel::Destructive),
+            &Principal::User,
+            &json!({})
+        )
+        .expect("a decision"),
+        AuthzDecision::Allow
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/stella-cli/tests/self_driving_consent.rs
+++ b/crates/stella-cli/tests/self_driving_consent.rs
@@ -31,10 +31,15 @@
 //! **What that check cannot do**, said plainly because a guard trusted past
 //! its reach is worse than none: the table below is an enumeration, so it
 //! catches drift in a power somebody already thought of. A driver that grew
-//! an entirely new capability nobody listed would pass it. Closing that needs
-//! the loader binding these declarations to a gate under
-//! `Principal::Plugin`, where an undeclared call is refused rather than
-//! merely unlisted — `doc:pipeline-as-plugins` §A4, and not this slice.
+//! an entirely new capability nobody listed would pass it.
+//!
+//! The gate that would refuse such a call now exists. `stella-cli`'s
+//! `plugin_authz` turns an installed list into a rule, and its
+//! `the_shipped_selfdriving_grant_is_exactly_what_the_gate_enforces` puts
+//! this manifest in front of it. The hole here stays open. The rule judges
+//! one thing: a call Stella makes for the plugin. Stella starts no program
+//! in this package, so it makes none. `scripts/self-driving.sh` runs as you.
+//! To close the hole, the loop has to become a program Stella drives.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};

--- a/plugins/stella-selfdriving/plugin.toml
+++ b/plugins/stella-selfdriving/plugin.toml
@@ -32,11 +32,17 @@
 # is still the working driver and is deliberately untouched — §10's rule is
 # that the shell driver is not deleted until its replacement is proven, and no
 # replacement has been written. So installing this copies a declaration and a
-# README, and starts nothing. Nothing here is enforced either: binding a
-# declared capability to an `AuthzGate` rule under `Principal::Plugin` is the
-# loader's job (`doc:pipeline-as-plugins` §A4) and has not landed for a host
-# plugin. Read the capability list as "what this loop does to your machine
-# today, written down", because that is exactly what it is.
+# README, and starts nothing.
+#
+# WHAT THE HOST NOW DOES WITH THIS LIST. Installing it builds a rule from it.
+# The loader turns each entry below into an `AuthzGate` rule
+# (`crates/stella-cli/src/plugin_authz.rs`, bound by `agent/tool_stack.rs`'s
+# `session_gate`), so a tool call Stella attributes to this plugin is refused
+# unless this list allows it, at a grade this list allows. That rule is built
+# and never asked, because Stella starts no program here and so attributes
+# nothing to this plugin. `scripts/self-driving.sh` runs as you and holds these
+# powers directly. Read the capability list as "what this loop does to your
+# machine today, written down", because that is exactly what it is.
 #
 # The grades below are read off `scripts/self-driving.sh` itself, and
 # `crates/stella-cli/tests/self_driving_consent.rs` fails if a power named


### PR DESCRIPTION
## What and why

The plugin capability gate binds an installed manifest's `[[capabilities]]`
list to an `AuthzGate` rule, and `crates/stella-cli/src/agent/tool_stack.rs`'s
`session_gate` hands it to every session. Four tests already pin that, end to
end. Every one of them writes its own fixture manifest inside the test file.

So no manifest this repository ships had ever been put in front of the rule
that governs it — including the widest grant in the tree,
`plugins/stella-selfdriving/plugin.toml`, which asks for `bash` and
`write_file` at destructive and `process_spawn` at high.

`crates/stella-cli/tests/self_driving_consent.rs` names this gap in its own
module doc. It pairs each declared power with the file that performs it, and
says the pairing is an enumeration: a driver that grew a power nobody listed
would still pass, and closing that needs the loader binding a declaration to a
gate under `Principal::Plugin`. That binding has since landed, so the check is
now writable.

## What this PR does

`the_shipped_selfdriving_grant_is_exactly_what_the_gate_enforces` copies the
real `plugins/stella-selfdriving/plugin.toml` into a temp workspace, asks the
shipped `session_gate` for a gate, and drives it as `Principal::Plugin`:

- every entry the manifest declares is allowed at the grade the manifest
  declares — read out of the manifest, not restated, so an entry added later is
  covered the day it is added;
- a declared entry asked for above its accepted grade is denied;
- `delete_file`, which the manifest does not declare, is denied, and the reason
  names both the plugin and the tool;
- anti-vacuity: the identical denied call as `Principal::User` runs, so the
  test cannot pass by refusing everything, and the empty-manifest case is
  refused up front so it cannot pass by allowing everything.

It also corrects two comments that said the binding had not landed. Both now
say which half is enforced and which is not: the rule is built from this list
at install, and it is never asked, because Stella starts no program in that
package — `scripts/self-driving.sh` runs as you.

## Witness mechanism

This is a regression pin over shipped behaviour rather than a fail-on-main
witness, and the PR says so rather than dressing it up. The behaviour it checks
already ships; what did not exist is any check that a manifest **this
repository ships** binds. The test fails by construction the moment a shipped
manifest's declared entry stops reaching a rule — a roster filter that skipped
a plugin with no `[runtime]`, for instance, which is exactly the shape
`PluginRoster::hook_routes` already has one file over. It is anti-vacuous in
both directions, so it cannot go green by allowing everything or by refusing
everything.

Verified locally with the guards that compile nothing: `cargo fmt --all`,
`make guards-fast` (prose, line-citations, file-size, lockfile-sync, the rest),
all green. CI is the compiler.

## Exemplar

The test follows the file it lives in: the temp-workspace install and the
`Principal::Plugin` / `Principal::User` pairing are
`the_shipped_session_gate_enforces_an_installed_plugins_declared_grant`'s
shape, and `repo_root()` is the derivation
`crates/stella-cli/tests/self_driving_consent.rs` already uses to reach the
shipped manifest.

Closes #6058

Tests deleted: None

## Remaining work filed

- #6060 — a plugin that asks for no capabilities is held to nothing at all.
  `PluginGates::from_roster` skips an empty list on purpose, the module says
  the leftover hole is tracked separately, and nothing tracked it. This PR
  makes the module cite it.
- A follow-up for the self-driving program itself is filed separately and is
  named in the epic thread; this PR does not attempt it.

Advances the plugin epic's P4, first half. The epic keeps its own issue number
out of this body on purpose: the DoD check reads every issue a PR body links,
and an epic's checklist is not this PR's to tick.

## Summary by Sourcery

Verify that the shipped self-driving capability manifest is bound to and correctly enforced by the plugin authorization gate.

Enhancements:
- Add an end-to-end regression test that validates the shipped self-driving plugin manifest is enforced by the assembled authorization gate, including declared, over-grade, and undeclared tool requests.
- Strengthen anti-vacuity checks so the regression test verifies both plugin denial and user access, while documenting that the self-driving shell is not currently executed under plugin authorization.

Documentation:
- Update authorization and self-driving documentation to reflect that manifest-to-gate binding is implemented, while the self-driving program itself remains outside the gate.

Tests:
- Test the repository-shipped self-driving capability grant against the shipped session gate rather than relying only on synthetic fixture manifests.

Chores:
- Link the empty-capability-list limitation to its follow-up issue.

---

### DoD verification (SCR-003)

#6058's checklist is now complete, so the `dod / dod` gate should clear on this
re-read.

All seven items were checked against this branch at `25bfedd`, reading the body
of `the_shipped_selfdriving_grant_is_exactly_what_the_gate_enforces` rather
than this description. The six code items were settled from the diff: the test
reads the real `plugins/stella-selfdriving/plugin.toml` through `repo_root()`
and drives the shipped `session_gate`; the undeclared-tool refusal is asserted
to name both the plugin and the tool; the over-grade loop is guarded by
`below_the_top > 0`; the anti-vacuity check re-runs the *identical* contract
value as `Principal::User`; every expectation is read off `manifest.capabilities`
with a non-empty guard; and both stale sentences now state which half is
enforced and which is not.

The seventh item was "CI green", which no reading of a diff can answer. It is
now answered: `fmt + clippy + test` reported `success` on `25bfedd`, which is
the job that actually runs the new test, and every other check on that head is
green.

Full evidence is recorded per-item on #6058.


---
_Generated by [Claude Code](https://claude.ai/code)_