### PR TITLE
fix(stella-cli): record the effort knob under the key settings carry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,15 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-role-names.sh
 
+      # The other half of that story. `check-role-names.sh` holds four
+      # languages to one SPELLING of the role words; this asks whether Rust
+      # still uses them. #3908 retired the five `pipeline_<role>_model` keys,
+      # and a live string naming one is inert configuration that reads like a
+      # capability — the defect that retirement ended (#6061).
+      - name: no shipping Rust spells a retired role model key
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: python3 ./scripts/check-retired-model-keys.py
+
       # Also toolchain-free, and the reason it must be: `dev_t` is signed on
       # macOS and unsigned on Linux, so a raw `libc::stat` identity comparison
       # compiles on the author's machine and fails on this runner — or the

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -172,6 +172,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-dead-code-allows.sh
 
+      - name: retired model key guard directions
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-retired-model-keys.sh
+
       - name: deck path guard directions
         if: ${{ !cancelled() }}
         run: ./scripts/test-deck-paths.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #     stated once, in SCR-005, and the triage guard's
                          #     regex covers exactly the levels it names)
                          #   + left-behind + role-names
+                         #   + retired-model-keys (no shipping Rust
+                         #     spells a key #3908 retired)
                          #   + stat-portability + module-reachability
                          #   + core-reachability (a stella-core module is
                          #     reachable from the engine's step path; down-only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ python3 ./scripts/check-guard-trigger-coverage.py
 python3 ./scripts/check-priority-scheme.py
 ./scripts/check-left-behind.sh
 ./scripts/check-role-names.sh
+python3 ./scripts/check-retired-model-keys.py
 ./scripts/check-stat-portability.sh
 python3 ./scripts/check-module-reachability.py
 python3 ./scripts/check-core-reachability.py

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     command-docs website-inputs brand-case file-size god-files gate-parity \
                     schema-tier-parity \
                     guard-trigger-coverage priority-scheme left-behind \
-                    role-names stat-portability module-reachability core-reachability \
+                    role-names retired-model-keys \
+                    stat-portability module-reachability core-reachability \
                     typed-errors \
                     tool-error-class \
                     dead-code-allows measured-constants diagnostic-codes consumer-sites \
@@ -818,6 +819,14 @@ left-behind-update: ## Regenerate the left-behind baseline (it should stay empty
 .PHONY: role-names
 role-names: ## Assert the agent-config role names match across Rust, Python and JS (#1449)
 	@./scripts/check-role-names.sh
+
+.PHONY: retired-model-keys
+retired-model-keys: ## Assert no shipping Rust spells a retired pipeline_<role>_model key (#6061)
+	@python3 ./scripts/check-retired-model-keys.py
+
+.PHONY: retired-model-keys-test
+retired-model-keys-test: ## Test the retired-key guard's directions (hermetic; not part of `gate`)
+	./scripts/test-retired-model-keys.sh
 
 .PHONY: stat-portability
 stat-portability: ## Assert file identity is read through MetadataExt, not a raw libc::stat (#1758)

--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -425,10 +425,10 @@ pub(crate) struct EngineWiring {
     /// [`ModelRef`] the pins route to (adapters bind their model id at
     /// construction, so each distinct ref needs its own instance).
     pub(crate) extra_providers: Vec<(ModelRef, Box<dyn Provider>)>,
-    /// The model `Role::Worker`/`Role::Plan` actually resolve to: the
-    /// worker's own `pipeline_worker_model`/`agents.worker.*` pin when one
-    /// is configured and its provider is credentialed (issue #276), else
-    /// the session default this wiring was built with. Callers building the
+    /// The model `Role::Worker` actually resolves to: the configured
+    /// `default_model` / `agents.default.model` pin when one is set and its
+    /// provider is credentialed (issue #276), else the session default this
+    /// wiring was built with. Callers building the
     /// worker's own [`EngineConfig`] (catalog-based context-window and
     /// reasoning-capability clamps) must key off THIS, not `cfg` directly.
     pub(crate) worker_model: ModelRef,
@@ -946,19 +946,15 @@ pub(crate) struct ReflectionRoute {
     pub(crate) posture: crate::memory::ReflectionPosture,
 }
 
-/// Resolve where post-turn reflection dispatches (#1847): the configured
-/// triage model when it is routable, else `None` — ride the worker.
+/// Resolve where post-turn reflection dispatches (#1847): the session's own
+/// configured model when it is routable, else `None` — ride the worker.
 ///
-/// Reflection ran on the WORKER model from the day it shipped, with a 2048
-/// output-token allowance and no effort pin, while `crate::memory`'s own
-/// module doc called it "one cheap model call". Nothing routed it to a cheap
-/// tier. The triage pin (`pipeline_triage_model`/`agents.triage.*`) is
-/// already the posture's declaration of "the cheap, fast model", so
-/// reflection rides that declaration rather than adding a second cheap-model
-/// knob the two settings could drift apart on.
+/// It rode a cheap triage tier until that role was retired; the body's
+/// comment carries why the choice was made and where it may go next. What is
+/// read now is `default_model` / `agents.default.model`.
 ///
 /// Every miss is soft, matching [`resolve_cross_family_verifier`] and
-/// `pin_role`: no engine settings, no triage spec, an uncredentialed
+/// `pin_role`: no engine settings, no model spec, an uncredentialed
 /// provider, or an adapter that will not build all yield `None`, and the
 /// caller keeps dispatching on the worker exactly as every reflection call
 /// always has. A triage spec that resolves to the session default model is
@@ -968,10 +964,10 @@ pub(crate) struct ReflectionRoute {
 /// adapter" rule the wiring's `pin_role` applies) — but the pin still chose
 /// that model, so its posture still rides out.
 ///
-/// Returns the triage agent's **posture** alongside the adapter, and returns
-/// it even in the same-model case where no adapter is needed. Reflection runs
-/// on the model this pin selected, so `agents.triage.reasoning` /
-/// `agents.triage.effort` are the settings that govern the call — before
+/// Returns the agent's **posture** alongside the adapter, and returns it even
+/// in the same-model case where no adapter is needed. Reflection runs on the
+/// model this pin selected, so `agents.default.reasoning` /
+/// `agents.default.effort` are the settings that govern the call — before
 /// #2174 they chose the model and then could not reach it, so an operator who
 /// switched thinking off still paid for a reasoning stream billed against
 /// reflection's output cap.

--- a/crates/stella-cli/src/config.rs
+++ b/crates/stella-cli/src/config.rs
@@ -282,10 +282,10 @@ pub struct Config {
     ///
     /// `load_with_settings` folds the flag and the settings-configured
     /// default into one `Option<&str>` before resolution, so by the time a
-    /// `Config` exists the two are otherwise indistinguishable. The pipeline
-    /// wiring needs to tell them apart: an explicit flag is a per-invocation
-    /// pin of the WORKER model that `pipeline_worker_model`/`agents.worker.*`
-    /// must not override (see `crate::agent::resolve_engine_wiring`).
+    /// `Config` exists the two are otherwise indistinguishable. The engine
+    /// wiring must tell them apart. An explicit flag pins the model for one
+    /// run, and a configured `default_model` must not win over it (see
+    /// `crate::agent::resolve_engine_wiring`).
     pub model_pinned_by_flag: bool,
     pub api_key: ApiKey,
     /// `--turn-timeout`: the wall clock one turn may spend, used only to decide
@@ -564,9 +564,9 @@ impl Config {
             }
         });
         // Captured BEFORE the fold below, which is the last point where the
-        // flag and the settings default are still distinguishable. The
-        // pipeline wiring needs the distinction to stop
-        // `pipeline_worker_model` from overriding an explicit `--model`.
+        // flag and the settings default are still distinguishable. The engine
+        // wiring needs that: a configured `default_model` must not win over
+        // an explicit `--model`.
         let model_pinned_by_flag = model_override.is_some();
         let model_override = model_override.or(engine_default.as_deref());
 

--- a/crates/stella-cli/src/memory/self_tuning.rs
+++ b/crates/stella-cli/src/memory/self_tuning.rs
@@ -2,7 +2,7 @@
 //! slice). It sits beside [`crate::memory::rules_mining`]: the pure selection
 //! math is [`stella_learn::self_tuning`]; this module reads loop-bench results,
 //! folds each trial into a reward sample, asks the core which arm won, and — on
-//! a confident win — writes the winning worker reasoning-effort to settings and
+//! a confident win — writes the winning reasoning effort to settings and
 //! appends a reversible [`RollbackRecord`] to an append-only ledger under
 //! `.stella/private/`.
 //!
@@ -12,11 +12,11 @@
 //! rewards. The shipping CLI does **not** depend on the dev-only `loop-bench`
 //! crate — it parses the JSON with the minimal [`BenchTrial`] view below.
 //!
-//! **The `effort_auto` gotcha.** A pinned `agents.worker.effort` is ignored
+//! **The `effort_auto` gotcha.** A pinned `agents.default.effort` is ignored
 //! while `effort_auto: on` (the auto table picks the effort instead). So a
 //! promotion also turns `effort_auto` off in the target scope, and the rollback
 //! record captures the prior `effort_auto` so a rollback restores it exactly.
-//! Worker effort is not safety-relevant policy (authority, scope-review, and
+//! The effort knob is not safety-relevant policy (authority, scope-review, and
 //! budget are), so this is within the allowed blast radius — and it is fully
 //! reversible.
 
@@ -35,7 +35,22 @@ use crate::settings::{
 
 /// The settings path the effort knob lives at — the `knob` field of every
 /// ledger record, and what a rollback restores.
-pub(crate) const WORKER_EFFORT_KNOB: &str = "agent_engine_config.agents.worker.effort";
+pub(crate) const EFFORT_KNOB: &str = "agent_engine_config.agents.default.effort";
+
+/// The path this ledger wrote before the `worker` persona was retired.
+///
+/// [`promote`] has always written `agents.default.effort`; only the recorded
+/// name said `worker`. So the ledger named a key the settings file does not
+/// have, and an operator undoing a promotion by hand edited a key that reads
+/// nothing. New records carry [`EFFORT_KNOB`]; this spelling is still read,
+/// because a ledger on disk keeps whatever name it was written with and a
+/// rollback must still find it.
+const RETIRED_WORKER_EFFORT_KNOB: &str = "agent_engine_config.agents.worker.effort";
+
+/// Whether `knob` names this module's effort knob, in either spelling.
+fn is_effort_knob(knob: &str) -> bool {
+    knob == EFFORT_KNOB || knob == RETIRED_WORKER_EFFORT_KNOB
+}
 
 /// The append-only self-tuning ledger, under `.stella/private/` (git-ignored).
 const LEDGER: &str = "self_tuning.jsonl";
@@ -250,7 +265,7 @@ pub(crate) fn run_experiment(
     let candidate = ArmStats::from_samples(&candidate_arm);
     let decision = select_winner(&[baseline_arm, candidate_arm], "baseline", config);
     ExperimentReport {
-        knob: WORKER_EFFORT_KNOB.to_string(),
+        knob: EFFORT_KNOB.to_string(),
         decision,
         baseline,
         candidate,
@@ -314,10 +329,10 @@ fn active_promotion(
                 previous_effort_auto,
                 scope,
                 ..
-            } if rollback.knob == WORKER_EFFORT_KNOB => {
+            } if is_effort_knob(&rollback.knob) => {
                 active = Some((rollback, previous_effort_auto, scope));
             }
-            LedgerEntry::Rolledback { knob, .. } if knob == WORKER_EFFORT_KNOB => {
+            LedgerEntry::Rolledback { knob, .. } if is_effort_knob(&knob) => {
                 active = None;
             }
             _ => {}
@@ -347,7 +362,7 @@ pub(crate) struct PriorState {
     pub effort_auto: Option<bool>,
 }
 
-/// Write `chosen` worker effort to `scope`, disabling `effort_auto` so the
+/// Write `chosen` effort to `scope`, disabling `effort_auto` so the
 /// pinned value binds, and append a promotion record. Returns the prior state
 /// captured for rollback. `save_to` preserves every other settings key.
 pub(crate) fn promote(
@@ -366,15 +381,14 @@ pub(crate) fn promote(
     let prior_auto = cfg.effort_auto.map(Toggle::is_on);
 
     let agents = cfg.agents.get_or_insert_with(Default::default);
-    let worker = agents.default.get_or_insert_with(AgentEngineAgent::default);
-    worker.effort = Some(chosen);
+    let agent = agents.default.get_or_insert_with(AgentEngineAgent::default);
+    agent.effort = Some(chosen);
     // Disable auto-effort so the pinned effort actually takes effect.
     cfg.effort_auto = Some(Toggle::Off);
 
     cfg.save_to(&path)?;
 
-    let record =
-        RollbackRecord::from_promotion(WORKER_EFFORT_KNOB, prior_effort.clone(), promotion);
+    let record = RollbackRecord::from_promotion(EFFORT_KNOB, prior_effort.clone(), promotion);
     append_entry(
         workspace_root,
         &LedgerEntry::Promotion {
@@ -395,8 +409,8 @@ pub(crate) fn promote(
 pub(crate) enum RollbackOutcome {
     /// Nothing to roll back — no active promotion.
     Nothing,
-    /// Restored the worker effort to the given prior value (`None` = cleared
-    /// back to auto/default), in the named scope.
+    /// Restored the effort to the given prior value (`None` = cleared back to
+    /// auto/default), in the named scope.
     Restored {
         knob: String,
         restored: Option<String>,
@@ -404,8 +418,8 @@ pub(crate) enum RollbackOutcome {
     },
 }
 
-/// Revert the last effort promotion: restore the worker effort and the
-/// `effort_auto` value that were in place before it, in the scope it wrote.
+/// Revert the last effort promotion: restore the effort and the `effort_auto`
+/// value that were in place before it, in the scope it wrote.
 pub(crate) fn rollback(workspace_root: &Path) -> Result<RollbackOutcome, String> {
     let Some((record, prior_auto, scope)) = active_promotion(workspace_root) else {
         return Ok(RollbackOutcome::Nothing);
@@ -413,14 +427,14 @@ pub(crate) fn rollback(workspace_root: &Path) -> Result<RollbackOutcome, String>
     let path = scope.path(workspace_root)?;
     let mut cfg = load_scope_engine_config(&path);
 
-    // Restore worker effort to its prior value (or clear it entirely).
+    // Restore the effort to its prior value (or clear it entirely).
     let restored_effort = match &record.previous_value {
         Some(label) => Some(parse_effort(label)?),
         None => None,
     };
     let agents = cfg.agents.get_or_insert_with(Default::default);
-    let worker = agents.default.get_or_insert_with(AgentEngineAgent::default);
-    worker.effort = restored_effort;
+    let agent = agents.default.get_or_insert_with(AgentEngineAgent::default);
+    agent.effort = restored_effort;
 
     // Restore effort_auto exactly (absent stays absent).
     cfg.effort_auto = prior_auto.map(|on| if on { Toggle::On } else { Toggle::Off });
@@ -465,7 +479,7 @@ mod tests {
         rewards.iter().copied().map(trial).collect()
     }
 
-    fn worker_effort_in(path: &Path) -> Option<String> {
+    fn pinned_effort_in(path: &Path) -> Option<String> {
         let cfg = load_scope_engine_config(path);
         cfg.agent()
             .and_then(|a| a.effort)
@@ -593,10 +607,10 @@ mod tests {
         };
         let chosen = parse_effort(&p.winner.value).unwrap();
         let prior = promote(root, SettingsScope::Project, chosen, p).unwrap();
-        assert_eq!(prior.effort, None, "worker effort was unset before");
+        assert_eq!(prior.effort, None, "no effort was pinned before");
 
         let settings = project_settings_path(root);
-        assert_eq!(worker_effort_in(&settings).as_deref(), Some("high"));
+        assert_eq!(pinned_effort_in(&settings).as_deref(), Some("high"));
         // effort_auto was forced off so the pinned effort binds.
         let cfg = load_scope_engine_config(&settings);
         assert_eq!(cfg.effort_auto, Some(Toggle::Off));
@@ -609,13 +623,13 @@ mod tests {
                 .any(|e| matches!(e, LedgerEntry::Promotion { .. }))
         );
 
-        // Rollback restores the prior (unset) worker effort.
+        // Rollback restores the prior (unset) effort.
         match rollback(root).unwrap() {
             RollbackOutcome::Restored { restored, .. } => assert_eq!(restored, None),
             RollbackOutcome::Nothing => panic!("expected a rollback"),
         }
         assert_eq!(
-            worker_effort_in(&settings),
+            pinned_effort_in(&settings),
             None,
             "effort cleared on rollback"
         );
@@ -630,7 +644,7 @@ mod tests {
         let root = dir.path();
         let settings = project_settings_path(root);
 
-        // Seed a prior worker effort of "low".
+        // Seed a prior pinned effort of "low".
         let mut seed = AgentEngineConfig::default();
         let agents = seed.agents.get_or_insert_with(Default::default);
         agents
@@ -658,11 +672,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(prior.effort.as_deref(), Some("low"));
-        assert_eq!(worker_effort_in(&settings).as_deref(), Some("high"));
+        assert_eq!(pinned_effort_in(&settings).as_deref(), Some("high"));
 
         rollback(root).unwrap();
         assert_eq!(
-            worker_effort_in(&settings).as_deref(),
+            pinned_effort_in(&settings).as_deref(),
             Some("low"),
             "rollback restores the pre-promotion effort"
         );
@@ -698,5 +712,107 @@ mod tests {
             !report.decision.is_promotion(),
             "overlapping noisy arms must not promote"
         );
+    }
+
+    /// The ledger names the key the settings file carries.
+    ///
+    /// Before this test it recorded `agents.worker.effort` while [`promote`]
+    /// wrote `agents.default.effort`. The `worker` persona is retired, so the
+    /// recorded name was a key the file does not have: an operator undoing a
+    /// promotion by hand edited a key that reads nothing, and the settings
+    /// kept the pin.
+    #[test]
+    fn a_promotion_records_the_key_the_settings_carry() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let report = run_experiment(
+            &trials(&[Some(0.0); 6]),
+            "medium",
+            &trials(&[Some(1.0); 6]),
+            "high",
+            &RewardWeights::default(),
+            &SelectionConfig::default(),
+        );
+        let Decision::Promote(p) = &report.decision else {
+            panic!("expected promotion")
+        };
+        promote(
+            root,
+            SettingsScope::Project,
+            parse_effort(&p.winner.value).unwrap(),
+            p,
+        )
+        .unwrap();
+
+        assert_eq!(report.knob, EFFORT_KNOB, "the receipt names the live key");
+        let knobs: Vec<String> = read_ledger(root)
+            .into_iter()
+            .filter_map(|entry| match entry {
+                LedgerEntry::Promotion { rollback, .. } => Some(rollback.knob),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            knobs,
+            vec![EFFORT_KNOB.to_string()],
+            "the promotion record names the live key"
+        );
+    }
+
+    /// A ledger written before that fix keeps the retired name, and a rollback
+    /// still has to find it. Reading only the live spelling would strand the
+    /// pin an upgraded workspace is already running under.
+    #[test]
+    fn a_ledger_naming_the_retired_worker_key_still_rolls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let settings = project_settings_path(root);
+
+        let report = run_experiment(
+            &trials(&[Some(0.0); 6]),
+            "low",
+            &trials(&[Some(1.0); 6]),
+            "high",
+            &RewardWeights::default(),
+            &SelectionConfig::default(),
+        );
+        let Decision::Promote(p) = &report.decision else {
+            panic!("expected promotion")
+        };
+
+        // The state the older build left: the pin it wrote to settings, and
+        // the ledger line it recorded under the retired name.
+        let mut seed = AgentEngineConfig::default();
+        seed.agents
+            .get_or_insert_with(Default::default)
+            .default
+            .get_or_insert_with(AgentEngineAgent::default)
+            .effort = Some(ReasoningEffort::High);
+        seed.effort_auto = Some(Toggle::Off);
+        seed.save_to(&settings).unwrap();
+        append_entry(
+            root,
+            &LedgerEntry::Promotion {
+                rollback: RollbackRecord::from_promotion(
+                    RETIRED_WORKER_EFFORT_KNOB,
+                    Some("low".to_string()),
+                    p,
+                ),
+                previous_effort_auto: None,
+                scope: SettingsScope::Project,
+                at_ms: 0,
+            },
+        )
+        .unwrap();
+
+        match rollback(root).unwrap() {
+            RollbackOutcome::Restored { knob, restored, .. } => {
+                assert_eq!(knob, RETIRED_WORKER_EFFORT_KNOB);
+                assert_eq!(restored.as_deref(), Some("low"));
+            }
+            RollbackOutcome::Nothing => panic!("an older ledger must still roll back"),
+        }
+        assert_eq!(pinned_effort_in(&settings).as_deref(), Some("low"));
     }
 }

--- a/crates/stella-tui/src/envelope/engine_config.rs
+++ b/crates/stella-tui/src/envelope/engine_config.rs
@@ -95,8 +95,9 @@ pub struct EngineAgentState {
 /// the type carries a *rendering*, not a model to reason over.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RoleWiringRow {
-    /// The settings key this role is spelled as (`default` / `worker` /
-    /// `verifier` / `triage`) — the word a user would type to change it.
+    /// The name this row is spelled as: `default` for the session's own
+    /// model, and a plugin-declared seat beside it once one is installed.
+    /// The word a user would type to change it.
     pub role: String,
     /// `provider/slug` exactly as it goes on the wire.
     pub model: String,
@@ -107,7 +108,7 @@ pub struct RoleWiringRow {
     /// `reasoning_auto` disclosure.
     pub thinking: String,
     /// The settings key that decided `model`, as a path a user can edit:
-    /// `agents.verifier.model`, `pipeline_triage_model`, `default_model`,
+    /// `agents.default.model`, `default_model`,
     /// `--model (this invocation)`, or `session default`.
     pub source: String,
     /// What a session started **now** would resolve for this role, when a
@@ -119,8 +120,8 @@ pub struct RoleWiringRow {
     /// running" is the question this dialog exists to answer and showing a
     /// mid-session edit as though it were in force would misreport exactly
     /// that. But saying nothing about the edit was its own lie: a user who
-    /// changed `pipeline_verifier_model` and saved saw their old pin with no
-    /// explanation, and read the dialog as having ignored the save (#1521).
+    /// changed a model pin and saved saw their old one with no explanation,
+    /// and read the dialog as having ignored the save (#1521).
     /// So this is strictly *additional* information, pre-rendered driver-side
     /// like every other cell, holding only the parts that differ.
     pub next_session: Option<String>,

--- a/crates/stella-tui/src/views/models_card.rs
+++ b/crates/stella-tui/src/views/models_card.rs
@@ -40,9 +40,9 @@
 //! mid-session settings edit as though it were in force would misreport the
 //! exact thing the dialog exists to answer.
 //!
-//! But saying nothing about a saved edit was its own way of lying. Someone who
-//! changed `pipeline_verifier_model` in the ENGINE panel, saved, and opened
-//! this dialog saw their **old** pin with no explanation — and the panel's own
+//! But saying nothing about a saved edit was its own way of lying. Someone
+//! who changed a model pin in the ENGINE panel, saved, and opened this dialog
+//! saw the **old** one, with no note — and the panel's own
 //! "applies to runs started from now on" line is one tab away and gone by
 //! then. The dialog read as having ignored the save (#1521).
 //!

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -156,6 +156,7 @@ step_command() {
   doc-links) echo 'check-doc-links' ;;
   module-reachability) echo 'check-module-reachability' ;;
   core-reachability) echo 'check-core-reachability' ;;
+  retired-model-keys) echo 'check-retired-model-keys' ;;
   typed-errors) echo 'check-typed-errors' ;;
   tool-error-class) echo 'check-tool-error-class' ;;
   dead-code-allows) echo 'check-dead-code-allows' ;;

--- a/scripts/check-retired-model-keys.py
+++ b/scripts/check-retired-model-keys.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Guard: shipping Rust must not spell a retired role model key.
+
+Five `agent_engine_config` keys are gone. So are the `agents.<persona>`
+blocks. The core loop has one role. A model for any other role is a seat.
+A plugin declares the seat. A user assigns it in `[seats]`.
+
+The keys are still known. `crates/stella-cli/src/settings/unknown.rs` names
+each one back to the user. It gives the seat that takes its place. The
+trusted launcher still takes a posture that carries one.
+
+What must not come back is code that uses one. A live string named
+`pipeline_verifier_model` is dead config that reads like a feature. That is
+the flaw the retirement ended.
+
+`scripts/check-role-names.sh` asks a different thing. It holds four languages
+to one spelling of the role words. It never asks if Rust still uses them.
+
+A hit is a quoted string on a line of code. A doc comment may cite a retired
+key. Half these files explain the retirement that way. Test code is skipped
+for the same reason.
+
+`HOMES` names the files where the spelling is the subject. `DEBT` holds what
+came before this guard. A count there may fall. It may never rise.
+
+Usage:
+    ./scripts/check-retired-model-keys.py [ROOT]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# The five retired personas. A settings file spelled each one twice: as
+# the flat `pipeline_<role>_model` key, and as the `agents.<role>` block.
+PERSONAS = ("worker", "verifier", "triage", "research", "plan")
+
+KEY = re.compile(
+    r'"[^"\n]*(?:pipeline_(?:%s)_model|agents\.(?:%s))[^"\n]*"'
+    % ("|".join(PERSONAS), "|".join(PERSONAS))
+)
+
+CFG_TEST = re.compile(r"#\[cfg\((?:all\()?test\b")
+
+# Files where a retired spelling is the subject. None of them is a use.
+HOMES = {
+    # The retirement table. It holds every key, the reason, and the seat
+    # that takes its place.
+    "crates/stella-cli/src/settings/unknown.rs",
+    # The self-tuning ledger reads the name it wrote before the change.
+    # An older build's promotion can then still be rolled back.
+    "crates/stella-cli/src/memory/self_tuning.rs",
+}
+
+# Down-only. Each line is what a file held before this guard. Never raise a
+# number here. Never add a file. Delete the spelling instead.
+DEBT = {
+    # The demo session behind `stella deck` shots and the `/models` golden
+    # frame. It still draws six rows from retired keys. A rebuild on seats
+    # redraws the golden frame, so it lands with the settings pane.
+    "crates/stella-tui/src/scenario.rs": 2,
+}
+
+
+def strip_cfg_test(src: str) -> str:
+    """Drop `#[cfg(test)]` / `#[cfg(all(test, ...))]` blocks."""
+    out: list[str] = []
+    i = 0
+    while True:
+        m = CFG_TEST.search(src, i)
+        if not m:
+            out.append(src[i:])
+            return "".join(out)
+        out.append(src[i : m.start()])
+        brace = src.find("{", m.start())
+        if brace < 0:
+            return "".join(out)
+        depth = 0
+        j = brace
+        while j < len(src):
+            if src[j] == "{":
+                depth += 1
+            elif src[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        i = j + 1
+
+
+def hits(root: Path) -> dict[str, list[tuple[int, str]]]:
+    """Every retired spelling in a string literal, by repo-relative path."""
+    found: dict[str, list[tuple[int, str]]] = {}
+    for path in sorted(root.glob("crates/*/src/**/*.rs")):
+        rel = path.relative_to(root).as_posix()
+        parts = path.relative_to(root).parts
+        if rel in HOMES or "tests" in parts or path.name == "tests.rs":
+            continue
+        src = strip_cfg_test(path.read_text(encoding="utf-8", errors="replace"))
+        for number, line in enumerate(src.splitlines(), 1):
+            if line.lstrip().startswith("//"):
+                continue
+            if KEY.search(line):
+                found.setdefault(rel, []).append((number, line.strip()[:100]))
+    return found
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    root = Path(argv[0]) if argv else Path(__file__).resolve().parent.parent
+    root = root.resolve()
+
+    found = hits(root)
+
+    # The verdict is settled before a word is written. A guard that prints
+    # as it scans dies mid-report when its reader exits early. The half-done
+    # state then becomes the exit status.
+    report: list[str] = []
+    status = 0
+    for rel in sorted(set(found) | set(DEBT)):
+        now = len(found.get(rel, []))
+        allowed = DEBT.get(rel, 0)
+        if now > allowed:
+            status = 1
+            report.append(f"{rel}: {now} retired key(s) in code, {allowed} allowed.")
+            for number, line in found.get(rel, [])[:20]:
+                report.append(f"    {rel}:{number}  {line}")
+        elif now < allowed and (root / rel).is_file():
+            report.append(
+                f"note: {rel} is down to {now} (DEBT says {allowed}) -- "
+                "lower the number in this script to lock the win in."
+            )
+
+    if status:
+        report.append("")
+        report.append(
+            "These keys are retired: a model for anything but the session's "
+            "own role is a plugin-declared seat, assigned in `[seats]` "
+            "(`agent_engine_config.seat_models`). Cite a retired key in a doc "
+            "comment if you must name it; do not put one in code."
+        )
+
+    if report:
+        sys.stderr.write("\n".join(report) + "\n")
+    if not status:
+        total = sum(len(v) for v in found.values())
+        print(f"check-retired-model-keys: OK -- {total} recorded, none new.")
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-retired-model-keys.sh
+++ b/scripts/test-retired-model-keys.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Tests for check-retired-model-keys.py. It must flag a retired key in code.
+# It must leave alone the three places one may still appear.
+#
+#   ./scripts/test-retired-model-keys.sh
+#
+# Run it after you touch that script. It is not part of `make gate`: it
+# builds throwaway trees under $TMP, as `make typed-errors-test` does.
+#
+# ── Why a fixture, not the real workspace ────────────────────────────────────
+#
+# Run the guard on this tree and it can only pass. No fresh violation is in
+# it. A guard nobody has watched fail is a guard nobody knows still works.
+# So each case below builds its own root.
+#
+# ── What has to be true ──────────────────────────────────────────────────────
+#
+# The guard says "no retired key in code". It has to hold both ends of that.
+# Flag too little and the flaw comes back. Flag too much and it dies: three
+# files here cite a retired key to explain the change, and a guard that fails
+# on those gets turned off. F* holds the first end. Q* holds the second.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-retired-model-keys.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# A throwaway workspace root with a `crates/` tree for the guard to walk.
+# $1 = case name. Echoes the root path.
+new_root() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/crates"
+  echo "$dir"
+}
+
+# Write a source file. $1 = root, $2 = crate, $3 = path under src/, then the
+# file body on stdin.
+src_file() {
+  local path="$1/crates/$2/src/$3"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path"
+}
+
+# want <name> <expect-pass|expect-fail> <root> <substring>
+#
+# The substring is checked on both verdicts. On expect-fail it pins what was
+# flagged, and in what words. On expect-pass it pins what a passing run said.
+# A guard that passed by never looking cannot meet that.
+want() {
+  local name="$1" expect="$2" root="$3" sub="${4:-}" out rc
+  out="$(python3 "$SCRIPT" "$root" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -ne 0 ]; then
+      fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+      return
+    fi
+    case "$out" in
+      *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+      *) fail=$((fail + 1)); echo "FAIL $name — passed, but did not report '$sub':"; echo "$out" ;;
+    esac
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1)); echo "FAIL $name — the guard passed a violation it should have flagged:"; echo "$out"
+    return
+  fi
+  case "$out" in
+    *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+    *) fail=$((fail + 1)); echo "FAIL $name — flagged the wrong thing (wanted '$sub'):"; echo "$out" ;;
+  esac
+}
+
+# ── F: a retired key in code is flagged ──────────────────────────────────────
+
+r="$(new_root flat_key)"
+src_file "$r" stella-fixture lib.rs <<'EOF'
+//! Fixture crate.
+pub fn source() -> &'static str {
+    "pipeline_verifier_model"
+}
+EOF
+want "F1 a flat pipeline key in a string literal is flagged" \
+  expect-fail "$r" "crates/stella-fixture/src/lib.rs"
+
+r="$(new_root persona_key)"
+src_file "$r" stella-fixture lib.rs <<'EOF'
+//! Fixture crate.
+pub const KNOB: &str = "agent_engine_config.agents.triage.effort";
+EOF
+want "F2 a retired persona block in a string literal is flagged" \
+  expect-fail "$r" "1 retired key(s) in code"
+
+r="$(new_root every_persona)"
+src_file "$r" stella-fixture lib.rs <<'EOF'
+//! Fixture crate.
+pub const KEYS: [&str; 5] = [
+    "pipeline_worker_model",
+    "pipeline_verifier_model",
+    "pipeline_triage_model",
+    "pipeline_research_model",
+    "pipeline_plan_model",
+];
+EOF
+want "F3 all five retired personas are known" expect-fail "$r" "5 retired key(s)"
+
+r="$(new_root remedy)"
+src_file "$r" stella-fixture lib.rs <<'EOF'
+//! Fixture crate.
+pub const KEY: &str = "pipeline_plan_model";
+EOF
+want "F4 the failure names the seat assignment that replaces the key" \
+  expect-fail "$r" "seats"
+
+# ── Q: the three places a retired key may still appear ───────────────────────
+
+r="$(new_root doc_comment)"
+src_file "$r" stella-fixture lib.rs <<'EOF'
+//! Fixture crate.
+//! `pipeline_verifier_model` is retired; assign a seat instead.
+
+/// Retired: `pipeline_triage_model` steers nothing.
+pub fn live() {}
+EOF
+want "Q1 a doc comment citing a retired key passes" expect-pass "$r" "none new"
+
+r="$(new_root cfg_test)"
+src_file "$r" stella-fixture lib.rs <<'EOF'
+//! Fixture crate.
+pub fn live() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn the_retired_key_is_reported() {
+        assert_eq!("pipeline_verifier_model", "pipeline_verifier_model");
+    }
+}
+EOF
+want "Q2 a #[cfg(test)] block naming a retired key passes" expect-pass "$r" "none new"
+
+r="$(new_root test_module)"
+src_file "$r" stella-fixture tests.rs <<'EOF'
+//! Test module.
+pub const SEEDED: &str = "pipeline_verifier_model";
+EOF
+src_file "$r" stella-fixture settings/tests/retired.rs <<'EOF'
+//! A file under a `tests/` directory.
+pub const SEEDED: &str = "pipeline_triage_model";
+EOF
+want "Q3 tests.rs and a tests/ directory are not scanned" expect-pass "$r" "none new"
+
+r="$(new_root clean_tree)"
+src_file "$r" stella-fixture lib.rs <<'EOF'
+//! Fixture crate.
+pub const SEATS: &str = "seat_models";
+pub const DEFAULT: &str = "default_model";
+EOF
+want "Q4 the live keys pass" expect-pass "$r" "0 recorded"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "test-retired-model-keys: OK — $pass checks passed"
+  exit 0
+fi
+echo "test-retired-model-keys: FAILED — $fail of $((pass + fail)) checks"
+exit 1

--- a/website/content/docs/configuration/agent-engine-config.mdx
+++ b/website/content/docs/configuration/agent-engine-config.mdx
@@ -128,6 +128,35 @@ Or in `stella.toml`, where it is a section of its own:
 Quote the key in TOML. `vera.verifier` is dotted-key syntax and would parse as
 a table `vera` containing `verifier`.
 
+## Retired keys
+
+Older settings files pinned a model per pipeline role. That pipeline is gone,
+and so are its keys. stella still recognises each one, names it on stderr, and
+reads nothing from it. Delete the key. Where a plugin declares the role,
+assign its seat instead.
+
+| Retired key | Write this now |
+| --- | --- |
+| `pipeline_worker_model` | `default_model` |
+| `pipeline_verifier_model` | `[seats]` — `"<plugin-id>/verifier"` |
+| `pipeline_triage_model` | `[seats]` — `"<plugin-id>/triage"` |
+| `pipeline_research_model` | `[seats]` — `"<plugin-id>/research"` |
+| `pipeline_plan_model` | `[seats]` — `"<plugin-id>/plan"` |
+| `agents.worker` | `agents.default` |
+| `agents.verifier`, `agents.triage`, `agents.research`, `agents.plan` | the seat above |
+
+Each key gets its own line, because the reason differs:
+
+```text
+  ! .stella/settings.json: `agent_engine_config.pipeline_verifier_model` is
+    retired and reads nothing — it pinned a model for a role the core loop
+    does not have — it was a pin on the staged pipeline deleted in #3865 and
+    has read nothing since. assign the seat the verification plugin declares:
+    `[seats] "<plugin-id>/verifier" = "…"`. Delete the key.
+```
+
+A retired key never fails a run. It is reported, then ignored.
+
 ## Model precedence
 
 **The session's model.** First hit wins:


### PR DESCRIPTION
## What

Slice 4 of #3903 (roleless core) shipped the config collapse in #3908: the five
`pipeline_<role>_model` keys and the `agents.<persona>` blocks left the schema,
`settings/unknown.rs` names each one back to the operator with the `[seats]`
assignment that replaces it, and `config_wiring::deck_rows` emits one row named
`default`. Three pieces did not travel with it. This PR carries them.

**1. The self-tuning ledger wrote a retired key.**
`crates/stella-cli/src/memory/self_tuning.rs` recorded every promotion under
`agent_engine_config.agents.worker.effort` while `promote` wrote
`agents.default.effort`. The recorded name was a key the settings file does not
have, so an operator who read the record and undid the change by hand edited a
key that reads nothing — and the pinned effort stayed in force. New records
carry `EFFORT_KNOB` (`agents.default.effort`); `RETIRED_WORKER_EFFORT_KNOB` is
still *read*, because a ledger already on disk keeps the name it was written
with and a rollback has to find it.

**2. Nothing kept the retired keys out of code.** `check-role-names.sh` holds
four languages to one *spelling* of the role words; it never asks whether Rust
still uses them. `make retired-model-keys`
(`scripts/check-retired-model-keys.py`) asks that: a retired key in a
double-quoted string on a line of shipping Rust fails the gate. A doc comment
citing one passes, because that is how several files here explain the
retirement; `#[cfg(test)]` bodies, `tests/` directories and `tests.rs` are
skipped, because proving the retirement is what those files are for.
`settings/unknown.rs` (the retirement table) and `memory/self_tuning.rs` (the
legacy ledger name) are declared homes.

**3. Four doc comments described retired keys as governing live code** —
`EngineWiring::worker_model`, `reflection_route`, `RoleWiringRow::role` /
`::source`, and `Config::model_pinned_by_flag`. Each now names what its code
reads. The settings docs gained a "Retired keys" table mapping each retired key
to `default_model` or the seat that replaces it.

## Witness

Two tests in `crates/stella-cli/src/memory/self_tuning.rs`:

- `a_promotion_records_the_key_the_settings_carry` — **fails on `main` by
  construction.** It asserts the promotion record's `knob` is
  `agent_engine_config.agents.default.effort`; `main` writes
  `…agents.worker.effort` from `WORKER_EFFORT_KNOB`, so the assertion compares
  two different strings.
- `a_ledger_naming_the_retired_worker_key_still_rolls_back` — the
  compatibility half. It seeds the settings and the ledger line an older build
  left, then asserts `rollback` finds it. This one passes on `main` (which
  reads only that spelling) and would fail on a fix that simply renamed the
  constant, which is the mistake it exists to prevent.

The guard's own directions are covered by `scripts/test-retired-model-keys.sh`
(8 cases: each of the five personas flagged in code, the failure naming the
seat remedy, and the four places a retired key may still appear). It runs in
`guard-self-tests.yml`. Run locally: 8/8 pass.

Exemplar followed: `scripts/check-typed-errors.py` and
`scripts/test-dead-code-allows.sh` — same `strip_cfg_test` walk, same
verdict-before-write reporting, same fixture-root self-test shape.

## Why the guard carries its debt in the script, not a baseline file

`crates/stella-tui/src/scenario.rs` is the one file that predates the guard: the
demo session behind `stella deck` screenshots still sources two of its six
`/models` rows from `pipeline_verifier_model` and `agents.triage.model`, and
the committed golden frame pins that picture. Rebuilding it on seats re-renders
`tests/snapshots/deck/card_models.txt`, which belongs to the settings-UI slice
(#3909, and #6072 carries the demo), so this PR records it rather than changing it. It lives in the
script's `DEBT` dict rather than a `scripts/*-baseline.txt`: one entry does not
justify another shared cell for two PRs to collide on, and AGENTS.md's own
account of the file-size and lockfile baselines is why.

## Not in scope, and why

- **The bench harness still writes `pipeline_verifier_model`**
  (`bench/harbor_adapter/stella_harbor/posture.py`). `doc:roleless-core` §6
  and `RETIRED_ENGINE_ROOT`'s doc comment both record the reason: migrating it
  re-hashes every posture digest registered in `bench/READINESS.md` §8.4, which
  is the published-numbers call #3870 reserves for a maintainer. It lands with
  slice 6 (#3910).
- **`Router::resolve_with`'s per-tier match arms still read roles.** That is
  gap A in `doc:roleless-core` §5, not gap D, and `Role::Verifier`'s one live
  use is `stella goal`'s cross-family *selection strategy*
  (`resolve_seat_provider`). Retiring it is a `stella-core` + `stella-protocol`
  change with a wire cost; filed as #6071.

## Tests deleted

None.

## Residue filed

- #6071 — `Role`'s four unused tiers, and the cross-family strategy wearing
  `Role::Verifier`'s name.
- #6072 — the demo scenario and its golden frame still draw six persona rows.

Closes #6061
Refs #3903

## Summary by Sourcery

Carry the roleless configuration migration through self-tuning, documentation, and automated retired-key safeguards.

Bug Fixes:
- Record self-tuning effort promotions under the live default effort setting while preserving rollback compatibility with legacy worker-key ledger entries.

Enhancements:
- Clarify configuration and model-wiring documentation to describe the current default model and seat-based settings.
- Add a guard that prevents retired role model keys from reappearing in shipping Rust code while allowing documented, test, and explicitly tracked legacy uses.

Build:
- Add the retired-model-key check to the Make gate, gate-parity checks, and contributor validation commands.

CI:
- Run the retired-model-key guard in CI and add hermetic self-tests covering its detection and exemptions.

Documentation:
- Document retired model keys and their replacements through the default model or plugin-declared seats.

Tests:
- Add coverage for recording the live effort knob and rolling back ledgers written with the retired worker key.

---

### DoD verification (SCR-003)

#6061's checklist is now complete, so the `dod / dod` gate should clear on this
re-read. All seven items were checked against this branch at `5e85a18`, reading
each file rather than this description.

Three were settled by an *observed* green check rather than by reading the diff,
which is the stronger evidence and is worth naming:

- `guard self-tests` reported `success`, so `scripts/test-retired-model-keys.sh`
  actually exercised the new guard's directions — that is what establishes the
  guard *fails* on a re-added key, rather than merely being wired up.
- `docs guards`, the workflow that runs `gate-parity`, reported `success`, which
  settles "the new step is named in AGENTS.md and CONTRIBUTING.md and runs in a
  workflow".
- `fmt + clippy + test` reported `success`, which is the job that runs
  `a_promotion_records_the_key_the_settings_carry` and
  `a_ledger_naming_the_retired_worker_key_still_rolls_back`. That was the last
  item outstanding.

The remaining items were read off the diff: `DEBT` holds exactly
`crates/stella-tui/src/scenario.rs` and the docstring states the never-rise
rule; all five doc comments (`EngineWiring::worker_model`, `reflection_route`,
`RoleWiringRow::role`, `RoleWiringRow::source`, `Config::model_pinned_by_flag`)
now name `default_model` / `agents.default.*` instead of a retired key; and the
settings docs carry a "Retired keys" table covering all five
`pipeline_<role>_model` keys plus the `agents.<persona>` blocks against their
`[seats]` replacements.

Full per-item evidence is recorded on #6061.


---
_Generated by [Claude Code](https://claude.ai/code)_