### PR TITLE
fix(stella-store,stella-cli): let the hub prune reach a removed tree and an orphan id

### DIFF
--- a/crates/stella-cli/src/usage_cmd.rs
+++ b/crates/stella-cli/src/usage_cmd.rs
@@ -13,7 +13,7 @@
 //! keep its token) and mints the durable, committable per-workspace
 //! `workspace_id`. Until registration, hub rows carry NULL org/workspace ids.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
 use colored::Colorize as _;
@@ -550,12 +550,48 @@ pub(crate) fn parse_age_window(s: &str) -> Result<String, String> {
     Ok(modifier)
 }
 
-/// Whether a project's checkout looks *deleted* (GC-eligible) rather than merely
-/// unreachable. The root being gone while its parent still exists is a deletion;
-/// a missing parent usually means the whole volume/mount is absent (an unplugged
-/// drive, a down network share), which must not trigger GC of local history.
+/// Whether a project's checkout is deleted, rather than on a volume that is
+/// not mounted right now.
+///
+/// A root that is gone while its parent still stands was deleted. A root
+/// whose parent is gone too is ambiguous on its own: an unplugged drive or a
+/// down share looks the same as a whole tree removed at once. The tie is
+/// broken by [`mounted_anchors`]: the home directory and the OS temp
+/// directory exist for this process to be running at all, so anything
+/// missing beneath either was deleted, never unmounted. A bench harness
+/// leaves thousands of trial workspaces under the temp directory and removes
+/// each series whole, which is the shape the parent rule alone could not
+/// reach: on 2026-09-05 one hub held 2,311 such projects it would never GC.
 fn checkout_is_deleted(root: &Path) -> bool {
-    !root.exists() && root.parent().is_some_and(Path::exists)
+    checkout_is_deleted_under(root, &mounted_anchors())
+}
+
+/// [`checkout_is_deleted`] against an explicit anchor list, so the rule can
+/// be tested with directories a test owns.
+fn checkout_is_deleted_under(root: &Path, anchors: &[PathBuf]) -> bool {
+    if root.exists() {
+        return false;
+    }
+    if root.parent().is_some_and(Path::exists) {
+        return true;
+    }
+    anchors
+        .iter()
+        .any(|anchor| anchor.exists() && root.starts_with(anchor))
+}
+
+/// Directories that are present whenever this process runs. Each is listed
+/// as spelled and as canonicalized, because a hub records the canonical
+/// path (`/private/var/...` on macOS) while `temp_dir` reports the symlink.
+fn mounted_anchors() -> Vec<PathBuf> {
+    let mut anchors = vec![std::env::temp_dir()];
+    anchors.extend(stella_home::home_dir());
+    let canonical: Vec<PathBuf> = anchors
+        .iter()
+        .filter_map(|anchor| anchor.canonicalize().ok())
+        .collect();
+    anchors.extend(canonical);
+    anchors
 }
 
 fn prune(
@@ -580,14 +616,21 @@ fn prune(
     let hub = open_hub()?;
 
     // The store enforces the "unregistered" invariant; the CLI owns the
-    // filesystem check for "the checkout is gone".
+    // filesystem check for "the checkout is gone". An id with no project row
+    // has no checkout to check and joins the set as it is.
     let gc_project_ids = if gc_deleted {
-        hub.registered_projects()
+        let mut ids: Vec<String> = hub
+            .registered_projects()
             .map_err(|e| format!("cannot list hub projects: {e}"))?
             .into_iter()
             .filter(|(_, _, root)| checkout_is_deleted(Path::new(root)))
             .map(|(id, _, _)| id)
-            .collect()
+            .collect();
+        ids.extend(
+            hub.orphan_project_ids()
+                .map_err(|e| format!("cannot list orphan hub rows: {e}"))?,
+        );
+        ids
     } else {
         Vec::new()
     };
@@ -879,7 +922,9 @@ pub fn run_cloud(cmd: CloudCmd) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{checkout_is_deleted, parse_age_window, register_transition};
+    use std::path::PathBuf;
+
+    use super::{checkout_is_deleted_under, parse_age_window, register_transition};
 
     /// The org-change ruling (#465): same org is idempotent, a different org
     /// is refused until an explicit deregister, unregistered registers freely.
@@ -924,18 +969,44 @@ mod tests {
         assert!(parse_age_window("0d").is_err(), "zero window is a footgun");
     }
 
+    /// With no anchor to consult, the parent rule stands alone: a gone root
+    /// under a standing parent is deleted, and a root whose parent is gone too
+    /// is unreachable, which must not GC local history.
     #[test]
     fn checkout_is_deleted_distinguishes_gone_from_unreachable() {
         let tmp = tempfile::tempdir().unwrap();
         let present = tmp.path().join("repo");
         std::fs::create_dir(&present).unwrap();
-        // Parent (tempdir) exists, child gone → a real deletion.
-        assert!(checkout_is_deleted(&present.join("missing-child")));
-        // The path itself exists → not deleted.
-        assert!(!checkout_is_deleted(&present));
-        // Parent also absent (whole volume/mount gone) → NOT a deletion.
-        assert!(!checkout_is_deleted(
-            &present.join("gone-parent").join("repo")
+        let no_anchors: Vec<PathBuf> = Vec::new();
+        assert!(checkout_is_deleted_under(
+            &present.join("missing-child"),
+            &no_anchors
         ));
+        assert!(!checkout_is_deleted_under(&present, &no_anchors));
+        assert!(!checkout_is_deleted_under(
+            &present.join("gone-parent").join("repo"),
+            &no_anchors
+        ));
+    }
+
+    /// **The witness for the anchors.** A bench series removed whole leaves a
+    /// root with no parent. Beneath a directory this process can see, that is
+    /// a deletion, not a missing volume. An anchor that is itself gone says
+    /// nothing, and a root outside every anchor keeps the unreachable ruling.
+    #[test]
+    fn a_tree_removed_whole_under_a_standing_anchor_is_deleted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("series-005").join("work").join("trial-3");
+        assert!(checkout_is_deleted_under(
+            &root,
+            &[tmp.path().to_path_buf()]
+        ));
+        assert!(!checkout_is_deleted_under(
+            &root,
+            &[tmp.path().join("nowhere")]
+        ));
+        let other = tmp.path().join("other");
+        std::fs::create_dir(&other).unwrap();
+        assert!(!checkout_is_deleted_under(&root, &[other]));
     }
 }

--- a/crates/stella-store/src/usage.rs
+++ b/crates/stella-store/src/usage.rs
@@ -587,6 +587,29 @@ impl UsageStore {
         Ok(out)
     }
 
+    /// Project ids the data tables carry with no `projects` row: telemetry
+    /// replicated under an id nothing ever registered, or rows a rekey left
+    /// behind. An orphan has no root to check, so the CLI's gone-checkout scan
+    /// can never name it. It is GC-eligible on its own, and [`Self::prune`]'s
+    /// org-row guard still holds for it.
+    pub fn orphan_project_ids(&self) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT project_id FROM telemetry \
+             WHERE project_id NOT IN (SELECT project_id FROM projects) \
+             UNION \
+             SELECT project_id FROM execution_rollup \
+             WHERE project_id NOT IN (SELECT project_id FROM projects) \
+             ORDER BY 1",
+        )?;
+        let rows = stmt.query_map([], |r| r.get(0))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Bound the hub's growth per a [`PrunePolicy`] — the engine behind
     /// `stella usage prune`. Runs, in order: project GC → age cutoff → row
     /// ceiling, all in one transaction, then (optionally) `VACUUM`.
@@ -1470,6 +1493,49 @@ mod tests {
         assert_eq!(report.aged_out, 2, "acked org + NULL-org rows both drop");
         assert_eq!(report.protected_unacked, 0);
         assert_eq!(telemetry_rows(&hub), 0);
+    }
+
+    /// **The witness for orphan GC.** `replicate_telemetry` writes rows under
+    /// a project id; `sync_execution` is what registers the project. Rows that
+    /// only ever came through the first path have no `projects` row, so the
+    /// CLI's gone-checkout scan never names them. `orphan_project_ids` does,
+    /// and `prune` clears them under the same org-row guard: a NULL-org orphan
+    /// goes, an org-scoped one stays for the drain.
+    #[test]
+    fn telemetry_with_no_registered_project_is_an_orphan_the_prune_reaches() {
+        let hub = UsageStore::in_memory().unwrap();
+        let mut ghost = scope(None, None);
+        ghost.project_id = "proj_ghost".into();
+        hub.replicate_telemetry(&ghost, &[source_row(1, 0.01), source_row(2, 0.01)])
+            .unwrap();
+        let mut acme = scope(Some("acme"), Some("ws-1"));
+        acme.project_id = "proj_acme_ghost".into();
+        hub.replicate_telemetry(&acme, &[source_row(1, 0.05)])
+            .unwrap();
+        // A registered project is never an orphan.
+        hub.sync_execution(&rollup(1, vec![])).unwrap();
+
+        let orphans = hub.orphan_project_ids().unwrap();
+        assert_eq!(
+            orphans,
+            vec!["proj_acme_ghost".to_string(), "proj_ghost".to_string()]
+        );
+
+        let report = hub
+            .prune(&PrunePolicy {
+                gc_project_ids: orphans,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            report.gc_projects, 1,
+            "the org-scoped orphan is kept for the drain"
+        );
+        assert_eq!(report.gc_rows, 2);
+        assert_eq!(
+            hub.orphan_project_ids().unwrap(),
+            vec!["proj_acme_ghost".to_string()]
+        );
     }
 
     #[test]

--- a/crates/stella-store/src/usage.rs
+++ b/crates/stella-store/src/usage.rs
@@ -587,29 +587,6 @@ impl UsageStore {
         Ok(out)
     }
 
-    /// Project ids the data tables carry with no `projects` row: telemetry
-    /// replicated under an id nothing ever registered, or rows a rekey left
-    /// behind. An orphan has no root to check, so the CLI's gone-checkout scan
-    /// can never name it. It is GC-eligible on its own, and [`Self::prune`]'s
-    /// org-row guard still holds for it.
-    pub fn orphan_project_ids(&self) -> Result<Vec<String>> {
-        let conn = self.lock();
-        let mut stmt = conn.prepare(
-            "SELECT project_id FROM telemetry \
-             WHERE project_id NOT IN (SELECT project_id FROM projects) \
-             UNION \
-             SELECT project_id FROM execution_rollup \
-             WHERE project_id NOT IN (SELECT project_id FROM projects) \
-             ORDER BY 1",
-        )?;
-        let rows = stmt.query_map([], |r| r.get(0))?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
-    }
-
     /// Bound the hub's growth per a [`PrunePolicy`] — the engine behind
     /// `stella usage prune`. Runs, in order: project GC → age cutoff → row
     /// ceiling, all in one transaction, then (optionally) `VACUUM`.
@@ -1018,6 +995,7 @@ mod tool_report;
 pub use tool_report::ToolReportRow;
 // Drain observability: last-attempt record + cursor/backlog readers (#464).
 pub mod drain_state;
+mod orphans;
 // Project re-key: merge a forked path-derived identity into the stable one (#408).
 mod rekey;
 
@@ -1142,7 +1120,7 @@ mod tests {
         }
     }
 
-    fn source_row(source_rowid: i64, cost: f64) -> crate::SourceTelemetryRow {
+    pub(super) fn source_row(source_rowid: i64, cost: f64) -> crate::SourceTelemetryRow {
         crate::SourceTelemetryRow {
             source_rowid,
             execution_id: 1,
@@ -1493,49 +1471,6 @@ mod tests {
         assert_eq!(report.aged_out, 2, "acked org + NULL-org rows both drop");
         assert_eq!(report.protected_unacked, 0);
         assert_eq!(telemetry_rows(&hub), 0);
-    }
-
-    /// **The witness for orphan GC.** `replicate_telemetry` writes rows under
-    /// a project id; `sync_execution` is what registers the project. Rows that
-    /// only ever came through the first path have no `projects` row, so the
-    /// CLI's gone-checkout scan never names them. `orphan_project_ids` does,
-    /// and `prune` clears them under the same org-row guard: a NULL-org orphan
-    /// goes, an org-scoped one stays for the drain.
-    #[test]
-    fn telemetry_with_no_registered_project_is_an_orphan_the_prune_reaches() {
-        let hub = UsageStore::in_memory().unwrap();
-        let mut ghost = scope(None, None);
-        ghost.project_id = "proj_ghost".into();
-        hub.replicate_telemetry(&ghost, &[source_row(1, 0.01), source_row(2, 0.01)])
-            .unwrap();
-        let mut acme = scope(Some("acme"), Some("ws-1"));
-        acme.project_id = "proj_acme_ghost".into();
-        hub.replicate_telemetry(&acme, &[source_row(1, 0.05)])
-            .unwrap();
-        // A registered project is never an orphan.
-        hub.sync_execution(&rollup(1, vec![])).unwrap();
-
-        let orphans = hub.orphan_project_ids().unwrap();
-        assert_eq!(
-            orphans,
-            vec!["proj_acme_ghost".to_string(), "proj_ghost".to_string()]
-        );
-
-        let report = hub
-            .prune(&PrunePolicy {
-                gc_project_ids: orphans,
-                ..Default::default()
-            })
-            .unwrap();
-        assert_eq!(
-            report.gc_projects, 1,
-            "the org-scoped orphan is kept for the drain"
-        );
-        assert_eq!(report.gc_rows, 2);
-        assert_eq!(
-            hub.orphan_project_ids().unwrap(),
-            vec!["proj_acme_ghost".to_string()]
-        );
     }
 
     #[test]

--- a/crates/stella-store/src/usage/orphans.rs
+++ b/crates/stella-store/src/usage/orphans.rs
@@ -1,0 +1,102 @@
+//! Project ids the hub's data tables carry with no `projects` row.
+//!
+//! The prune's gone-checkout scan lists its candidates from `projects` and
+//! asks whether each root still exists on disk. An id that was never
+//! registered has no row there, so that scan cannot name it however long it
+//! runs — the rows are unreachable by construction, not merely unmatched.
+//!
+//! Two paths produce one. `replicate_telemetry` writes under whatever
+//! `project_id` its scope carries, while `sync_execution` is what registers
+//! the project; a hub that only ever saw the first call holds telemetry for a
+//! project it has no record of. A re-key ([`super::rekey`]) that moved some
+//! tables and not others leaves the same shape behind.
+//!
+//! An orphan is GC-eligible on its own — there is no root to check, because
+//! nothing ever said where it was — and [`UsageStore::prune`]'s org-row guard
+//! still holds for it: an id with un-acked cloud-drain rows stays until the
+//! drain acknowledges them, exactly as a registered project would.
+
+use super::{Result, UsageStore};
+
+impl UsageStore {
+    /// Project ids present in `telemetry` or `execution_rollup` with no
+    /// matching `projects` row, sorted. See the module doc for how a hub comes
+    /// to hold one and why the prune may take it.
+    pub fn orphan_project_ids(&self) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT project_id FROM telemetry \
+             WHERE project_id NOT IN (SELECT project_id FROM projects) \
+             UNION \
+             SELECT project_id FROM execution_rollup \
+             WHERE project_id NOT IN (SELECT project_id FROM projects) \
+             ORDER BY 1",
+        )?;
+        let rows = stmt.query_map([], |r| r.get(0))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{rollup, source_row};
+    use super::super::{PrunePolicy, UsageStore};
+    use crate::identity::TelemetryScope;
+
+    /// Local rather than borrowed from the parent's fixtures: widening that
+    /// one reflows its signature across four lines, and `usage.rs` is a
+    /// grandfathered god file sitting on its ceiling.
+    fn scope(org: Option<&str>, project_id: &str) -> TelemetryScope {
+        TelemetryScope {
+            org_id: org.map(String::from),
+            workspace_id: org.map(|_| "ws-1".into()),
+            repo_id: "repo01".into(),
+            project_id: project_id.into(),
+        }
+    }
+
+    /// **The witness for orphan GC.** `replicate_telemetry` writes rows under
+    /// a project id; `sync_execution` is what registers the project. Rows that
+    /// only ever came through the first path have no `projects` row, so the
+    /// CLI's gone-checkout scan never names them. `orphan_project_ids` does,
+    /// and `prune` clears them under the same org-row guard: a NULL-org orphan
+    /// goes, an org-scoped one stays for the drain.
+    #[test]
+    fn telemetry_with_no_registered_project_is_an_orphan_the_prune_reaches() {
+        let hub = UsageStore::in_memory().unwrap();
+        let ghost = scope(None, "proj_ghost");
+        hub.replicate_telemetry(&ghost, &[source_row(1, 0.01), source_row(2, 0.01)])
+            .unwrap();
+        let acme = scope(Some("acme"), "proj_acme_ghost");
+        hub.replicate_telemetry(&acme, &[source_row(1, 0.05)])
+            .unwrap();
+        // A registered project is never an orphan.
+        hub.sync_execution(&rollup(1, vec![])).unwrap();
+
+        let orphans = hub.orphan_project_ids().unwrap();
+        assert_eq!(
+            orphans,
+            vec!["proj_acme_ghost".to_string(), "proj_ghost".to_string()]
+        );
+
+        let report = hub
+            .prune(&PrunePolicy {
+                gc_project_ids: orphans,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            report.gc_projects, 1,
+            "the org-scoped orphan is kept for the drain"
+        );
+        assert_eq!(report.gc_rows, 2);
+        assert_eq!(
+            hub.orphan_project_ids().unwrap(),
+            vec!["proj_acme_ghost".to_string()]
+        );
+    }
+}

--- a/crates/stella-store/src/usage/orphans.rs
+++ b/crates/stella-store/src/usage/orphans.rs
@@ -1,27 +1,27 @@
 //! Project ids the hub's data tables carry with no `projects` row.
 //!
-//! The prune's gone-checkout scan lists its candidates from `projects` and
-//! asks whether each root still exists on disk. An id that was never
-//! registered has no row there, so that scan cannot name it however long it
-//! runs — the rows are unreachable by construction, not merely unmatched.
+//! The prune's gone-checkout scan reads its candidates from `projects`. For
+//! each one it asks whether the root is still on disk. An id that was never
+//! registered has no row there. That scan cannot name it, however long it
+//! runs. The rows are out of its reach by construction.
 //!
-//! Two paths produce one. `replicate_telemetry` writes under whatever
-//! `project_id` its scope carries, while `sync_execution` is what registers
-//! the project; a hub that only ever saw the first call holds telemetry for a
-//! project it has no record of. A re-key ([`super::rekey`]) that moved some
-//! tables and not others leaves the same shape behind.
+//! Two paths produce one. `replicate_telemetry` writes under the
+//! `project_id` its scope carries. `sync_execution` is the call that
+//! registers the project. A hub that saw only the first one holds telemetry
+//! for a project it has no record of. A re-key ([`super::rekey`]) that moved
+//! some tables and not others leaves the same shape.
 //!
-//! An orphan is GC-eligible on its own — there is no root to check, because
-//! nothing ever said where it was — and [`UsageStore::prune`]'s org-row guard
-//! still holds for it: an id with un-acked cloud-drain rows stays until the
-//! drain acknowledges them, exactly as a registered project would.
+//! An orphan is GC-eligible on its own. There is no root to check, because
+//! nothing ever said where it was. [`UsageStore::prune`]'s org-row guard
+//! still holds for it. An id with un-acked cloud-drain rows stays until the
+//! drain acks them, just as a registered project would.
 
 use super::{Result, UsageStore};
 
 impl UsageStore {
     /// Project ids present in `telemetry` or `execution_rollup` with no
-    /// matching `projects` row, sorted. See the module doc for how a hub comes
-    /// to hold one and why the prune may take it.
+    /// matching `projects` row, sorted. The module doc says how a hub comes
+    /// to hold one. It also says why the prune may take it.
     pub fn orphan_project_ids(&self) -> Result<Vec<String>> {
         let conn = self.lock();
         let mut stmt = conn.prepare(
@@ -47,9 +47,9 @@ mod tests {
     use super::super::{PrunePolicy, UsageStore};
     use crate::identity::TelemetryScope;
 
-    /// Local rather than borrowed from the parent's fixtures: widening that
-    /// one reflows its signature across four lines, and `usage.rs` is a
-    /// grandfathered god file sitting on its ceiling.
+    /// Local, not borrowed from the parent's fixtures. Widening that one
+    /// reflows its signature across four lines, and `usage.rs` is a
+    /// grandfathered god file already at its ceiling.
     fn scope(org: Option<&str>, project_id: &str) -> TelemetryScope {
         TelemetryScope {
             org_id: org.map(String::from),
@@ -60,11 +60,11 @@ mod tests {
     }
 
     /// **The witness for orphan GC.** `replicate_telemetry` writes rows under
-    /// a project id; `sync_execution` is what registers the project. Rows that
-    /// only ever came through the first path have no `projects` row, so the
-    /// CLI's gone-checkout scan never names them. `orphan_project_ids` does,
-    /// and `prune` clears them under the same org-row guard: a NULL-org orphan
-    /// goes, an org-scoped one stays for the drain.
+    /// a project id. `sync_execution` is what registers the project. Rows
+    /// that came only through the first path have no `projects` row. So the
+    /// CLI's gone-checkout scan never names them. `orphan_project_ids` does.
+    /// `prune` then clears them under the same org-row guard: a NULL-org
+    /// orphan goes, an org-scoped one stays for the drain.
     #[test]
     fn telemetry_with_no_registered_project_is_an_orphan_the_prune_reaches() {
         let hub = UsageStore::in_memory().unwrap();


### PR DESCRIPTION
## What & why

`~/.stella/usage.db` on the maintainer's machine held 2,795 registered projects. They were not worktrees: 2,313 were first seen in July, and their roots were bench trial workspaces under the OS temp directory, one per trial, each synced into the hub and registered forever. Only 36 roots still existed. `stella usage prune --gc-deleted` is the sanctioned way out, and it reached 448 of the 2,759 dead projects (#6100):

- **The "checkout is deleted" rule needed the parent to survive.** A bench series is removed whole, so every trial under it lost its parent too, and the rule read that as an unmounted volume. The rule now consults two anchors that exist whenever the process runs: the home directory and the OS temp directory. A root missing beneath either was deleted, never unmounted. A missing parent anywhere else still reads as a missing volume. Both spellings of each anchor are checked, because a hub records the canonical `/private/var/...` path while `temp_dir` reports the `/var/...` symlink.
- **Orphan ids were unreachable by construction.** 33,177 telemetry rows sat under 206 project ids with no `projects` row (replicated without a `sync_execution`, or left by a rekey). The prune listed candidates from `projects`, so it could never name them. `UsageStore::orphan_project_ids` lists ids seen in `telemetry` or `execution_rollup` with no project row, and the CLI adds them to the GC set. The per-id GC already refuses an id with org-scoped rows, so an orphan joins under the same guard.

Run on the hub in question: `would remove 2855 row(s) from 448 deleted project(s)` before; `248733 row(s) from 2759` and then `33177 row(s) from 206` after. The file went from 84 MB to 9.2 MB and the hub is consistent: 36 projects, 36 ids in telemetry.

Closes #6100

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

- `usage_cmd::tests::a_tree_removed_whole_under_a_standing_anchor_is_deleted`: a root three levels under a standing anchor with no parent is deleted; an absent anchor says nothing; a root outside every anchor keeps the unreachable ruling. On `main` the anchored function does not exist, and the old rule returns false for that root, which is what the 2,311 unreachable projects measured.
- `usage::tests::telemetry_with_no_registered_project_is_an_orphan_the_prune_reaches`: rows seeded through `replicate_telemetry` alone are listed as orphans, the prune clears the NULL-org one and keeps the org-scoped one. On `main` the method does not exist.
- The existing `checkout_is_deleted_distinguishes_gone_from_unreachable` pinned the old ruling for a path under the temp dir, which this change flips on purpose. It moves to the explicit-anchor form with an empty anchor list, so the parent rule it was really about is still pinned.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-store -p stella-cli --all-targets -- -D warnings` (targeted; CI runs the workspace)
- [x] `cargo test -p stella-store --lib usage::tests`, `cargo test -p stella-cli --bin stella usage_cmd::tests` (targeted; CI runs the workspace)
- [x] Docs updated where behavior changed (doc comments on the rule and the new method)
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #6100 carries the open question of why bench trials register in the user's hub at all; the harness lives in the proving-ground repo.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

Tests deleted: none. One test changed shape as described above.

## Summary by Sourcery

Make usage garbage collection reach deleted checkout trees and orphaned project data without removing unreachable or protected records.

Bug Fixes:
- Allow usage pruning to identify projects whose entire checkout tree was removed beneath the home or temporary-directory anchors.
- Include orphaned telemetry and execution-rollup project IDs in garbage-collection candidates while preserving protection for org-scoped data.

Enhancements:
- Improve deleted-checkout detection for paths recorded through alternate canonical and symlinked anchor spellings.

Tests:
- Add coverage for whole-tree deletion beneath a standing anchor and orphan project garbage collection.