### PR TITLE
feat(stella-protocol): record what interactive mode reads in the consumer ledger

### DIFF
--- a/crates/stella-protocol/src/event/consumers.rs
+++ b/crates/stella-protocol/src/event/consumers.rs
@@ -76,15 +76,10 @@ use super::KNOWN_TYPE_TAGS;
 
 /// A surface that renders some signals and not others.
 ///
-/// Narrow. Two plausible surfaces are **absent** because
-/// membership in them is not a per-case fact:
-///
-/// - **Interactive mode** matches `AgentEvent` exhaustively
-///   (`stella-tui`'s `model::Model::apply`, `textline::event_line`,
-///   `deck::trace_of`), so every case reaches it by construction.
-/// - **Replay** likewise tagged every case, in the then-existing
-///   `stella-pipeline`'s `replay::event_signature`; that crate was deleted in
-///   #3865 and no replay tagger has replaced it yet.
+/// Narrow. One plausible surface is **absent** because membership in it is
+/// not a per-case fact: **replay** tagged every case, in the then-existing
+/// `stella-pipeline`'s `replay::event_signature`; that crate was deleted in
+/// #3865 and no replay tagger has replaced it yet.
 ///
 /// `stella-serve` mostly forwards the stream opaquely, which is why it was
 /// listed here as absent until the #4501 census read its `observe/tally.rs`:
@@ -105,6 +100,23 @@ pub enum Surface {
     /// The non-interactive engine server, for the arms where it does something
     /// case-specific rather than forwarding.
     Serve,
+    /// A `stella-tui` feature that reads one tag by name. This is not
+    /// interactive mode's exhaustive matchers (`model::Model::apply`,
+    /// `textline::event_line`, `deck::trace_of`). Those reach every case, so
+    /// they stay out of this enum, the same reason replay does. This surface
+    /// is the narrower claim: one reader picks out this one tag, the same
+    /// bar `Serve` holds `TallyFold::observe` to. Three rows hold it today:
+    ///
+    /// - the Files tab (`views/files_tab.rs`, fed by `model/file_state.rs`'s
+    ///   `touch_file`) selects
+    ///   [`AgentEvent::FileChange`](super::AgentEvent::FileChange);
+    /// - the SUB-AGENTS overlay (`views/subagents/rows.rs::delegates_of`)
+    ///   filters the transcript for
+    ///   [`AgentEvent::SubAgent`](super::AgentEvent::SubAgent) specifically;
+    /// - the ask card (`deck_ui/gates.rs::handle_focused_gates`) reads the
+    ///   `pending_ask_user` latch that only
+    ///   [`AgentEvent::AskUser`](super::AgentEvent::AskUser) sets.
+    Interactive,
 }
 
 /// Where an emitted signal's value is realized.
@@ -270,9 +282,11 @@ impl std::fmt::Display for LedgerViolation {
             Self::SurfacedNowhere { type_tag } => write!(
                 f,
                 "`{type_tag}` is Surfaced but lists no selecting surface. Note \
-                 that Surface omits interactive mode and replay, which render \
-                 every case: if those are the only consumers, the correct \
-                 posture is RecordedOnly with a tracking issue"
+                 that Surface omits replay, and that Surface::Interactive names \
+                 only a feature that selects this tag by name — not interactive \
+                 mode's exhaustive matchers, which render every case regardless: \
+                 if the only consumer is one of those, the correct posture is \
+                 RecordedOnly with a tracking issue"
             ),
             Self::RecordedYetSurfaced { type_tag } => write!(
                 f,

--- a/crates/stella-protocol/src/event/consumers/tests.rs
+++ b/crates/stella-protocol/src/event/consumers/tests.rs
@@ -144,6 +144,29 @@ fn the_observatory_view_of_the_ledger_is_a_strict_subset() {
     }
 }
 
+/// The ledger can now say "interactive mode reads this" for three tags.
+/// Each one reaches a *selecting* stella-tui reader, not just the
+/// exhaustive `Model::apply`/`textline`/`deck::trace_of` matchers: the
+/// Files tab (`file_change`), the SUB-AGENTS overlay (`sub_agent`), and the
+/// ask card (`ask_user`).
+///
+/// This is a witness by construction. `Surface::Interactive` did not exist
+/// before this test was written. So this test, and the three rows it
+/// checks, failed to build without them — the same way a missing
+/// `AgentEvent` consumer row is a build error, not a red test.
+#[test]
+fn the_interactive_surface_names_the_three_selecting_readers() {
+    let selected = tags_surfaced_by(Surface::Interactive);
+    for tag in ["file_change", "sub_agent", "ask_user"] {
+        assert!(
+            selected.contains(&tag),
+            "`{tag}` is read by a specific interactive-mode feature (the \
+             Files tab, the SUB-AGENTS overlay, or the ask card), but the \
+             ledger does not record Surface::Interactive for it: {selected:?}"
+        );
+    }
+}
+
 // ---- negative controls: the audit must be able to fail -----------------
 
 /// A minimal well-formed ledger, so each control below alters exactly one

--- a/crates/stella-protocol/src/event/tags.rs
+++ b/crates/stella-protocol/src/event/tags.rs
@@ -371,11 +371,16 @@ agent_event_tags! {
     // `task_ledger::task_events` and inherits that same contract: the tag
     // says which task was running when the change was measured, which is no
     // more an attribution of authorship than the row it rides on.
+    //
+    // `Surface::Interactive`: the Files tab reads it too, and not by the
+    // exhaustive `Model::apply` match alone — `model/file_state.rs`'s
+    // `touch_file` keeps the per-path diff history the tab renders, and
+    // nothing else feeds that history.
     FileChange => "file_change",
         ConsumerPosture::Behavioral {
             site: "stella-cli/src/turn_facts.rs::TurnFacts::observe",
         },
-        &[Surface::Observatory];
+        &[Surface::Observatory, Surface::Interactive];
     // `Behavioral`: the deck's forwarder holds the run's `Stage(Execute)`
     // boundary until the first event that is not a recall, so a turn's recall
     // renders ahead of the stage it opens. The Observatory's recall-timings
@@ -533,11 +538,16 @@ agent_event_tags! {
     // (`stella-cli/src/command_deck/mid_turn_ask.rs`, which blocks on the
     // answer rather than on this event) never receives a reply and the turn
     // sits there until the session is killed.
+    //
+    // `Surface::Interactive`: `handle_focused_gates` is exactly the
+    // narrower, tag-specific claim that surface names — it exists only
+    // because `pending_ask_user` is set, not because `Model::apply` happens
+    // to reach every case.
     AskUser => "ask_user",
         ConsumerPosture::Behavioral {
             site: "stella-tui/src/model.rs::Model::apply (latches pending_ask_user)",
         },
-        &[];
+        &[Surface::Interactive];
     // The media pair (#4454). `RecordedOnly` because #4448 removed
     // `stella-media` and left these with zero producers in this tree: they are
     // kept as the wire contract an out-of-tree media MCP surface would speak,
@@ -579,14 +589,22 @@ agent_event_tags! {
     TaskUpdate => "task_update",
         ConsumerPosture::RecordedOnly { issue: "#4501" },
         &[];
-    // `RecordedOnly`: the delegation itself is driven by
+    // `Surfaced`, not `RecordedOnly` — this row named a still-open gap;
+    // the readers below close it. The delegation itself is driven by
     // `stella-core::subagent`'s dispatcher and this reports its phases. The
-    // deck stamps a start/finish bracket from them (`deck.rs`), which is the
-    // elapsed a human reads; nothing else consumes them. The controllable
-    // sub-session lanes are a separate mechanism and do not ride this case.
+    // deck's own per-case match (`deck.rs`'s derived-counters block, not the
+    // exhaustive `Model::apply`) stamps a start/finish bracket from them into
+    // `delegate_clocks`, and the SUB-AGENTS overlay
+    // (`views/subagents/rows.rs::delegates_of`, also a per-case filter rather
+    // than the exhaustive transcript match) reads both that clock and the
+    // `TranscriptEntry::SubAgent` bracket to list every `delegate` child.
+    // Rendering is the whole of it — nothing branches on the phase, only what
+    // a human sees does — which is `Surfaced`, not `Behavioral`, by this
+    // module's own test. The controllable sub-session lanes are a separate
+    // mechanism and do not ride this case.
     SubAgent => "sub_agent",
-        ConsumerPosture::RecordedOnly { issue: "#4501" },
-        &[];
+        ConsumerPosture::Surfaced,
+        &[Surface::Interactive];
     // The delivery decision (#2942). `Surfaced` rather than `RecordedOnly`
     // because the observatory's journal query was widened to select it in the
     // same change — a reader asking "did this candidate's work land?" gets the


### PR DESCRIPTION
## What

`crates/stella-protocol/src/event/consumers.rs`'s `Surface` enum had no
option for interactive mode. Its own doc explained why: interactive mode's
exhaustive matchers (`model::Model::apply`, `textline::event_line`,
`deck::trace_of`) reach every `AgentEvent` case by construction, so
"interactive mode reads this" was never a per-case fact worth recording.

That reasoning is correct for the exhaustive matchers, but PR #4547 found
three rows where a *specific* stella-tui feature reads one tag by name, not
by riding the exhaustive match:

- the Files tab reads `file_change` (`model/file_state.rs`'s `touch_file`
  keeps the per-path diff history it renders)
- the SUB-AGENTS overlay reads `sub_agent`
  (`views/subagents/rows.rs::delegates_of` filters the transcript for it
  specifically)
- the ask card reads `ask_user` (`deck_ui/gates.rs::handle_focused_gates`
  reads the `pending_ask_user` latch that only this tag sets)

The ledger had no vocabulary for that narrower, checkable claim, so those
three rows were recorded in the vaguest way the table allows (`FileChange`
and `AskUser` were `Behavioral` with no interactive surface listed;
`SubAgent` was `RecordedOnly` citing the #4501 census as an open gap), and
nothing checked that the code still actually reads them.

## The fix

Adds `Surface::Interactive`, documented the same way `Surface::Serve` is:
narrow, and legitimate only where a *downstream* reader singles out one tag
by name (the same bar `Serve` holds `TallyFold::observe` to), not because
the exhaustive matchers happen to reach it.

- `FileChange` and `AskUser` gain `Surface::Interactive` in their existing
  `Behavioral` rows.
- `SubAgent` moves from `RecordedOnly { issue: "#4501" }` to `Surfaced`,
  since both of its real consumers (`deck.rs`'s per-case derived-counters
  match, and the SUB-AGENTS overlay) only render — nothing branches on the
  phase, which is this module's own test for `Behavioral` vs. `Surfaced`.

No script change was needed for the "#4518 guard hookup" the audit verdict
named: `scripts/check-consumer-sites.sh` already validates every
`Behavioral` row's `site` string generically, and `FileChange`/`AskUser`
already carried sites it checks.

## Witness

`the_interactive_surface_names_the_three_selecting_readers`
(`crates/stella-protocol/src/event/consumers/tests.rs`) asserts
`tags_surfaced_by(Surface::Interactive)` contains `file_change`,
`sub_agent` and `ask_user`.

This is a witness by construction, the same shape this module already uses
for a missing `AgentEvent` consumer row (a build error, not a red test):
`Surface::Interactive` does not exist on `main`, so this test, and the
three ledger rows it checks, fail to compile there. Confirmed locally by
stashing this change: with it stashed, the crate no longer builds
(`Surface::Interactive` unresolved) and the test cannot run; unstashed, the
crate's `event::consumers` tests all pass, 17 of 17, the new one included.

## Verified

- The crate's `event::consumers` test module: 17/17 pass.
- `./scripts/check-consumer-sites.sh` — OK, 25 Behavioral sites, all live.
- `python3 scripts/check-prose.py` — OK, no new content-free constructions
  or reading-grade regressions.
- `./scripts/check-file-size.sh`, `make line-citations`, `make
  dead-code-allows` — all OK.
- `make guards-fast` — full green.
- Formatting is clean (`cargo fmt --all -- --check`).

## Not done

Nothing skipped. This is the "declaration change plus the #4518 guard
hookup" the maintainer's audit verdict scoped — see the design-pointer
comment on the issue.

Tests deleted: None.

Residue: none found beyond what's already tracked. `Surface::Observatory`'s
own claims still have no live parity check against the Observatory's real
query (tracked as #2707, pre-existing, unrelated to this change).

Closes #4554
