### PR TITLE
feat(stella-tui): the seats pane lists the session's own role, not just the plugins'

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -23,7 +23,7 @@ use super::*;
 /// conflated: a call routed to a smaller-context or non-reasoning model still
 /// got the session model's clamps, which is the wire-shape/400 class #273
 /// exists to warn about. The role that used to diverge here was the worker's;
-/// the ones that will diverge again are plugin-declared seats (#3909), which
+/// the ones that will diverge again are plugin-declared seats, which
 /// resolve their own model through [`crate::agent::seats`].
 fn tuned_engine_config(cfg: &Config, catalog_ref: (&str, &str)) -> EngineConfig {
     let (provider_id, model_id) = catalog_ref;

--- a/crates/stella-cli/src/command_deck/model_cmd.rs
+++ b/crates/stella-cli/src/command_deck/model_cmd.rs
@@ -86,7 +86,7 @@ pub fn configured_role_pins(
     // both: settings can no longer express a model for either, so publishing a
     // pin for them would be the deck reporting an intent nothing recorded.
     // They now render unconfigured, which is what they are — and what a
-    // plugin's declared seat will replace in #3909.
+    // plugin's declared seat will replace in #6088.
     [PipelineRole::Worker]
         .into_iter()
         .map(|slot| {

--- a/crates/stella-cli/src/config_wiring.rs
+++ b/crates/stella-cli/src/config_wiring.rs
@@ -26,8 +26,8 @@
 //! product to be wrong.
 //!
 //! The shape stays a `Vec` rather than collapsing to one struct because the
-//! rows come back in slice 5 (#3909) as **plugin-declared seats**, resolved
-//! the same way and rendered by the same `/models` dialog.
+//! rows come back as **plugin-declared seats**, resolved the same way and
+//! rendered by the same `/models` dialog (#6088).
 //! [`RoleWiring::role`] is a `String` for that reason: the deck's
 //! `envelope::roles::role_table` already renders a row for a role it has never
 //! heard of, so a seat needs no new plumbing here — only a row.
@@ -36,13 +36,13 @@ use crate::engine_config::{ModelSpec, model_spec_for, tuning_for};
 use crate::settings::AgentEngineConfig;
 use stella_protocol::ReasoningEffort;
 
-/// The one role core has. Seats a plugin declares join this list in #3909.
+/// The one role core has. Seats a plugin declares join this list in #6088.
 pub const DEFAULT_ROLE: &str = "default";
 
 /// One role's resolved wiring.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RoleWiring {
-    /// The role's name — [`DEFAULT_ROLE`], or (from #3909) a plugin-declared
+    /// The role's name — [`DEFAULT_ROLE`], or (from #6088) a plugin-declared
     /// seat. A `String` because core does not enumerate the possibilities.
     pub role: String,
     /// Provider id and the slug as it goes on the wire.

--- a/crates/stella-cli/src/engine_config.rs
+++ b/crates/stella-cli/src/engine_config.rs
@@ -617,10 +617,10 @@ pub fn state_from_settings(
     let agents = EngineRole::ALL
         .iter()
         .map(|role| {
-            // One role, so one arm. The `match` survives the collapse
-            // deliberately: slice 5 (#3909) re-populates this from the live
-            // session's plugin seats, and a `match` is where each new row's
-            // source lands.
+            // One role, so one arm. The `match` survives the collapse so a
+            // second editable agent has somewhere to declare where its
+            // overrides come from. Plugin seats did not become one: they are
+            // `seats` below, an open map the deck reads beside this list.
             let agent = match role {
                 EngineRole::Default => engine.agent(),
             };

--- a/crates/stella-cli/src/profile.rs
+++ b/crates/stella-cli/src/profile.rs
@@ -273,7 +273,7 @@ pub struct Plan {
     /// The session role's pick.
     ///
     /// One, since #3908. A `Vec` rather than a bare `RolePick` because the
-    /// entries come back as plugin-declared seats in #3909, and every consumer
+    /// entries come back as plugin-declared seats in #6088, and every consumer
     /// here already iterates.
     pub picks: Vec<RolePick>,
     pub verbosity: Verbosity,

--- a/crates/stella-tui/src/envelope/engine_config.rs
+++ b/crates/stella-tui/src/envelope/engine_config.rs
@@ -17,13 +17,13 @@
 /// stopped steering anything. An overlay tab that writes a dead key is worse
 /// than a missing tab — it reports success.
 ///
-/// It stays an enum rather than collapsing into a bare struct because the
-/// pane's replacement is a **list**, not a single row: slice 5 (#3909) turns
-/// this into rows from the live session — the installed plugins' declared
-/// seats, each with its assigned model or `default` — the way
-/// `views/tools.rs` already sources MCP and custom tools. Keeping the
-/// role-indexed shape is what lets that land without re-plumbing
-/// `EngineConfigState`.
+/// It stays an enum rather than collapsing into a bare struct because a
+/// second editable agent would be one more name in this list rather than a new
+/// shape everywhere. The plugin seats are not in it: they are
+/// [`EngineConfigState::seats`], an open list the SEATS pane draws beside the
+/// resolved roles ([`crate::views::seats::rows`]), the way `views/tools.rs`
+/// sources MCP and custom tools. This enum indexes
+/// `agent_engine_config.agents` and nothing more.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EngineRole {
     Default,

--- a/crates/stella-tui/src/views/seats.rs
+++ b/crates/stella-tui/src/views/seats.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! The SEATS pane — which model each **plugin-declared** role runs on:
+//! The SEATS pane — which model each role of this session runs on:
 //!
 //! ```text
-//! seats · 2 · read-only
+//! seats · 3 · read-only
+//!  default               zai/glm-5.2               from default_model
 //!  acme/second-opinion   anthropic/claude-opus-5   from acme
 //!  vera/test_author      default                   from vera
 //! ```
@@ -21,14 +22,33 @@
 //! removed — which is the whole contract, and why this file contains no list of
 //! roles and no `match` on a role name.
 //!
+//! # The session's own role leads the list
+//!
+//! [`rows`] puts the roles the driver **resolved** first
+//! ([`EngineConfigState::roles`], an open list of names the driver chose —
+//! today just `default`), then the roles installed plugins **declared**. The
+//! driver supplies each one, so the pane still names nothing: a session with
+//! no plugin shows its one role, and a plugin declaring `reviewer` makes that
+//! two rows.
+//!
+//! Leading with the resolved role is what lets the pane answer the question a
+//! reader brings to it. Plugin seats alone say which roles run on a model of
+//! their own and leave "then what runs everything else?" unanswered, while
+//! `default` is the model every unassigned row above already points at.
+//!
 //! # What a row says, and what it does not
 //!
-//! Each row is a seat key (`<plugin-id>/<role>`, `doc:roleless-core` §8.4), the
-//! model assigned to it, and the plugin it came from. The key is **rendered
-//! whole and never split**: the deck has no business knowing which half is the
-//! plugin, which is why [`stella_protocol`]-side callers send
-//! [`SeatRow::from`](crate::envelope::SeatRow::from) separately rather than
-//! letting this pane parse it out.
+//! Each row is a name, the model it runs on, and where that answer came from.
+//! For a plugin seat the name is a seat key (`<plugin-id>/<role>`,
+//! `doc:roleless-core` §8.4) and the source is the plugin. For a resolved role
+//! the source is the settings key that chose the model — `default_model`,
+//! `agents.default.model`, `session default`, `--model (this invocation)` —
+//! pre-rendered driver-side like every other cell in this module tree.
+//!
+//! A seat key is **rendered whole and never split**: the deck has no business
+//! knowing which half is the plugin, which is why [`stella_protocol`]-side
+//! callers send [`SeatRow::from`](crate::envelope::SeatRow::from) separately
+//! rather than letting this pane parse it out.
 //!
 //! An unassigned seat renders as `default`, not as a blank. That is the truth —
 //! an unassigned seat genuinely runs on the session's model — and a blank cell
@@ -37,15 +57,11 @@
 //! # Read-only, for now, and that is a smaller claim than AGENTS makes
 //!
 //! This pane renders; it does not edit. Assigning a model writes
-//! `agent_engine_config.seat_models`, which is #3909's second half — the
-//! editor arrives with the AGENTS pane's persona tabs leaving
-//! (`doc:roleless-core` slice 5b), because until then the two panes would
-//! offer two different ways to say the same thing. Rendering a seat the user
-//! cannot yet edit reflects what the driver already knows; editing one whose
-//! settings block is about to be restructured would not. The header says
-//! `read-only` so a reader who pressed
-//! `e` and saw nothing happen learns why from the screen rather than from the
-//! source.
+//! `agent_engine_config.seat_models`, and that editor is #6086. Rendering a
+//! seat the user cannot yet edit reflects what the driver already knows;
+//! editing one before the write path is proved would not. The header says
+//! `read-only` so a reader who pressed `e` and saw nothing happen learns why
+//! from the screen rather than from the source.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -54,7 +70,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
 use stella_tui_theme::token;
 
-use crate::envelope::SeatRow;
+use crate::envelope::{EngineConfigState, SeatRow};
 use crate::render::columns;
 
 /// Shown when the driver has not delivered an engine snapshot yet — a race
@@ -62,11 +78,11 @@ use crate::render::columns;
 /// remedy) as the TOOLS panel's.
 const NO_SNAPSHOT_HINT: &str = "waiting for the seat list — r to reload";
 
-/// Shown when the snapshot arrived and named no seats.
+/// Shown when the snapshot arrived and named no rows at all — no resolved role
+/// and no declared seat.
 ///
-/// Not an apology or an error. No plugin declaring a role is the
-/// ordinary state of a fresh install, and the line says what would change it
-/// rather than implying something is missing.
+/// Not an apology or an error. The line says what runs instead rather than
+/// implying something is missing.
 const NO_SEATS_HINT: &str = "no installed plugin declares a role — every turn runs on the default \
                              model";
 
@@ -86,10 +102,37 @@ const MIN_KEY_CELLS: usize = 12;
 /// Cells between two columns.
 const GAP: usize = 3;
 
+/// The pane's rows: the roles the driver resolved, then the roles installed
+/// plugins declared.
+///
+/// A pure fold over the snapshot, which is what lets the painter below stay a
+/// painter. Every row comes from the driver — this function holds no list of
+/// role names, and adding one is the defect it exists to prevent.
+///
+/// A resolved role takes the same row shape as a declared seat: its name, the
+/// model it resolved to, and the settings key that chose that model. Its model
+/// is always `Some`, because a resolved role has one by definition; an
+/// unassigned plugin seat stays `None` and renders as `default`.
+#[must_use]
+pub fn rows(state: &EngineConfigState) -> Vec<SeatRow> {
+    state
+        .roles
+        .iter()
+        .map(|role| SeatRow {
+            key: role.role.clone(),
+            model: Some(role.model.clone()),
+            from: role.source.clone(),
+        })
+        .chain(state.seats.iter().cloned())
+        .collect()
+}
+
 /// Draw the SEATS pane into `area`.
 ///
 /// `seats` is `None` while the driver has sent no engine snapshot, which is a
-/// different fact from an empty slice and renders as a different line.
+/// different fact from an empty slice and renders as a different line. Build
+/// the slice with [`rows`] rather than handing over a raw seat list, or the
+/// session's own role goes missing from its own seat list.
 pub fn render(seats: Option<&[SeatRow]>, area: Rect, buf: &mut Buffer) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -248,6 +291,108 @@ mod tests {
             model: model.map(str::to_string),
             from: from.to_string(),
         }
+    }
+
+    /// One resolved role as the driver sends it: a name, the model it landed
+    /// on, and the settings key that chose it.
+    fn resolved(role: &str, model: &str, source: &str) -> crate::envelope::RoleWiringRow {
+        crate::envelope::RoleWiringRow {
+            role: role.to_string(),
+            model: model.to_string(),
+            source: source.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn snapshot(
+        roles: Vec<crate::envelope::RoleWiringRow>,
+        seats: Vec<SeatRow>,
+    ) -> EngineConfigState {
+        EngineConfigState {
+            roles,
+            seats,
+            ..Default::default()
+        }
+    }
+
+    /// The keys of the rows [`rows`] folds out of a snapshot, in order.
+    fn keys(state: &EngineConfigState) -> Vec<String> {
+        rows(state).into_iter().map(|row| row.key).collect()
+    }
+
+    /// **The witness.** One plugin declaring `reviewer`, and the pane is two
+    /// rows: the session's own role first, then the plugin's.
+    ///
+    /// The fold is what puts the first row there. A pane handed `state.seats`
+    /// alone draws one row and never names the model everything else runs on,
+    /// which is what this asserts against.
+    #[test]
+    fn the_session_role_leads_the_plugin_seats() {
+        let state = snapshot(
+            vec![resolved("default", "zai/glm-5.2", "default_model")],
+            vec![seat("acme/reviewer", None, "acme")],
+        );
+        assert_eq!(keys(&state), ["default", "acme/reviewer"]);
+
+        let folded = rows(&state);
+        let text = draw(Some(&folded), 90, 12);
+        assert!(text.contains("seats · 2 · read-only"), "{text}");
+        assert!(text.contains("zai/glm-5.2"), "{text}");
+        assert!(text.contains("from default_model"), "{text}");
+        assert!(text.contains("acme/reviewer"), "{text}");
+    }
+
+    /// A fresh install has no plugin, and the pane is the one row the session
+    /// does have rather than a hint that it has none.
+    #[test]
+    fn a_session_with_no_plugin_still_shows_its_own_role() {
+        let state = snapshot(
+            vec![resolved(
+                "default",
+                "anthropic/claude-opus-5",
+                "session default",
+            )],
+            Vec::new(),
+        );
+        assert_eq!(keys(&state), ["default"]);
+
+        let folded = rows(&state);
+        let text = draw(Some(&folded), 90, 12);
+        assert!(text.contains("anthropic/claude-opus-5"), "{text}");
+        assert!(!text.contains("no installed plugin"), "{text}");
+    }
+
+    /// The fold names nothing. A driver that calls the session's own role
+    /// something else gets that word back, which is what proves the row is
+    /// read rather than written here.
+    #[test]
+    fn the_leading_row_is_named_by_the_driver_not_by_this_pane() {
+        let state = snapshot(
+            vec![resolved("lead", "zai/glm-5.2", "default_model")],
+            vec![],
+        );
+        assert_eq!(keys(&state), ["lead"]);
+    }
+
+    /// A snapshot the driver sent no rows in draws the hint, not an invented
+    /// `default` row: the pane must not answer a question the driver has not.
+    #[test]
+    fn an_empty_snapshot_invents_no_row() {
+        assert!(rows(&EngineConfigState::default()).is_empty());
+    }
+
+    /// An unassigned plugin seat stays unassigned through the fold. Filling it
+    /// with the leading row's model would make it indistinguishable from a
+    /// seat somebody pinned there.
+    #[test]
+    fn the_fold_leaves_an_unassigned_seat_unassigned() {
+        let state = snapshot(
+            vec![resolved("default", "zai/glm-5.2", "default_model")],
+            vec![seat("vera/test_author", None, "vera")],
+        );
+        let folded = rows(&state);
+        assert_eq!(folded[0].model.as_deref(), Some("zai/glm-5.2"));
+        assert_eq!(folded[1].model, None);
     }
 
     /// **The witness.** A role no core enum has ever heard of renders, because

--- a/crates/stella-tui/src/views/settings.rs
+++ b/crates/stella-tui/src/views/settings.rs
@@ -8,9 +8,9 @@
 //!   toggles.
 //! - **TOOLS** ([`crate::views::tools`]): which of this session's tools are
 //!   switched off.
-//! - **SEATS** ([`crate::views::seats`]): which model each **plugin-declared**
-//!   role runs on. Read-only for now; the editor arrives with the AGENTS
-//!   pane's persona tabs leaving (`doc:roleless-core` slice 5b).
+//! - **SEATS** ([`crate::views::seats`]): which model each role runs on. The
+//!   role this session resolved, then one row per plugin-declared role. It
+//!   draws them; nothing writes them yet.
 //! - **one pane per installed plugin** that declares
 //!   `PanelSurface::Settings` (SPEC 12.2), drawn from the last frame that
 //!   plugin sent and labelled with the name its installer consented to.
@@ -190,11 +190,13 @@ pub fn render(_model: &WorkspaceModel, ui: &mut DeckUi, area: Rect, buf: &mut Bu
     match ui.settings_pane {
         SettingsPane::Agents => crate::views::engine_panel::render(ui, body, buf),
         SettingsPane::Tools => crate::views::tools::render_panel(ui, body, buf),
-        SettingsPane::Seats => crate::views::seats::render(
-            ui.engine.state.as_ref().map(|state| &state.seats[..]),
-            body,
-            buf,
-        ),
+        // Through the pane's own fold, never the raw seat slice: the list is
+        // the session's resolved roles followed by the plugin-declared ones,
+        // and handing over `state.seats` alone drops the first half.
+        SettingsPane::Seats => {
+            let rows = ui.engine.state.as_ref().map(crate::views::seats::rows);
+            crate::views::seats::render(rows.as_deref(), body, buf);
+        }
         // The plugin's own rectangle, drawn from the last frame it sent. The
         // chrome round it is the host's (`crate::plugin_panel::chrome`), so a
         // pane a plugin fills is still labelled by the name its installer read.
@@ -239,8 +241,8 @@ pub fn handle_key(
         }),
         // `e` edits what you are looking at — the one key every pane shares,
         // rather than a per-pane letter to remember. SEATS has no editor yet
-        // (`crate::views::seats`, slice 5b), so it claims the key and does
-        // nothing rather than silently focusing a different pane's editor.
+        // (`crate::views::seats`), so it claims the key and does nothing
+        // rather than silently focusing a different pane's editor.
         KeyCode::Char('e') => Some(match ui.settings_pane {
             SettingsPane::Agents => crate::views::engine_panel::focus_panel(ui),
             SettingsPane::Tools => crate::views::tools::focus_panel(ui),

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -126,6 +126,11 @@ mod plan_economics;
 #[path = "deck_render_snapshots/voice.rs"]
 mod voice;
 
+/// The SETTINGS tab's SEATS pane. See [`graph`]'s doc for the `#[path]`, and
+/// [`plan_economics`]'s for why this line is appended.
+#[path = "deck_render_snapshots/settings_seats.rs"]
+mod settings_seats;
+
 /// The command used to regenerate every golden in this file. Quoted verbatim in
 /// each snapshot header and in every failure message, so nobody has to go
 /// looking for it.

--- a/crates/stella-tui/tests/deck_render_snapshots/settings_seats.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots/settings_seats.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The SEATS pane of the SETTINGS tab, with one plugin seat on screen.
+//!
+//! A child of `deck_render_snapshots`, like [`super::voice`]. The parent file
+//! is near its size cap.
+//!
+//! **The witness.** The pane lists the role this session resolved. Then it
+//! lists each role a plugin declares. So one plugin makes two rows. Fed the
+//! plugin seats alone, the pane draws one row. It then says nothing at all
+//! about the model the rest of the turn runs on.
+//!
+//! The fixture is its own, not `super::base_ui`'s. The demo config still
+//! names five roles the config collapse took away. A golden of this pane
+//! would teach words the product does not have.
+
+use stella_tui::envelope::{EngineConfigState, RoleWiringRow};
+use stella_tui::{DeckTab, SeatRow, SettingsPane};
+
+use super::{H, W, assert_golden, fixture_model, render_frame, ui_for};
+
+/// One session role and one plugin. That is the least a fixture needs to tell
+/// the two halves of the list apart.
+fn fixture_seats() -> EngineConfigState {
+    EngineConfigState {
+        roles: vec![RoleWiringRow {
+            role: "default".to_string(),
+            model: "zai/glm-5.2-air".to_string(),
+            effort: "medium".to_string(),
+            thinking: "thinking on".to_string(),
+            source: "default_model".to_string(),
+            next_session: None,
+        }],
+        seats: vec![SeatRow {
+            key: "acme/reviewer".to_string(),
+            // No model, so the frame pins what such a row says: the word
+            // `default`, not a blank cell.
+            model: None,
+            from: "acme".to_string(),
+        }],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn deck_render_snapshots_pin_the_settings_seats_pane() {
+    let model = fixture_model();
+    let mut ui = ui_for(DeckTab::Settings);
+    ui.settings_pane = SettingsPane::Seats;
+    // Through the fold a driver snapshot takes, never by hand. That call
+    // writes both copies. A fixture that sets one claims edits the panel
+    // does not hold.
+    stella_tui::views::engine_panel::ingest_config(&mut ui, &fixture_seats(), &None);
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "pane_settings_seats",
+        "the SETTINGS tab's SEATS pane: the session's role, then a plugin's",
+        W,
+        H,
+        &frame,
+    );
+}

--- a/crates/stella-tui/tests/snapshots/deck/pane_settings_seats.txt
+++ b/crates/stella-tui/tests/snapshots/deck/pane_settings_seats.txt
@@ -1,0 +1,45 @@
+# deck golden · pane_settings_seats
+# the SETTINGS tab's SEATS pane: the session's role, then a plugin's
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SESSION AGENTS TRACES GRAPH FILES SKILLS MCP ISSUES   SETTINGS                                                                                         stella*
+  AGENTS  │  TOOLS  │  SEATS   ←/→
+ seats · 2 · read-only
+ default         zai/glm-5.2-air   from default_model
+ acme/reviewer   default           from acme
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ ▶ sub:ci  running · quiet 0:00 · starting: no model call yet
+>>>
+ ⏎ queue · ↓ 2 sub-agents · $ shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help


### PR DESCRIPTION
## What and why

Slice 5 of the roleless-core plan (#3903).

The SETTINGS tab's SEATS pane drew one row per role an installed plugin
declares, and nothing else. Two consequences on screen:

- A fresh install has no plugin, so the pane showed a hint line and no rows at
  all — the one surface whose subject is "which model runs what" had nothing to
  say about a session that runs on one model.
- Even with a plugin on, every unassigned seat rendered the word `default` and
  the pane never said what `default` resolves to.

The issue asks for "one row for the default model, one row per seat declared by
an installed plugin". This adds the first half.

`crates/stella-tui/src/views/seats.rs` gains `rows(&EngineConfigState)`, a pure
fold that returns the pane's list: the roles the driver **resolved**
(`EngineConfigState::roles`, an open vocabulary since #3472 — today exactly one,
`default`, with the model it resolved to and the settings key that chose it),
then one row per **declared** seat. `views/settings.rs` calls the fold instead
of handing the painter `state.seats` directly.

No new type. A `RoleWiringRow` maps onto the `SeatRow` shape the painter already
draws: name, model, source. The pane still names nothing — both halves arrive
from the driver, which is the same contract `views/tools.rs` holds for MCP and
custom tools.

## Witness mechanism

`the_session_role_leads_the_plugin_seats`
(`crates/stella-tui/src/views/seats.rs`) builds a snapshot with one resolved
role and one plugin-declared `acme/reviewer`, and asserts the fold returns
exactly two rows in that order, then that the painted pane shows the resolved
model and `from default_model`. It fails on `main` by construction: `rows` does
not exist there, and the pane was handed `state.seats`, so the list was one row
long and `default` appeared nowhere.

Beside it:

- `a_session_with_no_plugin_still_shows_its_own_role` — the fresh-install case,
  which was the hint line before.
- `the_leading_row_is_named_by_the_driver_not_by_this_pane` — a driver that
  calls the session's role `lead` gets `lead` back. This is what proves the row
  is read rather than written here, and it fails the day someone adds a list of
  role names to the pane.
- `an_empty_snapshot_invents_no_row` — a driver that sent nothing still gets the
  hint, not a fabricated `default` row.
- `the_fold_leaves_an_unassigned_seat_unassigned` — the fold must not fill an
  unassigned seat with the leading row's model, or a pinned seat and an
  inherited one become indistinguishable.

**Golden frame.** `crates/stella-tui/tests/deck_render_snapshots/settings_seats.rs`
renders the pane at the canonical viewport with one plugin seat on screen, and
`crates/stella-tui/tests/snapshots/deck/pane_settings_seats.txt` pins it. The
frame was read, not blessed: two rows, the resolved `default` carrying
`zai/glm-5.2-air` and `from default_model`, then `acme/reviewer` reading
`default` in the model column and `from acme`. That is the same claim the two
unit tests above make, held at the character grid.

It is a submodule rather than more lines in `deck_render_snapshots.rs`, which
sits close to the 1500-line ceiling — the shape `voice.rs` and `mcp.rs` already
use. Its fixture is its own rather than `base_ui`'s, because the demo scenario's
engine config still carries the five roles #3908 retired (#6061) and a committed
golden of this pane would then teach a vocabulary the product does not have.

## Exemplar

`crates/stella-tui/src/views/tools.rs` — rows from the assembled session, never
from a compiled-in table. Its module doc states the reason and the issue quotes
it.

## Where this departs from the issue, and why

The issue's stated done condition was "No role name is compiled into
`stella-tui`". That is not true today and this change cannot make it true:

- `crates/stella-tui/src/views/models_card.rs`'s `SLOTS` table still names
  `triage`, `research`, `plan`, `worker` and `verifier`. Dead vocabulary — the
  driver only ever sends `default` — but present. Filed as #6087.
- `crates/stella-tui/src/deck.rs`'s `PipelineRole` names three of the same
  words for a live purpose: it groups spend by the `ModelCallRole` the wire
  reports. That is receipt vocabulary rather than routing, and #3910 owns it.

Ticking that box would be claiming something the tree contradicts, so the
issue's checklist was split into what this slice proves, with a comment on
#3909 saying so and both remainders filed. The rest of the issue is unchanged.

## Stale comments repointed

Seven comments in `stella-cli` and `stella-tui` named #3909 as the issue that
would fold plugin seats into `RoleWiring` and into `EngineRole`. This did
neither — the seats stay a separate list the deck composes — so each comment now
says what actually happened, and the ones predicting a `/models` change point at
#6088 instead.

## Tests deleted

None.

## Remaining work

Filed as issues rather than left in this description:

- #6086 — the SEATS pane is read-only; assigning a model to a seat writes
  `agent_engine_config.seat_models` and nothing does it.
- #6087 — the `/models` card's five dead role words.
- #6088 — `/models` and `stella config` name one role when the session has more.

Closes #3909

## Summary by Sourcery

Display the session's resolved role alongside plugin-declared seats in the SETTINGS SEATS pane.

New Features:
- Show the session's driver-resolved roles in the SETTINGS SEATS pane before plugin-declared seats, including each role's resolved model and source.

Bug Fixes:
- Ensure fresh sessions without plugins still display their active model instead of an empty seat list.
- Preserve driver-provided role names and leave unassigned plugin seats rendered as inherited defaults.

Enhancements:
- Centralize SEATS row assembly in a driver-backed fold while keeping the pane role-agnostic and read-only.

Documentation:
- Update SEATS pane documentation and stale issue references to reflect that resolved roles and plugin seats remain separate data.

Tests:
- Add coverage for row ordering, plugin-free sessions, driver-defined role names, empty snapshots, and unassigned seats.
- Add a golden-render snapshot for the SETTINGS SEATS pane.
