### PR TITLE
feat(stella-learn): key the trial ledger by artifact, not by skill

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -941,6 +941,7 @@ impl SessionMemory {
         }
         appraisals::record_turn(
             &self.workspace_root,
+            stella_learn::ledger::ArtifactKind::Skill,
             &join.trigger_matched,
             &join.selected,
             &stella_learn::skills::appraisal::SkillTrial {

--- a/crates/stella-cli/src/memory/appraisals.rs
+++ b/crates/stella-cli/src/memory/appraisals.rs
@@ -1,7 +1,7 @@
-//! The skill-appraisal ledger — the durable half of the measured promote/retire
+//! The appraisal ledgers — the durable half of the measured promote/retire
 //! gate (#1067, #1068).
 //!
-//! `stella-core`'s [`stella_learn::skills::appraisal`] decides; this module is
+//! [`stella_learn::skills::appraisal`] decides; this module is
 //! where the evidence lives between sessions, because neither direction of that
 //! gate can be answered from one turn:
 //!
@@ -15,10 +15,25 @@
 //!   trigger matched — and the join is recorded explicitly, never inferred
 //!   from the work a turn produced.
 //!
-//! Both files are append-only JSONL under `.stella/private/` (0700, files
+//! Every file here is append-only JSONL under `.stella/private/` (0700, files
 //! 0600), for the same reason `trace.rs` is: they carry prompts' worth of
 //! context about what a workspace does, and nothing here reaches a store table
 //! an egress path reads (AGENTS.md invariant 3).
+//!
+//! # One trial ledger, three kinds
+//!
+//! [`TRIALS_FILE`] holds a row per artifact per turn, keyed by
+//! [`stella_learn::ledger::ArtifactKind`] and an id. Skills are the only kind
+//! with a producer today. A memory record and a mined rule are recalled by
+//! `memory::recall`, which reports no join, so each needs a seam of its own
+//! before it can be written here. The key is shared so that when those seams
+//! land there is one ledger to read rather than three.
+//!
+//! [`LEGACY_TRIALS_FILE`] holds the rows a build that only knew skills wrote:
+//! a `skill` field and no kind. [`sweep`] reads both files and
+//! [`stella_learn::ledger::ArtifactTrial`] reads both field names, so a
+//! workspace keeps the window it already paid for. Nothing rewrites that
+//! file. An append-only ledger is not edited; it simply stops growing.
 //!
 //! # How the loop closes
 //!
@@ -52,6 +67,7 @@ use std::path::Path;
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use stella_context::ContextStore;
+use stella_learn::ledger::{ArtifactKind, ArtifactTrial};
 use stella_learn::skills::SkillCandidate;
 use stella_learn::skills::appraisal::{
     AppraisalConfig, DemotionDecision, EvalEvidence, SkillAppraisal, SkillTrial, appraise,
@@ -65,8 +81,12 @@ pub const APPRAISALS_FILE: &str = "skill_appraisals.jsonl";
 /// Candidates the eval gate held, newest last.
 pub const QUEUE_FILE: &str = "skill_candidates.jsonl";
 
-/// The selection→outcome join, one line per skill per turn.
-pub const TRIALS_FILE: &str = "skill_trials.jsonl";
+/// The selection→outcome join, one line per artifact per turn.
+pub const TRIALS_FILE: &str = "artifact_trials.jsonl";
+
+/// The same join as [`TRIALS_FILE`], written by a build that only knew
+/// skills. Read, never written, and never rewritten in place.
+pub const LEGACY_TRIALS_FILE: &str = "skill_trials.jsonl";
 
 /// The shared pairing key live trials are recorded under.
 ///
@@ -189,29 +209,33 @@ pub fn queued_candidates(workspace_root: &Path) -> Vec<QueuedCandidate> {
     out
 }
 
-/// Append this turn's trigger→outcome join: one trial per skill whose trigger
-/// matched this turn, `selected` set from the selection the turn actually ran
+/// Append this turn's offered→outcome join: one trial per artifact of `kind`
+/// this turn could have used, `selected` set from what the turn actually ran
 /// with.
 ///
-/// `trigger_matched` is the population, and it has to be exactly that — every
-/// skill the prompt matched, not only the ones injected and not every skill on
-/// disk. Narrower and there is no control arm, so a skill can only be measured
-/// against itself. Wider and the baseline fills with turns the skill's trigger
-/// never matched, which measures those turns rather than the skill.
+/// `offered` is the population, and it has to be exactly that — every artifact
+/// the turn could have injected, not only the ones it did and not everything on
+/// disk. Narrower and there is no control arm, so an artifact can only be
+/// measured against itself. Wider and the baseline fills with turns the
+/// artifact could not have affected, which measures those turns rather than the
+/// artifact. For a skill that population is the skills whose trigger matched
+/// the prompt.
 pub fn record_turn(
     workspace_root: &Path,
-    trigger_matched: &[String],
+    kind: ArtifactKind,
+    offered: &[String],
     selected: &[String],
     trial: &SkillTrial,
 ) {
-    for name in trigger_matched {
+    for id in offered {
         append(
             workspace_root,
             TRIALS_FILE,
-            &StoredTrial {
-                skill: name.clone(),
+            &ArtifactTrial {
+                kind,
+                id: id.clone(),
                 trial: SkillTrial {
-                    selected: selected.iter().any(|s| s == name),
+                    selected: selected.iter().any(|s| s == id),
                     ..trial.clone()
                 },
             },
@@ -219,40 +243,52 @@ pub fn record_turn(
     }
 }
 
-/// One stored trial, keyed by the skill it is evidence about.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct StoredTrial {
-    skill: String,
-    #[serde(flatten)]
-    trial: SkillTrial,
+/// Every trial row the workspace holds, oldest first — the current file after
+/// the legacy one, so a fold that keeps the last write keeps the newest.
+fn stored_trials(workspace_root: &Path) -> Vec<ArtifactTrial> {
+    let mut rows = read_jsonl::<ArtifactTrial>(&path(workspace_root, LEGACY_TRIALS_FILE));
+    rows.extend(read_jsonl::<ArtifactTrial>(&path(
+        workspace_root,
+        TRIALS_FILE,
+    )));
+    rows
 }
 
-/// Appraise every skill the trial ledger has evidence for, and return the
-/// demotion decisions for the ones whose origin allows it.
+/// Appraise every artifact of `kind` the trial ledger has evidence for, and
+/// return the demotion decisions for the ones whose origin allows it.
 ///
-/// `origins` maps a skill name to its origin; a skill absent from it is
-/// treated as hand-authored, which is the fail-safe direction — an unknown
-/// provenance must never be enough to retire something.
+/// The kind is a filter rather than a fan-out because each surface retires on
+/// its own terms: a skill leaves selection, a memory record is retired, a rule
+/// is retracted. One sweep returning all three would hand its caller a list it
+/// has to sort back out.
+///
+/// `origins` maps an id to its origin; an id absent from it is treated as
+/// hand-authored, which is the fail-safe direction — an unknown provenance must
+/// never be enough to retire something.
 pub fn sweep(
     workspace_root: &Path,
+    kind: ArtifactKind,
     origins: &HashMap<String, stella_learn::skills::SkillOrigin>,
     config: &AppraisalConfig,
 ) -> Vec<(SkillAppraisal, DemotionDecision)> {
-    let mut by_skill: HashMap<String, Vec<SkillTrial>> = HashMap::new();
-    for stored in read_jsonl::<StoredTrial>(&path(workspace_root, TRIALS_FILE)) {
-        by_skill.entry(stored.skill).or_default().push(stored.trial);
+    let mut by_id: HashMap<String, Vec<SkillTrial>> = HashMap::new();
+    for stored in stored_trials(workspace_root) {
+        if stored.kind != kind {
+            continue;
+        }
+        by_id.entry(stored.id).or_default().push(stored.trial);
     }
     // Sorted so a sweep's output — and the ledger lines it writes — do not
     // depend on a hash seed.
-    let mut names: Vec<String> = by_skill.keys().cloned().collect();
-    names.sort();
+    let mut ids: Vec<String> = by_id.keys().cloned().collect();
+    ids.sort();
 
     let mut out = Vec::new();
-    for name in names {
-        let trials = by_skill.remove(&name).unwrap_or_default();
-        let appraisal = appraise(&name, &trials, config);
+    for id in ids {
+        let trials = by_id.remove(&id).unwrap_or_default();
+        let appraisal = appraise(&id, &trials, config);
         let origin = origins
-            .get(&name)
+            .get(&id)
             .copied()
             .unwrap_or(stella_learn::skills::SkillOrigin::Workspace);
         let decision = decide_demotion(origin, &appraisal);

--- a/crates/stella-cli/src/memory/appraisals/tests.rs
+++ b/crates/stella-cli/src/memory/appraisals/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the skill-appraisal ledger: the gate's evidence source, the
 //! held-candidate queue, and the retirement sweep.
 
+use stella_learn::ledger::ArtifactKind;
 use stella_learn::self_tuning::TaskOutcome;
 use stella_learn::skills::SkillOrigin;
 use stella_learn::skills::appraisal::{DemotionReason, KeepSkillReason, SkillVerdict};
@@ -51,7 +52,15 @@ fn an_absent_ledger_yields_no_verdicts() {
     let root = workspace("absent");
     assert!(latest_verdicts(&root).is_empty());
     assert!(queued_candidates(&root).is_empty());
-    assert!(sweep(&root, &HashMap::new(), &AppraisalConfig::default()).is_empty());
+    assert!(
+        sweep(
+            &root,
+            ArtifactKind::Skill,
+            &HashMap::new(),
+            &AppraisalConfig::default()
+        )
+        .is_empty()
+    );
 }
 
 /// The newest appraisal per skill wins: a skill that stopped helping must not
@@ -114,16 +123,26 @@ fn a_held_candidate_is_queued_exactly_once() {
 fn the_turn_join_records_the_control_arm_too() {
     let root = workspace("join");
     let matched = vec!["helper".to_string(), "bystander".to_string()];
-    record_turn(&root, &matched, &["helper".to_string()], &trial(true));
-    record_turn(&root, &matched, &[], &trial(false));
+    record_turn(
+        &root,
+        ArtifactKind::Skill,
+        &matched,
+        &["helper".to_string()],
+        &trial(true),
+    );
+    record_turn(&root, ArtifactKind::Skill, &matched, &[], &trial(false));
 
-    let stored = read_jsonl::<StoredTrial>(&path(&root, TRIALS_FILE));
+    let stored = stored_trials(&root);
     assert_eq!(stored.len(), 4, "two skills × two turns");
-    let helper: Vec<&StoredTrial> = stored.iter().filter(|s| s.skill == "helper").collect();
+    assert!(
+        stored.iter().all(|s| s.kind == ArtifactKind::Skill),
+        "the skill seam writes skill rows"
+    );
+    let helper: Vec<&ArtifactTrial> = stored.iter().filter(|s| s.id == "helper").collect();
     assert_eq!(helper.len(), 2);
     assert!(helper[0].trial.selected, "turn one injected it");
     assert!(!helper[1].trial.selected, "turn two is its control");
-    let bystander: Vec<&StoredTrial> = stored.iter().filter(|s| s.skill == "bystander").collect();
+    let bystander: Vec<&ArtifactTrial> = stored.iter().filter(|s| s.id == "bystander").collect();
     assert!(bystander.iter().all(|s| !s.trial.selected));
     let _ = std::fs::remove_dir_all(&root);
 }
@@ -138,15 +157,20 @@ fn the_sweep_demotes_only_the_auto_created_regressor() {
     // Eight turns with both skills injected and failing, eight without them
     // and passing: removing either confidently wins.
     for _ in 0..8 {
-        record_turn(&root, &known, &known, &trial(false));
-        record_turn(&root, &known, &[], &trial(true));
+        record_turn(&root, ArtifactKind::Skill, &known, &known, &trial(false));
+        record_turn(&root, ArtifactKind::Skill, &known, &[], &trial(true));
     }
 
     let origins = HashMap::from([
         ("auto-stale".to_string(), SkillOrigin::AutoCreated),
         ("house-style".to_string(), SkillOrigin::Workspace),
     ]);
-    let swept = sweep(&root, &origins, &AppraisalConfig::default());
+    let swept = sweep(
+        &root,
+        ArtifactKind::Skill,
+        &origins,
+        &AppraisalConfig::default(),
+    );
     assert_eq!(swept.len(), 2);
     // Sorted by skill name, so the order is not a hash seed's.
     let (auto, auto_decision) = &swept[0];
@@ -181,10 +205,15 @@ fn an_unknown_origin_is_never_demoted() {
     let root = workspace("unknown-origin");
     let known = vec!["mystery".to_string()];
     for _ in 0..8 {
-        record_turn(&root, &known, &known, &trial(false));
-        record_turn(&root, &known, &[], &trial(true));
+        record_turn(&root, ArtifactKind::Skill, &known, &known, &trial(false));
+        record_turn(&root, ArtifactKind::Skill, &known, &[], &trial(true));
     }
-    let swept = sweep(&root, &HashMap::new(), &AppraisalConfig::default());
+    let swept = sweep(
+        &root,
+        ArtifactKind::Skill,
+        &HashMap::new(),
+        &AppraisalConfig::default(),
+    );
     assert_eq!(swept.len(), 1);
     assert_eq!(
         swept[0].1,
@@ -226,5 +255,88 @@ fn the_ledgers_are_owner_only() {
         .mode()
         & 0o777;
     assert_eq!(mode, 0o600);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **The witness for the shared key.** Two artifacts of different kinds can
+/// share an id, and the sweep for one kind must not read the other's turns.
+///
+/// This cannot be written against the ledger that came before: a row was
+/// filed under a skill name and nothing else, so there was no way to record a
+/// memory trial at all, and no second kind for a skill sweep to pick up by
+/// mistake. The memory rows below say the opposite of the skill rows, so a
+/// sweep that mixed them would find no lift instead of harm.
+#[test]
+fn a_sweep_reads_only_its_own_kind() {
+    let root = workspace("kinds");
+    let shared = vec!["shared-id".to_string()];
+    for _ in 0..8 {
+        // The skill hurts: injected turns fail, withheld turns pass.
+        record_turn(&root, ArtifactKind::Skill, &shared, &shared, &trial(false));
+        record_turn(&root, ArtifactKind::Skill, &shared, &[], &trial(true));
+        // The memory under the same id does the reverse.
+        record_turn(&root, ArtifactKind::Memory, &shared, &shared, &trial(true));
+        record_turn(&root, ArtifactKind::Memory, &shared, &[], &trial(false));
+    }
+
+    let origins = HashMap::from([("shared-id".to_string(), SkillOrigin::AutoCreated)]);
+    let skills = sweep(
+        &root,
+        ArtifactKind::Skill,
+        &origins,
+        &AppraisalConfig::default(),
+    );
+    assert_eq!(skills.len(), 1);
+    assert!(
+        matches!(skills[0].0.verdict, SkillVerdict::Harms { .. }),
+        "the skill's own turns say it hurts: {:?}",
+        skills[0].0.verdict
+    );
+
+    let memories = sweep(
+        &root,
+        ArtifactKind::Memory,
+        &origins,
+        &AppraisalConfig::default(),
+    );
+    assert_eq!(memories.len(), 1);
+    assert!(
+        matches!(memories[0].0.verdict, SkillVerdict::Helps { .. }),
+        "and the memory's say it helps: {:?}",
+        memories[0].0.verdict
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A workspace with history keeps it. The rows a build before this one wrote
+/// live in another file, under another field name, with no kind on them —
+/// and the skill sweep still reads them as the skill turns they are.
+#[test]
+fn the_sweep_still_reads_the_rows_an_older_build_wrote() {
+    let root = workspace("legacy");
+    let mut lines = String::new();
+    for _ in 0..8 {
+        for (selected, succeeded) in [(true, false), (false, true)] {
+            lines.push_str(&format!(
+                r#"{{"skill":"old-timer","task":"live-window","selected":{selected},"outcome":{{"succeeded":{succeeded},"cost_usd":0.1,"tokens":1000,"retries":0}},"turns":4}}"#
+            ));
+            lines.push('\n');
+        }
+    }
+    let target = path(&root, LEGACY_TRIALS_FILE);
+    std::fs::create_dir_all(target.parent().expect("a parent")).expect("the private dir");
+    std::fs::write(&target, lines).expect("the legacy ledger");
+
+    let origins = HashMap::from([("old-timer".to_string(), SkillOrigin::AutoCreated)]);
+    let swept = sweep(
+        &root,
+        ArtifactKind::Skill,
+        &origins,
+        &AppraisalConfig::default(),
+    );
+    assert_eq!(swept.len(), 1, "the old file is still a window");
+    assert_eq!(swept[0].0.skill, "old-timer");
+    assert!(matches!(swept[0].0.verdict, SkillVerdict::Harms { .. }));
+    assert!(swept[0].1.is_demotion());
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -680,6 +680,7 @@ impl SessionMemory {
 
         for (appraisal, decision) in super::appraisals::sweep(
             &self.workspace_root,
+            stella_learn::ledger::ArtifactKind::Skill,
             &origins,
             &stella_learn::skills::appraisal::AppraisalConfig::default(),
         ) {

--- a/crates/stella-cli/src/memory/learning/skill_lifecycle.rs
+++ b/crates/stella-cli/src/memory/learning/skill_lifecycle.rs
@@ -83,13 +83,15 @@ fn session(root: &Path) -> SessionMemory {
 
 /// The `selected` flag of every trial the ledger holds for `skill`, in the
 /// order they were appended. Read as raw JSON rather than through
-/// `appraisals`' private row type, so the test reads the file the sweep reads.
+/// `appraisals`' row type, so the test reads the file the sweep reads — the
+/// kind and the id included, because a row filed under the wrong kind would
+/// still fold under the right id.
 fn trials(root: &Path, skill: &str) -> Vec<bool> {
     std::fs::read_to_string(root.join(".stella/private").join(appraisals::TRIALS_FILE))
         .unwrap_or_default()
         .lines()
         .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-        .filter(|row| row["skill"].as_str() == Some(skill))
+        .filter(|row| row["kind"].as_str() == Some("skill") && row["id"].as_str() == Some(skill))
         .map(|row| row["selected"].as_bool().unwrap_or(false))
         .collect()
 }

--- a/crates/stella-learn/README.md
+++ b/crates/stella-learn/README.md
@@ -2,7 +2,7 @@
 
 What the agent learns, and what steers it.
 
-Five module trees do the work.
+These module trees do the work.
 
 - `skills` — the skill catalog. Read a `SKILL.md` file. Pick the skills a
   prompt needs. Render the block the prompt carries. Mine new ones out of
@@ -17,6 +17,9 @@ Five module trees do the work.
 - `holdout` — the schedule that makes the arm they compare against. On some
   turns it names one item to leave out, so that item gets a control arm. The
   item is an opaque id, so one schedule serves skills, memories and rules.
+- `ledger` — one row of the trial ledger, and the key it is filed under: a
+  kind and an id. A row can name a memory, a rule or a skill, so the three
+  surfaces share one ledger rather than keeping one each.
 - `redact` — strip secrets out of text before it leaves the machine.
 
 ## Boundary
@@ -58,6 +61,7 @@ clause (b). `stella-records` needs the rule parser and the redactor, and
 | Change the A/B report shape | `src/comparison/report.rs` |
 | Change the stats test | `src/self_tuning.rs` |
 | Change how often a holdout fires, or which item it picks | `src/holdout.rs` |
+| Add a kind of artifact the trial ledger can hold | `src/ledger.rs` |
 
 ## God files — do not add lines
 

--- a/crates/stella-learn/src/ledger.rs
+++ b/crates/stella-learn/src/ledger.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One row of the trial ledger, and the key it is filed under.
+//!
+//! Memory records, skills, and mined rules all change on evidence, and each
+//! of them asks one question. Does putting this in front of the model change
+//! how the turn goes?
+//!
+//! [`crate::comparison`] answers it and [`crate::skills::appraisal`] drives
+//! it. Neither knows what an arm names, and [`crate::holdout`] does not know
+//! what an id names either. That is what lets one engine serve all three.
+//!
+//! A row is what the answer is built from, so a row has to name the artifact
+//! it is about. [`ArtifactKind`] plus an id is a key all three fit.
+//!
+//! No I/O here. A row is a plain serde shape, and the caller owns the file.
+
+use serde::{Deserialize, Serialize};
+
+use crate::skills::appraisal::SkillTrial;
+
+/// Which of the three surfaces a trial is evidence about.
+///
+/// Small on purpose. A kind earns a place here when something can be held
+/// back and measured, not when it merely exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactKind {
+    /// A memory the recall query put in front of the model.
+    Memory,
+    /// A published context record — what a mined rule becomes.
+    Rule,
+    /// A skill the selector injected.
+    Skill,
+}
+
+impl ArtifactKind {
+    /// The `snake_case` word the ledger writes, and the one a reader sees.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::Rule => "rule",
+            Self::Skill => "skill",
+        }
+    }
+}
+
+/// One ledger row: which artifact the trial is about, and the trial.
+///
+/// The trial is flattened, so a row stays one flat JSON object and the
+/// fields an older build wrote keep the names it wrote them under.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArtifactTrial {
+    /// Which surface [`Self::id`] names.
+    ///
+    /// A row with no kind on it reads as [`ArtifactKind::Skill`], because a
+    /// build that wrote no kind wrote skill rows and nothing else. The ledger
+    /// is append-only and a workspace has months of it on disk, so a default
+    /// here is what saves a pass over the file.
+    #[serde(default = "skill_kind")]
+    pub kind: ArtifactKind,
+    /// The artifact's stable id: a skill slug, a memory id, a record handle.
+    ///
+    /// `skill` is what the older build called this field, so it is read as an
+    /// alias. New rows are written under `id`.
+    #[serde(alias = "skill")]
+    pub id: String,
+    /// The turn, and whether the artifact was part of it.
+    #[serde(flatten)]
+    pub trial: SkillTrial,
+}
+
+/// What a row with no kind meant. See [`ArtifactTrial::kind`].
+fn skill_kind() -> ArtifactKind {
+    ArtifactKind::Skill
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::self_tuning::TaskOutcome;
+
+    fn trial(selected: bool) -> SkillTrial {
+        SkillTrial {
+            task: "live-window".into(),
+            selected,
+            outcome: TaskOutcome {
+                succeeded: true,
+                cost_usd: 0.1,
+                tokens: 1_000,
+                retries: 0,
+            },
+            turns: 4,
+        }
+    }
+
+    /// A row a build before this one wrote still loads, and it loads as the
+    /// skill row it was. The ledger is append-only, so this is the only way
+    /// a workspace keeps the window it already paid for.
+    #[test]
+    fn a_row_written_before_kinds_existed_reads_as_a_skill() {
+        let old = r#"{"skill":"prefer-tables","task":"live-window","selected":true,
+            "outcome":{"succeeded":true,"cost_usd":0.1,"tokens":1000,"retries":0},"turns":4}"#;
+        let row: ArtifactTrial = serde_json::from_str(old).expect("a skill-only row still loads");
+        assert_eq!(row.kind, ArtifactKind::Skill);
+        assert_eq!(row.id, "prefer-tables");
+        assert_eq!(row.trial, trial(true));
+    }
+
+    /// A new row names its kind and its id, and reads back the same.
+    #[test]
+    fn a_row_round_trips_through_json() {
+        let row = ArtifactTrial {
+            kind: ArtifactKind::Memory,
+            id: "nod_7f".into(),
+            trial: trial(false),
+        };
+        let raw = serde_json::to_string(&row).expect("a row serializes");
+        assert!(raw.contains(r#""kind":"memory""#), "{raw}");
+        assert!(raw.contains(r#""id":"nod_7f""#), "{raw}");
+        assert_eq!(
+            serde_json::from_str::<ArtifactTrial>(&raw).expect("and reads back"),
+            row
+        );
+    }
+
+    /// The word on the wire and the word a reader sees are one word.
+    #[test]
+    fn every_kind_writes_the_word_it_names() {
+        for kind in [
+            ArtifactKind::Memory,
+            ArtifactKind::Rule,
+            ArtifactKind::Skill,
+        ] {
+            let raw = serde_json::to_string(&kind).expect("a kind serializes");
+            assert_eq!(raw, format!("\"{}\"", kind.as_str()));
+        }
+    }
+}

--- a/crates/stella-learn/src/lib.rs
+++ b/crates/stella-learn/src/lib.rs
@@ -3,11 +3,11 @@
 
 //! What the agent learns, and what steers it.
 //!
-//! Six trees live here. `skills` is the skill catalog. `rules` is the rule
-//! engine. `mining` is the text miner both of them share. `comparison` and
-//! `self_tuning` answer whether arm B beat arm A. `holdout` is the schedule
-//! that makes the arm they compare against. `redact` strips secrets out of
-//! text.
+//! `skills` is the skill catalog. `rules` is the rule engine. `mining` is
+//! the text miner both of them share. `comparison` and `self_tuning` answer
+//! whether arm B beat arm A. `holdout` is the schedule that makes the arm
+//! they compare against, and `ledger` is the row those turns are filed under.
+//! `redact` strips secrets out of text.
 //!
 //! No I/O. Every entry point is a plain function. A caller reads the file
 //! and hands the text in. `RuleSource` and `SkillSource` are the ports for
@@ -22,6 +22,7 @@
 
 pub mod comparison;
 pub mod holdout;
+pub mod ledger;
 pub(crate) mod mining;
 pub mod redact;
 pub mod rules;


### PR DESCRIPTION
## What and why

Slice **A** of epic #5200, second half — the trial ledger row.

The ledger was keyed by skill, not by artifact.
`crates/stella-cli/src/memory/appraisals.rs` wrote
`.stella/private/skill_trials.jsonl` as
`StoredTrial { skill: String, #[serde(flatten)] trial: SkillTrial }`. No
artifact kind on the row, and `SkillTrial` carries none either — so a memory
record and a mined rule had nowhere to be recorded. #5200 asks for "one
ledger, three kinds"; there was one ledger and one kind.

This adds the row. Giving a memory record and a mined rule a turn-end seam of
their own is #6096, per the scope narrowing on #6068.

- `crates/stella-learn/src/ledger.rs` (new) — `ArtifactKind`
  (`Memory` / `Rule` / `Skill`) and `ArtifactTrial { kind, id, trial }`. Plain
  serde shapes, no I/O; the caller owns the file, so the crate keeps its
  no-I/O boundary and its single `stella-protocol` workspace dependency.
- `appraisals.rs` — `record_turn` and `sweep` take an `ArtifactKind`. The
  sweep filters on the kind and folds by id. `appraise` and `decide_demotion`
  are untouched: `ArtifactTrial` wraps the `SkillTrial` they already take.
- New rows go to `artifact_trials.jsonl` (`TRIALS_FILE`). The old file stays
  as `LEGACY_TRIALS_FILE`, read beside it and never rewritten — an
  append-only ledger is not edited, it simply stops growing.

## Backward compatibility

A workspace has months of ledger on disk. `ArtifactTrial::kind` defaults to
`Skill` when a row carries none, and `id` reads `skill` as a serde alias, so
every row an older build wrote still loads as the skill row it is.

## Witness mechanism

Two tests carry the change, and neither can be written against the ledger
that came before — a row was filed under a skill name and nothing else, so
there was no second kind for a sweep to pick up by mistake and no way to
record a memory trial at all.

- `a_sweep_reads_only_its_own_kind` (`appraisals/tests.rs`) — two artifacts
  share one id, and their turns say the opposite of each other. The skill
  sweep returns `Harms`, the memory sweep returns `Helps`. A sweep that mixed
  them would find no lift instead of harm.
- `the_sweep_still_reads_the_rows_an_older_build_wrote` — a hand-written
  legacy file, `skill` field and no kind, still folds into the skill sweep and
  still produces a demotion.

Beside them in `ledger.rs`: `a_row_written_before_kinds_existed_reads_as_a_skill`,
`a_row_round_trips_through_json`, and `every_kind_writes_the_word_it_names`.

## Tests deleted

None.

## Residue

None new. #6096 (the memory and rule turn-end seams) and #6067 (the
per-artifact holdout scheduler) were already filed and are what this
unblocks.

Closes #6068

---

**Description corrected 2026-09-05 by an autonomous PR sweep.** This body was
previously a verbatim copy of #6095's, describing the SETTINGS SEATS pane and
carrying `Closes #3909`. That diff is #6095's, not this one — merging this PR
would have closed #3909 (which #6095 owns) and left #6068 open. The text above
is written from this PR's actual diff.