### PR TITLE
ci(dod-check): re-pin the gate to the build that reads Refs-only and negation

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -16,7 +16,12 @@ name: dod-check
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+    # `ready_for_review` because a PR opened as a draft and later marked ready
+    # never re-ran the check, so it kept whatever verdict its draft head got
+    # (oxagen#2638). The caller owns this list; the implementation cannot add
+    # an event on our behalf.
+    types:
+      [opened, edited, reopened, ready_for_review, synchronize, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -25,4 +30,4 @@ permissions:
 
 jobs:
   dod:
-    uses: macanderson/oxagen/.github/workflows/dod-check.yml@acf3509c0012240362e8af8eb91bb1aad6f9a428 # oxagen main, #2643
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@f4c13eb924f6b2ac63da2e12d0504d7c2278af7f # oxagen main, #2663


### PR DESCRIPTION
## What and why

macanderson/oxagen#2663 landed three fixes to the shared DoD check, and this
repository pins the implementation to a commit rather than `@main`, so none of
them reached it:

- a clause-scoped negation, so "does not close #N" is no longer read as a claim
  to close N (oxagen#2636);
- a third passing state for a PR that only advances an issue with `Refs #N`
  (oxagen#2640);
- a failure message that says outright that ticking the issue's boxes does not
  re-run the check.

**#6093 is red right now for exactly the missing state.** Its body carries
`Refs #6068` and `Refs #5200` and no `Closes`, which is the correct choice —
the PR closes the ledger half of #6068 and says so — and the pinned build
reports it as `This PR links no issue`. The two escape hatches the old build
offers are both wrong for it: `Closes` would close an issue whose DoD is not
met, and `no-issue` would assert a 355-line feature change is trivial.

`ready_for_review` joins the trigger list in the same change. The caller stub
owns that list — oxagen#2663 added the event to oxagen's own caller and could
not add it here on our behalf — so a PR opened as a draft and later marked
ready kept whatever verdict its draft head got (oxagen#2638).

The file's own header already names this as the maintenance this pin costs:
"Re-pin when the implementation changes, which is a reviewable one-line diff
naming the version it moved to."

## Verification

No crate is touched, so nothing here compiles. The guards that judge this diff:

- `check-action-pins` — OK, all 102 `uses:` references pinned to a commit SHA
  (this is the guard the SHA pin exists to satisfy).
- `check-prose` — OK, none added.
- `check-line-citations` — OK, none added.
- The workflow parses as YAML.
- The pinned SHA `f4c13eb` is the tip of `macanderson/oxagen`'s `main` and
  carries the Refs-only state: `git show f4c13eb:tools/scripts/scr-dod-check.mjs`
  shows `REFS_PATTERN`, `referencedIssues()` and the `refsOnly` verdict field.

**This PR is its own witness, and the witness has now run.** Its body is
`Refs`-only with no `Closes`, so under the *old* pin `linkedIssues()` returns
nothing, there is no `refs` concept to fall back on, and `dod / dod` fails with
`This PR links no issue` — which is the failure #6093 is sitting on. Under the
new pin the same body takes the `refsOnly` branch and passes.

`dod / dod` on `981a89e` — [run 33987600937](https://github.com/macanderson/stella/actions/runs/33987600937),
completed 19:42:15Z — **success**. A `pull_request` event resolves the caller
workflow from the merge ref, so that run used this branch's pin. The old pin
could not have produced that result on this body, which is what makes the green
a witness rather than a coincidence.

## Tests deleted

None.

## Residue

The other three consumer repositories (`arenabench`, `cgp-website`,
`context-graph-protocol`) use `@main` and already have the fix — checked, not
assumed. This repository is the only one that pins a SHA, which is the whole
reason it lagged.

## Correction

An earlier revision of this description claimed this PR was "the live
confirmation #6089 asks for". That was wrong, and #6089 is untouched by this
change: it asks whether `dod-recheck.yml` starts on an `issues: [edited]` event
once that workflow is on `main` — a question about #6091's diff, not about which
build the gate is pinned to. The green run above confirms the re-pin, and
nothing more.

Refs macanderson/oxagen#2640
Refs macanderson/oxagen#2638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iQ1TL85RiG2HARN5YoLJZ