### PR TITLE
fix(deps): re-resolve Cargo.lock after the version sync passed stella-ansi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,7 +3184,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stella-ansi"
-version = "0.9.337"
+version = "0.9.340"
 
 [[package]]
 name = "stella-autonomy"


### PR DESCRIPTION
## What & why

`main` is red at `7b479bf93`. The canary filed #6081 naming two failures, `lockfile-sync` and `compile`, both with one cause:

```
error: cannot update the lock file /home/runner/work/stella/stella/Cargo.lock because --locked was passed to prevent this
```

`stella-ansi` arrived in #6055 with its `Cargo.lock` entry recorded at `0.9.337` — the workspace version at the moment that branch was cut. Two release syncs (#6064, #6077) landed between that cut and the merge, so `[workspace.package].version` on `main` is now `0.9.340` while the new crate's entry alone still read `0.9.337`. The lock therefore no longer resolved against the manifests, and everything passing `--locked` broke with it.

The diff is that one line:

```diff
 [[package]]
 name = "stella-ansi"
-version = "0.9.337"
+version = "0.9.340"
```

## Neither branch was wrong

`Cargo.lock` is the shared cell AGENTS.md names: one file every PR of a shape must write. #6055 wrote it correctly for the tree it was cut from, the release syncs wrote it correctly for theirs, and the two composed into a lock that does not resolve. No pre-merge check has both halves in front of it — which is exactly what `main-canary.yml` exists to catch, and it did.

## Verification

Both checks the canary named, run on this branch:

```
$ ./scripts/check-lockfile-sync.sh
check-lockfile-sync: OK — Cargo.lock resolves against the manifests.

$ cargo metadata --format-version 1 --locked >/dev/null; echo $?
0
```

Both fail on `7b479bf93` without this commit — I reproduced the failure on a fresh checkout of `main` before regenerating, and `check-lockfile-sync.sh` printed the same remedy text the canary quoted.

The lock was regenerated with the command the issue prescribes (`cargo metadata --format-version 1`), not hand-edited.

## Definition of done (#6081)

- [x] `lockfile-sync` passes on a fresh `main` with the fix applied — output above.
- [x] `compile` passes on a fresh `main` with the fix applied — the `compile` failure was the same `--locked` refusal, and `cargo metadata --locked` now exits 0. CI's own `compile` step on this PR is the authoritative run.
- [x] The repair landed on its own from a fresh `main`, not folded into an unrelated PR — this branch was cut from `7b479bf93` and carries one commit touching one file.

## Tests deleted

None.

## Note on how this arose

I merged the batch of green PRs that composed into this, during an automated PR sweep. The systemic half — that `main`'s protection appears not to require up-to-date branches, so a stale-but-green PR merges without re-testing against current `main` — is filed separately as #6078, since it outlives this one-line repair.

Closes #6081

---

## DoD boxes ticked on #6081 — independently re-verified

The `dod` check reads the **issue's** checklist, not this description's, and #6081's three boxes were still unticked, so the check failed here. I re-ran each item against this head (`2373f70`) before ticking, with a control so the result can distinguish the claim from its opposite:

```
$ git checkout 2373f70 && ./scripts/check-lockfile-sync.sh
check-lockfile-sync: OK — Cargo.lock resolves against the manifests.
EXIT=0

$ git checkout 7b479bf93 && ./scripts/check-lockfile-sync.sh
check-lockfile-sync: FAIL — Cargo.lock is out of sync with the manifests.
CONTROL_EXIT=1
```

Fails on the commit the canary tested, passes with the one-line fix. On the `compile` half, the quoted failure is not a Rust error — it is the same `--locked` refusal raised before any crate builds — and CI on this head agrees: `cargo check on the declared MSRV` (a `--locked` check) and `build image + smoke the container` both passed.

The full evidence is recorded on #6081 itself.

## Follow-on: #6080 is the same hazard, queued

`bot/version-sync` (#6080) was cut from `6ca1cfec`, which predates `stella-ansi` entirely — verified: the crate is in neither `crates/` nor `Cargo.lock` at that ref. Its sync therefore bumped 26 members to `0.9.341` and could not bump the 27th. Its own `--locked` checks pass because its tree is self-consistent; the break would appear only on composition, exactly as this one did. Merging it after this PR would strand `stella-ansi` at `0.9.340` and re-red `main`.

I re-synced that branch onto current `main` rather than let its auto-merge fire on a green that predates #6081, and commented there with the detail. It is not blocked on anything in this PR beyond ordering.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqjm6N2eJwNpsnZFDPrn3R