### PR TITLE
docs(ci): record that main's branch protection stays non-strict

### DIFF
--- a/.github/workflows/automerge-nudge.yml
+++ b/.github/workflows/automerge-nudge.yml
@@ -1,17 +1,33 @@
 name: automerge-nudge
 
-# Keep armed auto-merge PRs from deadlocking at BEHIND (#1527).
+# Drains armed auto-merge PRs stuck at GitHub's BEHIND merge state — but only
+# while main's branch protection has required_status_checks.strict on, and it
+# does not today (ADR 0029, #6078). Read straight from the protection API:
 #
-# `main`'s protection sets required_status_checks.strict — head branches must
-# be up to date with base — and auto-merge does not update branches on its own.
-# So a PR with every check green and auto-merge armed stops dead the moment
-# main moves under it. Six of them piled up that way on 2026-08-05 and drained
-# only because someone ran `gh pr update-branch` by hand in a loop.
+#   $ gh api repos/macanderson/stella/branches/main/protection \
+#       --jq '.required_status_checks.strict'
+#   false
 #
-# The strict rule stays: the same evening, two individually-green PRs merged
-# into a semantically incompatible stella-pipeline and broke main (#1482/#1462).
-# That is the counterexample that justifies requiring up-to-date branches, so
-# this fixes the deadlock rather than relaxing the rule.
+# `strict` is what makes GitHub report BEHIND at all: with it off, a PR whose
+# branch is many commits behind main reports CLEAN, never BEHIND, so this
+# workflow's selector (mergeStateStatus == "BEHIND", scripts/automerge-nudge.sh)
+# has nothing to ever select. Automatic triggers below are disabled for that
+# reason — a workflow that can provably never act has no business running on
+# every push to main and every 15 minutes forever. workflow_dispatch stays, so
+# a maintainer can run it by hand, and it is cheap to re-enable in full: restore
+# the `on.push`/`on.schedule` block this comment used to sit above (see this
+# file's git history, or ADR 0029) if `strict` is ever turned back on.
+#
+# The history this workflow was built for, kept for whoever revisits ADR 0029:
+# a PR with every check green and auto-merge armed used to stop dead the moment
+# main moved under it while strict was on. Six of them piled up that way on
+# 2026-08-05 and drained only because someone ran `gh pr update-branch` by hand
+# in a loop (#1527). `strict` was kept on at the time because the same evening,
+# two individually-green PRs merged into a semantically incompatible
+# stella-pipeline and broke main (#1482/#1462) — the counterexample that
+# justified requiring up-to-date branches. ADR 0029 revisits that trade under
+# today's much higher concurrent-merge load and lands on `strict` off, with
+# main-canary.yml and main-red-hold.yml as the after-the-fact backstop instead.
 #
 # ── Why one PR per run ───────────────────────────────────────────────────────
 #
@@ -22,25 +38,29 @@ name: automerge-nudge
 #
 # ── Triggers ─────────────────────────────────────────────────────────────────
 #
-# `push: main` is the responsive one: main moving is the event that creates the
-# deadlock, so it is the moment to start draining. The schedule is the backstop
-# for a main that stopped moving with PRs still queued behind it, and for a
-# push whose event did not reach Actions.
+# workflow_dispatch only, while strict is off (see the header). The automatic
+# pair this ran on before — `push: main`, the responsive trigger for the
+# moment main moves; and a 15-minute `schedule`, the backstop for a main that
+# stopped moving with PRs still queued behind it — has nothing to trigger for,
+# since the selector they both feed can never match. Restoring them is the
+# first step in undoing this record if `strict` returns:
+#
+#   on:
+#     push:
+#       branches: [main]
+#     schedule:
+#       - cron: "*/15 * * * *"
+#     workflow_dispatch:
+#       inputs: { ... }   # keep the block below
 #
 # ── Why this cannot be the merge queue (yet) ─────────────────────────────────
 #
-# GitHub's merge queue is #1527's preferred fix and would make this workflow
-# unnecessary: it serializes candidates and tests each against the true merge
-# result, so armed PRs drain themselves. Turning it on is a repository settings
-# change that needs admin, so this ships the mechanism that does not.
+# GitHub's merge queue would make this workflow unnecessary even with strict
+# back on: it serializes candidates and tests each against the true merge
+# result, so armed PRs drain themselves. Turning it on is a repository
+# settings change that needs admin, tracked at #4998 rather than here.
 
 on:
-  push:
-    branches: [main]
-  schedule:
-    # Every 15 minutes. One `gh pr list` call, and scheduled workflows are
-    # delayed under load anyway — a tighter cron buys nothing.
-    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       dry-run:

--- a/docs/adr/0029-branch-protection-stays-non-strict.md
+++ b/docs/adr/0029-branch-protection-stays-non-strict.md
@@ -1,0 +1,118 @@
+---
+id: adr/0029-branch-protection-stays-non-strict
+title: "ADR 0029: Branch protection stays non-strict"
+status: implemented
+---
+
+# ADR 0029: Branch protection stays non-strict
+
+- Status: accepted
+- Date: 2026-09-05
+- Decides: `#6078`
+
+## Context
+
+`main`'s branch protection has a setting named `required_status_checks.strict`.
+Turned on, a pull request cannot merge until its branch has run its checks
+against the current tip of `main`. Turned off, a pull request can merge on
+a green run from an older `main`, even many commits behind.
+
+`#6078` asked which one this repository has. Read straight from the
+protection API, with an admin-scoped token:
+
+```
+$ gh api repos/macanderson/stella/branches/main/protection \
+    --jq '.required_status_checks | {strict, contexts}'
+{
+  "contexts": [
+    "fmt + clippy + test",
+    "cargo deny + cargo audit",
+    "harbor_adapter + analyzer pytest",
+    "main is not known-broken",
+    "gate steps no other workflow runs"
+  ],
+  "strict": false
+}
+```
+
+`strict` is `false`. `enforce_admins` is `true`. A red required check still
+blocks everyone, admins included. The only thing not required is a fresh run
+against the latest `main`.
+
+Two files already argued as if `strict` were on:
+`.github/workflows/automerge-nudge.yml` and `scripts/automerge-nudge.sh`.
+Both open by saying branch protection sets `required_status_checks.strict`,
+and both build their reason for existing on that — a workflow that unsticks
+pull requests parked at GitHub's `BEHIND` merge state. Neither file is right
+about the setting today. `git log` shows `AGENTS.md` never made this claim,
+so the fix belongs in those two files, not there.
+
+Turning `strict` off was not a new decision made here. A repository setting
+does not flip itself. But nobody had written the choice down, so nobody could
+tell a chosen setting from a forgotten one. Proof the choice matters arrived
+within the hour `#6078` was filed: `main` broke at 16:59 UTC (`#6081`, closed
+by `#6082`). Two pull requests, each green and each correct on its own, both
+touched `Cargo.lock`. Together they made a lock file that would not resolve.
+Every pull request merged in that window had run its checks against a `main`
+that was 4 to 14 commits old.
+
+## Decision
+
+Leave `strict` off.
+
+Many agent sessions merge into this repository at once. A scheduled sweep
+runs. Several other sessions run too. They often overlap. Turning
+`strict` on would force every open pull request through `gh pr
+update-branch` plus a full ~12-minute CI run each time `main` moves. Under
+this load, `main` moves every few minutes. Merging would slow to a handful
+of pull requests an hour. The pile-up `automerge-nudge.yml` already exists
+to drain (`#1527`) would come back, and worse than before. `strict` is the
+exact rule that makes GitHub's `BEHIND` deadlock happen at all.
+
+The risk `strict` would have caught still gets watched, just later. It has a
+name in `AGENTS.md`: the shared-cell hazard behind `Cargo.lock` and
+`scripts/file-size-baseline.txt`. Two branches, each correct alone, can
+compose into a broken tree once both land — and no check on either branch
+alone can see that coming. `main-canary.yml` asks the same question again,
+against `main` itself, after every push. `main-red-hold.yml` — a required
+check since 2026-09-02 — blocks further merges while a `main-red` issue from
+the canary stays open. That pair catches a break after the merge, not before
+it. This record accepts that gap on purpose, rather than leaving it unnamed.
+
+The lasting fix for the gap is GitHub's merge queue. It tests each candidate
+against the true merged result before it lands, so a queued pull request
+never merges on a stale green. Turning it on is a separate repository
+setting, and a separate decision from this one. `#4998` already asks the
+same question: a merge queue, or a cheaper scheduled composer? It is still
+open, and neither one is picked yet. This record only answers `#6078`'s
+question: is `strict` on. `#4998`'s bigger question stays there. A second
+issue asking the same thing would not help.
+
+`automerge-nudge.yml` exists to drain pull requests stuck at GitHub's
+`BEHIND` merge state. It cannot fire while `strict` is off. GitHub only
+reports `BEHIND` when required status checks are strict. `#6078`'s own
+table already showed this: pull requests 4 to 14 commits behind all
+reported `clean`, never `behind`. Deleting the workflow and its script is a
+bigger change than a documentation record should make on its own. So both
+files stay. Their `push`/`schedule` triggers are turned off, and
+`workflow_dispatch` is kept. Restarting them is cheap if `strict` ever
+comes back. Their headers say what the repository does today.
+
+## Consequences
+
+`AGENTS.md` never claimed `strict` was on, so it needed no fix. The false
+claim lived in `automerge-nudge.yml` and `automerge-nudge.sh`. Both are
+fixed in the same change that adds this record. Both now say their
+selection rule cannot match anything until `strict` returns. Both say how
+to turn them back on: run `workflow_dispatch` by hand today, or restore
+the `push`/`schedule` triggers this record turns off.
+
+A pull request can still merge on a run against a `main` that has since
+moved. `main-canary.yml` and `main-red-hold.yml` are the safety net for
+that, and they run after the merge, not before it. This record accepts that
+gap; `#4998` is tracking the lasting fix for it.
+
+A later measurement may show the break rate is too high, even with
+`main-canary.yml` catching most of them. If so, amend this record. Turn
+`strict` back on. Turn `automerge-nudge.yml`'s automatic triggers back on
+with it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,6 +95,7 @@ open; nothing before Phase 3 forces it.
 | [0026](0026-context-editing-ships-off-until-measured.md) | Context Editing Ships Off Until Its Trigger Is Measured | Accepted |
 | [0027](0027-a-fleet-worker-gets-its-own-worktree.md) | A Fleet Worker Gets Its Own Worktree | Accepted |
 | [0028](0028-panel-cells-are-glyphs-in-the-contract.md) | A Panel Cell Is a Glyph in the Contract and a Column in the Host | Accepted |
+| [0029](0029-branch-protection-stays-non-strict.md) | Branch Protection Stays Non-Strict | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -146,3 +147,11 @@ ADR 0028 settles what a panel frame's cell count measures. The wire contract
 counts glyphs; the host counts terminal columns. A row of wide glyphs the
 contract admits is cut at the lease's edge, and the two tests named in the
 record hold both halves of that.
+
+ADR 0029 records that `main`'s branch protection keeps
+`required_status_checks.strict` off, read from the protection API rather than
+assumed. Many concurrent agent sessions merging at once make the `strict`
+up-to-date requirement serialize merges to a handful an hour; the composition
+risk it would have caught is left to `main-canary.yml` and
+`main-red-hold.yml` as an after-the-fact backstop, with the durable close
+tracked at `#4998` rather than a merge queue enabled here.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -145,6 +145,11 @@
       "status": "implemented",
       "title": "ADR 0028: A panel cell is a glyph in the contract and a column in the host"
     },
+    "adr/0029-branch-protection-stays-non-strict": {
+      "path": "docs/adr/0029-branch-protection-stays-non-strict.md",
+      "status": "implemented",
+      "title": "ADR 0029: Branch protection stays non-strict"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",

--- a/scripts/automerge-nudge.sh
+++ b/scripts/automerge-nudge.sh
@@ -6,18 +6,32 @@
 #   ./scripts/automerge-nudge.sh --select [--base main]   # pure: JSON on stdin
 # --help text ends here.
 #
-# ── The deadlock ─────────────────────────────────────────────────────────────
+# ── The deadlock, and why it is dormant now ──────────────────────────────────
 #
-# Branch protection on `main` sets `required_status_checks.strict` — head
-# branches must be up to date with base. Auto-merge does not update branches on
-# its own. So a PR with every check green and auto-merge armed sits forever at
-# `mergeStateStatus=BEHIND` as soon as `main` moves under it. On 2026-08-05 six
-# of them (#1502/#1504/#1505/#1514/#1515/#1523) piled up that way and only
-# drained because a human loop kept running `gh pr update-branch` by hand.
+# This script drains PRs stuck at GitHub's `mergeStateStatus=BEHIND`. GitHub
+# only reports `BEHIND` when `main`'s branch protection has
+# `required_status_checks.strict` on. That is off today, per ADR 0029:
 #
-# The strict rule is NOT the bug and must stay: the same evening produced the
-# counterexample that justifies it, when two individually-green PRs merged into
-# a semantically incompatible stella-pipeline (#1482/#1462) and broke main.
+#   gh api repos/macanderson/stella/branches/main/protection \
+#     --jq '.required_status_checks.strict'
+#   false
+#
+# With `strict` off, a PR many commits behind main reports `CLEAN`, never
+# `BEHIND`. So `select_pr`'s `BEHIND` filter below can never match anything.
+# The workflow that calls this script
+# (`.github/workflows/automerge-nudge.yml`) runs only on `workflow_dispatch`
+# for the same reason. Both files' headers say how to turn this back on if
+# `strict` returns.
+#
+# Kept for whoever revisits ADR 0029: on 2026-08-05, six PRs
+# (#1502/#1504/#1505/#1514/#1515/#1523) sat at `BEHIND` as soon as `main`
+# moved under them, and drained only because a human ran `gh pr
+# update-branch` by hand, in a loop. `strict` stayed on that day for a
+# reason: the same evening, two green PRs merged into a broken
+# stella-pipeline (#1482/#1462) and broke main. ADR 0029 weighs that
+# trade against today's much higher merge rate and turns `strict` off.
+# `main-canary.yml` and `main-red-hold.yml` catch a broken merge after the
+# fact instead.
 #
 # ── One at a time ────────────────────────────────────────────────────────────
 #

--- a/scripts/test-automerge-nudge.sh
+++ b/scripts/test-automerge-nudge.sh
@@ -94,7 +94,7 @@ want "E4 a CLEAN PR is left alone" \
 want "E5 a DIRTY (conflicted) PR is left alone" \
   "" "[$(pr 305 DIRTY yes no 2026-08-05T10:00:00Z)]"
 
-# A stacked PR targeting another branch is not subject to main's strict rule.
+# A PR aimed at another branch skips main's protection rule.
 want "E6 a PR based on another branch is left alone" \
   "" "[$(pr 306 BEHIND yes no 2026-08-05T10:00:00Z release/0.6)]"
 


### PR DESCRIPTION
## What / why

`#6078` asked whether `main`'s branch protection actually enforces
`required_status_checks.strict`, since two files
(`.github/workflows/automerge-nudge.yml`, `scripts/automerge-nudge.sh`) argue
their whole reason for existing from the premise that it does, while the
issue's own `mergeable_state`/`behind_by` table suggested otherwise.

Settled, with an admin-scoped token:

```
$ gh api repos/macanderson/stella/branches/main/protection \
    --jq '.required_status_checks | {strict, contexts}'
{
  "contexts": [
    "fmt + clippy + test",
    "cargo deny + cargo audit",
    "harbor_adapter + analyzer pytest",
    "main is not known-broken",
    "gate steps no other workflow runs"
  ],
  "strict": false
}
$ gh api repos/macanderson/stella/branches/main/protection --jq '.enforce_admins'
{"enabled": true, ...}
```

`strict` is `false`. `enforce_admins` is `true`.

**This PR does not change that setting.** It records the decision to keep it
off (`docs/adr/0029-branch-protection-stays-non-strict.md`, per SCR-002) and
corrects the two files that were wrong about it.

**Inference vs. observation, per CLAUDE.md's evidence rule:** the `gh api`
output above is a direct observation. That `mergeStateStatus` can never be
`BEHIND` while `strict` is off is an inference — GitHub's docs and this
issue's own `clean`-while-14-commits-behind table both point the same way,
but I did not flip `strict` on this repo to watch `BEHIND` appear. That
inference is what the ADR and the two corrected files' headers are built on.

**One correction to the design pointer I was given, verified in-code:**
`AGENTS.md` was said to contain an `automerge-nudge.yml` section asserting
`strict` is on. `git log -S"automerge-nudge.yml" -- AGENTS.md` and
`git log -S"required_status_checks.strict" -- AGENTS.md` both return nothing —
no commit in this repo's history ever put that claim in `AGENTS.md`. The false
claim lives in the workflow and script headers themselves. This PR fixes those
two files instead, and the ADR states this explicitly so nobody re-greps
`AGENTS.md` for it later.

## Why `strict` stays off (ADR 0029)

Many agent sessions merge into this repository concurrently. Turning `strict`
on would force every open PR through `gh pr update-branch` plus a full
~12-minute CI re-run each time `main` moves — which, under this load, is every
few minutes — serializing merges to a handful an hour and reviving the exact
`BEHIND` pile-up `automerge-nudge.yml` (`#1527`) was built to drain. The
composition risk `strict` would have caught (two individually-green PRs
composing into a broken tree — the shared-cell hazard `AGENTS.md` documents
for `Cargo.lock`/`scripts/file-size-baseline.txt`) is instead caught after the
merge by `main-canary.yml`, and blocked from compounding by the now-required
`main-red-hold.yml`. That is an accepted, named gap, not an unnoticed one.

The durable close for that gap is a GitHub merge queue. `#4998` already asks
that exact question (merge queue vs. a cheaper scheduled composer) and is
still open — I did not fork a second issue asking the same thing; the ADR
cites `#4998` instead.

## What else this PR does

- `.github/workflows/automerge-nudge.yml` and `scripts/automerge-nudge.sh`:
  corrected headers (no longer assert `strict` is on), and both now say their
  `mergeStateStatus == "BEHIND"` selector can never match anything while
  `strict` is off (GitHub only reports `BEHIND` under strict checks). The
  workflow's `push`/`schedule` triggers are disabled — a selector that can
  provably never match has no reason to run on every push to `main` and every
  15 minutes forever — and `workflow_dispatch` is kept, with the exact
  `on:` block to restore if `strict` ever returns written into the comment.
  `scripts/test-automerge-nudge.sh`'s selection-logic tests are unaffected
  (verified: `bash scripts/test-automerge-nudge.sh` → 11/11 pass) since they
  exercise the pure selector, not the trigger.
- `docs/adr/0029-branch-protection-stays-non-strict.md` (+ `docs/adr/README.md`
  index entry, `docs/manifest.json` regenerated via `make doc-links-fix`).
- `AGENTS.md`: no change — it never made the claim.

## Witness / verification

This is a documentation + workflow-trigger change, not library or interface
code — no crate placement question, no god-file growth, no design-system
surface. Per `AGENTS.md`'s witness-test section, docs/CI changes don't need a
fail→pass test; verification here is:

- The `gh api` output above (this issue's "before" row, already recorded).
- `python3 scripts/check-adr-numbering.py` → OK, 29 records, all indexed.
- `python3 scripts/check-doc-links.py check` → OK, 1178 citations resolve.
- `python3 scripts/check-prose.py` → OK (this PR's new/changed prose ships at
  or under its file's reading-grade ceiling and adds zero content-free
  constructions).
- `bash scripts/test-automerge-nudge.sh` → 11/11 pass (selector logic
  untouched).
- `make guards-fast` → full pass locally (see CI for the authoritative run).

No re-run of the `mergeable_state`/`behind_by` table is included, because
this PR does not change `strict` — the DoD item asking for an "after" table
only applies if the fix were to flip the setting, which the ADR explicitly
decides against.

## Tests deleted

None.

## Residue filed

- Commented on `#4998` linking it from this PR/ADR 0029, so whoever picks
  the merge-queue-vs-composer question has the concurrency-load context this
  PR gathered.
- Commented on `#1834` ("automerge-nudge drains only auto-merge-armed PRs...")
  noting its premise (`main requires up-to-date branches`) is now known false,
  since `BEHIND` cannot occur at all while `strict` is off — flagged for
  triage to decide whether it should close as moot.

Closes #6078

## Summary by Sourcery

Document main's non-strict branch protection setting and align the dormant automerge-nudge workflow and script with that decision.

Enhancements:
- Record and preserve the decision to keep main's required status checks non-strict, including its operational trade-offs and follow-up path.
- Correct automerge-nudge documentation to reflect current branch protection behavior and disable automatic triggers that cannot select any BEHIND pull requests.

Documentation:
- Add and index ADR 0029 documenting main's non-strict branch protection decision and its accepted post-merge composition-risk gap.