### PR TITLE
ci(dod-check): re-run the DoD check when its issue changes

### DIFF
--- a/.github/workflows/dod-recheck.yml
+++ b/.github/workflows/dod-recheck.yml
@@ -1,0 +1,62 @@
+name: dod-recheck
+
+# Re-read a DoD checklist the moment the checklist changes (#6079).
+#
+# `dod-check` judges the linked issue's checklist, and fires on pull request
+# events. Those are two different objects. Ticking the last box on the issue —
+# the remedy the failure message names — raises no pull request event, so the
+# red `dod / dod` stands until someone touches the pull request.
+#
+# This workflow is the missing event. `scripts/dod-recheck.sh` finds the open
+# pull requests whose body names the edited issue and runs the failed check
+# again on each. The new run reports under the same name on the same commit,
+# which is all the branch rules read — so nothing here has to report a check
+# against a head this event does not own.
+#
+# Same shape as `main-red-clear.yml`, for the same bug one gate over: a check
+# that was right when it ran, on a commit with no event left to correct it.
+
+on:
+  issues:
+    types: [edited]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: The issue number whose pull requests should be re-checked
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  # To read each open pull request's body and head commit.
+  pull-requests: read
+  # To run the failed check again. This is the scope an agent session does not
+  # hold, which is why the re-run lives in a workflow rather than in the
+  # session that ticked the box.
+  actions: write
+
+# One sweep per issue. A cancelled sweep costs nothing: the next one asks the
+# same questions and re-runs whatever is still failing.
+concurrency:
+  group: dod-recheck-${{ github.event.issue.number || inputs.issue }}
+  cancel-in-progress: true
+
+jobs:
+  recheck:
+    name: re-read the checklist the issue edit changed
+    # A title-only edit changes no checklist. GitHub sends `changes.body` only
+    # when the body moved, so this drops half the traffic before it starts a
+    # runner.
+    if: >-
+      github.event_name != 'issues'
+      || github.event.changes.body != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Re-run the dod check on every pull request naming this issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number || inputs.issue }}
+        run: ./scripts/dod-recheck.sh "$ISSUE"

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -195,6 +195,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-dependabot-pip-dirs.sh
 
+      - name: which PRs an issue edit re-checks, and which it leaves alone
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-dod-recheck.sh
+
       # Was in UNHOSTED_SELF_TESTS until #4443: 14 of its 38 cases failed
       # everywhere, not just outside a Linux dev box as first suspected — the
       # fixture built a synthetic repo shaped `stella-core/src/`, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,24 @@ the first pass cleared. `make clear-main-red-holds` prints what a sweep would
 re-run without re-running it; `make main-red-hold-test` covers the clearing
 half beside the blocking one.
 
+**The same staleness reaches `dod-check`, one gate over.** That check reads the
+linked issue's checklist and fires on pull request events, so the object it
+judges and the events it hears are two different things. Tick the last box on
+the issue — the remedy its own failure message names — and nothing happens. The
+red `dod / dod` is still the last run on that commit. On 2026-09-05 four pull
+requests sat red on that check alone, and three had to be nudged by editing a
+pull request body somebody else wrote (`#6079`). `dod-recheck.yml` is the missing
+event: on an edit to any issue it runs `scripts/dod-recheck.sh`, which finds the
+open pull requests whose body names that issue and runs the failed check again
+on each. Running the old run again, rather than reporting a new check, is what
+settles the awkward half — the new run lands under the same name on the same
+commit, so nothing here has to report a check against a head the issue event
+does not own. The failure is the scope too: a pull request whose `dod / dod`
+already passes is left alone, which is what stops one body edit fanning out
+over every pull request that ever named the issue. It fails open, like the rest
+of this chain. `make dod-recheck N=6079` prints what a sweep would re-run;
+`make dod-recheck-test` covers it, both negative controls included.
+
 The chain has a third link, and it is not a workflow: **before you repair a
 red `main`, check whether somebody already is.** On 2026-08-24 three sessions
 each wrote the same two-line fix for the same break and merged them 95 seconds

--- a/Makefile
+++ b/Makefile
@@ -941,6 +941,18 @@ main-red-claim: ## Ask whether somebody is already repairing a red `main` (reads
 main-red-claim-test: ## Test the red-main claim pre-flight, standing-down branch included (hermetic; not part of `gate`)
 	./scripts/test-main-red-claim.sh
 
+# The same staleness one gate over: `dod-check` reads the linked issue's
+# checklist and fires on pull request events, so ticking the last box on the
+# issue leaves the red check standing (#6079). CI runs the check again on an
+# issue edit; this prints what it would re-run, and changes nothing.
+.PHONY: dod-recheck
+dod-recheck: ## List the failing `dod / dod` checks an issue's PRs still carry: make dod-recheck N=6079
+	@./scripts/dod-recheck.sh --dry-run $(N)
+
+.PHONY: dod-recheck-test
+dod-recheck-test: ## Test the DoD re-check, both negative controls included (hermetic; not part of `gate`)
+	./scripts/test-dod-recheck.sh
+
 .PHONY: issue-claim
 issue-claim: ## Ask whether somebody is already implementing an issue: make issue-claim N=5045
 	@./scripts/issue-claim.sh check $(N)

--- a/scripts/dod-recheck.sh
+++ b/scripts/dod-recheck.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Run the DoD check again after its issue changed. Filed as `#6079`.
+#
+# `dod-check` reads the checklist on the linked issue. But it runs on pull
+# request events. So the thing it reads and the events it hears are two
+# different objects. Tick the last box on the issue and nothing happens. The
+# pull request keeps a red `dod / dod` until someone touches the pull request.
+#
+# On 2026-09-05 four pull requests sat red on that check alone. Every other
+# check was green. Three of them had to be nudged by editing the pull request
+# body, which rewrites the description of a pull request someone else wrote.
+#
+# This script is the missing step. Give it an issue number. It finds the open
+# pull requests whose body names that issue, finds the last `dod-check` run on
+# each head, and runs it again when that run failed.
+#
+# ## Why run it again, and not post a new check
+#
+# A new check would have to be reported against a head this event does not
+# own. Running the old run again needs no such thing. The new run lands under
+# the same name on the same commit, which is all the branch rules read. This
+# is the shape `#5913` settled for the red-main hold, and the reason is the
+# same both times.
+#
+# ## What bounds the fan-out
+#
+# One issue can be named by many pull requests, and a body edit is cheap. So
+# the failure itself is the scope: a pull request whose `dod / dod` already
+# passes is left alone. Only a head whose last run failed is run again.
+#
+# ## Who calls it
+#
+# `dod-recheck.yml`, on an edit to any issue. An edit by `GITHUB_TOKEN` starts
+# no workflow, so a box ticked by that token is the one case this misses.
+#
+# ## Fails open, out loud
+#
+# Every unknown prints a note and exits 0. A red job here would say the
+# checklist is unmet when nobody asked it that. The check itself is the only
+# thing allowed to answer that question.
+#
+# Usage:
+#   scripts/dod-recheck.sh 6079
+#   scripts/dod-recheck.sh --dry-run 6079
+#
+# Needs `gh` and a POSIX shell, so it runs on a bare CI runner.
+set -uo pipefail
+
+workflow="dod-check.yml"
+limit=100
+dry_run=0
+issue=""
+fixture_open_prs=""
+fixture_failed_runs=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --dry-run)
+    dry_run=1
+    shift
+    ;;
+  --limit)
+    [ $# -ge 2 ] || {
+      echo "dod-recheck: --limit needs a number" >&2
+      exit 2
+    }
+    limit="$2"
+    shift 2
+    ;;
+  # Test-only seams. Either one stubs every lookup, and stops the re-run from
+  # being sent. So a case cannot half-reach the network, and cannot pass or
+  # fail for a reason it did not pick. Same rule as the fixtures in
+  # `clear-main-red-holds.sh`.
+  --fixture-open-prs)
+    [ $# -ge 2 ] || {
+      echo "dod-recheck: --fixture-open-prs needs a value" >&2
+      exit 2
+    }
+    fixture_open_prs="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-failed-runs)
+    [ $# -ge 2 ] || {
+      echo "dod-recheck: --fixture-failed-runs needs a value" >&2
+      exit 2
+    }
+    fixture_failed_runs="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  -h | --help)
+    # The whole block after the shebang, cut off at its first line of code. A
+    # line number here goes stale the first time the header grows. Same reader
+    # as the one in `clear-main-red-holds.sh`.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  -*)
+    echo "dod-recheck: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  *)
+    if [ -n "$issue" ]; then
+      echo "dod-recheck: one issue number, not two ('$issue' and '$1')" >&2
+      exit 2
+    fi
+    issue="$1"
+    shift
+    ;;
+  esac
+done
+
+[ "$use_fixture" -eq 1 ] && dry_run=1
+
+note() { printf 'dod-recheck: %s\n' "$*" >&2 || true; }
+say() {
+  # Ignore SIGPIPE and drop the write. A reader that closes the pipe must not
+  # turn this into a failure — the `#1815` shape.
+  trap '' PIPE
+  printf 'dod-recheck: %s\n' "$*" || true
+}
+
+# A missing or malformed number is a wiring bug in the caller, not an unknown
+# about the world. It exits loudly, where every other failure here fails open.
+case "$issue" in
+"")
+  echo "dod-recheck: needs an issue number" >&2
+  exit 2
+  ;;
+*[!0-9]*)
+  echo "dod-recheck: '$issue' is not an issue number" >&2
+  exit 2
+  ;;
+esac
+
+if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  note "gh is not installed, so no check could be run again. A push to the"
+  note "branch still re-runs it."
+  exit 0
+fi
+
+# ── The open pull requests, one per line ─────────────────────────────────────
+#
+# Each line is the number, the head commit, then the body with its line breaks
+# flattened to spaces. The match happens below, on the line, so the fixture
+# seam and the live path are read by the same matcher.
+#
+# The bodies are read rather than searched. Code search is an index, and an
+# index lags. A pull request opened a minute ago is the exact case this has to
+# get right.
+
+if [ "$use_fixture" -eq 1 ]; then
+  open_prs="$fixture_open_prs"
+elif ! open_prs="$(gh pr list --state open --limit "$limit" \
+  --json number,headRefOid,body \
+  --jq '.[] | "\(.number) \(.headRefOid) \(.body // "" | gsub("[\r\n]+"; " "))"' \
+  2>/dev/null)"; then
+  note "could not list the open pull requests, so nothing was run again."
+  exit 0
+fi
+
+# The last `dod-check` run on this head, and only if it failed. A re-run
+# updates the run in place, so `[0]` is that run, and its conclusion is the
+# verdict the branch rules read.
+failed_run_for() {
+  head="$1"
+  if [ "$use_fixture" -eq 1 ]; then
+    printf '%s\n' "$fixture_failed_runs" |
+      awk -v head="$head" '$1 == head { print $2; exit }'
+    return 0
+  fi
+  gh api "repos/{owner}/{repo}/actions/workflows/$workflow/runs?head_sha=$head&per_page=20" \
+    --jq '.workflow_runs[0] | select(.conclusion == "failure") | .id' 2>/dev/null || true
+}
+
+rerun=0
+named=0
+
+while read -r pr head rest; do
+  [ -n "$pr" ] || continue
+  # `#6079` and not `#60791`. A bare `6079` is not a reference, and would
+  # match a run id or a date as readily as an issue.
+  printf '%s' "$rest" | grep -Eq "#${issue}([^0-9]|\$)" || continue
+  named=$((named + 1))
+  run="$(failed_run_for "$head")"
+  if [ -z "$run" ]; then
+    say "PR #$pr names the issue and its dod check is not failing — left alone."
+    continue
+  fi
+  if [ "$dry_run" -eq 1 ]; then
+    say "would re-run the dod check on PR #$pr (head $head, run $run)"
+    rerun=$((rerun + 1))
+    continue
+  fi
+  if gh api -X POST --silent \
+    "repos/{owner}/{repo}/actions/runs/$run/rerun-failed-jobs" 2>/dev/null; then
+    say "re-ran the dod check on PR #$pr (head $head, run $run)"
+    rerun=$((rerun + 1))
+  else
+    # This needs `actions: write`. A job without it must say so, rather than
+    # report a sweep it did not do.
+    note "could not re-run run $run for PR #$pr — does this job have"
+    note "\`actions: write\`? That check stays red until the branch is pushed."
+  fi
+done <<EOF
+$open_prs
+EOF
+
+say "#$issue is named by $named open pull request(s); ran the dod check again on $rerun."
+exit 0

--- a/scripts/test-dod-recheck.sh
+++ b/scripts/test-dod-recheck.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Hermetic tests for the DoD re-check (`#6079`).
+#
+#   ./scripts/test-dod-recheck.sh     (or: make dod-recheck-test)
+#
+# No network and no `gh`: every case drives the fixture seams, so the suite is
+# the same on a bare runner as on a dev box with a live tracker.
+#
+# The cases that matter most are the two negative controls. A sweep that
+# re-runs everything looks the same as a correct one from the outside, and a
+# sweep that re-runs nothing looks the same as a quiet day. So the suite pins
+# both edges: the pull request that names the issue and is already green is
+# left alone, and the pull request that names no such issue is never touched
+# at all.
+#
+# Not a `make gate` step, matching `main-red-hold-test`: the thing under test
+# asks GitHub a question, and the gate is hermetic and offline by contract.
+#
+# bash 3.2 compatible.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/dod-recheck.sh"
+
+pass=0
+fail=0
+
+ok() { printf '  \033[32m✓\033[0m %s\n' "$*"; pass=$((pass + 1)); }
+bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=$((fail + 1)); }
+
+if [ ! -x "$SCRIPT" ]; then
+  printf '\033[31mtest-dod-recheck: FAILED\033[0m — %s is missing or not executable.\n' \
+    "$SCRIPT"
+  exit 1
+fi
+
+# The state of 2026-09-05, as fixtures. Four pull requests are open. Three
+# name the issue under test. Two of those carry a failed dod check on the head
+# they have now.
+#
+# The third field is the body, with its line breaks already flattened — the
+# same shape the live `gh pr list` gives the matcher.
+open_prs="6046 aaaaaaa Closes #6079 — the re-check trigger.
+6062 bbbbbbb Refs #6079 and #5913, already green.
+6073 ccccccc Closes #60791, a different issue.
+6074 ddddddd Closes #6079 as well."
+
+failed_runs="aaaaaaa 33951700124
+ccccccc 33950666389
+ddddddd 33952811235"
+
+# Every case checks the exit code too. This script runs on an issue edit, and
+# a red job there would read as a verdict about the checklist. It has no such
+# verdict to give.
+says() { # says <name> <want-substring> <issue> <prs> <runs>
+  local name="$1" want_text="$2" issue="$3" prs="$4" runs="$5"
+  local out rc
+  out="$("$SCRIPT" --fixture-open-prs "$prs" --fixture-failed-runs "$runs" \
+    "$issue" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    bad "$name — expected exit 0 (fail-open), got $rc: $out"
+    return
+  fi
+  case "$out" in
+  *"$want_text"*) ok "$name" ;;
+  *) bad "$name — wanted '$want_text': $out" ;;
+  esac
+}
+
+lacks() { # lacks <name> <unwanted-substring> <issue> <prs> <runs>
+  local name="$1" unwanted="$2" issue="$3" prs="$4" runs="$5"
+  local out
+  out="$("$SCRIPT" --fixture-open-prs "$prs" --fixture-failed-runs "$runs" \
+    "$issue" 2>&1)"
+  case "$out" in
+  *"$unwanted"*) bad "$name — said '$unwanted' when it should not: $out" ;;
+  *) ok "$name" ;;
+  esac
+}
+
+exits_two() { # exits_two <name> <args...>
+  local name="$1"
+  shift
+  "$SCRIPT" "$@" >/dev/null 2>&1
+  if [ $? -eq 2 ]; then ok "$name"; else bad "$name — did not exit 2"; fi
+}
+
+printf '\033[1mdod-recheck — a ticked box reaches the pull request\033[0m\n'
+
+# The witness. Before this fix nothing ran the check again. The failure from
+# the unticked checklist stayed the last word on that commit, and the pull
+# request could not merge until someone edited it.
+#
+# Each case names the run as well as the pull request. Running the wrong run
+# would still look like a sweep, and would clear nothing.
+says "a ticked box re-runs the check on the first pull request that names it" \
+  "6046 (head aaaaaaa, run 33951700124)" 6079 "$open_prs" "$failed_runs"
+
+says "...and on every other pull request naming the same issue" \
+  "6074 (head ddddddd, run 33952811235)" 6079 "$open_prs" "$failed_runs"
+
+# First negative control: the fan-out bound. A green check is already the
+# right answer, and running it again would spend a job to change nothing.
+lacks "a pull request whose dod check already passes is not re-run" \
+  "6062 (head bbbbbbb, run" 6079 "$open_prs" "$failed_runs"
+
+says "...and it says so, so a quiet sweep is not mistaken for a broken one" \
+  "6062 names the issue and its dod check is not failing" 6079 \
+  "$open_prs" "$failed_runs"
+
+# Second negative control: the match. `#60791` is a different issue, and its
+# check is failing, so a loose matcher would re-run it here.
+lacks "a longer number that starts with the issue number is not a match" \
+  "33950666389" 6079 "$open_prs" "$failed_runs"
+
+says "the summary counts what it swept" \
+  "named by 3 open pull request(s); ran the dod check again on 2" 6079 \
+  "$open_prs" "$failed_runs"
+
+# An issue no open pull request names is a state, not an error.
+says "an issue nothing references says so and stops" \
+  "named by 0 open pull request(s); ran the dod check again on 0" 4242 \
+  "$open_prs" "$failed_runs"
+
+says "no open pull request at all is a state too" \
+  "named by 0 open pull request(s)" 6079 "" ""
+
+# A caller that passes no number, or a number that is not one, has a wiring
+# bug. That is the one thing here that must be loud.
+exits_two "no issue number exits 2, not 0" --fixture-open-prs "$open_prs"
+exits_two "a non-numeric issue exits 2, not 0" --fixture-open-prs "$open_prs" main
+exits_two "two issue numbers exit 2, not 0" --fixture-open-prs "$open_prs" 1 2
+exits_two "an unknown flag exits 2, not 0" --nonsense 6079
+exits_two "a flag missing its value exits 2, not 0" --limit
+
+printf '\n\033[1mwiring — a sweep nothing calls sweeps nothing\033[0m\n'
+
+# The three cases below read the workflow file. On a tree where an issue edit
+# does not call the sweep, they fail.
+holds_text() { # holds_text <name> <file> <pattern>
+  local name="$1" file="$repo_root/.github/workflows/$2" pattern="$3"
+  if [ -f "$file" ] && grep -q -- "$pattern" "$file"; then
+    ok "$name"
+  else
+    bad "$name — $2 does not carry '$pattern'"
+  fi
+}
+
+holds_text "an edit to an issue starts a sweep" \
+  dod-recheck.yml "types: \[edited\]"
+
+holds_text "...which runs this script" \
+  dod-recheck.yml "dod-recheck.sh"
+
+holds_text "...and holds the write scope a re-run needs" \
+  dod-recheck.yml "actions: write"
+
+printf '\n'
+if [ "$fail" -eq 0 ]; then
+  printf '\033[32mtest-dod-recheck: OK\033[0m — %d checks passed\n' "$pass"
+  exit 0
+fi
+printf '\033[31mtest-dod-recheck: FAILED\033[0m — %d passed, %d failed\n' "$pass" "$fail"
+exit 1


### PR DESCRIPTION
## What and why

`dod-check` judges the **linked issue's** checklist and fires on **pull
request** events. Those are two different objects. Tick the last box on the
issue — the exact remedy its failure message names — and nothing happens: the
red `dod / dod` is still the last run on that commit. On 2026-09-05 four pull
requests sat red on that check alone, and three had to be nudged by editing a
pull request body somebody else wrote.

This adds the missing event.

- `.github/workflows/dod-recheck.yml`, on `issues: [edited]`, with
  `actions: write` and a `workflow_dispatch` for a manual nudge.
- `scripts/dod-recheck.sh` — find the open pull requests whose body names the
  edited issue, find the last `dod-check` run on each head, and run it again
  when that run failed.
- `scripts/test-dod-recheck.sh`, wired into `guard-self-tests.yml`.
- `AGENTS.md` and two `make` targets.

## The design, and where it differs from the issue

The issue sketched the fix in `macanderson/oxagen`'s `dod-check.yml`: an
`issues: [edited]` trigger there, reporting a check against each pull
request's head SHA. The maintainer session pointed at the shape #5913 already
proved here instead (PR #6027, `scripts/clear-main-red-holds.sh` +
`.github/workflows/main-red-clear.yml`). That is the exemplar this copies, and
it is the same bug one gate over: a check that was right when it ran, on a
commit with no event left to correct it.

Re-running settles both design questions the issue left open.

- **Head SHA.** No check is reported at all. The re-run lands under the same
  name on the same commit, which is all the branch rules read — so nothing
  here has to report a check against a head the issue event does not own.
- **Fan-out.** The failure is the scope. Only a head whose last `dod-check`
  run failed is run again; a pull request already green is left alone and
  says so.

Two consequences, both restated in the issue's checklist rather than left to
be discovered:

- **Nothing changes in oxagen**, so the caller stub keeps the SHA it has.
- **The live proof has to come after the merge.** A workflow on an `issues`
  event runs from the default branch, so this one cannot fire on its own pull
  request. Filed as #6089, with the exact steps and the three ways it can fail
  to fire.

The bodies are read (`gh pr list --json body`) rather than searched
(`--search "<n> in:body"`). Code search is an index, and an index lags — a
pull request opened a minute ago is the exact case this has to get right. The
match is `#<n>` not followed by a digit, so `#60791` is not `#6079`.

## Witness mechanism

`scripts/test-dod-recheck.sh` — hermetic, no network and no `gh`. Every case
drives the two fixture seams, and either seam forces dry-run, so a case cannot
half-reach the network.

It fails on the old code by construction: `scripts/dod-recheck.sh` does not
exist on `main`, and the suite exits 1 naming the missing file before it runs
a case. Its three wiring cases read `dod-recheck.yml`, which does not exist
there either.

The two cases that carry the fix are the negative controls, because a sweep
that re-runs everything and a sweep that re-runs nothing both look correct
from outside. Both were shown to be capable of failing, by adding a failed run
for the already-green pull request to the fixture:

```
✗ a pull request whose dod check already passes is not re-run — said
  're-run the dod check on PR #6062' when it should not
✗ ...and it says so, so a quiet sweep is not mistaken for a broken one
test-dod-recheck: FAILED — 13 passed, 3 failed
```

Green on this branch: 16 checks passed.

## Exemplar

`scripts/clear-main-red-holds.sh` and `.github/workflows/main-red-clear.yml`
(#5913, PR #6027) — the fixture seams, the fail-open discipline, the
`rerun-failed-jobs` call, and the `-h` header reader are all that file's.

## Local verification

`make guards-fast` green, including `gate-parity` (which is what checks the
new self-test runs in a workflow), `shellcheck`, `check-prose` and
`check-line-citations`. No crate is touched, so nothing here compiles.

Tests deleted: None

Residue filed: #6089 (live confirmation after the merge), #6090 (say in the
failure message that the check re-runs itself, in the oxagen implementation
this repository cannot edit).

Closes #6079

## Summary by Sourcery

Re-run failed DoD checks for affected pull requests when their linked issue checklist changes.

New Features:
- Automatically re-run failed DoD checks for open pull requests when their linked issue body is edited.
- Add a manual workflow dispatch and dry-run command for triggering or previewing DoD re-checks.￼

Bug Fixes:
- Refresh stale failed DoD checks after checklist changes without requiring an unrelated pull request edit.
- Avoid re-running checks for already-passing pull requests or pull requests referencing a different issue number.￼

Enhancements:
- Document the DoD re-check workflow and expose make targets for previewing and testing it.

CI:
- Run hermetic DoD re-check tests as part of the guard self-test workflow.

Tests:
- Add offline coverage for issue matching, failed-run fan-out, negative controls, argument validation, and workflow wiring.

---

**DoD verified 2026-09-05 by an autonomous PR sweep.** #6079's 10 items were checked against this diff, not taken from the description: `scripts/test-dod-recheck.sh` runs 16/16 locally including both negative controls (the already-green PR left alone, `#60791` not matching `#6079`); `scripts/dod-recheck.sh` is absent on `main`, so the suite fails there by construction; the sweep is scoped by `select(.conclusion == "failure")`; #6089 and #6090 are filed with the `triage` label only. The red `dod / dod` here is stale — it ran at 19:21:45, before #6079's boxes were ticked at 19:23:16 — which is precisely the bug this PR fixes.


---
_Generated by [Claude Code](https://claude.ai/code)_