### PR TITLE
docs(scr): record the Refs-only state in the compiled SCR-003 summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1559,7 +1559,10 @@ macanderson org repos.
 - **[SCR-003](docs/scr/SCR-003-dod-verified-close.md) — Definition of
   done:** An issue closes only when every DoD checklist item is satisfied
   and verified. Reference-grade includes tests, code comments, docs, and
-  CI — not just the implementation.
+  CI — not just the implementation. A PR that advances an issue without
+  finishing it links it with `Refs #N` rather than `Closes #N`: `Refs`
+  does not close, so the merge gate does not hold that PR against the
+  issue's DoD. A PR may carry both, and is gated only on what it closes.
 - **[SCR-004](docs/scr/SCR-004-residue-becomes-issues.md) — Residue:**
   Before declaring any task complete, file a GitHub issue for every
   follow-up, tech-debt item, or logical next step you noticed. Apply ONLY


### PR DESCRIPTION
The merge gate now accepts a pull request that references an issue with `Refs #N` without claiming to close it. That was documented in the specification itself, but not in the compiled summary every agent loads at session start — which is the copy anyone actually reads before writing a pull request description.

Documentation only. Nothing in this repository's behaviour changes.

Synced from macanderson/oxagen.

Refs macanderson/oxagen#2640

## Summary by Sourcery

Documentation:
- Document the SCR-003 Refs-only workflow in the compiled AGENTS.md summary, clarifying that `Refs #N` links an issue without making the pull request subject to its DoD merge gate.